### PR TITLE
ks-409 fix the mock trigger to ensure events are sent

### DIFF
--- a/.changeset/odd-hats-repeat.md
+++ b/.changeset/odd-hats-repeat.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal fix the mock trigger to ensure events are sent

--- a/core/capabilities/integration_tests/mock_trigger.go
+++ b/core/capabilities/integration_tests/mock_trigger.go
@@ -88,18 +88,20 @@ func (s *streamsTrigger) RegisterTrigger(ctx context.Context, request capabiliti
 
 	responseCh := make(chan capabilities.CapabilityResponse)
 
-	ctxWithCancel, cancel := context.WithCancel(ctx)
+	ctxWithCancel, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
-		select {
-		case <-s.stopCh:
-			return
-		case <-ctxWithCancel.Done():
-			return
-		case resp := <-s.toSend:
-			responseCh <- resp
+		for {
+			select {
+			case <-s.stopCh:
+				return
+			case <-ctxWithCancel.Done():
+				return
+			case resp := <-s.toSend:
+				responseCh <- resp
+			}
 		}
 	}()
 

--- a/core/capabilities/integration_tests/streams_test.go
+++ b/core/capabilities/integration_tests/streams_test.go
@@ -24,7 +24,7 @@ func Test_AllAtOnceTransmissionSchedule(t *testing.T) {
 	// in the setupCapabilitiesRegistryContract function, should this order change the don IDs will need updating.
 	workflowDonInfo := createDonInfo(t, don{id: 1, numNodes: 7, f: 2})
 	triggerDonInfo := createDonInfo(t, don{id: 2, numNodes: 7, f: 2})
-	targetDonInfo := createDonInfo(t, don{id: 3, numNodes: 4, f: 2})
+	targetDonInfo := createDonInfo(t, don{id: 3, numNodes: 4, f: 1})
 
 	consumer, feedIDs, triggerSink := setupStreamDonsWithTransmissionSchedule(ctx, t, workflowDonInfo, triggerDonInfo, targetDonInfo, 3,
 		"2s", "allAtOnce")
@@ -45,8 +45,8 @@ func Test_OneAtATimeTransmissionSchedule(t *testing.T) {
 
 	// The don IDs set in the below calls are inferred from the order in which the dons are added to the capabilities registry
 	// in the setupCapabilitiesRegistryContract function, should this order change the don IDs will need updating.
-	workflowDonInfo := createDonInfo(t, don{id: 1, numNodes: 5, f: 1})
-	triggerDonInfo := createDonInfo(t, don{id: 2, numNodes: 7, f: 1})
+	workflowDonInfo := createDonInfo(t, don{id: 1, numNodes: 7, f: 2})
+	triggerDonInfo := createDonInfo(t, don{id: 2, numNodes: 7, f: 2})
 	targetDonInfo := createDonInfo(t, don{id: 3, numNodes: 4, f: 1})
 
 	consumer, feedIDs, triggerSink := setupStreamDonsWithTransmissionSchedule(ctx, t, workflowDonInfo, triggerDonInfo, targetDonInfo, 3,


### PR DESCRIPTION
fixes https://smartcontract-it.atlassian.net/browse/KS-409

Intermittent failue caused by the trigger selecting on the ctx from the register trigger call which cancelled before messages sent, also it was not looping the goroutine to send the messages.
