### PR TITLE
core: service audit

### DIFF
--- a/core/capabilities/gateway_connector/service_wrapper.go
+++ b/core/capabilities/gateway_connector/service_wrapper.go
@@ -55,7 +55,7 @@ func NewGatewayConnectorServiceWrapper(config config.GatewayConnector, keystore 
 		config:   config,
 		keystore: keystore,
 		clock:    clock,
-		lggr:     lggr,
+		lggr:     lggr.Named("GatewayConnectorServiceWrapper"),
 	}
 }
 
@@ -106,7 +106,7 @@ func (e *ServiceWrapper) HealthReport() map[string]error {
 }
 
 func (e *ServiceWrapper) Name() string {
-	return "GatewayConnectorServiceWrapper"
+	return e.lggr.Name()
 }
 
 func (e *ServiceWrapper) GetGatewayConnector() connector.GatewayConnector {

--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -124,7 +124,7 @@ func (w *launcher) HealthReport() map[string]error {
 }
 
 func (w *launcher) Name() string {
-	return "CapabilitiesLauncher"
+	return w.lggr.Name()
 }
 
 func (w *launcher) Launch(ctx context.Context, state *registrysyncer.LocalRegistry) error {

--- a/core/capabilities/remote/dispatcher.go
+++ b/core/capabilities/remote/dispatcher.go
@@ -236,5 +236,5 @@ func (d *dispatcher) HealthReport() map[string]error {
 }
 
 func (d *dispatcher) Name() string {
-	return "Dispatcher"
+	return d.lggr.Name()
 }

--- a/core/capabilities/remote/target/client.go
+++ b/core/capabilities/remote/target/client.go
@@ -202,5 +202,5 @@ func (c *client) HealthReport() map[string]error {
 }
 
 func (c *client) Name() string {
-	return "TargetClient"
+	return c.lggr.Name()
 }

--- a/core/capabilities/remote/target/server.go
+++ b/core/capabilities/remote/target/server.go
@@ -226,5 +226,5 @@ func (r *server) HealthReport() map[string]error {
 }
 
 func (r *server) Name() string {
-	return "TargetServer"
+	return r.lggr.Name()
 }

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -333,5 +333,5 @@ func (p *triggerPublisher) HealthReport() map[string]error {
 }
 
 func (p *triggerPublisher) Name() string {
-	return "TriggerPublisher"
+	return p.lggr.Name()
 }

--- a/core/capabilities/remote/trigger_subscriber.go
+++ b/core/capabilities/remote/trigger_subscriber.go
@@ -3,7 +3,7 @@ package remote
 import (
 	"context"
 	"errors"
-	sync "sync"
+	"sync"
 	"time"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
@@ -269,5 +269,5 @@ func (s *triggerSubscriber) HealthReport() map[string]error {
 }
 
 func (s *triggerSubscriber) Name() string {
-	return "TriggerSubscriber"
+	return s.lggr.Name()
 }

--- a/core/capabilities/webapi/trigger/trigger.go
+++ b/core/capabilities/webapi/trigger/trigger.go
@@ -265,7 +265,7 @@ func (h *triggerConnectorHandler) HealthReport() map[string]error {
 }
 
 func (h *triggerConnectorHandler) Name() string {
-	return "WebAPITrigger"
+	return h.lggr.Name()
 }
 
 func (h *triggerConnectorHandler) sendResponse(ctx context.Context, gatewayID string, requestBody *api.MessageBody, payload any) error {

--- a/core/services/p2p/peer.go
+++ b/core/services/p2p/peer.go
@@ -232,5 +232,5 @@ func (p *peer) HealthReport() map[string]error {
 }
 
 func (p *peer) Name() string {
-	return "P2PPeer"
+	return p.lggr.Name()
 }

--- a/core/services/p2p/wrapper/wrapper.go
+++ b/core/services/p2p/wrapper/wrapper.go
@@ -36,7 +36,7 @@ func NewExternalPeerWrapper(keystoreP2P keystore.P2P, p2pConfig config.P2P, ds s
 	return &peerWrapper{
 		keystoreP2P: keystoreP2P,
 		p2pConfig:   p2pConfig,
-		lggr:        lggr,
+		lggr:        lggr.Named("PeerWrapper"),
 		ds:          ds,
 	}
 }
@@ -126,7 +126,7 @@ func (e *peerWrapper) HealthReport() map[string]error {
 }
 
 func (e *peerWrapper) Name() string {
-	return "PeerWrapper"
+	return e.lggr.Name()
 }
 
 func (e *peerWrapper) Sign(msg []byte) ([]byte, error) {

--- a/core/services/registrysyncer/syncer.go
+++ b/core/services/registrysyncer/syncer.go
@@ -444,14 +444,10 @@ func (s *registrySyncer) Close() error {
 	})
 }
 
-func (s *registrySyncer) Ready() error {
-	return nil
-}
-
 func (s *registrySyncer) HealthReport() map[string]error {
-	return nil
+	return map[string]error{s.Name(): s.Healthy()}
 }
 
 func (s *registrySyncer) Name() string {
-	return "RegistrySyncer"
+	return s.lggr.Name()
 }

--- a/core/services/relay/evm/chain_writer.go
+++ b/core/services/relay/evm/chain_writer.go
@@ -223,17 +223,11 @@ func (w *chainWriter) Close() error {
 }
 
 func (w *chainWriter) HealthReport() map[string]error {
-	return map[string]error{
-		w.Name(): nil,
-	}
+	return map[string]error{w.Name(): w.Healthy()}
 }
 
 func (w *chainWriter) Name() string {
-	return "chain-writer"
-}
-
-func (w *chainWriter) Ready() error {
-	return nil
+	return w.logger.Name()
 }
 
 func (w *chainWriter) Start(ctx context.Context) error {

--- a/core/services/relay/evm/commit_provider.go
+++ b/core/services/relay/evm/commit_provider.go
@@ -3,6 +3,7 @@ package evm
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 
 	"go.uber.org/multierr"
@@ -47,7 +48,7 @@ func NewSrcCommitProvider(
 	maxGasPrice *big.Int,
 ) commontypes.CCIPCommitProvider {
 	return &SrcCommitProvider{
-		lggr:        lggr,
+		lggr:        logger.Named(lggr, "SrcCommitProvider"),
 		startBlock:  startBlock,
 		client:      client,
 		lp:          lp,
@@ -84,7 +85,7 @@ func NewDstCommitProvider(
 	configWatcher *configWatcher,
 ) commontypes.CCIPCommitProvider {
 	return &DstCommitProvider{
-		lggr:                lggr,
+		lggr:                logger.Named(lggr, "DstCommitProvider"),
 		versionFinder:       versionFinder,
 		startBlock:          startBlock,
 		client:              client,
@@ -96,24 +97,24 @@ func NewDstCommitProvider(
 	}
 }
 
-func (P *SrcCommitProvider) Name() string {
-	return "CCIPCommitProvider.SrcRelayerProvider"
+func (p *SrcCommitProvider) Name() string {
+	return p.lggr.Name()
 }
 
 // Close is called when the job that created this provider is deleted.
 // At this time, any of the methods on the provider may or may not have been called.
 // If NewOnRampReader has not been called, their corresponding
 // Close methods will be expected to error.
-func (P *SrcCommitProvider) Close() error {
+func (p *SrcCommitProvider) Close() error {
 	versionFinder := ccip.NewEvmVersionFinder()
 
 	unregisterFuncs := make([]func() error, 0, 2)
 	unregisterFuncs = append(unregisterFuncs, func() error {
 		// avoid panic in the case NewOnRampReader wasn't called
-		if P.seenOnRampAddress == nil {
+		if p.seenOnRampAddress == nil {
 			return nil
 		}
-		return ccip.CloseOnRampReader(P.lggr, versionFinder, *P.seenSourceChainSelector, *P.seenDestChainSelector, *P.seenOnRampAddress, P.lp, P.client)
+		return ccip.CloseOnRampReader(p.lggr, versionFinder, *p.seenSourceChainSelector, *p.seenDestChainSelector, *p.seenOnRampAddress, p.lp, p.client)
 	})
 
 	var multiErr error
@@ -125,59 +126,59 @@ func (P *SrcCommitProvider) Close() error {
 	return multiErr
 }
 
-func (P *SrcCommitProvider) Ready() error {
+func (p *SrcCommitProvider) Ready() error {
 	return nil
 }
 
-func (P *SrcCommitProvider) HealthReport() map[string]error {
-	return make(map[string]error)
+func (p *SrcCommitProvider) HealthReport() map[string]error {
+	return map[string]error{p.Name(): nil}
 }
 
-func (P *SrcCommitProvider) OffchainConfigDigester() ocrtypes.OffchainConfigDigester {
+func (p *SrcCommitProvider) OffchainConfigDigester() ocrtypes.OffchainConfigDigester {
 	// TODO CCIP-2494
 	// "OffchainConfigDigester called on SrcCommitProvider. Valid on DstCommitProvider."
 	return UnimplementedOffchainConfigDigester{}
 }
 
-func (P *SrcCommitProvider) ContractConfigTracker() ocrtypes.ContractConfigTracker {
+func (p *SrcCommitProvider) ContractConfigTracker() ocrtypes.ContractConfigTracker {
 	// // TODO CCIP-2494
 	// "ContractConfigTracker called on SrcCommitProvider. Valid on DstCommitProvider.")
 	return UnimplementedContractConfigTracker{}
 }
 
-func (P *SrcCommitProvider) ContractTransmitter() ocrtypes.ContractTransmitter {
+func (p *SrcCommitProvider) ContractTransmitter() ocrtypes.ContractTransmitter {
 	// // TODO CCIP-2494
 	// "ContractTransmitter called on SrcCommitProvider. Valid on DstCommitProvider."
 	return UnimplementedContractTransmitter{}
 }
 
-func (P *SrcCommitProvider) ContractReader() commontypes.ContractReader {
+func (p *SrcCommitProvider) ContractReader() commontypes.ContractReader {
 	return nil
 }
 
-func (P *SrcCommitProvider) Codec() commontypes.Codec {
+func (p *SrcCommitProvider) Codec() commontypes.Codec {
 	return nil
 }
 
-func (P *DstCommitProvider) Name() string {
-	return "CCIPCommitProvider.DstRelayerProvider"
+func (p *DstCommitProvider) Name() string {
+	return p.lggr.Name()
 }
 
-func (P *DstCommitProvider) Close() error {
+func (p *DstCommitProvider) Close() error {
 	versionFinder := ccip.NewEvmVersionFinder()
 
 	unregisterFuncs := make([]func() error, 0, 2)
 	unregisterFuncs = append(unregisterFuncs, func() error {
-		if P.seenCommitStoreAddress == nil {
+		if p.seenCommitStoreAddress == nil {
 			return nil
 		}
-		return ccip.CloseCommitStoreReader(P.lggr, versionFinder, *P.seenCommitStoreAddress, P.client, P.lp)
+		return ccip.CloseCommitStoreReader(p.lggr, versionFinder, *p.seenCommitStoreAddress, p.client, p.lp)
 	})
 	unregisterFuncs = append(unregisterFuncs, func() error {
-		if P.seenOffRampAddress == nil {
+		if p.seenOffRampAddress == nil {
 			return nil
 		}
-		return ccip.CloseOffRampReader(P.lggr, versionFinder, *P.seenOffRampAddress, P.client, P.lp, nil, big.NewInt(0))
+		return ccip.CloseOffRampReader(p.lggr, versionFinder, *p.seenOffRampAddress, p.client, p.lp, nil, big.NewInt(0))
 	})
 
 	var multiErr error
@@ -189,110 +190,116 @@ func (P *DstCommitProvider) Close() error {
 	return multiErr
 }
 
-func (P *DstCommitProvider) Ready() error {
+func (p *DstCommitProvider) Ready() error {
 	return nil
 }
 
-func (P *DstCommitProvider) HealthReport() map[string]error {
+func (p *DstCommitProvider) HealthReport() map[string]error {
 	return make(map[string]error)
 }
 
-func (P *DstCommitProvider) OffchainConfigDigester() ocrtypes.OffchainConfigDigester {
-	return P.configWatcher.OffchainConfigDigester()
+func (p *DstCommitProvider) OffchainConfigDigester() ocrtypes.OffchainConfigDigester {
+	return p.configWatcher.OffchainConfigDigester()
 }
 
-func (P *DstCommitProvider) ContractConfigTracker() ocrtypes.ContractConfigTracker {
-	return P.configWatcher.ContractConfigTracker()
+func (p *DstCommitProvider) ContractConfigTracker() ocrtypes.ContractConfigTracker {
+	return p.configWatcher.ContractConfigTracker()
 }
 
-func (P *DstCommitProvider) ContractTransmitter() ocrtypes.ContractTransmitter {
-	return P.contractTransmitter
+func (p *DstCommitProvider) ContractTransmitter() ocrtypes.ContractTransmitter {
+	return p.contractTransmitter
 }
 
-func (P *DstCommitProvider) ContractReader() commontypes.ContractReader {
+func (p *DstCommitProvider) ContractReader() commontypes.ContractReader {
 	return nil
 }
 
-func (P *DstCommitProvider) Codec() commontypes.Codec {
+func (p *DstCommitProvider) Codec() commontypes.Codec {
 	return nil
 }
 
-func (P *SrcCommitProvider) Start(ctx context.Context) error {
-	if P.startBlock != 0 {
-		P.lggr.Infow("start replaying src chain", "fromBlock", P.startBlock)
-		return P.lp.Replay(ctx, int64(P.startBlock))
+func (p *SrcCommitProvider) Start(ctx context.Context) error {
+	if p.startBlock != 0 {
+		p.lggr.Infow("start replaying src chain", "fromBlock", p.startBlock)
+		if p.startBlock > math.MaxInt64 {
+			return fmt.Errorf("start block overflows int64: %d", p.startBlock)
+		}
+		return p.lp.Replay(ctx, int64(p.startBlock)) //nolint:gosec // G115 false positive
 	}
 	return nil
 }
 
-func (P *DstCommitProvider) Start(ctx context.Context) error {
-	if P.startBlock != 0 {
-		P.lggr.Infow("start replaying dst chain", "fromBlock", P.startBlock)
-		return P.lp.Replay(ctx, int64(P.startBlock))
+func (p *DstCommitProvider) Start(ctx context.Context) error {
+	if p.startBlock != 0 {
+		p.lggr.Infow("start replaying dst chain", "fromBlock", p.startBlock)
+		if p.startBlock > math.MaxInt64 {
+			return fmt.Errorf("start block overflows int64: %d", p.startBlock)
+		}
+		return p.lp.Replay(ctx, int64(p.startBlock)) //nolint:gosec // G115 false positive
 	}
 	return nil
 }
 
-func (P *SrcCommitProvider) NewPriceGetter(ctx context.Context) (priceGetter cciptypes.PriceGetter, err error) {
+func (p *SrcCommitProvider) NewPriceGetter(ctx context.Context) (priceGetter cciptypes.PriceGetter, err error) {
 	return nil, fmt.Errorf("can't construct a price getter from one relayer")
 }
 
-func (P *DstCommitProvider) NewPriceGetter(ctx context.Context) (priceGetter cciptypes.PriceGetter, err error) {
+func (p *DstCommitProvider) NewPriceGetter(ctx context.Context) (priceGetter cciptypes.PriceGetter, err error) {
 	return nil, fmt.Errorf("can't construct a price getter from one relayer")
 }
 
-func (P *SrcCommitProvider) NewCommitStoreReader(ctx context.Context, commitStoreAddress cciptypes.Address) (commitStoreReader cciptypes.CommitStoreReader, err error) {
-	commitStoreReader = NewIncompleteSourceCommitStoreReader(P.estimator, P.maxGasPrice)
+func (p *SrcCommitProvider) NewCommitStoreReader(ctx context.Context, commitStoreAddress cciptypes.Address) (commitStoreReader cciptypes.CommitStoreReader, err error) {
+	commitStoreReader = NewIncompleteSourceCommitStoreReader(p.estimator, p.maxGasPrice)
 	return
 }
 
-func (P *DstCommitProvider) NewCommitStoreReader(ctx context.Context, commitStoreAddress cciptypes.Address) (commitStoreReader cciptypes.CommitStoreReader, err error) {
-	P.seenCommitStoreAddress = &commitStoreAddress
+func (p *DstCommitProvider) NewCommitStoreReader(ctx context.Context, commitStoreAddress cciptypes.Address) (commitStoreReader cciptypes.CommitStoreReader, err error) {
+	p.seenCommitStoreAddress = &commitStoreAddress
 
 	versionFinder := ccip.NewEvmVersionFinder()
-	commitStoreReader, err = NewIncompleteDestCommitStoreReader(P.lggr, versionFinder, commitStoreAddress, P.client, P.lp)
+	commitStoreReader, err = NewIncompleteDestCommitStoreReader(p.lggr, versionFinder, commitStoreAddress, p.client, p.lp)
 	return
 }
 
-func (P *SrcCommitProvider) NewOnRampReader(ctx context.Context, onRampAddress cciptypes.Address, sourceChainSelector uint64, destChainSelector uint64) (onRampReader cciptypes.OnRampReader, err error) {
-	P.seenOnRampAddress = &onRampAddress
-	P.seenSourceChainSelector = &sourceChainSelector
-	P.seenDestChainSelector = &destChainSelector
+func (p *SrcCommitProvider) NewOnRampReader(ctx context.Context, onRampAddress cciptypes.Address, sourceChainSelector uint64, destChainSelector uint64) (onRampReader cciptypes.OnRampReader, err error) {
+	p.seenOnRampAddress = &onRampAddress
+	p.seenSourceChainSelector = &sourceChainSelector
+	p.seenDestChainSelector = &destChainSelector
 
 	versionFinder := ccip.NewEvmVersionFinder()
-	onRampReader, err = ccip.NewOnRampReader(P.lggr, versionFinder, sourceChainSelector, destChainSelector, onRampAddress, P.lp, P.client)
+	onRampReader, err = ccip.NewOnRampReader(p.lggr, versionFinder, sourceChainSelector, destChainSelector, onRampAddress, p.lp, p.client)
 	return
 }
 
-func (P *DstCommitProvider) NewOnRampReader(ctx context.Context, onRampAddress cciptypes.Address, sourceChainSelector uint64, destChainSelector uint64) (onRampReader cciptypes.OnRampReader, err error) {
+func (p *DstCommitProvider) NewOnRampReader(ctx context.Context, onRampAddress cciptypes.Address, sourceChainSelector uint64, destChainSelector uint64) (onRampReader cciptypes.OnRampReader, err error) {
 	return nil, fmt.Errorf("invalid: NewOnRampReader called for DstCommitProvider.NewOnRampReader should be called on SrcCommitProvider")
 }
 
-func (P *SrcCommitProvider) NewOffRampReader(ctx context.Context, offRampAddr cciptypes.Address) (offRampReader cciptypes.OffRampReader, err error) {
+func (p *SrcCommitProvider) NewOffRampReader(ctx context.Context, offRampAddr cciptypes.Address) (offRampReader cciptypes.OffRampReader, err error) {
 	return nil, fmt.Errorf("invalid: NewOffRampReader called for SrcCommitProvider. NewOffRampReader should be called on DstCommitProvider")
 }
 
-func (P *DstCommitProvider) NewOffRampReader(ctx context.Context, offRampAddr cciptypes.Address) (offRampReader cciptypes.OffRampReader, err error) {
-	offRampReader, err = ccip.NewOffRampReader(P.lggr, P.versionFinder, offRampAddr, P.client, P.lp, P.gasEstimator, &P.maxGasPrice, true)
+func (p *DstCommitProvider) NewOffRampReader(ctx context.Context, offRampAddr cciptypes.Address) (offRampReader cciptypes.OffRampReader, err error) {
+	offRampReader, err = ccip.NewOffRampReader(p.lggr, p.versionFinder, offRampAddr, p.client, p.lp, p.gasEstimator, &p.maxGasPrice, true)
 	return
 }
 
-func (P *SrcCommitProvider) NewPriceRegistryReader(ctx context.Context, addr cciptypes.Address) (priceRegistryReader cciptypes.PriceRegistryReader, err error) {
+func (p *SrcCommitProvider) NewPriceRegistryReader(ctx context.Context, addr cciptypes.Address) (priceRegistryReader cciptypes.PriceRegistryReader, err error) {
 	return nil, fmt.Errorf("invalid: NewPriceRegistryReader called for SrcCommitProvider. NewOffRampReader should be called on DstCommitProvider")
 }
 
-func (P *DstCommitProvider) NewPriceRegistryReader(ctx context.Context, addr cciptypes.Address) (priceRegistryReader cciptypes.PriceRegistryReader, err error) {
-	destPriceRegistry := ccip.NewEvmPriceRegistry(P.lp, P.client, P.lggr, ccip.CommitPluginLabel)
+func (p *DstCommitProvider) NewPriceRegistryReader(ctx context.Context, addr cciptypes.Address) (priceRegistryReader cciptypes.PriceRegistryReader, err error) {
+	destPriceRegistry := ccip.NewEvmPriceRegistry(p.lp, p.client, p.lggr, ccip.CommitPluginLabel)
 	priceRegistryReader, err = destPriceRegistry.NewPriceRegistryReader(ctx, addr)
 	return
 }
 
-func (P *SrcCommitProvider) SourceNativeToken(ctx context.Context, sourceRouterAddr cciptypes.Address) (cciptypes.Address, error) {
+func (p *SrcCommitProvider) SourceNativeToken(ctx context.Context, sourceRouterAddr cciptypes.Address) (cciptypes.Address, error) {
 	sourceRouterAddrHex, err := ccip.GenericAddrToEvm(sourceRouterAddr)
 	if err != nil {
 		return "", err
 	}
-	sourceRouter, err := router.NewRouter(sourceRouterAddrHex, P.client)
+	sourceRouter, err := router.NewRouter(sourceRouterAddrHex, p.client)
 	if err != nil {
 		return "", err
 	}
@@ -304,6 +311,6 @@ func (P *SrcCommitProvider) SourceNativeToken(ctx context.Context, sourceRouterA
 	return ccip.EvmAddrToGeneric(sourceNative), nil
 }
 
-func (P *DstCommitProvider) SourceNativeToken(ctx context.Context, sourceRouterAddr cciptypes.Address) (cciptypes.Address, error) {
+func (p *DstCommitProvider) SourceNativeToken(ctx context.Context, sourceRouterAddr cciptypes.Address) (cciptypes.Address, error) {
 	return "", fmt.Errorf("invalid: SourceNativeToken called for DstCommitProvider. SourceNativeToken should be called on SrcCommitProvider")
 }

--- a/core/services/relay/evm/exec_provider.go
+++ b/core/services/relay/evm/exec_provider.go
@@ -71,7 +71,7 @@ func NewSrcExecProvider(
 	}
 
 	return &SrcExecProvider{
-		lggr:                                   lggr,
+		lggr:                                   logger.Named(lggr, "SrcExecProvider"),
 		versionFinder:                          versionFinder,
 		client:                                 client,
 		estimator:                              estimator,
@@ -87,7 +87,7 @@ func NewSrcExecProvider(
 }
 
 func (s *SrcExecProvider) Name() string {
-	return "CCIP.SrcExecProvider"
+	return s.lggr.Name()
 }
 
 func (s *SrcExecProvider) Start(ctx context.Context) error {
@@ -258,7 +258,7 @@ func NewDstExecProvider(
 	offRampAddress cciptypes.Address,
 ) (commontypes.CCIPExecProvider, error) {
 	return &DstExecProvider{
-		lggr:                lggr,
+		lggr:                logger.Named(lggr, "DstExecProvider"),
 		versionFinder:       versionFinder,
 		client:              client,
 		lp:                  lp,
@@ -273,7 +273,7 @@ func NewDstExecProvider(
 }
 
 func (d *DstExecProvider) Name() string {
-	return "CCIP.DestRelayerExecProvider"
+	return d.lggr.Name()
 }
 
 func (d *DstExecProvider) Start(ctx context.Context) error {

--- a/plugins/cmd/capabilities/log-event-trigger/main.go
+++ b/plugins/cmd/capabilities/log-event-trigger/main.go
@@ -65,11 +65,11 @@ func (cs *LogEventTriggerGRPCService) Ready() error {
 }
 
 func (cs *LogEventTriggerGRPCService) HealthReport() map[string]error {
-	return nil
+	return map[string]error{cs.Name(): nil}
 }
 
 func (cs *LogEventTriggerGRPCService) Name() string {
-	return serviceName
+	return cs.s.Logger.Name()
 }
 
 func (cs *LogEventTriggerGRPCService) Infos(ctx context.Context) ([]capabilities.CapabilityInfo, error) {


### PR DESCRIPTION
Mostly updating `Name()` to return the logger name
https://pkg.go.dev/github.com/smartcontractkit/chainlink-common@v0.3.0/pkg/services#HealthReporter
> // Name returns the fully qualified name of the component. Usually the logger name.