### PR TITLE
fix data race in syncer/launcher

### DIFF
--- a/.changeset/twelve-balloons-turn.md
+++ b/.changeset/twelve-balloons-turn.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal fix data race in syncer launcher

--- a/core/capabilities/registry.go
+++ b/core/capabilities/registry.go
@@ -37,6 +37,8 @@ func (r *Registry) LocalNode(ctx context.Context) (capabilities.Node, error) {
 }
 
 func (r *Registry) ConfigForCapability(ctx context.Context, capabilityID string, donID uint32) (capabilities.CapabilityConfiguration, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	if r.metadataRegistry == nil {
 		return capabilities.CapabilityConfiguration{}, errors.New("metadataRegistry information not available")
 	}


### PR DESCRIPTION
Fixes a datarace identified by the e2e keystone tests,  details here->  https://smartcontract-it.atlassian.net/browse/KS-415.