### PR TITLE
[TT-1796] preinstall solc version to avoid 'text file busy' error

### DIFF
--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -174,7 +174,11 @@ jobs:
         with:
           version: ${{ needs.define-matrix.outputs.foundry-version }}
 
-      - name: Check if Solc version is set in Foundry.toml
+      # If Solc version is not set in foundry.toml, then what `forge build` does is that it lazily-installs required solc versions
+      # using SVM. This is done in parallel, but SVM has a bug and is not thread-safe, which sometimes leads to `Text file busy` error.
+      # In order to avoid it, in such cases we will extract all required solc versions manually and install them sequentially.
+      # More information: https://github.com/foundry-rs/foundry/issues/4736
+      - name: Check if Solc version is set in foundry.toml
         shell: bash
         id: check-for-solc-version
         working-directory: contracts
@@ -196,7 +200,7 @@ jobs:
         with:
           crate: svm-rs
 
-      - name: Find and install all solc versions
+      - name: Find and install all Solc versions with SVM
         if: ${{ steps.check-for-solc-version.outputs.has_solc_version == 'false' }}
         shell: bash
         working-directory: contracts/src/v0.8
@@ -206,9 +210,8 @@ jobs:
             echo "Installing exact version: $version"
             svm install "$version"
           done
-          svm list
           latest_version=$(svm list | grep -Eo '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"' | sort -V | tail -n1)
-          echo "Installing latest version: $version"
+          echo "Installing latest version: $latest_version"
           svm install "$latest_version"
 
       - name: Run Forge build

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -208,11 +208,15 @@ jobs:
           exact_versions=$(grep -rh "pragma solidity" ${{ matrix.product.name }} | sort | uniq | grep -v '\^' | awk '{print $3}' | tr -d ';')  
           for version in $exact_versions; do
             echo "Installing exact version: $version"
-            svm install "$version"
+            if ! svm install "$version"; then
+                echo "::error::Failed to install solc version: $version"
+            fi
           done
           latest_version=$(svm list | grep -Eo '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"' | sort -V | tail -n1)
           echo "Installing latest version: $latest_version"
-          svm install "$latest_version"
+          if ! svm install "$latest_version"; then
+            echo "::error::Failed to install solc version: $latest_version"
+          fi
 
       - name: Run Forge build
         if: ${{ contains(fromJson(needs.changes.outputs.all_changes), matrix.product.name)

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -206,6 +206,7 @@ jobs:
             echo "Installing exact version: $version"
             svm install "$version"
           done
+          svm list
           latest_version=$(svm list | grep -Eo '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"' | sort -V | tail -n1)
           echo "Installing latest version: $version"
           svm install "$latest_version"

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -174,6 +174,42 @@ jobs:
         with:
           version: ${{ needs.define-matrix.outputs.foundry-version }}
 
+      - name: Check if Solc version is set in Foundry.toml
+        shell: bash
+        id: check-for-solc-version
+        working-directory: contracts
+        env:
+          FOUNDRY_PROFILE: ${{ matrix.product.name }}
+        run: |
+          VERSION_IN_PROFILE=$(forge config --json | jq .solc)
+          if [[ "$VERSION_IN_PROFILE" = "null" ]]; then
+            echo "Solc version is not set in Foundry.toml"
+            echo "has_solc_version=false" >> $GITHUB_OUTPUT
+          else
+            echo "Solc version is set in Foundry.toml to: $VERSION_IN_PROFILE"
+            echo "has_solc_version=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install SVM
+        if: ${{ steps.check-for-solc-version.outputs.has_solc_version == 'false' }}
+        uses: baptiste0928/cargo-install@904927dbe77864e0f2281519fe9d5bd097a220b3 # v3.1.1
+        with:
+          crate: svm-rs
+
+      - name: Find and install all solc versions
+        if: ${{ steps.check-for-solc-version.outputs.has_solc_version == 'false' }}
+        shell: bash
+        working-directory: contracts/src/v0.8
+        run: |
+          exact_versions=$(grep -rh "pragma solidity" ${{ matrix.product.name }} | sort | uniq | grep -v '\^' | awk '{print $3}' | tr -d ';')  
+          for version in $exact_versions; do
+            echo "Installing exact version: $version"
+            svm install "$version"
+          done
+          latest_version=$(svm list | grep -Eo '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"' | sort -V | tail -n1)
+          echo "Installing latest version: $version"
+          svm install "$latest_version"
+
       - name: Run Forge build
         if: ${{ contains(fromJson(needs.changes.outputs.all_changes), matrix.product.name)
           || contains(fromJson(needs.changes.outputs.all_changes), 'shared')


### PR DESCRIPTION
This PR attempts to solve unsafe parallel installation of `solc` version during `forge build` by extracting required `solc` versions and installing them manually and sequentially. It only executes if there's no `solc_version` defined for given product profile in `foundry.toml`.

It's a known forge issue described [here](https://github.com/foundry-rs/foundry/issues/4736).

As a result this manual `solc` installation doesn't run for `ccip`:
![image](https://github.com/user-attachments/assets/c9a14186-abb0-4270-866f-c13e5b6878a1)

but it does run for `automation`:
![image](https://github.com/user-attachments/assets/2033f233-a432-4859-9003-1efe8d3fb93e)
and we can see that `forge build` doesn't install any `solc` versions.

The change attempts to be error-tolerant in the sense that if `svm install` fails we will log the error, but we won't fail the job and allow `forge build` to install `solc` versions automatically. This is to handle situations like connection errors or broken version extraction due to changes in the `svm` output.