### PR TITLE
[chore] Use the factory to get the config

### DIFF
--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -882,6 +882,7 @@ type WorkflowSpec struct {
 	SpecType      WorkflowSpecType `toml:"spec_type" db:"spec_type"`
 	sdkWorkflow   *sdk.WorkflowSpec
 	rawSpec       []byte
+	config        []byte
 }
 
 var (
@@ -945,6 +946,25 @@ func (w *WorkflowSpec) RawSpec(ctx context.Context) ([]byte, error) {
 	}
 
 	w.rawSpec = rs
+	return rs, nil
+}
+
+func (w *WorkflowSpec) GetConfig(ctx context.Context) ([]byte, error) {
+	if w.config != nil {
+		return w.config, nil
+	}
+
+	workflowSpecFactory, ok := workflowSpecFactories[w.SpecType]
+	if !ok {
+		return nil, fmt.Errorf("unknown spec type %s", w.SpecType)
+	}
+
+	rs, err := workflowSpecFactory.Config(ctx, w.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	w.config = rs
 	return rs, nil
 }
 

--- a/core/services/job/wasm_file_spec_factory.go
+++ b/core/services/job/wasm_file_spec_factory.go
@@ -22,7 +22,7 @@ import (
 type WasmFileSpecFactory struct{}
 
 func (w WasmFileSpecFactory) Spec(ctx context.Context, workflow, configLocation string) (sdk.WorkflowSpec, []byte, string, error) {
-	config, err := os.ReadFile(configLocation)
+	config, err := w.Config(ctx, configLocation)
 	if err != nil {
 		return sdk.WorkflowSpec{}, nil, "", err
 	}
@@ -43,14 +43,23 @@ func (w WasmFileSpecFactory) Spec(ctx context.Context, workflow, configLocation 
 	return *spec, compressedBinary, sha, nil
 }
 
-func (w WasmFileSpecFactory) RawSpec(_ context.Context, workflow, configLocation string) ([]byte, error) {
-	config, err := os.ReadFile(configLocation)
+func (w WasmFileSpecFactory) RawSpec(ctx context.Context, workflow, configLocation string) ([]byte, error) {
+	config, err := w.Config(ctx, configLocation)
 	if err != nil {
 		return nil, err
 	}
 
 	raw, _, err := w.rawSpecAndSha(workflow, config)
 	return raw, err
+}
+
+func (w WasmFileSpecFactory) Config(_ context.Context, configLocation string) ([]byte, error) {
+	config, err := os.ReadFile(configLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
 }
 
 // rawSpecAndSha returns the brotli compressed version of the raw wasm file, alongside the sha256 hash of the raw wasm file

--- a/core/services/job/wasm_file_spec_factory_test.go
+++ b/core/services/job/wasm_file_spec_factory_test.go
@@ -77,6 +77,14 @@ func TestWasmFileSpecFactory(t *testing.T) {
 
 		assert.Equal(t, b.Bytes(), rawSpec)
 	})
+
+	t.Run("Config", func(t *testing.T) {
+		factory := job.WasmFileSpecFactory{}
+		actual, err3 := factory.Config(testutils.Context(t), configLocation)
+		require.NoError(t, err3)
+
+		assert.Equal(t, config, actual)
+	})
 }
 
 func createTestBinary(t *testing.T) string {

--- a/core/services/job/workflow_spec_factory.go
+++ b/core/services/job/workflow_spec_factory.go
@@ -9,6 +9,7 @@ import (
 type WorkflowSpecFactory interface {
 	Spec(ctx context.Context, workflow, config string) (sdk.WorkflowSpec, []byte, string, error)
 	RawSpec(ctx context.Context, workflow, config string) ([]byte, error)
+	Config(ctx context.Context, config string) ([]byte, error)
 }
 
 var workflowSpecFactories = map[WorkflowSpecType]WorkflowSpecFactory{

--- a/core/services/job/yaml_spec_factory.go
+++ b/core/services/job/yaml_spec_factory.go
@@ -21,3 +21,7 @@ func (y YAMLSpecFactory) Spec(_ context.Context, workflow, _ string) (sdk.Workfl
 func (y YAMLSpecFactory) RawSpec(_ context.Context, workflow, _ string) ([]byte, error) {
 	return []byte(workflow), nil
 }
+
+func (y YAMLSpecFactory) Config(_ context.Context, config string) ([]byte, error) {
+	return []byte(config), nil
+}

--- a/core/services/job/yaml_spec_factory_test.go
+++ b/core/services/job/yaml_spec_factory_test.go
@@ -77,3 +77,12 @@ func TestYamlSpecFactory_GetSpec(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256([]byte(anyYamlSpec))), actualSha)
 	assert.Equal(t, anyYamlSpec, string(raw))
 }
+
+func TestYamlSpecFactory_Config(t *testing.T) {
+	t.Parallel()
+
+	config := "config"
+	actual, err := job.YAMLSpecFactory{}.Config(testutils.Context(t), config)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(config), actual)
+}

--- a/core/services/workflows/delegate.go
+++ b/core/services/workflows/delegate.go
@@ -47,6 +47,11 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 		return nil, err
 	}
 
+	config, err := spec.WorkflowSpec.GetConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := Config{
 		Lggr:           d.logger,
 		Workflow:       sdkSpec,
@@ -55,7 +60,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 		WorkflowName:   spec.WorkflowSpec.WorkflowName,
 		Registry:       d.registry,
 		Store:          d.store,
-		Config:         []byte(spec.WorkflowSpec.Config),
+		Config:         config,
 		Binary:         binary,
 		SecretsFetcher: d.secretsFetcher,
 	}


### PR DESCRIPTION
Get the workflow config via the workflow spec factory, thus ensuring that for WASM file types, the config corresponds to the actual config contents, not the path to the config.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
