### PR TITLE
Bumping the setup-github-token to version 0.2.1

### DIFF
--- a/.github/workflows/solidity-wrappers.yml
+++ b/.github/workflows/solidity-wrappers.yml
@@ -55,7 +55,7 @@ jobs:
         working-directory: ./contracts
 
       - name: Assume role capable of dispatching action
-        uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.0 
+        uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
         id: get-gh-token
         with:
           aws-role-arn:  ${{ secrets.AWS_OIDC_CHAINLINK_CI_AUTO_PR_TOKEN_ISSUER_ROLE_ARN }}


### PR DESCRIPTION
## What

Ticket: https://smartcontract-it.atlassian.net/browse/RE-1943

## Why

The [setup-github-token](https://github.com/smartcontractkit/.github/blob/main/actions/setup-github-token/action.yml) action should have a role session name parameter which it passes to the configure-aws-credentials step.