### PR TITLE
core/services/ocr/plugins/llo: fix onchain cache test race

### DIFF
--- a/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go
+++ b/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go
@@ -58,6 +58,7 @@ func (h *mockHTTPClient) SetResponse(resp *http.Response, err error) {
 
 type MockReadCloser struct {
 	data   []byte
+	mu     sync.RWMutex
 	reader *bytes.Reader
 }
 
@@ -70,11 +71,15 @@ func NewMockReadCloser(data []byte) *MockReadCloser {
 
 // Read reads from the underlying data
 func (m *MockReadCloser) Read(p []byte) (int, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.reader.Read(p)
 }
 
 // Close resets the reader to the beginning of the data
 func (m *MockReadCloser) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.reader.Seek(0, io.SeekStart)
 	return nil
 }


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/10533939073/job/29190791150
```
==================
WARNING: DATA RACE
Read at 0x00c00566f608 by goroutine 21187:
  bytes.(*Reader).Read()
      /opt/hostedtoolcache/go/1.22.5/x64/src/bytes/reader.go:40 +0x7c
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/llo_test.(*MockReadCloser).Read()
      /home/runner/work/chainlink/chainlink/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go:73 +0x2e
  net/http.(*maxBytesReader).Read()
      /opt/hostedtoolcache/go/1.22.5/x64/src/net/http/request.go:1[19](https://github.com/smartcontractkit/chainlink/actions/runs/10533939073/job/29190791150#step:19:20)7 +0x10f
  io.(*teeReader).Read()
      /opt/hostedtoolcache/go/1.22.5/x64/src/io/io.go:628 +0x5c
  io.copyBuffer()
      /opt/hostedtoolcache/go/1.22.5/x64/src/io/io.go:429 +0x29a
  io.Copy()
      /opt/hostedtoolcache/go/1.22.5/x64/src/io/io.go:388 +0xcaf
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchChannelDefinitions()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:401 +0xc3d
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchAndSetChannelDefinitions()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:341 +0x177
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLoop()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:322 +0xd1d
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLatestLoop.gowrap2()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:293 +0x4f

Previous write at 0x00c00566f608 by goroutine 21[20](https://github.com/smartcontractkit/chainlink/actions/runs/10533939073/job/29190791150#step:19:21)4:
  bytes.(*Reader).Seek()
      /opt/hostedtoolcache/go/1.22.5/x64/src/bytes/reader.go:132 +0x73
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/llo_test.(*MockReadCloser).Close()
      /home/runner/work/chainlink/chainlink/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go:78 +0x25
  net/http.(*maxBytesReader).Close()
      /opt/hostedtoolcache/go/1.22.5/x64/src/net/http/request.go:1226 +0x42
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchChannelDefinitions.deferwrap1()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:381 +0x42
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.22.5/x64/src/runtime/panic.go:602 +0x5d
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchAndSetChannelDefinitions()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:341 +0x177
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLoop()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:309 +0x1ba
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLatestLoop.gowrap2()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:293 +0x4f

Goroutine [21](https://github.com/smartcontractkit/chainlink/actions/runs/10533939073/job/29190791150#step:19:22)187 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLatestLoop()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:293 +0xc9
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).Start.func1.gowrap2()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:166 +0x33

Goroutine 21204 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLatestLoop()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:[29](https://github.com/smartcontractkit/chainlink/actions/runs/10533939073/job/29190791150#step:19:30)3 +0xc9
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).Start.func1.gowrap2()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:166 +0x[33](https://github.com/smartcontractkit/chainlink/actions/runs/10533939073/job/29190791150#step:19:34)
==================
```