### PR TITLE
adding otel attributes to config_telemetry

### DIFF
--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -97,7 +97,7 @@ func initGlobals(cfgProm config.Prometheus, cfgTracing config.Tracing, cfgTeleme
 			for k, v := range cfgTelemetry.ResourceAttributes() {
 				attributes = append(attributes, attribute.String(k, v))
 			}
-			lggr.Criticalf("static.Version: %s", static.Version)
+
 			clientCfg := beholder.Config{
 				InsecureConnection:       cfgTelemetry.InsecureConnection(),
 				CACertFile:               cfgTelemetry.CACertFile(),

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -97,6 +97,7 @@ func initGlobals(cfgProm config.Prometheus, cfgTracing config.Tracing, cfgTeleme
 			for k, v := range cfgTelemetry.ResourceAttributes() {
 				attributes = append(attributes, attribute.String(k, v))
 			}
+			lggr.Criticalf("static.Version: %s", static.Version)
 			clientCfg := beholder.Config{
 				InsecureConnection:       cfgTelemetry.InsecureConnection(),
 				CACertFile:               cfgTelemetry.CACertFile(),

--- a/core/services/chainlink/config_telemetry.go
+++ b/core/services/chainlink/config_telemetry.go
@@ -2,6 +2,7 @@ package chainlink
 
 import (
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
+	"github.com/smartcontractkit/chainlink/v2/core/static"
 )
 
 type telemetryConfig struct {
@@ -31,8 +32,24 @@ func (b *telemetryConfig) OtelExporterGRPCEndpoint() string {
 	return *b.s.Endpoint
 }
 
+// ResourceAttributes returns the resource attributes set in the TOML config
+// by the user, but first sets OTEL required attributes:
+//
+//	service.name
+//	service.version
+//
+// These can be overridden by the TOML if the user so chooses
 func (b *telemetryConfig) ResourceAttributes() map[string]string {
-	return b.s.ResourceAttributes
+	defaults := map[string]string{
+		"service.name":    "chainlink",
+		"service.version": static.Version,
+	}
+
+	for k, v := range b.s.ResourceAttributes {
+		defaults[k] = v
+	}
+
+	return defaults
 }
 
 func (b *telemetryConfig) TraceSampleRatio() float64 {

--- a/core/services/chainlink/config_telemetry_test.go
+++ b/core/services/chainlink/config_telemetry_test.go
@@ -127,13 +127,12 @@ func TestTelemetryConfig_TraceSampleRatio(t *testing.T) {
 		expected  float64
 	}{
 		{"TraceSampleRatioSet", toml.Telemetry{TraceSampleRatio: ptrFloat(0.5)}, 0.5},
-		{"TraceSampleRatioNil", toml.Telemetry{TraceSampleRatio: nil}, 0.0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tc := telemetryConfig{s: tt.telemetry}
-			assert.Equal(t, tt.expected, tc.TraceSampleRatio())
+			assert.InEpsilon(t, tt.expected, tc.TraceSampleRatio(), 0.0001)
 		})
 	}
 }

--- a/core/services/chainlink/config_telemetry_test.go
+++ b/core/services/chainlink/config_telemetry_test.go
@@ -1,0 +1,143 @@
+package chainlink
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
+	"github.com/smartcontractkit/chainlink/v2/core/static"
+)
+
+func TestTelemetryConfig_Enabled(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name      string
+		telemetry toml.Telemetry
+		expected  bool
+	}{
+		{"EnabledTrue", toml.Telemetry{Enabled: &trueVal}, true},
+		{"EnabledFalse", toml.Telemetry{Enabled: &falseVal}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := telemetryConfig{s: tt.telemetry}
+			assert.Equal(t, tt.expected, tc.Enabled())
+		})
+	}
+}
+
+func TestTelemetryConfig_InsecureConnection(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name      string
+		telemetry toml.Telemetry
+		expected  bool
+	}{
+		{"InsecureConnectionTrue", toml.Telemetry{InsecureConnection: &trueVal}, true},
+		{"InsecureConnectionFalse", toml.Telemetry{InsecureConnection: &falseVal}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := telemetryConfig{s: tt.telemetry}
+			assert.Equal(t, tt.expected, tc.InsecureConnection())
+		})
+	}
+}
+
+func TestTelemetryConfig_CACertFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		telemetry toml.Telemetry
+		expected  string
+	}{
+		{"CACertFileSet", toml.Telemetry{CACertFile: ptr("test.pem")}, "test.pem"},
+		{"CACertFileNil", toml.Telemetry{CACertFile: nil}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := telemetryConfig{s: tt.telemetry}
+			assert.Equal(t, tt.expected, tc.CACertFile())
+		})
+	}
+}
+
+func TestTelemetryConfig_OtelExporterGRPCEndpoint(t *testing.T) {
+	tests := []struct {
+		name      string
+		telemetry toml.Telemetry
+		expected  string
+	}{
+		{"EndpointSet", toml.Telemetry{Endpoint: ptr("localhost:4317")}, "localhost:4317"},
+		{"EndpointNil", toml.Telemetry{Endpoint: nil}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := telemetryConfig{s: tt.telemetry}
+			assert.Equal(t, tt.expected, tc.OtelExporterGRPCEndpoint())
+		})
+	}
+}
+
+func TestTelemetryConfig_ResourceAttributes(t *testing.T) {
+	tests := []struct {
+		name      string
+		telemetry toml.Telemetry
+		expected  map[string]string
+	}{
+		{
+			"DefaultAttributes",
+			toml.Telemetry{ResourceAttributes: nil},
+			map[string]string{
+				"service.name":    "chainlink",
+				"service.version": static.Version,
+			},
+		},
+		{
+			"CustomAttributes",
+			toml.Telemetry{ResourceAttributes: map[string]string{"custom.key": "custom.value"}},
+			map[string]string{
+				"service.name":    "chainlink",
+				"service.version": static.Version,
+				"custom.key":      "custom.value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := telemetryConfig{s: tt.telemetry}
+			assert.Equal(t, tt.expected, tc.ResourceAttributes())
+		})
+	}
+}
+
+func TestTelemetryConfig_TraceSampleRatio(t *testing.T) {
+	tests := []struct {
+		name      string
+		telemetry toml.Telemetry
+		expected  float64
+	}{
+		{"TraceSampleRatioSet", toml.Telemetry{TraceSampleRatio: ptrFloat(0.5)}, 0.5},
+		{"TraceSampleRatioNil", toml.Telemetry{TraceSampleRatio: nil}, 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := telemetryConfig{s: tt.telemetry}
+			assert.Equal(t, tt.expected, tc.TraceSampleRatio())
+		})
+	}
+}
+
+func ptrFloat(f float64) *float64 {
+	return &f
+}


### PR DESCRIPTION
[NONEVM-828](https://smartcontract-it.atlassian.net/browse/NONEVM-828)

I considered 3 options while implementing this:
1. Make these fields defaults in the TOML. The `static.Version` field is set at build time, so its available to tests that test default TOML. From a user experience though, I may want to always set these fields, so user configurable does not seem like a perfect fit.
2. The current approach, which overrides the getter on ResourceAttributes after the general app config has been made
3. Set these values way higher in the stack for the consumers of `beholder.Config`. Most straightforward to read and reason about, but either introduces duplication when loops are spun up or pollutes a clean default initialization of a beholder client.
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[NONEVM-828]: https://smartcontract-it.atlassian.net/browse/NONEVM-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NONEVM-828]: https://smartcontract-it.atlassian.net/browse/NONEVM-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ