### PR TITLE
Move long running CCIP tests to nightly tests

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -938,7 +938,6 @@ runner-test-matrix:
     test_env_type: docker
     runs_on: ubuntu-latest
     workflows:
-      - PR E2E CCIP Tests
       - Nightly E2E Tests
     test_cmd: cd integration-tests/ccip-tests/smoke && go test ccip_test.go -test.run ^TestSmokeCCIPOffRampCapacityLimit$ -timeout 30m -count=1 -test.parallel=1 -json
     test_env_vars:
@@ -949,7 +948,6 @@ runner-test-matrix:
     test_env_type: docker
     runs_on: ubuntu-latest
     workflows:
-      - PR E2E CCIP Tests
       - Nightly E2E Tests
     test_cmd: cd integration-tests/ccip-tests/smoke && go test ccip_test.go -test.run ^TestSmokeCCIPOffRampAggRateLimit$ -timeout 30m -count=1 -test.parallel=1 -json
     test_env_vars:


### PR DESCRIPTION
These tests take more than 20 min to run and are too long for PR/commits
<img width="846" alt="image" src="https://github.com/user-attachments/assets/70bc5644-11e1-4215-9cf4-ab831a5c8bc8">

@kalverra agreed to move these tests to nightly runs.