### PR TITLE
fix diff checks

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -526,10 +526,14 @@ jobs:
           make rm-mocked
           make generate
       - name: Ensure clean after generate
-        run: git diff --stat --exit-code
+        run: |
+          git add --all
+          git diff --stat --cached --exit-code
       - run: make gomodtidy
       - name: Ensure clean after tidy
-        run: git diff --minimal --exit-code
+        run: |
+          git add --all
+          git diff --minimal --cached --exit-code
 
   run-frequency:
     name: Scheduled Run Frequency

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -97,7 +97,9 @@ jobs:
         run: ./tools/ci/check_solc_hashes
       - name: Check if Go solidity wrappers are updated
         if: ${{ needs.changes.outputs.changes == 'true' }}
-        run: git diff --minimal --color --exit-code | diff-so-fancy
+        run: |
+          git add --all
+          git diff --minimal --color --cached --exit-code | diff-so-fancy
 
   # The if statements for steps after checkout repo is a workaround for
   # passing required check for PRs that don't have filtered changes.


### PR DESCRIPTION
Our `git diff` checks (used to verify tidiness and that generated files are up to date) fail in cases where there are completely new files. This is both due to the files being unstaged as well as the default behavior of `git diff` to be to ignore them. We can call `git add -all` first, and include the `--cached` flag to get the behavior we want.