### PR TITLE
fix: codeql-analysis caching

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,9 +26,10 @@ jobs:
 
       - name: Set up Go
         if: ${{ matrix.language == 'go' }}
-        uses: actions/setup-go@v5.0.2
+        uses: ./.github/actions/setup-go
         with:
           go-version-file: 'go.mod'
+          only-modules: 'true'
 
       - name: Touching core/web/assets/index.html
         if: ${{ matrix.language == 'go' }}


### PR DESCRIPTION
### Changes

- Use `setup-go` for the `codeql-analysis` workflow

### Motivation

This workflow was creating many cache entries in our [actions cache](https://github.com/smartcontractkit/chainlink/actions/caches) which leads to quicker eviction times for in progress PRs.
We should either not cache for this, or use our own go cache to lower our total cache usage.

[Example](https://github.com/smartcontractkit/chainlink/actions/runs/11582679897/job/32246219897?pr=14988#step:3:23):
```
Cache Size: ~1442 MB (1511835647 B)
/usr/bin/tar -xf /home/runner/work/_temp/4c661f71-fa5f-473e-add1-ae7f57b9229e/cache.tzst -P -C /home/runner/work/chainlink/chainlink --use-compress-program unzstd
Received 1511835647 of 1511835647 (100.0%), 360.2 MBs/sec
Cache restored successfully
Cache restored from key: setup-go-Linux-ubuntu22-go-1.22.8-56fa815235e10498dd19dff386c146720654fb9cdd87a04c56359a6f90162c5d
```

---

RE-3155