### PR TITLE
core/utils: fix TestThreadControl_GoCtx flake

### DIFF
--- a/core/utils/thread_control_test.go
+++ b/core/utils/thread_control_test.go
@@ -36,9 +36,10 @@ func TestThreadControl_GoCtx(t *testing.T) {
 	var wg sync.WaitGroup
 	finished := atomic.Int32{}
 
-	timeout := 10 * time.Millisecond
+	timeout := 100 * time.Millisecond
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	start := time.Now()
+	ctx, cancel := context.WithDeadline(context.Background(), start.Add(timeout))
 	defer cancel()
 
 	wg.Add(1)
@@ -48,10 +49,9 @@ func TestThreadControl_GoCtx(t *testing.T) {
 		finished.Add(1)
 	})
 
-	start := time.Now()
 	wg.Wait()
-	end := time.Since(start)
-	assert.Greater(t, end, timeout-1)
-	assert.Less(t, end, 2*timeout)
+	elapsed := time.Since(start)
+	assert.GreaterOrEqual(t, elapsed, timeout)
+	assert.Less(t, elapsed, 2*timeout)
 	require.Equal(t, int32(1), finished.Load())
 }


### PR DESCRIPTION
This test occasionally flakes, usually like:
```
 TestThreadControl_GoCtx (0.01s) 
          	Error Trace:	/home/runner/work/chainlink/chainlink/core/utils/thread_control_test.go:54 
          	Error:      	"9.018742ms" is not greater than "9.999999ms" 
          	Test:       	TestThreadControl_GoCtx 
```
This looks superficially like it should be impossible, but that is based on an assumption that the main goroutine will continue to execute without yielding. However, the scheduler can pre-empt and run another goroutine at any time, and when that happens after creating the context but before capturing the start timestamp, then it can introduce arbitrary delay and make it appear as if our context was cancelled early. About `0.1ms` ealier in this case. By establishing the start timestamp first, then using a deadline derived from it, we can ensure that this error is not possible, and being preempted will only add to the elapsed time, for which we already account for a 2x slowdown. I also extended the timeout from 10ms to 100ms as well, to widen this window.