### PR TITLE
Errors Package Cleanup

### DIFF
--- a/core/services/relay/evm/address.go
+++ b/core/services/relay/evm/address.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/pkg/errors"
+
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 )
 
@@ -13,10 +13,10 @@ func AccountToAddress(accounts []types.Account) (addresses []common.Address, err
 	for _, signer := range accounts {
 		bytes, err := hexutil.Decode(string(signer))
 		if err != nil {
-			return []common.Address{}, errors.Wrap(err, fmt.Sprintf("given address is not valid %s", signer))
+			return []common.Address{}, fmt.Errorf("%w: given address is not valid %s", err, signer)
 		}
 		if len(bytes) != 20 {
-			return []common.Address{}, errors.Errorf("address is not 20 bytes %s", signer)
+			return []common.Address{}, fmt.Errorf("address is not 20 bytes %s", signer)
 		}
 		addresses = append(addresses, common.BytesToAddress(bytes))
 	}
@@ -26,7 +26,7 @@ func AccountToAddress(accounts []types.Account) (addresses []common.Address, err
 func OnchainPublicKeyToAddress(publicKeys []types.OnchainPublicKey) (addresses []common.Address, err error) {
 	for _, signer := range publicKeys {
 		if len(signer) != 20 {
-			return []common.Address{}, errors.Errorf("address is not 20 bytes %s", signer)
+			return []common.Address{}, fmt.Errorf("address is not 20 bytes %s", signer)
 		}
 		addresses = append(addresses, common.BytesToAddress(signer))
 	}

--- a/core/services/relay/evm/config_poller.go
+++ b/core/services/relay/evm/config_poller.go
@@ -3,11 +3,11 @@ package evm
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 

--- a/core/services/relay/evm/config_poller_test.go
+++ b/core/services/relay/evm/config_poller_test.go
@@ -2,6 +2,7 @@ package evm
 
 import (
 	"database/sql"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/core/services/relay/evm/contract_transmitter.go
+++ b/core/services/relay/evm/contract_transmitter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -11,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -153,10 +154,10 @@ func (oc *contractTransmitter) Transmit(ctx context.Context, reportCtx ocrtypes.
 
 	payload, err := oc.contractABI.Pack("transmit", rawReportCtx, []byte(report), rs, ss, vs)
 	if err != nil {
-		return errors.Wrap(err, "abi.Pack failed")
+		return fmt.Errorf("%w: abi.Pack failed", err)
 	}
 
-	return errors.Wrap(oc.transmitter.CreateEthTransaction(ctx, oc.contractAddress, payload, txMeta), "failed to send Eth transaction")
+	return fmt.Errorf("%w: failed to send Eth transaction", oc.transmitter.CreateEthTransaction(ctx, oc.contractAddress, payload, txMeta))
 }
 
 type contractReader interface {

--- a/core/services/relay/evm/functions.go
+++ b/core/services/relay/evm/functions.go
@@ -3,10 +3,10 @@ package evm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
@@ -93,7 +93,7 @@ func NewFunctionsProvider(ctx context.Context, chain legacyevm.Chain, rargs comm
 		return nil, err
 	}
 	if !common.IsHexAddress(rargs.ContractID) {
-		return nil, errors.Errorf("invalid contractID, expected hex address")
+		return nil, errors.New("invalid contractID, expected hex address")
 	}
 	var pluginConfig config.PluginConfig
 	if err2 := json.Unmarshal(pargs.PluginConfig, &pluginConfig); err2 != nil {
@@ -122,7 +122,7 @@ func NewFunctionsProvider(ctx context.Context, chain legacyevm.Chain, rargs comm
 
 func newFunctionsConfigProvider(ctx context.Context, pluginType functionsRelay.FunctionsPluginType, chain legacyevm.Chain, args commontypes.RelayArgs, fromBlock uint64, logPollerWrapper evmRelayTypes.LogPollerWrapper, lggr logger.Logger) (*configWatcher, error) {
 	if !common.IsHexAddress(args.ContractID) {
-		return nil, errors.Errorf("invalid contractID, expected hex address")
+		return nil, errors.New("invalid contractID, expected hex address")
 	}
 
 	routerContractAddress := common.HexToAddress(args.ContractID)
@@ -163,7 +163,7 @@ func newFunctionsContractTransmitter(ctx context.Context, contractVersion uint32
 			return nil, errors.New("the transmitter is a local sending key with transaction forwarding enabled")
 		}
 		if err := ethKeystore.CheckEnabled(ctx, common.HexToAddress(s), configWatcher.chain.Config().EVM().ChainID()); err != nil {
-			return nil, errors.Wrap(err, "one of the sending keys given is not enabled")
+			return nil, fmt.Errorf("%w: one of the sending keys given is not enabled", err)
 		}
 		fromAddresses = append(fromAddresses, common.HexToAddress(s))
 	}

--- a/core/services/relay/evm/llo_config_provider.go
+++ b/core/services/relay/evm/llo_config_provider.go
@@ -2,11 +2,11 @@ package evm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 

--- a/core/services/relay/evm/median.go
+++ b/core/services/relay/evm/median.go
@@ -2,12 +2,12 @@ package evm
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
 	offchain_aggregator_wrapper "github.com/smartcontractkit/chainlink/v2/core/internal/gethwrappers2/generated/offchainaggregator"
 )
@@ -35,17 +36,17 @@ func newMedianContract(configTracker types.ContractConfigTracker, contractAddres
 	lggr = logger.Named(lggr, "MedianContract")
 	contract, err := offchain_aggregator_wrapper.NewOffchainAggregator(contractAddress, chain.Client())
 	if err != nil {
-		return nil, errors.Wrap(err, "could not instantiate NewOffchainAggregator")
+		return nil, fmt.Errorf("%w: could not instantiate NewOffchainAggregator", err)
 	}
 
 	contractFilterer, err := ocr2aggregator.NewOCR2AggregatorFilterer(contractAddress, chain.Client())
 	if err != nil {
-		return nil, errors.Wrap(err, "could not instantiate NewOffchainAggregatorFilterer")
+		return nil, fmt.Errorf("%w: could not instantiate NewOffchainAggregatorFilterer", err)
 	}
 
 	contractCaller, err := ocr2aggregator.NewOCR2AggregatorCaller(contractAddress, chain.Client())
 	if err != nil {
-		return nil, errors.Wrap(err, "could not instantiate NewOffchainAggregatorCaller")
+		return nil, fmt.Errorf("%w: could not instantiate NewOffchainAggregatorCaller", err)
 	}
 
 	return &medianContract{
@@ -86,7 +87,7 @@ func (oc *medianContract) HealthReport() map[string]error {
 func (oc *medianContract) LatestTransmissionDetails(ctx context.Context) (ocrtypes.ConfigDigest, uint32, uint8, *big.Int, time.Time, error) {
 	opts := bind.CallOpts{Context: ctx, Pending: false}
 	result, err := oc.contractCaller.LatestTransmissionDetails(&opts)
-	return result.ConfigDigest, result.Epoch, result.Round, result.LatestAnswer, time.Unix(int64(result.LatestTimestamp), 0), errors.Wrap(err, "error getting LatestTransmissionDetails")
+	return result.ConfigDigest, result.Epoch, result.Round, result.LatestAnswer, time.Unix(int64(result.LatestTimestamp), 0), fmt.Errorf("%w: error getting LatestTransmissionDetails", err)
 }
 
 // LatestRoundRequested returns the configDigest, epoch, and round from the latest

--- a/core/services/relay/evm/ocr2keeper.go
+++ b/core/services/relay/evm/ocr2keeper.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
@@ -229,7 +228,7 @@ func newOCR2KeeperConfigProvider(ctx context.Context, lggr logger.Logger, chain 
 		},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create config poller")
+		return nil, fmt.Errorf("%w: failed to create config poller", err)
 	}
 
 	offchainConfigDigester := evmutil.EVMOffchainConfigDigester{

--- a/core/services/relay/evm/relayer_extender.go
+++ b/core/services/relay/evm/relayer_extender.go
@@ -2,11 +2,9 @@ package evm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
-
-	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop/adapters/relay"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -153,7 +151,8 @@ func NewChainRelayerExtenders(ctx context.Context, opts legacyevm.ChainRelayExte
 		privOpts.Logger.Infow(fmt.Sprintf("Loading chain %s", cid), "evmChainID", cid)
 		chain, err2 := legacyevm.NewTOMLChain(ctx, enabled[i], privOpts)
 		if err2 != nil {
-			err = multierr.Combine(err, fmt.Errorf("failed to create chain %s: %w", cid, err2))
+			err = errors.Join(err, fmt.Errorf("failed to create chain %s: %w", cid, err2))
+
 			continue
 		}
 

--- a/core/services/relay/evm/request_round_db.go
+++ b/core/services/relay/evm/request_round_db.go
@@ -3,8 +3,8 @@ package evm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
@@ -39,7 +39,7 @@ func (d *requestRoundDB) WithDataSource(ds sqlutil.DataSource) RequestRoundDB {
 func (d *requestRoundDB) SaveLatestRoundRequested(ctx context.Context, rr ocr2aggregator.OCR2AggregatorRoundRequested) error {
 	rawLog, err := json.Marshal(rr.Raw)
 	if err != nil {
-		return errors.Wrap(err, "could not marshal log as JSON")
+		return fmt.Errorf("%w: could not marshal log as JSON", err)
 	}
 	_, err = d.ds.ExecContext(ctx, `
 INSERT INTO ocr2_latest_round_requested (ocr2_oracle_spec_id, requester, config_digest, epoch, round, raw)
@@ -51,7 +51,7 @@ VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT (ocr2_oracle_spec_id) DO UPDATE SET
 	raw = EXCLUDED.raw
 `, d.oracleSpecID, rr.Requester, rr.ConfigDigest[:], rr.Epoch, rr.Round, rawLog)
 
-	return errors.Wrap(err, "could not save latest round requested")
+	return fmt.Errorf("%w: could not save latest round requested", err)
 }
 
 func (d *requestRoundDB) LoadLatestRoundRequested(ctx context.Context) (ocr2aggregator.OCR2AggregatorRoundRequested, error) {
@@ -63,7 +63,7 @@ WHERE ocr2_oracle_spec_id = $1
 LIMIT 1
 `, d.oracleSpecID)
 	if err != nil {
-		return rr, errors.Wrap(err, "LoadLatestRoundRequested failed to query rows")
+		return rr, fmt.Errorf("%w: LoadLatestRoundRequested failed to query rows", err)
 	}
 	defer rows.Close()
 
@@ -73,17 +73,17 @@ LIMIT 1
 
 		err = rows.Scan(&rr.Requester, &configDigest, &rr.Epoch, &rr.Round, &rawLog)
 		if err != nil {
-			return rr, errors.Wrap(err, "LoadLatestRoundRequested failed to scan row")
+			return rr, fmt.Errorf("%w: LoadLatestRoundRequested failed to scan row", err)
 		}
 
 		rr.ConfigDigest, err = ocrtypes.BytesToConfigDigest(configDigest)
 		if err != nil {
-			return rr, errors.Wrap(err, "LoadLatestRoundRequested failed to decode config digest")
+			return rr, fmt.Errorf("%w: LoadLatestRoundRequested failed to decode config digest", err)
 		}
 
 		err = json.Unmarshal(rawLog, &rr.Raw)
 		if err != nil {
-			return rr, errors.Wrap(err, "LoadLatestRoundRequested failed to unmarshal raw log")
+			return rr, fmt.Errorf("%w: LoadLatestRoundRequested failed to unmarshal raw log", err)
 		}
 	}
 

--- a/core/services/relay/evm/request_round_tracker.go
+++ b/core/services/relay/evm/request_round_tracker.go
@@ -2,12 +2,12 @@ package evm
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -77,7 +77,7 @@ func (t *RequestRoundTracker) Start(ctx context.Context) error {
 	return t.StartOnce("RequestRoundTracker", func() (err error) {
 		t.latestRoundRequested, err = t.odb.LoadLatestRoundRequested(ctx)
 		if err != nil {
-			return errors.Wrap(err, "RequestRoundTracker#Start: failed to load latest round requested")
+			return fmt.Errorf("%w: RequestRoundTracker#Start: failed to load latest round requested", err)
 		}
 
 		t.unsubscribeLogs = t.logBroadcaster.Register(t, log.ListenerOpts{

--- a/core/services/relay/evm/request_round_tracker_test.go
+++ b/core/services/relay/evm/request_round_tracker_test.go
@@ -1,12 +1,12 @@
 package evm_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Removed usage of `github.com/pkg/errors` in `relayer/evm` for cases of `errors.Wrap` and `errors.New` to use default `errors` package instead.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
