### PR TITLE
add 'StartOnce' protection to syncer

### DIFF
--- a/.changeset/friendly-needles-ring.md
+++ b/.changeset/friendly-needles-ring.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal syncer start onc3

--- a/core/services/registrysyncer/syncer.go
+++ b/core/services/registrysyncer/syncer.go
@@ -36,6 +36,7 @@ type Syncer interface {
 }
 
 type registrySyncer struct {
+	services.StateMachine
 	stopCh          services.StopChan
 	launchers       []Launcher
 	reader          types.ContractReader
@@ -118,12 +119,14 @@ func newReader(ctx context.Context, lggr logger.Logger, relayer contractReaderFa
 }
 
 func (s *registrySyncer) Start(ctx context.Context) error {
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
-		s.syncLoop()
-	}()
-	return nil
+	return s.StartOnce("testAsyncMessageBroker", func() error {
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.syncLoop()
+		}()
+		return nil
+	})
 }
 
 func (s *registrySyncer) syncLoop() {
@@ -232,9 +235,11 @@ func (s *registrySyncer) AddLauncher(launchers ...Launcher) {
 }
 
 func (s *registrySyncer) Close() error {
-	close(s.stopCh)
-	s.wg.Wait()
-	return nil
+	return s.StopOnce("testAsyncMessageBroker", func() error {
+		close(s.stopCh)
+		s.wg.Wait()
+		return nil
+	})
 }
 
 func (s *registrySyncer) Ready() error {


### PR DESCRIPTION
Ensure syncer is only started once - keystone end to end integration test encountered a very intermittent fail where the syncer attempted to execute the initial registry sync more than once.   Wrapping the syncer with 'StartOnce' protection will prevent this reoccurring. 