### PR TITLE
Automation - Lock reads and writes from and to the ConfigDigest

### DIFF
--- a/.changeset/curvy-months-wave.md
+++ b/.changeset/curvy-months-wave.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Use a lock to sync access to the ConfigDigest #internal

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/autotelemetry21/custom_telemetry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/autotelemetry21/custom_telemetry.go
@@ -126,7 +126,8 @@ func (e *AutomationCustomTelemetryService) Close() error {
 
 func (e *AutomationCustomTelemetryService) sendNodeVersionMsg() {
 	e.mu.RLock()
-	defer e.mu.RUnlock()
+	configDigest := e.configDigest
+	e.mu.RUnlock()
 
 	vMsg := &telem.NodeVersion{
 		Timestamp:    uint64(time.Now().UTC().UnixMilli()),


### PR DESCRIPTION
This data race was flagged up in #topic-data-races

The change here is adding a `RWMutex` to synchronize reads and writes from/to the ConfigDigest