### PR TITLE
Bcfr 880/fix flakey resume pending runs test

### DIFF
--- a/.changeset/cool-queens-peel.md
+++ b/.changeset/cool-queens-peel.md
@@ -1,5 +1,5 @@
 ---
-"chainlink": minor
+"chainlink": patch
 ---
 
 fix flakey confirmer resumePendingRuns test #internal

--- a/.changeset/cool-queens-peel.md
+++ b/.changeset/cool-queens-peel.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+fix flakey confirmer resumePendingRuns test #internal

--- a/common/txmgr/confirmer.go
+++ b/common/txmgr/confirmer.go
@@ -1280,11 +1280,11 @@ func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) Res
 		}
 
 		ec.lggr.Debugw("Callback: resuming tx with receipt", "output", output, "taskErr", taskErr, "pipelineTaskRunID", data.ID)
-		if err := ec.resumeCallback(ctx, data.ID, output, taskErr); err != nil {
+		if err = ec.resumeCallback(ctx, data.ID, output, taskErr); err != nil {
 			return fmt.Errorf("failed to resume suspended pipeline run: %w", err)
 		}
 		// Mark tx as having completed callback
-		if err := ec.txStore.UpdateTxCallbackCompleted(ctx, data.ID, ec.chainID); err != nil {
+		if err = ec.txStore.UpdateTxCallbackCompleted(ctx, data.ID, ec.chainID); err != nil {
 			return err
 		}
 	}

--- a/core/chains/evm/txmgr/confirmer_test.go
+++ b/core/chains/evm/txmgr/confirmer_test.go
@@ -3176,7 +3176,7 @@ func TestEthConfirmer_ResumePendingRuns(t *testing.T) {
 			assert.Nil(t, data.value)
 
 		case <-time.After(tests.WaitTimeout(t)):
-			t.Errorf("no value received")
+			t.Fatal("no value received")
 		}
 		wg.Wait()
 	})


### PR DESCRIPTION
### Description
A resume pending runs test in the Confirmer was picked up as flakey. The problem was the unit test exited before waiting for a in-test goroutine to finish, causing context cancel error in the go-routine. This PR fixes it by using waitgroup instead.

### Acceptance Criteria
- TestEthConfirmer_ResumePendingRuns’s processes eth_txes with receipt older than minConfirmations that reverted test no longer flakes
- The same changes are applied to processes eth_txes with receipts older than minConfirmations in case it has the same issue

### Tickets:
[BCFR-880](https://smartcontract-it.atlassian.net/browse/BCFR-880)


[BCFR-880]: https://smartcontract-it.atlassian.net/browse/BCFR-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ