### PR TITLE
Fix flaky evm batch caller test

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/rpclib/evm_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/rpclib/evm_test.go
@@ -116,7 +116,7 @@ func TestDefaultEvmBatchCaller_batchCallLimit(t *testing.T) {
 		{numCalls: 10, batchSize: 100, parallelRpcCallsLimit: 10},
 		{numCalls: 1, batchSize: 100, parallelRpcCallsLimit: 10},
 		{numCalls: 1000, batchSize: 10, parallelRpcCallsLimit: 2},
-		{numCalls: rand.Uint() % 1000, batchSize: rand.Uint() % 500, parallelRpcCallsLimit: rand.Uint() % 500},
+		{numCalls: 1 + rand.Uint()%1000, batchSize: 1 + rand.Uint()%500, parallelRpcCallsLimit: 1 + rand.Uint()%500},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Zero was not an acceptable value for this test.