### PR TITLE
ccip: use unknown address type.

### DIFF
--- a/core/capabilities/ccip/ccipevm/commitcodec.go
+++ b/core/capabilities/ccip/ccipevm/commitcodec.go
@@ -8,8 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/ccip_encoding_utils"
@@ -128,7 +126,7 @@ func (c *CommitPluginCodecV1) Decode(ctx context.Context, bytes []byte) (cciptyp
 	tokenPriceUpdates := make([]cciptypes.TokenPrice, 0, len(commitReport.PriceUpdates.TokenPriceUpdates))
 	for _, update := range commitReport.PriceUpdates.TokenPriceUpdates {
 		tokenPriceUpdates = append(tokenPriceUpdates, cciptypes.TokenPrice{
-			TokenID: types.Account(update.SourceToken.String()),
+			TokenID: cciptypes.UnknownEncodedAddress(update.SourceToken.String()),
 			Price:   cciptypes.NewBigInt(big.NewInt(0).Set(update.UsdPerToken)),
 		})
 	}

--- a/core/capabilities/ccip/ccipevm/commitcodec_test.go
+++ b/core/capabilities/ccip/ccipevm/commitcodec_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -41,7 +39,7 @@ var randomCommitReport = func() cciptypes.CommitPluginReport {
 		PriceUpdates: cciptypes.PriceUpdates{
 			TokenPriceUpdates: []cciptypes.TokenPrice{
 				{
-					TokenID: types.Account(utils.RandomAddress().String()),
+					TokenID: cciptypes.UnknownEncodedAddress(utils.RandomAddress().String()),
 					Price:   cciptypes.NewBigInt(utils.RandUint256()),
 				},
 			},

--- a/core/capabilities/ccip/ccipevm/executecodec.go
+++ b/core/capabilities/ccip/ccipevm/executecodec.go
@@ -161,15 +161,15 @@ func (e *ExecutePluginCodecV1) Decode(ctx context.Context, encodedReport []byte)
 					DestChainSelector:   cciptypes.ChainSelector(evmMessage.Header.DestChainSelector),
 					SequenceNumber:      cciptypes.SeqNum(evmMessage.Header.SequenceNumber),
 					Nonce:               evmMessage.Header.Nonce,
-					MsgHash:             cciptypes.Bytes32{}, // <-- todo: info not available, but not required atm
-					OnRamp:              cciptypes.Bytes{},   // <-- todo: info not available, but not required atm
+					MsgHash:             cciptypes.Bytes32{},        // todo: info not available, but not required atm
+					OnRamp:              cciptypes.UnknownAddress{}, // todo: info not available, but not required atm
 				},
 				Sender:         evmMessage.Sender,
 				Data:           evmMessage.Data,
 				Receiver:       evmMessage.Receiver.Bytes(),
-				ExtraArgs:      cciptypes.Bytes{},  // <-- todo: info not available, but not required atm
-				FeeToken:       cciptypes.Bytes{},  // <-- todo: info not available, but not required atm
-				FeeTokenAmount: cciptypes.BigInt{}, // <-- todo: info not available, but not required atm
+				ExtraArgs:      cciptypes.Bytes{},          // <-- todo: info not available, but not required atm
+				FeeToken:       cciptypes.UnknownAddress{}, // <-- todo: info not available, but not required atm
+				FeeTokenAmount: cciptypes.BigInt{},         // <-- todo: info not available, but not required atm
 				TokenAmounts:   tokenAmounts,
 			}
 			messages = append(messages, message)

--- a/core/capabilities/ccip/ccipevm/executecodec_test.go
+++ b/core/capabilities/ccip/ccipevm/executecodec_test.go
@@ -151,8 +151,8 @@ func TestExecutePluginCodecV1(t *testing.T) {
 			for i := range report.ChainReports {
 				for j := range report.ChainReports[i].Messages {
 					report.ChainReports[i].Messages[j].Header.MsgHash = cciptypes.Bytes32{}
-					report.ChainReports[i].Messages[j].Header.OnRamp = cciptypes.Bytes{}
-					report.ChainReports[i].Messages[j].FeeToken = cciptypes.Bytes{}
+					report.ChainReports[i].Messages[j].Header.OnRamp = cciptypes.UnknownAddress{}
+					report.ChainReports[i].Messages[j].FeeToken = cciptypes.UnknownAddress{}
 					report.ChainReports[i].Messages[j].ExtraArgs = cciptypes.Bytes{}
 					report.ChainReports[i].Messages[j].FeeTokenAmount = cciptypes.BigInt{}
 				}

--- a/core/capabilities/ccip/ccipevm/rmncrypto.go
+++ b/core/capabilities/ccip/ccipevm/rmncrypto.go
@@ -77,7 +77,7 @@ func (r *EVMRMNCrypto) VerifyReportSignatures(
 	_ context.Context,
 	sigs []cciptypes.RMNECDSASignature,
 	report cciptypes.RMNReport,
-	signerAddresses []cciptypes.Bytes,
+	signerAddresses []cciptypes.UnknownAddress,
 ) error {
 	if sigs == nil {
 		return fmt.Errorf("no signatures provided")

--- a/core/capabilities/ccip/ccipevm/rmncrypto_test.go
+++ b/core/capabilities/ccip/ccipevm/rmncrypto_test.go
@@ -63,7 +63,7 @@ func Test_VerifyRmnReportSignatures(t *testing.T) {
 		ctx,
 		[]cciptypes.RMNECDSASignature{{R: r, S: s}},
 		reportData,
-		[]cciptypes.Bytes{onchainRmnRemoteAddr.Bytes()},
+		[]cciptypes.UnknownAddress{onchainRmnRemoteAddr.Bytes()},
 	)
 	assert.NoError(t, err)
 }

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -287,7 +287,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.3 // indirect
 	github.com/smartcontractkit/ccip-owner-contracts v0.0.0-20240926212305-a6deabdfce86 // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.27 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241018134907-a00ba3729b5e // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.1 // indirect

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -287,7 +287,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.3 // indirect
 	github.com/smartcontractkit/ccip-owner-contracts v0.0.0-20240926212305-a6deabdfce86 // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.27 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47 // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241018134907-a00ba3729b5e // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.1 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1072,8 +1072,8 @@ github.com/smartcontractkit/chain-selectors v1.0.27 h1:VE/ftX9Aae4gnw67yR1raKi+3
 github.com/smartcontractkit/chain-selectors v1.0.27/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v0.8.0 h1:hFz2EHU06bkEfhcqhK8JdjKTWpDOr0XJ6xL9oELDoUg=
 github.com/smartcontractkit/chainlink-automation v0.8.0/go.mod h1:ObdjDfgGIaiE48Bb3yYcx1CeGBm392WlEw92U83LlUA=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f h1:g9sM6SbASd40qea/8kn9ASF4JPs54Cv9gczLNkS9v24=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47 h1:kyOANlbz29uaevkjRaXlO1750A43xAvwAOKXiVNWpFQ=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286 h1:qx5p01fqee86cj6EUOCzFc2zILw56v1Q3c5DUuEQWLs=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286/go.mod h1:tsGgeEJc5SUSlfVGSX0wR0EkRU3pM58D6SKF97V68ko=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f h1:BwrIaQIx5Iy6eT+DfLhFfK2XqjxRm74mVdlX8gbu4dw=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1072,8 +1072,8 @@ github.com/smartcontractkit/chain-selectors v1.0.27 h1:VE/ftX9Aae4gnw67yR1raKi+3
 github.com/smartcontractkit/chain-selectors v1.0.27/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v0.8.0 h1:hFz2EHU06bkEfhcqhK8JdjKTWpDOr0XJ6xL9oELDoUg=
 github.com/smartcontractkit/chainlink-automation v0.8.0/go.mod h1:ObdjDfgGIaiE48Bb3yYcx1CeGBm392WlEw92U83LlUA=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638 h1:BS9i2P/b+PsomEP//bH4j6N2a1DCgLVVzoRw02CnN2s=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f h1:g9sM6SbASd40qea/8kn9ASF4JPs54Cv9gczLNkS9v24=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286 h1:qx5p01fqee86cj6EUOCzFc2zILw56v1Q3c5DUuEQWLs=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286/go.mod h1:tsGgeEJc5SUSlfVGSX0wR0EkRU3pM58D6SKF97V68ko=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f h1:BwrIaQIx5Iy6eT+DfLhFfK2XqjxRm74mVdlX8gbu4dw=

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.27
 	github.com/smartcontractkit/chainlink-automation v0.8.0
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286
 	github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241018134907-a00ba3729b5e

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.27
 	github.com/smartcontractkit/chainlink-automation v0.8.0
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286
 	github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241018134907-a00ba3729b5e

--- a/go.sum
+++ b/go.sum
@@ -1055,8 +1055,8 @@ github.com/smartcontractkit/chain-selectors v1.0.27 h1:VE/ftX9Aae4gnw67yR1raKi+3
 github.com/smartcontractkit/chain-selectors v1.0.27/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v0.8.0 h1:hFz2EHU06bkEfhcqhK8JdjKTWpDOr0XJ6xL9oELDoUg=
 github.com/smartcontractkit/chainlink-automation v0.8.0/go.mod h1:ObdjDfgGIaiE48Bb3yYcx1CeGBm392WlEw92U83LlUA=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638 h1:BS9i2P/b+PsomEP//bH4j6N2a1DCgLVVzoRw02CnN2s=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f h1:g9sM6SbASd40qea/8kn9ASF4JPs54Cv9gczLNkS9v24=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286 h1:qx5p01fqee86cj6EUOCzFc2zILw56v1Q3c5DUuEQWLs=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286/go.mod h1:tsGgeEJc5SUSlfVGSX0wR0EkRU3pM58D6SKF97V68ko=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f h1:BwrIaQIx5Iy6eT+DfLhFfK2XqjxRm74mVdlX8gbu4dw=

--- a/go.sum
+++ b/go.sum
@@ -1055,8 +1055,8 @@ github.com/smartcontractkit/chain-selectors v1.0.27 h1:VE/ftX9Aae4gnw67yR1raKi+3
 github.com/smartcontractkit/chain-selectors v1.0.27/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v0.8.0 h1:hFz2EHU06bkEfhcqhK8JdjKTWpDOr0XJ6xL9oELDoUg=
 github.com/smartcontractkit/chainlink-automation v0.8.0/go.mod h1:ObdjDfgGIaiE48Bb3yYcx1CeGBm392WlEw92U83LlUA=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f h1:g9sM6SbASd40qea/8kn9ASF4JPs54Cv9gczLNkS9v24=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47 h1:kyOANlbz29uaevkjRaXlO1750A43xAvwAOKXiVNWpFQ=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286 h1:qx5p01fqee86cj6EUOCzFc2zILw56v1Q3c5DUuEQWLs=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286/go.mod h1:tsGgeEJc5SUSlfVGSX0wR0EkRU3pM58D6SKF97V68ko=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f h1:BwrIaQIx5Iy6eT+DfLhFfK2XqjxRm74mVdlX8gbu4dw=

--- a/integration-tests/deployment/ccip/add_chain_test.go
+++ b/integration-tests/deployment/ccip/add_chain_test.go
@@ -45,7 +45,7 @@ func TestAddChainInbound(t *testing.T) {
 	)
 	tokenConfig.UpsertTokenInfo(WethSymbol,
 		pluginconfig.TokenInfo{
-			AggregatorAddress: feeds[WethSymbol].Address().String(),
+			AggregatorAddress: cciptypes.UnknownEncodedAddress(feeds[WethSymbol].Address().String()),
 			Decimals:          WethDecimals,
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},

--- a/integration-tests/deployment/ccip/add_chain_test.go
+++ b/integration-tests/deployment/ccip/add_chain_test.go
@@ -38,7 +38,7 @@ func TestAddChainInbound(t *testing.T) {
 	tokenConfig := NewTokenConfig()
 	tokenConfig.UpsertTokenInfo(LinkSymbol,
 		pluginconfig.TokenInfo{
-			AggregatorAddress: feeds[LinkSymbol].Address().String(),
+			AggregatorAddress: cciptypes.UnknownEncodedAddress(feeds[LinkSymbol].Address().String()),
 			Decimals:          LinkDecimals,
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},

--- a/integration-tests/deployment/ccip/changeset/initial_deploy_test.go
+++ b/integration-tests/deployment/ccip/changeset/initial_deploy_test.go
@@ -31,7 +31,7 @@ func TestInitialDeploy(t *testing.T) {
 	tokenConfig := ccdeploy.NewTokenConfig()
 	tokenConfig.UpsertTokenInfo(ccdeploy.LinkSymbol,
 		pluginconfig.TokenInfo{
-			AggregatorAddress: feeds[ccdeploy.LinkSymbol].Address().String(),
+			AggregatorAddress: cciptypes.UnknownEncodedAddress(feeds[ccdeploy.LinkSymbol].Address().String()),
 			Decimals:          ccdeploy.LinkDecimals,
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},

--- a/integration-tests/deployment/ccip/changeset/initial_deploy_test.go
+++ b/integration-tests/deployment/ccip/changeset/initial_deploy_test.go
@@ -38,7 +38,7 @@ func TestInitialDeploy(t *testing.T) {
 	)
 	tokenConfig.UpsertTokenInfo(ccdeploy.WethSymbol,
 		pluginconfig.TokenInfo{
-			AggregatorAddress: feeds[ccdeploy.WethSymbol].Address().String(),
+			AggregatorAddress: cciptypes.UnknownEncodedAddress(feeds[ccdeploy.WethSymbol].Address().String()),
 			Decimals:          ccdeploy.WethDecimals,
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},

--- a/integration-tests/deployment/ccip/deploy_home_chain.go
+++ b/integration-tests/deployment/ccip/deploy_home_chain.go
@@ -23,10 +23,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
 
-	"github.com/smartcontractkit/chainlink/integration-tests/deployment"
 	confighelper2 "github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
 
+	"github.com/smartcontractkit/chainlink/integration-tests/deployment"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/ccip_home"

--- a/integration-tests/deployment/ccip/deploy_home_chain.go
+++ b/integration-tests/deployment/ccip/deploy_home_chain.go
@@ -23,11 +23,9 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
 
+	"github.com/smartcontractkit/chainlink/integration-tests/deployment"
 	confighelper2 "github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-
-	"github.com/smartcontractkit/chainlink/integration-tests/deployment"
 
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
@@ -278,7 +276,7 @@ func BuildOCR3ConfigForCCIPHome(
 	dest deployment.Chain,
 	feedChainSel uint64,
 	// Token address on Dest chain to aggregate address on feed chain
-	tokenInfo map[ocrtypes.Account]pluginconfig.TokenInfo,
+	tokenInfo map[ccipocr3.UnknownEncodedAddress]pluginconfig.TokenInfo,
 	nodes deployment.Nodes,
 	rmnHomeAddress common.Address,
 ) (map[cctypes.PluginType]ccip_home.CCIPHomeOCR3Config, error) {
@@ -1002,7 +1000,7 @@ func AddDON(
 	offRamp *offramp.OffRamp,
 	feedChainSel uint64,
 	// Token address on Dest chain to aggregate address on feed chain
-	tokenInfo map[ocrtypes.Account]pluginconfig.TokenInfo,
+	tokenInfo map[ccipocr3.UnknownEncodedAddress]pluginconfig.TokenInfo,
 	dest deployment.Chain,
 	home deployment.Chain,
 	nodes deployment.Nodes,

--- a/integration-tests/deployment/ccip/test_helpers.go
+++ b/integration-tests/deployment/ccip/test_helpers.go
@@ -2,7 +2,6 @@ package ccipdeployment
 
 import (
 	"context"
-
 	"fmt"
 	"math/big"
 	"sort"
@@ -320,7 +319,7 @@ func NewLocalDevEnvironmentWithRMN(t *testing.T, lggr logger.Logger) (DeployedEn
 	)
 	tokenConfig.UpsertTokenInfo(WethSymbol,
 		pluginconfig.TokenInfo{
-			AggregatorAddress: feeds[WethSymbol].Address().String(),
+			AggregatorAddress: cciptypes.UnknownEncodedAddress(feeds[WethSymbol].Address().String()),
 			Decimals:          WethDecimals,
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},

--- a/integration-tests/deployment/ccip/test_helpers.go
+++ b/integration-tests/deployment/ccip/test_helpers.go
@@ -313,7 +313,7 @@ func NewLocalDevEnvironmentWithRMN(t *testing.T, lggr logger.Logger) (DeployedEn
 	tokenConfig := NewTokenConfig()
 	tokenConfig.UpsertTokenInfo(LinkSymbol,
 		pluginconfig.TokenInfo{
-			AggregatorAddress: feeds[LinkSymbol].Address().String(),
+			AggregatorAddress: cciptypes.UnknownEncodedAddress(feeds[LinkSymbol].Address().String()),
 			Decimals:          LinkDecimals,
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},

--- a/integration-tests/deployment/ccip/token_info.go
+++ b/integration-tests/deployment/ccip/token_info.go
@@ -47,7 +47,7 @@ func (tc *TokenConfig) GetTokenInfo(
 		lggr.Debugw("Weth aggregator not found, deploy without mapping link token")
 	} else {
 		lggr.Debugw("Mapping WethToken to Weth aggregator")
-		acc := ocrtypes.Account(wethToken.Address().String())
+		acc := ccipocr3.UnknownEncodedAddress(wethToken.Address().String())
 		tokenToAggregate[acc] = tc.TokenSymbolToInfo[WethSymbol]
 	}
 

--- a/integration-tests/deployment/ccip/token_info.go
+++ b/integration-tests/deployment/ccip/token_info.go
@@ -1,13 +1,12 @@
 package ccipdeployment
 
 import (
+	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/weth9"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/burn_mint_erc677"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 )
 
 // TokenConfig mapping between token Symbol (e.g. LinkSymbol, WethSymbol)
@@ -34,13 +33,13 @@ func (tc *TokenConfig) GetTokenInfo(
 	lggr logger.Logger,
 	linkToken *burn_mint_erc677.BurnMintERC677,
 	wethToken *weth9.WETH9,
-) map[ocrtypes.Account]pluginconfig.TokenInfo {
-	tokenToAggregate := make(map[ocrtypes.Account]pluginconfig.TokenInfo)
+) map[ccipocr3.UnknownEncodedAddress]pluginconfig.TokenInfo {
+	tokenToAggregate := make(map[ccipocr3.UnknownEncodedAddress]pluginconfig.TokenInfo)
 	if _, ok := tc.TokenSymbolToInfo[LinkSymbol]; !ok {
 		lggr.Debugw("Link aggregator not found, deploy without mapping link token")
 	} else {
 		lggr.Debugw("Mapping LinkToken to Link aggregator")
-		acc := ocrtypes.Account(linkToken.Address().String())
+		acc := ccipocr3.UnknownEncodedAddress(linkToken.Address().String())
 		tokenToAggregate[acc] = tc.TokenSymbolToInfo[LinkSymbol]
 	}
 

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.0.0-20240926212305-a6deabdfce86
 	github.com/smartcontractkit/chain-selectors v1.0.27
 	github.com/smartcontractkit/chainlink-automation v0.8.0
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.4.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.0

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.0.0-20240926212305-a6deabdfce86
 	github.com/smartcontractkit/chain-selectors v1.0.27
 	github.com/smartcontractkit/chainlink-automation v0.8.0
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.4.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.0

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1402,8 +1402,8 @@ github.com/smartcontractkit/chain-selectors v1.0.27 h1:VE/ftX9Aae4gnw67yR1raKi+3
 github.com/smartcontractkit/chain-selectors v1.0.27/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v0.8.0 h1:hFz2EHU06bkEfhcqhK8JdjKTWpDOr0XJ6xL9oELDoUg=
 github.com/smartcontractkit/chainlink-automation v0.8.0/go.mod h1:ObdjDfgGIaiE48Bb3yYcx1CeGBm392WlEw92U83LlUA=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f h1:g9sM6SbASd40qea/8kn9ASF4JPs54Cv9gczLNkS9v24=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47 h1:kyOANlbz29uaevkjRaXlO1750A43xAvwAOKXiVNWpFQ=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286 h1:qx5p01fqee86cj6EUOCzFc2zILw56v1Q3c5DUuEQWLs=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286/go.mod h1:tsGgeEJc5SUSlfVGSX0wR0EkRU3pM58D6SKF97V68ko=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f h1:BwrIaQIx5Iy6eT+DfLhFfK2XqjxRm74mVdlX8gbu4dw=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1402,8 +1402,8 @@ github.com/smartcontractkit/chain-selectors v1.0.27 h1:VE/ftX9Aae4gnw67yR1raKi+3
 github.com/smartcontractkit/chain-selectors v1.0.27/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v0.8.0 h1:hFz2EHU06bkEfhcqhK8JdjKTWpDOr0XJ6xL9oELDoUg=
 github.com/smartcontractkit/chainlink-automation v0.8.0/go.mod h1:ObdjDfgGIaiE48Bb3yYcx1CeGBm392WlEw92U83LlUA=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638 h1:BS9i2P/b+PsomEP//bH4j6N2a1DCgLVVzoRw02CnN2s=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f h1:g9sM6SbASd40qea/8kn9ASF4JPs54Cv9gczLNkS9v24=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286 h1:qx5p01fqee86cj6EUOCzFc2zILw56v1Q3c5DUuEQWLs=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286/go.mod h1:tsGgeEJc5SUSlfVGSX0wR0EkRU3pM58D6SKF97V68ko=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f h1:BwrIaQIx5Iy6eT+DfLhFfK2XqjxRm74mVdlX8gbu4dw=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -406,7 +406,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.27 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.0 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241018134907-a00ba3729b5e // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.1 // indirect
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.3.0 // indirect

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -406,7 +406,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.27 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.0 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241018134907-a00ba3729b5e // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.1 // indirect
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.3.0 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1379,8 +1379,8 @@ github.com/smartcontractkit/chain-selectors v1.0.27 h1:VE/ftX9Aae4gnw67yR1raKi+3
 github.com/smartcontractkit/chain-selectors v1.0.27/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v0.8.0 h1:hFz2EHU06bkEfhcqhK8JdjKTWpDOr0XJ6xL9oELDoUg=
 github.com/smartcontractkit/chainlink-automation v0.8.0/go.mod h1:ObdjDfgGIaiE48Bb3yYcx1CeGBm392WlEw92U83LlUA=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f h1:g9sM6SbASd40qea/8kn9ASF4JPs54Cv9gczLNkS9v24=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47 h1:kyOANlbz29uaevkjRaXlO1750A43xAvwAOKXiVNWpFQ=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022184834-e8564a286a47/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286 h1:qx5p01fqee86cj6EUOCzFc2zILw56v1Q3c5DUuEQWLs=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286/go.mod h1:tsGgeEJc5SUSlfVGSX0wR0EkRU3pM58D6SKF97V68ko=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f h1:BwrIaQIx5Iy6eT+DfLhFfK2XqjxRm74mVdlX8gbu4dw=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1379,8 +1379,8 @@ github.com/smartcontractkit/chain-selectors v1.0.27 h1:VE/ftX9Aae4gnw67yR1raKi+3
 github.com/smartcontractkit/chain-selectors v1.0.27/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v0.8.0 h1:hFz2EHU06bkEfhcqhK8JdjKTWpDOr0XJ6xL9oELDoUg=
 github.com/smartcontractkit/chainlink-automation v0.8.0/go.mod h1:ObdjDfgGIaiE48Bb3yYcx1CeGBm392WlEw92U83LlUA=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638 h1:BS9i2P/b+PsomEP//bH4j6N2a1DCgLVVzoRw02CnN2s=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20241021132654-e5f3ecb77638/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f h1:g9sM6SbASd40qea/8kn9ASF4JPs54Cv9gczLNkS9v24=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20241022182841-dfbaf574a68f/go.mod h1:4adKaHNaxFsRvV/lYfqtbsWyyvIPUMLR0FdOJN/ljis=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286 h1:qx5p01fqee86cj6EUOCzFc2zILw56v1Q3c5DUuEQWLs=
 github.com/smartcontractkit/chainlink-common v0.3.1-0.20241021103500-39a6e78c0286/go.mod h1:tsGgeEJc5SUSlfVGSX0wR0EkRU3pM58D6SKF97V68ko=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241017133723-5277829bd53f h1:BwrIaQIx5Iy6eT+DfLhFfK2XqjxRm74mVdlX8gbu4dw=

--- a/integration-tests/smoke/ccip_test.go
+++ b/integration-tests/smoke/ccip_test.go
@@ -33,7 +33,7 @@ func TestInitialDeployOnLocal(t *testing.T) {
 	tokenConfig := ccdeploy.NewTokenConfig()
 	tokenConfig.UpsertTokenInfo(ccdeploy.LinkSymbol,
 		pluginconfig.TokenInfo{
-			AggregatorAddress: feeds[ccdeploy.LinkSymbol].Address().String(),
+			AggregatorAddress: cciptypes.UnknownEncodedAddress(feeds[ccdeploy.LinkSymbol].Address().String()),
 			Decimals:          ccdeploy.LinkDecimals,
 			DeviationPPB:      cciptypes.NewBigIntFromInt64(1e9),
 		},


### PR DESCRIPTION
Update ccip capability to use the unknown address type introduced with https://github.com/smartcontractkit/chainlink-ccip/pull/248 