### PR TITLE
using underscore for hierarchies so that prom data source in grafana can support metric names

### DIFF
--- a/core/services/registrysyncer/monitoring.go
+++ b/core/services/registrysyncer/monitoring.go
@@ -16,12 +16,12 @@ var remoteRegistrySyncFailureCounter metric.Int64Counter
 var launcherFailureCounter metric.Int64Counter
 
 func initMonitoringResources() (err error) {
-	remoteRegistrySyncFailureCounter, err = beholder.GetMeter().Int64Counter("platform.registry_syncer.sync.failures")
+	remoteRegistrySyncFailureCounter, err = beholder.GetMeter().Int64Counter("platform_registrysyncer_sync_failures")
 	if err != nil {
 		return fmt.Errorf("failed to register sync failure counter: %w", err)
 	}
 
-	launcherFailureCounter, err = beholder.GetMeter().Int64Counter("platform.registry_syncer.launch.failures")
+	launcherFailureCounter, err = beholder.GetMeter().Int64Counter("platform_registrysyncer_launch.failures")
 	if err != nil {
 		return fmt.Errorf("failed to register launcher failure counter: %w", err)
 	}

--- a/core/services/workflows/monitoring.go
+++ b/core/services/workflows/monitoring.go
@@ -20,32 +20,32 @@ var workflowStepErrorCounter metric.Int64Counter
 var engineHeartbeatCounter metric.Int64UpDownCounter
 
 func initMonitoringResources() (err error) {
-	registerTriggerFailureCounter, err = beholder.GetMeter().Int64Counter("platform.engine.register_trigger.failures")
+	registerTriggerFailureCounter, err = beholder.GetMeter().Int64Counter("platform_engine_registertrigger_failures")
 	if err != nil {
 		return fmt.Errorf("failed to register trigger failure counter: %w", err)
 	}
 
-	workflowsRunningGauge, err = beholder.GetMeter().Int64Gauge("platform.engine.workflows.count")
+	workflowsRunningGauge, err = beholder.GetMeter().Int64Gauge("platform_engine_workflow_count")
 	if err != nil {
 		return fmt.Errorf("failed to register workflows running gauge: %w", err)
 	}
 
-	capabilityInvocationCounter, err = beholder.GetMeter().Int64Counter("platform.engine.capabilities_invoked.count")
+	capabilityInvocationCounter, err = beholder.GetMeter().Int64Counter("platform_engine_capabilities_count")
 	if err != nil {
 		return fmt.Errorf("failed to register capability invocation counter: %w", err)
 	}
 
-	workflowExecutionLatencyGauge, err = beholder.GetMeter().Int64Gauge("platform.engine.workflow.time")
+	workflowExecutionLatencyGauge, err = beholder.GetMeter().Int64Gauge("platform_engine_workflow_time")
 	if err != nil {
 		return fmt.Errorf("failed to register workflow execution latency gauge: %w", err)
 	}
 
-	workflowStepErrorCounter, err = beholder.GetMeter().Int64Counter("platform.engine.workflow.errors")
+	workflowStepErrorCounter, err = beholder.GetMeter().Int64Counter("platform_engine_workflow_errors")
 	if err != nil {
 		return fmt.Errorf("failed to register workflow step error counter: %w", err)
 	}
 
-	engineHeartbeatCounter, err = beholder.GetMeter().Int64UpDownCounter("platform.engine.heartbeat")
+	engineHeartbeatCounter, err = beholder.GetMeter().Int64UpDownCounter("platform_engine_heartbeat")
 	if err != nil {
 		return fmt.Errorf("failed to register engine heartbeat counter: %w", err)
 	}


### PR DESCRIPTION
OTEL is compatible with prom ... except for metric and label names. The dot separated hierarchical metric names caused some 500s in grafana.