### PR TITLE
chore: update goreleaser develop tag mutable

### DIFF
--- a/.github/workflows/build-publish-develop-pr.yml
+++ b/.github/workflows/build-publish-develop-pr.yml
@@ -49,7 +49,7 @@ jobs:
               echo "image-tag=release-${short_sha}" | tee -a $GITHUB_OUTPUT
               echo "build-publish=true" | tee -a $GITHUB_OUTPUT
             else
-              echo "image-tag=develop-${short_sha}" | tee -a $GITHUB_OUTPUT
+              echo "image-tag=develop" | tee -a $GITHUB_OUTPUT
               echo "build-publish=true" | tee -a $GITHUB_OUTPUT
             fi
           elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then

--- a/.goreleaser.develop.yaml
+++ b/.goreleaser.develop.yaml
@@ -1,4 +1,3 @@
-## goreleaser <1.14.0
 project_name: chainlink
 
 env:
@@ -80,6 +79,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{ .Env.CHAINLINK_VERSION }}"
       - "--label=org.opencontainers.image.url={{ .Env.IMAGE_LABEL_SOURCE }}"
     image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}"
       - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}-amd64"
       - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:sha-{{ .ShortCommit }}-amd64"
   - id: linux-arm64
@@ -133,6 +133,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{ .Env.CHAINLINK_VERSION }}"
       - "--label=org.opencontainers.image.url={{ .Env.IMAGE_LABEL_SOURCE }}"
     image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}-plugins"
       - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}-plugins-amd64"
       - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:sha-{{ .ShortCommit }}-plugins-amd64"
   - id: linux-arm64-plugins
@@ -169,6 +170,7 @@ dockers:
 docker_manifests:
   - name_template: "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}"
     image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}"
       - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}-amd64"
       - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}-arm64"
   - name_template: "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:sha-{{ .ShortCommit }}"
@@ -177,6 +179,7 @@ docker_manifests:
       - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:sha-{{ .ShortCommit }}-arm64"
   - name_template: "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}-plugins"
     image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}-plugins"
       - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}-plugins-amd64"
       - "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:{{ .Env.IMAGE_TAG }}-plugins-arm64"
   - name_template: "{{ .Env.IMAGE_PREFIX }}/{{ .Env.IMAGE_NAME }}:sha-{{ .ShortCommit }}-plugins"


### PR DESCRIPTION
This updates the `build-publish-develop-pr` workflow to have `develop` without the `sha` suffix and creates an extra image that does not have the `arch` suffix which is just `amd64` arch.
