### PR TITLE
ci: downgrade and different runners for ci-core matrix

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -94,7 +94,8 @@ jobs:
             os: ubuntu-latest-4cores-16GB
           - cmd: go_core_race_tests
             id: core_race
-            os: ubuntu-latest-16cores-64GB
+            # use 64cores for overnight runs only
+            os: ${{ github.event_name == 'schedule' && 'ubuntu-latest-64cores-256GB' || 'ubuntu-latest-32cores-128GB' }}
           - cmd: go_core_fuzz
             id: core_fuzz
             os: ubuntu-latest-8cores-32GB

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -89,9 +89,6 @@ jobs:
           - cmd: go_core_tests
             id: core_unit
             os: ubuntu-latest-32cores-128GB
-          - cmd: go_core_tests_short
-            id: core_unit_short
-            os: ubuntu-latest-4cores-16GB
           - cmd: go_core_race_tests
             id: core_race
             # use 64cores for overnight runs only
@@ -118,38 +115,40 @@ jobs:
       - name: Setup Go
         if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-go
+        # Run short-tests first to short-circuit failures for `go_core_tests`
+        # These tests would be run below anyways if they didn't run here (cached)
       - name: Run short tests
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd == 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd == 'go_core_tests' }}
         run: go test -short ./...
       - name: Setup Solana
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-solana
       - name: Setup wasmd
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-wasmd
       - name: Setup Postgres
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-postgres
       - name: Touching core/web/assets/index.html
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: mkdir -p core/web/assets && touch core/web/assets/index.html
       - name: Download Go vendor packages
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: go mod download
       - name: Replace chainlink-evm deps
         if: ${{ needs.filter.outputs.changes == 'true' && inputs.evm-ref != ''}}
         shell: bash
         run: go get github.com/smartcontractkit/chainlink-evm@${{ inputs.evm-ref }}
       - name: Build binary
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: go build -o chainlink.test .
       - name: Setup DB
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: ./chainlink.test local db preparetest
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
       - name: Install LOOP Plugins
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: |
           pushd $(go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-feeds)
           go install ./cmd/chainlink-feeds
@@ -169,10 +168,10 @@ jobs:
           echo "TIMEOUT=10m" >> $GITHUB_ENV
           echo "COUNT=50" >> $GITHUB_ENV
       - name: Install gotestloghelper
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/gotestloghelper@v1.1.1
       - name: Run tests
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
+        if: ${{ needs.filter.outputs.changes == 'true' }}
         id: run-tests
         env:
           OUTPUT_FILE: ./output.txt

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -55,7 +55,7 @@ jobs:
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: ${{ (github.event_name == 'pull_request' ||  github.event_name == 'schedule') && github.actor != 'dependabot[bot]' }}
     name: lint
-    runs-on: ubuntu-latest-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     needs: [filter]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -88,19 +88,19 @@ jobs:
         type:
           - cmd: go_core_tests
             id: core_unit
-            os: ubuntu-latest-32cores-128GB
+            os: ubuntu22.04-32cores-128GB
           - cmd: go_core_race_tests
             id: core_race
             # use 64cores for overnight runs only due to massive number of runs from PRs
             os: ${{ github.event_name == 'schedule' && 'ubuntu-latest-64cores-256GB' || 'ubuntu-latest-32cores-128GB' }}
           - cmd: go_core_fuzz
             id: core_fuzz
-            os: ubuntu-latest-8cores-32GB
+            os: ubuntu22.04-8cores-32GB
     name: Core Tests (${{ matrix.type.cmd }})
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: github.actor != 'dependabot[bot]'
     needs: [filter]
-    runs-on: ${{matrix.type.os}}
+    runs-on: ${{ matrix.type.os }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -358,7 +358,7 @@ jobs:
   clean:
     name: Clean Go Tidy & Generate
     if: ${{ !contains(join(github.event.pull_request.labels.*.name, ' '), 'skip-smoke-tests') && github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu-latest-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -55,7 +55,7 @@ jobs:
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: ${{ (github.event_name == 'pull_request' ||  github.event_name == 'schedule') && github.actor != 'dependabot[bot]' }}
     name: lint
-    runs-on: ubuntu22.04-8cores-32GB
+    runs-on: ubuntu-latest-8cores-32GB
     needs: [filter]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -88,15 +88,21 @@ jobs:
         type:
           - cmd: go_core_tests
             id: core_unit
+            os: ubuntu-latest-32cores-128GB
+          - cmd: go_core_tests_short
+            id: core_unit_short
+            os: ubuntu-latest-4cores-16GB
           - cmd: go_core_race_tests
             id: core_race
+            os: ubuntu-latest-16cores-64GB
           - cmd: go_core_fuzz
             id: core_fuzz
+            os: ubuntu-latest-8cores-32GB
     name: Core Tests (${{ matrix.type.cmd }})
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: github.actor != 'dependabot[bot]'
     needs: [filter]
-    runs-on: ubuntu-latest-64cores-256GB
+    runs-on: ${{matrix.type.os}}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -112,37 +118,37 @@ jobs:
         if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-go
       - name: Run short tests
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd == 'go_core_tests' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd == 'go_core_tests_short' }}
         run: go test -short ./...
       - name: Setup Solana
-        if: ${{ needs.filter.outputs.changes == 'true' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
         uses: ./.github/actions/setup-solana
       - name: Setup wasmd
-        if: ${{ needs.filter.outputs.changes == 'true' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
         uses: ./.github/actions/setup-wasmd
       - name: Setup Postgres
-        if: ${{ needs.filter.outputs.changes == 'true' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
         uses: ./.github/actions/setup-postgres
       - name: Touching core/web/assets/index.html
-        if: ${{ needs.filter.outputs.changes == 'true' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
         run: mkdir -p core/web/assets && touch core/web/assets/index.html
       - name: Download Go vendor packages
-        if: ${{ needs.filter.outputs.changes == 'true' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
         run: go mod download
       - name: Replace chainlink-evm deps
         if: ${{ needs.filter.outputs.changes == 'true' && inputs.evm-ref != ''}}
         shell: bash
         run: go get github.com/smartcontractkit/chainlink-evm@${{ inputs.evm-ref }}
       - name: Build binary
-        if: ${{ needs.filter.outputs.changes == 'true' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
         run: go build -o chainlink.test .
       - name: Setup DB
-        if: ${{ needs.filter.outputs.changes == 'true' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
         run: ./chainlink.test local db preparetest
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
       - name: Install LOOP Plugins
-        if: ${{ needs.filter.outputs.changes == 'true' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
         run: |
           pushd $(go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-feeds)
           go install ./cmd/chainlink-feeds
@@ -162,10 +168,10 @@ jobs:
           echo "TIMEOUT=10m" >> $GITHUB_ENV
           echo "COUNT=50" >> $GITHUB_ENV
       - name: Install gotestloghelper
-        if: ${{ needs.filter.outputs.changes == 'true' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
         run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/gotestloghelper@v1.1.1
       - name: Run tests
-        if: ${{ needs.filter.outputs.changes == 'true' }}
+        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd != 'go_core_tests_short' }}
         id: run-tests
         env:
           OUTPUT_FILE: ./output.txt
@@ -357,7 +363,7 @@ jobs:
   clean:
     name: Clean Go Tidy & Generate
     if: ${{ !contains(join(github.event.pull_request.labels.*.name, ' '), 'skip-smoke-tests') && github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu22.04-8cores-32GB
+    runs-on: ubuntu-latest-8cores-32GB
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -91,7 +91,7 @@ jobs:
             os: ubuntu-latest-32cores-128GB
           - cmd: go_core_race_tests
             id: core_race
-            # use 64cores for overnight runs only
+            # use 64cores for overnight runs only due to massive number of runs from PRs
             os: ${{ github.event_name == 'schedule' && 'ubuntu-latest-64cores-256GB' || 'ubuntu-latest-32cores-128GB' }}
           - cmd: go_core_fuzz
             id: core_fuzz
@@ -115,11 +115,6 @@ jobs:
       - name: Setup Go
         if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-go
-        # Run short-tests first to short-circuit failures for `go_core_tests`
-        # These tests would be run below anyways if they didn't run here (cached)
-      - name: Run short tests
-        if: ${{ needs.filter.outputs.changes == 'true' && matrix.type.cmd == 'go_core_tests' }}
-        run: go test -short ./...
       - name: Setup Solana
         if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-solana


### PR DESCRIPTION
### Changes

* Set the runner type in the matrix for ci-core
* Downgrade the runners used for ci-core matrix
	* core tests: 64 core -> 32 core
 		* Remove `short-tests` step due to it being re-run regardless (no caching)
	* core race: 64 core -> 32 core
   	* 64 cores on overnight cron runs
	* core fuzz: 64 core -> 8 core

These runners were chosen for cost effectiveness, and reliability based on testing. 

### Why

Estimated 64% cost reduction per CI core run (7.04$ -> 2.64$), with a decrease in execution time.

```
Cost estimation per run:
- 8 cores - 21 minutes = 0.336 (linting, clean, core_fuzz)
- 32 cores - 18 minutes = 2.304 (core_race, core_tests)

2.304 + 0.336 = 2.64$ (62.5% decrease)
```

### Testing

- I've tested this workflow multiple times by retrying the CI Core workflow: https://github.com/smartcontractkit/chainlink/actions/runs/9862906132?pr=13784
- Other testing
	- https://github.com/smartcontractkit/chainlink/actions/runs/9862493203?pr=13784 
	- https://github.com/smartcontractkit/chainlink/actions/runs/9848215332?pr=13784 
	- https://smartcontract-it.atlassian.net/browse/RE-2796
	- https://github.com/smartcontractkit/chainlink/pull/13782

### Requires Dependencies

N/A

### Resolves Dependencies

N/A

---

[RE-2796](https://smartcontract-it.atlassian.net/browse/RE-2796)


[RE-2796]: https://smartcontract-it.atlassian.net/browse/RE-2796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ