### PR TITLE
change chain reader to use nil block number when reading unconfirmed latest value

### DIFF
--- a/.changeset/fresh-badgers-pull.md
+++ b/.changeset/fresh-badgers-pull.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal change chain reader to use nil blocknumber when reading latest value

--- a/core/services/relay/evm/method_binding.go
+++ b/core/services/relay/evm/method_binding.go
@@ -115,7 +115,7 @@ func (m *methodBinding) blockNumberFromConfidence(ctx context.Context, confidenc
 		return nil, err
 	}
 
-	latest, finalized, err := m.ht.LatestAndFinalizedBlock(ctx)
+	_, finalized, err := m.ht.LatestAndFinalizedBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (m *methodBinding) blockNumberFromConfidence(ctx context.Context, confidenc
 	if confirmations == evmtypes.Finalized {
 		return big.NewInt(finalized.Number), nil
 	} else if confirmations == evmtypes.Unconfirmed {
-		return big.NewInt(latest.BlockNumber()), nil
+		return nil, nil
 	}
 
 	return nil, fmt.Errorf("unknown evm confirmations: %v for contract: %s, method: %s", confirmations, m.contractName, m.method)


### PR DESCRIPTION
Required for this PR-> https://github.com/smartcontractkit/chainlink/pull/13838 for the keystone end to end tests.

In short when using the simulated ethereum backed requesting to read a value at anything other that the latest block will error.  The chain reader was currently passing in the block number for the unconfirmed confidence level, ocassionally this would mean that a read was requested for a blocknumber other than the latest.  Using nil instead of the block number ensures the read always occurs at the latest block.

Discussed with @ilija42 introducing a different confidence level for this case, but agreed that using nil for the 'unconfirmed' confidence level was the simplest and best solution.