### PR TITLE
add missing $ before variable name

### DIFF
--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -170,7 +170,7 @@ jobs:
               implementations_arr+=("nethermind")
             fi
             new_reth=$(ghlatestreleasechecker "paradigmxyz/reth" $RELEASED_DAYS_AGO)
-            if [ "new_reth" != "none" ]; then
+            if [ "$new_reth" != "none" ]; then
               echo "New reth release found: $new_reth"
               implementations_arr+=("reth")
             fi


### PR DESCRIPTION
Why?
Otherwise schedule always runs Reth tests, even if there is no new release.