### PR TITLE
rename mock to fake for clarity in capability integration testing framework 

### DIFF
--- a/core/capabilities/integration_tests/framework/don.go
+++ b/core/capabilities/integration_tests/framework/don.go
@@ -40,13 +40,13 @@ import (
 
 type DonContext struct {
 	EthBlockchain      *EthBlockchain
-	p2pNetwork         *MockRageP2PNetwork
+	p2pNetwork         *FakeRageP2PNetwork
 	capabilityRegistry *CapabilitiesRegistry
 }
 
 func CreateDonContext(ctx context.Context, t *testing.T) DonContext {
 	ethBlockchain := NewEthBlockchain(t, 1000, 1*time.Second)
-	rageP2PNetwork := NewMockRageP2PNetwork(t, 1000)
+	rageP2PNetwork := NewFakeRageP2PNetwork(t, 1000)
 	capabilitiesRegistry := NewCapabilitiesRegistry(ctx, t, ethBlockchain)
 
 	servicetest.Run(t, rageP2PNetwork)
@@ -85,9 +85,9 @@ func NewDON(ctx context.Context, t *testing.T, lggr logger.Logger, donConfig Don
 	don := &DON{t: t, lggr: lggr.Named(donConfig.name), config: donConfig, capabilitiesRegistry: donContext.capabilityRegistry}
 
 	var newOracleFactoryFn standardcapabilities.NewOracleFactoryFn
-	var libOcr *MockLibOCR
+	var libOcr *FakeLibOCR
 	if supportsOCR {
-		libOcr = NewMockLibOCR(t, lggr, donConfig.F, 1*time.Second)
+		libOcr = NewFakeLibOCR(t, lggr, donConfig.F, 1*time.Second)
 		servicetest.Run(t, libOcr)
 	}
 
@@ -110,7 +110,7 @@ func NewDON(ctx context.Context, t *testing.T, lggr logger.Logger, donConfig Don
 		don.nodes = append(don.nodes, cn)
 
 		if supportsOCR {
-			factory := newMockLibOcrOracleFactory(libOcr, donConfig.KeyBundles[i], len(donConfig.Members), int(donConfig.F))
+			factory := newFakeOracleFactory(libOcr, donConfig.KeyBundles[i], len(donConfig.Members), int(donConfig.F))
 			newOracleFactoryFn = factory.NewOracleFactory
 		}
 
@@ -184,7 +184,7 @@ func (d *DON) Start(ctx context.Context, t *testing.T) {
 	}
 
 	if d.addOCR3NonStandardCapability {
-		libocr := NewMockLibOCR(t, d.lggr, d.config.F, 1*time.Second)
+		libocr := NewFakeLibOCR(t, d.lggr, d.config.F, 1*time.Second)
 		servicetest.Run(t, libocr)
 
 		for _, node := range d.nodes {
@@ -366,7 +366,7 @@ func (d *DON) AddEthereumWriteTargetNonStandardCapability(forwarderAddr common.A
 }
 
 func addOCR3Capability(ctx context.Context, t *testing.T, lggr logger.Logger, capabilityRegistry *capabilities.Registry,
-	libocr *MockLibOCR, donF uint8, ocr2KeyBundle ocr2key.KeyBundle) {
+	libocr *FakeLibOCR, donF uint8, ocr2KeyBundle ocr2key.KeyBundle) {
 	requestTimeout := 10 * time.Minute
 	cfg := ocr3.Config{
 		Logger:            lggr,

--- a/core/capabilities/integration_tests/framework/fake_target.go
+++ b/core/capabilities/integration_tests/framework/fake_target.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	_ capabilities.ActionCapability = &mockTarget{}
+	_ capabilities.ActionCapability = &target{}
 )
 
 type TargetSink struct {
@@ -18,7 +18,7 @@ type TargetSink struct {
 	targetName string
 	version    string
 
-	targets []mockTarget
+	targets []target
 	Sink    chan capabilities.CapabilityRequest
 }
 
@@ -56,38 +56,38 @@ func (ts *TargetSink) Close() error {
 }
 
 func (ts *TargetSink) CreateNewTarget(t *testing.T) capabilities.TargetCapability {
-	target := mockTarget{
+	trgt := target{
 		t:        t,
 		targetID: ts.targetID,
 		ch:       ts.Sink,
 	}
-	ts.targets = append(ts.targets, target)
-	return &target
+	ts.targets = append(ts.targets, trgt)
+	return &trgt
 }
 
-type mockTarget struct {
+type target struct {
 	t        *testing.T
 	targetID string
 	ch       chan capabilities.CapabilityRequest
 }
 
-func (mt *mockTarget) Execute(ctx context.Context, rawRequest capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+func (mt *target) Execute(ctx context.Context, rawRequest capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
 	mt.ch <- rawRequest
 	return capabilities.CapabilityResponse{}, nil
 }
 
-func (mt *mockTarget) Info(ctx context.Context) (capabilities.CapabilityInfo, error) {
+func (mt *target) Info(ctx context.Context) (capabilities.CapabilityInfo, error) {
 	return capabilities.MustNewCapabilityInfo(
 		mt.targetID,
 		capabilities.CapabilityTypeTarget,
-		"mock target for target ID "+mt.targetID,
+		"fake target for target ID "+mt.targetID,
 	), nil
 }
 
-func (mt *mockTarget) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {
+func (mt *target) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {
 	return nil
 }
 
-func (mt *mockTarget) UnregisterFromWorkflow(ctx context.Context, request capabilities.UnregisterFromWorkflowRequest) error {
+func (mt *target) UnregisterFromWorkflow(ctx context.Context, request capabilities.UnregisterFromWorkflowRequest) error {
 	return nil
 }

--- a/core/capabilities/integration_tests/framework/fake_target.go
+++ b/core/capabilities/integration_tests/framework/fake_target.go
@@ -56,13 +56,13 @@ func (ts *TargetSink) Close() error {
 }
 
 func (ts *TargetSink) CreateNewTarget(t *testing.T) capabilities.TargetCapability {
-	trgt := target{
+	trg := target{
 		t:        t,
 		targetID: ts.targetID,
 		ch:       ts.Sink,
 	}
-	ts.targets = append(ts.targets, trgt)
-	return &trgt
+	ts.targets = append(ts.targets, trg)
+	return &trg
 }
 
 type target struct {


### PR DESCRIPTION
rename mock to fake for clarity in capability integration testing framework 
