### PR TITLE
Fix potential data race issue with TXM test

### DIFF
--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -603,11 +603,11 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil).Maybe()
 	feeEstimator := gasmocks.NewEvmFeeEstimator(t)
 	feeEstimator.On("Start", mock.Anything).Return(nil).Once()
+	feeEstimator.On("Close", mock.Anything).Return(nil).Once()
 	feeEstimator.On("OnNewLongestChain", mock.Anything, mock.Anything).Once()
 	txm, err := makeTestEvmTxm(t, db, ethClient, feeEstimator, cfg.EVM(), cfg.EVM().GasEstimator(), cfg.EVM().Transactions(), gcfg.Database(), gcfg.Database().Listener(), ethKeyStore)
 	require.NoError(t, err)
-	err = txm.Start(ctx)
-	require.NoError(t, err)
+	servicetest.Run(t, txm)
 
 	head := &evmtypes.Head{
 		Hash:   utils.NewHash(),


### PR DESCRIPTION
Experienced the following error during local testing. Updated the test to properly cleanup after the test has completed.
```
Error occurred while handling tx queue in ProcessUnstartedTxs   {"err": "processUnstartedTxs failed on handleAnyInProgressTx: handleAnyInProgressTx failed: getInProgressEthTx failed: sql: database is closed"}
```