### PR TITLE
fix: arm64 builds with goreleaser 2.4.x

### DIFF
--- a/.github/workflows/build-publish-develop-pr.yml
+++ b/.github/workflows/build-publish-develop-pr.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/cache/restore@v4
         with:
-          path: dist/linux_arm64
+          path: dist/linux_arm64_v8.0
           key: chainlink-arm64-${{ github.sha }}
           fail-on-cache-miss: true
 
@@ -86,7 +86,7 @@ jobs:
 
           - runner: ubuntu-24.04-4cores-16GB-ARM
             goarch: arm64
-            dist_name: linux_arm64
+            dist_name: linux_arm64_v8.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.1

--- a/.github/workflows/build-publish-develop-pr.yml
+++ b/.github/workflows/build-publish-develop-pr.yml
@@ -63,8 +63,6 @@ jobs:
       - name: Merge images for both architectures
         uses: ./.github/actions/goreleaser-build-sign-publish
         with:
-            # Temporary pin to working version as 2.4.2+ is breaking arm64 builds
-          goreleaser-version: "v2.3.2"
           docker-registry: ${{ secrets.AWS_SDLC_ECR_HOSTNAME }}
           docker-image-tag: ${{ needs.image-tag.outputs.image-tag }}
           goreleaser-release-type: "merge"
@@ -114,8 +112,6 @@ jobs:
         uses: ./.github/actions/goreleaser-build-sign-publish
         if: steps.cache.outputs.cache-hit != 'true'
         with:
-          # Temporary pin to working version as 2.4.2+ is breaking arm64 builds
-          goreleaser-version: "v2.3.2"
           docker-registry: ${{ secrets.AWS_SDLC_ECR_HOSTNAME }}
           docker-image-tag: ${{ needs.image-tag.outputs.image-tag }}
           goreleaser-release-type: ${{ needs.image-tag.outputs.release-type }}

--- a/.github/workflows/build-publish-goreleaser.yml
+++ b/.github/workflows/build-publish-goreleaser.yml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/cache/restore@v4
         with:
-          path: dist/linux_arm64
+          path: dist/linux_arm64_v8.0
           key: chainlink-arm64-${{ github.sha }}-${{ github.ref_name }}
           fail-on-cache-miss: true
 
@@ -87,7 +87,7 @@ jobs:
 
           - runner: ubuntu-24.04-4cores-16GB-ARM
             goarch: arm64
-            dist_name: linux_arm64
+            dist_name: linux_arm64_v8.0
     environment: build-publish
     permissions:
       id-token: write

--- a/.github/workflows/build-publish-goreleaser.yml
+++ b/.github/workflows/build-publish-goreleaser.yml
@@ -67,8 +67,6 @@ jobs:
         id: goreleaser-build-sign-publish
         uses: ./.github/actions/goreleaser-build-sign-publish
         with:
-          # Temporary pin to working version as 2.4.2+ is breaking arm64 builds
-          goreleaser-version: "v2.3.2"
           docker-registry: ${{ env.ECR_HOSTNAME }}
           docker-image-tag: ${{ github.ref_name }}
           goreleaser-config: .goreleaser.production.yaml
@@ -121,8 +119,6 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/goreleaser-build-sign-publish
         with:
-          # Temporary pin to working version as 2.4.2+ is breaking arm64 builds
-          goreleaser-version: "v2.3.2"
           docker-registry: ${{ env.ECR_HOSTNAME }}
           docker-image-tag: ${{ github.ref_name }}
           goreleaser-release-type: release

--- a/tools/bin/goreleaser_utils
+++ b/tools/bin/goreleaser_utils
@@ -27,7 +27,7 @@ before_hook() {
   # linux_arm64, rather than being suffixless on native platforms
   if [ "$GOARCH" = "arm64" ]; then
     if [ -d "$BIN_DIR/linux_arm64" ]; then
-      cp "$BIN_DIR/linux_arm64"/chainlink* "$PLUGIN_DIR"
+      cp "$BIN_DIR/linux_arm64_v8.0"/chainlink* "$PLUGIN_DIR"
     else 
       cp "$BIN_DIR"/chainlink* "$PLUGIN_DIR"
     fi


### PR DESCRIPTION
### Changes

- This reverts commit 8bbff53 - unpinning goreleaser version
    - There was a bug in goreleaser 2.4.x which has been fixed as 2.4.4 (https://github.com/goreleaser/goreleaser/issues/5245). 
- Updates pathing to arm64 dist directories which now include a `_v8.0` suffix

### Testing

- Successful Run (wo/ merge): https://github.com/smartcontractkit/chainlink/actions/runs/11678086586/job/32517013850?pr=15110
- Successful Run (w/ merge): https://github.com/smartcontractkit/chainlink/actions/runs/11678148487/job/32517494146
---

RE-3177


