### PR TITLE
chore: update dependabot config gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     ignore:
       # Old versions are pinned for libocr.
       - dependency-name: github.com/libp2p/go-libp2p-core


### PR DESCRIPTION
This updates the dependabot gomod pr limit to `0`.
