### PR TITLE
adding spancheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,20 +2,21 @@ run:
   timeout: 15m0s
 linters:
   enable:
+    - containedctx
+    - depguard
+    - errorlint
     - exhaustive
     - exportloopref
-    - revive
     - goimports
     - gosec
     - misspell
-    - rowserrcheck
-    - errorlint
-    - unconvert
-    - sqlclosecheck
     - noctx
-    - depguard
+    - revive
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - unconvert
     - whitespace
-    - containedctx
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true


### PR DESCRIPTION
Enables a span linter to ensure proper usage of spans, from memory leaks to just getting better value out of them. 

@jmank88 pointed me to https://github.com/jjti/go-spancheck, which has the associated `spancheck` option in golangci-lint. 

Depends on https://github.com/smartcontractkit/chainlink/pull/13598