### PR TITLE
support native token in v23 smoke tests

### DIFF
--- a/.changeset/shaggy-bananas-do.md
+++ b/.changeset/shaggy-bananas-do.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+add native billing in smoke test #added

--- a/integration-tests/actions/actions.go
+++ b/integration-tests/actions/actions.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"math"
 	"math/big"
 	"strings"
 	"sync"
@@ -40,7 +41,6 @@ import (
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
 	"github.com/test-go/testify/require"
-	"math"
 
 	ctfconfig "github.com/smartcontractkit/chainlink-testing-framework/config"
 	"github.com/smartcontractkit/chainlink-testing-framework/utils/testcontext"

--- a/integration-tests/actions/automationv2/actions.go
+++ b/integration-tests/actions/automationv2/actions.go
@@ -565,10 +565,19 @@ func (a *AutomationTest) SetConfigOnRegistry() error {
 		} else if a.RegistrySettings.RegistryVersion == ethereum.RegistryVersion_2_3 {
 			ocrConfig.TypedOnchainConfig23 = a.RegistrySettings.Create23OnchainConfig(a.Registrar.Address(), a.UpkeepPrivilegeManager, a.Registry.ChainModuleAddress(), a.Registry.ReorgProtectionEnabled())
 			ocrConfig.BillingTokens = []common.Address{
-				common.HexToAddress(a.LinkToken.Address()), // TODO add more billing tokens
+				common.HexToAddress(a.LinkToken.Address()),
+				common.HexToAddress(a.WETHToken.Address()),
 			}
 
 			ocrConfig.BillingConfigs = []i_automation_registry_master_wrapper_2_3.AutomationRegistryBase23BillingConfig{
+				{
+					GasFeePPB:         100,
+					FlatFeeMilliCents: big.NewInt(500),
+					PriceFeed:         common.HexToAddress(a.EthUSDFeed.Address()), // ETH/USD feed and LINK/USD feed are the same
+					Decimals:          18,
+					FallbackPrice:     big.NewInt(1000),
+					MinSpend:          big.NewInt(200),
+				},
 				{
 					GasFeePPB:         100,
 					FlatFeeMilliCents: big.NewInt(500),

--- a/integration-tests/chaos/automation_chaos_test.go
+++ b/integration-tests/chaos/automation_chaos_test.go
@@ -286,8 +286,8 @@ func TestAutomationChaos(t *testing.T) {
 					}
 					require.NoError(t, err, "Error setting OCR config")
 
-					consumersConditional, upkeepidsConditional := actions.DeployConsumers(t, chainClient, registry, registrar, linkToken, numberOfUpkeeps, big.NewInt(defaultLinkFunds), defaultUpkeepGasLimit, false, false)
-					consumersLogtrigger, upkeepidsLogtrigger := actions.DeployConsumers(t, chainClient, registry, registrar, linkToken, numberOfUpkeeps, big.NewInt(defaultLinkFunds), defaultUpkeepGasLimit, true, false)
+					consumersConditional, upkeepidsConditional := actions.DeployConsumers(t, chainClient, registry, registrar, linkToken, numberOfUpkeeps, big.NewInt(defaultLinkFunds), defaultUpkeepGasLimit, false, false, false, nil)
+					consumersLogtrigger, upkeepidsLogtrigger := actions.DeployConsumers(t, chainClient, registry, registrar, linkToken, numberOfUpkeeps, big.NewInt(defaultLinkFunds), defaultUpkeepGasLimit, true, false, false, nil)
 
 					consumers := append(consumersConditional, consumersLogtrigger...)
 					upkeepIDs := append(upkeepidsConditional, upkeepidsLogtrigger...)

--- a/integration-tests/contracts/ethereum_keeper_contracts.go
+++ b/integration-tests/contracts/ethereum_keeper_contracts.go
@@ -27,6 +27,8 @@ type KeeperRegistrar interface {
 	EncodeRegisterRequest(name string, email []byte, upkeepAddr string, gasLimit uint32, adminAddr string, checkData []byte, amount *big.Int, source uint8, senderAddr string, isLogTrigger bool, isMercury bool, linkTokenAddr string) ([]byte, error)
 
 	Fund(ethAmount *big.Float) error
+
+	RegisterUpkeepFromKey(keyNum int, name string, email []byte, upkeepAddr string, gasLimit uint32, adminAddr string, checkData []byte, amount *big.Int, wethTokenAddr string, isLogTrigger bool, isMercury bool) (*types.Transaction, error)
 }
 
 type UpkeepTranscoder interface {

--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -229,6 +229,8 @@ func TestAutomationReorg(t *testing.T) {
 				defaultUpkeepGasLimit,
 				isLogTrigger,
 				false,
+				false,
+				nil,
 			)
 
 			if isLogTrigger {

--- a/integration-tests/smoke/automation_test.go
+++ b/integration-tests/smoke/automation_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -98,22 +99,25 @@ func TestAutomationBasic(t *testing.T) {
 func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 	t.Parallel()
 
+	// native, mercury_v02, mercury_v03 and logtrigger are reserved keywords, use them with caution
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
-		"registry_2_0":                                 ethereum.RegistryVersion_2_0,
-		"registry_2_1_conditional":                     ethereum.RegistryVersion_2_1,
-		"registry_2_1_logtrigger":                      ethereum.RegistryVersion_2_1,
-		"registry_2_1_with_mercury_v02":                ethereum.RegistryVersion_2_1,
-		"registry_2_1_with_mercury_v03":                ethereum.RegistryVersion_2_1,
-		"registry_2_1_with_logtrigger_and_mercury_v02": ethereum.RegistryVersion_2_1,
-		"registry_2_2_conditional":                     ethereum.RegistryVersion_2_2,
-		"registry_2_2_logtrigger":                      ethereum.RegistryVersion_2_2,
-		"registry_2_2_with_mercury_v02":                ethereum.RegistryVersion_2_2,
-		"registry_2_2_with_mercury_v03":                ethereum.RegistryVersion_2_2,
-		"registry_2_2_with_logtrigger_and_mercury_v02": ethereum.RegistryVersion_2_2,
-		"registry_2_3_conditional_native":              ethereum.RegistryVersion_2_3,
-		"registry_2_3_conditional_link":                ethereum.RegistryVersion_2_3,
-		"registry_2_3_logtrigger_native":               ethereum.RegistryVersion_2_3,
-		"registry_2_3_logtrigger_link":                 ethereum.RegistryVersion_2_3,
+		"registry_2_0":                                      ethereum.RegistryVersion_2_0,
+		"registry_2_1_conditional":                          ethereum.RegistryVersion_2_1,
+		"registry_2_1_logtrigger":                           ethereum.RegistryVersion_2_1,
+		"registry_2_1_with_mercury_v02":                     ethereum.RegistryVersion_2_1,
+		"registry_2_1_with_mercury_v03":                     ethereum.RegistryVersion_2_1,
+		"registry_2_1_with_logtrigger_and_mercury_v02":      ethereum.RegistryVersion_2_1,
+		"registry_2_2_conditional":                          ethereum.RegistryVersion_2_2,
+		"registry_2_2_logtrigger":                           ethereum.RegistryVersion_2_2,
+		"registry_2_2_with_mercury_v02":                     ethereum.RegistryVersion_2_2,
+		"registry_2_2_with_mercury_v03":                     ethereum.RegistryVersion_2_2,
+		"registry_2_2_with_logtrigger_and_mercury_v02":      ethereum.RegistryVersion_2_2,
+		"registry_2_3_conditional_native":                   ethereum.RegistryVersion_2_3,
+		"registry_2_3_conditional_link":                     ethereum.RegistryVersion_2_3,
+		"registry_2_3_logtrigger_native":                    ethereum.RegistryVersion_2_3,
+		"registry_2_3_logtrigger_link":                      ethereum.RegistryVersion_2_3,
+		"registry_2_3_with_mercury_v03_link":                ethereum.RegistryVersion_2_3,
+		"registry_2_3_with_logtrigger_and_mercury_v02_link": ethereum.RegistryVersion_2_3,
 	}
 
 	for n, rv := range registryVersions {
@@ -132,11 +136,11 @@ func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 				}
 			}
 
-			// Use the name to determine if this is a log trigger or mercury or billing token is LINK
-			isBillingTokenNative := name == "registry_2_3_conditional_native" || name == "registry_2_3_logtrigger_native"
-			isLogTrigger := name == "registry_2_1_logtrigger" || name == "registry_2_1_with_logtrigger_and_mercury_v02" || name == "registry_2_2_logtrigger" || name == "registry_2_2_with_logtrigger_and_mercury_v02" || name == "registry_2_3_logtrigger_native" || name == "registry_2_3_logtrigger_link"
-			isMercuryV02 := name == "registry_2_1_with_mercury_v02" || name == "registry_2_1_with_logtrigger_and_mercury_v02" || name == "registry_2_2_with_mercury_v02" || name == "registry_2_2_with_logtrigger_and_mercury_v02"
-			isMercuryV03 := name == "registry_2_1_with_mercury_v03" || name == "registry_2_2_with_mercury_v03"
+			// Use the name to determine if this is a log trigger or mercury or billing token is native
+			isBillingTokenNative := strings.Contains(name, "native")
+			isLogTrigger := strings.Contains(name, "logtrigger")
+			isMercuryV02 := strings.Contains(name, "mercury_v02")
+			isMercuryV03 := strings.Contains(name, "mercury_v03")
 			isMercury := isMercuryV02 || isMercuryV03
 
 			a := setupAutomationTestDocker(

--- a/integration-tests/smoke/automation_test.go
+++ b/integration-tests/smoke/automation_test.go
@@ -110,7 +110,10 @@ func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 		"registry_2_2_with_mercury_v02":                ethereum.RegistryVersion_2_2,
 		"registry_2_2_with_mercury_v03":                ethereum.RegistryVersion_2_2,
 		"registry_2_2_with_logtrigger_and_mercury_v02": ethereum.RegistryVersion_2_2,
-		"registry_2_3_conditional":                     ethereum.RegistryVersion_2_3,
+		"registry_2_3_conditional_native":              ethereum.RegistryVersion_2_3,
+		"registry_2_3_conditional_link":                ethereum.RegistryVersion_2_3,
+		"registry_2_3_logtrigger_native":               ethereum.RegistryVersion_2_3,
+		"registry_2_3_logtrigger_link":                 ethereum.RegistryVersion_2_3,
 	}
 
 	for n, rv := range registryVersions {
@@ -129,8 +132,9 @@ func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 				}
 			}
 
-			// Use the name to determine if this is a log trigger or mercury
-			isLogTrigger := name == "registry_2_1_logtrigger" || name == "registry_2_1_with_logtrigger_and_mercury_v02" || name == "registry_2_2_logtrigger" || name == "registry_2_2_with_logtrigger_and_mercury_v02"
+			// Use the name to determine if this is a log trigger or mercury or billing token is LINK
+			isBillingTokenNative := name == "registry_2_3_conditional_native" || name == "registry_2_3_logtrigger_native"
+			isLogTrigger := name == "registry_2_1_logtrigger" || name == "registry_2_1_with_logtrigger_and_mercury_v02" || name == "registry_2_2_logtrigger" || name == "registry_2_2_with_logtrigger_and_mercury_v02" || name == "registry_2_3_logtrigger_native" || name == "registry_2_3_logtrigger_link"
 			isMercuryV02 := name == "registry_2_1_with_mercury_v02" || name == "registry_2_1_with_logtrigger_and_mercury_v02" || name == "registry_2_2_with_mercury_v02" || name == "registry_2_2_with_logtrigger_and_mercury_v02"
 			isMercuryV03 := name == "registry_2_1_with_mercury_v03" || name == "registry_2_2_with_mercury_v03"
 			isMercury := isMercuryV02 || isMercuryV03
@@ -153,6 +157,8 @@ func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 				automationDefaultUpkeepGasLimit,
 				isLogTrigger,
 				isMercury,
+				isBillingTokenNative,
+				a.WETHToken,
 			)
 
 			// Do it in two separate loops, so we don't end up setting up one upkeep, but starting the consumer for another one
@@ -189,8 +195,6 @@ func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 				actions.GetStalenessReportCleanupFn(t, a.Logger, a.ChainClient, sb, a.Registry, registryVersion)()
 			})
 
-			// TODO Tune this timeout window after stress testing
-			l.Info().Msg("Waiting 10m for all upkeeps to perform at least 1 upkeep")
 			gom.Eventually(func(g gomega.Gomega) {
 				// Check if the upkeeps are performing multiple times by analyzing their counters
 				for i := 0; i < len(upkeepIDs); i++ {
@@ -292,6 +296,8 @@ func TestSetUpkeepTriggerConfig(t *testing.T) {
 				automationDefaultUpkeepGasLimit,
 				true,
 				false,
+				false,
+				nil,
 			)
 
 			// Start log trigger based upkeeps for all consumers
@@ -473,6 +479,8 @@ func TestAutomationAddFunds(t *testing.T) {
 				automationDefaultUpkeepGasLimit,
 				false,
 				false,
+				false,
+				nil,
 			)
 
 			t.Cleanup(func() {
@@ -551,6 +559,8 @@ func TestAutomationPauseUnPause(t *testing.T) {
 				automationDefaultUpkeepGasLimit,
 				false,
 				false,
+				false,
+				nil,
 			)
 
 			t.Cleanup(func() {
@@ -650,6 +660,8 @@ func TestAutomationRegisterUpkeep(t *testing.T) {
 				automationDefaultUpkeepGasLimit,
 				false,
 				false,
+				false,
+				nil,
 			)
 
 			t.Cleanup(func() {
@@ -744,6 +756,8 @@ func TestAutomationPauseRegistry(t *testing.T) {
 				automationDefaultUpkeepGasLimit,
 				false,
 				false,
+				false,
+				nil,
 			)
 
 			t.Cleanup(func() {
@@ -822,6 +836,8 @@ func TestAutomationKeeperNodesDown(t *testing.T) {
 				automationDefaultUpkeepGasLimit,
 				false,
 				false,
+				false,
+				nil,
 			)
 
 			t.Cleanup(func() {
@@ -1235,6 +1251,8 @@ func TestSetOffchainConfigWithMaxGasPrice(t *testing.T) {
 				automationDefaultUpkeepGasLimit,
 				false,
 				false,
+				false,
+				nil,
 			)
 
 			t.Cleanup(func() {

--- a/integration-tests/smoke/automation_test.go_test_list.json
+++ b/integration-tests/smoke/automation_test.go_test_list.json
@@ -37,12 +37,26 @@
     },
     {
       "name": "TestAutomationBasic",
-      "nodes": 4,
+      "nodes": 2,
       "run":[
         {"name":"registry_2_3_conditional_native"},
-        {"name":"registry_2_3_conditional_link"},
+        {"name":"registry_2_3_conditional_link"}
+      ]
+    },
+    {
+      "name": "TestAutomationBasic",
+      "nodes": 2,
+      "run":[
         {"name":"registry_2_3_logtrigger_native"},
         {"name":"registry_2_3_logtrigger_link"}
+      ]
+    },
+    {
+      "name": "TestAutomationBasic",
+      "nodes": 2,
+      "run":[
+        {"name":"registry_2_3_with_mercury_v03_link"},
+        {"name":"registry_2_3_with_logtrigger_and_mercury_v02_link"}
       ]
     },
     {

--- a/integration-tests/smoke/automation_test.go_test_list.json
+++ b/integration-tests/smoke/automation_test.go_test_list.json
@@ -37,9 +37,12 @@
     },
     {
       "name": "TestAutomationBasic",
-      "nodes": 1,
+      "nodes": 4,
       "run":[
-        {"name":"registry_2_3_conditional"}
+        {"name":"registry_2_3_conditional_native"},
+        {"name":"registry_2_3_conditional_link"},
+        {"name":"registry_2_3_logtrigger_native"},
+        {"name":"registry_2_3_logtrigger_link"}
       ]
     },
     {

--- a/integration-tests/smoke/log_poller_test.go
+++ b/integration-tests/smoke/log_poller_test.go
@@ -317,6 +317,8 @@ func prepareEnvironment(l zerolog.Logger, t *testing.T, testConfig *tc.TestConfi
 		uint32(2500000),
 		true,
 		false,
+		false,
+		nil,
 	)
 
 	err = logpoller.AssertUpkeepIdsUniqueness(upkeepIDs)

--- a/integration-tests/testsetups/keeper_benchmark.go
+++ b/integration-tests/testsetups/keeper_benchmark.go
@@ -801,7 +801,7 @@ func (k *KeeperBenchmarkTest) DeployBenchmarkKeeperContracts(index int) {
 	err = actions.DeployMultiCallAndFundDeploymentAddresses(k.chainClient, k.linkToken, upkeep.NumberOfUpkeeps, linkFunds)
 	require.NoError(k.t, err, "Sending link funds to deployment addresses shouldn't fail")
 
-	upkeepIds := actions.RegisterUpkeepContractsWithCheckData(k.t, k.chainClient, k.linkToken, linkFunds, uint32(upkeep.UpkeepGasLimit), registry, registrar, upkeep.NumberOfUpkeeps, upkeepAddresses, checkData, false, false)
+	upkeepIds := actions.RegisterUpkeepContractsWithCheckData(k.t, k.chainClient, k.linkToken, linkFunds, uint32(upkeep.UpkeepGasLimit), registry, registrar, upkeep.NumberOfUpkeeps, upkeepAddresses, checkData, false, false, false, nil)
 
 	k.keeperRegistries[index] = registry
 	k.keeperRegistrars[index] = registrar


### PR DESCRIPTION
AUTO-9980

add native token and log trigger cases for v23 smoke tests.
