### PR TITLE
Fix the log event trigger to match the schema.

### DIFF
--- a/core/capabilities/triggers/logevent/logeventcap/event_trigger-schema.json
+++ b/core/capabilities/triggers/logevent/logeventcap/event_trigger-schema.json
@@ -17,7 +17,8 @@
                     "type": "integer",
                     "minimum": 0
                 }
-            }
+            },
+            "required": ["Height", "Hash", "Timestamp"]
         },
         "config": {
             "type": "object",

--- a/core/capabilities/triggers/logevent/logeventcap/event_trigger_generated.go
+++ b/core/capabilities/triggers/logevent/logeventcap/event_trigger_generated.go
@@ -85,26 +85,39 @@ func (j *Config) UnmarshalJSON(b []byte) error {
 
 type Head struct {
 	// Hash corresponds to the JSON schema field "Hash".
-	Hash *string `json:"Hash,omitempty" yaml:"Hash,omitempty" mapstructure:"Hash,omitempty"`
+	Hash string `json:"Hash" yaml:"Hash" mapstructure:"Hash"`
 
 	// Height corresponds to the JSON schema field "Height".
-	Height *string `json:"Height,omitempty" yaml:"Height,omitempty" mapstructure:"Height,omitempty"`
+	Height string `json:"Height" yaml:"Height" mapstructure:"Height"`
 
 	// Timestamp corresponds to the JSON schema field "Timestamp".
-	Timestamp *uint64 `json:"Timestamp,omitempty" yaml:"Timestamp,omitempty" mapstructure:"Timestamp,omitempty"`
+	Timestamp uint64 `json:"Timestamp" yaml:"Timestamp" mapstructure:"Timestamp"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *Head) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["Hash"]; raw != nil && !ok {
+		return fmt.Errorf("field Hash in Head: required")
+	}
+	if _, ok := raw["Height"]; raw != nil && !ok {
+		return fmt.Errorf("field Height in Head: required")
+	}
+	if _, ok := raw["Timestamp"]; raw != nil && !ok {
+		return fmt.Errorf("field Timestamp in Head: required")
+	}
 	type Plain Head
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	if plain.Hash != nil && len(*plain.Hash) < 1 {
+	if len(plain.Hash) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "Hash", 1)
 	}
-	if plain.Height != nil && len(*plain.Height) < 1 {
+	if len(plain.Height) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "Height", 1)
 	}
 	*j = Head(plain)

--- a/core/capabilities/triggers/logevent/trigger.go
+++ b/core/capabilities/triggers/logevent/trigger.go
@@ -183,14 +183,14 @@ func createTriggerResponse(log types.Sequence, version string) capabilities.Trig
 	dataAsValuesMap, err := values.WrapMap(log.Data)
 	if err != nil {
 		return capabilities.TriggerResponse{
-			Err: fmt.Errorf("error decoding log data as values.Map: %s", err),
+			Err: fmt.Errorf("error decoding log data as values.Map: %w", err),
 		}
 	}
 	dataAsMap := map[string]any{}
 	err = dataAsValuesMap.UnwrapTo(&dataAsMap)
 	if err != nil {
 		return capabilities.TriggerResponse{
-			Err: fmt.Errorf("error decoding log data as map[string]any: %s", err),
+			Err: fmt.Errorf("error decoding log data as map[string]any: %w", err),
 		}
 	}
 
@@ -205,7 +205,7 @@ func createTriggerResponse(log types.Sequence, version string) capabilities.Trig
 	})
 	if err != nil {
 		return capabilities.TriggerResponse{
-			Err: fmt.Errorf("error wrapping trigger event: %s", err),
+			Err: fmt.Errorf("error wrapping trigger event: %w", err),
 		}
 	}
 

--- a/core/capabilities/triggers/logevent/trigger.go
+++ b/core/capabilities/triggers/logevent/trigger.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-viper/mapstructure/v2"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -181,10 +180,17 @@ func (l *logEventTrigger) listen() {
 
 // Create log event trigger capability response
 func createTriggerResponse(log types.Sequence, version string) capabilities.TriggerResponse {
-	dataAsMap := map[string]any{}
-	if err := mapstructure.Decode(log.Data, &dataAsMap); err != nil {
+	dataAsValuesMap, err := values.WrapMap(log.Data)
+	if err != nil {
 		return capabilities.TriggerResponse{
-			Err: fmt.Errorf("error decoding log data: %s", err),
+			Err: fmt.Errorf("error decoding log data as values.Map: %s", err),
+		}
+	}
+	dataAsMap := map[string]any{}
+	err = dataAsValuesMap.UnwrapTo(&dataAsMap)
+	if err != nil {
+		return capabilities.TriggerResponse{
+			Err: fmt.Errorf("error decoding log data as map[string]any: %s", err),
 		}
 	}
 
@@ -192,7 +198,7 @@ func createTriggerResponse(log types.Sequence, version string) capabilities.Trig
 		Cursor: log.Cursor,
 		Data:   dataAsMap,
 		Head: logeventcap.Head{
-			Hash:      string(log.Hash),
+			Hash:      fmt.Sprintf("0x%x", log.Hash),
 			Height:    log.Height,
 			Timestamp: log.Timestamp,
 		},

--- a/core/capabilities/triggers/logevent/trigger.go
+++ b/core/capabilities/triggers/logevent/trigger.go
@@ -2,6 +2,7 @@ package logevent
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -192,7 +193,7 @@ func createTriggerResponse(log types.Sequence, version string) capabilities.Trig
 		Cursor: log.Cursor,
 		Data:   dataAsMap,
 		Head: logeventcap.Head{
-			Hash:      string(log.Hash),
+			Hash:      "0x" + hex.EncodeToString(log.Hash),
 			Height:    log.Height,
 			Timestamp: log.Timestamp,
 		},

--- a/core/capabilities/triggers/logevent/trigger.go
+++ b/core/capabilities/triggers/logevent/trigger.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -180,12 +181,28 @@ func (l *logEventTrigger) listen() {
 
 // Create log event trigger capability response
 func createTriggerResponse(log types.Sequence, version string) capabilities.TriggerResponse {
-	wrappedPayload, err := values.WrapMap(log)
+	dataAsMap := map[string]any{}
+	if err := mapstructure.Decode(log.Data, &dataAsMap); err != nil {
+		return capabilities.TriggerResponse{
+			Err: fmt.Errorf("error decoding log data: %s", err),
+		}
+	}
+
+	wrappedPayload, err := values.WrapMap(&logeventcap.Output{
+		Cursor: log.Cursor,
+		Data:   dataAsMap,
+		Head: logeventcap.Head{
+			Hash:      string(log.Hash),
+			Height:    log.Height,
+			Timestamp: log.Timestamp,
+		},
+	})
 	if err != nil {
 		return capabilities.TriggerResponse{
 			Err: fmt.Errorf("error wrapping trigger event: %s", err),
 		}
 	}
+
 	return capabilities.TriggerResponse{
 		Event: capabilities.TriggerEvent{
 			TriggerType: version,

--- a/core/scripts/gateway/web_api_trigger/test_server/test_server.go
+++ b/core/scripts/gateway/web_api_trigger/test_server/test_server.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// Log request method and URL
+	fmt.Printf("Received %s request for %s\n", r.Method, r.URL.Path)
+
+	// Handle GET requests
+	if r.Method == http.MethodGet {
+		fmt.Println("GET request received")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("GET request received"))
+	}
+
+	// Handle POST requests
+	if r.Method == http.MethodPost {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Could not read request body", http.StatusInternalServerError)
+			return
+		}
+		fmt.Printf("POST request body: %s\n", string(body))
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func lockHandler(w http.ResponseWriter, r *http.Request) {
+	// Log request method and URL
+	fmt.Printf("Received %s request for %s\n", r.Method, r.URL.Path)
+
+	// Handle POST requests
+	if r.Method == http.MethodPost {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Could not read request body", http.StatusInternalServerError)
+			return
+		}
+		fmt.Printf("Assets locked. E2E ID: %s\n", string(body))
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func unlockHandler(w http.ResponseWriter, r *http.Request) {
+	// Log request method and URL
+	fmt.Printf("Received %s request for %s\n", r.Method, r.URL.Path)
+
+	// Handle POST requests
+	if r.Method == http.MethodPost {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Could not read request body", http.StatusInternalServerError)
+			return
+		}
+		fmt.Printf("Assets unlocked. Settlement E2E ID: %s\n", string(body))
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func main() {
+	// Register the handler for all incoming requests
+	http.HandleFunc("/", handler)
+	http.HandleFunc("/lock", lockHandler)
+	http.HandleFunc("/unlock", unlockHandler)
+
+	// Listen on port 1000
+	port := ":1000"
+	fmt.Printf("Server listening on port %s\n", port)
+	log.Fatal(http.ListenAndServe(port, nil))
+}

--- a/core/scripts/gateway/web_api_trigger/test_server/test_server.go
+++ b/core/scripts/gateway/web_api_trigger/test_server/test_server.go
@@ -3,9 +3,8 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
-	"log"
 	"net/http"
+	"time"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -16,12 +15,16 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodGet {
 		fmt.Println("GET request received")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("GET request received"))
+		_, err := w.Write([]byte("GET request received"))
+		if err != nil {
+			http.Error(w, "could not write request body", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Handle POST requests
 	if r.Method == http.MethodPost {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "Could not read request body", http.StatusInternalServerError)
 			return
@@ -75,5 +78,12 @@ func main() {
 	// Listen on port 1000
 	port := ":1000"
 	fmt.Printf("Server listening on port %s\n", port)
-	log.Fatal(http.ListenAndServe(port, nil))
+	server := &http.Server{
+		Addr:              port,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	err := server.ListenAndServe()
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
## Testing

```
$ go test -count=1 -v -run="^TestLogEventTrigger" ./core/services/relay/evm/capabilities

    logger.go:146: 2024-10-30T18:54:06.764Z     INFO    testutils/chain_reader.go:119   Received log from ContractReader        {"version": "unset@unset", "event": "5-0-0x628a5a8a350ef002867da9f312efc69624334cbfd5efceafef04c91881fbe2ff"}
    logger.go:146: 2024-10-30T18:54:06.764Z     INFO    capabilities/log_event_trigger_test.go:142      EmitLog {"version": "unset@unset", "output": {"Cursor":"5-0-0x628a5a8a350ef002867da9f312efc69624334cbfd5efceafef04c91881fbe2ff","Data":{"Arg0":11},"Head":{"Hash":"0xd19dff3f9dbdc4a8ebd715205f0f3f261c529c48a7af1e58c74f76100906da66","Height":"5","Timestamp":1730228093}}}
    logger.go:146: 2024-10-30T18:54:06.764Z     INFO    testutils/chain_reader.go:119   Received log from ContractReader        {"version": "unset@unset", "event": "5-1-0x628a5a8a350ef002867da9f312efc69624334cbfd5efceafef04c91881fbe2ff"}
    logger.go:146: 2024-10-30T18:54:06.764Z     INFO    capabilities/log_event_trigger_test.go:142      EmitLog {"version": "unset@unset", "output": {"Cursor":"5-1-0x628a5a8a350ef002867da9f312efc69624334cbfd5efceafef04c91881fbe2ff","Data":{"Arg0":12},"Head":{"Hash":"0xd19dff3f9dbdc4a8ebd715205f0f3f261c529c48a7af1e58c74f76100906da66","Height":"5","Timestamp":1730228093}}}
    logger.go:146: 2024-10-30T18:54:06.764Z     INFO    LogEventTriggerCapabilityService        logevent/service.go:149 Stopping LogEventTriggerCapabilityService       {"version": "unset@unset"}
    logger.go:146: 2024-10-30T18:54:06.764Z     INFO    LogEventTriggerCapabilityService.LogEventTrigger.       logevent/trigger.go:132 Closing trigger server for (waiting for waitGroup)    {"version": "unset@unset", "ChainID": "1337", "ContractName": "LogEmitter", "ContractAddress": "0x8ce5C96406EeC86BbA6D74860F5BeBaA73ea46D3", "ContractEventName": "Log1"}
--- PASS: TestLogEventTriggerCursorNewLogs (3.03s)
PASS
ok      github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/capabilities   4.244s
```