### PR TITLE
.github/pull_request_template.md: shorter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,36 +1,16 @@
-<!---
-  Does this work have a corresponding ticket?
-
-  Please link your Jira ticket by including it in one of the following reference:
+<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
     - the PR title
     - branch name
     - commit message
-  
-  By referencing it, it will let the QA team to know what to watch out for when creating a new release.
-
-  Example:
-
-  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
+[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
 --> 
 
-### Requires Dependencies
-<!---
-  Does this work depend on other open PRs?
-
-  Please list other PRs that are blocking this PR.
-
-  Example:
-
-  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
+### Requires
+<!--- Does this work depend on other open PRs? Please list them.
+- https://github.com/smartcontractkit/chainlink-common/pull/7777777
 -->
 
-### Resolves Dependencies
-<!---
-  Does this work support other open PRs? 
-
-  Please list other PRs that are waiting for this PR to be merged.
-
-  Example:
-
-  - https://github.com/smartcontractkit/ccip/pull/7777777
+### Resolves
+<!--- Does this work support other open PRs?  Please list them.
+- https://github.com/smartcontractkit/ccip/pull/7777777
 -->


### PR DESCRIPTION
The pull request template is often ignored. This PR shortens it, hoping that will make it easier to read and use.