### PR TITLE
CRIB CI integration

### DIFF
--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -83,5 +83,6 @@ jobs:
           GAP_URL: ${{ secrets.GAP_URL }}
           SETH_LOG_LEVEL: info
 #          RESTY_DEBUG: true
+#          TEST_PERSISTENCE: true
         run: |-
           go test -v -timeout 60m -run TestCRIB

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -56,18 +56,20 @@ jobs:
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-      #      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      #        name: Checkout CRIB repository
-      #        with:
-      #          repository: 'smartcontractkit/crib'
-      #          ref: 'main'
-      #      - name: Generate Short UUID
-      #        id: uuid
-      #        run: echo "CRIB_NAMESPACE=$(uuidgen | cut -c1-5)" >> $GITHUB_ENV
-      #      - name: Create a new CRIB environment
-      #        run: |-
-      #          devspace use namespace $CRIB_NAMESPACE
-      #          devspace deploy --profile local-dev-simulated-core-ocr1
+
+
+      - name: Deploy and validate CRIB Environment for Core
+        uses: smartcontractkit/.github/actions/setup-crib-environment@fb4c26ad00aab4121a26c55a67acb0c8057bb4a7
+        id: deploy-crib
+        with:
+          disable-environment-teardown: true
+          api-gateway-host: ${{ secrets.AWS_API_GW_HOST_K8S_STAGE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_CRIB_ROLE_ARN_STAGE }}
+          ecr-private-registry-stage: ${{ secrets.AWS_ACCOUNT_ID_STAGE }}
+          ecr-private-registry: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          ingress-base-domain: ${{ secrets.INGRESS_BASE_DOMAIN_STAGE }}
+          k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_STAGE }}
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Setup go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
@@ -77,7 +79,7 @@ jobs:
         working-directory: integration-tests/crib
         env:
           K8S_STAGING_INGRESS_SUFFIX: ${{ secrets.K8S_STAGING_INGRESS_SUFFIX }}
-          CRIB_NAMESPACE: crib-skudasov
+          CRIB_NAMESPACE: ${{ steps.deploy-crib.outputs.devspace-namespace }}
           CRIB_NETWORK: geth
           CRIB_NODES: 5
           GAP_URL: ${{ secrets.GAP_URL }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
-      - uses: cachix/install-nix-action@v18 # v18
+      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Setup GitHub token using GATI
         id: token
-        uses: smartcontractkit/.github/actions/setup-github-token@main # main
+        uses: smartcontractkit/.github/actions/setup-github-token@c0b38e6c40d72d01b8d2f24f92623a2538b3dedb # main
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -22,8 +22,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: setup-gap crib
-        # TODO: update after testing and latest changes are released.
-        uses: smartcontractkit/.github/actions/setup-gap@crib-274/multi-gap-and-tls # setup-gap@0.4.0
+        uses: smartcontractkit/.github/actions/setup-gap@00b58566e0ee2761e56d9db0ea72b783fdb89b8d # setup-gap@0.4.0
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CRIB_ROLE_ARN_STAGE }}
           api-gateway-host: ${{ secrets.AWS_API_GW_HOST_CRIB_STAGE }}
@@ -40,8 +39,7 @@ jobs:
           gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
 
       - name: setup-gap k8s
-        # TODO: update after testing and latest changes are released.
-        uses: smartcontractkit/.github/actions/setup-gap@crib-274/multi-gap-and-tls # setup-gap@0.4.0
+        uses: smartcontractkit/.github/actions/setup-gap@00b58566e0ee2761e56d9db0ea72b783fdb89b8d # setup-gap@0.4.0
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CRIB_ROLE_ARN_STAGE }}
           api-gateway-host: ${{ secrets.AWS_API_GW_HOST_K8S_STAGE }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -67,7 +67,7 @@ jobs:
           aws-role-duration-seconds: "1800"
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@334a434a4a1334042ac299b69c4778cbc849b48c
+        uses: smartcontractkit/.github/actions/setup-crib-environment@1fae13b7a996eb7a2c86c1e507c9ac667dff82eb
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v18 # v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Setup GitHub token using GATI
         id: token
-        uses: smartcontractkit/.github/actions/setup-github-token@main
+        uses: smartcontractkit/.github/actions/setup-github-token@main # main
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
@@ -97,8 +97,8 @@ jobs:
           CRIB_NETWORK: geth
           CRIB_NODES: 5
           GAP_URL: ${{ secrets.GAP_URL }}
-          SETH_LOG_LEVEL: debug
-          RESTY_DEBUG: true
+#          SETH_LOG_LEVEL: debug
+#          RESTY_DEBUG: true
 #          TEST_PERSISTENCE: true
         run: |-
           go test -v -run TestCRIB

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -72,7 +72,7 @@ jobs:
           echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@6c800885ebd68c610328f23fa2f808e067861113
+        uses: smartcontractkit/.github/actions/setup-crib-environment@f616649d75bd97266f1446a89b54eb3ccd127bfc
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -61,8 +61,8 @@ jobs:
         id: token
         uses: smartcontractkit/.github/actions/setup-github-token@main
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GLOBAL_READ_ONLY }}
-          aws-lambda-url: ${{ secrets.GATI_LAMBDA_RELENG_URL }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-role-duration-seconds: "1800"
 
@@ -70,7 +70,7 @@ jobs:
         uses: smartcontractkit/.github/actions/setup-crib-environment@fb4c26ad00aab4121a26c55a67acb0c8057bb4a7
         id: deploy-crib
         with:
-          github_token: ${{ steps.token.outputs.access-token }}
+          github-token: ${{ steps.token.outputs.access-token }}
           disable-environment-teardown: true
           api-gateway-host: ${{ secrets.AWS_API_GW_HOST_K8S_STAGE }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -67,7 +67,7 @@ jobs:
           aws-role-duration-seconds: "1800"
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@1fae13b7a996eb7a2c86c1e507c9ac667dff82eb
+        uses: smartcontractkit/.github/actions/setup-crib-environment@d88bff0ab4ec170afe4d37bffd197bcd5ceb48bb
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -72,7 +72,7 @@ jobs:
           echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@f7ce0546f0c2b9bd76d9b445dcd6042bd6cc760c
+        uses: smartcontractkit/.github/actions/setup-crib-environment@828ff604e500769fdd891ed6b09ffe69895a4054
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}
@@ -84,6 +84,7 @@ jobs:
           ecr-private-registry: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           ingress-base-domain: ${{ secrets.INGRESS_BASE_DOMAIN_STAGE }}
           k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_STAGE }}
+          devspace-profiles: "local-dev-simulated-core-ocr1"
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Setup go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -79,7 +79,7 @@ jobs:
           CRIB_NETWORK: geth
           CRIB_NODES: 5
           GAP_URL: ${{ secrets.GAP_URL }}
-          SETH_LOG_LEVEL: debug
-          RESTY_DEBUG: true
+          SETH_LOG_LEVEL: info
+#          RESTY_DEBUG: true
         run: |-
           go test -v -run TestCRIB

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -1,6 +1,7 @@
 name: CRIB Integration Tests
 on:
-  push:
+  schedule:
+    - cron: "0 1 * * *"
   workflow_call:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -65,9 +65,14 @@ jobs:
           aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-role-duration-seconds: "1800"
+      - name: Debug workspace dir
+        shell: bash
+        run: |
+          echo ${{ github.workspace }}
+          echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@fda734ff95d585f3c7a990aadf0b9c4765d8f7e3
+        uses: smartcontractkit/.github/actions/setup-crib-environment@1fc88731538c4abae81ff65f7cd37832da431d7d
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -1,51 +1,40 @@
-# this is disabled because of GAP limitations, should be re-enabled when github-actions-controller will be installed
+name: CRIB Integration Tests
+on:
+  push:
+  workflow_call:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment: integration
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
-#name: CRIB Integration Tests
-#on:
-#  push:
-#  workflow_call:
-#concurrency:
-#  group: ${{ github.workflow }}-${{ github.ref }}
-#  cancel-in-progress: true
-#jobs:
-#  test:
-#    runs-on: ubuntu-latest
-#    environment: integration
-#    permissions:
-#      id-token: write
-#      contents: read
-#      actions: read
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-#
-#      - name: Setup Nix + GATI environment
-#        uses: smartcontractkit/.github/actions/setup-nix-gati@514fe346780e2eddf7ea8b9f48120c2fba120d94
-#        with:
-#          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_AUTO_PR_TOKEN_ISSUER_ROLE_ARN }}
-#          aws-lambda-url: ${{ secrets.AWS_CORE_TOKEN_ISSUER_LAMBDA_URL }} # see https://github.com/smartcontractkit/  infra/blob/a79bcfb48315c4411023c182e98eb80ff9e9cda6/accounts/production/us-west-2/lambda/  github-app-token-issuer-production/teams/releng/config.json#L9
-#          aws-region: ${{ secrets.AWS_REGION }}
-#          aws-role-duration-seconds: ${{ secrets.AWS_ROLE_DURATION_SECONDS }}
-#          enable-magic-cache: true
-#
-#      - name: Nix Develop Action
-#        uses: nicknovitski/nix-develop@v1
-#        with:
-#          arguments: "--accept-flake-config"
-#      - name: setup-gap
-#        uses: smartcontractkit/.github/actions/setup-gap@d316f66b2990ea4daa479daa3de6fc92b00f863e # setup-gap@0.3.2
-#        with:
-#          aws-role-arn: ${{ secrets.AWS_OIDC_CRIB_ROLE_ARN_STAGE }}
-#          api-gateway-host: ${{ secrets.AWS_API_GW_HOST_K8S_STAGE }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#          ecr-private-registry: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-#          k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_STAGE }}
-#          use-private-ecr-registry: true
-#          use-k8s: true
-#          metrics-job-name: "k8s"
-#          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-#          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-#          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: setup-gap
+        uses: smartcontractkit/.github/actions/setup-gap@d316f66b2990ea4daa479daa3de6fc92b00f863e # setup-gap@0.3.2
+        with:
+          aws-role-arn: ${{ secrets.AWS_OIDC_CRIB_ROLE_ARN_STAGE }}
+          api-gateway-host: ${{ secrets.AWS_API_GW_HOST_CRIB_STAGE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          ecr-private-registry: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_STAGE }}
+          use-private-ecr-registry: true
+          use-k8s: true
+          metrics-job-name: "k8s"
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
 #      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 #        name: Checkout CRIB repository
 #        with:
@@ -58,17 +47,20 @@
 #        run: |-
 #          devspace use namespace $CRIB_NAMESPACE
 #          devspace deploy --profile local-dev-simulated-core-ocr1
-#      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-#      - name: Setup go
-#        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-#        with:
-#          go-version-file: "go.mod"
-#      - name: Run CRIB integration test
-#        working-directory: integration-tests/crib
-#        env:
-#          K8S_STAGING_INGRESS_SUFFIX: ${{ secrets.K8S_STAGING_INGRESS_SUFFIX }}
-#          CRIB_NAMESPACE: ${{ env.CRIB_NAMESPACE }}
-#          CRIB_NETWORK: geth
-#          CRIB_NODES: 5
-#        run: |-
-#          go test -v -run TestCRIB
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - name: Setup go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: "go.mod"
+      - name: Run CRIB integration test
+        working-directory: integration-tests/crib
+        env:
+          K8S_STAGING_INGRESS_SUFFIX: ${{ secrets.K8S_STAGING_INGRESS_SUFFIX }}
+          CRIB_NAMESPACE: crib-skudasov
+          CRIB_NETWORK: geth
+          CRIB_NODES: 5
+          GAP_URL: ${{ secrets.GAP_URL }}
+          SETH_LOG_LEVEL: debug
+          RESTY_DEBUG: true
+        run: |-
+          go test -v -run TestCRIB

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -72,7 +72,7 @@ jobs:
           echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@1fc88731538c4abae81ff65f7cd37832da431d7d
+        uses: smartcontractkit/.github/actions/setup-crib-environment@162332bdacb97f76a4f327691547ac47bc6c4815
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -72,7 +72,7 @@ jobs:
           echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@f616649d75bd97266f1446a89b54eb3ccd127bfc
+        uses: smartcontractkit/.github/actions/setup-crib-environment@f7ce0546f0c2b9bd76d9b445dcd6042bd6cc760c
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -97,8 +97,8 @@ jobs:
           CRIB_NETWORK: geth
           CRIB_NODES: 5
           GAP_URL: ${{ secrets.GAP_URL }}
-          SETH_LOG_LEVEL: info
-#          RESTY_DEBUG: true
+          SETH_LOG_LEVEL: debug
+          RESTY_DEBUG: true
 #          TEST_PERSISTENCE: true
         run: |-
           go test -v -run TestCRIB

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -24,6 +24,7 @@ jobs:
       - name: setup-gap crib
         uses: smartcontractkit/.github/actions/setup-gap@00b58566e0ee2761e56d9db0ea72b783fdb89b8d # setup-gap@0.4.0
         with:
+          aws-role-duration-seconds: 3600 # 1 hour
           aws-role-arn: ${{ secrets.AWS_OIDC_CRIB_ROLE_ARN_STAGE }}
           api-gateway-host: ${{ secrets.AWS_API_GW_HOST_CRIB_STAGE }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -41,6 +42,7 @@ jobs:
       - name: setup-gap k8s
         uses: smartcontractkit/.github/actions/setup-gap@00b58566e0ee2761e56d9db0ea72b783fdb89b8d # setup-gap@0.4.0
         with:
+          aws-role-duration-seconds: 3600 # 1 hour
           aws-role-arn: ${{ secrets.AWS_OIDC_CRIB_ROLE_ARN_STAGE }}
           api-gateway-host: ${{ secrets.AWS_API_GW_HOST_K8S_STAGE }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -82,4 +84,4 @@ jobs:
           SETH_LOG_LEVEL: info
 #          RESTY_DEBUG: true
         run: |-
-          go test -v -timeout 15m -run TestCRIB
+          go test -v -timeout 60m -run TestCRIB

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -21,32 +21,53 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - name: setup-gap
-        uses: smartcontractkit/.github/actions/setup-gap@d316f66b2990ea4daa479daa3de6fc92b00f863e # setup-gap@0.3.2
+      - name: setup-gap crib
+        # TODO: update after testing and latest changes are released.
+        uses: smartcontractkit/.github/actions/setup-gap@crib-274/multi-gap-and-tls # setup-gap@0.4.0
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CRIB_ROLE_ARN_STAGE }}
           api-gateway-host: ${{ secrets.AWS_API_GW_HOST_CRIB_STAGE }}
           aws-region: ${{ secrets.AWS_REGION }}
           ecr-private-registry: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_STAGE }}
+          gap-name: crib
           use-private-ecr-registry: true
-          use-k8s: true
-          metrics-job-name: "k8s"
+          use-tls: true
+          proxy-port: 8443
+          metrics-job-name: "test"
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-#      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-#        name: Checkout CRIB repository
-#        with:
-#          repository: 'smartcontractkit/crib'
-#          ref: 'main'
-#      - name: Generate Short UUID
-#        id: uuid
-#        run: echo "CRIB_NAMESPACE=$(uuidgen | cut -c1-5)" >> $GITHUB_ENV
-#      - name: Create a new CRIB environment
-#        run: |-
-#          devspace use namespace $CRIB_NAMESPACE
-#          devspace deploy --profile local-dev-simulated-core-ocr1
+
+      - name: setup-gap k8s
+        # TODO: update after testing and latest changes are released.
+        uses: smartcontractkit/.github/actions/setup-gap@crib-274/multi-gap-and-tls # setup-gap@0.4.0
+        with:
+          aws-role-arn: ${{ secrets.AWS_OIDC_CRIB_ROLE_ARN_STAGE }}
+          api-gateway-host: ${{ secrets.AWS_API_GW_HOST_K8S_STAGE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          ecr-private-registry: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_STAGE }}
+          gap-name: k8s
+          use-private-ecr-registry: true
+          use-k8s: true
+          proxy-port: 9443
+          metrics-job-name: "test"
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+      #      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      #        name: Checkout CRIB repository
+      #        with:
+      #          repository: 'smartcontractkit/crib'
+      #          ref: 'main'
+      #      - name: Generate Short UUID
+      #        id: uuid
+      #        run: echo "CRIB_NAMESPACE=$(uuidgen | cut -c1-5)" >> $GITHUB_ENV
+      #      - name: Create a new CRIB environment
+      #        run: |-
+      #          devspace use namespace $CRIB_NAMESPACE
+      #          devspace deploy --profile local-dev-simulated-core-ocr1
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Setup go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -33,7 +33,7 @@ jobs:
           gap-name: crib
           use-private-ecr-registry: true
           use-tls: true
-          proxy-port: 8443
+          proxy-port: 8080
           metrics-job-name: "test"
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
@@ -51,7 +51,7 @@ jobs:
           gap-name: k8s
           use-private-ecr-registry: true
           use-k8s: true
-          proxy-port: 9443
+          proxy-port: 8443
           metrics-job-name: "test"
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -67,7 +67,7 @@ jobs:
           aws-role-duration-seconds: "1800"
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@d88bff0ab4ec170afe4d37bffd197bcd5ceb48bb
+        uses: smartcontractkit/.github/actions/setup-crib-environment@fda734ff95d585f3c7a990aadf0b9c4765d8f7e3
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -72,7 +72,7 @@ jobs:
           echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@6e3838a448d29b530032a71b2f1619d6b75c7825
+        uses: smartcontractkit/.github/actions/setup-crib-environment@6c800885ebd68c610328f23fa2f808e067861113
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -57,11 +57,20 @@ jobs:
           gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
 
+      - name: Setup GitHub token using GATI
+        id: token
+        uses: smartcontractkit/.github/actions/setup-github-token@main
+        with:
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GLOBAL_READ_ONLY }}
+          aws-lambda-url: ${{ secrets.GATI_LAMBDA_RELENG_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-duration-seconds: "1800"
 
       - name: Deploy and validate CRIB Environment for Core
         uses: smartcontractkit/.github/actions/setup-crib-environment@fb4c26ad00aab4121a26c55a67acb0c8057bb4a7
         id: deploy-crib
         with:
+          github_token: ${{ steps.token.outputs.access-token }}
           disable-environment-teardown: true
           api-gateway-host: ${{ secrets.AWS_API_GW_HOST_K8S_STAGE }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -87,4 +96,4 @@ jobs:
 #          RESTY_DEBUG: true
 #          TEST_PERSISTENCE: true
         run: |-
-          go test -v -timeout 60m -run TestCRIB
+          go test -v -run TestCRIB

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -72,7 +72,7 @@ jobs:
           echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@162332bdacb97f76a4f327691547ac47bc6c4815
+        uses: smartcontractkit/.github/actions/setup-crib-environment@6e3838a448d29b530032a71b2f1619d6b75c7825
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -72,7 +72,7 @@ jobs:
           echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/crib-deploy-environment@65dcdddbc181f9cd8ff80979adba11aef56e82a1
+        uses: smartcontractkit/.github/actions/crib-deploy-environment@c0b38e6c40d72d01b8d2f24f92623a2538b3dedb
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}
@@ -105,6 +105,6 @@ jobs:
       - name: Destroy CRIB Environment
         id: destroy
         if: always() && steps.deploy-crib.outputs.devspace-namespace != ''
-        uses: smartcontractkit/.github/actions/crib-purge-environment@65dcdddbc181f9cd8ff80979adba11aef56e82a1
+        uses: smartcontractkit/.github/actions/crib-purge-environment@c0b38e6c40d72d01b8d2f24f92623a2538b3dedb
         with:
           namespace: ${{ steps.deploy-crib.outputs.devspace-namespace }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -72,7 +72,7 @@ jobs:
           echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/crib-deploy-environment@c0b38e6c40d72d01b8d2f24f92623a2538b3dedb
+        uses: smartcontractkit/.github/actions/crib-deploy-environment@c0b38e6c40d72d01b8d2f24f92623a2538b3dedb # crib-deploy-environment@0.5.0
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}
@@ -105,6 +105,6 @@ jobs:
       - name: Destroy CRIB Environment
         id: destroy
         if: always() && steps.deploy-crib.outputs.devspace-namespace != ''
-        uses: smartcontractkit/.github/actions/crib-purge-environment@c0b38e6c40d72d01b8d2f24f92623a2538b3dedb
+        uses: smartcontractkit/.github/actions/crib-purge-environment@c0b38e6c40d72d01b8d2f24f92623a2538b3dedb # crib-purge-environment@0.1.0
         with:
           namespace: ${{ steps.deploy-crib.outputs.devspace-namespace }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -72,11 +72,10 @@ jobs:
           echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@828ff604e500769fdd891ed6b09ffe69895a4054
+        uses: smartcontractkit/.github/actions/crib-deploy-environment@65dcdddbc181f9cd8ff80979adba11aef56e82a1
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}
-          disable-environment-teardown: true
           api-gateway-host: ${{ secrets.AWS_API_GW_HOST_K8S_STAGE }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-role-arn: ${{ secrets.AWS_OIDC_CRIB_ROLE_ARN_STAGE }}
@@ -103,3 +102,9 @@ jobs:
 #          TEST_PERSISTENCE: true
         run: |-
           go test -v -run TestCRIB
+      - name: Destroy CRIB Environment
+        id: destroy
+        if: always() && steps.deploy-crib.outputs.devspace-namespace != ''
+        uses: smartcontractkit/.github/actions/crib-purge-environment@65dcdddbc181f9cd8ff80979adba11aef56e82a1
+        with:
+          namespace: ${{ steps.deploy-crib.outputs.devspace-namespace }}

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -82,4 +82,4 @@ jobs:
           SETH_LOG_LEVEL: info
 #          RESTY_DEBUG: true
         run: |-
-          go test -v -run TestCRIB
+          go test -v -timeout 15m -run TestCRIB

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -67,7 +67,7 @@ jobs:
           aws-role-duration-seconds: "1800"
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/setup-crib-environment@fb4c26ad00aab4121a26c55a67acb0c8057bb4a7
+        uses: smartcontractkit/.github/actions/setup-crib-environment@334a434a4a1334042ac299b69c4778cbc849b48c
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -129,3 +129,9 @@ Run soak/ocr_test.go with RPC network chaos by bringing down network to RPC node
 ```bash
 make test_soak_ocr_rpc_down_half_cl_nodes
 ```
+
+### Debugging HTTP and RPC clients
+```bash
+export SETH_LOG_LEVEL=debug
+export RESTY_DEBUG=true
+```

--- a/integration-tests/actions/vrf/common/actions.go
+++ b/integration-tests/actions/vrf/common/actions.go
@@ -429,7 +429,7 @@ type RPCRawClient struct {
 }
 
 func NewRPCRawClient(url string) *RPCRawClient {
-	isDebug := os.Getenv("DEBUG_RESTY") == "true"
+	isDebug := os.Getenv("RESTY_DEBUG") == "true"
 	restyClient := resty.New().SetDebug(isDebug).SetBaseURL(url)
 	return &RPCRawClient{
 		resty: restyClient,

--- a/integration-tests/client/chainlink.go
+++ b/integration-tests/client/chainlink.go
@@ -66,14 +66,12 @@ func initRestyClient(url string, email string, password string, headers map[stri
 	if timeout != nil {
 		rc.SetTimeout(*timeout)
 	}
-	log.Warn().Bool("Debug", rc.Debug).Msg("here")
 	session := &Session{Email: email, Password: password}
 	// Retry the connection on boot up, sometimes pods can still be starting up and not ready to accept connections
 	var resp *resty.Response
 	var err error
 	retryCount := 20
 	for i := 0; i < retryCount; i++ {
-		log.Warn().Bool("Debug", rc.Debug).Msg("here")
 		resp, err = rc.R().SetBody(session).Post("/sessions")
 		if err != nil {
 			log.Warn().Err(err).Str("URL", url).Interface("Session Details", session).Msg("Error connecting to Chainlink node, retrying")

--- a/integration-tests/client/chainlink_k8s.go
+++ b/integration-tests/client/chainlink_k8s.go
@@ -2,7 +2,6 @@
 package client
 
 import (
-	"os"
 	"regexp"
 
 	"github.com/rs/zerolog/log"
@@ -23,13 +22,9 @@ type ChainlinkK8sClient struct {
 
 // NewChainlink creates a new Chainlink model using a provided config
 func NewChainlinkK8sClient(c *ChainlinkConfig, podName, chartName string) (*ChainlinkK8sClient, error) {
-	rc, err := initRestyClient(c.URL, c.Email, c.Password, c.HTTPTimeout)
+	rc, err := initRestyClient(c.URL, c.Email, c.Password, c.Headers, c.HTTPTimeout)
 	if err != nil {
 		return nil, err
-	}
-	_, isSet := os.LookupEnv("CL_CLIENT_DEBUG")
-	if isSet {
-		rc.SetDebug(true)
 	}
 	return &ChainlinkK8sClient{
 		ChainlinkClient: &ChainlinkClient{

--- a/integration-tests/client/chainlink_models.go
+++ b/integration-tests/client/chainlink_models.go
@@ -20,11 +20,12 @@ type EIServiceConfig struct {
 
 // ChainlinkConfig represents the variables needed to connect to a Chainlink node
 type ChainlinkConfig struct {
-	URL         string         `toml:",omitempty"`
-	Email       string         `toml:",omitempty"`
-	Password    string         `toml:",omitempty"`
-	InternalIP  string         `toml:",omitempty"`
-	HTTPTimeout *time.Duration `toml:"-"`
+	URL         string            `toml:",omitempty"`
+	Email       string            `toml:",omitempty"`
+	Password    string            `toml:",omitempty"`
+	InternalIP  string            `toml:",omitempty"`
+	Headers     map[string]string `toml:",omitempty"`
+	HTTPTimeout *time.Duration    `toml:"-"`
 }
 
 // ResponseSlice is the generic model that can be used for all Chainlink API responses that are an slice

--- a/integration-tests/crib/README.md
+++ b/integration-tests/crib/README.md
@@ -17,6 +17,6 @@ export CRIB_NETWORK=geth # only "geth" is supported for now
 export CRIB_NODES=5 # min 5 nodes
 #export SETH_LOG_LEVEL=debug # these two can be enabled to debug connection issues
 #export RESTY_DEBUG=true
-export GAP_URL=https://localhost:8080/primary # only applicable in CI
+export GAP_URL=https://localhost:8080/primary # only applicable in CI, unset the var to connect locally
 go test -v -run TestCRIB
 ```

--- a/integration-tests/crib/README.md
+++ b/integration-tests/crib/README.md
@@ -12,8 +12,11 @@ devspace deploy --debug --profile local-dev-simulated-core-ocr1
 
 ## Run the tests
 ```shell
-CRIB_NAMESPACE=crib-oh-my-crib
-CRIB_NETWORK=geth # only "geth" is supported for now
-CRIB_NODES=5 # min 5 nodes
+export CRIB_NAMESPACE=crib-oh-my-crib
+export CRIB_NETWORK=geth # only "geth" is supported for now
+export CRIB_NODES=5 # min 5 nodes
+#export SETH_LOG_LEVEL=info # these two can be enabled to debug connection issues
+#export RESTY_DEBUG=true
+export GAP_URL=https://localhost:8080/primary # only applicable in CI
 go test -v -run TestCRIB
 ```

--- a/integration-tests/crib/README.md
+++ b/integration-tests/crib/README.md
@@ -17,6 +17,7 @@ export CRIB_NETWORK=geth # only "geth" is supported for now
 export CRIB_NODES=5 # min 5 nodes
 #export SETH_LOG_LEVEL=debug # these two can be enabled to debug connection issues
 #export RESTY_DEBUG=true
+#export TEST_PERSISTENCE=true # to run the chaos test
 export GAP_URL=https://localhost:8080/primary # only applicable in CI, unset the var to connect locally
 go test -v -run TestCRIB
 ```

--- a/integration-tests/crib/README.md
+++ b/integration-tests/crib/README.md
@@ -15,7 +15,7 @@ devspace deploy --debug --profile local-dev-simulated-core-ocr1
 export CRIB_NAMESPACE=crib-oh-my-crib
 export CRIB_NETWORK=geth # only "geth" is supported for now
 export CRIB_NODES=5 # min 5 nodes
-#export SETH_LOG_LEVEL=info # these two can be enabled to debug connection issues
+#export SETH_LOG_LEVEL=debug # these two can be enabled to debug connection issues
 #export RESTY_DEBUG=true
 export GAP_URL=https://localhost:8080/primary # only applicable in CI
 go test -v -run TestCRIB

--- a/integration-tests/crib/README.md
+++ b/integration-tests/crib/README.md
@@ -1,4 +1,4 @@
-### CRIB Health Check Test
+### Example e2e product test using CRIB
 
 ## Setup CRIB
 This is a simple smoke + chaos test for CRIB deployment.
@@ -21,3 +21,6 @@ export CRIB_NODES=5 # min 5 nodes
 export GAP_URL=https://localhost:8080/primary # only applicable in CI, unset the var to connect locally
 go test -v -run TestCRIB
 ```
+
+## Configuring CI workflow
+We are using GAP and GATI to access the infrastructure, please follow [configuration guide](https://smartcontract-it.atlassian.net/wiki/spaces/CRIB/pages/909967436/CRIB+CI+Integration)

--- a/integration-tests/crib/connect.go
+++ b/integration-tests/crib/connect.go
@@ -38,7 +38,7 @@ func ConnectRemote() (
 	[]*client.ChainlinkK8sClient,
 	error,
 ) {
-	vars, err := crib.CoreDONConnection()
+	vars, err := crib.CoreDONSimulatedConnection()
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/integration-tests/crib/connect.go
+++ b/integration-tests/crib/connect.go
@@ -1,10 +1,10 @@
 package crib
 
 import (
-	"fmt"
-	"os"
-	"strconv"
+	"net/http"
 	"time"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/crib"
 
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/seth"
@@ -18,17 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 )
 
-const (
-	// these are constants for simulated CRIB that should never change
-	// CRIB: https://github.com/smartcontractkit/crib/tree/main/core
-	// Core Chart: https://github.com/smartcontractkit/infra-charts/tree/main/chainlink-cluster
-	mockserverCRIBTemplate        = "https://%s-mockserver%s"
-	internalNodeDNSTemplate       = "app-node%d"
-	ingressNetworkWSURLTemplate   = "wss://%s-geth-1337-ws%s"
-	ingressNetworkHTTPURLTemplate = "https://%s-geth-1337-http%s"
-)
-
-func setSethConfig(cfg tc.TestConfig, netWSURL string, netHTTPURL string) {
+func setSethConfig(cfg tc.TestConfig, netWSURL string, netHTTPURL string, headers http.Header) {
 	netName := "CRIB_SIMULATED"
 	cfg.Network.SelectedNetworks = []string{netName}
 	cfg.Network.RpcHttpUrls = map[string][]string{}
@@ -36,42 +26,7 @@ func setSethConfig(cfg tc.TestConfig, netWSURL string, netHTTPURL string) {
 	cfg.Network.RpcWsUrls = map[string][]string{}
 	cfg.Network.RpcWsUrls[netName] = []string{netWSURL}
 	cfg.Seth.EphemeralAddrs = ptr.Ptr(int64(0))
-}
-
-type ConnectionVars struct {
-	IngressSuffix string
-	Namespace     string
-	Network       string
-	Nodes         int
-}
-
-func ReadCRIBVars() (*ConnectionVars, error) {
-	ingressSuffix := os.Getenv("K8S_STAGING_INGRESS_SUFFIX")
-	if ingressSuffix == "" {
-		return nil, errors.New("K8S_STAGING_INGRESS_SUFFIX must be set to connect to k8s ingresses")
-	}
-	cribNamespace := os.Getenv("CRIB_NAMESPACE")
-	if cribNamespace == "" {
-		return nil, errors.New("CRIB_NAMESPACE must be set to connect")
-	}
-	cribNetwork := os.Getenv("CRIB_NETWORK")
-	if cribNetwork == "" {
-		return nil, errors.New("CRIB_NETWORK must be set to connect, only 'geth' is supported for now")
-	}
-	cribNodes := os.Getenv("CRIB_NODES")
-	nodes, err := strconv.Atoi(cribNodes)
-	if err != nil {
-		return nil, errors.New("CRIB_NODES must be a number, 5-19 nodes")
-	}
-	if nodes < 2 {
-		return nil, fmt.Errorf("not enough chainlink nodes, need at least 2")
-	}
-	return &ConnectionVars{
-		IngressSuffix: ingressSuffix,
-		Namespace:     cribNamespace,
-		Network:       cribNetwork,
-		Nodes:         nodes,
-	}, nil
+	cfg.Seth.RPCHeaders = headers
 }
 
 // ConnectRemote connects to a local environment, see https://github.com/smartcontractkit/crib/tree/main/core
@@ -83,39 +38,33 @@ func ConnectRemote() (
 	[]*client.ChainlinkK8sClient,
 	error,
 ) {
-	vars, err := ReadCRIBVars()
+	vars, err := crib.CoreDONConnection()
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+	// TODO: move all the parts of ConnectRemote() to CTF when Seth config refactor is finalized
 	config, err := tc.GetConfig([]string{"CRIB"}, tc.OCR)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	if vars.Nodes < 2 {
-		return nil, nil, nil, nil, fmt.Errorf("not enough chainlink nodes, need at least 2")
-	}
-	mockserverURL := fmt.Sprintf(mockserverCRIBTemplate, vars.Namespace, vars.IngressSuffix)
 	var sethClient *seth.Client
 	switch vars.Network {
 	case "geth":
-		netWSURL := fmt.Sprintf(ingressNetworkWSURLTemplate, vars.Namespace, vars.IngressSuffix)
-		netHTTPURL := fmt.Sprintf(ingressNetworkHTTPURLTemplate, vars.Namespace, vars.IngressSuffix)
-		setSethConfig(config, netWSURL, netHTTPURL)
+		setSethConfig(config, vars.NetworkWSURL, vars.NetworkHTTPURL, vars.BlockchainNodeHeaders)
 		net := blockchain.EVMNetwork{
-			Name:                 vars.Network,
-			Simulated:            true,
-			SupportsEIP1559:      true,
-			ClientImplementation: blockchain.EthereumClientImplementation,
-			ChainID:              1337,
-			PrivateKeys: []string{
-				"ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-			},
-			URLs:                      []string{netWSURL},
-			HTTPURLs:                  []string{netHTTPURL},
+			Name:                      vars.Network,
+			Simulated:                 true,
+			SupportsEIP1559:           true,
+			ClientImplementation:      blockchain.EthereumClientImplementation,
+			ChainID:                   vars.ChainID,
+			PrivateKeys:               vars.PrivateKeys,
+			URLs:                      []string{vars.NetworkWSURL},
+			HTTPURLs:                  []string{vars.NetworkHTTPURL},
 			ChainlinkTransactionLimit: 500000,
 			Timeout:                   blockchain.StrDuration{Duration: 2 * time.Minute},
 			MinimumConfirmations:      1,
 			GasEstimationBuffer:       10000,
+			Headers:                   vars.BlockchainNodeHeaders,
 		}
 		sethClient, err = seth_utils.GetChainClient(config, net)
 		if err != nil {
@@ -127,31 +76,34 @@ func ConnectRemote() (
 	// bootstrap node
 	clClients := make([]*client.ChainlinkK8sClient, 0)
 	c, err := client.NewChainlinkK8sClient(&client.ChainlinkConfig{
-		URL:        fmt.Sprintf("https://%s-node%d%s", vars.Namespace, 1, vars.IngressSuffix),
 		Email:      client.CLNodeTestEmail,
-		InternalIP: fmt.Sprintf(internalNodeDNSTemplate, 1),
 		Password:   client.CLNodeTestPassword,
-	}, fmt.Sprintf(internalNodeDNSTemplate, 1), vars.Namespace)
+		URL:        vars.NodeURLs[0],
+		InternalIP: vars.NodeInternalDNS[0],
+		Headers:    vars.NodeHeaders[0],
+	}, vars.NodeInternalDNS[0], vars.Namespace)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
 	clClients = append(clClients, c)
 	// all the other nodes, indices of nodes in CRIB starts with 1
-	for i := 2; i <= vars.Nodes; i++ {
+	for i := 1; i < vars.Nodes; i++ {
 		cl, err := client.NewChainlinkK8sClient(&client.ChainlinkConfig{
-			URL:        fmt.Sprintf("https://%s-node%d%s", vars.Namespace, i, vars.IngressSuffix),
 			Email:      client.CLNodeTestEmail,
-			InternalIP: fmt.Sprintf(internalNodeDNSTemplate, i),
 			Password:   client.CLNodeTestPassword,
-		}, fmt.Sprintf(internalNodeDNSTemplate, i), vars.Namespace)
+			URL:        vars.NodeURLs[i],
+			InternalIP: vars.NodeInternalDNS[i],
+			Headers:    vars.NodeHeaders[i],
+		}, vars.NodeInternalDNS[i], vars.Namespace)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
 		clClients = append(clClients, cl)
 	}
 	mockServerClient := msClient.NewMockserverClient(&msClient.MockserverConfig{
-		LocalURL:   mockserverURL,
-		ClusterURL: mockserverURL,
+		LocalURL:   vars.MockserverURL,
+		ClusterURL: "http://mockserver:1080",
+		Headers:    vars.MockserverHeaders,
 	})
 
 	//nolint:gosec // G602 - false positive https://github.com/securego/gosec/issues/1005

--- a/integration-tests/crib/ocr_test.go
+++ b/integration-tests/crib/ocr_test.go
@@ -50,5 +50,5 @@ func TestCRIB(t *testing.T) {
 			return false
 		}
 		return true
-	}, 20*time.Minute, 5*time.Second)
+	}, 60*time.Minute, 5*time.Second)
 }

--- a/integration-tests/crib/ocr_test.go
+++ b/integration-tests/crib/ocr_test.go
@@ -50,5 +50,5 @@ func TestCRIB(t *testing.T) {
 			return false
 		}
 		return true
-	}, 10*time.Minute, 5*time.Second)
+	}, 20*time.Minute, 5*time.Second)
 }

--- a/integration-tests/crib/ocr_test.go
+++ b/integration-tests/crib/ocr_test.go
@@ -50,5 +50,5 @@ func TestCRIB(t *testing.T) {
 			return false
 		}
 		return true
-	}, 3*time.Minute, 5*time.Second)
+	}, 10*time.Minute, 5*time.Second)
 }

--- a/integration-tests/crib/ocr_test.go
+++ b/integration-tests/crib/ocr_test.go
@@ -1,12 +1,9 @@
 package crib
 
 import (
-	"context"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/havoc/k8schaos"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/actions"
@@ -33,16 +30,16 @@ func TestCRIB(t *testing.T) {
 	err = actions.WatchNewOCRRound(l, sethClient, 1, contracts.V1OffChainAgrregatorToOffChainAggregatorWithRounds(ocrInstances), 5*time.Minute)
 	require.NoError(t, err, "Error watching for new OCR round")
 
-	ch, err := rebootCLNamespace(
-		1*time.Second,
-		os.Getenv("CRIB_NAMESPACE"),
-	)
-	ch.Create(context.Background())
-	ch.AddListener(k8schaos.NewChaosLogger(l))
-	t.Cleanup(func() {
-		err := ch.Delete(context.Background())
-		require.NoError(t, err)
-	})
+	//ch, err := rebootCLNamespace(
+	//	1*time.Second,
+	//	os.Getenv("CRIB_NAMESPACE"),
+	//)
+	//ch.Create(context.Background())
+	//ch.AddListener(k8schaos.NewChaosLogger(l))
+	//t.Cleanup(func() {
+	//	err := ch.Delete(context.Background())
+	//	require.NoError(t, err)
+	//})
 	require.Eventually(t, func() bool {
 		err = actions.WatchNewOCRRound(l, sethClient, 3, contracts.V1OffChainAgrregatorToOffChainAggregatorWithRounds(ocrInstances), 5*time.Minute)
 		if err != nil {

--- a/integration-tests/crib/ocr_test.go
+++ b/integration-tests/crib/ocr_test.go
@@ -2,10 +2,11 @@ package crib
 
 import (
 	"context"
-	"github.com/smartcontractkit/havoc/k8schaos"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/smartcontractkit/havoc/k8schaos"
 
 	"github.com/stretchr/testify/require"
 

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -375,7 +375,7 @@ require (
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240710170203-5b41615da827 // indirect
 	github.com/smartcontractkit/chainlink-solana v1.1.1-0.20240806154405-8e5684f98564 // indirect
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240709043547-03612098f799 // indirect
-	github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240405215812-5a72bc9af239 // indirect
+	github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.2-0.20240805111647-acf86c1e347a // indirect
 	github.com/smartcontractkit/havoc/k8schaos v0.0.0-20240409145249-e78d20847e37 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230906073235-9e478e5e19f1 // indirect
 	github.com/smartcontractkit/wsrpc v0.7.3 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1486,8 +1486,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.202407
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240709043547-03612098f799/go.mod h1:UVFRacRkP7O7TQAzFmR52v5mUlxf+G1ovMlCQAB/cHU=
 github.com/smartcontractkit/chainlink-testing-framework v1.34.2 h1:YL3ft7KJB7SAopdmJeyeR4/kv0j4jOdagNihXq8OZ38=
 github.com/smartcontractkit/chainlink-testing-framework v1.34.2/go.mod h1:hRZEDh2+afO8MSZb9qYNscmWb+3mHZf01J5ACZuIdTQ=
-github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240405215812-5a72bc9af239 h1:Kk5OVlx/5g9q3Z3lhxytZS4/f8ds1MiNM8yaHgK3Oe8=
-github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240405215812-5a72bc9af239/go.mod h1:DC8sQMyTlI/44UCTL8QWFwb0bYNoXCfjwCv2hMivYZU=
+github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.2-0.20240805111647-acf86c1e347a h1:8GtvGJaGyKzx/ar1yX74GxrzIYWTZVTyv4pYB/1ln8w=
+github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.2-0.20240805111647-acf86c1e347a/go.mod h1:DC8sQMyTlI/44UCTL8QWFwb0bYNoXCfjwCv2hMivYZU=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16 h1:TFe+FvzxClblt6qRfqEhUfa4kFQx5UobuoFGO2W4mMo=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16/go.mod h1:lBS5MtSSBZk0SHc66KACcjjlU6WzEVP/8pwz68aMkCI=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f h1:hgJif132UCdjo8u43i7iPN1/MFnu49hv7lFGFftCHKU=

--- a/integration-tests/smoke/README.md
+++ b/integration-tests/smoke/README.md
@@ -75,9 +75,3 @@ Then execute:
 go test -v -run ${TestName}
 ```
 
-
-
-### Debugging CL client API calls
-```bash
-export CL_CLIENT_DEBUG=true
-```

--- a/integration-tests/testsetups/ocr.go
+++ b/integration-tests/testsetups/ocr.go
@@ -547,7 +547,6 @@ func (o *OCRSoakTest) LoadState() error {
 	}
 
 	o.mockServer = ctf_client.ConnectMockServerURL(testState.MockServerURL)
-
 	return err
 }
 


### PR DESCRIPTION
This PR introduces an example smoke + chaos test for CRIB and CI integration.
It allows us to spin up CRIB environment and run various tests then teardown.

This test can be run locally with an already deployed OCRv1 crib or remotely in [this](https://github.com/smartcontractkit/chainlink/blob/c99ef07887e33a048b7116d4e2735fa5b5cc5bd8/.github/workflows/crib-integration-test.yml) workflow.
Docs are [here](https://github.com/smartcontractkit/chainlink/blob/7ed473f2441a6da839686bbc84047b1ebfe48087/integration-tests/crib/README.md)

This PR enables temporary nightly runs while CRIB is under heavy development.