### PR TITLE
[TT-1546] change the parameter of chains' Confirm() function

### DIFF
--- a/integration-tests/deployment/ccip/changeset/2_initial_deploy_test.go
+++ b/integration-tests/deployment/ccip/changeset/2_initial_deploy_test.go
@@ -101,21 +101,21 @@ func Test0002_InitialDeploy(t *testing.T) {
 				Value:  fee,
 			})
 			require.NoError(t, err)
-			_, err = srcChain.Confirm(tx.Hash())
+			_, err = srcChain.Confirm(tx)
 			require.NoError(t, err)
 
 			// TODO: should be able to avoid this by using native?
 			tx, err = state.Chains[src].Weth9.Approve(e.Chains[src].DeployerKey,
 				state.Chains[src].Router.Address(), fee)
 			require.NoError(t, err)
-			_, err = srcChain.Confirm(tx.Hash())
+			_, err = srcChain.Confirm(tx)
 			require.NoError(t, err)
 
 			t.Logf("Sending CCIP request from chain selector %d to chain selector %d",
 				src, dest)
 			tx, err = state.Chains[src].Router.CcipSend(e.Chains[src].DeployerKey, dest, msg)
 			require.NoError(t, err)
-			_, err = srcChain.Confirm(tx.Hash())
+			_, err = srcChain.Confirm(tx)
 			require.NoError(t, err)
 		}
 	}

--- a/integration-tests/deployment/ccip/deploy.go
+++ b/integration-tests/deployment/ccip/deploy.go
@@ -87,7 +87,7 @@ func deployContract[C Contracts](
 		lggr.Errorw("Failed to deploy contract", "err", contractDeploy.Err)
 		return nil, contractDeploy.Err
 	}
-	_, err := chain.Confirm(contractDeploy.Tx.Hash())
+	_, err := chain.Confirm(contractDeploy.Tx)
 	if err != nil {
 		lggr.Errorw("Failed to confirm deployment", "err", err)
 		return nil, err

--- a/integration-tests/deployment/ccip/deploy_home_chain.go
+++ b/integration-tests/deployment/ccip/deploy_home_chain.go
@@ -143,7 +143,7 @@ func AddNodes(
 	if err != nil {
 		return err
 	}
-	_, err = chain.Confirm(tx.Hash())
+	_, err = chain.Confirm(tx)
 	return err
 }
 

--- a/integration-tests/deployment/environment.go
+++ b/integration-tests/deployment/environment.go
@@ -43,7 +43,7 @@ type Chain struct {
 	Client   OnchainClient
 	// Note the Sign function can be abstract supporting a variety of key storage mechanisms (e.g. KMS etc).
 	DeployerKey *bind.TransactOpts
-	Confirm     func(tx common.Hash) (uint64, error)
+	Confirm     func(tx *types.Transaction) (uint64, error)
 }
 
 type Environment struct {
@@ -72,7 +72,7 @@ func ConfirmIfNoError(chain Chain, tx *types.Transaction, err error) (uint64, er
 		}
 		return 0, err
 	}
-	return chain.Confirm(tx.Hash())
+	return chain.Confirm(tx)
 }
 
 func MaybeDataErr(err error) error {

--- a/integration-tests/deployment/memory/environment.go
+++ b/integration-tests/deployment/memory/environment.go
@@ -2,10 +2,11 @@ package memory
 
 import (
 	"context"
+	"fmt"
+	"github.com/ethereum/go-ethereum/core/types"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/hashicorp/consul/sdk/freeport"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
@@ -39,16 +40,19 @@ func NewMemoryChains(t *testing.T, numChains int) map[uint64]deployment.Chain {
 			Selector:    sel,
 			Client:      chain.Backend,
 			DeployerKey: chain.DeployerKey,
-			Confirm: func(tx common.Hash) (uint64, error) {
+			Confirm: func(tx *types.Transaction) (uint64, error) {
+				if tx == nil {
+					return 0, fmt.Errorf("tx was nil, nothing to confirm")
+				}
 				for {
 					chain.Backend.Commit()
-					receipt, err := chain.Backend.TransactionReceipt(context.Background(), tx)
+					receipt, err := chain.Backend.TransactionReceipt(context.Background(), tx.Hash())
 					if err != nil {
 						t.Log("failed to get receipt", err)
 						continue
 					}
 					if receipt.Status == 0 {
-						t.Logf("Status (reverted) %d for txhash %s\n", receipt.Status, tx.String())
+						t.Logf("Status (reverted) %d for txhash %s\n", receipt.Status, tx.Hash().Hex())
 					}
 					return receipt.BlockNumber.Uint64(), nil
 				}

--- a/integration-tests/deployment/memory/environment.go
+++ b/integration-tests/deployment/memory/environment.go
@@ -3,14 +3,15 @@ package memory
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core/types"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hashicorp/consul/sdk/freeport"
-	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/deployment"
 


### PR DESCRIPTION
pass `*types.Transaction` instead of `common.Hash` to chain's `Confirm()` function, so that Seth can use `Decode()` function to wait for tx to be mined and then trace it.