### PR TITLE
fix: delete unused artfiacts during flakey test execution

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -287,7 +287,14 @@ jobs:
         if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
+          name: go_core_tests_logs
           path: ./artifacts
+      - name: Delete go_core_tests_logs/coverage.txt
+        if: ${{ needs.filter.outputs.changes == 'true' }}
+        shell: bash
+        run: |
+          # Need to delete coverage.txt so the disk doesn't fill up
+          rm -f ./artifacts/go_core_tests_logs/coverage.txt
       - name: Build flakey test runner
         if: ${{ needs.filter.outputs.changes == 'true' }}
         run: go build ./tools/flakeytests/cmd/runner


### PR DESCRIPTION
### Changes

* Only download `go_core_tests_logs` during flakey test execution
* Delete `coverage.txt` to free up disk space before processing

### Motivation

Example error: https://github.com/smartcontractkit/chainlink/actions/runs/9912503464
```
Flakey Test Detection
System.IO.IOException: No space left on device : '/home/runner/runners/2.317.0/_diag/Worker_20240712-184326-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.Strategies.BufferedFileStreamStrategy.FlushWrite()
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
Unhandled exception. System.IO.IOException: No space left on device : '/home/runner/runners/2.317.0/_diag/Worker_20240712-184326-utc.log'
```

Related to #13830. The upgrade to go 1.22 increased the size of the `coverage.txt` file by a lot and this is now occasionally filling up the disk of the flakey test runner.

