### PR TITLE
Unorder changesets

### DIFF
--- a/integration-tests/deployment/README.md
+++ b/integration-tests/deployment/README.md
@@ -20,7 +20,6 @@ environments like testnet/mainnet.
 - EVM only
 
 /deployment/devenv
-- Coming soon
 - package name `devenv`
 - Docker environment for higher fidelity testing
 - Support non-EVMs (yet to be implemented)
@@ -36,20 +35,22 @@ environments like testnet/mainnet.
 - package name `changeset` imported as `ccipchangesets`
 - These function like scripts describing state transitions
   you wish to apply to _persistent_ environments like testnet/mainnet
-- Ordered list of Go functions following the format
+- They should be go functions where the first argument is an
+  environment and the second argument is a config struct which can be unique to the 
+  changeset. The return value should be a `deployment.ChangesetOutput` and an error.
 ```Go
-0001_descriptive_name.go
-func Apply0001(env deployment.Environment, c ccipdeployment.Config) (deployment.ChangesetOutput, error)
+do_something.go
+func DoSomethingChangeSet(env deployment.Environment, c ccipdeployment.Config) (deployment.ChangesetOutput, error)
 {
     // Deploy contracts, generate MCMS proposals, generate
     // job specs according to contracts etc.
     return deployment.ChangesetOutput{}, nil
 }
-0001_descriptive_name_test.go
-func TestApply0001(t *testing.T)
+do_something_test.go
+func TestDoSomething(t *testing.T)
 {
     // Set up memory env
-    // Apply0001 function
+    // DoSomethingChangeSet function
     // Take the artifacts from ChangeSet output
     // Apply them to the memory env
     // Send traffic, run assertions etc.

--- a/integration-tests/deployment/ccip/changeset/cap_reg.go
+++ b/integration-tests/deployment/ccip/changeset/cap_reg.go
@@ -7,8 +7,8 @@ import (
 	ccipdeployment "github.com/smartcontractkit/chainlink/integration-tests/deployment/ccip"
 )
 
-// Separate migration because cap reg is an env var for CL nodes.
-func Apply0001(env deployment.Environment, homeChainSel uint64) (deployment.ChangesetOutput, error) {
+// Separated changset because cap reg is an env var for CL nodes.
+func CapRegChangSet(env deployment.Environment, homeChainSel uint64) (deployment.ChangesetOutput, error) {
 	// Note we also deploy the cap reg.
 	ab, _, err := ccipdeployment.DeployCapReg(env.Logger, env.Chains[homeChainSel])
 	if err != nil {

--- a/integration-tests/deployment/ccip/changeset/cap_reg.go
+++ b/integration-tests/deployment/ccip/changeset/cap_reg.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Separated changset because cap reg is an env var for CL nodes.
-func CapRegChangSet(env deployment.Environment, homeChainSel uint64) (deployment.ChangesetOutput, error) {
+func CapRegChangeSet(env deployment.Environment, homeChainSel uint64) (deployment.ChangesetOutput, error) {
 	// Note we also deploy the cap reg.
 	ab, _, err := ccipdeployment.DeployCapReg(env.Logger, env.Chains[homeChainSel])
 	if err != nil {

--- a/integration-tests/deployment/ccip/changeset/initial_deploy.go
+++ b/integration-tests/deployment/ccip/changeset/initial_deploy.go
@@ -12,7 +12,7 @@ import (
 // TODO: Maybe there's a generics approach here?
 // Note if the change set is a deployment and it fails we have 2 options:
 // - Just throw away the addresses, fix issue and try again (potentially expensive on mainnet)
-func Apply0002(env deployment.Environment, c ccipdeployment.DeployCCIPContractConfig) (deployment.ChangesetOutput, error) {
+func InitialDeployChangeSet(env deployment.Environment, c ccipdeployment.DeployCCIPContractConfig) (deployment.ChangesetOutput, error) {
 	ab, err := ccipdeployment.DeployCCIPContracts(env, c)
 	if err != nil {
 		env.Logger.Errorw("Failed to deploy CCIP contracts", "err", err, "addresses", ab)

--- a/integration-tests/deployment/ccip/changeset/initial_deploy_test.go
+++ b/integration-tests/deployment/ccip/changeset/initial_deploy_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
-func Test0002_InitialDeploy(t *testing.T) {
+func TestInitialDeploy(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	ctx := ccdeploy.Context(t)
 	tenv := ccdeploy.NewMemoryEnvironment(t, lggr, 3)
@@ -35,8 +35,8 @@ func Test0002_InitialDeploy(t *testing.T) {
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},
 	)
-	// Apply migration
-	output, err := Apply0002(tenv.Env, ccdeploy.DeployCCIPContractConfig{
+	// Apply changeset
+	output, err := InitialDeployChangeSet(tenv.Env, ccdeploy.DeployCCIPContractConfig{
 		HomeChainSel:   tenv.HomeChainSel,
 		FeedChainSel:   tenv.FeedChainSel,
 		ChainsToDeploy: tenv.Env.AllChainSelectors(),

--- a/integration-tests/smoke/ccip_test.go
+++ b/integration-tests/smoke/ccip_test.go
@@ -35,7 +35,7 @@ func Test0002_InitialDeployOnLocal(t *testing.T) {
 		},
 	)
 	// Apply migration
-	output, err := changeset.Apply0002(tenv.Env, ccdeploy.DeployCCIPContractConfig{
+	output, err := changeset.InitialDeployChangeSet(tenv.Env, ccdeploy.DeployCCIPContractConfig{
 		HomeChainSel:   tenv.HomeChainSel,
 		FeedChainSel:   tenv.FeedChainSel,
 		ChainsToDeploy: tenv.Env.AllChainSelectors(),

--- a/integration-tests/smoke/ccip_test.go
+++ b/integration-tests/smoke/ccip_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
-func Test0002_InitialDeployOnLocal(t *testing.T) {
+func TestInitialDeployOnLocal(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	ctx := ccdeploy.Context(t)
 	tenv := ccdeploy.NewLocalDevEnvironment(t, lggr)


### PR DESCRIPTION
Could be for staging environments you want to apply different changes. To avoid boilerplate of defining per env changesets, we just make them unordered here. Then in the deployment repo you can select the relevant ones and order them there. 