### PR TITLE
Add StreamSpec graphql type

### DIFF
--- a/core/web/resolver/spec.go
+++ b/core/web/resolver/spec.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"fmt"
+
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -131,6 +133,14 @@ func (r *SpecResolver) ToStandardCapabilitiesSpec() (*StandardCapabilitiesSpecRe
 	}
 
 	return &StandardCapabilitiesSpecResolver{spec: *r.j.StandardCapabilitiesSpec}, true
+}
+
+func (r *SpecResolver) ToStreamSpec() (*StreamSpecResolver, bool) {
+	if r.j.Type != job.Stream {
+		return nil, false
+	}
+
+	return &StreamSpecResolver{streamID: fmt.Sprintf("%d", r.j.StreamID)}, true
 }
 
 type CronSpecResolver struct {
@@ -1044,4 +1054,12 @@ func (r *StandardCapabilitiesSpecResolver) Command() string {
 
 func (r *StandardCapabilitiesSpecResolver) Config() *string {
 	return &r.spec.Config
+}
+
+type StreamSpecResolver struct {
+	streamID string
+}
+
+func (r *StreamSpecResolver) StreamID() string {
+	return r.streamID
 }

--- a/core/web/schema/type/spec.graphql
+++ b/core/web/schema/type/spec.graphql
@@ -12,7 +12,8 @@ union JobSpec =
     BootstrapSpec |
     GatewaySpec |
     WorkflowSpec |
-    StandardCapabilitiesSpec
+    StandardCapabilitiesSpec |
+    StreamSpec
 
 type CronSpec {
     schedule: String!
@@ -178,4 +179,8 @@ type StandardCapabilitiesSpec {
     createdAt: Time!
     command: String!
     config: String
+}
+
+type StreamSpec {
+    streamID: String!
 }


### PR DESCRIPTION
This PR adds a new `StreamSpec` graphql type corresponding to the new Stream job type.

Unlike other job types, the [`Job`](https://github.com/smartcontractkit/chainlink/blob/develop/core/services/job/models.go#L142-L198) Go struct doesn't have a stream spec field, and instead it has a new StreamID field. However, because the gql Job type requires a spec field that's a union type of across all of the underlying job types, I feel like it's simpler to define a StreamSpec gql type that contains this StreamID, rather than make the spec field optional.