### PR TITLE
Broadcast transactions only to a single healthy RPC instead of all 

### DIFF
--- a/.changeset/three-otters-drum.md
+++ b/.changeset/three-otters-drum.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Hedera chain type: broadcast transactions only to a single healthy RPC instead of all healthy RPCs to avoid redundant relay fees. #changed

--- a/core/chains/evm/client/chain_client.go
+++ b/core/chains/evm/client/chain_client.go
@@ -174,6 +174,14 @@ func (c *chainClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) e
 
 // Similar to BatchCallContext, ensure the provided BatchElem slice is passed through
 func (c *chainClient) BatchCallContextAll(ctx context.Context, b []rpc.BatchElem) error {
+	if c.chainType == chaintype.ChainHedera {
+		activeRPC, err := c.multiNode.SelectNodeRPC()
+		if err != nil {
+			return err
+		}
+
+		return activeRPC.BatchCallContext(ctx, b)
+	}
 	return c.multiNode.BatchCallContextAll(ctx, b)
 }
 
@@ -291,6 +299,13 @@ func (c *chainClient) PendingNonceAt(ctx context.Context, account common.Address
 }
 
 func (c *chainClient) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	if c.chainType == chaintype.ChainHedera {
+		activeRPC, err := c.multiNode.SelectNodeRPC()
+		if err != nil {
+			return err
+		}
+		return activeRPC.SendTransaction(ctx, tx)
+	}
 	return c.multiNode.SendTransaction(ctx, tx)
 }
 

--- a/core/chains/evm/client/chain_client_test.go
+++ b/core/chains/evm/client/chain_client_test.go
@@ -874,8 +874,9 @@ func TestEthClient_ErroringClient(t *testing.T) {
 	err = erroringClient.SendTransaction(ctx, nil)
 	require.Equal(t, err, commonclient.ErroringNodeError)
 
-	code, err := erroringClient.SendTransactionReturnCode(ctx, nil, common.Address{})
-	require.Equal(t, code, commonclient.Unknown)
+	tx := testutils.NewLegacyTransaction(uint64(42), testutils.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
+	code, err := erroringClient.SendTransactionReturnCode(ctx, tx, common.Address{})
+	require.Equal(t, code, commonclient.Retryable)
 	require.Equal(t, err, commonclient.ErroringNodeError)
 
 	_, err = erroringClient.SequenceAt(ctx, common.Address{}, nil)

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -390,7 +390,11 @@ func (s *SendError) IsL2Full(configErrors *ClientErrors) bool {
 
 // IsServiceUnavailable indicates if the error was caused by a service being unavailable
 func (s *SendError) IsServiceUnavailable(configErrors *ClientErrors) bool {
-	return s.is(ServiceUnavailable, configErrors)
+	if s == nil || s.err == nil {
+		return false
+	}
+
+	return s.is(ServiceUnavailable, configErrors) || pkgerrors.Is(s.err, commonclient.ErroringNodeError)
 }
 
 // IsTerminallyStuck indicates if a transaction was stuck without any chance of inclusion

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -9,6 +9,7 @@ import (
 	pkgerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
+	commonclient "github.com/smartcontractkit/chainlink/v2/common/client"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 )
 
@@ -247,6 +248,12 @@ func Test_Eth_Errors(t *testing.T) {
 			assert.Equal(t, err.IsServiceUnavailable(clientErrors), test.expect)
 			err = newSendErrorWrapped(test.message)
 			assert.Equal(t, err.IsServiceUnavailable(clientErrors), test.expect)
+		}
+		{
+			err = evmclient.NewSendError(commonclient.ErroringNodeError)
+			assert.True(t, err.IsServiceUnavailable(clientErrors))
+			err = evmclient.NewSendError(fmt.Errorf("failed to send transaction: %w", commonclient.ErroringNodeError))
+			assert.True(t, err.IsServiceUnavailable(clientErrors))
 		}
 	})
 


### PR DESCRIPTION
Hedera doesn't have a mempool and has instant finality. Sending the transaction to the first node gets the transaction included so broadcasting to other nodes after leads to [nonce too low errors](https://hashscan.io/testnet/transaction/1727790548.862009226). This normally wouldn't be a problem since these types of errors are usually surfaced upfront by the RPC, but in the case of Hedera, they make it on-chain and the error is only available through receipts which means NOPs have to pay for these transactions.

To avoid this we should only broadcast transactions to a single active RPC.