### PR TITLE
[TT-1428] Build Image for Tags

### DIFF
--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -284,7 +284,6 @@ jobs:
     if: |
       always() &&
       needs.should-run.outputs.should_run == 'true' &&
-      github.ref_type != 'tag' &&
       (
         needs.select-versions.outputs.evm_implementations != '' ||
         github.event.inputs.base64TestList != ''


### PR DESCRIPTION
In a perfect world, we'd only build the Chainlink image once and reuse it in all workflows, but GHA makes it difficult to do this cleanly. For now we're switching back to the messy way, and [RE-2842](https://smartcontract-it.atlassian.net/browse/RE-2842) will track efforts towards the clean way.


[RE-2842]: https://smartcontract-it.atlassian.net/browse/RE-2842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ