### PR TITLE
Move chain writer send strategy to be config driven

### DIFF
--- a/.changeset/large-plants-count.md
+++ b/.changeset/large-plants-count.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal Added a configuration option to chain writer to set the tx send strategy.


### PR DESCRIPTION
- **evm: Add a stub chainwriter impl**
- **evm: Fix config parameter**
- **evm: Change the chainwriter receiver name**
- **evm: Remove the chain writer interface to reference chainlink-common**
- **evm: Update common dep, and fix signature**
- **go.sum: Run gomodtidy**
- **.changeset: Add a changeset**
- **evm: Pseudo-implement the submit transaction method on chainwriter**
- **evm: Add txm dependency to chainwriter**
- **evm: Use the txm param properly**
- **Update code to use the new interface**
- **nix: use monthly foundry branch that's persistent**
- **capabilities: Add config validation to write_target**
- **capabilities: Pass context into InitializeWrite**
- **minor: Resolve some inapplicable TODOs**
- **capabilities: Refactor write target by extracting commmon bits**
- **Refactor WriteTarget to use ChainWriter**
- **capabilities: Move evm specific code inside the relayer**
- **Chainwriter tests (#13360)**
- **Update chainlink-common to include the new interface**
- **write_target: Fix tests**
- **Move target capability init inside evm.NewRelayer()**
- **go mod tidy**
- **Address lints**
- **scripts: go mod tidy**
- **integration-tests: go mod tidy**
- **evm: Only initialize write target if config actually present**
- **more tidy, fix last lint**
- **evm: Move send strategy to be config driven**
