### PR TITLE
[KS-368] keystone/workflow engine logging

### DIFF
--- a/.changeset/popular-candles-mix.md
+++ b/.changeset/popular-candles-mix.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal Clean up workflow engine logging

--- a/core/capabilities/transmission/local_target_capability.go
+++ b/core/capabilities/transmission/local_target_capability.go
@@ -14,12 +14,14 @@ import (
 type LocalTargetCapability struct {
 	lggr logger.Logger
 	capabilities.TargetCapability
-	localNode capabilities.Node
+	localNode    capabilities.Node
+	capabilityID string
 }
 
-func NewLocalTargetCapability(lggr logger.Logger, localDON capabilities.Node, underlying capabilities.TargetCapability) *LocalTargetCapability {
+func NewLocalTargetCapability(lggr logger.Logger, capabilityID string, localDON capabilities.Node, underlying capabilities.TargetCapability) *LocalTargetCapability {
 	return &LocalTargetCapability{
 		TargetCapability: underlying,
+		capabilityID:     capabilityID,
 		lggr:             lggr,
 		localNode:        localDON,
 	}
@@ -38,7 +40,7 @@ func (l *LocalTargetCapability) Execute(ctx context.Context, req capabilities.Ca
 
 	peerIDToTransmissionDelay, err := GetPeerIDToTransmissionDelay(l.localNode.WorkflowDON.Members, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get peer ID to transmission delay map: %w", err)
+		return nil, fmt.Errorf("capability id: %s failed to get peer ID to transmission delay map: %w", l.capabilityID, err)
 	}
 
 	delay, existsForPeerID := peerIDToTransmissionDelay[*l.localNode.PeerID]

--- a/core/capabilities/transmission/local_target_capability_test.go
+++ b/core/capabilities/transmission/local_target_capability_test.go
@@ -139,7 +139,7 @@ func TestScheduledExecutionStrategy_LocalDON(t *testing.T) {
 				},
 				PeerID: &ids[tc.position],
 			}
-			localTargetCapability := NewLocalTargetCapability(log, localDON, mt)
+			localTargetCapability := NewLocalTargetCapability(log, "capabilityID", localDON, mt)
 
 			_, err = localTargetCapability.Execute(tests.Context(t), req)
 

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -353,7 +353,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 		jobORM         = job.NewORM(opts.DS, pipelineORM, bridgeORM, keyStore, globalLogger)
 		txmORM         = txmgr.NewTxStore(opts.DS, globalLogger)
 		streamRegistry = streams.NewRegistry(globalLogger, pipelineRunner)
-		workflowORM    = workflowstore.NewDBStore(opts.DS, clockwork.NewRealClock())
+		workflowORM    = workflowstore.NewDBStore(opts.DS, globalLogger, clockwork.NewRealClock())
 	)
 
 	for _, chain := range legacyEVMChains.Slice() {

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -216,14 +216,14 @@ func (e *Engine) init(ctx context.Context) {
 	e.logger.Debug("capabilities resolved, resuming in-progress workflows")
 	err := e.resumeInProgressExecutions(ctx)
 	if err != nil {
-		e.logger.Errorf("failed to resume workflows: %v", err)
+		e.logger.Errorf("failed to resume in-progress workflows: %v", err)
 	}
 
 	e.logger.Debug("registering triggers")
 	for idx, t := range e.workflow.triggers {
 		err := e.registerTrigger(ctx, t, idx)
 		if err != nil {
-			e.logger.Errorf("failed to register trigger: %s", err)
+			e.logger.Errorf("capability id: %s failed to register trigger: %s", t.ID, err)
 		}
 	}
 
@@ -314,7 +314,7 @@ func (e *Engine) registerTrigger(ctx context.Context, t *triggerCapability, trig
 	}
 	eventsCh, err := t.trigger.RegisterTrigger(ctx, triggerRegRequest)
 	if err != nil {
-		return fmt.Errorf("failed to instantiate trigger %s, %s", t.ID, err)
+		return fmt.Errorf("trigger id: %s failed to instantiate trigger: %s", t.ID, err)
 	}
 
 	go func() {

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -585,7 +585,7 @@ func (e *Engine) workerForStepRequest(ctx context.Context, msg stepRequest) {
 		Ref:         msg.stepRef,
 	}
 
-	inputs, outputs, err := e.executeStep(ctx, l, msg)
+	inputs, outputs, err := e.executeStep(ctx, msg)
 	var stepStatus string
 	switch {
 	case errors.Is(capabilities.ErrStopExecution, err):
@@ -618,7 +618,7 @@ func (e *Engine) workerForStepRequest(ctx context.Context, msg stepRequest) {
 }
 
 // executeStep executes the referenced capability within a step and returns the result.
-func (e *Engine) executeStep(ctx context.Context, l logger.Logger, msg stepRequest) (*values.Map, values.Value, error) {
+func (e *Engine) executeStep(ctx context.Context, msg stepRequest) (*values.Map, values.Value, error) {
 	step, err := e.workflow.Vertex(msg.stepRef)
 	if err != nil {
 		return nil, nil, err

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -195,7 +195,6 @@ func (e *Engine) initializeCapability(ctx context.Context, step *step) error {
 	err = cc.RegisterToWorkflow(ctx, registrationRequest)
 	if err != nil {
 		return newCPErr(fmt.Sprintf("failed to register capability to workflow (%+v)", registrationRequest), err)
-
 	}
 
 	step.capability = cc

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -94,8 +94,7 @@ func (e *Engine) resolveWorkflowCapabilities(ctx context.Context) error {
 	if !triggersInitialized {
 		return &workflowError{reason: "failed to resolve triggers", labels: map[string]string{
 			wIDKey: e.workflow.id,
-		},
-		}
+		}}
 	}
 
 	// Step 2. Walk the graph and register each step's capability to this workflow

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -108,9 +108,9 @@ func newTestEngine(t *testing.T, reg *coreCap.Registry, spec string, opts ...fun
 	clock := clockwork.NewFakeClock()
 	cfg := Config{
 		WorkflowID: testWorkflowId,
-		Lggr:     logger.TestLogger(t),
-		Registry: reg,
-		Spec:     spec,
+		Lggr:       logger.TestLogger(t),
+		Registry:   reg,
+		Spec:       spec,
 		GetLocalNode: func(ctx context.Context) (capabilities.Node, error) {
 			return capabilities.Node{
 				WorkflowDON: capabilities.DON{

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -563,6 +563,82 @@ func TestEngine_MultiStepDependencies(t *testing.T) {
 	assert.Equal(t, obs.([]any)[1], o)
 }
 
+func TestEngine_CustomErrors(t *testing.T) {
+	t.Parallel()
+	var wfe *WorkflowExecutionError
+	var we *WorkflowError
+	var se *StepError
+	var see *StepExecutionError
+
+	underlyingErr := errors.New("underlying error")
+	executionID := "<execution-id>"
+	capabilityID := "<capability-id>"
+
+	t.Run("workflow error", func(t *testing.T) {
+		workflowError := newWorkflowError(underlyingErr, testWorkflowId, "my-workflow-error")
+		assert.Equal(t,
+			"workflow id: <workflow-id> my-workflow-error: underlying error",
+			fmt.Sprintf("%s", workflowError),
+		)
+		assert.ErrorAs(t, workflowError, &we)
+	})
+
+	t.Run("workflow execution error", func(t *testing.T) {
+		workflowExecutionError := newWorkflowExecutionError(underlyingErr, testWorkflowId, executionID, "my-workflow-execution-error")
+		assert.Equal(t,
+			"execution id: <execution-id> workflow id: <workflow-id> my-workflow-execution-error: underlying error",
+			fmt.Sprintf("%s", workflowExecutionError),
+		)
+		assert.ErrorAs(t, workflowExecutionError, &we)
+		assert.ErrorAs(t, workflowExecutionError, &wfe)
+
+		noReasonError := newWorkflowExecutionError(underlyingErr, testWorkflowId, executionID, "")
+		assert.Equal(t,
+			"execution id: <execution-id> workflow id: <workflow-id> underlying error",
+			fmt.Sprintf("%s", noReasonError),
+		)
+	})
+
+	t.Run("step error", func(t *testing.T) {
+		stepError := newStepError(underlyingErr, testWorkflowId, "<capability-id>", "<step-ref>", "my-step-error")
+		assert.Equal(t,
+			"step ref: <step-ref> capability id: <capability-id> workflow id: <workflow-id> my-step-error: underlying error",
+			fmt.Sprintf("%s", stepError),
+		)
+		assert.ErrorAs(t, stepError, &we)
+		assert.ErrorAs(t, stepError, &se)
+	})
+	t.Run("capability error", func(t *testing.T) {
+		capabilityError := newCapabilityError(underlyingErr, testWorkflowId, capabilityID, "my-capability-error")
+		assert.Equal(t,
+			fmt.Sprintf("capability id: %s workflow id: %s my-capability-error: %v", capabilityID, testWorkflowId, underlyingErr),
+			fmt.Sprintf("%s", capabilityError),
+		)
+		assert.ErrorAs(t, capabilityError, &we)
+	})
+
+	triggerID := "<trigger-id>"
+	t.Run("trigger error", func(t *testing.T) {
+		triggerError := newTriggerError(underlyingErr, testWorkflowId, capabilityID, triggerID, "my-trigger-error")
+		assert.Equal(t,
+			fmt.Sprintf("trigger id: %s capability id: %s workflow id: %s my-trigger-error: %v", triggerID, capabilityID, testWorkflowId, underlyingErr),
+			fmt.Sprintf("%s", triggerError),
+		)
+		assert.ErrorAs(t, triggerError, &we)
+	})
+
+	t.Run("step execution error", func(t *testing.T) {
+		stepExecutionError := newStepExecutionError(underlyingErr, testWorkflowId, executionID, "<capability-id>", "<step-ref>", "my-step-execution-error")
+		assert.Equal(t,
+			"step ref: <step-ref> capability id: <capability-id> execution id: <execution-id> workflow id: <workflow-id> my-step-execution-error: underlying error",
+			fmt.Sprintf("%s", stepExecutionError),
+		)
+		assert.ErrorAs(t, stepExecutionError, &wfe)
+		assert.ErrorAs(t, stepExecutionError, &we)
+		assert.ErrorAs(t, stepExecutionError, &see)
+	})
+}
+
 func TestEngine_ResumesPendingExecutions(t *testing.T) {
 	t.Parallel()
 	ctx := testutils.Context(t)

--- a/core/services/workflows/store/store_db.go
+++ b/core/services/workflows/store/store_db.go
@@ -199,6 +199,7 @@ func stateToStep(state *WorkflowExecutionStep) (workflowStepRow, error) {
 // `Add` creates the relevant workflow_execution and workflow_step entries
 // to persist the passed in ExecutionState.
 func (d *DBStore) Add(ctx context.Context, state *WorkflowExecution) error {
+	l := d.lggr.With("executionID", state.ExecutionID, "workflowID", state.WorkflowID, "status", state.Status)
 	return d.transact(ctx, func(db *DBStore) error {
 		var wid *string
 		if state.WorkflowID != "" {
@@ -210,7 +211,7 @@ func (d *DBStore) Add(ctx context.Context, state *WorkflowExecution) error {
 			WorkflowID: wid,
 			Status:     state.Status,
 		}
-		d.lggr.Debugw("Adding workflow execution", "executionID", state.ExecutionID, "workflowID", state.WorkflowID, "status", state.Status)
+		l.Debug("Adding workflow execution")
 
 		err := db.insertWorkflowExecution(ctx, wex)
 		if err != nil {
@@ -223,7 +224,7 @@ func (d *DBStore) Add(ctx context.Context, state *WorkflowExecution) error {
 			if err != nil {
 				return err
 			}
-			d.lggr.Debugw("Adding workflow step", "executionID", state.ExecutionID, "ref", step.Ref, "status", step.Status)
+			l.With("stepRef", step.Ref).Debug("Adding workflow step")
 			ws = append(ws, step)
 		}
 		if len(ws) > 0 {

--- a/core/services/workflows/store/store_db_test.go
+++ b/core/services/workflows/store/store_db_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func randomID() string {
@@ -24,9 +25,13 @@ func randomID() string {
 	return hex.EncodeToString(b)
 }
 
-func Test_StoreDB(t *testing.T) {
+func newTestDBStore(t *testing.T) *DBStore {
 	db := pgtest.NewSqlxDB(t)
-	store := &DBStore{db: db, clock: clockwork.NewFakeClock()}
+	return &DBStore{db: db, lggr: logger.TestLogger(t), clock: clockwork.NewFakeClock()}
+}
+
+func Test_StoreDB(t *testing.T) {
+	store := newTestDBStore(t)
 
 	id := randomID()
 	es := WorkflowExecution{
@@ -58,8 +63,7 @@ func Test_StoreDB(t *testing.T) {
 }
 
 func Test_StoreDB_DuplicateEntry(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
-	store := &DBStore{db: db, clock: clockwork.NewFakeClock()}
+	store := newTestDBStore(t)
 
 	id := randomID()
 	es := WorkflowExecution{
@@ -87,8 +91,7 @@ func Test_StoreDB_DuplicateEntry(t *testing.T) {
 }
 
 func Test_StoreDB_UpdateStatus(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
-	store := &DBStore{db: db, clock: clockwork.NewFakeClock()}
+	store := newTestDBStore(t)
 
 	id := randomID()
 	es := WorkflowExecution{
@@ -122,8 +125,7 @@ func Test_StoreDB_UpdateStatus(t *testing.T) {
 }
 
 func Test_StoreDB_UpdateStep(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
-	store := &DBStore{db: db, clock: clockwork.NewFakeClock()}
+	store := newTestDBStore(t)
 
 	id := randomID()
 	stepOne := &WorkflowExecutionStep{
@@ -170,8 +172,7 @@ func Test_StoreDB_UpdateStep(t *testing.T) {
 }
 
 func Test_StoreDB_WorkflowStatus(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
-	store := &DBStore{db: db, clock: clockwork.NewFakeClock()}
+	store := newTestDBStore(t)
 
 	for s := range ValidStatuses {
 		id := randomID()
@@ -200,8 +201,7 @@ func Test_StoreDB_WorkflowStatus(t *testing.T) {
 }
 
 func Test_StoreDB_WorkflowStepStatus(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
-	store := &DBStore{db: db, clock: clockwork.NewFakeClock()}
+	store := newTestDBStore(t)
 
 	id := randomID()
 	stepOne := &WorkflowExecutionStep{
@@ -234,8 +234,7 @@ func Test_StoreDB_WorkflowStepStatus(t *testing.T) {
 }
 
 func Test_StoreDB_GetUnfinishedSteps(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
-	store := &DBStore{db: db, clock: clockwork.NewFakeClock()}
+	store := newTestDBStore(t)
 
 	id := randomID()
 	stepOne := &WorkflowExecutionStep{


### PR DESCRIPTION
- **Remove unused logger arg**
- **Make capability id logging consistent**
- **Clean up init logs**
- **Normalize executionID and capabilityID**
- **Adding store level logging**
- **Added custom errors to engine**
- **Remove wrapped logging variants**

I ended up creating custom error structs at the workflow engine level, so that we're able to resurface lower level errors as wrapped ones which have fields such as execution id, workflow id, and capability id.
If i didnt do this, there's a mismatch in how we log errors. There are functions that we have which return errors rather than log them. This results in errors which store the context as plaintext inside the error message itself, rather than having them as separate fields.

Ex
Without custom errors you'd get a log message like:` capability id: write_chain@1.0.0 could not find capability in registry.`.
With custom errors, we can log them as: `could not find capability in registry {"capabilityID": "write_chain@1.0.0"}`.