### PR TITLE
additional logging to check response id and removal of incorrect error logging when expiring a server request

### DIFF
--- a/.changeset/sour-guests-exercise.md
+++ b/.changeset/sour-guests-exercise.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal additional logging to remote target capability

--- a/core/capabilities/remote/target/request/server_request.go
+++ b/core/capabilities/remote/target/request/server_request.go
@@ -101,13 +101,11 @@ func (e *ServerRequest) Cancel(err types.Error, msg string) error {
 	e.mux.Lock()
 	defer e.mux.Unlock()
 
-	if e.hasResponse() {
-		return fmt.Errorf("request already has response")
-	}
-
-	e.setError(err, msg)
-	if err := e.sendResponses(); err != nil {
-		return fmt.Errorf("failed to send responses: %w", err)
+	if !e.hasResponse() {
+		e.setError(err, msg)
+		if err := e.sendResponses(); err != nil {
+			return fmt.Errorf("failed to send responses: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
additional logging to check response id and removal of incorrect error logging when expiring a server request