### PR TITLE
chore: update goreleaser github action dependencies

### DIFF
--- a/.github/actions/goreleaser-build-sign-publish/action.yml
+++ b/.github/actions/goreleaser-build-sign-publish/action.yml
@@ -33,14 +33,14 @@ runs:
       name: Set up QEMU 
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     - name: Setup docker buildx
-      uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0
+      uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.0
     - name: Set up Go
       uses: ./.github/actions/setup-go
       with:
         go-version-file: 'go.mod'
         only-modules: 'true'
     - name: Setup goreleaser
-      uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
+      uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
       with:
         distribution: goreleaser-pro
         install-only: true
@@ -49,12 +49,12 @@ runs:
         GORELEASER_KEY: ${{ inputs.goreleaser-key }}
 
     - name: Login to docker registry
-      uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
       with:
         registry: ${{ inputs.docker-registry }}
 
     - name: Install syft
-      uses: anchore/sbom-action/download-syft@61119d458adab75f756bc0b9e4bde25725f86a7a # v0.17.2
+      uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb # v0.17.7
 
     - name: Run goreleaser release
       shell: bash


### PR DESCRIPTION
### Changes

Update all actions referenced by the `goreleaser-build-sign-publish` action to the latest release.

### Motivation

Builds are currently broken, and may be a result of `buildx`. Updating these might fix it. For example:
- https://github.com/docker/setup-buildx-action/commit/3382292cd51ea1cda5852caf2e65d8e7b3f1c2ca


---

RE-3215