### PR TITLE
Make FeeHistory call Geth compatible and remove ConfiguredChain

### DIFF
--- a/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
@@ -415,7 +415,7 @@ func makeTestEvmTxm(
 	keyStore keystore.Eth) (txmgr.TxManager, gas.EvmFeeEstimator) {
 	config, dbConfig, evmConfig := MakeTestConfigs(t)
 
-	estimator, err := gas.NewEstimator(logger.TestLogger(t), ethClient, config.ChainType(), evmConfig.GasEstimator(), nil)
+	estimator, err := gas.NewEstimator(logger.TestLogger(t), ethClient, config.ChainType(), ethClient.ConfiguredChainID(), evmConfig.GasEstimator(), nil)
 	require.NoError(t, err, "failed to create gas estimator")
 
 	lggr := logger.TestLogger(t)

--- a/core/chains/evm/client/chain_client.go
+++ b/core/chains/evm/client/chain_client.go
@@ -81,7 +81,7 @@ type Client interface {
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 	LatestBlockHeight(ctx context.Context) (*big.Int, error)
-	FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error)
+	FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error)
 
 	HeaderByNumber(ctx context.Context, n *big.Int) (*types.Header, error)
 	HeaderByHash(ctx context.Context, h common.Hash) (*types.Header, error)
@@ -473,12 +473,12 @@ func (c *chainClient) LatestFinalizedBlock(ctx context.Context) (*evmtypes.Head,
 	return r.LatestFinalizedBlock(ctx)
 }
 
-func (c *chainClient) FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error) {
+func (c *chainClient) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error) {
 	r, err := c.multiNode.SelectRPC()
 	if err != nil {
 		return feeHistory, err
 	}
-	return r.FeeHistory(ctx, blockCount, rewardPercentiles)
+	return r.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
 }
 
 func (c *chainClient) CheckTxValidity(ctx context.Context, from common.Address, to common.Address, data []byte) *SendError {

--- a/core/chains/evm/client/mocks/client.go
+++ b/core/chains/evm/client/mocks/client.go
@@ -723,9 +723,9 @@ func (_c *Client_EstimateGas_Call) RunAndReturn(run func(context.Context, ethere
 	return _c
 }
 
-// FeeHistory provides a mock function with given fields: ctx, blockCount, rewardPercentiles
-func (_m *Client) FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (*ethereum.FeeHistory, error) {
-	ret := _m.Called(ctx, blockCount, rewardPercentiles)
+// FeeHistory provides a mock function with given fields: ctx, blockCount, lastBlock, rewardPercentiles
+func (_m *Client) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (*ethereum.FeeHistory, error) {
+	ret := _m.Called(ctx, blockCount, lastBlock, rewardPercentiles)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FeeHistory")
@@ -733,19 +733,19 @@ func (_m *Client) FeeHistory(ctx context.Context, blockCount uint64, rewardPerce
 
 	var r0 *ethereum.FeeHistory
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, []float64) (*ethereum.FeeHistory, error)); ok {
-		return rf(ctx, blockCount, rewardPercentiles)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, *big.Int, []float64) (*ethereum.FeeHistory, error)); ok {
+		return rf(ctx, blockCount, lastBlock, rewardPercentiles)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, []float64) *ethereum.FeeHistory); ok {
-		r0 = rf(ctx, blockCount, rewardPercentiles)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, *big.Int, []float64) *ethereum.FeeHistory); ok {
+		r0 = rf(ctx, blockCount, lastBlock, rewardPercentiles)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ethereum.FeeHistory)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, uint64, []float64) error); ok {
-		r1 = rf(ctx, blockCount, rewardPercentiles)
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, *big.Int, []float64) error); ok {
+		r1 = rf(ctx, blockCount, lastBlock, rewardPercentiles)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -761,14 +761,15 @@ type Client_FeeHistory_Call struct {
 // FeeHistory is a helper method to define mock.On call
 //   - ctx context.Context
 //   - blockCount uint64
+//   - lastBlock *big.Int
 //   - rewardPercentiles []float64
-func (_e *Client_Expecter) FeeHistory(ctx interface{}, blockCount interface{}, rewardPercentiles interface{}) *Client_FeeHistory_Call {
-	return &Client_FeeHistory_Call{Call: _e.mock.On("FeeHistory", ctx, blockCount, rewardPercentiles)}
+func (_e *Client_Expecter) FeeHistory(ctx interface{}, blockCount interface{}, lastBlock interface{}, rewardPercentiles interface{}) *Client_FeeHistory_Call {
+	return &Client_FeeHistory_Call{Call: _e.mock.On("FeeHistory", ctx, blockCount, lastBlock, rewardPercentiles)}
 }
 
-func (_c *Client_FeeHistory_Call) Run(run func(ctx context.Context, blockCount uint64, rewardPercentiles []float64)) *Client_FeeHistory_Call {
+func (_c *Client_FeeHistory_Call) Run(run func(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64)) *Client_FeeHistory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint64), args[2].([]float64))
+		run(args[0].(context.Context), args[1].(uint64), args[2].(*big.Int), args[3].([]float64))
 	})
 	return _c
 }
@@ -778,7 +779,7 @@ func (_c *Client_FeeHistory_Call) Return(feeHistory *ethereum.FeeHistory, err er
 	return _c
 }
 
-func (_c *Client_FeeHistory_Call) RunAndReturn(run func(context.Context, uint64, []float64) (*ethereum.FeeHistory, error)) *Client_FeeHistory_Call {
+func (_c *Client_FeeHistory_Call) RunAndReturn(run func(context.Context, uint64, *big.Int, []float64) (*ethereum.FeeHistory, error)) *Client_FeeHistory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/chains/evm/client/null_client.go
+++ b/core/chains/evm/client/null_client.go
@@ -236,6 +236,6 @@ func (nc *NullClient) CheckTxValidity(_ context.Context, _ common.Address, _ com
 	return nil
 }
 
-func (nc *NullClient) FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error) {
+func (nc *NullClient) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error) {
 	return nil, nil
 }

--- a/core/chains/evm/client/rpc_client.go
+++ b/core/chains/evm/client/rpc_client.go
@@ -1093,7 +1093,7 @@ func (r *RPCClient) BalanceAt(ctx context.Context, account common.Address, block
 	return
 }
 
-func (r *RPCClient) FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error) {
+func (r *RPCClient) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error) {
 	ctx, cancel, ws, http := r.makeLiveQueryCtxAndSafeGetClients(ctx, r.rpcTimeout)
 	defer cancel()
 	lggr := r.newRqLggr().With("blockCount", blockCount, "rewardPercentiles", rewardPercentiles)
@@ -1101,10 +1101,10 @@ func (r *RPCClient) FeeHistory(ctx context.Context, blockCount uint64, rewardPer
 	lggr.Debug("RPC call: evmclient.Client#FeeHistory")
 	start := time.Now()
 	if http != nil {
-		feeHistory, err = http.geth.FeeHistory(ctx, blockCount, nil, rewardPercentiles)
+		feeHistory, err = http.geth.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
 		err = r.wrapHTTP(err)
 	} else {
-		feeHistory, err = ws.geth.FeeHistory(ctx, blockCount, nil, rewardPercentiles)
+		feeHistory, err = ws.geth.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
 		err = r.wrapWS(err)
 	}
 	duration := time.Since(start)

--- a/core/chains/evm/client/simulated_backend_client.go
+++ b/core/chains/evm/client/simulated_backend_client.go
@@ -156,7 +156,7 @@ func (c *SimulatedBackendClient) LINKBalance(ctx context.Context, address common
 	panic("not implemented")
 }
 
-func (c *SimulatedBackendClient) FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error) {
+func (c *SimulatedBackendClient) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error) {
 	panic("not implemented")
 }
 

--- a/core/chains/evm/gas/fee_history_estimator.go
+++ b/core/chains/evm/gas/fee_history_estimator.go
@@ -69,7 +69,7 @@ type FeeHistoryEstimatorConfig struct {
 
 type feeHistoryEstimatorClient interface {
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
-	FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error)
+	FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error)
 }
 
 type FeeHistoryEstimator struct {
@@ -235,7 +235,7 @@ func (f *FeeHistoryEstimator) RefreshDynamicPrice() error {
 	defer cancel()
 
 	// RewardPercentile will be used for maxPriorityFeePerGas estimations and connectivityPercentile to set the highest threshold for bumping.
-	feeHistory, err := f.client.FeeHistory(ctx, max(f.config.BlockHistorySize, 1), []float64{f.config.RewardPercentile, ConnectivityPercentile})
+	feeHistory, err := f.client.FeeHistory(ctx, max(f.config.BlockHistorySize, 1), nil, []float64{f.config.RewardPercentile, ConnectivityPercentile})
 	if err != nil {
 		return err
 	}

--- a/core/chains/evm/gas/fee_history_estimator_test.go
+++ b/core/chains/evm/gas/fee_history_estimator_test.go
@@ -230,7 +230,7 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 			BaseFee:      []*big.Int{baseFee, baseFee},
 			GasUsedRatio: nil,
 		}
-		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
 
 		blockHistoryLength := 2
 		cfg := gas.FeeHistoryEstimatorConfig{BlockHistorySize: uint64(blockHistoryLength)}
@@ -269,7 +269,7 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 			BaseFee:      []*big.Int{baseFee},
 			GasUsedRatio: nil,
 		}
-		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
 
 		cfg := gas.FeeHistoryEstimatorConfig{BlockHistorySize: 1}
 
@@ -303,7 +303,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 			BaseFee:      []*big.Int{big.NewInt(5)},
 			GasUsedRatio: nil,
 		}
-		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
 
 		cfg := gas.FeeHistoryEstimatorConfig{
 			BlockHistorySize: 2,
@@ -366,7 +366,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 			BaseFee:      []*big.Int{baseFee},
 			GasUsedRatio: nil,
 		}
-		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
 
 		maxFee := (*assets.Wei)(baseFee).AddPercentage(gas.BaseFeeBufferPercentage).Add((*assets.Wei)(maxPriorityFeePerGas))
 
@@ -400,7 +400,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 			BaseFee:      []*big.Int{baseFee},
 			GasUsedRatio: nil,
 		}
-		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
 
 		cfg := gas.FeeHistoryEstimatorConfig{
 			BlockHistorySize: 1,
@@ -432,7 +432,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 			BaseFee:      []*big.Int{baseFee},
 			GasUsedRatio: nil,
 		}
-		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
 
 		cfg := gas.FeeHistoryEstimatorConfig{
 			BlockHistorySize: 1,
@@ -465,7 +465,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 			BaseFee:      []*big.Int{baseFee},
 			GasUsedRatio: nil,
 		}
-		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
 
 		cfg := gas.FeeHistoryEstimatorConfig{
 			BlockHistorySize: 1,
@@ -495,7 +495,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 			BaseFee:      []*big.Int{baseFee},
 			GasUsedRatio: nil,
 		}
-		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil)
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil)
 
 		cfg := gas.FeeHistoryEstimatorConfig{
 			BlockHistorySize: 0,

--- a/core/chains/evm/gas/mocks/fee_estimator_client.go
+++ b/core/chains/evm/gas/mocks/fee_estimator_client.go
@@ -194,53 +194,6 @@ func (_c *FeeEstimatorClient_CallContract_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
-// ConfiguredChainID provides a mock function with given fields:
-func (_m *FeeEstimatorClient) ConfiguredChainID() *big.Int {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for ConfiguredChainID")
-	}
-
-	var r0 *big.Int
-	if rf, ok := ret.Get(0).(func() *big.Int); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*big.Int)
-		}
-	}
-
-	return r0
-}
-
-// FeeEstimatorClient_ConfiguredChainID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConfiguredChainID'
-type FeeEstimatorClient_ConfiguredChainID_Call struct {
-	*mock.Call
-}
-
-// ConfiguredChainID is a helper method to define mock.On call
-func (_e *FeeEstimatorClient_Expecter) ConfiguredChainID() *FeeEstimatorClient_ConfiguredChainID_Call {
-	return &FeeEstimatorClient_ConfiguredChainID_Call{Call: _e.mock.On("ConfiguredChainID")}
-}
-
-func (_c *FeeEstimatorClient_ConfiguredChainID_Call) Run(run func()) *FeeEstimatorClient_ConfiguredChainID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *FeeEstimatorClient_ConfiguredChainID_Call) Return(_a0 *big.Int) *FeeEstimatorClient_ConfiguredChainID_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *FeeEstimatorClient_ConfiguredChainID_Call) RunAndReturn(run func() *big.Int) *FeeEstimatorClient_ConfiguredChainID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // EstimateGas provides a mock function with given fields: ctx, call
 func (_m *FeeEstimatorClient) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
 	ret := _m.Called(ctx, call)

--- a/core/chains/evm/gas/mocks/fee_estimator_client.go
+++ b/core/chains/evm/gas/mocks/fee_estimator_client.go
@@ -298,9 +298,9 @@ func (_c *FeeEstimatorClient_EstimateGas_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
-// FeeHistory provides a mock function with given fields: ctx, blockCount, rewardPercentiles
-func (_m *FeeEstimatorClient) FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (*ethereum.FeeHistory, error) {
-	ret := _m.Called(ctx, blockCount, rewardPercentiles)
+// FeeHistory provides a mock function with given fields: ctx, blockCount, lastBlock, rewardPercentiles
+func (_m *FeeEstimatorClient) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (*ethereum.FeeHistory, error) {
+	ret := _m.Called(ctx, blockCount, lastBlock, rewardPercentiles)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FeeHistory")
@@ -308,19 +308,19 @@ func (_m *FeeEstimatorClient) FeeHistory(ctx context.Context, blockCount uint64,
 
 	var r0 *ethereum.FeeHistory
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, []float64) (*ethereum.FeeHistory, error)); ok {
-		return rf(ctx, blockCount, rewardPercentiles)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, *big.Int, []float64) (*ethereum.FeeHistory, error)); ok {
+		return rf(ctx, blockCount, lastBlock, rewardPercentiles)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, []float64) *ethereum.FeeHistory); ok {
-		r0 = rf(ctx, blockCount, rewardPercentiles)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, *big.Int, []float64) *ethereum.FeeHistory); ok {
+		r0 = rf(ctx, blockCount, lastBlock, rewardPercentiles)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ethereum.FeeHistory)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, uint64, []float64) error); ok {
-		r1 = rf(ctx, blockCount, rewardPercentiles)
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, *big.Int, []float64) error); ok {
+		r1 = rf(ctx, blockCount, lastBlock, rewardPercentiles)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -336,14 +336,15 @@ type FeeEstimatorClient_FeeHistory_Call struct {
 // FeeHistory is a helper method to define mock.On call
 //   - ctx context.Context
 //   - blockCount uint64
+//   - lastBlock *big.Int
 //   - rewardPercentiles []float64
-func (_e *FeeEstimatorClient_Expecter) FeeHistory(ctx interface{}, blockCount interface{}, rewardPercentiles interface{}) *FeeEstimatorClient_FeeHistory_Call {
-	return &FeeEstimatorClient_FeeHistory_Call{Call: _e.mock.On("FeeHistory", ctx, blockCount, rewardPercentiles)}
+func (_e *FeeEstimatorClient_Expecter) FeeHistory(ctx interface{}, blockCount interface{}, lastBlock interface{}, rewardPercentiles interface{}) *FeeEstimatorClient_FeeHistory_Call {
+	return &FeeEstimatorClient_FeeHistory_Call{Call: _e.mock.On("FeeHistory", ctx, blockCount, lastBlock, rewardPercentiles)}
 }
 
-func (_c *FeeEstimatorClient_FeeHistory_Call) Run(run func(ctx context.Context, blockCount uint64, rewardPercentiles []float64)) *FeeEstimatorClient_FeeHistory_Call {
+func (_c *FeeEstimatorClient_FeeHistory_Call) Run(run func(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64)) *FeeEstimatorClient_FeeHistory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint64), args[2].([]float64))
+		run(args[0].(context.Context), args[1].(uint64), args[2].(*big.Int), args[3].([]float64))
 	})
 	return _c
 }
@@ -353,7 +354,7 @@ func (_c *FeeEstimatorClient_FeeHistory_Call) Return(feeHistory *ethereum.FeeHis
 	return _c
 }
 
-func (_c *FeeEstimatorClient_FeeHistory_Call) RunAndReturn(run func(context.Context, uint64, []float64) (*ethereum.FeeHistory, error)) *FeeEstimatorClient_FeeHistory_Call {
+func (_c *FeeEstimatorClient_FeeHistory_Call) RunAndReturn(run func(context.Context, uint64, *big.Int, []float64) (*ethereum.FeeHistory, error)) *FeeEstimatorClient_FeeHistory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/chains/evm/gas/mocks/fee_history_estimator_client.go
+++ b/core/chains/evm/gas/mocks/fee_history_estimator_client.go
@@ -24,9 +24,9 @@ func (_m *FeeHistoryEstimatorClient) EXPECT() *FeeHistoryEstimatorClient_Expecte
 	return &FeeHistoryEstimatorClient_Expecter{mock: &_m.Mock}
 }
 
-// FeeHistory provides a mock function with given fields: ctx, blockCount, rewardPercentiles
-func (_m *FeeHistoryEstimatorClient) FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (*ethereum.FeeHistory, error) {
-	ret := _m.Called(ctx, blockCount, rewardPercentiles)
+// FeeHistory provides a mock function with given fields: ctx, blockCount, lastBlock, rewardPercentiles
+func (_m *FeeHistoryEstimatorClient) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (*ethereum.FeeHistory, error) {
+	ret := _m.Called(ctx, blockCount, lastBlock, rewardPercentiles)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FeeHistory")
@@ -34,19 +34,19 @@ func (_m *FeeHistoryEstimatorClient) FeeHistory(ctx context.Context, blockCount 
 
 	var r0 *ethereum.FeeHistory
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, []float64) (*ethereum.FeeHistory, error)); ok {
-		return rf(ctx, blockCount, rewardPercentiles)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, *big.Int, []float64) (*ethereum.FeeHistory, error)); ok {
+		return rf(ctx, blockCount, lastBlock, rewardPercentiles)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, []float64) *ethereum.FeeHistory); ok {
-		r0 = rf(ctx, blockCount, rewardPercentiles)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, *big.Int, []float64) *ethereum.FeeHistory); ok {
+		r0 = rf(ctx, blockCount, lastBlock, rewardPercentiles)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ethereum.FeeHistory)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, uint64, []float64) error); ok {
-		r1 = rf(ctx, blockCount, rewardPercentiles)
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, *big.Int, []float64) error); ok {
+		r1 = rf(ctx, blockCount, lastBlock, rewardPercentiles)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -62,14 +62,15 @@ type FeeHistoryEstimatorClient_FeeHistory_Call struct {
 // FeeHistory is a helper method to define mock.On call
 //   - ctx context.Context
 //   - blockCount uint64
+//   - lastBlock *big.Int
 //   - rewardPercentiles []float64
-func (_e *FeeHistoryEstimatorClient_Expecter) FeeHistory(ctx interface{}, blockCount interface{}, rewardPercentiles interface{}) *FeeHistoryEstimatorClient_FeeHistory_Call {
-	return &FeeHistoryEstimatorClient_FeeHistory_Call{Call: _e.mock.On("FeeHistory", ctx, blockCount, rewardPercentiles)}
+func (_e *FeeHistoryEstimatorClient_Expecter) FeeHistory(ctx interface{}, blockCount interface{}, lastBlock interface{}, rewardPercentiles interface{}) *FeeHistoryEstimatorClient_FeeHistory_Call {
+	return &FeeHistoryEstimatorClient_FeeHistory_Call{Call: _e.mock.On("FeeHistory", ctx, blockCount, lastBlock, rewardPercentiles)}
 }
 
-func (_c *FeeHistoryEstimatorClient_FeeHistory_Call) Run(run func(ctx context.Context, blockCount uint64, rewardPercentiles []float64)) *FeeHistoryEstimatorClient_FeeHistory_Call {
+func (_c *FeeHistoryEstimatorClient_FeeHistory_Call) Run(run func(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64)) *FeeHistoryEstimatorClient_FeeHistory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint64), args[2].([]float64))
+		run(args[0].(context.Context), args[1].(uint64), args[2].(*big.Int), args[3].([]float64))
 	})
 	return _c
 }
@@ -79,7 +80,7 @@ func (_c *FeeHistoryEstimatorClient_FeeHistory_Call) Return(feeHistory *ethereum
 	return _c
 }
 
-func (_c *FeeHistoryEstimatorClient_FeeHistory_Call) RunAndReturn(run func(context.Context, uint64, []float64) (*ethereum.FeeHistory, error)) *FeeHistoryEstimatorClient_FeeHistory_Call {
+func (_c *FeeHistoryEstimatorClient_FeeHistory_Call) RunAndReturn(run func(context.Context, uint64, *big.Int, []float64) (*ethereum.FeeHistory, error)) *FeeHistoryEstimatorClient_FeeHistory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/chains/evm/gas/models.go
+++ b/core/chains/evm/gas/models.go
@@ -49,7 +49,7 @@ type feeEstimatorClient interface {
 	HeadByNumber(ctx context.Context, n *big.Int) (*evmtypes.Head, error)
 	EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error)
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
-	FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error)
+	FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error)
 }
 
 // NewEstimator returns the estimator for a given config

--- a/core/chains/evm/gas/models.go
+++ b/core/chains/evm/gas/models.go
@@ -45,7 +45,6 @@ type feeEstimatorClient interface {
 	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 	BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
-	ConfiguredChainID() *big.Int
 	HeadByNumber(ctx context.Context, n *big.Int) (*evmtypes.Head, error)
 	EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error)
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
@@ -53,7 +52,7 @@ type feeEstimatorClient interface {
 }
 
 // NewEstimator returns the estimator for a given config
-func NewEstimator(lggr logger.Logger, ethClient feeEstimatorClient, chaintype chaintype.ChainType, geCfg evmconfig.GasEstimator, clientsByChainID map[string]rollups.DAClient) (EvmFeeEstimator, error) {
+func NewEstimator(lggr logger.Logger, ethClient feeEstimatorClient, chaintype chaintype.ChainType, chainID *big.Int, geCfg evmconfig.GasEstimator, clientsByChainID map[string]rollups.DAClient) (EvmFeeEstimator, error) {
 	bh := geCfg.BlockHistory()
 	s := geCfg.Mode()
 	lggr.Infow(fmt.Sprintf("Initializing EVM gas estimator in mode: %s", s),
@@ -98,7 +97,7 @@ func NewEstimator(lggr logger.Logger, ethClient feeEstimatorClient, chaintype ch
 		}
 	case "BlockHistory":
 		newEstimator = func(l logger.Logger) EvmEstimator {
-			return NewBlockHistoryEstimator(lggr, ethClient, chaintype, geCfg, bh, ethClient.ConfiguredChainID(), l1Oracle)
+			return NewBlockHistoryEstimator(lggr, ethClient, chaintype, geCfg, bh, chainID, l1Oracle)
 		}
 	case "FixedPrice":
 		newEstimator = func(l logger.Logger) EvmEstimator {
@@ -117,7 +116,7 @@ func NewEstimator(lggr logger.Logger, ethClient feeEstimatorClient, chaintype ch
 				BlockHistorySize: uint64(geCfg.BlockHistory().BlockHistorySize()),
 				RewardPercentile: float64(geCfg.BlockHistory().TransactionPercentile()),
 			}
-			return NewFeeHistoryEstimator(lggr, ethClient, ccfg, ethClient.ConfiguredChainID(), l1Oracle)
+			return NewFeeHistoryEstimator(lggr, ethClient, ccfg, chainID, l1Oracle)
 		}
 
 	default:

--- a/core/chains/evm/gas/rollups/l1_oracle.go
+++ b/core/chains/evm/gas/rollups/l1_oracle.go
@@ -36,7 +36,7 @@ type l1OracleClient interface {
 // DAClient is interface of client connections for additional chains layers
 type DAClient interface {
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
-	FeeHistory(ctx context.Context, blockCount uint64, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error)
+	FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (feeHistory *ethereum.FeeHistory, err error)
 }
 
 type priceEntry struct {

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -101,7 +101,7 @@ func TestTxm_SendNativeToken_DoesNotSendToZero(t *testing.T) {
 
 	keyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := testutils.NewEthClientMockWithDefaultChain(t)
-	estimator, err := gas.NewEstimator(logger.Test(t), ethClient, config.ChainType(), evmConfig.GasEstimator(), nil)
+	estimator, err := gas.NewEstimator(logger.Test(t), ethClient, config.ChainType(), ethClient.ConfiguredChainID(), evmConfig.GasEstimator(), nil)
 	require.NoError(t, err)
 	txm, err := makeTestEvmTxm(t, db, ethClient, estimator, evmConfig, evmConfig.GasEstimator(), evmConfig.Transactions(), dbConfig, dbConfig.Listener(), keyStore)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 
 	ethClient := testutils.NewEthClientMockWithDefaultChain(t)
 
-	estimator, err := gas.NewEstimator(logger.Test(t), ethClient, config.ChainType(), evmConfig.GasEstimator(), nil)
+	estimator, err := gas.NewEstimator(logger.Test(t), ethClient, config.ChainType(), ethClient.ConfiguredChainID(), evmConfig.GasEstimator(), nil)
 	require.NoError(t, err)
 	txm, err := makeTestEvmTxm(t, db, ethClient, estimator, evmConfig, evmConfig.GasEstimator(), evmConfig.Transactions(), dbConfig, dbConfig.Listener(), kst.Eth())
 	require.NoError(t, err)
@@ -409,7 +409,7 @@ func TestTxm_CreateTransaction_OutOfEth(t *testing.T) {
 	config, dbConfig, evmConfig := txmgr.MakeTestConfigs(t)
 
 	ethClient := testutils.NewEthClientMockWithDefaultChain(t)
-	estimator, err := gas.NewEstimator(logger.Test(t), ethClient, config.ChainType(), evmConfig.GasEstimator(), nil)
+	estimator, err := gas.NewEstimator(logger.Test(t), ethClient, config.ChainType(), ethClient.ConfiguredChainID(), evmConfig.GasEstimator(), nil)
 	require.NoError(t, err)
 	txm, err := makeTestEvmTxm(t, db, ethClient, estimator, evmConfig, evmConfig.GasEstimator(), evmConfig.Transactions(), dbConfig, dbConfig.Listener(), etKeyStore)
 	require.NoError(t, err)
@@ -507,7 +507,7 @@ func TestTxm_Lifecycle(t *testing.T) {
 	keyChangeCh := make(chan struct{})
 	unsub := cltest.NewAwaiter()
 	kst.On("SubscribeToKeyChanges", mock.Anything).Return(keyChangeCh, unsub.ItHappened)
-	estimator, err := gas.NewEstimator(logger.Test(t), ethClient, config.ChainType(), evmConfig.GasEstimator(), nil)
+	estimator, err := gas.NewEstimator(logger.Test(t), ethClient, config.ChainType(), ethClient.ConfiguredChainID(), evmConfig.GasEstimator(), nil)
 	require.NoError(t, err)
 	txm, err := makeTestEvmTxm(t, db, ethClient, estimator, evmConfig, evmConfig.GasEstimator(), evmConfig.Transactions(), dbConfig, dbConfig.Listener(), kst)
 	require.NoError(t, err)
@@ -562,7 +562,7 @@ func TestTxm_Reset(t *testing.T) {
 	ethClient.On("PendingNonceAt", mock.Anything, addr).Return(uint64(128), nil).Maybe()
 	ethClient.On("PendingNonceAt", mock.Anything, addr2).Return(uint64(44), nil).Maybe()
 
-	estimator, err := gas.NewEstimator(logger.Test(t), ethClient, cfg.EVM().ChainType(), cfg.EVM().GasEstimator(), nil)
+	estimator, err := gas.NewEstimator(logger.Test(t), ethClient, cfg.EVM().ChainType(), ethClient.ConfiguredChainID(), cfg.EVM().GasEstimator(), nil)
 	require.NoError(t, err)
 	txm, err := makeTestEvmTxm(t, db, ethClient, estimator, cfg.EVM(), cfg.EVM().GasEstimator(), cfg.EVM().Transactions(), gcfg.Database(), gcfg.Database().Listener(), kst.Eth())
 	require.NoError(t, err)

--- a/core/chains/legacyevm/evm_txm.go
+++ b/core/chains/legacyevm/evm_txm.go
@@ -47,7 +47,7 @@ func newEvmTxm(
 
 	// build estimator from factory
 	if opts.GenGasEstimator == nil {
-		if estimator, err = gas.NewEstimator(lggr, client, cfg.ChainType(), cfg.GasEstimator(), clientsByChainID); err != nil {
+		if estimator, err = gas.NewEstimator(lggr, client, cfg.ChainType(), chainID, cfg.GasEstimator(), clientsByChainID); err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize estimator: %w", err)
 		}
 	} else {

--- a/core/services/headreporter/prometheus_reporter_test.go
+++ b/core/services/headreporter/prometheus_reporter_test.go
@@ -109,7 +109,7 @@ func newLegacyChainContainer(t *testing.T, db *sqlx.DB) legacyevm.LegacyChainCon
 	config, dbConfig, evmConfig := txmgr.MakeTestConfigs(t)
 	keyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	estimator, err := gas.NewEstimator(logger.TestLogger(t), ethClient, config.ChainType(), evmConfig.GasEstimator(), nil)
+	estimator, err := gas.NewEstimator(logger.TestLogger(t), ethClient, config.ChainType(), ethClient.ConfiguredChainID(), evmConfig.GasEstimator(), nil)
 	require.NoError(t, err)
 	lggr := logger.TestLogger(t)
 	lpOpts := logpoller.Opts{


### PR DESCRIPTION
Make FeeHistory RPC call backwards compatible with Geth and remove unnecessary ConfiguredChainID call from estimators
