### PR TITLE
Add Geth InsufficientEth client error

### DIFF
--- a/.changeset/fuzzy-bobcats-shave.md
+++ b/.changeset/fuzzy-bobcats-shave.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal Added new Geth InsufficientEth client error for internal TXM classification

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -106,7 +106,7 @@ var geth = ClientErrors{
 	ReplacementTransactionUnderpriced: regexp.MustCompile(`(: |^)replacement transaction underpriced$`),
 	TransactionAlreadyInMempool:       regexp.MustCompile(`(: |^)(?i)(known transaction|already known)`),
 	TerminallyUnderpriced:             regexp.MustCompile(`(: |^)transaction underpriced$`),
-	InsufficientEth:                   regexp.MustCompile(`(: |^)(insufficient funds for transfer|insufficient funds for gas \* price \+ value|insufficient balance for transfer)$`),
+	InsufficientEth:                   regexp.MustCompile(`(: |^)(insufficient funds for transfer|insufficient funds for gas \* price \+ value|insufficient balance for transfer|transaction would cause overdraft)$`),
 	TxFeeExceedsCap:                   regexp.MustCompile(`(: |^)tx fee \([0-9\.]+ [a-zA-Z]+\) exceeds the configured cap \([0-9\.]+ [a-zA-Z]+\)$`),
 	Fatal:                             gethFatal,
 }

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -213,6 +213,7 @@ func Test_Eth_Errors(t *testing.T) {
 			{"insufficient balance for transfer", true, "zkSync"},
 			{"insufficient funds for gas + value. balance: 42719769622667482000, fee: 48098250000000, value: 42719769622667482000", true, "celo"},
 			{"client error insufficient eth", true, "tomlConfig"},
+			{"transaction would cause overdraft", true, "Geth"},
 		}
 		for _, test := range tests {
 			err = evmclient.NewSendErrorS(test.message)


### PR DESCRIPTION
Added `transaction would cause overdraft` error to the Geth `InsufficientEth` list. This error was experienced during automation nightly upgrade testing.