### PR TITLE
Only encode non nil block numbers

### DIFF
--- a/.changeset/curvy-months-change.md
+++ b/.changeset/curvy-months-change.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-Allow block 0 in buildCallOpts to prevent nil pointer
+Allow block 0 in buildCallOpts to prevent nil pointer #changed

--- a/.changeset/curvy-months-change.md
+++ b/.changeset/curvy-months-change.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-Allow block 0 in buildCallOpts to prevent nil pointer #changed
+Only encode non nil block numbers for eth_call #changed

--- a/.changeset/curvy-months-change.md
+++ b/.changeset/curvy-months-change.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Allow block 0 in buildCallOpts to prevent nil pointer

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry.go
@@ -462,7 +462,7 @@ func (r *EvmRegistry) addToActive(ctx context.Context, id *big.Int, force bool) 
 func (r *EvmRegistry) buildCallOpts(ctx context.Context, block *big.Int) (*bind.CallOpts, error) {
 	opts := bind.CallOpts{
 		Context:     ctx,
-		BlockNumber: nil,
+		BlockNumber: block,
 	}
 
 	if block == nil || block.Int64() == 0 {
@@ -716,7 +716,7 @@ func (r *EvmRegistry) getUpkeepConfigs(ctx context.Context, ids []*big.Int) ([]a
 	)
 
 	for i, id := range ids {
-		opts, err := r.buildCallOpts(ctx, nil)
+		opts, err := r.buildCallOpts(ctx, big.NewInt(0))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get call opts: %s", err)
 		}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry.go
@@ -462,13 +462,11 @@ func (r *EvmRegistry) addToActive(ctx context.Context, id *big.Int, force bool) 
 func (r *EvmRegistry) buildCallOpts(ctx context.Context, block *big.Int) (*bind.CallOpts, error) {
 	opts := bind.CallOpts{
 		Context:     ctx,
-		BlockNumber: block,
+		BlockNumber: nil,
 	}
 
 	if block == nil || block.Int64() == 0 {
-		if r.LatestBlock() != 0 {
-			opts.BlockNumber = big.NewInt(r.LatestBlock())
-		}
+		opts.BlockNumber = big.NewInt(r.LatestBlock())
 	} else {
 		opts.BlockNumber = block
 	}
@@ -716,7 +714,7 @@ func (r *EvmRegistry) getUpkeepConfigs(ctx context.Context, ids []*big.Int) ([]a
 	)
 
 	for i, id := range ids {
-		opts, err := r.buildCallOpts(ctx, big.NewInt(0))
+		opts, err := r.buildCallOpts(ctx, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get call opts: %s", err)
 		}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry.go
@@ -466,7 +466,9 @@ func (r *EvmRegistry) buildCallOpts(ctx context.Context, block *big.Int) (*bind.
 	}
 
 	if block == nil || block.Int64() == 0 {
-		opts.BlockNumber = big.NewInt(r.LatestBlock())
+		if r.LatestBlock() != 0 {
+			opts.BlockNumber = big.NewInt(r.LatestBlock())
+		}
 	} else {
 		opts.BlockNumber = block
 	}
@@ -592,16 +594,21 @@ func (r *EvmRegistry) checkUpkeeps(ctx context.Context, keys []ocr2keepers.Upkee
 			return nil, err
 		}
 
+		args := []interface{}{
+			map[string]interface{}{
+				"to":   r.addr.Hex(),
+				"data": hexutil.Bytes(payload),
+			},
+		}
+
+		if opts.BlockNumber != nil {
+			args = append(args, hexutil.EncodeBig(opts.BlockNumber))
+		}
+
 		var result string
 		checkReqs[i] = rpc.BatchElem{
 			Method: "eth_call",
-			Args: []interface{}{
-				map[string]interface{}{
-					"to":   r.addr.Hex(),
-					"data": hexutil.Bytes(payload),
-				},
-				hexutil.EncodeBig(opts.BlockNumber),
-			},
+			Args:   args,
 			Result: &result,
 		}
 
@@ -658,16 +665,21 @@ func (r *EvmRegistry) simulatePerformUpkeeps(ctx context.Context, checkResults [
 			return nil, err
 		}
 
+		args := []interface{}{
+			map[string]interface{}{
+				"to":   r.addr.Hex(),
+				"data": hexutil.Bytes(payload),
+			},
+		}
+
+		if opts.BlockNumber != nil {
+			args = append(args, hexutil.EncodeBig(opts.BlockNumber))
+		}
+
 		var result string
 		performReqs = append(performReqs, rpc.BatchElem{
 			Method: "eth_call",
-			Args: []interface{}{
-				map[string]interface{}{
-					"to":   r.addr.Hex(),
-					"data": hexutil.Bytes(payload),
-				},
-				hexutil.EncodeBig(opts.BlockNumber),
-			},
+			Args:   args,
 			Result: &result,
 		})
 
@@ -724,16 +736,21 @@ func (r *EvmRegistry) getUpkeepConfigs(ctx context.Context, ids []*big.Int) ([]a
 			return nil, fmt.Errorf("failed to pack id with abi: %s", err)
 		}
 
+		args := []interface{}{
+			map[string]interface{}{
+				"to":   r.addr.Hex(),
+				"data": hexutil.Bytes(payload),
+			},
+		}
+
+		if opts.BlockNumber != nil {
+			args = append(args, hexutil.EncodeBig(opts.BlockNumber))
+		}
+
 		var result string
 		uReqs[i] = rpc.BatchElem{
 			Method: "eth_call",
-			Args: []interface{}{
-				map[string]interface{}{
-					"to":   r.addr.Hex(),
-					"data": hexutil.Bytes(payload),
-				},
-				hexutil.EncodeBig(opts.BlockNumber),
-			},
+			Args:   args,
 			Result: &result,
 		}
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline.go
@@ -347,7 +347,7 @@ func (r *EvmRegistry) simulatePerformUpkeeps(ctx context.Context, checkResults [
 				"data": hexutil.Bytes(payload),
 			},
 		}
-		
+
 		if opts.BlockNumber != nil {
 			args = append(args, hexutil.EncodeBig(opts.BlockNumber))
 		}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline.go
@@ -233,17 +233,22 @@ func (r *EvmRegistry) checkUpkeeps(ctx context.Context, payloads []ocr2keepers.U
 		indices[len(checkReqs)] = i
 		results[i] = encoding.GetIneligibleCheckResultWithoutPerformData(p, encoding.UpkeepFailureReasonNone, encoding.NoPipelineError, false)
 
+		args := []interface{}{
+			map[string]interface{}{
+				"from": zeroAddress,
+				"to":   r.addr.Hex(),
+				"data": hexutil.Bytes(payload),
+			},
+		}
+
+		if opts.BlockNumber != nil {
+			args = append(args, hexutil.EncodeBig(opts.BlockNumber))
+		}
+
 		var result string
 		checkReqs = append(checkReqs, rpc.BatchElem{
 			Method: "eth_call",
-			Args: []interface{}{
-				map[string]interface{}{
-					"from": zeroAddress,
-					"to":   r.addr.Hex(),
-					"data": hexutil.Bytes(payload),
-				},
-				hexutil.EncodeBig(opts.BlockNumber),
-			},
+			Args:   args,
 			Result: &result,
 		})
 
@@ -334,17 +339,23 @@ func (r *EvmRegistry) simulatePerformUpkeeps(ctx context.Context, checkResults [
 		}
 
 		opts := r.buildCallOpts(ctx, block)
+
+		args := []interface{}{
+			map[string]interface{}{
+				"from": zeroAddress,
+				"to":   r.addr.Hex(),
+				"data": hexutil.Bytes(payload),
+			},
+		}
+		
+		if opts.BlockNumber != nil {
+			args = append(args, hexutil.EncodeBig(opts.BlockNumber))
+		}
+
 		var result string
 		performReqs = append(performReqs, rpc.BatchElem{
 			Method: "eth_call",
-			Args: []interface{}{
-				map[string]interface{}{
-					"from": zeroAddress,
-					"to":   r.addr.Hex(),
-					"data": hexutil.Bytes(payload),
-				},
-				hexutil.EncodeBig(opts.BlockNumber),
-			},
+			Args:   args,
 			Result: &result,
 		})
 


### PR DESCRIPTION
# AUTO-11111

The node upgrade test for automation 2.0 was panicking due to a nil block number; this PR modifies `buildCallOpts` to allow for block 0 to be specified, in order to prevent a nil pointer.

Node upgrade test passing here: https://github.com/smartcontractkit/chainlink/actions/runs/9746647010