### PR TITLE
Add deployment.ExistingAddresses field

### DIFF
--- a/deployment/ccip/add_lane_test.go
+++ b/deployment/ccip/add_lane_test.go
@@ -30,10 +30,6 @@ func TestAddLane(t *testing.T) {
 	feeds := state.Chains[e.FeedChainSel].USDFeeds
 	tokenConfig := NewTestTokenConfig(feeds)
 
-	feeTokenContracts := make(map[uint64]FeeTokenContracts)
-	for _, sel := range []uint64{chain1, chain2} {
-		feeTokenContracts[sel] = e.FeeTokenContracts[sel]
-	}
 	// Set up CCIP contracts and a DON per chain.
 	newAddresses := deployment.NewMemoryAddressBook()
 	err = DeployCCIPContracts(e.Env, newAddresses, DeployCCIPContractConfig{

--- a/deployment/ccip/add_lane_test.go
+++ b/deployment/ccip/add_lane_test.go
@@ -20,7 +20,7 @@ func TestAddLane(t *testing.T) {
 	// We add more chains to the chainlink nodes than the number of chains where CCIP is deployed.
 	e := NewMemoryEnvironmentWithJobs(t, logger.TestLogger(t), 4, 4)
 	// Here we have CR + nodes set up, but no CCIP contracts deployed.
-	state, err := LoadOnchainState(e.Env, e.Ab)
+	state, err := LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
 	selectors := e.Env.AllChainSelectors()
@@ -35,19 +35,20 @@ func TestAddLane(t *testing.T) {
 		feeTokenContracts[sel] = e.FeeTokenContracts[sel]
 	}
 	// Set up CCIP contracts and a DON per chain.
-	err = DeployCCIPContracts(e.Env, e.Ab, DeployCCIPContractConfig{
-		HomeChainSel:        e.HomeChainSel,
-		FeedChainSel:        e.FeedChainSel,
-		TokenConfig:         tokenConfig,
-		MCMSConfig:          NewTestMCMSConfig(t, e.Env),
-		ExistingAddressBook: e.Ab,
-		ChainsToDeploy:      []uint64{chain1, chain2},
-		OCRSecrets:          deployment.XXXGenerateTestOCRSecrets(),
+	newAddresses := deployment.NewMemoryAddressBook()
+	err = DeployCCIPContracts(e.Env, newAddresses, DeployCCIPContractConfig{
+		HomeChainSel:   e.HomeChainSel,
+		FeedChainSel:   e.FeedChainSel,
+		TokenConfig:    tokenConfig,
+		MCMSConfig:     NewTestMCMSConfig(t, e.Env),
+		ChainsToDeploy: []uint64{chain1, chain2},
+		OCRSecrets:     deployment.XXXGenerateTestOCRSecrets(),
 	})
 	require.NoError(t, err)
+	require.NoError(t, e.Env.ExistingAddresses.Merge(newAddresses))
 
 	// We expect no lanes available on any chain.
-	state, err = LoadOnchainState(e.Env, e.Ab)
+	state, err = LoadOnchainState(e.Env)
 	require.NoError(t, err)
 	for _, sel := range []uint64{chain1, chain2} {
 		chain := state.Chains[sel]

--- a/deployment/ccip/changeset/add_chain_test.go
+++ b/deployment/ccip/changeset/add_chain_test.go
@@ -29,7 +29,7 @@ import (
 func TestAddChainInbound(t *testing.T) {
 	// 4 chains where the 4th is added after initial deployment.
 	e := ccipdeployment.NewMemoryEnvironmentWithJobs(t, logger.TestLogger(t), 4, 4)
-	state, err := ccipdeployment.LoadOnchainState(e.Env, e.Ab)
+	state, err := ccipdeployment.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 	// Take first non-home chain as the new chain.
 	newChain := e.Env.AllChainSelectorsExcluding([]uint64{e.HomeChainSel})[0]
@@ -37,17 +37,18 @@ func TestAddChainInbound(t *testing.T) {
 	initialDeploy := e.Env.AllChainSelectorsExcluding([]uint64{newChain})
 
 	tokenConfig := ccipdeployment.NewTestTokenConfig(state.Chains[e.FeedChainSel].USDFeeds)
-	err = ccipdeployment.DeployCCIPContracts(e.Env, e.Ab, ccipdeployment.DeployCCIPContractConfig{
-		HomeChainSel:        e.HomeChainSel,
-		FeedChainSel:        e.FeedChainSel,
-		ChainsToDeploy:      initialDeploy,
-		TokenConfig:         tokenConfig,
-		MCMSConfig:          ccipdeployment.NewTestMCMSConfig(t, e.Env),
-		ExistingAddressBook: e.Ab,
-		OCRSecrets:          deployment.XXXGenerateTestOCRSecrets(),
+	newAddresses := deployment.NewMemoryAddressBook()
+	err = ccipdeployment.DeployCCIPContracts(e.Env, newAddresses, ccipdeployment.DeployCCIPContractConfig{
+		HomeChainSel:   e.HomeChainSel,
+		FeedChainSel:   e.FeedChainSel,
+		ChainsToDeploy: initialDeploy,
+		TokenConfig:    tokenConfig,
+		MCMSConfig:     ccipdeployment.NewTestMCMSConfig(t, e.Env),
+		OCRSecrets:     deployment.XXXGenerateTestOCRSecrets(),
 	})
 	require.NoError(t, err)
-	state, err = ccipdeployment.LoadOnchainState(e.Env, e.Ab)
+	require.NoError(t, e.Env.ExistingAddresses.Merge(newAddresses))
+	state, err = ccipdeployment.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
 	// Connect all the existing lanes.
@@ -59,16 +60,18 @@ func TestAddChainInbound(t *testing.T) {
 		}
 	}
 
-	rmnHomeAddress, err := deployment.SearchAddressBook(e.Ab, e.HomeChainSel, ccipdeployment.RMNHome)
+	rmnHomeAddress, err := deployment.SearchAddressBook(e.Env.ExistingAddresses, e.HomeChainSel, ccipdeployment.RMNHome)
 	require.NoError(t, err)
 	require.True(t, common.IsHexAddress(rmnHomeAddress))
 	rmnHome, err := rmn_home.NewRMNHome(common.HexToAddress(rmnHomeAddress), e.Env.Chains[e.HomeChainSel].Client)
 	require.NoError(t, err)
 
 	//  Deploy contracts to new chain
-	err = ccipdeployment.DeployChainContracts(e.Env, e.Env.Chains[newChain], e.Ab, e.FeeTokenContracts[newChain], ccipdeployment.NewTestMCMSConfig(t, e.Env), rmnHome)
+	newChainAddresses := deployment.NewMemoryAddressBook()
+	err = ccipdeployment.DeployChainContracts(e.Env, e.Env.Chains[newChain], newChainAddresses, e.FeeTokenContracts[newChain], ccipdeployment.NewTestMCMSConfig(t, e.Env), rmnHome)
 	require.NoError(t, err)
-	state, err = ccipdeployment.LoadOnchainState(e.Env, e.Ab)
+	require.NoError(t, e.Env.ExistingAddresses.Merge(newChainAddresses))
+	state, err = ccipdeployment.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
 	// Transfer onramp/fq ownership to timelock.
@@ -187,7 +190,7 @@ func TestAddChainInbound(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert the inbound lanes to the new chain are wired correctly.
-	state, err = ccipdeployment.LoadOnchainState(e.Env, e.Ab)
+	state, err = ccipdeployment.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 	for _, chain := range initialDeploy {
 		cfg, err2 := state.Chains[chain].OnRamp.GetDestChainConfig(nil, newChain)

--- a/deployment/ccip/changeset/add_chain_test.go
+++ b/deployment/ccip/changeset/add_chain_test.go
@@ -68,7 +68,12 @@ func TestAddChainInbound(t *testing.T) {
 
 	//  Deploy contracts to new chain
 	newChainAddresses := deployment.NewMemoryAddressBook()
-	err = ccipdeployment.DeployChainContracts(e.Env, e.Env.Chains[newChain], newChainAddresses, e.FeeTokenContracts[newChain], ccipdeployment.NewTestMCMSConfig(t, e.Env), rmnHome)
+	err = ccipdeployment.DeployChainContracts(e.Env,
+		e.Env.Chains[newChain], newChainAddresses,
+		ccipdeployment.FeeTokenContracts{
+			LinkToken: state.Chains[newChain].LinkToken,
+			Weth9:     state.Chains[newChain].Weth9,
+		}, ccipdeployment.NewTestMCMSConfig(t, e.Env), rmnHome)
 	require.NoError(t, err)
 	require.NoError(t, e.Env.ExistingAddresses.Merge(newChainAddresses))
 	state, err = ccipdeployment.LoadOnchainState(e.Env)

--- a/deployment/ccip/changeset/initial_deploy.go
+++ b/deployment/ccip/changeset/initial_deploy.go
@@ -15,19 +15,19 @@ func InitialDeploy(env deployment.Environment, config interface{}) (deployment.C
 	if !ok {
 		return deployment.ChangesetOutput{}, deployment.ErrInvalidConfig
 	}
-	ab := deployment.NewMemoryAddressBook()
-	err := ccipdeployment.DeployCCIPContracts(env, ab, c)
+	newAddresses := deployment.NewMemoryAddressBook()
+	err := ccipdeployment.DeployCCIPContracts(env, newAddresses, c)
 	if err != nil {
-		env.Logger.Errorw("Failed to deploy CCIP contracts", "err", err, "addresses", ab)
-		return deployment.ChangesetOutput{AddressBook: ab}, deployment.MaybeDataErr(err)
+		env.Logger.Errorw("Failed to deploy CCIP contracts", "err", err, "newAddresses", newAddresses)
+		return deployment.ChangesetOutput{AddressBook: newAddresses}, deployment.MaybeDataErr(err)
 	}
 	js, err := ccipdeployment.NewCCIPJobSpecs(env.NodeIDs, env.Offchain)
 	if err != nil {
-		return deployment.ChangesetOutput{AddressBook: ab}, err
+		return deployment.ChangesetOutput{AddressBook: newAddresses}, err
 	}
 	return deployment.ChangesetOutput{
 		Proposals:   []timelock.MCMSWithTimelockProposal{},
-		AddressBook: ab,
+		AddressBook: newAddresses,
 		// Mapping of which nodes get which jobs.
 		JobSpecs: js,
 	}, nil

--- a/deployment/ccip/changeset/initial_deploy_test.go
+++ b/deployment/ccip/changeset/initial_deploy_test.go
@@ -22,23 +22,22 @@ func TestInitialDeploy(t *testing.T) {
 	tenv := ccdeploy.NewMemoryEnvironment(t, lggr, 3, 4)
 	e := tenv.Env
 
-	state, err := ccdeploy.LoadOnchainState(tenv.Env, tenv.Ab)
+	state, err := ccdeploy.LoadOnchainState(tenv.Env)
 	require.NoError(t, err)
 	require.NotNil(t, state.Chains[tenv.HomeChainSel].LinkToken)
 
 	output, err := InitialDeploy(tenv.Env, ccdeploy.DeployCCIPContractConfig{
-		HomeChainSel:        tenv.HomeChainSel,
-		FeedChainSel:        tenv.FeedChainSel,
-		ChainsToDeploy:      tenv.Env.AllChainSelectors(),
-		TokenConfig:         ccdeploy.NewTestTokenConfig(state.Chains[tenv.FeedChainSel].USDFeeds),
-		MCMSConfig:          ccdeploy.NewTestMCMSConfig(t, e),
-		ExistingAddressBook: tenv.Ab,
-		OCRSecrets:          deployment.XXXGenerateTestOCRSecrets(),
+		HomeChainSel:   tenv.HomeChainSel,
+		FeedChainSel:   tenv.FeedChainSel,
+		ChainsToDeploy: tenv.Env.AllChainSelectors(),
+		TokenConfig:    ccdeploy.NewTestTokenConfig(state.Chains[tenv.FeedChainSel].USDFeeds),
+		MCMSConfig:     ccdeploy.NewTestMCMSConfig(t, e),
+		OCRSecrets:     deployment.XXXGenerateTestOCRSecrets(),
 	})
 	require.NoError(t, err)
 	// Get new state after migration.
-	require.NoError(t, tenv.Ab.Merge(output.AddressBook))
-	state, err = ccdeploy.LoadOnchainState(e, tenv.Ab)
+	require.NoError(t, tenv.Env.ExistingAddresses.Merge(output.AddressBook))
+	state, err = ccdeploy.LoadOnchainState(e)
 	require.NoError(t, err)
 
 	// Ensure capreg logs are up to date.

--- a/deployment/ccip/changeset/view.go
+++ b/deployment/ccip/changeset/view.go
@@ -11,8 +11,8 @@ import (
 
 var _ deployment.ViewState = ViewCCIP
 
-func ViewCCIP(e deployment.Environment, ab deployment.AddressBook) (json.Marshaler, error) {
-	state, err := ccipdeployment.LoadOnchainState(e, ab)
+func ViewCCIP(e deployment.Environment) (json.Marshaler, error) {
+	state, err := ccipdeployment.LoadOnchainState(e)
 	if err != nil {
 		return nil, err
 	}

--- a/deployment/ccip/deploy.go
+++ b/deployment/ccip/deploy.go
@@ -118,11 +118,10 @@ func deployContract[C Contracts](
 }
 
 type DeployCCIPContractConfig struct {
-	HomeChainSel        uint64
-	FeedChainSel        uint64
-	ChainsToDeploy      []uint64
-	TokenConfig         TokenConfig
-	ExistingAddressBook deployment.AddressBook
+	HomeChainSel   uint64
+	FeedChainSel   uint64
+	ChainsToDeploy []uint64
+	TokenConfig    TokenConfig
 	// I believe it makes sense to have the same signers across all chains
 	// since that's the point MCMS.
 	MCMSConfig MCMSConfig
@@ -148,7 +147,7 @@ func DeployCCIPContracts(e deployment.Environment, ab deployment.AddressBook, c 
 		e.Logger.Errorw("Failed to get node info", "err", err)
 		return err
 	}
-	existingState, err := LoadOnchainState(e, c.ExistingAddressBook)
+	existingState, err := LoadOnchainState(e)
 	if err != nil {
 		e.Logger.Errorw("Failed to load existing onchain state", "err")
 		return err
@@ -364,16 +363,14 @@ func DeployMCMSContracts(
 	}, nil
 }
 
-func DeployFeeTokensToChains(lggr logger.Logger, ab deployment.AddressBook, chains map[uint64]deployment.Chain) (map[uint64]FeeTokenContracts, error) {
-	feeTokenContractsByChain := make(map[uint64]FeeTokenContracts)
+func DeployFeeTokensToChains(lggr logger.Logger, ab deployment.AddressBook, chains map[uint64]deployment.Chain) error {
 	for _, chain := range chains {
-		feeTokenContracts, err := DeployFeeTokens(lggr, chain, ab)
+		_, err := DeployFeeTokens(lggr, chain, ab)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		feeTokenContractsByChain[chain.Selector] = feeTokenContracts
 	}
-	return feeTokenContractsByChain, nil
+	return nil
 }
 
 // DeployFeeTokens deploys link and weth9. This is _usually_ for test environments only,

--- a/deployment/ccip/state.go
+++ b/deployment/ccip/state.go
@@ -201,12 +201,12 @@ func (s CCIPOnChainState) View(chains []uint64) (map[string]view.ChainView, erro
 	return m, nil
 }
 
-func LoadOnchainState(e deployment.Environment, ab deployment.AddressBook) (CCIPOnChainState, error) {
+func LoadOnchainState(e deployment.Environment) (CCIPOnChainState, error) {
 	state := CCIPOnChainState{
 		Chains: make(map[uint64]CCIPChainState),
 	}
 	for chainSelector, chain := range e.Chains {
-		addresses, err := ab.AddressesForChain(chainSelector)
+		addresses, err := e.ExistingAddresses.AddressesForChain(chainSelector)
 		if err != nil {
 			// Chain not found in address book, initialize empty
 			if errors.Is(err, deployment.ErrChainNotFound) {

--- a/deployment/ccip/test_helpers.go
+++ b/deployment/ccip/test_helpers.go
@@ -62,7 +62,6 @@ func Context(tb testing.TB) context.Context {
 
 type DeployedEnv struct {
 	Env               deployment.Environment
-	Ab                deployment.AddressBook
 	HomeChainSel      uint64
 	FeedChainSel      uint64
 	ReplayBlocks      map[uint64]uint64
@@ -107,16 +106,16 @@ func DeployTestContracts(t *testing.T,
 	homeChainSel,
 	feedChainSel uint64,
 	chains map[uint64]deployment.Chain,
-) (map[uint64]FeeTokenContracts, deployment.CapabilityRegistryConfig) {
+) deployment.CapabilityRegistryConfig {
 	capReg, err := DeployCapReg(lggr, ab, chains[homeChainSel])
 	require.NoError(t, err)
 	_, err = DeployFeeds(lggr, ab, chains[feedChainSel])
 	require.NoError(t, err)
-	feeTokenContracts, err := DeployFeeTokensToChains(lggr, ab, chains)
+	err = DeployFeeTokensToChains(lggr, ab, chains)
 	require.NoError(t, err)
 	evmChainID, err := chainsel.ChainIdFromSelector(homeChainSel)
 	require.NoError(t, err)
-	return feeTokenContracts, deployment.CapabilityRegistryConfig{
+	return deployment.CapabilityRegistryConfig{
 		EVMChainID: evmChainID,
 		Contract:   capReg.Address,
 	}
@@ -161,7 +160,7 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, numChains int, numNo
 	require.NoError(t, err)
 
 	ab := deployment.NewMemoryAddressBook()
-	feeTokenContracts, crConfig := DeployTestContracts(t, lggr, ab, homeChainSel, feedSel, chains)
+	crConfig := DeployTestContracts(t, lggr, ab, homeChainSel, feedSel, chains)
 	nodes := memory.NewNodes(t, zapcore.InfoLevel, chains, numNodes, 1, crConfig)
 	for _, node := range nodes {
 		require.NoError(t, node.App.Start(ctx))
@@ -171,13 +170,12 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, numChains int, numNo
 	}
 
 	e := memory.NewMemoryEnvironmentFromChainsNodes(t, lggr, chains, nodes)
+	e.ExistingAddresses = ab
 	return DeployedEnv{
-		Ab:                ab,
-		Env:               e,
-		HomeChainSel:      homeChainSel,
-		FeedChainSel:      feedSel,
-		ReplayBlocks:      replayBlocks,
-		FeeTokenContracts: feeTokenContracts,
+		Env:          e,
+		HomeChainSel: homeChainSel,
+		FeedChainSel: feedSel,
+		ReplayBlocks: replayBlocks,
 	}
 }
 

--- a/deployment/ccip/test_helpers.go
+++ b/deployment/ccip/test_helpers.go
@@ -61,11 +61,10 @@ func Context(tb testing.TB) context.Context {
 }
 
 type DeployedEnv struct {
-	Env               deployment.Environment
-	HomeChainSel      uint64
-	FeedChainSel      uint64
-	ReplayBlocks      map[uint64]uint64
-	FeeTokenContracts map[uint64]FeeTokenContracts
+	Env          deployment.Environment
+	HomeChainSel uint64
+	FeedChainSel uint64
+	ReplayBlocks map[uint64]uint64
 }
 
 func (e *DeployedEnv) SetupJobs(t *testing.T) {

--- a/deployment/ccip/view/view.go
+++ b/deployment/ccip/view/view.go
@@ -53,5 +53,7 @@ type CCIPView struct {
 }
 
 func (v CCIPView) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v)
+	// Alias to avoid recursive calls
+	type Alias CCIPView
+	return json.MarshalIndent(&struct{ Alias }{Alias: Alias(v)}, "", " ")
 }

--- a/deployment/changeset.go
+++ b/deployment/changeset.go
@@ -21,13 +21,15 @@ var (
 type ChangeSet func(e Environment, config interface{}) (ChangesetOutput, error)
 
 // ChangesetOutput is the output of a Changeset function.
+// Think of it like a state transition output.
+// The address book here should contain only new addresses created in
+// this changeset.
 type ChangesetOutput struct {
-	JobSpecs  map[string][]string
-	Proposals []timelock.MCMSWithTimelockProposal
-	// The address book here should contain only new addresses created in this changeset.
+	JobSpecs    map[string][]string
+	Proposals   []timelock.MCMSWithTimelockProposal
 	AddressBook AddressBook
 }
 
 // ViewState produces a product specific JSON representation of
 // the on and offchain state of the environment.
-type ViewState func(e Environment, ab AddressBook) (json.Marshaler, error)
+type ViewState func(e Environment) (json.Marshaler, error)

--- a/deployment/environment/clo/env.go
+++ b/deployment/environment/clo/env.go
@@ -30,14 +30,14 @@ func NewDonEnv(t *testing.T, cfg DonEnvConfig) *deployment.Environment {
 			}
 		}
 	}
-	out := deployment.Environment{
-		Name:              cfg.DonName,
-		Offchain:          NewJobClient(cfg.Logger, cfg.Nops),
-		NodeIDs:           make([]string, 0),
-		Chains:            cfg.Chains,
-		Logger:            cfg.Logger,
-		ExistingAddresses: deployment.NewMemoryAddressBook(),
-	}
+	out := deployment.NewEnvironment(
+		cfg.DonName,
+		cfg.Logger,
+		deployment.NewMemoryAddressBook(),
+		cfg.Chains,
+		make([]string, 0),
+		NewJobClient(cfg.Logger, cfg.Nops),
+	)
 	// assume that all the nodes in the provided input nops are part of the don
 	for _, nop := range cfg.Nops {
 		for _, node := range nop.Nodes {
@@ -45,7 +45,7 @@ func NewDonEnv(t *testing.T, cfg DonEnvConfig) *deployment.Environment {
 		}
 	}
 
-	return &out
+	return out
 }
 
 func NewDonEnvWithMemoryChains(t *testing.T, cfg DonEnvConfig, ignore func(*models.NodeChainConfig) bool) *deployment.Environment {
@@ -88,19 +88,18 @@ type MultiDonEnvironment struct {
 }
 
 func (mde MultiDonEnvironment) Flatten(name string) *deployment.Environment {
-	return &deployment.Environment{
-		Name:              name,
-		Chains:            mde.Chains,
-		Logger:            mde.Logger,
-		ExistingAddresses: deployment.NewMemoryAddressBook(),
-
-		// TODO: KS-460 integrate with the clo offchain client impl
-		// may need to extend the Environment abstraction use maps rather than slices for Nodes
-		// somehow we need to capture the fact that each nodes belong to nodesets which have different capabilities
-		// purposely nil to catch misuse until we do that work
-		Offchain: nil,
-		NodeIDs:  nil,
-	}
+	// TODO: KS-460 integrate with the clo offchain client impl
+	// may need to extend the Environment abstraction use maps rather than slices for Nodes
+	// somehow we need to capture the fact that each nodes belong to nodesets which have different capabilities
+	// purposely nil to catch misuse until we do that work
+	return deployment.NewEnvironment(
+		name,
+		mde.Logger,
+		deployment.NewMemoryAddressBook(),
+		mde.Chains,
+		nil,
+		nil,
+	)
 }
 
 func newMultiDonEnvironment(logger logger.Logger, donToEnv map[string]*deployment.Environment) *MultiDonEnvironment {

--- a/deployment/environment/clo/env.go
+++ b/deployment/environment/clo/env.go
@@ -31,11 +31,12 @@ func NewDonEnv(t *testing.T, cfg DonEnvConfig) *deployment.Environment {
 		}
 	}
 	out := deployment.Environment{
-		Name:     cfg.DonName,
-		Offchain: NewJobClient(cfg.Logger, cfg.Nops),
-		NodeIDs:  make([]string, 0),
-		Chains:   cfg.Chains,
-		Logger:   cfg.Logger,
+		Name:              cfg.DonName,
+		Offchain:          NewJobClient(cfg.Logger, cfg.Nops),
+		NodeIDs:           make([]string, 0),
+		Chains:            cfg.Chains,
+		Logger:            cfg.Logger,
+		ExistingAddresses: deployment.NewMemoryAddressBook(),
 	}
 	// assume that all the nodes in the provided input nops are part of the don
 	for _, nop := range cfg.Nops {
@@ -88,9 +89,10 @@ type MultiDonEnvironment struct {
 
 func (mde MultiDonEnvironment) Flatten(name string) *deployment.Environment {
 	return &deployment.Environment{
-		Name:   name,
-		Chains: mde.Chains,
-		Logger: mde.Logger,
+		Name:              name,
+		Chains:            mde.Chains,
+		Logger:            mde.Logger,
+		ExistingAddresses: deployment.NewMemoryAddressBook(),
 
 		// TODO: KS-460 integrate with the clo offchain client impl
 		// may need to extend the Environment abstraction use maps rather than slices for Nodes

--- a/deployment/environment/devenv/environment.go
+++ b/deployment/environment/devenv/environment.go
@@ -44,11 +44,12 @@ func NewEnvironment(ctx context.Context, lggr logger.Logger, config EnvironmentC
 	}
 	nodeIDs := jd.don.NodeIds()
 
-	return &deployment.Environment{
-		Name:     DevEnv,
-		Offchain: offChain,
-		NodeIDs:  nodeIDs,
-		Chains:   chains,
-		Logger:   lggr,
-	}, jd.don, nil
+	return deployment.NewEnvironment(
+		DevEnv,
+		lggr,
+		deployment.NewMemoryAddressBook(),
+		chains,
+		nodeIDs,
+		offChain,
+	), jd.don, nil
 }

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -134,11 +134,12 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 	for id := range nodes {
 		nodeIDs = append(nodeIDs, id)
 	}
-	return deployment.Environment{
-		Name:     Memory,
-		Offchain: NewMemoryJobClient(nodes),
-		NodeIDs:  nodeIDs,
-		Chains:   chains,
-		Logger:   lggr,
-	}
+	return *deployment.NewEnvironment(
+		Memory,
+		lggr,
+		deployment.NewMemoryAddressBook(),
+		chains,
+		nodeIDs,
+		NewMemoryJobClient(nodes),
+	)
 }

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -116,14 +116,14 @@ func NewMemoryEnvironmentFromChainsNodes(t *testing.T,
 	for id := range nodes {
 		nodeIDs = append(nodeIDs, id)
 	}
-	return deployment.Environment{
-		Name:     Memory,
-		Offchain: NewMemoryJobClient(nodes),
-		// Note these have the p2p_ prefix.
-		NodeIDs: nodeIDs,
-		Chains:  chains,
-		Logger:  lggr,
-	}
+	return *deployment.NewEnvironment(
+		Memory,
+		lggr,
+		deployment.NewMemoryAddressBook(),
+		chains,
+		nodeIDs, // Note these have the p2p_ prefix.
+		NewMemoryJobClient(nodes),
+	)
 }
 
 // To be used by tests and any kind of deployment logic.

--- a/deployment/environment/memory/job_client.go
+++ b/deployment/environment/memory/job_client.go
@@ -55,8 +55,18 @@ func (j JobClient) ListKeypairs(ctx context.Context, in *csav1.ListKeypairsReque
 }
 
 func (j JobClient) GetNode(ctx context.Context, in *nodev1.GetNodeRequest, opts ...grpc.CallOption) (*nodev1.GetNodeResponse, error) {
-	//TODO CCIP-3108 implement me
-	panic("implement me")
+	n, ok := j.Nodes[in.Id]
+	if !ok {
+		return nil, errors.New("node not found")
+	}
+	return &nodev1.GetNodeResponse{
+		Node: &nodev1.Node{
+			Id:          in.Id,
+			PublicKey:   n.Keys.OCRKeyBundle.ID(), // is this the correct val?
+			IsEnabled:   true,
+			IsConnected: true,
+		},
+	}, nil
 }
 
 func (j JobClient) ListNodes(ctx context.Context, in *nodev1.ListNodesRequest, opts ...grpc.CallOption) (*nodev1.ListNodesResponse, error) {

--- a/deployment/keystone/changeset/configure_contracts.go
+++ b/deployment/keystone/changeset/configure_contracts.go
@@ -14,7 +14,7 @@ func ConfigureInitialContracts(lggr logger.Logger, req *kslib.ConfigureContracts
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to validate request: %w", err)
 	}
 
-	regAddrs, err := req.AddressBook.AddressesForChain(req.RegistryChainSel)
+	regAddrs, err := req.Env.ExistingAddresses.AddressesForChain(req.RegistryChainSel)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("no addresses found for chain %d: %w", req.RegistryChainSel, err)
 	}
@@ -38,7 +38,7 @@ func ConfigureInitialContracts(lggr logger.Logger, req *kslib.ConfigureContracts
 	// forwarder on all chains
 	foundForwarder = false
 	for _, c := range req.Env.Chains {
-		addrs, err2 := req.AddressBook.AddressesForChain(c.Selector)
+		addrs, err2 := req.Env.ExistingAddresses.AddressesForChain(c.Selector)
 		if err2 != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("no addresses found for chain %d: %w", c.Selector, err2)
 		}

--- a/deployment/keystone/changeset/deploy_forwarder.go
+++ b/deployment/keystone/changeset/deploy_forwarder.go
@@ -9,23 +9,19 @@ import (
 
 var _ deployment.ChangeSet = DeployForwarder
 
-type DeployRegistryConfig struct {
-	RegistryChainSelector uint64
-}
-
 func DeployForwarder(env deployment.Environment, config interface{}) (deployment.ChangesetOutput, error) {
-	c, ok := config.(DeployRegistryConfig)
+	registryChainSel, ok := config.(uint64)
 	if !ok {
 		return deployment.ChangesetOutput{}, deployment.ErrInvalidConfig
 	}
 	lggr := env.Logger
 	// expect OCR3 to be deployed & capabilities registry
-	regAddrs, err := env.ExistingAddresses.AddressesForChain(c.RegistryChainSelector)
+	regAddrs, err := env.ExistingAddresses.AddressesForChain(registryChainSel)
 	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("no addresses found for chain %d: %w", c.RegistryChainSelector, err)
+		return deployment.ChangesetOutput{}, fmt.Errorf("no addresses found for chain %d: %w", registryChainSel, err)
 	}
 	if len(regAddrs) != 2 {
-		return deployment.ChangesetOutput{}, fmt.Errorf("expected 2 addresses for chain %d, got %d", c.RegistryChainSelector, len(regAddrs))
+		return deployment.ChangesetOutput{}, fmt.Errorf("expected 2 addresses for chain %d, got %d", registryChainSel, len(regAddrs))
 	}
 	ab := deployment.NewMemoryAddressBook()
 	for _, chain := range env.Chains {

--- a/deployment/keystone/changeset/deploy_forwarder.go
+++ b/deployment/keystone/changeset/deploy_forwarder.go
@@ -11,7 +11,6 @@ var _ deployment.ChangeSet = DeployForwarder
 
 type DeployRegistryConfig struct {
 	RegistryChainSelector uint64
-	ExistingAddressBook   deployment.AddressBook
 }
 
 func DeployForwarder(env deployment.Environment, config interface{}) (deployment.ChangesetOutput, error) {
@@ -21,7 +20,7 @@ func DeployForwarder(env deployment.Environment, config interface{}) (deployment
 	}
 	lggr := env.Logger
 	// expect OCR3 to be deployed & capabilities registry
-	regAddrs, err := c.ExistingAddressBook.AddressesForChain(c.RegistryChainSelector)
+	regAddrs, err := env.ExistingAddresses.AddressesForChain(c.RegistryChainSelector)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("no addresses found for chain %d: %w", c.RegistryChainSelector, err)
 	}

--- a/deployment/keystone/changeset/deploy_forwarder_test.go
+++ b/deployment/keystone/changeset/deploy_forwarder_test.go
@@ -37,9 +37,7 @@ func TestDeployForwarder(t *testing.T) {
 		}
 		env.ExistingAddresses = deployment.NewMemoryAddressBookFromMap(m)
 		// capabilities registry and ocr3 must be deployed on registry chain
-		_, err := changeset.DeployForwarder(env, changeset.DeployRegistryConfig{
-			RegistryChainSelector: registrySel,
-		})
+		_, err := changeset.DeployForwarder(env, registrySel)
 		require.Error(t, err)
 	})
 
@@ -50,9 +48,7 @@ func TestDeployForwarder(t *testing.T) {
 		}
 		env.ExistingAddresses = deployment.NewMemoryAddressBookFromMap(m)
 		// capabilities registry and ocr3 must be deployed on registry chain
-		_, err := changeset.DeployForwarder(env, changeset.DeployRegistryConfig{
-			RegistryChainSelector: registrySel,
-		})
+		_, err := changeset.DeployForwarder(env, registrySel)
 		require.Error(t, err)
 	})
 
@@ -67,9 +63,7 @@ func TestDeployForwarder(t *testing.T) {
 		require.NoError(t, err)
 		// deploy forwarder
 		env.ExistingAddresses = ab
-		resp, err := changeset.DeployForwarder(env, changeset.DeployRegistryConfig{
-			RegistryChainSelector: registrySel,
-		})
+		resp, err := changeset.DeployForwarder(env, registrySel)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		// registry, ocr3, forwarder should be deployed on registry chain

--- a/deployment/keystone/changeset/deploy_forwarder_test.go
+++ b/deployment/keystone/changeset/deploy_forwarder_test.go
@@ -35,8 +35,7 @@ func TestDeployForwarder(t *testing.T) {
 		m[registrySel] = map[string]deployment.TypeAndVersion{
 			"0x0000000000000000000000000000000000000002": ocrTV,
 		}
-		ab := deployment.NewMemoryAddressBookFromMap(m)
-		env.ExistingAddresses.Merge(ab)
+		env.ExistingAddresses = deployment.NewMemoryAddressBookFromMap(m)
 		// capabilities registry and ocr3 must be deployed on registry chain
 		_, err := changeset.DeployForwarder(env, changeset.DeployRegistryConfig{
 			RegistryChainSelector: registrySel,
@@ -49,8 +48,7 @@ func TestDeployForwarder(t *testing.T) {
 		m[registrySel] = map[string]deployment.TypeAndVersion{
 			"0x0000000000000000000000000000000000000001": crTV,
 		}
-		ab := deployment.NewMemoryAddressBookFromMap(m)
-		env.ExistingAddresses.Merge(ab)
+		env.ExistingAddresses = deployment.NewMemoryAddressBookFromMap(m)
 		// capabilities registry and ocr3 must be deployed on registry chain
 		_, err := changeset.DeployForwarder(env, changeset.DeployRegistryConfig{
 			RegistryChainSelector: registrySel,
@@ -68,7 +66,7 @@ func TestDeployForwarder(t *testing.T) {
 		err = ab.Save(registrySel, "0x0000000000000000000000000000000000000002", ocrTV)
 		require.NoError(t, err)
 		// deploy forwarder
-		env.ExistingAddresses.Merge(ab)
+		env.ExistingAddresses = ab
 		resp, err := changeset.DeployForwarder(env, changeset.DeployRegistryConfig{
 			RegistryChainSelector: registrySel,
 		})

--- a/deployment/keystone/changeset/deploy_forwarder_test.go
+++ b/deployment/keystone/changeset/deploy_forwarder_test.go
@@ -36,10 +36,10 @@ func TestDeployForwarder(t *testing.T) {
 			"0x0000000000000000000000000000000000000002": ocrTV,
 		}
 		ab := deployment.NewMemoryAddressBookFromMap(m)
+		env.ExistingAddresses.Merge(ab)
 		// capabilities registry and ocr3 must be deployed on registry chain
 		_, err := changeset.DeployForwarder(env, changeset.DeployRegistryConfig{
 			RegistryChainSelector: registrySel,
-			ExistingAddressBook:   ab,
 		})
 		require.Error(t, err)
 	})
@@ -50,10 +50,10 @@ func TestDeployForwarder(t *testing.T) {
 			"0x0000000000000000000000000000000000000001": crTV,
 		}
 		ab := deployment.NewMemoryAddressBookFromMap(m)
+		env.ExistingAddresses.Merge(ab)
 		// capabilities registry and ocr3 must be deployed on registry chain
 		_, err := changeset.DeployForwarder(env, changeset.DeployRegistryConfig{
 			RegistryChainSelector: registrySel,
-			ExistingAddressBook:   ab,
 		})
 		require.Error(t, err)
 	})
@@ -68,9 +68,9 @@ func TestDeployForwarder(t *testing.T) {
 		err = ab.Save(registrySel, "0x0000000000000000000000000000000000000002", ocrTV)
 		require.NoError(t, err)
 		// deploy forwarder
+		env.ExistingAddresses.Merge(ab)
 		resp, err := changeset.DeployForwarder(env, changeset.DeployRegistryConfig{
 			RegistryChainSelector: registrySel,
-			ExistingAddressBook:   ab,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)

--- a/deployment/keystone/changeset/view.go
+++ b/deployment/keystone/changeset/view.go
@@ -42,7 +42,7 @@ func ViewKeystone(e deployment.Environment) (json.Marshaler, error) {
 	if err != nil {
 		return nil, err
 	}
-	return view.KeystoneView{
+	return &view.KeystoneView{
 		Chains: chainViews,
 		Nops:   nopsView,
 	}, nil

--- a/deployment/keystone/changeset/view.go
+++ b/deployment/keystone/changeset/view.go
@@ -13,10 +13,10 @@ import (
 
 var _ deployment.ViewState = ViewKeystone
 
-func ViewKeystone(e deployment.Environment, ab deployment.AddressBook) (json.Marshaler, error) {
+func ViewKeystone(e deployment.Environment) (json.Marshaler, error) {
 	state, err := keystone.GetContractSets(&keystone.GetContractSetsRequest{
 		Chains:      e.Chains,
-		AddressBook: ab,
+		AddressBook: e.ExistingAddresses,
 	})
 	if err != nil {
 		return nil, err

--- a/deployment/keystone/changeset/view_test.go
+++ b/deployment/keystone/changeset/view_test.go
@@ -1,0 +1,42 @@
+package changeset
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+)
+
+func TestKeystoneView(t *testing.T) {
+	t.Parallel()
+	env := memory.NewMemoryEnvironment(t, logger.Test(t), zapcore.DebugLevel, memory.MemoryEnvironmentConfig{
+		Nodes:  1,
+		Chains: 2,
+	})
+	registryChain := env.AllChainSelectors()[0]
+	resp, err := DeployCapabilityRegistry(env, registryChain)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NoError(t, env.ExistingAddresses.Merge(resp.AddressBook))
+	resp, err = DeployForwarder(env, DeployRegistryConfig{
+		RegistryChainSelector: registryChain,
+		ExistingAddressBook:   nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NoError(t, env.ExistingAddresses.Merge(resp.AddressBook))
+	resp, err = DeployOCR3(env, DeployRegistryConfig{
+		RegistryChainSelector: registryChain,
+		ExistingAddressBook:   nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NoError(t, env.ExistingAddresses.Merge(resp.AddressBook))
+
+	a, err := ViewKeystone(env)
+	fmt.Println(a)
+}

--- a/deployment/keystone/changeset/view_test.go
+++ b/deployment/keystone/changeset/view_test.go
@@ -25,9 +25,7 @@ func TestKeystoneView(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NoError(t, env.ExistingAddresses.Merge(resp.AddressBook))
-	resp, err = DeployForwarder(env, DeployRegistryConfig{
-		RegistryChainSelector: registryChain,
-	})
+	resp, err = DeployForwarder(env, registryChain)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NoError(t, env.ExistingAddresses.Merge(resp.AddressBook))

--- a/deployment/keystone/changeset/view_test.go
+++ b/deployment/keystone/changeset/view_test.go
@@ -1,7 +1,6 @@
 package changeset
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,21 +21,21 @@ func TestKeystoneView(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NoError(t, env.ExistingAddresses.Merge(resp.AddressBook))
-	resp, err = DeployForwarder(env, DeployRegistryConfig{
-		RegistryChainSelector: registryChain,
-		ExistingAddressBook:   nil,
-	})
+	resp, err = DeployOCR3(env, registryChain)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NoError(t, env.ExistingAddresses.Merge(resp.AddressBook))
-	resp, err = DeployOCR3(env, DeployRegistryConfig{
+	resp, err = DeployForwarder(env, DeployRegistryConfig{
 		RegistryChainSelector: registryChain,
-		ExistingAddressBook:   nil,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NoError(t, env.ExistingAddresses.Merge(resp.AddressBook))
 
 	a, err := ViewKeystone(env)
-	fmt.Println(a)
+	require.NoError(t, err)
+	b, err := a.MarshalJSON()
+	require.NoError(t, err)
+	require.NotEmpty(t, b)
+	t.Log(string(b))
 }

--- a/deployment/keystone/deploy.go
+++ b/deployment/keystone/deploy.go
@@ -39,7 +39,6 @@ type ConfigureContractsRequest struct {
 	Dons       []DonCapabilities        // externally sourced based on the environment
 	OCR3Config *OracleConfigWithSecrets // TODO: probably should be a map of don to config; but currently we only have one wf don therefore one config
 
-	AddressBook      deployment.AddressBook
 	DoContractDeploy bool // if false, the contracts are assumed to be deployed and the address book is used
 }
 
@@ -49,9 +48,6 @@ func (r ConfigureContractsRequest) Validate() error {
 	}
 	if r.Env == nil {
 		return errors.New("environment is nil")
-	}
-	if r.AddressBook == nil {
-		return errors.New("address book is nil")
 	}
 	if len(r.Dons) == 0 {
 		return errors.New("no DONS")
@@ -75,7 +71,7 @@ func ConfigureContracts(ctx context.Context, lggr logger.Logger, req ConfigureCo
 		return nil, fmt.Errorf("invalid request: %w", err)
 	}
 
-	addrBook := req.AddressBook
+	addrBook := req.Env.ExistingAddresses
 	if req.DoContractDeploy {
 		contractDeployCS, err := DeployContracts(lggr, req.Env, req.RegistryChainSel)
 		if err != nil {

--- a/deployment/keystone/deploy_test.go
+++ b/deployment/keystone/deploy_test.go
@@ -68,13 +68,14 @@ func TestDeploy(t *testing.T) {
 	// explicitly deploy the contracts
 	cs, err := keystone.DeployContracts(lggr, env, registryChainSel)
 	require.NoError(t, err)
+	// Deploy successful these are now part of our env.
+	require.NoError(t, env.ExistingAddresses.Merge(cs.AddressBook))
 
 	deployReq := keystone.ConfigureContractsRequest{
 		RegistryChainSel: registryChainSel,
 		Env:              env,
 		OCR3Config:       &ocr3Config,
 		Dons:             []keystone.DonCapabilities{wfDon, cwDon, assetDon},
-		AddressBook:      cs.AddressBook,
 		DoContractDeploy: false,
 	}
 	deployResp, err := keystone.ConfigureContracts(ctx, lggr, deployReq)
@@ -159,6 +160,9 @@ func TestDeploy(t *testing.T) {
 		_, err := cs.OCR3.LatestConfigDetails(&bind.CallOpts{})
 		require.NoError(t, err)
 	}
+
+	// Ensure we can view the state.
+	ViewK
 }
 
 func requireChains(t *testing.T, donNops []*models.NodeOperator, cs []models.ChainType) {

--- a/deployment/keystone/deploy_test.go
+++ b/deployment/keystone/deploy_test.go
@@ -160,9 +160,6 @@ func TestDeploy(t *testing.T) {
 		_, err := cs.OCR3.LatestConfigDetails(&bind.CallOpts{})
 		require.NoError(t, err)
 	}
-
-	// Ensure we can view the state.
-	ViewK
 }
 
 func requireChains(t *testing.T, donNops []*models.NodeOperator, cs []models.ChainType) {

--- a/deployment/keystone/state.go
+++ b/deployment/keystone/state.go
@@ -29,7 +29,7 @@ type ContractSet struct {
 }
 
 func (cs ContractSet) View() (view.KeystoneChainView, error) {
-	var out view.KeystoneChainView
+	out := view.NewKeystoneChainView()
 	if cs.CapabilitiesRegistry != nil {
 		capRegView, err := common_v1_0.GenerateCapRegView(cs.CapabilitiesRegistry)
 		if err != nil {

--- a/deployment/keystone/view/view.go
+++ b/deployment/keystone/view/view.go
@@ -12,6 +12,12 @@ type KeystoneChainView struct {
 	// TODO forwarders etc
 }
 
+func NewKeystoneChainView() KeystoneChainView {
+	return KeystoneChainView{
+		CapabilityRegistry: make(map[string]common_v1_0.CapRegView),
+	}
+}
+
 type KeystoneView struct {
 	Chains map[string]KeystoneChainView `json:"chains,omitempty"`
 	Nops   map[string]view.NopView      `json:"nops,omitempty"`

--- a/deployment/keystone/view/view.go
+++ b/deployment/keystone/view/view.go
@@ -24,5 +24,7 @@ type KeystoneView struct {
 }
 
 func (v KeystoneView) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v)
+	// Alias to avoid recursive calls
+	type Alias KeystoneView
+	return json.MarshalIndent(&struct{ Alias }{Alias: Alias(v)}, "", " ")
 }

--- a/integration-tests/smoke/ccip_rmn_test.go
+++ b/integration-tests/smoke/ccip_rmn_test.go
@@ -61,7 +61,7 @@ func TestRMN(t *testing.T) {
 		})
 	}
 
-	onChainState, err := ccipdeployment.LoadOnchainState(envWithRMN.Env, envWithRMN.Ab)
+	onChainState, err := ccipdeployment.LoadOnchainState(envWithRMN.Env)
 	require.NoError(t, err)
 	t.Logf("onChainState: %#v", onChainState)
 

--- a/integration-tests/smoke/ccip_test.go
+++ b/integration-tests/smoke/ccip_test.go
@@ -26,7 +26,7 @@ func TestInitialDeployOnLocal(t *testing.T) {
 	tenv, _, _ := testsetups.NewLocalDevEnvironment(t, lggr)
 	e := tenv.Env
 
-	state, err := ccdeploy.LoadOnchainState(tenv.Env, tenv.Ab)
+	state, err := ccdeploy.LoadOnchainState(tenv.Env)
 	require.NoError(t, err)
 
 	feeds := state.Chains[tenv.FeedChainSel].USDFeeds
@@ -40,18 +40,17 @@ func TestInitialDeployOnLocal(t *testing.T) {
 	)
 	// Apply migration
 	output, err := changeset.InitialDeploy(tenv.Env, ccdeploy.DeployCCIPContractConfig{
-		HomeChainSel:        tenv.HomeChainSel,
-		FeedChainSel:        tenv.FeedChainSel,
-		ChainsToDeploy:      tenv.Env.AllChainSelectors(),
-		TokenConfig:         tokenConfig,
-		MCMSConfig:          ccdeploy.NewTestMCMSConfig(t, e),
-		ExistingAddressBook: tenv.Ab,
-		OCRSecrets:          deployment.XXXGenerateTestOCRSecrets(),
+		HomeChainSel:   tenv.HomeChainSel,
+		FeedChainSel:   tenv.FeedChainSel,
+		ChainsToDeploy: tenv.Env.AllChainSelectors(),
+		TokenConfig:    tokenConfig,
+		MCMSConfig:     ccdeploy.NewTestMCMSConfig(t, e),
+		OCRSecrets:     deployment.XXXGenerateTestOCRSecrets(),
 	})
 	require.NoError(t, err)
-	require.NoError(t, tenv.Ab.Merge(output.AddressBook))
+	require.NoError(t, tenv.Env.ExistingAddresses.Merge(output.AddressBook))
 	// Get new state after migration.
-	state, err = ccdeploy.LoadOnchainState(e, tenv.Ab)
+	state, err = ccdeploy.LoadOnchainState(e)
 	require.NoError(t, err)
 
 	// Ensure capreg logs are up to date.


### PR DESCRIPTION
Its common that changesets need to be aware of the existing address set, for example reading existing state in order to produce inputs for onchain changes - as evidenced by both keystone and CCIP passing existing addresses around for changesets. So here we add it as a primary field for the environment, then changesets will always have access to the existing onchain state. Adding it as a field is also natural and analogous to NodeIDs (they serve as "offchain pointers" whereas existing addresses serve as "onchain pointers") and it allows for a nice 1-1 mapping of product/env deployment directory to a deployment.Environment instance. 