### PR TITLE
fix: sonarscan ci error

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -349,7 +349,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_SCANNER_OPTS: "-Xmx3072m" # increase memory
+          SONAR_SCANNER_OPTS: "-Xms6g -Xmx8g"
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -340,7 +340,7 @@ jobs:
           echo "sonarqube_tests_report_paths=$(find go_core_tests_logs -name output.txt | paste -sd "," -)" >> $GITHUB_OUTPUT
           echo "sonarqube_coverage_report_paths=$(find go_core_tests_logs -name coverage.txt | paste -sd "," -)" >> $GITHUB_OUTPUT
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@69c1a75940dec6249b86dace6b630d3a2ae9d2a7 # v2.0.1
+        uses: sonarsource/sonarqube-scan-action@aecaf43ae57e412bd97d70ef9ce6076e672fe0a9 # v2.3.0
         with:
           args: >
             -Dsonar.go.tests.reportPaths=${{ steps.sonarqube_report_paths.outputs.sonarqube_tests_report_paths }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -349,7 +349,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_SCANNER_OPTS: "-Xmx512m" # increase memory
+          SONAR_SCANNER_OPTS: "-Xmx3072m" # increase memory
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -349,6 +349,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_SCANNER_OPTS: "-Xmx512m" # increase memory
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -16,8 +16,6 @@ use_tee() {
     cat > "$@"
   fi
 }
-# disable coverage redesign due to massive coverage output files
-export GOEXPERIMENT=nocoverageredesign
 go test -json -ldflags "$GO_LDFLAGS" -tags integration $TEST_FLAGS -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt $1 | use_tee $OUTPUT_FILE
 EXITCODE=${PIPESTATUS[0]}
 

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -16,6 +16,8 @@ use_tee() {
     cat > "$@"
   fi
 }
+# disable coverage redesign due to massive coverage output files
+export GOEXPERIMENT=nocoverageredesign
 go test -json -ldflags "$GO_LDFLAGS" -tags integration $TEST_FLAGS -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt $1 | use_tee $OUTPUT_FILE
 EXITCODE=${PIPESTATUS[0]}
 


### PR DESCRIPTION
### Changes

* Bump sonarscan action to v2.3.0
* Increase memory limit to 8G (half of the 16GB runner)

### Motivation

Sonarqube scan failing with `java.lang.OutOfMemoryError`. This is because of inflated coverage.txt size with Go v1.22 upgrade.

https://tip.golang.org/doc/go1.22
> go test -cover now prints coverage summaries for covered packages that do not have their own test files. Prior to Go 1.22 a go test -cover run for such a package would report
> ?     mymod/mypack    [no test files]
> and now with Go 1.22, functions in the package are treated as uncovered:
> mymod/mypack    coverage: 0.0% of statements
> Note that if a package contains no executable code at all, we can’t report a meaningful coverage percentage; for such packages the go tool will continue to report that there are no test files.