### PR TITLE
Fix slack notification for client compatibility tests

### DIFF
--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -710,7 +710,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": "${{ contains(join(needs.*.result, ','), 'failure') && format('Some tests failed, notifying <!subteam^{0}|{0}>', secrets.COMPAT_SLACK_NOTIFICATION_HANDLE) || 'All Good!' }}"
+                        "text": "${{ contains(join(needs.*.result, ','), 'failure') && format('Some tests failed, notifying <!subteam^{0}|bix-scale-eng>', secrets.COMPAT_SLACK_NOTIFICATION_HANDLE) || 'All Good!' }}"
                       }
                     },
                     {


### PR DESCRIPTION
1. Updated `secrets.COMPAT_SLACK_NOTIFICATION_HANDLE` with user group handle it according to https://stackoverflow.com/questions/54284389/mention-users-group-via-slack-api
2. Updated handle that is rendered in the notification

Successful notification https://chainlink-core.slack.com/archives/C0364FG2CN9/p1725264231814869