### PR TITLE
revert gomods

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -27,8 +27,12 @@ gomod: ## Ensure chainlink's go dependencies are installed.
 	go mod download
 
 .PHONY: gomodtidy
-gomodtidy: gomods ## Run go mod tidy on all modules.
-	gomods tidy
+gomodtidy: ## Run go mod tidy on all modules.
+	go mod tidy
+	cd ./core/scripts && go mod tidy
+	cd ./integration-tests && go mod tidy
+	cd ./integration-tests/load && go mod tidy
+	cd ./dashboard-lib && go mod tidy
 
 .PHONY: docs
 docs: ## Install and run pkgsite to view Go docs
@@ -85,8 +89,12 @@ abigen: ## Build & install abigen.
 	./tools/bin/build_abigen
 
 .PHONY: generate
-generate: gomods abigen codecgen mockery protoc ## Execute all go:generate commands.
-	gomods -w go generate -x ./...
+generate: abigen codecgen mockery protoc ## Execute all go:generate commands.
+	go generate -x ./...
+	cd ./core/scripts && go generate -x ./...
+	cd ./integration-tests && go generate -x ./...
+	cd ./integration-tests/load && go generate -x ./...
+	cd ./dashboard-lib && go generate -x ./...
 
 .PHONY: testscripts
 testscripts: chainlink-test ## Install and run testscript against testdata/scripts/* files.


### PR DESCRIPTION
There is still an edge case bug when a `go.mod` file is dirty, for example if you drop in a hash intending for tidy to clean it up for you. We cannot use `go list -json` or `modfile.Parse` to read the file in that case.