### PR TITLE
fix: seperate caches for non x86 runners

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -60,9 +60,9 @@ runs:
       # os-id will be "linux-arm64" for an ARM64 linux runner
       run: |
         if [[ "${{ runner.arch }}" == "X64" ]]; then
-          echo "os-id=${{ steps.runner-os.outputs.os-id }}" >> $GITHUB_OUTPUT
+          echo "os-id=${{ runner.os }}" >> $GITHUB_OUTPUT
         else
-          echo "os-id=${{ steps.runner-os.outputs.os-id }}-${{ runner.arch }}" >> $GITHUB_OUTPUT
+          echo "os-id=${{ runner.os }}-${{ runner.arch }}" >> $GITHUB_OUTPUT
         fi
 
     # By default, restore the cache only.

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -52,6 +52,19 @@ runs:
       shell: bash
       run: echo "path=./${{ inputs.go-module-file }}" >> $GITHUB_OUTPUT
 
+    - name: Set runner OS
+      id: runner-os
+      shell: bash
+      # Needed for ARM runners.
+      # os-id will be "linux" for an x86 linux runner
+      # os-id will be "linux-arm64" for an ARM64 linux runner
+      run: |
+        if [[ "${{ runner.arch }}" == "X64" ]]; then
+          echo "os-id=${{ steps.runner-os.outputs.os-id }}" >> $GITHUB_OUTPUT
+        else
+          echo "os-id=${{ steps.runner-os.outputs.os-id }}-${{ runner.arch }}" >> $GITHUB_OUTPUT
+        fi
+
     # By default, restore the cache only.
     # If multiple jobs call actions/cache, then only one will get priority to create upon a cache miss.
     # We will only restore the cache by default (by calling actions/cache/restore) and let the
@@ -64,9 +77,9 @@ runs:
           ${{ steps.go-cache-dir.outputs.gomodcache }}
         # The lifetime of go modules is much higher than the build outputs, so we increase cache efficiency
         # here by not having the primary key contain the branch name
-        key: ${{ runner.os }}-gomod-${{ inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}
+        key: ${{ steps.runner-os.outputs.os-id }}-gomod-${{ inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}
         restore-keys: |
-          ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
+          ${{ steps.runner-os.outputs.os-id }}-gomod-${{ inputs.cache-version }}-
 
     # If this is called, then it will create the cache entry upon a cache miss.
     # The cache is created after a cache miss, and after job completes successfully.
@@ -78,9 +91,9 @@ runs:
           ${{ steps.go-cache-dir.outputs.gomodcache }}
         # The lifetime of go modules is much higher than the build outputs, so we increase cache efficiency
         # here by not having the primary key contain the branch name
-        key: ${{ runner.os }}-gomod-${{ inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}
+        key: ${{ steps.runner-os.outputs.os-id }}-gomod-${{ inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}
         restore-keys: |
-          ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
+          ${{ steps.runner-os.outputs.os-id }}-gomod-${{ inputs.cache-version }}-
 
     - uses: actions/cache/restore@v4.1.1
       name: Cache Go Build Outputs (restore)
@@ -89,12 +102,12 @@ runs:
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
-        key: ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-${{ steps.branch-name.outputs.current_branch }}
+        key: ${{ steps.runner-os.outputs.os-id }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-${{ steps.branch-name.outputs.current_branch }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-develop
-          ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-
-          ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-
-          ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-
+          ${{ steps.runner-os.outputs.os-id }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-develop
+          ${{ steps.runner-os.outputs.os-id }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-
+          ${{ steps.runner-os.outputs.os-id }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-
+          ${{ steps.runner-os.outputs.os-id }}-gobuild-${{ inputs.cache-version }}-
 
     - uses: actions/cache@v4.1.1
       # don't save cache on merge queue events
@@ -104,9 +117,9 @@ runs:
         path: |
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
         # The lifetime of go build outputs is pretty short, so we make our primary cache key be the branch name
-        key: ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-${{ steps.branch-name.outputs.current_branch }}
+        key: ${{ steps.runner-os.outputs.os-id }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-${{ steps.branch-name.outputs.current_branch }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-develop
-          ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-
-          ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-
-          ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-
+          ${{ steps.runner-os.outputs.os-id }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-develop
+          ${{ steps.runner-os.outputs.os-id }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-
+          ${{ steps.runner-os.outputs.os-id }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-
+          ${{ steps.runner-os.outputs.os-id }}-gobuild-${{ inputs.cache-version }}-


### PR DESCRIPTION
We are seeing failures in goreleaser image builds for ARM64 runners only. 
- https://github.com/smartcontractkit/chainlink/actions/workflows/build-publish-develop-pr.yml

```
  • docker images
    • 8 images were not built as they don't match the current partial build
```

We believe this is due to the recent changes to the action (https://github.com/smartcontractkit/chainlink/commit/0a4b5ac58570685e493d2c9dfb1dc78aefb0d657#diff-bece67f0e414c80e8463ee2c82d2c6c0da0986fd0f32cb0a754928a7f1efc8c1) which changed the caching. However, this in turn meant ARM64 runners were using a cache populated by x86 runners.

### Changes

- Update `setup-go` action to have the runner architecture in the cache name, when it's not an x86 runner.
    - It is done conditionally to not disrupt existing caches. 

### Testing

Should be fixed here: https://github.com/smartcontractkit/chainlink/actions/runs/11673040114/job/32502925578?pr=15106


