### PR TITLE
LinkBalMonV2(minPerform) and CCIPWatchlist AutoUpdate Contract

### DIFF
--- a/contracts/src/v0.8/automation/upkeeps/CCIPAutoWatchlist.sol
+++ b/contracts/src/v0.8/automation/upkeeps/CCIPAutoWatchlist.sol
@@ -6,89 +6,67 @@ import "../../shared/access/ConfirmedOwner.sol";
 import {AutomationCompatibleInterface} from "../interfaces/AutomationCompatibleInterface.sol";
 import {AccessControl} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/access/AccessControl.sol";
 import {LinkAvailableBalanceMonitor} from "../upkeeps/LinkAvailableBalanceMonitor.sol";
+import "../interfaces/ILogAutomation.sol";
 
+contract CCIPOnRampAutoWatchlist is ILogAutomation, ConfirmedOwner {
+  event setWatchlistOnMonitor(uint64 indexed _dstChainSelector, address indexed _onRamp);
 
-struct Log {
-    uint256 index; // Index of the log in the block
-    uint256 timestamp; // Timestamp of the block containing the log
-    bytes32 txHash; // Hash of the transaction containing the log
-    uint256 blockNumber; // Number of the block containing the log
-    bytes32 blockHash; // Hash of the block containing the log
-    address source; // Address of the contract that emitted the log
-    bytes32[] topics; // Indexed topics of the log
-    bytes data; // Data of the log
-}
+  LinkAvailableBalanceMonitor public linkAvailableBalanceMonitorAddress;
+  address public routerAddress;
 
-interface ILogAutomation {
-    function checkLog(
-        Log calldata log,
-        bytes memory checkData
-    ) external returns (bool upkeepNeeded, bytes memory performData);
+  // keccak256 signature for OnRampSet event set as constant
+  bytes32 private constant EVENT_SIGNATURE = 0x1f7d0ec248b80e5c0dde0ee531c4fc8fdb6ce9a2b3d90f560c74acd6a7202f23;
 
-    function performUpkeep(bytes calldata performData) external;
-}
+  constructor(address contractaddress, address _routerAddress) ConfirmedOwner(msg.sender) {
+    linkAvailableBalanceMonitorAddress = LinkAvailableBalanceMonitor(contractaddress);
+    routerAddress = _routerAddress;
+  }
 
- contract CCIPOnRampAutoWatchlist is ILogAutomation,ConfirmedOwner {
+  // Option to change the Balance Monitor Address
+  function setBalanceMonitorAddress(address _newBalMonAddress) external onlyOwner {
+    linkAvailableBalanceMonitorAddress = LinkAvailableBalanceMonitor(_newBalMonAddress);
+  }
 
+  // Option to change the Router Address
+  // Changing Router Address would also require setting up new Upkeep as Upkeep is linked with the Router and cannot be changed
+  function setRouterAddress(address _newRouterAddress) external onlyOwner {
+    routerAddress = _newRouterAddress;
+  }
 
-    event setWatchlistOnMonitor(uint64 indexed _dstChainSelector,address indexed _onRamp);
+  function updateWatchList(address _targetAddress, uint64 _dstChainSelector) internal {
+    linkAvailableBalanceMonitorAddress.addToWatchListOrDecommission(_targetAddress, _dstChainSelector);
+  }
 
-    LinkAvailableBalanceMonitor public LinkAvailableBalanceMonitorAddress;
-    address public routerAddress;
-
-
-    constructor(address contractaddress,address _routerAddress) ConfirmedOwner(msg.sender){
-        LinkAvailableBalanceMonitorAddress = LinkAvailableBalanceMonitor(contractaddress);
-        routerAddress = _routerAddress;
-    }
-
-    // Option to change the Balance Monitor Address
-    function setBalanceMonitorAddress(address _newBalMonAddress) external onlyOwner{
-        LinkAvailableBalanceMonitorAddress = LinkAvailableBalanceMonitor(_newBalMonAddress);
-    }
-
-    // Option to change the Router Address
-    // Changing Router Address would also require setting up new Upkeep as Upkeep is linked with the Router and cannot be changed
-    function setRouterAddress(address _newRouterAddress) external onlyOwner{
-        routerAddress = _newRouterAddress;
-    }
-
-    function updateWatchList(address _targetAddress, uint64 _dstChainSelector) internal{
-        LinkAvailableBalanceMonitorAddress.addToWatchListOrDecommission(_targetAddress, _dstChainSelector);
-    }
-
-    function checkLog(
+  function checkLog(
     Log calldata log,
     bytes memory checkData
-) external view override returns (bool upkeepNeeded, bytes memory performData) {
-    
+  ) external view override returns (bool upkeepNeeded, bytes memory performData) {
     // Ensure Router address is set
     require(routerAddress != address(0), "Router address not set");
 
     // Define the event signature for OnRampSet(uint64,address)
-    bytes32 eventSignature = keccak256(abi.encodePacked("OnRampSet(uint64,address)"));
+    //bytes32 eventSignature = keccak256(abi.encodePacked("OnRampSet(uint64,address)"));
 
     // Check if the log source matches router contract and topics contain the event signature
-    if (log.source == routerAddress && log.topics.length > 0 && log.topics[0] == eventSignature) {
-        // Extract the indexed parameter from the log
-        uint64 destChainSelector = uint64(uint256(log.topics[1])); // cast to uint64
-        address onRamp = address(uint160(uint256(bytes32(log.data)))); // extract from log.data
+    if (log.source == routerAddress && log.topics.length > 0 && log.topics[0] == EVENT_SIGNATURE) {
+      // Extract the indexed parameter from the log
+      uint64 destChainSelector = uint64(uint256(log.topics[1])); // cast to uint64
+      address onRamp = address(uint160(uint256(bytes32(log.data)))); // extract from log.data
 
-        // Determine if upkeep is needed based on the emitted log
-        // For simplicity, always return true to trigger performUpkeep
-        return (true, abi.encode(destChainSelector, onRamp));
+      // No sanity checks necessary as the would on to relay information to LinkAvailableBalanceMonitor as it is
+      // Checking is enabled in LinkAvailableBalanceMonitor contract
+      return (true, abi.encode(destChainSelector, onRamp));
     }
 
     // If the event signature doesn't match or log source is not Router contract, no upkeep is needed
     return (false, "");
-}
+  }
 
-
-    function performUpkeep(bytes memory performData) external override{
-        // Decode the data received from checkLog
-        (uint64 destChainSelector, address onRamp) = abi.decode(performData, (uint64, address));
-        // Perform the necessary upkeep actions based on the decoded data
-        updateWatchList(onRamp,destChainSelector);
-        emit setWatchlistOnMonitor(destChainSelector,onRamp);
-    }
+  function performUpkeep(bytes memory performData) external override {
+    // Decode the data received from checkLog
+    (uint64 destChainSelector, address onRamp) = abi.decode(performData, (uint64, address));
+    // Perform the necessary upkeep actions based on the decoded data
+    updateWatchList(onRamp, destChainSelector);
+    emit setWatchlistOnMonitor(destChainSelector, onRamp);
+  }
 }

--- a/contracts/src/v0.8/automation/upkeeps/CCIPAutoWatchlist.sol
+++ b/contracts/src/v0.8/automation/upkeeps/CCIPAutoWatchlist.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.19;
+
+import "../../shared/access/ConfirmedOwner.sol";
+import {AutomationCompatibleInterface} from "../interfaces/AutomationCompatibleInterface.sol";
+import {AccessControl} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/access/AccessControl.sol";
+import {LinkAvailableBalanceMonitor} from "../upkeeps/LinkAvailableBalanceMonitor.sol";
+
+
+struct Log {
+    uint256 index; // Index of the log in the block
+    uint256 timestamp; // Timestamp of the block containing the log
+    bytes32 txHash; // Hash of the transaction containing the log
+    uint256 blockNumber; // Number of the block containing the log
+    bytes32 blockHash; // Hash of the block containing the log
+    address source; // Address of the contract that emitted the log
+    bytes32[] topics; // Indexed topics of the log
+    bytes data; // Data of the log
+}
+
+interface ILogAutomation {
+    function checkLog(
+        Log calldata log,
+        bytes memory checkData
+    ) external returns (bool upkeepNeeded, bytes memory performData);
+
+    function performUpkeep(bytes calldata performData) external;
+}
+
+ contract CCIPOnRampAutoWatchlist is ILogAutomation,ConfirmedOwner {
+
+
+    event setWatchlistOnMonitor(uint64 indexed _dstChainSelector,address indexed _onRamp);
+
+    LinkAvailableBalanceMonitor public LinkAvailableBalanceMonitorAddress;
+    address public routerAddress;
+
+
+    constructor(address contractaddress,address _routerAddress) ConfirmedOwner(msg.sender){
+        LinkAvailableBalanceMonitorAddress = LinkAvailableBalanceMonitor(contractaddress);
+        routerAddress = _routerAddress;
+    }
+
+    // Option to change the Balance Monitor Address
+    function setBalanceMonitorAddress(address _newBalMonAddress) external onlyOwner{
+        LinkAvailableBalanceMonitorAddress = LinkAvailableBalanceMonitor(_newBalMonAddress);
+    }
+
+    // Option to change the Router Address
+    // Changing Router Address would also require setting up new Upkeep as Upkeep is linked with the Router and cannot be changed
+    function setRouterAddress(address _newRouterAddress) external onlyOwner{
+        routerAddress = _newRouterAddress;
+    }
+
+    function updateWatchList(address _targetAddress, uint64 _dstChainSelector) internal{
+        LinkAvailableBalanceMonitorAddress.addToWatchListOrDecommission(_targetAddress, _dstChainSelector);
+    }
+
+    function checkLog(
+    Log calldata log,
+    bytes memory checkData
+) external view override returns (bool upkeepNeeded, bytes memory performData) {
+    
+    // Ensure Router address is set
+    require(routerAddress != address(0), "Router address not set");
+
+    // Define the event signature for OnRampSet(uint64,address)
+    bytes32 eventSignature = keccak256(abi.encodePacked("OnRampSet(uint64,address)"));
+
+    // Check if the log source matches router contract and topics contain the event signature
+    if (log.source == routerAddress && log.topics.length > 0 && log.topics[0] == eventSignature) {
+        // Extract the indexed parameter from the log
+        uint64 destChainSelector = uint64(uint256(log.topics[1])); // cast to uint64
+        address onRamp = address(uint160(uint256(bytes32(log.data)))); // extract from log.data
+
+        // Determine if upkeep is needed based on the emitted log
+        // For simplicity, always return true to trigger performUpkeep
+        return (true, abi.encode(destChainSelector, onRamp));
+    }
+
+    // If the event signature doesn't match or log source is not Router contract, no upkeep is needed
+    return (false, "");
+}
+
+
+    function performUpkeep(bytes memory performData) external override{
+        // Decode the data received from checkLog
+        (uint64 destChainSelector, address onRamp) = abi.decode(performData, (uint64, address));
+        // Perform the necessary upkeep actions based on the decoded data
+        updateWatchList(onRamp,destChainSelector);
+        emit setWatchlistOnMonitor(destChainSelector,onRamp);
+    }
+}

--- a/contracts/src/v0.8/automation/upkeeps/LinkAvailableBalanceMonitor.sol
+++ b/contracts/src/v0.8/automation/upkeeps/LinkAvailableBalanceMonitor.sol
@@ -117,6 +117,7 @@ contract LinkAvailableBalanceMonitor is AccessControl, AutomationCompatibleInter
     i_linkToken = linkToken;
     setMinWaitPeriodSeconds(minWaitPeriodSeconds);
     setMaxPerform(maxPerform);
+    setMinPerform(minPerform);
     setMaxCheck(maxCheck);
     setUpkeepInterval(upkeepInterval);
   }

--- a/contracts/src/v0.8/automation/upkeeps/LinkAvailableBalanceMonitor.sol
+++ b/contracts/src/v0.8/automation/upkeeps/LinkAvailableBalanceMonitor.sol
@@ -337,8 +337,7 @@ contract LinkAvailableBalanceMonitor is AccessControl, AutomationCompatibleInter
     bytes calldata
   ) external view override whenNotPaused returns (bool upkeepNeeded, bytes memory performData) {
     address[] memory needsFunding = sampleUnderfundedAddresses();
-    uint16 minPerform = s_minPerform;
-    if (needsFunding.length <= minPerform) {
+    if (needsFunding.length <= s_minPerform) {
       return (false, "");
     }
     uint96 total_batch_balance;
@@ -395,9 +394,9 @@ contract LinkAvailableBalanceMonitor is AccessControl, AutomationCompatibleInter
   }
 
   /// @notice Update s_minPerform
-  function setMinPerform(uint16 minPerform) public onlyRole(ADMIN_ROLE) {
-    emit MinPerformSet(s_minPerform, minPerform);
+  function setMinPerform(uint16 minPerform) external onlyRole(ADMIN_ROLE) {
     s_minPerform = minPerform;
+    emit MinPerformSet(s_minPerform, minPerform);
   }
 
   /// @notice Update s_maxCheck

--- a/contracts/src/v0.8/automation/upkeeps/LinkAvailableBalanceMonitor.sol
+++ b/contracts/src/v0.8/automation/upkeeps/LinkAvailableBalanceMonitor.sol
@@ -35,7 +35,7 @@ interface ILinkAvailable {
 ///  this is a "trustless" upkeep, meaning it does not trust the caller of performUpkeep;
 /// we could save a fair amount of gas and re-write this upkeep for use with Automation v2.0+,
 /// which has significantly different trust assumptions
-contract LinkAvailableBalanceMonitor2 is AccessControl, AutomationCompatibleInterface, Pausable {
+contract LinkAvailableBalanceMonitor is AccessControl, AutomationCompatibleInterface, Pausable {
   using EnumerableMap for EnumerableMap.UintToAddressMap;
   using EnumerableSet for EnumerableSet.AddressSet;
 


### PR DESCRIPTION
Adding 2 files. 
1. I added a minPerform() function to the LinkBalMonV2 contract and tested it on Sepolia. The purpose of the minPerform function is to establish a minimum batch size required for the sampleUnderfunded address array. If the array size is less than minPerform, no top-up operation will be performed. This optimization is crucial for deploying the BalanceMonitor contract on Ethereum, which consumes significant gas. 

2. Creation of a CCIPOnRampWatchlistUpdate contract to allow auto update of the watchlist on the LinkBalMonV2 when deployed to fund CCIP On-Ramps

Testing File Link - https://docs.google.com/spreadsheets/d/1zk4J4xQrhSJhIEt7l1bpsG6_jrl6qTQLNa5EZia3JzU/edit?gid=829494086#gid=829494086 Specification File - https://docs.google.com/document/d/1p4naJOlrdPmZ5xsZkZE7FDw1cEQqWcQ3hgguhI21SNQ/edit#heading=h.3t9vh460y192

## Ticket
<!---
  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
  
  By referencing it, it will let the QA team to know what to watch out for when creating a new release.

  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

## Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

## Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
