### PR TITLE
fix: optimize CodeQL run conditions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,34 +11,68 @@ on:
     - cron: '23 19 * * 4'
 
 jobs:
-  analyze:
-    name: Analyze ${{ matrix.language }}
+  filter:
+    name: Detect Changes
+    permissions:
+      pull-requests: read
+    outputs:
+      should-run-go: ${{ steps.changes.outputs.go-changes == 'true' || steps.changes.outputs.workflow-changes == 'true' || github.event == 'schedule' }}
+      should-run-js: ${{ steps.changes.outputs.js-changes == 'true' || steps.changes.outputs.workflow-changes == 'true' || github.event == 'schedule' }}
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4.2.1
+        with:
+          repository: smartcontractkit/chainlink
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          filters: |
+            go-changes:
+              - '**/*.go'
+              - '**/go.mod'
+              - '**/go.sum'
+            js-changes:
+              - '**/package.json'
+              - '**/pnpm-lock.yaml'
+              - '**/*.js'
+              - '**/*.ts'
+            workflow-changes:
+              - '.github/workflows/codeql-analysis.yml'
 
+  analyze:
+    needs: filter
+    name: Analyze ${{ matrix.type.language }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        language: ['go', 'javascript']
-
+        type:
+          - language: 'go'
+            should-run: ${{ needs.filter.outputs.should-run-go }}
+          - language: 'javascript'
+            should-run: ${{ needs.filter.outputs.should-run-js }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.1
 
       - name: Set up Go
-        if: ${{ matrix.language == 'go' }}
+        if: ${{ matrix.type.language == 'go' && matrix.type.should-run == 'true' }}
         uses: ./.github/actions/setup-go
         with:
           go-version-file: 'go.mod'
           only-modules: 'true'
 
       - name: Touching core/web/assets/index.html
-        if: ${{ matrix.language == 'go' }}
+        if: ${{ matrix.type.language == 'go' && matrix.type.should-run == 'true' }}
         run: mkdir -p core/web/assets && touch core/web/assets/index.html
 
       - name: Initialize CodeQL
+        if: ${{ matrix.type.should-run == 'true' }}
         uses: github/codeql-action/init@65c74964a9ed8c44ed9f19d4bbc5757a6a8e9ab9 # codeql-bundle-v2.16.1
         with:
-          languages: ${{ matrix.language }}
+          languages: ${{ matrix.type.language }}
 
       - name: Perform CodeQL Analysis
+        if: ${{ matrix.type.should-run == 'true' }}
         uses: github/codeql-action/analyze@65c74964a9ed8c44ed9f19d4bbc5757a6a8e9ab9 # codeql-bundle-v2.16.1


### PR DESCRIPTION
Optimize CodeQL workflow run conditions.
- Only run CodeQL analysis on Go files if a `.go`, `go.mod`, or a `go.sum` file was changed
- Only run CodeQL analysis on JS files if a `.js`, `.ts`, `package.json`, or a`pnpm-lock.yaml` file was changed
- Run CodeQL if the workflow was changed

### Changes

- Add a filter step to the CodeQL workflow which checks for specific file changes
- Skip over CodeQL analysis if there were no changes to specific files 

---

RE-3155