### PR TITLE
Fix bad changesets in contracts

### DIFF
--- a/contracts/.changeset/heavy-balloons-cheat.md
+++ b/contracts/.changeset/heavy-balloons-cheat.md
@@ -1,5 +1,5 @@
 ---
-"chainlink": patch
+'@chainlink/contracts': patch
 ---
 
 #added Add ZKSync L2EP SequencerUptimeFeed contract

--- a/contracts/.changeset/itchy-deers-deny.md
+++ b/contracts/.changeset/itchy-deers-deny.md
@@ -1,5 +1,5 @@
 ---
-"@chainlink/contracts": patch
+'@chainlink/contracts': patch
 ---
 
 More comprehensive & product-scoped Solidity Foundry pipeline


### PR DESCRIPTION
Fixes this issue:

```shell
❯ pnpm changeset version # apply the changesets which bumps the version automatically
🦋  error TypeError: Cannot destructure property 'packageJson' of 'undefined' as it is undefined.
🦋  error     at Object.shouldSkipPackage (/Users/chainchad/Code/smartcontractkit/chainlink/contracts/node_modules/.pnpm/@changesets+should-skip-package@0.1.1/node_modules/@changesets/should-skip-package/dist/changesets-should-skip-package.cjs.js:6:3)
🦋  error     at getRelevantChangesets (/Users/chainchad/Code/smartcontractkit/chainlink/contracts/node_modules/.pnpm/@changesets+assemble-release-plan@6.0.4/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:608:29)
🦋  error     at Object.assembleReleasePlan [as default] (/Users/chainchad/Code/smartcontractkit/chainlink/contracts/node_modules/.pnpm/@changesets+assemble-release-plan@6.0.4/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:536:30)
🦋  error     at version (/Users/chainchad/Code/smartcontractkit/chainlink/contracts/node_modules/.pnpm/@changesets+cli@2.27.8/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1281:60)
🦋  error     at async run (/Users/chainchad/Code/smartcontractkit/chainlink/contracts/node_modules/.pnpm/@changesets+cli@2.27.8/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1463:11)
```

Created a separate task to have CI validate these going forward.