### PR TITLE
Correct Read Error Format

### DIFF
--- a/core/services/relay/evm/read/batch.go
+++ b/core/services/relay/evm/read/batch.go
@@ -128,7 +128,7 @@ func newDefaultEvmBatchCaller(
 }
 
 // batchCall formats a batch, calls the rpc client, and unpacks results.
-// this function only returns errors of type ErrRead which should wrap lower errors.
+// this function only returns errors of type ReadError which should wrap lower errors.
 func (c *defaultEvmBatchCaller) batchCall(ctx context.Context, blockNumber uint64, batchCall BatchCall) ([]dataAndErr, error) {
 	if len(batchCall) == 0 {
 		return nil, nil
@@ -147,9 +147,9 @@ func (c *defaultEvmBatchCaller) batchCall(ctx context.Context, blockNumber uint6
 	if err = c.evmClient.BatchCallContext(ctx, rpcBatchCalls); err != nil {
 		// return a basic read error with no detail or result since this is a general client
 		// error instead of an error for a specific batch call.
-		return nil, ErrRead{
-			Err:   fmt.Errorf("%w: batch call context: %s", types.ErrInternal, err.Error()),
-			Batch: true,
+		return nil, ReadError{
+			Err:  fmt.Errorf("%w: batch call context: %s", types.ErrInternal, err.Error()),
+			Type: batchReadType,
 		}
 	}
 
@@ -176,7 +176,7 @@ func (c *defaultEvmBatchCaller) createBatchCalls(
 				fmt.Errorf("%w: encode params: %s", types.ErrInvalidConfig, err.Error()),
 				call,
 				block,
-				true,
+				batchReadType,
 			)
 		}
 
@@ -217,7 +217,7 @@ func (c *defaultEvmBatchCaller) unpackBatchResults(
 		if rpcBatchCalls[idx].Error != nil {
 			results[idx].err = newErrorFromCall(
 				fmt.Errorf("%w: rpc call error: %w", types.ErrInternal, rpcBatchCalls[idx].Error),
-				call, block, true,
+				call, block, batchReadType,
 			)
 
 			continue
@@ -233,7 +233,7 @@ func (c *defaultEvmBatchCaller) unpackBatchResults(
 		if err != nil {
 			callErr := newErrorFromCall(
 				fmt.Errorf("%w: hex decode result: %s", types.ErrInternal, err.Error()),
-				call, block, true,
+				call, block, batchReadType,
 			)
 
 			callErr.Result = &hexEncodedOutputs[idx]
@@ -250,7 +250,7 @@ func (c *defaultEvmBatchCaller) unpackBatchResults(
 			if len(packedBytes) == 0 {
 				callErr := newErrorFromCall(
 					fmt.Errorf("%w: %w: %s", types.ErrInternal, errEmptyOutput, err.Error()),
-					call, block, true,
+					call, block, batchReadType,
 				)
 
 				callErr.Result = &hexEncodedOutputs[idx]
@@ -259,7 +259,7 @@ func (c *defaultEvmBatchCaller) unpackBatchResults(
 			} else {
 				callErr := newErrorFromCall(
 					fmt.Errorf("%w: codec decode result: %s", types.ErrInvalidType, err.Error()),
-					call, block, true,
+					call, block, batchReadType,
 				)
 
 				callErr.Result = &hexEncodedOutputs[idx]
@@ -290,9 +290,9 @@ func (c *defaultEvmBatchCaller) batchCallDynamicLimitRetries(ctx context.Context
 		}
 
 		if lim <= 1 {
-			return nil, ErrRead{
-				Err:   fmt.Errorf("%w: limited call: call data: %+v", err, calls),
-				Batch: true,
+			return nil, ReadError{
+				Err:  fmt.Errorf("%w: limited call: call data: %+v", err, calls),
+				Type: batchReadType,
 			}
 		}
 

--- a/core/services/relay/evm/read/batch.go
+++ b/core/services/relay/evm/read/batch.go
@@ -128,7 +128,7 @@ func newDefaultEvmBatchCaller(
 }
 
 // batchCall formats a batch, calls the rpc client, and unpacks results.
-// this function only returns errors of type ReadError which should wrap lower errors.
+// this function only returns errors of type Error which should wrap lower errors.
 func (c *defaultEvmBatchCaller) batchCall(ctx context.Context, blockNumber uint64, batchCall BatchCall) ([]dataAndErr, error) {
 	if len(batchCall) == 0 {
 		return nil, nil
@@ -147,7 +147,7 @@ func (c *defaultEvmBatchCaller) batchCall(ctx context.Context, blockNumber uint6
 	if err = c.evmClient.BatchCallContext(ctx, rpcBatchCalls); err != nil {
 		// return a basic read error with no detail or result since this is a general client
 		// error instead of an error for a specific batch call.
-		return nil, ReadError{
+		return nil, Error{
 			Err:  fmt.Errorf("%w: batch call context: %s", types.ErrInternal, err.Error()),
 			Type: batchReadType,
 		}
@@ -290,7 +290,7 @@ func (c *defaultEvmBatchCaller) batchCallDynamicLimitRetries(ctx context.Context
 		}
 
 		if lim <= 1 {
-			return nil, ReadError{
+			return nil, Error{
 				Err:  fmt.Errorf("%w: limited call: call data: %+v", err, calls),
 				Type: batchReadType,
 			}

--- a/core/services/relay/evm/read/errors.go
+++ b/core/services/relay/evm/read/errors.go
@@ -18,7 +18,7 @@ const (
 	eventReadType  readType = "QueryKey"
 )
 
-type ReadError struct {
+type Error struct {
 	Err    error
 	Type   readType
 	Detail *readDetail
@@ -33,8 +33,8 @@ type readDetail struct {
 	Block          string
 }
 
-func newErrorFromCall(err error, call Call, block string, tp readType) ReadError {
-	return ReadError{
+func newErrorFromCall(err error, call Call, block string, tp readType) Error {
+	return Error{
 		Err:  err,
 		Type: tp,
 		Detail: &readDetail{
@@ -48,7 +48,7 @@ func newErrorFromCall(err error, call Call, block string, tp readType) ReadError
 	}
 }
 
-func (e ReadError) Error() string {
+func (e Error) Error() string {
 	var builder strings.Builder
 
 	builder.WriteString("[read error]")
@@ -71,7 +71,7 @@ func (e ReadError) Error() string {
 	return builder.String()
 }
 
-func (e ReadError) Unwrap() error {
+func (e Error) Unwrap() error {
 	return e.Err
 }
 

--- a/core/services/relay/evm/read/errors.go
+++ b/core/services/relay/evm/read/errors.go
@@ -43,8 +43,8 @@ func newErrorFromCall(err error, call Call, block string, batch bool) ErrRead {
 func (e ErrRead) Error() string {
 	var builder strings.Builder
 
-	builder.WriteString("[rpc error]")
-	builder.WriteString(fmt.Sprintf(" batch: %T;", e.Batch))
+	builder.WriteString("[read error]")
+	builder.WriteString(fmt.Sprintf(" batch: %t;", e.Batch))
 	builder.WriteString(fmt.Sprintf(" err: %s;", e.Err.Error()))
 
 	if e.Detail != nil {

--- a/core/services/relay/evm/read/errors.go
+++ b/core/services/relay/evm/read/errors.go
@@ -10,9 +10,17 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 )
 
-type ErrRead struct {
+type readType string
+
+const (
+	batchReadType  readType = "BatchGetLatestValue"
+	singleReadType readType = "GetLatestValue"
+	eventReadType  readType = "QueryKey"
+)
+
+type ReadError struct {
 	Err    error
-	Batch  bool
+	Type   readType
 	Detail *readDetail
 	Result *string
 }
@@ -25,10 +33,10 @@ type readDetail struct {
 	Block          string
 }
 
-func newErrorFromCall(err error, call Call, block string, batch bool) ErrRead {
-	return ErrRead{
-		Err:   err,
-		Batch: batch,
+func newErrorFromCall(err error, call Call, block string, tp readType) ReadError {
+	return ReadError{
+		Err:  err,
+		Type: tp,
 		Detail: &readDetail{
 			Address:  call.ContractAddress.Hex(),
 			Contract: call.ContractName,
@@ -40,15 +48,12 @@ func newErrorFromCall(err error, call Call, block string, batch bool) ErrRead {
 	}
 }
 
-func (e ErrRead) Error() string {
+func (e ReadError) Error() string {
 	var builder strings.Builder
 
 	builder.WriteString("[read error]")
 	builder.WriteString(fmt.Sprintf(" err: %s;", e.Err.Error()))
-
-	if e.Batch {
-		builder.WriteString(" batch;")
-	}
+	builder.WriteString(fmt.Sprintf(" type: %s;", e.Type))
 
 	if e.Detail != nil {
 		builder.WriteString(fmt.Sprintf(" block: %s;", e.Detail.Block))
@@ -66,7 +71,7 @@ func (e ErrRead) Error() string {
 	return builder.String()
 }
 
-func (e ErrRead) Unwrap() error {
+func (e ReadError) Unwrap() error {
 	return e.Err
 }
 

--- a/core/services/relay/evm/read/errors.go
+++ b/core/services/relay/evm/read/errors.go
@@ -44,8 +44,11 @@ func (e ErrRead) Error() string {
 	var builder strings.Builder
 
 	builder.WriteString("[read error]")
-	builder.WriteString(fmt.Sprintf(" batch: %t;", e.Batch))
 	builder.WriteString(fmt.Sprintf(" err: %s;", e.Err.Error()))
+
+	if e.Batch {
+		builder.WriteString(" batch;")
+	}
 
 	if e.Detail != nil {
 		builder.WriteString(fmt.Sprintf(" block: %s;", e.Detail.Block))

--- a/core/services/relay/evm/read/event.go
+++ b/core/services/relay/evm/read/event.go
@@ -247,7 +247,7 @@ func (b *EventBinding) GetLatestValueWithHeadData(ctx context.Context, address c
 				ReadName:        b.eventName,
 				Params:          params,
 				ReturnVal:       into,
-			}, strconv.Itoa(int(confs)), false)
+			}, strconv.Itoa(int(confs)), eventReadType)
 
 			callErr.Result = result
 
@@ -315,7 +315,7 @@ func (b *EventBinding) QueryKey(ctx context.Context, address common.Address, fil
 				ContractName:    b.contractName,
 				ReadName:        b.eventName,
 				ReturnVal:       sequenceDataType,
-			}, "", false)
+			}, "", eventReadType)
 		}
 	}()
 

--- a/core/services/relay/evm/read/method.go
+++ b/core/services/relay/evm/read/method.go
@@ -68,7 +68,7 @@ func (b *MethodBinding) Bind(ctx context.Context, bindings ...common.Address) er
 		// check for contract byte code at the latest block and provided address
 		byteCode, err := b.client.CodeAt(ctx, binding, nil)
 		if err != nil {
-			return ReadError{
+			return Error{
 				Err:  fmt.Errorf("%w: code at call failure: %s", commontypes.ErrInternal, err.Error()),
 				Type: singleReadType,
 				Detail: &readDetail{

--- a/core/services/relay/evm/read/method.go
+++ b/core/services/relay/evm/read/method.go
@@ -68,8 +68,9 @@ func (b *MethodBinding) Bind(ctx context.Context, bindings ...common.Address) er
 		// check for contract byte code at the latest block and provided address
 		byteCode, err := b.client.CodeAt(ctx, binding, nil)
 		if err != nil {
-			return ErrRead{
-				Err: fmt.Errorf("%w: code at call failure: %s", commontypes.ErrInternal, err.Error()),
+			return ReadError{
+				Err:  fmt.Errorf("%w: code at call failure: %s", commontypes.ErrInternal, err.Error()),
+				Type: singleReadType,
 				Detail: &readDetail{
 					Address:  binding.Hex(),
 					Contract: b.contractName,
@@ -146,7 +147,7 @@ func (b *MethodBinding) GetLatestValueWithHeadData(ctx context.Context, addr com
 				ReadName:        b.method,
 				Params:          params,
 				ReturnVal:       returnVal,
-			}, blockNum.String(), false)
+			}, blockNum.String(), singleReadType)
 
 		return nil, callErr
 	}
@@ -167,7 +168,7 @@ func (b *MethodBinding) GetLatestValueWithHeadData(ctx context.Context, addr com
 				ReadName:        b.method,
 				Params:          params,
 				ReturnVal:       returnVal,
-			}, blockNum.String(), false)
+			}, blockNum.String(), singleReadType)
 
 		return nil, callErr
 	}
@@ -181,7 +182,7 @@ func (b *MethodBinding) GetLatestValueWithHeadData(ctx context.Context, addr com
 				ReadName:        b.method,
 				Params:          params,
 				ReturnVal:       returnVal,
-			}, blockNum.String(), false)
+			}, blockNum.String(), singleReadType)
 
 		strResult := hexutil.Encode(bytes)
 		callErr.Result = &strResult


### PR DESCRIPTION
Changed error text to be `read error` instead of `rpc error` to limit confusion. Batch flag to string corrected to show `true|false` instead of bool type.