### PR TITLE
integration-tests/deployment/memory: faster lp interval

### DIFF
--- a/integration-tests/deployment/memory/node.go
+++ b/integration-tests/deployment/memory/node.go
@@ -256,7 +256,7 @@ func createConfigV2Chain(chainID uint64) *v2toml.EVMConfig {
 	chainIDBig := evmutils.NewI(int64(chainID))
 	chain := v2toml.Defaults(chainIDBig)
 	chain.GasEstimator.LimitDefault = ptr(uint64(5e6))
-	chain.LogPollInterval = config.MustNewDuration(1000 * time.Millisecond)
+	chain.LogPollInterval = config.MustNewDuration(500 * time.Millisecond)
 	chain.Transactions.ForwardersEnabled = ptr(false)
 	chain.FinalityDepth = ptr(uint32(2))
 	return &v2toml.EVMConfig{


### PR DESCRIPTION
Reduce the log polling interval from 1 second to 500 milliseconds. This speeds up the current integration test by around 30%. 
