### PR TITLE
core/services/relay/evm: fix commit race

### DIFF
--- a/core/services/relay/evm/chain_components_test.go
+++ b/core/services/relay/evm/chain_components_test.go
@@ -236,7 +236,6 @@ func (h *helper) Init(t *testing.T) {
 	h.client = h.Client(t)
 
 	h.txm = h.TXM(t, h.client)
-	h.Commit()
 }
 
 func (h *helper) SetupKeys(t *testing.T) {


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/11803701580/job/32882272245
```
==================
WARNING: DATA RACE
Read at 0x00c001378400 by goroutine 936:
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).sealBlock()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/eth/catalyst/simulated_beacon.go:153 +0x72
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).Commit()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/eth/catalyst/simulated_beacon.go:281 +0xfa
  github.com/ethereum/go-ethereum/ethclient/simulated.(*Backend).Commit()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/ethclient/simulated/backend.go:160 +0x49
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.Mine.func1()
      /home/runner/work/chainlink/chainlink/core/internal/cltest/simulated_backend.go:105 +0x241

Previous write at 0x00c001378400 by goroutine 5772:
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).sealBlock()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/eth/catalyst/simulated_beacon.go:232 +0x1418
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).Commit()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/eth/catalyst/simulated_beacon.go:281 +0xfa
  github.com/ethereum/go-ethereum/ethclient/simulated.(*Backend).Commit()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/ethclient/simulated/backend.go:160 +0x52
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm_test.(*helper).Commit()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/chain_components_test.go:284 +0x1d
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting.(*EVMChainComponentsInterfaceTester[go.shape.*uint8]).deployNewContract()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/evmtesting/chain_components_interface_tester.go:467 +0x1c9
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting.(*EVMChainComponentsInterfaceTester[go.shape.*uint8]).deployNewContracts()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/evmtesting/chain_components_interface_tester.go:452 +0x165
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting.(*EVMChainComponentsInterfaceTester[go.shape.*uint8]).Setup()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/evmtesting/chain_components_interface_tester.go:103 +0x556
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting.(*EVMChainComponentsInterfaceTester[*testing.T]).Setup()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/evmtesting/chain_components_interface_tester.go:83 +0x44
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.RunTests[go.shape.*uint8].func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.1-0.20241112140826-0e2daed34ef6/pkg/types/interfacetests/utils.go:62 +0x4c
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:[17](https://github.com/smartcontractkit/chainlink/actions/runs/11803701580/job/32882272245#step:19:18)42 +0x44

Goroutine 936 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.Mine()
      /home/runner/work/chainlink/chainlink/core/internal/cltest/simulated_backend.go:100 +0x1e4
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm_test.(*helper).Backend()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/chain_components_test.go:277 +0x488
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm_test.(*helper).Init()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/chain_components_test.go:235 +0x12c
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting.(*EVMChainComponentsInterfaceTester[go.shape.*uint8]).Init()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/evmtesting/chain_components_interface_tester.go:479 +0x55
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm_test.TestChainComponents()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/chain_components_test.go:210 +0x149
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44

Goroutine 5772 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x825
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.RunTests[go.shape.*uint8]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.1-0.[20](https://github.com/smartcontractkit/chainlink/actions/runs/11803701580/job/32882272245#step:19:21)241112140826-0e2daed34ef6/pkg/types/interfacetests/utils.go:61 +0x26a
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runContractReaderGetLatestValueInterfaceTests[go.shape.*uint8]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.1-0.2024111[21](https://github.com/smartcontractkit/chainlink/actions/runs/11803701580/job/32882272245#step:19:22)40826-0e2daed34ef6/pkg/types/interfacetests/chain_components_interface_tests.go:442 +0xcea
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.RunContractReaderInterfaceTests[go.shape.*uint8].func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.1-0.20241112140826-0e2daed34ef6/pkg/types/interfacetests/chain_components_interface_tests.go:102 +0x79
  testing.tRunner()
      /opt/hostedtoolcache/go/1.[22](https://github.com/smartcontractkit/chainlink/actions/runs/11803701580/job/32882272245#step:19:23).8/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44
==================
```