### PR TITLE
golangci-lint: add new rules; sort list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,29 +2,29 @@ run:
   timeout: 15m0s
 linters:
   enable:
+    - containedctx
+    - depguard
+    - errname
+    - errorlint
     - exhaustive
     - exportloopref
-    - revive
+    - fatcontext
+    - ginkgolinter
     - goimports
     - gosec
-    - misspell
-    - rowserrcheck
-    - errorlint
-    - unconvert
-    - sqlclosecheck
-    - noctx
-    - depguard
-    - whitespace
-    - containedctx
-    - fatcontext
-    - mirror
     - loggercheck
-    - errname
-    - ginkgolinter
+    - mirror
+    - misspell
+    - noctx
     - perfsprint
     - prealloc
+    - revive
+    - rowserrcheck
     - spancheck
+    - sqlclosecheck
     - testifylint
+    - unconvert
+    - whitespace
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,12 @@ linters:
     - fatcontext
     - mirror
     - loggercheck
+    - errname
+    - ginkgolinter
+    - perfsprint
+    - prealloc
+    - spancheck
+    - testifylint
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true


### PR DESCRIPTION
- errname (19)
- ginkgolinter (6)
- perfsprint (619)
- prealloc (241)
- spancheck (0)
- testifylint (2679)