### PR TITLE
MERC-5889:  Tests for Fee Manager SBRV

### DIFF
--- a/contracts/src/v0.8/llo-feeds/v0.4.0/DestinationFeeManager.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/DestinationFeeManager.sol
@@ -226,7 +226,7 @@ contract DestinationFeeManager is IDestinationFeeManager, ConfirmedOwner, TypeAn
 
     uint256 feesAndRewardsIndex;
     for (uint256 i; i < payloads.length; ++i) {
-      if (poolIds[i] == bytes32(0)) revert InvalidAddress();
+      if (poolIds[i] == emptyBytes) revert InvalidAddress();
 
       (Common.Asset memory fee, Common.Asset memory reward, uint256 appliedDiscount) = _calculateFee(
         payloads[i],

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/DestinationFeeManager.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/DestinationFeeManager.sol
@@ -225,6 +225,7 @@ contract DestinationFeeManager is IDestinationFeeManager, ConfirmedOwner, TypeAn
     uint256 numberOfNativeFees;
 
     uint256 feesAndRewardsIndex;
+    bytes32 emptyBytes = bytes32(0);
     for (uint256 i; i < payloads.length; ++i) {
       if (poolIds[i] == emptyBytes) revert InvalidAddress();
 

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/DestinationFeeManager.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/DestinationFeeManager.sol
@@ -226,6 +226,8 @@ contract DestinationFeeManager is IDestinationFeeManager, ConfirmedOwner, TypeAn
 
     uint256 feesAndRewardsIndex;
     for (uint256 i; i < payloads.length; ++i) {
+      if (poolIds[i] == bytes32(0)) revert InvalidAddress();
+
       (Common.Asset memory fee, Common.Asset memory reward, uint256 appliedDiscount) = _calculateFee(
         payloads[i],
         parameterPayload,

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/BaseDestinationFeeManager.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/BaseDestinationFeeManager.t.sol
@@ -48,6 +48,7 @@ contract BaseDestinationFeeManagerTest is Test {
 
   bytes32 internal constant DEFAULT_FEED_2_V3 = (keccak256("LINK-USD") & V_MASK) | V3_BITMASK;
   bytes32 internal constant DEFAULT_CONFIG_DIGEST = keccak256("DEFAULT_CONFIG_DIGEST");
+  bytes32 internal constant DEFAULT_CONFIG_DIGEST2 = keccak256("DEFAULT_CONFIG_DIGEST2");
 
   //report
   uint256 internal constant DEFAULT_REPORT_LINK_FEE = 1e10;

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/BaseDestinationFeeManager.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/BaseDestinationFeeManager.t.sol
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import {Test} from "forge-std/Test.sol";
+import {DestinationFeeManager} from "../../DestinationFeeManager.sol";
+import {DestinationRewardManager} from "../../DestinationRewardManager.sol";
+import {Common} from "../../../libraries/Common.sol";
+import {ERC20Mock} from "../../../../vendor/openzeppelin-solidity/v4.8.3/contracts/mocks/ERC20Mock.sol";
+import {WERC20Mock} from "../../../../shared/mocks/WERC20Mock.sol";
+import {IDestinationRewardManager} from "../../interfaces/IDestinationRewardManager.sol";
+import {DestinationFeeManagerProxy} from "../mocks/DestinationFeeManagerProxy.sol";
+
+/**
+ * @title BaseDestinationFeeManagerTest
+ * @author Michael Fletcher
+ * @notice Base class for all feeManager tests
+ * @dev This contract is intended to be inherited from and not used directly. It contains functionality to setup the feeManager
+ */
+contract BaseDestinationFeeManagerTest is Test {
+  //contracts
+  DestinationFeeManager internal feeManager;
+  DestinationRewardManager internal rewardManager;
+  DestinationFeeManagerProxy internal feeManagerProxy;
+
+  ERC20Mock internal link;
+  WERC20Mock internal native;
+
+  //erc20 config
+  uint256 internal constant DEFAULT_LINK_MINT_QUANTITY = 100 ether;
+  uint256 internal constant DEFAULT_NATIVE_MINT_QUANTITY = 100 ether;
+
+  //contract owner
+  address internal constant INVALID_ADDRESS = address(0);
+  address internal constant ADMIN = address(uint160(uint256(keccak256("ADMIN"))));
+  address internal constant USER = address(uint160(uint256(keccak256("USER"))));
+  address internal constant PROXY = address(uint160(uint256(keccak256("PROXY"))));
+
+  //version masks
+  bytes32 internal constant V_MASK = 0x0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+  bytes32 internal constant V1_BITMASK = 0x0001000000000000000000000000000000000000000000000000000000000000;
+  bytes32 internal constant V2_BITMASK = 0x0002000000000000000000000000000000000000000000000000000000000000;
+  bytes32 internal constant V3_BITMASK = 0x0003000000000000000000000000000000000000000000000000000000000000;
+
+  //feed ids & config digests
+  bytes32 internal constant DEFAULT_FEED_1_V1 = (keccak256("ETH-USD") & V_MASK) | V1_BITMASK;
+  bytes32 internal constant DEFAULT_FEED_1_V2 = (keccak256("ETH-USD") & V_MASK) | V2_BITMASK;
+  bytes32 internal constant DEFAULT_FEED_1_V3 = (keccak256("ETH-USD") & V_MASK) | V3_BITMASK;
+
+  bytes32 internal constant DEFAULT_FEED_2_V3 = (keccak256("LINK-USD") & V_MASK) | V3_BITMASK;
+  bytes32 internal constant DEFAULT_CONFIG_DIGEST = keccak256("DEFAULT_CONFIG_DIGEST");
+
+  //report
+  uint256 internal constant DEFAULT_REPORT_LINK_FEE = 1e10;
+  uint256 internal constant DEFAULT_REPORT_NATIVE_FEE = 1e12;
+
+  //rewards
+  uint64 internal constant FEE_SCALAR = 1e18;
+
+  address internal constant NATIVE_WITHDRAW_ADDRESS = address(0);
+
+  //the selector for each error
+  bytes4 internal immutable INVALID_DISCOUNT_ERROR = DestinationFeeManager.InvalidDiscount.selector;
+  bytes4 internal immutable INVALID_ADDRESS_ERROR = DestinationFeeManager.InvalidAddress.selector;
+  bytes4 internal immutable INVALID_SURCHARGE_ERROR = DestinationFeeManager.InvalidSurcharge.selector;
+  bytes4 internal immutable EXPIRED_REPORT_ERROR = DestinationFeeManager.ExpiredReport.selector;
+  bytes4 internal immutable INVALID_DEPOSIT_ERROR = DestinationFeeManager.InvalidDeposit.selector;
+  bytes4 internal immutable INVALID_QUOTE_ERROR = DestinationFeeManager.InvalidQuote.selector;
+  bytes4 internal immutable UNAUTHORIZED_ERROR = DestinationFeeManager.Unauthorized.selector;
+  bytes internal constant ONLY_CALLABLE_BY_OWNER_ERROR = "Only callable by owner";
+  bytes internal constant INSUFFICIENT_ALLOWANCE_ERROR = "ERC20: insufficient allowance";
+  bytes4 internal immutable ZERO_DEFICIT = DestinationFeeManager.ZeroDeficit.selector;
+
+  //events emitted
+  event SubscriberDiscountUpdated(address indexed subscriber, bytes32 indexed feedId, address token, uint64 discount);
+  event NativeSurchargeUpdated(uint64 newSurcharge);
+  event InsufficientLink(IDestinationRewardManager.FeePayment[] feesAndRewards);
+  event Withdraw(address adminAddress, address recipient, address assetAddress, uint192 quantity);
+  event LinkDeficitCleared(bytes32 indexed configDigest, uint256 linkQuantity);
+  event DiscountApplied(
+    bytes32 indexed configDigest,
+    address indexed subscriber,
+    Common.Asset fee,
+    Common.Asset reward,
+    uint256 appliedDiscountQuantity
+  );
+
+  function setUp() public virtual {
+    //change to admin user
+    vm.startPrank(ADMIN);
+
+    //init required contracts
+    _initializeContracts();
+  }
+
+  function _initializeContracts() internal {
+    link = new ERC20Mock("LINK", "LINK", ADMIN, 0);
+    native = new WERC20Mock();
+
+    feeManagerProxy = new DestinationFeeManagerProxy();
+    rewardManager = new DestinationRewardManager(address(link));
+    feeManager = new DestinationFeeManager(address(link), address(native), address(feeManagerProxy), address(rewardManager));
+
+    //link the feeManager to the proxy
+    feeManagerProxy.setDestinationFeeManager(feeManager);
+
+    //link the feeManager to the reward manager
+    rewardManager.setFeeManager(address(feeManager));
+
+    //mint some tokens to the admin
+    link.mint(ADMIN, DEFAULT_LINK_MINT_QUANTITY);
+    native.mint(ADMIN, DEFAULT_NATIVE_MINT_QUANTITY);
+    vm.deal(ADMIN, DEFAULT_NATIVE_MINT_QUANTITY);
+
+    //mint some tokens to the user
+    link.mint(USER, DEFAULT_LINK_MINT_QUANTITY);
+    native.mint(USER, DEFAULT_NATIVE_MINT_QUANTITY);
+    vm.deal(USER, DEFAULT_NATIVE_MINT_QUANTITY);
+
+    //mint some tokens to the proxy
+    link.mint(PROXY, DEFAULT_LINK_MINT_QUANTITY);
+    native.mint(PROXY, DEFAULT_NATIVE_MINT_QUANTITY);
+    vm.deal(PROXY, DEFAULT_NATIVE_MINT_QUANTITY);
+  }
+
+  function setSubscriberDiscount(
+    address subscriber,
+    bytes32 feedId,
+    address token,
+    uint256 discount,
+    address sender
+  ) internal {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(sender);
+
+    //set the discount
+    feeManager.updateSubscriberDiscount(subscriber, feedId, token, uint64(discount));
+
+    //change back to the original address
+    changePrank(originalAddr);
+  }
+
+  function setNativeSurcharge(uint256 surcharge, address sender) public {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(sender);
+
+    //set the surcharge
+    feeManager.setNativeSurcharge(uint64(surcharge));
+
+    //change back to the original address
+    changePrank(originalAddr);
+  }
+
+  // solium-disable-next-line no-unused-vars
+  function getFee(bytes memory report, address quote, address subscriber) public view returns (Common.Asset memory) {
+    //get the fee
+    (Common.Asset memory fee, , ) = feeManager.getFeeAndReward(subscriber, report, quote);
+
+    return fee;
+  }
+
+  function getReward(bytes memory report, address quote, address subscriber) public view returns (Common.Asset memory) {
+    //get the reward
+    (, Common.Asset memory reward, ) = feeManager.getFeeAndReward(subscriber, report, quote);
+
+    return reward;
+  }
+
+  function getAppliedDiscount(bytes memory report, address quote, address subscriber) public view returns (uint256) {
+    //get the reward
+    (, , uint256 appliedDiscount) = feeManager.getFeeAndReward(subscriber, report, quote);
+
+    return appliedDiscount;
+  }
+
+  function getV1Report(bytes32 feedId) public pure returns (bytes memory) {
+    return abi.encode(feedId, uint32(0), int192(0), int192(0), int192(0), uint64(0), bytes32(0), uint64(0), uint64(0));
+  }
+
+  function getV2Report(bytes32 feedId) public view returns (bytes memory) {
+    return
+      abi.encode(
+        feedId,
+        uint32(0),
+        uint32(0),
+        uint192(DEFAULT_REPORT_NATIVE_FEE),
+        uint192(DEFAULT_REPORT_LINK_FEE),
+        uint32(block.timestamp),
+        int192(0)
+      );
+  }
+
+  function getV3Report(bytes32 feedId) public view returns (bytes memory) {
+    return
+      abi.encode(
+        feedId,
+        uint32(0),
+        uint32(0),
+        uint192(DEFAULT_REPORT_NATIVE_FEE),
+        uint192(DEFAULT_REPORT_LINK_FEE),
+        uint32(block.timestamp),
+        int192(0),
+        int192(0),
+        int192(0)
+      );
+  }
+
+  function getV3ReportWithCustomExpiryAndFee(
+    bytes32 feedId,
+    uint256 expiry,
+    uint256 linkFee,
+    uint256 nativeFee
+  ) public pure returns (bytes memory) {
+    return
+      abi.encode(
+        feedId,
+        uint32(0),
+        uint32(0),
+        uint192(nativeFee),
+        uint192(linkFee),
+        uint32(expiry),
+        int192(0),
+        int192(0),
+        int192(0)
+      );
+  }
+
+  function getLinkQuote() public view returns (address) {
+    return address(link);
+  }
+
+  function getNativeQuote() public view returns (address) {
+    return address(native);
+  }
+
+  function withdraw(address assetAddress, address recipient, uint256 amount, address sender) public {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(sender);
+
+    //set the surcharge
+    feeManager.withdraw(assetAddress, recipient, uint192(amount));
+
+    //change back to the original address
+    changePrank(originalAddr);
+  }
+
+  function getLinkBalance(address balanceAddress) public view returns (uint256) {
+    return link.balanceOf(balanceAddress);
+  }
+
+  function getNativeBalance(address balanceAddress) public view returns (uint256) {
+    return native.balanceOf(balanceAddress);
+  }
+
+  function getNativeUnwrappedBalance(address balanceAddress) public view returns (uint256) {
+    return balanceAddress.balance;
+  }
+
+  function mintLink(address recipient, uint256 amount) public {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(ADMIN);
+
+    //mint the link to the recipient
+    link.mint(recipient, amount);
+
+    //change back to the original address
+    changePrank(originalAddr);
+  }
+
+  function mintNative(address recipient, uint256 amount, address sender) public {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(sender);
+
+    //mint the native to the recipient
+    native.mint(recipient, amount);
+
+    //change back to the original address
+    changePrank(originalAddr);
+  }
+
+  function issueUnwrappedNative(address recipient, uint256 quantity) public {
+    vm.deal(recipient, quantity);
+  }
+
+  function ProcessFeeAsUser(
+    bytes32 poolId,
+    bytes memory payload,
+    address subscriber,
+    address tokenAddress,
+    uint256 wrappedNativeValue,
+    address sender
+  ) public {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(sender);
+
+    //process the fee
+    feeManager.processFee{value: wrappedNativeValue}(poolId, payload, abi.encode(tokenAddress), subscriber);
+
+    //change ProcessFeeAsUserback to the original address
+    changePrank(originalAddr);
+  }
+
+  function processFee(bytes32 poolId, bytes memory payload, address subscriber, address feeAddress, uint256 wrappedNativeValue) public {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(subscriber);
+
+    //process the fee
+    feeManagerProxy.processFee{value: wrappedNativeValue}(poolId, payload, abi.encode(feeAddress));
+
+    //change back to the original address
+    changePrank(originalAddr);
+  }
+
+  function processFee(
+    bytes32[] memory poolIds,
+    bytes[] memory payloads,
+    address subscriber,
+    address feeAddress,
+    uint256 wrappedNativeValue
+  ) public {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(subscriber);
+
+    //process the fee
+    feeManagerProxy.processFeeBulk{value: wrappedNativeValue}(poolIds, payloads, abi.encode(feeAddress));
+
+    //change back to the original address
+    changePrank(originalAddr);
+  }
+
+  function getPayload(bytes memory reportPayload) public pure returns (bytes memory) {
+    return abi.encode([DEFAULT_CONFIG_DIGEST, 0, 0], reportPayload, new bytes32[](1), new bytes32[](1), bytes32(""));
+  }
+
+  function approveLink(address spender, uint256 quantity, address sender) public {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(sender);
+
+    //approve the link to be transferred
+    link.approve(spender, quantity);
+
+    //change back to the original address
+    changePrank(originalAddr);
+  }
+
+  function approveNative(address spender, uint256 quantity, address sender) public {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(sender);
+
+    //approve the link to be transferred
+    native.approve(spender, quantity);
+
+    //change back to the original address
+    changePrank(originalAddr);
+  }
+
+  function payLinkDeficit(bytes32 configDigest, address sender) public {
+    //record the current address and switch to the recipient
+    address originalAddr = msg.sender;
+    changePrank(sender);
+
+    //approve the link to be transferred
+    feeManager.payLinkDeficit(configDigest);
+
+    //change back to the original address
+    changePrank(originalAddr);
+  }
+
+  function getLinkDeficit(bytes32 configDigest) public view returns (uint256) {
+    return feeManager.s_linkDeficit(configDigest);
+  }
+}

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/BaseDestinationFeeManager.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/BaseDestinationFeeManager.t.sol
@@ -66,6 +66,7 @@ contract BaseDestinationFeeManagerTest is Test {
   bytes4 internal immutable INVALID_DEPOSIT_ERROR = DestinationFeeManager.InvalidDeposit.selector;
   bytes4 internal immutable INVALID_QUOTE_ERROR = DestinationFeeManager.InvalidQuote.selector;
   bytes4 internal immutable UNAUTHORIZED_ERROR = DestinationFeeManager.Unauthorized.selector;
+  bytes4 internal immutable POOLID_MISMATCH_ERROR = DestinationFeeManager.PoolIdMismatch.selector;
   bytes internal constant ONLY_CALLABLE_BY_OWNER_ERROR = "Only callable by owner";
   bytes internal constant INSUFFICIENT_ALLOWANCE_ERROR = "ERC20: insufficient allowance";
   bytes4 internal immutable ZERO_DEFICIT = DestinationFeeManager.ZeroDeficit.selector;

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.general.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.general.t.sol
@@ -239,4 +239,16 @@ contract DestinationFeeManagerProcessFeeTest is BaseDestinationFeeManagerTest {
 
     payLinkDeficit(DEFAULT_CONFIG_DIGEST, USER);
   }
+
+   function test_revertOnSettingAnAddressZeroVerifier() public {
+    vm.expectRevert(INVALID_ADDRESS_ERROR);
+    feeManager.setVerifier(address(0));
+   }
+
+ function test_onlyCallableByOwnerReverts() public {
+    address STRANGER = address(999);
+    changePrank(STRANGER);
+    vm.expectRevert(bytes("Only callable by owner"));
+    feeManager.setVerifier(address(0));
+   }
 }

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.general.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.general.t.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import "./BaseDestinationFeeManager.t.sol";
+
+/**
+ * @title BaseDestinationFeeManagerTest
+ * @author Michael Fletcher
+ * @notice This contract will test the setup functionality of the feemanager
+ */
+contract DestinationFeeManagerProcessFeeTest is BaseDestinationFeeManagerTest {
+  function setUp() public override {
+    super.setUp();
+  }
+
+  function test_WithdrawERC20() public {
+    //simulate a fee
+    mintLink(address(feeManager), DEFAULT_LINK_MINT_QUANTITY);
+
+    //get the balances to ne used for comparison
+    uint256 contractBalance = getLinkBalance(address(feeManager));
+    uint256 adminBalance = getLinkBalance(ADMIN);
+
+    //the amount to withdraw
+    uint256 withdrawAmount = contractBalance / 2;
+
+    //withdraw some balance
+    withdraw(address(link), ADMIN, withdrawAmount, ADMIN);
+
+    //check the balance has been reduced
+    uint256 newContractBalance = getLinkBalance(address(feeManager));
+    uint256 newAdminBalance = getLinkBalance(ADMIN);
+
+    //check the balance is greater than zero
+    assertGt(newContractBalance, 0);
+    //check the balance has been reduced by the correct amount
+    assertEq(newContractBalance, contractBalance - withdrawAmount);
+    //check the admin balance has increased by the correct amount
+    assertEq(newAdminBalance, adminBalance + withdrawAmount);
+  }
+
+  function test_WithdrawUnwrappedNative() public {
+    //issue funds straight to the contract to bypass the lack of fallback function
+    issueUnwrappedNative(address(feeManager), DEFAULT_NATIVE_MINT_QUANTITY);
+
+    //get the balances to be used for comparison
+    uint256 contractBalance = getNativeUnwrappedBalance(address(feeManager));
+    uint256 adminBalance = getNativeUnwrappedBalance(ADMIN);
+
+    //the amount to withdraw
+    uint256 withdrawAmount = contractBalance / 2;
+
+    //withdraw some balance
+    withdraw(NATIVE_WITHDRAW_ADDRESS, ADMIN, withdrawAmount, ADMIN);
+
+    //check the balance has been reduced
+    uint256 newContractBalance = getNativeUnwrappedBalance(address(feeManager));
+    uint256 newAdminBalance = getNativeUnwrappedBalance(ADMIN);
+
+    //check the balance is greater than zero
+    assertGt(newContractBalance, 0);
+    //check the balance has been reduced by the correct amount
+    assertEq(newContractBalance, contractBalance - withdrawAmount);
+    //check the admin balance has increased by the correct amount
+    assertEq(newAdminBalance, adminBalance + withdrawAmount);
+  }
+
+  function test_WithdrawNonAdminAddr() public {
+    //simulate a fee
+    mintLink(address(feeManager), DEFAULT_LINK_MINT_QUANTITY);
+
+    //should revert if not admin
+    vm.expectRevert(ONLY_CALLABLE_BY_OWNER_ERROR);
+
+    //withdraw some balance
+    withdraw(address(link), ADMIN, DEFAULT_LINK_MINT_QUANTITY, USER);
+  }
+
+  function test_eventIsEmittedAfterSurchargeIsSet() public {
+    //native surcharge
+    uint64 nativeSurcharge = FEE_SCALAR / 5;
+
+    //expect an emit
+    vm.expectEmit();
+
+    //emit the event that is expected to be emitted
+    emit NativeSurchargeUpdated(nativeSurcharge);
+
+    //set the surcharge
+    setNativeSurcharge(nativeSurcharge, ADMIN);
+  }
+
+  function test_subscriberDiscountEventIsEmittedOnUpdate() public {
+    //native surcharge
+    uint64 discount = FEE_SCALAR / 3;
+
+    //an event should be emitted
+    vm.expectEmit();
+
+    //emit the event that is expected to be emitted
+    emit SubscriberDiscountUpdated(USER, DEFAULT_FEED_1_V3, address(native), discount);
+
+    //set the surcharge
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), discount, ADMIN);
+  }
+
+  function test_eventIsEmittedUponWithdraw() public {
+    //simulate a fee
+    mintLink(address(feeManager), DEFAULT_LINK_MINT_QUANTITY);
+
+    //the amount to withdraw
+    uint192 withdrawAmount = 1;
+
+    //expect an emit
+    vm.expectEmit();
+
+    //the event to be emitted
+    emit Withdraw(ADMIN, ADMIN, address(link), withdrawAmount);
+
+    //withdraw some balance
+    withdraw(address(link), ADMIN, withdrawAmount, ADMIN);
+  }
+
+  function test_linkAvailableForPaymentReturnsLinkBalance() public {
+    //simulate a deposit of link for the conversion pool
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    //check there's a balance
+    assertGt(getLinkBalance(address(feeManager)), 0);
+
+    //check the link available for payment is the link balance
+    assertEq(feeManager.linkAvailableForPayment(), getLinkBalance(address(feeManager)));
+  }
+
+  function test_payLinkDeficit() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV2Report(DEFAULT_FEED_1_V3));
+
+    approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE, USER);
+
+    //not enough funds in the reward pool should trigger an insufficient link event
+    vm.expectEmit();
+
+    IDestinationRewardManager.FeePayment[] memory contractFees = new IDestinationRewardManager.FeePayment[](1);
+    contractFees[0] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
+
+    emit InsufficientLink(contractFees);
+
+    //process the fee
+    processFee(contractFees[0].poolId, payload, USER, address(native), 0);
+
+    //double check the rewardManager balance is 0
+    assertEq(getLinkBalance(address(rewardManager)), 0);
+
+    //simulate a deposit of link to cover the deficit
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    vm.expectEmit();
+    emit LinkDeficitCleared(DEFAULT_CONFIG_DIGEST, DEFAULT_REPORT_LINK_FEE);
+
+    //pay the deficit which will transfer link from the rewardManager to the rewardManager
+    payLinkDeficit(DEFAULT_CONFIG_DIGEST, ADMIN);
+
+    //check the rewardManager received the link
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_payLinkDeficitTwice() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV2Report(DEFAULT_FEED_1_V3));
+
+    approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE, USER);
+
+    //not enough funds in the reward pool should trigger an insufficient link event
+    vm.expectEmit();
+
+    IDestinationRewardManager.FeePayment[] memory contractFees = new IDestinationRewardManager.FeePayment[](1);
+    contractFees[0] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
+
+    //emit the event that is expected to be emitted
+    emit InsufficientLink(contractFees);
+
+    //process the fee
+    processFee(contractFees[0].poolId, payload, USER, address(native), 0);
+
+    //double check the rewardManager balance is 0
+    assertEq(getLinkBalance(address(rewardManager)), 0);
+
+    //simulate a deposit of link to cover the deficit
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    vm.expectEmit();
+    emit LinkDeficitCleared(DEFAULT_CONFIG_DIGEST, DEFAULT_REPORT_LINK_FEE);
+
+    //pay the deficit which will transfer link from the rewardManager to the rewardManager
+    payLinkDeficit(DEFAULT_CONFIG_DIGEST, ADMIN);
+
+    //check the rewardManager received the link
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE);
+
+    //paying again should revert with 0
+    vm.expectRevert(ZERO_DEFICIT);
+
+    payLinkDeficit(DEFAULT_CONFIG_DIGEST, ADMIN);
+  }
+
+  function test_payLinkDeficitPaysAllFeesProcessed() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV2Report(DEFAULT_FEED_1_V3));
+
+    //approve the native to be transferred from the user
+    approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE * 2, USER);
+
+    //processing the fee will transfer the native from the user to the feeManager
+    IDestinationRewardManager.FeePayment[] memory contractFees = new IDestinationRewardManager.FeePayment[](1);
+    contractFees[0] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
+    processFee(contractFees[0].poolId, payload, USER, address(native), 0);
+    processFee(contractFees[0].poolId, payload, USER, address(native), 0);
+
+    //check the deficit has been increased twice
+    assertEq(getLinkDeficit(DEFAULT_CONFIG_DIGEST), DEFAULT_REPORT_LINK_FEE * 2);
+
+    //double check the rewardManager balance is 0
+    assertEq(getLinkBalance(address(rewardManager)), 0);
+
+    //simulate a deposit of link to cover the deficit
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE * 2);
+
+    vm.expectEmit();
+    emit LinkDeficitCleared(DEFAULT_CONFIG_DIGEST, DEFAULT_REPORT_LINK_FEE * 2);
+
+    //pay the deficit which will transfer link from the rewardManager to the rewardManager
+    payLinkDeficit(DEFAULT_CONFIG_DIGEST, ADMIN);
+
+    //check the rewardManager received the link
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE * 2);
+  }
+
+  function test_payLinkDeficitOnlyCallableByAdmin() public {
+    vm.expectRevert(ONLY_CALLABLE_BY_OWNER_ERROR);
+
+    payLinkDeficit(DEFAULT_CONFIG_DIGEST, USER);
+  }
+}

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.general.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.general.t.sol
@@ -212,10 +212,8 @@ contract DestinationFeeManagerProcessFeeTest is BaseDestinationFeeManagerTest {
     approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE * 2, USER);
 
     //processing the fee will transfer the native from the user to the feeManager
-    IDestinationRewardManager.FeePayment[] memory contractFees = new IDestinationRewardManager.FeePayment[](1);
-    contractFees[0] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
-    processFee(contractFees[0].poolId, payload, USER, address(native), 0);
-    processFee(contractFees[0].poolId, payload, USER, address(native), 0);
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(native), 0);
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(native), 0);
 
     //check the deficit has been increased twice
     assertEq(getLinkDeficit(DEFAULT_CONFIG_DIGEST), DEFAULT_REPORT_LINK_FEE * 2);

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.getFeeAndReward.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.getFeeAndReward.t.sol
@@ -1,0 +1,606 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import {Common} from "../../../libraries/Common.sol";
+import "./BaseDestinationFeeManager.t.sol";
+
+/**
+ * @title BaseFeeManagerTest
+ * @author Michael Fletcher
+ * @notice This contract will test the functionality of the feeManager's getFeeAndReward
+ */
+contract DestinationFeeManagerProcessFeeTest is BaseDestinationFeeManagerTest {
+  function test_baseFeeIsAppliedForNative() public {
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //fee should be the default
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_baseFeeIsAppliedForLink() public {
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //fee should be the default
+    assertEq(fee.amount, DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_discountAIsNotAppliedWhenSetForOtherUsers() public {
+    //set the subscriber discount for another user
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), INVALID_ADDRESS);
+
+    //fee should be the default
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_discountIsNotAppliedForInvalidTokenAddress() public {
+    //should revert with invalid address as it's not a configured token
+    vm.expectRevert(INVALID_ADDRESS_ERROR);
+
+    //set the subscriber discount for another user
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, INVALID_ADDRESS, FEE_SCALAR / 2, ADMIN);
+  }
+
+  function test_discountIsAppliedForLink() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //fee should be half the default
+    assertEq(fee.amount, DEFAULT_REPORT_LINK_FEE / 2);
+  }
+
+  function test_DiscountIsAppliedForNative() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //fee should be half the default
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE / 2);
+  }
+
+  function test_discountIsNoLongerAppliedAfterRemoving() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //fee should be half the default
+    assertEq(fee.amount, DEFAULT_REPORT_LINK_FEE / 2);
+
+    //remove the discount
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), 0, ADMIN);
+
+    //get the fee required by the feeManager
+    fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //fee should be the default
+    assertEq(fee.amount, DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_surchargeIsApplied() public {
+    //native surcharge
+    uint256 nativeSurcharge = FEE_SCALAR / 5;
+
+    //set the surcharge
+    setNativeSurcharge(nativeSurcharge, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected surcharge
+    uint256 expectedSurcharge = ((DEFAULT_REPORT_NATIVE_FEE * nativeSurcharge) / FEE_SCALAR);
+
+    //expected fee should the base fee offset by the surcharge and discount
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE + expectedSurcharge);
+  }
+
+  function test_surchargeIsNotAppliedForLinkFee() public {
+    //native surcharge
+    uint256 nativeSurcharge = FEE_SCALAR / 5;
+
+    //set the surcharge
+    setNativeSurcharge(nativeSurcharge, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //fee should be the default
+    assertEq(fee.amount, DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_surchargeIsNoLongerAppliedAfterRemoving() public {
+    //native surcharge
+    uint256 nativeSurcharge = FEE_SCALAR / 5;
+
+    //set the surcharge
+    setNativeSurcharge(nativeSurcharge, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected surcharge
+    uint256 expectedSurcharge = ((DEFAULT_REPORT_NATIVE_FEE * nativeSurcharge) / FEE_SCALAR);
+
+    //expected fee should be the base fee offset by the surcharge and discount
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE + expectedSurcharge);
+
+    //remove the surcharge
+    setNativeSurcharge(0, ADMIN);
+
+    //get the fee required by the feeManager
+    fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //fee should be the default
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_feeIsUpdatedAfterNewSurchargeIsApplied() public {
+    //native surcharge
+    uint256 nativeSurcharge = FEE_SCALAR / 5;
+
+    //set the surcharge
+    setNativeSurcharge(nativeSurcharge, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected surcharge
+    uint256 expectedSurcharge = ((DEFAULT_REPORT_NATIVE_FEE * nativeSurcharge) / FEE_SCALAR);
+
+    //expected fee should the base fee offset by the surcharge and discount
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE + expectedSurcharge);
+
+    //change the surcharge
+    setNativeSurcharge(nativeSurcharge, ADMIN);
+
+    //get the fee required by the feeManager
+    fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected surcharge
+    expectedSurcharge = ((DEFAULT_REPORT_NATIVE_FEE * nativeSurcharge) / FEE_SCALAR);
+
+    //expected fee should the base fee offset by the surcharge and discount
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE + expectedSurcharge);
+  }
+
+  function test_surchargeIsAppliedForNativeFeeWithDiscount() public {
+    //native surcharge
+    uint256 nativeSurcharge = FEE_SCALAR / 5;
+
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //set the surcharge
+    setNativeSurcharge(nativeSurcharge, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected surcharge quantity
+    uint256 expectedSurcharge = ((DEFAULT_REPORT_NATIVE_FEE * nativeSurcharge) / FEE_SCALAR);
+
+    //calculate the expected discount quantity
+    uint256 expectedDiscount = ((DEFAULT_REPORT_NATIVE_FEE + expectedSurcharge) / 2);
+
+    //expected fee should the base fee offset by the surcharge and discount
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE + expectedSurcharge - expectedDiscount);
+  }
+
+  function test_emptyQuoteRevertsWithError() public {
+    //expect a revert
+    vm.expectRevert(INVALID_QUOTE_ERROR);
+
+    //get the fee required by the feeManager
+    getFee(getV3Report(DEFAULT_FEED_1_V3), address(0), USER);
+  }
+
+  function test_nativeSurcharge100Percent() public {
+    //set the surcharge
+    setNativeSurcharge(FEE_SCALAR, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //fee should be twice the base fee
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE * 2);
+  }
+
+  function test_nativeSurcharge0Percent() public {
+    //set the surcharge
+    setNativeSurcharge(0, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //fee should base fee
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_nativeSurchargeCannotExceed100Percent() public {
+    //should revert if surcharge is greater than 100%
+    vm.expectRevert(INVALID_SURCHARGE_ERROR);
+
+    //set the surcharge above the max
+    setNativeSurcharge(FEE_SCALAR + 1, ADMIN);
+  }
+
+  function test_discountIsAppliedWith100PercentSurcharge() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //set the surcharge
+    setNativeSurcharge(FEE_SCALAR, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected discount quantity
+    uint256 expectedDiscount = DEFAULT_REPORT_NATIVE_FEE;
+
+    //fee should be twice the surcharge minus the discount
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE * 2 - expectedDiscount);
+  }
+
+  function test_feeIsZeroWith100PercentDiscount() public {
+    //set the subscriber discount to 100%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //fee should be zero
+    assertEq(fee.amount, 0);
+  }
+
+  function test_feeIsUpdatedAfterDiscountIsRemoved() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected discount quantity
+    uint256 expectedDiscount = DEFAULT_REPORT_NATIVE_FEE / 2;
+
+    //fee should be 50% of the base fee
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE - expectedDiscount);
+
+    //remove the discount
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), 0, ADMIN);
+
+    //get the fee required by the feeManager
+    fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //fee should be the base fee
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_feeIsUpdatedAfterNewDiscountIsApplied() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected discount quantity
+    uint256 expectedDiscount = DEFAULT_REPORT_NATIVE_FEE / 2;
+
+    //fee should be 50% of the base fee
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE - expectedDiscount);
+
+    //change the discount to 25%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 4, ADMIN);
+
+    //get the fee required by the feeManager
+    fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //expected discount is now 25%
+    expectedDiscount = DEFAULT_REPORT_NATIVE_FEE / 4;
+
+    //fee should be the base fee minus the expected discount
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE - expectedDiscount);
+  }
+
+  function test_setDiscountOver100Percent() public {
+    //should revert with invalid discount
+    vm.expectRevert(INVALID_DISCOUNT_ERROR);
+
+    //set the subscriber discount to over 100%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR + 1, ADMIN);
+  }
+
+  function test_surchargeIsNotAppliedWith100PercentDiscount() public {
+    //native surcharge
+    uint256 nativeSurcharge = FEE_SCALAR / 5;
+
+    //set the subscriber discount to 100%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR, ADMIN);
+
+    //set the surcharge
+    setNativeSurcharge(nativeSurcharge, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //fee should be zero
+    assertEq(fee.amount, 0);
+  }
+
+  function test_nonAdminUserCanNotSetDiscount() public {
+    //should revert with unauthorized
+    vm.expectRevert(ONLY_CALLABLE_BY_OWNER_ERROR);
+
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR, USER);
+  }
+
+  function test_surchargeFeeRoundsUpWhenUneven() public {
+    //native surcharge
+    uint256 nativeSurcharge = FEE_SCALAR / 3;
+
+    //set the surcharge
+    setNativeSurcharge(nativeSurcharge, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected surcharge quantity
+    uint256 expectedSurcharge = (DEFAULT_REPORT_NATIVE_FEE * nativeSurcharge) / FEE_SCALAR;
+
+    //expected fee should the base fee offset by the expected surcharge
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE + expectedSurcharge + 1);
+  }
+
+  function test_discountFeeRoundsDownWhenUneven() public {
+    //native surcharge
+    uint256 discount = FEE_SCALAR / 3;
+
+    //set the subscriber discount to 33.333%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), discount, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected quantity
+    uint256 expectedDiscount = ((DEFAULT_REPORT_NATIVE_FEE * discount) / FEE_SCALAR);
+
+    //expected fee should the base fee offset by the expected surcharge
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE - expectedDiscount);
+  }
+
+  function test_reportWithNoExpiryOrFeeReturnsZero() public {
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV1Report(DEFAULT_FEED_1_V1), getNativeQuote(), USER);
+
+    //fee should be zero
+    assertEq(fee.amount, 0);
+  }
+
+  function test_correctDiscountIsAppliedWhenBothTokensAreDiscounted() public {
+    //set the subscriber and native discounts
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), FEE_SCALAR / 4, ADMIN);
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager for both tokens
+    Common.Asset memory linkFee = getFee(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+    Common.Asset memory nativeFee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //calculate the expected discount quantity for each token
+    uint256 expectedDiscountLink = (DEFAULT_REPORT_LINK_FEE * FEE_SCALAR) / 4 / FEE_SCALAR;
+    uint256 expectedDiscountNative = (DEFAULT_REPORT_NATIVE_FEE * FEE_SCALAR) / 2 / FEE_SCALAR;
+
+    //check the fee calculation for each token
+    assertEq(linkFee.amount, DEFAULT_REPORT_LINK_FEE - expectedDiscountLink);
+    assertEq(nativeFee.amount, DEFAULT_REPORT_NATIVE_FEE - expectedDiscountNative);
+  }
+
+  function test_discountIsNotAppliedToOtherFeeds() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_2_V3), getNativeQuote(), USER);
+
+    //fee should be the base fee
+    assertEq(fee.amount, DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_noFeeIsAppliedWhenReportHasZeroFee() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(
+      getV3ReportWithCustomExpiryAndFee(DEFAULT_FEED_1_V3, uint32(block.timestamp), 0, 0),
+      getNativeQuote(),
+      USER
+    );
+
+    //fee should be zero
+    assertEq(fee.amount, 0);
+  }
+
+  function test_noFeeIsAppliedWhenReportHasZeroFeeAndDiscountAndSurchargeIsSet() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //set the surcharge
+    setNativeSurcharge(FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(
+      getV3ReportWithCustomExpiryAndFee(DEFAULT_FEED_1_V3, uint32(block.timestamp), 0, 0),
+      getNativeQuote(),
+      USER
+    );
+
+    //fee should be zero
+    assertEq(fee.amount, 0);
+  }
+
+  function test_nativeSurchargeEventIsEmittedOnUpdate() public {
+    //native surcharge
+    uint64 nativeSurcharge = FEE_SCALAR / 3;
+
+    //an event should be emitted
+    vm.expectEmit();
+
+    //emit the event that is expected to be emitted
+    emit NativeSurchargeUpdated(nativeSurcharge);
+
+    //set the surcharge
+    setNativeSurcharge(nativeSurcharge, ADMIN);
+  }
+
+  function test_getBaseRewardWithLinkQuote() public {
+    //get the fee required by the feeManager
+    Common.Asset memory reward = getReward(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //the reward should equal the base fee
+    assertEq(reward.amount, DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_getRewardWithLinkQuoteAndLinkDiscount() public {
+    //set the link discount
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory reward = getReward(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //the reward should equal the discounted base fee
+    assertEq(reward.amount, DEFAULT_REPORT_LINK_FEE / 2);
+  }
+
+  function test_getRewardWithNativeQuote() public {
+    //get the fee required by the feeManager
+    Common.Asset memory reward = getReward(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //the reward should equal the base fee in link
+    assertEq(reward.amount, DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_getRewardWithNativeQuoteAndSurcharge() public {
+    //set the native surcharge
+    setNativeSurcharge(FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory reward = getReward(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //the reward should equal the base fee in link regardless of the surcharge
+    assertEq(reward.amount, DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_getRewardWithLinkDiscount() public {
+    //set the link discount
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory reward = getReward(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //the reward should equal the discounted base fee
+    assertEq(reward.amount, DEFAULT_REPORT_LINK_FEE / 2);
+  }
+
+  function test_getLinkFeeIsRoundedUp() public {
+    //set the link discount
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), FEE_SCALAR / 3, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //the reward should equal .66% + 1 of the base fee due to a 33% discount rounded up
+    assertEq(fee.amount, (DEFAULT_REPORT_LINK_FEE * 2) / 3 + 1);
+  }
+
+  function test_getLinkRewardIsSameAsFee() public {
+    //set the link discount
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), FEE_SCALAR / 3, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+    Common.Asset memory reward = getReward(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //check the reward is in link
+    assertEq(fee.assetAddress, address(link));
+
+    //the reward should equal .66% of the base fee due to a 33% discount rounded down
+    assertEq(reward.amount, fee.amount);
+  }
+
+  function test_getLinkRewardWithNativeQuoteAndSurchargeWithLinkDiscount() public {
+    //set the native surcharge
+    setNativeSurcharge(FEE_SCALAR / 2, ADMIN);
+
+    //set the link discount
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), FEE_SCALAR / 3, ADMIN);
+
+    //get the fee required by the feeManager
+    Common.Asset memory reward = getReward(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //the reward should equal the base fee in link regardless of the surcharge
+    assertEq(reward.amount, DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_testRevertIfReportHasExpired() public {
+    //expect a revert
+    vm.expectRevert(EXPIRED_REPORT_ERROR);
+
+    //get the fee required by the feeManager
+    getFee(
+      getV3ReportWithCustomExpiryAndFee(
+        DEFAULT_FEED_1_V3,
+        block.timestamp - 1,
+        DEFAULT_REPORT_LINK_FEE,
+        DEFAULT_REPORT_NATIVE_FEE
+      ),
+      getNativeQuote(),
+      USER
+    );
+  }
+
+  function test_discountIsReturnedForLink() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(link), FEE_SCALAR / 2, ADMIN);
+
+    //get the fee applied
+    uint256 discount = getAppliedDiscount(getV3Report(DEFAULT_FEED_1_V3), getLinkQuote(), USER);
+
+    //fee should be half the default
+    assertEq(discount, FEE_SCALAR / 2);
+  }
+
+  function test_DiscountIsReturnedForNative() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //get the discount applied
+    uint256 discount = getAppliedDiscount(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //fee should be half the default
+    assertEq(discount, FEE_SCALAR / 2);
+  }
+
+  function test_DiscountIsReturnedForNativeWithSurcharge() public {
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //set the surcharge
+    setNativeSurcharge(FEE_SCALAR / 5, ADMIN);
+
+    //get the discount applied
+    uint256 discount = getAppliedDiscount(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    //fee should be half the default
+    assertEq(discount, FEE_SCALAR / 2);
+  }
+}

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFee.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFee.t.sol
@@ -105,11 +105,8 @@ contract FeeManagerProcessFeeTest is BaseDestinationFeeManagerTest {
     //get the default payload
     bytes memory payload = getPayload(getV1Report(DEFAULT_FEED_1_V1));
 
-    IDestinationRewardManager.FeePayment[] memory contractFees = new IDestinationRewardManager.FeePayment[](1);
-    contractFees[0] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
-
     //processing the fee will not withdraw anything as there is no fee to collect
-    processFee(contractFees[0].poolId, payload, USER, address(link), 0);
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), 0);
   }
 
   function test_processFeeNative() public {

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFee.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFee.t.sol
@@ -1,0 +1,495 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import {Common} from "../../../libraries/Common.sol";
+import "./BaseDestinationFeeManager.t.sol";
+import {IDestinationRewardManager} from "../../interfaces/IDestinationRewardManager.sol";
+
+/**
+ * @title BaseFeeManagerTest
+ * @author Michael Fletcher
+ * @notice This contract will test the functionality of the feeManager processFee
+ */
+contract FeeManagerProcessFeeTest is BaseDestinationFeeManagerTest {
+  function setUp() public override {
+    super.setUp();
+  }
+
+  function test_nonAdminProxyUserCannotProcessFee() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //should revert as the user is not the owner
+    vm.expectRevert(UNAUTHORIZED_ERROR);
+
+    //process the fee
+    ProcessFeeAsUser(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), 0, USER);
+  }
+
+  function test_processFeeAsProxy() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //approve the link to be transferred from the from the subscriber to the rewardManager
+    approveLink(address(rewardManager), DEFAULT_REPORT_LINK_FEE, USER);
+
+    //processing the fee will transfer the link from the user to the rewardManager
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), 0);
+
+    //check the link has been transferred
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE);
+
+    //check the user has had the link fee deducted
+    assertEq(getLinkBalance(USER), DEFAULT_LINK_MINT_QUANTITY - DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_processFeeIfSubscriberIsSelf() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //expect a revert due to the feeManager being the subscriber
+    vm.expectRevert(INVALID_ADDRESS_ERROR);
+
+    //process the fee will fail due to assertion
+    processFee(DEFAULT_CONFIG_DIGEST, payload, address(feeManager), address(native), 0);
+  }
+
+  function test_processFeeWithWithEmptyQuotePayload() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //expect a revert as the quote is invalid
+    vm.expectRevert();
+
+    //processing the fee will transfer the link by default
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(0), 0);
+  }
+
+  function test_processFeeWithWithZeroQuotePayload() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //expect a revert as the quote is invalid
+    vm.expectRevert(INVALID_QUOTE_ERROR);
+
+    //processing the fee will transfer the link by default
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, INVALID_ADDRESS, 0);
+  }
+
+  function test_processFeeWithWithCorruptQuotePayload() public {
+    //get the default payload
+    bytes memory payload = abi.encode(
+      [DEFAULT_CONFIG_DIGEST, 0, 0],
+      getV3Report(DEFAULT_FEED_1_V3),
+      new bytes32[](1),
+      new bytes32[](1),
+      bytes32("")
+    );
+
+    //expect an evm revert as the quote is corrupt
+    vm.expectRevert();
+
+    //processing the fee will not withdraw anything as there is no fee to collect
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), 0);
+  }
+
+  function test_processFeeDefaultReportsStillVerifiesWithEmptyQuote() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV1Report(DEFAULT_FEED_1_V1));
+
+    //processing the fee will transfer the link from the user to the rewardManager
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(0), 0);
+  }
+
+  function test_processFeeWithDefaultReportPayloadAndQuoteStillVerifies() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV1Report(DEFAULT_FEED_1_V1));
+
+    IDestinationRewardManager.FeePayment[] memory contractFees = new IDestinationRewardManager.FeePayment[](1);
+    contractFees[0] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
+
+    //processing the fee will not withdraw anything as there is no fee to collect
+    processFee(contractFees[0].poolId, payload, USER, address(link), 0);
+  }
+
+  function test_processFeeNative() public {
+    //simulate a deposit of link for the conversion pool
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //approve the native to be transferred from the user
+    approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE, USER);
+
+    //processing the fee will transfer the native from the user to the feeManager
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(native), 0);
+
+    //check the native has been transferred
+    assertEq(getNativeBalance(address(feeManager)), DEFAULT_REPORT_NATIVE_FEE);
+
+    //check the link has been transferred to the rewardManager
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE);
+
+    //check the feeManager has had the link deducted, the remaining balance should be 0
+    assertEq(getLinkBalance(address(feeManager)), 0);
+
+    //check the subscriber has had the native deducted
+    assertEq(getNativeBalance(USER), DEFAULT_NATIVE_MINT_QUANTITY - DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_processFeeEmitsEventIfNotEnoughLink() public {
+    //simulate a deposit of half the link required for the fee
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE / 2);
+
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //approve the native to be transferred from the user
+    approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE, USER);
+
+    //expect an emit as there's not enough link
+    vm.expectEmit();
+
+    IDestinationRewardManager.FeePayment[] memory contractFees = new IDestinationRewardManager.FeePayment[](1);
+    contractFees[0] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
+
+    //emit the event that is expected to be emitted
+    emit InsufficientLink(contractFees);
+
+    //processing the fee will transfer the native from the user to the feeManager
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(native), 0);
+
+    //check the native has been transferred
+    assertEq(getNativeBalance(address(feeManager)), DEFAULT_REPORT_NATIVE_FEE);
+
+    //check no link has been transferred to the rewardManager
+    assertEq(getLinkBalance(address(rewardManager)), 0);
+    assertEq(getLinkBalance(address(feeManager)), DEFAULT_REPORT_LINK_FEE / 2);
+
+    //check the subscriber has had the native deducted
+    assertEq(getNativeBalance(USER), DEFAULT_NATIVE_MINT_QUANTITY - DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_processFeeWithUnwrappedNative() public {
+    //simulate a deposit of link for the conversion pool
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //only the proxy or admin can call processFee, they will pass in the native value on the users behalf
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(native), DEFAULT_REPORT_NATIVE_FEE);
+
+    //check the native has been transferred and converted to wrapped native
+    assertEq(getNativeBalance(address(feeManager)), DEFAULT_REPORT_NATIVE_FEE);
+    assertEq(getNativeUnwrappedBalance(address(feeManager)), 0);
+
+    //check the link has been transferred to the rewardManager
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE);
+
+    //check the feeManager has had the link deducted, the remaining balance should be 0
+    assertEq(getLinkBalance(address(feeManager)), 0);
+
+    //check the subscriber has had the native deducted
+    assertEq(getNativeUnwrappedBalance(USER), DEFAULT_NATIVE_MINT_QUANTITY - DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_processFeeWithUnwrappedNativeShortFunds() public {
+    //simulate a deposit of link for the conversion pool
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //expect a revert as not enough funds
+    vm.expectRevert(INVALID_DEPOSIT_ERROR);
+
+    //only the proxy or admin can call processFee, they will pass in the native value on the users behalf
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(native), DEFAULT_REPORT_NATIVE_FEE - 1);
+  }
+
+  function test_processFeeWithUnwrappedNativeLinkAddress() public {
+    //simulate a deposit of link for the conversion pool
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //expect a revert as not enough funds
+    vm.expectRevert(INSUFFICIENT_ALLOWANCE_ERROR);
+
+    //the change will be returned and the user will attempted to be billed in LINK
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), DEFAULT_REPORT_NATIVE_FEE - 1);
+  }
+
+  function test_processFeeWithUnwrappedNativeLinkAddressExcessiveFee() public {
+    //approve the link to be transferred from the from the subscriber to the rewardManager
+    approveLink(address(rewardManager), DEFAULT_REPORT_LINK_FEE, PROXY);
+
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //call processFee from the proxy to test whether the funds are returned to the subscriber. In reality, the funds would be returned to the caller of the proxy.
+    processFee(DEFAULT_CONFIG_DIGEST, payload, PROXY, address(link), DEFAULT_REPORT_NATIVE_FEE);
+
+    //check the native unwrapped is no longer in the account
+    assertEq(getNativeBalance(address(feeManager)), 0);
+    assertEq(getNativeUnwrappedBalance(address(feeManager)), 0);
+
+    //check the link has been transferred to the rewardManager
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE);
+
+    //check the feeManager has had the link deducted, the remaining balance should be 0
+    assertEq(getLinkBalance(address(feeManager)), 0);
+
+    //native should not be deducted
+    assertEq(getNativeUnwrappedBalance(PROXY), DEFAULT_NATIVE_MINT_QUANTITY);
+  }
+
+  function test_processFeeWithUnwrappedNativeWithExcessiveFee() public {
+    //simulate a deposit of link for the conversion pool
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //call processFee from the proxy to test whether the funds are returned to the subscriber. In reality, the funds would be returned to the caller of the proxy.
+    processFee(DEFAULT_CONFIG_DIGEST, payload, PROXY, address(native), DEFAULT_REPORT_NATIVE_FEE * 2);
+
+    //check the native has been transferred and converted to wrapped native
+    assertEq(getNativeBalance(address(feeManager)), DEFAULT_REPORT_NATIVE_FEE);
+    assertEq(getNativeUnwrappedBalance(address(feeManager)), 0);
+
+    //check the link has been transferred to the rewardManager
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE);
+
+    //check the feeManager has had the link deducted, the remaining balance should be 0
+    assertEq(getLinkBalance(address(feeManager)), 0);
+
+    //check the subscriber has had the native deducted
+    assertEq(getNativeUnwrappedBalance(PROXY), DEFAULT_NATIVE_MINT_QUANTITY - DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_processFeeUsesCorrectDigest() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //approve the link to be transferred from the from the subscriber to the rewardManager
+    approveLink(address(rewardManager), DEFAULT_REPORT_LINK_FEE, USER);
+
+    //processing the fee will transfer the link from the user to the rewardManager
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), 0);
+
+    //check the link has been transferred
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE);
+
+    //check the user has had the link fee deducted
+    assertEq(getLinkBalance(USER), DEFAULT_LINK_MINT_QUANTITY - DEFAULT_REPORT_LINK_FEE);
+
+    //check funds have been paid to the reward manager
+    assertEq(rewardManager.s_totalRewardRecipientFees(DEFAULT_CONFIG_DIGEST), DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_V1PayloadVerifies() public {
+    //replicate a default payload
+    bytes memory payload = abi.encode(
+      [DEFAULT_CONFIG_DIGEST, 0, 0],
+      getV2Report(DEFAULT_FEED_1_V1),
+      new bytes32[](1),
+      new bytes32[](1),
+      bytes32("")
+    );
+
+    //processing the fee will transfer the link from the user to the rewardManager
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(0), 0);
+  }
+
+  function test_V2PayloadVerifies() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV2Report(DEFAULT_FEED_1_V2));
+
+    //approve the link to be transferred from the from the subscriber to the rewardManager
+    approveLink(address(rewardManager), DEFAULT_REPORT_LINK_FEE, USER);
+
+    //processing the fee will transfer the link from the user to the rewardManager
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), 0);
+
+    //check the link has been transferred
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE);
+
+    //check the user has had the link fee deducted
+    assertEq(getLinkBalance(USER), DEFAULT_LINK_MINT_QUANTITY - DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_V2PayloadWithoutQuoteFails() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV2Report(DEFAULT_FEED_1_V2));
+
+    //expect a revert as the quote is invalid
+    vm.expectRevert();
+
+    //processing the fee will transfer the link from the user to the rewardManager
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(0), 0);
+  }
+
+  function test_V2PayloadWithoutZeroFee() public {
+    //get the default payload
+    bytes memory payload = getPayload(getV2Report(DEFAULT_FEED_1_V2));
+
+    //expect a revert as the quote is invalid
+    vm.expectRevert();
+
+    //processing the fee will transfer the link from the user to the rewardManager
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), 0);
+  }
+
+  function test_processFeeWithInvalidReportVersionFailsToDecode() public {
+    bytes memory data = abi.encode(0x0000100000000000000000000000000000000000000000000000000000000000);
+
+    //get the default payload
+    bytes memory payload = getPayload(data);
+
+    //serialization will fail as there is no report to decode
+    vm.expectRevert();
+
+    //processing the fee will not withdraw anything as there is no fee to collect
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), 0);
+  }
+
+  function test_processFeeWithZeroNativeNonZeroLinkWithNativeQuote() public {
+    //get the default payload
+    bytes memory payload = getPayload(
+      getV3ReportWithCustomExpiryAndFee(DEFAULT_FEED_1_V3, block.timestamp, DEFAULT_REPORT_LINK_FEE, 0)
+    );
+
+    //call processFee should not revert as the fee is 0
+    processFee(DEFAULT_CONFIG_DIGEST, payload, PROXY, address(native), 0);
+  }
+
+  function test_processFeeWithZeroNativeNonZeroLinkWithLinkQuote() public {
+    //get the default payload
+    bytes memory payload = getPayload(
+      getV3ReportWithCustomExpiryAndFee(DEFAULT_FEED_1_V3, block.timestamp, DEFAULT_REPORT_LINK_FEE, 0)
+    );
+
+    //approve the link to be transferred from the from the subscriber to the rewardManager
+    approveLink(address(rewardManager), DEFAULT_REPORT_LINK_FEE, USER);
+
+    //processing the fee will transfer the link to the rewardManager from the user
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), 0);
+
+    //check the link has been transferred
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE);
+
+    //check the user has had the link fee deducted
+    assertEq(getLinkBalance(USER), DEFAULT_LINK_MINT_QUANTITY - DEFAULT_REPORT_LINK_FEE);
+  }
+
+  function test_processFeeWithZeroLinkNonZeroNativeWithNativeQuote() public {
+    //simulate a deposit of link for the conversion pool
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    //get the default payload
+    bytes memory payload = getPayload(
+      getV3ReportWithCustomExpiryAndFee(DEFAULT_FEED_1_V3, block.timestamp, 0, DEFAULT_REPORT_NATIVE_FEE)
+    );
+
+    //approve the native to be transferred from the user
+    approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE, USER);
+
+    //processing the fee will transfer the native from the user to the feeManager
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(native), 0);
+
+    //check the native has been transferred
+    assertEq(getNativeBalance(address(feeManager)), DEFAULT_REPORT_NATIVE_FEE);
+
+    //check no link has been transferred to the rewardManager
+    assertEq(getLinkBalance(address(rewardManager)), 0);
+
+    //check the feeManager has had no link deducted
+    assertEq(getLinkBalance(address(feeManager)), DEFAULT_REPORT_LINK_FEE);
+
+    //check the subscriber has had the native deducted
+    assertEq(getNativeBalance(USER), DEFAULT_NATIVE_MINT_QUANTITY - DEFAULT_REPORT_NATIVE_FEE);
+  }
+
+  function test_processFeeWithZeroLinkNonZeroNativeWithLinkQuote() public {
+    //get the default payload
+    bytes memory payload = getPayload(
+      getV3ReportWithCustomExpiryAndFee(DEFAULT_FEED_1_V3, block.timestamp, 0, DEFAULT_REPORT_NATIVE_FEE)
+    );
+
+    //call processFee should not revert as the fee is 0
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), 0);
+  }
+
+  function test_processFeeWithZeroNativeNonZeroLinkReturnsChange() public {
+    //get the default payload
+    bytes memory payload = getPayload(
+      getV3ReportWithCustomExpiryAndFee(DEFAULT_FEED_1_V3, block.timestamp, 0, DEFAULT_REPORT_NATIVE_FEE)
+    );
+
+    //call processFee should not revert as the fee is 0
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(link), DEFAULT_REPORT_NATIVE_FEE);
+
+    //check the change has been returned
+    assertEq(USER.balance, DEFAULT_NATIVE_MINT_QUANTITY);
+  }
+
+  function test_V1PayloadVerifiesAndReturnsChange() public {
+    //emulate a V1 payload with no quote
+    bytes memory payload = getPayload(getV1Report(DEFAULT_FEED_1_V1));
+
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(0), DEFAULT_REPORT_NATIVE_FEE);
+
+    //Fee manager should not contain any native
+    assertEq(address(feeManager).balance, 0);
+    assertEq(getNativeBalance(address(feeManager)), 0);
+
+    //check the unused native passed in is returned
+    assertEq(USER.balance, DEFAULT_NATIVE_MINT_QUANTITY);
+  }
+
+  function test_processFeeWithDiscountEmitsEvent() public {
+    //simulate a deposit of link for the conversion pool
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    //set the subscriber discount to 50%
+    setSubscriberDiscount(USER, DEFAULT_FEED_1_V3, address(native), FEE_SCALAR / 2, ADMIN);
+
+    //approve the native to be transferred from the user
+    approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE / 2, USER);
+
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    Common.Asset memory fee = getFee(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+    Common.Asset memory reward = getReward(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+    uint256 appliedDiscount = getAppliedDiscount(getV3Report(DEFAULT_FEED_1_V3), getNativeQuote(), USER);
+
+    vm.expectEmit();
+
+    emit DiscountApplied(DEFAULT_CONFIG_DIGEST, USER, fee, reward, appliedDiscount);
+
+    //call processFee should not revert as the fee is 0
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(native), 0);
+  }
+
+  function test_processFeeWithNoDiscountDoesNotEmitEvent() public {
+    //simulate a deposit of link for the conversion pool
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE);
+
+    //approve the native to be transferred from the user
+    approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE, USER);
+
+    //get the default payload
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    //call processFee should not revert as the fee is 0
+    processFee(DEFAULT_CONFIG_DIGEST, payload, USER, address(native), 0);
+
+    //no logs should have been emitted
+    assertEq(vm.getRecordedLogs().length, 0);
+  }
+}

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFeeBulk.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFeeBulk.t.sol
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import "./BaseDestinationFeeManager.t.sol";
+import {IDestinationRewardManager} from "../../interfaces/IDestinationRewardManager.sol";
+
+/**
+ * @title BaseFeeManagerTest
+ * @author Michael Fletcher
+ * @notice This contract will test the functionality of the feeManager processFee
+ */
+contract FeeManagerProcessFeeTest is BaseDestinationFeeManagerTest {
+  uint256 internal constant NUMBER_OF_REPORTS = 5;
+
+  function setUp() public override {
+    super.setUp();
+  }
+
+  function test_processMultipleLinkReports() public {
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    bytes[] memory payloads = new bytes[](NUMBER_OF_REPORTS);
+    for (uint256 i = 0; i < NUMBER_OF_REPORTS; ++i) {
+      payloads[i] = payload;
+    }
+
+    bytes32[] memory poolIds = new bytes32[](NUMBER_OF_REPORTS);
+    for (uint256 i = 0; i < NUMBER_OF_REPORTS; ++i) {
+      poolIds[i] = DEFAULT_CONFIG_DIGEST;
+    }
+
+    approveLink(address(rewardManager), DEFAULT_REPORT_LINK_FEE * NUMBER_OF_REPORTS, USER);
+
+    processFee(poolIds, payloads, USER, address(link), DEFAULT_NATIVE_MINT_QUANTITY);
+
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE * NUMBER_OF_REPORTS);
+    assertEq(getLinkBalance(address(feeManager)), 0);
+    assertEq(getLinkBalance(USER), DEFAULT_LINK_MINT_QUANTITY - DEFAULT_REPORT_LINK_FEE * NUMBER_OF_REPORTS);
+
+    //the subscriber (user) should receive funds back and not the proxy, although when live the proxy will forward the funds sent and not cover it seen here
+    assertEq(USER.balance, DEFAULT_NATIVE_MINT_QUANTITY);
+    assertEq(PROXY.balance, DEFAULT_NATIVE_MINT_QUANTITY);
+  }
+
+  function test_processMultipleWrappedNativeReports() public {
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE * NUMBER_OF_REPORTS + 1);
+
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    bytes[] memory payloads = new bytes[](NUMBER_OF_REPORTS);
+    for (uint256 i; i < NUMBER_OF_REPORTS; ++i) {
+      payloads[i] = payload;
+    }
+
+    bytes32[] memory poolIds = new bytes32[](NUMBER_OF_REPORTS);
+    for (uint256 i = 0; i < NUMBER_OF_REPORTS; ++i) {
+      poolIds[i] = DEFAULT_CONFIG_DIGEST;
+    }
+
+    approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE * NUMBER_OF_REPORTS, USER);
+
+    processFee(poolIds, payloads, USER, address(native), 0);
+
+    assertEq(getNativeBalance(address(feeManager)), DEFAULT_REPORT_NATIVE_FEE * NUMBER_OF_REPORTS);
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE * NUMBER_OF_REPORTS);
+    assertEq(getLinkBalance(address(feeManager)), 1);
+    assertEq(getNativeBalance(USER), DEFAULT_NATIVE_MINT_QUANTITY - DEFAULT_REPORT_NATIVE_FEE * NUMBER_OF_REPORTS);
+  }
+
+  function test_processMultipleUnwrappedNativeReports() public {
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE * NUMBER_OF_REPORTS + 1);
+
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    bytes[] memory payloads = new bytes[](NUMBER_OF_REPORTS);
+    for (uint256 i; i < NUMBER_OF_REPORTS; ++i) {
+      payloads[i] = payload;
+    }
+
+
+    bytes32[] memory poolIds = new bytes32[](NUMBER_OF_REPORTS);
+    for (uint256 i = 0; i < NUMBER_OF_REPORTS; ++i) {
+      poolIds[i] = DEFAULT_CONFIG_DIGEST;
+    }
+
+
+    processFee(poolIds, payloads, USER, address(native), DEFAULT_REPORT_NATIVE_FEE * NUMBER_OF_REPORTS * 2);
+
+    assertEq(getNativeBalance(address(feeManager)), DEFAULT_REPORT_NATIVE_FEE * NUMBER_OF_REPORTS);
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE * NUMBER_OF_REPORTS);
+    assertEq(getLinkBalance(address(feeManager)), 1);
+
+    assertEq(PROXY.balance, DEFAULT_NATIVE_MINT_QUANTITY);
+    assertEq(USER.balance, DEFAULT_NATIVE_MINT_QUANTITY - DEFAULT_REPORT_NATIVE_FEE * NUMBER_OF_REPORTS);
+  }
+
+  function test_processV1V2V3Reports() public {
+    mintLink(address(feeManager), 1);
+
+    bytes memory payloadV1 = abi.encode(
+      [DEFAULT_CONFIG_DIGEST, 0, 0],
+      getV1Report(DEFAULT_FEED_1_V1),
+      new bytes32[](1),
+      new bytes32[](1),
+      bytes32("")
+    );
+
+    bytes memory linkPayloadV2 = getPayload(getV2Report(DEFAULT_FEED_1_V2));
+    bytes memory linkPayloadV3 = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    bytes[] memory payloads = new bytes[](5);
+    payloads[0] = payloadV1;
+    payloads[1] = linkPayloadV2;
+    payloads[2] = linkPayloadV2;
+    payloads[3] = linkPayloadV3;
+    payloads[4] = linkPayloadV3;
+
+    approveLink(address(rewardManager), DEFAULT_REPORT_LINK_FEE * 4, USER);
+
+    bytes32[] memory poolIds = new bytes32[](5);
+    for (uint256 i = 0; i < 5; ++i) {
+      poolIds[i] = DEFAULT_CONFIG_DIGEST;
+    }
+
+    processFee(poolIds, payloads, USER, address(link), 0);
+
+    assertEq(getNativeBalance(address(feeManager)), 0);
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE * 4);
+    assertEq(getLinkBalance(address(feeManager)), 1);
+
+    assertEq(getLinkBalance(USER), DEFAULT_LINK_MINT_QUANTITY - DEFAULT_REPORT_LINK_FEE * 4);
+    assertEq(getNativeBalance(USER), DEFAULT_NATIVE_MINT_QUANTITY - 0);
+  }
+
+  function test_processV1V2V3ReportsWithUnwrapped() public {
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE * 4 + 1);
+
+    bytes memory payloadV1 = abi.encode(
+      [DEFAULT_CONFIG_DIGEST, 0, 0],
+      getV1Report(DEFAULT_FEED_1_V1),
+      new bytes32[](1),
+      new bytes32[](1),
+      bytes32("")
+    );
+
+    bytes memory nativePayloadV2 = getPayload(getV2Report(DEFAULT_FEED_1_V2));
+    bytes memory nativePayloadV3 = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    bytes[] memory payloads = new bytes[](5);
+    payloads[0] = payloadV1;
+    payloads[1] = nativePayloadV2;
+    payloads[2] = nativePayloadV2;
+    payloads[3] = nativePayloadV3;
+    payloads[4] = nativePayloadV3;
+
+    bytes32[] memory poolIds = new bytes32[](5);
+    for (uint256 i = 0; i < 5; ++i) {
+      poolIds[i] = DEFAULT_CONFIG_DIGEST;
+    }
+
+    processFee(poolIds, payloads, USER, address(native), DEFAULT_REPORT_NATIVE_FEE * 4);
+
+    assertEq(getNativeBalance(address(feeManager)), DEFAULT_REPORT_NATIVE_FEE * 4);
+    assertEq(getLinkBalance(address(rewardManager)), DEFAULT_REPORT_LINK_FEE * 4);
+    assertEq(getLinkBalance(address(feeManager)), 1);
+
+    assertEq(USER.balance, DEFAULT_NATIVE_MINT_QUANTITY - DEFAULT_REPORT_NATIVE_FEE * 4);
+    assertEq(PROXY.balance, DEFAULT_NATIVE_MINT_QUANTITY);
+  }
+
+  function test_processMultipleV1Reports() public {
+    bytes memory payload = abi.encode(
+      [DEFAULT_CONFIG_DIGEST, 0, 0],
+      getV1Report(DEFAULT_FEED_1_V1),
+      new bytes32[](1),
+      new bytes32[](1),
+      bytes32("")
+    );
+
+    bytes[] memory payloads = new bytes[](NUMBER_OF_REPORTS);
+    for (uint256 i = 0; i < NUMBER_OF_REPORTS; ++i) {
+      payloads[i] = payload;
+    }
+
+    bytes32[] memory poolIds = new bytes32[](NUMBER_OF_REPORTS);
+    for (uint256 i = 0; i < NUMBER_OF_REPORTS; ++i) {
+      poolIds[i] = DEFAULT_CONFIG_DIGEST;
+    }
+
+    processFee(poolIds, payloads, USER, address(native), DEFAULT_REPORT_NATIVE_FEE * 5);
+
+    assertEq(USER.balance, DEFAULT_NATIVE_MINT_QUANTITY);
+    assertEq(PROXY.balance, DEFAULT_NATIVE_MINT_QUANTITY);
+  }
+
+  function test_eventIsEmittedIfNotEnoughLink() public {
+    bytes memory nativePayload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    bytes[] memory payloads = new bytes[](5);
+    payloads[0] = nativePayload;
+    payloads[1] = nativePayload;
+    payloads[2] = nativePayload;
+    payloads[3] = nativePayload;
+    payloads[4] = nativePayload;
+
+    approveNative(address(feeManager), DEFAULT_REPORT_NATIVE_FEE * 5, USER);
+
+    IDestinationRewardManager.FeePayment[] memory payments = new IDestinationRewardManager.FeePayment[](5);
+    payments[0] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
+    payments[1] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
+    payments[2] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
+    payments[3] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
+    payments[4] = IDestinationRewardManager.FeePayment(DEFAULT_CONFIG_DIGEST, uint192(DEFAULT_REPORT_LINK_FEE));
+
+    vm.expectEmit();
+
+   bytes32[] memory poolIds = new bytes32[](5);
+    for (uint256 i = 0; i < 5; ++i) {
+      poolIds[i] = DEFAULT_CONFIG_DIGEST;
+    }
+
+    emit InsufficientLink(payments);
+
+    processFee(poolIds, payloads, USER, address(native), 0);
+
+    assertEq(getNativeBalance(address(feeManager)), DEFAULT_REPORT_NATIVE_FEE * 5);
+    assertEq(getNativeBalance(USER), DEFAULT_NATIVE_MINT_QUANTITY - DEFAULT_REPORT_NATIVE_FEE * 5);
+    assertEq(getLinkBalance(USER), DEFAULT_LINK_MINT_QUANTITY);
+  }
+}

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFeeBulk.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFeeBulk.t.sol
@@ -216,7 +216,7 @@ contract FeeManagerProcessFeeTest is BaseDestinationFeeManagerTest {
 
    bytes32[] memory poolIds = new bytes32[](5);
     for (uint256 i = 0; i < 5; ++i) {
-      poolIds[i] = DEFAULT_CONFIG_DIGEST;
+      poolIds[i] = payments[i].poolId;
     }
 
     emit InsufficientLink(payments);

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFeeBulk.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFeeBulk.t.sol
@@ -227,4 +227,30 @@ contract FeeManagerProcessFeeTest is BaseDestinationFeeManagerTest {
     assertEq(getNativeBalance(USER), DEFAULT_NATIVE_MINT_QUANTITY - DEFAULT_REPORT_NATIVE_FEE * 5);
     assertEq(getLinkBalance(USER), DEFAULT_LINK_MINT_QUANTITY);
   }
+
+
+  function test_processPoolIdsPassedMismatched() public {
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE * NUMBER_OF_REPORTS + 1);
+
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    bytes[] memory payloads = new bytes[](NUMBER_OF_REPORTS);
+    for (uint256 i; i < NUMBER_OF_REPORTS; ++i) {
+      payloads[i] = payload;
+    }
+
+    // poolIds passed are different that number of reports in payload
+    bytes32[] memory poolIds = new bytes32[](NUMBER_OF_REPORTS - 1);
+    for (uint256 i = 0; i < NUMBER_OF_REPORTS - 1; ++i) {
+      poolIds[i] = DEFAULT_CONFIG_DIGEST;
+    }
+
+
+    vm.expectRevert(POOLID_MISMATCH_ERROR);
+    processFee(poolIds, payloads, USER, address(native), DEFAULT_REPORT_NATIVE_FEE * NUMBER_OF_REPORTS * 2);
+
+  }
+
+
+ 
 }

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFeeBulk.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/fee-manager/DestinationFeeManager.processFeeBulk.t.sol
@@ -252,5 +252,32 @@ contract FeeManagerProcessFeeTest is BaseDestinationFeeManagerTest {
   }
 
 
+function test_poolIdsCannotBeZeroAddress()public {
+    mintLink(address(feeManager), DEFAULT_REPORT_LINK_FEE * NUMBER_OF_REPORTS + 1);
+
+    bytes memory payload = getPayload(getV3Report(DEFAULT_FEED_1_V3));
+
+    bytes[] memory payloads = new bytes[](NUMBER_OF_REPORTS);
+    for (uint256 i; i < NUMBER_OF_REPORTS; ++i) {
+      payloads[i] = payload;
+    }
+
+
+    bytes32[] memory poolIds = new bytes32[](NUMBER_OF_REPORTS);
+    for (uint256 i = 0; i < NUMBER_OF_REPORTS; ++i) {
+      poolIds[i] = DEFAULT_CONFIG_DIGEST;
+    }
+
+    poolIds[2] = 0x000;
+    vm.expectRevert(INVALID_ADDRESS_ERROR);
+    processFee(poolIds, payloads, USER, address(native), DEFAULT_REPORT_NATIVE_FEE * NUMBER_OF_REPORTS * 2);
+}
+
+function test_rewardsAreCorrectlySentToEachAssociatedPoolWhenVerifyingInBulk() public {
+// sugested in PR
+}
+
+
+
  
 }

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/mocks/DestinationFeeManagerProxy.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/mocks/DestinationFeeManagerProxy.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import "../../interfaces/IDestinationFeeManager.sol";
+
+contract DestinationFeeManagerProxy {
+  IDestinationFeeManager internal i_feeManager;
+
+  function processFee(bytes32 poolId, bytes calldata payload, bytes calldata parameterPayload) public payable {
+    i_feeManager.processFee{value: msg.value}(poolId, payload, parameterPayload, msg.sender);
+  }
+
+  function processFeeBulk(bytes32[] memory poolIds, bytes[] calldata payloads, bytes calldata parameterPayload) public payable {
+    i_feeManager.processFeeBulk{value: msg.value}(poolIds, payloads, parameterPayload, msg.sender);
+  }
+
+  function setDestinationFeeManager(IDestinationFeeManager feeManager) public {
+    i_feeManager = feeManager;
+  }
+}


### PR DESCRIPTION
[MERC-5889](https://smartcontract-it.atlassian.net/browse/MERC-5889)



### Resolves Dependencies
- https://github.com/smartcontractkit/chainlink/pull/13813

## What ?

- Tests for `DestinationFeeManager (aka `FeeManager` in v0.3.0)
 - Tests are copy and paste from v0.3.0
   - because `DestinationFeeManager` (v0.4.0) has no changes with respect to `FeeeManager` (v0.3.0). 
   - Tiny adjustments were made e.g: class names / filenames  (e.g`IRewardManager` ->  `IDestinationRewardManager`)
   - Passing `PoolId` to a few function calls in tests (see comments)
   - Made v0.3.0 tests passed
   
- Added a new test: `test_processPoolIdsPassedMismatched`
 - this test is currently failing 
 - it checks that we use a new error type: `PoolIdMismatch`
   
## Notes

>  forge test --match-path "src/v0.8/llo-feeds/v0.4.0/test/fee-manager/*"

```
Ran 4 test suites in 159.80ms (53.76ms CPU time): 90 tests passed, 1 failed, 0 skipped (91 total tests)
```   

- failing test is a new test checking that we get an error of type: `PoolIdsPassedMismatched`
 


[MERC-5889]: https://smartcontract-it.atlassian.net/browse/MERC-5889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


--

ToDo:
- [x] onlyAdminCanSetVerifier
- [x] poolIdsCannotBeZeroAddress
- [x] rewardsAreCorrectlySentToEachAssociatedPoolWhenVerifyingInBulk
- [x] Run a diff, double check major changes / add tests for major changes