### PR TITLE
Remove arbitrum and zksync from daOracle config switch

### DIFF
--- a/.changeset/breezy-weeks-watch.md
+++ b/.changeset/breezy-weeks-watch.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Remove arbitrum and zksync from daOracle config switch #bugfix

--- a/core/chains/evm/gas/rollups/l1_oracle.go
+++ b/core/chains/evm/gas/rollups/l1_oracle.go
@@ -59,17 +59,13 @@ func NewL1GasOracle(lggr logger.Logger, ethClient l1OracleClient, chainType chai
 		switch daOracle.OracleType() {
 		case toml.DAOracleOPStack:
 			l1Oracle, err = NewOpStackL1GasOracle(lggr, ethClient, chainType, daOracle)
-		case toml.DAOracleArbitrum:
-			l1Oracle, err = NewArbitrumL1GasOracle(lggr, ethClient)
-		case toml.DAOracleZKSync:
-			l1Oracle = NewZkSyncL1GasOracle(lggr, ethClient)
-		default:
-			err = fmt.Errorf("unsupported DA oracle type %s. Going forward all chain configs should specify an oracle type", daOracle.OracleType())
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize L1 oracle for chaintype %s: %w", chainType, err)
 		}
-		return l1Oracle, nil
+		if l1Oracle != nil {
+			return l1Oracle, nil
+		}
 	}
 
 	// Going forward all configs should specify a DAOracle config. This is a fall back to maintain backwards compat.


### PR DESCRIPTION
- Arbitrum and ZKSync DA oracle configs have not been set yet
- However it looks like their `daOracle` was still non-nil which caused them to enter the `switch daOracle.OracleType()` but not hit the `toml.DAOracleArbitrum` case since the oracle type was not set in the DA oracle config
- This caused the `default` case to be hit and return an error instead of falling back to the existing logic below starting at the line with the comment `// Going forward all configs...`