### PR TITLE
Add OCR soak tests with blockchain reorg 

### DIFF
--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -146,7 +146,17 @@ test_node_migrations_simulated_verbose:
 .PHONY: test_soak_ocr
 test_soak_ocr:
 	. ./scripts/check_base64_env_var.sh
-	go test -v -count=1 -run TestOCRSoak ./soak
+	go test -v -count=1 -run ^TestOCRSoak$$ ./soak
+
+.PHONY: test_soak_ocr_reorg_1
+test_soak_ocr_reorg_1:
+	. ./scripts/check_base64_env_var.sh
+	go test -v -count=1 -run ^TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled$$ ./soak	
+
+.PHONY: test_soak_ocr_reorg_2
+test_soak_ocr_reorg_2:
+	. ./scripts/check_base64_env_var.sh
+	go test -v -count=1 -run ^TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled$$ ./soak	
 
 .PHONY: test_soak_forwarder_ocr
 test_soak_forwarder_ocr:

--- a/integration-tests/soak/ocr_test.go
+++ b/integration-tests/soak/ocr_test.go
@@ -10,11 +10,9 @@ import (
 	actions_seth "github.com/smartcontractkit/chainlink/integration-tests/actions/seth"
 	tc "github.com/smartcontractkit/chainlink/integration-tests/testconfig"
 	"github.com/smartcontractkit/chainlink/integration-tests/testsetups"
-	"github.com/smartcontractkit/chainlink/integration-tests/utils"
 )
 
 func TestOCRSoak(t *testing.T) {
-	l := logging.GetTestLogger(t)
 	// Use this variable to pass in any custom EVM specific TOML values to your Chainlink nodes
 	customNetworkTOML := ``
 	// Uncomment below for debugging TOML issues on the node
@@ -22,9 +20,25 @@ func TestOCRSoak(t *testing.T) {
 	// fmt.Println("Using Chainlink TOML\n---------------------")
 	// fmt.Println(networks.AddNetworkDetailedConfig(config.BaseOCR1Config, customNetworkTOML, network))
 	// fmt.Println("---------------------")
-	confName := utils.GetenvOrDefault("TEST_CONFIG_NAME", "Soak")
-	config, err := tc.GetConfig(confName, tc.OCR)
+	config, err := tc.GetConfig("Soak", tc.OCR)
 	require.NoError(t, err, "Error getting config")
+	runOCRSoakTest(t, config, customNetworkTOML)
+}
+
+func TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled(t *testing.T) {
+	config, err := tc.GetConfig(t.Name(), tc.OCR)
+	require.NoError(t, err, "Error getting config")
+	runOCRSoakTest(t, config, "")
+}
+
+func TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled(t *testing.T) {
+	config, err := tc.GetConfig(t.Name(), tc.OCR)
+	require.NoError(t, err, "Error getting config")
+	runOCRSoakTest(t, config, "")
+}
+
+func runOCRSoakTest(t *testing.T, config tc.TestConfig, customNetworkTOML string) {
+	l := logging.GetTestLogger(t)
 
 	ocrSoakTest, err := testsetups.NewOCRSoakTest(t, &config, false)
 	require.NoError(t, err, "Error creating soak test")

--- a/integration-tests/soak/ocr_test.go
+++ b/integration-tests/soak/ocr_test.go
@@ -40,6 +40,8 @@ func TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled(t *testing.T) {
 func runOCRSoakTest(t *testing.T, config tc.TestConfig, customNetworkTOML string) {
 	l := logging.GetTestLogger(t)
 
+	l.Info().Str("test", t.Name()).Msg("Starting OCR soak test")
+
 	ocrSoakTest, err := testsetups.NewOCRSoakTest(t, &config, false)
 	require.NoError(t, err, "Error creating soak test")
 	if !ocrSoakTest.Interrupted() {

--- a/integration-tests/soak/ocr_test.go
+++ b/integration-tests/soak/ocr_test.go
@@ -10,6 +10,7 @@ import (
 	actions_seth "github.com/smartcontractkit/chainlink/integration-tests/actions/seth"
 	tc "github.com/smartcontractkit/chainlink/integration-tests/testconfig"
 	"github.com/smartcontractkit/chainlink/integration-tests/testsetups"
+	"github.com/smartcontractkit/chainlink/integration-tests/utils"
 )
 
 func TestOCRSoak(t *testing.T) {
@@ -21,8 +22,8 @@ func TestOCRSoak(t *testing.T) {
 	// fmt.Println("Using Chainlink TOML\n---------------------")
 	// fmt.Println(networks.AddNetworkDetailedConfig(config.BaseOCR1Config, customNetworkTOML, network))
 	// fmt.Println("---------------------")
-
-	config, err := tc.GetConfig("Soak", tc.OCR)
+	confName := utils.GetenvOrDefault("TEST_CONFIG_NAME", "Soak")
+	config, err := tc.GetConfig(confName, tc.OCR)
 	require.NoError(t, err, "Error getting config")
 
 	ocrSoakTest, err := testsetups.NewOCRSoakTest(t, &config, false)

--- a/integration-tests/testconfig/ocr/ocr.toml
+++ b/integration-tests/testconfig/ocr/ocr.toml
@@ -99,6 +99,15 @@ selected_networks=["simulated"]
 enabled = true
 depth = 15
 delay_create = "3s"
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled.Common]
+chainlink_node_funding = 100
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled.OCR]
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled.OCR.Common]
+test_duration="15m"
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled.OCR.Soak]
+ocr_version="1"
+number_of_contracts=2
+time_between_rounds="1m"
 
 # Soak test configuration with Geth reorg below finality with FinalityTagEnabled=true
 [TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled.NodeConfig]
@@ -118,3 +127,12 @@ selected_networks=["simulated"]
 enabled = true
 depth = 15
 delay_create = "3s"
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled.Common]
+chainlink_node_funding = 100
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled.OCR]
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled.OCR.Common]
+test_duration="15m"
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled.OCR.Soak]
+ocr_version="1"
+number_of_contracts=2
+time_between_rounds="1m"

--- a/integration-tests/testconfig/ocr/ocr.toml
+++ b/integration-tests/testconfig/ocr/ocr.toml
@@ -82,3 +82,39 @@ test_duration="15m"
 ocr_version="1"
 number_of_contracts=2
 time_between_rounds="1m"
+
+# Soak test configuration with Geth reorg below finality with FinalityTagEnabled=false
+[SoakWithGethReorgBelowFinality_FinalityTagDisabled.NodeConfig]
+CommonChainConfigTOML = """
+AutoCreateKey = true
+MinContractPayment = 0
+LogPollInterval="500ms"
+BackupLogPollerBlockDelay = 0
+FinalityDepth = 30
+FinalityTagEnabled = false
+"""
+[SoakWithGethReorgBelowFinality_FinalityTagDisabled.Network]
+selected_networks=["simulated"]
+[SoakWithGethReorgBelowFinality_FinalityTagDisabled.Network.GethReorgConfig]
+enabled = true
+depth = 15
+delay_create = "3s"
+
+# Soak test configuration with Geth reorg below finality with FinalityTagEnabled=true
+[SoakWithGethReorgBelowFinality_FinalityTagEnabled.NodeConfig]
+CommonChainConfigTOML = """
+AutoCreateKey = true
+MinContractPayment = 0
+LogPollInterval="500ms"
+BackupLogPollerBlockDelay = 0
+FinalityTagEnabled = true
+
+[HeadTracker]
+HistoryDepth = 10
+"""
+[SoakWithGethReorgBelowFinality_FinalityTagEnabled.Network]
+selected_networks=["simulated"]
+[SoakWithGethReorgBelowFinality_FinalityTagEnabled.Network.GethReorgConfig]
+enabled = true
+depth = 15
+delay_create = "3s"

--- a/integration-tests/testconfig/ocr/ocr.toml
+++ b/integration-tests/testconfig/ocr/ocr.toml
@@ -84,7 +84,7 @@ number_of_contracts=2
 time_between_rounds="1m"
 
 # Soak test configuration with Geth reorg below finality with FinalityTagEnabled=false
-[SoakWithGethReorgBelowFinality_FinalityTagDisabled.NodeConfig]
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled.NodeConfig]
 CommonChainConfigTOML = """
 AutoCreateKey = true
 MinContractPayment = 0
@@ -93,15 +93,15 @@ BackupLogPollerBlockDelay = 0
 FinalityDepth = 30
 FinalityTagEnabled = false
 """
-[SoakWithGethReorgBelowFinality_FinalityTagDisabled.Network]
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled.Network]
 selected_networks=["simulated"]
-[SoakWithGethReorgBelowFinality_FinalityTagDisabled.Network.GethReorgConfig]
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled.Network.GethReorgConfig]
 enabled = true
 depth = 15
 delay_create = "3s"
 
 # Soak test configuration with Geth reorg below finality with FinalityTagEnabled=true
-[SoakWithGethReorgBelowFinality_FinalityTagEnabled.NodeConfig]
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled.NodeConfig]
 CommonChainConfigTOML = """
 AutoCreateKey = true
 MinContractPayment = 0
@@ -112,9 +112,9 @@ FinalityTagEnabled = true
 [HeadTracker]
 HistoryDepth = 10
 """
-[SoakWithGethReorgBelowFinality_FinalityTagEnabled.Network]
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled.Network]
 selected_networks=["simulated"]
-[SoakWithGethReorgBelowFinality_FinalityTagEnabled.Network.GethReorgConfig]
+[TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled.Network.GethReorgConfig]
 enabled = true
 depth = 15
 delay_create = "3s"

--- a/integration-tests/utils/common.go
+++ b/integration-tests/utils/common.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"math/big"
 	"net"
+	"os"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 )
@@ -30,4 +31,13 @@ func BigIntSliceContains(slice []*big.Int, b *big.Int) bool {
 		}
 	}
 	return false
+}
+
+// GetenvOrDefault returns the value of an environment variable or a default value if not set.
+func GetenvOrDefault(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
 }

--- a/integration-tests/utils/common.go
+++ b/integration-tests/utils/common.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"math/big"
 	"net"
-	"os"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 )
@@ -31,13 +30,4 @@ func BigIntSliceContains(slice []*big.Int, b *big.Int) bool {
 		}
 	}
 	return false
-}
-
-// GetenvOrDefault returns the value of an environment variable or a default value if not set.
-func GetenvOrDefault(key, defaultValue string) string {
-	value := os.Getenv(key)
-	if value == "" {
-		return defaultValue
-	}
-	return value
 }


### PR DESCRIPTION
This PR adds OCR soak tests with blockchain reorg:
1. TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled
2. TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled

- [x] Fix makefile