### PR TITLE
Add Mantle NonceTooLow Error

### DIFF
--- a/.changeset/pretty-worms-smell.md
+++ b/.changeset/pretty-worms-smell.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Added a custom client error message for Mantle to capture NonceTooLow error. #added

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -265,6 +265,7 @@ var aStar = ClientErrors{
 var mantle = ClientErrors{
 	InsufficientEth: regexp.MustCompile(`(: |^)'*insufficient funds for gas \* price \+ value`),
 	Fatal:           regexp.MustCompile(`(: |^)'*invalid sender`),
+	NonceTooLow:     regexp.MustCompile(`(: |^)'*nonce too low`),
 }
 
 var hederaFatal = regexp.MustCompile(`(: |^)(execution reverted)(:|$) | ^Transaction gas limit '(\d+)' exceeds block gas limit '(\d+)' | ^Transaction gas limit provided '(\d+)' is insufficient of intrinsic gas required '(\d+)' | ^Oversized data:|status INVALID_SIGNATURE`)

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -48,6 +48,7 @@ func Test_Eth_Errors(t *testing.T) {
 			{"nonce too low. allowed nonce range: 427 - 447, actual: 426", true, "zkSync"},
 			{"client error nonce too low", true, "tomlConfig"},
 			{"[Request ID: 2e952947-ffad-408b-aed9-35f3ed152001] Nonce too low. Provided nonce: 15, current nonce: 15", true, "hedera"},
+			{"failed to forward tx to sequencer, please try again. Error message: 'nonce too low'", true, "Mantle"},
 		}
 
 		for _, test := range tests {


### PR DESCRIPTION
### What
- Added a custom client error message for Mantle to capture NonceTooLow error.
- Closes [SHIP-3889](https://smartcontract-it.atlassian.net/browse/SHIP-3889?atlOrigin=eyJpIjoiMmJjMWJhMjhkYTI2NDBhNjg0ZDIzOTEwNjc0MTMwYTQiLCJwIjoiaiJ9)

### Why
- During QA for the Mantle CCIP Integration, an error was observed in the prod-testnet cluster where "nonce too low" was not correctly handled ([context](https://chainlink-core.slack.com/archives/C05FXR1A1MM/p1729279270391379))



[SHIP-3889]: https://smartcontract-it.atlassian.net/browse/SHIP-3889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ