### PR TITLE
add ci-protobuf gha workflow

### DIFF
--- a/.github/workflows/ci-protobuf.yml
+++ b/.github/workflows/ci-protobuf.yml
@@ -9,20 +9,17 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-        with:
-          fetch-depth: 0
 
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
+      - name: Setup buf
+        uses: bufbuild/buf-setup-action@35c243d7f2a909b1d4e40399b348a7fdab27d78d # v1.34.0
 
-      - name: Check Breaking Changes
-        shell: bash
+      - name: Run buf breaking
+        uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1.1.4
         env:
           REPO_URL: https://github.com/${{ github.repository }}
           BASE_BRANCH: ${{ github.base_ref }}
-        run: |
-          go install github.com/bufbuild/buf/cmd/buf@v1.34.0
-          buf breaking --against "${REPO_URL}#branch=${BASE_BRANCH}"
+        with:
+          against: "${REPO_URL}.git#branch=${BASE_BRANCH}"
 
       - name: Collect Metrics
         if: always()

--- a/.github/workflows/ci-protobuf.yml
+++ b/.github/workflows/ci-protobuf.yml
@@ -1,7 +1,6 @@
 name: CI ProtoBuf
 
 on:
-  merge_group:
   pull_request:
 
 jobs:
@@ -18,9 +17,12 @@ jobs:
 
       - name: Check Breaking Changes
         shell: bash
+        env:
+          REPO_URL: ${{ github.repositoryUrl }}
+          BASE_BRANCH: ${{ github.base_ref }}
         run: |
           go install github.com/bufbuild/buf/cmd/buf@v1.34.0
-          buf breaking --against '.git#branch=develop'
+          buf breaking --against "${REPO_URL}#branch=${BASE_BRANCH}"
 
       - name: Collect Metrics
         if: always()

--- a/.github/workflows/ci-protobuf.yml
+++ b/.github/workflows/ci-protobuf.yml
@@ -1,0 +1,34 @@
+name: CI ProtoBuf
+
+on:
+  merge_group:
+  pull_request:
+
+jobs:
+  buf-breaking:
+    name: Check Breaking Changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Check Breaking Changes
+        shell: bash
+        run: |
+          go install github.com/bufbuild/buf/cmd/buf@v1.34.0
+          buf breaking --against '.git#branch=develop'
+
+      - name: Collect Metrics
+        if: always()
+        id: collect-gha-metrics
+        uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
+        with:
+          id: ci-protobuf
+          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          this-job-name: buf-breaking
+        continue-on-error: true

--- a/.github/workflows/ci-protobuf.yml
+++ b/.github/workflows/ci-protobuf.yml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Setup buf
         uses: bufbuild/buf-setup-action@35c243d7f2a909b1d4e40399b348a7fdab27d78d # v1.34.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run buf breaking
         uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1.1.4

--- a/.github/workflows/ci-protobuf.yml
+++ b/.github/workflows/ci-protobuf.yml
@@ -6,11 +6,12 @@ on:
 
 jobs:
   buf-breaking:
-    name: Check Breaking Changes
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          fetch-depth: 0
 
       - name: Setup Go
         uses: ./.github/actions/setup-go

--- a/.github/workflows/ci-protobuf.yml
+++ b/.github/workflows/ci-protobuf.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check Breaking Changes
         shell: bash
         env:
-          REPO_URL: ${{ github.repositoryUrl }}
+          REPO_URL: https://github.com/${{ github.repository }}
           BASE_BRANCH: ${{ github.base_ref }}
         run: |
           go install github.com/bufbuild/buf/cmd/buf@v1.34.0

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,9 +2,6 @@
 # 1. Per Github docs: "Order is important; the last matching pattern takes the most precedence."
 # Please define less specific codeowner paths before more specific codeowner paths in order for the more specific rule to have priority
 
-# Core
-/core @smartcontractkit/foundations
-
 # Chains
 /common @smartcontractkit/bix-framework
 /core/chains/ @smartcontractkit/bix-framework
@@ -12,7 +9,7 @@
 # Services
 /core/services/directrequest @smartcontractkit/keepers
 /core/services/feeds @smartcontractkit/FMS
-/core/services/synchronization/telem/**/*.proto @smartcontractkit/realtime
+/core/services/synchronization/telem @smartcontractkit/realtime
 
 # To be deprecated in Chainlink V3
 /core/services/fluxmonitorv2 @smartcontractkit/foundations
@@ -51,6 +48,9 @@ core/services/relay/evm/functions @smartcontractkit/functions
 core/services/relay/evm/functions @smartcontractkit/functions
 core/scripts/functions @smartcontractkit/functions
 core/scripts/gateway @smartcontractkit/functions
+
+# Core
+/core @smartcontractkit/foundations
 
 # Contracts
 /contracts/ @RensR

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@
 # Services
 /core/services/directrequest @smartcontractkit/keepers
 /core/services/feeds @smartcontractkit/FMS
-/core/services/synchronization/telem/ @smartcontractkit/realtime
+/core/services/synchronization/telem/**/*.proto @smartcontractkit/realtime
 
 # To be deprecated in Chainlink V3
 /core/services/fluxmonitorv2 @smartcontractkit/foundations

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,8 +11,8 @@
 
 # Services
 /core/services/directrequest @smartcontractkit/keepers
-/core/services/feeds @smartcontractkit/fms
-/core/services/synchronization/telem @smartcontractkit/realtime
+/core/services/feeds @smartcontractkit/FMS
+/core/services/synchronization/telem/ @smartcontractkit/realtime
 
 # To be deprecated in Chainlink V3
 /core/services/fluxmonitorv2 @smartcontractkit/foundations

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,9 @@
 # 1. Per Github docs: "Order is important; the last matching pattern takes the most precedence."
 # Please define less specific codeowner paths before more specific codeowner paths in order for the more specific rule to have priority
 
+# Core
+/core @smartcontractkit/foundations
+
 # Chains
 /common @smartcontractkit/bix-framework
 /core/chains/ @smartcontractkit/bix-framework
@@ -9,7 +12,7 @@
 # Services
 /core/services/directrequest @smartcontractkit/keepers
 /core/services/feeds @smartcontractkit/FMS
-/core/services/synchronization/telem @smartcontractkit/realtime
+/core/services/synchronization/telem/**/*.proto @smartcontractkit/realtime
 
 # To be deprecated in Chainlink V3
 /core/services/fluxmonitorv2 @smartcontractkit/foundations
@@ -49,8 +52,8 @@ core/services/relay/evm/functions @smartcontractkit/functions
 core/scripts/functions @smartcontractkit/functions
 core/scripts/gateway @smartcontractkit/functions
 
-# Core
-/core @smartcontractkit/foundations
+# General services
+/core/services/ @smartcontractkit/foundations
 
 # Contracts
 /contracts/ @RensR

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,7 @@
 # Services
 /core/services/directrequest @smartcontractkit/keepers
 /core/services/feeds @smartcontractkit/FMS
+/core/services/synchronization/telem @smartcontractkit/realtime
 
 # To be deprecated in Chainlink V3
 /core/services/fluxmonitorv2 @smartcontractkit/foundations

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@
 # Services
 /core/services/directrequest @smartcontractkit/keepers
 /core/services/feeds @smartcontractkit/FMS
-/core/services/synchronization/telem/**/*.proto @smartcontractkit/realtime
+/core/services/synchronization/telem @smartcontractkit/realtime
 
 # To be deprecated in Chainlink V3
 /core/services/fluxmonitorv2 @smartcontractkit/foundations
@@ -51,9 +51,6 @@ core/services/relay/evm/functions @smartcontractkit/functions
 core/services/relay/evm/functions @smartcontractkit/functions
 core/scripts/functions @smartcontractkit/functions
 core/scripts/gateway @smartcontractkit/functions
-
-# General services
-/core/services/ @smartcontractkit/foundations
 
 # Contracts
 /contracts/ @RensR

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,7 +11,7 @@
 
 # Services
 /core/services/directrequest @smartcontractkit/keepers
-/core/services/feeds @smartcontractkit/FMS
+/core/services/feeds @smartcontractkit/fms
 /core/services/synchronization/telem @smartcontractkit/realtime
 
 # To be deprecated in Chainlink V3

--- a/core/services/synchronization/telem/telem_enhanced_ea.proto
+++ b/core/services/synchronization/telem/telem_enhanced_ea.proto
@@ -18,5 +18,5 @@ message EnhancedEA {
   int64 observation=11;
   string config_digest = 12;
   int64 round=13;
-  int64 epoch=15;
+  int64 epoch=14;
 }

--- a/core/services/synchronization/telem/telem_enhanced_ea.proto
+++ b/core/services/synchronization/telem/telem_enhanced_ea.proto
@@ -18,5 +18,5 @@ message EnhancedEA {
   int64 observation=11;
   string config_digest = 12;
   int64 round=13;
-  int64 epoch=14;
+  int64 epoch=15;
 }


### PR DESCRIPTION
This adds a new GHA workflow `ci-protobuf` to run:

`buf breaking` to check for breaking changes related to protobufs.

Tested here:
https://github.com/smartcontractkit/chainlink/actions/runs/9652945452/job/26624185180?pr=13677
