### PR TITLE
BCF-3244 Index only the fifth word to reduce the db size overhead

### DIFF
--- a/.changeset/big-bats-grin.md
+++ b/.changeset/big-bats-grin.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Reducing the scope of 0233 migration to include only 5th word index which is required for CCIP #db_update

--- a/core/store/migrate/migrations/0233_log_poller_word_topic_indexes.sql
+++ b/core/store/migrate/migrations/0233_log_poller_word_topic_indexes.sql
@@ -1,65 +1,8 @@
 -- +goose Up
 
-drop index if exists evm.evm_logs_idx_data_word_one;
-drop index if exists evm.evm_logs_idx_data_word_two;
-drop index if exists evm.evm_logs_idx_data_word_three;
-drop index if exists evm.evm_logs_idx_data_word_four;
-drop index if exists evm.evm_logs_idx_topic_two;
-drop index if exists evm.evm_logs_idx_topic_three;
-drop index if exists evm.evm_logs_idx_topic_four;
-
-create index evm_logs_idx_data_word_one
-    on evm.logs (address, event_sig, evm_chain_id, "substring"(data, 1, 32));
-
-create index evm_logs_idx_data_word_two
-    on evm.logs (address, event_sig, evm_chain_id, "substring"(data, 33, 32));
-
-create index evm_logs_idx_data_word_three
-    on evm.logs (address, event_sig, evm_chain_id, "substring"(data, 65, 32));
-
-create index evm_logs_idx_data_word_four
-    on evm.logs (address, event_sig, evm_chain_id, "substring"(data, 97, 32));
-
 create index evm_logs_idx_data_word_five
     on evm.logs (address, event_sig, evm_chain_id, "substring"(data, 129, 32));
 
-create index evm_logs_idx_topic_two
-    on evm.logs (address, event_sig, evm_chain_id, (topics[2]));
-
-create index evm_logs_idx_topic_three
-    on evm.logs (address, event_sig, evm_chain_id, (topics[3]));
-
-create index evm_logs_idx_topic_four
-    on evm.logs (address, event_sig, evm_chain_id, (topics[4]));
-
 -- +goose Down
 
-drop index if exists evm.evm_logs_idx_data_word_one;
-drop index if exists evm.evm_logs_idx_data_word_two;
-drop index if exists evm.evm_logs_idx_data_word_three;
-drop index if exists evm.evm_logs_idx_data_word_four;
 drop index if exists evm.evm_logs_idx_data_word_five;
-drop index if exists evm.evm_logs_idx_topic_two;
-drop index if exists evm.evm_logs_idx_topic_three;
-drop index if exists evm.evm_logs_idx_topic_four;
-
-create index evm_logs_idx_data_word_one
-    on evm.logs ("substring"(data, 1, 32));
-
-create index evm_logs_idx_data_word_two
-    on evm.logs ("substring"(data, 33, 32));
-
-create index evm_logs_idx_data_word_three
-    on evm.logs ("substring"(data, 65, 32));
-
-create index evm_logs_idx_data_word_four
-    on evm.logs ("substring"(data, 97, 32));
-
-create index evm_logs_idx_topic_two
-    on evm.logs ((topics[2]));
-
-create index evm_logs_idx_topic_three
-    on evm.logs ((topics[3]));
-
-create index evm_logs_idx_topic_four
-    on evm.logs ((topics[4]));


### PR DESCRIPTION
Before the migration 0233

```sql
 schema_name | table_name |                  index_name                  | index_size
-------------+------------+----------------------------------------------+------------
 evm         | logs       | evm_logs_by_timestamp                        | 1274 MB
 evm         | logs       | idx_evm_logs_ordered_by_block_and_created_at | 1273 MB
 evm         | logs       | evm_logs_idx                                 | 1151 MB
 evm         | logs       | evm_logs_idx_tx_hash                         | 426 MB
 evm         | logs       | logs_pkey                                    | 272 MB
 evm         | logs       | evm_logs_idx_data_word_two                   | 167 MB
 evm         | logs       | evm_logs_idx_topic_three                     | 128 MB
 evm         | logs       | evm_logs_idx_data_word_three                 | 106 MB
 evm         | logs       | evm_logs_idx_data_word_one                   | 102 MB
 evm         | logs       | evm_logs_idx_topic_two                       | 92 MB
 evm         | logs       | evm_logs_idx_data_word_four                  | 91 MB
 evm         | logs       | evm_logs_idx_topic_four                      | 84 MB

 database_size
---------------
 12 GB
```


After the migration with only single index 

```sql
 schema_name | table_name |                  index_name                  | index_size
-------------+------------+----------------------------------------------+------------
 evm         | logs       | evm_logs_by_timestamp                        | 1274 MB
 evm         | logs       | idx_evm_logs_ordered_by_block_and_created_at | 1273 MB
 evm         | logs       | evm_logs_idx                                 | 1151 MB
 evm         | logs       | evm_logs_idx_data_word_five                  | 1136 MB
 evm         | logs       | evm_logs_idx_tx_hash                         | 426 MB
 evm         | logs       | logs_pkey                                    | 272 MB
 evm         | logs       | evm_logs_idx_data_word_two                   | 167 MB
 evm         | logs       | evm_logs_idx_topic_three                     | 128 MB
 evm         | logs       | evm_logs_idx_data_word_three                 | 106 MB
 evm         | logs       | evm_logs_idx_data_word_one                   | 102 MB
 evm         | logs       | evm_logs_idx_topic_two                       | 92 MB
 evm         | logs       | evm_logs_idx_data_word_four                  | 91 MB
 evm         | logs       | evm_logs_idx_topic_four                      | 84 MB


 database_size
---------------
 13 GB
```

Applying the change directly to the migration script to prevent creating these indexes and then dropping them immediately - db size growing and then immediately shrinking