### PR TITLE
core/services/chainlink: normalize feature config

### DIFF
--- a/core/config/app_config.go
+++ b/core/config/app_config.go
@@ -56,8 +56,6 @@ type AppConfig interface {
 	Threshold() Threshold
 	WebServer() WebServer
 	Tracing() Tracing
-
-	FeatureMultiFeedsManagers() bool
 }
 
 type DatabaseBackupMode string

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -577,6 +577,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 			jobSpawner,
 			keyStore,
 			cfg,
+			cfg.Feature(),
 			cfg.Insecure(),
 			cfg.JobPipeline(),
 			cfg.OCR(),

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -282,10 +282,6 @@ func (g *generalConfig) FeatureFeedsManager() bool {
 	return *g.c.Feature.FeedsManager
 }
 
-func (g *generalConfig) FeatureMultiFeedsManagers() bool {
-	return *g.c.Feature.MultiFeedsManagers
-}
-
 func (g *generalConfig) OCR() config.OCR {
 	return &ocrConfig{c: g.c.OCR}
 }

--- a/core/services/chainlink/mocks/general_config.go
+++ b/core/services/chainlink/mocks/general_config.go
@@ -694,51 +694,6 @@ func (_c *GeneralConfig_Feature_Call) RunAndReturn(run func() config.Feature) *G
 	return _c
 }
 
-// FeatureMultiFeedsManagers provides a mock function with given fields:
-func (_m *GeneralConfig) FeatureMultiFeedsManagers() bool {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for FeatureMultiFeedsManagers")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// GeneralConfig_FeatureMultiFeedsManagers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FeatureMultiFeedsManagers'
-type GeneralConfig_FeatureMultiFeedsManagers_Call struct {
-	*mock.Call
-}
-
-// FeatureMultiFeedsManagers is a helper method to define mock.On call
-func (_e *GeneralConfig_Expecter) FeatureMultiFeedsManagers() *GeneralConfig_FeatureMultiFeedsManagers_Call {
-	return &GeneralConfig_FeatureMultiFeedsManagers_Call{Call: _e.mock.On("FeatureMultiFeedsManagers")}
-}
-
-func (_c *GeneralConfig_FeatureMultiFeedsManagers_Call) Run(run func()) *GeneralConfig_FeatureMultiFeedsManagers_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *GeneralConfig_FeatureMultiFeedsManagers_Call) Return(_a0 bool) *GeneralConfig_FeatureMultiFeedsManagers_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *GeneralConfig_FeatureMultiFeedsManagers_Call) RunAndReturn(run func() bool) *GeneralConfig_FeatureMultiFeedsManagers_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // FluxMonitor provides a mock function with given fields:
 func (_m *GeneralConfig) FluxMonitor() config.FluxMonitor {
 	ret := _m.Called()

--- a/core/services/feeds/config.go
+++ b/core/services/feeds/config.go
@@ -10,7 +10,10 @@ import (
 type GeneralConfig interface {
 	OCR() coreconfig.OCR
 	Insecure() coreconfig.Insecure
-	FeatureMultiFeedsManagers() bool
+}
+
+type FeatureConfig interface {
+	MultiFeedsManagers() bool
 }
 
 type JobConfig interface {

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -124,6 +124,7 @@ type service struct {
 	ocr2KeyStore        keystore.OCR2
 	jobSpawner          job.Spawner
 	gCfg                GeneralConfig
+	featCfg             FeatureConfig
 	insecureCfg         InsecureConfig
 	jobCfg              JobConfig
 	ocrCfg              OCRConfig
@@ -143,6 +144,7 @@ func NewService(
 	jobSpawner job.Spawner,
 	keyStore keystore.Master,
 	gCfg GeneralConfig,
+	fCfg FeatureConfig,
 	insecureCfg InsecureConfig,
 	jobCfg JobConfig,
 	ocrCfg OCRConfig,
@@ -163,6 +165,7 @@ func NewService(
 		ocr1KeyStore:        keyStore.OCR(),
 		ocr2KeyStore:        keyStore.OCR2(),
 		gCfg:                gCfg,
+		featCfg:             fCfg,
 		insecureCfg:         insecureCfg,
 		jobCfg:              jobCfg,
 		ocrCfg:              ocrCfg,
@@ -187,7 +190,7 @@ type RegisterManagerParams struct {
 // RegisterManager registers a new ManagerService and attempts to establish a
 // connection.
 func (s *service) RegisterManager(ctx context.Context, params RegisterManagerParams) (int64, error) {
-	if s.gCfg.FeatureMultiFeedsManagers() {
+	if s.featCfg.MultiFeedsManagers() {
 		exists, err := s.orm.ManagerExists(ctx, params.PublicKey)
 		if err != nil {
 			return 0, err
@@ -1034,7 +1037,7 @@ func (s *service) Start(ctx context.Context) error {
 			return nil
 		}
 
-		if s.gCfg.FeatureMultiFeedsManagers() {
+		if s.featCfg.MultiFeedsManagers() {
 			s.lggr.Infof("starting connection to %d feeds managers", len(mgrs))
 			for _, mgr := range mgrs {
 				s.connectFeedManager(ctx, mgr, privkey)

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -194,7 +194,7 @@ func setupTestServiceCfg(t *testing.T, overrideCfg func(c *chainlink.Config, s *
 	keyStore.On("P2P").Return(p2pKeystore)
 	keyStore.On("OCR").Return(ocr1Keystore)
 	keyStore.On("OCR2").Return(ocr2Keystore)
-	svc := feeds.NewService(orm, jobORM, db, spawner, keyStore, gcfg, gcfg.Insecure(), gcfg.JobPipeline(), gcfg.OCR(), gcfg.OCR2(), legacyChains, lggr, "1.0.0", nil)
+	svc := feeds.NewService(orm, jobORM, db, spawner, keyStore, gcfg, gcfg.Feature(), gcfg.Insecure(), gcfg.JobPipeline(), gcfg.OCR(), gcfg.OCR2(), legacyChains, lggr, "1.0.0", nil)
 	svc.SetConnectionsManager(connMgr)
 
 	return &TestService{


### PR DESCRIPTION
The new `MultiFeedsManagers` feature flag came with an extra exceptional method for accessing indirectly via global config. This PR removes `FeatureMultiFeedsManagers()` and adjusts callers to use the standard pattern.