### PR TITLE
use services.Config.NewService/Engine (part 3)

### DIFF
--- a/common/client/poller.go
+++ b/common/client/poller.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -15,83 +14,80 @@ import (
 // and delivers the result to a channel. It is used by multinode to poll
 // for new heads and implements the Subscription interface.
 type Poller[T any] struct {
-	services.StateMachine
+	services.Service
+	eng *services.Engine
+
 	pollingInterval time.Duration
 	pollingFunc     func(ctx context.Context) (T, error)
 	pollingTimeout  time.Duration
-	logger          logger.Logger
 	channel         chan<- T
 	errCh           chan error
-
-	stopCh services.StopChan
-	wg     sync.WaitGroup
 }
 
 // NewPoller creates a new Poller instance and returns a channel to receive the polled data
 func NewPoller[
 	T any,
-](pollingInterval time.Duration, pollingFunc func(ctx context.Context) (T, error), pollingTimeout time.Duration, logger logger.Logger) (Poller[T], <-chan T) {
+](pollingInterval time.Duration, pollingFunc func(ctx context.Context) (T, error), pollingTimeout time.Duration, lggr logger.Logger) (Poller[T], <-chan T) {
 	channel := make(chan T)
-	return Poller[T]{
+	p := Poller[T]{
 		pollingInterval: pollingInterval,
 		pollingFunc:     pollingFunc,
 		pollingTimeout:  pollingTimeout,
 		channel:         channel,
-		logger:          logger,
 		errCh:           make(chan error),
-		stopCh:          make(chan struct{}),
-	}, channel
+	}
+	p.Service, p.eng = services.Config{
+		Name:  "Poller",
+		Start: p.start,
+		Close: p.close,
+	}.NewServiceEngine(lggr)
+	return p, channel
 }
 
 var _ types.Subscription = &Poller[any]{}
 
-func (p *Poller[T]) Start() error {
-	return p.StartOnce("Poller", func() error {
-		p.wg.Add(1)
-		go p.pollingLoop()
-		return nil
-	})
+func (p *Poller[T]) start(ctx context.Context) error {
+	p.eng.Go(p.pollingLoop)
+	return nil
 }
 
 // Unsubscribe cancels the sending of events to the data channel
 func (p *Poller[T]) Unsubscribe() {
-	_ = p.StopOnce("Poller", func() error {
-		close(p.stopCh)
-		p.wg.Wait()
-		close(p.errCh)
-		close(p.channel)
-		return nil
-	})
+	_ = p.Close()
+}
+
+func (p *Poller[T]) close() error {
+	close(p.errCh)
+	close(p.channel)
+	return nil
 }
 
 func (p *Poller[T]) Err() <-chan error {
 	return p.errCh
 }
 
-func (p *Poller[T]) pollingLoop() {
-	defer p.wg.Done()
-
+func (p *Poller[T]) pollingLoop(ctx context.Context) {
 	ticker := time.NewTicker(p.pollingInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-p.stopCh:
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			// Set polling timeout
-			pollingCtx, cancelPolling := p.stopCh.CtxCancel(context.WithTimeout(context.Background(), p.pollingTimeout))
+			pollingCtx, cancelPolling := context.WithTimeout(ctx, p.pollingTimeout)
 			// Execute polling function
 			result, err := p.pollingFunc(pollingCtx)
 			cancelPolling()
 			if err != nil {
-				p.logger.Warnf("polling error: %v", err)
+				p.eng.Warnf("polling error: %v", err)
 				continue
 			}
 			// Send result to channel or block if channel is full
 			select {
 			case p.channel <- result:
-			case <-p.stopCh:
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/core/capabilities/remote/target/endtoend_test.go
+++ b/core/capabilities/remote/target/endtoend_test.go
@@ -276,67 +276,47 @@ func testRemoteTarget(ctx context.Context, t *testing.T, underlying commoncap.Ta
 }
 
 type testAsyncMessageBroker struct {
-	services.StateMachine
-	t *testing.T
+	services.Service
+	eng *services.Engine
+	t   *testing.T
 
 	nodes map[p2ptypes.PeerID]remotetypes.Receiver
 
 	sendCh chan *remotetypes.MessageBody
-
-	stopCh services.StopChan
-	wg     sync.WaitGroup
-}
-
-func (a *testAsyncMessageBroker) HealthReport() map[string]error {
-	return nil
-}
-
-func (a *testAsyncMessageBroker) Name() string {
-	return "testAsyncMessageBroker"
 }
 
 func newTestAsyncMessageBroker(t *testing.T, sendChBufferSize int) *testAsyncMessageBroker {
-	return &testAsyncMessageBroker{
+	b := &testAsyncMessageBroker{
 		t:      t,
 		nodes:  make(map[p2ptypes.PeerID]remotetypes.Receiver),
-		stopCh: make(services.StopChan),
 		sendCh: make(chan *remotetypes.MessageBody, sendChBufferSize),
 	}
+	b.Service, b.eng = services.Config{
+		Name:  "testAsyncMessageBroker",
+		Start: b.start,
+	}.NewServiceEngine(logger.TestLogger(t))
+	return b
 }
 
-func (a *testAsyncMessageBroker) Start(ctx context.Context) error {
-	return a.StartOnce("testAsyncMessageBroker", func() error {
-		a.wg.Add(1)
-		go func() {
-			defer a.wg.Done()
+func (a *testAsyncMessageBroker) start(ctx context.Context) error {
+	a.eng.Go(func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg := <-a.sendCh:
+				receiverId := toPeerID(msg.Receiver)
 
-			for {
-				select {
-				case <-a.stopCh:
-					return
-				case msg := <-a.sendCh:
-					receiverId := toPeerID(msg.Receiver)
-
-					receiver, ok := a.nodes[receiverId]
-					if !ok {
-						panic("server not found for peer id")
-					}
-
-					receiver.Receive(tests.Context(a.t), msg)
+				receiver, ok := a.nodes[receiverId]
+				if !ok {
+					panic("server not found for peer id")
 				}
+
+				receiver.Receive(tests.Context(a.t), msg)
 			}
-		}()
-		return nil
+		}
 	})
-}
-
-func (a *testAsyncMessageBroker) Close() error {
-	return a.StopOnce("testAsyncMessageBroker", func() error {
-		close(a.stopCh)
-
-		a.wg.Wait()
-		return nil
-	})
+	return nil
 }
 
 func (a *testAsyncMessageBroker) NewDispatcherForNode(nodePeerID p2ptypes.PeerID) remotetypes.Dispatcher {

--- a/core/chains/evm/client/rpc_client.go
+++ b/core/chains/evm/client/rpc_client.go
@@ -546,14 +546,14 @@ func (r *rpcClient) SubscribeToHeads(ctx context.Context) (ch <-chan *evmtypes.H
 	return channel, forwarder, err
 }
 
-func (r *rpcClient) SubscribeToFinalizedHeads(_ context.Context) (<-chan *evmtypes.Head, commontypes.Subscription, error) {
+func (r *rpcClient) SubscribeToFinalizedHeads(ctx context.Context) (<-chan *evmtypes.Head, commontypes.Subscription, error) {
 	interval := r.finalizedBlockPollInterval
 	if interval == 0 {
 		return nil, nil, errors.New("FinalizedBlockPollInterval is 0")
 	}
 	timeout := interval
 	poller, channel := commonclient.NewPoller[*evmtypes.Head](interval, r.LatestFinalizedBlock, timeout, r.rpcLog)
-	if err := poller.Start(); err != nil {
+	if err := poller.Start(ctx); err != nil {
 		return nil, nil, err
 	}
 	return channel, &poller, nil

--- a/core/chains/evm/forwarders/forwarder_manager.go
+++ b/core/chains/evm/forwarders/forwarder_manager.go
@@ -33,7 +33,9 @@ type Config interface {
 }
 
 type FwdMgr struct {
-	services.StateMachine
+	services.Service
+	eng *services.Engine
+
 	ORM       ORM
 	evmClient evmclient.Client
 	cfg       Config
@@ -48,61 +50,51 @@ type FwdMgr struct {
 	authRcvr    authorized_receiver.AuthorizedReceiverInterface
 	offchainAgg offchain_aggregator_wrapper.OffchainAggregatorInterface
 
-	stopCh services.StopChan
-
 	cacheMu sync.RWMutex
-	wg      sync.WaitGroup
 }
 
-func NewFwdMgr(ds sqlutil.DataSource, client evmclient.Client, logpoller evmlogpoller.LogPoller, l logger.Logger, cfg Config) *FwdMgr {
-	lggr := logger.Sugared(logger.Named(l, "EVMForwarderManager"))
-	fwdMgr := FwdMgr{
-		logger:       lggr,
+func NewFwdMgr(ds sqlutil.DataSource, client evmclient.Client, logpoller evmlogpoller.LogPoller, lggr logger.Logger, cfg Config) *FwdMgr {
+	fm := FwdMgr{
 		cfg:          cfg,
 		evmClient:    client,
 		ORM:          NewORM(ds),
 		logpoller:    logpoller,
 		sendersCache: make(map[common.Address][]common.Address),
 	}
-	fwdMgr.stopCh = make(chan struct{})
-	return &fwdMgr
+	fm.Service, fm.eng = services.Config{
+		Name:  "ForwarderManager",
+		Start: fm.start,
+	}.NewServiceEngine(lggr)
+	fm.logger = logger.Sugared(fm.eng)
+	return &fm
 }
 
-func (f *FwdMgr) Name() string {
-	return f.logger.Name()
-}
+func (f *FwdMgr) start(ctx context.Context) error {
+	chainId := f.evmClient.ConfiguredChainID()
 
-// Start starts Forwarder Manager.
-func (f *FwdMgr) Start(ctx context.Context) error {
-	return f.StartOnce("EVMForwarderManager", func() error {
-		f.logger.Debug("Initializing EVM forwarder manager")
-		chainId := f.evmClient.ConfiguredChainID()
-
-		fwdrs, err := f.ORM.FindForwardersByChain(ctx, big.Big(*chainId))
-		if err != nil {
-			return pkgerrors.Wrapf(err, "Failed to retrieve forwarders for chain %d", chainId)
+	fwdrs, err := f.ORM.FindForwardersByChain(ctx, big.Big(*chainId))
+	if err != nil {
+		return pkgerrors.Wrapf(err, "Failed to retrieve forwarders for chain %d", chainId)
+	}
+	if len(fwdrs) != 0 {
+		f.initForwardersCache(ctx, fwdrs)
+		if err = f.subscribeForwardersLogs(ctx, fwdrs); err != nil {
+			return err
 		}
-		if len(fwdrs) != 0 {
-			f.initForwardersCache(ctx, fwdrs)
-			if err = f.subscribeForwardersLogs(ctx, fwdrs); err != nil {
-				return err
-			}
-		}
+	}
 
-		f.authRcvr, err = authorized_receiver.NewAuthorizedReceiver(common.Address{}, f.evmClient)
-		if err != nil {
-			return pkgerrors.Wrap(err, "Failed to init AuthorizedReceiver")
-		}
+	f.authRcvr, err = authorized_receiver.NewAuthorizedReceiver(common.Address{}, f.evmClient)
+	if err != nil {
+		return pkgerrors.Wrap(err, "Failed to init AuthorizedReceiver")
+	}
 
-		f.offchainAgg, err = offchain_aggregator_wrapper.NewOffchainAggregator(common.Address{}, f.evmClient)
-		if err != nil {
-			return pkgerrors.Wrap(err, "Failed to init OffchainAggregator")
-		}
+	f.offchainAgg, err = offchain_aggregator_wrapper.NewOffchainAggregator(common.Address{}, f.evmClient)
+	if err != nil {
+		return pkgerrors.Wrap(err, "Failed to init OffchainAggregator")
+	}
 
-		f.wg.Add(1)
-		go f.runLoop()
-		return nil
-	})
+	f.eng.Go(f.runLoop)
+	return nil
 }
 
 func FilterName(addr common.Address) string {
@@ -176,7 +168,7 @@ func (f *FwdMgr) ConvertPayload(dest common.Address, origPayload []byte) ([]byte
 		if err != nil {
 			f.logger.AssumptionViolationw("Forwarder encoding failed, this should never happen",
 				"err", err, "to", dest, "payload", origPayload)
-			f.SvcErrBuffer.Append(err)
+			f.eng.EmitHealthErr(err)
 		}
 	}
 	return databytes, nil
@@ -269,11 +261,7 @@ func (f *FwdMgr) getCachedSenders(addr common.Address) ([]common.Address, bool) 
 	return addrs, ok
 }
 
-func (f *FwdMgr) runLoop() {
-	defer f.wg.Done()
-	ctx, cancel := f.stopCh.NewCtx()
-	defer cancel()
-
+func (f *FwdMgr) runLoop(ctx context.Context) {
 	ticker := services.NewTicker(time.Minute)
 	defer ticker.Stop()
 
@@ -352,17 +340,4 @@ func (f *FwdMgr) collectAddresses() (addrs []common.Address) {
 		addrs = append(addrs, addr)
 	}
 	return
-}
-
-// Stop cancels all outgoings calls and stops internal ticker loop.
-func (f *FwdMgr) Close() error {
-	return f.StopOnce("EVMForwarderManager", func() (err error) {
-		close(f.stopCh)
-		f.wg.Wait()
-		return nil
-	})
-}
-
-func (f *FwdMgr) HealthReport() map[string]error {
-	return map[string]error{f.Name(): f.Healthy()}
 }


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-3337

This PR upgrades more types to use `services.Engine`.

Follow up from part one & two: 
- #13851
- #14117