### PR TITLE
Use repo var for JIRA_HOST

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -92,7 +92,7 @@ jobs:
           pnpm install && pnpm issue:update 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JIRA_HOST: ${{ secrets.JIRA_HOST }}
+          JIRA_HOST: ${{ vars.JIRA_HOST }}
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           CHAINLINK_VERSION: ${{ steps.chainlink-version.outputs.chainlink_version }}

--- a/.github/workflows/solidity-foundry-artifacts.yml
+++ b/.github/workflows/solidity-foundry-artifacts.yml
@@ -404,7 +404,7 @@ jobs:
           HEAD_REF: ${{ env.head_ref }}
           ARTIFACT_URL: ${{ steps.gather-all-artifacts.outputs.artifact-url }}
 
-          JIRA_HOST: https://smartcontract-it.atlassian.net/
+          JIRA_HOST: ${{ vars.JIRA_HOST }} 
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 

--- a/.github/workflows/solidity-tracability.yml
+++ b/.github/workflows/solidity-tracability.yml
@@ -107,7 +107,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
 
-          JIRA_HOST: https://smartcontract-it.atlassian.net/ 
+          JIRA_HOST: ${{ vars.JIRA_HOST }} 
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 


### PR DESCRIPTION
We can’t have `JIRA_HOST` be a secret, since the `solidity-foundry-artifacts.yml` file posts a Jira URL that contains a link to all  issues that are a part of the SBOM. 

It’s fine to make non-secret since the Jira host URL is exposed everywhere in the codebase, it’s not a secret value to begin with.