### PR TITLE
go.md: add chainlink-integrations

### DIFF
--- a/go.md
+++ b/go.md
@@ -3,9 +3,13 @@
 flowchart LR
   subgraph chains
     chainlink-cosmos
-    chainlink-evm
     chainlink-solana
     chainlink-starknet/relayer
+    subgraph chainlink-integrations
+      direction LR
+      chainlink-integrations/evm/relayer
+      chainlink-integrations/common
+    end
   end
 
   subgraph products

--- a/tools/bin/modgraph
+++ b/tools/bin/modgraph
@@ -9,9 +9,13 @@ echo "# smartcontractkit Go modules
 flowchart LR
   subgraph chains
     chainlink-cosmos
-    chainlink-evm
     chainlink-solana
     chainlink-starknet/relayer
+    subgraph chainlink-integrations
+      direction LR
+      chainlink-integrations/evm/relayer
+      chainlink-integrations/common
+    end
   end
 
   subgraph products


### PR DESCRIPTION
This PR updates go.md to reflect the new chainlink-integrations repo, and moves the evm module within it.