### PR TITLE
Remove LD_LIBRARY_PATH env var

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -55,7 +55,6 @@ in
         libudev-zero
         libusb1
       ];
-    LD_LIBRARY_PATH = "${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
     GOROOT = "${go}/share/go";
 
     PGDATA = "db";


### PR DESCRIPTION
Linux users get GLIBC errors when trying to use `fish` shell with this set. I tried to trace the source of this change, but there isnt much. It's part of the original `shell.nix` changes: https://github.com/smartcontractkit/chainlink/blob/2ffef9d74e6d3408404e787ae338a333ece8ae1f/shell.nix 

I ran a regular core CRIB deployment and everything seemed to be fine