### PR TITLE
KS-106: Refactor Discover Database implementation to support DON2DON use case

### DIFF
--- a/.changeset/rich-melons-sin.md
+++ b/.changeset/rich-melons-sin.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#db_update add persistence for DON-2-DON discovery announcements

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -203,7 +203,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 
 	var externalPeerWrapper p2ptypes.PeerWrapper
 	if cfg.Capabilities().Peering().Enabled() {
-		externalPeer := externalp2p.NewExternalPeerWrapper(keyStore.P2P(), cfg.Capabilities().Peering(), globalLogger)
+		externalPeer := externalp2p.NewExternalPeerWrapper(keyStore.P2P(), cfg.Capabilities().Peering(), opts.DS, globalLogger)
 		signer := externalPeer
 		externalPeerWrapper = externalPeer
 

--- a/core/services/ocrcommon/discoverer_database.go
+++ b/core/services/ocrcommon/discoverer_database.go
@@ -22,12 +22,15 @@ const (
 	don2donDiscovererTable = "don2don_discoverer_announcements"
 )
 
+// DiscovererDatabase is a key-value store for p2p announcements
+// that are based on the RageP2P library and bootstrap nodes
 type DiscovererDatabase struct {
 	ds        sqlutil.DataSource
 	peerID    string
 	tableName string
 }
 
+// NewOCRDiscovererDatabase creates a new DiscovererDatabase for OCR announcements
 func NewOCRDiscovererDatabase(ds sqlutil.DataSource, peerID string) *DiscovererDatabase {
 	return &DiscovererDatabase{
 		ds:        ds,
@@ -36,6 +39,7 @@ func NewOCRDiscovererDatabase(ds sqlutil.DataSource, peerID string) *DiscovererD
 	}
 }
 
+// NewDON2DONDiscovererDatabase creates a new DiscovererDatabase for DON2DON announcements
 func NewDON2DONDiscovererDatabase(ds sqlutil.DataSource, peerID string) *DiscovererDatabase {
 	return &DiscovererDatabase{
 		ds:        ds,

--- a/core/services/ocrcommon/discoverer_database.go
+++ b/core/services/ocrcommon/discoverer_database.go
@@ -55,7 +55,7 @@ updated_at = EXCLUDED.updated_at
 ;`, d.tableName)
 
 	_, err := d.ds.ExecContext(ctx,
-		q, d.tableName, d.peerID, peerID, ann)
+		q, d.peerID, peerID, ann)
 	return errors.Wrap(err, "DiscovererDatabase failed to StoreAnnouncement")
 }
 

--- a/core/services/ocrcommon/discoverer_database.go
+++ b/core/services/ocrcommon/discoverer_database.go
@@ -2,6 +2,7 @@ package ocrcommon
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
@@ -14,35 +15,56 @@ import (
 
 var _ ocrnetworking.DiscovererDatabase = &DiscovererDatabase{}
 
+const (
+	// ocrDiscovererTable is the name of the table used to store OCR announcements
+	ocrDiscovererTable = "ocr_discoverer_announcements"
+	// don2donDiscovererTable is the name of the table used to store DON2DON announcements
+	don2donDiscovererTable = "don2don_discoverer_announcements"
+)
+
 type DiscovererDatabase struct {
-	ds     sqlutil.DataSource
-	peerID string
+	ds        sqlutil.DataSource
+	peerID    string
+	tableName string
 }
 
-func NewDiscovererDatabase(ds sqlutil.DataSource, peerID string) *DiscovererDatabase {
+func NewOCRDiscovererDatabase(ds sqlutil.DataSource, peerID string) *DiscovererDatabase {
 	return &DiscovererDatabase{
-		ds,
-		peerID,
+		ds:        ds,
+		peerID:    peerID,
+		tableName: ocrDiscovererTable,
+	}
+}
+
+func NewDON2DONDiscovererDatabase(ds sqlutil.DataSource, peerID string) *DiscovererDatabase {
+	return &DiscovererDatabase{
+		ds:        ds,
+		peerID:    peerID,
+		tableName: don2donDiscovererTable,
 	}
 }
 
 // StoreAnnouncement has key-value-store semantics and stores a peerID (key) and an associated serialized
 // announcement (value).
 func (d *DiscovererDatabase) StoreAnnouncement(ctx context.Context, peerID string, ann []byte) error {
-	_, err := d.ds.ExecContext(ctx, `
-INSERT INTO ocr_discoverer_announcements (local_peer_id, remote_peer_id, ann, created_at, updated_at)
-VALUES ($1,$2,$3,NOW(),NOW()) ON CONFLICT (local_peer_id, remote_peer_id) DO UPDATE SET 
+	q := fmt.Sprintf(`
+INSERT INTO %s (local_peer_id, remote_peer_id, ann, created_at, updated_at)
+VALUES ($1,$2,$3,NOW(),NOW()) ON CONFLICT (local_peer_id, remote_peer_id) DO UPDATE SET
 ann = EXCLUDED.ann,
 updated_at = EXCLUDED.updated_at
-;`, d.peerID, peerID, ann)
+;`, d.tableName)
+
+	_, err := d.ds.ExecContext(ctx,
+		q, d.tableName, d.peerID, peerID, ann)
 	return errors.Wrap(err, "DiscovererDatabase failed to StoreAnnouncement")
 }
 
 // ReadAnnouncements returns one serialized announcement (if available) for each of the peerIDs in the form of a map
 // keyed by each announcement's corresponding peer ID.
 func (d *DiscovererDatabase) ReadAnnouncements(ctx context.Context, peerIDs []string) (results map[string][]byte, err error) {
-	rows, err := d.ds.QueryContext(ctx, `
-SELECT remote_peer_id, ann FROM ocr_discoverer_announcements WHERE remote_peer_id = ANY($1) AND local_peer_id = $2`, pq.Array(peerIDs), d.peerID)
+	q := fmt.Sprintf(`SELECT remote_peer_id, ann FROM %s WHERE remote_peer_id = ANY($1) AND local_peer_id = $2`, d.tableName)
+
+	rows, err := d.ds.QueryContext(ctx, q, pq.Array(peerIDs), d.peerID)
 	if err != nil {
 		return nil, errors.Wrap(err, "DiscovererDatabase failed to ReadAnnouncements")
 	}

--- a/core/services/ocrcommon/discoverer_database_test.go
+++ b/core/services/ocrcommon/discoverer_database_test.go
@@ -21,8 +21,8 @@ func Test_DiscovererDatabase(t *testing.T) {
 	localPeerID1 := mustRandomP2PPeerID(t)
 	localPeerID2 := mustRandomP2PPeerID(t)
 
-	dd1 := ocrcommon.NewDiscovererDatabase(db, localPeerID1.Raw())
-	dd2 := ocrcommon.NewDiscovererDatabase(db, localPeerID2.Raw())
+	dd1 := ocrcommon.NewOCRDiscovererDatabase(db, localPeerID1.Raw())
+	dd2 := ocrcommon.NewOCRDiscovererDatabase(db, localPeerID2.Raw())
 
 	ctx := testutils.Context(t)
 
@@ -74,7 +74,7 @@ func Test_DiscovererDatabase(t *testing.T) {
 	})
 
 	t.Run("persists data across restarts", func(t *testing.T) {
-		dd3 := ocrcommon.NewDiscovererDatabase(db, localPeerID1.Raw())
+		dd3 := ocrcommon.NewOCRDiscovererDatabase(db, localPeerID1.Raw())
 
 		announcements, err := dd3.ReadAnnouncements(ctx, []string{"remote1"})
 		require.NoError(t, err)

--- a/core/services/ocrcommon/peer_wrapper.go
+++ b/core/services/ocrcommon/peer_wrapper.go
@@ -117,7 +117,7 @@ func (p *SingletonPeerWrapper) peerConfig() (ocrnetworking.PeerConfig, error) {
 	}
 	p.PeerID = key.PeerID()
 
-	discovererDB := NewDiscovererDatabase(p.ds, p.PeerID.Raw())
+	discovererDB := NewOCRDiscovererDatabase(p.ds, p.PeerID.Raw())
 
 	config := p.p2pCfg
 	peerConfig := ocrnetworking.PeerConfig{

--- a/core/services/p2p/wrapper/wrapper_test.go
+++ b/core/services/p2p/wrapper/wrapper_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -18,6 +19,8 @@ import (
 )
 
 func TestPeerWrapper_CleanStartClose(t *testing.T) {
+	db := pgtest.NewSqlxDB(t)
+
 	lggr := logger.TestLogger(t)
 	port := freeport.GetOne(t)
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
@@ -30,7 +33,7 @@ func TestPeerWrapper_CleanStartClose(t *testing.T) {
 	require.NoError(t, err)
 	keystoreP2P.On("GetOrFirst", mock.Anything).Return(key, nil)
 
-	wrapper := wrapper.NewExternalPeerWrapper(keystoreP2P, cfg.Capabilities().Peering(), lggr)
+	wrapper := wrapper.NewExternalPeerWrapper(keystoreP2P, cfg.Capabilities().Peering(), db, lggr)
 	require.NotNil(t, wrapper)
 	require.NoError(t, wrapper.Start(testutils.Context(t)))
 	require.NoError(t, wrapper.Close())

--- a/core/store/migrate/migrations/0240_don2don_discoverer.sql
+++ b/core/store/migrate/migrations/0240_don2don_discoverer.sql
@@ -2,7 +2,7 @@
 -- this migration is for the don2don_discoverer_announcements table
 -- it is essentially the same as ocr_discoverer_announcements but scoped to the don2don use case
 CREATE TABLE don2don_discoverer_announcements (
-	local_peer_id text NOT NULL REFERENCES encrypted_p2p_keys (peer_id) DEFERRABLE INITIALLY IMMEDIATE,
+	local_peer_id text NOT NULL,
 	remote_peer_id text NOT NULL,
 	ann bytea NOT NULL,
 	created_at timestamptz not null,

--- a/core/store/migrate/migrations/0240_don2don_discoverer.sql
+++ b/core/store/migrate/migrations/0240_don2don_discoverer.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- this migration is for the don2don_discoverer_announcements table
+-- it is essentially the same as ocr_discoverer_announcements but scoped to the don2don use case
+CREATE TABLE don2don_discoverer_announcements (
+	local_peer_id text NOT NULL REFERENCES encrypted_p2p_keys (peer_id) DEFERRABLE INITIALLY IMMEDIATE,
+	remote_peer_id text NOT NULL,
+	ann bytea NOT NULL,
+	created_at timestamptz not null,
+	updated_at timestamptz not null,
+	PRIMARY KEY(local_peer_id, remote_peer_id)
+);
+-- +goose Down
+DROP TABLE don2don_discoverer_announcements;

--- a/core/store/migrate/migrations/0240_don2don_discoverer.sql
+++ b/core/store/migrate/migrations/0240_don2don_discoverer.sql
@@ -1,6 +1,7 @@
 -- +goose Up
 -- this migration is for the don2don_discoverer_announcements table
 -- it is essentially the same as ocr_discoverer_announcements but scoped to the don2don use case
+-- both cases are based on RageP2P library and bootstrap nodes. for now but we want to keep their addresses separate to avoid accidental cross-communication
 CREATE TABLE don2don_discoverer_announcements (
 	local_peer_id text NOT NULL,
 	remote_peer_id text NOT NULL,


### PR DESCRIPTION
Adds new table for the don2don discovery announcement persistence.

Refactors the existing golang to support both the existing OCR use case and the new DON2DON use case