### PR TITLE
fix: changelog generation formatting RE-3152

### DIFF
--- a/.changeset/changelog-generator.js
+++ b/.changeset/changelog-generator.js
@@ -1,0 +1,105 @@
+/*
+ * Based off of https://github.com/changesets/changesets/blob/7323704dff6e76f488370db384579b86c95c866f/packages/changelog-github/src/index.ts
+ */
+
+const ghInfo = require("@changesets/get-github-info");
+
+const getDependencyReleaseLine = async (changesets, dependenciesUpdated, options) => {
+  if (dependenciesUpdated.length === 0) return "";
+  if (!options || !options.repo) {
+    throw new Error(
+      'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
+    );
+  }
+
+  const changesetLink = `- Updated dependencies [${(
+    await Promise.all(
+      changesets.map(async (cs) => {
+        if (cs.commit) {
+          let { links } = await ghInfo.getInfo({
+            repo: options.repo,
+            commit: cs.commit,
+          });
+          return links.commit;
+        }
+      })
+    )
+  )
+    .filter((_) => _)
+    .join(", ")}]:`;
+
+
+  const updatedDepsList = dependenciesUpdated.map(
+    (dependency) => `  - ${dependency.name}@${dependency.newVersion}`
+  );
+
+  return [changesetLink, ...updatedDepsList].join("\n");
+};
+
+const getReleaseLine = async (changeset, _, options) => {
+  if (!options || !options.repo) {
+    throw new Error(
+      'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
+    );
+  }
+
+  let prFromSummary;
+  let commitFromSummary;
+
+  const replacedChangelog = changeset.summary
+    .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
+      let num = Number(pr);
+      if (!isNaN(num)) prFromSummary = num;
+      return "";
+    })
+    .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
+      commitFromSummary = commit;
+      return "";
+    })
+    .trim();
+
+  const [firstLine, ...futureLines] = replacedChangelog
+    .split("\n")
+    .map((l) => l.trimRight());
+
+  const links = await (async () => {
+    if (prFromSummary !== undefined) {
+      let { links } = await ghInfo.getInfoFromPullRequest({
+        repo: options.repo,
+        pull: prFromSummary,
+      });
+      if (commitFromSummary) {
+        const shortCommitId = commitFromSummary.slice(0, 7);
+        links = {
+          ...links,
+          commit: `[\`${shortCommitId}\`](https://github.com/${options.repo}/commit/${commitFromSummary})`,
+        };
+      }
+      return links;
+    }
+    const commitToFetchFrom = commitFromSummary || changeset.commit;
+    if (commitToFetchFrom) {
+      let { links } = await ghInfo.getInfo({
+        repo: options.repo,
+        commit: commitToFetchFrom,
+      });
+      return links;
+    }
+    return {
+      commit: null,
+      pull: null,
+      user: null,
+    };
+  })();
+
+  const prefix = [
+    links.pull === null ? "" : ` ${links.pull}`,
+    links.commit === null ? "" : ` ${links.commit}`,
+  ].join("");
+
+  return `\n\n-${prefix ? `${prefix} -` : ""} ${firstLine}\n${futureLines
+    .map((l) => `  ${l}`)
+    .join("\n")}`;
+};
+
+module.exports = { getReleaseLine, getDependencyReleaseLine };

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "./changelog-generator.js",
     {
       "repo": "smartcontractkit/chainlink"
     }

--- a/.changeset/tasty-years-behave.md
+++ b/.changeset/tasty-years-behave.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Modify release changelog generation format #internal

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -52,7 +52,7 @@ jobs:
               - '!core/chainlink.Dockerfile'
               - '!core/gethwrappers/**'
             core-changeset:
-              - added: '.changeset/**'
+              - added: '.changeset/*.md'
 
       - name: Check for changeset tags for core
         id: changeset-tags

--- a/contracts/.changeset/config.json
+++ b/contracts/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "../../.changeset/changelog-generator.js",
     {
       "repo": "smartcontractkit/chainlink"
     }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -80,8 +80,8 @@
   "dependencies": {
     "@arbitrum/nitro-contracts": "1.1.1",
     "@arbitrum/token-bridge-contracts": "1.1.2",
-    "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "~2.27.8",
+    "@changesets/get-github-info": "^0.6.0",
     "@eth-optimism/contracts": "0.6.0",
     "@openzeppelin/contracts": "4.9.3",
     "@openzeppelin/contracts-upgradeable": "4.9.3",

--- a/contracts/pnpm-lock.yaml
+++ b/contracts/pnpm-lock.yaml
@@ -17,12 +17,12 @@ importers:
       '@arbitrum/token-bridge-contracts':
         specifier: 1.1.2
         version: 1.1.2
-      '@changesets/changelog-github':
-        specifier: ^0.5.0
-        version: 0.5.0
       '@changesets/cli':
         specifier: ~2.27.8
         version: 2.27.8
+      '@changesets/get-github-info':
+        specifier: ^0.6.0
+        version: 0.6.0
       '@eth-optimism/contracts':
         specifier: 0.6.0
         version: 0.6.0(ethers@5.7.2)
@@ -203,9 +203,6 @@ packages:
 
   '@changesets/changelog-git@0.2.0':
     resolution: {integrity: sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==}
-
-  '@changesets/changelog-github@0.5.0':
-    resolution: {integrity: sha512-zoeq2LJJVcPJcIotHRJEEA2qCqX0AQIeFE+L21L8sRLPVqDhSXY8ZWAt2sohtBpFZkBwu+LUwMSKRr2lMy3LJA==}
 
   '@changesets/cli@2.27.8':
     resolution: {integrity: sha512-gZNyh+LdSsI82wBSHLQ3QN5J30P4uHKJ4fXgoGwQxfXwYFTJzDdvIJasZn8rYQtmKhyQuiBj4SSnLuKlxKWq4w==}
@@ -1360,10 +1357,6 @@ packages:
 
   dot-case@2.1.1:
     resolution: {integrity: sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==}
-
-  dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
 
   elliptic@6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
@@ -3266,14 +3259,6 @@ snapshots:
     dependencies:
       '@changesets/types': 6.0.0
 
-  '@changesets/changelog-github@0.5.0':
-    dependencies:
-      '@changesets/get-github-info': 0.6.0
-      '@changesets/types': 6.0.0
-      dotenv: 8.6.0
-    transitivePeerDependencies:
-      - encoding
-
   '@changesets/cli@2.27.8':
     dependencies:
       '@changesets/apply-release-plan': 7.0.5
@@ -4909,8 +4894,6 @@ snapshots:
   dot-case@2.1.1:
     dependencies:
       no-case: 2.3.2
-
-  dotenv@8.6.0: {}
 
   elliptic@6.5.4:
     dependencies:

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "pnpm": ">=9"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "~2.26.2",
+    "@changesets/get-github-info": "^0.6.0",
     "semver": "^7.6.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,12 @@ importers:
 
   .:
     devDependencies:
-      '@changesets/changelog-github':
-        specifier: ^0.4.8
-        version: 0.4.8
       '@changesets/cli':
         specifier: ~2.26.2
         version: 2.26.2
+      '@changesets/get-github-info':
+        specifier: ^0.6.0
+        version: 0.6.0
       semver:
         specifier: ^7.6.3
         version: 7.6.3
@@ -45,9 +45,6 @@ packages:
   '@changesets/changelog-git@0.1.14':
     resolution: {integrity: sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==}
 
-  '@changesets/changelog-github@0.4.8':
-    resolution: {integrity: sha512-jR1DHibkMAb5v/8ym77E4AMNWZKB5NPzw5a5Wtqm1JepAuIF+hrKp2u04NKM14oBZhHglkCfrla9uq8ORnK/dw==}
-
   '@changesets/cli@2.26.2':
     resolution: {integrity: sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==}
     hasBin: true
@@ -61,8 +58,8 @@ packages:
   '@changesets/get-dependents-graph@1.3.6':
     resolution: {integrity: sha512-Q/sLgBANmkvUm09GgRsAvEtY3p1/5OCzgBE5vX3vgb5CvW0j7CEljocx5oPXeQSNph6FXulJlXV3Re/v3K3P3Q==}
 
-  '@changesets/get-github-info@0.5.2':
-    resolution: {integrity: sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==}
+  '@changesets/get-github-info@0.6.0':
+    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
 
   '@changesets/get-release-plan@3.0.17':
     resolution: {integrity: sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==}
@@ -289,10 +286,6 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
-
-  dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1104,14 +1097,6 @@ snapshots:
     dependencies:
       '@changesets/types': 5.2.1
 
-  '@changesets/changelog-github@0.4.8':
-    dependencies:
-      '@changesets/get-github-info': 0.5.2
-      '@changesets/types': 5.2.1
-      dotenv: 8.6.0
-    transitivePeerDependencies:
-      - encoding
-
   '@changesets/cli@2.26.2':
     dependencies:
       '@babel/runtime': 7.25.6
@@ -1170,7 +1155,7 @@ snapshots:
       fs-extra: 7.0.1
       semver: 7.6.3
 
-  '@changesets/get-github-info@0.5.2':
+  '@changesets/get-github-info@0.6.0':
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.7.0
@@ -1462,8 +1447,6 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-
-  dotenv@8.6.0: {}
 
   emoji-regex@8.0.0: {}
 


### PR DESCRIPTION
### Changes

- Switch from `@changesets/changelog-github` to a local file which doesn't include users in the changelog generation
    - This applies to both the root .changesets, and the contracts/.changesets configs
- Updated `package.json`s to remove the unused dependency, and explicitly declare the pre-existing transitive dependency which is now referenced in the changelog generation code

### Testing

Tested locally, new format of changelog is like:

```
# Changelog Chainlink Core

## 2.19.0

### Minor Changes

- [#14898](https://github.com/smartcontractkit/chainlink/pull/14898) [`a417740`](https://github.com/smartcontractkit/chainlink/commit/a41774035961ce88be2fed7c6759758a7f00881d) - Bump to start the next version

...
```

---

RE-3152

> Since this is for NOPs and the names can be unprofessional and it adds unwanted noise, we’d like to remove the `thanks @ghusername` in the changesets generated changelogs.
