### PR TITLE
fixed bug related to differences in cursor structure

### DIFF
--- a/core/chains/evm/logpoller/parser.go
+++ b/core/chains/evm/logpoller/parser.go
@@ -433,7 +433,7 @@ func orderToString(dir query.SortDirection) (string, error) {
 }
 
 // MakeContractReaderCursor is exported to ensure cursor structure remains consistent.
-func MakeContractReaderCursor(log Log) string {
+func FormatContractReaderCursor(log Log) string {
 	return fmt.Sprintf("%d-%d-%s", log.BlockNumber, log.LogIndex, log.TxHash)
 }
 

--- a/core/chains/evm/logpoller/parser.go
+++ b/core/chains/evm/logpoller/parser.go
@@ -432,6 +432,12 @@ func orderToString(dir query.SortDirection) (string, error) {
 	}
 }
 
+// MakeContractReaderCursor is exported to ensure cursor structure remains consistent.
+func MakeContractReaderCursor(log Log) string {
+	return fmt.Sprintf("%d-%d-%s", log.BlockNumber, log.LogIndex, log.TxHash)
+}
+
+// ensure valuesFromCursor remains consistent with the function above that creates a cursor
 func valuesFromCursor(cursor string) (int64, int, []byte, error) {
 	partCount := 3
 

--- a/core/services/relay/evm/read/event.go
+++ b/core/services/relay/evm/read/event.go
@@ -338,7 +338,7 @@ func (b *EventBinding) decodeLogsIntoSequences(ctx context.Context, logs []logpo
 
 	for idx := range logs {
 		sequences[idx] = commontypes.Sequence{
-			Cursor: fmt.Sprintf("%s-%s-%d", logs[idx].BlockHash, logs[idx].TxHash, logs[idx].LogIndex),
+			Cursor: logpoller.MakeContractReaderCursor(logs[idx]),
 			Head: commontypes.Head{
 				Height:    fmt.Sprint(logs[idx].BlockNumber),
 				Hash:      logs[idx].BlockHash.Bytes(),

--- a/core/services/relay/evm/read/event.go
+++ b/core/services/relay/evm/read/event.go
@@ -338,7 +338,7 @@ func (b *EventBinding) decodeLogsIntoSequences(ctx context.Context, logs []logpo
 
 	for idx := range logs {
 		sequences[idx] = commontypes.Sequence{
-			Cursor: logpoller.MakeContractReaderCursor(logs[idx]),
+			Cursor: logpoller.FormatContractReaderCursor(logs[idx]),
 			Head: commontypes.Head{
 				Height:    fmt.Sprint(logs[idx].BlockNumber),
 				Hash:      logs[idx].BlockHash.Bytes(),


### PR DESCRIPTION
The pattern for creating a cursor and splitting data in a cursor were not consistent and resulting in inconsistent results when using cursors in `QueryKey`.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves
No corresponding tickets, but fixes a bug related to cursors in `QueryKey`.