### PR TITLE
[CAPPL-20] Support per-method handlers in GatewayConnector

### DIFF
--- a/.changeset/thick-jobs-kneel.md
+++ b/.changeset/thick-jobs-kneel.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Support per-method handlers in GatewayConnector

--- a/core/scripts/gateway/connector/run_connector.go
+++ b/core/scripts/gateway/connector/run_connector.go
@@ -69,7 +69,13 @@ func main() {
 	sampleKey, _ := crypto.HexToECDSA("cd47d3fafdbd652dd2b66c6104fa79b372c13cb01f4a4fbfc36107cce913ac1d")
 	lggr, _ := logger.NewLogger()
 	client := &client{privateKey: sampleKey, lggr: lggr}
-	connector, _ := connector.NewGatewayConnector(&cfg, client, client, clockwork.NewRealClock(), lggr)
+	// client acts as a signer here
+	connector, _ := connector.NewGatewayConnector(&cfg, client, clockwork.NewRealClock(), lggr)
+	err = connector.AddHandler([]string{"test_method"}, client)
+	if err != nil {
+		fmt.Println("error adding handler:", err)
+		return
+	}
 	client.connector = connector
 
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)

--- a/core/services/gateway/connector/mocks/gateway_connector.go
+++ b/core/services/gateway/connector/mocks/gateway_connector.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	api "github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
+	connector "github.com/smartcontractkit/chainlink/v2/core/services/gateway/connector"
 
 	context "context"
 
@@ -23,6 +24,53 @@ type GatewayConnector_Expecter struct {
 
 func (_m *GatewayConnector) EXPECT() *GatewayConnector_Expecter {
 	return &GatewayConnector_Expecter{mock: &_m.Mock}
+}
+
+// AddHandler provides a mock function with given fields: methods, handler
+func (_m *GatewayConnector) AddHandler(methods []string, handler connector.GatewayConnectorHandler) error {
+	ret := _m.Called(methods, handler)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddHandler")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string, connector.GatewayConnectorHandler) error); ok {
+		r0 = rf(methods, handler)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// GatewayConnector_AddHandler_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddHandler'
+type GatewayConnector_AddHandler_Call struct {
+	*mock.Call
+}
+
+// AddHandler is a helper method to define mock.On call
+//   - methods []string
+//   - handler connector.GatewayConnectorHandler
+func (_e *GatewayConnector_Expecter) AddHandler(methods interface{}, handler interface{}) *GatewayConnector_AddHandler_Call {
+	return &GatewayConnector_AddHandler_Call{Call: _e.mock.On("AddHandler", methods, handler)}
+}
+
+func (_c *GatewayConnector_AddHandler_Call) Run(run func(methods []string, handler connector.GatewayConnectorHandler)) *GatewayConnector_AddHandler_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]string), args[1].(connector.GatewayConnectorHandler))
+	})
+	return _c
+}
+
+func (_c *GatewayConnector_AddHandler_Call) Return(_a0 error) *GatewayConnector_AddHandler_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *GatewayConnector_AddHandler_Call) RunAndReturn(run func([]string, connector.GatewayConnectorHandler) error) *GatewayConnector_AddHandler_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // ChallengeResponse provides a mock function with given fields: _a0, challenge

--- a/core/services/gateway/integration_tests/gateway_integration_test.go
+++ b/core/services/gateway/integration_tests/gateway_integration_test.go
@@ -152,8 +152,10 @@ func TestIntegration_Gateway_NoFullNodes_BasicConnectionAndMessage(t *testing.T)
 
 	// Launch Connector
 	client := &client{privateKey: nodeKeys.PrivateKey}
-	connector, err := connector.NewGatewayConnector(parseConnectorConfig(t, nodeConfigTemplate, nodeKeys.Address, nodeUrl), client, client, clockwork.NewRealClock(), lggr)
+	// client acts as a signer here
+	connector, err := connector.NewGatewayConnector(parseConnectorConfig(t, nodeConfigTemplate, nodeKeys.Address, nodeUrl), client, clockwork.NewRealClock(), lggr)
 	require.NoError(t, err)
+	require.NoError(t, connector.AddHandler([]string{"test"}, client))
 	client.connector = connector
 	servicetest.Run(t, connector)
 

--- a/core/services/ocr2/plugins/functions/plugin.go
+++ b/core/services/ocr2/plugins/functions/plugin.go
@@ -23,6 +23,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/functions"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/connector"
 	hc "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/common"
+	hf "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/functions"
 	gwAllowlist "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/functions/allowlist"
 	gwSubscriptions "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/functions/subscriptions"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -174,11 +175,12 @@ func NewFunctionsServices(ctx context.Context, functionsOracleArgs, thresholdOra
 			return nil, errors.Wrap(err, "failed to create a OnchainSubscriptions")
 		}
 		connectorLogger := conf.Logger.Named("GatewayConnector").With("jobName", conf.Job.PipelineSpec.JobName)
-		connector, err2 := NewConnector(ctx, &pluginConfig, conf.EthKeystore, conf.Chain.ID(), s4Storage, allowlist, rateLimiter, subscriptions, functionsListener, offchainTransmitter, connectorLogger)
+		connector, handler, err2 := NewConnector(ctx, &pluginConfig, conf.EthKeystore, conf.Chain.ID(), s4Storage, allowlist, rateLimiter, subscriptions, functionsListener, offchainTransmitter, connectorLogger)
 		if err2 != nil {
 			return nil, errors.Wrap(err, "failed to create a GatewayConnector")
 		}
 		allServices = append(allServices, connector)
+		allServices = append(allServices, handler)
 	} else {
 		listenerLogger.Warn("Insufficient config, GatewayConnector will not be enabled")
 	}
@@ -201,29 +203,34 @@ func NewFunctionsServices(ctx context.Context, functionsOracleArgs, thresholdOra
 	return allServices, nil
 }
 
-func NewConnector(ctx context.Context, pluginConfig *config.PluginConfig, ethKeystore keystore.Eth, chainID *big.Int, s4Storage s4.Storage, allowlist gwAllowlist.OnchainAllowlist, rateLimiter *hc.RateLimiter, subscriptions gwSubscriptions.OnchainSubscriptions, listener functions.FunctionsListener, offchainTransmitter functions.OffchainTransmitter, lggr logger.Logger) (connector.GatewayConnector, error) {
+func NewConnector(ctx context.Context, pluginConfig *config.PluginConfig, ethKeystore keystore.Eth, chainID *big.Int, s4Storage s4.Storage, allowlist gwAllowlist.OnchainAllowlist, rateLimiter *hc.RateLimiter, subscriptions gwSubscriptions.OnchainSubscriptions, listener functions.FunctionsListener, offchainTransmitter functions.OffchainTransmitter, lggr logger.Logger) (connector.GatewayConnector, connector.GatewayConnectorHandler, error) {
 	enabledKeys, err := ethKeystore.EnabledKeysForChain(ctx, chainID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	configuredNodeAddress := common.HexToAddress(pluginConfig.GatewayConnectorConfig.NodeAddress)
 	idx := slices.IndexFunc(enabledKeys, func(key ethkey.KeyV2) bool { return key.Address == configuredNodeAddress })
 	if idx == -1 {
-		return nil, errors.New("key for configured node address not found")
+		return nil, nil, errors.New("key for configured node address not found")
 	}
 	signerKey := enabledKeys[idx].ToEcdsaPrivKey()
 	if enabledKeys[idx].ID() != pluginConfig.GatewayConnectorConfig.NodeAddress {
-		return nil, errors.New("node address mismatch")
+		return nil, nil, errors.New("node address mismatch")
 	}
 
 	handler, err := functions.NewFunctionsConnectorHandler(pluginConfig, signerKey, s4Storage, allowlist, rateLimiter, subscriptions, listener, offchainTransmitter, lggr)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	connector, err := connector.NewGatewayConnector(pluginConfig.GatewayConnectorConfig, handler, handler, clockwork.NewRealClock(), lggr)
+	// handler acts as a signer here
+	connector, err := connector.NewGatewayConnector(pluginConfig.GatewayConnectorConfig, handler, clockwork.NewRealClock(), lggr)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+	err = connector.AddHandler([]string{hf.MethodSecretsSet, hf.MethodSecretsList, hf.MethodHeartbeat}, handler)
+	if err != nil {
+		return nil, nil, err
 	}
 	handler.SetConnector(connector)
-	return connector, nil
+	return connector, handler, nil
 }

--- a/core/services/ocr2/plugins/functions/plugin_test.go
+++ b/core/services/ocr2/plugins/functions/plugin_test.go
@@ -47,7 +47,7 @@ func TestNewConnector_Success(t *testing.T) {
 	config := &config.PluginConfig{
 		GatewayConnectorConfig: gwcCfg,
 	}
-	_, err = functions.NewConnector(ctx, config, ethKeystore, chainID, s4Storage, allowlist, rateLimiter, subscriptions, listener, offchainTransmitter, logger.TestLogger(t))
+	_, _, err = functions.NewConnector(ctx, config, ethKeystore, chainID, s4Storage, allowlist, rateLimiter, subscriptions, listener, offchainTransmitter, logger.TestLogger(t))
 	require.NoError(t, err)
 }
 
@@ -78,6 +78,6 @@ func TestNewConnector_NoKeyForConfiguredAddress(t *testing.T) {
 	config := &config.PluginConfig{
 		GatewayConnectorConfig: gwcCfg,
 	}
-	_, err = functions.NewConnector(ctx, config, ethKeystore, chainID, s4Storage, allowlist, rateLimiter, subscriptions, listener, offchainTransmitter, logger.TestLogger(t))
+	_, _, err = functions.NewConnector(ctx, config, ethKeystore, chainID, s4Storage, allowlist, rateLimiter, subscriptions, listener, offchainTransmitter, logger.TestLogger(t))
 	require.Error(t, err)
 }


### PR DESCRIPTION
Making GatewayConnector compatible with the new design, where each capability is able to add its own handler independently.