### PR TITLE
fix unhandled already seen tx error for gnosis chiado 

### DIFF
--- a/.changeset/chilly-cars-attend.md
+++ b/.changeset/chilly-cars-attend.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+add error handle for gnosis chaidao for seen tx #added

--- a/.changeset/chilly-cars-attend.md
+++ b/.changeset/chilly-cars-attend.md
@@ -2,4 +2,4 @@
 "chainlink": minor
 ---
 
-add error handle for gnosis chaidao for seen tx #added
+add error handle for gnosis chiado for seen tx #added

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -259,6 +259,10 @@ var mantle = ClientErrors{
 	Fatal:           regexp.MustCompile(`(: |^)'*invalid sender`),
 }
 
+var gnosis = ClientErrors{
+	TransactionAlreadyInMempool: regexp.MustCompile(`(: |^)(alreadyknown)`),
+}
+
 const TerminallyStuckMsg = "transaction terminally stuck"
 
 // Tx.Error messages that are set internally so they are not chain or client specific
@@ -266,11 +270,7 @@ var internal = ClientErrors{
 	TerminallyStuck: regexp.MustCompile(TerminallyStuckMsg),
 }
 
-var gnosis = ClientErrors{
-	TransactionAlreadyInMempool: regexp.MustCompile(`(: |^)(alreadyknown)`),
-}
-
-var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, mantle, aStar, internal, gnosis}
+var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, mantle, aStar, gnosis, internal}
 
 // ClientErrorRegexes returns a map of compiled regexes for each error type
 func ClientErrorRegexes(errsRegex config.ClientErrors) *ClientErrors {

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -266,7 +266,11 @@ var internal = ClientErrors{
 	TerminallyStuck: regexp.MustCompile(TerminallyStuckMsg),
 }
 
-var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, mantle, aStar, internal}
+var gnosis = ClientErrors{
+	TransactionAlreadyInMempool: regexp.MustCompile(`(: |^)(alreadyknown)`),
+}
+
+var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, mantle, aStar, internal, gnosis}
 
 // ClientErrorRegexes returns a map of compiled regexes for each error type
 func ClientErrorRegexes(errsRegex config.ClientErrors) *ClientErrors {

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -136,7 +136,7 @@ func Test_Eth_Errors(t *testing.T) {
 			// This seems to be an erroneous message from the zkSync client, we'll have to match it anyway
 			{"ErrorObject { code: ServerError(3), message: \\\"known transaction. transaction with hash 0xf016…ad63 is already in the system\\\", data: Some(RawValue(\\\"0x\\\")) }", true, "zkSync"},
 			{"client error transaction already in mempool", true, "tomlConfig"},
-			{"alreadyknown", true, "Genosis"},
+			{"alreadyknown", true, "Gnosis"},
 		}
 		for _, test := range tests {
 			err = evmclient.NewSendErrorS(test.message)

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -136,6 +136,7 @@ func Test_Eth_Errors(t *testing.T) {
 			// This seems to be an erroneous message from the zkSync client, we'll have to match it anyway
 			{"ErrorObject { code: ServerError(3), message: \\\"known transaction. transaction with hash 0xf016…ad63 is already in the system\\\", data: Some(RawValue(\\\"0x\\\")) }", true, "zkSync"},
 			{"client error transaction already in mempool", true, "tomlConfig"},
+			{"alreadyknown", true, "Genosis"},
 		}
 		for _, test := range tests {
 			err = evmclient.NewSendErrorS(test.message)


### PR DESCRIPTION
Ticket: https://smartcontract-it.atlassian.net/browse/BCI-3934

**Description**
Alchemy on gnosis chaidao for transactions that are already known returns “alreadyknown”, while we expect the msg to contain space. This causes MultiNode to log critical error as result is classified as “unknown”.

**Acceptance Criteria**
“alreadyknown” is properly classified 