### PR TITLE
fix: disable solidity-wrappers ci for dependabot

### DIFF
--- a/.github/workflows/solidity-wrappers.yml
+++ b/.github/workflows/solidity-wrappers.yml
@@ -15,6 +15,8 @@ concurrency:
 
 jobs:
   changes:
+    # We don't directly merge dependabot PRs, so let's not waste the resources
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Dependabot PRs have failing checks due to this workflow. Disabling them.

Example failures:
- https://github.com/smartcontractkit/chainlink/actions/runs/9255987039
- https://github.com/smartcontractkit/chainlink/actions/runs/9255983748