### PR TITLE
[do not merge] integration test changes

### DIFF
--- a/core/capabilities/triggers/logevent/trigger.go
+++ b/core/capabilities/triggers/logevent/trigger.go
@@ -134,7 +134,6 @@ func (l *logEventTrigger) listen() {
 				"startBlockNum", l.startBlockNum,
 				"cursor", cursor)
 			if cursor != "" {
-				limitAndSort.Limit = query.Limit{Cursor: cursor}
 			}
 			logs, err = l.contractReader.QueryKey(
 				ctx,


### PR DESCRIPTION
These are just the changes made to get it working locally, they shouldn't be merged. This mitigates an error:
```
Limit cursor and cursor direction must both be defined or undefined
```

from `chain_reader.go`

probably, the correct way to do this would be to add the cursorDirection, but I'm not sure.