### PR TITLE
feat: optimize Go Mod cache

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -13,6 +13,11 @@ inputs:
   go-module-file:
     description: Set where the go module file is located at
     default: "go.sum"
+  restore-module-cache-only:
+    description: |
+      Only restore the module cache, don't automatically update it.
+      Leave the updating to go-mod-cache.yml.
+    default: "true"
 
 runs:
   using: composite
@@ -40,14 +45,33 @@ runs:
       shell: bash
       run: echo "path=./${{ inputs.go-module-file }}" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v4.1.1
+    # By default, restore the cache only.
+    # If multiple jobs call actions/cache, then only one will get priority to create upon a cache miss.
+    # We will only restore the cache by default (by calling actions/cache/restore) and let the
+    # `go-mod-cache.yml` workflow handle the creation.
+    - uses: actions/cache/restore@v4.1.1
+      if: ${{ inputs.restore-module-cache-only == 'true' }}
       name: Cache Go Modules
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gomodcache }}
         # The lifetime of go modules is much higher than the build outputs, so we increase cache efficiency
         # here by not having the primary key contain the branch name
-        key: ${{ runner.os }}-gomod-${{ inputs.cache-version }}-${{ hashFiles(steps.go-module-path.output.path) }}
+        key: ${{ runner.os }}-gomod-${{ inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}
+        restore-keys: |
+          ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
+
+    # If this is called, then it will create the cache entry upon a cache miss.
+    # The cache is created after a cache miss, and after job completes successfully.
+    - uses: actions/cache@v4.1.1
+      if: ${{ inputs.restore-module-cache-only != 'true' }}
+      name: Cache Go Modules
+      with:
+        path: |
+          ${{ steps.go-cache-dir.outputs.gomodcache }}
+        # The lifetime of go modules is much higher than the build outputs, so we increase cache efficiency
+        # here by not having the primary key contain the branch name
+        key: ${{ runner.os }}-gomod-${{ inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}
         restore-keys: |
           ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
 

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -25,9 +25,6 @@ jobs:
           go-directory: core/scripts
           go-version-file: core/scripts/go.mod
           go-module-file: core/scripts/go.sum
-          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
 
   test-scripts:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:
+          only-modules: "true"
           restore-module-cache-only: "false"
       
       - name: Install Dependencies

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -1,0 +1,42 @@
+name: Go Module Cache
+
+# This workflow is responsible for updating the Go Module Cache.
+# It will maintain the cache: linux-gomod-1-<hash>
+# All other workflows should only restore this cache.
+
+# This workflow is useful because it will:
+# 1. Create the cache if it doesn't exist
+#   - This can be a problem when multiple jobs load the same cache.
+#     Only one will get priority to create the cache.
+# 2. Should not fail, therefore creating a cache
+#   - When a Job errors/fails it will not upload a new cache.
+#     So when test/build jobs are responsible for creating the new cache,
+#     they can fail causing cache misses on subsequent runs. Even though
+#     the dependencies haven't changed.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+
+jobs:
+  go-cache:
+    name: Go Cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4.2.1
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+        with:
+          restore-module-cache-only: "false"
+      
+      - name: Install Dependencies
+        shell: bash
+        run:  go mod download all


### PR DESCRIPTION
Fixing and optimizing the go mod cache.

### Changes
- `setup-go` action:
    - only restore go mod cache by default
    - fix usage of `steps.<step>.outputs` so it actually hashes the file 
- `go-mod-cache` workflow - responsible for creating and updating the go-mod-cache 
 
### Motivation

- When multiple jobs reference the same cache then only one gets priority to update it. If that job fails then the cache will not be populated. By restoring only, this should fix that.
- `setup-go` was actually broken as the cache key it was trying to use didn't include the go.sum
    - Cache key by default was `Linux-gomod-1-`, and the cache was ~800 **bytes**
    - So most workflows are using an empty go mod cache
- To stop the above from happening, setup a dedicated workflow to actually create/maintain the cache

---

RE-2800, RE-3155.
