### PR TITLE
chore: update feeds service codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 
 # Services
 /core/services/directrequest @smartcontractkit/foundations
-/core/services/feeds @smartcontractkit/op-core @eutopian @yevshev
+/core/services/feeds @smartcontractkit/deployment-automation @eutopian @yevshev
 /core/services/synchronization/telem @smartcontractkit/realtime
 /core/capabilities/ @smartcontractkit/keystone @smartcontractkit/capabilities-team
 /core/capabilities/ccip @smartcontractkit/ccip-offchain


### PR DESCRIPTION
Code owners for the feeds service have been updated to reflect the current team structure.
