### PR TITLE
Rename EVM.ChainWriter config to EVM.Workflow

### DIFF
--- a/core/chains/evm/config/chain_scoped.go
+++ b/core/chains/evm/config/chain_scoped.go
@@ -68,8 +68,8 @@ func (e *EVMConfig) OCR2() OCR2 {
 	return &ocr2Config{c: e.C.OCR2}
 }
 
-func (e *EVMConfig) ChainWriter() ChainWriter {
-	return &chainWriterConfig{c: e.C.ChainWriter}
+func (e *EVMConfig) Workflow() Workflow {
+	return &workflowConfig{c: e.C.Workflow}
 }
 
 func (e *EVMConfig) GasEstimator() GasEstimator {

--- a/core/chains/evm/config/chain_scoped_workflow.go
+++ b/core/chains/evm/config/chain_scoped_workflow.go
@@ -5,14 +5,14 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 )
 
-type chainWriterConfig struct {
-	c toml.ChainWriter
+type workflowConfig struct {
+	c toml.Workflow
 }
 
-func (b *chainWriterConfig) FromAddress() *types.EIP55Address {
+func (b *workflowConfig) FromAddress() *types.EIP55Address {
 	return b.c.FromAddress
 }
 
-func (b *chainWriterConfig) ForwarderAddress() *types.EIP55Address {
+func (b *workflowConfig) ForwarderAddress() *types.EIP55Address {
 	return b.c.ForwarderAddress
 }

--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -21,7 +21,7 @@ type EVM interface {
 	GasEstimator() GasEstimator
 	OCR() OCR
 	OCR2() OCR2
-	ChainWriter() ChainWriter
+	Workflow() Workflow
 	NodePool() NodePool
 
 	AutoCreateKey() bool
@@ -156,7 +156,7 @@ type BlockHistory interface {
 	TransactionPercentile() uint16
 }
 
-type ChainWriter interface {
+type Workflow interface {
 	FromAddress() *types.EIP55Address
 	ForwarderAddress() *types.EIP55Address
 }

--- a/core/chains/evm/config/toml/config.go
+++ b/core/chains/evm/config/toml/config.go
@@ -367,7 +367,7 @@ type Chain struct {
 	NodePool       NodePool          `toml:",omitempty"`
 	OCR            OCR               `toml:",omitempty"`
 	OCR2           OCR2              `toml:",omitempty"`
-	ChainWriter    ChainWriter       `toml:",omitempty"`
+	Workflow       Workflow          `toml:",omitempty"`
 }
 
 func (c *Chain) ValidateConfig() (err error) {
@@ -507,12 +507,12 @@ func (a *Automation) setFrom(f *Automation) {
 	}
 }
 
-type ChainWriter struct {
+type Workflow struct {
 	FromAddress      *types.EIP55Address `toml:",omitempty"`
 	ForwarderAddress *types.EIP55Address `toml:",omitempty"`
 }
 
-func (m *ChainWriter) setFrom(f *ChainWriter) {
+func (m *Workflow) setFrom(f *Workflow) {
 	if v := f.FromAddress; v != nil {
 		m.FromAddress = v
 	}

--- a/core/chains/evm/config/toml/defaults.go
+++ b/core/chains/evm/config/toml/defaults.go
@@ -181,5 +181,5 @@ func (c *Chain) SetFrom(f *Chain) {
 	c.NodePool.setFrom(&f.NodePool)
 	c.OCR.setFrom(&f.OCR)
 	c.OCR2.setFrom(&f.OCR2)
-	c.ChainWriter.setFrom(&f.ChainWriter)
+	c.Workflow.setFrom(&f.Workflow)
 }

--- a/core/config/docs/chains-evm.toml
+++ b/core/config/docs/chains-evm.toml
@@ -437,7 +437,7 @@ Order = 100 # Default
 # GasLimit controls the gas limit for transmit transactions from ocr2automation job.
 GasLimit = 5400000 # Default
 
-[EVM.ChainWriter]
+[EVM.Workflow]
 # FromAddress is Address of the transmitter key to use for workflow writes.
 FromAddress = '0x2a3e23c6f242F5345320814aC8a1b4E58707D292' # Example
 # ForwarderAddress is the keystone forwarder contract address on chain.

--- a/core/config/docs/docs_test.go
+++ b/core/config/docs/docs_test.go
@@ -81,10 +81,10 @@ func TestDoc(t *testing.T) {
 		docDefaults.FlagsContractAddress = nil
 		docDefaults.LinkContractAddress = nil
 		docDefaults.OperatorFactoryAddress = nil
-		require.Empty(t, docDefaults.ChainWriter.FromAddress)
-		require.Empty(t, docDefaults.ChainWriter.ForwarderAddress)
-		docDefaults.ChainWriter.FromAddress = nil
-		docDefaults.ChainWriter.ForwarderAddress = nil
+		require.Empty(t, docDefaults.Workflow.FromAddress)
+		require.Empty(t, docDefaults.Workflow.ForwarderAddress)
+		docDefaults.Workflow.FromAddress = nil
+		docDefaults.Workflow.ForwarderAddress = nil
 		docDefaults.NodePool.Errors = evmcfg.ClientErrors{}
 
 		// Transactions.AutoPurge configs are only set if the feature is enabled

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -1210,11 +1210,11 @@ func TestConfig_full(t *testing.T) {
 	for c := range got.EVM {
 		addr, err := types.NewEIP55Address("0x2a3e23c6f242F5345320814aC8a1b4E58707D292")
 		require.NoError(t, err)
-		if got.EVM[c].ChainWriter.FromAddress == nil {
-			got.EVM[c].ChainWriter.FromAddress = &addr
+		if got.EVM[c].Workflow.FromAddress == nil {
+			got.EVM[c].Workflow.FromAddress = &addr
 		}
-		if got.EVM[c].ChainWriter.ForwarderAddress == nil {
-			got.EVM[c].ChainWriter.ForwarderAddress = &addr
+		if got.EVM[c].Workflow.ForwarderAddress == nil {
+			got.EVM[c].Workflow.ForwarderAddress = &addr
 		}
 		for n := range got.EVM[c].Nodes {
 			if got.EVM[c].Nodes[n].WSURL == nil {

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -146,7 +146,7 @@ func NewRelayer(lggr logger.Logger, chain legacyevm.Chain, opts RelayerOpts) (*R
 	}
 
 	// Initialize write target capability if configuration is defined
-	if chain.Config().EVM().ChainWriter().ForwarderAddress() != nil {
+	if chain.Config().EVM().Workflow().ForwarderAddress() != nil {
 		ctx := context.Background()
 		capability, err := NewWriteTarget(ctx, relayer, chain, lggr)
 		if err != nil {

--- a/core/services/relay/evm/write_target.go
+++ b/core/services/relay/evm/write_target.go
@@ -24,7 +24,7 @@ func NewWriteTarget(ctx context.Context, relayer *Relayer, chain legacyevm.Chain
 	}
 
 	// EVM-specific init
-	config := chain.Config().EVM().ChainWriter()
+	config := chain.Config().EVM().Workflow()
 
 	// Initialize a reader to check whether a value was already transmitted on chain
 	contractReaderConfigEncoded, err := json.Marshal(relayevmtypes.ChainReaderConfig{

--- a/core/services/relay/evm/write_target_test.go
+++ b/core/services/relay/evm/write_target_test.go
@@ -53,12 +53,12 @@ func TestEvmWrite(t *testing.T) {
 		a := testutils.NewAddress()
 		addr, err2 := types.NewEIP55Address(a.Hex())
 		require.NoError(t, err2)
-		c.EVM[0].ChainWriter.FromAddress = &addr
+		c.EVM[0].Workflow.FromAddress = &addr
 
 		forwarderA := testutils.NewAddress()
 		forwarderAddr, err2 := types.NewEIP55Address(forwarderA.Hex())
 		require.NoError(t, err2)
-		c.EVM[0].ChainWriter.ForwarderAddress = &forwarderAddr
+		c.EVM[0].Workflow.ForwarderAddress = &forwarderAddr
 	})
 	evmCfg := evmtest.NewChainScopedConfig(t, cfg)
 
@@ -91,7 +91,7 @@ func TestEvmWrite(t *testing.T) {
 		require.NoError(t, err)
 
 		config, err := values.NewMap(map[string]any{
-			"Address": evmCfg.EVM().ChainWriter().ForwarderAddress().String(),
+			"Address": evmCfg.EVM().Workflow().ForwarderAddress().String(),
 		})
 		require.NoError(t, err)
 
@@ -124,7 +124,7 @@ func TestEvmWrite(t *testing.T) {
 		require.NoError(t, err)
 
 		config, err := values.NewMap(map[string]any{
-			"Address": evmCfg.EVM().ChainWriter().ForwarderAddress().String(),
+			"Address": evmCfg.EVM().Workflow().ForwarderAddress().String(),
 		})
 		require.NoError(t, err)
 
@@ -185,7 +185,7 @@ func TestEvmWrite(t *testing.T) {
 		require.NoError(t, err)
 
 		config, err := values.NewMap(map[string]any{
-			"Address": evmCfg.EVM().ChainWriter().ForwarderAddress().String(),
+			"Address": evmCfg.EVM().Workflow().ForwarderAddress().String(),
 		})
 		require.NoError(t, err)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -8002,9 +8002,9 @@ GasLimit = 5400000 # Default
 ```
 GasLimit controls the gas limit for transmit transactions from ocr2automation job.
 
-## EVM.ChainWriter
+## EVM.Workflow
 ```toml
-[EVM.ChainWriter]
+[EVM.Workflow]
 FromAddress = '0x2a3e23c6f242F5345320814aC8a1b4E58707D292' # Example
 ForwarderAddress = '0x2a3e23c6f242F5345320814aC8a1b4E58707D292' # Example
 ```


### PR DESCRIPTION
It was incorrectly named when it was created and is only used for keystone workflows.