### PR TITLE
bumped crib-deploy-environment to 2.1.0 to fix crib-integration-tests workflow

### DIFF
--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -76,7 +76,7 @@ jobs:
           echo $GITHUB_WORKSPACE
 
       - name: Deploy and validate CRIB Environment for Core
-        uses: smartcontractkit/.github/actions/crib-deploy-environment@fa63a0fb95039c4d89fec6a9a78b53c0cacf5457 # crib-deploy-environment@2.0.0
+        uses: smartcontractkit/.github/actions/crib-deploy-environment@a4058228b4b9b6e30bb0e2b883e3b4f0cd447970 # crib-deploy-environment@2.1.0
         id: deploy-crib
         with:
           github-token: ${{ steps.token.outputs.access-token }}


### PR DESCRIPTION
now required after https://github.com/smartcontractkit/crib/pull/227