### PR TITLE
Core changes for changing Execute Capability API to sync

### DIFF
--- a/.changeset/cold-suns-hope.md
+++ b/.changeset/cold-suns-hope.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal changes required for capability api chance to sync

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -46,8 +46,8 @@ type mockCapability struct {
 	capabilities.CapabilityInfo
 }
 
-func (m *mockCapability) Execute(ctx context.Context, req capabilities.CapabilityRequest) (<-chan capabilities.CapabilityResponse, error) {
-	return nil, nil
+func (m *mockCapability) Execute(ctx context.Context, req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+	return capabilities.CapabilityResponse{}, nil
 }
 
 func (m *mockCapability) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {

--- a/core/capabilities/registry_test.go
+++ b/core/capabilities/registry_test.go
@@ -21,8 +21,8 @@ type mockCapability struct {
 	capabilities.CapabilityInfo
 }
 
-func (m *mockCapability) Execute(ctx context.Context, req capabilities.CapabilityRequest) (<-chan capabilities.CapabilityResponse, error) {
-	return nil, nil
+func (m *mockCapability) Execute(ctx context.Context, req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+	return capabilities.CapabilityResponse{}, nil
 }
 
 func (m *mockCapability) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {

--- a/core/capabilities/remote/target/client_test.go
+++ b/core/capabilities/remote/target/client_test.go
@@ -35,9 +35,8 @@ func Test_Client_DonTopologies(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	responseTest := func(t *testing.T, responseCh <-chan commoncap.CapabilityResponse, responseError error) {
+	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
 		require.NoError(t, responseError)
-		response := <-responseCh
 		mp, err := response.Value.Unwrap()
 		require.NoError(t, err)
 		assert.Equal(t, "aValue1", mp.(map[string]any)["response"].(string))
@@ -66,9 +65,8 @@ func Test_Client_DonTopologies(t *testing.T) {
 func Test_Client_TransmissionSchedules(t *testing.T) {
 	ctx := testutils.Context(t)
 
-	responseTest := func(t *testing.T, responseCh <-chan commoncap.CapabilityResponse, responseError error) {
+	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
 		require.NoError(t, responseError)
-		response := <-responseCh
 		mp, err := response.Value.Unwrap()
 		require.NoError(t, err)
 		assert.Equal(t, "aValue1", mp.(map[string]any)["response"].(string))
@@ -104,10 +102,8 @@ func Test_Client_TransmissionSchedules(t *testing.T) {
 func Test_Client_TimesOutIfInsufficientCapabilityPeerResponses(t *testing.T) {
 	ctx := testutils.Context(t)
 
-	responseTest := func(t *testing.T, responseCh <-chan commoncap.CapabilityResponse, responseError error) {
-		require.NoError(t, responseError)
-		response := <-responseCh
-		assert.NotNil(t, response.Err)
+	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
+		assert.NotNil(t, responseError)
 	}
 
 	capability := &TestCapability{}
@@ -126,7 +122,7 @@ func Test_Client_TimesOutIfInsufficientCapabilityPeerResponses(t *testing.T) {
 
 func testClient(ctx context.Context, t *testing.T, numWorkflowPeers int, workflowNodeResponseTimeout time.Duration,
 	numCapabilityPeers int, capabilityDonF uint8, underlying commoncap.TargetCapability, transmissionSchedule *values.Map,
-	responseTest func(t *testing.T, responseCh <-chan commoncap.CapabilityResponse, responseError error)) {
+	responseTest func(t *testing.T, responseCh commoncap.CapabilityResponse, responseError error)) {
 	lggr := logger.TestLogger(t)
 
 	capabilityPeers := make([]p2ptypes.PeerID, numCapabilityPeers)
@@ -261,8 +257,7 @@ func (t *clientTestServer) Receive(_ context.Context, msg *remotetypes.MessageBo
 			panic(err)
 		}
 
-		respCh, responseErr := t.targetCapability.Execute(context.Background(), capabilityRequest)
-		resp := <-respCh
+		resp, responseErr := t.targetCapability.Execute(context.Background(), capabilityRequest)
 
 		for receiver := range t.messageIDToSenders[messageID] {
 			var responseMsg = &remotetypes.MessageBody{

--- a/core/capabilities/remote/target/endtoend_test.go
+++ b/core/capabilities/remote/target/endtoend_test.go
@@ -151,7 +151,6 @@ func Test_RemoteTargetCapability_RandomCapabilityError(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
-
 		assert.Equal(t, "request expired", responseError.Error())
 	}
 

--- a/core/capabilities/remote/target/request/client_request.go
+++ b/core/capabilities/remote/target/request/client_request.go
@@ -22,9 +22,14 @@ import (
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
 
+type asyncCapabilityResponse struct {
+	capabilities.CapabilityResponse
+	Err error
+}
+
 type ClientRequest struct {
 	cancelFn         context.CancelFunc
-	responseCh       chan commoncap.CapabilityResponse
+	responseCh       chan asyncCapabilityResponse
 	createdAt        time.Time
 	responseIDCount  map[[32]byte]int
 	errorCount       map[string]int
@@ -101,13 +106,13 @@ func NewClientRequest(ctx context.Context, lggr logger.Logger, req commoncap.Cap
 		responseIDCount:            make(map[[32]byte]int),
 		errorCount:                 make(map[string]int),
 		responseReceived:           responseReceived,
-		responseCh:                 make(chan commoncap.CapabilityResponse, 1),
+		responseCh:                 make(chan asyncCapabilityResponse, 1),
 		wg:                         wg,
 		lggr:                       lggr,
 	}, nil
 }
 
-func (c *ClientRequest) ResponseChan() <-chan commoncap.CapabilityResponse {
+func (c *ClientRequest) ResponseChan() <-chan asyncCapabilityResponse {
 	return c.responseCh
 }
 
@@ -121,11 +126,10 @@ func (c *ClientRequest) Cancel(err error) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 	if !c.respSent {
-		c.sendResponse(commoncap.CapabilityResponse{Err: err})
+		c.sendResponse(asyncCapabilityResponse{Err: err})
 	}
 }
 
-// TODO OnMessage assumes that only one response is received from each peer, if streaming responses need to be supported this will need to be updated
 func (c *ClientRequest) OnMessage(_ context.Context, msg *types.MessageBody) error {
 	c.mux.Lock()
 	defer c.mux.Unlock()
@@ -167,22 +171,22 @@ func (c *ClientRequest) OnMessage(_ context.Context, msg *types.MessageBody) err
 		if c.responseIDCount[responseID] == c.requiredIdenticalResponses {
 			capabilityResponse, err := pb.UnmarshalCapabilityResponse(msg.Payload)
 			if err != nil {
-				c.sendResponse(commoncap.CapabilityResponse{Err: fmt.Errorf("failed to unmarshal capability response: %w", err)})
+				c.sendResponse(asyncCapabilityResponse{Err: fmt.Errorf("failed to unmarshal capability response: %w", err)})
 			} else {
-				c.sendResponse(commoncap.CapabilityResponse{Value: capabilityResponse.Value})
+				c.sendResponse(asyncCapabilityResponse{CapabilityResponse: commoncap.CapabilityResponse{Value: capabilityResponse.Value}})
 			}
 		}
 	} else {
 		c.lggr.Warnw("received error response", "error", remote.SanitizeLogString(msg.ErrorMsg))
 		c.errorCount[msg.ErrorMsg]++
 		if c.errorCount[msg.ErrorMsg] == c.requiredIdenticalResponses {
-			c.sendResponse(commoncap.CapabilityResponse{Err: errors.New(msg.ErrorMsg)})
+			c.sendResponse(asyncCapabilityResponse{Err: errors.New(msg.ErrorMsg)})
 		}
 	}
 	return nil
 }
 
-func (c *ClientRequest) sendResponse(response commoncap.CapabilityResponse) {
+func (c *ClientRequest) sendResponse(response asyncCapabilityResponse) {
 	c.responseCh <- response
 	close(c.responseCh)
 	c.respSent = true

--- a/core/capabilities/remote/target/request/client_request_test.go
+++ b/core/capabilities/remote/target/request/client_request_test.go
@@ -84,7 +84,6 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 	require.NoError(t, err)
 	capabilityResponse := commoncap.CapabilityResponse{
 		Value: m,
-		Err:   nil,
 	}
 
 	rawResponse, err := pb.MarshalCapabilityResponse(capabilityResponse)
@@ -117,7 +116,6 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		require.NoError(t, err)
 		capabilityResponse2 := commoncap.CapabilityResponse{
 			Value: nm,
-			Err:   nil,
 		}
 
 		rawResponse2, err := pb.MarshalCapabilityResponse(capabilityResponse2)

--- a/core/capabilities/remote/target/request/server_request.go
+++ b/core/capabilities/remote/target/request/server_request.go
@@ -125,20 +125,19 @@ func (e *ServerRequest) executeRequest(ctx context.Context, payload []byte) erro
 	}
 
 	e.lggr.Debugw("executing capability", "metadata", capabilityRequest.Metadata)
-	capResponseCh, err := e.capability.Execute(ctxWithTimeout, capabilityRequest)
+	capResponse, err := e.capability.Execute(ctxWithTimeout, capabilityRequest)
 
 	if err != nil {
+		e.lggr.Debugw("received execution error", "workflowExecutionID", capabilityRequest.Metadata.WorkflowExecutionID, "error", err)
 		return fmt.Errorf("failed to execute capability: %w", err)
 	}
 
-	// NOTE working on the assumption that the capability will only ever return one response from its channel
-	capResponse := <-capResponseCh
 	responsePayload, err := pb.MarshalCapabilityResponse(capResponse)
 	if err != nil {
 		return fmt.Errorf("failed to marshal capability response: %w", err)
 	}
 
-	e.lggr.Debugw("received execution results", "workflowExecutionID", capabilityRequest.Metadata.WorkflowExecutionID, "error", capResponse.Err)
+	e.lggr.Debugw("received execution results", "workflowExecutionID", capabilityRequest.Metadata.WorkflowExecutionID)
 	e.setResult(responsePayload)
 	return nil
 }

--- a/core/capabilities/remote/target/request/server_request_test.go
+++ b/core/capabilities/remote/target/request/server_request_test.go
@@ -241,7 +241,6 @@ type TestCapability struct {
 }
 
 func (t TestCapability) Execute(ctx context.Context, request commoncap.CapabilityRequest) (commoncap.CapabilityResponse, error) {
-
 	value := request.Inputs.Underlying["executeValue1"]
 
 	response, err := values.NewMap(map[string]any{"response": value})

--- a/core/capabilities/remote/target/request/server_request_test.go
+++ b/core/capabilities/remote/target/request/server_request_test.go
@@ -240,28 +240,26 @@ type TestCapability struct {
 	abstractTestCapability
 }
 
-func (t TestCapability) Execute(ctx context.Context, request commoncap.CapabilityRequest) (<-chan commoncap.CapabilityResponse, error) {
-	ch := make(chan commoncap.CapabilityResponse, 1)
+func (t TestCapability) Execute(ctx context.Context, request commoncap.CapabilityRequest) (commoncap.CapabilityResponse, error) {
 
 	value := request.Inputs.Underlying["executeValue1"]
 
 	response, err := values.NewMap(map[string]any{"response": value})
 	if err != nil {
-		return nil, err
-	}
-	ch <- commoncap.CapabilityResponse{
-		Value: response,
+		return commoncap.CapabilityResponse{}, err
 	}
 
-	return ch, nil
+	return commoncap.CapabilityResponse{
+		Value: response,
+	}, nil
 }
 
 type TestErrorCapability struct {
 	abstractTestCapability
 }
 
-func (t TestErrorCapability) Execute(ctx context.Context, request commoncap.CapabilityRequest) (<-chan commoncap.CapabilityResponse, error) {
-	return nil, errors.New("an error")
+func (t TestErrorCapability) Execute(ctx context.Context, request commoncap.CapabilityRequest) (commoncap.CapabilityResponse, error) {
+	return commoncap.CapabilityResponse{}, errors.New("an error")
 }
 
 func NewP2PPeerID(t *testing.T) p2ptypes.PeerID {

--- a/core/capabilities/targets/write_target.go
+++ b/core/capabilities/targets/write_target.go
@@ -170,16 +170,7 @@ func evaluate(rawRequest capabilities.CapabilityRequest) (r Request, err error) 
 	return r, nil
 }
 
-func success() <-chan capabilities.CapabilityResponse {
-	callback := make(chan capabilities.CapabilityResponse)
-	go func() {
-		callback <- capabilities.CapabilityResponse{}
-		close(callback)
-	}()
-	return callback
-}
-
-func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.CapabilityRequest) (<-chan capabilities.CapabilityResponse, error) {
+func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
 	// Bind to the contract address on the write path.
 	// Bind() requires a connection to the node's RPCs and
 	// cannot be run during initialization.
@@ -190,7 +181,7 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 			Name:    "forwarder",
 		}})
 		if err != nil {
-			return nil, err
+			return capabilities.CapabilityResponse{}, err
 		}
 		cap.bound = true
 	}
@@ -199,12 +190,12 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 
 	request, err := evaluate(rawRequest)
 	if err != nil {
-		return nil, err
+		return capabilities.CapabilityResponse{}, err
 	}
 
 	rawExecutionID, err := hex.DecodeString(request.Metadata.WorkflowExecutionID)
 	if err != nil {
-		return nil, err
+		return capabilities.CapabilityResponse{}, err
 	}
 
 	// Check whether value was already transmitted on chain
@@ -219,7 +210,7 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 	}
 	var transmissionInfo TransmissionInfo
 	if err = cap.cr.GetLatestValue(ctx, "forwarder", "getTransmissionInfo", primitives.Unconfirmed, queryInputs, &transmissionInfo); err != nil {
-		return nil, fmt.Errorf("failed to getTransmissionInfo latest value: %w", err)
+		return capabilities.CapabilityResponse{}, fmt.Errorf("failed to getTransmissionInfo latest value: %w", err)
 	}
 
 	switch {
@@ -227,10 +218,10 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 		cap.lggr.Infow("non-empty report - transmission not attempted - attempting to push to txmgr", "request", request, "reportLen", len(request.Inputs.SignedReport.Report), "reportContextLen", len(request.Inputs.SignedReport.Context), "nSignatures", len(request.Inputs.SignedReport.Signatures), "executionID", request.Metadata.WorkflowExecutionID)
 	case transmissionInfo.State == 1: // SUCCEEDED
 		cap.lggr.Infow("returning without a transmission attempt - report already onchain ", "executionID", request.Metadata.WorkflowExecutionID)
-		return success(), nil
+		return capabilities.CapabilityResponse{}, nil
 	case transmissionInfo.State == 2: // INVALID_RECEIVER
 		cap.lggr.Infow("returning without a transmission attempt - transmission already attempted, receiver was marked as invalid", "executionID", request.Metadata.WorkflowExecutionID)
-		return success(), nil
+		return capabilities.CapabilityResponse{}, nil
 	case transmissionInfo.State == 3: // FAILED
 		receiverGasMinimum := cap.receiverGasMinimum
 		if request.Config.GasLimit != nil {
@@ -238,17 +229,17 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 		}
 		if transmissionInfo.GasLimit.Uint64() > receiverGasMinimum {
 			cap.lggr.Infow("returning without a transmission attempt - transmission already attempted and failed, sufficient gas was provided", "executionID", request.Metadata.WorkflowExecutionID, "receiverGasMinimum", receiverGasMinimum, "transmissionGasLimit", transmissionInfo.GasLimit)
-			return success(), nil
+			return capabilities.CapabilityResponse{}, nil
 		} else {
 			cap.lggr.Infow("non-empty report - retrying a failed transmission - attempting to push to txmgr", "request", request, "reportLen", len(request.Inputs.SignedReport.Report), "reportContextLen", len(request.Inputs.SignedReport.Context), "nSignatures", len(request.Inputs.SignedReport.Signatures), "executionID", request.Metadata.WorkflowExecutionID, "receiverGasMinimum", receiverGasMinimum, "transmissionGasLimit", transmissionInfo.GasLimit)
 		}
 	default:
-		return nil, fmt.Errorf("unexpected transmission state: %v", transmissionInfo.State)
+		return capabilities.CapabilityResponse{}, fmt.Errorf("unexpected transmission state: %v", transmissionInfo.State)
 	}
 
 	txID, err := uuid.NewUUID() // NOTE: CW expects us to generate an ID, rather than return one
 	if err != nil {
-		return nil, err
+		return capabilities.CapabilityResponse{}, err
 	}
 
 	// Note: The codec that ChainWriter uses to encode the parameters for the contract ABI cannot handle
@@ -284,15 +275,15 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 		if commontypes.ErrSettingTransactionGasLimitNotSupported.Is(err) {
 			meta.GasLimit = nil
 			if err := cap.cw.SubmitTransaction(ctx, "forwarder", "report", req, txID.String(), cap.forwarderAddress, &meta, value); err != nil {
-				return nil, fmt.Errorf("failed to submit transaction: %w", err)
+				return capabilities.CapabilityResponse{}, fmt.Errorf("failed to submit transaction: %w", err)
 			}
 		} else {
-			return nil, fmt.Errorf("failed to submit transaction: %w", err)
+			return capabilities.CapabilityResponse{}, fmt.Errorf("failed to submit transaction: %w", err)
 		}
 	}
 
 	cap.lggr.Debugw("Transaction submitted", "request", request, "transaction", txID)
-	return success(), nil
+	return capabilities.CapabilityResponse{}, nil
 }
 
 func (cap *WriteTarget) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {

--- a/core/capabilities/targets/write_target_test.go
+++ b/core/capabilities/targets/write_target_test.go
@@ -97,9 +97,8 @@ func TestWriteTarget(t *testing.T) {
 			Inputs:   validInputs,
 		}
 
-		ch, err2 := writeTarget.Execute(ctx, req)
+		response, err2 := writeTarget.Execute(ctx, req)
 		require.NoError(t, err2)
-		response := <-ch
 		require.NotNil(t, response)
 	})
 

--- a/core/capabilities/transmission/local_target_capability_test.go
+++ b/core/capabilities/transmission/local_target_capability_test.go
@@ -162,7 +162,7 @@ func randKey() [32]byte {
 
 type mockCapability struct {
 	capabilities.CapabilityInfo
-	capabilities.CallbackExecutable
+	capabilities.Executable
 	response  chan capabilities.CapabilityResponse
 	transform func(capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error)
 }
@@ -175,18 +175,14 @@ func newMockCapability(info capabilities.CapabilityInfo, transform func(capabili
 	}
 }
 
-func (m *mockCapability) Execute(ctx context.Context, req capabilities.CapabilityRequest) (<-chan capabilities.CapabilityResponse, error) {
+func (m *mockCapability) Execute(ctx context.Context, req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
 	cr, err := m.transform(req)
 	if err != nil {
-		return nil, err
+		return capabilities.CapabilityResponse{}, err
 	}
 
-	ch := make(chan capabilities.CapabilityResponse, 10)
-
 	m.response <- cr
-	ch <- cr
-	close(ch)
-	return ch, nil
+	return cr, nil
 }
 
 func (m *mockCapability) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d
+	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7
 	github.com/spf13/cobra v1.8.0

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1190,8 +1190,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8um
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20240905153234-86019f205c9b h1:/PQDTP/ETmEXCv3qokVs5JqMcHDFP8TWdkcQAzs/nQg=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20240905153234-86019f205c9b/go.mod h1:Z9lQ5t20kRk28pzRLnqAJZUVOw8E6/siA3P3MLyKqoM=
-github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d h1:VVtgseTBEJN0/NcewMcka1qwslKhY1HPXs4EEpZa7ek=
-github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d/go.mod h1:D/qaCoq0SxXzg5NRN5FtBRv98VBf+D2NOC++RbvvuOc=
+github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f h1:a6zEDLYgTQ4G+9PgLX8G2bF40BdsOY5//5i+whYwLlQ=
+github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f/go.mod h1:D/qaCoq0SxXzg5NRN5FtBRv98VBf+D2NOC++RbvvuOc=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240710121324-3ed288aa9b45 h1:NBQLtqk8zsyY4qTJs+NElI3aDFTcAo83JHvqD04EvB0=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240710121324-3ed288aa9b45/go.mod h1:LV0h7QBQUpoC2UUi6TcUvcIFm1xjP/DtEcqV8+qeLUs=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240904093355-e40169857652 h1:0aZ3HiEz2bMM5ywHAyKlFMN95qTzpNDn7uvnHLrFX6s=

--- a/core/services/relay/evm/write_target_test.go
+++ b/core/services/relay/evm/write_target_test.go
@@ -209,11 +209,8 @@ func TestEvmWrite(t *testing.T) {
 			Inputs:   validInputs,
 		}
 
-		ch, err := capability.Execute(ctx, req)
+		_, err = capability.Execute(ctx, req)
 		require.NoError(t, err)
-
-		response := <-ch
-		require.Nil(t, response.Err)
 	})
 
 	t.Run("fails with invalid config", func(t *testing.T) {

--- a/core/services/workflows/models.go
+++ b/core/services/workflows/models.go
@@ -79,7 +79,7 @@ func (w *workflow) dependents(start string) ([]*step, error) {
 // step wraps a Vertex with additional context for execution that is mutated by the engine
 type step struct {
 	workflows.Vertex
-	capability capabilities.CallbackCapability
+	capability capabilities.ExecutableCapability
 	info       capabilities.CapabilityInfo
 	config     *values.Map
 }

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.21
 	github.com/smartcontractkit/chainlink-automation v1.0.4
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20240905153234-86019f205c9b
-	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d
+	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240710121324-3ed288aa9b45
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240904093355-e40169857652
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240710170203-5b41615da827

--- a/go.sum
+++ b/go.sum
@@ -1147,8 +1147,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8um
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20240905153234-86019f205c9b h1:/PQDTP/ETmEXCv3qokVs5JqMcHDFP8TWdkcQAzs/nQg=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20240905153234-86019f205c9b/go.mod h1:Z9lQ5t20kRk28pzRLnqAJZUVOw8E6/siA3P3MLyKqoM=
-github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d h1:VVtgseTBEJN0/NcewMcka1qwslKhY1HPXs4EEpZa7ek=
-github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d/go.mod h1:D/qaCoq0SxXzg5NRN5FtBRv98VBf+D2NOC++RbvvuOc=
+github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f h1:a6zEDLYgTQ4G+9PgLX8G2bF40BdsOY5//5i+whYwLlQ=
+github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f/go.mod h1:D/qaCoq0SxXzg5NRN5FtBRv98VBf+D2NOC++RbvvuOc=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240710121324-3ed288aa9b45 h1:NBQLtqk8zsyY4qTJs+NElI3aDFTcAo83JHvqD04EvB0=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240710121324-3ed288aa9b45/go.mod h1:LV0h7QBQUpoC2UUi6TcUvcIFm1xjP/DtEcqV8+qeLUs=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240904093355-e40169857652 h1:0aZ3HiEz2bMM5ywHAyKlFMN95qTzpNDn7uvnHLrFX6s=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.21
 	github.com/smartcontractkit/chainlink-automation v1.0.4
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20240905153234-86019f205c9b
-	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d
+	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1425,8 +1425,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8um
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20240905153234-86019f205c9b h1:/PQDTP/ETmEXCv3qokVs5JqMcHDFP8TWdkcQAzs/nQg=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20240905153234-86019f205c9b/go.mod h1:Z9lQ5t20kRk28pzRLnqAJZUVOw8E6/siA3P3MLyKqoM=
-github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d h1:VVtgseTBEJN0/NcewMcka1qwslKhY1HPXs4EEpZa7ek=
-github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d/go.mod h1:D/qaCoq0SxXzg5NRN5FtBRv98VBf+D2NOC++RbvvuOc=
+github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f h1:a6zEDLYgTQ4G+9PgLX8G2bF40BdsOY5//5i+whYwLlQ=
+github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f/go.mod h1:D/qaCoq0SxXzg5NRN5FtBRv98VBf+D2NOC++RbvvuOc=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240710121324-3ed288aa9b45 h1:NBQLtqk8zsyY4qTJs+NElI3aDFTcAo83JHvqD04EvB0=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240710121324-3ed288aa9b45/go.mod h1:LV0h7QBQUpoC2UUi6TcUvcIFm1xjP/DtEcqV8+qeLUs=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240904093355-e40169857652 h1:0aZ3HiEz2bMM5ywHAyKlFMN95qTzpNDn7uvnHLrFX6s=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d
+	github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.1
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.0

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1395,8 +1395,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8um
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20240905153234-86019f205c9b h1:/PQDTP/ETmEXCv3qokVs5JqMcHDFP8TWdkcQAzs/nQg=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20240905153234-86019f205c9b/go.mod h1:Z9lQ5t20kRk28pzRLnqAJZUVOw8E6/siA3P3MLyKqoM=
-github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d h1:VVtgseTBEJN0/NcewMcka1qwslKhY1HPXs4EEpZa7ek=
-github.com/smartcontractkit/chainlink-common v0.2.2-0.20240905145927-2ff0f9628f4d/go.mod h1:D/qaCoq0SxXzg5NRN5FtBRv98VBf+D2NOC++RbvvuOc=
+github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f h1:a6zEDLYgTQ4G+9PgLX8G2bF40BdsOY5//5i+whYwLlQ=
+github.com/smartcontractkit/chainlink-common v0.2.2-0.20240906132254-14a5c7af361f/go.mod h1:D/qaCoq0SxXzg5NRN5FtBRv98VBf+D2NOC++RbvvuOc=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240710121324-3ed288aa9b45 h1:NBQLtqk8zsyY4qTJs+NElI3aDFTcAo83JHvqD04EvB0=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240710121324-3ed288aa9b45/go.mod h1:LV0h7QBQUpoC2UUi6TcUvcIFm1xjP/DtEcqV8+qeLUs=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240904093355-e40169857652 h1:0aZ3HiEz2bMM5ywHAyKlFMN95qTzpNDn7uvnHLrFX6s=


### PR DESCRIPTION
Change the Execute Capability API from Async to sync. https://smartcontract-it.atlassian.net/browse/CAPPL-27

As its used right now, in all places, callers of the API expect one result and block on the channel to wait for that single result, i.e.they are effectively sync calls. Moving to a sync API will improve the capability developer experience and protect against bugs where the capability developer sends more that one result or forgets to close the channel (for example this would break current remote target implementation). This does not preclude adding an additional Async capability type in future should the need arise.

Requires:

- https://github.com/smartcontractkit/chainlink-common/pull/748