### PR TITLE
[BCFR-899] MaxLogsKept implementation

### DIFF
--- a/.changeset/flat-horses-argue.md
+++ b/.changeset/flat-horses-argue.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#added LogPoller MaxLogsKept feature: recency count-based instaed of time based log retention

--- a/.changeset/flat-horses-argue.md
+++ b/.changeset/flat-horses-argue.md
@@ -2,4 +2,4 @@
 "chainlink": minor
 ---
 
-#added LogPoller MaxLogsKept feature: recency count-based instaed of time based log retention
+#added LogPoller MaxLogsKept feature: recency count-based instead of time based log retention

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -1134,8 +1134,9 @@ func (lp *logPoller) PruneExpiredLogs(ctx context.Context) (bool, error) {
 	if err != nil {
 		lp.lggr.Errorw("Unable to find excess logs for pruning", "err", err)
 		return false, err
+	} else if lp.logPrunePageSize != 0 && rowsRemoved == lp.logPrunePageSize {
+		done = false
 	}
-	return lp.logPrunePageSize == 0 || rowsRemoved < lp.logPrunePageSize, err
 
 	rowIDs, err := lp.orm.SelectExcessLogIDs(ctx, lp.logPrunePageSize)
 	if err != nil {

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -134,8 +134,8 @@ type logPoller struct {
 	// Usually the only way to recover is to manually remove the offending logs and block from the database.
 	// LogPoller keeps running in infinite loop, so whenever the invalid state is removed from the database it should
 	// recover automatically without needing to restart the LogPoller.
-	finalityViolated           *atomic.Bool
-	countBasedLogPruningActive *atomic.Bool
+	finalityViolated           atomic.Bool
+	countBasedLogPruningActive atomic.Bool
 }
 
 type Opts struct {
@@ -162,26 +162,24 @@ type Opts struct {
 // support chain, polygon, which has 2s block times, we need RPCs roughly with <= 500ms latency
 func NewLogPoller(orm ORM, ec Client, lggr logger.Logger, headTracker HeadTracker, opts Opts) *logPoller {
 	return &logPoller{
-		stopCh:                     make(chan struct{}),
-		ec:                         ec,
-		orm:                        orm,
-		headTracker:                headTracker,
-		lggr:                       logger.Sugared(logger.Named(lggr, "LogPoller")),
-		replayStart:                make(chan int64),
-		replayComplete:             make(chan error),
-		pollPeriod:                 opts.PollPeriod,
-		backupPollerBlockDelay:     opts.BackupPollerBlockDelay,
-		finalityDepth:              opts.FinalityDepth,
-		useFinalityTag:             opts.UseFinalityTag,
-		backfillBatchSize:          opts.BackfillBatchSize,
-		rpcBatchSize:               opts.RpcBatchSize,
-		keepFinalizedBlocksDepth:   opts.KeepFinalizedBlocksDepth,
-		logPrunePageSize:           opts.LogPrunePageSize,
-		clientErrors:               opts.ClientErrors,
-		filters:                    make(map[string]Filter),
-		filterDirty:                true, // Always build Filter on first call to cache an empty filter if nothing registered yet.
-		finalityViolated:           new(atomic.Bool),
-		countBasedLogPruningActive: new(atomic.Bool),
+		stopCh:                   make(chan struct{}),
+		ec:                       ec,
+		orm:                      orm,
+		headTracker:              headTracker,
+		lggr:                     logger.Sugared(logger.Named(lggr, "LogPoller")),
+		replayStart:              make(chan int64),
+		replayComplete:           make(chan error),
+		pollPeriod:               opts.PollPeriod,
+		backupPollerBlockDelay:   opts.BackupPollerBlockDelay,
+		finalityDepth:            opts.FinalityDepth,
+		useFinalityTag:           opts.UseFinalityTag,
+		backfillBatchSize:        opts.BackfillBatchSize,
+		rpcBatchSize:             opts.RpcBatchSize,
+		keepFinalizedBlocksDepth: opts.KeepFinalizedBlocksDepth,
+		logPrunePageSize:         opts.LogPrunePageSize,
+		clientErrors:             opts.ClientErrors,
+		filters:                  make(map[string]Filter),
+		filterDirty:              true, // Always build Filter on first call to cache an empty filter if nothing registered yet.
 	}
 }
 

--- a/core/chains/evm/logpoller/observability.go
+++ b/core/chains/evm/logpoller/observability.go
@@ -136,9 +136,9 @@ func (o *ObservedORM) DeleteLogsAndBlocksAfter(ctx context.Context, start int64)
 	})
 }
 
-func (o *ObservedORM) DeleteLogsByRowID(ctx context.Context, rowIDs []uint64) (int64, error) {
-	return withObservedExecAndRowsAffected(o, "DeleteLogsByRowID", del, func() (int64, error) {
-		return o.ORM.DeleteLogsByRowID(ctx, rowIDs)
+func (o *ObservedORM) DeleteExpiredLogs(ctx context.Context, limit int64) (int64, error) {
+	return withObservedExecAndRowsAffected(o, "DeleteExpiredLogs", del, func() (int64, error) {
+		return o.ORM.DeleteExpiredLogs(ctx, limit)
 	})
 }
 
@@ -148,9 +148,15 @@ func (o *ObservedORM) SelectUnmatchedLogIDs(ctx context.Context, limit int64) (i
 	})
 }
 
-func (o *ObservedORM) DeleteExpiredLogs(ctx context.Context, limit int64) (int64, error) {
-	return withObservedExecAndRowsAffected(o, "DeleteExpiredLogs", del, func() (int64, error) {
-		return o.ORM.DeleteExpiredLogs(ctx, limit)
+func (o *ObservedORM) SelectExcessLogIDs(ctx context.Context, limit int64) ([]uint64, error) {
+	return withObservedQueryAndResults[uint64](o, "SelectExcessLogIDs", func() ([]uint64, error) {
+		return o.ORM.SelectExcessLogIDs(ctx, limit)
+	})
+}
+
+func (o *ObservedORM) DeleteLogsByRowID(ctx context.Context, rowIDs []uint64) (int64, error) {
+	return withObservedExecAndRowsAffected(o, "DeleteLogsByRowID", del, func() (int64, error) {
+		return o.ORM.DeleteLogsByRowID(ctx, rowIDs)
 	})
 }
 

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -295,23 +295,19 @@ func (o *DSORM) SelectLatestLogByEventSigWithConfs(ctx context.Context, eventSig
 	return &l, nil
 }
 
-// DeleteBlocksBefore delete blocks before and including end. When limit is set, it will delete at most limit blocks.
-// Otherwise, it will delete all blocks at once.
-func (o *DSORM) DeleteBlocksBefore(ctx context.Context, end int64, limit int64) (int64, error) {
-	var result sql.Result
-	var err error
-
+// ExecPagedQuery runs a query accepting an upper limit block (end) in a fast paged way. limit is the maximum number
+// of results to be returned, but it is also used to break the query up into smaller queries restricted to limit # of blocks.
+// The first range of blocks will be from MIN(block_number) to MIN(block_number) + limit. The iterative process ends either once
+// the limit on results is reached or block_number = end. The query will never be exeucted on blocks where
+// block_number > end, and it will never be executed on block_number = B unless it has also been executed on all
+// blocks with block_number < B
+func (o *DSORM) ExecPagedQuery(ctx context.Context, limit int64, end int64, query func(lower, upper int64) (int64, error)) (numResults int64, err error) {
 	if limit == 0 {
-		result, err = o.ds.ExecContext(ctx, `DELETE FROM evm.log_poller_blocks
-			WHERE block_number <= $1 AND evm_chain_id = $2`, end, ubig.New(o.chainID))
-		if err != nil {
-			return 0, err
-		}
-		return result.RowsAffected()
+		return query(0, end)
 	}
 
-	var limitBlock int64
-	err = o.ds.GetContext(ctx, &limitBlock, `SELECT MIN(block_number) FROM evm.log_poller_blocks
+	var start int64
+	err = o.ds.GetContext(ctx, &start, `SELECT MIN(block_number) FROM evm.log_poller_blocks
 		WHERE evm_chain_id = $1`, ubig.New(o.chainID))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -321,27 +317,35 @@ func (o *DSORM) DeleteBlocksBefore(ctx context.Context, end int64, limit int64) 
 	}
 
 	// Remove up to limit blocks at a time, until we've reached the limit or removed everything eligible for deletion
-	var deleted, rows int64
-	for limitBlock += (limit - 1); deleted < limit; limitBlock += limit {
-		if limitBlock > end {
-			limitBlock = end
+	for lower, upper := start, start+limit-1; numResults < limit; lower = upper + 1 {
+		upper = lower + limit - 1
+		if upper > end {
+			upper = end
 		}
-		result, err = o.ds.ExecContext(ctx, `DELETE FROM evm.log_poller_blocks WHERE block_number <= $1 AND evm_chain_id = $2`, limitBlock, ubig.New(o.chainID))
-		if err != nil {
-			return deleted, err
+		rows, err2 := query(lower, upper)
+		if err2 != nil {
+			return numResults, err
 		}
+		numResults += rows
 
-		if rows, err = result.RowsAffected(); err != nil {
-			return deleted, err
-		}
-
-		deleted += rows
-
-		if limitBlock == end {
+		if upper == end {
 			break
 		}
 	}
-	return deleted, err
+	return numResults, nil
+}
+
+// DeleteBlocksBefore delete blocks before and including end. When limit is set, it will delete at most limit blocks.
+// Otherwise, it will delete all blocks at once.
+func (o *DSORM) DeleteBlocksBefore(ctx context.Context, end int64, limit int64) (int64, error) {
+	return o.ExecPagedQuery(ctx, limit, end, func(lower, upper int64) (int64, error) {
+		result, err := o.ds.ExecContext(ctx, `DELETE FROM evm.log_poller_blocks WHERE evm_chain_id = $1 AND block_number >= $2 AND block_number <= $3`,
+			ubig.New(o.chainID), lower, upper)
+		if err != nil {
+			return 0, err
+		}
+		return result.RowsAffected()
+	})
 }
 
 func (o *DSORM) DeleteLogsAndBlocksAfter(ctx context.Context, start int64) error {
@@ -407,42 +411,49 @@ func (o *DSORM) SelectUnmatchedLogIDs(ctx context.Context, limit int64) (ids []u
 }
 
 // SelectExcessLogIDs finds any logs old enough that MaxLogsKept has been exceeded for every filter they match.
-func (o *DSORM) SelectExcessLogIDs(ctx context.Context, limit int64) (rowIDs []uint64, err error) {
-	var limitClause string
-	if limit > 0 {
-		// We have to count the logs in descending order first, to know which ones to keep. But then reverse the order
-		// of them all if we want to delete only the oldest {limit} # of logs. Omitting this 2nd ORDER BY is fine if we're
-		// deleting all prunable logs, but if paging is enabled we don't want to have non-contiguous
-		// block ranges of logs in the db while waiting for the next page to be pruned
-		limitClause = fmt.Sprintf(" ORDER BY block_number, log_index LIMIT %d", limit)
-	}
-
-	// Allow SELECT query to run for up to 3 minutes. DELETE query will still have default 10s timeout
-	selectCtx, cancel := context.WithTimeout(sqlutil.WithoutDefaultTimeout(ctx), 3*time.Minute)
-	defer cancel()
-
-	query := `
-		WITH filters AS (SELECT name,
+func (o *DSORM) SelectExcessLogIDs(ctx context.Context, limit int64) (results []uint64, err error) {
+	withSubQuery := ` -- Roll up the filter table into 1 row per filter
+		SELECT name,
 				ARRAY_AGG(address) AS addresses, ARRAY_AGG(event) AS events,
 				(ARRAY_AGG(topic2) FILTER(WHERE topic2 IS NOT NULL)) AS topic2,
 				(ARRAY_AGG(topic3) FILTER(WHERE topic3 IS NOT NULL)) AS topic3,
 				(ARRAY_AGG(topic4) FILTER(WHERE topic4 IS NOT NULL)) AS topic4,
-				MAX(max_logs_kept) AS max_logs_kept -- Should all be the same, but just in case use MAX
+				MAX(max_logs_kept) AS max_logs_kept -- Should all be the same, just need MAX for GROUP BY
 			FROM evm.log_poller_filters WHERE evm_chain_id=$1
-			GROUP BY name
-		) SELECT id FROM (
-			SELECT l.id, block_number, log_index, max_logs_kept != 0 AND
-				ROW_NUMBER() OVER(PARTITION BY f.name ORDER BY block_number, log_index DESC) > max_logs_kept AS old
-				FROM filters f JOIN evm.logs l ON l.evm_chain_id=$1 AND
-					l.address = ANY(f.addresses) AND
-					l.event_sig = ANY(f.events) AND
-					(f.topic2 IS NULL OR l.topics[1] = ANY(f.topic2)) AND
-					(f.topic3 IS NULL OR l.topics[2] = ANY(f.topic3)) AND
-					(f.topic4 IS NULL OR l.topics[3] = ANY(f.topic4))
-		) x GROUP BY id, block_number, log_index HAVING BOOL_AND(old)` + limitClause
+			GROUP BY name`
 
-	err = o.ds.SelectContext(selectCtx, &rowIDs, query, ubig.New(o.chainID))
-	return rowIDs, err
+	countLogsSubQuery := ` -- Count logs matching each filter in reverse order, labeling anything after the filter.max_logs_kept'th with old=true
+		SELECT l.id, block_number, log_index, max_logs_kept != 0 AND
+				ROW_NUMBER() OVER(PARTITION BY f.name ORDER BY block_number, log_index DESC) > max_logs_kept AS old
+			FROM filters f JOIN evm.logs l ON
+				l.address = ANY(f.addresses) AND
+				l.event_sig = ANY(f.events) AND
+				(f.topic2 IS NULL OR l.topics[1] = ANY(f.topic2)) AND
+				(f.topic3 IS NULL OR l.topics[2] = ANY(f.topic3)) AND
+				(f.topic4 IS NULL OR l.topics[3] = ANY(f.topic4))
+			WHERE evm_chain_id = $1 AND block_number >= $2 AND block_number <= $3
+	`
+
+	// Return all logs considered "old" by every filter they match
+	query := fmt.Sprintf(`WITH filters AS ( %s ) SELECT id FROM ( %s ) x GROUP BY id, block_number, log_index HAVING BOOL_AND(old)`,
+		withSubQuery, countLogsSubQuery)
+
+	latestBlock, err := o.SelectLatestBlock(ctx)
+	if err != nil {
+		return results, err
+	}
+
+	o.ExecPagedQuery(ctx, limit, latestBlock.FinalizedBlockNumber, func(lower, upper int64) (int64, error) {
+		var rowIDs []uint64
+		err = o.ds.SelectContext(ctx, &rowIDs, query, ubig.New(o.chainID), lower, upper)
+		if err != nil {
+			return 0, err
+		}
+		results = append(results, rowIDs...)
+		return int64(len(rowIDs)), err
+	})
+
+	return results, err
 }
 
 // DeleteExpiredLogs removes any logs which either:

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -459,7 +459,7 @@ func TestORM(t *testing.T) {
 	require.Equal(t, 2, len(lgs))
 
 	require.NoError(t, o1.InsertBlock(ctx, common.HexToHash("0x1237"), 16, time.Now(), 0))
-	require.NoError(t, o1.InsertBlock(ctx, common.HexToHash("0x1238"), 17, time.Now(), 0))
+	require.NoError(t, o1.InsertBlock(ctx, common.HexToHash("0x1238"), 17, time.Now(), 17))
 
 	filter0 := logpoller.Filter{
 		Name:      "permanent retention filter",
@@ -1206,7 +1206,7 @@ func TestORM_ExecPagedQuery(t *testing.T) {
 	_, err = o.ExecPagedQuery(ctx, 300, 1000, m.Exec)
 	assert.Error(t, err)
 
-	o.InsertBlock(ctx, common.HexToHash("0x1234"), 42, time.Now(), 0)
+	require.NoError(t, o.InsertBlock(ctx, common.HexToHash("0x1234"), 42, time.Now(), 0))
 
 	m.On("Exec", mock.Anything, mock.Anything).Return(3, nil)
 

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -2,7 +2,6 @@ package logpoller_test
 
 import (
 	"bytes"
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -17,7 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/jackc/pgx/v4"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -548,16 +546,160 @@ func TestORM(t *testing.T) {
 	assert.Zero(t, len(logs))
 }
 
-type PgxLogger struct {
-	lggr logger.Logger
-}
+func TestORM_SelectExcessLogs(t *testing.T) {
+	t.Parallel()
+	th := SetupTH(t, lpOpts)
+	o1 := th.ORM
+	o2 := th.ORM2
+	ctx := testutils.Context(t)
 
-func NewPgxLogger(lggr logger.Logger) PgxLogger {
-	return PgxLogger{lggr}
-}
+	topic := common.HexToHash("0x1599")
+	topic2 := common.HexToHash("0x1600")
 
-func (l PgxLogger) Log(ctx context.Context, log pgx.LogLevel, msg string, data map[string]interface{}) {
+	blockHashes := []common.Hash{common.HexToHash("0x1234"), common.HexToHash("0x1235"), common.HexToHash("0x1236")}
 
+	// Insert blocks for active chain
+	for i := int64(0); i < 3; i++ {
+		blockNumber := 10 + i
+		require.NoError(t, o1.InsertBlock(ctx, blockHashes[i], blockNumber, time.Now(), blockNumber))
+		b1, err := o1.SelectBlockByHash(ctx, blockHashes[i])
+		require.NoError(t, err)
+		require.Equal(t, blockNumber, b1.BlockNumber)
+	}
+
+	// Insert block from a different chain
+	require.NoError(t, o2.InsertBlock(ctx, common.HexToHash("0x1234"), 17, time.Now(), 17))
+	b, err := o2.SelectBlockByHash(ctx, common.HexToHash("0x1234"))
+	require.NoError(t, err)
+	require.Equal(t, int64(17), b.BlockNumber)
+
+	for i := int64(0); i < 7; i++ {
+		require.NoError(t, o1.InsertLogs(ctx, []logpoller.Log{
+			{
+				EvmChainId:     ubig.New(th.ChainID),
+				LogIndex:       i,
+				BlockHash:      common.HexToHash("0x1234"),
+				BlockNumber:    int64(10),
+				EventSig:       topic,
+				Topics:         [][]byte{topic[:]},
+				Address:        common.HexToAddress("0x1234"),
+				TxHash:         common.HexToHash("0x1888"),
+				Data:           []byte("hello"),
+				BlockTimestamp: time.Now(),
+			},
+			{
+				EvmChainId:     ubig.New(th.ChainID),
+				LogIndex:       i,
+				BlockHash:      common.HexToHash("0x1234"),
+				BlockNumber:    int64(11),
+				EventSig:       topic,
+				Topics:         [][]byte{topic[:]},
+				Address:        common.HexToAddress("0x1235"),
+				TxHash:         common.HexToHash("0x1888"),
+				Data:           []byte("hello"),
+				BlockTimestamp: time.Now(),
+			},
+			{
+				EvmChainId:     ubig.New(th.ChainID),
+				LogIndex:       i,
+				BlockHash:      common.HexToHash("0x1234"),
+				BlockNumber:    int64(12),
+				EventSig:       topic2,
+				Topics:         [][]byte{topic2[:]},
+				Address:        common.HexToAddress("0x1235"),
+				TxHash:         common.HexToHash("0x1888"),
+				Data:           []byte("hello"),
+				BlockTimestamp: time.Now(),
+			},
+		}))
+	}
+
+	logs, err := o1.SelectLogsByBlockRange(ctx, 1, 12)
+	require.NoError(t, err)
+	require.Len(t, logs, 21)
+
+	// Insert a log on a different chain, to make sure
+	// it's not affected by any operations on the chain LogPoller
+	// is managing.
+	require.NoError(t, o2.InsertLogs(ctx, []logpoller.Log{
+		{
+			EvmChainId:     ubig.New(th.ChainID2),
+			LogIndex:       8,
+			BlockHash:      common.HexToHash("0x1238"),
+			BlockNumber:    int64(17),
+			EventSig:       topic2,
+			Topics:         [][]byte{topic2[:]},
+			Address:        common.HexToAddress("0x1236"),
+			TxHash:         common.HexToHash("0x1888"),
+			Data:           []byte("same log on unrelated chain"),
+			BlockTimestamp: time.Now(),
+		},
+	}))
+
+	logs, err = o2.SelectLogsByBlockRange(ctx, 1, 17)
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+
+	filter1 := logpoller.Filter{
+		Name:        "MaxLogsKept = 0 (addr 1234 topic1)",
+		Addresses:   []common.Address{common.HexToAddress("0x1234")},
+		EventSigs:   types.HashArray{topic},
+		MaxLogsKept: 0,
+	}
+
+	filter12 := logpoller.Filter{ // retain both topic1 and topic2 on contract3 for at least 1ms
+		Name:        "MaxLogsKept = 1 (addr 1235 topic1 & topic2)",
+		Addresses:   []common.Address{common.HexToAddress("0x1235")},
+		EventSigs:   types.HashArray{topic, topic2},
+		Retention:   time.Millisecond,
+		MaxLogsKept: 1,
+	}
+	filter2 := logpoller.Filter{ // retain topic2 on contract3 for at least 1 hour
+		Name:        "MaxLogsKept = 5 (addr 1235 topic2)",
+		Addresses:   []common.Address{common.HexToAddress("0x1235")},
+		EventSigs:   types.HashArray{topic2},
+		MaxLogsKept: 5,
+	}
+
+	// Test inserting filters and reading them back
+	require.NoError(t, o1.InsertFilter(ctx, filter1))
+	require.NoError(t, o1.InsertFilter(ctx, filter12))
+	require.NoError(t, o1.InsertFilter(ctx, filter2))
+
+	filters, err := o1.LoadFilters(ctx)
+	require.NoError(t, err)
+	require.Len(t, filters, 3)
+	assert.Equal(t, filter1, filters["MaxLogsKept = 0 (addr 1234 topic1)"])
+	assert.Equal(t, filter12, filters["MaxLogsKept = 1 (addr 1235 topic1 & topic2)"])
+	assert.Equal(t, filter2, filters["MaxLogsKept = 5 (addr 1235 topic2)"])
+
+	ids, err := o1.SelectUnmatchedLogIDs(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, ids, 0)
+
+	// Number of excess logs eligible for pruning:
+	// 2 of the 7 matching filter2 + 6 of the 7 matching filter12 but not filter2 = 8 total of 21
+
+	// Test SelectExcessLogIDs with limit less than # blocks
+	// ( should only consider blocks 10 & 11, returning 6 excess events from block 11
+	// but ignoring the 2 in block 12 )
+	ids, err = o1.SelectExcessLogIDs(ctx, 2)
+	require.NoError(t, err)
+	assert.Len(t, ids, 6)
+
+	// Test SelectExcessLogIDs with limit greater than # blocks:
+	ids, err = o1.SelectExcessLogIDs(ctx, 4)
+	require.NoError(t, err)
+	assert.Len(t, ids, 8)
+
+	// Test SelectExcessLogIDs with no limit
+	ids, err = o1.SelectExcessLogIDs(ctx, 10)
+	require.NoError(t, err)
+	assert.Len(t, ids, 8)
+
+	deleted, err := o1.DeleteLogsByRowID(ctx, ids)
+	require.NoError(t, err)
+	assert.Equal(t, int64(8), deleted)
 }
 
 func TestLogPollerFilters(t *testing.T) {

--- a/core/services/relay/evm/contract_transmitter.go
+++ b/core/services/relay/evm/contract_transmitter.go
@@ -56,6 +56,12 @@ func WithRetention(retention time.Duration) OCRTransmitterOption {
 	}
 }
 
+func WithMaxLogsKept(maxLogsKept uint64) OCRTransmitterOption {
+	return func(ct *contractTransmitter) {
+		ct.maxLogsKept = maxLogsKept
+	}
+}
+
 func WithReportToEthMetadata(reportToEvmTxMeta ReportToEthMetadata) OCRTransmitterOption {
 	return func(ct *contractTransmitter) {
 		if reportToEvmTxMeta != nil {
@@ -76,6 +82,7 @@ type contractTransmitter struct {
 	reportToEvmTxMeta ReportToEthMetadata
 	excludeSigs       bool
 	retention         time.Duration
+	maxLogsKept       uint64
 }
 
 func transmitterFilterName(addr common.Address) string {
@@ -108,15 +115,14 @@ func NewOCRContractTransmitter(
 		reportToEvmTxMeta:   reportToEvmTxMetaNoop,
 		excludeSigs:         false,
 		retention:           0,
+		maxLogsKept:         0,
 	}
 
 	for _, opt := range opts {
 		opt(newContractTransmitter)
 	}
 
-	// TODO It would be better to keep MaxLogsKept = 1 for the OCR contract transmitter instead of Retention. We are always interested only in the latest log.
-	// Although MaxLogsKept is present in the Filter struct, it is not supported by LogPoller yet.
-	err := lp.RegisterFilter(ctx, logpoller.Filter{Name: transmitterFilterName(address), EventSigs: []common.Hash{transmitted.ID}, Addresses: []common.Address{address}, Retention: newContractTransmitter.retention})
+	err := lp.RegisterFilter(ctx, logpoller.Filter{Name: transmitterFilterName(address), EventSigs: []common.Hash{transmitted.ID}, Addresses: []common.Address{address}, Retention: newContractTransmitter.retention, MaxLogsKept: newContractTransmitter.maxLogsKept})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[BCFR-899](https://smartcontract-it.atlassian.net/browse/BCFR-899)

# Motivation
Presently, LogPoller supports only time-based retention, via the Retention field in the filters passed to RegisterFilter. The MaxLogsKept field was added earlier in anticipation of the need for also supporting recency-count based retention. One example of a case where time based retention is risky is the Transmit event in the OCR Contract Transmitter. No matter how long the retention period is set to, there's a chance the node will be down for longer than that, and miss logs when it comes back up. This would make a bad situation even worse, because the transmit event would never be picked up at all.

# Solution
This implements the MaxLogsKept feature in LogPoller. When specified, this field tells LogPoller it's okay to prune logs matching a filter if there are at least MaxLogsKept more recent matching logs in the db.
In the example above, this avoid storing any more logs than needed while always having the latest transmit event available. In this case, older transmit events are no longer relevant if there is a more recent one.
In general, this should be just as useful for anything accessed only via ChainReader's GetLatestValue() method rather than QueryKey().

A log may be pruned either because it's too old in terms of time or in terms of the number of logs being saved. It need not satisfy both theRetention and MaxLogsKeptcriteria in order to get pruned.


[BCF-899]: https://smartcontract-it.atlassian.net/browse/BCF-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BCFR-899]: https://smartcontract-it.atlassian.net/browse/BCFR-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# Testing

This was tested by changing the MaxLogsKept setting on the ContractTransmitter filter passed to LogPoller from 0 to 1, and running the CCIP load tests.

Without paging, this query is one of the most cpu intensive. Similar to the DeleteExpiredLogs query, it must go though every row of the logs table unless LogPrunePageSize is set to non-zero.  But it's slower than DeleteExpiredLogs because on top of that, it also has to group, sort, and count every log in each group in order to figure out how many there are and which ones are the excess logs eligible for deletion. Also similar to DeleteExpiredLogs, the final step is to merge together all the results for logs matching multiple filters by making sure that no log is dropped unless ALL of its matching filters agree that it came before their own MaxLogsKept threshold was hit.

Without paging, the SelectExcessLogs query grew in median duration linearly as the number of logs in the table increased. After a few hours it was taking longer than the Insert queries (and any other queries) and started causing timeouts to occur, not just for itself but for other queries as well. It eventually got to a point where the p90 & p99 charts were continuously in the 4-5s range, generating many critical errors as well as a lot of backlogged queries waiting on connections.

With a paging size of 4000, you could see that the query durations grew linearly at first with the size of the table, and then leveled off at slightly more than the insert queries. It still resulted in a couple fairly large bursts of critical errors (query timeouts) during the heaviest cpu usage.

A paging size of 1000-2000 worked much better. There were a much smaller # of timeouts, and only during a brief window of time.  The p99 durations were noticeably lower than the insert query durations, aside from some very brief but high spikes which we believe are due to an unrelated bug (which has been fixed in Chainlink repo, but hasn't been back posted to CCIP yet) in not letting go of connections quickly enough (due to sql logging).
Aside from these spikes, the charts look pretty healthy... so we should retest once that bug is backported but before the MaxLogsKept feature is enabled.

Another scenario tested was the performance of the query when all filters have MaxLogsKept=0. This was tested both with and without the code which skips the query unless there is at least one filter with MaxLogsKept > 0. Obviously, skipping the query took it off the chart entirely... so the rest of the chart looked the same as before this PR. Without slipping the query, it was slightly faster than the MaxLogs=1 case, but not a very significant reduction. Based on this it was decided it did make sense to disable the pruning until this feature starts being used by at least 1 filter.

With MaxLogsKept=1:
<img width="2496" alt="Screenshot 2024-10-15 at 5 54 53 PM" src="https://github.com/user-attachments/assets/fb97be8d-2e67-432b-80c0-54dcdb2d8e86">
<img width="2487" alt="Screenshot 2024-10-15 at 5 55 11 PM" src="https://github.com/user-attachments/assets/4e179f97-4e81-422a-bece-89eed1be6246">

With MaxLogsKept=0 (disabled):
<img width="2489" alt="Screenshot 2024-10-15 at 5 58 09 PM" src="https://github.com/user-attachments/assets/f8de0a00-356e-4b98-a0f9-fb0eb9df735c">
<img width="2516" alt="Screenshot 2024-10-15 at 5 58 46 PM" src="https://github.com/user-attachments/assets/17109b1a-96f6-4c3e-979e-26c745acac28">

For both of these tests, the pruning of unmatched logs--which is also an expensive query--has been increased in frequency from every 20 ticks to every 4 ticks, to see what it looks like under the most severe conditions while they're both happening at once (with every 20 ticks, the test usually completes before the first one happens).  On the MaxLogsKept=1 charts, SelectUnmatchedLogs query durations show up as cyan and SelectExcessLogs query durations as bright yellow. On the MaxLogsKept=0 charts, SelectUnmatchedLogs is pale yellow (and SelectExcessLogs does not run--as desired). LogPrunePageSize was set to 1000 for both.
