### PR TITLE
Add forceful testdb creation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -114,7 +114,11 @@ setup-testdb: ## Setup the test database.
 testdb: ## Prepares the test database.
 	go run . local db preparetest
 
-.PHONY: testdb
+.PHONY: testdb-force
+testdb-force: ## Prepares the test database, drops any pesky user connections that stand in the the way.
+	go run . local db preparetest --force
+
+.PHONY: testdb-user-only
 testdb-user-only: ## Prepares the test database with user only.
 	go run . local db preparetest --user-only
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ source .dbenv
 make testdb
 ```
 
+If you encounter the error `database accessed by other users (SQLSTATE 55006) exit status 1`
+and you want force the database creation then use
+```
+source .dbenv
+make testdb-force
+```
+
+
 7. Run tests:
 
 ```bash

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -173,6 +173,10 @@ func initLocalSubCmds(s *Shell, safe bool) []cli.Command {
 							Name:  "dangerWillRobinson",
 							Usage: "set to true to enable dropping non-test databases",
 						},
+						cli.BoolFlag{
+							Name:  "force",
+							Usage: "set to true to force the reset by dropping any existing connections to the database",
+						},
 					},
 				},
 				{
@@ -185,6 +189,10 @@ func initLocalSubCmds(s *Shell, safe bool) []cli.Command {
 						cli.BoolFlag{
 							Name:  "user-only",
 							Usage: "only include test user fixture",
+						},
+						cli.BoolFlag{
+							Name:  "force",
+							Usage: "set to true to force the reset by dropping any existing connections to the database",
 						},
 					},
 				},
@@ -748,7 +756,7 @@ func (s *Shell) ResetDatabase(c *cli.Context) error {
 	}
 
 	dangerMode := c.Bool("dangerWillRobinson")
-
+	force := c.Bool("force")
 	dbname := parsed.Path[1:]
 	if !dangerMode && !strings.HasSuffix(dbname, "_test") {
 		return s.errorOut(fmt.Errorf("cannot reset database named `%s`. This command can only be run against databases with a name that ends in `_test`, to prevent accidental data loss. If you REALLY want to reset this database, pass in the -dangerWillRobinson option", dbname))
@@ -756,7 +764,7 @@ func (s *Shell) ResetDatabase(c *cli.Context) error {
 	lggr := s.Logger
 	lggr.Infof("Resetting database: %#v", parsed.String())
 	lggr.Debugf("Dropping and recreating database: %#v", parsed.String())
-	if err := dropAndCreateDB(parsed); err != nil {
+	if err := dropAndCreateDB(parsed, force); err != nil {
 		return s.errorOut(err)
 	}
 	lggr.Debugf("Migrating database: %#v", parsed.String())
@@ -1079,7 +1087,7 @@ func newConnection(cfg dbConfig) (*sqlx.DB, error) {
 	return pg.NewConnection(parsed.String(), cfg.Dialect(), cfg)
 }
 
-func dropAndCreateDB(parsed url.URL) (err error) {
+func dropAndCreateDB(parsed url.URL, force bool) (err error) {
 	// Cannot drop the database if we are connected to it, so we must connect
 	// to a different one. template1 should be present on all postgres installations
 	dbname := parsed.Path[1:]
@@ -1093,7 +1101,13 @@ func dropAndCreateDB(parsed url.URL) (err error) {
 			err = multierr.Append(err, cerr)
 		}
 	}()
-
+	if force {
+		// supports pg < 13. https://stackoverflow.com/questions/17449420/postgresql-unable-to-drop-database-because-of-some-auto-connections-to-db
+		_, err = db.Exec(fmt.Sprintf("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s';", dbname))
+		if err != nil {
+			return fmt.Errorf("unable to terminate connections to postgres database: %v", err)
+		}
+	}
 	_, err = db.Exec(fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, dbname))
 	if err != nil {
 		return fmt.Errorf("unable to drop postgres database: %v", err)

--- a/core/scripts/setup_testdb.sh
+++ b/core/scripts/setup_testdb.sh
@@ -57,7 +57,7 @@ echo $db_url
 repo=$(git rev-parse --show-toplevel)
 pushd $repo
 export $db_url 
-make testdb || exit_error "Failed to create test database"
+make testdb-force || exit_error "Failed to create test database"
 popd
 
 # Set the database URL in the .dbenv file

--- a/testdata/scripts/node/db/preparetest/help.txtar
+++ b/testdata/scripts/node/db/preparetest/help.txtar
@@ -11,4 +11,5 @@ USAGE:
 
 OPTIONS:
    --user-only  only include test user fixture
+   --force      set to true to force the reset by dropping any existing connections to the database
    

--- a/testdata/scripts/node/db/reset/help.txtar
+++ b/testdata/scripts/node/db/reset/help.txtar
@@ -11,4 +11,5 @@ USAGE:
 
 OPTIONS:
    --dangerWillRobinson  set to true to enable dropping non-test databases
+   --force               set to true to force the reset by dropping any existing connections to the database
    


### PR DESCRIPTION
I often encounter 
`postgres drop database accessed by other users (SQLSTATE 55006) exit status 1`

when developing the DB.

this adds a utility to force create it by dropping the connections.

tested locally and works.
```
make testdb || make testdb-force  
go run . local db preparetest
time=2024-06-20T12:52:30.514-06:00 level=INFO msg="Version was unset on production build. Chainlink should be built with static.Version set to a valid semver for production builds."
2024-06-20T12:52:30.515-0600 [INFO]  Resetting database: "postgres://chainlink_dev:insecurepassword@localhost:5432/chainlink_development_test?sslmode=disable" cmd/shell_local.go:765           version=unset@unset 
unable to drop postgres database: ERROR: database "chainlink_development_test" is being accessed by other users (SQLSTATE 55006)
exit status 1
make: *** [testdb] Error 1
go run . local db preparetest --force
time=2024-06-20T12:52:40.996-06:00 level=INFO msg="Version was unset on production build. Chainlink should be built with static.Version set to a valid semver for production builds."
2024-06-20T12:52:40.997-0600 [INFO]  Resetting database: "postgres://chainlink_dev:insecurepassword@localhost:5432/chainlink_development_test?sslmode=disable" cmd/shell_local.go:765           version=unset@unset 
time=2024-06-20T12:52:41.327-06:00 level=INFO msg="Error checking mercury jobs: ERROR: relation \"ocr2_oracle_specs\" does not exist (SQLSTATE 42P01)"
time=2024-06-20T12:52:41.551-06:00 level=INFO msg="OK   0001_initial.sql (210.89ms)"
...
time=2024-06-20T12:52:44.597-06:00 level=INFO msg="goose: successfully migrated database to version: 244"
