### PR TITLE
Fix infinite loop while returning funds

### DIFF
--- a/integration-tests/actions/refund.go
+++ b/integration-tests/actions/refund.go
@@ -159,13 +159,13 @@ func (r *GasTooLowTransferRetrier) Retry(ctx context.Context, logger zerolog.Log
 
 	if r.nextRetrier != nil {
 		logger.Debug().
-			Str("retrier", "OvershotTransferRetrier").
+			Str("retrier", "GasTooLowTransferRetrier").
 			Msg(NotSupportedMsg)
 		return r.nextRetrier.Retry(ctx, logger, client, txErr, payload, 0)
 	}
 
 	logger.Warn().
-		Str("retrier", "OvershotTransferRetrier").
+		Str("retrier", "GasTooLowTransferRetrier").
 		Msg("No more retriers available. Unable to retry transaction. Returning error.")
 
 	return txErr
@@ -223,6 +223,8 @@ func (r *OvershotTransferRetrier) Retry(ctx context.Context, logger zerolog.Logg
 
 		if strings.Contains(retryErr.Error(), OvershotErr) {
 			return r.Retry(ctx, logger, client, retryErr, payload, currentAttempt+1)
+		} else {
+			txErr = retryErr
 		}
 	}
 

--- a/integration-tests/actions/refund.go
+++ b/integration-tests/actions/refund.go
@@ -223,9 +223,9 @@ func (r *OvershotTransferRetrier) Retry(ctx context.Context, logger zerolog.Logg
 
 		if strings.Contains(retryErr.Error(), OvershotErr) {
 			return r.Retry(ctx, logger, client, retryErr, payload, currentAttempt+1)
-		} else {
-			txErr = retryErr
 		}
+
+		txErr = retryErr
 	}
 
 	if r.nextRetrier != nil {

--- a/integration-tests/actions/refund.go
+++ b/integration-tests/actions/refund.go
@@ -26,9 +26,11 @@ import (
 )
 
 const (
-	InsufficientFundsErr = "insufficient funds"
-	GasTooLowErr         = "gas too low"
-	OvershotErr          = "overshot"
+	InsufficientFundsErr       = "insufficient funds"
+	TransactionUnderPriced     = "transaction underpriced"
+	FailedToWaitForTransaction = "failed to wait for transaction"
+	GasTooLowErr               = "gas too low"
+	OvershotErr                = "overshot"
 )
 
 var (
@@ -52,21 +54,21 @@ func (r *InsufficientFundTransferRetrier) Retry(ctx context.Context, logger zero
 	if currentAttempt >= r.maxRetries {
 		if r.nextRetrier != nil {
 			logger.Debug().
-				Str("retier", "InsufficientFundTransferRetrier").
+				Str("retrier", "InsufficientFundTransferRetrier").
 				Msg("Max retries reached. Passing to next retrier")
 			return r.nextRetrier.Retry(ctx, logger, client, txErr, payload, 0)
 		}
 		return txErr
 	}
 
-	for txErr != nil && (strings.Contains(txErr.Error(), InsufficientFundsErr)) {
+	for txErr != nil && (strings.Contains(txErr.Error(), InsufficientFundsErr) || strings.Contains(txErr.Error(), TransactionUnderPriced) || strings.Contains(txErr.Error(), FailedToWaitForTransaction)) {
 		logger.Info().
 			Msg("Insufficient funds error detected, retrying with less funds")
 
 		newAmount := big.NewInt(0).Sub(payload.Amount, big.NewInt(blockchain.GWei))
 
 		logger.Debug().
-			Str("retier", "InsufficientFundTransferRetrier").
+			Str("retrier", "InsufficientFundTransferRetrier").
 			Str("old amount", payload.Amount.String()).
 			Str("new amount", newAmount.String()).
 			Str("diff", big.NewInt(0).Sub(payload.Amount, newAmount).String()).
@@ -77,25 +79,26 @@ func (r *InsufficientFundTransferRetrier) Retry(ctx context.Context, logger zero
 		_, retryErr := SendFunds(logger, client, payload)
 		if retryErr == nil {
 			logger.Info().
-				Str("retier", "InsufficientFundTransferRetrier").
+				Str("retrier", "InsufficientFundTransferRetrier").
 				Msg(RetrySuccessfulMsg)
 			return nil
 		}
-
-		if strings.Contains(retryErr.Error(), InsufficientFundsErr) {
+		if strings.Contains(retryErr.Error(), InsufficientFundsErr) || strings.Contains(retryErr.Error(), TransactionUnderPriced) || strings.Contains(retryErr.Error(), FailedToWaitForTransaction) {
 			return r.Retry(ctx, logger, client, retryErr, payload, currentAttempt+1)
+		} else {
+			return retryErr
 		}
 	}
 
 	if r.nextRetrier != nil {
 		logger.Debug().
-			Str("retier", "InsufficientFundTransferRetrier").
+			Str("retrier", "InsufficientFundTransferRetrier").
 			Msg(NotSupportedMsg)
 		return r.nextRetrier.Retry(ctx, logger, client, txErr, payload, 0)
 	}
 
 	logger.Warn().
-		Str("retier", "InsufficientFundTransferRetrier").
+		Str("retrier", "InsufficientFundTransferRetrier").
 		Msg("No more retriers available. Unable to retry transaction. Returning error.")
 
 	return txErr
@@ -112,7 +115,7 @@ func (r *GasTooLowTransferRetrier) Retry(ctx context.Context, logger zerolog.Log
 	if payload.GasLimit != nil && *payload.GasLimit >= r.maxGasLimit {
 		if r.nextRetrier != nil {
 			logger.Debug().
-				Str("retier", "GasTooLowTransferRetrier").
+				Str("retrier", "GasTooLowTransferRetrier").
 				Msg("Max gas limit reached. Passing to next retrier")
 			return r.nextRetrier.Retry(ctx, logger, client, txErr, payload, 0)
 		}
@@ -130,7 +133,7 @@ func (r *GasTooLowTransferRetrier) Retry(ctx context.Context, logger zerolog.Log
 		}
 
 		logger.Debug().
-			Str("retier", "GasTooLowTransferRetrier").
+			Str("retrier", "GasTooLowTransferRetrier").
 			Int64("old gas limit", newGasLimit/2).
 			Int64("new gas limit", newGasLimit).
 			Int64("diff", newGasLimit).
@@ -141,25 +144,27 @@ func (r *GasTooLowTransferRetrier) Retry(ctx context.Context, logger zerolog.Log
 		_, retryErr := SendFunds(logger, client, payload)
 		if retryErr == nil {
 			logger.Info().
-				Str("retier", "GasTooLowTransferRetrier").
+				Str("retrier", "GasTooLowTransferRetrier").
 				Msg(RetrySuccessfulMsg)
 			return nil
 		}
 
 		if strings.Contains(retryErr.Error(), GasTooLowErr) {
 			return r.Retry(ctx, logger, client, retryErr, payload, currentAttempt+1)
+		} else {
+			return retryErr
 		}
 	}
 
 	if r.nextRetrier != nil {
 		logger.Debug().
-			Str("retier", "OvershotTransferRetrier").
+			Str("retrier", "OvershotTransferRetrier").
 			Msg(NotSupportedMsg)
 		return r.nextRetrier.Retry(ctx, logger, client, txErr, payload, 0)
 	}
 
 	logger.Warn().
-		Str("retier", "OvershotTransferRetrier").
+		Str("retrier", "OvershotTransferRetrier").
 		Msg("No more retriers available. Unable to retry transaction. Returning error.")
 
 	return txErr
@@ -175,7 +180,7 @@ type OvershotTransferRetrier struct {
 func (r *OvershotTransferRetrier) Retry(ctx context.Context, logger zerolog.Logger, client *seth.Client, txErr error, payload FundsToSendPayload, currentAttempt int) error {
 	if currentAttempt >= r.maxRetries {
 		logger.Debug().
-			Str("retier", "OvershotTransferRetrier").
+			Str("retrier", "OvershotTransferRetrier").
 			Msg("Max retries reached. Passing to next retrier")
 		if r.nextRetrier != nil {
 			return r.nextRetrier.Retry(ctx, logger, client, txErr, payload, 0)
@@ -199,7 +204,7 @@ func (r *OvershotTransferRetrier) Retry(ctx context.Context, logger zerolog.Logg
 
 		newAmount := big.NewInt(0).Sub(payload.Amount, big.NewInt(int64(overshotAmount)))
 		logger.Debug().
-			Str("retier", "OvershotTransferRetrier").
+			Str("retrier", "OvershotTransferRetrier").
 			Str("old amount", payload.Amount.String()).
 			Str("new amount", newAmount.String()).
 			Str("diff", big.NewInt(0).Sub(payload.Amount, newAmount).String()).
@@ -210,19 +215,21 @@ func (r *OvershotTransferRetrier) Retry(ctx context.Context, logger zerolog.Logg
 		_, retryErr := SendFunds(logger, client, payload)
 		if retryErr == nil {
 			logger.Info().
-				Str("retier", "OvershotTransferRetrier").
+				Str("retrier", "OvershotTransferRetrier").
 				Msg(RetrySuccessfulMsg)
 			return nil
 		}
 
 		if strings.Contains(retryErr.Error(), OvershotErr) {
 			return r.Retry(ctx, logger, client, retryErr, payload, currentAttempt+1)
+		} else {
+			return retryErr
 		}
 	}
 
 	if r.nextRetrier != nil {
 		logger.Debug().
-			Str("retier", "OvershotTransferRetrier").
+			Str("retrier", "OvershotTransferRetrier").
 			Msg(NotSupportedMsg)
 		return r.nextRetrier.Retry(ctx, logger, client, txErr, payload, 0)
 	}

--- a/integration-tests/actions/refund.go
+++ b/integration-tests/actions/refund.go
@@ -83,11 +83,12 @@ func (r *InsufficientFundTransferRetrier) Retry(ctx context.Context, logger zero
 				Msg(RetrySuccessfulMsg)
 			return nil
 		}
+
 		if strings.Contains(retryErr.Error(), InsufficientFundsErr) || strings.Contains(retryErr.Error(), TransactionUnderPriced) || strings.Contains(retryErr.Error(), FailedToWaitForTransaction) {
 			return r.Retry(ctx, logger, client, retryErr, payload, currentAttempt+1)
-		} else {
-			return retryErr
 		}
+
+		txErr = retryErr
 	}
 
 	if r.nextRetrier != nil {
@@ -151,9 +152,9 @@ func (r *GasTooLowTransferRetrier) Retry(ctx context.Context, logger zerolog.Log
 
 		if strings.Contains(retryErr.Error(), GasTooLowErr) {
 			return r.Retry(ctx, logger, client, retryErr, payload, currentAttempt+1)
-		} else {
-			return retryErr
 		}
+
+		txErr = retryErr
 	}
 
 	if r.nextRetrier != nil {
@@ -222,8 +223,6 @@ func (r *OvershotTransferRetrier) Retry(ctx context.Context, logger zerolog.Logg
 
 		if strings.Contains(retryErr.Error(), OvershotErr) {
 			return r.Retry(ctx, logger, client, retryErr, payload, currentAttempt+1)
-		} else {
-			return retryErr
 		}
 	}
 

--- a/integration-tests/testconfig/ocr2/overrides/base_sepolia.toml
+++ b/integration-tests/testconfig/ocr2/overrides/base_sepolia.toml
@@ -2,11 +2,11 @@
 selected_networks = ["BASE_SEPOLIA"]
 
 [Soak.Common]
-chainlink_node_funding = 0.1
+chainlink_node_funding = 1
 
 [Soak.OCR2]
 [Soak.OCR2.Common]
-test_duration = "2m"
+test_duration = "24h"
 
 [Soak.OCR2.Soak]
 time_between_rounds = "2m"

--- a/integration-tests/testconfig/ocr2/overrides/base_sepolia.toml
+++ b/integration-tests/testconfig/ocr2/overrides/base_sepolia.toml
@@ -6,7 +6,7 @@ chainlink_node_funding = 1
 
 [Soak.OCR2]
 [Soak.OCR2.Common]
-test_duration = "24h"
+test_duration = "2m"
 
 [Soak.OCR2.Soak]
 time_between_rounds = "2m"

--- a/integration-tests/testconfig/ocr2/overrides/base_sepolia.toml
+++ b/integration-tests/testconfig/ocr2/overrides/base_sepolia.toml
@@ -2,7 +2,7 @@
 selected_networks = ["BASE_SEPOLIA"]
 
 [Soak.Common]
-chainlink_node_funding = 1
+chainlink_node_funding = 0.1
 
 [Soak.OCR2]
 [Soak.OCR2.Common]


### PR DESCRIPTION
[SHIP-3730](https://smartcontract-it.atlassian.net/browse/SHIP-3730)

The goal of this pr is to remove an infinite loop in return funds logic. This was noticed when the gas estimation to return the funds was not accurate and the tests would hang for a very long time (days) trying to submit and retrying a transaction to extract those funds.

[SHIP-3730]: https://smartcontract-it.atlassian.net/browse/SHIP-3730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ