### PR TITLE
Add more tests to OCR soak test CI workflow

### DIFF
--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -2,6 +2,19 @@ name: On Demand OCR Soak Test
 on:
   workflow_dispatch:
     inputs:
+      testToRun:
+        description: Select a test to run
+        required: true
+        default: TestOCRSoak
+        type: choice
+        options:
+          - TestOCRSoak
+          - TestOCRSoak_GethReorgBelowFinality_FinalityTagDisabled
+          - TestOCRSoak_GethReorgBelowFinality_FinalityTagEnabled
+          - TestOCRSoak_GasSpike
+          - TestOCRSoak_ChangeBlockGasLimit
+          - TestOCRSoak_RPCDownForAllCLNodes
+          - TestOCRSoak_RPCDownForHalfCLNodes
       base64Config:
         description: base64-ed config
         required: true
@@ -83,7 +96,7 @@ jobs:
           TEST_UPLOAD_CPU_PROFILE: true
           TEST_UPLOAD_MEM_PROFILE: true
         with:
-          test_command_to_run: cd ./integration-tests && go test -v -count=1 -run ^TestOCRSoak$ ./soak
+          test_command_to_run: cd ./integration-tests && go test -v -count=1 -run ^${{ github.event.inputs.testToRun }}$ ./soak
           test_download_vendor_packages_command: make gomod
           cl_repo: ${{ env.CHAINLINK_IMAGE }}
           cl_image_tag: ${{ env.CHAINLINK_VERSION }}


### PR DESCRIPTION
This PR enables running `on-demand-ocr-soak-test.yml` with any OCR soak test. By default, it is set to `TestOCRSoak`, so it works the same way as before.

<img width="519" alt="image" src="https://github.com/smartcontractkit/chainlink/assets/120112546/bfd872be-2a7f-4573-8037-1d16a71bb802">


Here's example build with `TestOCRSoak_GasSpike` https://github.com/smartcontractkit/chainlink/actions/runs/9594677888/job/26457769742