### PR TITLE
add limiter for no values to upsert

### DIFF
--- a/core/bridges/cache.go
+++ b/core/bridges/cache.go
@@ -239,6 +239,10 @@ func (c *Cache) doBulkUpsert() {
 	values := maps.Values(c.bridgeLastValueCache)
 	c.mu.RUnlock()
 
+	if len(values) == 0 {
+		return
+	}
+
 	if err := c.ORM.BulkUpsertBridgeResponse(context.Background(), values); err != nil {
 		c.lggr.Warnf("bulk upsert of bridge responses failed: %s", err.Error())
 	}


### PR DESCRIPTION
Bulk upsert was attempting to run with an empty list, resulting in repeated errors. This fix does a length check before attempting to upsert.
