### PR TITLE
Move chaintype configs to evm

### DIFF
--- a/.changeset/rotten-hats-search.md
+++ b/.changeset/rotten-hats-search.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Move chaintype #internal

--- a/common/client/mocks/config.go
+++ b/common/client/mocks/config.go
@@ -1,20 +1,11 @@
 package mocks
 
-import (
-	"time"
-
-	commonconfig "github.com/smartcontractkit/chainlink/v2/common/config"
-)
+import "time"
 
 type ChainConfig struct {
 	IsFinalityTagEnabled   bool
 	FinalityDepthVal       uint32
 	NoNewHeadsThresholdVal time.Duration
-	ChainTypeVal           commonconfig.ChainType
-}
-
-func (t ChainConfig) ChainType() commonconfig.ChainType {
-	return t.ChainTypeVal
 }
 
 func (t ChainConfig) NodeNoNewHeadsThreshold() time.Duration {

--- a/common/client/multi_node.go
+++ b/common/client/multi_node.go
@@ -17,7 +17,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	feetypes "github.com/smartcontractkit/chainlink/v2/common/fee/types"
 	"github.com/smartcontractkit/chainlink/v2/common/types"
 )
@@ -73,7 +72,6 @@ type MultiNode[
 
 	BatchCallContextAll(ctx context.Context, b []BATCH_ELEM) error
 	ConfiguredChainID() CHAIN_ID
-	IsL2() bool
 }
 
 type multiNode[
@@ -95,7 +93,6 @@ type multiNode[
 	nodes               []Node[CHAIN_ID, HEAD, RPC_CLIENT]
 	sendonlys           []SendOnlyNode[CHAIN_ID, RPC_CLIENT]
 	chainID             CHAIN_ID
-	chainType           config.ChainType
 	lggr                logger.SugaredLogger
 	selectionMode       string
 	noNewHeadsThreshold time.Duration
@@ -137,7 +134,6 @@ func NewMultiNode[
 	nodes []Node[CHAIN_ID, HEAD, RPC_CLIENT],
 	sendonlys []SendOnlyNode[CHAIN_ID, RPC_CLIENT],
 	chainID CHAIN_ID,
-	chainType config.ChainType,
 	chainFamily string,
 	classifySendTxError func(tx TX, err error) SendTxReturnCode,
 	sendTxSoftTimeout time.Duration,
@@ -153,7 +149,6 @@ func NewMultiNode[
 		nodes:               nodes,
 		sendonlys:           sendonlys,
 		chainID:             chainID,
-		chainType:           chainType,
 		lggr:                logger.Sugared(lggr).Named("MultiNode").With("chainID", chainID.String()),
 		selectionMode:       selectionMode,
 		noNewHeadsThreshold: noNewHeadsThreshold,
@@ -489,10 +484,6 @@ func (c *multiNode[CHAIN_ID, SEQ, ADDR, BLOCK_HASH, TX, TX_HASH, EVENT, EVENT_OP
 	return n.RPC().ChainID(ctx)
 }
 
-func (c *multiNode[CHAIN_ID, SEQ, ADDR, BLOCK_HASH, TX, TX_HASH, EVENT, EVENT_OPS, TX_RECEIPT, FEE, HEAD, RPC_CLIENT, BATCH_ELEM]) ChainType() config.ChainType {
-	return c.chainType
-}
-
 func (c *multiNode[CHAIN_ID, SEQ, ADDR, BLOCK_HASH, TX, TX_HASH, EVENT, EVENT_OPS, TX_RECEIPT, FEE, HEAD, RPC_CLIENT, BATCH_ELEM]) CodeAt(ctx context.Context, account ADDR, blockNumber *big.Int) (code []byte, err error) {
 	n, err := c.selectNode()
 	if err != nil {
@@ -519,10 +510,6 @@ func (c *multiNode[CHAIN_ID, SEQ, ADDR, BLOCK_HASH, TX, TX_HASH, EVENT, EVENT_OP
 		return e, err
 	}
 	return n.RPC().FilterEvents(ctx, query)
-}
-
-func (c *multiNode[CHAIN_ID, SEQ, ADDR, BLOCK_HASH, TX, TX_HASH, EVENT, EVENT_OPS, TX_RECEIPT, FEE, HEAD, RPC_CLIENT, BATCH_ELEM]) IsL2() bool {
-	return c.ChainType().IsL2()
 }
 
 func (c *multiNode[CHAIN_ID, SEQ, ADDR, BLOCK_HASH, TX, TX_HASH, EVENT, EVENT_OPS, TX_RECEIPT, FEE, HEAD, RPC_CLIENT, BATCH_ELEM]) LatestBlockHeight(ctx context.Context) (h *big.Int, err error) {

--- a/common/client/multi_node_test.go
+++ b/common/client/multi_node_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/common/types"
 )
 
@@ -37,7 +36,6 @@ type multiNodeOpts struct {
 	nodes               []Node[types.ID, types.Head[Hashable], multiNodeRPCClient]
 	sendonlys           []SendOnlyNode[types.ID, multiNodeRPCClient]
 	chainID             types.ID
-	chainType           config.ChainType
 	chainFamily         string
 	classifySendTxError func(tx any, err error) SendTxReturnCode
 	sendTxSoftTimeout   time.Duration
@@ -51,7 +49,7 @@ func newTestMultiNode(t *testing.T, opts multiNodeOpts) testMultiNode {
 	result := NewMultiNode[types.ID, *big.Int, Hashable, Hashable, any, Hashable, any, any,
 		types.Receipt[Hashable, Hashable], Hashable, types.Head[Hashable], multiNodeRPCClient, any](opts.logger,
 		opts.selectionMode, opts.leaseDuration, opts.noNewHeadsThreshold, opts.nodes, opts.sendonlys,
-		opts.chainID, opts.chainType, opts.chainFamily, opts.classifySendTxError, opts.sendTxSoftTimeout)
+		opts.chainID, opts.chainFamily, opts.classifySendTxError, opts.sendTxSoftTimeout)
 	return testMultiNode{
 		result.(*multiNode[types.ID, *big.Int, Hashable, Hashable, any, Hashable, any, any,
 			types.Receipt[Hashable, Hashable], Hashable, types.Head[Hashable], multiNodeRPCClient, any]),

--- a/common/client/node.go
+++ b/common/client/node.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 
-	commonconfig "github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/common/types"
 )
 
@@ -51,7 +50,6 @@ type ChainConfig interface {
 	NodeNoNewHeadsThreshold() time.Duration
 	FinalityDepth() uint32
 	FinalityTagEnabled() bool
-	ChainType() commonconfig.ChainType
 }
 
 //go:generate mockery --quiet --name Node --structname mockNode --filename "mock_node_test.go" --inpackage --case=underscore

--- a/core/chains/evm/client/chain_client.go
+++ b/core/chains/evm/client/chain_client.go
@@ -12,10 +12,11 @@ import (
 
 	commonassets "github.com/smartcontractkit/chainlink-common/pkg/assets"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	commonclient "github.com/smartcontractkit/chainlink/v2/common/client"
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 	evmconfig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 )
 
@@ -117,7 +118,7 @@ type chainClient struct {
 		rpc.BatchElem,
 	]
 	logger       logger.SugaredLogger
-	chainType    config.ChainType
+	chainType    chaintype.ChainType
 	clientErrors evmconfig.ClientErrors
 }
 
@@ -129,7 +130,7 @@ func NewChainClient(
 	nodes []commonclient.Node[*big.Int, *evmtypes.Head, RPCClient],
 	sendonlys []commonclient.SendOnlyNode[*big.Int, RPCClient],
 	chainID *big.Int,
-	chainType config.ChainType,
+	chainType chaintype.ChainType,
 	clientErrors evmconfig.ClientErrors,
 ) Client {
 	multiNode := commonclient.NewMultiNode(
@@ -140,7 +141,6 @@ func NewChainClient(
 		nodes,
 		sendonlys,
 		chainID,
-		chainType,
 		"EVM",
 		func(tx *types.Transaction, err error) commonclient.SendTxReturnCode {
 			return ClassifySendError(err, clientErrors, logger.Sugared(logger.Nop()), tx, common.Address{}, chainType.IsL2())
@@ -254,7 +254,7 @@ func (c *chainClient) HeadByNumber(ctx context.Context, n *big.Int) (*evmtypes.H
 }
 
 func (c *chainClient) IsL2() bool {
-	return c.multiNode.IsL2()
+	return c.chainType.IsL2()
 }
 
 func (c *chainClient) LINKBalance(ctx context.Context, address common.Address, linkAddress common.Address) (*commonassets.Link, error) {

--- a/core/chains/evm/client/config_builder.go
+++ b/core/chains/evm/client/config_builder.go
@@ -8,10 +8,10 @@ import (
 	"go.uber.org/multierr"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 
 	commonclient "github.com/smartcontractkit/chainlink/v2/common/client"
 	evmconfig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/toml"
 )
 
@@ -56,7 +56,7 @@ func NewClientConfigs(
 	chainConfig := &evmconfig.EVMConfig{
 		C: &toml.EVMConfig{
 			Chain: toml.Chain{
-				ChainType:           config.NewChainTypeConfig(chainType),
+				ChainType:           chaintype.NewChainTypeConfig(chainType),
 				FinalityDepth:       finalityDepth,
 				FinalityTagEnabled:  finalityTagEnabled,
 				NoNewHeadsThreshold: commonconfig.MustNewDuration(noNewHeadsThreshold),

--- a/core/chains/evm/client/config_builder_test.go
+++ b/core/chains/evm/client/config_builder_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 )
 
 func TestClientConfigBuilder(t *testing.T) {
@@ -50,13 +51,12 @@ func TestClientConfigBuilder(t *testing.T) {
 	require.Equal(t, *nodeConfigs[0].HTTPURL, (*nodes[0].HTTPURL).String())
 
 	// Validate chain config
-	require.Equal(t, chainTypeStr, string(chainCfg.ChainType()))
 	require.Equal(t, noNewHeadsThreshold, chainCfg.NodeNoNewHeadsThreshold())
 	require.Equal(t, *finalityDepth, chainCfg.FinalityDepth())
 	require.Equal(t, *finalityTagEnabled, chainCfg.FinalityTagEnabled())
 
 	// let combiler tell us, when we do not have sufficient data to create evm client
-	_ = client.NewEvmClient(nodePool, chainCfg, nil, logger.Test(t), big.NewInt(10), nodes)
+	_ = client.NewEvmClient(nodePool, chainCfg, nil, logger.Test(t), big.NewInt(10), nodes, chaintype.ChainType(chainTypeStr))
 }
 
 func TestNodeConfigs(t *testing.T) {

--- a/core/chains/evm/client/evm_client.go
+++ b/core/chains/evm/client/evm_client.go
@@ -8,11 +8,12 @@ import (
 
 	commonclient "github.com/smartcontractkit/chainlink/v2/common/client"
 	evmconfig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/toml"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 )
 
-func NewEvmClient(cfg evmconfig.NodePool, chainCfg commonclient.ChainConfig, clientErrors evmconfig.ClientErrors, lggr logger.Logger, chainID *big.Int, nodes []*toml.Node) Client {
+func NewEvmClient(cfg evmconfig.NodePool, chainCfg commonclient.ChainConfig, clientErrors evmconfig.ClientErrors, lggr logger.Logger, chainID *big.Int, nodes []*toml.Node, chainType chaintype.ChainType) Client {
 	var empty url.URL
 	var primaries []commonclient.Node[*big.Int, *evmtypes.Head, RPCClient]
 	var sendonlys []commonclient.SendOnlyNode[*big.Int, RPCClient]
@@ -34,5 +35,5 @@ func NewEvmClient(cfg evmconfig.NodePool, chainCfg commonclient.ChainConfig, cli
 	}
 
 	return NewChainClient(lggr, cfg.SelectionMode(), cfg.LeaseDuration(), chainCfg.NodeNoNewHeadsThreshold(),
-		primaries, sendonlys, chainID, chainCfg.ChainType(), clientErrors)
+		primaries, sendonlys, chainID, chainType, clientErrors)
 }

--- a/core/chains/evm/client/evm_client_test.go
+++ b/core/chains/evm/client/evm_client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/testutils"
 )
 
@@ -36,6 +37,6 @@ func TestNewEvmClient(t *testing.T) {
 		pollFailureThreshold, pollInterval, syncThreshold, nodeIsSyncingEnabled, noNewHeadsThreshold, finalityDepth, finalityTagEnabled)
 	require.NoError(t, err)
 
-	client := client.NewEvmClient(nodePool, chainCfg, nil, logger.Test(t), testutils.FixtureChainID, nodes)
+	client := client.NewEvmClient(nodePool, chainCfg, nil, logger.Test(t), testutils.FixtureChainID, nodes, chaintype.ChainType(chainTypeStr))
 	require.NotNil(t, client)
 }

--- a/core/chains/evm/client/helpers_test.go
+++ b/core/chains/evm/client/helpers_test.go
@@ -13,8 +13,8 @@ import (
 
 	commonclient "github.com/smartcontractkit/chainlink/v2/common/client"
 	clientMocks "github.com/smartcontractkit/chainlink/v2/common/client/mocks"
-	commonconfig "github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/toml"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 )
@@ -148,7 +148,7 @@ func NewChainClientWithTestNode(
 		sendonlys = append(sendonlys, s)
 	}
 
-	var chainType commonconfig.ChainType
+	var chainType chaintype.ChainType
 	clientErrors := NewTestClientErrors()
 	c := NewChainClient(lggr, nodeCfg.SelectionMode(), leaseDuration, noNewHeadsThreshold, primaries, sendonlys, chainID, chainType, &clientErrors)
 	t.Cleanup(c.Close)
@@ -164,7 +164,7 @@ func NewChainClientWithEmptyNode(
 ) Client {
 	lggr := logger.Test(t)
 
-	var chainType commonconfig.ChainType
+	var chainType chaintype.ChainType
 	c := NewChainClient(lggr, selectionMode, leaseDuration, noNewHeadsThreshold, nil, nil, chainID, chainType, nil)
 	t.Cleanup(c.Close)
 	return c
@@ -180,7 +180,7 @@ func NewChainClientWithMockedRpc(
 ) Client {
 	lggr := logger.Test(t)
 
-	var chainType commonconfig.ChainType
+	var chainType chaintype.ChainType
 
 	cfg := TestNodePoolConfig{
 		NodeSelectionMode: commonclient.NodeSelectionModeRoundRobin,

--- a/core/chains/evm/client/tx_simulator.go
+++ b/core/chains/evm/client/tx_simulator.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink/v2/common/config"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 )
 
 type simulatorClient interface {
@@ -17,7 +18,7 @@ type simulatorClient interface {
 // ZK chains can return an out-of-counters error
 // This method allows a caller to determine if a tx would fail due to OOC error by simulating the transaction
 // Used as an entry point in case custom simulation is required across different chains
-func SimulateTransaction(ctx context.Context, client simulatorClient, lggr logger.SugaredLogger, chainType config.ChainType, msg ethereum.CallMsg) *SendError {
+func SimulateTransaction(ctx context.Context, client simulatorClient, lggr logger.SugaredLogger, chainType chaintype.ChainType, msg ethereum.CallMsg) *SendError {
 	err := simulateTransactionDefault(ctx, client, msg)
 	return NewSendError(err)
 }

--- a/core/chains/evm/config/chain_scoped.go
+++ b/core/chains/evm/config/chain_scoped.go
@@ -7,7 +7,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/assets"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	commonconfig "github.com/smartcontractkit/chainlink/v2/common/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/toml"
 )
 
@@ -124,7 +124,7 @@ func (e *EVMConfig) BlockEmissionIdleWarningThreshold() time.Duration {
 	return e.C.NoNewHeadsThreshold.Duration()
 }
 
-func (e *EVMConfig) ChainType() commonconfig.ChainType {
+func (e *EVMConfig) ChainType() chaintype.ChainType {
 	if e.C.ChainType == nil {
 		return ""
 	}

--- a/core/chains/evm/config/chaintype/chaintype.go
+++ b/core/chains/evm/config/chaintype/chaintype.go
@@ -1,4 +1,4 @@
-package config
+package chaintype
 
 import (
 	"fmt"

--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -9,8 +9,8 @@ import (
 
 	commonassets "github.com/smartcontractkit/chainlink-common/pkg/assets"
 
-	commonconfig "github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 )
 
@@ -29,7 +29,7 @@ type EVM interface {
 	BlockBackfillSkip() bool
 	BlockEmissionIdleWarningThreshold() time.Duration
 	ChainID() *big.Int
-	ChainType() commonconfig.ChainType
+	ChainType() chaintype.ChainType
 	FinalityDepth() uint32
 	FinalityTagEnabled() bool
 	FlagsContractAddress() string

--- a/core/chains/evm/config/toml/config.go
+++ b/core/chains/evm/config/toml/config.go
@@ -17,8 +17,8 @@ import (
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils/big"
 )
@@ -341,7 +341,7 @@ type Chain struct {
 	AutoCreateKey             *bool
 	BlockBackfillDepth        *uint32
 	BlockBackfillSkip         *bool
-	ChainType                 *config.ChainTypeConfig
+	ChainType                 *chaintype.ChainTypeConfig
 	FinalityDepth             *uint32
 	FinalityTagEnabled        *bool
 	FlagsContractAddress      *types.EIP55Address
@@ -373,7 +373,7 @@ type Chain struct {
 func (c *Chain) ValidateConfig() (err error) {
 	if !c.ChainType.ChainType().IsValid() {
 		err = multierr.Append(err, commonconfig.ErrInvalid{Name: "ChainType", Value: c.ChainType.ChainType(),
-			Msg: config.ErrInvalidChainType.Error()})
+			Msg: chaintype.ErrInvalidChainType.Error()})
 	}
 
 	if c.GasEstimator.BumpTxDepth != nil && *c.GasEstimator.BumpTxDepth > *c.Transactions.MaxInFlight {
@@ -397,7 +397,7 @@ func (c *Chain) ValidateConfig() (err error) {
 	if c.Transactions.AutoPurge.Enabled != nil && *c.Transactions.AutoPurge.Enabled {
 		chainType := c.ChainType.ChainType()
 		switch chainType {
-		case config.ChainScroll:
+		case chaintype.ChainScroll:
 			if c.Transactions.AutoPurge.DetectionApiUrl == nil {
 				err = multierr.Append(err, commonconfig.ErrMissing{Name: "Transactions.AutoPurge.DetectionApiUrl", Msg: fmt.Sprintf("must be set for %s", chainType)})
 			} else if c.Transactions.AutoPurge.DetectionApiUrl.IsZero() {
@@ -409,7 +409,7 @@ func (c *Chain) ValidateConfig() (err error) {
 					err = multierr.Append(err, commonconfig.ErrInvalid{Name: "Transactions.AutoPurge.DetectionApiUrl", Value: c.Transactions.AutoPurge.DetectionApiUrl.Scheme, Msg: "must be http or https"})
 				}
 			}
-		case config.ChainZkEvm:
+		case chaintype.ChainZkEvm:
 			// No other configs are needed
 		default:
 			// Bump Threshold is required because the stuck tx heuristic relies on a minimum number of bump attempts to exist

--- a/core/chains/evm/config/toml/defaults.go
+++ b/core/chains/evm/config/toml/defaults.go
@@ -10,7 +10,7 @@ import (
 
 	cconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils/big"
 )
 
@@ -91,7 +91,7 @@ func Defaults(chainID *big.Big, with ...*Chain) Chain {
 	return c
 }
 
-func ChainTypeForID(chainID *big.Big) (config.ChainType, bool) {
+func ChainTypeForID(chainID *big.Big) (chaintype.ChainType, bool) {
 	s := chainID.String()
 	if d, ok := defaults[s]; ok {
 		return d.ChainType.ChainType(), true

--- a/core/chains/evm/gas/block_history_estimator.go
+++ b/core/chains/evm/gas/block_history_estimator.go
@@ -20,10 +20,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mathutil"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	commonfee "github.com/smartcontractkit/chainlink/v2/common/fee"
 	feetypes "github.com/smartcontractkit/chainlink/v2/common/fee/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/rollups"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 )
@@ -80,7 +80,7 @@ const BumpingHaltedLabel = "Tx gas bumping halted since price exceeds current bl
 var _ EvmEstimator = &BlockHistoryEstimator{}
 
 type chainConfig interface {
-	ChainType() config.ChainType
+	ChainType() chaintype.ChainType
 }
 
 type estimatorGasEstimatorConfig interface {
@@ -843,7 +843,7 @@ func (b *BlockHistoryEstimator) setPercentileGasPrice(gasPrice *assets.Wei) {
 
 // isUsable returns true if the tx is usable both generally and specifically for
 // this Config.
-func (b *BlockHistoryEstimator) IsUsable(tx evmtypes.Transaction, block evmtypes.Block, chainType config.ChainType, minGasPrice *assets.Wei, lggr logger.Logger) bool {
+func (b *BlockHistoryEstimator) IsUsable(tx evmtypes.Transaction, block evmtypes.Block, chainType chaintype.ChainType, minGasPrice *assets.Wei, lggr logger.Logger) bool {
 	// GasLimit 0 is impossible on Ethereum official, but IS possible
 	// on forks/clones such as RSK. We should ignore these transactions
 	// if they come up on any chain since they are not normal.

--- a/core/chains/evm/gas/block_history_estimator_test.go
+++ b/core/chains/evm/gas/block_history_estimator_test.go
@@ -21,11 +21,11 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	commonfee "github.com/smartcontractkit/chainlink/v2/common/fee"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	evmmocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client/mocks"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/rollups"
 	rollupMocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/rollups/mocks"
@@ -990,12 +990,12 @@ func TestBlockHistoryEstimator_Recalculate_NoEIP1559(t *testing.T) {
 		require.Equal(t, assets.NewWeiI(11), gas.GetGasPrice(bhe))
 
 		// Set chainType to Gnosis - GasEstimator should now ignore zero priced transactions
-		cfg.ChainTypeF = string(config.ChainGnosis)
+		cfg.ChainTypeF = string(chaintype.ChainGnosis)
 		bhe.Recalculate(testutils.Head(0))
 		require.Equal(t, assets.NewWeiI(80), gas.GetGasPrice(bhe))
 
 		// And for X Layer
-		cfg.ChainTypeF = string(config.ChainXLayer)
+		cfg.ChainTypeF = string(chaintype.ChainXLayer)
 		bhe.Recalculate(testutils.Head(0))
 		require.Equal(t, assets.NewWeiI(80), gas.GetGasPrice(bhe))
 	})
@@ -1413,7 +1413,7 @@ func TestBlockHistoryEstimator_IsUsable(t *testing.T) {
 	})
 
 	t.Run("returns false if transaction is of type 0x71 or 0xff only on zkSync", func(t *testing.T) {
-		cfg.ChainTypeF = string(config.ChainZkSync)
+		cfg.ChainTypeF = string(chaintype.ChainZkSync)
 		tx := evmtypes.Transaction{Type: 0x71, GasPrice: assets.NewWeiI(10), GasLimit: 42, Hash: utils.NewHash()}
 		assert.Equal(t, false, bhe.IsUsable(tx, block, cfg.ChainType(), geCfg.PriceMin(), logger.Test(t)))
 

--- a/core/chains/evm/gas/chain_specific.go
+++ b/core/chains/evm/gas/chain_specific.go
@@ -1,15 +1,15 @@
 package gas
 
 import (
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 )
 
 // chainSpecificIsUsable allows for additional logic specific to a particular
 // Config that determines whether a transaction should be used for gas estimation
-func chainSpecificIsUsable(tx evmtypes.Transaction, baseFee *assets.Wei, chainType config.ChainType, minGasPriceWei *assets.Wei) bool {
-	if chainType == config.ChainGnosis || chainType == config.ChainXLayer {
+func chainSpecificIsUsable(tx evmtypes.Transaction, baseFee *assets.Wei, chainType chaintype.ChainType, minGasPriceWei *assets.Wei) bool {
+	if chainType == chaintype.ChainGnosis || chainType == chaintype.ChainXLayer {
 		// GasPrice 0 on most chains is great since it indicates cheap/free transactions.
 		// However, Gnosis and XLayer reserve a special type of "bridge" transaction with 0 gas
 		// price that is always processed at top priority. Ordinary transactions
@@ -19,7 +19,7 @@ func chainSpecificIsUsable(tx evmtypes.Transaction, baseFee *assets.Wei, chainTy
 			return false
 		}
 	}
-	if chainType == config.ChainOptimismBedrock || chainType == config.ChainKroma {
+	if chainType == chaintype.ChainOptimismBedrock || chainType == chaintype.ChainKroma {
 		// This is a special deposit transaction type introduced in Bedrock upgrade.
 		// This is a system transaction that it will occur at least one time per block.
 		// We should discard this type before even processing it to avoid flooding the
@@ -29,7 +29,7 @@ func chainSpecificIsUsable(tx evmtypes.Transaction, baseFee *assets.Wei, chainTy
 			return false
 		}
 	}
-	if chainType == config.ChainCelo {
+	if chainType == chaintype.ChainCelo {
 		// Celo specific transaction types that utilize the feeCurrency field.
 		if tx.Type == 0x7c || tx.Type == 0x7b {
 			return false
@@ -42,14 +42,14 @@ func chainSpecificIsUsable(tx evmtypes.Transaction, baseFee *assets.Wei, chainTy
 			return false
 		}
 	}
-	if chainType == config.ChainWeMix {
+	if chainType == chaintype.ChainWeMix {
 		// WeMix specific transaction types that enables fee delegation.
 		// https://docs.wemix.com/v/en/design/fee-delegation
 		if tx.Type == 0x16 {
 			return false
 		}
 	}
-	if chainType == config.ChainZkSync {
+	if chainType == chaintype.ChainZkSync {
 		// zKSync specific type for contract deployment & priority transactions
 		// https://era.zksync.io/docs/reference/concepts/transactions.html#eip-712-0x71
 		if tx.Type == 0x71 || tx.Type == 0xff {

--- a/core/chains/evm/gas/helpers_test.go
+++ b/core/chains/evm/gas/helpers_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 )
 
@@ -119,8 +119,8 @@ func NewMockConfig() *MockConfig {
 	return &MockConfig{}
 }
 
-func (m *MockConfig) ChainType() config.ChainType {
-	return config.ChainType(m.ChainTypeF)
+func (m *MockConfig) ChainType() chaintype.ChainType {
+	return chaintype.ChainType(m.ChainTypeF)
 }
 
 func (m *MockConfig) FinalityDepth() uint32 {

--- a/core/chains/evm/gas/mocks/config.go
+++ b/core/chains/evm/gas/mocks/config.go
@@ -3,7 +3,7 @@
 package mocks
 
 import (
-	config "github.com/smartcontractkit/chainlink/v2/common/config"
+	chaintype "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -14,18 +14,18 @@ type Config struct {
 }
 
 // ChainType provides a mock function with given fields:
-func (_m *Config) ChainType() config.ChainType {
+func (_m *Config) ChainType() chaintype.ChainType {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for ChainType")
 	}
 
-	var r0 config.ChainType
-	if rf, ok := ret.Get(0).(func() config.ChainType); ok {
+	var r0 chaintype.ChainType
+	if rf, ok := ret.Get(0).(func() chaintype.ChainType); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(config.ChainType)
+		r0 = ret.Get(0).(chaintype.ChainType)
 	}
 
 	return r0

--- a/core/chains/evm/gas/models.go
+++ b/core/chains/evm/gas/models.go
@@ -15,12 +15,12 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	bigmath "github.com/smartcontractkit/chainlink-common/pkg/utils/big_math"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	commonfee "github.com/smartcontractkit/chainlink/v2/common/fee"
 	feetypes "github.com/smartcontractkit/chainlink/v2/common/fee/types"
 	"github.com/smartcontractkit/chainlink/v2/common/headtracker"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 	evmconfig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/rollups"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/label"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
@@ -338,7 +338,7 @@ func (e *evmFeeEstimator) BumpFee(ctx context.Context, originalFee EvmFee, feeLi
 //
 //go:generate mockery --quiet --name Config --output ./mocks/ --case=underscore
 type Config interface {
-	ChainType() config.ChainType
+	ChainType() chaintype.ChainType
 	FinalityDepth() uint32
 	FinalityTagEnabled() bool
 }

--- a/core/chains/evm/gas/models_test.go
+++ b/core/chains/evm/gas/models_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/rollups"
@@ -65,7 +65,7 @@ func TestWrappedEvmEstimator(t *testing.T) {
 		assert.Nil(t, l1Oracle)
 
 		// expect l1Oracle
-		oracle := rollups.NewL1GasOracle(lggr, nil, config.ChainOptimismBedrock)
+		oracle := rollups.NewL1GasOracle(lggr, nil, chaintype.ChainOptimismBedrock)
 		// cast oracle to L1Oracle interface
 		estimator = gas.NewEvmFeeEstimator(lggr, getEst, false, geCfg)
 

--- a/core/chains/evm/gas/rollups/arbitrum_l1_oracle.go
+++ b/core/chains/evm/gas/rollups/arbitrum_l1_oracle.go
@@ -20,9 +20,9 @@ import (
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/smartcontractkit/chainlink/v2/common/client"
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 )
 
 type ArbL1GasOracle interface {
@@ -36,7 +36,7 @@ type arbitrumL1Oracle struct {
 	client     l1OracleClient
 	pollPeriod time.Duration
 	logger     logger.SugaredLogger
-	chainType  config.ChainType
+	chainType  chaintype.ChainType
 
 	l1GasPriceAddress   string
 	gasPriceMethod      string
@@ -94,7 +94,7 @@ func NewArbitrumL1GasOracle(lggr logger.Logger, ethClient l1OracleClient) *arbit
 		client:     ethClient,
 		pollPeriod: PollPeriod,
 		logger:     logger.Sugared(logger.Named(lggr, "L1GasOracle(arbitrum)")),
-		chainType:  config.ChainArbitrum,
+		chainType:  chaintype.ChainArbitrum,
 
 		l1GasPriceAddress:   l1GasPriceAddress,
 		gasPriceMethod:      gasPriceMethod,

--- a/core/chains/evm/gas/rollups/l1_oracle.go
+++ b/core/chains/evm/gas/rollups/l1_oracle.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 )
 
 // L1Oracle provides interface for fetching L1-specific fee components if the chain is an L2.
@@ -46,21 +46,21 @@ const (
 	PollPeriod = 6 * time.Second
 )
 
-var supportedChainTypes = []config.ChainType{config.ChainArbitrum, config.ChainOptimismBedrock, config.ChainKroma, config.ChainScroll}
+var supportedChainTypes = []chaintype.ChainType{chaintype.ChainArbitrum, chaintype.ChainOptimismBedrock, chaintype.ChainKroma, chaintype.ChainScroll}
 
-func IsRollupWithL1Support(chainType config.ChainType) bool {
+func IsRollupWithL1Support(chainType chaintype.ChainType) bool {
 	return slices.Contains(supportedChainTypes, chainType)
 }
 
-func NewL1GasOracle(lggr logger.Logger, ethClient l1OracleClient, chainType config.ChainType) L1Oracle {
+func NewL1GasOracle(lggr logger.Logger, ethClient l1OracleClient, chainType chaintype.ChainType) L1Oracle {
 	if !IsRollupWithL1Support(chainType) {
 		return nil
 	}
 	var l1Oracle L1Oracle
 	switch chainType {
-	case config.ChainOptimismBedrock, config.ChainKroma, config.ChainScroll:
+	case chaintype.ChainOptimismBedrock, chaintype.ChainKroma, chaintype.ChainScroll:
 		l1Oracle = NewOpStackL1GasOracle(lggr, ethClient, chainType)
-	case config.ChainArbitrum:
+	case chaintype.ChainArbitrum:
 		l1Oracle = NewArbitrumL1GasOracle(lggr, ethClient)
 	default:
 		panic(fmt.Sprintf("Received unspported chaintype %s", chainType))

--- a/core/chains/evm/gas/rollups/l1_oracle_test.go
+++ b/core/chains/evm/gas/rollups/l1_oracle_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/rollups/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 )
@@ -30,7 +30,7 @@ func TestL1Oracle(t *testing.T) {
 	t.Run("Unsupported ChainType returns nil", func(t *testing.T) {
 		ethClient := mocks.NewL1OracleClient(t)
 
-		assert.Nil(t, NewL1GasOracle(logger.Test(t), ethClient, config.ChainCelo))
+		assert.Nil(t, NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainCelo))
 	})
 }
 
@@ -40,7 +40,7 @@ func TestL1Oracle_GasPrice(t *testing.T) {
 	t.Run("Calling GasPrice on unstarted L1Oracle returns error", func(t *testing.T) {
 		ethClient := mocks.NewL1OracleClient(t)
 
-		oracle := NewL1GasOracle(logger.Test(t), ethClient, config.ChainOptimismBedrock)
+		oracle := NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainOptimismBedrock)
 
 		_, err := oracle.GasPrice(tests.Context(t))
 		assert.EqualError(t, err, "L1GasOracle is not started; cannot estimate gas")
@@ -62,7 +62,7 @@ func TestL1Oracle_GasPrice(t *testing.T) {
 			assert.Nil(t, blockNumber)
 		}).Return(common.BigToHash(l1BaseFee).Bytes(), nil)
 
-		oracle := NewL1GasOracle(logger.Test(t), ethClient, config.ChainArbitrum)
+		oracle := NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainArbitrum)
 		servicetest.RunHealthy(t, oracle)
 
 		gasPrice, err := oracle.GasPrice(tests.Context(t))
@@ -101,7 +101,7 @@ func TestL1Oracle_GasPrice(t *testing.T) {
 			assert.Nil(t, blockNumber)
 		}).Return(common.BigToHash(l1BaseFee).Bytes(), nil)
 
-		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, config.ChainKroma, KromaGasOracleAddress)
+		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, chaintype.ChainKroma, KromaGasOracleAddress)
 		servicetest.RunHealthy(t, oracle)
 
 		gasPrice, err := oracle.GasPrice(tests.Context(t))
@@ -140,7 +140,7 @@ func TestL1Oracle_GasPrice(t *testing.T) {
 			assert.Nil(t, blockNumber)
 		}).Return(common.BigToHash(l1BaseFee).Bytes(), nil)
 
-		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, config.ChainOptimismBedrock, OPGasOracleAddress)
+		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, chaintype.ChainOptimismBedrock, OPGasOracleAddress)
 		servicetest.RunHealthy(t, oracle)
 
 		gasPrice, err := oracle.GasPrice(tests.Context(t))
@@ -178,7 +178,7 @@ func TestL1Oracle_GasPrice(t *testing.T) {
 			assert.Nil(t, blockNumber)
 		}).Return(common.BigToHash(l1BaseFee).Bytes(), nil)
 
-		oracle := NewL1GasOracle(logger.Test(t), ethClient, config.ChainScroll)
+		oracle := NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainScroll)
 		require.NoError(t, oracle.Start(tests.Context(t)))
 		t.Cleanup(func() { assert.NoError(t, oracle.Close()) })
 
@@ -222,7 +222,7 @@ func TestL1Oracle_GetGasCost(t *testing.T) {
 			require.Equal(t, blockNum, blockNumber)
 		}).Return(result, nil)
 
-		oracle := NewL1GasOracle(logger.Test(t), ethClient, config.ChainArbitrum)
+		oracle := NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainArbitrum)
 
 		gasCost, err := oracle.GetGasCost(tests.Context(t), tx, blockNum)
 		require.NoError(t, err)
@@ -234,7 +234,7 @@ func TestL1Oracle_GetGasCost(t *testing.T) {
 		tx := types.NewTx(&types.LegacyTx{})
 
 		ethClient := mocks.NewL1OracleClient(t)
-		oracle := NewL1GasOracle(logger.Test(t), ethClient, config.ChainKroma)
+		oracle := NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainKroma)
 
 		_, err := oracle.GetGasCost(tests.Context(t), tx, blockNum)
 		require.Error(t, err, "L1 gas cost not supported for this chain: kroma")
@@ -268,7 +268,7 @@ func TestL1Oracle_GetGasCost(t *testing.T) {
 			require.Equal(t, blockNum, blockNumber)
 		}).Return(common.BigToHash(l1GasCost).Bytes(), nil)
 
-		oracle := NewL1GasOracle(logger.Test(t), ethClient, config.ChainOptimismBedrock)
+		oracle := NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainOptimismBedrock)
 
 		gasCost, err := oracle.GetGasCost(tests.Context(t), tx, blockNum)
 		require.NoError(t, err)
@@ -303,7 +303,7 @@ func TestL1Oracle_GetGasCost(t *testing.T) {
 			require.Equal(t, blockNum, blockNumber)
 		}).Return(common.BigToHash(l1GasCost).Bytes(), nil)
 
-		oracle := NewL1GasOracle(logger.Test(t), ethClient, config.ChainScroll)
+		oracle := NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainScroll)
 
 		gasCost, err := oracle.GetGasCost(tests.Context(t), tx, blockNum)
 		require.NoError(t, err)

--- a/core/chains/evm/gas/rollups/op_l1_oracle.go
+++ b/core/chains/evm/gas/rollups/op_l1_oracle.go
@@ -21,9 +21,9 @@ import (
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/smartcontractkit/chainlink/v2/common/client"
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 )
 
 // Reads L2-specific precompiles and caches the l1GasPrice set by the L2.
@@ -32,7 +32,7 @@ type OptimismL1Oracle struct {
 	client     l1OracleClient
 	pollPeriod time.Duration
 	logger     logger.SugaredLogger
-	chainType  config.ChainType
+	chainType  chaintype.ChainType
 
 	l1OracleAddress     string
 	gasPriceMethod      string
@@ -84,14 +84,14 @@ const (
 	ScrollGasOracleAddress = "0x5300000000000000000000000000000000000002"
 )
 
-func NewOpStackL1GasOracle(lggr logger.Logger, ethClient l1OracleClient, chainType config.ChainType) *OptimismL1Oracle {
+func NewOpStackL1GasOracle(lggr logger.Logger, ethClient l1OracleClient, chainType chaintype.ChainType) *OptimismL1Oracle {
 	var precompileAddress string
 	switch chainType {
-	case config.ChainOptimismBedrock:
+	case chaintype.ChainOptimismBedrock:
 		precompileAddress = OPGasOracleAddress
-	case config.ChainKroma:
+	case chaintype.ChainKroma:
 		precompileAddress = KromaGasOracleAddress
-	case config.ChainScroll:
+	case chaintype.ChainScroll:
 		precompileAddress = ScrollGasOracleAddress
 	default:
 		panic(fmt.Sprintf("Received unspported chaintype %s", chainType))
@@ -99,7 +99,7 @@ func NewOpStackL1GasOracle(lggr logger.Logger, ethClient l1OracleClient, chainTy
 	return newOpStackL1GasOracle(lggr, ethClient, chainType, precompileAddress)
 }
 
-func newOpStackL1GasOracle(lggr logger.Logger, ethClient l1OracleClient, chainType config.ChainType, precompileAddress string) *OptimismL1Oracle {
+func newOpStackL1GasOracle(lggr logger.Logger, ethClient l1OracleClient, chainType chaintype.ChainType, precompileAddress string) *OptimismL1Oracle {
 	var l1OracleAddress, gasPriceMethod, gasCostMethod string
 	var l1GasPriceMethodAbi, l1GasCostMethodAbi abi.ABI
 	var gasPriceErr, gasCostErr error
@@ -274,7 +274,7 @@ func (o *OptimismL1Oracle) GetGasCost(ctx context.Context, tx *gethtypes.Transac
 	defer cancel()
 	var callData, b []byte
 	var err error
-	if o.chainType == config.ChainKroma {
+	if o.chainType == chaintype.ChainKroma {
 		return nil, fmt.Errorf("L1 gas cost not supported for this chain: %s", o.chainType)
 	}
 	// Append rlp-encoded tx

--- a/core/chains/evm/gas/rollups/op_l1_oracle_test.go
+++ b/core/chains/evm/gas/rollups/op_l1_oracle_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/rollups/mocks"
 )
 
@@ -87,7 +87,7 @@ func TestDAPriceReader_ReadV1GasPrice(t *testing.T) {
 				}).Return(common.BigToHash(l1BaseFee).Bytes(), nil).Once()
 			}
 
-			oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, config.ChainOptimismBedrock, oracleAddress)
+			oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, chaintype.ChainOptimismBedrock, oracleAddress)
 			gasPrice, err := oracle.GetDAGasPrice(tests.Context(t))
 
 			if tc.returnBadData {
@@ -155,7 +155,7 @@ func TestDAPriceReader_ReadEcotoneGasPrice(t *testing.T) {
 			rpcElements[1].Result = &res2
 		}).Return(nil).Once()
 
-		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, config.ChainOptimismBedrock, oracleAddress)
+		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, chaintype.ChainOptimismBedrock, oracleAddress)
 		gasPrice, err := oracle.GetDAGasPrice(tests.Context(t))
 		require.NoError(t, err)
 		assert.Equal(t, l1BaseFee, gasPrice)
@@ -170,7 +170,7 @@ func TestDAPriceReader_ReadEcotoneGasPrice(t *testing.T) {
 			rpcElements[1].Result = &badData
 		}).Return(nil).Once()
 
-		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, config.ChainOptimismBedrock, oracleAddress)
+		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, chaintype.ChainOptimismBedrock, oracleAddress)
 		_, err := oracle.GetDAGasPrice(tests.Context(t))
 		assert.Error(t, err)
 	})
@@ -179,7 +179,7 @@ func TestDAPriceReader_ReadEcotoneGasPrice(t *testing.T) {
 		ethClient := setupIsEcotone(t, oracleAddress)
 		ethClient.On("BatchCallContext", mock.Anything, mock.IsType([]rpc.BatchElem{})).Return(fmt.Errorf("revert")).Once()
 
-		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, config.ChainOptimismBedrock, oracleAddress)
+		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, chaintype.ChainOptimismBedrock, oracleAddress)
 		_, err := oracle.GetDAGasPrice(tests.Context(t))
 		assert.Error(t, err)
 	})
@@ -193,7 +193,7 @@ func TestDAPriceReader_ReadEcotoneGasPrice(t *testing.T) {
 			rpcElements[1].Error = fmt.Errorf("revert")
 		}).Return(nil).Once()
 
-		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, config.ChainOptimismBedrock, oracleAddress)
+		oracle := newOpStackL1GasOracle(logger.Test(t), ethClient, chaintype.ChainOptimismBedrock, oracleAddress)
 		_, err := oracle.GetDAGasPrice(tests.Context(t))
 		assert.Error(t, err)
 	})

--- a/core/chains/evm/txmgr/config.go
+++ b/core/chains/evm/txmgr/config.go
@@ -5,9 +5,9 @@ import (
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	txmgrtypes "github.com/smartcontractkit/chainlink/v2/common/txmgr/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 )
 
 // ChainConfig encompasses config used by txmgr package
@@ -15,7 +15,7 @@ import (
 //
 //go:generate mockery --quiet --recursive --name ChainConfig --output ./mocks/ --case=underscore --structname Config --filename config.go
 type ChainConfig interface {
-	ChainType() config.ChainType
+	ChainType() chaintype.ChainType
 	FinalityDepth() uint32
 	FinalityTagEnabled() bool
 	NonceAutoSync() bool

--- a/core/chains/evm/txmgr/mocks/config.go
+++ b/core/chains/evm/txmgr/mocks/config.go
@@ -3,7 +3,7 @@
 package mocks
 
 import (
-	config "github.com/smartcontractkit/chainlink/v2/common/config"
+	chaintype "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -13,18 +13,18 @@ type Config struct {
 }
 
 // ChainType provides a mock function with given fields:
-func (_m *Config) ChainType() config.ChainType {
+func (_m *Config) ChainType() chaintype.ChainType {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for ChainType")
 	}
 
-	var r0 config.ChainType
-	if rf, ok := ret.Get(0).(func() config.ChainType); ok {
+	var r0 chaintype.ChainType
+	if rf, ok := ret.Get(0).(func() chaintype.ChainType); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(config.ChainType)
+		r0 = ret.Get(0).(chaintype.ChainType)
 	}
 
 	return r0

--- a/core/chains/evm/txmgr/stuck_tx_detector.go
+++ b/core/chains/evm/txmgr/stuck_tx_detector.go
@@ -14,11 +14,11 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	feetypes "github.com/smartcontractkit/chainlink/v2/common/fee/types"
 	"github.com/smartcontractkit/chainlink/v2/common/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/common/txmgr/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
 )
 
@@ -44,7 +44,7 @@ type stuckTxDetectorConfig interface {
 type stuckTxDetector struct {
 	lggr      logger.Logger
 	chainID   *big.Int
-	chainType config.ChainType
+	chainType chaintype.ChainType
 	maxPrice  *assets.Wei
 	cfg       stuckTxDetectorConfig
 
@@ -57,7 +57,7 @@ type stuckTxDetector struct {
 	purgeBlockNumMap  map[common.Address]int64 // Tracks the last block num a tx was purged for each from address if the PurgeOverflowTxs feature is enabled
 }
 
-func NewStuckTxDetector(lggr logger.Logger, chainID *big.Int, chainType config.ChainType, maxPrice *assets.Wei, cfg stuckTxDetectorConfig, gasEstimator stuckTxDetectorGasEstimator, txStore stuckTxDetectorTxStore, chainClient stuckTxDetectorClient) *stuckTxDetector {
+func NewStuckTxDetector(lggr logger.Logger, chainID *big.Int, chainType chaintype.ChainType, maxPrice *assets.Wei, cfg stuckTxDetectorConfig, gasEstimator stuckTxDetectorGasEstimator, txStore stuckTxDetectorTxStore, chainClient stuckTxDetectorClient) *stuckTxDetector {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.DisableCompression = true
 	httpClient := &http.Client{Transport: t}
@@ -124,9 +124,9 @@ func (d *stuckTxDetector) DetectStuckTransactions(ctx context.Context, enabledAd
 	}
 
 	switch d.chainType {
-	case config.ChainScroll:
+	case chaintype.ChainScroll:
 		return d.detectStuckTransactionsScroll(ctx, txs)
-	case config.ChainZkEvm:
+	case chaintype.ChainZkEvm:
 		return d.detectStuckTransactionsZkEVM(ctx, txs)
 	default:
 		return d.detectStuckTransactionsHeuristic(ctx, txs, blockNum)
@@ -365,7 +365,7 @@ func (d *stuckTxDetector) SetPurgeBlockNum(fromAddress common.Address, blockNum 
 func (d *stuckTxDetector) StuckTxFatalError() *string {
 	var errorMsg string
 	switch d.chainType {
-	case config.ChainScroll, config.ChainZkEvm:
+	case chaintype.ChainScroll, chaintype.ChainZkEvm:
 		errorMsg = "transaction skipped by chain"
 	default:
 		errorMsg = "transaction terminally stuck"

--- a/core/chains/evm/txmgr/stuck_tx_detector_test.go
+++ b/core/chains/evm/txmgr/stuck_tx_detector_test.go
@@ -18,10 +18,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
-	commonconfig "github.com/smartcontractkit/chainlink/v2/common/config"
 	txmgrcommon "github.com/smartcontractkit/chainlink/v2/common/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink/v2/common/txmgr/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
 	gasmocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/testutils"
@@ -271,7 +271,7 @@ func TestStuckTxDetector_DetectStuckTransactionsZkEVM(t *testing.T) {
 		enabled: true,
 	}
 	blockNum := int64(100)
-	stuckTxDetector := txmgr.NewStuckTxDetector(lggr, testutils.FixtureChainID, commonconfig.ChainZkEvm, assets.NewWei(assets.NewEth(100).ToInt()), autoPurgeCfg, feeEstimator, txStore, ethClient)
+	stuckTxDetector := txmgr.NewStuckTxDetector(lggr, testutils.FixtureChainID, chaintype.ChainZkEvm, assets.NewWei(assets.NewEth(100).ToInt()), autoPurgeCfg, feeEstimator, txStore, ethClient)
 	t.Run("returns empty list if no stuck transactions identified", func(t *testing.T) {
 		_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 		tx := mustInsertUnconfirmedTxWithBroadcastAttempts(t, txStore, 0, fromAddress, 1, blockNum, tenGwei)
@@ -354,7 +354,7 @@ func TestStuckTxDetector_DetectStuckTransactionsScroll(t *testing.T) {
 			enabled:         true,
 			detectionApiUrl: testUrl,
 		}
-		stuckTxDetector := txmgr.NewStuckTxDetector(lggr, testutils.FixtureChainID, commonconfig.ChainScroll, assets.NewWei(assets.NewEth(100).ToInt()), autoPurgeCfg, feeEstimator, txStore, ethClient)
+		stuckTxDetector := txmgr.NewStuckTxDetector(lggr, testutils.FixtureChainID, chaintype.ChainScroll, assets.NewWei(assets.NewEth(100).ToInt()), autoPurgeCfg, feeEstimator, txStore, ethClient)
 
 		txs, err := stuckTxDetector.DetectStuckTransactions(ctx, []common.Address{fromAddress1, fromAddress2}, blockNum)
 		require.NoError(t, err)

--- a/core/chains/evm/txmgr/test_helpers.go
+++ b/core/chains/evm/txmgr/test_helpers.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	commonconfig "github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 	evmconfig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 )
@@ -63,7 +63,7 @@ func (e *TestEvmConfig) NonceAutoSync() bool { return true }
 
 func (e *TestEvmConfig) FinalityDepth() uint32 { return 42 }
 
-func (e *TestEvmConfig) ChainType() commonconfig.ChainType { return "" }
+func (e *TestEvmConfig) ChainType() chaintype.ChainType { return "" }
 
 type TestGasEstimatorConfig struct {
 	bumpThreshold uint64
@@ -151,12 +151,12 @@ func (c *MockConfig) EVM() evmconfig.EVM {
 	return c.EvmConfig
 }
 
-func (c *MockConfig) NonceAutoSync() bool               { return true }
-func (c *MockConfig) ChainType() commonconfig.ChainType { return "" }
-func (c *MockConfig) FinalityDepth() uint32             { return c.finalityDepth }
-func (c *MockConfig) SetFinalityDepth(fd uint32)        { c.finalityDepth = fd }
-func (c *MockConfig) FinalityTagEnabled() bool          { return c.finalityTagEnabled }
-func (c *MockConfig) RPCDefaultBatchSize() uint32       { return c.RpcDefaultBatchSize }
+func (c *MockConfig) NonceAutoSync() bool            { return true }
+func (c *MockConfig) ChainType() chaintype.ChainType { return "" }
+func (c *MockConfig) FinalityDepth() uint32          { return c.finalityDepth }
+func (c *MockConfig) SetFinalityDepth(fd uint32)     { c.finalityDepth = fd }
+func (c *MockConfig) FinalityTagEnabled() bool       { return c.finalityTagEnabled }
+func (c *MockConfig) RPCDefaultBatchSize() uint32    { return c.RpcDefaultBatchSize }
 
 func MakeTestConfigs(t *testing.T) (*MockConfig, *TestDatabaseConfig, *TestEvmConfig) {
 	db := &TestDatabaseConfig{defaultQueryTimeout: utils.DefaultQueryTimeout}

--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -212,7 +212,7 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 	if !opts.AppConfig.EVMRPCEnabled() {
 		client = evmclient.NewNullClient(chainID, l)
 	} else if opts.GenEthClient == nil {
-		client = evmclient.NewEvmClient(cfg.EVM().NodePool(), cfg.EVM(), cfg.EVM().NodePool().Errors(), l, chainID, nodes)
+		client = evmclient.NewEvmClient(cfg.EVM().NodePool(), cfg.EVM(), cfg.EVM().NodePool().Errors(), l, chainID, nodes, cfg.EVM().ChainType())
 	} else {
 		client = opts.GenEthClient(chainID)
 	}

--- a/core/config/docs/docs_test.go
+++ b/core/config/docs/docs_test.go
@@ -15,8 +15,8 @@ import (
 	stkcfg "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/config"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
-	commonconfig "github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	evmcfg "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/config/docs"
@@ -47,7 +47,7 @@ func TestDoc(t *testing.T) {
 		fallbackDefaults := evmcfg.Defaults(nil)
 		docDefaults := defaults.EVM[0].Chain
 
-		require.Equal(t, commonconfig.ChainType(""), docDefaults.ChainType.ChainType())
+		require.Equal(t, chaintype.ChainType(""), docDefaults.ChainType.ChainType())
 		docDefaults.ChainType = nil
 
 		// clean up KeySpecific as a special case

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -26,9 +26,9 @@ import (
 	stkcfg "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/config"
 
 	"github.com/smartcontractkit/chainlink/v2/common/client"
-	commonconfig "github.com/smartcontractkit/chainlink/v2/common/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	evmcfg "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	ubig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils/big"
@@ -495,7 +495,7 @@ func TestConfig_Marshal(t *testing.T) {
 				},
 				BlockBackfillDepth:   ptr[uint32](100),
 				BlockBackfillSkip:    ptr(true),
-				ChainType:            commonconfig.NewChainTypeConfig("Optimism"),
+				ChainType:            chaintype.NewChainTypeConfig("Optimism"),
 				FinalityDepth:        ptr[uint32](42),
 				FinalityTagEnabled:   ptr[bool](false),
 				FlagsContractAddress: mustAddress("0xae4E781a6218A8031764928E88d457937A954fC3"),

--- a/core/services/ocr/contract_tracker.go
+++ b/core/services/ocr/contract_tracker.go
@@ -22,8 +22,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	httypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/log"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
@@ -217,7 +217,7 @@ func (t *OCRContractTracker) processLogs() {
 		select {
 		case <-t.configsMB.Notify():
 			// NOTE: libocr could take an arbitrary amount of time to process a
-			// new config. To avoid blocking the log broadcaster, we use this
+			// new chaintype. To avoid blocking the log broadcaster, we use this
 			// background thread to deliver them and a mailbox as the buffer.
 			for {
 				cc, exists := t.configsMB.Retrieve()
@@ -395,12 +395,12 @@ func (t *OCRContractTracker) ConfigFromLogs(ctx context.Context, changedInBlock 
 // LatestBlockHeight queries the eth node for the most recent header
 func (t *OCRContractTracker) LatestBlockHeight(ctx context.Context) (blockheight uint64, err error) {
 	switch t.cfg.ChainType() {
-	case config.ChainMetis:
+	case chaintype.ChainMetis:
 		// We skip confirmation checking anyway on these L2s so there's no need to
 		// care about the block height; we have no way of getting the L1 block
 		// height anyway
 		return 0, nil
-	case "", config.ChainArbitrum, config.ChainCelo, config.ChainGnosis, config.ChainKroma, config.ChainOptimismBedrock, config.ChainScroll, config.ChainWeMix, config.ChainXLayer, config.ChainZkEvm, config.ChainZkSync:
+	case "", chaintype.ChainArbitrum, chaintype.ChainCelo, chaintype.ChainGnosis, chaintype.ChainKroma, chaintype.ChainOptimismBedrock, chaintype.ChainScroll, chaintype.ChainWeMix, chaintype.ChainXLayer, chaintype.ChainZkEvm, chaintype.ChainZkSync:
 		// continue
 	}
 	latestBlockHeight := t.getLatestBlockHeight()

--- a/core/services/ocr/validate.go
+++ b/core/services/ocr/validate.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/smartcontractkit/libocr/offchainreporting"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	evmconfig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
 	coreconfig "github.com/smartcontractkit/chainlink/v2/core/config"
@@ -25,7 +25,7 @@ type GeneralConfig interface {
 }
 
 type ValidationConfig interface {
-	ChainType() config.ChainType
+	ChainType() chaintype.ChainType
 }
 
 type OCRValidationConfig interface {

--- a/core/services/ocrcommon/block_translator.go
+++ b/core/services/ocrcommon/block_translator.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -19,9 +19,9 @@ type BlockTranslator interface {
 // NewBlockTranslator returns the block translator for the given chain
 func NewBlockTranslator(cfg Config, client evmclient.Client, lggr logger.Logger) BlockTranslator {
 	switch cfg.ChainType() {
-	case config.ChainArbitrum:
+	case chaintype.ChainArbitrum:
 		return NewArbitrumBlockTranslator(client, lggr)
-	case "", config.ChainCelo, config.ChainGnosis, config.ChainKroma, config.ChainMetis, config.ChainOptimismBedrock, config.ChainScroll, config.ChainWeMix, config.ChainXLayer, config.ChainZkEvm, config.ChainZkSync:
+	case "", chaintype.ChainCelo, chaintype.ChainGnosis, chaintype.ChainKroma, chaintype.ChainMetis, chaintype.ChainOptimismBedrock, chaintype.ChainScroll, chaintype.ChainWeMix, chaintype.ChainXLayer, chaintype.ChainZkEvm, chaintype.ChainZkSync:
 		fallthrough
 	default:
 		return &l1BlockTranslator{}

--- a/core/services/ocrcommon/config.go
+++ b/core/services/ocrcommon/config.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/smartcontractkit/libocr/commontypes"
 
-	"github.com/smartcontractkit/chainlink/v2/common/config"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/chaintype"
 )
 
 type Config interface {
-	ChainType() config.ChainType
+	ChainType() chaintype.ChainType
 }
 
 func ParseBootstrapPeers(peers []string) (bootstrapPeers []commontypes.BootstrapperLocator, err error) {


### PR DESCRIPTION
Move chaintype configs from common to evm. `chaintype.go` needs to be moved in its own package because it gets imported both by `config` and `toml` packages and it can create cyclic references.