### PR TITLE
fix: setup-go usages

### DIFF
--- a/.github/actions/goreleaser-build-sign-publish/action.yml
+++ b/.github/actions/goreleaser-build-sign-publish/action.yml
@@ -34,10 +34,11 @@ runs:
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     - name: Setup docker buildx
       uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0
-    - name: Setup go
-      uses: actions/setup-go@v5.0.2
+    - name: Set up Go
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: "go.mod"
+        go-version-file: 'go.mod'
+        only-modules: 'true'
     - name: Setup goreleaser
       uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
       with:

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -81,7 +81,7 @@ runs:
     - uses: actions/cache/restore@v4.1.1
       name: Cache Go Build Outputs (restore)
       # For certain events, we don't necessarily want to create a build cache, but we will benefit from restoring from one. 
-      if: ${{ inputs.only-modules == 'false' && github.event == 'merge_queue' }}
+      if: ${{ inputs.only-modules == 'false' && github.event == 'merge_group' }}
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
@@ -94,7 +94,7 @@ runs:
 
     - uses: actions/cache@v4.1.1
       # don't save cache on merge queue events, only restore
-      if: ${{ inputs.only-modules == 'false' && github.event != 'merge_queue' }}
+      if: ${{ inputs.only-modules == 'false' && github.event != 'merge_group' }}
       name: Cache Go Build Outputs
       with:
         path: |

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -91,10 +91,10 @@ jobs:
           product-image: ${{ secrets.AWS_SDLC_ECR_HOSTNAME }}/chainlink
           product-image-tag: develop
       - uses: actions/checkout@v4.2.1
-      - name: Setup go
-        uses: actions/setup-go@v5.0.2
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
+          go-version-file: 'go.mod'
       - name: Run CRIB integration test
         working-directory: integration-tests/crib
         env:

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -24,15 +24,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes]
     steps:
-      - name: Check out code
+      - name: Checkout repository
         uses: actions/checkout@v4.2.1
 
       - name: Set up Go
         if: needs.changes.outputs.src == 'true'
-        uses: actions/setup-go@v5.0.2
+        uses: ./.github/actions/setup-go
         with:
           go-version-file: 'go.mod'
-        id: go
+          only-modules: 'true'
 
       - name: Write Go Modules list
         if: needs.changes.outputs.src == 'true'


### PR DESCRIPTION
As a follow up to #14988, start using the local `setup-go` action everywhere to ensure caches are reused where possible. This should allow for more cache hits, and should stop a ton of single-use caches from being created accidentally.

### Changes

- Switch all usages of `actions/setup-go` to `./.github/actions/setup-go`.
- Fix  type `merge_queue/merge_group` in `setup-go` action

---

RE-3155

