### PR TITLE
fix: race/fuzz test build cache restore

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -21,6 +21,10 @@ inputs:
       Only restore the module cache, don't automatically update it.
       Leave the updating to go-mod-cache.yml.
     default: "true"
+  restore-build-cache-only:
+    description: |
+      Only restore the build cache, don't automatically update/upload it.
+    default: "false"
 
 runs:
   using: composite
@@ -81,7 +85,7 @@ runs:
     - uses: actions/cache/restore@v4.1.1
       name: Cache Go Build Outputs (restore)
       # For certain events, we don't necessarily want to create a build cache, but we will benefit from restoring from one. 
-      if: ${{ inputs.only-modules == 'false' && github.event == 'merge_group' }}
+      if: ${{ inputs.only-modules == 'false' && (github.event == 'merge_group' || inputs.restore-build-cache-only == 'true') }}
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
@@ -93,8 +97,8 @@ runs:
           ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-
 
     - uses: actions/cache@v4.1.1
-      # don't save cache on merge queue events, only restore
-      if: ${{ inputs.only-modules == 'false' && github.event != 'merge_group' }}
+      # don't save cache on merge queue events
+      if: ${{ inputs.only-modules == 'false' && (github.event != 'merge_group' && inputs.restore-build-cache-only == 'false') }}
       name: Cache Go Build Outputs
       with:
         path: |

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -138,8 +138,8 @@ jobs:
         if: ${{ needs.filter.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-go
         with:
-          # race/fuzz tests don't benefit from build caching
-          only-modules: ${{ matrix.type.cmd == 'go_core_race_tests' || matrix.type.cmd == 'go_core_fuzz' }}
+          # race/fuzz tests don't benefit repeated caching, so restore from develop's build cache
+          restore-build-cache-only: ${{ matrix.type.cmd == 'go_core_race_tests' || matrix.type.cmd == 'go_core_fuzz' }}
           build-cache-version: ${{ matrix.type.cmd }}
 
       - name: Replace chainlink-evm deps


### PR DESCRIPTION
Follow up from #14988 - race/fuzz tests do benefit from the build cache when they build the test binary. Can see about a 30sec slow down from restoring the build cache, but see about a minute improvement in building the test binary.

### Changes

- `setup-go` - add a `restore-build-cache-only` input that forces a restore-only of the build cache
- Only restore the build cache for the fuzz/race tests

---

RE-3155
