### PR TITLE
tools/bin: rm -vet=off

### DIFF
--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -12,15 +12,15 @@ echo "Failed tests and panics: ---------------------"
 echo ""
 if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
   if [[ $DEBUG == "true" ]]; then 
-    go test -json -vet=off ./... -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt | tee $OUTPUT_FILE
+    go test -json ./... -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt | tee $OUTPUT_FILE
   else
-    go test -json -vet=off ./... -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt | cat > $OUTPUT_FILE
+    go test -json ./... -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt | cat > $OUTPUT_FILE
   fi
 else
   if [[ $DEBUG == "true" ]]; then 
-    go test -vet=off ./... | tee $OUTPUT_FILE
+    go test ./... | tee $OUTPUT_FILE
   else
-    go test -vet=off ./... | cat > $OUTPUT_FILE
+    go test ./... | cat > $OUTPUT_FILE
   fi
 fi
 EXITCODE=${PIPESTATUS[0]}

--- a/tools/bin/go_core_race_tests
+++ b/tools/bin/go_core_race_tests
@@ -8,15 +8,15 @@ echo "Failed tests and panics: ---------------------"
 echo ""
 if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
   if [[  $DEBUG == "true" ]]; then 
-    GORACE="log_path=$PWD/race" go test -json -vet=off -race -shuffle on -timeout "$TIMEOUT" -count "$COUNT" $1 | tee $OUTPUT_FILE
+    GORACE="log_path=$PWD/race" go test -json -race -shuffle on -timeout "$TIMEOUT" -count "$COUNT" $1 | tee $OUTPUT_FILE
   else
-    GORACE="log_path=$PWD/race" go test -vet=off -race -shuffle on -timeout "$TIMEOUT" -count "$COUNT" $1 | cat > $OUTPUT_FILE
+    GORACE="log_path=$PWD/race" go test -race -shuffle on -timeout "$TIMEOUT" -count "$COUNT" $1 | cat > $OUTPUT_FILE
   fi
 else
   if [[ $DEBUG == "true" ]]; then 
-        GORACE="log_path=$PWD/race" go test -json -vet=off -race -shuffle on -timeout "$TIMEOUT" -count "$COUNT" $1 | tee $OUTPUT_FILE
+        GORACE="log_path=$PWD/race" go test -json -race -shuffle on -timeout "$TIMEOUT" -count "$COUNT" $1 | tee $OUTPUT_FILE
   else
-    GORACE="log_path=$PWD/race" go test -vet=off -race -shuffle on -timeout "$TIMEOUT" -count "$COUNT" $1 | cat > $OUTPUT_FILE
+    GORACE="log_path=$PWD/race" go test -race -shuffle on -timeout "$TIMEOUT" -count "$COUNT" $1 | cat > $OUTPUT_FILE
   fi
 fi
 EXITCODE=${PIPESTATUS[0]}

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -9,15 +9,15 @@ echo "Failed tests and panics: ---------------------"
 echo ""
 if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
   if [[ $DEBUG == "true" ]]; then 
-    go test -json -vet=off -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt $1 | tee $OUTPUT_FILE
+    go test -json -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt $1 | tee $OUTPUT_FILE
   else
-    go test -json -vet=off -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt $1 | cat > $OUTPUT_FILE
+    go test -json -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt $1 | cat > $OUTPUT_FILE
   fi
 else
   if [[ $DEBUG == "true" ]]; then 
-    go test -vet=off $1 | tee $OUTPUT_FILE
+    go test $1 | tee $OUTPUT_FILE
   else
-    go test -vet=off $1 | cat > $OUTPUT_FILE
+    go test $1 | cat > $OUTPUT_FILE
   fi
 fi
 EXITCODE=${PIPESTATUS[0]}

--- a/tools/bin/go_core_tests_integration
+++ b/tools/bin/go_core_tests_integration
@@ -21,15 +21,15 @@ if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
   # ALL_IMPORTS=$(go list -f '{{ join .Imports "\n" }}' $INTEGRATION_TEST_DIRS | sort -u)
   # COVERPKG_DIRS=$(echo "$INTEGRATION_TEST_DIRS $ALL_IMPORTS" | grep "smartcontractkit/chainlink" | tr '\n' ',')
   if [[ $DEBUG == "true" ]]; then 
-    go test -json -tags integration -vet=off -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt $INTEGRATION_TEST_DIRS_SPACE_DELIMITED | tee $OUTPUT_FILE
+    go test -json -tags integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt $INTEGRATION_TEST_DIRS_SPACE_DELIMITED | tee $OUTPUT_FILE
   else
-    go test -json -tags integration -vet=off -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt $INTEGRATION_TEST_DIRS_SPACE_DELIMITED | cat > $OUTPUT_FILE
+    go test -json -tags integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt $INTEGRATION_TEST_DIRS_SPACE_DELIMITED | cat > $OUTPUT_FILE
   fi
 else
   if [[ $DEBUG == "true" ]]; then 
-    go test -vet=off -tags integration $INTEGRATION_TEST_DIRS_SPACE_DELIMITED | tee $OUTPUT_FILE
+    go test -tags integration $INTEGRATION_TEST_DIRS_SPACE_DELIMITED | tee $OUTPUT_FILE
   else
-    go test -vet=off -tags integration $INTEGRATION_TEST_DIRS_SPACE_DELIMITED | cat > $OUTPUT_FILE
+    go test -tags integration $INTEGRATION_TEST_DIRS_SPACE_DELIMITED | cat > $OUTPUT_FILE
   fi
 fi
 EXITCODE=${PIPESTATUS[0]}


### PR DESCRIPTION
This PR re-enables vet checks, which were disabled in #14988.