### PR TITLE
bump starknet relayer: fix intermittent stale report

### DIFF
--- a/.changeset/giant-hounds-clap.md
+++ b/.changeset/giant-hounds-clap.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+fix stale report issue - read from pending block instead of latest #bugfix

--- a/.tool-versions
+++ b/.tool-versions
@@ -7,4 +7,3 @@ helm 3.10.3
 zig 0.11.0
 golangci-lint 1.55.2
 protoc 25.1
-starknet-foundry 0.27.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -7,3 +7,4 @@ helm 3.10.3
 zig 0.11.0
 golangci-lint 1.55.2
 protoc 25.1
+starknet-foundry 0.27.0

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -260,7 +260,7 @@ require (
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42 // indirect
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58 // indirect
-	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097 // indirect
+	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230906073235-9e478e5e19f1 // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20230906073235-9e478e5e19f1 // indirect
 	github.com/smartcontractkit/wsrpc v0.8.1 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1195,8 +1195,8 @@ github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42 h
 github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42/go.mod h1:PJlzwLaYsA7YcAKXdysMjNONeIolPrRjT9v/AMo4Er0=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58 h1:jc4ab5QrKZfkICyxJysCt7mSExuSPbePjgZsnJR3nRQ=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58/go.mod h1:oV5gIuSKrPEcjQ6uB6smBsm5kXHxyydVLNyAs4V9CoQ=
-github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097 h1:Vgo8p/9udAfuhS/T13KpSXe30pJo4XXFOugOQXw9OZ4=
-github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097/go.mod h1:Fqkjgw9r7sT0D6OvRyygm1sqeBE1XNtbmHkz9RFhNZg=
+github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb h1:IiB0+epMT2qK9lsdtUkxJAhDQDHbtt2JWGkCqgM6ADs=
+github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb/go.mod h1:Fqkjgw9r7sT0D6OvRyygm1sqeBE1XNtbmHkz9RFhNZg=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20240222010609-cd67d123c772 h1:LQmRsrzzaYYN3wEU1l5tWiccznhvbyGnu2N+wHSXZAo=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20240222010609-cd67d123c772/go.mod h1:Kn1Hape05UzFZ7bOUnm3GVsHzP0TNrVmpfXYNHdqGGs=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16 h1:TFe+FvzxClblt6qRfqEhUfa4kFQx5UobuoFGO2W4mMo=

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58
-	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097
+	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230906073235-9e478e5e19f1

--- a/go.sum
+++ b/go.sum
@@ -1190,8 +1190,8 @@ github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42 h
 github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42/go.mod h1:PJlzwLaYsA7YcAKXdysMjNONeIolPrRjT9v/AMo4Er0=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58 h1:jc4ab5QrKZfkICyxJysCt7mSExuSPbePjgZsnJR3nRQ=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58/go.mod h1:oV5gIuSKrPEcjQ6uB6smBsm5kXHxyydVLNyAs4V9CoQ=
-github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097 h1:Vgo8p/9udAfuhS/T13KpSXe30pJo4XXFOugOQXw9OZ4=
-github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097/go.mod h1:Fqkjgw9r7sT0D6OvRyygm1sqeBE1XNtbmHkz9RFhNZg=
+github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb h1:IiB0+epMT2qK9lsdtUkxJAhDQDHbtt2JWGkCqgM6ADs=
+github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb/go.mod h1:Fqkjgw9r7sT0D6OvRyygm1sqeBE1XNtbmHkz9RFhNZg=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868/go.mod h1:Kn1Hape05UzFZ7bOUnm3GVsHzP0TNrVmpfXYNHdqGGs=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16 h1:TFe+FvzxClblt6qRfqEhUfa4kFQx5UobuoFGO2W4mMo=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -381,7 +381,7 @@ require (
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42 // indirect
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58 // indirect
-	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097 // indirect
+	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230906073235-9e478e5e19f1 // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20230906073235-9e478e5e19f1 // indirect
 	github.com/smartcontractkit/wsrpc v0.8.1 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1527,8 +1527,8 @@ github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42 h
 github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42/go.mod h1:PJlzwLaYsA7YcAKXdysMjNONeIolPrRjT9v/AMo4Er0=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58 h1:jc4ab5QrKZfkICyxJysCt7mSExuSPbePjgZsnJR3nRQ=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58/go.mod h1:oV5gIuSKrPEcjQ6uB6smBsm5kXHxyydVLNyAs4V9CoQ=
-github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097 h1:Vgo8p/9udAfuhS/T13KpSXe30pJo4XXFOugOQXw9OZ4=
-github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097/go.mod h1:Fqkjgw9r7sT0D6OvRyygm1sqeBE1XNtbmHkz9RFhNZg=
+github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb h1:IiB0+epMT2qK9lsdtUkxJAhDQDHbtt2JWGkCqgM6ADs=
+github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb/go.mod h1:Fqkjgw9r7sT0D6OvRyygm1sqeBE1XNtbmHkz9RFhNZg=
 github.com/smartcontractkit/chainlink-testing-framework v1.28.7 h1:Yr93tBl5jVx1cfKywt0C0cbuObDPJ6JIU4FIsZ6bZlM=
 github.com/smartcontractkit/chainlink-testing-framework v1.28.7/go.mod h1:x1zDOz8zcLjEvs9fNA9y/DMguLam/2+CJdpxX0+rM8A=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -370,7 +370,7 @@ require (
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42 // indirect
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58 // indirect
-	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097 // indirect
+	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea // indirect
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230906073235-9e478e5e19f1 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1510,8 +1510,8 @@ github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42 h
 github.com/smartcontractkit/chainlink-feeds v0.0.0-20240617141425-d184a59a6b42/go.mod h1:PJlzwLaYsA7YcAKXdysMjNONeIolPrRjT9v/AMo4Er0=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58 h1:jc4ab5QrKZfkICyxJysCt7mSExuSPbePjgZsnJR3nRQ=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240422172640-59d47c73ba58/go.mod h1:oV5gIuSKrPEcjQ6uB6smBsm5kXHxyydVLNyAs4V9CoQ=
-github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097 h1:Vgo8p/9udAfuhS/T13KpSXe30pJo4XXFOugOQXw9OZ4=
-github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240718184359-6f396818d097/go.mod h1:Fqkjgw9r7sT0D6OvRyygm1sqeBE1XNtbmHkz9RFhNZg=
+github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb h1:IiB0+epMT2qK9lsdtUkxJAhDQDHbtt2JWGkCqgM6ADs=
+github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240801181751-d35782c173fb/go.mod h1:Fqkjgw9r7sT0D6OvRyygm1sqeBE1XNtbmHkz9RFhNZg=
 github.com/smartcontractkit/chainlink-testing-framework v1.28.7 h1:Yr93tBl5jVx1cfKywt0C0cbuObDPJ6JIU4FIsZ6bZlM=
 github.com/smartcontractkit/chainlink-testing-framework v1.28.7/go.mod h1:x1zDOz8zcLjEvs9fNA9y/DMguLam/2+CJdpxX0+rM8A=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea h1:ZdLmNAfKRjH8AYUvjiiDGUgiWQfq/7iNpxyTkvjx/ko=


### PR DESCRIPTION
Bump starknet to use the latest change here. Doing this fixes the stale reports we see every now and then because the node thinks the data hasn't been transmitted on chain yet

https://github.com/smartcontractkit/chainlink-starknet/pull/465

> the pending block contains finalized txs so it should be used for the most recent data


