### PR TITLE
add make test-short for running short tests with quiet logs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -175,6 +175,10 @@ goreleaser-dev-release: ## run goreleaser snapshot release
 modgraph:
 	./tools/bin/modgraph > go.md
 
+.PHONY: test-short
+test-short: ## Run 'go test -short' and suppress uninteresting output
+	go test -short ./... | grep -v "[no test files]" | grep -v "\(cached\)"
+
 help:
 	@echo ""
 	@echo "         .__           .__       .__  .__        __"


### PR DESCRIPTION
Running `go test ./...` produces a lot of output for packages which do not contain any test files. `(cached)` lines are also uninteresting. This PR adds `make test-short` to run `go test -short ./...` while suppressing those noisy lines.

```diff
-ok      github.com/smartcontractkit/chainlink/v2/core/web/resolver      (cached)
-?       github.com/smartcontractkit/chainlink/v2/tools/flakeytests/cmd/runner   [no test files]
-?       github.com/smartcontractkit/chainlink/v2/tools/txtar    [no test files]
-?       github.com/smartcontractkit/chainlink/v2/tools/txtar/cmd/lstxtardirs    [no test files]
-ok      github.com/smartcontractkit/chainlink/v2/plugins        (cached)
-ok      github.com/smartcontractkit/chainlink/v2/plugins/medianpoc      (cached)
```