### PR TITLE
core/services/ocr2/plugins/llo: use write lock during mock read closer Reads

### DIFF
--- a/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go
+++ b/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go
@@ -58,7 +58,7 @@ func (h *mockHTTPClient) SetResponse(resp *http.Response, err error) {
 
 type MockReadCloser struct {
 	data   []byte
-	mu     sync.RWMutex
+	mu     sync.Mutex
 	reader *bytes.Reader
 }
 
@@ -71,8 +71,8 @@ func NewMockReadCloser(data []byte) *MockReadCloser {
 
 // Read reads from the underlying data
 func (m *MockReadCloser) Read(p []byte) (int, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.reader.Read(p)
 }
 
@@ -80,8 +80,8 @@ func (m *MockReadCloser) Read(p []byte) (int, error) {
 func (m *MockReadCloser) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.reader.Seek(0, io.SeekStart)
-	return nil
+	_, err := m.reader.Seek(0, io.SeekStart)
+	return err
 }
 
 func Test_ChannelDefinitionCache_Integration(t *testing.T) {


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/10613884810/job/29418808426?pr=14258
```
==================
WARNING: DATA RACE
Read at 0x00c00258db18 by goroutine 7135:
  bytes.(*Reader).Read()
      /opt/hostedtoolcache/go/1.22.5/x64/src/bytes/reader.go:40 +0x12c
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/llo_test.(*MockReadCloser).Read()
      /home/runner/work/chainlink/chainlink/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go:76 +0xd4
  net/http.(*maxBytesReader).Read()
      /opt/hostedtoolcache/go/1.22.5/x64/src/net/http/request.go:1197 +0x10f
  io.(*teeReader).Read()
      /opt/hostedtoolcache/go/1.22.5/x64/src/io/io.go:628 +0x5c
  io.copyBuffer()
      /opt/hostedtoolcache/go/1.22.5/x64/src/io/io.go:429 +0x29a
  io.Copy()
      /opt/hostedtoolcache/go/1.22.5/x64/src/io/io.go:388 +0xcaf
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchChannelDefinitions()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:401 +0xc3d
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchAndSetChannelDefinitions()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:341 +0x[17](https://github.com/smartcontractkit/chainlink/actions/runs/10613884810/job/29418808426?pr=14258#step:19:18)7
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLoop()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:322 +0xd1d
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLatestLoop.gowrap2()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:293 +0x4f

Previous write at 0x00c00258db[18](https://github.com/smartcontractkit/chainlink/actions/runs/10613884810/job/29418808426?pr=14258#step:19:19) by goroutine 7153:
  bytes.(*Reader).Read()
      /opt/hostedtoolcache/go/1.22.5/x64/src/bytes/reader.go:45 +0x234
  github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/llo_test.(*MockReadCloser).Read()
      /home/runner/work/chainlink/chainlink/core/services/ocr2/plugins/llo/onchain_channel_definition_cache_integration_test.go:76 +0xd4
  net/http.(*maxBytesReader).Read()
      /opt/hostedtoolcache/go/1.22.5/x64/src/net/http/request.go:1[19](https://github.com/smartcontractkit/chainlink/actions/runs/10613884810/job/29418808426?pr=14258#step:19:20)7 +0x10f
  io.(*teeReader).Read()
      /opt/hostedtoolcache/go/1.22.5/x64/src/io/io.go:628 +0x5c
  io.copyBuffer()
      /opt/hostedtoolcache/go/1.22.5/x64/src/io/io.go:429 +0x29a
  io.Copy()
      /opt/hostedtoolcache/go/1.[22](https://github.com/smartcontractkit/chainlink/actions/runs/10613884810/job/29418808426?pr=14258#step:19:23).5/x64/src/io/io.go:388 +0xcaf
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchChannelDefinitions()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:401 +0xc3d
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchAndSetChannelDefinitions()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:341 +0x177
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLoop()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:309 +0x1ba
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLatestLoop.gowrap2()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:[29](https://github.com/smartcontractkit/chainlink/actions/runs/10613884810/job/29418808426?pr=14258#step:19:30)3 +0x4f

Goroutine 7135 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLatestLoop()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:293 +0xc9
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).Start.func1.gowrap2()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:166 +0x[33](https://github.com/smartcontractkit/chainlink/actions/runs/10613884810/job/29418808426?pr=14258#step:19:34)

Goroutine 7153 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).fetchLatestLoop()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:293 +0xc9
  github.com/smartcontractkit/chainlink/v2/core/services/llo.(*channelDefinitionCache).Start.func1.gowrap2()
      /home/runner/work/chainlink/chainlink/core/services/llo/onchain_channel_definition_cache.go:166 +0x33
==================
```