### PR TITLE
Fix TXM flakey test

### DIFF
--- a/.changeset/old-humans-watch.md
+++ b/.changeset/old-humans-watch.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Fix TXM flakey test #internal

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -501,8 +501,8 @@ func TestTxm_Lifecycle(t *testing.T) {
 	head := cltest.Head(42)
 	finalizedHead := cltest.Head(0)
 
-	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(head, nil).Once()
-	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(finalizedHead, nil).Once()
+	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(head, nil)
+	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(finalizedHead, nil)
 
 	keyChangeCh := make(chan struct{})
 	unsub := cltest.NewAwaiter()


### PR DESCRIPTION
[BCFR-1013](https://smartcontract-it.atlassian.net/browse/BCFR-1013)

During TXMLifecycle the confirmer may execute its main loop twice, requiring two more additional RPC calls.




[BCFR-1013]: https://smartcontract-it.atlassian.net/browse/BCFR-1013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ