### PR TITLE
.github/actions: decouple file changes from readonly file changes checks

### DIFF
--- a/.github/actions/detect-solidity-file-changes/action.yml
+++ b/.github/actions/detect-solidity-file-changes/action.yml
@@ -1,5 +1,5 @@
-name: 'Detect Changes Composite Action'
-description: 'Detects changes in solidity files and fails if read-only files are modified.'
+name: 'Detect Solidity File Changes Composite Action'
+description: 'Detects changes in solidity files and outputs the result.'
 outputs:
   changes:
     description: 'Whether or not changes were detected'
@@ -19,18 +19,3 @@ runs:
             - '.github/workflows/solidity.yml'
             - '.github/workflows/solidity-foundry.yml'
             - '.github/workflows/solidity-wrappers.yml'
-          read_only_sol:
-            - 'contracts/src/v0.8/interfaces/**/*'
-            - 'contracts/src/v0.8/automation/v1_2/**/*'
-            - 'contracts/src/v0.8/automation/v1_3/**/*'
-            - 'contracts/src/v0.8/automation/v2_0/**/*'
-
-    - name: Fail if read-only files have changed
-      if: ${{ steps.changed_files.outputs.read_only_sol == 'true' }}
-      shell: bash
-      run: |
-        echo "One or more read-only Solidity file(s) has changed."
-        for file in ${{ steps.changed_files.outputs.read_only_sol_files }}; do
-          echo "$file was changed"
-        done
-        exit 1

--- a/.github/actions/detect-solidity-readonly-file-changes/action.yml
+++ b/.github/actions/detect-solidity-readonly-file-changes/action.yml
@@ -1,0 +1,31 @@
+name: 'Detect Solidity Readonly Files Changes Composite Action'
+description: 'Detects changes in readonly solidity files and fails if they are modified.'
+outputs:
+  changes:
+    description: 'Whether or not changes were detected'
+    value: ${{ steps.changed_files.outputs.src }}
+runs:
+  using: 'composite'
+  steps:
+
+    - name: Filter paths
+      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      id: changed_files
+      with:
+        list-files: 'csv'
+        filters: |
+          read_only_sol:
+            - 'contracts/src/v0.8/interfaces/**/*'
+            - 'contracts/src/v0.8/automation/v1_2/**/*'
+            - 'contracts/src/v0.8/automation/v1_3/**/*'
+            - 'contracts/src/v0.8/automation/v2_0/**/*'
+
+    - name: Fail if read-only files have changed
+      if: ${{ steps.changed_files.outputs.read_only_sol == 'true' }}
+      shell: bash
+      run: |
+        echo "One or more read-only Solidity file(s) has changed."
+        for file in ${{ steps.changed_files.outputs.read_only_sol_files }}; do
+          echo "$file was changed"
+        done
+        exit 1

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -9,6 +9,18 @@ defaults:
     shell: bash
 
 jobs:
+  readonly_changes:
+    name: Detect readonly solidity file changes
+    runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.ch.outputs.changes }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - name: Detect readonly solidity file changes
+        id: ch
+        uses: ./.github/actions/detect-solidity-readonly-file-changes
+
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -39,7 +51,7 @@ jobs:
           # Match semver git tags with a "contracts-" prefix.
           RELEASE_REGEX: '^contracts-v[0-9]+\.[0-9]+\.[0-9]+$'
           PRE_RELEASE_REGEX: '^contracts-v[0-9]+\.[0-9]+\.[0-9]+-(.+)$'
-          # Get the version by stripping the "contracts-v" prefix. 
+          # Get the version by stripping the "contracts-v" prefix.
           VERSION_PREFIX: 'contracts-v'
 
   prepublish-test:


### PR DESCRIPTION
Decoupling these checks makes more sense because if a readonly file has changed (which has happened before) it blocks the entire solidity CI action from running, which we don't want.

The current structure was blocking the appropriate checks from executing when we did the last core -> ccip merge.