### PR TITLE
Unskip TestAddChainInbound using MCMS

### DIFF
--- a/integration-tests/deployment/ccip/add_chain.go
+++ b/integration-tests/deployment/ccip/add_chain.go
@@ -198,29 +198,212 @@ func NewChainInboundProposal(
 	)
 }
 
+func NewChainCandidateProposal(
+	e deployment.Environment,
+	state CCIPOnChainState,
+	homeChainSel uint64,
+	feedChainSel uint64,
+	newChainSel uint64,
+	sources []uint64,
+	tokenConfig TokenConfig,
+	rmnHomeAddress []byte,
+) (map[cctypes.PluginType]ccip_home.CCIPHomeOCR3Config, deployment.Nodes, uint32, *timelock.MCMSWithTimelockProposal, error) {
+	// Generate proposal which enables new destination (from test router) on all source chains.
+	var batches []timelock.BatchChainOperation
+	metaDataPerChain := make(map[mcms.ChainIdentifier]mcms.ChainMetadata)
+	timelockAddresses := make(map[mcms.ChainIdentifier]common.Address)
+	for _, source := range sources {
+		chain, _ := chainsel.ChainBySelector(source)
+		enableOnRampDest, err := state.Chains[source].OnRamp.ApplyDestChainConfigUpdates(deployment.SimTransactOpts(), []onramp.OnRampDestChainConfigArgs{
+			{
+				DestChainSelector: newChainSel,
+				Router:            state.Chains[source].TestRouter.Address(),
+			},
+		})
+		if err != nil {
+			return nil, nil, 0, nil, err
+		}
+		enableFeeQuoterDest, err := state.Chains[source].FeeQuoter.ApplyDestChainConfigUpdates(
+			deployment.SimTransactOpts(),
+			[]fee_quoter.FeeQuoterDestChainConfigArgs{
+				{
+					DestChainSelector: newChainSel,
+					DestChainConfig:   defaultFeeQuoterDestChainConfig(),
+				},
+			})
+		if err != nil {
+			return nil, nil, 0, nil, err
+		}
+		initialPrices, err := state.Chains[source].FeeQuoter.UpdatePrices(
+			deployment.SimTransactOpts(),
+			fee_quoter.InternalPriceUpdates{
+				TokenPriceUpdates: []fee_quoter.InternalTokenPriceUpdate{},
+				GasPriceUpdates: []fee_quoter.InternalGasPriceUpdate{
+					{
+						DestChainSelector: newChainSel,
+						// TODO: parameterize
+						UsdPerUnitGas: big.NewInt(2e12),
+					},
+				}})
+		if err != nil {
+			return nil, nil, 0, nil, err
+		}
+		batches = append(batches, timelock.BatchChainOperation{
+			ChainIdentifier: mcms.ChainIdentifier(chain.Selector),
+			Batch: []mcms.Operation{
+				{
+					// Enable the source in on ramp
+					To:    state.Chains[source].OnRamp.Address(),
+					Data:  enableOnRampDest.Data(),
+					Value: big.NewInt(0),
+				},
+				{
+					// Set initial dest prices to unblock testing.
+					To:    state.Chains[source].FeeQuoter.Address(),
+					Data:  initialPrices.Data(),
+					Value: big.NewInt(0),
+				},
+				{
+					To:    state.Chains[source].FeeQuoter.Address(),
+					Data:  enableFeeQuoterDest.Data(),
+					Value: big.NewInt(0),
+				},
+			},
+		})
+		opCount, err := state.Chains[source].ProposerMcm.GetOpCount(nil)
+		if err != nil {
+			return nil, nil, 0, nil, err
+		}
+		metaDataPerChain[mcms.ChainIdentifier(chain.Selector)] = mcms.ChainMetadata{
+			StartingOpCount: opCount.Uint64(),
+			MCMAddress:      state.Chains[source].ProposerMcm.Address(),
+		}
+		timelockAddresses[mcms.ChainIdentifier(chain.Selector)] = state.Chains[source].Timelock.Address()
+	}
+
+	// Home chain new don.
+	// - Add new DONs for destination to home chain
+	nodes, err := deployment.NodeInfo(e.NodeIDs, e.Offchain)
+	if err != nil {
+		return nil, nil, 0, nil, err
+	}
+	encodedExtraChainConfig, err := chainconfig.EncodeChainConfig(chainconfig.ChainConfig{
+		GasPriceDeviationPPB:    ccipocr3.NewBigIntFromInt64(1000),
+		DAGasPriceDeviationPPB:  ccipocr3.NewBigIntFromInt64(0),
+		OptimisticConfirmations: 1,
+	})
+	if err != nil {
+		return nil, nil, 0, nil, err
+	}
+	chainConfig := SetupConfigInfo(newChainSel, nodes.NonBootstraps().PeerIDs(),
+		nodes.DefaultF(), encodedExtraChainConfig)
+	addChain, err := state.Chains[homeChainSel].CCIPHome.ApplyChainConfigUpdates(
+		deployment.SimTransactOpts(), nil, []ccip_home.CCIPHomeChainConfigArgs{
+			chainConfig,
+		})
+	if err != nil {
+		return nil, nil, 0, nil, err
+	}
+
+	newDONArgs, err := BuildAddDONArgs(
+		e.Logger,
+		state.Chains[newChainSel].OffRamp,
+		e.Chains[newChainSel],
+		feedChainSel,
+		tokenConfig.GetTokenInfo(e.Logger, state.Chains[newChainSel].LinkToken),
+		nodes.NonBootstraps(),
+		rmnHomeAddress,
+	)
+	if err != nil {
+		return nil, nil, 0, nil, err
+	}
+
+	newDonWithCandidateOps, donId, err := createDONwithCandidates_owned(
+		state.Chains[homeChainSel].CapabilityRegistry,
+		newDONArgs,
+		nodes,
+	)
+	if err != nil {
+		return nil, nil, 0, nil, err
+	}
+
+	opCount, err := state.Chains[homeChainSel].ProposerMcm.GetOpCount(nil)
+	if err != nil {
+		return nil, nil, 0, nil, err
+	}
+	metaDataPerChain[mcms.ChainIdentifier(homeChainSel)] = mcms.ChainMetadata{
+		StartingOpCount: opCount.Uint64(),
+		MCMAddress:      state.Chains[homeChainSel].ProposerMcm.Address(),
+	}
+	timelockAddresses[mcms.ChainIdentifier(homeChainSel)] = state.Chains[homeChainSel].Timelock.Address()
+	batches = append(batches, timelock.BatchChainOperation{
+		ChainIdentifier: mcms.ChainIdentifier(homeChainSel),
+		Batch: append([]mcms.Operation{
+			{
+				// Add the chain first, don needs it to be there.
+				To:    state.Chains[homeChainSel].CCIPHome.Address(),
+				Data:  addChain.Data(),
+				Value: big.NewInt(0),
+			},
+		}, newDonWithCandidateOps...),
+	})
+
+	newProp, err := timelock.NewMCMSWithTimelockProposal(
+		"1",
+		2004259681, // TODO: should be parameterized and based on current block timestamp.
+		[]mcms.Signature{},
+		false,
+		metaDataPerChain,
+		timelockAddresses,
+		"initial new chain setup",
+		batches,
+		timelock.Schedule,
+		"0s", // TODO: Should be parameterized.
+	)
+	return newDONArgs, nodes, donId, newProp, err
+}
+
+func NewChainPromoteProposal(
+	ocr3Configs map[cctypes.PluginType]ccip_home.CCIPHomeOCR3Config,
+	state CCIPOnChainState,
+	homeSelector uint64,
+	nodes deployment.Nodes,
+	donId uint32,
+) (*timelock.MCMSWithTimelockProposal, error) {
+	ccipHome := state.Chains[homeSelector].CCIPHome
+	capReg := state.Chains[homeSelector].CapabilityRegistry
+	tl := state.Chains[homeSelector].Timelock
+	mcm := state.Chains[homeSelector].ProposerMcm
+	ops, err := promoteDONCandidates_owned(ccipHome, capReg, ocr3Configs, nodes, donId)
+	if err != nil {
+		return nil, fmt.Errorf("promoteDONCandidates_owned: %w", err)
+	}
+	return CreateSingleChainMCMSOps(ops, homeSelector, tl, mcm)
+}
+
 func createDONwithCandidates_owned(
 	capReg *capabilities_registry.CapabilitiesRegistry,
 	ocr3Configs map[cctypes.PluginType]ccip_home.CCIPHomeOCR3Config,
 	nodes deployment.Nodes,
-) ([]mcms.Operation, error) {
+) ([]mcms.Operation, uint32, error) {
 
 	commitConfig, ok := ocr3Configs[cctypes.PluginTypeCCIPCommit]
 	if !ok {
-		return nil, fmt.Errorf("missing commit plugin in ocr3Configs")
+		return nil, 0, fmt.Errorf("missing commit plugin in ocr3Configs")
 	}
 
 	execConfig, ok := ocr3Configs[cctypes.PluginTypeCCIPExec]
 	if !ok {
-		return nil, fmt.Errorf("missing exec plugin in ocr3Configs")
+		return nil, 0, fmt.Errorf("missing exec plugin in ocr3Configs")
 	}
 
 	tabi, err := ccip_home.CCIPHomeMetaData.GetAbi()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	latestDon, err := LatestCCIPDON(capReg)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	donID := latestDon.Id + 1
@@ -228,23 +411,23 @@ func createDONwithCandidates_owned(
 
 	donOp, err := addNewDonWithoutCapabilites_owned(capReg, nodes)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	mcmsOps = append(mcmsOps, donOp...)
 
 	proposeCommitPluginOp, err := proposePlugin_owned(tabi, donID, commitConfig, capReg, nodes)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	mcmsOps = append(mcmsOps, proposeCommitPluginOp...)
 
 	proposeExecPluginOp, err := proposePlugin_owned(tabi, donID, execConfig, capReg, nodes)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	mcmsOps = append(mcmsOps, proposeExecPluginOp...)
 
-	return mcmsOps, nil
+	return mcmsOps, donID, nil
 }
 
 func promoteDONCandidates_owned(

--- a/integration-tests/deployment/ccip/add_lane.go
+++ b/integration-tests/deployment/ccip/add_lane.go
@@ -2,9 +2,14 @@ package ccipdeployment
 
 import (
 	"encoding/hex"
+	"fmt"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/mcms"
+	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/deployment"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/offramp"
@@ -118,5 +123,130 @@ func defaultFeeQuoterDestChainConfig() fee_quoter.FeeQuoterDestChainConfig {
 		GasMultiplierWeiPerEth: 1,
 		NetworkFeeUSDCents:     1,
 		ChainFamilySelector:    [4]byte(evmFamilySelector),
+	}
+}
+
+func generateAddLaneProposal(e deployment.Environment, state CCIPOnChainState, from, to uint64) (*timelock.MCMSWithTimelockProposal, error) {
+	var batches []timelock.BatchChainOperation
+	metaDataPerChain := make(map[mcms.ChainIdentifier]mcms.ChainMetadata)
+	timelockAddresses := make(map[mcms.ChainIdentifier]common.Address)
+	var sourceBatch McmsAccumulator
+	var destBatch McmsAccumulator
+
+	_, err := state.Chains[from].Router.ApplyRampUpdates(sourceBatch.TxnAppender(), []router.RouterOnRamp{
+		{
+			DestChainSelector: to,
+			OnRamp:            state.Chains[from].OnRamp.Address(),
+		},
+	}, []router.RouterOffRamp{}, []router.RouterOffRamp{})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = state.Chains[from].OnRamp.ApplyDestChainConfigUpdates(sourceBatch.TxnAppender(),
+		[]onramp.OnRampDestChainConfigArgs{
+			{
+				DestChainSelector: to,
+				Router:            state.Chains[from].Router.Address(),
+			},
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = state.Chains[from].FeeQuoter.UpdatePrices(
+		sourceBatch.TxnAppender(), fee_quoter.InternalPriceUpdates{
+			TokenPriceUpdates: []fee_quoter.InternalTokenPriceUpdate{
+				{
+					SourceToken: state.Chains[from].LinkToken.Address(),
+					UsdPerToken: deployment.E18Mult(20),
+				},
+				{
+					SourceToken: state.Chains[from].Weth9.Address(),
+					UsdPerToken: deployment.E18Mult(4000),
+				},
+			},
+			GasPriceUpdates: []fee_quoter.InternalGasPriceUpdate{
+				{
+					DestChainSelector: to,
+					UsdPerUnitGas:     big.NewInt(2e12),
+				},
+			}})
+	if err != nil {
+		return nil, err
+	}
+
+	// Enable dest in fee quoter
+	_, err = state.Chains[from].FeeQuoter.ApplyDestChainConfigUpdates(sourceBatch.TxnAppender(),
+		[]fee_quoter.FeeQuoterDestChainConfigArgs{
+			{
+				DestChainSelector: to,
+				DestChainConfig:   defaultFeeQuoterDestChainConfig(),
+			},
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = state.Chains[to].OffRamp.ApplySourceChainConfigUpdates(destBatch.TxnAppender(),
+		[]offramp.OffRampSourceChainConfigArgs{
+			{
+				Router:              state.Chains[to].Router.Address(),
+				SourceChainSelector: from,
+				IsEnabled:           true,
+				OnRamp:              common.LeftPadBytes(state.Chains[from].OnRamp.Address().Bytes(), 32),
+			},
+		})
+	if err != nil {
+		return nil, err
+	}
+	_, err = state.Chains[to].Router.ApplyRampUpdates(destBatch.TxnAppender(), []router.RouterOnRamp{}, []router.RouterOffRamp{}, []router.RouterOffRamp{
+		{
+			SourceChainSelector: from,
+			OffRamp:             state.Chains[to].OffRamp.Address(),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	batches = append(batches, timelock.BatchChainOperation{
+		ChainIdentifier: mcms.ChainIdentifier(from),
+		Batch:           sourceBatch.B,
+	})
+	batches = append(batches, timelock.BatchChainOperation{
+		ChainIdentifier: mcms.ChainIdentifier(to),
+		Batch:           destBatch.B,
+	})
+
+	return timelock.NewMCMSWithTimelockProposal(
+		"1",
+		2004259681, // TODO
+		[]mcms.Signature{},
+		false,
+		metaDataPerChain,
+		timelockAddresses,
+		fmt.Sprintf("Add lane between source (%d) and destinatino (%d)", from, to),
+		batches,
+		timelock.Schedule, "0s")
+}
+
+type McmsAccumulator struct {
+	B []mcms.Operation
+}
+
+func (m *McmsAccumulator) TxnAppender() *bind.TransactOpts {
+	return &bind.TransactOpts{
+		Signer: func(address common.Address, transaction *types.Transaction) (*types.Transaction, error) {
+			m.B = append(m.B, mcms.Operation{
+				To:    *transaction.To(),
+				Data:  transaction.Data(),
+				Value: big.NewInt(0),
+			})
+			return transaction, nil
+		},
+		From:     common.HexToAddress("0x0"),
+		NoSend:   true,
+		GasLimit: 1_000_000,
 	}
 }

--- a/integration-tests/deployment/ccip/add_lane.go
+++ b/integration-tests/deployment/ccip/add_lane.go
@@ -226,7 +226,7 @@ func generateAddLaneProposal(e deployment.Environment, state CCIPOnChainState, f
 		false,
 		metaDataPerChain,
 		timelockAddresses,
-		fmt.Sprintf("Add lane between source (%d) and destinatino (%d)", from, to),
+		fmt.Sprintf("Add source (%d) and destination (%d)", from, to),
 		batches,
 		timelock.Schedule, "0s")
 }

--- a/integration-tests/deployment/ccip/add_lane_test.go
+++ b/integration-tests/deployment/ccip/add_lane_test.go
@@ -62,3 +62,34 @@ func TestAddLane(t *testing.T) {
 	// TODO: Add a second lane, then disable the first and
 	// ensure we can send on the second but not the first.
 }
+
+func Test_McmsAddLane(t *testing.T) {
+	e := NewMemoryEnvironmentWithJobs(t, logger.TestLogger(t), 3)
+	// Here we have CR + nodes set up, but no CCIP contracts deployed.
+	state, err := LoadOnchainState(e.Env, e.Ab)
+	require.NoError(t, err)
+	// Set up CCIP contracts and a DON per chain.
+	err = DeployCCIPContracts(e.Env, e.Ab, DeployCCIPContractConfig{
+		HomeChainSel:       e.HomeChainSel,
+		FeedChainSel:       e.FeedChainSel,
+		TokenConfig:        NewTokenConfig(),
+		MCMSConfig:         NewTestMCMSConfig(t, e.Env),
+		FeeTokenContracts:  e.FeeTokenContracts,
+		CapabilityRegistry: state.Chains[e.HomeChainSel].CapabilityRegistry.Address(),
+	})
+	require.NoError(t, err)
+
+	// We expect no lanes available on any chain.
+	state, err = LoadOnchainState(e.Env, e.Ab)
+	require.NoError(t, err)
+	for _, chain := range state.Chains {
+		offRamps, err := chain.Router.GetOffRamps(nil)
+		require.NoError(t, err)
+		require.Len(t, offRamps, 0)
+	}
+
+	from, to := e.Env.AllChainSelectors()[0], e.Env.AllChainSelectors()[1]
+
+	_, err = generateAddLaneProposal(e.Env, state, from, to)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Work to add integration tests using MCMS for [CCIP-3796](https://smartcontract-it.atlassian.net/browse/CCIP-3769)

This is a proof of concept of how we could accumulate mcms operations in a btach using a signer

[CCIP-3796]: https://smartcontract-it.atlassian.net/browse/CCIP-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ