### PR TITLE
core/utils: improve TestThreadControl_GoCtx checks for flake analysis

### DIFF
--- a/core/utils/thread_control_test.go
+++ b/core/utils/thread_control_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,7 +51,7 @@ func TestThreadControl_GoCtx(t *testing.T) {
 	start := time.Now()
 	wg.Wait()
 	end := time.Since(start)
-	require.True(t, end > timeout-1)
-	require.True(t, end < 2*timeout)
+	assert.Greater(t, end, timeout-1)
+	assert.Less(t, end, 2*timeout)
 	require.Equal(t, int32(1), finished.Load())
 }


### PR DESCRIPTION
`TestThreadControl_GoCtx` flaked here:
https://github.com/smartcontractkit/chainlink/actions/runs/9939155065/job/27453155517?pr=13836
The test is likely just too time dependent with just a 10ms timeout and an expectation for a goroutine to be reschedule very quickly afterwards, but we don't know how long it actually took, since it only says `should be true`:
```
TestThreadControl_GoCtx (0.02s) 
          	Error Trace:	/home/runner/work/chainlink/chainlink/core/utils/thread_control_test.go:54 
          	Error:      	Should be true 
          	Test:       	TestThreadControl_GoCtx 
```
 This change updates the checks so they will output the value, in order to be able to choose a better timeout in the future.