### PR TITLE
.github: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!--- Does this work have a corresponding ticket? --> 
+
+https://smartcontract-it.atlassian.net/browse/...
+
+<!--- Does this work depend on other open PRs? -->
+
+Requires:
+- https://github.com/smartcontractkit/chainlink-common/pull/123456
+
+<!--- Does this work support other open PRs? -->
+
+Supports:
+- https://github.com/smartcontractkit/ccip/pull/456789


### PR DESCRIPTION
This PR proposes adding a Pull Request template to remind authors to link Jira tickets as well as any related PRs in other repos.