### PR TITLE
[BCI-3837] - Remove tautological check inside EVM TXM

### DIFF
--- a/.changeset/dull-seals-jog.md
+++ b/.changeset/dull-seals-jog.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+remove tautological err check within evm txm. #internal

--- a/core/chains/evm/txmgr/evm_tx_store.go
+++ b/core/chains/evm/txmgr/evm_tx_store.go
@@ -1704,9 +1704,7 @@ func (o *evmTxStore) UpdateTxUnstartedToInProgress(ctx context.Context, etx *Tx,
 				pqErr.ConstraintName == "eth_tx_attempts_eth_tx_id_fkey" {
 				return txmgr.ErrTxRemoved
 			}
-			if err != nil {
-				return pkgerrors.Wrap(err, "UpdateTxUnstartedToInProgress failed to create eth_tx_attempt")
-			}
+			return pkgerrors.Wrap(err, "UpdateTxUnstartedToInProgress failed to create eth_tx_attempt")
 		}
 		dbAttempt.ToTxAttempt(attempt)
 		var dbEtx DbEthTx


### PR DESCRIPTION
### Description
There’s a [tautological condition](https://github.com/smartcontractkit/chainlink/blob/develop/core/chains/evm/txmgr/evm_tx_store.go#L1707) in the TXM code that can be removed. if `err != nil` is already true due to previous check in outer if

### Acceptance Criteria
- Tautological condition has been removed.

### Ticket:
- [BCI-3837](https://smartcontract-it.atlassian.net/browse/BCI-3837)

### Resources:
- [Slack Thread](https://chainlink-core.slack.com/archives/C0472BJ2Q58/p1720795684066969)

[BCI-3837]: https://smartcontract-it.atlassian.net/browse/BCI-3837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ