### PR TITLE
FHE returns ErrConnectivity error when halting bumping

### DIFF
--- a/.changeset/healthy-flowers-nail.md
+++ b/.changeset/healthy-flowers-nail.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Return ErrConnectivity error when halting bumping #internal

--- a/core/chains/evm/gas/fee_history_estimator.go
+++ b/core/chains/evm/gas/fee_history_estimator.go
@@ -385,8 +385,8 @@ func (f *FeeHistoryEstimator) BumpDynamicFee(ctx context.Context, originalFee Dy
 	}
 
 	if bumpedMaxPriorityFeePerGas.Cmp(priorityFeeThreshold) > 0 {
-		return bumped, fmt.Errorf("bumpedMaxPriorityFeePerGas: %s is above market's %sth percentile: %s, bumping is halted",
-			bumpedMaxPriorityFeePerGas, strconv.Itoa(ConnectivityPercentile), priorityFeeThreshold)
+		return bumped, fmt.Errorf("%w: bumpedMaxPriorityFeePerGas: %s is above market's %sth percentile: %s, bumping is halted",
+			commonfee.ErrConnectivity, bumpedMaxPriorityFeePerGas, strconv.Itoa(ConnectivityPercentile), priorityFeeThreshold)
 	}
 
 	bumpedMaxFeePerGas, err = LimitBumpedFee(originalFee.GasFeeCap, currentDynamicPrice.GasFeeCap, bumpedMaxFeePerGas, maxPrice)

--- a/core/chains/evm/gas/fee_history_estimator_test.go
+++ b/core/chains/evm/gas/fee_history_estimator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink/v2/common/fee"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
@@ -411,6 +412,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		assert.NoError(t, err)
 		_, err = u.BumpDynamicFee(tests.Context(t), originalFee, globalMaxPrice, nil)
 		assert.Error(t, err)
+		assert.True(t, fee.IsBumpErr(err))
 	})
 
 	t.Run("returns max price if the aggregation of max and original bumped fee is higher", func(t *testing.T) {


### PR DESCRIPTION
[BCFR-956](https://smartcontract-it.atlassian.net/browse/BCFR-956)

Returns ErrConnectivity error when halting bumping



[BCFR-956]: https://smartcontract-it.atlassian.net/browse/BCFR-956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ