### PR TITLE
Fix syntax error in workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -93,7 +93,7 @@ jobs:
               format(
                 'https://github.com/{0}/blob/{1}/CHANGELOG.md',
                 github.repository,
-                github.ref_name,
+                github.ref_name
               ) || ''
             }}
           docker-image-name: >-


### PR DESCRIPTION
Fixes:

```
[Invalid workflow file: .github/workflows/build-publish.yml#L90](https://github.com/smartcontractkit/chainlink/actions/runs/10150649826/workflow)
The workflow is not valid. .github/workflows/build-publish.yml (Line: 90, Col: 26): Unexpected symbol: ')'. Located at position 137 within expression: github.ref_type == 'tag' &&
  format(
    'https://github.com/{0}/blob/{1}/CHANGELOG.md',
    github.repository,
    github.ref_name,
  ) || ''
```

<!---
  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
  
  By referencing it, it will let the QA team to know what to watch out for when creating a new release.

  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
