### PR TITLE
Added VRFConsumerBaseV2PlusUpgradable.sol

### DIFF
--- a/contracts/src/v0.8/shared/access/ConfirmedOwnerUpgradeable.sol
+++ b/contracts/src/v0.8/shared/access/ConfirmedOwnerUpgradeable.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ConfirmedOwnerWithProposalUpgradeable} from "./ConfirmedOwnerWithProposalUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/// @title The ConfirmedOwner contract
+/// @notice A contract with helpers for basic contract ownership.
+contract ConfirmedOwnerUpgradeable is Initializable, ConfirmedOwnerWithProposalUpgradeable {
+  // solhint-disable-next-line func-name-mixedcase
+  function __ConfirmedOwner_init(address newOwner) internal initializer {
+    __ConfirmedOwnerWithProposal_init(newOwner, address(0));
+  }
+}

--- a/contracts/src/v0.8/shared/access/ConfirmedOwnerUpgradeable.sol
+++ b/contracts/src/v0.8/shared/access/ConfirmedOwnerUpgradeable.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import {ConfirmedOwnerWithProposalUpgradeable} from "./ConfirmedOwnerWithProposalUpgradeable.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 /// @title The ConfirmedOwner contract
 /// @notice A contract with helpers for basic contract ownership.

--- a/contracts/src/v0.8/shared/access/ConfirmedOwnerUpgradeable.sol
+++ b/contracts/src/v0.8/shared/access/ConfirmedOwnerUpgradeable.sol
@@ -6,9 +6,9 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 
 /// @title The ConfirmedOwner contract
 /// @notice A contract with helpers for basic contract ownership.
-contract ConfirmedOwnerUpgradeable is Initializable, ConfirmedOwnerWithProposalUpgradeable {
+contract ConfirmedOwnerUpgradeable is ConfirmedOwnerWithProposalUpgradeable {
   // solhint-disable-next-line func-name-mixedcase
-  function __ConfirmedOwner_init(address newOwner) internal initializer {
+  function __ConfirmedOwner_init(address newOwner) internal onlyInitializing {
     __ConfirmedOwnerWithProposal_init(newOwner, address(0));
   }
 }

--- a/contracts/src/v0.8/shared/access/ConfirmedOwnerWithProposalUpgradeable.sol
+++ b/contracts/src/v0.8/shared/access/ConfirmedOwnerWithProposalUpgradeable.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IOwnable} from "../interfaces/IOwnable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/// @title The ConfirmedOwner contract
+/// @notice A contract with helpers for basic contract ownership.
+contract ConfirmedOwnerWithProposalUpgradeable is IOwnable, Initializable {
+  address private s_owner;
+  address private s_pendingOwner;
+
+  event OwnershipTransferRequested(address indexed from, address indexed to);
+  event OwnershipTransferred(address indexed from, address indexed to);
+
+  // solhint-disable-next-line func-name-mixedcase
+  function __ConfirmedOwnerWithProposal_init(address newOwner, address pendingOwner) internal onlyInitializing {
+    // solhint-disable-next-line gas-custom-errors
+    require(newOwner != address(0), "Cannot set owner to zero");
+
+    s_owner = newOwner;
+    if (pendingOwner != address(0)) {
+      _transferOwnership(pendingOwner);
+    }
+  }
+
+  /// @notice Allows an owner to begin transferring ownership to a new address.
+  function transferOwnership(address to) public override onlyOwner {
+    _transferOwnership(to);
+  }
+
+  /// @notice Allows an ownership transfer to be completed by the recipient.
+  function acceptOwnership() external override {
+    // solhint-disable-next-line gas-custom-errors
+    require(msg.sender == s_pendingOwner, "Must be proposed owner");
+
+    address oldOwner = s_owner;
+    s_owner = msg.sender;
+    s_pendingOwner = address(0);
+
+    emit OwnershipTransferred(oldOwner, msg.sender);
+  }
+
+  /// @notice Get the current owner
+  function owner() public view override returns (address) {
+    return s_owner;
+  }
+
+  /// @notice validate, transfer ownership, and emit relevant events
+  function _transferOwnership(address to) private {
+    // solhint-disable-next-line gas-custom-errors
+    require(to != msg.sender, "Cannot transfer to self");
+
+    s_pendingOwner = to;
+
+    emit OwnershipTransferRequested(s_owner, to);
+  }
+
+  /// @notice validate access
+  function _validateOwnership() internal view {
+    // solhint-disable-next-line gas-custom-errors
+    require(msg.sender == s_owner, "Only callable by owner");
+  }
+
+  /// @notice Reverts if called by anyone other than the contract owner.
+  modifier onlyOwner() {
+    _validateOwnership();
+    _;
+  }
+}

--- a/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2PlusUpgradeable.sol
+++ b/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2PlusUpgradeable.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {IVRFCoordinatorV2Plus} from "@chainlink/contracts/src/v0.8/vrf/dev/interfaces/IVRFCoordinatorV2Plus.sol";
+import {IVRFMigratableConsumerV2Plus} from "@chainlink/contracts/src/v0.8/vrf/dev/interfaces/IVRFMigratableConsumerV2Plus.sol";
+import {ConfirmedOwner} from "@chainlink/contracts/src/v0.8/shared/access/ConfirmedOwner.sol";
+
+/** ****************************************************************************
+ * @notice Interface for contracts using VRF randomness
+ * *****************************************************************************
+ * @dev PURPOSE
+ *
+ * @dev Reggie the Random Oracle (not his real job) wants to provide randomness
+ * @dev to Vera the verifier in such a way that Vera can be sure he's not
+ * @dev making his output up to suit himself. Reggie provides Vera a public key
+ * @dev to which he knows the secret key. Each time Vera provides a seed to
+ * @dev Reggie, he gives back a value which is computed completely
+ * @dev deterministically from the seed and the secret key.
+ *
+ * @dev Reggie provides a proof by which Vera can verify that the output was
+ * @dev correctly computed once Reggie tells it to her, but without that proof,
+ * @dev the output is indistinguishable to her from a uniform random sample
+ * @dev from the output space.
+ *
+ * @dev The purpose of this contract is to make it easy for unrelated contracts
+ * @dev to talk to Vera the verifier about the work Reggie is doing, to provide
+ * @dev simple access to a verifiable source of randomness. It ensures 2 things:
+ * @dev 1. The fulfillment came from the VRFCoordinatorV2Plus.
+ * @dev 2. The consumer contract implements fulfillRandomWords.
+ * *****************************************************************************
+ * @dev USAGE
+ *
+ * @dev Calling contracts must inherit from VRFConsumerBaseV2Plus, and can
+ * @dev initialize VRFConsumerBaseV2Plus's attributes in their constructor as
+ * @dev shown:
+ *
+ * @dev   contract VRFConsumerV2Plus is VRFConsumerBaseV2Plus {
+ * @dev     constructor(<other arguments>, address _vrfCoordinator, address _subOwner)
+ * @dev       VRFConsumerBaseV2Plus(_vrfCoordinator, _subOwner) public {
+ * @dev         <initialization with other arguments goes here>
+ * @dev       }
+ * @dev   }
+ *
+ * @dev The oracle will have given you an ID for the VRF keypair they have
+ * @dev committed to (let's call it keyHash). Create a subscription, fund it
+ * @dev and your consumer contract as a consumer of it (see VRFCoordinatorInterface
+ * @dev subscription management functions).
+ * @dev Call requestRandomWords(keyHash, subId, minimumRequestConfirmations,
+ * @dev callbackGasLimit, numWords, extraArgs),
+ * @dev see (IVRFCoordinatorV2Plus for a description of the arguments).
+ *
+ * @dev Once the VRFCoordinatorV2Plus has received and validated the oracle's response
+ * @dev to your request, it will call your contract's fulfillRandomWords method.
+ *
+ * @dev The randomness argument to fulfillRandomWords is a set of random words
+ * @dev generated from your requestId and the blockHash of the request.
+ *
+ * @dev If your contract could have concurrent requests open, you can use the
+ * @dev requestId returned from requestRandomWords to track which response is associated
+ * @dev with which randomness request.
+ * @dev See "SECURITY CONSIDERATIONS" for principles to keep in mind,
+ * @dev if your contract could have multiple requests in flight simultaneously.
+ *
+ * @dev Colliding `requestId`s are cryptographically impossible as long as seeds
+ * @dev differ.
+ *
+ * *****************************************************************************
+ * @dev SECURITY CONSIDERATIONS
+ *
+ * @dev A method with the ability to call your fulfillRandomness method directly
+ * @dev could spoof a VRF response with any random value, so it's critical that
+ * @dev it cannot be directly called by anything other than this base contract
+ * @dev (specifically, by the VRFConsumerBaseV2Plus.rawFulfillRandomness method).
+ *
+ * @dev For your users to trust that your contract's random behavior is free
+ * @dev from malicious interference, it's best if you can write it so that all
+ * @dev behaviors implied by a VRF response are executed *during* your
+ * @dev fulfillRandomness method. If your contract must store the response (or
+ * @dev anything derived from it) and use it later, you must ensure that any
+ * @dev user-significant behavior which depends on that stored value cannot be
+ * @dev manipulated by a subsequent VRF request.
+ *
+ * @dev Similarly, both miners and the VRF oracle itself have some influence
+ * @dev over the order in which VRF responses appear on the blockchain, so if
+ * @dev your contract could have multiple VRF requests in flight simultaneously,
+ * @dev you must ensure that the order in which the VRF responses arrive cannot
+ * @dev be used to manipulate your contract's user-significant behavior.
+ *
+ * @dev Since the block hash of the block which contains the requestRandomness
+ * @dev call is mixed into the input to the VRF *last*, a sufficiently powerful
+ * @dev miner could, in principle, fork the blockchain to evict the block
+ * @dev containing the request, forcing the request to be included in a
+ * @dev different block with a different hash, and therefore a different input
+ * @dev to the VRF. However, such an attack would incur a substantial economic
+ * @dev cost. This cost scales with the number of blocks the VRF oracle waits
+ * @dev until it calls responds to a request. It is for this reason that
+ * @dev that you can signal to an oracle you'd like them to wait longer before
+ * @dev responding to the request (however this is not enforced in the contract
+ * @dev and so remains effective only in the case of unmodified oracle software).
+ */
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/**
+ * @dev The VRFConsumerBaseV2PlusUpgradable is an upgradable variant of VRFConsumerBaseV2Plus
+ * @dev (see https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable).
+ * @dev It's semantics are identical to VRFConsumerBaseV2Plus and can be inherited from
+ * @dev to create an upgradeable VRF v2.5 consumer contract.
+ */
+
+abstract contract VRFConsumerBaseV2PlusUpgradable is IVRFMigratableConsumerV2Plus, ConfirmedOwner, Initializable {
+  error OnlyCoordinatorCanFulfill(address have, address want);
+  error OnlyOwnerOrCoordinator(address have, address owner, address coordinator);
+  error ZeroAddress();
+
+  // s_vrfCoordinator should be used by consumers to make requests to vrfCoordinator
+  // so that coordinator reference is updated after migration
+  IVRFCoordinatorV2Plus public s_vrfCoordinator;
+
+  // See https://github.com/OpenZeppelin/openzeppelin-sdk/issues/37.
+  // Each uint256 covers a single storage slot, see https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html.
+  // solhint-disable-next-line chainlink-solidity/prefix-storage-variables-with-s-underscore
+  uint256[49] private __gap;
+
+  /**
+   * @param _vrfCoordinator the VRFCoordinatorV2_5 address.
+   * @dev See https://docs.chain.link/vrf/v2-5/supported-networks/ for coordinator
+   * @dev addresses on your preferred network.
+   */
+  // solhint-disable-next-line func-name-mixedcase
+  function __VRFConsumerBaseV2Plus_init(address _vrfCoordinator) internal onlyInitializing {
+    if (_vrfCoordinator == address(0)) {
+      // solhint-disable-next-line gas-custom-errors
+      revert ZeroAddress();
+    }
+
+    s_vrfCoordinator = IVRFCoordinatorV2Plus(_vrfCoordinator);
+  }
+
+  /**
+   * @notice fulfillRandomness handles the VRF response. Your contract must
+   * @notice implement it. See "SECURITY CONSIDERATIONS" above for important
+   * @notice principles to keep in mind when implementing your fulfillRandomness
+   * @notice method.
+   *
+   * @dev VRFConsumerBaseV2Plus expects its subcontracts to have a method with this
+   * @dev signature, and will call it once it has verified the proof
+   * @dev associated with the randomness. (It is triggered via a call to
+   * @dev rawFulfillRandomness, below.)
+   *
+   * @param requestId The Id initially returned by requestRandomness
+   * @param randomWords the VRF output expanded to the requested number of words
+   */
+  // solhint-disable-next-line chainlink-solidity/prefix-internal-functions-with-underscore
+  function fulfillRandomWords(uint256 requestId, uint256[] calldata randomWords) internal virtual;
+
+  // rawFulfillRandomness is called by VRFCoordinator when it receives a valid VRF
+  // proof. rawFulfillRandomness then calls fulfillRandomness, after validating
+  // the origin of the call
+  function rawFulfillRandomWords(uint256 requestId, uint256[] calldata randomWords) external {
+    if (msg.sender != address(s_vrfCoordinator)) {
+      revert OnlyCoordinatorCanFulfill(msg.sender, address(s_vrfCoordinator));
+    }
+    fulfillRandomWords(requestId, randomWords);
+  }
+
+  /**
+   * @inheritdoc IVRFMigratableConsumerV2Plus
+   */
+  function setCoordinator(address _vrfCoordinator) external override onlyOwnerOrCoordinator {
+    if (_vrfCoordinator == address(0)) {
+      revert ZeroAddress();
+    }
+    s_vrfCoordinator = IVRFCoordinatorV2Plus(_vrfCoordinator);
+
+    emit CoordinatorSet(_vrfCoordinator);
+  }
+
+  modifier onlyOwnerOrCoordinator() {
+    if (msg.sender != owner() && msg.sender != address(s_vrfCoordinator)) {
+      revert OnlyOwnerOrCoordinator(msg.sender, owner(), address(s_vrfCoordinator));
+    }
+    _;
+  }
+}

--- a/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2PlusUpgradeable.sol
+++ b/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2PlusUpgradeable.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import {IVRFCoordinatorV2Plus} from "@chainlink/contracts/src/v0.8/vrf/dev/interfaces/IVRFCoordinatorV2Plus.sol";
-import {IVRFMigratableConsumerV2Plus} from "@chainlink/contracts/src/v0.8/vrf/dev/interfaces/IVRFMigratableConsumerV2Plus.sol";
-import {ConfirmedOwner} from "@chainlink/contracts/src/v0.8/shared/access/ConfirmedOwner.sol";
+import {IVRFCoordinatorV2Plus} from "./interfaces/IVRFCoordinatorV2Plus.sol";
+import {IVRFMigratableConsumerV2Plus} from "./interfaces/IVRFMigratableConsumerV2Plus.sol";
+import {ConfirmedOwner} from "../../shared/access/ConfirmedOwner.sol";
 
 /** ****************************************************************************
  * @notice Interface for contracts using VRF randomness

--- a/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2PlusUpgradeable.sol
+++ b/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2PlusUpgradeable.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.4;
 
 import {IVRFCoordinatorV2Plus} from "./interfaces/IVRFCoordinatorV2Plus.sol";
 import {IVRFMigratableConsumerV2Plus} from "./interfaces/IVRFMigratableConsumerV2Plus.sol";
-import {ConfirmedOwner} from "../../shared/access/ConfirmedOwner.sol";
+import {ConfirmedOwnerUpgradeable} from "../../shared/access/ConfirmedOwnerUpgradeable.sol";
 
 /** ****************************************************************************
  * @notice Interface for contracts using VRF randomness
@@ -108,16 +108,14 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
  * @dev to create an upgradeable VRF v2.5 consumer contract.
  */
 
-abstract contract VRFConsumerBaseV2PlusUpgradable is IVRFMigratableConsumerV2Plus, Initializable {
+abstract contract VRFConsumerBaseV2PlusUpgradable is IVRFMigratableConsumerV2Plus, Initializable, ConfirmedOwnerUpgradeable {
   error OnlyCoordinatorCanFulfill(address have, address want);
   error OnlyOwnerOrCoordinator(address have, address owner, address coordinator);
-  error OnlyOwner(address have, address owner);
   error ZeroAddress();
 
   // s_vrfCoordinator should be used by consumers to make requests to vrfCoordinator
   // so that coordinator reference is updated after migration
   IVRFCoordinatorV2Plus public s_vrfCoordinator;
-  address public s_owner;
 
   // See https://github.com/OpenZeppelin/openzeppelin-sdk/issues/37.
   // Each uint256 covers a single storage slot, see https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html.
@@ -130,19 +128,14 @@ abstract contract VRFConsumerBaseV2PlusUpgradable is IVRFMigratableConsumerV2Plu
    * @dev addresses on your preferred network.
    */
   // solhint-disable-next-line func-name-mixedcase
-  function __VRFConsumerBaseV2Plus_init(address _vrfCoordinator, address _owner) internal onlyInitializing {
-    if (_vrfCoordinator == address(0)  || _owner == address(0)) {
+  function __VRFConsumerBaseV2Plus_init(address _vrfCoordinator) internal initializer {
+    if (_vrfCoordinator == address(0)) {
       // solhint-disable-next-line gas-custom-errors
       revert ZeroAddress();
     }
 
     s_vrfCoordinator = IVRFCoordinatorV2Plus(_vrfCoordinator);
-    s_owner = _owner;
-  }
-
-  /// @notice Allows an owner to begin transferring ownership to a new address.
-  function transferOwnership(address to) public onlyOwner {
-    s_owner = to;
+    __ConfirmedOwner_init(msg.sender);
   }
 
   /**
@@ -185,15 +178,8 @@ abstract contract VRFConsumerBaseV2PlusUpgradable is IVRFMigratableConsumerV2Plu
   }
 
   modifier onlyOwnerOrCoordinator() {
-    if (msg.sender != s_owner && msg.sender != address(s_vrfCoordinator)) {
-      revert OnlyOwnerOrCoordinator(msg.sender, s_owner, address(s_vrfCoordinator));
-    }
-    _;
-  }
-
-  modifier onlyOwner() {
-    if (msg.sender != s_owner) {
-      revert OnlyOwner(msg.sender, s_owner);
+    if (msg.sender != owner() && msg.sender != address(s_vrfCoordinator)) {
+      revert OnlyOwnerOrCoordinator(msg.sender, owner(), address(s_vrfCoordinator));
     }
     _;
   }

--- a/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2PlusUpgradeable.sol
+++ b/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2PlusUpgradeable.sol
@@ -99,8 +99,6 @@ import {ConfirmedOwnerUpgradeable} from "../../shared/access/ConfirmedOwnerUpgra
  * @dev and so remains effective only in the case of unmodified oracle software).
  */
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-
 /**
  * @dev The VRFConsumerBaseV2PlusUpgradable is an upgradable variant of VRFConsumerBaseV2Plus
  * @dev (see https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable).
@@ -108,7 +106,7 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
  * @dev to create an upgradeable VRF v2.5 consumer contract.
  */
 
-abstract contract VRFConsumerBaseV2PlusUpgradable is IVRFMigratableConsumerV2Plus, Initializable, ConfirmedOwnerUpgradeable {
+abstract contract VRFConsumerBaseV2PlusUpgradeable is IVRFMigratableConsumerV2Plus, ConfirmedOwnerUpgradeable {
   error OnlyCoordinatorCanFulfill(address have, address want);
   error OnlyOwnerOrCoordinator(address have, address owner, address coordinator);
   error ZeroAddress();
@@ -128,7 +126,7 @@ abstract contract VRFConsumerBaseV2PlusUpgradable is IVRFMigratableConsumerV2Plu
    * @dev addresses on your preferred network.
    */
   // solhint-disable-next-line func-name-mixedcase
-  function __VRFConsumerBaseV2Plus_init(address _vrfCoordinator) internal initializer {
+  function __VRFConsumerBaseV2Plus_init(address _vrfCoordinator) internal onlyInitializing {
     if (_vrfCoordinator == address(0)) {
       // solhint-disable-next-line gas-custom-errors
       revert ZeroAddress();


### PR DESCRIPTION
Added `VRFConsumerBaseV2PlusUpgradable` contract i.e., the upgradable version of [`VRFConsumerBaseV2Plus`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2Plus.sol), because the upgradable version is only available for VRF v2 i.e., [`VRFConsumerBaseV2Upgradeable`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2Upgradeable.sol), and some devs on Chainlink Discord are demanding for v2.5 as well:

![Screenshot 2024-09-15 at 5 03 47 PM](https://github.com/user-attachments/assets/51bcf349-849c-4371-8399-f3334fb37a7b)


Kindly please review the PR, and let me know if any changes or add-ons are required from my end.

Thanks.