### PR TITLE
core/internal/features/ocr2: remove skip from TestIntegration_OCR2

### DIFF
--- a/core/internal/features/ocr2/features_ocr2_test.go
+++ b/core/internal/features/ocr2/features_ocr2_test.go
@@ -190,7 +190,6 @@ func setupNodeOCR2(
 
 func TestIntegration_OCR2(t *testing.T) {
 	t.Parallel()
-	testutils.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/BCF-3417")
 	testIntegration_OCR2(t)
 }
 


### PR DESCRIPTION
Remove skip from `TestIntegration_OCR2`. This was a mistake. We only meant to skip `TestIntegration_OCR2_plugins`.