### PR TITLE
CCIP-3416 paginate token admin registry get all tokens call

### DIFF
--- a/integration-tests/deployment/ccip/view/v1_5/tokenadminregistry.go
+++ b/integration-tests/deployment/ccip/view/v1_5/tokenadminregistry.go
@@ -9,13 +9,17 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/token_admin_registry"
 )
 
+const (
+	GetTokensPaginationSize = 20
+)
+
 type TokenAdminRegistryView struct {
 	types.ContractMetaData
 	Tokens []common.Address `json:"tokens"`
 }
 
 func GenerateTokenAdminRegistryView(taContract *token_admin_registry.TokenAdminRegistry) (TokenAdminRegistryView, error) {
-	tokens, err := taContract.GetAllConfiguredTokens(nil, 0, 10)
+	tokens, err := getAllConfiguredTokensPaginated(taContract)
 	if err != nil {
 		return TokenAdminRegistryView{}, fmt.Errorf("view error for token admin registry: %w", err)
 	}
@@ -27,4 +31,21 @@ func GenerateTokenAdminRegistryView(taContract *token_admin_registry.TokenAdminR
 		ContractMetaData: tvMeta,
 		Tokens:           tokens,
 	}, nil
+}
+
+// getAllConfiguredTokensPaginated fetches all configured tokens from the TokenAdminRegistry contract in paginated
+// manner to avoid RPC timeouts since the list of configured tokens can grow to be very large over time.
+func getAllConfiguredTokensPaginated(taContract *token_admin_registry.TokenAdminRegistry) ([]common.Address, error) {
+	startIndex := uint64(0)
+	allTokens := make([]common.Address, 0)
+	fetchedTokens := make([]common.Address, 0)
+	for len(fetchedTokens) < GetTokensPaginationSize {
+		fetchedTokens, err := taContract.GetAllConfiguredTokens(nil, startIndex, GetTokensPaginationSize)
+		if err != nil {
+			return nil, err
+		}
+		allTokens = append(allTokens, fetchedTokens...)
+		startIndex += GetTokensPaginationSize
+	}
+	return allTokens, nil
 }

--- a/integration-tests/deployment/ccip/view/v1_5/tokenadminregistry.go
+++ b/integration-tests/deployment/ccip/view/v1_5/tokenadminregistry.go
@@ -41,14 +41,16 @@ func GenerateTokenAdminRegistryView(taContract *token_admin_registry.TokenAdminR
 func getAllConfiguredTokensPaginated(taContract *token_admin_registry.TokenAdminRegistry) ([]common.Address, error) {
 	startIndex := uint64(0)
 	allTokens := make([]common.Address, 0)
-	fetchedTokens := make([]common.Address, 0)
-	for len(fetchedTokens) < GetTokensPaginationSize {
+	for {
 		fetchedTokens, err := taContract.GetAllConfiguredTokens(nil, startIndex, GetTokensPaginationSize)
 		if err != nil {
 			return nil, err
 		}
 		allTokens = append(allTokens, fetchedTokens...)
 		startIndex += GetTokensPaginationSize
+		if len(fetchedTokens) < GetTokensPaginationSize {
+			break
+		}
 	}
 	return allTokens, nil
 }

--- a/integration-tests/deployment/ccip/view/v1_5/tokenadminregistry.go
+++ b/integration-tests/deployment/ccip/view/v1_5/tokenadminregistry.go
@@ -19,6 +19,9 @@ type TokenAdminRegistryView struct {
 }
 
 func GenerateTokenAdminRegistryView(taContract *token_admin_registry.TokenAdminRegistry) (TokenAdminRegistryView, error) {
+	if taContract == nil {
+		return TokenAdminRegistryView{}, fmt.Errorf("token admin registry contract is nil")
+	}
 	tokens, err := getAllConfiguredTokensPaginated(taContract)
 	if err != nil {
 		return TokenAdminRegistryView{}, fmt.Errorf("view error for token admin registry: %w", err)


### PR DESCRIPTION
CCIP-3416
Paginate call to `GetAllConfiguredTokens` since this can theoretically grow pretty large