### PR TITLE
feat: delete merge queue caches on pr merge

### DIFF
--- a/.github/workflows/delete-caches.yml
+++ b/.github/workflows/delete-caches.yml
@@ -20,23 +20,46 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4.1.2
 
-      - name: Cleanup Branch Caches
+      - name: Setup gh-actions-cache extension
+        run: gh extension install actions/gh-actions-cache
+
+      - name: Retrieve Trunk SHA
+        id: get-sha
         run: |
-          gh extension install actions/gh-actions-cache
-          
           REPO=${{ github.repository }}
-          BRANCH=refs/pull/${{ github.event.pull_request.number }}/merge
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          SHA=$(gh pr view -R $REPO $PR_NUMBER --json mergeCommit --jq .mergeCommit.oid)
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
 
-          echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
-
-          ## Setting this to not fail the workflow while deleting cache keys. 
+      - name: Cleanup Caches
+        run: |
           set +e
-          echo "Deleting caches..."
-          for cacheKey in $cacheKeysForPR
-          do
-              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+
+          REPO=${{ github.repository }}
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          PR_BRANCH=refs/pull/$PR_NUMBER/merge
+          
+          echo "Fetching list of cache keys for the PR branch"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $PR_BRANCH | cut -f 1)
+
+          echo "Deleting caches for PR branch..."
+          for cacheKey in $cacheKeysForPR; do
+              gh actions-cache delete $cacheKey -R $REPO -B $PR_BRANCH --confirm
           done
+
+          if [[ -n ${{ steps.get-sha.outputs.sha }} ]]; then
+            echo "Found corresponding merge commit ${{ steps.get-sha.outputs.sha }}"
+            QUEUE_BRANCH="gh-readonly-queue/develop/pr-${PR_NUMBER}-${{ steps.get-sha.outputs.sha }}"
+
+            echo "Fetching list of cache keys for the merge queue branch"
+            cacheKeysForQueue=$(gh actions-cache list -R $REPO -B $QUEUE_BRANCH | cut -f 1)
+
+            echo "Deleting caches for merge queue branch..."
+            for cacheKey in $cacheKeysForQueue; do
+                gh actions-cache delete $cacheKey -R $REPO -B $QUEUE_BRANCH --confirm
+            done
+          fi
+
           echo "Done"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-caches.yml
+++ b/.github/workflows/delete-caches.yml
@@ -16,6 +16,9 @@ jobs:
       #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
       actions: write
       contents: read
+    env:
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.2
@@ -26,40 +29,35 @@ jobs:
       - name: Retrieve Trunk SHA
         id: get-sha
         run: |
-          REPO=${{ github.repository }}
-          PR_NUMBER=${{ github.event.pull_request.number }}
           SHA=$(gh pr view -R $REPO $PR_NUMBER --json mergeCommit --jq .mergeCommit.oid)
           echo "sha=$SHA" >> $GITHUB_OUTPUT
 
       - name: Cleanup Caches
+        env:
+          TRUNK_SHA: ${{ steps.get-sha.outputs.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set +e
 
-          REPO=${{ github.repository }}
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          PR_BRANCH=refs/pull/$PR_NUMBER/merge
-          
-          echo "Fetching list of cache keys for the PR branch"
-          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $PR_BRANCH | cut -f 1)
+          PR_BRANCH=refs/pull/$PR_NUMBER/merge          
+          echo "Fetching list of cache keys for the PR branch ($PR_BRANCH)"
+          PR_CACHE_KEYS=$(gh actions-cache list -R $REPO -B $PR_BRANCH | cut -f 1)
 
-          echo "Deleting caches for PR branch..."
-          for cacheKey in $cacheKeysForPR; do
-              gh actions-cache delete $cacheKey -R $REPO -B $PR_BRANCH --confirm
+          echo "Deleting caches for PR branch ($PR_BRANCH)..."
+          for CACHE_KEY in $PR_CACHE_KEYS; do
+              gh actions-cache delete $CACHE_KEY -R $REPO -B $PR_BRANCH --confirm
           done
 
-          if [[ -n ${{ steps.get-sha.outputs.sha }} ]]; then
-            echo "Found corresponding merge commit ${{ steps.get-sha.outputs.sha }}"
-            QUEUE_BRANCH="gh-readonly-queue/develop/pr-${PR_NUMBER}-${{ steps.get-sha.outputs.sha }}"
-
-            echo "Fetching list of cache keys for the merge queue branch"
-            cacheKeysForQueue=$(gh actions-cache list -R $REPO -B $QUEUE_BRANCH | cut -f 1)
-
-            echo "Deleting caches for merge queue branch..."
-            for cacheKey in $cacheKeysForQueue; do
-                gh actions-cache delete $cacheKey -R $REPO -B $QUEUE_BRANCH --confirm
+          if [[ -n "$TRUNK_SHA" ]]; then
+            echo "Found corresponding merge commit $TRUNK_SHA"
+            QUEUE_BRANCH="gh-readonly-queue/develop/pr-${PR_NUMBER}-${TRUNK_SHA}"
+            echo "Fetching list of cache keys for the merge queue branch ($QUEUE_BRANCH)"            
+            QUEUE_CACHE_KEYS=$(gh actions-cache list -R $REPO -B $QUEUE_BRANCH | cut -f 1)
+          
+            echo "Deleting caches for merge queue branch ($QUEUE_BRANCH)..."
+            for CACHE_KEY in $QUEUE_CACHE_KEYS; do
+                gh actions-cache delete $CACHE_KEY -R $REPO -B $QUEUE_BRANCH --confirm
             done
           fi
 
           echo "Done"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes

- After PR is merged, also delete caches created during the merge queue.

### Motivation

Although I've tried to stop caches from being created on merge queue events, sometimes they're still created. This will also delete caches for refs of the format:
-  `gh-readonly-queue/develop/pr-<pr id>-<trunk sha>`

### Testing

I've only tested locally in bash. I think this will work in CI, but I will have to merge this and see.

---

RE-3205
