### PR TITLE
fix: cleanup caches workflow

### DIFF
--- a/.github/workflows/delete-caches.yml
+++ b/.github/workflows/delete-caches.yml
@@ -24,10 +24,14 @@ jobs:
         uses: actions/checkout@v4.1.2
 
       - name: Setup gh-actions-cache extension
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh extension install actions/gh-actions-cache
 
       - name: Retrieve Trunk SHA
         id: get-sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SHA=$(gh pr view -R $REPO $PR_NUMBER --json mergeCommit --jq .mergeCommit.oid)
           echo "sha=$SHA" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Changes

Add GH_TOKEN to env on every step.

### Motivation

https://github.com/smartcontractkit/chainlink/actions/runs/11846931692/job/33015590087?pr=14407

> gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
> env:
>    GH_TOKEN: ${{ github.token }}

---

RE-3205
