### PR TITLE
fix: only run flakey tests on cron or dispatch

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -14,7 +14,8 @@ on:
   merge_group:
   pull_request:
   schedule:
-    - cron: "0 0 * * *"
+    # Every 6 hours
+    - cron: "0 0,6,12,18 * * *"
   workflow_dispatch:
     inputs:
       distinct_run_name:
@@ -248,7 +249,7 @@ jobs:
     needs: [filter, core]
     name: Flakey Test Detection
     runs-on: ubuntu-latest
-    if: ${{ always() && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     env:
       CL_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
     permissions:
@@ -258,52 +259,40 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v4.2.1
       - name: Setup node
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: actions/setup-node@v4.0.4
       - name: Setup NodeJS
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-nodejs
         with:
           prod: "true"
       - name: Setup Go
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-go
       - name: Setup Postgres
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-postgres
       - name: Touching core/web/assets/index.html
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: mkdir -p core/web/assets && touch core/web/assets/index.html
       - name: Download Go vendor packages
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: go mod download
       - name: Replace chainlink-evm deps
-        if: ${{ needs.filter.outputs.changes == 'true' && inputs.evm-ref != ''}}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.evm-ref != ''}}
         shell: bash
         run: go get github.com/smartcontractkit/chainlink-integrations/evm/relayer@${{ inputs.evm-ref }}
       - name: Build binary
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: go build -o chainlink.test .
       - name: Setup DB
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: ./chainlink.test local db preparetest
       - name: Load test outputs
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: actions/download-artifact@v4.1.8
         with:
           name: go_core_tests_logs
           path: ./artifacts
       - name: Delete go_core_tests_logs/coverage.txt
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         shell: bash
         run: |
           # Need to delete coverage.txt so the disk doesn't fill up
           rm -f ./artifacts/go_core_tests_logs/coverage.txt
       - name: Build flakey test runner
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         run: go build ./tools/flakeytests/cmd/runner
       - name: Re-run tests
-        if: ${{ needs.filter.outputs.changes == 'true' }}
         env:
           GRAFANA_INTERNAL_BASIC_AUTH: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           GRAFANA_INTERNAL_HOST: ${{ secrets.GRAFANA_INTERNAL_HOST }}
@@ -323,7 +312,7 @@ jobs:
             -command=./tools/bin/go_core_tests \
             `ls -R ./artifacts/output.txt`
       - name: Store logs artifacts
-        if: ${{ needs.filter.outputs.changes == 'true' && always() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4.4.3
         with:
           name: flakey_test_runner_logs


### PR DESCRIPTION
### Changes

- Increases CI-Core scheduled frequency to every 6 hours, rather than every 24
- Only run flakey tests detection on scheduled runs, and workflow dispatches

### Motivation / Justification

- Flakey tests detection is annoying for iterating and development.
- The data is useful but should not interfere with regular validation
- 1 data point per day is likely not enough to catch any meaningful levels of flakiness, so upping it to 4 times a day
- Our scheduled runs cost about 8-10$ per run, so quadrupling the frequency of this scheduled run is a drop in the bucket in terms of added GHA costs