### PR TITLE
deterministically serialise remote target response

### DIFF
--- a/.changeset/cyan-schools-unite.md
+++ b/.changeset/cyan-schools-unite.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal deterministically serialise remote target response

--- a/core/capabilities/remote/target/request/server_request.go
+++ b/core/capabilities/remote/target/request/server_request.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
@@ -129,7 +131,8 @@ func (e *ServerRequest) executeRequest(ctx context.Context, payload []byte) erro
 
 	// NOTE working on the assumption that the capability will only ever return one response from its channel
 	capResponse := <-capResponseCh
-	responsePayload, err := pb.MarshalCapabilityResponse(capResponse)
+
+	responsePayload, err := proto.MarshalOptions{Deterministic: true}.Marshal(pb.CapabilityResponseToProto(capResponse))
 	if err != nil {
 		return fmt.Errorf("failed to marshal capability response: %w", err)
 	}


### PR DESCRIPTION
deterministically serialise the remote target response - unrelated to but surfaced during the investigation to determine why the remote target client was sending non-deterministic requests.
