### PR TITLE
TT-1174 Migrate automation reorg test to GethSetHead

### DIFF
--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -158,11 +158,6 @@ func TestAutomationReorg(t *testing.T) {
 					Simulated:   true,
 					WsURLs:      network.URLs,
 				})).
-				// TODO: enable blockscout
-				// AddChart(blockscout.New(&blockscout.Props{
-				// 	Name:    "geth-blockscout",
-				// 	WsURL:   network.URL,
-				// 	HttpURL: network.HTTPURLs[0]})).
 				AddHelm(cd)
 			err = testEnvironment.Run()
 			require.NoError(t, err, "Error setting up test environment")

--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -95,13 +95,16 @@ LimitDefault = 5_000_000
 )
 
 /*
- * This test verifies that conditional upkeeps automatically recover from chain reorgs
+ * This test verifies that conditional upkeeps automatically recover from chain reorgs.
+ *
  * The test starts with happy path where upkeeps are expected to be performed.
- * Then reorg below finality depth starts which makes the chain unstable.
+ * Then starts reorg below finality depth which makes the chain unstable.
  *
  * Upkeeps are expected to be performed during the reorg.
  */
 func TestAutomationReorg(t *testing.T) {
+	require.Less(t, reorgBlockCount, finalityDepth, "Reorg block count should be less than finality depth")
+
 	t.Parallel()
 	l := logging.GetTestLogger(t)
 

--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -40,11 +40,11 @@ Enabled = true
 AnnounceAddresses = ["0.0.0.0:6690"]
 ListenAddresses = ["0.0.0.0:6690"]`
 	networkTOML = `Enabled = true
-FinalityDepth = 200
+FinalityDepth = 20
 LogPollInterval = '1s'
 
 [EVM.HeadTracker]
-HistoryDepth = 400
+HistoryDepth = 40
 
 [EVM.GasEstimator]
 Mode = 'FixedPrice'

--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -108,9 +108,9 @@ func TestAutomationReorg(t *testing.T) {
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_2_0":             ethereum.RegistryVersion_2_0,
 		"registry_2_1_conditional": ethereum.RegistryVersion_2_1,
-		"registry_2_1_logtrigger":  ethereum.RegistryVersion_2_1,
-		"registry_2_2_conditional": ethereum.RegistryVersion_2_2,
-		"registry_2_2_logtrigger":  ethereum.RegistryVersion_2_2,
+		// "registry_2_1_logtrigger":  ethereum.RegistryVersion_2_1, // Fails on no upkeeps performed. Expected consumer counter to be greater than 5, but got 0
+		// "registry_2_2_conditional": ethereum.RegistryVersion_2_2, // Fails on no upkeeps performed. Expected consumer counter to be greater than 5, but got 0
+		// "registry_2_2_logtrigger":  ethereum.RegistryVersion_2_2, // Fails on no upkeeps performed. Expected consumer counter to be greater than 5, but got 0
 	}
 
 	for n, rv := range registryVersions {

--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -98,7 +98,7 @@ LimitDefault = 5_000_000
  * This test verifies that conditional upkeeps automatically recover from chain reorgs.
  *
  * The test starts with happy path where upkeeps are expected to be performed.
- * Then starts reorg below finality depth which makes the chain unstable.
+ * Then reorg below finality depth happens which makes the chain unstable.
  *
  * Upkeeps are expected to be performed during the reorg.
  */
@@ -112,8 +112,8 @@ func TestAutomationReorg(t *testing.T) {
 		"registry_2_0":             ethereum.RegistryVersion_2_0,
 		"registry_2_1_conditional": ethereum.RegistryVersion_2_1,
 		"registry_2_1_logtrigger":  ethereum.RegistryVersion_2_1,
-		// "registry_2_2_conditional": ethereum.RegistryVersion_2_2, // Fails on no upkeeps performed. Expected consumer counter to be greater than 5, but got 0
-		// "registry_2_2_logtrigger": ethereum.RegistryVersion_2_2, // Fails on no upkeeps performed. Expected consumer counter to be greater than 5, but got 0
+		"registry_2_2_conditional": ethereum.RegistryVersion_2_2, // Works only on Chainlink Node v2.10.0 or greater
+		"registry_2_2_logtrigger":  ethereum.RegistryVersion_2_2, // Works only on Chainlink Node v2.10.0 or greater
 	}
 
 	for n, rv := range registryVersions {

--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -136,8 +136,6 @@ func TestAutomationReorg(t *testing.T) {
 				ctf_config.MightConfigOverridePyroscopeKey(config.GetPyroscopeConfig(), target)
 			}
 
-			l.Info().Msgf("Chainlink Node config:\n%s", defaultAutomationSettings["toml"])
-
 			cd := chainlink.NewWithOverride(0, defaultAutomationSettings, config.ChainlinkImage, overrideFn)
 
 			testEnvironment := environment.

--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -96,31 +96,21 @@ LimitDefault = 5_000_000
 
 /*
  * This test verifies that conditional upkeeps automatically recover from chain reorgs
- * The blockchain is configured to have two separate miners and one geth node. The test starts
- * with happy path where the two miners remain in sync and upkeeps are expected to be performed.
- * Then reorg starts and the connection between the two geth miners is severed. This makes the
- * chain unstable, however all the CL nodes get the same view of the unstable chain through the
- * same geth node.
+ * The test starts with happy path where upkeeps are expected to be performed.
+ * Then reorg below finality depth starts which makes the chain unstable.
  *
- * Upkeeps are expected to be performed during the reorg as there are only two versions of the
- * the chain, on average 1/2 performUpkeeps should go through.
- *
- * The miner nodes are synced back after automationReorgBlocks. The syncing event can cause a
- * large reorg from CL node perspective, causing existing performUpkeeps to become staleUpkeeps.
- * Automation should be able to recover from this and upkeeps should continue to occur at a
- * normal pace after the event.
+ * Upkeeps are expected to be performed during the reorg.
  */
 func TestAutomationReorg(t *testing.T) {
 	t.Parallel()
 	l := logging.GetTestLogger(t)
 
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
-		"registry_2_0": ethereum.RegistryVersion_2_0,
-		// TODO: enable these tests
-		// "registry_2_1_conditional": ethereum.RegistryVersion_2_1,
-		// "registry_2_1_logtrigger":  ethereum.RegistryVersion_2_1,
-		// "registry_2_2_conditional": ethereum.RegistryVersion_2_2,
-		// "registry_2_2_logtrigger":  ethereum.RegistryVersion_2_2,
+		"registry_2_0":             ethereum.RegistryVersion_2_0,
+		"registry_2_1_conditional": ethereum.RegistryVersion_2_1,
+		"registry_2_1_logtrigger":  ethereum.RegistryVersion_2_1,
+		"registry_2_2_conditional": ethereum.RegistryVersion_2_2,
+		"registry_2_2_logtrigger":  ethereum.RegistryVersion_2_2,
 	}
 
 	for n, rv := range registryVersions {


### PR DESCRIPTION
This PR migrates `reorg/automation_reorg_test.go` to `GethSetHead()`. It simulates reorg below finality depth and checks if the upkeeps are still performed.

All test scenarios are passing in K8s:

```
	registryVersions := map[string]ethereum.KeeperRegistryVersion{
		"registry_2_0":             ethereum.RegistryVersion_2_0,
		"registry_2_1_conditional": ethereum.RegistryVersion_2_1,
		"registry_2_1_logtrigger":  ethereum.RegistryVersion_2_1,
		"registry_2_2_conditional": ethereum.RegistryVersion_2_2, // Works only on Chainlink Node v2.10.0 or greater
		"registry_2_2_logtrigger": ethereum.RegistryVersion_2_2, // Works only on Chainlink Node v2.10.0 or greater
	}
```

Chainlink node detects the reorg below finality depth and is able to recover:
```
{
    "level": "debug",
    "ts": "2024-06-07T12:10:29.009Z",
    "logger": "EVM.1337.Txm.Confirmer",
    "caller": "txmgr/confirmer.go:919",
    "msg": "Chain length supplied for re-org detection was shorter than FinalityDepth",
    "version": "2.8.0@04fbe42",
    "chainLength": 19,
    "finalityDepth": 20,
    "nConsecutiveBlocksChainTooShort": 1
}
```