### PR TITLE
ccip: Use new unknown address types

### DIFF
--- a/core/capabilities/ccip/ccipevm/commitcodec.go
+++ b/core/capabilities/ccip/ccipevm/commitcodec.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/offramp"
@@ -110,7 +109,7 @@ func (c *CommitPluginCodecV1) Decode(ctx context.Context, bytes []byte) (cciptyp
 	tokenPriceUpdates := make([]cciptypes.TokenPrice, 0, len(commitReport.PriceUpdates.TokenPriceUpdates))
 	for _, update := range commitReport.PriceUpdates.TokenPriceUpdates {
 		tokenPriceUpdates = append(tokenPriceUpdates, cciptypes.TokenPrice{
-			TokenID: types.Account(update.SourceToken.String()),
+			TokenID: cciptypes.UnknownEncodedAddress(update.SourceToken.String()),
 			Price:   cciptypes.NewBigInt(big.NewInt(0).Set(update.UsdPerToken)),
 		})
 	}

--- a/core/capabilities/ccip/ccipevm/commitcodec_test.go
+++ b/core/capabilities/ccip/ccipevm/commitcodec_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -40,7 +39,7 @@ var randomCommitReport = func() cciptypes.CommitPluginReport {
 		PriceUpdates: cciptypes.PriceUpdates{
 			TokenPriceUpdates: []cciptypes.TokenPrice{
 				{
-					TokenID: types.Account(utils.RandomAddress().String()),
+					TokenID: cciptypes.UnknownEncodedAddress(utils.RandomAddress().String()),
 					Price:   cciptypes.NewBigInt(utils.RandUint256()),
 				},
 			},

--- a/core/capabilities/ccip/ccipevm/executecodec.go
+++ b/core/capabilities/ccip/ccipevm/executecodec.go
@@ -149,15 +149,15 @@ func (e *ExecutePluginCodecV1) Decode(ctx context.Context, encodedReport []byte)
 					DestChainSelector:   cciptypes.ChainSelector(evmMessage.Header.DestChainSelector),
 					SequenceNumber:      cciptypes.SeqNum(evmMessage.Header.SequenceNumber),
 					Nonce:               evmMessage.Header.Nonce,
-					MsgHash:             cciptypes.Bytes32{}, // <-- todo: info not available, but not required atm
-					OnRamp:              cciptypes.Bytes{},   // <-- todo: info not available, but not required atm
+					MsgHash:             cciptypes.Bytes32{},        // todo: info not available, but not required atm
+					OnRamp:              cciptypes.UnknownAddress{}, // todo: info not available, but not required atm
 				},
 				Sender:         evmMessage.Sender,
 				Data:           evmMessage.Data,
 				Receiver:       evmMessage.Receiver.Bytes(),
-				ExtraArgs:      cciptypes.Bytes{},  // <-- todo: info not available, but not required atm
-				FeeToken:       cciptypes.Bytes{},  // <-- todo: info not available, but not required atm
-				FeeTokenAmount: cciptypes.BigInt{}, // <-- todo: info not available, but not required atm
+				ExtraArgs:      cciptypes.Bytes{},          // <-- todo: info not available, but not required atm
+				FeeToken:       cciptypes.UnknownAddress{}, // <-- todo: info not available, but not required atm
+				FeeTokenAmount: cciptypes.BigInt{},         // <-- todo: info not available, but not required atm
 				TokenAmounts:   tokenAmounts,
 			}
 			messages = append(messages, message)

--- a/core/capabilities/ccip/ccipevm/executecodec_test.go
+++ b/core/capabilities/ccip/ccipevm/executecodec_test.go
@@ -147,8 +147,8 @@ func TestExecutePluginCodecV1(t *testing.T) {
 			for i := range report.ChainReports {
 				for j := range report.ChainReports[i].Messages {
 					report.ChainReports[i].Messages[j].Header.MsgHash = cciptypes.Bytes32{}
-					report.ChainReports[i].Messages[j].Header.OnRamp = cciptypes.Bytes{}
-					report.ChainReports[i].Messages[j].FeeToken = cciptypes.Bytes{}
+					report.ChainReports[i].Messages[j].Header.OnRamp = cciptypes.UnknownAddress{}
+					report.ChainReports[i].Messages[j].FeeToken = cciptypes.UnknownAddress{}
 					report.ChainReports[i].Messages[j].ExtraArgs = cciptypes.Bytes{}
 					report.ChainReports[i].Messages[j].FeeTokenAmount = cciptypes.BigInt{}
 				}

--- a/core/capabilities/ccip/ccipevm/rmncrypto.go
+++ b/core/capabilities/ccip/ccipevm/rmncrypto.go
@@ -77,7 +77,7 @@ func (r *EVMRMNCrypto) VerifyReportSignatures(
 	_ context.Context,
 	sigs []cciptypes.RMNECDSASignature,
 	report cciptypes.RMNReport,
-	signerAddresses []cciptypes.Bytes,
+	signerAddresses []cciptypes.UnknownAddress,
 ) error {
 	if sigs == nil {
 		return fmt.Errorf("no signatures provided")

--- a/core/capabilities/ccip/ccipevm/rmncrypto_test.go
+++ b/core/capabilities/ccip/ccipevm/rmncrypto_test.go
@@ -62,7 +62,7 @@ func Test_VerifyRmnReportSignatures(t *testing.T) {
 		ctx,
 		[]cciptypes.RMNECDSASignature{{R: r, S: s}},
 		reportData,
-		[]cciptypes.Bytes{onchainRmnRemoteAddr.Bytes()},
+		[]cciptypes.UnknownAddress{onchainRmnRemoteAddr.Bytes()},
 	)
 	assert.NoError(t, err)
 }

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -278,7 +278,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/shirou/gopsutil/v3 v3.24.3 // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.23 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23 // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240916152957-433914114bd2 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240910155501-42f20443189f // indirect

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/prometheus/client_golang v1.20.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd
+	github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7
 	github.com/spf13/cobra v1.8.1

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1099,8 +1099,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8um
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371 h1:d2IS24wRrsUXyDcW9avaRo7l+eLCbBbcyXJoBwELueU=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371/go.mod h1:WbtjuYMnDAYojL3CSWmruc1ecSBgSTggzXJ6F1U6bxw=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd h1:DraA9kRpkyI02OEx7QDbSq3bCYxVFZ78TdOP2rUvHts=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9 h1:997WdHgKzTCUJyqSahDOlVXMSFwpcNUaCGXk4/cxaxk=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7 h1:lTGIOQYLk1Ufn++X/AvZnt6VOcuhste5yp+C157No/Q=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7/go.mod h1:BMYE1vC/pGmdFSsOJdPrAA0/4gZ0Xo0SxTMdGspBtRo=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240916152957-433914114bd2 h1:yRk4ektpx/UxwarqAfgxUXLrsYXlaNeP1NOwzHGrK2Q=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1097,8 +1097,8 @@ github.com/smartcontractkit/chain-selectors v1.0.23 h1:D2Eaex4Cw/O7Lg3tX6WklOqnj
 github.com/smartcontractkit/chain-selectors v1.0.23/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371 h1:d2IS24wRrsUXyDcW9avaRo7l+eLCbBbcyXJoBwELueU=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371/go.mod h1:WbtjuYMnDAYojL3CSWmruc1ecSBgSTggzXJ6F1U6bxw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23 h1:iO2nthO7NjwfZ7ZzEh7rTdMsBnhV2tmKJugyBsXaxhc=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23/go.mod h1:6sPJeZAJGiyB9j/BdEqYxpeB8Gt0gSfUZy9KNkwGvpQ=
 github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9 h1:997WdHgKzTCUJyqSahDOlVXMSFwpcNUaCGXk4/cxaxk=
 github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7 h1:lTGIOQYLk1Ufn++X/AvZnt6VOcuhste5yp+C157No/Q=

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.23
 	github.com/smartcontractkit/chainlink-automation v1.0.4
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371
-	github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd
+	github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240916152957-433914114bd2
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240910155501-42f20443189f

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.23
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23
 	github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240916152957-433914114bd2

--- a/go.sum
+++ b/go.sum
@@ -1058,8 +1058,8 @@ github.com/smartcontractkit/chain-selectors v1.0.23 h1:D2Eaex4Cw/O7Lg3tX6WklOqnj
 github.com/smartcontractkit/chain-selectors v1.0.23/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371 h1:d2IS24wRrsUXyDcW9avaRo7l+eLCbBbcyXJoBwELueU=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371/go.mod h1:WbtjuYMnDAYojL3CSWmruc1ecSBgSTggzXJ6F1U6bxw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23 h1:iO2nthO7NjwfZ7ZzEh7rTdMsBnhV2tmKJugyBsXaxhc=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23/go.mod h1:6sPJeZAJGiyB9j/BdEqYxpeB8Gt0gSfUZy9KNkwGvpQ=
 github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9 h1:997WdHgKzTCUJyqSahDOlVXMSFwpcNUaCGXk4/cxaxk=
 github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7 h1:lTGIOQYLk1Ufn++X/AvZnt6VOcuhste5yp+C157No/Q=

--- a/go.sum
+++ b/go.sum
@@ -1060,8 +1060,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8um
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371 h1:d2IS24wRrsUXyDcW9avaRo7l+eLCbBbcyXJoBwELueU=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371/go.mod h1:WbtjuYMnDAYojL3CSWmruc1ecSBgSTggzXJ6F1U6bxw=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd h1:DraA9kRpkyI02OEx7QDbSq3bCYxVFZ78TdOP2rUvHts=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9 h1:997WdHgKzTCUJyqSahDOlVXMSFwpcNUaCGXk4/cxaxk=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7 h1:lTGIOQYLk1Ufn++X/AvZnt6VOcuhste5yp+C157No/Q=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7/go.mod h1:BMYE1vC/pGmdFSsOJdPrAA0/4gZ0Xo0SxTMdGspBtRo=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240916152957-433914114bd2 h1:yRk4ektpx/UxwarqAfgxUXLrsYXlaNeP1NOwzHGrK2Q=

--- a/integration-tests/deployment/ccip/add_chain_test.go
+++ b/integration-tests/deployment/ccip/add_chain_test.go
@@ -36,7 +36,7 @@ func TestAddChainInbound(t *testing.T) {
 	tokenConfig := NewTokenConfig()
 	tokenConfig.UpsertTokenInfo(LinkSymbol,
 		pluginconfig.TokenInfo{
-			AggregatorAddress: feeds[LinkSymbol].Address().String(),
+			AggregatorAddress: cciptypes.UnknownEncodedAddress(feeds[LinkSymbol].Address().String()),
 			Decimals:          LinkDecimals,
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},

--- a/integration-tests/deployment/ccip/changeset/initial_deploy_test.go
+++ b/integration-tests/deployment/ccip/changeset/initial_deploy_test.go
@@ -31,7 +31,7 @@ func TestInitialDeploy(t *testing.T) {
 	tokenConfig := ccdeploy.NewTokenConfig()
 	tokenConfig.UpsertTokenInfo(ccdeploy.LinkSymbol,
 		pluginconfig.TokenInfo{
-			AggregatorAddress: feeds[ccdeploy.LinkSymbol].Address().String(),
+			AggregatorAddress: cciptypes.UnknownEncodedAddress(feeds[ccdeploy.LinkSymbol].Address().String()),
 			Decimals:          ccdeploy.LinkDecimals,
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},

--- a/integration-tests/deployment/ccip/deploy_home_chain.go
+++ b/integration-tests/deployment/ccip/deploy_home_chain.go
@@ -17,11 +17,9 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
+	"github.com/smartcontractkit/chainlink/integration-tests/deployment"
 	confighelper2 "github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-
-	"github.com/smartcontractkit/chainlink/integration-tests/deployment"
 
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
@@ -203,7 +201,7 @@ func BuildAddDONArgs(
 	dest deployment.Chain,
 	feedChainSel uint64,
 	// Token address on Dest chain to aggregate address on feed chain
-	tokenInfo map[ocrtypes.Account]pluginconfig.TokenInfo,
+	tokenInfo map[ccipocr3.UnknownEncodedAddress]pluginconfig.TokenInfo,
 	nodes deployment.Nodes,
 ) ([]byte, error) {
 	p2pIDs := nodes.PeerIDs()
@@ -374,7 +372,7 @@ func AddDON(
 	offRamp *offramp.OffRamp,
 	feedChainSel uint64,
 	// Token address on Dest chain to aggregate address on feed chain
-	tokenInfo map[ocrtypes.Account]pluginconfig.TokenInfo,
+	tokenInfo map[ccipocr3.UnknownEncodedAddress]pluginconfig.TokenInfo,
 	dest deployment.Chain,
 	home deployment.Chain,
 	nodes deployment.Nodes,

--- a/integration-tests/deployment/ccip/token_info.go
+++ b/integration-tests/deployment/ccip/token_info.go
@@ -2,11 +2,10 @@ package ccipdeployment
 
 import (
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/burn_mint_erc677"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 )
 
 // TokenConfig mapping between token Symbol (e.g. LinkSymbol, WethSymbol)
@@ -32,13 +31,13 @@ func (tc *TokenConfig) UpsertTokenInfo(
 func (tc *TokenConfig) GetTokenInfo(
 	lggr logger.Logger,
 	linkToken *burn_mint_erc677.BurnMintERC677,
-) map[ocrtypes.Account]pluginconfig.TokenInfo {
-	tokenToAggregate := make(map[ocrtypes.Account]pluginconfig.TokenInfo)
+) map[ccipocr3.UnknownEncodedAddress]pluginconfig.TokenInfo {
+	tokenToAggregate := make(map[ccipocr3.UnknownEncodedAddress]pluginconfig.TokenInfo)
 	if _, ok := tc.TokenSymbolToInfo[LinkSymbol]; !ok {
 		lggr.Debugw("Link aggregator not found, deploy without mapping link token")
 	} else {
 		lggr.Debugw("Mapping LinkToken to Link aggregator")
-		acc := ocrtypes.Account(linkToken.Address().String())
+		acc := ccipocr3.UnknownEncodedAddress(linkToken.Address().String())
 		tokenToAggregate[acc] = tc.TokenSymbolToInfo[LinkSymbol]
 	}
 

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.23
 	github.com/smartcontractkit/chainlink-automation v1.0.4
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371
-	github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd
+	github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.0.0-20240926212305-a6deabdfce86
 	github.com/smartcontractkit/chain-selectors v1.0.23
 	github.com/smartcontractkit/chainlink-automation v1.0.4
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23
 	github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.9

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1439,8 +1439,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8um
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371 h1:d2IS24wRrsUXyDcW9avaRo7l+eLCbBbcyXJoBwELueU=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371/go.mod h1:WbtjuYMnDAYojL3CSWmruc1ecSBgSTggzXJ6F1U6bxw=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd h1:DraA9kRpkyI02OEx7QDbSq3bCYxVFZ78TdOP2rUvHts=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9 h1:997WdHgKzTCUJyqSahDOlVXMSFwpcNUaCGXk4/cxaxk=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7 h1:lTGIOQYLk1Ufn++X/AvZnt6VOcuhste5yp+C157No/Q=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7/go.mod h1:BMYE1vC/pGmdFSsOJdPrAA0/4gZ0Xo0SxTMdGspBtRo=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240916152957-433914114bd2 h1:yRk4ektpx/UxwarqAfgxUXLrsYXlaNeP1NOwzHGrK2Q=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1437,8 +1437,8 @@ github.com/smartcontractkit/chain-selectors v1.0.23 h1:D2Eaex4Cw/O7Lg3tX6WklOqnj
 github.com/smartcontractkit/chain-selectors v1.0.23/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371 h1:d2IS24wRrsUXyDcW9avaRo7l+eLCbBbcyXJoBwELueU=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371/go.mod h1:WbtjuYMnDAYojL3CSWmruc1ecSBgSTggzXJ6F1U6bxw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23 h1:iO2nthO7NjwfZ7ZzEh7rTdMsBnhV2tmKJugyBsXaxhc=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23/go.mod h1:6sPJeZAJGiyB9j/BdEqYxpeB8Gt0gSfUZy9KNkwGvpQ=
 github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9 h1:997WdHgKzTCUJyqSahDOlVXMSFwpcNUaCGXk4/cxaxk=
 github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7 h1:lTGIOQYLk1Ufn++X/AvZnt6VOcuhste5yp+C157No/Q=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -391,7 +391,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.23 // indirect
 	github.com/smartcontractkit/chainlink-automation v1.0.4 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23 // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240916152957-433914114bd2 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240910155501-42f20443189f // indirect

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.12.2
-	github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd
+	github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.1
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.0

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1413,8 +1413,8 @@ github.com/smartcontractkit/chain-selectors v1.0.23 h1:D2Eaex4Cw/O7Lg3tX6WklOqnj
 github.com/smartcontractkit/chain-selectors v1.0.23/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8umfIfVVlwC7+n5izbLSFgjw8=
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371 h1:d2IS24wRrsUXyDcW9avaRo7l+eLCbBbcyXJoBwELueU=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371/go.mod h1:WbtjuYMnDAYojL3CSWmruc1ecSBgSTggzXJ6F1U6bxw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23 h1:iO2nthO7NjwfZ7ZzEh7rTdMsBnhV2tmKJugyBsXaxhc=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241007151332-7f1c1594fc23/go.mod h1:6sPJeZAJGiyB9j/BdEqYxpeB8Gt0gSfUZy9KNkwGvpQ=
 github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9 h1:997WdHgKzTCUJyqSahDOlVXMSFwpcNUaCGXk4/cxaxk=
 github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7 h1:lTGIOQYLk1Ufn++X/AvZnt6VOcuhste5yp+C157No/Q=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1415,8 +1415,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.4 h1:iyW181JjKHLNMnDleI8um
 github.com/smartcontractkit/chainlink-automation v1.0.4/go.mod h1:u4NbPZKJ5XiayfKHD/v3z3iflQWqvtdhj13jVZXj/cM=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371 h1:d2IS24wRrsUXyDcW9avaRo7l+eLCbBbcyXJoBwELueU=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241003141241-00dcd7fa8371/go.mod h1:WbtjuYMnDAYojL3CSWmruc1ecSBgSTggzXJ6F1U6bxw=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd h1:DraA9kRpkyI02OEx7QDbSq3bCYxVFZ78TdOP2rUvHts=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20241001210038-dd59341432bd/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9 h1:997WdHgKzTCUJyqSahDOlVXMSFwpcNUaCGXk4/cxaxk=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20241007144504-48389b7a22f9/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7 h1:lTGIOQYLk1Ufn++X/AvZnt6VOcuhste5yp+C157No/Q=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240911175228-daf2600bb7b7/go.mod h1:BMYE1vC/pGmdFSsOJdPrAA0/4gZ0Xo0SxTMdGspBtRo=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240916152957-433914114bd2 h1:yRk4ektpx/UxwarqAfgxUXLrsYXlaNeP1NOwzHGrK2Q=

--- a/integration-tests/smoke/ccip_test.go
+++ b/integration-tests/smoke/ccip_test.go
@@ -29,7 +29,7 @@ func TestInitialDeployOnLocal(t *testing.T) {
 	tokenConfig := ccdeploy.NewTokenConfig()
 	tokenConfig.UpsertTokenInfo(ccdeploy.LinkSymbol,
 		pluginconfig.TokenInfo{
-			AggregatorAddress: feeds[ccdeploy.LinkSymbol].Address().String(),
+			AggregatorAddress: cciptypes.UnknownEncodedAddress(feeds[ccdeploy.LinkSymbol].Address().String()),
 			Decimals:          ccdeploy.LinkDecimals,
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},


### PR DESCRIPTION
Use new address types in chainlink-common and chainlink-ccip.

Related:
* https://github.com/smartcontractkit/chainlink-common/pull/832
* https://github.com/smartcontractkit/chainlink-ccip/pull/212