### PR TITLE
MERC-5889 - test verify setAccessController

### DIFF
--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/verifier/VerifierProxyTest.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/verifier/VerifierProxyTest.t.sol
@@ -25,5 +25,20 @@ contract VerifierProxyInitializeVerifierTest is BaseTest {
 
     function test_setVerifierOk() public {
         s_verifierProxy.setVerifier(address(s_verifier));
+        assertEq(s_verifierProxy.s_feeManager(), s_verifier.getFeeManager());
+        assertEq(s_verifierProxy.s_accessController(), s_verifier.getAccessController());
     }
+
+   function test_correctlySetsTheOwner() public {
+     DestinationVerifierProxy proxy = new DestinationVerifierProxy();
+     assertEq(proxy.owner(), ADMIN);
+   }
+
+  function test_correctlySetsVersion() public {
+    string memory version = s_verifierProxy.typeAndVersion();
+    assertEq(version, "DestinationVerifierProxy 1.0.0");
+  }
+  
+  
+    
 }

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/verifier/VerifierSetAccessControllerTest.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/verifier/VerifierSetAccessControllerTest.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import {BaseTest} from "./BaseDestinationVerifierTest.t.sol";
+import {AccessControllerInterface} from "../../../../shared/interfaces/AccessControllerInterface.sol";
+
+contract VerifierSetAccessControllerTest is BaseTest {
+  event AccessControllerSet(address oldAccessController, address newAccessController);
+
+  function test_revertsIfCalledByNonOwner() public {
+    vm.expectRevert("Only callable by owner");
+
+    changePrank(USER);
+    s_verifier.setAccessController(ACCESS_CONTROLLER_ADDRESS);
+  }
+
+  function test_successfullySetsNewAccessController() public {
+    s_verifier.setAccessController(ACCESS_CONTROLLER_ADDRESS);
+    address ac = s_verifier.getAccessController();
+    assertEq(ac, ACCESS_CONTROLLER_ADDRESS);
+  }
+
+  function test_successfullySetsNewAccessControllerIsEmpty() public {
+    s_verifier.setAccessController(address(0));
+    address ac = s_verifier.getAccessController();
+    assertEq(ac, address(0));
+  }
+
+  function test_emitsTheCorrectEvent() public {
+    vm.expectEmit(true, false, false, false);
+    emit AccessControllerSet(address(0), ACCESS_CONTROLLER_ADDRESS);
+    s_verifier.setAccessController(ACCESS_CONTROLLER_ADDRESS);
+  }
+}

--- a/contracts/src/v0.8/llo-feeds/v0.4.0/test/verifier/VerifierSetAccessControllerTest.t.sol
+++ b/contracts/src/v0.8/llo-feeds/v0.4.0/test/verifier/VerifierSetAccessControllerTest.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.19;
 
 import {BaseTest} from "./BaseDestinationVerifierTest.t.sol";
-import {AccessControllerInterface} from "../../../../shared/interfaces/AccessControllerInterface.sol";
 
 contract VerifierSetAccessControllerTest is BaseTest {
   event AccessControllerSet(address oldAccessController, address newAccessController);


### PR DESCRIPTION
[MERC-5889](https://smartcontract-it.atlassian.net/browse/MERC-5889)

### Resolves Dependencies
- https://github.com/smartcontractkit/chainlink/pull/13813

## What ?

- Added Tests for verifier's `setAccessController`
   
  


[MERC-5889]: https://smartcontract-it.atlassian.net/browse/MERC-5889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ