### PR TITLE
Revert lookback blocks to 128

### DIFF
--- a/.changeset/poor-crews-cross.md
+++ b/.changeset/poor-crews-cross.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Revert lookbackBlocks back to 128 #changed

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/factory.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/factory.go
@@ -63,7 +63,7 @@ func NewOptions(finalityDepth int64, chainID *big.Int) LogTriggersOptions {
 // NOTE: o.LookbackBlocks should be set only from within tests
 func (o *LogTriggersOptions) Defaults(finalityDepth int64) {
 	if o.LookbackBlocks == 0 {
-		lookbackBlocks := int64(100)
+		lookbackBlocks := int64(128)
 		if lookbackBlocks < finalityDepth {
 			lookbackBlocks = finalityDepth
 		}
@@ -86,7 +86,7 @@ func (o *LogTriggersOptions) Defaults(finalityDepth int64) {
 func (o *LogTriggersOptions) defaultBlockRate() uint32 {
 	switch o.chainID.Int64() {
 	case 42161, 421613, 421614: // Arbitrum
-		return 2
+		return 4
 	default:
 		return 1
 	}
@@ -99,6 +99,6 @@ func (o *LogTriggersOptions) defaultLogLimit() uint32 {
 	case 10, 420, 56, 97, 137, 80001, 43113, 43114, 8453, 84531: // Optimism, BSC, Polygon, Avax, Base
 		return 5
 	default:
-		return 1
+		return 2
 	}
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/factory.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/factory.go
@@ -86,7 +86,7 @@ func (o *LogTriggersOptions) Defaults(finalityDepth int64) {
 func (o *LogTriggersOptions) defaultBlockRate() uint32 {
 	switch o.chainID.Int64() {
 	case 42161, 421613, 421614: // Arbitrum
-		return 4
+		return 2
 	default:
 		return 1
 	}
@@ -99,6 +99,6 @@ func (o *LogTriggersOptions) defaultLogLimit() uint32 {
 	case 10, 420, 56, 97, 137, 80001, 43113, 43114, 8453, 84531: // Optimism, BSC, Polygon, Avax, Base
 		return 5
 	default:
-		return 2
+		return 1
 	}
 }


### PR DESCRIPTION
Running the load test with 500x1 upkeeps encountered a strange issue after running for ~25 minutes:

```
key sync timeout, consider increasing key_sync_timeout in seth.toml, or increasing the number of keys
```

@anirudhwarrier tried adjusting the number of keys and increasing the gas limit, but this only offset when this issue occurred

Additionally, we observed that after a few minutes, the number of transactions per block had doubled beyond what was expected based on previous runs, e.g. the previous runs looked like:

![image](https://github.com/smartcontractkit/chainlink/assets/19188060/8598ef8e-8379-4f10-a7a4-d4b56dc68091)

Whereas with lookbackBlocks set to 100, we saw this:

![image](https://github.com/smartcontractkit/chainlink/assets/19188060/dc7fec83-4d9c-4793-81f5-835baa88d8b9)

Going back over the latest develop merges, the culprit was my PR for dequeuing minimum number of logs

The 500x1 test had ran successfully on the feature branch, but not after we changed the lookback blocks from 128 to 100

This PR reverts that one change, and the 500x1 load test now runs without this issue, though I'm not sure yet *why* it caused this issue

