### PR TITLE
Skip deleted proposals when checking `isJobManaged`

### DIFF
--- a/.changeset/tricky-eagles-knock.md
+++ b/.changeset/tricky-eagles-knock.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+skip checking isJobManaged if the proposal in fms has already been deleted #changed

--- a/core/services/feeds/orm.go
+++ b/core/services/feeds/orm.go
@@ -826,6 +826,7 @@ SELECT exists (
 	FROM job_proposals
 	INNER JOIN jobs ON job_proposals.external_job_id = jobs.external_job_id
 	WHERE jobs.id = $1
+	AND job_proposals.status <> 'deleted'
 );
 `
 

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -1653,6 +1653,14 @@ func Test_ORM_IsJobManaged(t *testing.T) {
 	isManaged, err = orm.IsJobManaged(ctx, int64(j.ID))
 	require.NoError(t, err)
 	assert.True(t, isManaged)
+
+	// delete the proposal
+	err = orm.DeleteProposal(ctx, jpID)
+	require.NoError(t, err)
+
+	isManaged, err = orm.IsJobManaged(ctx, int64(j.ID))
+	require.NoError(t, err)
+	assert.False(t, isManaged)
 }
 
 // Helpers


### PR DESCRIPTION
We should skip deleted proposals when checking `IsJobManaged` to allow deletion of any running jobs regardless of fms management