### PR TITLE
CODEOWNERS: add ccip-offchain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 /core/services/directrequest @smartcontractkit/keepers
 /core/services/feeds @smartcontractkit/FMS
 /core/services/synchronization/telem @smartcontractkit/realtime
+/core/capabilities/ccip @smartcontractkit/ccip-offchain
 
 # To be deprecated in Chainlink V3
 /core/services/fluxmonitorv2 @smartcontractkit/foundations


### PR DESCRIPTION
Add @smartcontractkit/ccip-offchain as codeowners of core/capabilities/ccip