### PR TITLE
[TT-1792] use newer ecrimagefetcher

### DIFF
--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -376,7 +376,7 @@ jobs:
       - name: Set Up ecrimagefetcher
         shell: bash
         run: |
-          go install github.com/smartcontractkit/chainlink-testing-framework/tools/ecrimagefetcher@v1.0.1
+          go install github.com/smartcontractkit/chainlink-testing-framework/tools/ecrimagefetcher@v1.50.2
       - name: Get latest docker images from ECR
         if: ${{ github.event.inputs.base64TestList == '' }}
         env:
@@ -678,7 +678,7 @@ jobs:
       - name: Show Grafana url in test summary
         if: always()
         uses: smartcontractkit/.github/actions/ctf-show-grafana-in-test-summary@b6e37806737eef87e8c9137ceeb23ef0bff8b1db # ctf-show-grafana-in-test-summary@0.1.0
-    
+
   start-slack-thread:
     name: Start Slack Thread
     if: always() && needs.*.result != 'skipped' && needs.*.result != 'cancelled' && needs.should-run.outputs.should_run == 'true' && (needs.select-versions.outputs.evm_implementations != '' || github.event.inputs.base64TestList != '')


### PR DESCRIPTION
Previous version was incorrectly sorting tags in some situations, e.g. `v1.0.2` was evaluated as higher than `v1.0.11`, which resulted in some images not being picked up by compatibility pipeline.

Now it works as expected:
```
+-----------------------------+--------+
| EVM Implementation          | Result |
+-----------------------------+--------+
|              automation              |
+-----------------------------+--------+
| ethereum/client-go:v1.14.11 | √      |
| ethereum/client-go:v1.14.11 | √      |
| ethereum/client-go:v1.14.8  | √      |
+-----------------------------+--------+
```

Successful run: https://github.com/smartcontractkit/chainlink/actions/runs/11515094147