### PR TITLE
Hotfix for v2.15: BCI-4095 rpc deadlock

### DIFF
--- a/.changeset/curly-birds-guess.md
+++ b/.changeset/curly-birds-guess.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Fixed deadlock in RPCClient causing CL Node to stop performing RPC requests for the affected chain #bugfix


### PR DESCRIPTION
Cherry-pick from [14236](https://github.com/smartcontractkit/chainlink/pull/14236)