### PR TITLE
[CAPPL-99] capability type assertion

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -396,9 +396,14 @@ func (w *launcher) exposeCapabilities(ctx context.Context, myPeerID p2ptypes.Pee
 		switch capability.CapabilityType {
 		case capabilities.CapabilityTypeTrigger:
 			newTriggerPublisher := func(cap capabilities.BaseCapability, info capabilities.CapabilityInfo) (remotetypes.ReceiverService, error) {
+				triggerCapability, ok := (cap).(capabilities.TriggerCapability)
+				if !ok {
+					return nil, errors.New("capability does not implement TriggerCapability")
+				}
+
 				publisher := remote.NewTriggerPublisher(
 					capabilityConfig.RemoteTriggerConfig,
-					cap.(capabilities.TriggerCapability),
+					triggerCapability,
 					info,
 					don.DON,
 					idsToDONs,
@@ -419,10 +424,15 @@ func (w *launcher) exposeCapabilities(ctx context.Context, myPeerID p2ptypes.Pee
 			w.lggr.Warn("no remote client configured for capability type consensus, skipping configuration")
 		case capabilities.CapabilityTypeTarget:
 			newTargetServer := func(cap capabilities.BaseCapability, info capabilities.CapabilityInfo) (remotetypes.ReceiverService, error) {
+				targetCapability, ok := (cap).(capabilities.TargetCapability)
+				if !ok {
+					return nil, errors.New("capability does not implement TargetCapability")
+				}
+
 				return target.NewServer(
 					capabilityConfig.RemoteTargetConfig,
 					myPeerID,
-					cap.(capabilities.TargetCapability),
+					targetCapability,
 					info,
 					don.DON,
 					idsToDONs,


### PR DESCRIPTION
### Description

Perform a type assertion before assuming the type is either Trigger or Target capability. incorrect assumptions without assertions was triggering a panic.
 
[CAPPL-99](https://smartcontract-it.atlassian.net/browse/CAPPL-99)


### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CAPPL-99]: https://smartcontract-it.atlassian.net/browse/CAPPL-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ