### PR TITLE
core/chainlink.Dockerfile: mount go cache

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -7,7 +7,9 @@ COPY GNUmakefile package.json ./
 COPY tools/bin/ldflags ./tools/bin/
 
 ADD go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 # Env vars needed for chainlink build
 ARG COMMIT_SHA


### PR DESCRIPTION
This is an experiment with `--mount`ing the go cache when downloading modules. I suspect we could do the same with the build cache on 26/28.