### PR TITLE
[CAPPL-98] fix wrong standard capability should not block initialisation

### DIFF
--- a/core/services/standardcapabilities/standard_capabilities.go
+++ b/core/services/standardcapabilities/standard_capabilities.go
@@ -3,6 +3,7 @@ package standardcapabilities
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -26,6 +27,9 @@ type standardCapabilities struct {
 	oracleFactory        core.OracleFactory
 
 	capabilitiesLoop *loop.StandardCapabilitiesService
+
+	wg       sync.WaitGroup
+	stopChan services.StopChan
 }
 
 func newStandardCapabilities(
@@ -51,6 +55,7 @@ func newStandardCapabilities(
 		pipelineRunner:       pipelineRunner,
 		relayerSet:           relayerSet,
 		oracleFactory:        oracleFactory,
+		stopChan:             make(chan struct{}),
 	}
 }
 
@@ -74,27 +79,36 @@ func (s *standardCapabilities) Start(ctx context.Context) error {
 			return fmt.Errorf("error starting standard capabilities service: %v", err)
 		}
 
-		if err = s.capabilitiesLoop.WaitCtx(ctx); err != nil {
-			return fmt.Errorf("error waiting for standard capabilities service to start: %v", err)
-		}
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			cctx, cancel := s.stopChan.NewCtx()
+			defer cancel()
 
-		if err = s.capabilitiesLoop.Service.Initialise(ctx, s.spec.Config, s.telemetryService, s.store, s.CapabilitiesRegistry, s.errorLog,
-			s.pipelineRunner, s.relayerSet, s.oracleFactory); err != nil {
-			return fmt.Errorf("error initialising standard capabilities service: %v", err)
-		}
+			if err = s.capabilitiesLoop.WaitCtx(cctx); err != nil {
+				s.log.Errorf("error waiting for standard capabilities service to start: %v", err)
+			}
 
-		capabilityInfos, err := s.capabilitiesLoop.Service.Infos(ctx)
-		if err != nil {
-			return fmt.Errorf("error getting standard capabilities service info: %v", err)
-		}
+			if err = s.capabilitiesLoop.Service.Initialise(cctx, s.spec.Config, s.telemetryService, s.store, s.CapabilitiesRegistry, s.errorLog,
+				s.pipelineRunner, s.relayerSet, s.oracleFactory); err != nil {
+				s.log.Errorf("error initialising standard capabilities service: %v", err)
+			}
 
-		s.log.Info("Started standard capabilities for job spec", "spec", s.spec, "capabilities", capabilityInfos)
+			capabilityInfos, err := s.capabilitiesLoop.Service.Infos(cctx)
+			if err != nil {
+				s.log.Errorf("error getting standard capabilities service info: %v", err)
+			}
+
+			s.log.Info("Started standard capabilities for job spec", "spec", s.spec, "capabilities", capabilityInfos)
+		}()
 
 		return nil
 	})
 }
 
 func (s *standardCapabilities) Close() error {
+	close(s.stopChan)
+	s.wg.Wait()
 	return s.StopOnce("StandardCapabilities", func() error {
 		if s.capabilitiesLoop != nil {
 			return s.capabilitiesLoop.Close()

--- a/core/services/standardcapabilities/standard_capabilities.go
+++ b/core/services/standardcapabilities/standard_capabilities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -12,6 +13,8 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/plugins"
 )
+
+const defaultStartTimeout = 3 * time.Minute
 
 type standardCapabilities struct {
 	services.StateMachine
@@ -28,8 +31,9 @@ type standardCapabilities struct {
 
 	capabilitiesLoop *loop.StandardCapabilitiesService
 
-	wg       sync.WaitGroup
-	stopChan services.StopChan
+	wg           sync.WaitGroup
+	stopChan     services.StopChan
+	startTimeout time.Duration
 }
 
 func newStandardCapabilities(
@@ -68,13 +72,11 @@ func (s *standardCapabilities) Start(ctx context.Context) error {
 			Cmd: cmdName,
 			Env: nil,
 		})
-
 		if err != nil {
 			return fmt.Errorf("error registering loop: %v", err)
 		}
 
 		s.capabilitiesLoop = loop.NewStandardCapabilitiesService(s.log, opts, cmdFn)
-
 		if err = s.capabilitiesLoop.Start(ctx); err != nil {
 			return fmt.Errorf("error starting standard capabilities service: %v", err)
 		}
@@ -82,21 +84,29 @@ func (s *standardCapabilities) Start(ctx context.Context) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			cctx, cancel := s.stopChan.NewCtx()
+
+			if s.startTimeout == 0 {
+				s.startTimeout = defaultStartTimeout
+			}
+
+			cctx, cancel := s.stopChan.CtxWithTimeout(s.startTimeout)
 			defer cancel()
 
 			if err = s.capabilitiesLoop.WaitCtx(cctx); err != nil {
 				s.log.Errorf("error waiting for standard capabilities service to start: %v", err)
+				return
 			}
 
 			if err = s.capabilitiesLoop.Service.Initialise(cctx, s.spec.Config, s.telemetryService, s.store, s.CapabilitiesRegistry, s.errorLog,
 				s.pipelineRunner, s.relayerSet, s.oracleFactory); err != nil {
 				s.log.Errorf("error initialising standard capabilities service: %v", err)
+				return
 			}
 
 			capabilityInfos, err := s.capabilitiesLoop.Service.Infos(cctx)
 			if err != nil {
 				s.log.Errorf("error getting standard capabilities service info: %v", err)
+				return
 			}
 
 			s.log.Info("Started standard capabilities for job spec", "spec", s.spec, "capabilities", capabilityInfos)

--- a/core/services/standardcapabilities/standard_capabilities_test.go
+++ b/core/services/standardcapabilities/standard_capabilities_test.go
@@ -1,0 +1,99 @@
+package standardcapabilities
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core/mocks"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/test-go/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/plugins"
+)
+
+func TestStandardCapabilityStart(t *testing.T) {
+	t.Run("NOK-not_found_binary_does_not_block", func(t *testing.T) {
+		ctx := tests.Context(t)
+		lggr := logger.TestLogger(t)
+
+		pluginRegistrar := plugins.NewRegistrarConfig(loop.GRPCOpts{}, func(name string) (*plugins.RegisteredLoop, error) { return &plugins.RegisteredLoop{}, nil }, func(loopId string) {})
+		registry := mocks.NewCapabilitiesRegistry(t)
+
+		spec := &job.StandardCapabilitiesSpec{
+			Command: "not/found/path/to/binary",
+			OracleFactory: job.OracleFactoryConfig{
+				Enabled: true,
+				BootstrapPeers: []string{
+					"12D3KooWEBVwbfdhKnicois7FTYVsBFGFcoMhMCKXQC57BQyZMhz@localhost:6690",
+				},
+				OCRContractAddress: "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
+				ChainID:            "31337",
+				Network:            "evm",
+			}}
+
+		standardCapability := newStandardCapabilities(lggr, spec, pluginRegistrar, &telemetryServiceMock{}, &kvstoreMock{}, registry, &errorLogMock{}, &pipelineRunnerServiceMock{}, &relayerSetMock{}, &oracleFactoryMock{})
+		standardCapability.startTimeout = 1 * time.Second
+		err := standardCapability.Start(ctx)
+		require.NoError(t, err)
+
+		standardCapability.wg.Wait()
+	})
+
+}
+
+type telemetryServiceMock struct{}
+
+func (t *telemetryServiceMock) Send(ctx context.Context, network string, chainID string, contractID string, telemetryType string, payload []byte) error {
+	return nil
+}
+
+type kvstoreMock struct{}
+
+func (k *kvstoreMock) Store(ctx context.Context, key string, val []byte) error {
+	return nil
+}
+func (k *kvstoreMock) Get(ctx context.Context, key string) ([]byte, error) {
+	return nil, nil
+}
+
+type errorLogMock struct{}
+
+func (e *errorLogMock) SaveError(ctx context.Context, msg string) error {
+	return nil
+}
+
+type relayerSetMock struct{}
+
+func (r *relayerSetMock) Get(ctx context.Context, relayID types.RelayID) (core.Relayer, error) {
+	return nil, nil
+}
+func (r *relayerSetMock) List(ctx context.Context, relayIDs ...types.RelayID) (map[types.RelayID]core.Relayer, error) {
+	return nil, nil
+}
+
+type pipelineRunnerServiceMock struct{}
+
+func (p *pipelineRunnerServiceMock) ExecuteRun(ctx context.Context, spec string, vars core.Vars, options core.Options) (core.TaskResults, error) {
+	return nil, nil
+}
+
+type oracleFactoryMock struct{}
+
+func (o *oracleFactoryMock) NewOracle(ctx context.Context, args core.OracleArgs) (core.Oracle, error) {
+	return &oracleMock{}, nil
+}
+
+type oracleMock struct{}
+
+func (o *oracleMock) Start(ctx context.Context) error {
+	return nil
+}
+func (o *oracleMock) Close(ctx context.Context) error {
+	return nil
+}

--- a/core/services/standardcapabilities/standard_capabilities_test.go
+++ b/core/services/standardcapabilities/standard_capabilities_test.go
@@ -5,15 +5,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core/mocks"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
-	"github.com/test-go/testify/require"
-
 	"github.com/smartcontractkit/chainlink/v2/plugins"
 )
 
@@ -44,7 +45,6 @@ func TestStandardCapabilityStart(t *testing.T) {
 
 		standardCapability.wg.Wait()
 	})
-
 }
 
 type telemetryServiceMock struct{}


### PR DESCRIPTION
### Description
This pr introduces a fix to the [CAPPL-98](https://smartcontract-it.atlassian.net/browse/CAPPL-98) error in which whenever a standardcapability job spec had a wrong path to the LOOP binary, it was preventing the NOP UI to load.

### How was this tested
The error was reproduced locally by spinning up a node and introducing an invalid job spec & re-starting the node which would cause the NOP UI not to load. After the fix the same steps where reproduced validating the NOP UI was loading.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CAPPL-98]: https://smartcontract-it.atlassian.net/browse/CAPPL-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ