### PR TITLE
Added 0x7e (126) transaction type for Celo

### DIFF
--- a/.changeset/mighty-horses-share.md
+++ b/.changeset/mighty-horses-share.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-Ignoring tx type 126 for celo
+#updated - Ignoring tx type 126 for celo

--- a/.changeset/mighty-horses-share.md
+++ b/.changeset/mighty-horses-share.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Ignoring tx type 126 for celo

--- a/core/chains/evm/gas/block_history_estimator_test.go
+++ b/core/chains/evm/gas/block_history_estimator_test.go
@@ -1459,7 +1459,7 @@ func TestBlockHistoryEstimator_IsUsable(t *testing.T) {
 		assert.Equal(t, true, bhe.IsUsable(tx, block, cfg.ChainType(), geCfg.PriceMin(), logger.Test(t)))
 	})
 
-	t.Run("returns false if transaction is of type 0x7c or 0x7b only on Celo", func(t *testing.T) {
+	t.Run("returns false if transaction is of type 0x7c, 0x7b, or 0x7e only on Celo", func(t *testing.T) {
 		cfg.ChainTypeF = "celo"
 		tx := evmtypes.Transaction{Type: 0x7c, GasPrice: assets.NewWeiI(10), GasLimit: 42, Hash: utils.NewHash()}
 		assert.Equal(t, false, bhe.IsUsable(tx, block, cfg.ChainType(), geCfg.PriceMin(), logger.Test(t)))
@@ -1467,9 +1467,13 @@ func TestBlockHistoryEstimator_IsUsable(t *testing.T) {
 		tx2 := evmtypes.Transaction{Type: 0x7b, GasPrice: assets.NewWeiI(10), GasLimit: 42, Hash: utils.NewHash()}
 		assert.Equal(t, false, bhe.IsUsable(tx2, block, cfg.ChainType(), geCfg.PriceMin(), logger.Test(t)))
 
+		tx3 := evmtypes.Transaction{Type: 0x7e, GasPrice: assets.NewWeiI(10), GasLimit: 42, Hash: utils.NewHash()}
+		assert.Equal(t, false, bhe.IsUsable(tx2, block, cfg.ChainType(), geCfg.PriceMin(), logger.Test(t)))
+
 		cfg.ChainTypeF = ""
 		assert.Equal(t, true, bhe.IsUsable(tx, block, cfg.ChainType(), geCfg.PriceMin(), logger.Test(t)))
 		assert.Equal(t, true, bhe.IsUsable(tx2, block, cfg.ChainType(), geCfg.PriceMin(), logger.Test(t)))
+		assert.Equal(t, true, bhe.IsUsable(tx3, block, cfg.ChainType(), geCfg.PriceMin(), logger.Test(t)))
 	})
 
 	t.Run("returns false if transaction is of type 0x16 only on WeMix", func(t *testing.T) {

--- a/core/chains/evm/gas/chain_specific.go
+++ b/core/chains/evm/gas/chain_specific.go
@@ -31,7 +31,7 @@ func chainSpecificIsUsable(tx evmtypes.Transaction, baseFee *assets.Wei, chainTy
 	}
 	if chainType == chaintype.ChainCelo {
 		// Celo specific transaction types that utilize the feeCurrency field.
-		if tx.Type == 0x7c || tx.Type == 0x7b {
+		if tx.Type == 0x7c || tx.Type == 0x7b || tx.Type == 0x7e {
 			return false
 		}
 		// Celo has not yet fully migrated to the 0x7c type for special feeCurrency transactions


### PR DESCRIPTION
Need to ignore tx type 126 due to Celo L2 migration.

[Context](https://docs.google.com/document/d/1w-zUtks61yUInMdmYPURROXBXBginHBCGG_Fg5E6rUc/edit#heading=h.qjv5gyis1h5n)