### PR TITLE
Add context.Context to deployment.Environment. 

### DIFF
--- a/deployment/ccip/changeset/test_helpers.go
+++ b/deployment/ccip/changeset/test_helpers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
@@ -200,7 +201,7 @@ func NewMemoryEnvironment(
 			require.NoError(t, node.App.Stop())
 		})
 	}
-	e := memory.NewMemoryEnvironmentFromChainsNodes(t, lggr, chains, nodes)
+	e := memory.NewMemoryEnvironmentFromChainsNodes(func() context.Context { return ctx }, lggr, chains, nodes)
 	envNodes, err := deployment.NodeInfo(e.NodeIDs, e.Offchain)
 	require.NoError(t, err)
 	e.ExistingAddresses = ab

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -76,6 +76,7 @@ type Environment struct {
 	Chains            map[uint64]Chain
 	NodeIDs           []string
 	Offchain          OffchainClient
+	GetContext        func() context.Context
 }
 
 func NewEnvironment(
@@ -85,6 +86,7 @@ func NewEnvironment(
 	chains map[uint64]Chain,
 	nodeIDs []string,
 	offchain OffchainClient,
+	ctx func() context.Context,
 ) *Environment {
 	return &Environment{
 		Name:              name,
@@ -93,6 +95,7 @@ func NewEnvironment(
 		Chains:            chains,
 		NodeIDs:           nodeIDs,
 		Offchain:          offchain,
+		GetContext:        ctx,
 	}
 }
 

--- a/deployment/environment/devenv/environment.go
+++ b/deployment/environment/devenv/environment.go
@@ -20,12 +20,12 @@ type EnvironmentConfig struct {
 	JDConfig          JDConfig
 }
 
-func NewEnvironment(ctx context.Context, lggr logger.Logger, config EnvironmentConfig) (*deployment.Environment, *DON, error) {
+func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config EnvironmentConfig) (*deployment.Environment, *DON, error) {
 	chains, err := NewChains(lggr, config.Chains)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create chains: %w", err)
 	}
-	offChain, err := NewJDClient(ctx, config.JDConfig)
+	offChain, err := NewJDClient(ctx(), config.JDConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create JD client: %w", err)
 	}
@@ -39,7 +39,7 @@ func NewEnvironment(ctx context.Context, lggr logger.Logger, config EnvironmentC
 	}
 	var nodeIDs []string
 	if jd.don != nil {
-		err = jd.don.CreateSupportedChains(ctx, config.Chains, *jd)
+		err = jd.don.CreateSupportedChains(ctx(), config.Chains, *jd)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -53,5 +53,6 @@ func NewEnvironment(ctx context.Context, lggr logger.Logger, config EnvironmentC
 		chains,
 		nodeIDs,
 		offChain,
+		ctx,
 	), jd.don, nil
 }

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -13,6 +13,7 @@ import (
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink/deployment"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -110,10 +111,12 @@ func NewNodes(t *testing.T, logLevel zapcore.Level, chains map[uint64]deployment
 	return nodesByPeerID
 }
 
-func NewMemoryEnvironmentFromChainsNodes(t *testing.T,
+func NewMemoryEnvironmentFromChainsNodes(
+	ctx func() context.Context,
 	lggr logger.Logger,
 	chains map[uint64]deployment.Chain,
-	nodes map[string]Node) deployment.Environment {
+	nodes map[string]Node,
+) deployment.Environment {
 	var nodeIDs []string
 	for id := range nodes {
 		nodeIDs = append(nodeIDs, id)
@@ -125,6 +128,7 @@ func NewMemoryEnvironmentFromChainsNodes(t *testing.T,
 		chains,
 		nodeIDs, // Note these have the p2p_ prefix.
 		NewMemoryJobClient(nodes),
+		ctx,
 	)
 }
 
@@ -143,5 +147,6 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 		chains,
 		nodeIDs,
 		NewMemoryJobClient(nodes),
+		func() context.Context { return tests.Context(t) },
 	)
 }

--- a/deployment/keystone/deploy_test.go
+++ b/deployment/keystone/deploy_test.go
@@ -1,6 +1,7 @@
 package keystone_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -26,6 +28,7 @@ import (
 
 func TestDeploy(t *testing.T) {
 	lggr := logger.Test(t)
+	ctx := tests.Context(t)
 
 	// sepolia; all nodes are on the this chain
 	sepoliaChainId := uint64(11155111)
@@ -100,7 +103,7 @@ func TestDeploy(t *testing.T) {
 	maps.Copy(allNodes, wfNodes)
 	maps.Copy(allNodes, cwNodes)
 	maps.Copy(allNodes, assetNodes)
-	env := memory.NewMemoryEnvironmentFromChainsNodes(t, lggr, allChains, allNodes)
+	env := memory.NewMemoryEnvironmentFromChainsNodes(func() context.Context { return ctx }, lggr, allChains, allNodes)
 
 	var ocr3Config = keystone.OracleConfigWithSecrets{
 		OracleConfig: keystone.OracleConfig{
@@ -109,7 +112,6 @@ func TestDeploy(t *testing.T) {
 		OCRSecrets: deployment.XXXGenerateTestOCRSecrets(),
 	}
 
-	ctx := tests.Context(t)
 	// explicitly deploy the contracts
 	cs, err := keystone.DeployContracts(lggr, &env, sepoliaChainSel)
 	require.NoError(t, err)

--- a/integration-tests/testsetups/ccip/test_helpers.go
+++ b/integration-tests/testsetups/ccip/test_helpers.go
@@ -2,6 +2,7 @@ package ccip
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math/big"
 	"os"
@@ -123,7 +124,7 @@ func NewLocalDevEnvironment(
 		testEnv, cfg)
 	require.NoError(t, err)
 
-	e, don, err := devenv.NewEnvironment(ctx, lggr, *envConfig)
+	e, don, err := devenv.NewEnvironment(func() context.Context { return ctx }, lggr, *envConfig)
 	require.NoError(t, err)
 	require.NotNil(t, e)
 	e.ExistingAddresses = ab


### PR DESCRIPTION
We expose the context.Context via a lambda/pure-function on deployment.Environment. Mostly the ctx was already present where we create development.Environment (for other reasons), but now we expose it through the environment for attaching to remote-calls that aren't already managed by a wrapper client. Or, for whatever other things changesets may need to attach to the context for. (We are considering global timeouts for changset operations, for instance)

Plumb this through in the test environment and devenv as well in chainlink/deployments as well. 

> TODO: Apply a more robust cancellation signal handling, rather than dumbly plumbing through existing outer contexts (e.g. a cancellation method on Environment, and registering it where important). This will be done in a subsequent PR.