### PR TITLE
update onchain codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,24 +58,26 @@ core/scripts/gateway @smartcontractkit/dev-services
 /core/services/standardcapabilities @smartcontractkit/keystone
 /core/scripts/keystone @smartcontractkit/keystone
 
-# Contracts
+# Contracts catch all, for files not matched by the more specific patterns below
 /contracts/ @RensR @matYang @RayXpub @elatoskinas
 
-# First we match on project names to catch files like the compilation scripts,
-# gas snapshots and other files not places in the project directories.
-# This could give some false positives, so afterwards we match on the project directories
-# to ensure the entire directory is always owned by the correct team.
-
+# First we match on project names to catch files like the compilation scripts and other files
+# not placed in the project directories. This could give some false positives, so afterwards
+# we match on the project directories to ensure the entire directory is always owned by the
+# correct team.
 /contracts/**/*keeper* @smartcontractkit/dev-services
 /contracts/**/*upkeep* @smartcontractkit/dev-services
 /contracts/**/*automation* @smartcontractkit/dev-services
+/contracts/**/*ccip* @RensR @matYang @jhweintraub @0xsuryansh @RyanRHall
 /contracts/**/*functions* @smartcontractkit/dev-services
-/contracts/**/*llo-feeds* @smartcontractkit/data-streams-engineers
-/contracts/**/*vrf* @smartcontractkit/dev-services
 /contracts/**/*l2ep* @smartcontractkit/bix-ship
+/contracts/**/*llo-feeds* @smartcontractkit/data-streams-engineers
+/contracts/**/*operatorforwarder* @smartcontractkit/data-feeds-engineers
+/contracts/**/*vrf* @smartcontractkit/dev-services
 /contracts/**/*keystone* @smartcontractkit/keystone
 
 /contracts/src/v0.8/automation @smartcontractkit/dev-services
+/contracts/src/v0.8/ccip @RensR @matYang @jhweintraub @0xsuryansh @RyanRHall
 /contracts/src/v0.8/functions @smartcontractkit/dev-services
 # TODO: interfaces folder, folder should be removed and files moved to the correct folders
 /contracts/src/v0.8/l2ep @smartcontractkit/bix-build
@@ -86,15 +88,19 @@ core/scripts/gateway @smartcontractkit/dev-services
 # TODO: tests folder, folder should be removed and files moved to the correct folders
 # TODO: transmission folder, owner should be found
 /contracts/src/v0.8/vrf @smartcontractkit/dev-services
+/contracts/src/v0.8/keystone @smartcontractkit/keystone
+
+# Remove changeset files from the codeowners
+/contracts/.changeset
+# Gas snapshots are always checked by the CI so they don't need codeowners.
+/contracts/gas-snapshots 
+
+# At the end, match any files missed by the patterns above
+/contracts/scripts/native_solc_compile_all_events_mock @smartcontractkit/dev-services
 
 # GQL API
 /core/web/resolver @smartcontractkit/deployment-automation @smartcontractkit/foundations
 /core/web/schema @smartcontractkit/deployment-automation @smartcontractkit/foundations
-
-# At the end, match any files missed by the patterns above
-/contracts/scripts/native_solc_compile_all_events_mock @smartcontractkit/dev-services
-# Remove changeset files from the codeowners
-/contracts/.changeset
 
 
 # Tests


### PR DESCRIPTION
This PR aims to do the following

- add owners for ccip 
- add the operatorforwarder catch all to correctly label files outside of their folder as well
- add keystone as owner of their folder
- remove snapshots from ownership. These files are required to be correct by CI and should therefore not require team approval to change. This significantly improves the process of updating Foundry, forge-std and other dependencies that don't change any of the bytecode. 