### PR TITLE
Increase maxQueryDuration in ccip tests

### DIFF
--- a/deployment/ccip/deploy_home_chain.go
+++ b/deployment/ccip/deploy_home_chain.go
@@ -59,7 +59,7 @@ const (
 	DeltaCertifiedCommitRequest             = 10 * time.Second
 	DeltaStage                              = 10 * time.Second
 	Rmax                                    = 3
-	MaxDurationQuery                        = 50 * time.Millisecond
+	MaxDurationQuery                        = 500 * time.Millisecond
 	MaxDurationObservation                  = 5 * time.Second
 	MaxDurationShouldAcceptAttestedReport   = 10 * time.Second
 	MaxDurationShouldTransmitAcceptedReport = 10 * time.Second


### PR DESCRIPTION
`50ms` is no longer ideal.
After the RMN integration, oracle needs to communicate with RMN nodes in the query phase.
Even though this is working so far it might end up in flaky / long running tests.