### PR TITLE
fix: downgrade buildkit version

### DIFF
--- a/.github/actions/goreleaser-build-sign-publish/action.yml
+++ b/.github/actions/goreleaser-build-sign-publish/action.yml
@@ -45,6 +45,10 @@ runs:
       uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.0
       with:
         buildkitd-flags: ${{ inputs.enable-debug == 'true' && '--debug' || '' }}
+        # v0.16.0 until grpc fix is released
+        # see: https://github.com/docker/buildx/issues/2789#issuecomment-2487981922
+        driver-opts: |
+          image=moby/buildkit:v0.16.0
 
     - name: Set up Go
       uses: ./.github/actions/setup-go


### PR DESCRIPTION
### Changes

- Pin buildkit version to `v0.16.0`

### Motivation

https://github.com/docker/buildx/issues/2789#issuecomment-2487981922

---

RE-3215