### PR TITLE
Set cursor direction in Log Event Trigger Capability

### DIFF
--- a/core/capabilities/triggers/logevent/service.go
+++ b/core/capabilities/triggers/logevent/service.go
@@ -40,6 +40,7 @@ type Config struct {
 	Network        string `json:"network"`
 	LookbackBlocks uint64 `json:"lookbakBlocks"`
 	PollPeriod     uint32 `json:"pollPeriod"`
+	QueryCount     uint64 `json:"queryCount"`
 }
 
 func (config Config) Version(capabilityVersion string) string {

--- a/core/capabilities/triggers/logevent/trigger.go
+++ b/core/capabilities/triggers/logevent/trigger.go
@@ -134,7 +134,7 @@ func (l *logEventTrigger) listen() {
 				"startBlockNum", l.startBlockNum,
 				"cursor", cursor)
 			if cursor != "" {
-				limitAndSort.Limit = query.Limit{Cursor: cursor}
+				limitAndSort.Limit = query.CursorLimit(cursor, query.CursorFollowing, 20)
 			}
 			logs, err = l.contractReader.QueryKey(
 				ctx,


### PR DESCRIPTION
## Update

- Set cursor direction in Log Event Trigger Capability

## Testing

```
$ go test -count=1 -v -run="^TestLogEventTriggerCursorNewLogs$" ./core/services/relay/evm/capabilities
```