### PR TITLE
deployment: use pointer for eth tx

### DIFF
--- a/core/scripts/chaincli/handler/report.go
+++ b/core/scripts/chaincli/handler/report.go
@@ -210,7 +210,7 @@ func NewOCR2Transaction(raw map[string]interface{}) (*OCR2Transaction, error) {
 		encoder: evm.EVMAutomationEncoder20{},
 		abi:     contract,
 		raw:     raw,
-		tx:      tx,
+		tx:      &tx,
 	}, nil
 }
 
@@ -218,7 +218,7 @@ type OCR2Transaction struct {
 	encoder evm.EVMAutomationEncoder20
 	abi     abi.ABI
 	raw     map[string]interface{}
-	tx      types.Transaction
+	tx      *types.Transaction
 }
 
 func (t *OCR2Transaction) TransactionHash() common.Hash {
@@ -252,7 +252,7 @@ func (t *OCR2Transaction) To() *common.Address {
 func (t *OCR2Transaction) From() (common.Address, error) {
 	switch t.tx.Type() {
 	case 2:
-		from, err := types.Sender(types.NewLondonSigner(t.tx.ChainId()), &t.tx)
+		from, err := types.Sender(types.NewLondonSigner(t.tx.ChainId()), t.tx)
 		if err != nil {
 			return common.Address{}, fmt.Errorf("failed to get from addr: %s", err)
 		} else {

--- a/deployment/environment/devenv/chain.go
+++ b/deployment/environment/devenv/chain.go
@@ -74,7 +74,7 @@ func NewChains(logger logger.Logger, configs []ChainConfig) (map[uint64]deployme
 				}
 				blockNumber = receipt.BlockNumber.Uint64()
 				if receipt.Status == 0 {
-					errReason, err := deployment.GetErrorReasonFromTx(ec, chainCfg.DeployerKey.From, *tx, receipt)
+					errReason, err := deployment.GetErrorReasonFromTx(ec, chainCfg.DeployerKey.From, tx, receipt)
 					if err == nil && errReason != "" {
 						return blockNumber, fmt.Errorf("tx %s reverted,error reason: %s", tx.Hash().Hex(), errReason)
 					}

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -63,7 +63,7 @@ func generateMemoryChain(t *testing.T, inputs map[uint64]EVMChain) map[uint64]de
 						continue
 					}
 					if receipt.Status == 0 {
-						errReason, err := deployment.GetErrorReasonFromTx(chain.Backend, chain.DeployerKey.From, *tx, receipt)
+						errReason, err := deployment.GetErrorReasonFromTx(chain.Backend, chain.DeployerKey.From, tx, receipt)
 						if err == nil && errReason != "" {
 							return 0, fmt.Errorf("tx %s reverted,error reason: %s", tx.Hash().Hex(), errReason)
 						}

--- a/deployment/helpers.go
+++ b/deployment/helpers.go
@@ -44,7 +44,7 @@ func SimTransactOpts() *bind.TransactOpts {
 	}, From: common.HexToAddress("0x0"), NoSend: true, GasLimit: 1_000_000}
 }
 
-func GetErrorReasonFromTx(client bind.ContractBackend, from common.Address, tx types.Transaction, receipt *types.Receipt) (string, error) {
+func GetErrorReasonFromTx(client bind.ContractBackend, from common.Address, tx *types.Transaction, receipt *types.Receipt) (string, error) {
 	call := ethereum.CallMsg{
 		From:     from,
 		To:       tx.To(),

--- a/deployment/multiclient.go
+++ b/deployment/multiclient.go
@@ -103,9 +103,9 @@ func (mc *MultiClient) WaitMined(ctx context.Context, tx *types.Transaction) (*t
 	resultCh := make(chan *types.Receipt)
 	doneCh := make(chan struct{})
 
-	waitMined := func(client *ethclient.Client, tx types.Transaction) {
+	waitMined := func(client *ethclient.Client, tx *types.Transaction) {
 		mc.lggr.Debugf("Waiting for tx %s to be mined with client %v", tx.Hash().Hex(), client)
-		receipt, err := bind.WaitMined(ctx, client, &tx)
+		receipt, err := bind.WaitMined(ctx, client, tx)
 		if err != nil {
 			mc.lggr.Warnf("WaitMined error %v with client %v", err, client)
 			return
@@ -118,9 +118,7 @@ func (mc *MultiClient) WaitMined(ctx context.Context, tx *types.Transaction) (*t
 	}
 
 	for _, client := range append([]*ethclient.Client{mc.Client}, mc.Backups...) {
-		txn := tx
-		c := client
-		go waitMined(c, *txn)
+		go waitMined(client, tx)
 	}
 	var receipt *types.Receipt
 	select {


### PR DESCRIPTION
Geth `Transaction`s must not be passed by value (copied), because they contain atomic fields.