### PR TITLE
fix: pinning goreleaser version to fix builds

### DIFF
--- a/.github/workflows/build-publish-develop-pr.yml
+++ b/.github/workflows/build-publish-develop-pr.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Merge images for both architectures
         uses: ./.github/actions/goreleaser-build-sign-publish
         with:
+            # Temporary pin to working version as 2.4.2+ is breaking arm64 builds
+          goreleaser-version: "v2.3.2"
           docker-registry: ${{ secrets.AWS_SDLC_ECR_HOSTNAME }}
           docker-image-tag: ${{ needs.image-tag.outputs.image-tag }}
           goreleaser-release-type: "merge"
@@ -112,6 +114,8 @@ jobs:
         uses: ./.github/actions/goreleaser-build-sign-publish
         if: steps.cache.outputs.cache-hit != 'true'
         with:
+          # Temporary pin to working version as 2.4.2+ is breaking arm64 builds
+          goreleaser-version: "v2.3.2"
           docker-registry: ${{ secrets.AWS_SDLC_ECR_HOSTNAME }}
           docker-image-tag: ${{ needs.image-tag.outputs.image-tag }}
           goreleaser-release-type: ${{ needs.image-tag.outputs.release-type }}

--- a/.github/workflows/build-publish-goreleaser.yml
+++ b/.github/workflows/build-publish-goreleaser.yml
@@ -119,6 +119,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/goreleaser-build-sign-publish
         with:
+          # Temporary pin to working version as 2.4.2+ is breaking arm64 builds
+          goreleaser-version: "v2.3.2"
           docker-registry: ${{ env.ECR_HOSTNAME }}
           docker-image-tag: ${{ github.ref_name }}
           goreleaser-release-type: release

--- a/.github/workflows/build-publish-goreleaser.yml
+++ b/.github/workflows/build-publish-goreleaser.yml
@@ -67,6 +67,8 @@ jobs:
         id: goreleaser-build-sign-publish
         uses: ./.github/actions/goreleaser-build-sign-publish
         with:
+          # Temporary pin to working version as 2.4.2+ is breaking arm64 builds
+          goreleaser-version: "v2.3.2"
           docker-registry: ${{ env.ECR_HOSTNAME }}
           docker-image-tag: ${{ github.ref_name }}
           goreleaser-config: .goreleaser.production.yaml


### PR DESCRIPTION
We are seeing failures in goreleaser image builds for ARM64 runners only. 
- https://github.com/smartcontractkit/chainlink/actions/workflows/build-publish-develop-pr.yml

```
  • docker images
    • 8 images were not built as they don't match the current partial build
```

This seems to be due to the goreleaser 2.4.2 update. 

https://github.com/goreleaser/goreleaser/releases/tag/v2.4.2
```
    6ef6623: fix: build override (#5239) (@nekohasekai)
    a4ead4b: fix: build override consider goarm64 (@caarlos0)
    cb8997e: fix: goreleaser build --single-target on arm64 (@caarlos0)
```

### Testing

If this goes green: https://github.com/smartcontractkit/chainlink/actions/runs/11673726630/job/32505031106?pr=15108