### PR TITLE
Add `FromAddressIndex` config to write target

### DIFF
--- a/.changeset/blue-dragons-carry.md
+++ b/.changeset/blue-dragons-carry.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-#updated Add ETH address as default fromAddress in the forwarder when only one key exists and config is not provided.
+#updated Add `fromAddressIndex` config parameter to avoid having to specify a specific ETH address. This is a backward compatible change because `fromAddress` takes precedence if it exists.

--- a/.changeset/blue-dragons-carry.md
+++ b/.changeset/blue-dragons-carry.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#patch Add ETH address as default fromAddress in the forwarder when only one key exists and config is not provided.

--- a/.changeset/blue-dragons-carry.md
+++ b/.changeset/blue-dragons-carry.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-#patch Add ETH address as default fromAddress in the forwarder when only one key exists and config is not provided.
+#updated Add ETH address as default fromAddress in the forwarder when only one key exists and config is not provided.

--- a/core/chains/evm/config/chain_scoped_workflow.go
+++ b/core/chains/evm/config/chain_scoped_workflow.go
@@ -13,7 +13,7 @@ func (b *workflowConfig) FromAddress() *types.EIP55Address {
 	return b.c.FromAddress
 }
 
-func (b *workflowConfig) FromAddressIndex() *uint64 {
+func (b *workflowConfig) FromAddressIndex() *int {
 	return b.c.FromAddressIndex
 }
 

--- a/core/chains/evm/config/chain_scoped_workflow.go
+++ b/core/chains/evm/config/chain_scoped_workflow.go
@@ -13,6 +13,10 @@ func (b *workflowConfig) FromAddress() *types.EIP55Address {
 	return b.c.FromAddress
 }
 
+func (b *workflowConfig) FromAddressIndex() *uint64 {
+	return b.c.FromAddressIndex
+}
+
 func (b *workflowConfig) ForwarderAddress() *types.EIP55Address {
 	return b.c.ForwarderAddress
 }

--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -176,6 +176,7 @@ type FeeHistory interface {
 
 type Workflow interface {
 	FromAddress() *types.EIP55Address
+	FromAddressIndex() *uint64
 	ForwarderAddress() *types.EIP55Address
 	GasLimitDefault() *uint64
 }

--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -176,7 +176,7 @@ type FeeHistory interface {
 
 type Workflow interface {
 	FromAddress() *types.EIP55Address
-	FromAddressIndex() *uint64
+	FromAddressIndex() *int
 	ForwarderAddress() *types.EIP55Address
 	GasLimitDefault() *uint64
 }

--- a/core/chains/evm/config/toml/config.go
+++ b/core/chains/evm/config/toml/config.go
@@ -546,7 +546,7 @@ func (a *Automation) setFrom(f *Automation) {
 
 type Workflow struct {
 	FromAddress      *types.EIP55Address `toml:",omitempty"`
-	FromAddressIndex *uint64             `toml:",omitempty"`
+	FromAddressIndex *int                `toml:",omitempty"`
 	ForwarderAddress *types.EIP55Address `toml:",omitempty"`
 	GasLimitDefault  *uint64
 }

--- a/core/chains/evm/config/toml/config.go
+++ b/core/chains/evm/config/toml/config.go
@@ -546,6 +546,7 @@ func (a *Automation) setFrom(f *Automation) {
 
 type Workflow struct {
 	FromAddress      *types.EIP55Address `toml:",omitempty"`
+	FromAddressIndex *uint64             `toml:",omitempty"`
 	ForwarderAddress *types.EIP55Address `toml:",omitempty"`
 	GasLimitDefault  *uint64
 }

--- a/core/config/docs/chains-evm.toml
+++ b/core/config/docs/chains-evm.toml
@@ -498,6 +498,9 @@ GasLimit = 5400000 # Default
 [EVM.Workflow]
 # FromAddress is Address of the transmitter key to use for workflow writes.
 FromAddress = '0x2a3e23c6f242F5345320814aC8a1b4E58707D292' # Example
+# FromAddressIndex is the index of the key to use for workflow from address.
+# FromAddress takes precedence over FromAddressIndex.
+FromAddressIndex = 0 # Example
 # ForwarderAddress is the keystone forwarder contract address on chain.
 ForwarderAddress = '0x2a3e23c6f242F5345320814aC8a1b4E58707D292' # Example
 # GasLimitDefault is the default gas limit for workflow transactions.

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -197,9 +197,9 @@ func NewRelayer(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, 
 	sugared := logger.Sugared(lggr).Named("Relayer")
 	mercuryORM := mercury.NewORM(opts.DS)
 	cdcFactory := sync.OnceValues(func() (llo.ChannelDefinitionCacheFactory, error) {
-		chainSelector, err2 := chainselectors.SelectorFromChainId(chain.ID().Uint64())
-		if err2 != nil {
-			return nil, fmt.Errorf("failed to get chain selector for chain id %s: %w", chain.ID(), err2)
+		chainSelector, err := chainselectors.SelectorFromChainId(chain.ID().Uint64())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get chain selector for chain id %s: %w", chain.ID(), err)
 		}
 		lloORM := llo.NewChainScopedORM(opts.DS, chainSelector)
 		return llo.NewChannelDefinitionCacheFactory(sugared, lloORM, chain.LogPoller(), opts.HTTPClient), nil
@@ -228,9 +228,9 @@ func NewRelayer(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, 
 
 	// If fromAddress is not specified, default to the eth key if there is only one
 	if fromAddress == nil {
-		ethKeys, err2 := opts.CSAETHKeystore.Eth().GetAll(ctx)
-		if err2 != nil {
-			return nil, fmt.Errorf("failed to get all eth keys: %w", err2)
+		ethKeys, err := opts.CSAETHKeystore.Eth().GetAll(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get all eth keys: %w", err)
 		}
 
 		// Do not register write target if there are multiple or no eth keys
@@ -449,11 +449,11 @@ func (r *Relayer) NewMercuryProvider(ctx context.Context, rargs commontypes.Rela
 			lggr.Errorw("trigger capability is enabled but capabilities registry is not set")
 		} else {
 			r.triggerCapability = triggers.NewMercuryTriggerService(0, lggr)
-			if err2 := r.triggerCapability.Start(ctx); err2 != nil {
-				return nil, err2
+			if err := r.triggerCapability.Start(ctx); err != nil {
+				return nil, err
 			}
-			if err2 := r.capabilitiesRegistry.Add(ctx, r.triggerCapability); err2 != nil {
-				return nil, err2
+			if err := r.capabilitiesRegistry.Add(ctx, r.triggerCapability); err != nil {
+				return nil, err
 			}
 			lggr.Infow("successfully added trigger service to the Registry")
 		}

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -224,23 +224,25 @@ func NewRelayer(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, 
 		return relayer, nil
 	}
 
-	ethKeys, err := opts.CSAETHKeystore.Eth().GetAll(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get all eth keys: %w", err)
+	fromAddress := wCfg.FromAddress()
+
+	// If fromAddress is not specified, default to the eth key if there is only one
+	if fromAddress == nil {
+		ethKeys, err := opts.CSAETHKeystore.Eth().GetAll(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get all eth keys: %w", err)
+		}
+
+		// Do not register write target if there are multiple or no eth keys
+		if len(ethKeys) > 1 || len(ethKeys) == 0 {
+			return relayer, nil
+		}
+
+		fromAddress = &ethKeys[0].EIP55Address
 	}
 
-	// Do not register write target if there are multiple keys and no from address is set
-	if len(ethKeys) > 1 && wCfg.FromAddress() != nil {
-		return relayer, nil
-	}
-
-	// Do not register write target if there are no keys
-	if len(ethKeys) == 0 {
-		return relayer, nil
-	}
-
-	// Initialize write target capability if configuration is defined
-	capability, err := NewWriteTarget(ctx, relayer, chain, *wCfg.GasLimitDefault(), lggr, &ethKeys[0].EIP55Address)
+	// Initialize write target capability
+	capability, err := NewWriteTarget(ctx, relayer, chain, *wCfg.GasLimitDefault(), lggr, fromAddress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize write target: %w", err)
 	}

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -218,21 +218,36 @@ func NewRelayer(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, 
 	}
 
 	wCfg := chain.Config().EVM().Workflow()
-	// Initialize write target capability if configuration is defined
-	if wCfg.ForwarderAddress() != nil && wCfg.FromAddress() != nil {
-		if wCfg.GasLimitDefault() == nil {
-			return nil, fmt.Errorf("unable to instantiate write target as default gas limit is not set")
-		}
 
-		capability, err := NewWriteTarget(ctx, relayer, chain, *wCfg.GasLimitDefault(), lggr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize write target: %w", err)
-		}
-		if err := relayer.capabilitiesRegistry.Add(ctx, capability); err != nil {
-			return nil, err
-		}
-		lggr.Infow("Registered write target", "chain_id", chain.ID())
+	// Do not register write target without required configuration
+	if wCfg.ForwarderAddress() == nil || wCfg.GasLimitDefault() == nil {
+		return relayer, nil
 	}
+
+	ethKeys, err := opts.CSAETHKeystore.Eth().GetAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get all eth keys: %w", err)
+	}
+
+	// Do not register write target if there are multiple keys and no from address is set
+	if len(ethKeys) > 1 && wCfg.FromAddress() != nil {
+		return relayer, nil
+	}
+
+	// Do not register write target if there are no keys
+	if len(ethKeys) == 0 {
+		return relayer, nil
+	}
+
+	// Initialize write target capability if configuration is defined
+	capability, err := NewWriteTarget(ctx, relayer, chain, *wCfg.GasLimitDefault(), lggr, &ethKeys[0].EIP55Address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize write target: %w", err)
+	}
+	if err := relayer.capabilitiesRegistry.Add(ctx, capability); err != nil {
+		return nil, err
+	}
+	lggr.Infow("Registered write target", "chain_id", chain.ID())
 
 	return relayer, nil
 }

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -237,8 +237,8 @@ func NewRelayer(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, 
 		if err2 != nil {
 			return nil, fmt.Errorf("failed to get all eth keys: %w", err2)
 		}
-		fromAddressIndex := *wCfg.FromAddressIndex()
 
+		fromAddressIndex := *wCfg.FromAddressIndex()
 		if len(ethKeys) <= int(fromAddressIndex) {
 			return nil, fmt.Errorf("eth key with index %d not found", fromAddressIndex)
 		}

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -228,25 +228,22 @@ func NewRelayer(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, 
 
 	// If fromAddress is not specified, default to the eth key if there is only one
 	if fromAddress == nil {
+		// Neither fromAddress nor fromAddressIndex is specified, return without registering write target
+		if wCfg.FromAddressIndex() == nil {
+			return relayer, nil
+		}
+
 		ethKeys, err2 := opts.CSAETHKeystore.Eth().GetAll(ctx)
 		if err2 != nil {
 			return nil, fmt.Errorf("failed to get all eth keys: %w", err2)
 		}
+		fromAddressIndex := *wCfg.FromAddressIndex()
 
-		// Do not register write target if there are no eth keys
-		// We don't want to error here, because the user may not want to instantiate a write target
-		if len(ethKeys) == 0 {
-			return relayer, nil
+		if len(ethKeys) <= int(fromAddressIndex) {
+			return nil, fmt.Errorf("eth key with index %d not found", fromAddressIndex)
 		}
 
-		// Error if theere are multiple eth keys, fromAddress is not specified and other target configuration is present
-		if len(ethKeys) > 1 &&
-			wCfg.ForwarderAddress() != nil &&
-			wCfg.GasLimitDefault() != nil {
-			return nil, errors.New("fromAddress not specified and multiple eth keys found")
-		}
-
-		fromAddress = &ethKeys[0].EIP55Address
+		fromAddress = &ethKeys[fromAddressIndex].EIP55Address
 	}
 
 	// Initialize write target capability

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -233,9 +233,17 @@ func NewRelayer(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, 
 			return nil, fmt.Errorf("failed to get all eth keys: %w", err2)
 		}
 
-		// Do not register write target if there are multiple or no eth keys
-		if len(ethKeys) > 1 || len(ethKeys) == 0 {
+		// Do not register write target if there are no eth keys
+		// We don't want to error here, because the user may not want to instantiate a write target
+		if len(ethKeys) == 0 {
 			return relayer, nil
+		}
+
+		// Error if theere are multiple eth keys, fromAddress is not specified and other target configuration is present
+		if len(ethKeys) > 1 &&
+			wCfg.ForwarderAddress() != nil &&
+			wCfg.GasLimitDefault() != nil {
+			return nil, errors.New("fromAddress not specified and multiple eth keys found")
 		}
 
 		fromAddress = &ethKeys[0].EIP55Address

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -239,7 +239,7 @@ func NewRelayer(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, 
 		}
 
 		fromAddressIndex := *wCfg.FromAddressIndex()
-		if len(ethKeys) <= int(fromAddressIndex) {
+		if len(ethKeys) <= fromAddressIndex {
 			return nil, fmt.Errorf("eth key with index %d not found", fromAddressIndex)
 		}
 

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -197,9 +197,9 @@ func NewRelayer(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, 
 	sugared := logger.Sugared(lggr).Named("Relayer")
 	mercuryORM := mercury.NewORM(opts.DS)
 	cdcFactory := sync.OnceValues(func() (llo.ChannelDefinitionCacheFactory, error) {
-		chainSelector, err := chainselectors.SelectorFromChainId(chain.ID().Uint64())
-		if err != nil {
-			return nil, fmt.Errorf("failed to get chain selector for chain id %s: %w", chain.ID(), err)
+		chainSelector, err2 := chainselectors.SelectorFromChainId(chain.ID().Uint64())
+		if err2 != nil {
+			return nil, fmt.Errorf("failed to get chain selector for chain id %s: %w", chain.ID(), err2)
 		}
 		lloORM := llo.NewChainScopedORM(opts.DS, chainSelector)
 		return llo.NewChannelDefinitionCacheFactory(sugared, lloORM, chain.LogPoller(), opts.HTTPClient), nil
@@ -228,9 +228,9 @@ func NewRelayer(ctx context.Context, lggr logger.Logger, chain legacyevm.Chain, 
 
 	// If fromAddress is not specified, default to the eth key if there is only one
 	if fromAddress == nil {
-		ethKeys, err := opts.CSAETHKeystore.Eth().GetAll(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get all eth keys: %w", err)
+		ethKeys, err2 := opts.CSAETHKeystore.Eth().GetAll(ctx)
+		if err2 != nil {
+			return nil, fmt.Errorf("failed to get all eth keys: %w", err2)
 		}
 
 		// Do not register write target if there are multiple or no eth keys
@@ -449,11 +449,11 @@ func (r *Relayer) NewMercuryProvider(ctx context.Context, rargs commontypes.Rela
 			lggr.Errorw("trigger capability is enabled but capabilities registry is not set")
 		} else {
 			r.triggerCapability = triggers.NewMercuryTriggerService(0, lggr)
-			if err := r.triggerCapability.Start(ctx); err != nil {
-				return nil, err
+			if err2 := r.triggerCapability.Start(ctx); err2 != nil {
+				return nil, err2
 			}
-			if err := r.capabilitiesRegistry.Add(ctx, r.triggerCapability); err != nil {
-				return nil, err
+			if err2 := r.capabilitiesRegistry.Add(ctx, r.triggerCapability); err2 != nil {
+				return nil, err2
 			}
 			lggr.Infow("successfully added trigger service to the Registry")
 		}

--- a/core/services/relay/evm/write_target.go
+++ b/core/services/relay/evm/write_target.go
@@ -10,12 +10,20 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/targets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/forwarder"
 	relayevmtypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
 )
 
-func NewWriteTarget(ctx context.Context, relayer *Relayer, chain legacyevm.Chain, gasLimitDefault uint64, lggr logger.Logger) (*targets.WriteTarget, error) {
+func NewWriteTarget(
+	ctx context.Context,
+	relayer *Relayer,
+	chain legacyevm.Chain,
+	gasLimitDefault uint64,
+	lggr logger.Logger,
+	fromAddress *types.EIP55Address,
+) (*targets.WriteTarget, error) {
 	// generate ID based on chain selector
 	id := fmt.Sprintf("write_%v@1.0.0", chain.ID())
 	chainName, err := chainselectors.NameFromChainId(chain.ID().Uint64())
@@ -54,7 +62,7 @@ func NewWriteTarget(ctx context.Context, relayer *Relayer, chain legacyevm.Chain
 				Configs: map[string]*relayevmtypes.ChainWriterDefinition{
 					"report": {
 						ChainSpecificName: "report",
-						FromAddress:       config.FromAddress().Address(),
+						FromAddress:       fromAddress.Address(),
 						GasLimit:          gasLimitDefault,
 					},
 				},

--- a/core/services/relay/evm/write_target_test.go
+++ b/core/services/relay/evm/write_target_test.go
@@ -206,7 +206,7 @@ func TestEvmWrite(t *testing.T) {
 
 	t.Run("succeeds with valid report", func(t *testing.T) {
 		ctx := testutils.Context(t)
-		capability, err := evm.NewWriteTarget(ctx, relayer, chain, gasLimitDefault, lggr)
+		capability, err := evm.NewWriteTarget(ctx, relayer, chain, gasLimitDefault, lggr, evmCfg.EVM().Workflow().FromAddress())
 		require.NoError(t, err)
 
 		req := capabilities.CapabilityRequest{
@@ -221,7 +221,7 @@ func TestEvmWrite(t *testing.T) {
 
 	t.Run("fails with invalid config", func(t *testing.T) {
 		ctx := testutils.Context(t)
-		capability, err := evm.NewWriteTarget(ctx, relayer, chain, gasLimitDefault, logger.TestLogger(t))
+		capability, err := evm.NewWriteTarget(ctx, relayer, chain, gasLimitDefault, logger.TestLogger(t), evmCfg.EVM().Workflow().FromAddress())
 		require.NoError(t, err)
 
 		invalidConfig, err := values.NewMap(map[string]any{
@@ -241,7 +241,7 @@ func TestEvmWrite(t *testing.T) {
 
 	t.Run("fails when TXM CreateTransaction returns error", func(t *testing.T) {
 		ctx := testutils.Context(t)
-		capability, err := evm.NewWriteTarget(ctx, relayer, chain, gasLimitDefault, logger.TestLogger(t))
+		capability, err := evm.NewWriteTarget(ctx, relayer, chain, gasLimitDefault, logger.TestLogger(t), evmCfg.EVM().Workflow().FromAddress())
 		require.NoError(t, err)
 
 		req := capabilities.CapabilityRequest{

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -9903,6 +9903,7 @@ GasLimit controls the gas limit for transmit transactions from ocr2automation jo
 ```toml
 [EVM.Workflow]
 FromAddress = '0x2a3e23c6f242F5345320814aC8a1b4E58707D292' # Example
+FromAddressIndex = 0 # Example
 ForwarderAddress = '0x2a3e23c6f242F5345320814aC8a1b4E58707D292' # Example
 GasLimitDefault = 400_000 # Default
 ```
@@ -9913,6 +9914,13 @@ GasLimitDefault = 400_000 # Default
 FromAddress = '0x2a3e23c6f242F5345320814aC8a1b4E58707D292' # Example
 ```
 FromAddress is Address of the transmitter key to use for workflow writes.
+
+### FromAddressIndex
+```toml
+FromAddressIndex = 0 # Example
+```
+FromAddressIndex is the index of the key to use for workflow from address.
+FromAddress takes precedence over FromAddressIndex.
 
 ### ForwarderAddress
 ```toml


### PR DESCRIPTION
Allow write target to specify `FromAddressIndex`, which doesn't require node re-boot to acquire. This eliminates the requirement to get the EVM key from the running node and should be sufficient in most cases.

The change is fully backward compatible - if the `FromAddress` configuration exists, it takes precedence over the `FromAddressIndex`.