### PR TITLE
Cappl 292 update keys capabilities registry

### DIFF
--- a/deployment/keystone/changeset/internal/append_node_capabilities.go
+++ b/deployment/keystone/changeset/internal/append_node_capabilities.go
@@ -42,19 +42,19 @@ func AppendNodeCapabilitiesImpl(lggr logger.Logger, req *AppendNodeCapabilitiesR
 	}
 
 	// for each node, merge the new capabilities with the existing ones and update the node
-	capsByPeer := make(map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability)
+	updatesByPeer := make(map[p2pkey.PeerID]NodeUpdate)
 	for p2pID, caps := range req.P2pToCapabilities {
 		caps, err := AppendCapabilities(lggr, req.Registry, req.Chain, []p2pkey.PeerID{p2pID}, caps)
 		if err != nil {
 			return nil, fmt.Errorf("failed to append capabilities for p2p %s: %w", p2pID, err)
 		}
-		capsByPeer[p2pID] = caps[p2pID]
+		updatesByPeer[p2pID] = NodeUpdate{Capabilities: caps[p2pID]}
 	}
 
 	updateNodesReq := &UpdateNodesRequest{
-		Chain:             req.Chain,
-		Registry:          req.Registry,
-		P2pToCapabilities: capsByPeer,
+		Chain:        req.Chain,
+		Registry:     req.Registry,
+		P2pToUpdates: updatesByPeer,
 	}
 	resp, err := UpdateNodes(lggr, updateNodesReq)
 	if err != nil {

--- a/deployment/keystone/changeset/internal/update_node_capabilities.go
+++ b/deployment/keystone/changeset/internal/update_node_capabilities.go
@@ -42,10 +42,15 @@ func UpdateNodeCapabilitiesImpl(lggr logger.Logger, req *UpdateNodeCapabilitiesI
 		return nil, fmt.Errorf("failed to add capabilities: %w", err)
 	}
 
+	p2pToUpdates := map[p2pkey.PeerID]NodeUpdate{}
+	for id, caps := range req.P2pToCapabilities {
+		p2pToUpdates[id] = NodeUpdate{Capabilities: caps}
+	}
+
 	updateNodesReq := &UpdateNodesRequest{
-		Chain:             req.Chain,
-		Registry:          req.Registry,
-		P2pToCapabilities: req.P2pToCapabilities,
+		Chain:        req.Chain,
+		Registry:     req.Registry,
+		P2pToUpdates: p2pToUpdates,
 	}
 	resp, err := UpdateNodes(lggr, updateNodesReq)
 	if err != nil {

--- a/deployment/keystone/changeset/update_nodes.go
+++ b/deployment/keystone/changeset/update_nodes.go
@@ -1,0 +1,24 @@
+package changeset
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
+)
+
+var _ deployment.ChangeSet[*UpdateNodesRequest] = UpdateNodes
+
+type UpdateNodesRequest = internal.UpdateNodesRequest
+type NodeUpdate = internal.NodeUpdate
+
+// UpdateNodes updates the a set of nodes.
+// This a complex action in practice that involves registering missing capabilities, adding the nodes, and updating
+// the capabilities of the DON
+func UpdateNodes(env deployment.Environment, req *UpdateNodesRequest) (deployment.ChangesetOutput, error) {
+	_, err := internal.UpdateNodes(env.Logger, req)
+	if err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("failed to update don: %w", err)
+	}
+	return deployment.ChangesetOutput{}, nil
+}


### PR DESCRIPTION
- Add an update nodes action so that we can update the encryption keys on the capabilities registry contract.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
