### PR TITLE
Nonevm 825/remove evm config dependency from plugin

### DIFF
--- a/.changeset/brave-frogs-greet.md
+++ b/.changeset/brave-frogs-greet.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+update plugin and evm chainwriter to remove evmConfig dependency #updated

--- a/core/capabilities/ccip/configs/evm/chain_writer.go
+++ b/core/capabilities/ccip/configs/evm/chain_writer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/offramp"
 	evmrelaytypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
@@ -21,18 +20,11 @@ var (
 // ChainWriterConfigRaw returns a ChainWriterConfig that can be used to transmit commit and execute reports.
 func ChainWriterConfigRaw(
 	fromAddress common.Address,
-	maxGasPrice *assets.Wei,
 	commitGasLimit,
 	execBatchGasLimit uint64,
 ) (evmrelaytypes.ChainWriterConfig, error) {
 	if fromAddress == common.HexToAddress("0x0") {
 		return evmrelaytypes.ChainWriterConfig{}, fmt.Errorf("fromAddress cannot be zero")
-	}
-	if maxGasPrice == nil {
-		return evmrelaytypes.ChainWriterConfig{}, fmt.Errorf("maxGasPrice cannot be nil")
-	}
-	if maxGasPrice.Cmp(assets.NewWeiI(0)) <= 0 {
-		return evmrelaytypes.ChainWriterConfig{}, fmt.Errorf("maxGasPrice must be greater than zero")
 	}
 	if commitGasLimit == 0 {
 		return evmrelaytypes.ChainWriterConfig{}, fmt.Errorf("commitGasLimit must be greater than zero")
@@ -59,7 +51,6 @@ func ChainWriterConfigRaw(
 				},
 			},
 		},
-		MaxGasPrice: maxGasPrice,
 	}, nil
 }
 

--- a/core/capabilities/ccip/configs/evm/chain_writer_test.go
+++ b/core/capabilities/ccip/configs/evm/chain_writer_test.go
@@ -80,7 +80,7 @@ func TestChainWriterConfigRaw(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, err := evm.ChainWriterConfigRaw(tt.fromAddress, tt.maxGasPrice, tt.commitGasLimit, tt.execBatchGasLimit)
+			config, err := evm.ChainWriterConfigRaw(tt.fromAddress, tt.commitGasLimit, tt.execBatchGasLimit)
 			if tt.expectedError != "" {
 				assert.EqualError(t, err, tt.expectedError)
 			} else {

--- a/core/capabilities/ccip/configs/evm/chain_writer_test.go
+++ b/core/capabilities/ccip/configs/evm/chain_writer_test.go
@@ -8,14 +8,12 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/configs/evm"
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
 )
 
 func TestChainWriterConfigRaw(t *testing.T) {
 	tests := []struct {
 		name              string
 		fromAddress       common.Address
-		maxGasPrice       *assets.Wei
 		commitGasLimit    uint64
 		execBatchGasLimit uint64
 		expectedError     string
@@ -23,7 +21,6 @@ func TestChainWriterConfigRaw(t *testing.T) {
 		{
 			name:              "valid input",
 			fromAddress:       common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-			maxGasPrice:       assets.NewWeiI(1000000000),
 			commitGasLimit:    21000,
 			execBatchGasLimit: 42000,
 			expectedError:     "",
@@ -31,39 +28,13 @@ func TestChainWriterConfigRaw(t *testing.T) {
 		{
 			name:              "zero fromAddress",
 			fromAddress:       common.HexToAddress("0x0"),
-			maxGasPrice:       assets.NewWeiI(1000000000),
 			commitGasLimit:    21000,
 			execBatchGasLimit: 42000,
 			expectedError:     "fromAddress cannot be zero",
 		},
 		{
-			name:              "nil maxGasPrice",
-			fromAddress:       common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-			maxGasPrice:       nil,
-			commitGasLimit:    21000,
-			execBatchGasLimit: 42000,
-			expectedError:     "maxGasPrice cannot be nil",
-		},
-		{
-			name:              "zero maxGasPrice",
-			fromAddress:       common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-			maxGasPrice:       assets.NewWeiI(0),
-			commitGasLimit:    21000,
-			execBatchGasLimit: 42000,
-			expectedError:     "maxGasPrice must be greater than zero",
-		},
-		{
-			name:              "negative maxGasPrice",
-			fromAddress:       common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-			maxGasPrice:       assets.NewWeiI(-1),
-			commitGasLimit:    21000,
-			execBatchGasLimit: 42000,
-			expectedError:     "maxGasPrice must be greater than zero",
-		},
-		{
 			name:              "zero commitGasLimit",
 			fromAddress:       common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-			maxGasPrice:       assets.NewWeiI(1000000000),
 			commitGasLimit:    0,
 			execBatchGasLimit: 42000,
 			expectedError:     "commitGasLimit must be greater than zero",
@@ -71,7 +42,6 @@ func TestChainWriterConfigRaw(t *testing.T) {
 		{
 			name:              "zero execBatchGasLimit",
 			fromAddress:       common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-			maxGasPrice:       assets.NewWeiI(1000000000),
 			commitGasLimit:    21000,
 			execBatchGasLimit: 0,
 			expectedError:     "execBatchGasLimit must be greater than zero",
@@ -94,9 +64,6 @@ func TestChainWriterConfigRaw(t *testing.T) {
 				assert.Equal(t,
 					tt.execBatchGasLimit,
 					config.Contracts[consts.ContractNameOffRamp].Configs[consts.MethodExecute].GasLimit)
-				assert.Equal(t,
-					tt.maxGasPrice,
-					config.MaxGasPrice)
 			}
 		})
 	}

--- a/core/capabilities/ccip/delegate.go
+++ b/core/capabilities/ccip/delegate.go
@@ -205,7 +205,6 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 			bootstrapperLocators,
 			hcr,
 			cciptypes.ChainSelector(homeChainChainSelector),
-			d.evmConfigs,
 		)
 	} else {
 		oracleCreator = oraclecreator.NewBootstrapOracleCreator(

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -73,7 +73,6 @@ type pluginOracleCreator struct {
 	homeChainReader       ccipreaderpkg.HomeChain
 	homeChainSelector     cciptypes.ChainSelector
 	relayers              map[types.RelayID]loop.Relayer
-	evmConfigs            toml.EVMConfigs
 }
 
 func NewPluginOracleCreator(
@@ -91,7 +90,6 @@ func NewPluginOracleCreator(
 	bootstrapperLocators []commontypes.BootstrapperLocator,
 	homeChainReader ccipreaderpkg.HomeChain,
 	homeChainSelector cciptypes.ChainSelector,
-	evmConfigs toml.EVMConfigs,
 ) cctypes.OracleCreator {
 	return &pluginOracleCreator{
 		ocrKeyBundles:         ocrKeyBundles,
@@ -108,7 +106,6 @@ func NewPluginOracleCreator(
 		bootstrapperLocators:  bootstrapperLocators,
 		homeChainReader:       homeChainReader,
 		homeChainSelector:     homeChainSelector,
-		evmConfigs:            evmConfigs,
 	}
 }
 
@@ -365,7 +362,6 @@ func (i *pluginOracleCreator) createReadersAndWriters(
 
 		cw, err1 := createChainWriter(
 			chainID,
-			i.evmConfigs,
 			relayer,
 			i.transmitters,
 			execBatchGasLimit)
@@ -477,7 +473,6 @@ func isUSDCEnabled(chainID uint64, destChainID uint64, ofc offChainConfig) bool 
 
 func createChainWriter(
 	chainID *big.Int,
-	evmConfigs toml.EVMConfigs,
 	relayer loop.Relayer,
 	transmitters map[types.RelayID][]string,
 	execBatchGasLimit uint64,
@@ -489,14 +484,8 @@ func createChainWriter(
 		fromAddress = common.HexToAddress(transmitter[0])
 	}
 
-	maxGasPrice := getKeySpecificMaxGasPrice(evmConfigs, chainID, fromAddress)
-	if maxGasPrice == nil {
-		return nil, fmt.Errorf("failed to find max gas price for chain %s", chainID.String())
-	}
-
 	chainWriterRawConfig, err := evmconfig.ChainWriterConfigRaw(
 		fromAddress,
-		maxGasPrice,
 		defaultCommitGasLimit,
 		execBatchGasLimit,
 	)

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -838,6 +838,7 @@ func (r *Relayer) NewChainWriter(_ context.Context, config []byte) (commontypes.
 		return nil, fmt.Errorf("failed to unmarshall chain writer config err: %s", err)
 	}
 
+	cfg.MaxGasPrice = r.chain.Config().EVM().GasEstimator().PriceMax()
 	return NewChainWriterService(r.lggr, r.chain.Client(), r.chain.TxManager(), r.chain.GasEstimator(), cfg)
 }
 


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/NONEVM-825

Make oracle creater chain agnostic by removing dependency of evmConfig.

When relayer creates the chainWriter [here](https://github.com/smartcontractkit/chainlink/blob/7fc51b87dad409189bc4b32bf63215cd6a909f54/core/services/relay/evm/evm.go#L841), we can pass the existing maxGasPrice from relayer (r.chain.Config().EVM().GasEstimator().PriceMax()), instead of having the chain writer config keeping the maxGasPrice. That way we can remove the dependency of [evmConfig](https://github.com/smartcontractkit/chainlink/blob/7fc51b87dad409189bc4b32bf63215cd6a909f54/core/capabilities/ccip/oraclecreator/plugin.go#L486)