### PR TITLE
adding logs where it may be possible to call Close() on resources tha…

### DIFF
--- a/.changeset/angry-hounds-roll.md
+++ b/.changeset/angry-hounds-roll.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+debug log additions #internal

--- a/core/services/relay/evm/mercury/transmitter.go
+++ b/core/services/relay/evm/mercury/transmitter.go
@@ -350,6 +350,7 @@ func (mt *mercuryTransmitter) Start(ctx context.Context) (err error) {
 
 func (mt *mercuryTransmitter) Close() error {
 	return mt.StopOnce("MercuryTransmitter", func() error {
+		mt.lggr.Debug("Closing MercuryTransmitter and it's resources")
 		// Drain all the queues first
 		var qs []io.Closer
 		for _, s := range mt.servers {

--- a/core/services/relay/evm/mercury/transmitter.go
+++ b/core/services/relay/evm/mercury/transmitter.go
@@ -350,7 +350,7 @@ func (mt *mercuryTransmitter) Start(ctx context.Context) (err error) {
 
 func (mt *mercuryTransmitter) Close() error {
 	return mt.StopOnce("MercuryTransmitter", func() error {
-		mt.lggr.Debug("Closing MercuryTransmitter and it's resources")
+		mt.lggr.Debug("Closing MercuryTransmitter")
 		// Drain all the queues first
 		var qs []io.Closer
 		for _, s := range mt.servers {

--- a/core/services/relay/evm/mercury/wsrpc/cache/cache_set.go
+++ b/core/services/relay/evm/mercury/wsrpc/cache/cache_set.go
@@ -53,7 +53,7 @@ func (cs *cacheSet) Start(context.Context) error {
 
 func (cs *cacheSet) Close() error {
 	return cs.StopOnce("CacheSet", func() error {
-		cs.lggr.Debug("Clearing out CacheSet")
+		cs.lggr.Debug("Closing CacheSet")
 		cs.Lock()
 		defer cs.Unlock()
 		caches := maps.Values(cs.caches)

--- a/core/services/relay/evm/mercury/wsrpc/cache/cache_set.go
+++ b/core/services/relay/evm/mercury/wsrpc/cache/cache_set.go
@@ -53,6 +53,7 @@ func (cs *cacheSet) Start(context.Context) error {
 
 func (cs *cacheSet) Close() error {
 	return cs.StopOnce("CacheSet", func() error {
+		cs.lggr.Debug("Clearing out CacheSet")
 		cs.Lock()
 		defer cs.Unlock()
 		caches := maps.Values(cs.caches)

--- a/core/services/relay/evm/mercury/wsrpc/client.go
+++ b/core/services/relay/evm/mercury/wsrpc/client.go
@@ -182,7 +182,9 @@ func (w *client) runloop() {
 // resetTransport disconnects and reconnects to the mercury server
 func (w *client) resetTransport() {
 	w.connectionResetCountMetric.Inc()
+	w.logger.Debug("ResetTransport starting")
 	ok := w.IfStarted(func() {
+		w.logger.Debugw("ResetTransport closing wsrpc connection", "state", w.conn.GetState())
 		w.conn.Close() // Close is safe to call multiple times
 	})
 	if !ok {
@@ -209,6 +211,7 @@ func (w *client) resetTransport() {
 
 func (w *client) Close() error {
 	return w.StopOnce("WSRPC Client", func() error {
+		w.logger.Debugw("Closing WSRPC client", "state", w.conn.GetState())
 		close(w.chStop)
 		w.conn.Close()
 		w.wg.Wait()

--- a/core/services/relay/evm/mercury/wsrpc/pool.go
+++ b/core/services/relay/evm/mercury/wsrpc/pool.go
@@ -67,6 +67,7 @@ func (conn *connection) ensureStartedClient(ctx context.Context) error {
 }
 
 func (conn *connection) checkin(checkinCco *clientCheckout) {
+	conn.lggr.Debug("Checking in client", "serverURL", conn.serverURL)
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 	var removed bool
@@ -91,6 +92,7 @@ func (conn *connection) checkin(checkinCco *clientCheckout) {
 }
 
 func (conn *connection) forceCloseAll() (err error) {
+	conn.lggr.Debug("Force closing connection", "serverURL", conn.serverURL)
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 	if conn.Client != nil {
@@ -199,6 +201,7 @@ func (p *pool) Start(ctx context.Context) error {
 }
 
 func (p *pool) Close() (merr error) {
+	p.lggr.Debugw("Closing connection resources in WSRPC connection pool", "numConnections", len(p.connections))
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.closed = true

--- a/core/services/relay/evm/mercury/wsrpc/pool.go
+++ b/core/services/relay/evm/mercury/wsrpc/pool.go
@@ -67,7 +67,7 @@ func (conn *connection) ensureStartedClient(ctx context.Context) error {
 }
 
 func (conn *connection) checkin(checkinCco *clientCheckout) {
-	conn.lggr.Debug("Checking in client", "serverURL", conn.serverURL)
+	conn.lggr.Debug("Checking in client", "serverURL", conn.serverURL, "checkouts", len(conn.checkouts))
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 	var removed bool


### PR DESCRIPTION
adding logs where it may be possible to call Close() on resources that manage lifecycle of mercury WSRPC client and related components such as connection pool and cacheset

[MERC-5696](https://smartcontract-it.atlassian.net/browse/MERC-5696)

- The checked out client from pool.Checkout is given to the MercuryTransmitter. The MercuryTransmitter implements Close() on it's own which will close all it's resources when called. 
- Pool life cycle is managed by chainlink/application.go which will call Close() during shutdown

[MERC-5696]: https://smartcontract-it.atlassian.net/browse/MERC-5696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ