### PR TITLE
BCF-3322: automatically cleanup heavyweight test databases

### DIFF
--- a/.changeset/silver-peas-happen.md
+++ b/.changeset/silver-peas-happen.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal cleanup heavyweight test databases automatically

--- a/core/internal/cltest/heavyweight/orm.go
+++ b/core/internal/cltest/heavyweight/orm.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/jmoiron/sqlx"
@@ -68,7 +67,8 @@ func (c Kind) PrepareDB(t testing.TB, overrideFn func(c *chainlink.Config, s *ch
 	db, err := pg.NewConnection(migrationTestDBURL, dialects.Postgres, gcfg.Database())
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		assert.NoError(t, db.Close())
+		require.NoError(t, db.Close()) // must close before dropping
+		require.NoError(t, testdb.Drop(*testutils.MustParseURL(t, migrationTestDBURL)))
 		os.RemoveAll(gcfg.RootDir())
 	})
 


### PR DESCRIPTION
<!---
  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
  
  By referencing it, it will let the QA team to know what to watch out for when creating a new release.

  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[BCF-3322](https://smartcontract-it.atlassian.net/browse/BCF-3322)

Tested locally by running tests that use `heavyweight` db and seeing that on `develop` they strand dbs but on this branch they do not:

```
chainlink % git status
On branch develop
Your branch is up to date with 'origin/develop'.

nothing to commit, working tree clean
chainlink % make testdb
go run . local db preparetest
time=2024-07-12T17:13:19.878-06:00 level=INFO msg="Version was unset on production build. Chainlink should be built with static.Version set to a valid semver for production builds."
2024-07-12T17:13:19.879-0600 [INFO]  Resetting database: "postgres://chainlink_dev:insecurepassword@localhost:5432/chainlink_development_test?sslmode=disable" cmd/shell_local.go:765           version=unset@unset 
time=2024-07-12T17:13:20.095-06:00 level=INFO msg="Error checking mercury jobs: ERROR: relation \"ocr2_oracle_specs\" does not exist (SQLSTATE 42P01)"
chainlink % /opt/homebrew/bin/go test -count=1   github.com/smartcontractkit/chainlink/v2/core/chains/evm/... 
ok      github.com/smartcontractkit/chainlink/v2/core/chains/evm/abi    0.238s
...
chainlink % make testdb                                                                                          
go run . local db preparetest
time=2024-07-12T17:22:23.179-06:00 level=INFO msg="Version was unset on production build. Chainlink should be built with static.Version set to a valid semver for production builds."
2024-07-12T17:22:23.182-0600 [INFO]  Resetting database: "postgres://chainlink_dev:insecurepassword@localhost:5432/chainlink_development_test?sslmode=disable" cmd/shell_local.go:765           version=unset@unset 
time=2024-07-12T17:22:23.655-06:00 level=INFO msg="Error checking mercury jobs: ERROR: relation \"ocr2_oracle_specs\" does not exist (SQLSTATE 42P01)"
2024-07-12T17:22:27.174-0600 [INFO]  Dropping old, dangling test database: "chainlink_test_38e1c01b6023467f94c6ffee50e96bc5" cmd/shell_local.go:839           version=unset@unset 
2024-07-12T17:22:27.174-0600 [INFO]  Dropping old, dangling test database: "chainlink_test_8f75a5a9371e493285067c2c552d7c42" cmd/shell_local.go:839           version=unset@unset 
2024-07-12T17:22:27.174-0600 [INFO]  Dropping old, dangling test database: "chainlink_test_8b6a20f527ce410a8a229d0ef9e8ad0b" cmd/shell_local.go:839           version=unset@unset 
2024-07-12T17:22:27.174-0600 [INFO]  Dropping old, dangling test database: "chainlink_test_e11ad58751cd4ee8b20b30b8c23f8df6" cmd/shell_local.go:839           version=unset@unset 
chainlink % git status
On branch develop
Your branch is up to date with 'origin/develop'.

nothing to commit, working tree clean
chainlink % git switch bcf-3322/cleanup-heavyweight-dbs 
Switched to branch 'bcf-3322/cleanup-heavyweight-dbs'
Your branch is up to date with 'origin/bcf-3322/cleanup-heavyweight-dbs'.
(base) kreherma@MB-GPC9WG3DHF chainlink % make testdb                                
go run . local db preparetest
time=2024-07-12T17:23:05.159-06:00 level=INFO msg="Version was unset on production build. Chainlink should be built with static.Version set to a valid semver for production builds."
2024-07-12T17:23:05.160-0600 [INFO]  Resetting database: "postgres://chainlink_dev:insecurepassword@localhost:5432/chainlink_development_test?sslmode=disable" cmd/shell_local.go:765           version=unset@unset 
time=2024-07-12T17:23:05.334-06:00 level=INFO msg="Error checking mercury jobs: ERROR: relation \"ocr2_oracle_specs\" does not exist (SQLSTATE 42P01)"
(base) kreherma@MB-GPC9WG3DHF chainlink % /opt/homebrew/bin/go test -count=1   github.com/smartcontractkit/chainlink/v2/core/chains/evm/...
ok      github.com/smartcontractkit/chainlink/v2/core/chains/evm/abi    0.444s
...
(base) kreherma@MB-GPC9WG3DHF chainlink % make testdb                                                                                      
go run . local db preparetest
time=2024-07-12T17:26:05.637-06:00 level=INFO msg="Version was unset on production build. Chainlink should be built with static.Version set to a valid semver for production builds."
2024-07-12T17:26:05.638-0600 [INFO]  Resetting database: "postgres://chainlink_dev:insecurepassword@localhost:5432/chainlink_development_test?sslmode=disable" cmd/shell_local.go:765           version=unset@unset 
time=2024-07-12T17:26:05.786-06:00 level=INFO msg="Error checking mercury jobs: ERROR: relation \"ocr2_oracle_specs\" does not exist (SQLSTATE 42P01)"
chainlink % 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->


[BCF-3322]: https://smartcontract-it.atlassian.net/browse/BCF-3322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ