### PR TITLE
moving step error metric out of isFullyProcessed

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -611,6 +611,7 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 			l.Info("workflow finished")
 		case store.StatusErrored:
 			l.Info("execution errored")
+			e.metrics.incrementTotalWorkflowStepErrorsCounter(ctx)
 		case store.StatusCompletedEarlyExit:
 			l.Info("execution terminated early")
 			// NOTE: even though this marks the workflow as completed, any branches of the DAG
@@ -985,7 +986,6 @@ func (e *Engine) isWorkflowFullyProcessed(ctx context.Context, state store.Workf
 					}
 				}
 			}
-			e.metrics.incrementTotalWorkflowStepErrorsCounter(ctx)
 		}
 		return nil
 	})


### PR DESCRIPTION
The step error metric would have a higher value than expected if the workflow exited early. As well, isFullyProcessed may be called by consumers in the future w/o expecting the metric value to be incremented. 