### PR TITLE
Update STYLE_GUIDE.md

### DIFF
--- a/contracts/STYLE_GUIDE.md
+++ b/contracts/STYLE_GUIDE.md
@@ -219,7 +219,8 @@ The original error will not be human-readable in an off-chain explorer because i
 - Otherwise, Solidity contracts should have a pragma that is locked to a specific version.
   - Example: Most concrete contracts.
 - Avoid changing pragmas after the audit. Unless there is a bug that affects your contract, then you should try to stick to a known good pragma. In practice, this means we typically only support one (occasionally two) pragma for any “major”(minor by Semver naming) Solidity version.
-- The current advised pragma is `0.8.19` or higher, lower versions should be avoided when starting a new project. Newer versions can be considered.
+- The current advised pragma is `0.8.24`, lower versions should be avoided when starting a new project. Newer versions can be considered.
+  - Explicitly use the `Paris` hardfork when compiling with 0.8.24 to keep the bytecode compatible with all chains.
 - All contracts should have an SPDX license identifier. If unsure about which one to pick, please consult with legal. Most older contracts have been MIT, but some of the newer products have been using BUSL-1.1
 
 
@@ -263,8 +264,8 @@ contract SuperDuperAggregator is ITypeAndVersion {
 All contracts will expose a `typeAndVersion` constant.
 The string has the following format: `<contract name><SPACE><semver>-<dev>` with the `-dev` part only being applicable to contracts that have not been fully released.
 Try to fit it into 32 bytes to keep the impact on contract sizes minimal.
-Solhint will complain about a public constant variable that isn’t FULL_CAPS without the solhint-disable comment.
 
+Note that `ITypeAndVersion` should be used, not `TypeAndVersionInterface`.
 
 
 


### PR DESCRIPTION
Update the style guide to reflect the following changes

- Update the recommended Solidity version to 0.8.24
- Add an explicit callout to use the `Paris` hardfork
- Remove the text about Solhint complaining about TypeAndVersion, this has been fixed
- Mention using `ITypeAndVersion` over `TypeAndVersionInterface`