### PR TITLE
common/client: prevent double close of channel

### DIFF
--- a/common/client/poller_test.go
+++ b/common/client/poller_test.go
@@ -119,8 +119,9 @@ func Test_Poller(t *testing.T) {
 
 	t.Run("Test unsubscribe during polling", func(t *testing.T) {
 		wait := make(chan struct{})
+		closeOnce := sync.OnceFunc(func() { close(wait) })
 		pollFunc := func(ctx context.Context) (Head, error) {
-			close(wait)
+			closeOnce()
 			// Block in polling function until context is cancelled
 			if <-ctx.Done(); true {
 				return nil, ctx.Err()


### PR DESCRIPTION
[BCI-3380](https://smartcontract-it.atlassian.net/browse/BCI-3380)

[BCI-3380]: https://smartcontract-it.atlassian.net/browse/BCI-3380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ