### PR TITLE
deployment/ccip: fix buggy test assertions

### DIFF
--- a/deployment/ccip/changeset/active_candidate_test.go
+++ b/deployment/ccip/changeset/active_candidate_test.go
@@ -36,7 +36,7 @@ func TestActiveCandidate(t *testing.T) {
 	// Need to keep track of the block number for each chain so that event subscription can be done from that block.
 	startBlocks := make(map[uint64]*uint64)
 	// Send a message from each chain to every other chain.
-	expectedSeqNum := make(map[uint64]uint64)
+	expectedSeqNum := make(map[ccdeploy.SourceDestPair]uint64)
 	for src := range e.Chains {
 		for dest, destChain := range e.Chains {
 			if src == dest {
@@ -53,7 +53,10 @@ func TestActiveCandidate(t *testing.T) {
 				FeeToken:     common.HexToAddress("0x0"),
 				ExtraArgs:    nil,
 			})
-			expectedSeqNum[dest] = msgSentEvent.SequenceNumber
+			expectedSeqNum[ccdeploy.SourceDestPair{
+				SourceChainSelector: src,
+				DestChainSelector:   dest,
+			}] = msgSentEvent.SequenceNumber
 		}
 	}
 

--- a/deployment/ccip/changeset/initial_deploy_test.go
+++ b/deployment/ccip/changeset/initial_deploy_test.go
@@ -84,7 +84,7 @@ func TestInitialDeploy(t *testing.T) {
 	// Need to keep track of the block number for each chain so that event subscription can be done from that block.
 	startBlocks := make(map[uint64]*uint64)
 	// Send a message from each chain to every other chain.
-	expectedSeqNum := make(map[uint64]uint64)
+	expectedSeqNum := make(map[ccdeploy.SourceDestPair]uint64)
 
 	for src := range e.Chains {
 		for dest, destChain := range e.Chains {
@@ -102,7 +102,10 @@ func TestInitialDeploy(t *testing.T) {
 				FeeToken:     common.HexToAddress("0x0"),
 				ExtraArgs:    nil,
 			})
-			expectedSeqNum[dest] = msgSentEvent.SequenceNumber
+			expectedSeqNum[ccdeploy.SourceDestPair{
+				SourceChainSelector: src,
+				DestChainSelector:   dest,
+			}] = msgSentEvent.SequenceNumber
 		}
 	}
 

--- a/integration-tests/smoke/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip_messaging_test.go
@@ -317,8 +317,11 @@ func runMessagingTestCase(
 		FeeToken:     common.HexToAddress("0x0"),
 		ExtraArgs:    extraArgs,
 	})
-	expectedSeqNum := make(map[uint64]uint64)
-	expectedSeqNum[tc.destChain] = msgSentEvent.SequenceNumber
+	expectedSeqNum := make(map[ccdeploy.SourceDestPair]uint64)
+	expectedSeqNum[ccdeploy.SourceDestPair{
+		SourceChainSelector: tc.sourceChain,
+		DestChainSelector:   tc.destChain,
+	}] = msgSentEvent.SequenceNumber
 	out.msgSentEvent = msgSentEvent
 
 	// hack

--- a/integration-tests/smoke/ccip_rmn_test.go
+++ b/integration-tests/smoke/ccip_rmn_test.go
@@ -341,7 +341,7 @@ func runRmnTestCase(t *testing.T, tc rmnTestCase) {
 
 	// Need to keep track of the block number for each chain so that event subscription can be done from that block.
 	startBlocks := make(map[uint64]*uint64)
-	expectedSeqNum := make(map[uint64]uint64)
+	expectedSeqNum := make(map[ccipdeployment.SourceDestPair]uint64)
 	for _, msg := range tc.messagesToSend {
 		fromChain := chainSelectors[msg.fromChainIdx]
 		toChain := chainSelectors[msg.toChainIdx]
@@ -354,7 +354,10 @@ func runRmnTestCase(t *testing.T, tc rmnTestCase) {
 				FeeToken:     common.HexToAddress("0x0"),
 				ExtraArgs:    nil,
 			})
-			expectedSeqNum[toChain] = msgSentEvent.SequenceNumber
+			expectedSeqNum[ccipdeployment.SourceDestPair{
+				SourceChainSelector: fromChain,
+				DestChainSelector:   toChain,
+			}] = msgSentEvent.SequenceNumber
 			t.Logf("Sent message from chain %d to chain %d with seqNum %d", fromChain, toChain, msgSentEvent.SequenceNumber)
 		}
 

--- a/integration-tests/smoke/ccip_test.go
+++ b/integration-tests/smoke/ccip_test.go
@@ -27,7 +27,7 @@ func TestInitialDeployOnLocal(t *testing.T) {
 	// Need to keep track of the block number for each chain so that event subscription can be done from that block.
 	startBlocks := make(map[uint64]*uint64)
 	// Send a message from each chain to every other chain.
-	expectedSeqNum := make(map[uint64]uint64)
+	expectedSeqNum := make(map[ccdeploy.SourceDestPair]uint64)
 	for src := range e.Chains {
 		for dest, destChain := range e.Chains {
 			if src == dest {
@@ -44,7 +44,10 @@ func TestInitialDeployOnLocal(t *testing.T) {
 				FeeToken:     common.HexToAddress("0x0"),
 				ExtraArgs:    nil,
 			})
-			expectedSeqNum[dest] = msgSentEvent.SequenceNumber
+			expectedSeqNum[ccdeploy.SourceDestPair{
+				SourceChainSelector: src,
+				DestChainSelector:   dest,
+			}] = msgSentEvent.SequenceNumber
 		}
 	}
 
@@ -90,7 +93,7 @@ func TestTokenTransfer(t *testing.T) {
 	// Need to keep track of the block number for each chain so that event subscription can be done from that block.
 	startBlocks := make(map[uint64]*uint64)
 	// Send a message from each chain to every other chain.
-	expectedSeqNum := make(map[uint64]uint64)
+	expectedSeqNum := make(map[ccdeploy.SourceDestPair]uint64)
 
 	twoCoins := new(big.Int).Mul(big.NewInt(1e18), big.NewInt(2))
 	tx, err := srcToken.Mint(
@@ -154,7 +157,10 @@ func TestTokenTransfer(t *testing.T) {
 					FeeToken:     feeToken,
 					ExtraArgs:    nil,
 				})
-				expectedSeqNum[dest] = msgSentEvent.SequenceNumber
+				expectedSeqNum[ccdeploy.SourceDestPair{
+					SourceChainSelector: src,
+					DestChainSelector:   dest,
+				}] = msgSentEvent.SequenceNumber
 			} else {
 				msgSentEvent := ccdeploy.TestSendRequest(t, e, state, src, dest, false, router.ClientEVM2AnyMessage{
 					Receiver:     receiver,
@@ -163,7 +169,10 @@ func TestTokenTransfer(t *testing.T) {
 					FeeToken:     feeToken,
 					ExtraArgs:    nil,
 				})
-				expectedSeqNum[dest] = msgSentEvent.SequenceNumber
+				expectedSeqNum[ccdeploy.SourceDestPair{
+					SourceChainSelector: src,
+					DestChainSelector:   dest,
+				}] = msgSentEvent.SequenceNumber
 			}
 		}
 	}

--- a/integration-tests/smoke/ccip_usdc_test.go
+++ b/integration-tests/smoke/ccip_usdc_test.go
@@ -213,7 +213,7 @@ func transferAndWaitForSuccess(
 	data []byte,
 ) {
 	startBlocks := make(map[uint64]*uint64)
-	expectedSeqNum := make(map[uint64]uint64)
+	expectedSeqNum := make(map[ccdeploy.SourceDestPair]uint64)
 
 	latesthdr, err := env.Chains[destChain].Client.HeaderByNumber(testcontext.Get(t), nil)
 	require.NoError(t, err)
@@ -227,7 +227,10 @@ func transferAndWaitForSuccess(
 		FeeToken:     common.HexToAddress("0x0"),
 		ExtraArgs:    nil,
 	})
-	expectedSeqNum[destChain] = msgSentEvent.SequenceNumber
+	expectedSeqNum[ccdeploy.SourceDestPair{
+		SourceChainSelector: sourceChain,
+		DestChainSelector:   destChain,
+	}] = msgSentEvent.SequenceNumber
 
 	// Wait for all commit reports to land.
 	ccdeploy.ConfirmCommitForAllWithExpectedSeqNums(t, env, state, expectedSeqNum, startBlocks)

--- a/integration-tests/smoke/fee_boosting_test.go
+++ b/integration-tests/smoke/fee_boosting_test.go
@@ -94,7 +94,7 @@ func runFeeboostTestCase(tc feeboostTestCase) {
 	require.NoError(tc.t, ccdeploy.AddLane(tc.deployedEnv.Env, tc.onchainState, tc.sourceChain, tc.destChain, tc.initialPrices))
 
 	startBlocks := make(map[uint64]*uint64)
-	expectedSeqNum := make(map[uint64]uint64)
+	expectedSeqNum := make(map[ccdeploy.SourceDestPair]uint64)
 	msgSentEvent := ccdeploy.TestSendRequest(tc.t, tc.deployedEnv.Env, tc.onchainState, tc.sourceChain, tc.destChain, false, router.ClientEVM2AnyMessage{
 		Receiver:     common.LeftPadBytes(tc.onchainState.Chains[tc.destChain].Receiver.Address().Bytes(), 32),
 		Data:         []byte("message that needs fee boosting"),
@@ -102,7 +102,10 @@ func runFeeboostTestCase(tc feeboostTestCase) {
 		FeeToken:     common.HexToAddress("0x0"),
 		ExtraArgs:    nil,
 	})
-	expectedSeqNum[tc.destChain] = msgSentEvent.SequenceNumber
+	expectedSeqNum[ccdeploy.SourceDestPair{
+		SourceChainSelector: tc.sourceChain,
+		DestChainSelector:   tc.destChain,
+	}] = msgSentEvent.SequenceNumber
 
 	// hack
 	time.Sleep(30 * time.Second)


### PR DESCRIPTION
Tests have been underspecifying sequence numbers; we need to specify both source and dest for a sequence number to be fully identifiable. Fixing the helpers to force this by adding a SourceDestPair type that is used as the key to all maps.
