### PR TITLE
use deployment.Changeset as an interface for anything under 'changeset' directory

### DIFF
--- a/deployment/ccip/active_candidate.go
+++ b/deployment/ccip/active_candidate.go
@@ -1,0 +1,139 @@
+package ccipdeployment
+
+import (
+	"fmt"
+	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/mcms"
+	"github.com/smartcontractkit/chainlink/deployment"
+	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/ccip_home"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry"
+	"math/big"
+)
+
+// SetCandidateExecPluginOps calls setCandidate on CCIPHome contract through the UpdateDON call on CapReg contract
+// This proposes to set up OCR3 config for the provided plugin for the DON
+func SetCandidateOnExistingDon(
+	pluginConfig ccip_home.CCIPHomeOCR3Config,
+	capReg *capabilities_registry.CapabilitiesRegistry,
+	ccipHome *ccip_home.CCIPHome,
+	chainSelector uint64,
+	nodes deployment.Nodes,
+) ([]mcms.Operation, error) {
+	// fetch DON ID for the chain
+	donID, err := DonIDForChain(capReg, ccipHome, chainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("fetch don id for chain: %w", err)
+	}
+	fmt.Printf("donID: %d", donID)
+	encodedSetCandidateCall, err := CCIPHomeABI.Pack(
+		"setCandidate",
+		donID,
+		pluginConfig.PluginType,
+		pluginConfig,
+		[32]byte{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("pack set candidate call: %w", err)
+	}
+
+	// set candidate call
+	updateDonTx, err := capReg.UpdateDON(
+		deployment.SimTransactOpts(),
+		donID,
+		nodes.PeerIDs(),
+		[]capabilities_registry.CapabilitiesRegistryCapabilityConfiguration{
+			{
+				CapabilityId: CCIPCapabilityID,
+				Config:       encodedSetCandidateCall,
+			},
+		},
+		false,
+		nodes.DefaultF(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update don w/ exec config: %w", err)
+	}
+
+	return []mcms.Operation{{
+		To:    capReg.Address(),
+		Data:  updateDonTx.Data(),
+		Value: big.NewInt(0),
+	}}, nil
+}
+
+// PromoteCandidateOp will create the MCMS Operation for `promoteCandidateAndRevokeActive` directed towards the capabilityRegistry
+func PromoteCandidateOp(donID uint32, pluginType uint8, capReg *capabilities_registry.CapabilitiesRegistry,
+	ccipHome *ccip_home.CCIPHome, nodes deployment.Nodes) (mcms.Operation, error) {
+
+	allConfigs, err := ccipHome.GetAllConfigs(nil, donID, pluginType)
+	if err != nil {
+		return mcms.Operation{}, err
+	}
+
+	if allConfigs.CandidateConfig.ConfigDigest == [32]byte{} {
+		return mcms.Operation{}, fmt.Errorf("candidate digest is empty, expected nonempty")
+	}
+	fmt.Printf("commit candidate digest after setCandidate: %x\n", allConfigs.CandidateConfig.ConfigDigest)
+
+	encodedPromotionCall, err := CCIPHomeABI.Pack(
+		"promoteCandidateAndRevokeActive",
+		donID,
+		pluginType,
+		allConfigs.CandidateConfig.ConfigDigest,
+		allConfigs.ActiveConfig.ConfigDigest,
+	)
+	if err != nil {
+		return mcms.Operation{}, fmt.Errorf("pack promotion call: %w", err)
+	}
+
+	updateDonTx, err := capReg.UpdateDON(
+		deployment.SimTransactOpts(),
+		donID,
+		nodes.PeerIDs(),
+		[]capabilities_registry.CapabilitiesRegistryCapabilityConfiguration{
+			{
+				CapabilityId: CCIPCapabilityID,
+				Config:       encodedPromotionCall,
+			},
+		},
+		false,
+		nodes.DefaultF(),
+	)
+	if err != nil {
+		return mcms.Operation{}, fmt.Errorf("error creating updateDon op for donID(%d) and plugin type (%d): %w", donID, pluginType, err)
+	}
+	return mcms.Operation{
+		To:    capReg.Address(),
+		Data:  updateDonTx.Data(),
+		Value: big.NewInt(0),
+	}, nil
+}
+
+// PromoteAllCandidatesForChainOps promotes the candidate commit and exec configs to active by calling promoteCandidateAndRevokeActive on CCIPHome through the UpdateDON call on CapReg contract
+func PromoteAllCandidatesForChainOps(
+	capReg *capabilities_registry.CapabilitiesRegistry,
+	ccipHome *ccip_home.CCIPHome,
+	chainSelector uint64,
+	nodes deployment.Nodes,
+) ([]mcms.Operation, error) {
+	// fetch DON ID for the chain
+	donID, err := DonIDForChain(capReg, ccipHome, chainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("fetch don id for chain: %w", err)
+	}
+
+	var mcmsOps []mcms.Operation
+	updateCommitOp, err := PromoteCandidateOp(donID, uint8(cctypes.PluginTypeCCIPCommit), capReg, ccipHome, nodes)
+	if err != nil {
+		return nil, fmt.Errorf("promote candidate op: %w", err)
+	}
+	mcmsOps = append(mcmsOps, updateCommitOp)
+
+	updateExecOp, err := PromoteCandidateOp(donID, uint8(cctypes.PluginTypeCCIPExec), capReg, ccipHome, nodes)
+	if err != nil {
+		return nil, fmt.Errorf("promote candidate op: %w", err)
+	}
+	mcmsOps = append(mcmsOps, updateExecOp)
+
+	return mcmsOps, nil
+}

--- a/deployment/ccip/changeset/active_candidate.go
+++ b/deployment/ccip/changeset/active_candidate.go
@@ -2,145 +2,13 @@ package changeset
 
 import (
 	"fmt"
-	"math/big"
-
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/mcms"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	ccdeploy "github.com/smartcontractkit/chainlink/deployment/ccip"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
-	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/ccip_home"
-	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry"
 )
-
-// SetCandidateExecPluginOps calls setCandidate on CCIPHome contract through the UpdateDON call on CapReg contract
-// This proposes to set up OCR3 config for the provided plugin for the DON
-func setCandidateOnExistingDon(
-	pluginConfig ccip_home.CCIPHomeOCR3Config,
-	capReg *capabilities_registry.CapabilitiesRegistry,
-	ccipHome *ccip_home.CCIPHome,
-	chainSelector uint64,
-	nodes deployment.Nodes,
-) ([]mcms.Operation, error) {
-	// fetch DON ID for the chain
-	donID, err := ccdeploy.DonIDForChain(capReg, ccipHome, chainSelector)
-	if err != nil {
-		return nil, fmt.Errorf("fetch don id for chain: %w", err)
-	}
-	fmt.Printf("donID: %d", donID)
-	encodedSetCandidateCall, err := ccdeploy.CCIPHomeABI.Pack(
-		"setCandidate",
-		donID,
-		pluginConfig.PluginType,
-		pluginConfig,
-		[32]byte{},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("pack set candidate call: %w", err)
-	}
-
-	// set candidate call
-	updateDonTx, err := capReg.UpdateDON(
-		deployment.SimTransactOpts(),
-		donID,
-		nodes.PeerIDs(),
-		[]capabilities_registry.CapabilitiesRegistryCapabilityConfiguration{
-			{
-				CapabilityId: ccdeploy.CCIPCapabilityID,
-				Config:       encodedSetCandidateCall,
-			},
-		},
-		false,
-		nodes.DefaultF(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("update don w/ exec config: %w", err)
-	}
-
-	return []mcms.Operation{{
-		To:    capReg.Address(),
-		Data:  updateDonTx.Data(),
-		Value: big.NewInt(0),
-	}}, nil
-}
-
-// promoteCandidateOp will create the MCMS Operation for `promoteCandidateAndRevokeActive` directed towards the capabilityRegistry
-func promoteCandidateOp(donID uint32, pluginType uint8, capReg *capabilities_registry.CapabilitiesRegistry,
-	ccipHome *ccip_home.CCIPHome, nodes deployment.Nodes) (mcms.Operation, error) {
-
-	allConfigs, err := ccipHome.GetAllConfigs(nil, donID, pluginType)
-	if err != nil {
-		return mcms.Operation{}, err
-	}
-
-	if allConfigs.CandidateConfig.ConfigDigest == [32]byte{} {
-		return mcms.Operation{}, fmt.Errorf("candidate digest is empty, expected nonempty")
-	}
-	fmt.Printf("commit candidate digest after setCandidate: %x\n", allConfigs.CandidateConfig.ConfigDigest)
-
-	encodedPromotionCall, err := ccdeploy.CCIPHomeABI.Pack(
-		"promoteCandidateAndRevokeActive",
-		donID,
-		pluginType,
-		allConfigs.CandidateConfig.ConfigDigest,
-		allConfigs.ActiveConfig.ConfigDigest,
-	)
-	if err != nil {
-		return mcms.Operation{}, fmt.Errorf("pack promotion call: %w", err)
-	}
-
-	updateDonTx, err := capReg.UpdateDON(
-		deployment.SimTransactOpts(),
-		donID,
-		nodes.PeerIDs(),
-		[]capabilities_registry.CapabilitiesRegistryCapabilityConfiguration{
-			{
-				CapabilityId: ccdeploy.CCIPCapabilityID,
-				Config:       encodedPromotionCall,
-			},
-		},
-		false,
-		nodes.DefaultF(),
-	)
-	if err != nil {
-		return mcms.Operation{}, fmt.Errorf("error creating updateDon op for donID(%d) and plugin type (%d): %w", donID, pluginType, err)
-	}
-	return mcms.Operation{
-		To:    capReg.Address(),
-		Data:  updateDonTx.Data(),
-		Value: big.NewInt(0),
-	}, nil
-}
-
-// promoteAllCandidatesForChainOps promotes the candidate commit and exec configs to active by calling promoteCandidateAndRevokeActive on CCIPHome through the UpdateDON call on CapReg contract
-func promoteAllCandidatesForChainOps(
-	capReg *capabilities_registry.CapabilitiesRegistry,
-	ccipHome *ccip_home.CCIPHome,
-	chainSelector uint64,
-	nodes deployment.Nodes,
-) ([]mcms.Operation, error) {
-	// fetch DON ID for the chain
-	donID, err := ccdeploy.DonIDForChain(capReg, ccipHome, chainSelector)
-	if err != nil {
-		return nil, fmt.Errorf("fetch don id for chain: %w", err)
-	}
-
-	var mcmsOps []mcms.Operation
-	updateCommitOp, err := promoteCandidateOp(donID, uint8(cctypes.PluginTypeCCIPCommit), capReg, ccipHome, nodes)
-	if err != nil {
-		return nil, fmt.Errorf("promote candidate op: %w", err)
-	}
-	mcmsOps = append(mcmsOps, updateCommitOp)
-
-	updateExecOp, err := promoteCandidateOp(donID, uint8(cctypes.PluginTypeCCIPExec), capReg, ccipHome, nodes)
-	if err != nil {
-		return nil, fmt.Errorf("promote candidate op: %w", err)
-	}
-	mcmsOps = append(mcmsOps, updateExecOp)
-
-	return mcmsOps, nil
-}
 
 // PromoteAllCandidatesChangeset generates a proposal to call promoteCandidate on the CCIPHome through CapReg.
 // This needs to be called after SetCandidateProposal is executed.
@@ -149,7 +17,7 @@ func PromoteAllCandidatesChangeset(
 	homeChainSel, newChainSel uint64,
 	nodes deployment.Nodes,
 ) (deployment.ChangesetOutput, error) {
-	promoteCandidateOps, err := promoteAllCandidatesForChainOps(
+	promoteCandidateOps, err := ccdeploy.PromoteAllCandidatesForChainOps(
 		state.Chains[homeChainSel].CapabilityRegistry,
 		state.Chains[homeChainSel].CCIPHome,
 		newChainSel,
@@ -202,7 +70,7 @@ func SetCandidatePluginChangeset(
 		return deployment.ChangesetOutput{}, fmt.Errorf("missing exec plugin in ocr3Configs")
 	}
 
-	setCandidateMCMSOps, err := setCandidateOnExistingDon(
+	setCandidateMCMSOps, err := ccdeploy.SetCandidateOnExistingDon(
 		execConfig,
 		state.Chains[homeChainSel].CapabilityRegistry,
 		state.Chains[homeChainSel].CCIPHome,

--- a/deployment/ccip/changeset/active_candidate_test.go
+++ b/deployment/ccip/changeset/active_candidate_test.go
@@ -156,7 +156,7 @@ func TestActiveCandidate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	setCommitCandidateOp, err := setCandidateOnExistingDon(
+	setCommitCandidateOp, err := ccdeploy.SetCandidateOnExistingDon(
 		ocr3ConfigMap[cctypes.PluginTypeCCIPCommit],
 		state.Chains[homeCS].CapabilityRegistry,
 		state.Chains[homeCS].CCIPHome,
@@ -173,7 +173,7 @@ func TestActiveCandidate(t *testing.T) {
 	ccdeploy.ExecuteProposal(t, e, setCommitCandidateSigned, state, homeCS)
 
 	// create the op for the commit plugin as well
-	setExecCandidateOp, err := setCandidateOnExistingDon(
+	setExecCandidateOp, err := ccdeploy.SetCandidateOnExistingDon(
 		ocr3ConfigMap[cctypes.PluginTypeCCIPExec],
 		state.Chains[homeCS].CapabilityRegistry,
 		state.Chains[homeCS].CCIPHome,
@@ -207,7 +207,7 @@ func TestActiveCandidate(t *testing.T) {
 	oldCandidateDigest, err := state.Chains[homeCS].CCIPHome.GetCandidateDigest(nil, donID, uint8(cctypes.PluginTypeCCIPExec))
 	require.NoError(t, err)
 
-	promoteOps, err := promoteAllCandidatesForChainOps(state.Chains[homeCS].CapabilityRegistry, state.Chains[homeCS].CCIPHome, destCS, nodes.NonBootstraps())
+	promoteOps, err := ccdeploy.PromoteAllCandidatesForChainOps(state.Chains[homeCS].CapabilityRegistry, state.Chains[homeCS].CCIPHome, destCS, nodes.NonBootstraps())
 	require.NoError(t, err)
 	promoteProposal, err := ccdeploy.BuildProposalFromBatches(state, []timelock.BatchChainOperation{{
 		ChainIdentifier: mcms.ChainIdentifier(homeCS),

--- a/deployment/ccip/changeset/active_candidate_test.go
+++ b/deployment/ccip/changeset/active_candidate_test.go
@@ -156,7 +156,7 @@ func TestActiveCandidate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	setCommitCandidateOp, err := SetCandidateOnExistingDon(
+	setCommitCandidateOp, err := setCandidateOnExistingDon(
 		ocr3ConfigMap[cctypes.PluginTypeCCIPCommit],
 		state.Chains[homeCS].CapabilityRegistry,
 		state.Chains[homeCS].CCIPHome,
@@ -173,7 +173,7 @@ func TestActiveCandidate(t *testing.T) {
 	ccdeploy.ExecuteProposal(t, e, setCommitCandidateSigned, state, homeCS)
 
 	// create the op for the commit plugin as well
-	setExecCandidateOp, err := SetCandidateOnExistingDon(
+	setExecCandidateOp, err := setCandidateOnExistingDon(
 		ocr3ConfigMap[cctypes.PluginTypeCCIPExec],
 		state.Chains[homeCS].CapabilityRegistry,
 		state.Chains[homeCS].CCIPHome,
@@ -207,7 +207,7 @@ func TestActiveCandidate(t *testing.T) {
 	oldCandidateDigest, err := state.Chains[homeCS].CCIPHome.GetCandidateDigest(nil, donID, uint8(cctypes.PluginTypeCCIPExec))
 	require.NoError(t, err)
 
-	promoteOps, err := PromoteAllCandidatesForChainOps(state.Chains[homeCS].CapabilityRegistry, state.Chains[homeCS].CCIPHome, destCS, nodes.NonBootstraps())
+	promoteOps, err := promoteAllCandidatesForChainOps(state.Chains[homeCS].CapabilityRegistry, state.Chains[homeCS].CCIPHome, destCS, nodes.NonBootstraps())
 	require.NoError(t, err)
 	promoteProposal, err := ccdeploy.BuildProposalFromBatches(state, []timelock.BatchChainOperation{{
 		ChainIdentifier: mcms.ChainIdentifier(homeCS),

--- a/deployment/ccip/changeset/add_chain_test.go
+++ b/deployment/ccip/changeset/add_chain_test.go
@@ -132,34 +132,28 @@ func TestAddChainInbound(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate and sign inbound proposal to new 4th chain.
-	chainInboundProposal, err := NewChainInboundProposal(e.Env, state, e.HomeChainSel, newChain, initialDeploy)
+	chainInboundChangeset, err := NewChainInboundChangeset(e.Env, state, e.HomeChainSel, newChain, initialDeploy)
 	require.NoError(t, err)
-	chainInboundExec := ccipdeployment.SignProposal(t, e.Env, chainInboundProposal)
-	for _, sel := range initialDeploy {
-		ccipdeployment.ExecuteProposal(t, e.Env, chainInboundExec, state, sel)
-	}
+	ccipdeployment.ProcessChangeset(t, e.Env, e.Ab, chainInboundChangeset)
+
 	// TODO This currently is not working - Able to send the request here but request gets stuck in execution
 	// Send a new message and expect that this is delivered once the chain is completely set up as inbound
 	//TestSendRequest(t, e.Env, state, initialDeploy[0], newChain, true)
 
 	t.Logf("Executing add don and set candidate proposal for commit plugin on chain %d", newChain)
-	addDonProp, err := AddDonAndSetCandidateProposal(state, e.Env, nodes, deployment.XXXGenerateTestOCRSecrets(), e.HomeChainSel, e.FeedChainSel, newChain, tokenConfig, types.PluginTypeCCIPCommit)
+	addDonChangeset, err := AddDonAndSetCandidateChangeset(state, e.Env, nodes, deployment.XXXGenerateTestOCRSecrets(), e.HomeChainSel, e.FeedChainSel, newChain, tokenConfig, types.PluginTypeCCIPCommit)
 	require.NoError(t, err)
-
-	addDonExec := ccipdeployment.SignProposal(t, e.Env, addDonProp)
-	ccipdeployment.ExecuteProposal(t, e.Env, addDonExec, state, e.HomeChainSel)
+	ccipdeployment.ProcessChangeset(t, e.Env, e.Ab, addDonChangeset)
 
 	t.Logf("Executing promote candidate proposal for exec plugin on chain %d", newChain)
-	setCandidateForExecProposal, err := SetCandidatePluginProposal(state, e.Env, nodes, deployment.XXXGenerateTestOCRSecrets(), e.HomeChainSel, e.FeedChainSel, newChain, tokenConfig, types.PluginTypeCCIPExec)
+	setCandidateForExecChangeset, err := SetCandidatePluginChangeset(state, e.Env, nodes, deployment.XXXGenerateTestOCRSecrets(), e.HomeChainSel, e.FeedChainSel, newChain, tokenConfig, types.PluginTypeCCIPExec)
 	require.NoError(t, err)
-	setCandidateForExecExec := ccipdeployment.SignProposal(t, e.Env, setCandidateForExecProposal)
-	ccipdeployment.ExecuteProposal(t, e.Env, setCandidateForExecExec, state, e.HomeChainSel)
+	ccipdeployment.ProcessChangeset(t, e.Env, e.Ab, setCandidateForExecChangeset)
 
 	t.Logf("Executing promote candidate proposal for both commit and exec plugins on chain %d", newChain)
-	donPromoteProposal, err := PromoteAllCandidatesProposal(state, e.HomeChainSel, newChain, nodes)
+	donPromoteChangeset, err := PromoteAllCandidatesChangeset(state, e.HomeChainSel, newChain, nodes)
 	require.NoError(t, err)
-	donPromoteExec := ccipdeployment.SignProposal(t, e.Env, donPromoteProposal)
-	ccipdeployment.ExecuteProposal(t, e.Env, donPromoteExec, state, e.HomeChainSel)
+	ccipdeployment.ProcessChangeset(t, e.Env, e.Ab, donPromoteChangeset)
 
 	// verify if the configs are updated
 	require.NoError(t, ccipdeployment.ValidateCCIPHomeConfigSetUp(

--- a/deployment/ccip/changeset/add_chain_test.go
+++ b/deployment/ccip/changeset/add_chain_test.go
@@ -134,7 +134,7 @@ func TestAddChainInbound(t *testing.T) {
 	// Generate and sign inbound proposal to new 4th chain.
 	chainInboundChangeset, err := NewChainInboundChangeset(e.Env, state, e.HomeChainSel, newChain, initialDeploy)
 	require.NoError(t, err)
-	ccipdeployment.ProcessChangeset(t, e.Env, e.Ab, chainInboundChangeset)
+	ccipdeployment.ProcessChangeset(t, e.Env, chainInboundChangeset)
 
 	// TODO This currently is not working - Able to send the request here but request gets stuck in execution
 	// Send a new message and expect that this is delivered once the chain is completely set up as inbound
@@ -143,17 +143,17 @@ func TestAddChainInbound(t *testing.T) {
 	t.Logf("Executing add don and set candidate proposal for commit plugin on chain %d", newChain)
 	addDonChangeset, err := AddDonAndSetCandidateChangeset(state, e.Env, nodes, deployment.XXXGenerateTestOCRSecrets(), e.HomeChainSel, e.FeedChainSel, newChain, tokenConfig, types.PluginTypeCCIPCommit)
 	require.NoError(t, err)
-	ccipdeployment.ProcessChangeset(t, e.Env, e.Ab, addDonChangeset)
+	ccipdeployment.ProcessChangeset(t, e.Env, addDonChangeset)
 
 	t.Logf("Executing promote candidate proposal for exec plugin on chain %d", newChain)
 	setCandidateForExecChangeset, err := SetCandidatePluginChangeset(state, e.Env, nodes, deployment.XXXGenerateTestOCRSecrets(), e.HomeChainSel, e.FeedChainSel, newChain, tokenConfig, types.PluginTypeCCIPExec)
 	require.NoError(t, err)
-	ccipdeployment.ProcessChangeset(t, e.Env, e.Ab, setCandidateForExecChangeset)
+	ccipdeployment.ProcessChangeset(t, e.Env, setCandidateForExecChangeset)
 
 	t.Logf("Executing promote candidate proposal for both commit and exec plugins on chain %d", newChain)
 	donPromoteChangeset, err := PromoteAllCandidatesChangeset(state, e.HomeChainSel, newChain, nodes)
 	require.NoError(t, err)
-	ccipdeployment.ProcessChangeset(t, e.Env, e.Ab, donPromoteChangeset)
+	ccipdeployment.ProcessChangeset(t, e.Env, donPromoteChangeset)
 
 	// verify if the configs are updated
 	require.NoError(t, ccipdeployment.ValidateCCIPHomeConfigSetUp(

--- a/deployment/ccip/test_helpers.go
+++ b/deployment/ccip/test_helpers.go
@@ -390,13 +390,13 @@ func ConfirmRequestOnSourceAndDest(t *testing.T, env deployment.Environment, sta
 	return nil
 }
 
-func ProcessChangeset(t *testing.T, e deployment.Environment, ab deployment.AddressBook, c deployment.ChangesetOutput) {
+func ProcessChangeset(t *testing.T, e deployment.Environment, c deployment.ChangesetOutput) {
 
 	// TODO: Add support for jobspecs as well
 
 	// sign and execute all proposals provided
 	if len(c.Proposals) != 0 {
-		state, err := LoadOnchainState(e, ab)
+		state, err := LoadOnchainState(e)
 		require.NoError(t, err)
 		for _, prop := range c.Proposals {
 			chains := mapset.NewSet[uint64]()
@@ -413,7 +413,7 @@ func ProcessChangeset(t *testing.T, e deployment.Environment, ab deployment.Addr
 
 	// merge address books
 	if c.AddressBook != nil {
-		err := ab.Merge(c.AddressBook)
+		err := e.ExistingAddresses.Merge(c.AddressBook)
 		require.NoError(t, err)
 	}
 }

--- a/deployment/ccip/test_helpers.go
+++ b/deployment/ccip/test_helpers.go
@@ -3,6 +3,7 @@ package ccipdeployment
 import (
 	"context"
 	"fmt"
+	mapset "github.com/deckarep/golang-set/v2"
 	"math/big"
 	"sort"
 	"testing"
@@ -387,4 +388,32 @@ func ConfirmRequestOnSourceAndDest(t *testing.T, env deployment.Environment, sta
 		ConfirmExecWithSeqNr(t, env.Chains[sourceCS], env.Chains[destCS], state.Chains[destCS].OffRamp, &startBlock, seqNum))
 
 	return nil
+}
+
+func ProcessChangeset(t *testing.T, e deployment.Environment, ab deployment.AddressBook, c deployment.ChangesetOutput) {
+
+	// TODO: Add support for jobspecs as well
+
+	// sign and execute all proposals provided
+	if len(c.Proposals) != 0 {
+		state, err := LoadOnchainState(e, ab)
+		require.NoError(t, err)
+		for _, prop := range c.Proposals {
+			chains := mapset.NewSet[uint64]()
+			for _, op := range prop.Transactions {
+				chains.Add(uint64(op.ChainIdentifier))
+			}
+
+			signed := SignProposal(t, e, &prop)
+			for _, sel := range chains.ToSlice() {
+				ExecuteProposal(t, e, signed, state, sel)
+			}
+		}
+	}
+
+	// merge address books
+	if c.AddressBook != nil {
+		err := ab.Merge(c.AddressBook)
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
Refactor the `deployment/changeset` code. Any functions there should return a `deployment.Changeset`, while their support code should live under `/ccip`. 

Also introduced a function to "process changeset" for ease of executing the outputs of these operations