### PR TITLE
Fix Node Lifecycle OutOfSync bug

### DIFF
--- a/common/client/node_lifecycle.go
+++ b/common/client/node_lifecycle.go
@@ -168,6 +168,16 @@ func (n *node[CHAIN_ID, HEAD, RPC]) aliveLoop() {
 				n.declareUnreachable()
 				return
 			}
+		case bh, open := <-headsSub.Heads:
+			if !open {
+				lggr.Errorw("Subscription channel unexpectedly closed", "nodeState", n.getCachedState())
+				n.declareUnreachable()
+				return
+			}
+			receivedNewHead := n.onNewHead(lggr, &localHighestChainInfo, bh)
+			if receivedNewHead && noNewHeadsTimeoutThreshold > 0 {
+				headsSub.ResetTimer(noNewHeadsTimeoutThreshold)
+			}
 			_, latestChainInfo := n.StateAndLatest()
 			if outOfSync, liveNodes := n.isOutOfSyncWithPool(latestChainInfo); outOfSync {
 				// note: there must be another live node for us to be out of sync
@@ -178,16 +188,6 @@ func (n *node[CHAIN_ID, HEAD, RPC]) aliveLoop() {
 				}
 				n.declareOutOfSync(syncStatusNotInSyncWithPool)
 				return
-			}
-		case bh, open := <-headsSub.Heads:
-			if !open {
-				lggr.Errorw("Subscription channel unexpectedly closed", "nodeState", n.getCachedState())
-				n.declareUnreachable()
-				return
-			}
-			receivedNewHead := n.onNewHead(lggr, &localHighestChainInfo, bh)
-			if receivedNewHead && noNewHeadsTimeoutThreshold > 0 {
-				headsSub.ResetTimer(noNewHeadsTimeoutThreshold)
 			}
 		case err = <-headsSub.Errors:
 			lggr.Errorw("Subscription was terminated", "err", err, "nodeState", n.getCachedState())


### PR DESCRIPTION
A bug is causing nodes to be incorrectly declared `OutOfSync` due to checking `isOutOfSyncWithPool()` on each version check instead of when receiving a new head. This caused the localChainInfo to be behind the actual latest seen head for this node.

Ticket: https://smartcontract-it.atlassian.net/browse/BCI-4174

