### PR TITLE
KS-318 move name, owner to yaml spec

### DIFF
--- a/.changeset/thick-moles-travel.md
+++ b/.changeset/thick-moles-travel.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal moves workflow name and owner to the yaml spec

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20240222010609-cd67d123c772
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20240222010609-cd67d123c772
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20240222010609-cd67d123c772
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20240222010609-cd67d123c772
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1212,8 +1212,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f h1:MfEG+nDHibAFFF1iirnF849YJT8ne+adVEf8p2fVze8=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8 h1:nzaMb3DNrck+DI/XZPCwJ4FZpyxf+X9mwCEL5eDS0mg=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1212,8 +1212,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105 h1:CVc+DiO5cwBn3ckddc5XO3lJ78tWPAH7nh7dhqsDx28=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2 h1:csNU1pZCfW5zLDl9DF/9a/17781xHTzS8l0VdcVEhIk=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1212,8 +1212,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2 h1:csNU1pZCfW5zLDl9DF/9a/17781xHTzS8l0VdcVEhIk=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb h1:R4OkRLPz6mZm8k7JFfLpQ9Ib/e1n1qcxg+hVxc0pKOk=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1212,8 +1212,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8 h1:nzaMb3DNrck+DI/XZPCwJ4FZpyxf+X9mwCEL5eDS0mg=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105 h1:CVc+DiO5cwBn3ckddc5XO3lJ78tWPAH7nh7dhqsDx28=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -1179,7 +1179,7 @@ func (s *service) generateJob(ctx context.Context, spec string) (*job.Job, error
 	case job.FluxMonitor:
 		js, err = fluxmonitorv2.ValidatedFluxMonitorSpec(s.jobCfg, spec)
 	case job.Workflow:
-		js, err = workflows.ValidatedWorkflowSpec(spec)
+		js, err = workflows.ValidatedWorkflowJobSpec(spec)
 	default:
 		return nil, errors.Errorf("unknown job type: %s", jobType)
 	}

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -652,37 +652,7 @@ func Test_Service_ProposeJob(t *testing.T) {
 		httpTimeout = *commonconfig.MustNewDuration(1 * time.Second)
 
 		// variables for workflow spec
-		wfID     = "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
-		wfOwner  = "00000000000000000000000000000000000000aa"
-		wfName   = "myworkflow" // len 10
-		specYaml = `
-triggers:
-  - id: "a-trigger@1.0.0"
-    config: {}
-
-actions:
-  - id: "an-action@1.0.0"
-    ref: "an-action"
-    config: {}
-    inputs:
-      trigger_output: $(trigger.outputs)
-
-consensus:
-  - id: "a-consensus@1.0.0"
-    ref: "a-consensus"
-    config: {}
-    inputs:
-      trigger_output: $(trigger.outputs)
-      an-action_output: $(an-action.outputs)
-
-targets:
-  - id: "a-target@1.0.0"
-    config: {}
-    ref: "a-target"
-    inputs: 
-      consensus_output: $(a-consensus.outputs)
-`
-		wfSpec              = testspecs.GenerateWorkflowSpec(wfID, wfOwner, wfName, specYaml).Toml()
+		wfJobSpec           = testspecs.DefaultWorkflowJobSpec(t)
 		proposalIDWF        = int64(11)
 		jobProposalSpecIdWF = int64(101)
 		jobIDWF             = int32(1001)
@@ -690,7 +660,7 @@ targets:
 		argsWF              = &feeds.ProposeJobArgs{
 			FeedsManagerID: 1,
 			RemoteUUID:     remoteUUIDWF,
-			Spec:           wfSpec,
+			Spec:           wfJobSpec.Toml(),
 			Version:        1,
 		}
 		jpWF = feeds.JobProposal{
@@ -707,14 +677,14 @@ targets:
 			Status:         feeds.JobProposalStatusPending,
 		}
 		proposalSpecWF = feeds.JobProposalSpec{
-			Definition:    wfSpec,
+			Definition:    wfJobSpec.Toml(),
 			Status:        feeds.SpecStatusPending,
 			Version:       1,
 			JobProposalID: proposalIDWF,
 		}
 		autoApprovableProposalSpecWF = feeds.JobProposalSpec{
 			ID:            jobProposalSpecIdWF,
-			Definition:    wfSpec,
+			Definition:    wfJobSpec.Toml(),
 			Status:        feeds.SpecStatusPending,
 			Version:       1,
 			JobProposalID: proposalIDWF,
@@ -755,7 +725,11 @@ targets:
 						mock.Anything,
 						mock.Anything,
 						mock.MatchedBy(func(j *job.Job) bool {
-							return j.WorkflowSpec.WorkflowOwner == wfOwner
+							match := j.WorkflowSpec.Workflow == wfJobSpec.Job().WorkflowSpec.Workflow
+							if !match {
+								t.Logf("got wf spec %s want %s", j.WorkflowSpec.Workflow, wfJobSpec.Job().WorkflowSpec.Workflow)
+							}
+							return match
 						}),
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
@@ -807,7 +781,11 @@ targets:
 						mock.Anything,
 						mock.Anything,
 						mock.MatchedBy(func(j *job.Job) bool {
-							return j.WorkflowSpec.WorkflowOwner == wfOwner
+							match := j.WorkflowSpec.Workflow == wfJobSpec.Job().WorkflowSpec.Workflow
+							if !match {
+								t.Logf("got wf spec %s want %s", j.WorkflowSpec.Workflow, wfJobSpec.Job().WorkflowSpec.Workflow)
+							}
+							return match
 						}),
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).
@@ -855,7 +833,11 @@ targets:
 						mock.Anything,
 						mock.Anything,
 						mock.MatchedBy(func(j *job.Job) bool {
-							return j.WorkflowSpec.WorkflowOwner == wfOwner
+							match := j.WorkflowSpec.Workflow == wfJobSpec.Job().WorkflowSpec.Workflow
+							if !match {
+								t.Logf("got wf spec %s want %s", j.WorkflowSpec.Workflow, wfJobSpec.Job().WorkflowSpec.Workflow)
+							}
+							return match
 						}),
 					).
 					Run(func(args mock.Arguments) { (args.Get(2).(*job.Job)).ID = 1 }).

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/jsonserializable"
+	pkgworkflows "github.com/smartcontractkit/chainlink-common/pkg/workflows"
 
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
@@ -1806,12 +1807,13 @@ func Test_CountPipelineRunsByJobID(t *testing.T) {
 }
 
 func Test_ORM_FindJobByWorkflow(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		ds sqlutil.DataSource
 	}
 	type args struct {
-		spec   job.WorkflowSpec
-		before func(t *testing.T, o job.ORM, s job.WorkflowSpec) int32
+		spec   *job.WorkflowSpec
+		before func(t *testing.T, o job.ORM, s *job.WorkflowSpec) int32
 	}
 	tests := []struct {
 		name    string
@@ -1819,6 +1821,7 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
+
 		{
 			name: "wf not job found",
 			fields: fields{
@@ -1826,28 +1829,23 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 			},
 			args: args{
 				// before is nil, so no job is inserted
-				spec: job.WorkflowSpec{
-					ID:            1,
-					WorkflowID:    "workflow 1",
-					Workflow:      "abcd",
-					WorkflowOwner: "me",
-					WorkflowName:  "myworkflow",
+				spec: &job.WorkflowSpec{
+					ID:       1,
+					Workflow: pkgworkflows.WFYamlSpec(t, "workflow00", "0x0123456789012345678901234567890123456789"),
 				},
 			},
 			wantErr: true,
 		},
+
 		{
 			name: "wf job found",
 			fields: fields{
 				ds: pgtest.NewSqlxDB(t),
 			},
 			args: args{
-				spec: job.WorkflowSpec{
-					ID:            1,
-					WorkflowID:    "workflow 2",
-					Workflow:      "anything",
-					WorkflowOwner: "me",
-					WorkflowName:  "myworkflow",
+				spec: &job.WorkflowSpec{
+					ID:       1,
+					Workflow: pkgworkflows.WFYamlSpec(t, "workflow01", "0x0123456789012345678901234567890123456789"),
 				},
 				before: mustInsertWFJob,
 			},
@@ -1860,16 +1858,15 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 				ds: pgtest.NewSqlxDB(t),
 			},
 			args: args{
-				spec: job.WorkflowSpec{
-					ID:            1,
-					WorkflowID:    "workflow 3",
-					Workflow:      "anything",
-					WorkflowOwner: "me",
-					WorkflowName:  "wf3",
+				spec: &job.WorkflowSpec{
+					ID:       1,
+					Workflow: pkgworkflows.WFYamlSpec(t, "workflow02", "0x0123456789012345678901234567890123456789"),
 				},
-				before: func(t *testing.T, o job.ORM, s job.WorkflowSpec) int32 {
-					s.WorkflowName = "notmyworkflow"
-					return mustInsertWFJob(t, o, s)
+				before: func(t *testing.T, o job.ORM, s *job.WorkflowSpec) int32 {
+					var c job.WorkflowSpec
+					c.ID = s.ID
+					c.Workflow = pkgworkflows.WFYamlSpec(t, "workflow99", "0x0123456789012345678901234567890123456789") // insert with name "workflow99" instead of "workflow02"
+					return mustInsertWFJob(t, o, &c)
 				},
 			},
 			wantErr: true,
@@ -1880,16 +1877,15 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 				ds: pgtest.NewSqlxDB(t),
 			},
 			args: args{
-				spec: job.WorkflowSpec{
-					ID:            1,
-					WorkflowID:    "workflow 4",
-					Workflow:      "anything",
-					WorkflowOwner: "me",
-					WorkflowName:  "wf4",
+				spec: &job.WorkflowSpec{
+					ID:       1,
+					Workflow: pkgworkflows.WFYamlSpec(t, "workflow03", "0x0123456789012345678901234567890123456789"),
 				},
-				before: func(t *testing.T, o job.ORM, s job.WorkflowSpec) int32 {
-					s.WorkflowOwner = "not me"
-					return mustInsertWFJob(t, o, s)
+				before: func(t *testing.T, o job.ORM, s *job.WorkflowSpec) int32 {
+					var c job.WorkflowSpec
+					c.ID = s.ID
+					c.Workflow = pkgworkflows.WFYamlSpec(t, "workflow03", "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd") // insert with owner "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd" instead of "0x0123456789012345678901234567890123456789"
+					return mustInsertWFJob(t, o, &c)
 				},
 			},
 			wantErr: true,
@@ -1907,7 +1903,7 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 				wantJobID = tt.args.before(t, o, tt.args.spec)
 			}
 			ctx := testutils.Context(t)
-			gotJ, err := o.FindJobIDByWorkflow(ctx, tt.args.spec)
+			gotJ, err := o.FindJobIDByWorkflow(ctx, *tt.args.spec)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("orm.FindJobByWorkflow() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1917,7 +1913,10 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 			}
 		})
 	}
+}
 
+func Test_ORM_FindJobByWorkflow_Multiple(t *testing.T) {
+	t.Parallel()
 	t.Run("multiple jobs", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
 		o := NewTestORM(t,
@@ -1928,29 +1927,24 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 			bridges.NewORM(db),
 			cltest.NewKeyStore(t, db))
 		ctx := testutils.Context(t)
+
+		wfYaml1 := pkgworkflows.WFYamlSpec(t, "workflow00", "0x0123456789012345678901234567890123456fff")
 		s1 := job.WorkflowSpec{
-			WorkflowID:    "workflowid",
-			Workflow:      "anything",
-			WorkflowOwner: "me",
-			WorkflowName:  "a_common_name",
+			Workflow: wfYaml1,
 		}
-		wantJobID1 := mustInsertWFJob(t, o, s1)
+		wantJobID1 := mustInsertWFJob(t, o, &s1)
 
+		wfYaml2 := pkgworkflows.WFYamlSpec(t, "workflow01", "0x0123456789012345678901234567890123456fff")
 		s2 := job.WorkflowSpec{
-			WorkflowID:    "another workflowid",
-			Workflow:      "anything",
-			WorkflowOwner: "me",
-			WorkflowName:  "another workflow name",
+			Workflow: wfYaml2,
 		}
-		wantJobID2 := mustInsertWFJob(t, o, s2)
+		wantJobID2 := mustInsertWFJob(t, o, &s2)
 
+		wfYaml3 := pkgworkflows.WFYamlSpec(t, "workflow00", "0xabababbaababbaaababaababababababaabbaaba")
 		s3 := job.WorkflowSpec{
-			WorkflowID:    "xworkflowid",
-			Workflow:      "anything",
-			WorkflowOwner: "someone else",
-			WorkflowName:  "a_common_name",
+			Workflow: wfYaml3,
 		}
-		wantJobID3 := mustInsertWFJob(t, o, s3)
+		wantJobID3 := mustInsertWFJob(t, o, &s3)
 
 		expectedIDs := []int32{wantJobID1, wantJobID2, wantJobID3}
 		for i, s := range []job.WorkflowSpec{s1, s2, s3} {
@@ -1969,20 +1963,23 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 	})
 }
 
-func mustInsertWFJob(t *testing.T, orm job.ORM, s job.WorkflowSpec) int32 {
+func mustInsertWFJob(t *testing.T, orm job.ORM, s *job.WorkflowSpec) int32 {
 	t.Helper()
+	err := s.Validate()
+	require.NoError(t, err, "failed to validate spec %v", s)
 	ctx := testutils.Context(t)
-	_, err := toml.Marshal(s.Workflow)
-	require.NoError(t, err)
+	_, err = toml.Marshal(s.Workflow)
+	require.NoError(t, err, "failed to TOML marshal workflow %v", s.Workflow)
 	j := job.Job{
 		Type:          job.Workflow,
-		WorkflowSpec:  &s,
+		WorkflowSpec:  s,
 		ExternalJobID: uuid.New(),
 		Name:          null.StringFrom(s.WorkflowOwner + "_" + s.WorkflowName),
 		SchemaVersion: 1,
 	}
+
 	err = orm.CreateJob(ctx, &j)
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to insert job with wf spec %v %s", s, s.Workflow)
 	return j.ID
 }
 

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -1807,6 +1807,8 @@ func Test_CountPipelineRunsByJobID(t *testing.T) {
 }
 
 func Test_ORM_FindJobByWorkflow(t *testing.T) {
+	var addr1 = "0x0123456789012345678901234567890123456789"
+	var addr2 = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
 	t.Parallel()
 	type fields struct {
 		ds sqlutil.DataSource
@@ -1831,7 +1833,7 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 				// before is nil, so no job is inserted
 				spec: &job.WorkflowSpec{
 					ID:       1,
-					Workflow: pkgworkflows.WFYamlSpec(t, "workflow00", "0x0123456789012345678901234567890123456789"),
+					Workflow: pkgworkflows.WFYamlSpec(t, "workflow00", addr1),
 				},
 			},
 			wantErr: true,
@@ -1845,7 +1847,7 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 			args: args{
 				spec: &job.WorkflowSpec{
 					ID:       1,
-					Workflow: pkgworkflows.WFYamlSpec(t, "workflow01", "0x0123456789012345678901234567890123456789"),
+					Workflow: pkgworkflows.WFYamlSpec(t, "workflow01", addr1),
 				},
 				before: mustInsertWFJob,
 			},
@@ -1860,12 +1862,12 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 			args: args{
 				spec: &job.WorkflowSpec{
 					ID:       1,
-					Workflow: pkgworkflows.WFYamlSpec(t, "workflow02", "0x0123456789012345678901234567890123456789"),
+					Workflow: pkgworkflows.WFYamlSpec(t, "workflow02", addr1),
 				},
 				before: func(t *testing.T, o job.ORM, s *job.WorkflowSpec) int32 {
 					var c job.WorkflowSpec
 					c.ID = s.ID
-					c.Workflow = pkgworkflows.WFYamlSpec(t, "workflow99", "0x0123456789012345678901234567890123456789") // insert with name "workflow99" instead of "workflow02"
+					c.Workflow = pkgworkflows.WFYamlSpec(t, "workflow99", addr1) // insert with mismatched name
 					return mustInsertWFJob(t, o, &c)
 				},
 			},
@@ -1879,12 +1881,12 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 			args: args{
 				spec: &job.WorkflowSpec{
 					ID:       1,
-					Workflow: pkgworkflows.WFYamlSpec(t, "workflow03", "0x0123456789012345678901234567890123456789"),
+					Workflow: pkgworkflows.WFYamlSpec(t, "workflow03", addr1),
 				},
 				before: func(t *testing.T, o job.ORM, s *job.WorkflowSpec) int32 {
 					var c job.WorkflowSpec
 					c.ID = s.ID
-					c.Workflow = pkgworkflows.WFYamlSpec(t, "workflow03", "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd") // insert with owner "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd" instead of "0x0123456789012345678901234567890123456789"
+					c.Workflow = pkgworkflows.WFYamlSpec(t, "workflow03", addr2) // insert with mismatched owner
 					return mustInsertWFJob(t, o, &c)
 				},
 			},
@@ -1916,6 +1918,8 @@ func Test_ORM_FindJobByWorkflow(t *testing.T) {
 }
 
 func Test_ORM_FindJobByWorkflow_Multiple(t *testing.T) {
+	var addr1 = "0x012345678901234567890123456789012345ffff"
+	var addr2 = "0xabcdefabcdefabcdefabcdefabcdefabcdef0000"
 	t.Parallel()
 	t.Run("multiple jobs", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
@@ -1928,19 +1932,19 @@ func Test_ORM_FindJobByWorkflow_Multiple(t *testing.T) {
 			cltest.NewKeyStore(t, db))
 		ctx := testutils.Context(t)
 
-		wfYaml1 := pkgworkflows.WFYamlSpec(t, "workflow00", "0x0123456789012345678901234567890123456fff")
+		wfYaml1 := pkgworkflows.WFYamlSpec(t, "workflow00", addr1)
 		s1 := job.WorkflowSpec{
 			Workflow: wfYaml1,
 		}
 		wantJobID1 := mustInsertWFJob(t, o, &s1)
 
-		wfYaml2 := pkgworkflows.WFYamlSpec(t, "workflow01", "0x0123456789012345678901234567890123456fff")
+		wfYaml2 := pkgworkflows.WFYamlSpec(t, "workflow01", addr1)
 		s2 := job.WorkflowSpec{
 			Workflow: wfYaml2,
 		}
 		wantJobID2 := mustInsertWFJob(t, o, &s2)
 
-		wfYaml3 := pkgworkflows.WFYamlSpec(t, "workflow00", "0xabababbaababbaaababaababababababaabbaaba")
+		wfYaml3 := pkgworkflows.WFYamlSpec(t, "workflow00", addr2)
 		s3 := job.WorkflowSpec{
 			Workflow: wfYaml3,
 		}

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -878,7 +878,7 @@ func (w *WorkflowSpec) Validate() error {
 	}
 	w.WorkflowOwner = strings.TrimPrefix(s.Owner, "0x") // the json schema validation ensures it is a hex string with 0x prefix, but the database does not store the prefix
 	w.WorkflowName = s.Name
-	w.WorkflowID = s.CID
+	w.WorkflowID = s.CID()
 
 	if len(w.WorkflowID) != workflowIDLen {
 		return fmt.Errorf("%w: incorrect length for id %s: expected %d, got %d", ErrInvalidWorkflowID, w.WorkflowID, workflowIDLen, len(w.WorkflowID))

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -414,7 +414,7 @@ func (o *orm) CreateJob(ctx context.Context, jb *Job) error {
 			RETURNING id;`
 			specID, err := tx.prepareQuerySpecID(ctx, sql, jb.WorkflowSpec)
 			if err != nil {
-				return errors.Wrap(err, "failed to create WorkflowSpec for jobSpec")
+				return fmt.Errorf("failed to create WorkflowSpec for jobSpec given %v: %w", *jb.WorkflowSpec, err)
 			}
 			jb.WorkflowSpecID = &specID
 		case StandardCapabilities:

--- a/core/services/workflows/delegate.go
+++ b/core/services/workflows/delegate.go
@@ -93,7 +93,7 @@ func NewDelegate(logger logger.Logger, registry core.CapabilitiesRegistry, store
 	return &Delegate{logger: logger, registry: registry, store: store, peerID: peerID}
 }
 
-func ValidatedWorkflowSpec(tomlString string) (job.Job, error) {
+func ValidatedWorkflowJobSpec(tomlString string) (job.Job, error) {
 	var jb = job.Job{ExternalJobID: uuid.New()}
 
 	tree, err := toml.Load(tomlString)

--- a/core/services/workflows/delegate_test.go
+++ b/core/services/workflows/delegate_test.go
@@ -11,93 +11,19 @@ import (
 
 func TestDelegate_JobSpecValidator(t *testing.T) {
 	t.Parallel()
-	validName := "ten bytes!"
 	var tt = []struct {
 		name           string
 		workflowTomlFn func() string
 		valid          bool
 	}{
-		{
-			"not a hex owner",
-			func() string {
-				workflowId := "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
-				workflowOwner := "00000000000000000000000000000000000000aZ"
-				return testspecs.GenerateWorkflowSpec(workflowId, workflowOwner, "1234567890", "").Toml()
-			},
-			false,
-		},
-		{
-			"missing workflow field",
-			func() string {
-				id := "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
-				owner := "00000000000000000000000000000000000000aa"
-				return testspecs.GenerateWorkflowSpec(id, owner, validName, "").Toml()
-			},
-			false,
-		},
-
-		{
-			"null workflow",
-			func() string {
-				id := "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
-				owner := "00000000000000000000000000000000000000aa"
-				return testspecs.GenerateWorkflowSpec(id, owner, validName, "{}").Toml()
-			},
-			false,
-		},
-
-		{
-			"missing name",
-			func() string {
-				id := "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
-				owner := "00000000000000000000000000000000000000aa"
-				wf := `
-triggers: []
-consensus: []
-targets: []
-`
-				return testspecs.GenerateWorkflowSpec(id, owner, "", wf).Toml()
-			},
-			false,
-		},
-
-		{
-			"minimal passing workflow",
-			func() string {
-				id := "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
-				owner := "00000000000000000000000000000000000000aa"
-				wf := `
-triggers: []
-consensus: []
-targets: []
-`
-				return testspecs.GenerateWorkflowSpec(id, owner, validName, wf).Toml()
-			},
-			true,
-		},
-
-		{
-			"name too long",
-			func() string {
-				id := "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
-				owner := "00000000000000000000000000000000000000aa"
-				wf := `
-triggers: []
-consensus: []
-targets: []
-`
-				return testspecs.GenerateWorkflowSpec(id, owner, validName+"1", wf).Toml()
-			},
-			false,
-		},
 
 		// Taken from jobs controller test, as we want to fail early without a db / slow test dependency
 		{
 			"valid full spec",
 			func() string {
-				id := "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
-				owner := "00000000000000000000000000000000000000aa"
 				workflow := `
+name: "ten bytes!"
+owner: "0x00000000000000000000000000000000000000aa"
 triggers:
   - id: "mercury-trigger@1.0.0"
     config:
@@ -144,7 +70,7 @@ targets:
       params: ["$(report)"]
       abi: "receive(report bytes)"
 `
-				return testspecs.GenerateWorkflowSpec(id, owner, validName, workflow).Toml()
+				return testspecs.GenerateWorkflowJobSpec(t, workflow).Toml()
 			},
 			true,
 		},
@@ -173,7 +99,7 @@ schemaVersion = 1
 	for _, tc := range tt {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := workflows.ValidatedWorkflowSpec(tc.workflowTomlFn())
+			_, err := workflows.ValidatedWorkflowJobSpec(tc.workflowTomlFn())
 			if tc.valid {
 				require.NoError(t, err)
 			} else {

--- a/core/services/workflows/delegate_test.go
+++ b/core/services/workflows/delegate_test.go
@@ -22,7 +22,7 @@ func TestDelegate_JobSpecValidator(t *testing.T) {
 			"valid full spec",
 			func() string {
 				workflow := `
-name: "ten bytes!"
+name: "wf-name"
 owner: "0x00000000000000000000000000000000000000aa"
 triggers:
   - id: "mercury-trigger@1.0.0"

--- a/core/testdata/testspecs/v2_specs.go
+++ b/core/testdata/testspecs/v2_specs.go
@@ -4,14 +4,19 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/test-go/testify/require"
 
+	pkgworkflows "github.com/smartcontractkit/chainlink-common/pkg/workflows"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/vrf/vrfcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/webhook"
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows"
 )
 
 var (
@@ -864,26 +869,72 @@ ds -> ds_parse -> ds_multiply;
 	return StreamSpec{StreamSpecParams: params, toml: toml}
 }
 
-type WorkflowSpec struct {
+// WorkflowJobSpec is a test helper that wraps both the TOML and job.Job representation of a workflow job spec
+type WorkflowJobSpec struct {
 	toml string
+	j    job.Job
 }
 
-func (w WorkflowSpec) Toml() string {
+func (w WorkflowJobSpec) Toml() string {
 	return w.toml
 }
 
-func GenerateWorkflowSpec(id, owner, name, spec string) WorkflowSpec {
+func (w WorkflowJobSpec) Job() job.Job {
+	return w.j
+}
+
+// GenerateWorkflowJobSpec creates a WorkflowJobSpec from the given workflow yaml spec string
+func GenerateWorkflowJobSpec(t *testing.T, spec string) WorkflowJobSpec {
+	t.Helper()
+	s, err := pkgworkflows.ParseWorkflowSpecYaml(spec)
+	require.NoError(t, err, "failed to parse YAML workflow spec %s", spec)
+	id := s.CID
 	template := `
 type = "workflow"
 schemaVersion = 1
 name = "test-spec"
 workflowId = "%s"
-workflowOwner = "%s"
-workflowName = "%s"
 workflow = """
 %s
 """
 `
-	toml := fmt.Sprintf(template, id, owner, name, spec)
-	return WorkflowSpec{toml: toml}
+
+	toml := fmt.Sprintf(template, id, spec)
+	j, err := workflows.ValidatedWorkflowJobSpec(toml)
+	require.NoError(t, err, "failed to validate TOML job spec for workflow %s", toml)
+	return WorkflowJobSpec{toml: toml, j: j}
 }
+
+func DefaultWorkflowJobSpec(t *testing.T) WorkflowJobSpec {
+	return GenerateWorkflowJobSpec(t, defaultWFYamlSpec)
+}
+
+var defaultWFYamlSpec = `
+name: "myworkflow"
+owner: "0x00000000000000000000000000000000000000aa"
+triggers:
+  - id: "a-trigger@1.0.0"
+    config: {}
+
+actions:
+  - id: "an-action@1.0.0"
+    ref: "an-action"
+    config: {}
+    inputs:
+      trigger_output: $(trigger.outputs)
+
+consensus:
+  - id: "a-consensus@1.0.0"
+    ref: "a-consensus"
+    config: {}
+    inputs:
+      trigger_output: $(trigger.outputs)
+      an-action_output: $(an-action.outputs)
+
+targets:
+  - id: "a-target@1.0.0"
+    config: {}
+    ref: "a-target"
+    inputs: 
+      consensus_output: $(a-consensus.outputs)
+`

--- a/core/web/jobs_controller.go
+++ b/core/web/jobs_controller.go
@@ -255,7 +255,7 @@ func (jc *JobsController) validateJobSpec(ctx context.Context, tomlString string
 	case job.Stream:
 		jb, err = streams.ValidatedStreamSpec(tomlString)
 	case job.Workflow:
-		jb, err = workflows.ValidatedWorkflowSpec(tomlString)
+		jb, err = workflows.ValidatedWorkflowJobSpec(tomlString)
 	case job.StandardCapabilities:
 		jb, err = standardcapabilities.ValidatedStandardCapabilitiesSpec(tomlString)
 

--- a/core/web/jobs_controller_test.go
+++ b/core/web/jobs_controller_test.go
@@ -392,9 +392,6 @@ func TestJobController_Create_HappyPath(t *testing.T) {
 		{
 			name: "workflow",
 			tomlTemplate: func(_ string) string {
-				id := "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
-				owner := "00000000000000000000000000000000000000aa"
-				name := "myworkflow" // 10 bytes
 				workflow := `
 triggers:
   - id: "mercury-trigger@1.0.0"
@@ -442,7 +439,7 @@ targets:
       params: ["$(report)"]
       abi: "receive(report bytes)"
 `
-				return testspecs.GenerateWorkflowSpec(id, owner, name, workflow).Toml()
+				return testspecs.GenerateWorkflowJobSpec(t, workflow).Toml()
 			},
 			assertion: func(t *testing.T, nameAndExternalJobID string, r *http.Response) {
 				require.Equal(t, http.StatusOK, r.StatusCode)

--- a/core/web/presenters/job_test.go
+++ b/core/web/presenters/job_test.go
@@ -868,11 +868,11 @@ func TestJob(t *testing.T) {
 			job: job.Job{
 				ID: 1,
 				WorkflowSpec: &job.WorkflowSpec{
-					ID: 3,
-					//WorkflowID:    "<test-workflow-id>",
-					Workflow: `<test-workflow-spec>`,
-					//		WorkflowOwner: "<test-workflow-owner>",
-					//		WorkflowName:  "<test-workflow-name>",
+					ID:            3,
+					WorkflowID:    "<test-workflow-id>",
+					Workflow:      `<test-workflow-spec>`,
+					WorkflowOwner: "<test-workflow-owner>",
+					WorkflowName:  "<test-workflow-name>",
 				},
 				PipelineSpec: &pipeline.Spec{
 					ID:           1,

--- a/core/web/presenters/job_test.go
+++ b/core/web/presenters/job_test.go
@@ -868,11 +868,11 @@ func TestJob(t *testing.T) {
 			job: job.Job{
 				ID: 1,
 				WorkflowSpec: &job.WorkflowSpec{
-					ID:            3,
-					WorkflowID:    "<test-workflow-id>",
-					Workflow:      `<test-workflow-spec>`,
-					WorkflowOwner: "<test-workflow-owner>",
-					WorkflowName:  "<test-workflow-name>",
+					ID: 3,
+					//WorkflowID:    "<test-workflow-id>",
+					Workflow: `<test-workflow-spec>`,
+					//		WorkflowOwner: "<test-workflow-owner>",
+					//		WorkflowName:  "<test-workflow-name>",
 				},
 				PipelineSpec: &pipeline.Spec{
 					ID:           1,

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -1060,7 +1060,7 @@ func (r *Resolver) CreateJob(ctx context.Context, args struct {
 	case job.Gateway:
 		jb, err = gateway.ValidatedGatewaySpec(args.Input.TOML)
 	case job.Workflow:
-		jb, err = workflows.ValidatedWorkflowSpec(args.Input.TOML)
+		jb, err = workflows.ValidatedWorkflowJobSpec(args.Input.TOML)
 	case job.StandardCapabilities:
 		jb, err = standardcapabilities.ValidatedStandardCapabilitiesSpec(args.Input.TOML)
 	default:

--- a/core/web/resolver/spec_test.go
+++ b/core/web/resolver/spec_test.go
@@ -1008,9 +1008,9 @@ func TestResolver_WorkflowSpec(t *testing.T) {
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.Workflow,
 					WorkflowSpec: &job.WorkflowSpec{
-						ID: id,
-						//WorkflowID: "<test workflow id>",
-						Workflow: "<test workflow spec>",
+						ID:         id,
+						WorkflowID: "<test workflow id>",
+						Workflow:   "<test workflow spec>",
 					},
 				}, nil)
 			},

--- a/core/web/resolver/spec_test.go
+++ b/core/web/resolver/spec_test.go
@@ -1008,9 +1008,9 @@ func TestResolver_WorkflowSpec(t *testing.T) {
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.Workflow,
 					WorkflowSpec: &job.WorkflowSpec{
-						ID:         id,
-						WorkflowID: "<test workflow id>",
-						Workflow:   "<test workflow spec>",
+						ID: id,
+						//WorkflowID: "<test workflow id>",
+						Workflow: "<test workflow spec>",
 					},
 				}, nil)
 			},

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917
@@ -113,7 +113,6 @@ require (
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/guregu/null.v4 v4.0.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
-	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -333,6 +332,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	gopkg.in/guregu/null.v2 v2.1.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	pgregory.net/rapid v0.5.5 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240522213638-159fb2d99917
@@ -85,6 +85,7 @@ require (
 	github.com/smartcontractkit/wsrpc v0.8.1
 	github.com/spf13/cast v1.6.0
 	github.com/stretchr/testify v1.9.0
+	github.com/test-go/testify v1.1.4
 	github.com/theodesp/go-heaps v0.0.0-20190520121037-88e35354fe0a
 	github.com/tidwall/gjson v1.17.0
 	github.com/ugorji/go/codec v1.2.12
@@ -112,6 +113,7 @@ require (
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/guregu/null.v4 v4.0.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -297,7 +299,6 @@ require (
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect
 	github.com/teris-io/shortid v0.0.0-20201117134242-e59966efd125 // indirect
-	github.com/test-go/testify v1.1.4 // indirect
 	github.com/tidwall/btree v1.6.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
@@ -332,7 +333,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	gopkg.in/guregu/null.v2 v2.1.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	pgregory.net/rapid v0.5.5 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1171,8 +1171,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f h1:MfEG+nDHibAFFF1iirnF849YJT8ne+adVEf8p2fVze8=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8 h1:nzaMb3DNrck+DI/XZPCwJ4FZpyxf+X9mwCEL5eDS0mg=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/go.sum
+++ b/go.sum
@@ -1171,8 +1171,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2 h1:csNU1pZCfW5zLDl9DF/9a/17781xHTzS8l0VdcVEhIk=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb h1:R4OkRLPz6mZm8k7JFfLpQ9Ib/e1n1qcxg+hVxc0pKOk=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/go.sum
+++ b/go.sum
@@ -1171,8 +1171,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8 h1:nzaMb3DNrck+DI/XZPCwJ4FZpyxf+X9mwCEL5eDS0mg=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105 h1:CVc+DiO5cwBn3ckddc5XO3lJ78tWPAH7nh7dhqsDx28=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/go.sum
+++ b/go.sum
@@ -1171,8 +1171,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105 h1:CVc+DiO5cwBn3ckddc5XO3lJ78tWPAH7nh7dhqsDx28=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2 h1:csNU1pZCfW5zLDl9DF/9a/17781xHTzS8l0VdcVEhIk=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105
 	github.com/smartcontractkit/chainlink-testing-framework v1.30.4
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f
-	github.com/smartcontractkit/chainlink-testing-framework v1.30.5
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8
+	github.com/smartcontractkit/chainlink-testing-framework v1.30.4
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2
 	github.com/smartcontractkit/chainlink-testing-framework v1.30.4
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb
 	github.com/smartcontractkit/chainlink-testing-framework v1.30.4
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1512,8 +1512,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105 h1:CVc+DiO5cwBn3ckddc5XO3lJ78tWPAH7nh7dhqsDx28=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2 h1:csNU1pZCfW5zLDl9DF/9a/17781xHTzS8l0VdcVEhIk=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1512,8 +1512,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f h1:MfEG+nDHibAFFF1iirnF849YJT8ne+adVEf8p2fVze8=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8 h1:nzaMb3DNrck+DI/XZPCwJ4FZpyxf+X9mwCEL5eDS0mg=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=
@@ -1524,8 +1524,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240605170242-555ff582f36
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240605170242-555ff582f36a/go.mod h1:QqcZSwLgEIn7YraAIRmomnBMAuVFephiHrIWVlkWbFI=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240531021326-99118e47f696 h1:h1E87+z+JcUEfvbJVF56SnZA/YUFE5ewUE61MaR/Ewg=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240531021326-99118e47f696/go.mod h1:OiWUTrrpSLLTMh7FINWjEh6mmDJCVPaC4yEsDCVaWdU=
-github.com/smartcontractkit/chainlink-testing-framework v1.30.5 h1:RBeQkaUH095L/hOH6JbfScAo4jkI0osBp8kgULnGwos=
-github.com/smartcontractkit/chainlink-testing-framework v1.30.5/go.mod h1:E6uNEZhZZid9PHv6/Kq5Vn63GlO61ZcKB+/f0DKo3Q4=
+github.com/smartcontractkit/chainlink-testing-framework v1.30.4 h1:kf6zRL6v5D047gynYNNqXGl9QBvnQSa4LMs1iHLRu64=
+github.com/smartcontractkit/chainlink-testing-framework v1.30.4/go.mod h1:E6uNEZhZZid9PHv6/Kq5Vn63GlO61ZcKB+/f0DKo3Q4=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240328204215-ac91f55f1449 h1:fX/xmGm1GBsD1ZZnooNT+eWA0hiTAqFlHzOC5CY4dy8=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240328204215-ac91f55f1449/go.mod h1:DC8sQMyTlI/44UCTL8QWFwb0bYNoXCfjwCv2hMivYZU=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1512,8 +1512,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2 h1:csNU1pZCfW5zLDl9DF/9a/17781xHTzS8l0VdcVEhIk=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb h1:R4OkRLPz6mZm8k7JFfLpQ9Ib/e1n1qcxg+hVxc0pKOk=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1512,8 +1512,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8 h1:nzaMb3DNrck+DI/XZPCwJ4FZpyxf+X9mwCEL5eDS0mg=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105 h1:CVc+DiO5cwBn3ckddc5XO3lJ78tWPAH7nh7dhqsDx28=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f
-	github.com/smartcontractkit/chainlink-testing-framework v1.30.5
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8
+	github.com/smartcontractkit/chainlink-testing-framework v1.30.4
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105
 	github.com/smartcontractkit/chainlink-testing-framework v1.30.4
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2
 	github.com/smartcontractkit/chainlink-testing-framework v1.30.4
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb
 	github.com/smartcontractkit/chainlink-testing-framework v1.30.4
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1502,8 +1502,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8 h1:nzaMb3DNrck+DI/XZPCwJ4FZpyxf+X9mwCEL5eDS0mg=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105 h1:CVc+DiO5cwBn3ckddc5XO3lJ78tWPAH7nh7dhqsDx28=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1502,8 +1502,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f h1:MfEG+nDHibAFFF1iirnF849YJT8ne+adVEf8p2fVze8=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612013352-4fe4a2e2ed0f/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8 h1:nzaMb3DNrck+DI/XZPCwJ4FZpyxf+X9mwCEL5eDS0mg=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612025115-ee301a93dee8/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=
@@ -1514,8 +1514,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240605170242-555ff582f36
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240605170242-555ff582f36a/go.mod h1:QqcZSwLgEIn7YraAIRmomnBMAuVFephiHrIWVlkWbFI=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240531021326-99118e47f696 h1:h1E87+z+JcUEfvbJVF56SnZA/YUFE5ewUE61MaR/Ewg=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240531021326-99118e47f696/go.mod h1:OiWUTrrpSLLTMh7FINWjEh6mmDJCVPaC4yEsDCVaWdU=
-github.com/smartcontractkit/chainlink-testing-framework v1.30.5 h1:RBeQkaUH095L/hOH6JbfScAo4jkI0osBp8kgULnGwos=
-github.com/smartcontractkit/chainlink-testing-framework v1.30.5/go.mod h1:E6uNEZhZZid9PHv6/Kq5Vn63GlO61ZcKB+/f0DKo3Q4=
+github.com/smartcontractkit/chainlink-testing-framework v1.30.4 h1:kf6zRL6v5D047gynYNNqXGl9QBvnQSa4LMs1iHLRu64=
+github.com/smartcontractkit/chainlink-testing-framework v1.30.4/go.mod h1:E6uNEZhZZid9PHv6/Kq5Vn63GlO61ZcKB+/f0DKo3Q4=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240328204215-ac91f55f1449 h1:fX/xmGm1GBsD1ZZnooNT+eWA0hiTAqFlHzOC5CY4dy8=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240328204215-ac91f55f1449/go.mod h1:DC8sQMyTlI/44UCTL8QWFwb0bYNoXCfjwCv2hMivYZU=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1502,8 +1502,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2 h1:csNU1pZCfW5zLDl9DF/9a/17781xHTzS8l0VdcVEhIk=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb h1:R4OkRLPz6mZm8k7JFfLpQ9Ib/e1n1qcxg+hVxc0pKOk=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613201342-a855825f87bb/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1502,8 +1502,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105 h1:CVc+DiO5cwBn3ckddc5XO3lJ78tWPAH7nh7dhqsDx28=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240612174909-5ce871a28105/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2 h1:csNU1pZCfW5zLDl9DF/9a/17781xHTzS8l0VdcVEhIk=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240613164412-8b7ca61015e2/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d h1:5tgMC5Gi2UAOKZ+m28W8ubjLeR0pQCAcrz6eQ0rW510=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240524214833-c362c2ebbd2d/go.mod h1:0UNuO3nDt9MFsZPaHJBEUolxVkN0iC69j1ccDp95e8k=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket? --> 

https://smartcontract-it.atlassian.net/browse/KS-318

<!--- Does this work depend on other open PRs? -->

Requires:
- https://github.com/smartcontractkit/chainlink-common/pull/578

In conjunction with:
- https://github.com/smartcontractkit/feeds-manager/pull/3359

<!--- Does this work support other open PRs? -->

The key change is that Job Spec TOML now only needs the embedded WF YAML spec. The name, owner, and content hash are derived and do not need to be duplicated.

After this is merged, we will need to update the job specs to move the name and owner into the YAML and remove WorkflowID, WorkflowName, and WorkflowOwner from the job spec TOML

