### PR TITLE
Add docs about E2E chaos tests

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -60,3 +60,71 @@ You can see the results of each test in the terminal with normal `go test` outpu
 ## Running Soak, Performance, Benchmark, and Chaos Tests
 
 These tests remain bound to a Kubernetes run environment, and require more complex setup and running instructions not documented here. We endeavor to make these easier to run and configure, but for the time being please seek a member of the QA/Test Tooling team if you want to run these.
+
+### How to run reorg tests
+Run soak/ocr_test.go with reorg below finality and `FinalityTagEnabled=false`
+
+```bash
+make test_soak_ocr_reorg_1
+```
+
+Run soak/ocr_test.go with reorg below finality and `FinalityTagEnabled=true`:
+
+```bash
+make test_soak_ocr_reorg_2
+```
+
+Run reorg/automation_reorg_test.go with reorg settings:
+
+1. Use Simulated Geth network and put GethReorgConfig in overrides.toml 
+
+
+    ```toml
+    [Network]
+    selected_networks=["simulated"]
+    [Network.GethReorgConfig]
+    enabled = true
+    depth = 10
+    delay_create = "3s"
+    ```
+
+2. Then run the test:
+    ```bash
+    make test_reorg_automation
+    ```
+
+Run reorg above finality docker test:
+
+```bash
+go test -v -run ^TestReorgAboveFinality_FinalityTagDisabled$ ./smoke
+```
+
+### How to run gas simulation tests
+
+Run soak/ocr_test.go with gas spike:
+
+```bash
+make test_soak_ocr_gas_spike
+```
+
+Run soak/ocr_test.go with changing gas limit creating block congestion:
+
+```bash
+make test_soak_ocr_gas_limit_change
+```
+
+Note: you can update gas simulation params for the tests below in in testconfig/ocr.toml
+
+### How to run tests with RPC node failure
+
+Run soak/ocr_test.go with RPC network chaos by bringing down network to RPC node for all Chainlink Nodes:
+
+```bash
+make test_soak_ocr_rpc_down_all_cl_nodes
+```
+
+Run soak/ocr_test.go with RPC network chaos by bringing down network to RPC node for 50 percent of Chainlink Nodes:
+
+```bash
+make test_soak_ocr_rpc_down_half_cl_nodes
+```


### PR DESCRIPTION
This PR adds docs about E2E chaos tests to integration-tests/README.md