### PR TITLE
fix keystone e2e test dispatcher to correctly replicate duplicate reg…

### DIFF
--- a/.changeset/happy-adults-wash.md
+++ b/.changeset/happy-adults-wash.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal fix to keystone e2e test dispatcher to correctly mock duplicate registration error


### PR DESCRIPTION
fix keystone e2e test dispatcher to correctly replicate duplicate registration behaviour.   The syncer relies on the dispatcher returning a `ErrReceiverExists` error code to prevent duplicate creation of a capability.  The mocked dispatcher used for the e2e test was not replicating this behaviour resulting in duplicate registration of trigger publisher.