### PR TITLE
Gates CCIP CI to run only when CCIP files change

### DIFF
--- a/.github/workflows/ccip-live-network-tests.yml
+++ b/.github/workflows/ccip-live-network-tests.yml
@@ -1,7 +1,8 @@
 name: CCIP Live Network Tests
 on:
-  schedule:
-    - cron: '0 */6 * * *'
+  # TODO: TT-1470 - Turn back on as we solidify new realease and image strategy
+  # schedule:
+  #   - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       base64_test_input : # base64 encoded toml for test input

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -1,6 +1,9 @@
 name: CCIP Load Test
 on: 
   push:
+    paths:
+      - '**/*ccip*'
+      - '**/*ccip*/**'
     branches:
       - develop
     tags:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -101,6 +101,9 @@ jobs:
               - 'core/**/migrations/*.sql'
               - 'core/**/config/**/*.toml'
               - 'integration-tests/**/*.toml'
+            ccip-changes:
+              - '**/*ccip*'
+              - '**/*ccip*/**'
       - name: Ignore Filter On Workflow Dispatch
         if: ${{ github.event_name == 'workflow_dispatch' }}
         id: ignore-filter
@@ -514,7 +517,7 @@ jobs:
         uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/show-test-summary@75a9005952a9e905649cfb5a6971fd9429436acd # v2.3.25
 
   eth-smoke-tests-matrix-ccip:
-    if: ${{ !contains(join(github.event.pull_request.labels.*.name, ' '), 'skip-smoke-tests') }}
+    if: steps.changes.outputs.ccip-changes == 'true' && ${{ !contains(join(github.event.pull_request.labels.*.name, ' '), 'skip-smoke-tests') }} 
     environment: integration
     permissions:
       actions: read


### PR DESCRIPTION
Gates CCIP-specific tests are to run only when CCIP files or dirs are modified.

```yaml
    paths:
      - '**/*ccip*'
      - '**/*ccip*/**'
```

