### PR TITLE
speedup e2e keystone tests

### DIFF
--- a/.changeset/ninety-ways-run.md
+++ b/.changeset/ninety-ways-run.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal speed up keystone e2e tests

--- a/core/capabilities/integration_tests/keystone_contracts_setup.go
+++ b/core/capabilities/integration_tests/keystone_contracts_setup.go
@@ -209,7 +209,7 @@ func setupCapabilitiesRegistryContract(ctx context.Context, t *testing.T, workfl
 	triggerCapabilityConfig := newCapabilityConfig()
 	triggerCapabilityConfig.RemoteConfig = &pb.CapabilityConfig_RemoteTriggerConfig{
 		RemoteTriggerConfig: &pb.RemoteTriggerConfig{
-			RegistrationRefresh: durationpb.New(60000 * time.Millisecond),
+			RegistrationRefresh: durationpb.New(1000 * time.Millisecond),
 			RegistrationExpiry:  durationpb.New(60000 * time.Millisecond),
 			// F + 1
 			MinResponsesToAggregate: uint32(triggerDon.F) + 1,


### PR DESCRIPTION
fixes: https://smartcontract-it.atlassian.net/browse/KS-431

speed up keystone e2e tests - investigation shows tests taking a long time to run due to overlong configured registry resync interval