### PR TITLE
[BCFR-1048] - Logic to solve ocassional nonce gap issues

### DIFF
--- a/.changeset/short-gifts-eat.md
+++ b/.changeset/short-gifts-eat.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+use last mined nonce instead of pending nonce to recover from occasional nonce gap issues within nonce tracker. #internal

--- a/core/chains/evm/txmgr/nonce_tracker.go
+++ b/core/chains/evm/txmgr/nonce_tracker.go
@@ -23,6 +23,7 @@ type NonceTrackerTxStore interface {
 type NonceTrackerClient interface {
 	ConfiguredChainID() *big.Int
 	PendingSequenceAt(context.Context, common.Address) (evmtypes.Nonce, error)
+	SequenceAt(ctx context.Context, addr common.Address, blockNum *big.Int) (evmtypes.Nonce, error)
 }
 
 type nonceTracker struct {
@@ -70,8 +71,8 @@ func (s *nonceTracker) getSequenceForAddr(ctx context.Context, address common.Ad
 		return seq, nil
 	}
 	// Look for nonce on-chain if no tx found for address in TxStore or if error occurred
-	// Returns the nonce that should be used for the next transaction so no need to increment
-	nonce, err := s.client.PendingSequenceAt(ctx, address)
+	// Returns last mined nonce +1 that should be used for the next transaction
+	nonce, err := s.client.SequenceAt(ctx, address, nil)
 	if err == nil {
 		return nonce, nil
 	}

--- a/core/chains/evm/txmgr/nonce_tracker.go
+++ b/core/chains/evm/txmgr/nonce_tracker.go
@@ -70,8 +70,12 @@ func (s *nonceTracker) getSequenceForAddr(ctx context.Context, address common.Ad
 		seq++
 		return seq, nil
 	}
-	// Look for nonce on-chain if no tx found for address in TxStore or if error occurred
-	// Returns last mined nonce +1 that should be used for the next transaction
+	// Look for nonce on-chain if no tx found for address in TxStore or if error occurred.
+	// We use the mined transaction count (SequenceAt) to determine the next nonce to use instead of the pending transaction count (PendingSequenceAt).
+	// This allows the TXM to broadcast and track transactions for nonces starting from the last mined transaction preventing the perpetuation of a potential nonce gap.
+	// NOTE: Any transactions already in the mempool would be attempted to be overwritten but an older transaction can get included before being overwritten.
+	// Such could be the case if there was a nonce gap that gets filled unblocking the transactions.
+	// If that occurs, there could be short term noise in the logs surfacing that a transaction expired without ever getting a receipt.
 	nonce, err := s.client.SequenceAt(ctx, address, nil)
 	if err == nil {
 		return nonce, nil

--- a/core/chains/evm/txmgr/nonce_tracker_test.go
+++ b/core/chains/evm/txmgr/nonce_tracker_test.go
@@ -61,8 +61,8 @@ func TestNonceTracker_LoadSequenceMap(t *testing.T) {
 
 		randNonce1 := testutils.NewRandomPositiveInt64()
 		randNonce2 := testutils.NewRandomPositiveInt64()
-		client.On("PendingNonceAt", mock.Anything, addr1).Return(uint64(randNonce1), nil).Once()
-		client.On("PendingNonceAt", mock.Anything, addr2).Return(uint64(randNonce2), nil).Once()
+		client.On("NonceAt", mock.Anything, addr1, (*big.Int)(nil)).Return(uint64(randNonce1), nil).Once()
+		client.On("NonceAt", mock.Anything, addr2, (*big.Int)(nil)).Return(uint64(randNonce2), nil).Once()
 
 		nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 		seq, err := nonceTracker.GetNextSequence(ctx, addr1)
@@ -205,7 +205,7 @@ func TestNonceTracker_GetNextSequence(t *testing.T) {
 	t.Run("fails to get sequence if address is enabled, doesn't exist in map, and getSequenceForAddr fails", func(t *testing.T) {
 		enabledAddresses := []common.Address{addr}
 		txStore.On("FindLatestSequence", mock.Anything, addr, chainID).Return(types.Nonce(0), errors.New("no rows")).Twice()
-		client.On("PendingNonceAt", mock.Anything, addr).Return(uint64(0), errors.New("RPC unavailable")).Twice()
+		client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(0), errors.New("RPC unavailable")).Twice()
 		nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 
 		_, err := nonceTracker.GetNextSequence(ctx, addr)
@@ -217,7 +217,7 @@ func TestNonceTracker_GetNextSequence(t *testing.T) {
 		txStoreNonce := 4
 		enabledAddresses := []common.Address{addr}
 		txStore.On("FindLatestSequence", mock.Anything, addr, chainID).Return(types.Nonce(0), errors.New("no rows")).Once()
-		client.On("PendingNonceAt", mock.Anything, addr).Return(uint64(0), errors.New("RPC unavailable")).Once()
+		client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(0), errors.New("RPC unavailable")).Once()
 		nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 
 		txStore.On("FindLatestSequence", mock.Anything, addr, chainID).Return(types.Nonce(txStoreNonce), nil).Once()
@@ -272,8 +272,8 @@ func Test_SetNonceAfterInit(t *testing.T) {
 	addr := common.HexToAddress("0xd5e099c71b797516c10ed0f0d895f429c2781142")
 	enabledAddresses := []common.Address{addr}
 	randNonce := testutils.NewRandomPositiveInt64()
-	client.On("PendingNonceAt", mock.Anything, addr).Return(uint64(0), errors.New("failed to retrieve nonce at startup")).Once()
-	client.On("PendingNonceAt", mock.Anything, addr).Return(uint64(randNonce), nil).Once()
+	client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(0), errors.New("failed to retrieve nonce at startup")).Once()
+	client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(randNonce), nil).Once()
 	nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 
 	nonce, err := nonceTracker.GetNextSequence(ctx, addr)

--- a/core/chains/evm/txmgr/nonce_tracker_test.go
+++ b/core/chains/evm/txmgr/nonce_tracker_test.go
@@ -61,8 +61,8 @@ func TestNonceTracker_LoadSequenceMap(t *testing.T) {
 
 		randNonce1 := testutils.NewRandomPositiveInt64()
 		randNonce2 := testutils.NewRandomPositiveInt64()
-		client.On("NonceAt", mock.Anything, addr1, (*big.Int)(nil)).Return(uint64(randNonce1), nil).Once()
-		client.On("NonceAt", mock.Anything, addr2, (*big.Int)(nil)).Return(uint64(randNonce2), nil).Once()
+		client.On("NonceAt", mock.Anything, addr1, (*big.Int)(nil)).Return(uint64(randNonce1), nil).Once() //nolint:gosec // Disable G115: randNonce1 always positive
+		client.On("NonceAt", mock.Anything, addr2, (*big.Int)(nil)).Return(uint64(randNonce2), nil).Once() //nolint:gosec // Disable G115: randNonce2 always positive
 
 		nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 		seq, err := nonceTracker.GetNextSequence(ctx, addr1)
@@ -273,7 +273,7 @@ func Test_SetNonceAfterInit(t *testing.T) {
 	enabledAddresses := []common.Address{addr}
 	randNonce := testutils.NewRandomPositiveInt64()
 	client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(0), errors.New("failed to retrieve nonce at startup")).Once()
-	client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(randNonce), nil).Once()
+	client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(randNonce), nil).Once() //nolint:gosec // Disable G115: randNonce always positive
 	nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 
 	nonce, err := nonceTracker.GetNextSequence(ctx, addr)

--- a/core/chains/evm/txmgr/nonce_tracker_test.go
+++ b/core/chains/evm/txmgr/nonce_tracker_test.go
@@ -61,8 +61,8 @@ func TestNonceTracker_LoadSequenceMap(t *testing.T) {
 
 		randNonce1 := testutils.NewRandomPositiveInt64()
 		randNonce2 := testutils.NewRandomPositiveInt64()
-		client.On("NonceAt", mock.Anything, addr1, (*big.Int)(nil)).Return(uint64(randNonce1), nil).Once() //nolint:gosec // Disable G115: randNonce1 always positive
-		client.On("NonceAt", mock.Anything, addr2, (*big.Int)(nil)).Return(uint64(randNonce2), nil).Once() //nolint:gosec // Disable G115: randNonce2 always positive
+		client.On("NonceAt", mock.Anything, addr1, mock.Anything).Return(uint64(randNonce1), nil).Once() //nolint:gosec // Disable G115: randNonce1 always positive
+		client.On("NonceAt", mock.Anything, addr2, mock.Anything).Return(uint64(randNonce2), nil).Once() //nolint:gosec // Disable G115: randNonce2 always positive
 
 		nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 		seq, err := nonceTracker.GetNextSequence(ctx, addr1)
@@ -205,7 +205,7 @@ func TestNonceTracker_GetNextSequence(t *testing.T) {
 	t.Run("fails to get sequence if address is enabled, doesn't exist in map, and getSequenceForAddr fails", func(t *testing.T) {
 		enabledAddresses := []common.Address{addr}
 		txStore.On("FindLatestSequence", mock.Anything, addr, chainID).Return(types.Nonce(0), errors.New("no rows")).Twice()
-		client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(0), errors.New("RPC unavailable")).Twice()
+		client.On("NonceAt", mock.Anything, addr, mock.Anything).Return(uint64(0), errors.New("RPC unavailable")).Twice()
 		nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 
 		_, err := nonceTracker.GetNextSequence(ctx, addr)
@@ -217,7 +217,7 @@ func TestNonceTracker_GetNextSequence(t *testing.T) {
 		txStoreNonce := 4
 		enabledAddresses := []common.Address{addr}
 		txStore.On("FindLatestSequence", mock.Anything, addr, chainID).Return(types.Nonce(0), errors.New("no rows")).Once()
-		client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(0), errors.New("RPC unavailable")).Once()
+		client.On("NonceAt", mock.Anything, addr, mock.Anything).Return(uint64(0), errors.New("RPC unavailable")).Once()
 		nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 
 		txStore.On("FindLatestSequence", mock.Anything, addr, chainID).Return(types.Nonce(txStoreNonce), nil).Once()
@@ -272,8 +272,8 @@ func Test_SetNonceAfterInit(t *testing.T) {
 	addr := common.HexToAddress("0xd5e099c71b797516c10ed0f0d895f429c2781142")
 	enabledAddresses := []common.Address{addr}
 	randNonce := testutils.NewRandomPositiveInt64()
-	client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(0), errors.New("failed to retrieve nonce at startup")).Once()
-	client.On("NonceAt", mock.Anything, addr, (*big.Int)(nil)).Return(uint64(randNonce), nil).Once() //nolint:gosec // Disable G115: randNonce always positive
+	client.On("NonceAt", mock.Anything, addr, mock.Anything).Return(uint64(0), errors.New("failed to retrieve nonce at startup")).Once()
+	client.On("NonceAt", mock.Anything, addr, mock.Anything).Return(uint64(randNonce), nil).Once() //nolint:gosec // Disable G115: randNonce always positive
 	nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 
 	nonce, err := nonceTracker.GetNextSequence(ctx, addr)

--- a/core/cmd/eth_keys_commands_test.go
+++ b/core/cmd/eth_keys_commands_test.go
@@ -93,7 +93,7 @@ func TestShell_ListETHKeys(t *testing.T) {
 	ethClient := newEthMock(t)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("LINKBalance", mock.Anything, mock.Anything, mock.Anything).Return(commonassets.NewLinkFromJuels(13), nil)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)
 		c.EVM[0].NonceAutoSync = ptr(false)
@@ -118,7 +118,7 @@ func TestShell_ListETHKeys_Error(t *testing.T) {
 	ethClient := newEthMock(t)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("fake error"))
 	ethClient.On("LINKBalance", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("fake error"))
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)
 		c.EVM[0].NonceAutoSync = ptr(false)
@@ -172,7 +172,7 @@ func TestShell_CreateETHKey(t *testing.T) {
 	ethClient := newEthMock(t)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("LINKBalance", mock.Anything, mock.Anything, mock.Anything).Return(commonassets.NewLinkFromJuels(42), nil)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)
@@ -247,7 +247,7 @@ func TestShell_ImportExportETHKey_NoChains(t *testing.T) {
 	ethClient := newEthMock(t)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("LINKBalance", mock.Anything, mock.Anything, mock.Anything).Return(commonassets.NewLinkFromJuels(42), nil)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)
 		c.EVM[0].NonceAutoSync = ptr(false)
@@ -351,7 +351,7 @@ func TestShell_ImportExportETHKey_WithChains(t *testing.T) {
 	t.Cleanup(func() { deleteKeyExportFile(t) })
 
 	ethClient := newEthMock(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)
 		c.EVM[0].NonceAutoSync = ptr(false)

--- a/core/cmd/evm_transaction_commands_test.go
+++ b/core/cmd/evm_transaction_commands_test.go
@@ -139,8 +139,7 @@ func TestShell_SendEther_From_Txm(t *testing.T) {
 	ethMock := newEthMockWithTransactionsOnBlocksAssertions(t)
 
 	ethMock.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
-	ethMock.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Maybe()
-	ethMock.On("PendingNonceAt", mock.Anything, fromAddress).Return(uint64(0), nil).Once()
+	ethMock.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)
@@ -203,8 +202,7 @@ func TestShell_SendEther_From_Txm_WEI(t *testing.T) {
 	ethMock := newEthMockWithTransactionsOnBlocksAssertions(t)
 
 	ethMock.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
-	ethMock.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Maybe()
-	ethMock.On("PendingNonceAt", mock.Anything, fromAddress).Return(uint64(0), nil).Once()
+	ethMock.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)

--- a/core/cmd/evm_transaction_commands_test.go
+++ b/core/cmd/evm_transaction_commands_test.go
@@ -202,7 +202,7 @@ func TestShell_SendEther_From_Txm_WEI(t *testing.T) {
 	ethMock := newEthMockWithTransactionsOnBlocksAssertions(t)
 
 	ethMock.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
-	ethMock.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
+	ethMock.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil)
 
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)

--- a/core/cmd/evm_transaction_commands_test.go
+++ b/core/cmd/evm_transaction_commands_test.go
@@ -139,7 +139,7 @@ func TestShell_SendEther_From_Txm(t *testing.T) {
 	ethMock := newEthMockWithTransactionsOnBlocksAssertions(t)
 
 	ethMock.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
-	ethMock.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
+	ethMock.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil)
 
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)

--- a/core/web/eth_keys_controller_test.go
+++ b/core/web/eth_keys_controller_test.go
@@ -33,7 +33,7 @@ func TestETHKeysController_Index_Success(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
@@ -85,7 +85,7 @@ func TestETHKeysController_Index_Errors(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
@@ -158,7 +158,7 @@ func TestETHKeysController_Index_NotDev(t *testing.T) {
 	t.Parallel()
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
@@ -227,6 +227,7 @@ func TestETHKeysController_CreateSuccess(t *testing.T) {
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(ethBalanceInt, nil)
 	linkBalance := assets.NewLinkFromJuels(42)
 	ethClient.On("LINKBalance", mock.Anything, mock.Anything, mock.Anything).Return(linkBalance, nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 
 	client := app.NewHTTPClient(nil)
 
@@ -257,7 +258,7 @@ func TestETHKeysController_ChainSuccess_UpdateNonce(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
@@ -300,7 +301,7 @@ func TestETHKeysController_ChainSuccess_Disable(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
@@ -391,7 +392,7 @@ func TestETHKeysController_ChainSuccess_ResetWithAbandon(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
@@ -464,7 +465,7 @@ func TestETHKeysController_ChainFailure_InvalidAbandon(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
@@ -498,7 +499,7 @@ func TestETHKeysController_ChainFailure_InvalidEnabled(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
@@ -619,7 +620,7 @@ func TestETHKeysController_ChainFailure_MissingChainID(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
@@ -651,7 +652,7 @@ func TestETHKeysController_DeleteSuccess(t *testing.T) {
 	t.Parallel()
 	ctx := testutils.Context(t)
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Twice()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)

--- a/core/web/evm_transfer_controller_test.go
+++ b/core/web/evm_transfer_controller_test.go
@@ -41,8 +41,9 @@ func TestTransfersController_CreateSuccess_From(t *testing.T) {
 	balance, err := assets.NewEthValueS("200")
 	require.NoError(t, err)
 
-	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil)
+	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil).Maybe()
 	ethClient.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 
 	app := cltest.NewApplicationWithKey(t, ethClient, key)
 	require.NoError(t, app.Start(testutils.Context(t)))
@@ -83,8 +84,9 @@ func TestTransfersController_CreateSuccess_From_WEI(t *testing.T) {
 	balance, err := assets.NewEthValueS("2")
 	require.NoError(t, err)
 
-	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil)
+	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil).Maybe()
 	ethClient.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 
 	app := cltest.NewApplicationWithKey(t, ethClient, key)
 	require.NoError(t, app.Start(testutils.Context(t)))
@@ -124,8 +126,9 @@ func TestTransfersController_CreateSuccess_From_BalanceMonitorDisabled(t *testin
 	balance, err := assets.NewEthValueS("200")
 	require.NoError(t, err)
 
-	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil)
+	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil).Maybe()
 	ethClient.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
@@ -193,8 +196,9 @@ func TestTransfersController_TransferBalanceToLowError(t *testing.T) {
 
 	ethClient := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
 
-	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil)
+	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil).Maybe()
 	ethClient.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(assets.NewEth(10).ToInt(), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 
 	app := cltest.NewApplicationWithKey(t, ethClient, key)
 	require.NoError(t, app.Start(testutils.Context(t)))
@@ -231,8 +235,9 @@ func TestTransfersController_TransferBalanceToLowError_ZeroBalance(t *testing.T)
 	balance, err := assets.NewEthValueS("0")
 	require.NoError(t, err)
 
-	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil)
+	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil).Maybe()
 	ethClient.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 
 	app := cltest.NewApplicationWithKey(t, ethClient, key)
 	require.NoError(t, app.Start(testutils.Context(t)))
@@ -283,9 +288,9 @@ func TestTransfersController_CreateSuccess_eip1559(t *testing.T) {
 	balance, err := assets.NewEthValueS("200")
 	require.NoError(t, err)
 
-	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil)
+	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil).Maybe()
 	ethClient.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
-	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Maybe()
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].GasEstimator.EIP1559DynamicFees = ptr(true)

--- a/core/web/evm_transfer_controller_test.go
+++ b/core/web/evm_transfer_controller_test.go
@@ -288,7 +288,7 @@ func TestTransfersController_CreateSuccess_eip1559(t *testing.T) {
 	balance, err := assets.NewEthValueS("200")
 	require.NoError(t, err)
 
-	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil).Maybe()
+	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil).Once()
 	ethClient.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
 	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 

--- a/core/web/evm_transfer_controller_test.go
+++ b/core/web/evm_transfer_controller_test.go
@@ -288,9 +288,9 @@ func TestTransfersController_CreateSuccess_eip1559(t *testing.T) {
 	balance, err := assets.NewEthValueS("200")
 	require.NoError(t, err)
 
-	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil).Once()
+	ethClient.On("PendingNonceAt", mock.Anything, key.Address).Return(uint64(1), nil)
 	ethClient.On("BalanceAt", mock.Anything, key.Address, (*big.Int)(nil)).Return(balance.ToInt(), nil)
-	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil)
 
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].GasEstimator.EIP1559DynamicFees = ptr(true)

--- a/core/web/jobs_controller_test.go
+++ b/core/web/jobs_controller_test.go
@@ -801,6 +801,7 @@ func setupJobsControllerTests(t *testing.T) (ta *cltest.TestApplication, cc clte
 func setupEthClientForControllerTests(t *testing.T) *evmclimocks.Client {
 	ec := cltest.NewEthMocksWithStartupAssertions(t)
 	ec.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil).Maybe()
+	ec.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	ec.On("LatestBlockHeight", mock.Anything).Return(big.NewInt(100), nil).Maybe()
 	ec.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Once().Return(big.NewInt(0), nil).Maybe()
 	return ec

--- a/core/web/pipeline_runs_controller_test.go
+++ b/core/web/pipeline_runs_controller_test.go
@@ -254,7 +254,7 @@ func setupPipelineRunsControllerTests(t *testing.T) (cltest.HTTPClientCleaner, i
 	t.Parallel()
 	ctx := testutils.Context(t)
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+	ethClient.On("NonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Once()
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.OCR.Enabled = ptr(true)
 		c.P2P.V2.Enabled = ptr(true)


### PR DESCRIPTION
### Description: 
- Change the `getSequenceForAddr` function to use [NonceAt instead of PendingNonceAt](https://github.com/smartcontractkit/chainlink/blob/072bfb667a4e1f7cc0c874409ebfe6ef7f7b6cbe/core/chains/evm/txmgr/nonce_tracker.go#L74).
- We use the mined transaction count (SequenceAt) to determine the next nonce to use instead of the pending transaction count (PendingSequenceAt). This allows the TXM to broadcast and track transactions for nonces starting from the last mined transaction preventing the perpetuation of a potential nonce gap.
- Consideration: Any transactions already in the mempool would be attempted to be overwritten but an older transaction can get included before being overwritten. Such could be the case if there was a nonce gap that gets filled unblocking the transactions. If that occurs, there could be short term noise in the logs surfacing that a transaction expired without ever getting a receipt.

### Steps a NOP should follow to handle nonce gap issue:
- disable `NonceAutoSync`
- mark `abandon all current transactions` checkbox

### Resources
- [Ticket](https://smartcontract-it.atlassian.net/browse/BCFR-1048)
- [Discussion](https://chainlink-core.slack.com/archives/C03ANJB9VB7/p1727447872398279)

### Merge together with:
- https://github.com/smartcontractkit/operator-ui/pull/89