### PR TITLE
Handle reorgs in the provider - rework

### DIFF
--- a/.changeset/modern-ghosts-hang.md
+++ b/.changeset/modern-ghosts-hang.md
@@ -1,0 +1,4 @@
+---
+"chainlink": patch
+---
+Iterate over upkeeps using an upkeep selector #changed

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -1,7 +1,6 @@
 package logprovider
 
 import (
-	"math"
 	"math/big"
 	"sort"
 	"sync"
@@ -63,10 +62,6 @@ func (o *logBufferOptions) override(lookback, blockRate, logLimit uint32) {
 	o.windowLimit.Store(logLimit * 10)
 	o.lookback.Store(lookback)
 	o.blockRate.Store(blockRate)
-}
-
-func (o *logBufferOptions) windows() int {
-	return int(math.Ceil(float64(o.lookback.Load()) / float64(o.blockRate.Load())))
 }
 
 type logBuffer struct {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -26,7 +26,7 @@ type LogBuffer interface {
 	// It also accepts a function to select upkeeps.
 	// Returns logs (associated to upkeeps) and the number of remaining
 	// logs in that window for the involved upkeeps.
-	Dequeue(block int64, blockRate, upkeepLimit, maxResults int, upkeepSelector func(id *big.Int) bool) ([]BufferedLog, int)
+	Dequeue(start, end int64, upkeepLimit, maxResults int, upkeepSelector func(id *big.Int) bool) ([]BufferedLog, int)
 	// SetConfig sets the buffer size and the maximum number of logs to keep for each upkeep.
 	SetConfig(lookback, blockRate, logLimit uint32)
 	// NumOfUpkeeps returns the number of upkeeps that are being tracked by the buffer.
@@ -81,6 +81,7 @@ type logBuffer struct {
 	// map for then number of times we have enqueued logs for a block number
 	enqueuedBlocks    map[int64]map[string]int
 	enqueuedBlockLock sync.RWMutex
+	queueIDs          []string
 }
 
 func NewLogBuffer(lggr logger.Logger, lookback, blockRate, logLimit uint32) LogBuffer {
@@ -89,6 +90,7 @@ func NewLogBuffer(lggr logger.Logger, lookback, blockRate, logLimit uint32) LogB
 		opts:           newLogBufferOptions(lookback, blockRate, logLimit),
 		lastBlockSeen:  new(atomic.Int64),
 		enqueuedBlocks: map[int64]map[string]int{},
+		queueIDs:       []string{},
 		queues:         make(map[string]*upkeepLogQueue),
 	}
 }
@@ -167,11 +169,10 @@ func (b *logBuffer) trackBlockNumbersForUpkeep(uid *big.Int, uniqueBlocks map[in
 
 // Dequeue greedly pulls logs from the buffers.
 // Returns logs and the number of remaining logs in the buffer.
-func (b *logBuffer) Dequeue(block int64, blockRate, upkeepLimit, maxResults int, upkeepSelector func(id *big.Int) bool) ([]BufferedLog, int) {
+func (b *logBuffer) Dequeue(start, end int64, upkeepLimit, maxResults int, upkeepSelector func(id *big.Int) bool) ([]BufferedLog, int) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	start, end := getBlockWindow(block, blockRate)
 	return b.dequeue(start, end, upkeepLimit, maxResults, upkeepSelector)
 }
 
@@ -183,11 +184,14 @@ func (b *logBuffer) Dequeue(block int64, blockRate, upkeepLimit, maxResults int,
 func (b *logBuffer) dequeue(start, end int64, upkeepLimit, capacity int, upkeepSelector func(id *big.Int) bool) ([]BufferedLog, int) {
 	var result []BufferedLog
 	var remainingLogs int
-	for _, q := range b.queues {
+	var selectedUpkeeps int
+	numLogs := 0
+	for _, qid := range b.queueIDs {
+		q := b.queues[qid]
 		if !upkeepSelector(q.id) {
-			// if the upkeep is not selected, skip it
 			continue
 		}
+		selectedUpkeeps++
 		logsInRange := q.sizeOfRange(start, end)
 		if logsInRange == 0 {
 			// if there are no logs in the range, skip the upkeep
@@ -207,8 +211,10 @@ func (b *logBuffer) dequeue(start, end int64, upkeepLimit, capacity int, upkeepS
 			result = append(result, BufferedLog{ID: q.id, Log: l})
 			capacity--
 		}
+		numLogs += len(logs)
 		remainingLogs += remaining
 	}
+	b.lggr.Debugw("dequeued logs for upkeeps", "selectedUpkeeps", selectedUpkeeps, "numLogs", numLogs)
 	return result, remainingLogs
 }
 
@@ -230,12 +236,18 @@ func (b *logBuffer) SyncFilters(filterStore UpkeepFilterStore) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	for upkeepID := range b.queues {
+	for _, upkeepID := range b.queueIDs {
 		uid := new(big.Int)
 		_, ok := uid.SetString(upkeepID, 10)
 		if ok && !filterStore.Has(uid) {
 			// remove upkeep that is not in the filter store
 			delete(b.queues, upkeepID)
+			for i, v := range b.queueIDs {
+				if v == upkeepID {
+					b.queueIDs = append(b.queueIDs[:i], b.queueIDs[i+1:]...)
+					break
+				}
+			}
 		}
 	}
 
@@ -254,6 +266,16 @@ func (b *logBuffer) setUpkeepQueue(uid *big.Int, buf *upkeepLogQueue) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
+	found := false
+	for _, id := range b.queueIDs {
+		if id == uid.String() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		b.queueIDs = append(b.queueIDs, uid.String())
+	}
 	b.queues[uid.String()] = buf
 }
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/dequeue_coordinator.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/dequeue_coordinator.go
@@ -21,11 +21,7 @@ func (c *dequeueCoordinator) dequeueBlockWindow(start int64, latestBlock int64, 
 			return 0, 0, false
 		}
 
-		if hasDequeued, ok := c.dequeuedMinimum[startWindow]; ok {
-			if !hasDequeued {
-				return startWindow, end, true
-			}
-		} else {
+		if hasDequeued, ok := c.dequeuedMinimum[startWindow]; !ok || !hasDequeued {
 			return startWindow, end, true
 		}
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/dequeue_coordinator.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/dequeue_coordinator.go
@@ -1,0 +1,104 @@
+package logprovider
+
+import "math/big"
+
+type dequeueCoordinator struct {
+	dequeuedMinimum map[int64]bool
+	notReady        map[int64]bool
+	remainingLogs   map[int64]int
+	dequeuedLogs    map[int64]int
+	completeWindows map[int64]bool
+	dequeuedUpkeeps map[int64]map[string]int
+}
+
+func (c *dequeueCoordinator) dequeueBlockWindow(start int64, latestBlock int64, blockRate int) (int64, int64, bool) {
+	// check if minimum logs have been dequeued
+	for i := start; i <= latestBlock; i += int64(blockRate) {
+		startWindow, end := getBlockWindow(i, blockRate)
+		if latestBlock >= end {
+			c.completeWindows[startWindow] = true
+		} else if c.notReady[startWindow] { // the window is incomplete and has no logs to provide as of yet
+			return 0, 0, false
+		}
+
+		if hasDequeued, ok := c.dequeuedMinimum[startWindow]; ok {
+			if !hasDequeued {
+				return startWindow, end, true
+			}
+		} else {
+			return startWindow, end, true
+		}
+	}
+
+	// check best effort dequeue
+	for i := start; i < latestBlock; i += int64(blockRate) {
+		startWindow, end := getBlockWindow(i, blockRate)
+
+		if remainingLogs, ok := c.remainingLogs[startWindow]; ok {
+			if remainingLogs > 0 {
+				return startWindow, end, true
+			}
+		}
+	}
+
+	return 0, 0, false
+}
+
+// getUpkeepSelector returns a function that accepts an upkeep ID, and performs a modulus against the number of
+// iterations, and compares the result against the current iteration. When this comparison returns true, the
+// upkeep is selected for the dequeuing. This means that, for a given set of upkeeps, a different subset of
+// upkeeps will be dequeued for each iteration once only, and, across all iterations, all upkeeps will be
+// dequeued once.
+func (c *dequeueCoordinator) getUpkeepSelector(startWindow int64, logLimitLow, iterations, currentIteration int) func(id *big.Int) bool {
+	bestEffort := false
+
+	if hasDequeued, ok := c.dequeuedMinimum[startWindow]; ok {
+		if hasDequeued {
+			bestEffort = true
+		}
+	}
+
+	return func(id *big.Int) bool {
+		// query the map of block number to upkeep ID for dequeued count here when the block window is incomplete
+		dequeueUpkeep := true
+		if !bestEffort {
+			if windowUpkeeps, ok := c.dequeuedUpkeeps[startWindow]; ok {
+				if windowUpkeeps[id.String()] >= logLimitLow {
+					dequeueUpkeep = false
+				}
+			}
+		}
+		return dequeueUpkeep && id.Int64()%int64(iterations) == int64(currentIteration)
+	}
+}
+
+func (c *dequeueCoordinator) trackUpkeeps(startWindow int64, upkeepID *big.Int) {
+	if windowUpkeeps, ok := c.dequeuedUpkeeps[startWindow]; ok {
+		windowUpkeeps[upkeepID.String()] = windowUpkeeps[upkeepID.String()] + 1
+		c.dequeuedUpkeeps[startWindow] = windowUpkeeps
+	} else {
+		c.dequeuedUpkeeps[startWindow] = map[string]int{
+			upkeepID.String(): 1,
+		}
+	}
+}
+
+func (c *dequeueCoordinator) updateBlockWindow(startWindow int64, logs, remaining, numberOfUpkeeps, logLimitLow int) {
+	c.remainingLogs[startWindow] = remaining
+	c.dequeuedLogs[startWindow] += logs
+
+	if isComplete, ok := c.completeWindows[startWindow]; ok {
+		if isComplete {
+			// if the window is complete, and there are no more logs, then we have to consider this as min dequeued, even if no logs were dequeued
+			if c.remainingLogs[startWindow] == 0 || c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow {
+				c.dequeuedMinimum[startWindow] = true
+			}
+		} else if c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow { // this assumes we don't dequeue the same upkeeps more than logLimitLow in min commitment
+			c.dequeuedMinimum[startWindow] = true
+		}
+	} else if c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow { // this assumes we don't dequeue the same upkeeps more than logLimitLow in min commitment
+		c.dequeuedMinimum[startWindow] = true
+	} else if logs == 0 && remaining == 0 {
+		c.notReady[startWindow] = true
+	}
+}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/log.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/log.go
@@ -58,16 +58,23 @@ func logID(l logpoller.Log) string {
 }
 
 // blockStatistics returns the latest block number from the given logs, and a map of unique block numbers
-func blockStatistics(logs ...logpoller.Log) (int64, map[int64]bool) {
+func (b *logBuffer) blockStatistics(logs ...logpoller.Log) (int64, map[int64]bool, map[int64]bool) {
 	var latest int64
 	uniqueBlocks := map[int64]bool{}
+	reorgBlocks := map[int64]bool{}
 
 	for _, l := range logs {
 		if l.BlockNumber > latest {
 			latest = l.BlockNumber
 		}
 		uniqueBlocks[l.BlockNumber] = true
+		if hash, ok := b.blockHashes[l.BlockNumber]; ok {
+			if hash != l.BlockHash.String() {
+				reorgBlocks[l.BlockNumber] = true
+			}
+		}
+		b.blockHashes[l.BlockNumber] = l.BlockHash.String()
 	}
 
-	return latest, uniqueBlocks
+	return latest, uniqueBlocks, reorgBlocks
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -134,17 +134,18 @@ func newDequeueCoordinator() *dequeueCoordinator {
 }
 
 func NewLogProvider(lggr logger.Logger, poller logpoller.LogPoller, chainID *big.Int, packer LogDataPacker, filterStore UpkeepFilterStore, opts LogTriggersOptions) *logEventProvider {
+	dequeueCoordinator := newDequeueCoordinator()
 	return &logEventProvider{
 		threadCtrl:         utils.NewThreadControl(),
 		lggr:               lggr.Named("KeepersRegistry.LogEventProvider"),
 		packer:             packer,
 		buffer:             newLogEventBuffer(lggr, int(opts.LookbackBlocks), defaultNumOfLogUpkeeps, defaultFastExecLogsHigh),
-		bufferV1:           NewLogBuffer(lggr, uint32(opts.LookbackBlocks), opts.BlockRate, opts.LogLimit),
+		bufferV1:           NewLogBuffer(lggr, uint32(opts.LookbackBlocks), opts.BlockRate, opts.LogLimit, dequeueCoordinator),
 		poller:             poller,
 		opts:               opts,
 		filterStore:        filterStore,
 		chainID:            chainID,
-		dequeueCoordinator: newDequeueCoordinator(),
+		dequeueCoordinator: dequeueCoordinator,
 	}
 }
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -116,23 +116,21 @@ type logEventProvider struct {
 
 	chainID *big.Int
 
-	currentIteration    int
-	calculateIterations bool
-	iterations          int
+	currentIteration int
+	iterations       int
 }
 
 func NewLogProvider(lggr logger.Logger, poller logpoller.LogPoller, chainID *big.Int, packer LogDataPacker, filterStore UpkeepFilterStore, opts LogTriggersOptions) *logEventProvider {
 	return &logEventProvider{
-		threadCtrl:          utils.NewThreadControl(),
-		lggr:                lggr.Named("KeepersRegistry.LogEventProvider"),
-		packer:              packer,
-		buffer:              newLogEventBuffer(lggr, int(opts.LookbackBlocks), defaultNumOfLogUpkeeps, defaultFastExecLogsHigh),
-		bufferV1:            NewLogBuffer(lggr, uint32(opts.LookbackBlocks), opts.BlockRate, opts.LogLimit),
-		poller:              poller,
-		opts:                opts,
-		filterStore:         filterStore,
-		chainID:             chainID,
-		calculateIterations: true,
+		threadCtrl:  utils.NewThreadControl(),
+		lggr:        lggr.Named("KeepersRegistry.LogEventProvider"),
+		packer:      packer,
+		buffer:      newLogEventBuffer(lggr, int(opts.LookbackBlocks), defaultNumOfLogUpkeeps, defaultFastExecLogsHigh),
+		bufferV1:    NewLogBuffer(lggr, uint32(opts.LookbackBlocks), opts.BlockRate, opts.LogLimit),
+		poller:      poller,
+		opts:        opts,
+		filterStore: filterStore,
+		chainID:     chainID,
 	}
 }
 
@@ -297,11 +295,6 @@ func (p *logEventProvider) getLogsFromBuffer(latestBlock int64) []ocr2keepers.Up
 		blockRate, logLimitLow, maxResults, _ := p.getBufferDequeueArgs()
 
 		if p.iterations == p.currentIteration {
-			p.calculateIterations = true
-		}
-
-		if p.calculateIterations {
-			p.calculateIterations = false
 			p.currentIteration = 0
 			p.iterations = int(math.Ceil(float64(p.bufferV1.NumOfUpkeeps()*logLimitLow) / float64(maxResults)))
 			if p.iterations == 0 {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -171,9 +171,26 @@ func (c *dequeueCoordinator) dequeueBlockWindow(start int64, latestBlock int64, 
 	return 0, 0, false
 }
 
-func (c *dequeueCoordinator) getUpkeepSelector(startWindow int64, iterations, currentIteration int) func(id *big.Int) bool {
+func (c *dequeueCoordinator) getUpkeepSelector(startWindow int64, logLimitLow, iterations, currentIteration int) func(id *big.Int) bool {
+	bestEffort := false
+
+	if hasDequeued, ok := c.dequeuedMinimum[startWindow]; ok {
+		if hasDequeued {
+			bestEffort = true
+		}
+	}
+
 	return func(id *big.Int) bool {
-		return id.Int64()%int64(iterations) == int64(currentIteration)
+		// query the map of block number to upkeep ID for dequeued count here when the block window is incomplete
+		dequeueUpkeep := true
+		if !bestEffort {
+			if windowUpkeeps, ok := c.dequeuedUpkeeps[startWindow]; ok {
+				if windowUpkeeps[id.String()] >= logLimitLow {
+					dequeueUpkeep = false
+				}
+			}
+		}
+		return dequeueUpkeep && id.Int64()%int64(iterations) == int64(currentIteration)
 	}
 }
 
@@ -405,7 +422,7 @@ func (p *logEventProvider) getLogsFromBuffer(latestBlock int64) []ocr2keepers.Up
 				break
 			}
 
-			upkeepSelectorFn := p.dequeueCoordinator.getUpkeepSelector(startWindow, p.iterations, p.currentIteration)
+			upkeepSelectorFn := p.dequeueCoordinator.getUpkeepSelector(startWindow, logLimitLow, p.iterations, p.currentIteration)
 
 			logs, remaining := p.bufferV1.Dequeue(startWindow, end, logLimitLow, maxResults-len(payloads), upkeepSelectorFn)
 			if len(logs) > 0 {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -175,6 +175,11 @@ func (c *dequeueCoordinator) dequeueBlockWindow(start int64, latestBlock int64, 
 	return 0, 0, false
 }
 
+// getUpkeepSelector returns a function that accepts an upkeep ID, and performs a modulus against the number of
+// iterations, and compares the result against the current iteration. When this comparison returns true, the
+// upkeep is selected for the dequeuing. This means that, for a given set of upkeeps, a different subset of
+// upkeeps will be dequeued for each iteration once only, and, across all iterations, all upkeeps will be
+// dequeued once.
 func (c *dequeueCoordinator) getUpkeepSelector(startWindow int64, logLimitLow, iterations, currentIteration int) func(id *big.Int) bool {
 	bestEffort := false
 
@@ -416,11 +421,6 @@ func (p *logEventProvider) getLogsFromBuffer(latestBlock int64) []ocr2keepers.Up
 			}
 		}
 
-		// upkeepSelectorFn is a function that accepts an upkeep ID, and performs a modulus against the number of
-		// iterations, and compares the result against the current iteration. When this comparison returns true, the
-		// upkeep is selected for the dequeuing. This means that, for a given set of upkeeps, a different subset of
-		// upkeeps will be dequeued for each iteration once only, and, across all iterations, all upkeeps will be
-		// dequeued once.
 		for len(payloads) < maxResults {
 			startWindow, end, canDequeue := p.dequeueCoordinator.dequeueBlockWindow(start, latestBlock, blockRate)
 			if !canDequeue {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -215,10 +215,10 @@ func (c *dequeueCoordinator) updateBlockWindow(startWindow int64, logs, remainin
 			if c.remainingLogs[startWindow] == 0 || c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow {
 				c.dequeuedMinimum[startWindow] = true
 			}
-		} else if c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow {
+		} else if c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow { // this assumes we don't dequeue the same upkeeps more than logLimitLow in min commitment
 			c.dequeuedMinimum[startWindow] = true
 		}
-	} else if c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow {
+	} else if c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow { // this assumes we don't dequeue the same upkeeps more than logLimitLow in min commitment
 		c.dequeuedMinimum[startWindow] = true
 	}
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -133,107 +133,6 @@ func newDequeueCoordinator() *dequeueCoordinator {
 	}
 }
 
-type dequeueCoordinator struct {
-	dequeuedMinimum map[int64]bool
-	notReady        map[int64]bool
-	remainingLogs   map[int64]int
-	dequeuedLogs    map[int64]int
-	completeWindows map[int64]bool
-	dequeuedUpkeeps map[int64]map[string]int
-}
-
-func (c *dequeueCoordinator) dequeueBlockWindow(start int64, latestBlock int64, blockRate int) (int64, int64, bool) {
-	// check if minimum logs have been dequeued
-	for i := start; i <= latestBlock; i += int64(blockRate) {
-		startWindow, end := getBlockWindow(i, blockRate)
-		if latestBlock >= end {
-			c.completeWindows[startWindow] = true
-		} else if c.notReady[startWindow] { // the window is incomplete and has no logs to provide as of yet
-			return 0, 0, false
-		}
-
-		if hasDequeued, ok := c.dequeuedMinimum[startWindow]; ok {
-			if !hasDequeued {
-				return startWindow, end, true
-			}
-		} else {
-			return startWindow, end, true
-		}
-	}
-
-	// check best effort dequeue
-	for i := start; i < latestBlock; i += int64(blockRate) {
-		startWindow, end := getBlockWindow(i, blockRate)
-
-		if remainingLogs, ok := c.remainingLogs[startWindow]; ok {
-			if remainingLogs > 0 {
-				return startWindow, end, true
-			}
-		}
-	}
-
-	return 0, 0, false
-}
-
-// getUpkeepSelector returns a function that accepts an upkeep ID, and performs a modulus against the number of
-// iterations, and compares the result against the current iteration. When this comparison returns true, the
-// upkeep is selected for the dequeuing. This means that, for a given set of upkeeps, a different subset of
-// upkeeps will be dequeued for each iteration once only, and, across all iterations, all upkeeps will be
-// dequeued once.
-func (c *dequeueCoordinator) getUpkeepSelector(startWindow int64, logLimitLow, iterations, currentIteration int) func(id *big.Int) bool {
-	bestEffort := false
-
-	if hasDequeued, ok := c.dequeuedMinimum[startWindow]; ok {
-		if hasDequeued {
-			bestEffort = true
-		}
-	}
-
-	return func(id *big.Int) bool {
-		// query the map of block number to upkeep ID for dequeued count here when the block window is incomplete
-		dequeueUpkeep := true
-		if !bestEffort {
-			if windowUpkeeps, ok := c.dequeuedUpkeeps[startWindow]; ok {
-				if windowUpkeeps[id.String()] >= logLimitLow {
-					dequeueUpkeep = false
-				}
-			}
-		}
-		return dequeueUpkeep && id.Int64()%int64(iterations) == int64(currentIteration)
-	}
-}
-
-func (c *dequeueCoordinator) trackUpkeeps(startWindow int64, upkeepID *big.Int) {
-	if windowUpkeeps, ok := c.dequeuedUpkeeps[startWindow]; ok {
-		windowUpkeeps[upkeepID.String()] = windowUpkeeps[upkeepID.String()] + 1
-		c.dequeuedUpkeeps[startWindow] = windowUpkeeps
-	} else {
-		c.dequeuedUpkeeps[startWindow] = map[string]int{
-			upkeepID.String(): 1,
-		}
-	}
-}
-
-func (c *dequeueCoordinator) updateBlockWindow(startWindow int64, logs, remaining, numberOfUpkeeps, logLimitLow int) {
-	c.remainingLogs[startWindow] = remaining
-	c.dequeuedLogs[startWindow] += logs
-
-	if isComplete, ok := c.completeWindows[startWindow]; ok {
-		if isComplete {
-			// if the window is complete, and there are no more logs, then we have to consider this as min dequeued, even if no logs were dequeued
-			if c.remainingLogs[startWindow] == 0 || c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow {
-				c.dequeuedMinimum[startWindow] = true
-			}
-		} else if c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow { // this assumes we don't dequeue the same upkeeps more than logLimitLow in min commitment
-			c.dequeuedMinimum[startWindow] = true
-		}
-	} else if c.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow { // this assumes we don't dequeue the same upkeeps more than logLimitLow in min commitment
-		c.dequeuedMinimum[startWindow] = true
-	} else if logs == 0 && remaining == 0 {
-		c.notReady[startWindow] = true
-	}
-}
-
 func NewLogProvider(lggr logger.Logger, poller logpoller.LogPoller, chainID *big.Int, packer LogDataPacker, filterStore UpkeepFilterStore, opts LogTriggersOptions) *logEventProvider {
 	return &logEventProvider{
 		threadCtrl:         utils.NewThreadControl(),
@@ -442,7 +341,7 @@ func (p *logEventProvider) getLogsFromBuffer(latestBlock int64) []ocr2keepers.Up
 				}
 			}
 
-			p.dequeueCoordinator.updateBlockWindow(startWindow, len(logs), remaining, numUpkeeps, logLimitLow)
+			p.dequeueCoordinator.updateBlockWindow(startWindow, len(logs), remaining, numOfUpkeeps, logLimitLow)
 		}
 		p.currentIteration++
 	default:

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -1984,11 +1984,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 1000, countLogs(bufV1.queues["5"].logs))
 
 		for i := 0; i < 100; i++ {
-			payloads, err := provider.GetLatestPayloads(ctx)
+			latestPayloads, err := provider.GetLatestPayloads(ctx)
 			assert.NoError(t, err)
 
 			// we dequeue a maximum of 10 logs
-			assert.Equal(t, 10, len(payloads))
+			assert.Equal(t, 10, len(latestPayloads))
 		}
 
 		// the dequeue is evenly distributed across the 5 upkeeps

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -753,6 +753,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		// check that across all 300 upkeeps, we have only dequeued 700 of the 3000000 logs (7 dequeue calls of 100 logs)
 		assert.Equal(t, 2999300, remainingLogs)
 	})
+
+	// complete windows, dequeues min oldest to newest, then best effort oldest to newest
+	// complete window, no logs, dq min is true after
+	// incomplete window, dequeues but only considered minium dq when correct number of logs dequeued
+	// incomplete window, but with no logs, considered minium dq when window becomes complete
 }
 
 type mockedPacker struct {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -1356,7 +1356,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 935, len(bufV1.queues["5"].logs))
 
 		for i := 0; i < 467; i++ {
-			payloads, err = provider.GetLatestPayloads(ctx)
+			_, err = provider.GetLatestPayloads(ctx)
 			assert.NoError(t, err)
 		}
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -754,10 +754,1160 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 2999300, remainingLogs)
 	})
 
-	// complete windows, dequeues min oldest to newest, then best effort oldest to newest
-	// complete window, no logs, dq min is true after
-	// incomplete window, dequeues but only considered minium dq when correct number of logs dequeued
-	// incomplete window, but with no logs, considered minium dq when window becomes complete
+	t.Run("minimum guaranteed for all windows followed by best effort", func(t *testing.T) {
+		oldMaxPayloads := MaxPayloads
+		MaxPayloads = 10
+		defer func() {
+			MaxPayloads = oldMaxPayloads
+		}()
+
+		upkeepIDs := []*big.Int{
+			big.NewInt(1),
+			big.NewInt(2),
+			big.NewInt(3),
+			big.NewInt(4),
+			big.NewInt(5),
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 10; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		err := provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 10 logs * 100 blocks = 1000 logs
+		assert.Equal(t, 1000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 1000, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 1000, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 1000, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 1000, len(bufV1.queues["5"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 998, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 998, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 998, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 998, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 998, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts := map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the first block window
+		assert.Equal(t, 40, blockWindowCounts[1])
+		assert.Equal(t, 50, blockWindowCounts[2])
+		assert.Equal(t, 50, blockWindowCounts[3])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 996, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 996, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 996, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 996, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 996, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 40, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 50, blockWindowCounts[3])
+
+		for i := 0; i < 97; i++ {
+			payloads, err = provider.GetLatestPayloads(ctx)
+			assert.NoError(t, err)
+
+			// we dequeue a maximum of 10 logs
+			assert.Equal(t, 10, len(payloads))
+		}
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 802, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 802, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 802, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 802, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 802, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 40, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[99])
+		assert.Equal(t, 50, blockWindowCounts[100])
+
+		// at this point, all block windows except for the latest block window will have been dequeued
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 800, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 800, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 800, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 800, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 800, len(bufV1.queues["5"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 798, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 798, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 798, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 798, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 798, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 30, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 796, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 796, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 796, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 796, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 796, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 20, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 794, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 794, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 794, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 794, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 794, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 10, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 792, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 792, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 792, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 792, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 792, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 0, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 790, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 790, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 790, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 790, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 790, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 0, blockWindowCounts[1])
+		assert.Equal(t, 30, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[100])
+	})
+
+	t.Run("minimum guaranteed for all windows including an incomplete window followed by best effort", func(t *testing.T) {
+		oldMaxPayloads := MaxPayloads
+		MaxPayloads = 10
+		defer func() {
+			MaxPayloads = oldMaxPayloads
+		}()
+
+		upkeepIDs := []*big.Int{
+			big.NewInt(1),
+			big.NewInt(2),
+			big.NewInt(3),
+			big.NewInt(4),
+			big.NewInt(5),
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i <= end; i++ {
+				logsToAdd := 10
+				if i >= 100 {
+					logsToAdd = 1
+				}
+				for j := 0; j < logsToAdd; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i)),
+						BlockNumber: i,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 102, nil // make the latest window incomplete
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+		opts.BlockRate = 4 // block window will be 4 blocks big
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		err := provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
+
+		blockWindowCounts := map[int64]int{}
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the first block window
+		assert.Equal(t, 150, blockWindowCounts[0]) // block 0 is outside the block threshold of 1 and is not enqueued
+		assert.Equal(t, 200, blockWindowCounts[4])
+		assert.Equal(t, 200, blockWindowCounts[8])
+		assert.Equal(t, 15, blockWindowCounts[100]) // the block window starting at block 100 is only 3/4 complete as of block 102
+
+		// each upkeep should have 10 logs * 102 blocks = 1020 logs
+		assert.Equal(t, 993, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 993, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 993, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 993, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 993, len(bufV1.queues["5"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 991, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 991, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 991, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 991, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 991, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the first block window
+		assert.Equal(t, 140, blockWindowCounts[0])
+		assert.Equal(t, 200, blockWindowCounts[4])
+		assert.Equal(t, 200, blockWindowCounts[8])
+		assert.Equal(t, 15, blockWindowCounts[100]) // the block window starting at block 100 is only 3/4 complete as of block 102
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 989, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 989, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 989, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 989, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 989, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 140, blockWindowCounts[0])
+		assert.Equal(t, 190, blockWindowCounts[4])
+		assert.Equal(t, 200, blockWindowCounts[8])
+
+		for i := 0; i < 23; i++ {
+			payloads, err = provider.GetLatestPayloads(ctx)
+			assert.NoError(t, err)
+
+			// we dequeue a maximum of 10 logs
+			assert.Equal(t, 10, len(payloads))
+		}
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 943, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 943, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 943, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 943, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 943, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 140, blockWindowCounts[0])
+		assert.Equal(t, 190, blockWindowCounts[4])
+		assert.Equal(t, 190, blockWindowCounts[8])
+		assert.Equal(t, 190, blockWindowCounts[96])
+		assert.Equal(t, 15, blockWindowCounts[100]) // still not been dequeued at this point
+
+		// at this point, all block windows except for the latest block window will have been dequeued
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 941, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 941, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 941, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 941, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 941, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 140, blockWindowCounts[0])
+		assert.Equal(t, 190, blockWindowCounts[4])
+		assert.Equal(t, 190, blockWindowCounts[8])
+		assert.Equal(t, 190, blockWindowCounts[96])
+		assert.Equal(t, 5, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 939, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 939, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 939, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 939, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 939, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 130, blockWindowCounts[0])
+		assert.Equal(t, 190, blockWindowCounts[4])
+		assert.Equal(t, 190, blockWindowCounts[8])
+		assert.Equal(t, 190, blockWindowCounts[96])
+		assert.Equal(t, 5, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 937, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 937, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 937, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 937, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 937, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 120, blockWindowCounts[0]) // first block window is repeatedly dequeued as best effort
+		assert.Equal(t, 190, blockWindowCounts[4])
+		assert.Equal(t, 190, blockWindowCounts[8])
+		assert.Equal(t, 190, blockWindowCounts[96])
+		assert.Equal(t, 5, blockWindowCounts[100])
+
+		provider.poller = &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 103, nil // make the latest window incomplete
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 935, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 935, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 935, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 935, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 935, len(bufV1.queues["5"].logs))
+
+		for i := 0; i < 467; i++ {
+			payloads, err = provider.GetLatestPayloads(ctx)
+			assert.NoError(t, err)
+		}
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 0, blockWindowCounts[0]) // first block window is repeatedly dequeued as best effort
+		assert.Equal(t, 0, blockWindowCounts[4])
+		assert.Equal(t, 0, blockWindowCounts[8])
+		assert.Equal(t, 0, blockWindowCounts[96])
+		assert.Equal(t, 5, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 5, len(payloads))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 0, blockWindowCounts[0])
+		assert.Equal(t, 0, blockWindowCounts[4])
+		assert.Equal(t, 0, blockWindowCounts[8])
+		assert.Equal(t, 0, blockWindowCounts[96])
+		assert.Equal(t, 0, blockWindowCounts[100])
+
+	})
+
+	t.Run("a complete window with no logs present is immediately marked as having the min logs dequeued, logs are dequeued from the next window", func(t *testing.T) {
+		oldMaxPayloads := MaxPayloads
+		MaxPayloads = 10
+		defer func() {
+			MaxPayloads = oldMaxPayloads
+		}()
+
+		upkeepIDs := []*big.Int{
+			big.NewInt(1),
+			big.NewInt(2),
+			big.NewInt(3),
+			big.NewInt(4),
+			big.NewInt(5),
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start + 4; i <= end; i++ {
+				logsToAdd := 10
+				if i >= 100 {
+					logsToAdd = 1
+				}
+				for j := 0; j < logsToAdd; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i)),
+						BlockNumber: i,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 99, nil // make the latest window incomplete
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+		opts.BlockRate = 4 // block window will be 4 blocks big
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		err := provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		blockWindowCounts := map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the first block window
+		assert.Equal(t, 0, blockWindowCounts[0])
+		assert.Equal(t, 200, blockWindowCounts[4])
+		assert.Equal(t, 200, blockWindowCounts[8])
+		assert.Equal(t, 200, blockWindowCounts[96])
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 10, len(payloads))
+
+		// the first block window does not contain any logs, so it automatically gets marked as having the minimum dequeued
+		assert.True(t, true, provider.dequeueCoordinator.dequeuedMinimum[0])
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window
+		assert.Equal(t, 0, blockWindowCounts[0])
+		assert.Equal(t, 190, blockWindowCounts[4])
+		assert.Equal(t, 200, blockWindowCounts[8])
+		assert.Equal(t, 200, blockWindowCounts[96])
+	})
+
+	t.Run("an incomplete window with no logs present is marked as not ready then min dequeued when the window is complete", func(t *testing.T) {
+		oldMaxPayloads := MaxPayloads
+		MaxPayloads = 10
+		defer func() {
+			MaxPayloads = oldMaxPayloads
+		}()
+
+		upkeepIDs := []*big.Int{
+			big.NewInt(1),
+			big.NewInt(2),
+			big.NewInt(3),
+			big.NewInt(4),
+			big.NewInt(5),
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start + 4; i <= end; i++ {
+				logsToAdd := 10
+				if i >= 100 {
+					logsToAdd = 1
+				}
+				for j := 0; j < logsToAdd; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i)),
+						BlockNumber: i,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 2, nil // make the latest window incomplete
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+		opts.BlockRate = 4 // block window will be 4 blocks big
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		err := provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		blockWindowCounts := map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 0, blockWindowCounts[0])
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 0, len(payloads))
+
+		assert.Equal(t, false, provider.dequeueCoordinator.dequeuedMinimum[0])
+		assert.Equal(t, true, provider.dequeueCoordinator.notReady[0])
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window
+		assert.Equal(t, 0, blockWindowCounts[0])
+
+		provider.poller = &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 3, nil // make the latest window incomplete
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 0, len(payloads))
+
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[0]) // now that the window is complete, it should be marked as dequeued minimum
+		assert.Equal(t, true, provider.dequeueCoordinator.notReady[0])
+
+		provider.poller = &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 7, nil // make the latest window incomplete
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 10, len(payloads))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 0, blockWindowCounts[0])
+		assert.Equal(t, 190, blockWindowCounts[4])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 10, len(payloads))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 0, blockWindowCounts[0])
+		assert.Equal(t, 180, blockWindowCounts[4])
+
+		provider.poller = &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 11, nil // make the latest window incomplete
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 10, len(payloads))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 0, blockWindowCounts[0])
+		assert.Equal(t, 180, blockWindowCounts[4])
+		assert.Equal(t, 190, blockWindowCounts[8])
+
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[0])
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[4])
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[8])
+
+	})
+
+	t.Run("an incomplete window with minimum logs already present is marked as min dequeued", func(t *testing.T) {
+		oldMaxPayloads := MaxPayloads
+		MaxPayloads = 10
+		defer func() {
+			MaxPayloads = oldMaxPayloads
+		}()
+
+		upkeepIDs := []*big.Int{
+			big.NewInt(1),
+			big.NewInt(2),
+			big.NewInt(3),
+			big.NewInt(4),
+			big.NewInt(5),
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i <= end; i++ {
+				logsToAdd := 10
+				for j := 0; j < logsToAdd; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i)),
+						BlockNumber: i,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 2, nil // make the latest window incomplete
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+		opts.BlockRate = 4 // block window will be 4 blocks big
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		err := provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		blockWindowCounts := map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 100, blockWindowCounts[0]) // 100 logs because blocks 0, 1, 2 exist, 0 is omitted in enqueue, so blocks 1 and 2 have 10x5 logs each
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 10, len(payloads))
+
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[0])
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the first block window
+		assert.Equal(t, 90, blockWindowCounts[0])
+
+		logGenerator = func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start + 4; i <= end; i++ {
+				logsToAdd := 10
+				for j := 0; j < logsToAdd; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i)),
+						BlockNumber: i,
+					})
+				}
+			}
+			return res
+		}
+
+		provider.poller = &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 7, nil // make the latest window incomplete
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 10, len(payloads))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 90, blockWindowCounts[0])
+		assert.Equal(t, 190, blockWindowCounts[4])
+
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[0])
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[4])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 10, len(payloads))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 80, blockWindowCounts[0])
+		assert.Equal(t, 190, blockWindowCounts[4])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 10, len(payloads))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+
+				blockWindowCounts[startWindow]++
+			}
+		}
+
+		assert.Equal(t, 70, blockWindowCounts[0])
+		assert.Equal(t, 190, blockWindowCounts[4])
+	})
+
 }
 
 type mockedPacker struct {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -1396,7 +1396,6 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 0, blockWindowCounts[8])
 		assert.Equal(t, 0, blockWindowCounts[96])
 		assert.Equal(t, 0, blockWindowCounts[100])
-
 	})
 
 	t.Run("a complete window with no logs present is immediately marked as having the min logs dequeued, logs are dequeued from the next window", func(t *testing.T) {
@@ -1718,7 +1717,6 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[0])
 		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[4])
 		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[8])
-
 	})
 
 	t.Run("an incomplete window with minimum logs already present is marked as min dequeued", func(t *testing.T) {
@@ -1907,7 +1905,6 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 70, blockWindowCounts[0])
 		assert.Equal(t, 190, blockWindowCounts[4])
 	})
-
 }
 
 type mockedPacker struct {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -1984,11 +1984,8 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 1000, countLogs(bufV1.queues["5"].logs))
 
 		for i := 0; i < 100; i++ {
-			latestPayloads, err := provider.GetLatestPayloads(ctx)
+			_, err = provider.GetLatestPayloads(ctx)
 			assert.NoError(t, err)
-
-			// we dequeue a maximum of 10 logs
-			assert.Equal(t, 10, len(latestPayloads))
 		}
 
 		// the dequeue is evenly distributed across the 5 upkeeps

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -373,10 +373,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		ctx := context.Background()
 
-		_, err := provider.GetLatestPayloads(ctx)
-		assert.NoError(t, err)
-
-		err = provider.ReadLogs(ctx, upkeepIDs...)
+		err := provider.ReadLogs(ctx, upkeepIDs...)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
@@ -470,10 +467,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		ctx := context.Background()
 
-		_, err := provider.GetLatestPayloads(ctx)
-		assert.NoError(t, err)
-
-		err = provider.ReadLogs(ctx, upkeepIDs...)
+		err := provider.ReadLogs(ctx, upkeepIDs...)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 200, provider.bufferV1.NumOfUpkeeps())
@@ -597,10 +591,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		ctx := context.Background()
 
-		_, err := provider.GetLatestPayloads(ctx)
-		assert.NoError(t, err)
-
-		err = provider.ReadLogs(ctx, upkeepIDs...)
+		err := provider.ReadLogs(ctx, upkeepIDs...)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 200, provider.bufferV1.NumOfUpkeeps())

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -313,6 +315,453 @@ func newEntry(p *logEventProvider, i int, args ...string) (LogTriggerConfig, upk
 		topics:   topics,
 	}
 	return cfg, f
+}
+
+func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
+	t.Run("5 upkeeps, 100 logs per upkeep per block for 100 blocks", func(t *testing.T) {
+		upkeepIDs := []*big.Int{
+			big.NewInt(1),
+			big.NewInt(2),
+			big.NewInt(3),
+			big.NewInt(4),
+			big.NewInt(5),
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 100; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		_, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 100 logs * 100 blocks = 10000 logs
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["5"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 9980, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["5"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 9960, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["5"].logs))
+	})
+
+	t.Run("200 upkeeps", func(t *testing.T) {
+		var upkeepIDs []*big.Int
+
+		for i := int64(1); i <= 200; i++ {
+			upkeepIDs = append(upkeepIDs, big.NewInt(i))
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 100; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		_, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 200, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 100 logs * 100 blocks = 10000 logs
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.iterations)
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+	})
+
+	t.Run("200 upkeeps, increasing to 300 upkeeps midway through the test", func(t *testing.T) {
+		var upkeepIDs []*big.Int
+
+		for i := int64(1); i <= 200; i++ {
+			upkeepIDs = append(upkeepIDs, big.NewInt(i))
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 100; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		_, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 200, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 100 logs * 100 blocks = 10000 logs
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["9"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["21"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.iterations)
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; with 2 iterations this means even upkeep IDs are dequeued first
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["40"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["45"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; on the second iteration, odd upkeep IDs are dequeued
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["99"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["100"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; on the third iteration, even upkeep IDs are dequeued once again
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["160"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["170"].logs))
+
+		for i := int64(201); i <= 300; i++ {
+			upkeepIDs = append(upkeepIDs, big.NewInt(i))
+		}
+
+		for i := 200; i < len(upkeepIDs); i++ {
+			upkeepID := upkeepIDs[i]
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 300, provider.bufferV1.NumOfUpkeeps())
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.iterations)
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; the new iterations
+		// have not yet been recalculated despite the new logs being added; new iterations
+		// are only calculated when current iteration maxes out at the total number of iterations
+		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["51"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["52"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// with the newly added logs, iterations is recalculated
+		assert.Equal(t, 3, provider.iterations)
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["11"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["111"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 3, provider.iterations)
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9997, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["250"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["299"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["300"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 3, provider.iterations)
+		assert.Equal(t, 3, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		var remainingLogs int
+		// at this point, every queue should have had at least one log dequeued
+		for _, queue := range bufV1.queues {
+			assert.True(t, len(queue.logs) < 10000)
+			remainingLogs += len(queue.logs)
+		}
+
+		// check that across all 300 upkeeps, we have only dequeued 700 of the 3000000 logs (7 dequeue calls of 100 logs)
+		assert.Equal(t, 2999300, remainingLogs)
+	})
 }
 
 type mockedPacker struct {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -317,6 +317,14 @@ func newEntry(p *logEventProvider, i int, args ...string) (LogTriggerConfig, upk
 	return cfg, f
 }
 
+func countLogs(logs map[int64][]logpoller.Log) int {
+	count := 0
+	for _, logList := range logs {
+		count += len(logList)
+	}
+	return count
+}
+
 func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 	t.Run("5 upkeeps, 100 logs per upkeep per block for 100 blocks", func(t *testing.T) {
 		upkeepIDs := []*big.Int{
@@ -381,11 +389,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		bufV1 := provider.bufferV1.(*logBuffer)
 
 		// each upkeep should have 100 logs * 100 blocks = 10000 logs
-		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["5"].logs))
 
 		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -394,11 +402,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 9980, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9980, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 9980, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 9980, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 9980, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 9980, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9980, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 9980, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 9980, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 9980, countLogs(bufV1.queues["5"].logs))
 
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -407,11 +415,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 9960, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9960, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 9960, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 9960, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 9960, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 9960, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9960, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 9960, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 9960, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 9960, countLogs(bufV1.queues["5"].logs))
 	})
 
 	t.Run("200 upkeeps", func(t *testing.T) {
@@ -475,10 +483,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		bufV1 := provider.bufferV1.(*logBuffer)
 
 		// each upkeep should have 100 logs * 100 blocks = 10000 logs
-		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["150"].logs))
 
 		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -490,10 +498,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across selected upkeeps
-		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["150"].logs))
 
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -504,10 +512,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across selected upkeeps
-		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["150"].logs))
 
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -518,10 +526,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across selected upkeeps
-		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["150"].logs))
 
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -532,10 +540,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across selected upkeeps
-		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["150"].logs))
 	})
 
 	t.Run("200 upkeeps, increasing to 300 upkeeps midway through the test", func(t *testing.T) {
@@ -599,12 +607,12 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		bufV1 := provider.bufferV1.(*logBuffer)
 
 		// each upkeep should have 100 logs * 100 blocks = 10000 logs
-		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["9"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["21"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["9"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["21"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["150"].logs))
 
 		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -616,12 +624,12 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across selected upkeeps; with 2 iterations this means even upkeep IDs are dequeued first
-		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["40"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["45"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["40"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["45"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["150"].logs))
 
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -632,12 +640,12 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across selected upkeeps; on the second iteration, odd upkeep IDs are dequeued
-		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["99"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["100"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["99"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["100"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["150"].logs))
 
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -648,12 +656,12 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across selected upkeeps; on the third iteration, even upkeep IDs are dequeued once again
-		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["160"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["170"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["150"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["160"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["170"].logs))
 
 		for i := int64(201); i <= 300; i++ {
 			upkeepIDs = append(upkeepIDs, big.NewInt(i))
@@ -689,12 +697,12 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		// the dequeue is evenly distributed across selected upkeeps; the new iterations
 		// have not yet been recalculated despite the new logs being added; new iterations
 		// are only calculated when current iteration maxes out at the total number of iterations
-		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["51"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["52"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["51"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["52"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["150"].logs))
 
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -707,12 +715,12 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across selected upkeeps
-		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["11"].logs))
-		assert.Equal(t, 9997, len(bufV1.queues["111"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 9997, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["11"].logs))
+		assert.Equal(t, 9997, countLogs(bufV1.queues["111"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 9997, countLogs(bufV1.queues["150"].logs))
 
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -724,15 +732,15 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 100, len(payloads))
 
 		// the dequeue is evenly distributed across selected upkeeps
-		assert.Equal(t, 9997, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 9997, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
-		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
-		assert.Equal(t, 9997, len(bufV1.queues["150"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["250"].logs))
-		assert.Equal(t, 10000, len(bufV1.queues["299"].logs))
-		assert.Equal(t, 9999, len(bufV1.queues["300"].logs))
+		assert.Equal(t, 9997, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 9997, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, countLogs(bufV1.queues["101"].logs))
+		assert.Equal(t, 9997, countLogs(bufV1.queues["150"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["250"].logs))
+		assert.Equal(t, 10000, countLogs(bufV1.queues["299"].logs))
+		assert.Equal(t, 9999, countLogs(bufV1.queues["300"].logs))
 
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -746,8 +754,8 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		var remainingLogs int
 		// at this point, every queue should have had at least one log dequeued
 		for _, queue := range bufV1.queues {
-			assert.True(t, len(queue.logs) < 10000)
-			remainingLogs += len(queue.logs)
+			assert.True(t, countLogs(queue.logs) < 10000)
+			remainingLogs += countLogs(queue.logs)
 		}
 
 		// check that across all 300 upkeeps, we have only dequeued 700 of the 3000000 logs (7 dequeue calls of 100 logs)
@@ -823,11 +831,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		bufV1 := provider.bufferV1.(*logBuffer)
 
 		// each upkeep should have 10 logs * 100 blocks = 1000 logs
-		assert.Equal(t, 1000, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 1000, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 1000, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 1000, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 1000, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 1000, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 1000, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 1000, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 1000, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 1000, countLogs(bufV1.queues["5"].logs))
 
 		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -836,20 +844,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 998, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 998, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 998, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 998, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 998, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 998, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 998, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 998, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 998, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 998, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts := map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				blockWindowCounts[l.BlockNumber]++
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
 			}
 		}
-
 		// all 10 logs should have been dequeued from the first block window
 		assert.Equal(t, 40, blockWindowCounts[1])
 		assert.Equal(t, 50, blockWindowCounts[2])
@@ -862,17 +869,17 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 996, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 996, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 996, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 996, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 996, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 996, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 996, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 996, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 996, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 996, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				blockWindowCounts[l.BlockNumber]++
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
 			}
 		}
 
@@ -890,17 +897,17 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		}
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 802, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 802, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 802, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 802, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 802, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 802, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 802, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 802, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 802, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 802, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				blockWindowCounts[l.BlockNumber]++
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
 			}
 		}
 
@@ -919,11 +926,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 800, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 800, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 800, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 800, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 800, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 800, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 800, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 800, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 800, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 800, countLogs(bufV1.queues["5"].logs))
 
 		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -932,20 +939,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 798, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 798, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 798, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 798, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 798, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 798, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 798, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 798, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 798, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 798, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				blockWindowCounts[l.BlockNumber]++
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
 			}
 		}
-
 		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
 		assert.Equal(t, 30, blockWindowCounts[1])
 		assert.Equal(t, 40, blockWindowCounts[2])
@@ -959,20 +965,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 796, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 796, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 796, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 796, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 796, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 796, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 796, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 796, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 796, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 796, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				blockWindowCounts[l.BlockNumber]++
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
 			}
 		}
-
 		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
 		assert.Equal(t, 20, blockWindowCounts[1])
 		assert.Equal(t, 40, blockWindowCounts[2])
@@ -986,20 +991,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 794, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 794, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 794, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 794, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 794, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 794, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 794, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 794, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 794, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 794, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				blockWindowCounts[l.BlockNumber]++
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
 			}
 		}
-
 		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
 		assert.Equal(t, 10, blockWindowCounts[1])
 		assert.Equal(t, 40, blockWindowCounts[2])
@@ -1013,20 +1017,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 792, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 792, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 792, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 792, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 792, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 792, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 792, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 792, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 792, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 792, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				blockWindowCounts[l.BlockNumber]++
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
 			}
 		}
-
 		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
 		assert.Equal(t, 0, blockWindowCounts[1])
 		assert.Equal(t, 40, blockWindowCounts[2])
@@ -1040,20 +1043,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 790, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 790, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 790, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 790, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 790, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 790, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 790, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 790, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 790, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 790, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				blockWindowCounts[l.BlockNumber]++
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
 			}
 		}
-
 		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
 		assert.Equal(t, 0, blockWindowCounts[1])
 		assert.Equal(t, 30, blockWindowCounts[2])
@@ -1137,10 +1139,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		bufV1 := provider.bufferV1.(*logBuffer)
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1151,11 +1153,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 15, blockWindowCounts[100]) // the block window starting at block 100 is only 3/4 complete as of block 102
 
 		// each upkeep should have 10 logs * 102 blocks = 1020 logs
-		assert.Equal(t, 993, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 993, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 993, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 993, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 993, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 993, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 993, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 993, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 993, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 993, countLogs(bufV1.queues["5"].logs))
 
 		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
@@ -1164,19 +1166,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 991, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 991, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 991, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 991, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 991, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 991, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 991, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 991, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 991, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 991, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1193,19 +1195,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 989, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 989, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 989, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 989, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 989, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 989, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 989, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 989, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 989, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 989, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1223,19 +1225,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		}
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 943, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 943, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 943, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 943, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 943, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 943, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 943, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 943, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 943, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 943, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1253,19 +1255,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 941, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 941, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 941, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 941, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 941, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 941, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 941, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 941, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 941, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 941, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1282,19 +1284,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 939, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 939, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 939, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 939, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 939, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 939, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 939, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 939, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 939, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 939, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1311,19 +1313,19 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 937, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 937, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 937, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 937, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 937, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 937, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 937, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 937, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 937, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 937, countLogs(bufV1.queues["5"].logs))
 
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1349,11 +1351,11 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10, len(payloads))
 
 		// the dequeue is evenly distributed across the 5 upkeeps
-		assert.Equal(t, 935, len(bufV1.queues["1"].logs))
-		assert.Equal(t, 935, len(bufV1.queues["2"].logs))
-		assert.Equal(t, 935, len(bufV1.queues["3"].logs))
-		assert.Equal(t, 935, len(bufV1.queues["4"].logs))
-		assert.Equal(t, 935, len(bufV1.queues["5"].logs))
+		assert.Equal(t, 935, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 935, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 935, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 935, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 935, countLogs(bufV1.queues["5"].logs))
 
 		for i := 0; i < 467; i++ {
 			_, err = provider.GetLatestPayloads(ctx)
@@ -1363,10 +1365,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1384,10 +1386,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1474,10 +1476,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts := map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1498,10 +1500,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1588,10 +1590,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts := map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1608,10 +1610,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1655,10 +1657,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1673,10 +1675,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1703,10 +1705,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1792,10 +1794,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts := map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1811,10 +1813,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1856,10 +1858,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1877,10 +1879,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
@@ -1895,15 +1897,403 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		blockWindowCounts = map[int64]int{}
 
 		for _, q := range bufV1.queues {
-			for _, l := range q.logs {
-				startWindow, _ := getBlockWindow(l.BlockNumber, 4)
+			for blockNumber, logs := range q.logs {
+				startWindow, _ := getBlockWindow(blockNumber, 4)
 
-				blockWindowCounts[startWindow]++
+				blockWindowCounts[startWindow] += len(logs)
 			}
 		}
 
 		assert.Equal(t, 70, blockWindowCounts[0])
 		assert.Equal(t, 190, blockWindowCounts[4])
+	})
+
+	t.Run("min dequeue followed by best effort followed by reorg followed by best effort", func(t *testing.T) {
+		oldMaxPayloads := MaxPayloads
+		MaxPayloads = 10
+		defer func() {
+			MaxPayloads = oldMaxPayloads
+		}()
+
+		upkeepIDs := []*big.Int{
+			big.NewInt(1),
+			big.NewInt(2),
+			big.NewInt(3),
+			big.NewInt(4),
+			big.NewInt(5),
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 10; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		err := provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 10 logs * 100 blocks = 1000 logs
+		assert.Equal(t, 1000, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 1000, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 1000, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 1000, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 1000, countLogs(bufV1.queues["5"].logs))
+
+		for i := 0; i < 100; i++ {
+			payloads, err := provider.GetLatestPayloads(ctx)
+			assert.NoError(t, err)
+
+			// we dequeue a maximum of 10 logs
+			assert.Equal(t, 10, len(payloads))
+		}
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 800, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 800, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 800, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 800, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 800, countLogs(bufV1.queues["5"].logs))
+
+		blockWindowCounts := map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+		// min dequeue should have happened for all block windows
+		assert.Equal(t, 40, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[100])
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 798, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 798, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 798, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 798, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 798, countLogs(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+
+		// best effort dequeues first block window
+		assert.Equal(t, 30, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 796, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 796, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 796, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 796, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 796, countLogs(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+
+		// best effort dequeues first block window
+		assert.Equal(t, 20, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+
+		// reorg happens
+		logGenerator = func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				if i == 97 {
+					for j := 0; j < 10; j++ {
+						res = append(res, logpoller.Log{
+							LogIndex:    int64(j),
+							BlockHash:   common.HexToHash(fmt.Sprintf("%de", i+1)),
+							BlockNumber: i + 1,
+						})
+					}
+				} else {
+					for j := 0; j < 10; j++ {
+						res = append(res, logpoller.Log{
+							LogIndex:    int64(j),
+							BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+							BlockNumber: i + 1,
+						})
+					}
+				}
+			}
+			return res
+		}
+		// use a log poller that will create logs for the queried block range
+		provider.poller = &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 102, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+
+		assert.Equal(t, 20, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[98])
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+
+		assert.Equal(t, 20, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[97])
+		assert.Equal(t, 50, blockWindowCounts[98]) // reorg block window has had new logs added after reorg
+		assert.Equal(t, 40, blockWindowCounts[99])
+
+		assert.Equal(t, 818, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 818, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 818, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 818, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 818, countLogs(bufV1.queues["5"].logs))
+
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[1])
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[97])
+		assert.Equal(t, false, provider.dequeueCoordinator.dequeuedMinimum[98]) // this window has no min commitment met due to reorg
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[99])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[1])
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[97])
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[98]) // this window has had min commitment met following reorg
+		assert.Equal(t, true, provider.dequeueCoordinator.dequeuedMinimum[99])
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 816, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 816, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 816, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 816, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 816, countLogs(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+
+		assert.Equal(t, 20, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[98]) // this block window has had its min dequeue met following a reorg
+		assert.Equal(t, 50, blockWindowCounts[101])
+		assert.Equal(t, 50, blockWindowCounts[102])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 814, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 814, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 814, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 814, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 814, countLogs(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+
+		// best effort dequeues first block window
+		assert.Equal(t, 20, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[98])
+		assert.Equal(t, 40, blockWindowCounts[101])
+		assert.Equal(t, 50, blockWindowCounts[102])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 812, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 812, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 812, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 812, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 812, countLogs(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+
+		assert.Equal(t, 20, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[98])
+		assert.Equal(t, 40, blockWindowCounts[101])
+		assert.Equal(t, 40, blockWindowCounts[102]) // latest block window has now had min dequeue met
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 810, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 810, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 810, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 810, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 810, countLogs(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+
+		assert.Equal(t, 10, blockWindowCounts[1]) // best effort resumes on the first block window
+		assert.Equal(t, 40, blockWindowCounts[98])
+		assert.Equal(t, 40, blockWindowCounts[101])
+		assert.Equal(t, 40, blockWindowCounts[102])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 808, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 808, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 808, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 808, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 808, countLogs(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+
+		assert.Equal(t, 0, blockWindowCounts[1]) // best effort completes on the first block window
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[98])
+		assert.Equal(t, 40, blockWindowCounts[101])
+		assert.Equal(t, 40, blockWindowCounts[102])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 806, countLogs(bufV1.queues["1"].logs))
+		assert.Equal(t, 806, countLogs(bufV1.queues["2"].logs))
+		assert.Equal(t, 806, countLogs(bufV1.queues["3"].logs))
+		assert.Equal(t, 806, countLogs(bufV1.queues["4"].logs))
+		assert.Equal(t, 806, countLogs(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for blockNumber, logs := range q.logs {
+				blockWindowCounts[blockNumber] += len(logs)
+			}
+		}
+
+		assert.Equal(t, 0, blockWindowCounts[1])
+		assert.Equal(t, 30, blockWindowCounts[2]) // best effort continues on the second block window
+		assert.Equal(t, 40, blockWindowCounts[98])
+		assert.Equal(t, 40, blockWindowCounts[101])
+		assert.Equal(t, 40, blockWindowCounts[102])
 	})
 }
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
@@ -1187,10 +1187,15 @@ type mockFilterStore struct {
 	UpkeepFilterStore
 	HasFn               func(id *big.Int) bool
 	RangeFiltersByIDsFn func(iterator func(int, upkeepFilter), ids ...*big.Int)
+	UpdateFiltersFn     func(updater func(upkeepFilter, upkeepFilter) upkeepFilter, filters ...upkeepFilter)
 }
 
 func (s *mockFilterStore) RangeFiltersByIDs(iterator func(int, upkeepFilter), ids ...*big.Int) {
 	s.RangeFiltersByIDsFn(iterator, ids...)
+}
+
+func (s *mockFilterStore) UpdateFilters(updater func(upkeepFilter, upkeepFilter) upkeepFilter, filters ...upkeepFilter) {
+	s.UpdateFiltersFn(updater, filters...)
 }
 
 func (s *mockFilterStore) Has(id *big.Int) bool {


### PR DESCRIPTION
Use the dequeueCoordinator to mark block windows as having been reorg'd