### PR TITLE
Add maxPrice cap on getdynamicfee

### DIFF
--- a/.changeset/wise-pandas-join.md
+++ b/.changeset/wise-pandas-join.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Fix BHE PriceMax bug #internal

--- a/.changeset/wise-pandas-join.md
+++ b/.changeset/wise-pandas-join.md
@@ -2,4 +2,4 @@
 "chainlink": minor
 ---
 
-Fix BHE PriceMax bug #internal
+Fix BHE PriceMax bug #bugfix

--- a/core/chains/evm/gas/block_history_estimator.go
+++ b/core/chains/evm/gas/block_history_estimator.go
@@ -410,7 +410,8 @@ func (b *BlockHistoryEstimator) GetDynamicFee(_ context.Context, maxGasPriceWei 
 				"Using Evm.GasEstimator.TipCapDefault as fallback.", "blocks", b.getBlockHistoryNumbers())
 			tipCap = b.eConfig.TipCapDefault()
 		}
-		maxGasPrice := getMaxGasPrice(maxGasPriceWei, b.eConfig.PriceMax())
+		maxGasPrice := assets.WeiMin(maxGasPriceWei, b.eConfig.PriceMax())
+		tipCap = assets.WeiMin(tipCap, maxGasPrice)
 		if b.eConfig.BumpThreshold() == 0 {
 			// just use the max gas price if gas bumping is disabled
 			feeCap = maxGasPrice

--- a/core/chains/evm/gas/block_history_estimator_test.go
+++ b/core/chains/evm/gas/block_history_estimator_test.go
@@ -2197,7 +2197,7 @@ func TestBlockHistoryEstimator_GetDynamicFee(t *testing.T) {
 		fee, err := bhe.GetDynamicFee(tests.Context(t), assets.NewWeiI(100))
 		require.NoError(t, err)
 
-		assert.Equal(t, gas.DynamicFee{FeeCap: assets.NewWeiI(100), TipCap: assets.NewWeiI(6000)}, fee)
+		assert.Equal(t, gas.DynamicFee{FeeCap: assets.NewWeiI(100), TipCap: assets.NewWeiI(100)}, fee)
 	})
 
 	h = testutils.Head(1)


### PR DESCRIPTION
[BCFR-988](https://smartcontract-it.atlassian.net/browse/BCFR-988)
Fixes a bug where GetDynamicFee would not cap TipCap by the KeySpecific PriceMax


[BCFR-988]: https://smartcontract-it.atlassian.net/browse/BCFR-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ