### PR TITLE
Purge GAP From All E2E Test Runs

### DIFF
--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       test_path: .github/e2e-tests.yml
       test_ids: '${{ inputs.testType }}/automation_test.go:TestAutomationBenchmark'

--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       test_path: .github/e2e-tests.yml
       test_ids: '${{ inputs.testType }}/automation_test.go:TestAutomationBenchmark'

--- a/.github/workflows/automation-load-tests.yml
+++ b/.github/workflows/automation-load-tests.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       test_path: .github/e2e-tests.yml
       test_ids: 'load/automationv2_1/automationv2_1_test.go:TestLogTrigger'

--- a/.github/workflows/automation-load-tests.yml
+++ b/.github/workflows/automation-load-tests.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       test_path: .github/e2e-tests.yml
       test_ids: 'load/automationv2_1/automationv2_1_test.go:TestLogTrigger'

--- a/.github/workflows/automation-nightly-tests.yml
+++ b/.github/workflows/automation-nightly-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       test_path: .github/e2e-tests.yml
       test_trigger: Automation Nightly Tests

--- a/.github/workflows/automation-nightly-tests.yml
+++ b/.github/workflows/automation-nightly-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       test_path: .github/e2e-tests.yml
       test_trigger: Automation Nightly Tests

--- a/.github/workflows/automation-ondemand-tests.yml
+++ b/.github/workflows/automation-ondemand-tests.yml
@@ -153,7 +153,7 @@ jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       test_path: .github/e2e-tests.yml
       test_list: ${{ needs.set-tests-to-run.outputs.test_list }}

--- a/.github/workflows/automation-ondemand-tests.yml
+++ b/.github/workflows/automation-ondemand-tests.yml
@@ -153,7 +153,7 @@ jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       test_path: .github/e2e-tests.yml
       test_list: ${{ needs.set-tests-to-run.outputs.test_list }}

--- a/.github/workflows/ccip-chaos-tests.yml
+++ b/.github/workflows/ccip-chaos-tests.yml
@@ -15,8 +15,7 @@ concurrency:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
-    with:
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
       test_path: .github/e2e-tests.yml
       chainlink_version: ${{ github.sha }}
       require_chainlink_image_versions_in_qa_ecr: ${{ github.sha }}

--- a/.github/workflows/ccip-chaos-tests.yml
+++ b/.github/workflows/ccip-chaos-tests.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
       test_path: .github/e2e-tests.yml
       chainlink_version: ${{ github.sha }}
       require_chainlink_image_versions_in_qa_ecr: ${{ github.sha }}

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       test_path: .github/e2e-tests.yml
       test_trigger: E2E CCIP Load Tests

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       test_path: .github/e2e-tests.yml
       test_trigger: E2E CCIP Load Tests

--- a/.github/workflows/integration-chaos-tests.yml
+++ b/.github/workflows/integration-chaos-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       test_path: .github/e2e-tests.yml
       chainlink_version: ${{ github.sha }}

--- a/.github/workflows/integration-chaos-tests.yml
+++ b/.github/workflows/integration-chaos-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       test_path: .github/e2e-tests.yml
       chainlink_version: ${{ github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -210,7 +210,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -251,7 +251,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -296,7 +296,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -337,7 +337,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -210,7 +210,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 #ctf-run-tests@0.2.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -296,7 +296,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@ca50645120f0f07ed8c0df08175a5d6b3e4ac454 #ctf-run-tests@0.1.2
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -337,7 +337,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@ca50645120f0f07ed8c0df08175a5d6b3e4ac454 #ctf-run-tests@0.1.2
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || github.sha }}

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       test_path: .github/e2e-tests.yml
       test_ids: ${{ inputs.testToRun}}

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       test_path: .github/e2e-tests.yml
       test_ids: ${{ inputs.testToRun}}

--- a/.github/workflows/on-demand-vrfv2-performance-test.yml
+++ b/.github/workflows/on-demand-vrfv2-performance-test.yml
@@ -67,7 +67,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2-performance-test.yml
+++ b/.github/workflows/on-demand-vrfv2-performance-test.yml
@@ -67,7 +67,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2-smoke-tests.yml
+++ b/.github/workflows/on-demand-vrfv2-smoke-tests.yml
@@ -70,7 +70,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2-smoke-tests.yml
+++ b/.github/workflows/on-demand-vrfv2-smoke-tests.yml
@@ -70,7 +70,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2plus-performance-test.yml
+++ b/.github/workflows/on-demand-vrfv2plus-performance-test.yml
@@ -67,7 +67,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2plus-performance-test.yml
+++ b/.github/workflows/on-demand-vrfv2plus-performance-test.yml
@@ -67,7 +67,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2plus-smoke-tests.yml
+++ b/.github/workflows/on-demand-vrfv2plus-smoke-tests.yml
@@ -70,7 +70,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2plus-smoke-tests.yml
+++ b/.github/workflows/on-demand-vrfv2plus-smoke-tests.yml
@@ -70,7 +70,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/run-nightly-e2e-tests.yml
+++ b/.github/workflows/run-nightly-e2e-tests.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       chainlink_version: ${{ inputs.chainlink_version || 'develop' }}
       test_path: .github/e2e-tests.yml

--- a/.github/workflows/run-nightly-e2e-tests.yml
+++ b/.github/workflows/run-nightly-e2e-tests.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       chainlink_version: ${{ inputs.chainlink_version || 'develop' }}
       test_path: .github/e2e-tests.yml

--- a/.github/workflows/run-selected-e2e-tests.yml
+++ b/.github/workflows/run-selected-e2e-tests.yml
@@ -35,7 +35,7 @@ run-name: ${{ inputs.workflow_run_name }}
 jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@5412507526722a7b1c5d719fa686eed5a1bc4035 # ctf-run-tests@0.2.0
     with:
       chainlink_version: ${{ github.event.inputs.chainlink_version }}
       test_path: .github/e2e-tests.yml

--- a/.github/workflows/run-selected-e2e-tests.yml
+++ b/.github/workflows/run-selected-e2e-tests.yml
@@ -35,7 +35,7 @@ run-name: ${{ inputs.workflow_run_name }}
 jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f1f2dac0a20f0e02408eb7f528c768fe95c39229
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@47a3b0cf4e87a031049eef2d951982c94db04cae #ctf-run-tests@1.0.0
     with:
       chainlink_version: ${{ github.event.inputs.chainlink_version }}
       test_path: .github/e2e-tests.yml


### PR DESCRIPTION
It's still around and causing unnecessary flakes, especially in the merge queue