### PR TITLE
Fix weth price decimal

### DIFF
--- a/deployment/ccip/test_helpers.go
+++ b/deployment/ccip/test_helpers.go
@@ -274,7 +274,7 @@ const (
 
 var (
 	MockLinkPrice = big.NewInt(5e18)
-	MockWethPrice = big.NewInt(9e18)
+	MockWethPrice = big.NewInt(9e8)
 	// MockDescriptionToTokenSymbol maps a mock feed description to token descriptor
 	MockDescriptionToTokenSymbol = map[string]TokenSymbol{
 		MockLinkAggregatorDescription: LinkSymbol,


### PR DESCRIPTION
MockETHUSDAggregator is using 8 decimals but we are reporting a price with 18 which is creating a very high WETH token price reporting (x e10)

https://github.com/smartcontractkit/chainlink/blob/c4b3dbb7a3f12092e11b1ab04c70784972f6b111/contracts/src/v0.8/automation/testhelpers/MockETHUSDAggregator.sol#L15