### PR TITLE
[AUTO-11024] Fix txn overdraft flake in automation test

### DIFF
--- a/integration-tests/testconfig/automation/automation.toml
+++ b/integration-tests/testconfig/automation/automation.toml
@@ -1,6 +1,6 @@
 # product defaults
 [Common]
-chainlink_node_funding = 0.5
+chainlink_node_funding = 2.0
 
 [NodeConfig]
 BaseConfigTOML = """


### PR DESCRIPTION
Increase default chainlink node funding from 0.5 to 2