### PR TITLE
fix: (log_poller backfill) exit on non-rpc err

### DIFF
--- a/.changeset/gorgeous-carpets-grab.md
+++ b/.changeset/gorgeous-carpets-grab.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Fix backfill error detection

--- a/.changeset/gorgeous-carpets-grab.md
+++ b/.changeset/gorgeous-carpets-grab.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-Fix backfill error detection
+#bugfix backfill error detection

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -807,12 +807,10 @@ func (lp *logPoller) backfill(ctx context.Context, start, end int64) error {
 
 		gethLogs, err := lp.ec.FilterLogs(ctx, lp.Filter(big.NewInt(from), big.NewInt(to), nil))
 		if err != nil {
-			var rpcErr client.JsonError
-			if pkgerrors.As(err, &rpcErr) {
-				if rpcErr.Code != jsonRpcLimitExceeded {
-					lp.lggr.Errorw("Unable to query for logs", "err", err, "from", from, "to", to)
-					return err
-				}
+			var rpcErr *client.JsonError
+			if !pkgerrors.As(err, &rpcErr) || rpcErr.Code != jsonRpcLimitExceeded {
+				lp.lggr.Errorw("Unable to query for logs", "err", err, "from", from, "to", to)
+				return err
 			}
 			if batchSize == 1 {
 				lp.lggr.Criticalw("Too many log results in a single block, failed to retrieve logs! Node may be running in a degraded state.", "err", err, "from", from, "to", to, "LogBackfillBatchSize", lp.backfillBatchSize)

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -794,8 +794,6 @@ func (lp *logPoller) blocksFromLogs(ctx context.Context, logs []types.Log, endBl
 	return lp.GetBlocksRange(ctx, numbers)
 }
 
-const jsonRpcLimitExceeded = -32005 // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
-
 // backfill will query FilterLogs in batches for logs in the
 // block range [start, end] and save them to the db.
 // Retries until ctx cancelled. Will return an error if cancelled
@@ -817,10 +815,9 @@ func (lp *logPoller) backfill(ctx context.Context, start, end int64) error {
 				lp.lggr.Warnw("Too many log results, halving block range batch size.  Consider increasing LogBackfillBatchSize if this happens frequently", "err", err, "from", from, "to", to, "newBatchSize", batchSize, "LogBackfillBatchSize", lp.backfillBatchSize)
 				from -= batchSize // counteract +=batchSize on next loop iteration, so starting block does not change
 				continue
-			} else {
-				lp.lggr.Errorw("Unable to query for logs", "err", err, "from", from, "to", to)
-				return err
 			}
+			lp.lggr.Errorw("Unable to query for logs", "err", err, "from", from, "to", to)
+			return err
 		}
 		if len(gethLogs) == 0 {
 			continue


### PR DESCRIPTION
### What
Properly detect error type and exit on non-rpc error

### Why
On graceful shutdown backfill method reacts on `context canceled` error as rpc batch size error, which leads to `crit` log and failed test
Example log [cl-node-54af8721.log](https://github.com/user-attachments/files/16612560/cl-node-54af8721.log)

### Resolves Dependencies
https://github.com/smartcontractkit/chainlink/pull/13647
