### PR TITLE
core/services/fluxmonitorv2: fix TestFluxMonitor_Deviation race

### DIFF
--- a/core/services/fluxmonitorv2/integrations_test.go
+++ b/core/services/fluxmonitorv2/integrations_test.go
@@ -55,8 +55,9 @@ const fee = int64(100) // Amount paid by FA contract, in LINK-wei
 const faTimeout = uint32(1)
 
 var pollTimerPeriod = 200 * time.Millisecond // if failing due to timeouts, increase this
-var oneEth = big.NewInt(1000000000000000000)
 var emptyList = []common.Address{}
+
+func oneEth() *big.Int { return big.NewInt(1000000000000000000) }
 
 // fluxAggregatorUniverse represents the universe with which the aggregator
 // contract interacts
@@ -162,7 +163,7 @@ func setupFluxAggregatorUniverse(t *testing.T, configOptions ...func(cfg *fluxAg
 
 	f.sergey.GasLimit = oldGasLimit
 
-	_, err = f.linkContract.Transfer(f.sergey, f.aggregatorContractAddress, oneEth) // Actually, LINK
+	_, err = f.linkContract.Transfer(f.sergey, f.aggregatorContractAddress, oneEth()) // Actually, LINK
 	require.NoError(t, err, "failed to fund FluxAggregator contract with LINK")
 	f.backend.Commit()
 
@@ -172,9 +173,9 @@ func setupFluxAggregatorUniverse(t *testing.T, configOptions ...func(cfg *fluxAg
 	f.backend.Commit()
 	availableFunds, err := f.aggregatorContract.AvailableFunds(nil)
 	require.NoError(t, err, "failed to retrieve AvailableFunds")
-	require.Equal(t, availableFunds, oneEth)
+	require.Equal(t, availableFunds, oneEth())
 
-	ilogs, err := f.aggregatorContract.FilterAvailableFundsUpdated(nil, []*big.Int{oneEth})
+	ilogs, err := f.aggregatorContract.FilterAvailableFundsUpdated(nil, []*big.Int{oneEth()})
 	require.NoError(t, err, "failed to gather AvailableFundsUpdated logs")
 
 	logs := cltest.GetLogs(t, nil, ilogs)


### PR DESCRIPTION
Go-ethereum mutates `*big.Int`s passed to ABI bindings for some reason. This may be a bug/oversight, but in any case leads to a race between tests:
- https://github.com/ethereum/go-ethereum/blob/master/accounts/abi/topics.go#L44-L45
- https://github.com/ethereum/go-ethereum/blob/master/common/math/big.go#L176-L177
- https://cs.opensource.google/go/go/+/refs/tags/go1.23.3:src/math/big/int.go;l=1170-1171

<details><summary>Race:</summary>

```
==================
WARNING: DATA RACE
Read at 0x00c0010982c0 by goroutine 344:
  reflect.Value.Bool()
      /opt/hostedtoolcache/go/1.23.3/x64/src/reflect/value.go:283 +0x493
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.23.3/x64/src/reflect/deepequal.go:167 +0x494
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.23.3/x64/src/reflect/deepequal.go:130 +0x1dfb
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.23.3/x64/src/reflect/deepequal.go:127 +0x1689
  reflect.DeepEqual()
      /opt/hostedtoolcache/go/1.23.3/x64/src/reflect/deepequal.go:238 +0x244
  github.com/stretchr/testify/assert.ObjectsAreEqual()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:65 +0x[17](https://github.com/smartcontractkit/chainlink/actions/runs/11940570982/job/33283529603#step:19:18)2
  github.com/stretchr/testify/assert.Equal()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:463 +0x237
  github.com/stretchr/testify/require.Equal()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/require/require.go:159 +0xe7
  github.com/smartcontractkit/chainlink/v2/core/services/fluxmonitorv2_test.setupFluxAggregatorUniverse()
      /home/runner/work/chainlink/chainlink/core/services/fluxmonitorv2/integrations_test.go:175 +0x1407
  github.com/smartcontractkit/chainlink/v2/core/services/fluxmonitorv2_test.TestFluxMonitor_Deviation.func1()
      /home/runner/work/chainlink/chainlink/core/services/fluxmonitorv2/integrations_test.go:445 +0x7a
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44

Previous write at 0x00c0010982c0 by goroutine 343:
  math/big.(*Int).And()
      /opt/hostedtoolcache/go/1.23.3/x64/src/math/big/int.go:1[18](https://github.com/smartcontractkit/chainlink/actions/runs/11940570982/job/33283529603#step:19:19)4 +0x4ce
  github.com/ethereum/go-ethereum/common/math.U256()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/common/math/big.go:229 +0x3c
  github.com/ethereum/go-ethereum/common/math.U256Bytes()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/common/math/big.go:235 +0xe
  github.com/ethereum/go-ethereum/accounts/abi.MakeTopics()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/accounts/abi/topics.go:45 +0xbcc
  github.com/ethereum/go-ethereum/accounts/abi/bind.(*BoundContract).FilterLogs()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/accounts/abi/bind/base.go:444 +0x29b
  github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/flux_aggregator_wrapper.(*FluxAggregatorFilterer).FilterAvailableFundsUpdated()
      /home/runner/work/chainlink/chainlink/core/gethwrappers/generated/flux_aggregator_wrapper/flux_aggregator_wrapper.go:1181 +0x[20](https://github.com/smartcontractkit/chainlink/actions/runs/11940570982/job/33283529603#step:19:21)7
  github.com/smartcontractkit/chainlink/v2/core/services/fluxmonitorv2_test.setupFluxAggregatorUniverse()
      /home/runner/work/chainlink/chainlink/core/services/fluxmonitorv2/integrations_test.go:177 +0x147b
  github.com/smartcontractkit/chainlink/v2/core/services/fluxmonitorv2_test.TestFluxMonitor_Deviation.func1()
      /home/runner/work/chainlink/chainlink/core/services/fluxmonitorv2/integrations_test.go:445 +0x7a
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x[22](https://github.com/smartcontractkit/chainlink/actions/runs/11940570982/job/33283529603#step:19:23)6
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44

Goroutine 344 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.[23](https://github.com/smartcontractkit/chainlink/actions/runs/11940570982/job/33283529603#step:19:24).3/x64/src/testing/testing.go:1743 +0x825
  github.com/smartcontractkit/chainlink/v2/core/services/fluxmonitorv2_test.TestFluxMonitor_Deviation()
      /home/runner/work/chainlink/chainlink/core/services/fluxmonitorv2/integrations_test.go:442 +0xcf
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44

Goroutine 343 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x8[25](https://github.com/smartcontractkit/chainlink/actions/runs/11940570982/job/33283529603#step:19:26)
  github.com/smartcontractkit/chainlink/v2/core/services/fluxmonitorv2_test.TestFluxMonitor_Deviation()
      /home/runner/work/chainlink/chainlink/core/services/fluxmonitorv2/integrations_test.go:442 +0xcf
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x2[26](https://github.com/smartcontractkit/chainlink/actions/runs/11940570982/job/33283529603#step:19:27)
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44
==================
```
</details>