### PR TITLE
ks-327 remote target wait for initiated threads to finish on close

### DIFF
--- a/.changeset/sour-pigs-develop.md
+++ b/.changeset/sour-pigs-develop.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal remote target wait until initiated threads exit on close

--- a/core/capabilities/remote/target/client_test.go
+++ b/core/capabilities/remote/target/client_test.go
@@ -152,7 +152,7 @@ func testClient(ctx context.Context, t *testing.T, numWorkflowPeers int, workflo
 		ID:      "workflow-don",
 	}
 
-	broker := newTestMessageBroker()
+	broker := newTestAsyncMessageBroker(100)
 
 	receivers := make([]remotetypes.Receiver, numCapabilityPeers)
 	for i := 0; i < numCapabilityPeers; i++ {
@@ -171,6 +171,8 @@ func testClient(ctx context.Context, t *testing.T, numWorkflowPeers int, workflo
 		broker.RegisterReceiverNode(workflowPeers[i], caller)
 		callers[i] = caller
 	}
+
+	servicetest.Run(t, broker)
 
 	executeInputs, err := values.NewMap(
 		map[string]any{

--- a/core/capabilities/remote/target/endtoend_test.go
+++ b/core/capabilities/remote/target/endtoend_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/target"
@@ -214,7 +215,7 @@ func testRemoteTarget(ctx context.Context, t *testing.T, underlying commoncap.Ta
 		F:       workflowDonF,
 	}
 
-	broker := newTestMessageBroker()
+	broker := newTestAsyncMessageBroker(1000)
 
 	workflowDONs := map[string]commoncap.DON{
 		workflowDonInfo.ID: workflowDonInfo,
@@ -239,6 +240,8 @@ func testRemoteTarget(ctx context.Context, t *testing.T, underlying commoncap.Ta
 		broker.RegisterReceiverNode(workflowPeers[i], workflowNode)
 		workflowNodes[i] = workflowNode
 	}
+
+	servicetest.Run(t, broker)
 
 	executeInputs, err := values.NewMap(
 		map[string]any{
@@ -271,49 +274,97 @@ func testRemoteTarget(ctx context.Context, t *testing.T, underlying commoncap.Ta
 	wg.Wait()
 }
 
-type testMessageBroker struct {
+type testAsyncMessageBroker struct {
+	services.StateMachine
 	nodes map[p2ptypes.PeerID]remotetypes.Receiver
+
+	sendCh chan *remotetypes.MessageBody
+
+	stopCh services.StopChan
+	wg     sync.WaitGroup
 }
 
-func newTestMessageBroker() *testMessageBroker {
-	return &testMessageBroker{
-		nodes: make(map[p2ptypes.PeerID]remotetypes.Receiver),
+func (a *testAsyncMessageBroker) HealthReport() map[string]error {
+	return nil
+}
+
+func (a *testAsyncMessageBroker) Name() string {
+	return "testAsyncMessageBroker"
+}
+
+func newTestAsyncMessageBroker(sendChBufferSize int) *testAsyncMessageBroker {
+	return &testAsyncMessageBroker{
+		nodes:  make(map[p2ptypes.PeerID]remotetypes.Receiver),
+		stopCh: make(services.StopChan),
+		sendCh: make(chan *remotetypes.MessageBody, sendChBufferSize),
 	}
 }
 
-func (r *testMessageBroker) NewDispatcherForNode(nodePeerID p2ptypes.PeerID) remotetypes.Dispatcher {
+func (a *testAsyncMessageBroker) Start(ctx context.Context) error {
+	return a.StartOnce("testAsyncMessageBroker", func() error {
+		a.wg.Add(1)
+		go func() {
+			defer a.wg.Done()
+
+			for {
+				select {
+				case <-a.stopCh:
+					return
+				case msg := <-a.sendCh:
+					receiverId := toPeerID(msg.Receiver)
+
+					receiver, ok := a.nodes[receiverId]
+					if !ok {
+						panic("server not found for peer id")
+					}
+
+					receiver.Receive(msg)
+				}
+			}
+		}()
+		return nil
+	})
+}
+
+func (a *testAsyncMessageBroker) Close() error {
+	return a.StopOnce("testAsyncMessageBroker", func() error {
+		close(a.stopCh)
+
+		a.wg.Wait()
+		return nil
+	})
+}
+
+func (a *testAsyncMessageBroker) NewDispatcherForNode(nodePeerID p2ptypes.PeerID) remotetypes.Dispatcher {
 	return &nodeDispatcher{
 		callerPeerID: nodePeerID,
-		broker:       r,
+		broker:       a,
 	}
 }
 
-func (r *testMessageBroker) RegisterReceiverNode(nodePeerID p2ptypes.PeerID, node remotetypes.Receiver) {
-	if _, ok := r.nodes[nodePeerID]; ok {
+func (a *testAsyncMessageBroker) RegisterReceiverNode(nodePeerID p2ptypes.PeerID, node remotetypes.Receiver) {
+	if _, ok := a.nodes[nodePeerID]; ok {
 		panic("node already registered")
 	}
 
-	r.nodes[nodePeerID] = node
+	a.nodes[nodePeerID] = node
 }
 
-func (r *testMessageBroker) Send(msg *remotetypes.MessageBody) {
-	receiverId := toPeerID(msg.Receiver)
-
-	receiver, ok := r.nodes[receiverId]
-	if !ok {
-		panic("server not found for peer id")
-	}
-
-	receiver.Receive(msg)
+func (a *testAsyncMessageBroker) Send(msg *remotetypes.MessageBody) {
+	a.sendCh <- msg
 }
 
 func toPeerID(id []byte) p2ptypes.PeerID {
 	return [32]byte(id)
 }
 
+type broker interface {
+	Send(msg *remotetypes.MessageBody)
+}
+
 type nodeDispatcher struct {
 	callerPeerID p2ptypes.PeerID
-	broker       *testMessageBroker
+	broker       broker
 }
 
 func (t *nodeDispatcher) Send(peerID p2ptypes.PeerID, msgBody *remotetypes.MessageBody) error {

--- a/core/capabilities/remote/target/request/client_request_test.go
+++ b/core/capabilities/remote/target/request/client_request_test.go
@@ -2,6 +2,7 @@ package request_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -101,6 +102,8 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
 		request, err := request.NewClientRequest(ctx, lggr, capabilityRequest, messageID, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute)
+		defer request.Cancel(errors.New("test end"))
+
 		require.NoError(t, err)
 
 		capabilityResponse2 := commoncap.CapabilityResponse{
@@ -142,6 +145,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		request, err := request.NewClientRequest(ctx, lggr, capabilityRequest, messageID, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute)
 		require.NoError(t, err)
+		defer request.Cancel(errors.New("test end"))
 
 		msg.Sender = capabilityPeers[0][:]
 		err = request.OnMessage(ctx, msg)
@@ -167,6 +171,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		request, err := request.NewClientRequest(ctx, lggr, capabilityRequest, messageID, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute)
 		require.NoError(t, err)
+		defer request.Cancel(errors.New("test end"))
 
 		msg.Sender = capabilityPeers[0][:]
 		err = request.OnMessage(ctx, msg)
@@ -189,6 +194,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		request, err := request.NewClientRequest(ctx, lggr, capabilityRequest, messageID, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute)
 		require.NoError(t, err)
+		defer request.Cancel(errors.New("test end"))
 
 		<-dispatcher.msgs
 		<-dispatcher.msgs
@@ -226,6 +232,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		request, err := request.NewClientRequest(ctx, lggr, capabilityRequest, messageID, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute)
 		require.NoError(t, err)
+		defer request.Cancel(errors.New("test end"))
 
 		<-dispatcher.msgs
 		<-dispatcher.msgs
@@ -275,6 +282,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		request, err := request.NewClientRequest(ctx, lggr, capabilityRequest, messageID, capInfo,
 			workflowDonInfo, dispatcher, 10*time.Minute)
 		require.NoError(t, err)
+		defer request.Cancel(errors.New("test end"))
 
 		<-dispatcher.msgs
 		<-dispatcher.msgs

--- a/core/capabilities/remote/target/server.go
+++ b/core/capabilities/remote/target/server.go
@@ -106,8 +106,7 @@ func (r *server) expireRequests() {
 	}
 }
 
-// Receive handles incoming messages from remote nodes and dispatches them to the corresponding request without blocking
-// the client.
+// Receive handles incoming messages from remote nodes and dispatches them to the corresponding request.
 func (r *server) Receive(msg *types.MessageBody) {
 	r.receiveLock.Lock()
 	defer r.receiveLock.Unlock()
@@ -136,16 +135,13 @@ func (r *server) Receive(msg *types.MessageBody) {
 
 	req := r.requestIDToRequest[requestID]
 
-	r.wg.Add(1)
-	go func() {
-		defer r.wg.Done()
-		ctx, cancel := r.stopCh.NewCtx()
-		defer cancel()
-		err := req.OnMessage(ctx, msg)
-		if err != nil {
-			r.lggr.Errorw("request failed to OnMessage new message", "request", req, "err", err)
-		}
-	}()
+	// TODO context should be received from the dispatcher here - pending KS-296
+	ctx, cancel := r.stopCh.NewCtx()
+	defer cancel()
+	err := req.OnMessage(ctx, msg)
+	if err != nil {
+		r.lggr.Errorw("request failed to OnMessage new message", "request", req, "err", err)
+	}
 }
 
 func GetMessageID(msg *types.MessageBody) string {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/KS-327

Simplified the client and server Receive methods to be blocking as not required to be non-blocking once the dispatcher is changed to be multithreaded as part of-> https://smartcontract-it.atlassian.net/browse/KS-296
