### PR TITLE
Fix CCIP Load Test Faulty Fund Return

### DIFF
--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -1,5 +1,6 @@
 name: CCIP Load Test
 on: 
+  pull_request: # DEBUG: Checking changes stop failure
   push:
     paths:
       - '**/*ccip*'

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -1,6 +1,5 @@
 name: CCIP Load Test
 on: 
-  pull_request: # DEBUG: Checking changes stop failure
   push:
     paths:
       - '**/*ccip*'

--- a/integration-tests/actions/actions.go
+++ b/integration-tests/actions/actions.go
@@ -694,7 +694,7 @@ func TeardownSuite(
 		l.Warn().Msgf("Error deleting jobs %+v", err)
 	}
 
-	if chainlinkNodes != nil {
+	if chainlinkNodes != nil && chainClient != nil {
 		if err := ReturnFundsFromNodes(l, chainClient, contracts.ChainlinkK8sClientToChainlinkNodeWithKeysAndAddress(chainlinkNodes)); err != nil {
 			// This printed line is required for tests that use real funds to propagate the failure
 			// out to the system running the test. Do not remove


### PR DESCRIPTION
Bug causing CCIP load tests to show as failed when they fail to return non-existent funds.