### PR TITLE
[Keystone] Add remote target to syncer

### DIFF
--- a/.changeset/healthy-shoes-lie.md
+++ b/.changeset/healthy-shoes-lie.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal [Keystone] Add remote target to syncer

--- a/core/capabilities/remote/dispatcher.go
+++ b/core/capabilities/remote/dispatcher.go
@@ -72,6 +72,7 @@ func (d *dispatcher) SetReceiver(capabilityId string, donId string, receiver rem
 		return fmt.Errorf("receiver already exists for capability %s and don %s", capabilityId, donId)
 	}
 	d.receivers[k] = receiver
+	d.lggr.Debugw("receiver set", "capabilityId", capabilityId, "donId", donId)
 	return nil
 }
 
@@ -79,6 +80,7 @@ func (d *dispatcher) RemoveReceiver(capabilityId string, donId string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	delete(d.receivers, key{capabilityId, donId})
+	d.lggr.Debugw("receiver removed", "capabilityId", capabilityId, "donId", donId)
 }
 
 func (d *dispatcher) Send(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) error {

--- a/core/capabilities/remote/target/client.go
+++ b/core/capabilities/remote/target/client.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/target/request"
@@ -26,7 +25,7 @@ type client struct {
 	services.StateMachine
 	lggr                 logger.Logger
 	remoteCapabilityInfo commoncap.CapabilityInfo
-	localDONInfo         capabilities.DON
+	localDONInfo         commoncap.DON
 	dispatcher           types.Dispatcher
 	requestTimeout       time.Duration
 
@@ -40,7 +39,7 @@ var _ commoncap.TargetCapability = &client{}
 var _ types.Receiver = &client{}
 var _ services.Service = &client{}
 
-func NewClient(remoteCapabilityInfo commoncap.CapabilityInfo, localDonInfo capabilities.DON, dispatcher types.Dispatcher,
+func NewClient(remoteCapabilityInfo commoncap.CapabilityInfo, localDonInfo commoncap.DON, dispatcher types.Dispatcher,
 	requestTimeout time.Duration, lggr logger.Logger) *client {
 	return &client{
 		lggr:                     lggr,

--- a/core/capabilities/remote/target/client.go
+++ b/core/capabilities/remote/target/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/target/request"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -22,6 +23,7 @@ import (
 //
 // client communicates with corresponding server on remote nodes.
 type client struct {
+	services.StateMachine
 	lggr                 logger.Logger
 	remoteCapabilityInfo commoncap.CapabilityInfo
 	localDONInfo         capabilities.DON
@@ -30,36 +32,25 @@ type client struct {
 
 	messageIDToCallerRequest map[string]*request.ClientRequest
 	mutex                    sync.Mutex
+	stopCh                   services.StopChan
+	wg                       sync.WaitGroup
 }
 
 var _ commoncap.TargetCapability = &client{}
 var _ types.Receiver = &client{}
+var _ services.Service = &client{}
 
-func NewClient(ctx context.Context, lggr logger.Logger, remoteCapabilityInfo commoncap.CapabilityInfo, localDonInfo capabilities.DON, dispatcher types.Dispatcher,
-	requestTimeout time.Duration) *client {
-	c := &client{
+func NewClient(remoteCapabilityInfo commoncap.CapabilityInfo, localDonInfo capabilities.DON, dispatcher types.Dispatcher,
+	requestTimeout time.Duration, lggr logger.Logger) *client {
+	return &client{
 		lggr:                     lggr,
 		remoteCapabilityInfo:     remoteCapabilityInfo,
 		localDONInfo:             localDonInfo,
 		dispatcher:               dispatcher,
 		requestTimeout:           requestTimeout,
 		messageIDToCallerRequest: make(map[string]*request.ClientRequest),
+		stopCh:                   make(services.StopChan),
 	}
-
-	go func() {
-		ticker := time.NewTicker(requestTimeout)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				c.expireRequests()
-			}
-		}
-	}()
-
-	return c
 }
 
 func (c *client) expireRequests() {
@@ -72,6 +63,36 @@ func (c *client) expireRequests() {
 			delete(c.messageIDToCallerRequest, messageID)
 		}
 	}
+}
+
+func (c *client) Start(ctx context.Context) error {
+	return c.StartOnce(c.Name(), func() error {
+		c.wg.Add(1)
+		go func() {
+			defer c.wg.Done()
+			ticker := time.NewTicker(c.requestTimeout)
+			defer ticker.Stop()
+			c.lggr.Info("TargetClient started")
+			for {
+				select {
+				case <-c.stopCh:
+					return
+				case <-ticker.C:
+					c.expireRequests()
+				}
+			}
+		}()
+		return nil
+	})
+}
+
+func (c *client) Close() error {
+	return c.StopOnce(c.Name(), func() error {
+		close(c.stopCh)
+		c.wg.Wait()
+		c.lggr.Info("TargetClient closed")
+		return nil
+	})
 }
 
 func (c *client) Info(ctx context.Context) (commoncap.CapabilityInfo, error) {
@@ -101,7 +122,8 @@ func (c *client) Execute(ctx context.Context, capReq commoncap.CapabilityRequest
 		return nil, fmt.Errorf("request for message ID %s already exists", messageID)
 	}
 
-	req, err := request.NewClientRequest(ctx, c.lggr, capReq, messageID, c.remoteCapabilityInfo, c.localDONInfo, c.dispatcher,
+	cCtx, _ := c.stopCh.NewCtx()
+	req, err := request.NewClientRequest(cCtx, c.lggr, capReq, messageID, c.remoteCapabilityInfo, c.localDONInfo, c.dispatcher,
 		c.requestTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client request: %w", err)
@@ -115,8 +137,7 @@ func (c *client) Execute(ctx context.Context, capReq commoncap.CapabilityRequest
 func (c *client) Receive(msg *types.MessageBody) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	// TODO should the dispatcher be passing in a context?
-	ctx := context.Background()
+	ctx, _ := c.stopCh.NewCtx()
 
 	messageID := GetMessageID(msg)
 
@@ -139,4 +160,16 @@ func GetMessageIDForRequest(req commoncap.CapabilityRequest) (string, error) {
 	}
 
 	return req.Metadata.WorkflowID + req.Metadata.WorkflowExecutionID, nil
+}
+
+func (c *client) Ready() error {
+	return nil
+}
+
+func (c *client) HealthReport() map[string]error {
+	return nil
+}
+
+func (c *client) Name() string {
+	return "TargetClient"
 }

--- a/core/capabilities/remote/target/client_test.go
+++ b/core/capabilities/remote/target/client_test.go
@@ -167,7 +167,7 @@ func testClient(ctx context.Context, t *testing.T, numWorkflowPeers int, workflo
 	callers := make([]commoncap.TargetCapability, numWorkflowPeers)
 	for i := 0; i < numWorkflowPeers; i++ {
 		workflowPeerDispatcher := broker.NewDispatcherForNode(workflowPeers[i])
-		caller := target.NewClient(ctx, lggr, capInfo, workflowDonInfo, workflowPeerDispatcher, workflowNodeResponseTimeout)
+		caller := target.NewClient(capInfo, workflowDonInfo, workflowPeerDispatcher, workflowNodeResponseTimeout, lggr)
 		broker.RegisterReceiverNode(workflowPeers[i], caller)
 		callers[i] = caller
 	}

--- a/core/capabilities/remote/target/endtoend_test.go
+++ b/core/capabilities/remote/target/endtoend_test.go
@@ -229,8 +229,8 @@ func testRemoteTarget(ctx context.Context, t *testing.T, underlying commoncap.Ta
 	for i := 0; i < numCapabilityPeers; i++ {
 		capabilityPeer := capabilityPeers[i]
 		capabilityDispatcher := broker.NewDispatcherForNode(capabilityPeer)
-		capabilityNode := target.NewReceiver(ctx, lggr, capabilityPeer, underlying, capInfo, capDonInfo, workflowDONs, capabilityDispatcher,
-			capabilityNodeResponseTimeout)
+		capabilityNode := target.NewServer(capabilityPeer, underlying, capInfo, capDonInfo, workflowDONs, capabilityDispatcher,
+			capabilityNodeResponseTimeout, lggr)
 		broker.RegisterReceiverNode(capabilityPeer, capabilityNode)
 		capabilityNodes[i] = capabilityNode
 	}
@@ -238,7 +238,7 @@ func testRemoteTarget(ctx context.Context, t *testing.T, underlying commoncap.Ta
 	workflowNodes := make([]commoncap.TargetCapability, numWorkflowPeers)
 	for i := 0; i < numWorkflowPeers; i++ {
 		workflowPeerDispatcher := broker.NewDispatcherForNode(workflowPeers[i])
-		workflowNode := target.NewClient(ctx, lggr, capInfo, workflowDonInfo, workflowPeerDispatcher, workflowNodeTimeout)
+		workflowNode := target.NewClient(capInfo, workflowDonInfo, workflowPeerDispatcher, workflowNodeTimeout, lggr)
 		broker.RegisterReceiverNode(workflowPeers[i], workflowNode)
 		workflowNodes[i] = workflowNode
 	}

--- a/core/capabilities/remote/target/endtoend_test.go
+++ b/core/capabilities/remote/target/endtoend_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/target"
 	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
@@ -225,22 +226,27 @@ func testRemoteTarget(ctx context.Context, t *testing.T, underlying commoncap.Ta
 		workflowDonInfo.ID: workflowDonInfo,
 	}
 
+	srvcs := []services.Service{}
 	capabilityNodes := make([]remotetypes.Receiver, numCapabilityPeers)
 	for i := 0; i < numCapabilityPeers; i++ {
 		capabilityPeer := capabilityPeers[i]
 		capabilityDispatcher := broker.NewDispatcherForNode(capabilityPeer)
 		capabilityNode := target.NewServer(capabilityPeer, underlying, capInfo, capDonInfo, workflowDONs, capabilityDispatcher,
 			capabilityNodeResponseTimeout, lggr)
+		require.NoError(t, capabilityNode.Start(ctx))
 		broker.RegisterReceiverNode(capabilityPeer, capabilityNode)
 		capabilityNodes[i] = capabilityNode
+		srvcs = append(srvcs, capabilityNode)
 	}
 
 	workflowNodes := make([]commoncap.TargetCapability, numWorkflowPeers)
 	for i := 0; i < numWorkflowPeers; i++ {
 		workflowPeerDispatcher := broker.NewDispatcherForNode(workflowPeers[i])
 		workflowNode := target.NewClient(capInfo, workflowDonInfo, workflowPeerDispatcher, workflowNodeTimeout, lggr)
+		require.NoError(t, workflowNode.Start(ctx))
 		broker.RegisterReceiverNode(workflowPeers[i], workflowNode)
 		workflowNodes[i] = workflowNode
+		srvcs = append(srvcs, workflowNode)
 	}
 
 	executeInputs, err := values.NewMap(
@@ -272,6 +278,9 @@ func testRemoteTarget(ctx context.Context, t *testing.T, underlying commoncap.Ta
 	}
 
 	wg.Wait()
+	for _, srv := range srvcs {
+		require.NoError(t, srv.Close())
+	}
 }
 
 type testMessageBroker struct {

--- a/core/capabilities/remote/target/request/server_request_test.go
+++ b/core/capabilities/remote/target/request/server_request_test.go
@@ -16,10 +16,12 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/target/request"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
 
 func Test_ServerRequest_MessageValidation(t *testing.T) {
+	lggr := logger.TestLogger(t)
 	capability := TestCapability{}
 	capabilityPeerID := NewP2PPeerID(t)
 
@@ -57,7 +59,7 @@ func Test_ServerRequest_MessageValidation(t *testing.T) {
 
 	t.Run("Send duplicate message", func(t *testing.T) {
 		req := request.NewServerRequest(capability, "capabilityID", "capabilityDonID",
-			capabilityPeerID, callingDon, "requestMessageID", dispatcher, 10*time.Minute)
+			capabilityPeerID, callingDon, "requestMessageID", dispatcher, 10*time.Minute, lggr)
 
 		err := sendValidRequest(req, workflowPeers, capabilityPeerID, rawRequest)
 		require.NoError(t, err)
@@ -67,7 +69,7 @@ func Test_ServerRequest_MessageValidation(t *testing.T) {
 
 	t.Run("Send message with non calling don peer", func(t *testing.T) {
 		req := request.NewServerRequest(capability, "capabilityID", "capabilityDonID",
-			capabilityPeerID, callingDon, "requestMessageID", dispatcher, 10*time.Minute)
+			capabilityPeerID, callingDon, "requestMessageID", dispatcher, 10*time.Minute, lggr)
 
 		err := sendValidRequest(req, workflowPeers, capabilityPeerID, rawRequest)
 		require.NoError(t, err)
@@ -90,7 +92,7 @@ func Test_ServerRequest_MessageValidation(t *testing.T) {
 
 	t.Run("Send message invalid payload", func(t *testing.T) {
 		req := request.NewServerRequest(capability, "capabilityID", "capabilityDonID",
-			capabilityPeerID, callingDon, "requestMessageID", dispatcher, 10*time.Minute)
+			capabilityPeerID, callingDon, "requestMessageID", dispatcher, 10*time.Minute, lggr)
 
 		err := sendValidRequest(req, workflowPeers, capabilityPeerID, rawRequest)
 		require.NoError(t, err)
@@ -115,7 +117,7 @@ func Test_ServerRequest_MessageValidation(t *testing.T) {
 	t.Run("Send second valid request when capability errors", func(t *testing.T) {
 		dispatcher := &testDispatcher{}
 		req := request.NewServerRequest(TestErrorCapability{}, "capabilityID", "capabilityDonID",
-			capabilityPeerID, callingDon, "requestMessageID", dispatcher, 10*time.Minute)
+			capabilityPeerID, callingDon, "requestMessageID", dispatcher, 10*time.Minute, lggr)
 
 		err := sendValidRequest(req, workflowPeers, capabilityPeerID, rawRequest)
 		require.NoError(t, err)
@@ -142,7 +144,7 @@ func Test_ServerRequest_MessageValidation(t *testing.T) {
 	t.Run("Send second valid request", func(t *testing.T) {
 		dispatcher := &testDispatcher{}
 		request := request.NewServerRequest(capability, "capabilityID", "capabilityDonID",
-			capabilityPeerID, callingDon, "requestMessageID", dispatcher, 10*time.Minute)
+			capabilityPeerID, callingDon, "requestMessageID", dispatcher, 10*time.Minute, lggr)
 
 		err := sendValidRequest(request, workflowPeers, capabilityPeerID, rawRequest)
 		require.NoError(t, err)

--- a/core/capabilities/remote/target/server.go
+++ b/core/capabilities/remote/target/server.go
@@ -65,6 +65,7 @@ func (r *server) Start(ctx context.Context) error {
 	return r.StartOnce(r.Name(), func() error {
 		r.wg.Add(1)
 		go func() {
+			defer r.wg.Done()
 			ticker := time.NewTicker(r.requestTimeout)
 			defer ticker.Stop()
 			r.lggr.Info("TargetServer started")

--- a/core/capabilities/remote/target/server_test.go
+++ b/core/capabilities/remote/target/server_test.go
@@ -10,6 +10,7 @@ import (
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/target"
 	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -23,7 +24,7 @@ func Test_Server_RespondsAfterSufficientRequests(t *testing.T) {
 
 	numCapabilityPeers := 4
 
-	callers := testRemoteTargetServer(ctx, t, &TestCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute)
+	callers, srvcs := testRemoteTargetServer(ctx, t, &TestCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute)
 
 	for _, caller := range callers {
 		_, err := caller.Execute(context.Background(),
@@ -42,6 +43,7 @@ func Test_Server_RespondsAfterSufficientRequests(t *testing.T) {
 			assert.Equal(t, remotetypes.Error_OK, msg.Error)
 		}
 	}
+	closeServices(t, srvcs)
 }
 
 func Test_Server_InsufficientCallers(t *testing.T) {
@@ -50,7 +52,7 @@ func Test_Server_InsufficientCallers(t *testing.T) {
 
 	numCapabilityPeers := 4
 
-	callers := testRemoteTargetServer(ctx, t, &TestCapability{}, 10, 10, numCapabilityPeers, 3, 100*time.Millisecond)
+	callers, srvcs := testRemoteTargetServer(ctx, t, &TestCapability{}, 10, 10, numCapabilityPeers, 3, 100*time.Millisecond)
 
 	for _, caller := range callers {
 		_, err := caller.Execute(context.Background(),
@@ -69,6 +71,7 @@ func Test_Server_InsufficientCallers(t *testing.T) {
 			assert.Equal(t, remotetypes.Error_TIMEOUT, msg.Error)
 		}
 	}
+	closeServices(t, srvcs)
 }
 
 func Test_Server_CapabilityError(t *testing.T) {
@@ -77,7 +80,7 @@ func Test_Server_CapabilityError(t *testing.T) {
 
 	numCapabilityPeers := 4
 
-	callers := testRemoteTargetServer(ctx, t, &TestErrorCapability{}, 10, 9, numCapabilityPeers, 3, 100*time.Millisecond)
+	callers, srvcs := testRemoteTargetServer(ctx, t, &TestErrorCapability{}, 10, 9, numCapabilityPeers, 3, 100*time.Millisecond)
 
 	for _, caller := range callers {
 		_, err := caller.Execute(context.Background(),
@@ -96,12 +99,13 @@ func Test_Server_CapabilityError(t *testing.T) {
 			assert.Equal(t, remotetypes.Error_INTERNAL_ERROR, msg.Error)
 		}
 	}
+	closeServices(t, srvcs)
 }
 
 func testRemoteTargetServer(ctx context.Context, t *testing.T,
 	underlying commoncap.TargetCapability,
 	numWorkflowPeers int, workflowDonF uint8,
-	numCapabilityPeers int, capabilityDonF uint8, capabilityNodeResponseTimeout time.Duration) []*serverTestClient {
+	numCapabilityPeers int, capabilityDonF uint8, capabilityNodeResponseTimeout time.Duration) ([]*serverTestClient, []services.Service) {
 	lggr := logger.TestLogger(t)
 
 	capabilityPeers := make([]p2ptypes.PeerID, numCapabilityPeers)
@@ -141,13 +145,16 @@ func testRemoteTargetServer(ctx context.Context, t *testing.T,
 	}
 
 	capabilityNodes := make([]remotetypes.Receiver, numCapabilityPeers)
+	srvcs := make([]services.Service, numCapabilityPeers)
 	for i := 0; i < numCapabilityPeers; i++ {
 		capabilityPeer := capabilityPeers[i]
 		capabilityDispatcher := broker.NewDispatcherForNode(capabilityPeer)
 		capabilityNode := target.NewServer(capabilityPeer, underlying, capInfo, capDonInfo, workflowDONs, capabilityDispatcher,
 			capabilityNodeResponseTimeout, lggr)
+		require.NoError(t, capabilityNode.Start(ctx))
 		broker.RegisterReceiverNode(capabilityPeer, capabilityNode)
 		capabilityNodes[i] = capabilityNode
+		srvcs[i] = capabilityNode
 	}
 
 	workflowNodes := make([]*serverTestClient, numWorkflowPeers)
@@ -158,7 +165,13 @@ func testRemoteTargetServer(ctx context.Context, t *testing.T,
 		workflowNodes[i] = workflowNode
 	}
 
-	return workflowNodes
+	return workflowNodes, srvcs
+}
+
+func closeServices(t *testing.T, srvcs []services.Service) {
+	for _, srv := range srvcs {
+		require.NoError(t, srv.Close())
+	}
 }
 
 type serverTestClient struct {

--- a/core/capabilities/remote/target/server_test.go
+++ b/core/capabilities/remote/target/server_test.go
@@ -144,8 +144,8 @@ func testRemoteTargetServer(ctx context.Context, t *testing.T,
 	for i := 0; i < numCapabilityPeers; i++ {
 		capabilityPeer := capabilityPeers[i]
 		capabilityDispatcher := broker.NewDispatcherForNode(capabilityPeer)
-		capabilityNode := target.NewReceiver(ctx, lggr, capabilityPeer, underlying, capInfo, capDonInfo, workflowDONs, capabilityDispatcher,
-			capabilityNodeResponseTimeout)
+		capabilityNode := target.NewServer(capabilityPeer, underlying, capInfo, capDonInfo, workflowDONs, capabilityDispatcher,
+			capabilityNodeResponseTimeout, lggr)
 		broker.RegisterReceiverNode(capabilityPeer, capabilityNode)
 		capabilityNodes[i] = capabilityNode
 	}

--- a/core/capabilities/syncer.go
+++ b/core/capabilities/syncer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/triggers"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/target"
 
 	"github.com/smartcontractkit/libocr/ragep2p"
 	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
@@ -68,7 +69,7 @@ func NewRegistrySyncer(peerWrapper p2ptypes.PeerWrapper, registry core.Capabilit
 
 func (s *registrySyncer) Start(ctx context.Context) error {
 	s.wg.Add(1)
-	go s.launch(ctx)
+	go s.launch(context.Background())
 	return nil
 }
 
@@ -85,6 +86,19 @@ func (s *registrySyncer) launch(ctx context.Context) {
 	)
 	if err != nil {
 		s.lggr.Errorw("failed to create capability info for streams-trigger", "error", err)
+		return
+	}
+
+	targetCapId := "write_ethereum-testnet-sepolia"
+	targetInfo, err := capabilities.NewRemoteCapabilityInfo(
+		targetCapId,
+		capabilities.CapabilityTypeTarget,
+		"Remote Target",
+		"v0.0.1",
+		&s.networkSetup.TargetCapabilityDonInfo,
+	)
+	if err != nil {
+		s.lggr.Errorw("failed to create capability info for write_ethereum-testnet-sepolia", "error", err)
 		return
 	}
 
@@ -106,15 +120,29 @@ func (s *registrySyncer) launch(ctx context.Context) {
 		triggerCap := remote.NewTriggerSubscriber(config, triggerInfo, s.networkSetup.TriggerCapabilityDonInfo, s.networkSetup.WorkflowsDonInfo, s.dispatcher, aggregator, s.lggr)
 		err = s.registry.Add(ctx, triggerCap)
 		if err != nil {
-			s.lggr.Errorw("failed to add remote target capability to registry", "error", err)
+			s.lggr.Errorw("failed to add remote trigger capability to registry", "error", err)
 			return
 		}
 		err = s.dispatcher.SetReceiver(capId, s.networkSetup.TriggerCapabilityDonInfo.ID, triggerCap)
 		if err != nil {
-			s.lggr.Errorw("workflow DON failed to set receiver", "capabilityId", capId, "donId", s.networkSetup.TriggerCapabilityDonInfo.ID, "error", err)
+			s.lggr.Errorw("workflow DON failed to set receiver for trigger", "capabilityId", capId, "donId", s.networkSetup.TriggerCapabilityDonInfo.ID, "error", err)
 			return
 		}
 		s.subServices = append(s.subServices, triggerCap)
+
+		s.lggr.Info("member of a workflow DON - starting remote targets")
+		targetCap := target.NewClient(targetInfo, s.networkSetup.WorkflowsDonInfo, s.dispatcher, time.Duration(60*time.Second), s.lggr)
+		err = s.registry.Add(ctx, targetCap)
+		if err != nil {
+			s.lggr.Errorw("failed to add remote target capability to registry", "error", err)
+			return
+		}
+		err = s.dispatcher.SetReceiver(targetCapId, s.networkSetup.TargetCapabilityDonInfo.ID, targetCap)
+		if err != nil {
+			s.lggr.Errorw("workflow DON failed to set receiver for target", "capabilityId", capId, "donId", s.networkSetup.TargetCapabilityDonInfo.ID, "error", err)
+			return
+		}
+		s.subServices = append(s.subServices, targetCap)
 	}
 	if s.networkSetup.IsTriggerDon(myId) {
 		s.lggr.Info("member of a capability DON - starting remote publishers")
@@ -162,6 +190,24 @@ func (s *registrySyncer) launch(ctx context.Context) {
 			break
 		}
 	}
+	if s.networkSetup.IsTargetDon(myId) {
+		s.lggr.Info("member of a target DON - starting remote shims")
+		underlying, err2 := s.registry.GetTarget(ctx, targetCapId)
+		if err2 != nil {
+			s.lggr.Errorw("target not found yet", "capabilityId", targetCapId, "error", err2)
+			return
+		}
+		workflowDONs := map[string]capabilities.DON{
+			s.networkSetup.WorkflowsDonInfo.ID: s.networkSetup.WorkflowsDonInfo,
+		}
+		targetCap := target.NewServer(myId, underlying, targetInfo, *targetInfo.DON, workflowDONs, s.dispatcher, time.Duration(60*time.Second), s.lggr)
+		err = s.dispatcher.SetReceiver(targetCapId, s.networkSetup.TargetCapabilityDonInfo.ID, targetCap)
+		if err != nil {
+			s.lggr.Errorw("capability DON failed to set receiver", "capabilityId", capId, "donId", s.networkSetup.TargetCapabilityDonInfo.ID, "error", err)
+			return
+		}
+		s.subServices = append(s.subServices, targetCap)
+	}
 	// NOTE: temporary service start - should be managed by capability creation
 	for _, srv := range s.subServices {
 		err = srv.Start(ctx)
@@ -200,11 +246,13 @@ func (s *registrySyncer) Name() string {
 type HardcodedDonNetworkSetup struct {
 	workflowDonPeers  []string
 	triggerDonPeers   []string
+	targetDonPeers    []string
 	triggerDonSigners []string
 	allPeers          map[ragetypes.PeerID]p2ptypes.StreamConfig
 
 	WorkflowsDonInfo         capabilities.DON
 	TriggerCapabilityDonInfo capabilities.DON
+	TargetCapabilityDonInfo  capabilities.DON
 }
 
 func NewHardcodedDonNetworkSetup() (HardcodedDonNetworkSetup, error) {
@@ -234,6 +282,12 @@ func NewHardcodedDonNetworkSetup() (HardcodedDonNetworkSetup, error) {
 		"0x5d1e87d87bF2e0cD4Ea64F381a2dbF45e5f0a553",
 		"0x91d9b0062265514f012Eb8fABA59372fD9520f56",
 	}
+	result.targetDonPeers = []string{ // "cap-one"
+		"12D3KooWJrthXtnPHw7xyHFAxo6NxifYTvc8igKYaA6wRRRqtsMb",
+		"12D3KooWFQekP9sGex4XhqEJav5EScjTpDVtDqJFg1JvrePBCEGJ",
+		"12D3KooWFLEq4hYtdyKWwe47dXGEbSiHMZhmr5xLSJNhpfiEz8NF",
+		"12D3KooWN2hztiXNNS1jMQTTvvPRYcarK1C7T3Mdqk4x4gwyo5WS",
+	}
 
 	result.allPeers = make(map[ragetypes.PeerID]p2ptypes.StreamConfig)
 	addPeersToDONInfo := func(peers []string, donInfo *capabilities.DON) error {
@@ -257,6 +311,11 @@ func NewHardcodedDonNetworkSetup() (HardcodedDonNetworkSetup, error) {
 		return HardcodedDonNetworkSetup{}, fmt.Errorf("failed to add peers to trigger DON info: %w", err)
 	}
 
+	result.TargetCapabilityDonInfo = capabilities.DON{ID: "targetDon1", F: 1}
+	if err := addPeersToDONInfo(result.targetDonPeers, &result.TargetCapabilityDonInfo); err != nil {
+		return HardcodedDonNetworkSetup{}, fmt.Errorf("failed to add peers to target DON info: %w", err)
+	}
+
 	return result, nil
 }
 
@@ -266,6 +325,10 @@ func (h HardcodedDonNetworkSetup) IsWorkflowDon(id p2ptypes.PeerID) bool {
 
 func (h HardcodedDonNetworkSetup) IsTriggerDon(id p2ptypes.PeerID) bool {
 	return slices.Contains(h.triggerDonPeers, id.String())
+}
+
+func (h HardcodedDonNetworkSetup) IsTargetDon(id p2ptypes.PeerID) bool {
+	return slices.Contains(h.targetDonPeers, id.String())
 }
 
 type mockMercuryDataProducer struct {

--- a/core/capabilities/syncer.go
+++ b/core/capabilities/syncer.go
@@ -130,7 +130,7 @@ func (s *registrySyncer) launch(ctx context.Context) {
 		s.subServices = append(s.subServices, triggerCap)
 
 		s.lggr.Info("member of a workflow DON - starting remote targets")
-		targetCap := target.NewClient(targetInfo, s.networkSetup.WorkflowsDonInfo, s.dispatcher, time.Duration(60*time.Second), s.lggr)
+		targetCap := target.NewClient(targetInfo, s.networkSetup.WorkflowsDonInfo, s.dispatcher, 60*time.Second, s.lggr)
 		err = s.registry.Add(ctx, targetCap)
 		if err != nil {
 			s.lggr.Errorw("failed to add remote target capability to registry", "error", err)
@@ -199,7 +199,7 @@ func (s *registrySyncer) launch(ctx context.Context) {
 		workflowDONs := map[string]capabilities.DON{
 			s.networkSetup.WorkflowsDonInfo.ID: s.networkSetup.WorkflowsDonInfo,
 		}
-		targetCap := target.NewServer(myId, underlying, targetInfo, *targetInfo.DON, workflowDONs, s.dispatcher, time.Duration(60*time.Second), s.lggr)
+		targetCap := target.NewServer(myId, underlying, targetInfo, *targetInfo.DON, workflowDONs, s.dispatcher, 60*time.Second, s.lggr)
 		err = s.dispatcher.SetReceiver(targetCapId, s.networkSetup.TargetCapabilityDonInfo.ID, targetCap)
 		if err != nil {
 			s.lggr.Errorw("capability DON failed to set receiver", "capabilityId", capId, "donId", s.networkSetup.TargetCapabilityDonInfo.ID, "error", err)

--- a/core/capabilities/syncer.go
+++ b/core/capabilities/syncer.go
@@ -89,12 +89,11 @@ func (s *registrySyncer) launch(ctx context.Context) {
 		return
 	}
 
-	targetCapId := "write_ethereum-testnet-sepolia"
+	targetCapId := "write_ethereum-testnet-sepolia@0.0.1"
 	targetInfo, err := capabilities.NewRemoteCapabilityInfo(
 		targetCapId,
 		capabilities.CapabilityTypeTarget,
 		"Remote Target",
-		"v0.0.1",
 		&s.networkSetup.TargetCapabilityDonInfo,
 	)
 	if err != nil {

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20240222010609-cd67d123c772
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20240222010609-cd67d123c772
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1212,8 +1212,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79 h1:hs8dNt80KM3iBPBJ4fo6Kp3gsHhdJUe8RVr/JpGBaQM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa h1:hzEmh4Ggw++g2LemjrtPyBRumovT00wX5oYkDXUHDm8=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240606130021-a4b7359e1580 h1:nsnLzpBTDAQWkfsOz/qd8BTlb1hUpaow1KmA1tPwTf4=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1212,8 +1212,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa h1:hzEmh4Ggw++g2LemjrtPyBRumovT00wX5oYkDXUHDm8=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce h1:/CjY8L4lVJh9E8NKg3bdAgsxj+zKg9XYtXR71ZWWMXo=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240606130021-a4b7359e1580 h1:nsnLzpBTDAQWkfsOz/qd8BTlb1hUpaow1KmA1tPwTf4=

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -454,11 +455,6 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 
 	switch stepUpdate.Status {
 	case store.StatusCompleted:
-		if stepUpdate.Outputs.Err != nil && stepUpdate.Outputs.Err.Error() == capabilities.ErrStopExecution {
-			e.logger.Infow("execution terminated early", "executionID", state.ExecutionID)
-			return e.finishExecution(ctx, state.ExecutionID, store.StatusCompleted)
-		}
-
 		stepDependents, err := e.workflow.dependents(stepUpdate.Ref)
 		if err != nil {
 			return err
@@ -480,7 +476,7 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 				}
 
 				switch step.Status {
-				case store.StatusCompleted, store.StatusErrored:
+				case store.StatusCompleted, store.StatusErrored, store.StatusCompletedEarlyExit:
 				default:
 					workflowCompleted = false
 				}
@@ -498,6 +494,7 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 		// We haven't completed the workflow, but should we continue?
 		// If we've been executing for too long, let's time the workflow out and stop here.
 		if state.CreatedAt != nil && e.clock.Since(*state.CreatedAt) > e.maxExecutionDuration {
+			e.logger.Infow("execution timed out", "executionID", state.ExecutionID)
 			return e.finishExecution(ctx, state.ExecutionID, store.StatusTimeout)
 		}
 
@@ -506,7 +503,18 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 		for _, sd := range stepDependents {
 			e.queueIfReady(state, sd)
 		}
+	case store.StatusCompletedEarlyExit:
+		e.logger.Infow("execution terminated early", "executionID", state.ExecutionID)
+		// NOTE: even though this marks the workflow as completed, any branches of the DAG
+		// that don't depend on the step that signaled for an early exit will still complete.
+		// This is to ensure that any side effects are executed consistently, since otherwise
+		// the async nature of the workflow engine would provide no guarantees.
+		err := e.finishExecution(ctx, state.ExecutionID, store.StatusCompletedEarlyExit)
+		if err != nil {
+			return err
+		}
 	case store.StatusErrored:
+		e.logger.Infow("execution errored", "executionID", state.ExecutionID)
 		err := e.finishExecution(ctx, state.ExecutionID, store.StatusErrored)
 		if err != nil {
 			return err
@@ -573,22 +581,22 @@ func (e *Engine) workerForStepRequest(ctx context.Context, msg stepRequest) {
 	}
 
 	inputs, outputs, err := e.executeStep(ctx, l, msg)
-	if err != nil {
-		if err.Error() == capabilities.ErrStopExecution {
-			l.Infow("step executed successfully with a termination")
-			stepState.Outputs.Err = err
-			stepState.Status = store.StatusCompleted
-		} else {
-			l.Errorf("error executing step request: %s", err)
-			stepState.Outputs.Err = err
-			stepState.Status = store.StatusErrored
-		}
-	} else {
+	var stepStatus string
+	switch {
+	case errors.Is(err, capabilities.ErrStopExecution):
+		l.Infow("step executed successfully with a termination")
+		stepStatus = store.StatusCompletedEarlyExit
+	case err != nil:
+		l.Errorf("error executing step request: %s", err)
+		stepStatus = store.StatusErrored
+	default:
 		l.Infow("step executed successfully", "outputs", outputs)
-		stepState.Outputs.Value = outputs
-		stepState.Status = store.StatusCompleted
+		stepStatus = store.StatusCompleted
 	}
 
+	stepState.Status = stepStatus
+	stepState.Outputs.Value = outputs
+	stepState.Outputs.Err = err
 	stepState.Inputs = inputs
 
 	// Let's try and emit the stepUpdate.

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -339,14 +339,13 @@ func mockFailingConsensus() *mockCapability {
 func mockConsensusWithEarlyTermination() *mockCapability {
 	return newMockCapability(
 		capabilities.MustNewCapabilityInfo(
-			"offchain_reporting",
+			"offchain_reporting@1.0.0",
 			capabilities.CapabilityTypeConsensus,
 			"an ocr3 consensus capability",
-			"v3.0.0",
 		),
 		func(req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
 			return capabilities.CapabilityResponse{
-				Err: errors.New(capabilities.ErrStopExecution),
+				Err: capabilities.ErrStopExecution,
 			}, nil
 		},
 	)
@@ -440,7 +439,7 @@ func TestEngine_GracefulEarlyTermination(t *testing.T) {
 	state, err := eng.executionStates.Get(ctx, eid)
 	require.NoError(t, err)
 
-	assert.Equal(t, state.Status, store.StatusCompleted)
+	assert.Equal(t, state.Status, store.StatusCompletedEarlyExit)
 	assert.Nil(t, state.Steps["write_polygon-testnet-mumbai"])
 }
 

--- a/core/services/workflows/store/models.go
+++ b/core/services/workflows/store/models.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
-	StatusStarted   = "started"
-	StatusErrored   = "errored"
-	StatusTimeout   = "timeout"
-	StatusCompleted = "completed"
+	StatusStarted            = "started"
+	StatusErrored            = "errored"
+	StatusTimeout            = "timeout"
+	StatusCompleted          = "completed"
+	StatusCompletedEarlyExit = "completed_early_exit"
 )
 
 type StepOutput struct {

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240606130021-a4b7359e1580
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240606130021-a4b7359e1580
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917

--- a/go.sum
+++ b/go.sum
@@ -1171,8 +1171,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79 h1:hs8dNt80KM3iBPBJ4fo6Kp3gsHhdJUe8RVr/JpGBaQM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa h1:hzEmh4Ggw++g2LemjrtPyBRumovT00wX5oYkDXUHDm8=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240606130021-a4b7359e1580 h1:nsnLzpBTDAQWkfsOz/qd8BTlb1hUpaow1KmA1tPwTf4=

--- a/go.sum
+++ b/go.sum
@@ -1171,8 +1171,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa h1:hzEmh4Ggw++g2LemjrtPyBRumovT00wX5oYkDXUHDm8=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce h1:/CjY8L4lVJh9E8NKg3bdAgsxj+zKg9XYtXR71ZWWMXo=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240606130021-a4b7359e1580 h1:nsnLzpBTDAQWkfsOz/qd8BTlb1hUpaow1KmA1tPwTf4=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce
 	github.com/smartcontractkit/chainlink-testing-framework v1.30.1
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa
 	github.com/smartcontractkit/chainlink-testing-framework v1.30.1
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1512,8 +1512,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa h1:hzEmh4Ggw++g2LemjrtPyBRumovT00wX5oYkDXUHDm8=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce h1:/CjY8L4lVJh9E8NKg3bdAgsxj+zKg9XYtXR71ZWWMXo=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240606130021-a4b7359e1580 h1:nsnLzpBTDAQWkfsOz/qd8BTlb1hUpaow1KmA1tPwTf4=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1512,8 +1512,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79 h1:hs8dNt80KM3iBPBJ4fo6Kp3gsHhdJUe8RVr/JpGBaQM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa h1:hzEmh4Ggw++g2LemjrtPyBRumovT00wX5oYkDXUHDm8=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240606130021-a4b7359e1580 h1:nsnLzpBTDAQWkfsOz/qd8BTlb1hUpaow1KmA1tPwTf4=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa
 	github.com/smartcontractkit/chainlink-testing-framework v1.30.1
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.3
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce
 	github.com/smartcontractkit/chainlink-testing-framework v1.30.1
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1502,8 +1502,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa h1:hzEmh4Ggw++g2LemjrtPyBRumovT00wX5oYkDXUHDm8=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce h1:/CjY8L4lVJh9E8NKg3bdAgsxj+zKg9XYtXR71ZWWMXo=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607135320-c9bc0a2ac0ce/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240606130021-a4b7359e1580 h1:nsnLzpBTDAQWkfsOz/qd8BTlb1hUpaow1KmA1tPwTf4=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1502,8 +1502,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.3 h1:h/ijT0NiyV06VxYVgcNfsE3+8OEzT3Q0Z9au0z1BPWs=
 github.com/smartcontractkit/chainlink-automation v1.0.3/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79 h1:hs8dNt80KM3iBPBJ4fo6Kp3gsHhdJUe8RVr/JpGBaQM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240606173949-4d52ba4e3c79/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa h1:hzEmh4Ggw++g2LemjrtPyBRumovT00wX5oYkDXUHDm8=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240607092433-1df2ef9a10aa/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240606130021-a4b7359e1580 h1:nsnLzpBTDAQWkfsOz/qd8BTlb1hUpaow1KmA1tPwTf4=


### PR DESCRIPTION
1. Refactor remote target client/server to implement services.Service
2. Use service-wide context when launching NewClientRequest
3. Handle early termination in Engine
4. Logging improvements

Depends on https://github.com/smartcontractkit/chainlink-common/pull/565