### PR TITLE
Add selector comments for custom errors in SubscriptionAPI.sol

### DIFF
--- a/contracts/src/v0.8/vrf/dev/SubscriptionAPI.sol
+++ b/contracts/src/v0.8/vrf/dev/SubscriptionAPI.sol
@@ -20,24 +20,53 @@ abstract contract SubscriptionAPI is ConfirmedOwner, IERC677Receiver, IVRFSubscr
   // This bound ensures we are able to loop over them as needed.
   // Should a user require more consumers, they can use multiple subscriptions.
   uint16 public constant MAX_CONSUMERS = 100;
+  // Error Selector: 0x05a48e0f
   error TooManyConsumers();
+
+  // Error Selector: 0xf4d678b8
   error InsufficientBalance();
+
+  // Error Selector: 0x79bfd401
   error InvalidConsumer(uint256 subId, address consumer);
+
+  // Error Selector: 0x1f6a65b6
   error InvalidSubscription();
+
+  // Error Selector: 0x44b0e3c3
   error OnlyCallableFromLink();
+
+  // Error Selector: 0x8129bbcd
   error InvalidCalldata();
+
+  // Error Selector: 0xd8a3fb52
   error MustBeSubOwner(address owner);
+
+  // Error Selector: 0xb42f66e8
   error PendingRequestExists();
+
+  // Error Selector: 0xd084e975
   error MustBeRequestedOwner(address proposedOwner);
+
+  // Error Selector: 0xa99da302
   error BalanceInvariantViolated(uint256 internalBalance, uint256 externalBalance); // Should never happen
-  event FundsRecovered(address to, uint256 amount);
-  event NativeFundsRecovered(address to, uint256 amount);
+  
+  // Error Selector: 0x2d118a6e
   error LinkAlreadySet();
+
+  // Error Selector: 0x950b2479
   error FailedToSendNative();
+
+  // Error Selector: 0x7c07fc4c
   error FailedToTransferLink();
+
+  // Error Selector: 0x1390f2a1
   error IndexOutOfRange();
+
+  // Error Selector: 0xc1f0c0a1
   error LinkNotSet();
 
+  event FundsRecovered(address to, uint256 amount);
+  event NativeFundsRecovered(address to, uint256 amount);
   // We use the subscription struct (1 word)
   // at fulfillment time.
   struct Subscription {


### PR DESCRIPTION
When I was using the Chainlink VRF, I encountered this type of error from scanners:

> **🔴 Error:** The contract function `"requestRandomWords"` reverted with the following signature:  
`0x79bfd401` Unable to decode signature "0x79bfd401" as it was not found on the provided ABI. Make sure you are using the correct ABI and that the error exists on it. You can look up the decoded signature here: https://openchain.xyz/signatures?query=0x79bfd401. Contract Call: address: 0xE4CfdbC69ba3092cF3690a145Eb1C202ff318a5d function: requestRandomWords(bool enableNativePayment) args: (false) sender: 0x633aDfb3430b96238c9FB7026195D1d5b0889EA6 Docs: https://viem.sh/docs/contract/decodeErrorResult Version: viem@2.21.48



This happens because the custom error `InvalidConsumer(uint256 subId, address consumer)` is not found in the ABI unless the relevant contract is imported. However, importing the `SubscriptionAPI.sol` contract is not always practical or necessary for most use cases.

Additionally, the error signature provided (0x79bfd401) does not resolve correctly on OpenChain (https://openchain.xyz/signatures). As a result, developers cannot directly look up the error's meaning using this tool, leading to further confusion and making debugging significantly more time-consuming.

I encountered a similar issue in the Sign Protocol project, but their approach to including selector comments for custom errors made identifying the problem so much faster. So that we can find these errors directly from code [here](https://github.com/EthSign/sign-protocol-evm/blob/main/src/interfaces/ISP.sol)

### Benefits

I wanted to add this approach, inspired by the Sign Protocol project, where selectors are documented alongside their respective custom errors. This ensures that:

- Developers can quickly identify the error and its cause without needing to import additional contracts or manually compute selectors.
- It enhances the usability and readability of the Chainlink codebase, ensuring a smoother experience for developers interacting with it.

#### I used the following Solidity function to compute the selector for each custom error:
```javascript
error InvalidConsumer(uint256 subId, address consumer);

function getErrorSelector() external pure returns (bytes4) {
        return bytes4(keccak256("InvalidConsumer(uint256,address)"));
    }
```
I believe this change would be highly beneficial for developers and contribute to a stronger, more developer-friendly Chainlink codebase.