### PR TITLE
[OPCORE-855]: fix: support creating more than 1 manager

### DIFF
--- a/.changeset/moody-turkeys-provide.md
+++ b/.changeset/moody-turkeys-provide.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#changed Allow registration of more than 1 feeds manager on CreateFeedsManager

--- a/core/services/feeds/mocks/orm.go
+++ b/core/services/feeds/mocks/orm.go
@@ -6,6 +6,8 @@ import (
 	context "context"
 
 	feeds "github.com/smartcontractkit/chainlink/v2/core/services/feeds"
+	crypto "github.com/smartcontractkit/chainlink/v2/core/utils/crypto"
+
 	mock "github.com/stretchr/testify/mock"
 
 	sqlutil "github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
@@ -1500,6 +1502,63 @@ func (_c *ORM_ListSpecsByJobProposalIDs_Call) Return(_a0 []feeds.JobProposalSpec
 }
 
 func (_c *ORM_ListSpecsByJobProposalIDs_Call) RunAndReturn(run func(context.Context, []int64) ([]feeds.JobProposalSpec, error)) *ORM_ListSpecsByJobProposalIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ManagerExists provides a mock function with given fields: ctx, publicKey
+func (_m *ORM) ManagerExists(ctx context.Context, publicKey crypto.PublicKey) (bool, error) {
+	ret := _m.Called(ctx, publicKey)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ManagerExists")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, crypto.PublicKey) (bool, error)); ok {
+		return rf(ctx, publicKey)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, crypto.PublicKey) bool); ok {
+		r0 = rf(ctx, publicKey)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, crypto.PublicKey) error); ok {
+		r1 = rf(ctx, publicKey)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ORM_ManagerExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ManagerExists'
+type ORM_ManagerExists_Call struct {
+	*mock.Call
+}
+
+// ManagerExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - publicKey crypto.PublicKey
+func (_e *ORM_Expecter) ManagerExists(ctx interface{}, publicKey interface{}) *ORM_ManagerExists_Call {
+	return &ORM_ManagerExists_Call{Call: _e.mock.On("ManagerExists", ctx, publicKey)}
+}
+
+func (_c *ORM_ManagerExists_Call) Run(run func(ctx context.Context, publicKey crypto.PublicKey)) *ORM_ManagerExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(crypto.PublicKey))
+	})
+	return _c
+}
+
+func (_c *ORM_ManagerExists_Call) Return(_a0 bool, _a1 error) *ORM_ManagerExists_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ORM_ManagerExists_Call) RunAndReturn(run func(context.Context, crypto.PublicKey) (bool, error)) *ORM_ManagerExists_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/feeds/mocks/service.go
+++ b/core/services/feeds/mocks/service.go
@@ -220,62 +220,6 @@ func (_c *Service_CountJobProposalsByStatus_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// CountManagers provides a mock function with given fields: ctx
-func (_m *Service) CountManagers(ctx context.Context) (int64, error) {
-	ret := _m.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CountManagers")
-	}
-
-	var r0 int64
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (int64, error)); ok {
-		return rf(ctx)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context) int64); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Get(0).(int64)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Service_CountManagers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountManagers'
-type Service_CountManagers_Call struct {
-	*mock.Call
-}
-
-// CountManagers is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *Service_Expecter) CountManagers(ctx interface{}) *Service_CountManagers_Call {
-	return &Service_CountManagers_Call{Call: _e.mock.On("CountManagers", ctx)}
-}
-
-func (_c *Service_CountManagers_Call) Run(run func(ctx context.Context)) *Service_CountManagers_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
-	})
-	return _c
-}
-
-func (_c *Service_CountManagers_Call) Return(_a0 int64, _a1 error) *Service_CountManagers_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *Service_CountManagers_Call) RunAndReturn(run func(context.Context) (int64, error)) *Service_CountManagers_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // CreateChainConfig provides a mock function with given fields: ctx, cfg
 func (_m *Service) CreateChainConfig(ctx context.Context, cfg feeds.ChainConfig) (int64, error) {
 	ret := _m.Called(ctx, cfg)

--- a/core/services/feeds/orm.go
+++ b/core/services/feeds/orm.go
@@ -281,7 +281,8 @@ WHERE id = $1
 func (o *orm) ListManagers(ctx context.Context) (mgrs []FeedsManager, err error) {
 	stmt := `
 SELECT id, name, uri, public_key, created_at, updated_at
-FROM feeds_managers;
+FROM feeds_managers
+ORDER BY created_at;
 `
 
 	err = o.ds.SelectContext(ctx, &mgrs, stmt)

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -53,7 +53,7 @@ func setupORM(t *testing.T) *TestORM {
 
 // Managers
 
-func Test_ORM_CreateManager(t *testing.T) {
+func Test_ORM_CreateManager_CountManagers(t *testing.T) {
 	t.Parallel()
 	ctx := testutils.Context(t)
 
@@ -76,6 +76,33 @@ func Test_ORM_CreateManager(t *testing.T) {
 	count, err = orm.CountManagers(ctx)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), count)
+
+	assert.NotZero(t, id)
+}
+
+func Test_ORM_CreateManager(t *testing.T) {
+	t.Parallel()
+	ctx := testutils.Context(t)
+
+	var (
+		orm = setupORM(t)
+		mgr = &feeds.FeedsManager{
+			URI:       uri,
+			Name:      name,
+			PublicKey: publicKey,
+		}
+	)
+
+	exists, err := orm.ManagerExists(ctx, publicKey)
+	require.NoError(t, err)
+	require.Equal(t, false, exists)
+
+	id, err := orm.CreateManager(ctx, mgr)
+	require.NoError(t, err)
+
+	exists, err = orm.ManagerExists(ctx, publicKey)
+	require.NoError(t, err)
+	require.Equal(t, true, exists)
 
 	assert.NotZero(t, id)
 }

--- a/core/web/resolver/feeds_manager.go
+++ b/core/web/resolver/feeds_manager.go
@@ -145,9 +145,18 @@ func (r *CreateFeedsManagerPayloadResolver) ToCreateFeedsManagerSuccess() (*Crea
 	return nil, false
 }
 
+// TODO: delete once multiple feeds managers support is released
 func (r *CreateFeedsManagerPayloadResolver) ToSingleFeedsManagerError() (*SingleFeedsManagerErrorResolver, bool) {
 	if r.err != nil && errors.Is(r.err, feeds.ErrSingleFeedsManager) {
 		return NewSingleFeedsManagerError(r.err.Error()), true
+	}
+
+	return nil, false
+}
+
+func (r *CreateFeedsManagerPayloadResolver) ToDuplicateFeedsManagerError() (*DuplicateFeedsManagerErrorResolver, bool) {
+	if r.err != nil && errors.Is(r.err, feeds.ErrDuplicateFeedsManager) {
+		return NewDuplicateFeedsManagerError(r.err.Error()), true
 	}
 
 	return nil, false
@@ -182,6 +191,7 @@ func (r *CreateFeedsManagerSuccessResolver) FeedsManager() *FeedsManagerResolver
 }
 
 // SingleFeedsManagerErrorResolver -
+// TODO: delete once multiple feeds managers support is released
 type SingleFeedsManagerErrorResolver struct {
 	message string
 }
@@ -197,6 +207,25 @@ func (r *SingleFeedsManagerErrorResolver) Message() string {
 }
 
 func (r *SingleFeedsManagerErrorResolver) Code() ErrorCode {
+	return ErrorCodeUnprocessable
+}
+
+// DuplicateFeedsManagerErrorResolver -
+type DuplicateFeedsManagerErrorResolver struct {
+	message string
+}
+
+func NewDuplicateFeedsManagerError(message string) *DuplicateFeedsManagerErrorResolver {
+	return &DuplicateFeedsManagerErrorResolver{
+		message: message,
+	}
+}
+
+func (r *DuplicateFeedsManagerErrorResolver) Message() string {
+	return r.message
+}
+
+func (r *DuplicateFeedsManagerErrorResolver) Code() ErrorCode {
 	return ErrorCodeUnprocessable
 }
 

--- a/core/web/resolver/feeds_manager_test.go
+++ b/core/web/resolver/feeds_manager_test.go
@@ -183,6 +183,10 @@ func Test_CreateFeedsManager(t *testing.T) {
 						message
 						code
 					}
+					... on DuplicateFeedsManagerError {
+						message
+						code
+					}
 					... on NotFoundError {
 						message
 						code
@@ -260,6 +264,25 @@ func Test_CreateFeedsManager(t *testing.T) {
 			{
 				"createFeedsManager": {
 					"message": "only a single feeds manager is supported",
+					"code": "UNPROCESSABLE"
+				}
+			}`,
+		},
+		{
+			name:          "register duplicate feeds manager error",
+			authenticated: true,
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+				f.Mocks.feedsSvc.
+					On("RegisterManager", mock.Anything, mock.IsType(feeds.RegisterManagerParams{})).
+					Return(int64(0), feeds.ErrDuplicateFeedsManager)
+			},
+			query:     mutation,
+			variables: variables,
+			result: `
+			{
+				"createFeedsManager": {
+					"message": "manager was previously registered using the same public key",
 					"code": "UNPROCESSABLE"
 				}
 			}`,

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -424,7 +424,7 @@ func (r *Resolver) CreateFeedsManager(ctx context.Context, args struct {
 
 	id, err := feedsService.RegisterManager(ctx, params)
 	if err != nil {
-		if errors.Is(err, feeds.ErrSingleFeedsManager) {
+		if errors.Is(err, feeds.ErrSingleFeedsManager) || errors.Is(err, feeds.ErrDuplicateFeedsManager) {
 			return NewCreateFeedsManagerPayload(nil, err, nil), nil
 		}
 		return nil, err

--- a/core/web/schema/type/feeds_manager.graphql
+++ b/core/web/schema/type/feeds_manager.graphql
@@ -77,6 +77,13 @@ type CreateFeedsManagerSuccess {
     feedsManager: FeedsManager!
 }
 
+type DuplicateFeedsManagerError implements Error {
+	message: String!
+	code: ErrorCode!
+}
+
+# DEPRECATED: No longer used since we now support multiple feeds manager.
+# Keeping this to avoid breaking change.
 type SingleFeedsManagerError implements Error {
 	message: String!
 	code: ErrorCode!
@@ -84,7 +91,8 @@ type SingleFeedsManagerError implements Error {
 
 # CreateFeedsManagerPayload defines the response when creating a feeds manager
 union CreateFeedsManagerPayload = CreateFeedsManagerSuccess
-	| SingleFeedsManagerError
+	| DuplicateFeedsManagerError
+	| SingleFeedsManagerError # // TODO: delete once multiple feeds managers support is released
 	| NotFoundError
 	| InputErrors
 


### PR DESCRIPTION
In order to support connection to multiple feed managers due to an upcoming CCIP v2 requirement, we want to update the logic to allow more than 1 feed managers to be created per node.

The new behaviour is hidden under a feature tag.

JIRA: https://smartcontract-it.atlassian.net/browse/OPCORE-855

<!---
  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
  
  By referencing it, it will let the QA team to know what to watch out for when creating a new release.

  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
Depends on [this PR](https://github.com/smartcontractkit/chainlink/pull/14197) which introduces the new feature tag.

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->
