### PR TITLE
CCIP-3008 CCIP versioning which is semver compatible

### DIFF
--- a/core/services/versioning/orm_test.go
+++ b/core/services/versioning/orm_test.go
@@ -112,24 +112,6 @@ func TestORM_CheckVersion_CCIP(t *testing.T) {
 		expectedError  bool
 	}{
 		{
-			name:           "ccip beta.0 -> beta.1",
-			currentVersion: "2.5.0-ccip1.4.0+beta.0",
-			newVersion:     "2.5.0-ccip1.4.0+beta.1",
-			expectedError:  false,
-		},
-		{
-			name:           "downgrading ccip beta.1 -> beta.0 works",
-			currentVersion: "2.5.0-ccip1.4.0+beta.1",
-			newVersion:     "2.5.0-ccip1.4.0+beta.0",
-			expectedError:  false,
-		},
-		{
-			name:           "ccip beta.1 -> final release",
-			currentVersion: "2.5.0-ccip1.4.0+beta.1",
-			newVersion:     "2.5.0-ccip1.4.0",
-			expectedError:  false,
-		},
-		{
 			name:           "ccip patch version bump from 0 -> 2",
 			currentVersion: "2.5.0-ccip1.4.0",
 			newVersion:     "2.5.0-ccip1.4.2",

--- a/core/services/versioning/orm_test.go
+++ b/core/services/versioning/orm_test.go
@@ -130,7 +130,7 @@ func TestORM_CheckVersion_CCIP(t *testing.T) {
 			expectedError:  false,
 		},
 		{
-			name:           "ccip patch version bump from 9 -> 100",
+			name:           "ccip patch version bump from 9 -> 101",
 			currentVersion: "2.5.0-ccip1.4.9",
 			newVersion:     "2.5.0-ccip1.4.101",
 			expectedError:  false,

--- a/core/services/versioning/orm_test.go
+++ b/core/services/versioning/orm_test.go
@@ -97,6 +97,105 @@ func Test_Version_CheckVersion(t *testing.T) {
 	assert.Equal(t, "9.9.8", dbv.String())
 }
 
+func TestORM_CheckVersion_CCIP(t *testing.T) {
+	ctx := testutils.Context(t)
+	db := pgtest.NewSqlxDB(t)
+
+	lggr := logger.TestLogger(t)
+
+	orm := NewORM(db, lggr)
+
+	tests := []struct {
+		name           string
+		currentVersion string
+		newVersion     string
+		expectedError  bool
+	}{
+		{
+			name:           "ccip beta.0 -> beta.1",
+			currentVersion: "2.5.0-ccip1.4.0+beta.0",
+			newVersion:     "2.5.0-ccip1.4.0+beta.1",
+			expectedError:  false,
+		},
+		{
+			name:           "downgrading ccip beta.1 -> beta.0 works",
+			currentVersion: "2.5.0-ccip1.4.0+beta.1",
+			newVersion:     "2.5.0-ccip1.4.0+beta.0",
+			expectedError:  false,
+		},
+		{
+			name:           "ccip beta.1 -> final release",
+			currentVersion: "2.5.0-ccip1.4.0+beta.1",
+			newVersion:     "2.5.0-ccip1.4.0",
+			expectedError:  false,
+		},
+		{
+			name:           "ccip patch version bump from 0 -> 2",
+			currentVersion: "2.5.0-ccip1.4.0",
+			newVersion:     "2.5.0-ccip1.4.2",
+			expectedError:  false,
+		},
+		{
+			name:           "ccip patch downgrade errors",
+			currentVersion: "2.5.0-ccip1.4.2",
+			newVersion:     "2.5.0-ccip1.4.1",
+			expectedError:  true,
+		},
+		{
+			name:           "ccip patch version bump from 2 -> 10",
+			currentVersion: "2.5.0-ccip1.4.2",
+			newVersion:     "2.5.0-ccip1.4.10",
+			expectedError:  false,
+		},
+		{
+			name:           "ccip patch version bump from 9 -> 100",
+			currentVersion: "2.5.0-ccip1.4.9",
+			newVersion:     "2.5.0-ccip1.4.101",
+			expectedError:  false,
+		},
+		{
+			name:           "upgrading only core version",
+			currentVersion: "2.5.0-ccip1.4.10",
+			newVersion:     "2.6.0-ccip1.4.10",
+			expectedError:  false,
+		},
+		{
+			name:           "downgrading only core version errors",
+			currentVersion: "2.6.0-ccip1.4.10",
+			newVersion:     "2.5.0-ccip1.4.10",
+			expectedError:  true,
+		},
+		{
+			name:           "upgrading both core and ccip version",
+			currentVersion: "2.5.0-ccip1.4.10",
+			newVersion:     "2.6.0-ccip1.4.11",
+			expectedError:  false,
+		},
+		{
+			name:           "upgrading both core and ccip version but minor version",
+			currentVersion: "2.5.0-ccip1.4.10",
+			newVersion:     "2.6.0-ccip1.5.0",
+			expectedError:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := db.ExecContext(ctx, `TRUNCATE node_versions;`)
+			require.NoError(t, err)
+
+			require.NoError(t, orm.UpsertNodeVersion(ctx, NewNodeVersion(test.currentVersion)))
+			_, _, err = CheckVersion(ctx, db, lggr, test.newVersion)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+
+	}
+}
+
 func TestORM_NodeVersion_FindLatestNodeVersion(t *testing.T) {
 	ctx := testutils.Context(t)
 	db := pgtest.NewSqlxDB(t)


### PR DESCRIPTION
<!---
  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
  
  By referencing it, it will let the QA team to know what to watch out for when creating a new release.

  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 


The current versioning scheme for CCIP assumes that every pre-release is suffixed like this `2.4.0-ccip.1.5.0-beta.0`. That raises a problem: the final version cannot be `2.4.0-ccip1.5.0` but requires `-release` suffix to be properly compared by semver. In this approach `semver` compares the entire `ccip1.5.0-release` as a string not particular digits which leads to some weird behaviour like `2.4.0-ccip1.5.1-release > 2.4.0-ccip1.5.10-release`

Proposal for CCIP change in versioning to make it compatible with semver. To solve that problem once and for all we propose the following change
* pre-release versions are suffixed only on the git tag level, we don't put it in the package.json
* final release version doesn't have any suffixes, just `2.4.0-ccip1.5.0`