### PR TITLE
CCIP-3420: Fix IsRequestTriggeredWithinTimeframe

### DIFF
--- a/integration-tests/ccip-tests/testconfig/ccip.go
+++ b/integration-tests/ccip-tests/testconfig/ccip.go
@@ -242,6 +242,9 @@ func (l *LoadProfile) Validate() error {
 	if l.TestDuration == nil || l.TestDuration.Duration().Minutes() == 0 {
 		return fmt.Errorf("test duration should be set")
 	}
+	if l.SkipRequestIfAnotherRequestTriggeredWithin != nil && l.TimeUnit.Duration() < l.SkipRequestIfAnotherRequestTriggeredWithin.Duration() {
+		return fmt.Errorf("SkipRequestIfAnotherRequestTriggeredWithin should be set below the TimeUnit duration")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Porting this change from CCIP. PR: https://github.com/smartcontractkit/ccip/pull/1445
## Motivation
The prior approach to find if there is traffic in a lane was not detecting the transactions properly. It could be due to the `CCIPSendRequestedWatcher` captures the event after it is initiated not any transaction before that.

## Solution
The revised approach is to use the FilterCCIPSendRequested by a past derived block number and see if there is any traffic. The block number is derived by this formula:
`filterFromBlock = latestBlockNumber -
(SkipRequestIfAnotherRequestTriggeredWithin/avgBlockTime)` By this approach, we will be able to find traffic better.

https://smartcontract-it.atlassian.net/browse/CCIP-3420

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
