### PR TITLE
Nix shell bump pnpm to v9

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1714727549,
-        "narHash": "sha256-CWXRTxxcgMfQubJugpeg3yVWIfm70MYTtgaKWKgD60U=",
+        "lastModified": 1719997877,
+        "narHash": "sha256-/Edw+w0PiGgxwnCeJycM0VgH4HtlCi91v1d8xbi+REE=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "47cf189ec395eda4b3e0623179d1075c8027ca97",
+        "rev": "02febba4f1cf0606d790acdb24adcf7a64afb4e1",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1712439257,
-        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,15 +8,22 @@
     foundry.inputs.flake-utils.follows = "flake-utils";
   };
 
-  outputs = inputs@{ self, nixpkgs, flake-utils, foundry, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; overlays = [ foundry.overlay ]; };
-      in
-      rec {
-        devShell = pkgs.callPackage ./shell.nix {
-          inherit pkgs;
-        };
-        formatter = pkgs.nixpkgs-fmt;
-      });
+  outputs = inputs @ {
+    self,
+    nixpkgs,
+    flake-utils,
+    foundry,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [foundry.overlay];
+      };
+    in rec {
+      devShell = pkgs.callPackage ./shell.nix {
+        inherit pkgs;
+      };
+      formatter = pkgs.nixpkgs-fmt;
+    });
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,59 +1,63 @@
-{ pkgs }:
-with pkgs;
-let
+{pkgs}:
+with pkgs; let
   go = go_1_21;
   postgresql = postgresql_14;
   nodejs = nodejs-18_x;
-  nodePackages = pkgs.nodePackages.override { inherit nodejs; };
+  nodePackages = pkgs.nodePackages.override {inherit nodejs;};
+  pnpm = pnpm_9;
 
   mkShell' = mkShell.override {
     # The current nix default sdk for macOS fails to compile go projects, so we use a newer one for now.
-    stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+    stdenv =
+      if stdenv.isDarwin
+      then overrideSDK stdenv "11.0"
+      else stdenv;
   };
 in
-mkShell' {
-  nativeBuildInputs = [
-    go
-    goreleaser
-    postgresql
+  mkShell' {
+    nativeBuildInputs =
+      [
+        go
+        goreleaser
+        postgresql
 
-    python3
-    python3Packages.pip
-    protobuf
-    protoc-gen-go
-    protoc-gen-go-grpc
+        python3
+        python3Packages.pip
+        protobuf
+        protoc-gen-go
+        protoc-gen-go-grpc
 
-    foundry-bin
+        foundry-bin
 
-    curl
-    nodejs
-    nodePackages.pnpm
-    # TODO: compiler / gcc for secp compilation
-    go-ethereum # geth
-    go-mockery
+        curl
+        nodejs
+        pnpm
+        # TODO: compiler / gcc for secp compilation
+        go-ethereum # geth
+        go-mockery
 
-    # tooling
-    gotools
-    gopls
-    delve
-    golangci-lint
-    github-cli
-    jq
+        # tooling
+        gotools
+        gopls
+        delve
+        golangci-lint
+        github-cli
+        jq
 
-    # cross-compiling, used in CRIB
-    zig
+        # cross-compiling, used in CRIB
+        zig
 
-    # gofuzz
-  ] ++ lib.optionals stdenv.isLinux [
-    # some dependencies needed for node-gyp on pnpm install
-    pkg-config
-    libudev-zero
-    libusb1
-  ];
-  LD_LIBRARY_PATH = "${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
-  GOROOT = "${go}/share/go";
+        # gofuzz
+      ]
+      ++ lib.optionals stdenv.isLinux [
+        # some dependencies needed for node-gyp on pnpm install
+        pkg-config
+        libudev-zero
+        libusb1
+      ];
+    LD_LIBRARY_PATH = "${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
+    GOROOT = "${go}/share/go";
 
-  PGDATA = "db";
-  CL_DATABASE_URL = "postgresql://chainlink:chainlink@localhost:5432/chainlink_test?sslmode=disable";
-
-}
+    PGDATA = "db";
+    CL_DATABASE_URL = "postgresql://chainlink:chainlink@localhost:5432/chainlink_test?sslmode=disable";
+  }


### PR DESCRIPTION
pnpm dependency was bumped a few weeks ago here #13630

The same dependency was not updated in the Nix shell, which makes the build fail within the Nix shell.

Repro steps:

```bash
$ nix develop
$ make install
(cd contracts && pnpm i)
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/Users/krebernisak/Developer/chainlink/contracts".

Expected version: >=9
Got: 8.15.5

This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.

To install the latest version of pnpm, run "pnpm i -g pnpm".
To check your pnpm version, run "pnpm -v".
make: *** [GNUmakefile:20: pnpmdep] Error 1
```

This PR changes:

- Update `flake.lock` to latest deps (nixpkgs, foundry)
- Bump pnpm dependency to specific `pnpm_9`
- Nix code format ([github.com/kamadorueda/alejandra](https://github.com/kamadorueda/alejandra))

Future recommendations:

- Use Nix shell in CI and verify the build
