### PR TITLE
feat: goreleaser debug logs

### DIFF
--- a/.github/actions/goreleaser-build-sign-publish/action.yml
+++ b/.github/actions/goreleaser-build-sign-publish/action.yml
@@ -26,19 +26,32 @@ inputs:
     description: "The goreleaser configuration yaml"
     default: ".goreleaser.yaml"
     required: false
+  # other inputs
+  enable-debug:
+    description: |
+      Enable debug information for the run (true/false). This includes
+      buildkit debug information, and goreleaser debug, etc.
+    required: false
+    default: "${{ runner.debug == '1' }}"
+ 
 runs:
   using: composite
   steps:
     - # We need QEMU to test the cross architecture builds after they're built. 
       name: Set up QEMU 
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+
     - name: Setup docker buildx
       uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.0
+      with:
+        buildkitd-flags: ${{ inputs.enable-debug == 'true' && '--debug' || '' }}
+
     - name: Set up Go
       uses: ./.github/actions/setup-go
       with:
         go-version-file: 'go.mod'
         only-modules: 'true'
+
     - name: Setup goreleaser
       uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
       with:
@@ -65,6 +78,7 @@ runs:
         IMAGE_TAG: ${{ inputs.docker-image-tag }}
         GORELEASER_KEY: ${{ inputs.goreleaser-key }}
         GITHUB_TOKEN: ${{ github.token }}
+        DEBUG: ${{ inputs.enable-debug }}
       run: |
         # https://github.com/orgs/community/discussions/24950
         ${GITHUB_ACTION_PATH}/release.js

--- a/.github/actions/goreleaser-build-sign-publish/release.js
+++ b/.github/actions/goreleaser-build-sign-publish/release.js
@@ -168,6 +168,7 @@ function extractDockerImages(artifacts) {
 
 function constructGoreleaserCommand(releaseType, version, goreleaserConfig) {
   const flags = [];
+  const debugFlag = (process.env.DEBUG == 'true') ? '--verbose' : '';
 
   checkReleaseType(releaseType);
 
@@ -192,9 +193,9 @@ function constructGoreleaserCommand(releaseType, version, goreleaserConfig) {
 
   const flagsStr = flags.join(" ");
   if (releaseType === "merge") {
-    return `CHAINLINK_VERSION=${version} goreleaser ${subCmd} ${flagsStr}`;
+    return `CHAINLINK_VERSION=${version} goreleaser ${debugFlag} ${subCmd} ${flagsStr}`;
   } else {
-    return `CHAINLINK_VERSION=${version} goreleaser ${subCmd} --config ${goreleaserConfig} ${flagsStr}`;
+    return `CHAINLINK_VERSION=${version} goreleaser ${debugFlag} ${subCmd} --config ${goreleaserConfig} ${flagsStr}`;
   }
 }
 


### PR DESCRIPTION
### Changes

- Add the ability to get debug information from goreleaser builds when `runner.debug` is enabled.

### Motivation

It's been very hard to debug goreleaser/docker errors.


### Testing

- Tested by enabling manually (passing value to action), and by rerunning jobs with debug mode enabled.

---

RE-3215
