### PR TITLE
Config validation requires ws url when http polling disabled

### DIFF
--- a/.changeset/four-kangaroos-appear.md
+++ b/.changeset/four-kangaroos-appear.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Add config validation so it requires ws url when http polling disabled #bugfix

--- a/core/chains/evm/config/toml/config.go
+++ b/core/chains/evm/config/toml/config.go
@@ -314,8 +314,13 @@ func (c *EVMConfig) ValidateConfig() (err error) {
 	} else {
 		var hasPrimary bool
 		var logBroadcasterEnabled bool
+		var newHeadsPollingInterval commonconfig.Duration
 		if c.LogBroadcasterEnabled != nil {
 			logBroadcasterEnabled = *c.LogBroadcasterEnabled
+		}
+
+		if c.NodePool.NewHeadsPollInterval != nil {
+			newHeadsPollingInterval = *c.NodePool.NewHeadsPollInterval
 		}
 
 		for i, n := range c.Nodes {
@@ -325,9 +330,15 @@ func (c *EVMConfig) ValidateConfig() (err error) {
 
 			hasPrimary = true
 
-			// if the node is a primary node, then the WS URL is required when LogBroadcaster is enabled
-			if logBroadcasterEnabled && (n.WSURL == nil || n.WSURL.IsZero()) {
-				err = multierr.Append(err, commonconfig.ErrMissing{Name: "Nodes", Msg: fmt.Sprintf("%vth node (primary) must have a valid WSURL when LogBroadcaster is enabled", i)})
+			// if the node is a primary node, then the WS URL is required when
+			//	1. LogBroadcaster is enabled
+			//	2. The http polling is disabled (newHeadsPollingInterval == 0)
+			if n.WSURL == nil || n.WSURL.IsZero() {
+				if logBroadcasterEnabled {
+					err = multierr.Append(err, commonconfig.ErrMissing{Name: "Nodes", Msg: fmt.Sprintf("%vth node (primary) must have a valid WSURL when LogBroadcaster is enabled", i)})
+				} else if newHeadsPollingInterval.Duration() == 0 {
+					err = multierr.Append(err, commonconfig.ErrMissing{Name: "Nodes", Msg: fmt.Sprintf("%vth node (primary) must have a valid WSURL when http polling is disabled", i)})
+				}
 			}
 		}
 

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -1427,7 +1427,7 @@ func TestConfig_Validate(t *testing.T) {
 		- LDAP.RunUserGroupCN: invalid value (<nil>): LDAP ReadUserGroupCN can not be empty
 		- LDAP.RunUserGroupCN: invalid value (<nil>): LDAP RunUserGroupCN can not be empty
 		- LDAP.ReadUserGroupCN: invalid value (<nil>): LDAP ReadUserGroupCN can not be empty
-	- EVM: 9 errors:
+	- EVM: 10 errors:
 		- 1.ChainID: invalid value (1): duplicate - must be unique
 		- 0.Nodes.1.Name: invalid value (foo): duplicate - must be unique
 		- 3.Nodes.4.WSURL: invalid value (ws://dupe.com): duplicate - must be unique
@@ -1483,6 +1483,7 @@ func TestConfig_Validate(t *testing.T) {
 			- ChainID: missing: required for all chains
 			- Nodes: missing: must have at least one node
 		- 5.Transactions.AutoPurge.DetectionApiUrl: invalid value (): must be set for scroll
+		- 6.Nodes: missing: 0th node (primary) must have a valid WSURL when http polling is disabled
 	- Cosmos: 5 errors:
 		- 1.ChainID: invalid value (Malaga-420): duplicate - must be unique
 		- 0.Nodes.1.Name: invalid value (test): duplicate - must be unique

--- a/core/services/chainlink/testdata/config-invalid.toml
+++ b/core/services/chainlink/testdata/config-invalid.toml
@@ -117,6 +117,14 @@ Name = 'scroll node'
 WSURL = 'ws://foo.bar'
 HTTPURl = 'http://foo.bar'
 
+[[EVM]]
+ChainID = '100'
+LogBroadcasterEnabled = false
+
+[[EVM.Nodes]]
+Name = 'fake'
+HTTPURl = 'http://foo.bar1'
+
 [[Cosmos]]
 ChainID = 'Malaga-420'
 

--- a/core/services/chainlink/testdata/config-invalid.toml
+++ b/core/services/chainlink/testdata/config-invalid.toml
@@ -122,8 +122,19 @@ ChainID = '100'
 LogBroadcasterEnabled = false
 
 [[EVM.Nodes]]
-Name = 'fake'
+Name = 'failing-fake'
 HTTPURl = 'http://foo.bar1'
+
+[[EVM]]
+ChainID = '101'
+LogBroadcasterEnabled = false
+
+[EVM.NodePool]
+NewHeadsPollInterval = '1s'
+
+[[EVM.Nodes]]
+Name = 'passing-fake'
+HTTPURl = 'http://foo.bar2'
 
 [[Cosmos]]
 ChainID = 'Malaga-420'


### PR DESCRIPTION
### Description
We made WS URL to be optional after we supported HTTP polling. However the http polling requires newHeadPollingInterval flag to be > 0, otherwise ws subscription will be used and ws url can’t be missing.

Add the check in validation function to cover this case
### Reference:
https://smartcontract-it.atlassian.net/browse/BCFR-1067