### PR TITLE
fix lint issues

### DIFF
--- a/core/chains/evm/client/config_builder.go
+++ b/core/chains/evm/client/config_builder.go
@@ -64,7 +64,7 @@ func NewClientConfigs(
 	chainConfig := &evmconfig.EVMConfig{
 		C: &toml.EVMConfig{
 			Chain: toml.Chain{
-				ChainType:                    chaintype.NewChainTypeConfig(chainType),
+				ChainType:                    chaintype.NewConfig(chainType),
 				FinalityDepth:                finalityDepth,
 				FinalityTagEnabled:           finalityTagEnabled,
 				NoNewHeadsThreshold:          commonconfig.MustNewDuration(noNewHeadsThreshold),

--- a/core/chains/evm/config/chaintype/chaintype.go
+++ b/core/chains/evm/config/chaintype/chaintype.go
@@ -44,7 +44,7 @@ func (c ChainType) IsValid() bool {
 	return false
 }
 
-func ChainTypeFromSlug(slug string) ChainType {
+func FromSlug(slug string) ChainType {
 	switch slug {
 	case "arbitrum":
 		return ChainArbitrum
@@ -79,53 +79,53 @@ func ChainTypeFromSlug(slug string) ChainType {
 	}
 }
 
-type ChainTypeConfig struct {
+type Config struct {
 	value ChainType
 	slug  string
 }
 
-func NewChainTypeConfig(slug string) *ChainTypeConfig {
-	return &ChainTypeConfig{
-		value: ChainTypeFromSlug(slug),
+func NewConfig(slug string) *Config {
+	return &Config{
+		value: FromSlug(slug),
 		slug:  slug,
 	}
 }
 
-func (c *ChainTypeConfig) MarshalText() ([]byte, error) {
+func (c *Config) MarshalText() ([]byte, error) {
 	if c == nil {
 		return nil, nil
 	}
 	return []byte(c.slug), nil
 }
 
-func (c *ChainTypeConfig) UnmarshalText(b []byte) error {
+func (c *Config) UnmarshalText(b []byte) error {
 	c.slug = string(b)
-	c.value = ChainTypeFromSlug(c.slug)
+	c.value = FromSlug(c.slug)
 	return nil
 }
 
-func (c *ChainTypeConfig) Slug() string {
+func (c *Config) Slug() string {
 	if c == nil {
 		return ""
 	}
 	return c.slug
 }
 
-func (c *ChainTypeConfig) ChainType() ChainType {
+func (c *Config) ChainType() ChainType {
 	if c == nil {
 		return ""
 	}
 	return c.value
 }
 
-func (c *ChainTypeConfig) String() string {
+func (c *Config) String() string {
 	if c == nil {
 		return ""
 	}
 	return string(c.value)
 }
 
-var ErrInvalidChainType = fmt.Errorf("must be one of %s or omitted", strings.Join([]string{
+var ErrInvalid = fmt.Errorf("must be one of %s or omitted", strings.Join([]string{
 	string(ChainArbitrum),
 	string(ChainAstar),
 	string(ChainCelo),

--- a/core/chains/evm/config/toml/config.go
+++ b/core/chains/evm/config/toml/config.go
@@ -341,7 +341,7 @@ type Chain struct {
 	AutoCreateKey                *bool
 	BlockBackfillDepth           *uint32
 	BlockBackfillSkip            *bool
-	ChainType                    *chaintype.ChainTypeConfig
+	ChainType                    *chaintype.Config
 	FinalityDepth                *uint32
 	FinalityTagEnabled           *bool
 	FlagsContractAddress         *types.EIP55Address
@@ -376,7 +376,7 @@ type Chain struct {
 func (c *Chain) ValidateConfig() (err error) {
 	if !c.ChainType.ChainType().IsValid() {
 		err = multierr.Append(err, commonconfig.ErrInvalid{Name: "ChainType", Value: c.ChainType.ChainType(),
-			Msg: chaintype.ErrInvalidChainType.Error()})
+			Msg: chaintype.ErrInvalid.Error()})
 	}
 
 	if c.GasEstimator.BumpTxDepth != nil && *c.GasEstimator.BumpTxDepth > *c.Transactions.MaxInFlight {

--- a/core/scripts/vrfv2plus/testnet/main.go
+++ b/core/scripts/vrfv2plus/testnet/main.go
@@ -213,7 +213,7 @@ func main() {
 		for i := range preSeedSlice {
 			ps, err := proof.BigToSeed(preSeedSlice[i])
 			helpers.PanicErr(err)
-			extraArgs, err := extraargs.ExtraArgsV1(*nativePayment)
+			extraArgs, err := extraargs.EncodeV1(*nativePayment)
 			helpers.PanicErr(err)
 			preSeedData := proof.PreSeedDataV2Plus{
 				PreSeed:          ps,
@@ -308,7 +308,7 @@ func main() {
 		helpers.PanicErr(err)
 
 		parsedSubID := parseUInt256String(*subID)
-		extraArgs, err := extraargs.ExtraArgsV1(*nativePayment)
+		extraArgs, err := extraargs.EncodeV1(*nativePayment)
 		helpers.PanicErr(err)
 		preSeedData := proof.PreSeedDataV2Plus{
 			PreSeed:          ps,

--- a/core/scripts/vrfv2plus/testnet/proofs.go
+++ b/core/scripts/vrfv2plus/testnet/proofs.go
@@ -105,7 +105,7 @@ func generateProofForV2Plus(e helpers.Environment) {
 	if !ok {
 		helpers.PanicErr(fmt.Errorf("unable to parse subID: %s %w", *subId, err))
 	}
-	extraArgs, err := extraargs.ExtraArgsV1(*nativePayment)
+	extraArgs, err := extraargs.EncodeV1(*nativePayment)
 	helpers.PanicErr(err)
 	preSeedData := proof.PreSeedDataV2Plus{
 		PreSeed:          preSeed,

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -532,7 +532,7 @@ func TestConfig_Marshal(t *testing.T) {
 				},
 				BlockBackfillDepth:   ptr[uint32](100),
 				BlockBackfillSkip:    ptr(true),
-				ChainType:            chaintype.NewChainTypeConfig("Optimism"),
+				ChainType:            chaintype.NewConfig("Optimism"),
 				FinalityDepth:        ptr[uint32](42),
 				FinalityTagEnabled:   ptr[bool](false),
 				FlagsContractAddress: mustAddress("0xae4E781a6218A8031764928E88d457937A954fC3"),

--- a/core/services/relay/evm/mercury/wsrpc/mocks/mocks.go
+++ b/core/services/relay/evm/mercury/wsrpc/mocks/mocks.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+
 	grpc_connectivity "google.golang.org/grpc/connectivity"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/wsrpc/pb"

--- a/core/services/vrf/extraargs/types.go
+++ b/core/services/vrf/extraargs/types.go
@@ -13,7 +13,7 @@ const boolAbiType = `[{ "type": "bool" }]`
 
 var extraArgsV1Tag = crypto.Keccak256([]byte("VRF ExtraArgsV1"))[:4]
 
-func FromExtraArgsV1(extraArgs []byte) (nativePayment bool, err error) {
+func DecodeV1(extraArgs []byte) (nativePayment bool, err error) {
 	decodedBool, err := utils.ABIDecode(boolAbiType, extraArgs[functionSignatureLength:])
 	if err != nil {
 		return false, fmt.Errorf("failed to decode 0x%x to bool", extraArgs[functionSignatureLength:])
@@ -25,7 +25,7 @@ func FromExtraArgsV1(extraArgs []byte) (nativePayment bool, err error) {
 	return nativePayment, nil
 }
 
-func ExtraArgsV1(nativePayment bool) ([]byte, error) {
+func EncodeV1(nativePayment bool) ([]byte, error) {
 	encodedArgs, err := utils.ABIEncode(boolAbiType, nativePayment)
 	if err != nil {
 		return nil, err

--- a/core/services/vrf/v2/coordinator_v2x_interface.go
+++ b/core/services/vrf/v2/coordinator_v2x_interface.go
@@ -250,7 +250,7 @@ func (c *coordinatorV2_5) ParseRandomWordsFulfilled(log types.Log) (RandomWordsF
 }
 
 func (c *coordinatorV2_5) RequestRandomWords(opts *bind.TransactOpts, keyHash [32]byte, subID *big.Int, requestConfirmations uint16, callbackGasLimit uint32, numWords uint32, payInEth bool) (*types.Transaction, error) {
-	extraArgs, err := extraargs.ExtraArgsV1(payInEth)
+	extraArgs, err := extraargs.EncodeV1(payInEth)
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +569,7 @@ func (r *v2_5RandomWordsRequested) CallbackGasLimit() uint32 {
 }
 
 func (r *v2_5RandomWordsRequested) NativePayment() bool {
-	nativePayment, err := extraargs.FromExtraArgsV1(r.event.ExtraArgs)
+	nativePayment, err := extraargs.DecodeV1(r.event.ExtraArgs)
 	if err != nil {
 		panic(err)
 	}
@@ -1073,7 +1073,7 @@ func (r *RequestCommitment) NativePayment() bool {
 	if r.VRFVersion == vrfcommon.V2 {
 		return false
 	}
-	nativePayment, err := extraargs.FromExtraArgsV1(r.V2Plus.ExtraArgs)
+	nativePayment, err := extraargs.DecodeV1(r.V2Plus.ExtraArgs)
 	if err != nil {
 		panic(err)
 	}

--- a/core/services/vrf/v2/integration_v2_plus_test.go
+++ b/core/services/vrf/v2/integration_v2_plus_test.go
@@ -966,7 +966,7 @@ func requestAndEstimateFulfillmentCost(
 	requestLog := FindLatestRandomnessRequestedLog(t, uni.rootContract, vrfkey.PublicKey.MustHash(), nil)
 	s, err := proof.BigToSeed(requestLog.PreSeed())
 	require.NoError(t, err)
-	extraArgs, err := extraargs.ExtraArgsV1(nativePayment)
+	extraArgs, err := extraargs.EncodeV1(nativePayment)
 	require.NoError(t, err)
 	proof, rc, err := proof.GenerateProofResponseV2Plus(app.GetKeyStore().VRF(), vrfkey.ID(), proof.PreSeedDataV2Plus{
 		PreSeed:          s,

--- a/tools/txtar/visitor.go
+++ b/tools/txtar/visitor.go
@@ -13,13 +13,13 @@ const (
 	NoRecurse RecurseOpt = false
 )
 
-type TxtarDirVisitor struct {
+type DirVisitor struct {
 	rootDir string
 	cb      func(path string) error
 	recurse RecurseOpt
 }
 
-func (d *TxtarDirVisitor) Walk() error {
+func (d *DirVisitor) Walk() error {
 	return filepath.WalkDir(d.rootDir, func(path string, de fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -52,7 +52,7 @@ func (d *TxtarDirVisitor) Walk() error {
 	})
 }
 
-func (d *TxtarDirVisitor) isRootDir(de fs.DirEntry) (bool, error) {
+func (d *DirVisitor) isRootDir(de fs.DirEntry) (bool, error) {
 	fi, err := os.Stat(d.rootDir)
 	if err != nil {
 		return false, err
@@ -65,8 +65,8 @@ func (d *TxtarDirVisitor) isRootDir(de fs.DirEntry) (bool, error) {
 	return os.SameFile(fi, fi2), nil
 }
 
-func NewDirVisitor(rootDir string, recurse RecurseOpt, cb func(path string) error) *TxtarDirVisitor {
-	return &TxtarDirVisitor{
+func NewDirVisitor(rootDir string, recurse RecurseOpt, cb func(path string) error) *DirVisitor {
+	return &DirVisitor{
 		rootDir: rootDir,
 		cb:      cb,
 		recurse: recurse,


### PR DESCRIPTION
```
core/services/relay/evm/mercury/wsrpc/mocks/mocks.go:4: File is not `goimports`-ed with -local github.com/smartcontractkit/chainlink (goimports)
	"context"
tools/txtar/visitor.go:16:6: exported: type name will be used as txtar.TxtarDirVisitor by other packages, and that stutters; consider calling this DirVisitor (revive)
type TxtarDirVisitor struct {
     ^
core/services/vrf/extraargs/types.go:28:6: exported: func name will be used as extraargs.ExtraArgsV1 by other packages, and that stutters; consider calling this V1 (revive)
func ExtraArgsV1(nativePayment bool) ([]byte, error) {
     ^
core/chains/evm/config/chaintype/chaintype.go:47:6: exported: func name will be used as chaintype.ChainTypeFromSlug by other packages, and that stutters; consider calling this FromSlug (revive)
func ChainTypeFromSlug(slug string) ChainType {
     ^
core/chains/evm/config/chaintype/chaintype.go:82:6: exported: type name will be used as chaintype.ChainTypeConfig by other packages, and that stutters; consider calling this Config (revive)
type ChainTypeConfig struct {
     ^
```