### PR TITLE
classify arbitrum sequencer inaccessible error as retryable 

### DIFF
--- a/.changeset/calm-badgers-jump.md
+++ b/.changeset/calm-badgers-jump.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+add error handling when arbitrum sequencer is not accessible #added

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -158,7 +158,7 @@ var arbitrum = ClientErrors{
 	Fatal:                 arbitrumFatal,
 	L2FeeTooLow:           regexp.MustCompile(`(: |^)max fee per gas less than block base fee(:|$)`),
 	L2Full:                regexp.MustCompile(`(: |^)(queue full|sequencer pending tx pool full, please try again)(:|$)`),
-	ServiceUnavailable:    regexp.MustCompile(`(: |^)502 Bad Gateway: [\s\S]*$`),
+	ServiceUnavailable:    regexp.MustCompile(`(: |^)502 Bad Gateway: [\s\S]*$|network is unreachable|observed invariant violation on SendTransaction`),
 }
 
 var celo = ClientErrors{

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -158,7 +158,7 @@ var arbitrum = ClientErrors{
 	Fatal:                 arbitrumFatal,
 	L2FeeTooLow:           regexp.MustCompile(`(: |^)max fee per gas less than block base fee(:|$)`),
 	L2Full:                regexp.MustCompile(`(: |^)(queue full|sequencer pending tx pool full, please try again)(:|$)`),
-	ServiceUnavailable:    regexp.MustCompile(`(: |^)502 Bad Gateway: [\s\S]*$|network is unreachable|observed invariant violation on SendTransaction`),
+	ServiceUnavailable:    regexp.MustCompile(`(: |^)502 Bad Gateway: [\s\S]*$|network is unreachable|i/o timeout`),
 }
 
 var celo = ClientErrors{

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -229,6 +229,8 @@ func Test_Eth_Errors(t *testing.T) {
 		tests := []errorCase{
 			{"call failed: 503 Service Unavailable: <html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n</body>\r\n</html>\r\n", true, "Nethermind"},
 			{"call failed: 502 Bad Gateway: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>", true, "Arbitrum"},
+			{"observed invariant violation on SendTransaction", true, "Arbitrum"},
+			{"network is unreachable", true, "Arbitrum"},
 			{"client error service unavailable", true, "tomlConfig"},
 		}
 		for _, test := range tests {

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -229,7 +229,7 @@ func Test_Eth_Errors(t *testing.T) {
 		tests := []errorCase{
 			{"call failed: 503 Service Unavailable: <html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n</body>\r\n</html>\r\n", true, "Nethermind"},
 			{"call failed: 502 Bad Gateway: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>", true, "Arbitrum"},
-			{"observed invariant violation on SendTransaction", true, "Arbitrum"},
+			{"i/o timeout", true, "Arbitrum"},
 			{"network is unreachable", true, "Arbitrum"},
 			{"client error service unavailable", true, "tomlConfig"},
 		}


### PR DESCRIPTION
Ticket: https://smartcontract-it.atlassian.net/browse/BCI-3893

**Description**
In some cases RPCs are not able to reach Arbitrum Sequencer which causes Unknown errors. We should classify them as Retryable. example [log](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22jye%22%3A%7B%22datasource%22%3A%22P8E80F9AEF21F6940%22%2C%22queries%22%3A%5B%7B%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22P8E80F9AEF21F6940%22%7D%2C%22editorMode%22%3A%22code%22%2C%22expr%22%3A%22%7Bcluster%3D%5C%22production-us-west-2-main%5C%22%2C+app%3D%5C%22cl-auto-v2-arb-sepolia%5C%22%2C+instance%3D%7E%5C%22.*%5C%22%7D+%7C+json+%7C+level%3D%7E%5C%22crit%5C%22%22%2C%22queryType%22%3A%22range%22%2C%22refId%22%3A%22A%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%221722391880691%22%2C%22to%22%3A%221722420732536%22%7D%7D%7D&orgId=1)



**Acceptance Criteria**
Errors are classified to be Retryable