### PR TITLE
chore: pin buildx to v0.17.1

### DIFF
--- a/.github/actions/goreleaser-build-sign-publish/action.yml
+++ b/.github/actions/goreleaser-build-sign-publish/action.yml
@@ -34,6 +34,8 @@ runs:
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     - name: Setup docker buildx
       uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.0
+      with:
+        version: v0.17.1
     - name: Set up Go
       uses: ./.github/actions/setup-go
       with:


### PR DESCRIPTION
### Changes

Pin `buildx` version to `0.17.1`.

### Motivation

`0.18.0` released along with the new version of goreleaser, which is roughly when we started seeing failures. Thinking this might be the reason...

---

RE-3215