### PR TITLE
fix: solidity native compile diff checks

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -76,30 +76,43 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4.2.1
+        with:
+          path: chainlink
+
       - name: Checkout diff-so-fancy
         uses: actions/checkout@v4.2.1
         with:
           repository: so-fancy/diff-so-fancy
           ref: a673cb4d2707f64d92b86498a2f5f71c8e2643d5 # v1.4.3
           path: diff-so-fancy
+
       - name: Install diff-so-fancy
         run: echo "$GITHUB_WORKSPACE/diff-so-fancy" >> $GITHUB_PATH
+
       - name: Setup NodeJS
-        uses: ./.github/actions/setup-nodejs
+        uses: ./chainlink/.github/actions/setup-nodejs
         with:
+          base-path: "chainlink"
           prod: "true"
+
       - name: Setup Go
-        uses: ./.github/actions/setup-go
+        uses: ./chainlink/.github/actions/setup-go
+        with:
+          go-version-file: "chainlink/go.mod"
+
       - name: Run native compile and generate wrappers
+        working-directory: ./chainlink/contracts
         run: make wrappers-all
-        working-directory: ./contracts
+
       - name: Verify local solc binaries
+        working-directory: chainlink
         run: ./tools/ci/check_solc_hashes
+
       - name: Check if Go solidity wrappers are updated
         if: ${{ needs.changes.outputs.changes == 'true' }}
+        working-directory: chainlink
         run: |
-          # Add everything except for checked out repo for pretty printing
-          git add -- . ':!diff-so-fancy'
+          git add --all
           git diff --minimal --color --cached --exit-code | diff-so-fancy
 
   # The if statements for steps after checkout repo is a workaround for

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Check if Go solidity wrappers are updated
         if: ${{ needs.changes.outputs.changes == 'true' }}
         run: |
-          git add --all
+          # Add everything except for checked out repo for pretty printing
+          git add -- . ':!diff-so-fancy'
           git diff --minimal --color --cached --exit-code | diff-so-fancy
 
   # The if statements for steps after checkout repo is a workaround for


### PR DESCRIPTION
### Changes

- Checkout `chainlink` and `diff-so-fancy` repositories side-by-side so they're not nested.

### Motivation

#15258 broke the diff check, because `diff-so-fancy` is being used and is checked out inside the cwd, it gets added and then `git diff` returns a 1.

- https://github.com/smartcontractkit/chainlink/actions/runs/11917327152/job/33212210077?pr=15292
- https://github.com/smartcontractkit/chainlink/actions/runs/11917449441/job/33213113583?pr=15123

### Testing

- https://github.com/smartcontractkit/chainlink/actions/runs/11924335180/job/33234490354?pr=15312
