### PR TITLE
core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider: ru…

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
@@ -508,6 +509,7 @@ func setupDependencies(t *testing.T, db *sqlx.DB, backend *backends.SimulatedBac
 	}
 	ht := headtracker.NewSimulatedHeadTracker(ethClient, lpOpts.UseFinalityTag, lpOpts.FinalityDepth)
 	lp := logpoller.NewLogPoller(lorm, ethClient, pollerLggr, ht, lpOpts)
+	servicetest.Run(t, lp)
 	return lp, ethClient
 }
 


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/9702096112/job/26777177689?pr=11809
Fixing a data race from a test completing while log poller background routines are still running. Now the tests start/stop the log poller.