### PR TITLE
chore: use decred secp256k1 directly

### DIFF
--- a/core/services/signatures/secp256k1/curve.go
+++ b/core/services/signatures/secp256k1/curve.go
@@ -12,7 +12,7 @@ package secp256k1
 import (
 	"math/big"
 
-	secp256k1BTCD "github.com/btcsuite/btcd/btcec/v2"
+	secp256k1BTCD "github.com/decred/dcrd/dcrec/secp256k1/v4"
 
 	"go.dedis.ch/kyber/v3"
 )

--- a/core/services/signatures/secp256k1/scalar.go
+++ b/core/services/signatures/secp256k1/scalar.go
@@ -19,7 +19,7 @@ import (
 	"io"
 	"math/big"
 
-	secp256k1BTCD "github.com/btcsuite/btcd/btcec/v2"
+	secp256k1BTCD "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/ethereum/go-ethereum/common"
 
 	"go.dedis.ch/kyber/v3"

--- a/go.mod
+++ b/go.mod
@@ -11,11 +11,11 @@ require (
 	github.com/XSAM/otelsql v0.27.0
 	github.com/andybalholm/brotli v1.1.0
 	github.com/avast/retry-go/v4 v4.6.0
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/cometbft/cometbft v0.37.5
 	github.com/cosmos/cosmos-sdk v0.47.11
 	github.com/danielkov/gin-helmet v0.0.0-20171108135313-1387e224435e
 	github.com/deckarep/golang-set/v2 v2.6.0
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
 	github.com/dominikbraun/graph v0.23.0
 	github.com/esote/minmaxheap v1.0.0
 	github.com/ethereum/go-ethereum v1.13.8
@@ -149,6 +149,7 @@ require (
 	github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
+	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytecodealliance/wasmtime-go/v23 v23.0.0 // indirect
 	github.com/bytedance/sonic v1.10.1 // indirect
@@ -181,7 +182,6 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v0.7.0 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/dfuse-io/logging v0.0.0-20210109005628-b97a57253f70 // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.4 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect


### PR DESCRIPTION
Use `github.com/decred/dcrd/dcrec/secp256k1/v4` directly rather than `github.com/btcsuite/btcd/btcec/v2` which is just a wrapper around the underlying decred library. Inspired by [ethereum/go-ethereum#30595](https://github.com/ethereum/go-ethereum/pull/30595)

`github.com/btcsuite/btcd/btcec/v2` has a very annoying breaking change when upgrading from v2.3.3 to v2.3.4. The easiest way to work around this is to remove the wrapper.