### PR TITLE
for wasm file spec workflows, make the config a file instead of hard-coding in the job.

### DIFF
--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -919,7 +919,7 @@ func (w *WorkflowSpec) SDKSpec(ctx context.Context) (sdk.WorkflowSpec, error) {
 	if !ok {
 		return sdk.WorkflowSpec{}, fmt.Errorf("unknown spec type %s", w.SpecType)
 	}
-	spec, rawSpec, cid, err := workflowSpecFactory.Spec(ctx, w.Workflow, []byte(w.Config))
+	spec, rawSpec, cid, err := workflowSpecFactory.Spec(ctx, w.Workflow, w.Config)
 	if err != nil {
 		return sdk.WorkflowSpec{}, err
 	}
@@ -939,7 +939,7 @@ func (w *WorkflowSpec) RawSpec(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("unknown spec type %s", w.SpecType)
 	}
 
-	rs, err := workflowSpecFactory.RawSpec(ctx, w.Workflow, []byte(w.Config))
+	rs, err := workflowSpecFactory.RawSpec(ctx, w.Workflow, w.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/job/models_test.go
+++ b/core/services/job/models_test.go
@@ -2,7 +2,6 @@ package job_test
 
 import (
 	_ "embed"
-	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -12,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/codec"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	pkgworkflows "github.com/smartcontractkit/chainlink-common/pkg/workflows"
-	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -338,19 +336,15 @@ func TestWorkflowSpec_Validate(t *testing.T) {
 	}
 
 	t.Run("WASM can validate", func(t *testing.T) {
-		config, err := json.Marshal(sdk.NewWorkflowParams{
-			Owner: "owner",
-			Name:  "name",
-		})
-		require.NoError(t, err)
+		configLocation := "testdata/config.json"
 
 		w := &job.WorkflowSpec{
 			Workflow: createTestBinary(t),
 			SpecType: job.WASMFile,
-			Config:   string(config),
+			Config:   configLocation,
 		}
 
-		err = w.Validate(testutils.Context(t))
+		err := w.Validate(testutils.Context(t))
 		require.NoError(t, err)
 		assert.Equal(t, "owner", w.WorkflowOwner)
 		assert.Equal(t, "name", w.WorkflowName)

--- a/core/services/job/testdata/config.json
+++ b/core/services/job/testdata/config.json
@@ -1,0 +1,4 @@
+{
+  "Owner": "owner",
+  "Name":  "name"
+}

--- a/core/services/job/wasm_file_spec_factory.go
+++ b/core/services/job/wasm_file_spec_factory.go
@@ -21,7 +21,12 @@ import (
 
 type WasmFileSpecFactory struct{}
 
-func (w WasmFileSpecFactory) Spec(_ context.Context, workflow string, config []byte) (sdk.WorkflowSpec, []byte, string, error) {
+func (w WasmFileSpecFactory) Spec(_ context.Context, workflow, configLocation string) (sdk.WorkflowSpec, []byte, string, error) {
+	config, err := os.ReadFile(configLocation)
+	if err != nil {
+		return sdk.WorkflowSpec{}, nil, "", err
+	}
+
 	compressedBinary, sha, err := w.rawSpecAndSha(workflow, config)
 	if err != nil {
 		return sdk.WorkflowSpec{}, nil, "", err
@@ -38,7 +43,12 @@ func (w WasmFileSpecFactory) Spec(_ context.Context, workflow string, config []b
 	return *spec, compressedBinary, sha, nil
 }
 
-func (w WasmFileSpecFactory) RawSpec(_ context.Context, workflow string, config []byte) ([]byte, error) {
+func (w WasmFileSpecFactory) RawSpec(_ context.Context, workflow, configLocation string) ([]byte, error) {
+	config, err := os.ReadFile(configLocation)
+	if err != nil {
+		return nil, err
+	}
+
 	raw, _, err := w.rawSpecAndSha(workflow, config)
 	return raw, err
 }

--- a/core/services/job/wasm_file_spec_factory_test.go
+++ b/core/services/job/wasm_file_spec_factory_test.go
@@ -3,7 +3,6 @@ package job_test
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -14,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -24,10 +22,8 @@ import (
 
 func TestWasmFileSpecFactory(t *testing.T) {
 	binaryLocation := createTestBinary(t)
-	config, err := json.Marshal(sdk.NewWorkflowParams{
-		Owner: "owner",
-		Name:  "name",
-	})
+	configLocation := "testdata/config.json"
+	config, err := os.ReadFile(configLocation)
 	require.NoError(t, err)
 
 	rawBinary, err := os.ReadFile(binaryLocation)
@@ -42,7 +38,7 @@ func TestWasmFileSpecFactory(t *testing.T) {
 
 	t.Run("Raw binary", func(t *testing.T) {
 		factory := job.WasmFileSpecFactory{}
-		actual, rawSpec, actualSha, err2 := factory.Spec(testutils.Context(t), binaryLocation, config)
+		actual, rawSpec, actualSha, err2 := factory.Spec(testutils.Context(t), binaryLocation, configLocation)
 		require.NoError(t, err2)
 
 		expected, err2 := host.GetWorkflowSpec(&host.ModuleConfig{Logger: logger.NullLogger, IsUncompressed: true}, rawBinary, config)
@@ -64,7 +60,7 @@ func TestWasmFileSpecFactory(t *testing.T) {
 		require.NoError(t, os.WriteFile(brLoc, compressedBytes, 0600))
 
 		factory := job.WasmFileSpecFactory{}
-		actual, rawSpec, actualSha, err2 := factory.Spec(testutils.Context(t), brLoc, config)
+		actual, rawSpec, actualSha, err2 := factory.Spec(testutils.Context(t), brLoc, configLocation)
 		require.NoError(t, err2)
 
 		expected, err2 := host.GetWorkflowSpec(&host.ModuleConfig{Logger: logger.NullLogger, IsUncompressed: true}, rawBinary, config)

--- a/core/services/job/workflow_spec_factory.go
+++ b/core/services/job/workflow_spec_factory.go
@@ -7,8 +7,8 @@ import (
 )
 
 type WorkflowSpecFactory interface {
-	Spec(ctx context.Context, workflow string, config []byte) (sdk.WorkflowSpec, []byte, string, error)
-	RawSpec(ctx context.Context, workflow string, config []byte) ([]byte, error)
+	Spec(ctx context.Context, workflow, config string) (sdk.WorkflowSpec, []byte, string, error)
+	RawSpec(ctx context.Context, workflow, config string) ([]byte, error)
 }
 
 var workflowSpecFactories = map[WorkflowSpecType]WorkflowSpecFactory{

--- a/core/services/job/yaml_spec_factory.go
+++ b/core/services/job/yaml_spec_factory.go
@@ -13,11 +13,11 @@ type YAMLSpecFactory struct{}
 
 var _ WorkflowSpecFactory = (*YAMLSpecFactory)(nil)
 
-func (y YAMLSpecFactory) Spec(_ context.Context, workflow string, _ []byte) (sdk.WorkflowSpec, []byte, string, error) {
+func (y YAMLSpecFactory) Spec(_ context.Context, workflow, _ string) (sdk.WorkflowSpec, []byte, string, error) {
 	spec, err := workflows.ParseWorkflowSpecYaml(workflow)
 	return spec, []byte(workflow), fmt.Sprintf("%x", sha256.Sum256([]byte(workflow))), err
 }
 
-func (y YAMLSpecFactory) RawSpec(_ context.Context, workflow string, _ []byte) ([]byte, error) {
+func (y YAMLSpecFactory) RawSpec(_ context.Context, workflow, _ string) ([]byte, error) {
 	return []byte(workflow), nil
 }

--- a/core/services/job/yaml_spec_factory_test.go
+++ b/core/services/job/yaml_spec_factory_test.go
@@ -67,7 +67,7 @@ targets:
 func TestYamlSpecFactory_GetSpec(t *testing.T) {
 	t.Parallel()
 
-	actual, raw, actualSha, err := job.YAMLSpecFactory{}.Spec(testutils.Context(t), anyYamlSpec, []byte{})
+	actual, raw, actualSha, err := job.YAMLSpecFactory{}.Spec(testutils.Context(t), anyYamlSpec, "")
 	require.NoError(t, err)
 
 	expected, err := commonworkflows.ParseWorkflowSpecYaml(anyYamlSpec)

--- a/core/services/workflows/models_test.go
+++ b/core/services/workflows/models_test.go
@@ -294,7 +294,7 @@ targets:
 	for _, tc := range testCases {
 		t.Run(tc.name, func(st *testing.T) {
 
-			spec, _, _, err := job.YAMLSpecFactory{}.Spec(testutils.Context(t), tc.yaml, nil)
+			spec, _, _, err := job.YAMLSpecFactory{}.Spec(testutils.Context(t), tc.yaml, "")
 			require.NoError(t, err)
 
 			wf, err := Parse(spec)
@@ -323,7 +323,7 @@ targets:
 }
 
 func TestParsesIntsCorrectly(t *testing.T) {
-	spec, _, _, err := job.YAMLSpecFactory{}.Spec(testutils.Context(t), hardcodedWorkflow, nil)
+	spec, _, _, err := job.YAMLSpecFactory{}.Spec(testutils.Context(t), hardcodedWorkflow, "")
 	require.NoError(t, err)
 
 	wf, err := Parse(spec)


### PR DESCRIPTION
Note, this isn't used yet so the breaking change is ok.