### PR TITLE
Add explicit DA oracle type to arbitrum and zksync chaintype configs

### DIFF
--- a/.changeset/gorgeous-wolves-collect.md
+++ b/.changeset/gorgeous-wolves-collect.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Add DA oracle type to arbitrum and zksync configs #bugfix

--- a/ccip/config/evm/Arbitrum_Mainnet.toml
+++ b/ccip/config/evm/Arbitrum_Mainnet.toml
@@ -22,6 +22,9 @@ BumpThreshold = 5
 # Force an error if someone set GAS_UPDATER_ENABLED=true by accident; we never want to run the block history estimator on arbitrum
 BlockHistorySize = 0
 
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+
 [NodePool]
 SyncThreshold = 10
 

--- a/ccip/config/evm/Arbitrum_Sepolia.toml
+++ b/ccip/config/evm/Arbitrum_Sepolia.toml
@@ -20,6 +20,9 @@ BumpThreshold = 5
 # Force an error if someone set GAS_UPDATER_ENABLED=true by accident; we never want to run the block history estimator on arbitrum
 BlockHistorySize = 0
 
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+
 [NodePool]
 SyncThreshold = 10
 

--- a/ccip/config/evm/L3X_Mainnet.toml
+++ b/ccip/config/evm/L3X_Mainnet.toml
@@ -16,3 +16,6 @@ PriceMin = '0'
 PriceDefault = '0.1 gwei'
 FeeCapDefault = '1000 gwei'
 BumpThreshold = 5
+
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'

--- a/ccip/config/evm/L3X_Sepolia.toml
+++ b/ccip/config/evm/L3X_Sepolia.toml
@@ -16,3 +16,6 @@ PriceMin = '0'
 PriceDefault = '0.1 gwei'
 FeeCapDefault = '1000 gwei'
 BumpThreshold = 5
+
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'

--- a/ccip/config/evm/zkSync_Mainnet.toml
+++ b/ccip/config/evm/zkSync_Mainnet.toml
@@ -23,6 +23,9 @@ PriceMin = '25 mwei'
 # increasing this to smooth out gas estimation
 BlockHistorySize = 200
 
+[GasEstimator.DAOracle]
+OracleType = 'zksync'
+
 [HeadTracker]
 # tracks top N blocks to keep in heads database table. Should store atleast the same # of blocks as finalityDepth
 HistoryDepth = 1500

--- a/ccip/config/evm/zkSync_Sepolia.toml
+++ b/ccip/config/evm/zkSync_Sepolia.toml
@@ -23,6 +23,9 @@ PriceMin = '25 mwei'
 # increasing this to smooth out gas estimation
 BlockHistorySize = 200
 
+[GasEstimator.DAOracle]
+OracleType = 'zksync'
+
 [HeadTracker]
 # tracks top N blocks to keep in heads database table. Should store atleast the same # of blocks as finalityDepth
 HistoryDepth = 250

--- a/core/chains/evm/config/toml/defaults/Arbitrum_Goerli.toml
+++ b/core/chains/evm/config/toml/defaults/Arbitrum_Goerli.toml
@@ -19,6 +19,9 @@ BumpThreshold = 5
 # Force an error if someone set GAS_UPDATER_ENABLED=true by accident; we never want to run the block history estimator on arbitrum
 BlockHistorySize = 0
 
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+
 [NodePool]
 SyncThreshold = 10
 

--- a/core/chains/evm/config/toml/defaults/Arbitrum_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Arbitrum_Mainnet.toml
@@ -22,6 +22,9 @@ BumpThreshold = 5
 # Force an error if someone set GAS_UPDATER_ENABLED=true by accident; we never want to run the block history estimator on arbitrum
 BlockHistorySize = 0
 
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+
 [NodePool]
 SyncThreshold = 10
 

--- a/core/chains/evm/config/toml/defaults/Arbitrum_Rinkeby.toml
+++ b/core/chains/evm/config/toml/defaults/Arbitrum_Rinkeby.toml
@@ -19,5 +19,8 @@ BumpThreshold = 5
 # Force an error if someone set GAS_UPDATER_ENABLED=true by accident; we never want to run the block history estimator on arbitrum
 BlockHistorySize = 0
 
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+
 [NodePool]
 SyncThreshold = 10

--- a/core/chains/evm/config/toml/defaults/Arbitrum_Sepolia.toml
+++ b/core/chains/evm/config/toml/defaults/Arbitrum_Sepolia.toml
@@ -19,6 +19,9 @@ BumpThreshold = 5
 # Force an error if someone set GAS_UPDATER_ENABLED=true by accident; we never want to run the block history estimator on arbitrum
 BlockHistorySize = 0
 
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+
 [NodePool]
 SyncThreshold = 10
 

--- a/core/chains/evm/config/toml/defaults/L3X_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/L3X_Mainnet.toml
@@ -16,3 +16,6 @@ PriceMin = '0'
 PriceDefault = '0.1 gwei'
 FeeCapDefault = '1000 gwei'
 BumpThreshold = 5
+
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'

--- a/core/chains/evm/config/toml/defaults/L3X_Sepolia.toml
+++ b/core/chains/evm/config/toml/defaults/L3X_Sepolia.toml
@@ -16,3 +16,6 @@ PriceMin = '0'
 PriceDefault = '0.1 gwei'
 FeeCapDefault = '1000 gwei'
 BumpThreshold = 5
+
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'

--- a/core/chains/evm/config/toml/defaults/zkSync_Goerli.toml
+++ b/core/chains/evm/config/toml/defaults/zkSync_Goerli.toml
@@ -10,5 +10,8 @@ LimitDefault = 100_000_000
 PriceMax = 18446744073709551615
 PriceMin = 0
 
+[GasEstimator.DAOracle]
+OracleType = 'zksync'
+
 [HeadTracker]
 HistoryDepth = 50

--- a/core/chains/evm/config/toml/defaults/zkSync_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/zkSync_Mainnet.toml
@@ -10,5 +10,8 @@ LimitDefault = 100_000_000
 PriceMax = 18446744073709551615
 PriceMin = 0
 
+[GasEstimator.DAOracle]
+OracleType = 'zksync'
+
 [HeadTracker]
 HistoryDepth = 50

--- a/core/chains/evm/config/toml/defaults/zkSync_Sepolia.toml
+++ b/core/chains/evm/config/toml/defaults/zkSync_Sepolia.toml
@@ -10,5 +10,8 @@ LimitDefault = 100_000_000
 PriceMax = 18446744073709551615
 PriceMin = 0
 
+[GasEstimator.DAOracle]
+OracleType = 'zksync'
+
 [HeadTracker]
 HistoryDepth = 50

--- a/core/chains/evm/gas/rollups/l1_oracle.go
+++ b/core/chains/evm/gas/rollups/l1_oracle.go
@@ -63,13 +63,13 @@ func NewL1GasOracle(lggr logger.Logger, ethClient l1OracleClient, chainType chai
 			l1Oracle, err = NewArbitrumL1GasOracle(lggr, ethClient)
 		case toml.DAOracleZKSync:
 			l1Oracle = NewZkSyncL1GasOracle(lggr, ethClient)
-		default:
-			err = fmt.Errorf("unsupported DA oracle type %s. Going forward all chain configs should specify an oracle type", daOracle.OracleType())
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize L1 oracle for chaintype %s: %w", chainType, err)
 		}
-		return l1Oracle, nil
+		if l1Oracle != nil {
+			return l1Oracle, nil
+		}
 	}
 
 	// Going forward all configs should specify a DAOracle config. This is a fall back to maintain backwards compat.

--- a/core/chains/evm/gas/rollups/l1_oracle_test.go
+++ b/core/chains/evm/gas/rollups/l1_oracle_test.go
@@ -35,6 +35,34 @@ func TestL1Oracle(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, oracle)
 	})
+
+	t.Run("DAOracle config is nil, falls back to using chainType", func(t *testing.T) {
+		ethClient := mocks.NewL1OracleClient(t)
+
+		oracle, err := NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainArbitrum, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, oracle)
+	})
+
+	t.Run("DAOracle config is not nil, but OracleType is empty, falls back to using chainType arbitrum", func(t *testing.T) {
+		ethClient := mocks.NewL1OracleClient(t)
+
+		daOracle := CreateTestDAOracle(t, "", utils.RandomAddress().String(), "")
+		oracle, err := NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainArbitrum, daOracle)
+		require.NoError(t, err)
+		assert.NotNil(t, oracle)
+		assert.Equal(t, oracle.Name(), "L1GasOracle(arbitrum)")
+	})
+
+	t.Run("DAOracle config is not nil, but OracleType is empty, falls back to using chainType ZKSync", func(t *testing.T) {
+		ethClient := mocks.NewL1OracleClient(t)
+
+		daOracle := CreateTestDAOracle(t, "", utils.RandomAddress().String(), "")
+		oracle, err := NewL1GasOracle(logger.Test(t), ethClient, chaintype.ChainZkSync, daOracle)
+		require.NoError(t, err)
+		assert.NotNil(t, oracle)
+		assert.Equal(t, oracle.Name(), "L1GasOracle(zkSync)")
+	})
 }
 
 func TestL1Oracle_GasPrice(t *testing.T) {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -4012,6 +4012,10 @@ TransactionPercentile = 60
 [GasEstimator.FeeHistory]
 CacheTimeout = '10s'
 
+[GasEstimator.DAOracle]
+OracleType = 'zksync'
+CustomGasPriceCalldata = ''
+
 [HeadTracker]
 HistoryDepth = 50
 MaxBufferSize = 3
@@ -4324,6 +4328,10 @@ TransactionPercentile = 60
 [GasEstimator.FeeHistory]
 CacheTimeout = '10s'
 
+[GasEstimator.DAOracle]
+OracleType = 'zksync'
+CustomGasPriceCalldata = ''
+
 [HeadTracker]
 HistoryDepth = 50
 MaxBufferSize = 3
@@ -4427,6 +4435,10 @@ TransactionPercentile = 60
 
 [GasEstimator.FeeHistory]
 CacheTimeout = '10s'
+
+[GasEstimator.DAOracle]
+OracleType = 'zksync'
+CustomGasPriceCalldata = ''
 
 [HeadTracker]
 HistoryDepth = 50
@@ -6112,6 +6124,10 @@ TransactionPercentile = 60
 [GasEstimator.FeeHistory]
 CacheTimeout = '10s'
 
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+CustomGasPriceCalldata = ''
+
 [HeadTracker]
 HistoryDepth = 100
 MaxBufferSize = 3
@@ -6217,6 +6233,10 @@ TransactionPercentile = 60
 [GasEstimator.FeeHistory]
 CacheTimeout = '10s'
 
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+CustomGasPriceCalldata = ''
+
 [HeadTracker]
 HistoryDepth = 100
 MaxBufferSize = 3
@@ -6321,6 +6341,10 @@ TransactionPercentile = 60
 
 [GasEstimator.FeeHistory]
 CacheTimeout = '10s'
+
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+CustomGasPriceCalldata = ''
 
 [HeadTracker]
 HistoryDepth = 100
@@ -7905,6 +7929,10 @@ TransactionPercentile = 60
 [GasEstimator.FeeHistory]
 CacheTimeout = '10s'
 
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+CustomGasPriceCalldata = ''
+
 [HeadTracker]
 HistoryDepth = 100
 MaxBufferSize = 3
@@ -8010,6 +8038,10 @@ TransactionPercentile = 60
 [GasEstimator.FeeHistory]
 CacheTimeout = '10s'
 
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+CustomGasPriceCalldata = ''
+
 [HeadTracker]
 HistoryDepth = 100
 MaxBufferSize = 3
@@ -8113,6 +8145,10 @@ TransactionPercentile = 60
 
 [GasEstimator.FeeHistory]
 CacheTimeout = '10s'
+
+[GasEstimator.DAOracle]
+OracleType = 'arbitrum'
+CustomGasPriceCalldata = ''
 
 [HeadTracker]
 HistoryDepth = 100


### PR DESCRIPTION
- Arbitrum and ZKSync DA oracle types were not set causing l1_oracle `NewL1GasOracle()` to return an error
- This PR sets these oracle types so we follow the existing oracle init logic