### PR TITLE
migrate goreleaser to use ~> v2 as default version to use

### DIFF
--- a/.github/actions/goreleaser-build-sign-publish/README.md
+++ b/.github/actions/goreleaser-build-sign-publish/README.md
@@ -97,13 +97,17 @@ Following inputs can be used as `step.with` keys
 
 | Name                         | Type   | Default            | Description                                                             |
 | ---------------------------- | ------ | ------------------ | ----------------------------------------------------------------------- |
-| `goreleaser-version`         | String | `1.13.1`           | `goreleaser` version                                                    |
-| `zig-version`                | String | `0.10.0`           | `zig` version                                                           |
-| `cosign-version`             | String | `v1.13.1`          | `cosign` version                                                        |
+| `goreleaser-version`         | String | `~> v2`            | `goreleaser` version                                                    |
+| `zig-version`                | String | `0.10.1`           | `zig` version                                                           |
+| `cosign-version`             | String | `v2.2.2`           | `cosign` version                                                        |
 | `macos-sdk-dir`              | String | `MacOSX12.3.sdk`   | MacOSX sdk directory                                                    |
 | `enable-docker-publish`      | Bool   | `true`             | Enable publishing of Docker images / manifests                          |
 | `docker-registry`            | String | `localhost:5001`   | Docker registry                                                         |
+| `docker-image-name`          | String | `chainlink`        | Docker image name                                                       |
+| `docker-image-tag`           | String | `develop`          | Docker image tag                                                        |
 | `enable-goreleaser-snapshot` | Bool   | `false`            | Enable goreleaser build / release snapshot                              |
+| `enable-goreleaser-split`    | Bool   | `false`            | Enable goreleaser build using split and merge                           |
+| `goreleaser-split-arch`      | String | `""`               | The arch to build the image with - amd64, arm64                         |
 | `goreleaser-exec`            | String | `goreleaser`       | The goreleaser executable, can invoke wrapper script                    |
 | `goreleaser-config`          | String | `.goreleaser.yaml` | The goreleaser configuration yaml                                       |
 | `enable-cosign`              | Bool   | `false`            | Enable signing of Docker images                                         |

--- a/.github/actions/goreleaser-build-sign-publish/action.yml
+++ b/.github/actions/goreleaser-build-sign-publish/action.yml
@@ -3,7 +3,7 @@ description: A composite action that allows building and publishing signed chain
 inputs:
   goreleaser-version:
     description: The goreleaser version
-    default: 1.23.0
+    default: "~> v2"
     required: false
   goreleaser-key:
     description: The goreleaser key
@@ -83,7 +83,7 @@ runs:
       with:
         go-version-file: "go.mod"
     - name: Setup goreleaser
-      uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+      uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
       with:
         distribution: goreleaser-pro
         install-only: true

--- a/.goreleaser.develop.yaml
+++ b/.goreleaser.develop.yaml
@@ -1,5 +1,7 @@
 project_name: chainlink
 
+version: 2
+
 env:
   - ZIG_EXEC={{ if index .Env "ZIG_EXEC"  }}{{ .Env.ZIG_EXEC }}{{ else }}zig{{ end }}
   - IMAGE_PREFIX={{ if index .Env "IMAGE_PREFIX"  }}{{ .Env.IMAGE_PREFIX }}{{ else }}localhost:5001{{ end }}
@@ -196,7 +198,7 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{ .Env.CHAINLINK_VERSION }}-{{ .ShortCommit }}"
+  version_template: "{{ .Env.CHAINLINK_VERSION }}-{{ .ShortCommit }}"
 
 partial:
   by: target

--- a/.goreleaser.devspace.yaml
+++ b/.goreleaser.devspace.yaml
@@ -1,5 +1,6 @@
-## goreleaser <1.14.0
 project_name: chainlink-devspace
+
+version: 2
 
 env:
   - ZIG_EXEC={{ if index .Env "ZIG_EXEC"  }}{{ .Env.ZIG_EXEC }}{{ else }}zig{{ end }}
@@ -75,7 +76,7 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: '{{ .Env.CHAINLINK_VERSION }}-{{ .Runtime.Goarch }}-{{ .Now.Format "2006-01-02-15-04-05Z" }}'
+  version_template: '{{ .Env.CHAINLINK_VERSION }}-{{ .Runtime.Goarch }}-{{ .Now.Format "2006-01-02-15-04-05Z" }}'
 
 changelog:
   sort: asc


### PR DESCRIPTION
Need to update the goreleaser yaml:

https://goreleaser.com/deprecations/#snapshotname_template

as well as adding the `version`