### PR TITLE
ran nix flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1719997877,
-        "narHash": "sha256-/Edw+w0PiGgxwnCeJycM0VgH4HtlCi91v1d8xbi+REE=",
+        "lastModified": 1725354688,
+        "narHash": "sha256-KHHFemVt6C/hbGoMzIq7cpxmjdp+KZVZaqbvx02aliY=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "02febba4f1cf0606d790acdb24adcf7a64afb4e1",
+        "rev": "671672bd60a0d2e5f6757638fdf27e806df755a4",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1720957393,
-        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "lastModified": 1725103162,
+        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
After https://github.com/smartcontractkit/chainlink/pull/14190 got merged, `nix develop` still installs goreleaser 2.0.1 which is incompatible with the current configuration:

```
build:app + goreleaser release --snapshot --clean --config .goreleaser.devspace.yaml
build:app   • starting release...
build:app   ⨯ release failed after 0s                          error=yaml: unmarshal errors:
build:app   line 79: field version_template not found in type config.Snapshot
```

This PR is the result of running `nix flake update`, which fixes the above issue. 

Relates to https://smartcontract-it.atlassian.net/browse/CRIB-369

### Requires Dependencies
N/A

### Resolves Dependencies
Together with https://github.com/smartcontractkit/crib/pull/141, fixes https://smartcontract-it.atlassian.net/browse/CRIB-369