### PR TITLE
update automation tests

### DIFF
--- a/integration-tests/load/automationv2_1/automationv2_1_test.go
+++ b/integration-tests/load/automationv2_1/automationv2_1_test.go
@@ -323,7 +323,7 @@ Load Config:
 	a.PublicConfig = actions.ReadPublicConfig(loadedTestConfig)
 	a.RegistrarSettings = contracts.KeeperRegistrarSettings{
 		AutoApproveConfigType: uint8(2),
-		AutoApproveMaxAllowed: 1000,
+		AutoApproveMaxAllowed: math.MaxUint16,
 		MinLinkJuels:          big.NewInt(0),
 	}
 

--- a/integration-tests/load/automationv2_1/automationv2_1_test.go
+++ b/integration-tests/load/automationv2_1/automationv2_1_test.go
@@ -277,24 +277,29 @@ Load Config:
 		secretsTOML = ""
 	}
 
-	numberOfUpkeeps := *loadedTestConfig.Automation.General.NumberOfNodes
+	numberOfNodes := *loadedTestConfig.Automation.General.NumberOfNodes
 
-	for i := 0; i < numberOfUpkeeps+1; i++ { // +1 for the OCR boot node
+	for i := 0; i < numberOfNodes+1; i++ { // +1 for the OCR boot node
+		config := loadedTestConfig
+		if *config.Pyroscope.Enabled {
+			name := testEnvironment.Cfg.Namespace + "-" + strconv.Itoa(i)
+			config.Pyroscope.Environment = &name
+		}
 		var overrideFn = func(_ interface{}, target interface{}) {
-			ctfconfig.MustConfigOverrideChainlinkVersion(loadedTestConfig.GetChainlinkImageConfig(), target)
-			ctfconfig.MightConfigOverridePyroscopeKey(loadedTestConfig.GetPyroscopeConfig(), target)
+			ctfconfig.MustConfigOverrideChainlinkVersion(config.GetChainlinkImageConfig(), target)
+			ctfconfig.MightConfigOverridePyroscopeKey(config.GetPyroscopeConfig(), target)
 		}
 
-		tomlConfig, err := actions.BuildTOMLNodeConfigForK8s(&loadedTestConfig, testNetwork)
+		tomlConfig, err := actions.BuildTOMLNodeConfigForK8s(&config, testNetwork)
 		require.NoError(t, err, "Error building TOML config")
 
 		cd := chainlink.NewWithOverride(i, map[string]any{
 			"toml":        tomlConfig,
 			"chainlink":   nodeSpec,
 			"db":          dbSpec,
-			"prometheus":  *loadedTestConfig.Automation.General.UsePrometheus,
+			"prometheus":  *config.Automation.General.UsePrometheus,
 			"secretsToml": secretsTOML,
-		}, loadedTestConfig.ChainlinkImage, overrideFn)
+		}, config.ChainlinkImage, overrideFn)
 		testEnvironment.AddHelm(cd)
 	}
 

--- a/integration-tests/load/automationv2_1/helpers.go
+++ b/integration-tests/load/automationv2_1/helpers.go
@@ -52,7 +52,7 @@ func sendSlackNotification(header string, l zerolog.Logger, config *tc.TestConfi
 	notificationBlocks = append(notificationBlocks, slack.NewDividerBlock())
 	if *config.Pyroscope.Enabled {
 		pyroscopeServer := *config.Pyroscope.ServerUrl
-		pyroscopeEnvironment := *config.Pyroscope.Environment
+		pyroscopeEnvironment := *config.Pyroscope.Environment + "-1"
 
 		formattedPyroscopeUrl := fmt.Sprintf("%s/?query=chainlink-node.cpu{Environment=\"%s\"}&from=%s&to=%s", pyroscopeServer, pyroscopeEnvironment, startingTime, endingTime)
 		l.Info().Str("Pyroscope", formattedPyroscopeUrl).Msg("Dashboard URL")

--- a/integration-tests/testconfig/automation/automation.toml
+++ b/integration-tests/testconfig/automation/automation.toml
@@ -321,6 +321,7 @@ contract_call_interval = "4s"
 
 [Benchmark.Seth]
 # keeper benchmark running on simulated network requires 100k per node
+ephemeral_addresses_number = 100
 root_key_funds_buffer = 1_000_000
 
 [Benchmark.Automation]

--- a/integration-tests/testconfig/automation/overrides/benchmark/10000Upkeeps-24h-2_3.toml
+++ b/integration-tests/testconfig/automation/overrides/benchmark/10000Upkeeps-24h-2_3.toml
@@ -1,0 +1,18 @@
+[ChainlinkImage]
+version="2.16.0"
+
+[Benchmark.Automation.Benchmark]
+registry_to_test = "2_3"
+number_of_registries = 1
+number_of_nodes = 6
+number_of_upkeeps = 10000
+upkeep_gas_limit = 1500000
+check_gas_to_burn = 10000
+perform_gas_to_burn = 1000
+block_range = 86400
+block_interval = 60
+forces_single_tx_key = false
+delete_jobs_on_end = true
+
+[Pyroscope]
+enabled=true

--- a/integration-tests/testconfig/automation/overrides/load/50Upkeeps-1x-1000Upkeeps-0x-24h.toml
+++ b/integration-tests/testconfig/automation/overrides/load/50Upkeeps-1x-1000Upkeeps-0x-24h.toml
@@ -1,0 +1,55 @@
+[ChainlinkImage]
+version="2.16.0"
+
+[Load.Seth]
+root_key_funds_buffer = 1_000_000
+
+[Load.Common]
+chainlink_node_funding = 1000
+
+[Load.Automation.AutomationConfig]
+use_log_buffer_v1=false
+
+[Load.Automation.AutomationConfig.PluginConfig.LogProviderConfig]
+block_rate=1
+log_limit=2
+
+[Load.Automation]
+[Load.Automation.General]
+number_of_nodes=6
+duration=86400
+block_time=1
+spec_type="recommended"
+chainlink_node_log_level="debug"
+use_prometheus=true
+remove_namespace = true
+
+[Load.Automation.DataStreams]
+enabled=false
+
+[[Load.Automation.Load]]
+number_of_upkeeps=50
+number_of_events = 1
+number_of_spam_matching_events = 0
+number_of_spam_non_matching_events = 0
+check_burn_amount = 0
+perform_burn_amount = 0
+upkeep_gas_limit = 1000000
+shared_trigger = false
+is_streams_lookup = false
+feeds = []
+
+[[Load.Automation.Load]]
+number_of_upkeeps=1000
+number_of_events = 0
+number_of_spam_matching_events = 0
+number_of_spam_non_matching_events = 0
+check_burn_amount = 0
+perform_burn_amount = 0
+upkeep_gas_limit = 1000000
+shared_trigger = false
+is_streams_lookup = false
+feeds = []
+
+[Pyroscope]
+enabled=true


### PR DESCRIPTION
load - separate pyroscope profiling per node
benchmark - add pyroscope profiling per node
benchmark - improve slack notification ux

[DEVSVCS-722](https://smartcontract-it.atlassian.net/browse/DEVSVCS-722)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[DEVSVCS-722]: https://smartcontract-it.atlassian.net/browse/DEVSVCS-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ