### PR TITLE
Node: Support enable/disable JDs via API - Update mutation

### DIFF
--- a/.changeset/seven-worms-bathe.md
+++ b/.changeset/seven-worms-bathe.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#changed UpdateManager Allow operators to enable and disable JDs

--- a/.changeset/seven-worms-bathe.md
+++ b/.changeset/seven-worms-bathe.md
@@ -2,4 +2,4 @@
 "chainlink": minor
 ---
 
-#changed UpdateManager Allow operators to enable and disable JDs
+#added UpdateManager Allow operators to enable and disable JDs

--- a/core/services/feeds/mocks/orm.go
+++ b/core/services/feeds/mocks/orm.go
@@ -1810,7 +1810,7 @@ func (_c *ORM_UpdateJobProposalStatus_Call) RunAndReturn(run func(context.Contex
 }
 
 // UpdateManager provides a mock function with given fields: ctx, mgr
-func (_m *ORM) UpdateManager(ctx context.Context, mgr feeds.FeedsManager) error {
+func (_m *ORM) UpdateManager(ctx context.Context, mgr feeds.PartialFeedsManager) error {
 	ret := _m.Called(ctx, mgr)
 
 	if len(ret) == 0 {
@@ -1818,7 +1818,7 @@ func (_m *ORM) UpdateManager(ctx context.Context, mgr feeds.FeedsManager) error 
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, feeds.FeedsManager) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, feeds.PartialFeedsManager) error); ok {
 		r0 = rf(ctx, mgr)
 	} else {
 		r0 = ret.Error(0)
@@ -1834,14 +1834,14 @@ type ORM_UpdateManager_Call struct {
 
 // UpdateManager is a helper method to define mock.On call
 //   - ctx context.Context
-//   - mgr feeds.FeedsManager
+//   - mgr feeds.PartialFeedsManager
 func (_e *ORM_Expecter) UpdateManager(ctx interface{}, mgr interface{}) *ORM_UpdateManager_Call {
 	return &ORM_UpdateManager_Call{Call: _e.mock.On("UpdateManager", ctx, mgr)}
 }
 
-func (_c *ORM_UpdateManager_Call) Run(run func(ctx context.Context, mgr feeds.FeedsManager)) *ORM_UpdateManager_Call {
+func (_c *ORM_UpdateManager_Call) Run(run func(ctx context.Context, mgr feeds.PartialFeedsManager)) *ORM_UpdateManager_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(feeds.FeedsManager))
+		run(args[0].(context.Context), args[1].(feeds.PartialFeedsManager))
 	})
 	return _c
 }
@@ -1851,7 +1851,7 @@ func (_c *ORM_UpdateManager_Call) Return(_a0 error) *ORM_UpdateManager_Call {
 	return _c
 }
 
-func (_c *ORM_UpdateManager_Call) RunAndReturn(run func(context.Context, feeds.FeedsManager) error) *ORM_UpdateManager_Call {
+func (_c *ORM_UpdateManager_Call) RunAndReturn(run func(context.Context, feeds.PartialFeedsManager) error) *ORM_UpdateManager_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/feeds/mocks/service.go
+++ b/core/services/feeds/mocks/service.go
@@ -1380,7 +1380,7 @@ func (_c *Service_UpdateChainConfig_Call) RunAndReturn(run func(context.Context,
 }
 
 // UpdateManager provides a mock function with given fields: ctx, mgr
-func (_m *Service) UpdateManager(ctx context.Context, mgr feeds.FeedsManager) error {
+func (_m *Service) UpdateManager(ctx context.Context, mgr feeds.PartialFeedsManager) error {
 	ret := _m.Called(ctx, mgr)
 
 	if len(ret) == 0 {
@@ -1388,7 +1388,7 @@ func (_m *Service) UpdateManager(ctx context.Context, mgr feeds.FeedsManager) er
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, feeds.FeedsManager) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, feeds.PartialFeedsManager) error); ok {
 		r0 = rf(ctx, mgr)
 	} else {
 		r0 = ret.Error(0)
@@ -1404,14 +1404,14 @@ type Service_UpdateManager_Call struct {
 
 // UpdateManager is a helper method to define mock.On call
 //   - ctx context.Context
-//   - mgr feeds.FeedsManager
+//   - mgr feeds.PartialFeedsManager
 func (_e *Service_Expecter) UpdateManager(ctx interface{}, mgr interface{}) *Service_UpdateManager_Call {
 	return &Service_UpdateManager_Call{Call: _e.mock.On("UpdateManager", ctx, mgr)}
 }
 
-func (_c *Service_UpdateManager_Call) Run(run func(ctx context.Context, mgr feeds.FeedsManager)) *Service_UpdateManager_Call {
+func (_c *Service_UpdateManager_Call) Run(run func(ctx context.Context, mgr feeds.PartialFeedsManager)) *Service_UpdateManager_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(feeds.FeedsManager))
+		run(args[0].(context.Context), args[1].(feeds.PartialFeedsManager))
 	})
 	return _c
 }
@@ -1421,7 +1421,7 @@ func (_c *Service_UpdateManager_Call) Return(_a0 error) *Service_UpdateManager_C
 	return _c
 }
 
-func (_c *Service_UpdateManager_Call) RunAndReturn(run func(context.Context, feeds.FeedsManager) error) *Service_UpdateManager_Call {
+func (_c *Service_UpdateManager_Call) RunAndReturn(run func(context.Context, feeds.PartialFeedsManager) error) *Service_UpdateManager_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/feeds/models.go
+++ b/core/services/feeds/models.go
@@ -118,6 +118,16 @@ type FeedsManager struct {
 	IsConnectionActive bool
 	CreatedAt          time.Time
 	UpdatedAt          time.Time
+	IsEnabled          bool
+}
+
+// Partial Feeds Manager is used to update Feeds Manager in the database.
+type PartialFeedsManager struct {
+	ID        int64
+	Name      string
+	URI       string
+	PublicKey crypto.PublicKey
+	IsEnabled *bool
 }
 
 // ChainConfig defines the chain configuration for a Feeds Manager.

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -129,6 +129,7 @@ func Test_ORM_GetManager(t *testing.T) {
 	assert.Equal(t, uri, actual.URI)
 	assert.Equal(t, name, actual.Name)
 	assert.Equal(t, publicKey, actual.PublicKey)
+	assert.Equal(t, true, actual.IsEnabled)
 
 	_, err = orm.GetManager(ctx, -1)
 	require.Error(t, err)
@@ -159,6 +160,7 @@ func Test_ORM_ListManagers(t *testing.T) {
 	assert.Equal(t, uri, actual.URI)
 	assert.Equal(t, name, actual.Name)
 	assert.Equal(t, publicKey, actual.PublicKey)
+	assert.Equal(t, true, actual.IsEnabled)
 }
 
 func Test_ORM_ListManagersByIDs(t *testing.T) {
@@ -186,6 +188,7 @@ func Test_ORM_ListManagersByIDs(t *testing.T) {
 	assert.Equal(t, uri, actual.URI)
 	assert.Equal(t, name, actual.Name)
 	assert.Equal(t, publicKey, actual.PublicKey)
+	assert.Equal(t, true, actual.IsEnabled)
 }
 
 func Test_ORM_UpdateManager(t *testing.T) {
@@ -204,11 +207,13 @@ func Test_ORM_UpdateManager(t *testing.T) {
 	id, err := orm.CreateManager(ctx, mgr)
 	require.NoError(t, err)
 
-	updatedMgr := feeds.FeedsManager{
+	isEnabled := false
+	updatedMgr := feeds.PartialFeedsManager{
 		ID:        id,
 		URI:       "127.0.0.1",
 		Name:      "New Name",
 		PublicKey: crypto.PublicKey([]byte("22222222222222222222222222222222")),
+		IsEnabled: &isEnabled,
 	}
 
 	err = orm.UpdateManager(ctx, updatedMgr)
@@ -220,6 +225,7 @@ func Test_ORM_UpdateManager(t *testing.T) {
 	assert.Equal(t, updatedMgr.URI, actual.URI)
 	assert.Equal(t, updatedMgr.Name, actual.Name)
 	assert.Equal(t, updatedMgr.PublicKey, actual.PublicKey)
+	assert.Equal(t, *updatedMgr.IsEnabled, actual.IsEnabled)
 }
 
 // Chain Config

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -129,7 +129,7 @@ func Test_ORM_GetManager(t *testing.T) {
 	assert.Equal(t, uri, actual.URI)
 	assert.Equal(t, name, actual.Name)
 	assert.Equal(t, publicKey, actual.PublicKey)
-	assert.Equal(t, true, actual.IsEnabled)
+	assert.True(t, actual.IsEnabled)
 
 	_, err = orm.GetManager(ctx, -1)
 	require.Error(t, err)
@@ -160,7 +160,7 @@ func Test_ORM_ListManagers(t *testing.T) {
 	assert.Equal(t, uri, actual.URI)
 	assert.Equal(t, name, actual.Name)
 	assert.Equal(t, publicKey, actual.PublicKey)
-	assert.Equal(t, true, actual.IsEnabled)
+	assert.True(t, actual.IsEnabled)
 }
 
 func Test_ORM_ListManagersByIDs(t *testing.T) {
@@ -188,7 +188,7 @@ func Test_ORM_ListManagersByIDs(t *testing.T) {
 	assert.Equal(t, uri, actual.URI)
 	assert.Equal(t, name, actual.Name)
 	assert.Equal(t, publicKey, actual.PublicKey)
-	assert.Equal(t, true, actual.IsEnabled)
+	assert.True(t, actual.IsEnabled)
 }
 
 func Test_ORM_UpdateManager(t *testing.T) {

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -449,7 +449,7 @@ func Test_Service_UpdateFeedsManager(t *testing.T) {
 	key := cltest.DefaultCSAKey
 
 	var (
-		mgr = feeds.FeedsManager{ID: 1}
+		mgr = feeds.PartialFeedsManager{ID: 1}
 	)
 
 	svc := setupTestService(t)
@@ -463,6 +463,21 @@ func Test_Service_UpdateFeedsManager(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_Service_UpdateFeedsManager_Disabled(t *testing.T) {
+
+	var (
+		isEnabled = false
+		mgr = feeds.PartialFeedsManager{ID: 1, IsEnabled: &isEnabled}
+	)
+
+	svc := setupTestService(t)
+
+	svc.orm.On("UpdateManager", mock.Anything, mgr, mock.Anything).Return(nil)
+	svc.connMgr.On("Disconnect", mgr.ID).Return(nil)
+
+	err := svc.UpdateManager(testutils.Context(t), mgr)
+	require.NoError(t, err)
+}
 func Test_Service_ListManagersByIDs(t *testing.T) {
 	t.Parallel()
 	ctx := testutils.Context(t)

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -462,12 +462,10 @@ func Test_Service_UpdateFeedsManager(t *testing.T) {
 	err := svc.UpdateManager(testutils.Context(t), mgr)
 	require.NoError(t, err)
 }
-
 func Test_Service_UpdateFeedsManager_Disabled(t *testing.T) {
-
 	var (
 		isEnabled = false
-		mgr = feeds.PartialFeedsManager{ID: 1, IsEnabled: &isEnabled}
+		mgr       = feeds.PartialFeedsManager{ID: 1, IsEnabled: &isEnabled}
 	)
 
 	svc := setupTestService(t)

--- a/core/store/migrate/migrations/0258_add_is_enabled_column_to_feeds_manager.sql
+++ b/core/store/migrate/migrations/0258_add_is_enabled_column_to_feeds_manager.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE feeds_managers
+ADD COLUMN is_enabled BOOLEAN DEFAULT TRUE;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE feeds_managers
+DROP COLUMN is_enabled;
+-- +goose StatementEnd

--- a/core/web/resolver/feeds_manager.go
+++ b/core/web/resolver/feeds_manager.go
@@ -63,6 +63,11 @@ func (r *FeedsManagerResolver) IsConnectionActive() bool {
 	return r.mgr.IsConnectionActive
 }
 
+// IsEnabled resolves the feed managers's isEnabled field.
+func (r *FeedsManagerResolver) IsEnabled() bool {
+	return r.mgr.IsEnabled
+}
+
 func (r *FeedsManagerResolver) ChainConfigs(ctx context.Context) ([]*FeedsManagerChainConfigResolver, error) {
 	cfgs, err := loader.GetFeedsManagerChainConfigsByManagerID(ctx, r.mgr.ID)
 	if err != nil {

--- a/core/web/resolver/feeds_manager_test.go
+++ b/core/web/resolver/feeds_manager_test.go
@@ -60,7 +60,7 @@ func Test_FeedsManagers(t *testing.T) {
 						PublicKey:          *pubKey,
 						IsConnectionActive: true,
 						CreatedAt:          f.Timestamp(),
-						IsEnabled: isEnabled,
+						IsEnabled:          isEnabled,
 					},
 				}, nil)
 			},
@@ -110,7 +110,7 @@ func Test_FeedsManager(t *testing.T) {
 					}
 				}
 			}`
-			isEnabled = false
+		isEnabled = false
 	)
 	pubKey, err := crypto.PublicKeyFromHex("3b0f149627adb7b6fafe1497a9dfc357f22295a5440786c3bc566dfdb0176808")
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func Test_FeedsManager(t *testing.T) {
 					PublicKey:          *pubKey,
 					IsConnectionActive: true,
 					CreatedAt:          f.Timestamp(),
-					IsEnabled: isEnabled,
+					IsEnabled:          isEnabled,
 				}, nil)
 			},
 			query: query,
@@ -410,7 +410,7 @@ func Test_UpdateFeedsManager(t *testing.T) {
 					URI:                uri,
 					PublicKey:          *pubKey,
 					IsConnectionActive: false,
-					IsEnabled: 				isEnabled,
+					IsEnabled:          isEnabled,
 					CreatedAt:          f.Timestamp(),
 				}, nil)
 			},

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -520,6 +520,7 @@ type updateFeedsManagerInput struct {
 	Name      string
 	URI       string
 	PublicKey string
+	IsEnabled *bool
 }
 
 func (r *Resolver) UpdateFeedsManager(ctx context.Context, args struct {
@@ -542,20 +543,21 @@ func (r *Resolver) UpdateFeedsManager(ctx context.Context, args struct {
 		}), nil
 	}
 
-	mgr := &feeds.FeedsManager{
+	prtMgr := &feeds.PartialFeedsManager{
 		ID:        id,
 		URI:       args.Input.URI,
 		Name:      args.Input.Name,
 		PublicKey: *publicKey,
+		IsEnabled: args.Input.IsEnabled,
 	}
 
 	feedsService := r.App.GetFeedsService()
 
-	if err = feedsService.UpdateManager(ctx, *mgr); err != nil {
+	if err = feedsService.UpdateManager(ctx, *prtMgr); err != nil {
 		return nil, err
 	}
 
-	mgr, err = feedsService.GetManager(ctx, id)
+	mgr, err := feedsService.GetManager(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return NewUpdateFeedsManagerPayload(nil, err, nil), nil

--- a/core/web/schema/type/feeds_manager.graphql
+++ b/core/web/schema/type/feeds_manager.graphql
@@ -21,6 +21,7 @@ type FeedsManager {
 	isConnectionActive: Boolean!
 	createdAt: Time!
 	chainConfigs: [FeedsManagerChainConfig!]!
+	isEnabled: Boolean!
 }
 
 type FeedsManagerChainConfig {
@@ -100,6 +101,7 @@ input UpdateFeedsManagerInput {
 	name: String!
 	uri: String!
 	publicKey: String!
+	isEnabled: Boolean
 }
 
 # UpdateFeedsManagerSuccess defines the success response when updating a feeds


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/DPA-1066
Allow operators to enable and disable JDs when we start supporting multiple JDs per node - Update Mutation

Planned UI:
<img width="1144" alt="Screenshot 2024-10-23 at 09 15 16" src="https://github.com/user-attachments/assets/cfd9d0b7-20af-4b34-9ea4-dd2cc4d95dac">
<img width="1113" alt="Screenshot 2024-10-23 at 08 59 12" src="https://github.com/user-attachments/assets/987ca0a6-2a4e-4ffe-a213-5794e479f50d">
Planned UI without the new field (no changes):

<img width="1137" alt="Screenshot 2024-10-23 at 09 11 28" src="https://github.com/user-attachments/assets/93e5c772-b819-4c05-acbd-67b09c85ecf1">
<img width="1116" alt="Screenshot 2024-10-23 at 09 11 39" src="https://github.com/user-attachments/assets/91153ce1-4d52-4848-8cbf-95342a35c24a">

