### PR TITLE
CODEOWNERS: bump core/capabilities/ccip codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,3 +119,6 @@ flake.lock @smartcontractkit/prodsec-public
 # Config
 ./docs/CONFIG.md @smartcontractkit/foundations @smartcontractkit/devrel
 ./internal/config/docs.toml @smartcontractkit/foundations @smartcontractkit/devrel
+
+# CCIP Capabilities
+/core/capabilities/ccip @smartcontractkit/ccip-offchain


### PR DESCRIPTION
Add smartcontractkit/ccip-offchain as codeowners of the core/capabilities/ccip directory