### PR TITLE
core/services/pg: improve lockedDb lifecycle

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -304,6 +304,8 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 	t.Helper()
 	testutils.SkipShortDB(t)
 
+	ctx := testutils.Context(t)
+
 	var lggr logger.Logger
 	for _, dep := range flagsAndDeps {
 		argLggr, is := dep.(logger.Logger)
@@ -364,7 +366,7 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 	}
 
 	url := cfg.Database().URL()
-	db, err := pg.NewConnection(url.String(), cfg.Database().Dialect(), cfg.Database())
+	db, err := pg.NewConnection(ctx, url.String(), cfg.Database().Dialect(), cfg.Database())
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, db.Close()) })
 
@@ -435,9 +437,8 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 		}
 	}
 
-	testCtx := testutils.Context(t)
 	// evm alway enabled for backward compatibility
-	initOps := []chainlink.CoreRelayerChainInitFunc{chainlink.InitDummy(testCtx, relayerFactory), chainlink.InitEVM(testCtx, relayerFactory, evmOpts)}
+	initOps := []chainlink.CoreRelayerChainInitFunc{chainlink.InitDummy(ctx, relayerFactory), chainlink.InitEVM(ctx, relayerFactory, evmOpts)}
 
 	if cfg.CosmosEnabled() {
 		cosmosCfg := chainlink.CosmosFactoryConfig{
@@ -445,28 +446,28 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 			TOMLConfigs: cfg.CosmosConfigs(),
 			DS:          ds,
 		}
-		initOps = append(initOps, chainlink.InitCosmos(testCtx, relayerFactory, cosmosCfg))
+		initOps = append(initOps, chainlink.InitCosmos(ctx, relayerFactory, cosmosCfg))
 	}
 	if cfg.SolanaEnabled() {
 		solanaCfg := chainlink.SolanaFactoryConfig{
 			Keystore:    keyStore.Solana(),
 			TOMLConfigs: cfg.SolanaConfigs(),
 		}
-		initOps = append(initOps, chainlink.InitSolana(testCtx, relayerFactory, solanaCfg))
+		initOps = append(initOps, chainlink.InitSolana(ctx, relayerFactory, solanaCfg))
 	}
 	if cfg.StarkNetEnabled() {
 		starkCfg := chainlink.StarkNetFactoryConfig{
 			Keystore:    keyStore.StarkNet(),
 			TOMLConfigs: cfg.StarknetConfigs(),
 		}
-		initOps = append(initOps, chainlink.InitStarknet(testCtx, relayerFactory, starkCfg))
+		initOps = append(initOps, chainlink.InitStarknet(ctx, relayerFactory, starkCfg))
 	}
 	if cfg.AptosEnabled() {
 		aptosCfg := chainlink.AptosFactoryConfig{
 			Keystore:    keyStore.Aptos(),
 			TOMLConfigs: cfg.AptosConfigs(),
 		}
-		initOps = append(initOps, chainlink.InitAptos(testCtx, relayerFactory, aptosCfg))
+		initOps = append(initOps, chainlink.InitAptos(ctx, relayerFactory, aptosCfg))
 	}
 
 	relayChainInterops, err := chainlink.NewCoreRelayerChainInteroperators(initOps...)

--- a/core/services/ocr2/plugins/generic/pipeline_runner_adapter_test.go
+++ b/core/services/ocr2/plugins/generic/pipeline_runner_adapter_test.go
@@ -41,7 +41,7 @@ func TestAdapter_Integration(t *testing.T) {
 	logger := logger.TestLogger(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	url := cfg.Database().URL()
-	db, err := pg.NewConnection(url.String(), cfg.Database().Dialect(), cfg.Database())
+	db, err := pg.NewConnection(ctx, url.String(), cfg.Database().Dialect(), cfg.Database())
 	require.NoError(t, err)
 
 	keystore := keystore.NewInMemory(db, utils.FastScryptParams, logger)

--- a/core/services/pg/connection.go
+++ b/core/services/pg/connection.go
@@ -1,6 +1,7 @@
 package pg
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -17,7 +18,6 @@ import (
 	"github.com/scylladb/go-reflectx"
 	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
-	"golang.org/x/net/context"
 
 	"github.com/smartcontractkit/chainlink/v2/core/store/dialects"
 )
@@ -51,7 +51,7 @@ type ConnectionConfig interface {
 	MaxIdleConns() int
 }
 
-func NewConnection(uri string, dialect dialects.DialectName, config ConnectionConfig) (*sqlx.DB, error) {
+func NewConnection(ctx context.Context, uri string, dialect dialects.DialectName, config ConnectionConfig) (*sqlx.DB, error) {
 	opts := []otelsql.Option{otelsql.WithAttributes(semconv.DBSystemPostgreSQL),
 		otelsql.WithTracerProvider(otel.GetTracerProvider()),
 		otelsql.WithSQLCommenter(true),
@@ -83,7 +83,7 @@ func NewConnection(uri string, dialect dialects.DialectName, config ConnectionCo
 		if err != nil {
 			return nil, fmt.Errorf("failed to open txdb: %w", err)
 		}
-		_, err = sqldb.Exec(connParams)
+		_, err = sqldb.ExecContext(ctx, connParams)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set options: %w", err)
 		}

--- a/core/services/pg/locked_db_test.go
+++ b/core/services/pg/locked_db_test.go
@@ -58,9 +58,7 @@ func TestLockedDB_OpenTwice(t *testing.T) {
 
 	err := ldb.Open(testutils.Context(t))
 	require.NoError(t, err)
-	require.Panics(t, func() {
-		_ = ldb.Open(testutils.Context(t))
-	})
+	require.Error(t, ldb.Open(testutils.Context(t)))
 
 	_ = ldb.Close()
 }
@@ -88,14 +86,15 @@ func TestLockedDB_TwoInstances(t *testing.T) {
 
 func TestOpenUnlockedDB(t *testing.T) {
 	testutils.SkipShortDB(t)
+	ctx := testutils.Context(t)
 	config := configtest.NewGeneralConfig(t, nil)
 
-	db1, err1 := pg.OpenUnlockedDB(config.AppID(), config.Database())
+	db1, err1 := pg.OpenUnlockedDB(ctx, config.AppID(), config.Database())
 	require.NoError(t, err1)
 	require.NotNil(t, db1)
 
 	// should not block the second connection
-	db2, err2 := pg.OpenUnlockedDB(config.AppID(), config.Database())
+	db2, err2 := pg.OpenUnlockedDB(ctx, config.AppID(), config.Database())
 	require.NoError(t, err2)
 	require.NotNil(t, db2)
 

--- a/core/utils/testutils/heavyweight/orm.go
+++ b/core/utils/testutils/heavyweight/orm.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -64,7 +65,7 @@ func (c Kind) PrepareDB(t testing.TB, overrideFn func(c *chainlink.Config, s *ch
 	require.NoError(t, os.MkdirAll(gcfg.RootDir(), 0700))
 	migrationTestDBURL, err := testdb.CreateOrReplace(gcfg.Database().URL(), generateName(), c != KindEmpty)
 	require.NoError(t, err)
-	db, err := pg.NewConnection(migrationTestDBURL, dialects.Postgres, gcfg.Database())
+	db, err := pg.NewConnection(tests.Context(t), migrationTestDBURL, dialects.Postgres, gcfg.Database())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, db.Close()) // must close before dropping

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,6 @@ require (
 	golang.org/x/crypto v0.27.0
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/mod v0.21.0
-	golang.org/x/net v0.29.0
 	golang.org/x/sync v0.8.0
 	golang.org/x/term v0.24.0
 	golang.org/x/text v0.18.0
@@ -350,6 +349,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/ratelimit v0.3.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
+	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto v0.0.0-20240711142825-46eb208f015d // indirect


### PR DESCRIPTION
We have a double `lockedDb.Close()` call. This PR makes `lockedDB` lifecycle methods safe for concurrent use, and suppresses the double close error. Alternatively we could ensure that we only call Close once, but this seems less disruptive and thus less risky :shrug: 