### PR TITLE
handling connection fault on wsrpc LatestReport

### DIFF
--- a/.changeset/angry-hounds-roll.md
+++ b/.changeset/angry-hounds-roll.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-debug log additions #internal

--- a/.changeset/angry-hounds-roll.md
+++ b/.changeset/angry-hounds-roll.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+debug log additions #internal

--- a/.changeset/fast-dolphins-cry.md
+++ b/.changeset/fast-dolphins-cry.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-handling connection fault case #bugfix
+handle connection timeout on cache path for ws client LatestReport #bugfix

--- a/.changeset/fast-dolphins-cry.md
+++ b/.changeset/fast-dolphins-cry.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+handling connection fault case #bugfix

--- a/core/services/relay/evm/mercury/wsrpc/cache/cache.go
+++ b/core/services/relay/evm/mercury/wsrpc/cache/cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jpillora/backoff"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	mercuryutils "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/utils"

--- a/core/services/relay/evm/mercury/wsrpc/cache/cache.go
+++ b/core/services/relay/evm/mercury/wsrpc/cache/cache.go
@@ -311,6 +311,7 @@ func (m *memCache) fetch(req *pb.LatestReportRequest, v *cacheVal) {
 		// NOTE: must drop down to RawClient here otherwise we enter an
 		// infinite loop of calling a client that calls back to this same cache
 		// and on and on
+		// TODO this call a method that handle the raw client and raw client errors
 		val, err = m.client.RawClient().LatestReport(ctx, req)
 		cancel()
 		v.setError(err)

--- a/core/services/relay/evm/mercury/wsrpc/cache/helpers_test.go
+++ b/core/services/relay/evm/mercury/wsrpc/cache/helpers_test.go
@@ -17,10 +17,6 @@ func (m *mockClient) RawLatestReport(ctx context.Context, req *pb.LatestReportRe
 	return m.resp, m.err
 }
 
-//func (m *mockClient) LatestReport(ctx context.Context, req *pb.LatestReportRequest) (resp *pb.LatestReportResponse, err error) {
-//	return m.resp, m.err
-//}
-
 func (m *mockClient) ServerURL() string {
 	return "mock client url"
 }

--- a/core/services/relay/evm/mercury/wsrpc/cache/helpers_test.go
+++ b/core/services/relay/evm/mercury/wsrpc/cache/helpers_test.go
@@ -13,9 +13,13 @@ type mockClient struct {
 	err  error
 }
 
-func (m *mockClient) LatestReport(ctx context.Context, req *pb.LatestReportRequest) (resp *pb.LatestReportResponse, err error) {
+func (m *mockClient) RawLatestReport(ctx context.Context, req *pb.LatestReportRequest) (resp *pb.LatestReportResponse, err error) {
 	return m.resp, m.err
 }
+
+//func (m *mockClient) LatestReport(ctx context.Context, req *pb.LatestReportRequest) (resp *pb.LatestReportResponse, err error) {
+//	return m.resp, m.err
+//}
 
 func (m *mockClient) ServerURL() string {
 	return "mock client url"

--- a/core/services/relay/evm/mercury/wsrpc/client.go
+++ b/core/services/relay/evm/mercury/wsrpc/client.go
@@ -272,17 +272,6 @@ func (w *client) Transmit(ctx context.Context, req *pb.TransmitRequest) (resp *p
 }
 
 func (w *client) handleWSClientError(err error) {
-	// if the underlying client is closed by another goroutine we need to reset the transport
-	state := w.conn.GetState()
-	if state != connectivity.Ready && state != connectivity.Connecting {
-		w.logger.Infow("Transport is resetting - connection state unusable", "state", w.conn.GetState())
-		select {
-		case w.chResetTransport <- struct{}{}:
-		default:
-			w.logger.Debugf("Transport is already resetting")
-		}
-	}
-
 	if errors.Is(err, context.DeadlineExceeded) {
 		w.timeoutCountMetric.Inc()
 		cnt := w.consecutiveTimeoutCnt.Add(1)

--- a/core/services/relay/evm/mercury/wsrpc/client.go
+++ b/core/services/relay/evm/mercury/wsrpc/client.go
@@ -259,7 +259,7 @@ func (w *client) Transmit(ctx context.Context, req *pb.TransmitRequest) (resp *p
 		return nil, errors.Wrap(err, "Transmit call failed")
 	}
 	resp, err = w.rawClient.Transmit(ctx, req)
-	w.handleWSClientError(err)
+	w.handleTimeout(err)
 	if err != nil {
 		w.logger.Warnw("Transmit call failed due to networking error", "err", err, "resp", resp)
 		incRequestStatusMetric(statusFailed)
@@ -271,7 +271,7 @@ func (w *client) Transmit(ctx context.Context, req *pb.TransmitRequest) (resp *p
 	return
 }
 
-func (w *client) handleWSClientError(err error) {
+func (w *client) handleTimeout(err error) {
 	if errors.Is(err, context.DeadlineExceeded) {
 		w.timeoutCountMetric.Inc()
 		cnt := w.consecutiveTimeoutCnt.Add(1)
@@ -298,7 +298,6 @@ func (w *client) handleWSClientError(err error) {
 				// Debug log in case my reasoning is wrong.
 				w.logger.Debugf("Transport is resetting, cnt=%d", cnt)
 			}
-			return
 		}
 	} else {
 		w.consecutiveTimeoutCnt.Store(0)
@@ -308,7 +307,7 @@ func (w *client) handleWSClientError(err error) {
 
 func (w *client) RawLatestReport(ctx context.Context, req *pb.LatestReportRequest) (resp *pb.LatestReportResponse, err error) {
 	resp, err = w.rawClient.LatestReport(ctx, req)
-	w.handleWSClientError(err)
+	w.handleTimeout(err)
 	return
 }
 

--- a/core/services/relay/evm/mercury/wsrpc/client_test.go
+++ b/core/services/relay/evm/mercury/wsrpc/client_test.go
@@ -160,6 +160,7 @@ func Test_Client_LatestReport(t *testing.T) {
 
 			conn := &mocks.MockConn{
 				Ready: true,
+				State: connectivity.Ready,
 			}
 			c := newClient(lggr, csakey.KeyV2{}, nil, "", cacheSet)
 			c.conn = conn

--- a/core/services/relay/evm/mercury/wsrpc/client_test.go
+++ b/core/services/relay/evm/mercury/wsrpc/client_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smartcontractkit/wsrpc/connectivity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -73,6 +74,7 @@ func Test_Client_Transmit(t *testing.T) {
 		}
 		conn := &mocks.MockConn{
 			Ready: true,
+			State: connectivity.Ready,
 		}
 		c := newClient(lggr, csakey.KeyV2{}, nil, "", noopCacheSet)
 		c.conn = conn

--- a/core/services/relay/evm/mercury/wsrpc/client_test.go
+++ b/core/services/relay/evm/mercury/wsrpc/client_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/wsrpc/connectivity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -74,7 +73,6 @@ func Test_Client_Transmit(t *testing.T) {
 		}
 		conn := &mocks.MockConn{
 			Ready: true,
-			State: connectivity.Ready,
 		}
 		c := newClient(lggr, csakey.KeyV2{}, nil, "", noopCacheSet)
 		c.conn = conn
@@ -160,7 +158,6 @@ func Test_Client_LatestReport(t *testing.T) {
 
 			conn := &mocks.MockConn{
 				Ready: true,
-				State: connectivity.Ready,
 			}
 			c := newClient(lggr, csakey.KeyV2{}, nil, "", cacheSet)
 			c.conn = conn


### PR DESCRIPTION
handles an edge case here when LatestReport will consecutively timeout on the cache path and handle re-dialing WSRPC server