### PR TITLE
enable gomods

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -27,12 +27,8 @@ gomod: ## Ensure chainlink's go dependencies are installed.
 	go mod download
 
 .PHONY: gomodtidy
-gomodtidy: ## Run go mod tidy on all modules.
-	go mod tidy
-	cd ./core/scripts && go mod tidy
-	cd ./integration-tests && go mod tidy
-	cd ./integration-tests/load && go mod tidy
-	cd ./dashboard-lib && go mod tidy
+gomodtidy: gomods ## Run go mod tidy on all modules.
+	gomods tidy
 
 .PHONY: docs
 docs: ## Install and run pkgsite to view Go docs
@@ -89,12 +85,8 @@ abigen: ## Build & install abigen.
 	./tools/bin/build_abigen
 
 .PHONY: generate
-generate: abigen codecgen mockery protoc ## Execute all go:generate commands.
-	go generate -x ./...
-	cd ./core/scripts && go generate -x ./...
-	cd ./integration-tests && go generate -x ./...
-	cd ./integration-tests/load && go generate -x ./...
-	cd ./dashboard-lib && go generate -x ./...
+generate: abigen codecgen mockery protoc gomods ## Execute all go:generate commands.
+	gomods -w go generate -x ./...
 	mockery
 
 .PHONY: rm-mocked
@@ -136,7 +128,7 @@ presubmit: ## Format go files and imports.
 
 .PHONY: gomods
 gomods: ## Install gomods
-	go install github.com/jmank88/gomods@v0.1.1
+	go install github.com/jmank88/gomods@v0.1.3
 
 .PHONY: mockery
 mockery: $(mockery) ## Install mockery.


### PR DESCRIPTION
This PR re-enables [gomods](https://github.com/jmank88/gomods). This has been tried a few times:
![image](https://github.com/user-attachments/assets/d78b5435-b6e1-4e98-a2ed-747b18797b55)
But now the two outstanding bugs have been resolved.