### PR TITLE
fix: slack-notify conditional for ci-core for race tests failures

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -170,7 +170,7 @@ jobs:
         env:
           OUTPUT_FILE: ./output.txt
           USE_TEE: false
-          CL_DATABASE_URL: ${{ env.DB_URL }}  
+          CL_DATABASE_URL: ${{ env.DB_URL }}
         run: ./tools/bin/${{ matrix.type.cmd }} ./...
       - name: Print Filtered Test Results
         if: ${{ failure() && matrix.type.cmd == 'go_core_tests' && needs.filter.outputs.changes == 'true' }}
@@ -187,6 +187,8 @@ jobs:
           else
             echo "post_to_slack=false" >> $GITHUB_OUTPUT
           fi
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "github.ref: ${{ github.ref }}"
       - name: Print postgres logs
         if: ${{ always() &&  needs.filter.outputs.changes == 'true' }}
         run: docker compose logs postgres | tee ../../../postgres_logs.txt
@@ -203,7 +205,7 @@ jobs:
             ./coverage.txt
             ./postgres_logs.txt
       - name: Notify Slack
-        if: ${{ failure() && steps.print-races.outputs.post_to_slack == 'true' && matrix.type.cmd == 'go_core_race_tests' && (github.event_name == 'merge_group' || github.event.branch == 'develop') &&  needs.filter.outputs.changes == 'true' }}
+        if: ${{ failure() && steps.print-races.outputs.post_to_slack == 'true' && matrix.type.cmd == 'go_core_race_tests' && (github.event_name == 'merge_group' || github.ref == 'refs/heads/develop') && needs.filter.outputs.changes == 'true' }}
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}


### PR DESCRIPTION
This should fix the conditional to trigger notify slack step when race tests fails.

These runs didn't trigger slack conditonal:
https://github.com/smartcontractkit/chainlink/actions/runs/9357600927
https://github.com/smartcontractkit/chainlink/actions/runs/9307205853

These runs were triggered by a push to develop by the merge queue bot and this fix should detect the ref branch is `develop`.

Also adding to log the `event_name` and the `ref` from github context.
