### PR TITLE
chore: add deployment automation to GQL API codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,7 +87,9 @@ core/scripts/gateway @smartcontractkit/dev-services
 # TODO: transmission folder, owner should be found
 /contracts/src/v0.8/vrf @smartcontractkit/dev-services
 
-
+# GQL API
+/core/web/resolver @smartcontractkit/deployment-automation @smartcontractkit/foundations
+/core/web/schema @smartcontractkit/deployment-automation @smartcontractkit/foundations
 
 # At the end, match any files missed by the patterns above
 /contracts/scripts/native_solc_compile_all_events_mock @smartcontractkit/dev-services


### PR DESCRIPTION
Update CODEOWNERS file to allow DA team to approve PRs in related to the GQL API.

This is required to service the ob distribution APIs
