### PR TITLE
Do not log node config in E2E docker tests

### DIFF
--- a/integration-tests/docker/test_env/cl_node.go
+++ b/integration-tests/docker/test_env/cl_node.go
@@ -330,8 +330,6 @@ func (n *ClNode) containerStartOrRestart(restartDb bool) error {
 		Str("userEmail", n.UserEmail).
 		Str("userPassword", n.UserPassword).
 		Msg("Started Chainlink Node container")
-	nodeConfig, _ := n.GetNodeConfigStr()
-	n.l.Info().Str("containerName", n.ContainerName).Msgf("Chainlink Node config:\n%s", nodeConfig)
 	clClient, err := client.NewChainlinkClient(&client.ChainlinkConfig{
 		URL:        clEndpoint,
 		Email:      n.UserEmail,


### PR DESCRIPTION
Stop logging CL Node config in E2E Docker tests, as we do not have a solution for masking custom secrets in the GitHub console. This is to prevent secret leaks in the future, especially when running Docker tests with custom secrets on CI.