### PR TITLE
[CAPPL-257] GetUnfinished should filter by workflowID

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -357,7 +357,7 @@ var (
 )
 
 func (e *Engine) resumeInProgressExecutions(ctx context.Context) error {
-	wipExecutions, err := e.executionStates.GetUnfinished(ctx, defaultOffset, defaultLimit)
+	wipExecutions, err := e.executionStates.GetUnfinished(ctx, e.workflow.id, defaultOffset, defaultLimit)
 	if err != nil {
 		return err
 	}

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -35,7 +35,6 @@ import (
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/store"
-	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer"
 )
 
 const testWorkflowId = "<workflow-id>"
@@ -149,6 +148,12 @@ func newTestEngineWithYAMLSpec(t *testing.T, reg *coreCap.Registry, spec string,
 	return newTestEngine(t, reg, sdkSpec, opts...)
 }
 
+type mockSecretsFetcher struct{}
+
+func (s mockSecretsFetcher) SecretsFor(workflowOwner, workflowName string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // newTestEngine creates a new engine with some test defaults.
 func newTestEngine(t *testing.T, reg *coreCap.Registry, sdkSpec sdk.WorkflowSpec, opts ...func(c *Config)) (*Engine, *testHooks) {
 	initFailed := make(chan struct{})
@@ -174,7 +179,7 @@ func newTestEngine(t *testing.T, reg *coreCap.Registry, sdkSpec sdk.WorkflowSpec
 		onExecutionFinished: func(weid string) {
 			executionFinished <- weid
 		},
-		SecretsFetcher: syncer.NewWorkflowRegistry(),
+		SecretsFetcher: mockSecretsFetcher{},
 		clock:          clock,
 	}
 	for _, o := range opts {

--- a/core/services/workflows/store/store.go
+++ b/core/services/workflows/store/store.go
@@ -9,7 +9,7 @@ type Store interface {
 	UpsertStep(ctx context.Context, step *WorkflowExecutionStep) (WorkflowExecution, error)
 	UpdateStatus(ctx context.Context, executionID string, status string) error
 	Get(ctx context.Context, executionID string) (WorkflowExecution, error)
-	GetUnfinished(ctx context.Context, offset, limit int) ([]WorkflowExecution, error)
+	GetUnfinished(ctx context.Context, workflowID string, offset, limit int) ([]WorkflowExecution, error)
 }
 
 var _ Store = (*DBStore)(nil)

--- a/core/services/workflows/store/store_db_test.go
+++ b/core/services/workflows/store/store_db_test.go
@@ -12,13 +12,18 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func randomID() string {
-	b := make([]byte, 32)
+	return random(32)
+}
+
+func random(length int) string {
+	b := make([]byte, length)
 	_, err := rand.Read(b)
 	if err != nil {
 		panic(err)
@@ -234,10 +239,24 @@ func Test_StoreDB_WorkflowStepStatus(t *testing.T) {
 	}
 }
 
+func createWorkflow(t *testing.T, store *DBStore, id string) {
+	sql := `INSERT INTO workflow_specs (workflow, workflow_id, workflow_owner, workflow_name, created_at, updated_at)
+	VALUES (:workflow, :workflow_id, :workflow_owner, :workflow_name, NOW(), NOW())`
+	var wfSpec job.WorkflowSpec
+	wfSpec.Workflow = ""
+	wfSpec.WorkflowID = id
+	wfSpec.WorkflowOwner = random(20)
+	wfSpec.WorkflowName = random(20)
+	_, err := store.db.NamedExecContext(tests.Context(t), sql, wfSpec)
+	require.NoError(t, err)
+}
+
 func Test_StoreDB_GetUnfinishedSteps(t *testing.T) {
 	store := newTestDBStore(t)
 
 	id := randomID()
+	wid := randomID()
+	createWorkflow(t, store, wid)
 	stepOne := &WorkflowExecutionStep{
 		ExecutionID: id,
 		Ref:         "step1",
@@ -254,10 +273,27 @@ func Test_StoreDB_GetUnfinishedSteps(t *testing.T) {
 			"step2": stepTwo,
 		},
 		ExecutionID: id,
+		WorkflowID:  wid,
 		Status:      StatusStarted,
 	}
 
 	_, err := store.Add(tests.Context(t), &es)
+	require.NoError(t, err)
+
+	id2 := randomID()
+	wid2 := randomID()
+	createWorkflow(t, store, wid2)
+	es2 := WorkflowExecution{
+		Steps: map[string]*WorkflowExecutionStep{
+			"step1": stepOne,
+			"step2": stepTwo,
+		},
+		ExecutionID: id2,
+		WorkflowID:  wid2,
+		Status:      StatusStarted,
+	}
+
+	_, err = store.Add(tests.Context(t), &es2)
 	require.NoError(t, err)
 
 	id = randomID()
@@ -269,7 +305,7 @@ func Test_StoreDB_GetUnfinishedSteps(t *testing.T) {
 	_, err = store.Add(tests.Context(t), &esTwo)
 	require.NoError(t, err)
 
-	states, err := store.GetUnfinished(tests.Context(t), 0, 100)
+	states, err := store.GetUnfinished(tests.Context(t), wid, 0, 100)
 	require.NoError(t, err)
 
 	assert.Len(t, states, 1)


### PR DESCRIPTION
We weren't filtering by the workflow when rehydrating. This adds a workflow-level filter, ensuring that all engines only deal with executions of their own workflow.