### PR TITLE
[BCI-3863] - Use filtered logs in eventBinding GetLatestValue instead of manual filtering

### DIFF
--- a/.changeset/early-glasses-rhyme.md
+++ b/.changeset/early-glasses-rhyme.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+use FilteredLogs in EventBinding GetLatestValue instead of manual filtering. #internal

--- a/core/services/relay/evm/event_binding.go
+++ b/core/services/relay/evm/event_binding.go
@@ -230,7 +230,7 @@ func (e *eventBinding) getLatestValueWithFilters(
 	// Create limiter and filter for the query.
 	limiter := query.NewLimitAndSort(query.CountLimit(1), query.NewSortBySequence(query.Desc))
 	filter, err := query.Where(
-		e.address.String(),
+		"",
 		logpoller.NewAddressFilter(e.address),
 		logpoller.NewEventSigFilter(e.hash),
 		logpoller.NewConfirmationsFilter(confs),

--- a/core/services/relay/evm/event_binding.go
+++ b/core/services/relay/evm/event_binding.go
@@ -169,7 +169,7 @@ func (e *eventBinding) QueryKey(ctx context.Context, filter query.KeyFilter, lim
 	}
 	remapped.Expressions = append(defaultExpressions, remapped.Expressions...)
 
-	logs, err := e.lp.FilteredLogs(ctx, remapped, limitAndSort, e.contractName+"-"+e.eventName)
+	logs, err := e.lp.FilteredLogs(ctx, remapped, limitAndSort, e.contractName+"-"+e.address.String()+"-"+e.eventName)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (e *eventBinding) getLatestValueWithFilters(
 	}
 
 	// Gets the latest log that matches the filter and limiter.
-	logs, err := e.lp.FilteredLogs(ctx, filter, limiter, e.contractName+"-"+e.eventName)
+	logs, err := e.lp.FilteredLogs(ctx, filter, limiter, e.contractName+"-"+e.address.String()+"-"+e.eventName)
 	if err != nil {
 		return wrapInternalErr(err)
 	}

--- a/core/services/relay/evm/event_binding.go
+++ b/core/services/relay/evm/event_binding.go
@@ -254,6 +254,15 @@ func (e *eventBinding) getLatestValueWithFilters(
 }
 
 func createTopicFilters(filtersAndIndices []common.Hash) query.Expression {
+	// If there's only one filter, return a simple expression without a boolean combination.
+	if len(filtersAndIndices) == 1 {
+		value := filtersAndIndices[0]
+		return logpoller.NewEventByTopicFilter(1, []primitives.ValueComparator{
+			{Value: value.Hex(), Operator: primitives.Eq},
+		})
+	}
+
+	// For multiple filters, create a boolean expression.
 	topicFilters := query.BoolExpression{
 		Expressions:  make([]query.Expression, len(filtersAndIndices)),
 		BoolOperator: query.OR,

--- a/core/services/relay/evm/event_binding.go
+++ b/core/services/relay/evm/event_binding.go
@@ -265,7 +265,7 @@ func createTopicFilters(filtersAndIndices []common.Hash) query.Expression {
 	// For multiple filters, create a boolean expression.
 	topicFilters := query.BoolExpression{
 		Expressions:  make([]query.Expression, len(filtersAndIndices)),
-		BoolOperator: query.OR,
+		BoolOperator: query.AND,
 	}
 
 	// Every index represents a topic, and the underlying value represents what we want to match.


### PR DESCRIPTION
### Task Description:
Use log poller [Filtered logs](https://github.com/smartcontractkit/chainlink/blob/ca6e1c26a331af67a1d57bf69d8160c23fc1e297/core/chains/evm/logpoller/log_poller.go#L71) instead of [manual post filtering](https://github.com/smartcontractkit/chainlink/blob/ca6e1c26a331af67a1d57bf69d8160c23fc1e297/core/services/relay/evm/event_binding.go#L235). 

### This PR:
Replaces the use of [IndexedLogs](https://github.com/smartcontractkit/chainlink/blob/ca6e1c26a331af67a1d57bf69d8160c23fc1e297/core/services/relay/evm/event_binding.go#L230) and manual post filtering with log poller [Filtered logs](https://github.com/smartcontractkit/chainlink/blob/ca6e1c26a331af67a1d57bf69d8160c23fc1e297/core/chains/evm/logpoller/log_poller.go#L71) and query filters.

### Ticket:
- [BCI-3863](https://smartcontract-it.atlassian.net/browse/BCI-3863)

[BCI-3863]: https://smartcontract-it.atlassian.net/browse/BCI-3863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ