### PR TITLE
add empty bal spec

### DIFF
--- a/.changeset/eighty-points-bathe.md
+++ b/.changeset/eighty-points-bathe.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-add an empty BAL spec in migrations
+#db_update add an empty BAL spec in migrations

--- a/.changeset/eighty-points-bathe.md
+++ b/.changeset/eighty-points-bathe.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+add an empty BAL spec in migrations

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -156,6 +156,7 @@ type Job struct {
 	BlockhashStoreSpec            *BlockhashStoreSpec
 	BlockHeaderFeederSpecID       *int32
 	BlockHeaderFeederSpec         *BlockHeaderFeederSpec
+	BALSpecID                     *int32
 	LegacyGasStationServerSpecID  *int32
 	LegacyGasStationServerSpec    *LegacyGasStationServerSpec
 	LegacyGasStationSidecarSpecID *int32

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -646,18 +646,18 @@ func (o *orm) InsertJob(ctx context.Context, job *Job) error {
 		if job.ID == 0 {
 			query = `INSERT INTO jobs (name, stream_id, schema_version, type, max_task_duration, ocr_oracle_spec_id, ocr2_oracle_spec_id, direct_request_spec_id, flux_monitor_spec_id,
 				keeper_spec_id, cron_spec_id, vrf_spec_id, webhook_spec_id, blockhash_store_spec_id, bootstrap_spec_id, block_header_feeder_spec_id, gateway_spec_id, 
-                legacy_gas_station_server_spec_id, legacy_gas_station_sidecar_spec_id, workflow_spec_id, standard_capabilities_spec_id, external_job_id, gas_limit, forwarding_allowed, created_at)
+                bal_spec_id, legacy_gas_station_server_spec_id, legacy_gas_station_sidecar_spec_id, workflow_spec_id, standard_capabilities_spec_id, external_job_id, gas_limit, forwarding_allowed, created_at)
 		VALUES (:name, :stream_id, :schema_version, :type, :max_task_duration, :ocr_oracle_spec_id, :ocr2_oracle_spec_id, :direct_request_spec_id, :flux_monitor_spec_id,
 				:keeper_spec_id, :cron_spec_id, :vrf_spec_id, :webhook_spec_id, :blockhash_store_spec_id, :bootstrap_spec_id, :block_header_feeder_spec_id, :gateway_spec_id, 
-				:legacy_gas_station_server_spec_id, :legacy_gas_station_sidecar_spec_id, :workflow_spec_id, :standard_capabilities_spec_id, :external_job_id, :gas_limit, :forwarding_allowed, NOW())
+				:bal_spec_id, :legacy_gas_station_server_spec_id, :legacy_gas_station_sidecar_spec_id, :workflow_spec_id, :standard_capabilities_spec_id, :external_job_id, :gas_limit, :forwarding_allowed, NOW())
 		RETURNING *;`
 		} else {
 			query = `INSERT INTO jobs (id, name, stream_id, schema_version, type, max_task_duration, ocr_oracle_spec_id, ocr2_oracle_spec_id, direct_request_spec_id, flux_monitor_spec_id,
 			keeper_spec_id, cron_spec_id, vrf_spec_id, webhook_spec_id, blockhash_store_spec_id, bootstrap_spec_id, block_header_feeder_spec_id, gateway_spec_id, 
-                  legacy_gas_station_server_spec_id, legacy_gas_station_sidecar_spec_id, workflow_spec_id, standard_capabilities_spec_id, external_job_id, gas_limit, forwarding_allowed, created_at)
+                  bal_spec_id, legacy_gas_station_server_spec_id, legacy_gas_station_sidecar_spec_id, workflow_spec_id, standard_capabilities_spec_id, external_job_id, gas_limit, forwarding_allowed, created_at)
 		VALUES (:id, :name, :stream_id, :schema_version, :type, :max_task_duration, :ocr_oracle_spec_id, :ocr2_oracle_spec_id, :direct_request_spec_id, :flux_monitor_spec_id,
 				:keeper_spec_id, :cron_spec_id, :vrf_spec_id, :webhook_spec_id, :blockhash_store_spec_id, :bootstrap_spec_id, :block_header_feeder_spec_id, :gateway_spec_id, 
-				:legacy_gas_station_server_spec_id, :legacy_gas_station_sidecar_spec_id, :workflow_spec_id, :standard_capabilities_spec_id, :external_job_id, :gas_limit, :forwarding_allowed, NOW())
+				:bal_spec_id, :legacy_gas_station_server_spec_id, :legacy_gas_station_sidecar_spec_id, :workflow_spec_id, :standard_capabilities_spec_id, :external_job_id, :gas_limit, :forwarding_allowed, NOW())
 		RETURNING *;`
 		}
 		query, args, err := tx.ds.BindNamed(query, job)

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -646,18 +646,18 @@ func (o *orm) InsertJob(ctx context.Context, job *Job) error {
 		if job.ID == 0 {
 			query = `INSERT INTO jobs (name, stream_id, schema_version, type, max_task_duration, ocr_oracle_spec_id, ocr2_oracle_spec_id, direct_request_spec_id, flux_monitor_spec_id,
 				keeper_spec_id, cron_spec_id, vrf_spec_id, webhook_spec_id, blockhash_store_spec_id, bootstrap_spec_id, block_header_feeder_spec_id, gateway_spec_id, 
-                bal_spec_id, legacy_gas_station_server_spec_id, legacy_gas_station_sidecar_spec_id, workflow_spec_id, standard_capabilities_spec_id, external_job_id, gas_limit, forwarding_allowed, created_at)
+                legacy_gas_station_server_spec_id, legacy_gas_station_sidecar_spec_id, workflow_spec_id, standard_capabilities_spec_id, external_job_id, gas_limit, forwarding_allowed, created_at)
 		VALUES (:name, :stream_id, :schema_version, :type, :max_task_duration, :ocr_oracle_spec_id, :ocr2_oracle_spec_id, :direct_request_spec_id, :flux_monitor_spec_id,
 				:keeper_spec_id, :cron_spec_id, :vrf_spec_id, :webhook_spec_id, :blockhash_store_spec_id, :bootstrap_spec_id, :block_header_feeder_spec_id, :gateway_spec_id, 
-				:bal_spec_id, :legacy_gas_station_server_spec_id, :legacy_gas_station_sidecar_spec_id, :workflow_spec_id, :standard_capabilities_spec_id, :external_job_id, :gas_limit, :forwarding_allowed, NOW())
+				:legacy_gas_station_server_spec_id, :legacy_gas_station_sidecar_spec_id, :workflow_spec_id, :standard_capabilities_spec_id, :external_job_id, :gas_limit, :forwarding_allowed, NOW())
 		RETURNING *;`
 		} else {
 			query = `INSERT INTO jobs (id, name, stream_id, schema_version, type, max_task_duration, ocr_oracle_spec_id, ocr2_oracle_spec_id, direct_request_spec_id, flux_monitor_spec_id,
 			keeper_spec_id, cron_spec_id, vrf_spec_id, webhook_spec_id, blockhash_store_spec_id, bootstrap_spec_id, block_header_feeder_spec_id, gateway_spec_id, 
-                  bal_spec_id, legacy_gas_station_server_spec_id, legacy_gas_station_sidecar_spec_id, workflow_spec_id, standard_capabilities_spec_id, external_job_id, gas_limit, forwarding_allowed, created_at)
+                  legacy_gas_station_server_spec_id, legacy_gas_station_sidecar_spec_id, workflow_spec_id, standard_capabilities_spec_id, external_job_id, gas_limit, forwarding_allowed, created_at)
 		VALUES (:id, :name, :stream_id, :schema_version, :type, :max_task_duration, :ocr_oracle_spec_id, :ocr2_oracle_spec_id, :direct_request_spec_id, :flux_monitor_spec_id,
 				:keeper_spec_id, :cron_spec_id, :vrf_spec_id, :webhook_spec_id, :blockhash_store_spec_id, :bootstrap_spec_id, :block_header_feeder_spec_id, :gateway_spec_id, 
-				:bal_spec_id, :legacy_gas_station_server_spec_id, :legacy_gas_station_sidecar_spec_id, :workflow_spec_id, :standard_capabilities_spec_id, :external_job_id, :gas_limit, :forwarding_allowed, NOW())
+				:legacy_gas_station_server_spec_id, :legacy_gas_station_sidecar_spec_id, :workflow_spec_id, :standard_capabilities_spec_id, :external_job_id, :gas_limit, :forwarding_allowed, NOW())
 		RETURNING *;`
 		}
 		query, args, err := tx.ds.BindNamed(query, job)

--- a/core/store/migrate/migrations/0247_bal_spec_placeholder.sql
+++ b/core/store/migrate/migrations/0247_bal_spec_placeholder.sql
@@ -1,0 +1,57 @@
+-- +goose Up
+CREATE TABLE bal_specs (
+  id BIGSERIAL PRIMARY KEY
+);
+ALTER TABLE
+  jobs
+ADD
+  COLUMN bal_spec_id INT REFERENCES bal_specs (id),
+DROP
+  CONSTRAINT chk_specs,
+ADD
+  CONSTRAINT chk_specs CHECK (
+    num_nonnulls(
+      ocr_oracle_spec_id, ocr2_oracle_spec_id,
+      direct_request_spec_id, flux_monitor_spec_id,
+      keeper_spec_id, cron_spec_id, webhook_spec_id,
+      vrf_spec_id, blockhash_store_spec_id,
+      block_header_feeder_spec_id, bootstrap_spec_id,
+      gateway_spec_id,
+      legacy_gas_station_server_spec_id,
+      legacy_gas_station_sidecar_spec_id,
+      eal_spec_id,
+      workflow_spec_id,
+      standard_capabilities_spec_id,
+      bal_spec_id,
+      CASE "type" WHEN 'stream' THEN 1 ELSE NULL END -- 'stream' type lacks a spec but should not cause validation to fail
+    ) = 1
+  );
+
+-- +goose Down
+ALTER TABLE
+  jobs
+DROP
+  CONSTRAINT chk_specs,
+ADD
+  CONSTRAINT chk_specs CHECK (
+    num_nonnulls(
+      ocr_oracle_spec_id, ocr2_oracle_spec_id,
+      direct_request_spec_id, flux_monitor_spec_id,
+      keeper_spec_id, cron_spec_id, webhook_spec_id,
+      vrf_spec_id, blockhash_store_spec_id,
+      block_header_feeder_spec_id, bootstrap_spec_id,
+      gateway_spec_id,
+      legacy_gas_station_server_spec_id,
+      legacy_gas_station_sidecar_spec_id,
+      eal_spec_id,
+      workflow_spec_id,
+      standard_capabilities_spec_id,
+      CASE "type" WHEN 'stream' THEN 1 ELSE NULL END -- 'stream' type lacks a spec but should not cause validation to fail
+    ) = 1
+  );
+ALTER TABLE
+  jobs
+DROP
+  COLUMN bal_spec_id;
+DROP
+  TABLE IF EXISTS bal_specs;

--- a/core/store/migrate/migrations/0247_bal_spec_placeholder.sql
+++ b/core/store/migrate/migrations/0247_bal_spec_placeholder.sql
@@ -22,6 +22,8 @@ ADD
       eal_spec_id,
       workflow_spec_id,
       standard_capabilities_spec_id,
+      ccip_spec_id,
+      ccip_bootstrap_spec_id,
       bal_spec_id,
       CASE "type" WHEN 'stream' THEN 1 ELSE NULL END -- 'stream' type lacks a spec but should not cause validation to fail
     ) = 1
@@ -46,6 +48,8 @@ ADD
       eal_spec_id,
       workflow_spec_id,
       standard_capabilities_spec_id,
+      ccip_spec_id,
+      ccip_bootstrap_spec_id,
       CASE "type" WHEN 'stream' THEN 1 ELSE NULL END -- 'stream' type lacks a spec but should not cause validation to fail
     ) = 1
   );


### PR DESCRIPTION
adding a BAL job spec. Implementation details of this spec is in a forked repo. This change is needed in core repo because otherwise, `chk_specs` validation fails in downstream repos that already have a BAL spec in DB