### PR TITLE
fix: fix slice init length

### DIFF
--- a/common/txmgr/tracker.go
+++ b/common/txmgr/tracker.go
@@ -183,7 +183,7 @@ func (tr *Tracker[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) GetAbandone
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
 
-	abandonedAddrs := make([]ADDR, len(tr.txCache))
+	abandonedAddrs := make([]ADDR, 0, len(tr.txCache))
 	for _, fromAddress := range tr.txCache {
 		abandonedAddrs = append(abandonedAddrs, fromAddress)
 	}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->

The intention here should be to initialize a slice with a capacity of len(tr.txCache) rather than initializing the length of this slice.
The online demo: https://go.dev/play/p/vNUPNjdb2gJ

