### PR TITLE
TT-962 Increase default HTTPWriteTimeout in E2E tests

### DIFF
--- a/integration-tests/testconfig/automation/automation.toml
+++ b/integration-tests/testconfig/automation/automation.toml
@@ -20,7 +20,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/automation/example.toml
+++ b/integration-tests/testconfig/automation/example.toml
@@ -92,7 +92,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/default.toml
+++ b/integration-tests/testconfig/default.toml
@@ -47,7 +47,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/forwarder_ocr/example.toml
+++ b/integration-tests/testconfig/forwarder_ocr/example.toml
@@ -92,7 +92,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/forwarder_ocr/forwarder_ocr.toml
+++ b/integration-tests/testconfig/forwarder_ocr/forwarder_ocr.toml
@@ -16,7 +16,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/forwarder_ocr2/example.toml
+++ b/integration-tests/testconfig/forwarder_ocr2/example.toml
@@ -92,7 +92,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/forwarder_ocr2/forwarder_ocr2.toml
+++ b/integration-tests/testconfig/forwarder_ocr2/forwarder_ocr2.toml
@@ -16,7 +16,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/functions/example.toml
+++ b/integration-tests/testconfig/functions/example.toml
@@ -92,7 +92,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/keeper/example.toml
+++ b/integration-tests/testconfig/keeper/example.toml
@@ -92,7 +92,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/keeper/keeper.toml
+++ b/integration-tests/testconfig/keeper/keeper.toml
@@ -20,7 +20,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/log_poller/example.toml
+++ b/integration-tests/testconfig/log_poller/example.toml
@@ -92,7 +92,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/log_poller/log_poller.toml
+++ b/integration-tests/testconfig/log_poller/log_poller.toml
@@ -24,7 +24,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/ocr/example.toml
+++ b/integration-tests/testconfig/ocr/example.toml
@@ -92,7 +92,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/ocr/ocr.toml
+++ b/integration-tests/testconfig/ocr/ocr.toml
@@ -20,7 +20,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/ocr2/example.toml
+++ b/integration-tests/testconfig/ocr2/example.toml
@@ -92,7 +92,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/ocr2/ocr2.toml
+++ b/integration-tests/testconfig/ocr2/ocr2.toml
@@ -20,7 +20,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/vrf/vrf.toml
+++ b/integration-tests/testconfig/vrf/vrf.toml
@@ -16,7 +16,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/vrfv2/example.toml
+++ b/integration-tests/testconfig/vrfv2/example.toml
@@ -92,7 +92,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]

--- a/integration-tests/testconfig/vrfv2plus/example.toml
+++ b/integration-tests/testconfig/vrfv2plus/example.toml
@@ -92,7 +92,7 @@ MaxSize = '0b'
 AllowOrigins = '*'
 HTTPPort = 6688
 SecureCookies = false
-HTTPWriteTimeout = '1m'
+HTTPWriteTimeout = '3m'
 SessionTimeout = '999h0m0s'
 
 [WebServer.RateLimit]


### PR DESCRIPTION
I bumped HTTPWriteTimeout in TOML test configs from 1m to 3m. This should be applied to both docker as well as k8s tests. Afaik k8s tests pass Node TOML config to the chart by using toml value of the chart.