### PR TITLE
Bump CTF/lib mod for E2E tests

### DIFF
--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.16
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
-	github.com/smartcontractkit/chainlink-testing-framework/lib 5b12e5b967688c296cb699682a96121a8c973433
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008
+	github.com/smartcontractkit/chainlink-testing-framework/lib 5b12e5b967688c296cb699682a96121a8c973433
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1423,8 +1423,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14 h1:elSS3K5m39sCOvtd43SlAw60gxqAcGmkEDeMp9O+CTQ=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.16 h1:8vEUThgMBkInlrL/g8xeaV/G3ApiJLQJ03rK7+yuLxM=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.16/go.mod h1:06+ki+deFNGirahUQHzDI10kep96DGnzp9Y5uIQnRqc=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1423,8 +1423,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350 h1:PEdpLroSTiLo3KUxO4s+KyrDy39SJ4wWYz1kcFkTqGg=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5 h1:Di45Zv85o3rxCZqkiKRw7+aHfuXXEhNG8BFqpI1g0cw=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1423,8 +1423,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768 h1:HqNeA2g8qz9SZ2tBg3lNvMhpC2WG80zXlUr+bf3DxrA=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14 h1:elSS3K5m39sCOvtd43SlAw60gxqAcGmkEDeMp9O+CTQ=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1423,8 +1423,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d h1:65cITAygq6cO66kkapAdIUZc4AqCr2NRFBw3TDSzLmE=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008 h1:HhI2r9WJzwhOSLzOtUbnI52eyYAF2d1er2pMmZEWRnQ=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1423,8 +1423,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5 h1:Di45Zv85o3rxCZqkiKRw7+aHfuXXEhNG8BFqpI1g0cw=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d h1:65cITAygq6cO66kkapAdIUZc4AqCr2NRFBw3TDSzLmE=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1423,8 +1423,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008 h1:HhI2r9WJzwhOSLzOtUbnI52eyYAF2d1er2pMmZEWRnQ=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768 h1:HqNeA2g8qz9SZ2tBg3lNvMhpC2WG80zXlUr+bf3DxrA=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1423,8 +1423,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14 h1:elSS3K5m39sCOvtd43SlAw60gxqAcGmkEDeMp9O+CTQ=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350 h1:PEdpLroSTiLo3KUxO4s+KyrDy39SJ4wWYz1kcFkTqGg=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.16
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-00010101000000-000000000000

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-00010101000000-000000000000

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-00010101000000-000000000000

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-00010101000000-000000000000

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-00010101000000-000000000000

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-00010101000000-000000000000

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chainlink-common v0.3.1-0.20241120111740-a6a70ec7692b
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-00010101000000-000000000000

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1410,8 +1410,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14 h1:elSS3K5m39sCOvtd43SlAw60gxqAcGmkEDeMp9O+CTQ=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.16 h1:8vEUThgMBkInlrL/g8xeaV/G3ApiJLQJ03rK7+yuLxM=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.16/go.mod h1:06+ki+deFNGirahUQHzDI10kep96DGnzp9Y5uIQnRqc=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1410,8 +1410,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5 h1:Di45Zv85o3rxCZqkiKRw7+aHfuXXEhNG8BFqpI1g0cw=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d h1:65cITAygq6cO66kkapAdIUZc4AqCr2NRFBw3TDSzLmE=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1410,8 +1410,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768 h1:HqNeA2g8qz9SZ2tBg3lNvMhpC2WG80zXlUr+bf3DxrA=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14 h1:elSS3K5m39sCOvtd43SlAw60gxqAcGmkEDeMp9O+CTQ=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1410,8 +1410,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008 h1:HhI2r9WJzwhOSLzOtUbnI52eyYAF2d1er2pMmZEWRnQ=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768 h1:HqNeA2g8qz9SZ2tBg3lNvMhpC2WG80zXlUr+bf3DxrA=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120163524-5b12e5b96768/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1410,8 +1410,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350 h1:PEdpLroSTiLo3KUxO4s+KyrDy39SJ4wWYz1kcFkTqGg=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5 h1:Di45Zv85o3rxCZqkiKRw7+aHfuXXEhNG8BFqpI1g0cw=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120144349-91bd4d6fa6a5/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1410,8 +1410,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d h1:65cITAygq6cO66kkapAdIUZc4AqCr2NRFBw3TDSzLmE=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120151149-61ec31f9c86d/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008 h1:HhI2r9WJzwhOSLzOtUbnI52eyYAF2d1er2pMmZEWRnQ=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120154325-551417e4d008/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1410,8 +1410,8 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-1
 github.com/smartcontractkit/chainlink-starknet/relayer v0.1.1-0.20241017135645-176a23722fd8/go.mod h1:WkBqgBo+g34Gm5vWkDDl8Fh3Mzd7bF5hXp7rryg0t5o=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14 h1:elSS3K5m39sCOvtd43SlAw60gxqAcGmkEDeMp9O+CTQ=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.14/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350 h1:PEdpLroSTiLo3KUxO4s+KyrDy39SJ4wWYz1kcFkTqGg=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.15-0.20241120142015-872fd7504350/go.mod h1:wdHrnYLfZznafXeeneNzxQZjUjfwfcVAQFdopBBp5nI=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9 h1:yB1x5UXvpZNka+5h57yo1/GrKfXKCqMzChCISpldZx4=

--- a/integration-tests/smoke/ocr2_test.go
+++ b/integration-tests/smoke/ocr2_test.go
@@ -62,7 +62,7 @@ func TestOCRv2Basic(t *testing.T) {
 			testEnv, aggregatorContracts, sethClient := prepareORCv2SmokeTestEnv(t, test, l, 5)
 
 			err := testEnv.MockAdapter.SetAdapterBasedIntValuePath("ocr2", []string{http.MethodGet, http.MethodPost}, 10)
-			require.NoError(t, err)
+			require.Error(t, err)
 			err = actions.WatchNewOCRRound(l, sethClient, 2, contracts.V2OffChainAgrregatorToOffChainAggregatorWithRounds(aggregatorContracts), time.Minute*5)
 			require.NoError(t, err)
 

--- a/integration-tests/smoke/ocr2_test.go
+++ b/integration-tests/smoke/ocr2_test.go
@@ -62,7 +62,7 @@ func TestOCRv2Basic(t *testing.T) {
 			testEnv, aggregatorContracts, sethClient := prepareORCv2SmokeTestEnv(t, test, l, 5)
 
 			err := testEnv.MockAdapter.SetAdapterBasedIntValuePath("ocr2", []string{http.MethodGet, http.MethodPost}, 10)
-			require.Error(t, err)
+			require.NoError(t, err)
 			err = actions.WatchNewOCRRound(l, sethClient, 2, contracts.V2OffChainAgrregatorToOffChainAggregatorWithRounds(aggregatorContracts), time.Minute*5)
 			require.NoError(t, err)
 


### PR DESCRIPTION
This uses new CTF/lib with fixes for E2E tests Logstream https://github.com/smartcontractkit/chainlink-testing-framework/pull/1365

Related ticket: https://smartcontract-it.atlassian.net/browse/TT-1856