### PR TITLE
golangci-lint: add nolintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - mirror
     - misspell
     - noctx
+    - nolintlint
     - perfsprint
     - prealloc
     - revive
@@ -164,6 +165,9 @@ linters-settings:
       - (github.com/smartcontractkit/chainlink-common/pkg/logger.SugaredLogger).Tracew
       - (github.com/smartcontractkit/chainlink-common/pkg/logger.SugaredLogger).Criticalw
       - (github.com/smartcontractkit/chainlink-common/pkg/logger.SugaredLogger).With
+  nolintlint:
+    require-specific: true
+    require-explanation: true
 issues:
   exclude-rules:
     - path: test


### PR DESCRIPTION
https://golangci-lint.run/usage/linters/#nolintlint

<details><summary>58 oustanding</summary>

```
core/chains/evm/label/label.go:3:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/store/migrate/migrations/0036_external_job_id.go:34:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/store/migrate/migrations/0036_external_job_id.go:71:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/store/migrate/migrations/0054_remove_legacy_pipeline.go:35:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/store/migrate/migrations/0054_remove_legacy_pipeline.go:46:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/store/migrate/migrations/0056_multichain.go:47:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/store/migrate/migrations/0056_multichain.go:74:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/store/migrate/migrations/0195_add_not_null_to_evm_chain_id_in_job_specs.go:36:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/store/migrate/migrations/0195_add_not_null_to_evm_chain_id_in_job_specs.go:61:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/store/models/secrets_test.go:28:52: directive `//nolint:gosimple` should provide explanation such as `//nolint:gosimple // this is why` (nolintlint)
			assert.Equal(t, redacted, fmt.Sprintf("%s", v)) //nolint:gosimple
			                                                ^
core/services/chainlink/cfgtest/cfgtest.go:78:13: directive `//nolint:exhaustive` should provide explanation such as `//nolint:exhaustive // this is why` (nolintlint)
	switch k { //nolint:exhaustive
	           ^
core/utils/big_math/big_math.go:61:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/utils/files.go:107:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/utils/utils.go:598:1: directive `//nolint:errorlint // error type checks will fail on wrapped errors. Disabled since we are not doing checks on error types.` is unused for linter "errorlint" (nolintlint)
//nolint:errorlint // error type checks will fail on wrapped errors. Disabled since we are not doing checks on error types.
^
core/config/app_config.go:11:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/logger/null_logger.go:7:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
common/client/transaction_sender.go:246:4: directive `//nolint` should mention specific linter such as `//nolint:my-linter` (nolintlint)
			//nolint
			^
core/services/periodicbackup/backup.go:110:6: directive `//nolint:errcheck` should provide explanation such as `//nolint:errcheck // this is why` (nolintlint)
					//nolint:errcheck
					^
core/services/keystore/keys/ocr2key/key_bundle.go:22:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/services/keystore/keys/ocr2key/key_bundle.go:111:1: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
// nolint
^
core/services/relay/evm/mercury/v1/reportcodec/report_codec_test.go:160:23: directive `//nolint:gosec // G115` is unused for linter "gosec" (nolintlint)
	return int64(n), nil //nolint:gosec // G115
	                     ^
core/services/relay/relay.go:40:57: directive `//nolint:staticcheck` is unused for linter "staticcheck" (nolintlint)
func NewServerAdapter(r types.Relayer) *ServerAdapter { //nolint:staticcheck
                                                        ^
core/capabilities/ccip/ccipevm/rmncrypto.go:21:1: directive `// nolint:lll` should be written without leading space as `//nolint:lll` (nolintlint)
// nolint:lll
^
core/chains/evm/client/simulated_backend_client.go:324:48: directive `//nolint:gosec` is unused for linter "gosec" (nolintlint)
						Timestamp:  time.Unix(int64(h.Time), 0), //nolint:gosec
						                                         ^
core/chains/evm/logpoller/log_poller.go:690:50: directive `//nolint:gosec` should provide explanation such as `//nolint:gosec // this is why` (nolintlint)
	successfulExpiredLogPrunes := 5 + rand.Intn(10) //nolint:gosec
	                                                ^
core/services/llo/evm/report_codec_premium_legacy.go:161:30: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
	epoch = uint32(seqNr / 256) // nolint
	                            ^
core/services/llo/evm/report_codec_premium_legacy.go:162:30: directive `// nolint` should be written without leading space as `//nolint` (nolintlint)
	round = uint8(seqNr % 256)  // nolint
	                            ^
core/chains/evm/txmgr/client.go:124:2: directive `//nolint:gosec // disable G115` is unused for linter "gosec" (nolintlint)
	//nolint:gosec // disable G115
	^
core/services/llo/mercurytransmitter/orm.go:75:38: directive `//nolint` should mention specific linter such as `//nolint:my-linter` (nolintlint)
			SeqNr:            int64(t.SeqNr), //nolint
			                                  ^
core/services/llo/mercurytransmitter/orm.go:165:50: directive `//nolint` should mention specific linter such as `//nolint:my-linter` (nolintlint)
				Signer:    commontypes.OracleID(signers[i]), //nolint
				                                             ^
core/services/ocrcommon/adapters.go:115:81: directive `//nolint:gosec` is unused for linter "gosec" (nolintlint)
		if err = binary.Write(buf, binary.LittleEndian, uint16(length)); err != nil { //nolint:gosec
		                                                                              ^
core/services/ocr2/plugins/ccip/tokendata/bgworker.go:45:35: directive `//nolint:containedctx` should provide explanation such as `//nolint:containedctx // this is why` (nolintlint)
	backgroundCtx    context.Context //nolint:containedctx
	                                 ^
core/services/ocr/database.go:212:2: directive `//nolint sqlclosecheck false positive` should match `//nolint sqlclosecheck false positive[:<comma-separated-linters>] [// <explanation>]` (nolintlint)
	//nolint sqlclosecheck false positive
	^
core/services/ocr2/plugins/ccip/internal/cache/chain_health.go:61:35: directive `//nolint:containedctx` should provide explanation such as `//nolint:containedctx // this is why` (nolintlint)
	backgroundCtx    context.Context //nolint:containedctx
	                                 ^
core/services/llo/onchain_channel_definition_cache_test.go:300:78: directive `//nolint` should mention specific linter such as `//nolint:my-linter` (nolintlint)
			_, err := cdc.fetchChannelDefinitions(nil, "notvalid://foos", [32]byte{}) //nolint
			                                                                          ^
core/services/ocr2/plugins/ccip/internal/ccipdb/price_service.go:72:35: directive `//nolint:containedctx` should provide explanation such as `//nolint:containedctx // this is why` (nolintlint)
	backgroundCtx    context.Context //nolint:containedctx
	                                 ^
core/services/relay/evm/evm.go:88:40: directive `//nolint:staticcheck` is unused for linter "staticcheck" (nolintlint)
var _ commontypes.Relayer = &Relayer{} //nolint:staticcheck
                                       ^
core/services/relay/evm/chain_reader_historical_client_wrapper_test.go:16:76: directive `//nolint common practice to import test mods with .` should match `//nolint common practice to import test mods with .[:<comma-separated-linters>] [// <explanation>]` (nolintlint)
	. "github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests" //nolint common practice to import test mods with .
	                                                                          ^
core/capabilities/ccip/ccip_integration_tests/ccipreader/ccipreader_test.go:103:51: directive `//nolint:gosec // this won't overflow` is unused for linter "gosec" (nolintlint)
					MerkleRoot:          [32]byte{uint8(i) + 1}, //nolint:gosec // this won't overflow
					                                             ^
core/services/relay/evm/evmtesting/chain_components_interface_tester.go:19:76: directive `//nolint common practice to import test mods with .` should match `//nolint common practice to import test mods with .[:<comma-separated-linters>] [// <explanation>]` (nolintlint)
	. "github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests" //nolint common practice to import test mods with .
	                                                                          ^
core/services/relay/evm/evmtesting/run_tests.go:21:76: directive `//nolint common practice to import test mods with .` should match `//nolint common practice to import test mods with .[:<comma-separated-linters>] [// <explanation>]` (nolintlint)
	. "github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests" //nolint common practice to import test mods with .
	                                                                          ^
core/services/relay/evm/codec/codec_test.go:19:82: directive `//nolint common practice to import test mods with .` should match `//nolint common practice to import test mods with .[:<comma-separated-linters>] [// <explanation>]` (nolintlint)
	looptestutils "github.com/smartcontractkit/chainlink-common/pkg/loop/testutils" //nolint common practice to import test mods with .
	                                                                                ^
core/services/relay/evm/codec/codec_test.go:21:76: directive `//nolint common practice to import test mods with .` should match `//nolint common practice to import test mods with .[:<comma-separated-linters>] [// <explanation>]` (nolintlint)
	. "github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests" //nolint common practice to import test mods with .
	                                                                          ^
core/services/relay/evm/codec/codec_test.go:289:25: directive `//nolint we know it's non-zero len` should match `//nolint we know it's non-zero len[:<comma-separated-linters>] [// <explanation>]` (nolintlint)
		args = args[1:]       //nolint we know it's non-zero len
		                      ^
core/services/relay/evm/codec/codec_test.go:290:25: directive `//nolint we know it's non-zero len` should match `//nolint we know it's non-zero len[:<comma-separated-linters>] [// <explanation>]` (nolintlint)
		allArgs = allArgs[1:] //nolint we know it's non-zero len
		                      ^
core/services/ocr2/database.go:281:65: directive `//nolint sqlclosecheck false positive` should match `//nolint sqlclosecheck false positive[:<comma-separated-linters>] [// <explanation>]` (nolintlint)
	rows, err := d.ds.QueryxContext(ctx, stmt, d.oracleSpecID, cd) //nolint sqlclosecheck false positive
	                                                               ^
core/store/migrate/migrate.go:108:2: directive `//nolint` should mention specific linter such as `//nolint:my-linter` (nolintlint)
	//nolint
	^
core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go:29:25: directive `//nolint:staticcheck` should provide explanation such as `//nolint:staticcheck // this is why` (nolintlint)
	"k8s.io/utils/pointer" //nolint:staticcheck
	                       ^
core/web/loop_registry.go:98:38: directive `//nolint` should mention specific linter such as `//nolint:my-linter` (nolintlint)
	res, err := l.client.Get(pluginURL) //nolint
	                                    ^
core/web/middleware.go:66:3: directive `//nolint:errcheck` should provide explanation such as `//nolint:errcheck // this is why` (nolintlint)
		//nolint:errcheck
		^
core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/chainlink.go:28:25: directive `//nolint:staticcheck` should provide explanation such as `//nolint:staticcheck // this is why` (nolintlint)
	"k8s.io/utils/pointer" //nolint:staticcheck
	                       ^
core/cmd/shell_local.go:688:3: directive `//nolint:gosec // disable G115` is unused for linter "gosec" (nolintlint)
		//nolint:gosec // disable G115
		^
core/capabilities/integration_tests/framework/don.go:140:3: directive `//nolint:gosec // disable G115` is unused for linter "gosec" (nolintlint)
		//nolint:gosec // disable G115
		^
core/capabilities/integration_tests/framework/ethereum.go:36:2: directive `//nolint:gosec // disable G115` is unused for linter "gosec" (nolintlint)
	//nolint:gosec // disable G115
	^
core/services/relay/evm/capabilities/testutils/backend.go:59:55: directive `//nolint:gosec` is unused for linter "gosec" (nolintlint)
	gasLimit := uint32(ethconfig.Defaults.Miner.GasCeil) //nolint:gosec
	                                                     ^
core/services/relay/evm/capabilities/testutils/backend.go:61:80: directive `//nolint:gosec` is unused for linter "gosec" (nolintlint)
	blockTime := time.UnixMilli(int64(backend.Blockchain().CurrentHeader().Time)) //nolint:gosec
	                                                                              ^
core/capabilities/integration_tests/keystone/setup.go:129:3: directive `//nolint:gosec // disable G115` is unused for linter "gosec" (nolintlint)
		//nolint:gosec // disable G115
		^
core/services/relay/evm/chain_components_test.go:41:82: directive `//nolint common practice to import test mods with .` should match `//nolint common practice to import test mods with .[:<comma-separated-linters>] [// <explanation>]` (nolintlint)
	. "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting" //nolint common practice to import test mods with .
	                                                                                ^
```
</details>