### PR TITLE
CTF tests - increase gas_tip_cap for Polygon Amoy chain

### DIFF
--- a/integration-tests/load/vrfv2/vrfv2_test.go
+++ b/integration-tests/load/vrfv2/vrfv2_test.go
@@ -82,6 +82,8 @@ func TestVRFV2Performance(t *testing.T) {
 				Msg("Network is a simulated network. Skipping fund return for Coordinator Subscriptions.")
 		} else {
 			if *vrfv2Config.General.CancelSubsAfterTestRun {
+				// wait for all txs to be mined in order to avoid nonce issues
+				time.Sleep(10 * time.Second)
 				//cancel subs and return funds to sub owner
 				vrfv2.CancelSubsAndReturnFunds(testcontext.Get(t), vrfContracts, sethClient.MustGetRootKeyAddress().Hex(), subIDsForCancellingAfterTest, l)
 			}

--- a/integration-tests/load/vrfv2plus/vrfv2plus_test.go
+++ b/integration-tests/load/vrfv2plus/vrfv2plus_test.go
@@ -81,6 +81,8 @@ func TestVRFV2PlusPerformance(t *testing.T) {
 				Msg("Network is a simulated network. Skipping fund return for Coordinator Subscriptions.")
 		} else {
 			if *testConfig.VRFv2Plus.General.CancelSubsAfterTestRun {
+				// wait for all txs to be mined in order to avoid nonce issues
+				time.Sleep(10 * time.Second)
 				//cancel subs and return funds to sub owner
 				vrfv2plus.CancelSubsAndReturnFunds(testcontext.Get(t), vrfContracts, sethClient.MustGetRootKeyAddress().Hex(), subIDsForCancellingAfterTest, l)
 			}

--- a/integration-tests/testconfig/default.toml
+++ b/integration-tests/testconfig/default.toml
@@ -323,11 +323,11 @@ eip_1559_dynamic_fees = true
 
 # automated gas estimation for live networks
 # if set to true we will dynamically estimate gas for every transaction (based on suggested values, priority and congestion rate for last X blocks)
-# gas_price_estimation_enabled = true
+ gas_price_estimation_enabled = true
 # number of blocks to use for congestion rate estimation (it will determine buffer added on top of suggested values)
-# gas_price_estimation_blocks = 100
+ gas_price_estimation_blocks = 100
 # transaction priority, which determines adjustment factor multiplier applied to suggested values (fast - 1.2x, standard - 1x, slow - 0.8x)
-# gas_price_estimation_tx_priority = "standard"
+ gas_price_estimation_tx_priority = "standard"
 
 # URLs
 # if set they will overwrite URLs from EVMNetwork that Seth uses, can be either WS(S) or HTTP(S)

--- a/integration-tests/testconfig/default.toml
+++ b/integration-tests/testconfig/default.toml
@@ -346,7 +346,7 @@ gas_price = 200_000_000_000
 
 # EIP-1559 transactions
 gas_fee_cap = 200_000_000_000
-gas_tip_cap = 2_000_000_000
+gas_tip_cap = 25_000_000_000
 
 [[Seth.networks]]
 name = "Polygon zkEVM Goerli"


### PR DESCRIPTION
while executing CTF tests on Polygon Amoy, test would fail with 
```
Error setting up VRF V2 for Existing env, err: error loading existing CL env, err: failed to send transaction: transaction underpriced: tip needed 25000000000, tip permitted 2000000000
```
NOTE - for some reason this error message only when using specific RPC nodes

[example](https://github.com/smartcontractkit/chainlink/actions/runs/10488501335/job/29051103745)


<!---
  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
  
  By referencing it, it will let the QA team to know what to watch out for when creating a new release.

  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
