### PR TITLE
use csa key as default encryption key when registering nodes in cap reg

### DIFF
--- a/integration-tests/deployment/keystone/deploy.go
+++ b/integration-tests/deployment/keystone/deploy.go
@@ -577,7 +577,7 @@ func registerNodes(lggr logger.Logger, req *registerNodesRequest) (*registerNode
 					NodeOperatorId:      nop.NodeOperatorId,
 					Signer:              n.Signer,
 					P2pId:               n.P2PKey,
-					EncryptionPublicKey: [32]byte{0x01}, // unused in tests
+					EncryptionPublicKey: n.EncryptionPublicKey,
 					HashedCapabilityIds: hashedCapabilityIds,
 				}
 			} else {

--- a/integration-tests/deployment/keystone/ocr3config.go
+++ b/integration-tests/deployment/keystone/ocr3config.go
@@ -61,6 +61,7 @@ type NodeKeys struct {
 	OCR2OffchainPublicKey string `json:"OCR2OffchainPublicKey"` // ocr2off_evm_<key>
 	OCR2ConfigPublicKey   string `json:"OCR2ConfigPublicKey"`   // ocr2cfg_evm_<key>
 	CSAPublicKey          string `json:"CSAPublicKey"`
+	EncryptionPublicKey   string `json:"EncryptionPublicKey"`
 }
 
 type Orc2drOracleConfig struct {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[KS-472](https://smartcontract-it.atlassian.net/browse/KS-472)

Use CSA public key as the default EncryptionPublicKey when registering nodes in the capability registry

[KS-472]: https://smartcontract-it.atlassian.net/browse/KS-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ