### PR TITLE
Bump chainlink-testing-framework to remove secret config keys from test configs and BASE64_NETWORK_CONFIG env

### DIFF
--- a/integration-tests/ccip-tests/testconfig/global.go
+++ b/integration-tests/ccip-tests/testconfig/global.go
@@ -430,10 +430,6 @@ func (p *Common) Validate() error {
 	// read the default network config, if specified
 	p.Network.UpperCaseNetworkNames()
 	p.Network.OverrideURLsAndKeysFromEVMNetwork()
-	err := p.Network.Default()
-	if err != nil {
-		return fmt.Errorf("error reading default network config %w", err)
-	}
 	if err := p.Network.Validate(); err != nil {
 		return fmt.Errorf("error validating networks config %w", err)
 	}

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.21
 	github.com/smartcontractkit/chainlink-automation v1.0.4
 	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240829145110-4a45c426fbe8
-	github.com/smartcontractkit/chainlink-testing-framework v1.34.10
+	github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a
 	github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v0.1.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.2.1

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.21
 	github.com/smartcontractkit/chainlink-automation v1.0.4
 	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240829145110-4a45c426fbe8
-	github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a
+	github.com/smartcontractkit/chainlink-testing-framework v1.35.0
 	github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v0.1.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.2.1

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1437,8 +1437,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.1-0.20240821170223-a2f5c39f457
 github.com/smartcontractkit/chainlink-solana v1.1.1-0.20240821170223-a2f5c39f457f/go.mod h1:Ml88TJTwZCj6yHDkAEN/EhxVutzSlk+kDZgfibRIqF0=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240709043547-03612098f799 h1:HyLTySm7BR+oNfZqDTkVJ25wnmcTtxBBD31UkFL+kEM=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240709043547-03612098f799/go.mod h1:UVFRacRkP7O7TQAzFmR52v5mUlxf+G1ovMlCQAB/cHU=
-github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a h1:u+Mf1MAlj7ZpRpxZMY9drQPz7XpmFYEQnnuyP6Bvs8Y=
-github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a/go.mod h1:ekYJbRAxXcs/YgOjHsY9/tlvDvXzv3lxcZK2eFUZduc=
+github.com/smartcontractkit/chainlink-testing-framework v1.35.0 h1:5FzS4YOwzjRe59VMM7MmEyjgJCq4/aXR1fzdEJEPiL8=
+github.com/smartcontractkit/chainlink-testing-framework v1.35.0/go.mod h1:ekYJbRAxXcs/YgOjHsY9/tlvDvXzv3lxcZK2eFUZduc=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.1 h1:1/r1wQZ4TOFpZ13w94r7amdF096Z96RuEnkOmrz1BGE=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.1/go.mod h1:DC8sQMyTlI/44UCTL8QWFwb0bYNoXCfjwCv2hMivYZU=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v0.1.0 h1:eHsvf2SklyyZ5fTHJIsIZ3eUnfO0TJU2BSZ7j8kLvzM=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1437,8 +1437,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.1-0.20240821170223-a2f5c39f457
 github.com/smartcontractkit/chainlink-solana v1.1.1-0.20240821170223-a2f5c39f457f/go.mod h1:Ml88TJTwZCj6yHDkAEN/EhxVutzSlk+kDZgfibRIqF0=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240709043547-03612098f799 h1:HyLTySm7BR+oNfZqDTkVJ25wnmcTtxBBD31UkFL+kEM=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240709043547-03612098f799/go.mod h1:UVFRacRkP7O7TQAzFmR52v5mUlxf+G1ovMlCQAB/cHU=
-github.com/smartcontractkit/chainlink-testing-framework v1.34.10 h1:7boGJr/wkX5TF6TBb4wRnP6t1IFL6RD98+fZBJBZyCY=
-github.com/smartcontractkit/chainlink-testing-framework v1.34.10/go.mod h1:ekYJbRAxXcs/YgOjHsY9/tlvDvXzv3lxcZK2eFUZduc=
+github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a h1:u+Mf1MAlj7ZpRpxZMY9drQPz7XpmFYEQnnuyP6Bvs8Y=
+github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a/go.mod h1:ekYJbRAxXcs/YgOjHsY9/tlvDvXzv3lxcZK2eFUZduc=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.1 h1:1/r1wQZ4TOFpZ13w94r7amdF096Z96RuEnkOmrz1BGE=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.1/go.mod h1:DC8sQMyTlI/44UCTL8QWFwb0bYNoXCfjwCv2hMivYZU=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v0.1.0 h1:eHsvf2SklyyZ5fTHJIsIZ3eUnfO0TJU2BSZ7j8kLvzM=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
 	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240829145110-4a45c426fbe8
-	github.com/smartcontractkit/chainlink-testing-framework v1.34.10
+	github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.2.1
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v0.4.10
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
 	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240829145110-4a45c426fbe8
-	github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a
+	github.com/smartcontractkit/chainlink-testing-framework v1.35.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.2.1
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v0.4.10
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1407,8 +1407,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.1-0.20240821170223-a2f5c39f457
 github.com/smartcontractkit/chainlink-solana v1.1.1-0.20240821170223-a2f5c39f457f/go.mod h1:Ml88TJTwZCj6yHDkAEN/EhxVutzSlk+kDZgfibRIqF0=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240709043547-03612098f799 h1:HyLTySm7BR+oNfZqDTkVJ25wnmcTtxBBD31UkFL+kEM=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240709043547-03612098f799/go.mod h1:UVFRacRkP7O7TQAzFmR52v5mUlxf+G1ovMlCQAB/cHU=
-github.com/smartcontractkit/chainlink-testing-framework v1.34.10 h1:7boGJr/wkX5TF6TBb4wRnP6t1IFL6RD98+fZBJBZyCY=
-github.com/smartcontractkit/chainlink-testing-framework v1.34.10/go.mod h1:ekYJbRAxXcs/YgOjHsY9/tlvDvXzv3lxcZK2eFUZduc=
+github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a h1:u+Mf1MAlj7ZpRpxZMY9drQPz7XpmFYEQnnuyP6Bvs8Y=
+github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a/go.mod h1:ekYJbRAxXcs/YgOjHsY9/tlvDvXzv3lxcZK2eFUZduc=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.2-0.20240805111647-acf86c1e347a h1:8GtvGJaGyKzx/ar1yX74GxrzIYWTZVTyv4pYB/1ln8w=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.2-0.20240805111647-acf86c1e347a/go.mod h1:DC8sQMyTlI/44UCTL8QWFwb0bYNoXCfjwCv2hMivYZU=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v0.1.0 h1:eHsvf2SklyyZ5fTHJIsIZ3eUnfO0TJU2BSZ7j8kLvzM=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1407,8 +1407,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.1-0.20240821170223-a2f5c39f457
 github.com/smartcontractkit/chainlink-solana v1.1.1-0.20240821170223-a2f5c39f457f/go.mod h1:Ml88TJTwZCj6yHDkAEN/EhxVutzSlk+kDZgfibRIqF0=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240709043547-03612098f799 h1:HyLTySm7BR+oNfZqDTkVJ25wnmcTtxBBD31UkFL+kEM=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240709043547-03612098f799/go.mod h1:UVFRacRkP7O7TQAzFmR52v5mUlxf+G1ovMlCQAB/cHU=
-github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a h1:u+Mf1MAlj7ZpRpxZMY9drQPz7XpmFYEQnnuyP6Bvs8Y=
-github.com/smartcontractkit/chainlink-testing-framework v1.34.12-0.20240902081721-d8dc511c802a/go.mod h1:ekYJbRAxXcs/YgOjHsY9/tlvDvXzv3lxcZK2eFUZduc=
+github.com/smartcontractkit/chainlink-testing-framework v1.35.0 h1:5FzS4YOwzjRe59VMM7MmEyjgJCq4/aXR1fzdEJEPiL8=
+github.com/smartcontractkit/chainlink-testing-framework v1.35.0/go.mod h1:ekYJbRAxXcs/YgOjHsY9/tlvDvXzv3lxcZK2eFUZduc=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.2-0.20240805111647-acf86c1e347a h1:8GtvGJaGyKzx/ar1yX74GxrzIYWTZVTyv4pYB/1ln8w=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.2-0.20240805111647-acf86c1e347a/go.mod h1:DC8sQMyTlI/44UCTL8QWFwb0bYNoXCfjwCv2hMivYZU=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v0.1.0 h1:eHsvf2SklyyZ5fTHJIsIZ3eUnfO0TJU2BSZ7j8kLvzM=

--- a/integration-tests/testconfig/testconfig.go
+++ b/integration-tests/testconfig/testconfig.go
@@ -577,10 +577,6 @@ func (c *TestConfig) readNetworkConfiguration() error {
 
 	c.Network.UpperCaseNetworkNames()
 	c.Network.OverrideURLsAndKeysFromEVMNetwork()
-	err := c.Network.Default()
-	if err != nil {
-		return errors.Wrapf(err, "error reading default network config")
-	}
 
 	// this is the only value we need to generate dynamically before starting a new simulated chain
 	if c.PrivateEthereumNetwork != nil && c.PrivateEthereumNetwork.EthereumChainConfig != nil {

--- a/integration-tests/testconfig/testconfig_test.go
+++ b/integration-tests/testconfig/testconfig_test.go
@@ -15,17 +15,18 @@ import (
 )
 
 func TestBase64ConfigRead(t *testing.T) {
-	networkConfigTOML := `
-	[RpcHttpUrls]
-	arbitrum_goerli = ["https://devnet-1.mt/ABC/rpc/"]
-	optimism_goerli = ["https://devnet-3.mt/ABC/rpc/"]
-
-	[RpcWsUrls]
-	arbitrum_goerli = ["wss://devnet-1.mt/ABC/rpc/"]
-	optimism_goerli = ["wss://devnet-2.mt/ABC/rpc/"]
-	`
-	networksEncoded := base64.StdEncoding.EncodeToString([]byte(networkConfigTOML))
-	os.Setenv(ctf_config.Base64NetworkConfigEnvVarName, networksEncoded)
+	os.Setenv("E2E_TEST_ARBITRUM_GOERLI_RPC_HTTP_URL", "https://devnet-1.mt/ABC/rpc/")
+	os.Setenv("E2E_TEST_ARBITRUM_GOERLI_RPC_WS_URL", "wss://devnet-1.mt/ABC/rpc/")
+	os.Setenv("E2E_TEST_ARBITRUM_GOERLI_WALLET_KEY", "0x3333333333333333333333333333333333333333")
+	defer os.Unsetenv("E2E_TEST_ARBITRUM_GOERLI_RPC_HTTP_URL")
+	defer os.Unsetenv("E2E_TEST_ARBITRUM_GOERLI_RPC_WS_URL")
+	defer os.Unsetenv("E2E_TEST_ARBITRUM_GOERLI_WALLET_KEY")
+	os.Setenv("E2E_TEST_OPTIMISM_GOERLI_RPC_HTTP_URL", "https://devnet-3.mt/ABC/rpc/")
+	os.Setenv("E2E_TEST_OPTIMISM_GOERLI_RPC_WS_URL", "wss://devnet-3.mt/ABC/rpc/")
+	os.Setenv("E2E_TEST_OPTIMISM_GOERLI_WALLET_KEY", "0x3333333333333333333333333333333333333333")
+	defer os.Unsetenv("E2E_TEST_OPTIMISM_GOERLI_RPC_HTTP_URL")
+	defer os.Unsetenv("E2E_TEST_OPTIMISM_GOERLI_RPC_WS_URL")
+	defer os.Unsetenv("E2E_TEST_OPTIMISM_GOERLI_WALLET_KEY")
 
 	testConfig := TestConfig{
 		Automation: &a_config.Config{
@@ -35,6 +36,8 @@ func TestBase64ConfigRead(t *testing.T) {
 				BlockTime:             ptr.Ptr(10),
 				SpecType:              ptr.Ptr("minimum"),
 				ChainlinkNodeLogLevel: ptr.Ptr("debug"),
+				UsePrometheus:         ptr.Ptr(true),
+				RemoveNamespace:       ptr.Ptr(true),
 			},
 			Load: []a_config.Load{
 				{


### PR DESCRIPTION
This bumps CTF to v1.35.0