### PR TITLE
[TT-1267] test-base-image image being rebuilt when it already exists for tags

### DIFF
--- a/.github/actions/build-test-image/action.yml
+++ b/.github/actions/build-test-image/action.yml
@@ -73,7 +73,7 @@ runs:
       id: check-base-image
       uses: smartcontractkit/chainlink-github-actions/docker/image-exists@fc3e0df622521019f50d772726d6bf8dc919dd38 # v2.3.19
       with:
-        repository: ${{ inputs.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ inputs.QA_AWS_REGION }}.amazonaws.com/test-base-image
+        repository: test-base-image
         tag: ${{ steps.long_sha.outputs.long_sha }}
         AWS_REGION: ${{ inputs.QA_AWS_REGION }}
         AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
Fix an issue where the build-test-image action was showing a permission issue when checking if the test-base-image tag existed or not. We were not passing the correct repository name.
<!--- Does this work have a corresponding ticket? --> 

https://smartcontract-it.atlassian.net/browse/TT-1267