### PR TITLE
[TT-1609] Notify about compatibility pipeline failure if building image failed

### DIFF
--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -704,7 +704,7 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
-    needs: [run-client-compatibility-matrix, should-run, select-versions, build-chainlink]
+    needs: [run-client-compatibility-matrix, should-run, select-versions, build-chainlink, prepare-compatibility-matrix]
     steps:
       - name: Debug Result
         run: echo ${{ join(needs.*.result, ',') }}
@@ -731,7 +731,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": "${{ contains(join(needs.*.result, ','), 'failure') && format('Some tests failed, notifying <!subteam^{0}|bix-ship-emergent-task>', secrets.COMPAT_SLACK_NOTIFICATION_HANDLE) || needs.build-chainlink.result == 'failure' && 'Failed to build Chainlink image, notifying <!subteam^S06US88D6AK|guardian-test-tooling>' || 'All Good!' }}"
+                        "text": "${{ needs.prepare-compatibility-matrix.result == 'failure' && 'Failed to prepare test matrix, notifying <!subteam^S06US88D6AK|guardian-test-tooling>' || needs.build-chainlink.result == 'failure' && 'Failed to build Chainlink image, notifying <!subteam^S06US88D6AK|guardian-test-tooling>' || contains(join(needs.*.result, ','), 'failure') && format('Some tests failed, notifying <!subteam^{0}|bix-ship-emergent-task>', secrets.COMPAT_SLACK_NOTIFICATION_HANDLE) || 'All Good!' }}"
                       }
                     },
                     {

--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -323,6 +323,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [should-run, select-versions]
     steps:
+      # TODO: remove me
+      - run: exit 1
       - name: Checkout the repo
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:

--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -323,8 +323,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [should-run, select-versions]
     steps:
-      # TODO: remove me
-      - run: exit 1
       - name: Checkout the repo
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:

--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -98,15 +98,21 @@ jobs:
         id: should-run
         run: |
           if [ "${{ needs.check-dependency-bump.outputs.dependency_changed }}" == "true" ]; then
+            echo "## Build trigger" >> $GITHUB_STEP_SUMMARY
+            echo "go-ethereum dependency bump" >> $GITHUB_STEP_SUMMARY
             echo "Will run tests, because go-ethereum dependency was bumped"
             echo "should_run=true" >> $GITHUB_OUTPUT
           elif [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+            echo "## Build trigger" >> $GITHUB_STEP_SUMMARY
+            echo "schedule" >> $GITHUB_STEP_SUMMARY    
             echo "Will run tests, because trigger event was $GITHUB_EVENT_NAME"
             echo "should_run=true" >> $GITHUB_OUTPUT
           elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             echo "Will run tests, because trigger event was $GITHUB_EVENT_NAME"
             echo "should_run=true" >> $GITHUB_OUTPUT          
           elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            echo "## Build trigger" >> $GITHUB_STEP_SUMMARY
+            echo "new tag" >> $GITHUB_STEP_SUMMARY
             echo "Will run tests, because new tag was created"
             echo "should_run=true" >> $GITHUB_OUTPUT
           else
@@ -696,7 +702,7 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
-    needs: [run-client-compatibility-matrix, should-run, select-versions]
+    needs: [run-client-compatibility-matrix, should-run, select-versions, build-chainlink]
     steps:
       - name: Debug Result
         run: echo ${{ join(needs.*.result, ',') }}
@@ -709,7 +715,7 @@ jobs:
             {
               "attachments": [
                 {
-                  "color": "${{ contains(join(needs.*.result, ','), 'failure') && '#C62828' || '#2E7D32' }}",
+                  "color": "${{ (contains(join(needs.*.result, ','), 'failure') || needs.build-chainlink.result == 'failure') && '#C62828' || '#2E7D32' }}",
                   "blocks": [
                     {
                       "type": "header",
@@ -723,7 +729,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": "${{ contains(join(needs.*.result, ','), 'failure') && format('Some tests failed, notifying <!subteam^{0}|bix-ship-emergent-task>', secrets.COMPAT_SLACK_NOTIFICATION_HANDLE) || 'All Good!' }}"
+                        "text": "${{ contains(join(needs.*.result, ','), 'failure') && format('Some tests failed, notifying <!subteam^{0}|bix-ship-emergent-task>', secrets.COMPAT_SLACK_NOTIFICATION_HANDLE) || needs.build-chainlink.result == 'failure' && 'Failed to build Chainlink image, notifying <!subteam^S06US88D6AK|guardian-test-tooling>' || 'All Good!' }}"
                       }
                     },
                     {

--- a/integration-tests/smoke/cron_test.go
+++ b/integration-tests/smoke/cron_test.go
@@ -39,9 +39,6 @@ func TestCronBasic(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	// todo: remove me
-	require.True(t, false, "on purpose")
-
 	err = env.MockAdapter.SetAdapterBasedIntValuePath("/variable", []string{http.MethodGet, http.MethodPost}, 5)
 	require.NoError(t, err, "Setting value path in mock adapter shouldn't fail")
 

--- a/integration-tests/smoke/cron_test.go
+++ b/integration-tests/smoke/cron_test.go
@@ -39,6 +39,9 @@ func TestCronBasic(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
+	// todo: remove me
+	require.True(t, false, "on purpose")
+
 	err = env.MockAdapter.SetAdapterBasedIntValuePath("/variable", []string{http.MethodGet, http.MethodPost}, 5)
 	require.NoError(t, err, "Setting value path in mock adapter shouldn't fail")
 


### PR DESCRIPTION
This PR adds two small modifications:
* notifying tt guardian via Slack if building CL image fails
* notifying tt guardian via Slack if preparing test matrix fails

Tests:
- [x] fail image building and check if notification is sent
![image](https://github.com/user-attachments/assets/4082828f-79ce-4b80-8f1f-d64c2a2dcfcb)
- [x] fail test matrix preparation and check if notification is sent
![image](https://github.com/user-attachments/assets/626115c6-8c37-420c-b5c9-947e0a79b6ba)
- [x] fail a test and see if bix is notified 
![image](https://github.com/user-attachments/assets/70ffbd1f-08ff-452e-87bf-59d88bcc7818)