### PR TITLE
evm: Add a stub chainwriter impl

### DIFF
--- a/.changeset/tricky-flowers-exist.md
+++ b/.changeset/tricky-flowers-exist.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#added A ChainWriter implementation in the EVM relay.

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20240222010609-cd67d123c772
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1185,8 +1185,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303 h1:iyLE5c2YFxy89t2v5u+aQOHqRE4c+sCMze70KIo07mI=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8 h1:czecbzi/JWd2xbw60KpSFa+E49G+NMe9rbIdznaZlsY=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/core/services/ocr2/plugins/median/services.go
+++ b/core/services/ocr2/plugins/median/services.go
@@ -167,7 +167,7 @@ func NewMedianServices(ctx context.Context,
 			abort()
 			return
 		}
-		median := loop.NewMedianService(lggr, telem, cmdFn, medianProvider, dataSource, juelsPerFeeCoinSource, errorLog)
+		median := loop.NewMedianService(lggr, telem, cmdFn, medianProvider, dataSource, juelsPerFeeCoinSource, gasPriceSubunitsDataSource, errorLog)
 		argsNoPlugin.ReportingPluginFactory = median
 		srvs = append(srvs, median)
 	} else {

--- a/core/services/ocr2/plugins/median/services.go
+++ b/core/services/ocr2/plugins/median/services.go
@@ -167,7 +167,7 @@ func NewMedianServices(ctx context.Context,
 			abort()
 			return
 		}
-		median := loop.NewMedianService(lggr, telem, cmdFn, medianProvider, dataSource, juelsPerFeeCoinSource, gasPriceSubunitsDataSource, errorLog)
+		median := loop.NewMedianService(lggr, telem, cmdFn, medianProvider, dataSource, juelsPerFeeCoinSource, errorLog)
 		argsNoPlugin.ReportingPluginFactory = median
 		srvs = append(srvs, median)
 	} else {

--- a/core/services/relay/evm/chain_writer.go
+++ b/core/services/relay/evm/chain_writer.go
@@ -73,20 +73,20 @@ type chainWriter struct {
 	config config.ChainWriter
 }
 
-func (writer *chainWriter) SubmitSignedTransaction(ctx context.Context, payload []byte, signature map[string]any, transactionID uuid.UUID, toAddress string, meta *TxMeta, value big.Int) (int64, error) {
+func (w *chainWriter) SubmitSignedTransaction(ctx context.Context, payload []byte, signature map[string]any, transactionID uuid.UUID, toAddress string, meta *TxMeta, value big.Int) (int64, error) {
 	return 0, fmt.Errorf("not implemented")
 }
 
-func (writer *chainWriter) GetTransactionStatus(ctx context.Context, transactionID uuid.UUID) (TransactionStatus, error) {
+func (w *chainWriter) GetTransactionStatus(ctx context.Context, transactionID uuid.UUID) (TransactionStatus, error) {
 	return Unknown, fmt.Errorf("not implemented")
 }
 
-func (writer *chainWriter) GetFeeComponents(ctx context.Context) (ChainFeeComponents, error) {
+func (w *chainWriter) GetFeeComponents(ctx context.Context) (ChainFeeComponents, error) {
 	return ChainFeeComponents{}, fmt.Errorf("not implemented")
 }
 
-func (writer *chainWriter) Close() error {
-	return writer.StopOnce(writer.Name(), func() error {
+func (w *chainWriter) Close() error {
+	return w.StopOnce(w.Name(), func() error {
 		_, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
@@ -95,23 +95,23 @@ func (writer *chainWriter) Close() error {
 	})
 }
 
-func (writer *chainWriter) HealthReport() map[string]error {
+func (w *chainWriter) HealthReport() map[string]error {
 	return map[string]error{
-		writer.Name(): nil,
+		w.Name(): nil,
 	}
 }
 
-func (writer *chainWriter) Name() string {
+func (w *chainWriter) Name() string {
 	return "chain-writer"
 }
 
-func (writer *chainWriter) Ready() error {
+func (w *chainWriter) Ready() error {
 	// TODO(nickcorin): Return nil here once the implementation is done.
 	return fmt.Errorf("not fully implemented")
 }
 
-func (writer *chainWriter) Start(ctx context.Context) error {
-	return writer.StartOnce(writer.Name(), func() error {
+func (w *chainWriter) Start(ctx context.Context) error {
+	return w.StartOnce(w.Name(), func() error {
 		// TODO(nickcorin): Add startup steps here.
 		return nil
 	})

--- a/core/services/relay/evm/chain_writer.go
+++ b/core/services/relay/evm/chain_writer.go
@@ -12,50 +12,13 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
-
-type ChainWriter interface {
-	// SubmitSignedTransaction packs and broadcasts a transaction to the underlying chain.
-	//
-	// The `transactionID` will be used by the underlying TXM as an idempotency key, and unique reference to track transaction attempts.
-	SubmitSignedTransaction(ctx context.Context, payload []byte, signature map[string]any, transactionID uuid.UUID, toAddress string, meta *TxMeta, value big.Int) (int64, error)
-
-	// GetTransactionStatus returns the current status of a transaction in the underlying chain's TXM.
-	GetTransactionStatus(ctx context.Context, transactionID uuid.UUID) (TransactionStatus, error)
-
-	// GetFeeComponents retrieves the associated gas costs for executing a transaction.
-	GetFeeComponents(ctx context.Context) (ChainFeeComponents, error)
-}
-
-// TxMeta contains metadata fields for a transaction.
-//
-// Eventually this will replace, or be replaced by (via a move), the `TxMeta` in core:
-// https://github.com/smartcontractkit/chainlink/blob/dfc399da715f16af1fcf6441ea5fc47b71800fa1/common/txmgr/types/tx.go#L121
-type TxMeta = map[string]string
-
-// TransactionStatus are the status we expect every TXM to support and that can be returned by StatusForUUID.
-type TransactionStatus int
-
-const (
-	Unknown TransactionStatus = iota
-	Unconfirmed
-	Finalized
-	Failed
-	Fatal
-)
-
-// ChainFeeComponents contains the different cost components of executing a transaction.
-type ChainFeeComponents struct {
-	// The cost of executing transaction in the chain's EVM (or the L2 environment).
-	ExecutionFee big.Int
-
-	// The cost associated with an L2 posting a transaction's data to the L1.
-	DataAvailabilityFee big.Int
-}
 
 type ChainWriterService interface {
 	services.ServiceCtx
-	ChainWriter
+	types.ChainWriter
 }
 
 // Compile-time assertion that chainWriter implements the ChainWriterService interface.
@@ -73,16 +36,16 @@ type chainWriter struct {
 	config config.ChainWriter
 }
 
-func (w *chainWriter) SubmitSignedTransaction(ctx context.Context, payload []byte, signature map[string]any, transactionID uuid.UUID, toAddress string, meta *TxMeta, value big.Int) (int64, error) {
+func (w *chainWriter) SubmitSignedTransaction(ctx context.Context, payload []byte, signature map[string]any, transactionID uuid.UUID, toAddress string, meta *types.TxMeta, value big.Int) (int64, error) {
 	return 0, fmt.Errorf("not implemented")
 }
 
-func (w *chainWriter) GetTransactionStatus(ctx context.Context, transactionID uuid.UUID) (TransactionStatus, error) {
-	return Unknown, fmt.Errorf("not implemented")
+func (w *chainWriter) GetTransactionStatus(ctx context.Context, transactionID uuid.UUID) (types.TransactionStatus, error) {
+	return types.Unknown, fmt.Errorf("not implemented")
 }
 
-func (w *chainWriter) GetFeeComponents(ctx context.Context) (ChainFeeComponents, error) {
-	return ChainFeeComponents{}, fmt.Errorf("not implemented")
+func (w *chainWriter) GetFeeComponents(ctx context.Context) (*types.ChainFeeComponents, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func (w *chainWriter) Close() error {

--- a/core/services/relay/evm/chain_writer.go
+++ b/core/services/relay/evm/chain_writer.go
@@ -1,0 +1,118 @@
+package evm
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/google/uuid"
+	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
+	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
+)
+
+type ChainWriter interface {
+	// SubmitSignedTransaction packs and broadcasts a transaction to the underlying chain.
+	//
+	// The `transactionID` will be used by the underlying TXM as an idempotency key, and unique reference to track transaction attempts.
+	SubmitSignedTransaction(ctx context.Context, payload []byte, signature map[string]any, transactionID uuid.UUID, toAddress string, meta *TxMeta, value big.Int) (int64, error)
+
+	// GetTransactionStatus returns the current status of a transaction in the underlying chain's TXM.
+	GetTransactionStatus(ctx context.Context, transactionID uuid.UUID) (TransactionStatus, error)
+
+	// GetFeeComponents retrieves the associated gas costs for executing a transaction.
+	GetFeeComponents(ctx context.Context) (ChainFeeComponents, error)
+}
+
+// TxMeta contains metadata fields for a transaction.
+//
+// Eventually this will replace, or be replaced by (via a move), the `TxMeta` in core:
+// https://github.com/smartcontractkit/chainlink/blob/dfc399da715f16af1fcf6441ea5fc47b71800fa1/common/txmgr/types/tx.go#L121
+type TxMeta = map[string]string
+
+// TransactionStatus are the status we expect every TXM to support and that can be returned by StatusForUUID.
+type TransactionStatus int
+
+const (
+	Unknown TransactionStatus = iota
+	Unconfirmed
+	Finalized
+	Failed
+	Fatal
+)
+
+// ChainFeeComponents contains the different cost components of executing a transaction.
+type ChainFeeComponents struct {
+	// The cost of executing transaction in the chain's EVM (or the L2 environment).
+	ExecutionFee big.Int
+
+	// The cost associated with an L2 posting a transaction's data to the L1.
+	DataAvailabilityFee big.Int
+}
+
+type ChainWriterService interface {
+	services.ServiceCtx
+	ChainWriter
+}
+
+// Compile-time assertion that chainWriter implements the ChainWriterService interface.
+var _ ChainWriterService = (*chainWriter)(nil)
+
+func NewChainWriterService(config evm.ChainWrtier, logger logger.Logger, client evmclient.Client) ChainWriterService {
+	return &chainWriter{logger: logger, client: client, config: config}
+}
+
+type chainWriter struct {
+	commonservices.StateMachine
+
+	logger logger.Logger
+	client evmclient.Client
+	config evm.ChainWriter
+}
+
+func (writer *chainWriter) SubmitSignedTransaction(ctx context.Context, payload []byte, signature map[string]any, transactionID uuid.UUID, toAddress string, meta *TxMeta, value big.Int) (int64, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
+func (writer *chainWriter) GetTransactionStatus(ctx context.Context, transactionID uuid.UUID) (TransactionStatus, error) {
+	return Unknown, fmt.Errorf("not implemented")
+}
+
+func (writer *chainWriter) GetFeeComponents(ctx context.Context) (ChainFeeComponents, error) {
+	return ChainFeeComponents{}, fmt.Errorf("not implemented")
+}
+
+func (writer *chainWriter) Close() error {
+	return writer.StopOnce(writer.Name(), func() error {
+		_, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		// TODO(nickcorin): Add shutdown steps here.
+		return nil
+	})
+}
+
+func (writer *chainWriter) HealthReport() map[string]error {
+	return map[string]error{
+		writer.Name(): nil,
+	}
+}
+
+func (writer *chainWriter) Name() string {
+	return "chain-writer"
+}
+
+func (writer *chainWriter) Ready() error {
+	// TODO(nickcorin): Return nil here once the implementation is done.
+	return fmt.Errorf("not fully implemented")
+}
+
+func (writer *chainWriter) Start(ctx context.Context) error {
+	return writer.StartOnce(writer.Name(), func() error {
+		// TODO(nickcorin): Add startup steps here.
+		return nil
+	})
+}

--- a/core/services/relay/evm/chain_writer.go
+++ b/core/services/relay/evm/chain_writer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"

--- a/core/services/relay/evm/chain_writer.go
+++ b/core/services/relay/evm/chain_writer.go
@@ -9,9 +9,9 @@ import (
 	"github.com/google/uuid"
 	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services"
-	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 )
 
 type ChainWriter interface {
@@ -61,7 +61,7 @@ type ChainWriterService interface {
 // Compile-time assertion that chainWriter implements the ChainWriterService interface.
 var _ ChainWriterService = (*chainWriter)(nil)
 
-func NewChainWriterService(config evm.ChainWrtier, logger logger.Logger, client evmclient.Client) ChainWriterService {
+func NewChainWriterService(config config.ChainWriter, logger logger.Logger, client evmclient.Client) ChainWriterService {
 	return &chainWriter{logger: logger, client: client, config: config}
 }
 
@@ -70,7 +70,7 @@ type chainWriter struct {
 
 	logger logger.Logger
 	client evmclient.Client
-	config evm.ChainWriter
+	config config.ChainWriter
 }
 
 func (writer *chainWriter) SubmitSignedTransaction(ctx context.Context, payload []byte, signature map[string]any, transactionID uuid.UUID, toAddress string, meta *TxMeta, value big.Int) (int64, error) {

--- a/core/services/relay/evm/chain_writer.go
+++ b/core/services/relay/evm/chain_writer.go
@@ -36,8 +36,8 @@ type chainWriter struct {
 	config config.ChainWriter
 }
 
-func (w *chainWriter) SubmitSignedTransaction(ctx context.Context, payload []byte, signature map[string]any, transactionID uuid.UUID, toAddress string, meta *types.TxMeta, value big.Int) (int64, error) {
-	return 0, fmt.Errorf("not implemented")
+func (w *chainWriter) SubmitSignedTransaction(ctx context.Context, payload []byte, signature map[string]any, transactionID uuid.UUID, toAddress string, meta *types.TxMeta, value big.Int) error {
+	return fmt.Errorf("not implemented")
 }
 
 func (w *chainWriter) GetTransactionStatus(ctx context.Context, transactionID uuid.UUID) (types.TransactionStatus, error) {

--- a/go.mod
+++ b/go.mod
@@ -72,8 +72,13 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.3
+<<<<<<< HEAD
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
+=======
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240523205053-03a5a4e1a596
+	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69
+>>>>>>> c92767f4ce (evm: Remove the chain writer interface to reference chainlink-common)
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240524201401-88d0b3763b20

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524131122-70f94ee563a6
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917

--- a/go.mod
+++ b/go.mod
@@ -72,11 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-<<<<<<< HEAD
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303
-	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
-=======
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240523205053-03a5a4e1a596
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524131122-70f94ee563a6
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69
 >>>>>>> c92767f4ce (evm: Remove the chain writer interface to reference chainlink-common)
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.3
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303
-	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69
+	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240524201401-88d0b3763b20

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,6 @@ require (
 	github.com/smartcontractkit/chainlink-automation v1.0.3
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524131122-70f94ee563a6
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69
->>>>>>> c92767f4ce (evm: Remove the chain writer interface to reference chainlink-common)
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240524201401-88d0b3763b20

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528105007-2839b40ec43b
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917

--- a/go.sum
+++ b/go.sum
@@ -1171,8 +1171,6 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303 h1:iyLE5c2YFxy89t2v5u+aQOHqRE4c+sCMze70KIo07mI=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8 h1:czecbzi/JWd2xbw60KpSFa+E49G+NMe9rbIdznaZlsY=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=

--- a/go.sum
+++ b/go.sum
@@ -1173,6 +1173,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfs
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303 h1:iyLE5c2YFxy89t2v5u+aQOHqRE4c+sCMze70KIo07mI=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8 h1:czecbzi/JWd2xbw60KpSFa+E49G+NMe9rbIdznaZlsY=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/go.sum
+++ b/go.sum
@@ -1173,8 +1173,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfs
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303 h1:iyLE5c2YFxy89t2v5u+aQOHqRE4c+sCMze70KIo07mI=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
-github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69 h1:Sec/GpBpUVaTEax1kSHlTvkzF/+d3w5roAQXaj5+SLA=
-github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69/go.mod h1:ZQKf+0OLzCLYIisH/OdOIQuFRI6bDuw+jPBTATyHfFM=
+github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
+github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540/go.mod h1:sjAmX8K2kbQhvDarZE1ZZgDgmHJ50s0BBc/66vKY2ek=
 github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917 h1:MD80ZRCTvxxJ8PBmhtrKoTnky8cVNYrCrIBLVRbrOM0=

--- a/go.sum
+++ b/go.sum
@@ -1171,10 +1171,19 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
+<<<<<<< HEAD
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303 h1:iyLE5c2YFxy89t2v5u+aQOHqRE4c+sCMze70KIo07mI=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
+=======
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240522203001-10ea0211efd7 h1:od+11B83s0mQwAMPP3lhtb0nYz63pIKpJEKddfFpu/M=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240522203001-10ea0211efd7/go.mod h1:cFHRblGbGn/rFYOOGsNbtLicMc1+5YdN0KoebYr93pk=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240523205053-03a5a4e1a596 h1:WI1fUFlMVPUpSQrqd2NOEJ2+UCcflT+HnIKXYOiSXe8=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240523205053-03a5a4e1a596/go.mod h1:s+68EchlrXqHKRW3JJgZLEARvzMSKRI5+cE5Zx7pVJA=
+github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69 h1:Sec/GpBpUVaTEax1kSHlTvkzF/+d3w5roAQXaj5+SLA=
+github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69/go.mod h1:ZQKf+0OLzCLYIisH/OdOIQuFRI6bDuw+jPBTATyHfFM=
+>>>>>>> c92767f4ce (evm: Remove the chain writer interface to reference chainlink-common)
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540/go.mod h1:sjAmX8K2kbQhvDarZE1ZZgDgmHJ50s0BBc/66vKY2ek=
 github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917 h1:MD80ZRCTvxxJ8PBmhtrKoTnky8cVNYrCrIBLVRbrOM0=

--- a/go.sum
+++ b/go.sum
@@ -1171,8 +1171,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524131122-70f94ee563a6 h1:ChXBMCAlp2tNdPc6QAv/F+oNPiE/CHfiIjXZcIYPFlo=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524131122-70f94ee563a6/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303 h1:iyLE5c2YFxy89t2v5u+aQOHqRE4c+sCMze70KIo07mI=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69 h1:Sec/GpBpUVaTEax1kSHlTvkzF/+d3w5roAQXaj5+SLA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69/go.mod h1:ZQKf+0OLzCLYIisH/OdOIQuFRI6bDuw+jPBTATyHfFM=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/go.sum
+++ b/go.sum
@@ -1171,21 +1171,10 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-<<<<<<< HEAD
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303 h1:iyLE5c2YFxy89t2v5u+aQOHqRE4c+sCMze70KIo07mI=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
-github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
-github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
-=======
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240522203001-10ea0211efd7 h1:od+11B83s0mQwAMPP3lhtb0nYz63pIKpJEKddfFpu/M=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240522203001-10ea0211efd7/go.mod h1:cFHRblGbGn/rFYOOGsNbtLicMc1+5YdN0KoebYr93pk=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240523205053-03a5a4e1a596 h1:WI1fUFlMVPUpSQrqd2NOEJ2+UCcflT+HnIKXYOiSXe8=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240523205053-03a5a4e1a596/go.mod h1:s+68EchlrXqHKRW3JJgZLEARvzMSKRI5+cE5Zx7pVJA=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524131122-70f94ee563a6 h1:ChXBMCAlp2tNdPc6QAv/F+oNPiE/CHfiIjXZcIYPFlo=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524131122-70f94ee563a6/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69 h1:Sec/GpBpUVaTEax1kSHlTvkzF/+d3w5roAQXaj5+SLA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69/go.mod h1:ZQKf+0OLzCLYIisH/OdOIQuFRI6bDuw+jPBTATyHfFM=
->>>>>>> c92767f4ce (evm: Remove the chain writer interface to reference chainlink-common)
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540/go.mod h1:sjAmX8K2kbQhvDarZE1ZZgDgmHJ50s0BBc/66vKY2ek=
 github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917 h1:MD80ZRCTvxxJ8PBmhtrKoTnky8cVNYrCrIBLVRbrOM0=

--- a/go.sum
+++ b/go.sum
@@ -1181,6 +1181,8 @@ github.com/smartcontractkit/chainlink-common v0.1.7-0.20240522203001-10ea0211efd
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240522203001-10ea0211efd7/go.mod h1:cFHRblGbGn/rFYOOGsNbtLicMc1+5YdN0KoebYr93pk=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240523205053-03a5a4e1a596 h1:WI1fUFlMVPUpSQrqd2NOEJ2+UCcflT+HnIKXYOiSXe8=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240523205053-03a5a4e1a596/go.mod h1:s+68EchlrXqHKRW3JJgZLEARvzMSKRI5+cE5Zx7pVJA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524131122-70f94ee563a6 h1:ChXBMCAlp2tNdPc6QAv/F+oNPiE/CHfiIjXZcIYPFlo=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524131122-70f94ee563a6/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69 h1:Sec/GpBpUVaTEax1kSHlTvkzF/+d3w5roAQXaj5+SLA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240508101745-af1ed7bc8a69/go.mod h1:ZQKf+0OLzCLYIisH/OdOIQuFRI6bDuw+jPBTATyHfFM=
 >>>>>>> c92767f4ce (evm: Remove the chain writer interface to reference chainlink-common)

--- a/go.sum
+++ b/go.sum
@@ -1171,8 +1171,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8 h1:czecbzi/JWd2xbw60KpSFa+E49G+NMe9rbIdznaZlsY=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528105007-2839b40ec43b h1:pygJPFP7j/iKjuUF/CDeZpwBpw9C7ia5/rukCio081E=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528105007-2839b40ec43b/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8
 	github.com/smartcontractkit/chainlink-testing-framework v1.28.15
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1512,8 +1512,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303 h1:iyLE5c2YFxy89t2v5u+aQOHqRE4c+sCMze70KIo07mI=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8 h1:czecbzi/JWd2xbw60KpSFa+E49G+NMe9rbIdznaZlsY=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8
 	github.com/smartcontractkit/chainlink-testing-framework v1.28.15
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1502,8 +1502,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303 h1:iyLE5c2YFxy89t2v5u+aQOHqRE4c+sCMze70KIo07mI=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240524173852-a74b009c7303/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8 h1:czecbzi/JWd2xbw60KpSFa+E49G+NMe9rbIdznaZlsY=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240528111936-ee1f7b7f69c8/go.mod h1:DUZccDEW98n+J1mhdWGO7wr/Njad9p9Fzks839JN7Rs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=


### PR DESCRIPTION
Added a stub implementation for the `ChainWriterService` into the EVM relayer.

The `ChainWriter` interface does NOT belong here, and will be removed once [#523](https://github.com/smartcontractkit/chainlink-common/pull/523) has been merged. It has been copy-pasted here for review and build purposes.
