### PR TITLE
KS-311: allow 0x prefixed wf owner

### DIFF
--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -878,6 +878,7 @@ func (w *WorkflowSpec) Validate() error {
 		return fmt.Errorf("%w: incorrect length for id %s: expected %d, got %d", ErrInvalidWorkflowID, w.WorkflowID, workflowIDLen, len(w.WorkflowID))
 	}
 
+	w.WorkflowOwner = strings.TrimPrefix(w.WorkflowOwner, "0x")
 	_, err := hex.DecodeString(w.WorkflowOwner)
 	if err != nil {
 		return fmt.Errorf("%w: expected hex encoding got %s: %w", ErrInvalidWorkflowOwner, w.WorkflowOwner, err)

--- a/core/services/job/models_test.go
+++ b/core/services/job/models_test.go
@@ -294,7 +294,14 @@ func TestWorkflowSpec_Validate(t *testing.T) {
 				WorkflowName:  "ten bytes!",
 			},
 		},
-
+		{
+			name: "valid 0x prefix hex owner",
+			fields: fields{
+				WorkflowID:    "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef",
+				WorkflowOwner: "0x00000000000000000000000000000000000000ff",
+				WorkflowName:  "ten bytes!",
+			},
+		},
 		{
 			name: "not hex owner",
 			fields: fields{
@@ -304,7 +311,6 @@ func TestWorkflowSpec_Validate(t *testing.T) {
 			},
 			expectedErr: ErrInvalidWorkflowOwner,
 		},
-
 		{
 			name: "not len 40 owner",
 			fields: fields{
@@ -314,7 +320,6 @@ func TestWorkflowSpec_Validate(t *testing.T) {
 			},
 			expectedErr: ErrInvalidWorkflowOwner,
 		},
-
 		{
 			name: "not len 10 name",
 			fields: fields{


### PR DESCRIPTION
This was uncovered while testing with CLO. It's conventional to encode hex strings with the leading '0x' and this change make the UI similar to existing one