### PR TITLE
.github: reduce headings one level

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Ticket
+### Ticket
 <!---
   Does this work have a corresponding ticket?
 
@@ -14,7 +14,7 @@
   [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
 --> 
 
-## Requires Dependencies
+### Requires Dependencies
 <!---
   Does this work depend on other open PRs?
 
@@ -25,7 +25,7 @@
   - https://github.com/smartcontractkit/chainlink-common/pull/7777777
 -->
 
-## Resolves Dependencies
+### Resolves Dependencies
 <!---
   Does this work support other open PRs? 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-### Ticket
 <!---
   Does this work have a corresponding ticket?
 


### PR DESCRIPTION
IMHO the PR template headings are loud and busy. This PR proposes reducing them one level, and removing 'Ticket'.
<hr/>
Old:
<hr/>

## Ticket

## Requires Dependencies

## Resolves Dependencies

<hr/>
New:
<hr/>

### Requires Dependencies

### Resolves Dependencies
