### PR TITLE
fix: don't cache on merge_group events

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -85,7 +85,7 @@ runs:
     - uses: actions/cache/restore@v4.1.1
       name: Cache Go Build Outputs (restore)
       # For certain events, we don't necessarily want to create a build cache, but we will benefit from restoring from one. 
-      if: ${{ inputs.only-modules == 'false' && (github.event == 'merge_group' || inputs.restore-build-cache-only == 'true') }}
+      if: ${{ inputs.only-modules == 'false' && (github.event_name == 'merge_group' || inputs.restore-build-cache-only == 'true') }}
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
@@ -98,7 +98,7 @@ runs:
 
     - uses: actions/cache@v4.1.1
       # don't save cache on merge queue events
-      if: ${{ inputs.only-modules == 'false' && (github.event != 'merge_group' && inputs.restore-build-cache-only == 'false') }}
+      if: ${{ inputs.only-modules == 'false' && (github.event_name != 'merge_group' && inputs.restore-build-cache-only == 'false') }}
       name: Cache Go Build Outputs
       with:
         path: |


### PR DESCRIPTION
Noticed that merge queues were still saving caches, which should not be happening.

### Changes

Fixed my typo of `github.event` to `github.event_name` to skip cache saving during merge_queue.