### PR TITLE
core/services/ocr2/plugins/ccip/internal/ccipdata/factory: check error from TypeAndVersion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,10 @@
 /core/services/webhook @smartcontractkit/foundations @smartcontractkit/bix-framework
 /core/services/llo @smartcontractkit/data-streams-engineers
 
+# CCIP
+/core/services/ccip @smartcontractkit/ccip
+/core/services/ocr2/plugins/ccip @smartcontractkit/ccip
+
 # VRF-related services
 /core/services/vrf @smartcontractkit/dev-services
 /core/services/blockhashstore @smartcontractkit/dev-services

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/factory/price_registry.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/factory/price_registry.go
@@ -35,6 +35,9 @@ func initOrClosePriceRegistryReader(ctx context.Context, lggr logger.Logger, ver
 	}
 
 	contractType, version, err := versionFinder.TypeAndVersion(priceRegistryAddress, cl)
+	if err != nil {
+		return nil, err
+	}
 	if contractType != ccipconfig.PriceRegistry {
 		return nil, errors.Errorf("expected %v got %v", ccipconfig.PriceRegistry, contractType)
 	}


### PR DESCRIPTION
```
core/services/ocr2/plugins/ccip/internal/ccipdata/factory/price_registry.go:37:25: ineffectual assignment to err (ineffassign)
	contractType, version, err := versionFinder.TypeAndVersion(priceRegistryAddress, cl)
```