### PR TITLE
golangci-lint: enable only-new-issues for PRs

### DIFF
--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -58,7 +58,7 @@ runs:
         skip-pkg-cache: true
         skip-build-cache: true
         # only-new-issues is only applicable to PRs, otherwise it is always set to false
-        only-new-issues: false # disabled for PRs due to unreliability
+        only-new-issues: true
         args: --out-format colored-line-number,checkstyle:golangci-lint-report.xml
         working-directory: ${{ inputs.go-directory }}
     - name: Print lint report artifact


### PR DESCRIPTION
`only-new-issues` was disabled explicitly due to a bug that has since been resolved.