### PR TITLE
fix: only pass output to sonar when available (RE-2814)

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -340,23 +340,50 @@ jobs:
           fetch-depth: 0 # fetches all history for all tags and branches to provide more metadata for sonar reports
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+
       - name: Set SonarQube Report Paths
         id: sonarqube_report_paths
         shell: bash
         run: |
           echo "sonarqube_tests_report_paths=$(find go_core_tests_logs -name output.txt | paste -sd "," -)" >> $GITHUB_OUTPUT
           echo "sonarqube_coverage_report_paths=$(find go_core_tests_logs -name coverage.txt | paste -sd "," -)" >> $GITHUB_OUTPUT
+          echo "sonarqube_lint_report_paths=$(find golangci-lint-report -name golangci-lint-report.xml | paste -sd "," -)" >> $GITHUB_OUTPUT
+
+      - name: Check SonarQube Report Paths
+        id: check_sonarqube_paths
+        run: |
+          ARGS=""
+
+          if [[ -z "${{ steps.sonarqube_report_paths.outputs.sonarqube_tests_report_paths }}" ]]; then
+            echo "::warning::No test report paths found, will not pass to sonarqube"
+          else
+            ARGS="$ARGS -Dsonar.go.tests.reportPaths=${{ steps.sonarqube_report_paths.outputs.sonarqube_tests_report_paths }}"
+          fi
+
+          if [[ -z "${{ steps.sonarqube_report_paths.outputs.sonarqube_coverage_report_paths }}" ]]; then
+            echo "::warning::No coverage report paths found, will not pass to sonarqube"
+          else
+            ARGS="$ARGS -Dsonar.go.coverage.reportPaths=${{ steps.sonarqube_report_paths.outputs.sonarqube_coverage_report_paths }}"
+          fi
+
+          if [[ -z "${{ steps.sonarqube_report_paths.outputs.sonarqube_lint_report_paths }}" ]]; then
+            echo "::warning::No lint report paths found, will not pass to sonarqube"
+          else
+            ARGS="$ARGS -Dsonar.go.golangci-lint.reportPaths=${{ steps.sonarqube_report_paths.outputs.sonarqube_lint_report_paths }}"
+          fi
+
+          echo "SONARQUBE_ARGS=$ARGS" >> $GITHUB_ENV
+
       - name: SonarQube Scan
+        if: ${{ env.SONARQUBE_ARGS != '' }}
         uses: sonarsource/sonarqube-scan-action@aecaf43ae57e412bd97d70ef9ce6076e672fe0a9 # v2.3.0
         with:
-          args: >
-            -Dsonar.go.tests.reportPaths=${{ steps.sonarqube_report_paths.outputs.sonarqube_tests_report_paths }}
-            -Dsonar.go.coverage.reportPaths=${{ steps.sonarqube_report_paths.outputs.sonarqube_coverage_report_paths }}
-            -Dsonar.go.golangci-lint.reportPaths=golangci-lint-report/golangci-lint-report.xml
+          args: ${{ env.SONARQUBE_ARGS }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_SCANNER_OPTS: "-Xms6g -Xmx8g"
+
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics


### PR DESCRIPTION
### Changes

Fix sonarqube occasionally reporting 0% coverage when core tests are not run, and therefore there's no test or coverage output.

### Testing

Tested in #13866 - https://github.com/smartcontractkit/chainlink/actions/runs/9961379279/job/27522822549.

### Requires Dependencies

N/A

### Resolves Dependencies

N/A

---

[RE-2814](https://smartcontract-it.atlassian.net/browse/RE-2814)

[RE-2814]: https://smartcontract-it.atlassian.net/browse/RE-2814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ