### PR TITLE
MERC-6389: Add support for stream jobs to the feeds service.

### DIFF
--- a/.changeset/thin-cats-try.md
+++ b/.changeset/thin-cats-try.md
@@ -2,4 +2,4 @@
 "chainlink": minor
 ---
 
-Add support for Mercury LLO streams to feeds service.
+Add support for Mercury LLO streams to feeds service. #added

--- a/.changeset/thin-cats-try.md
+++ b/.changeset/thin-cats-try.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Add support for Mercury LLO streams to feeds service.

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -862,14 +862,12 @@ func (s *service) ApproveSpec(ctx context.Context, id int64, force bool) error {
 					return fmt.Errorf("failed while checking for existing ccip job: %w", txerr)
 				}
 			case job.Stream:
-				var existingJob job.Job
-				existingJob, txerr = tx.jobORM.FindJobByExternalJobID(ctx, j.ExternalJobID)
+				existingJobID, txerr = tx.jobORM.FindJobIDByStreamID(ctx, *j.StreamID)
 				// Return an error if the repository errors. If there is a not found
 				// error we want to continue with approving the job.
 				if txerr != nil && !errors.Is(txerr, sql.ErrNoRows) {
-					return fmt.Errorf("failed while checking for existing ccip job: %w", txerr)
+					return fmt.Errorf("failed while checking for existing stream job: %w", txerr)
 				}
-				existingJobID = existingJob.ID
 			default:
 				return errors.Errorf("unsupported job type when approving job proposal specs: %s", j.Type)
 			}

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -19,9 +19,11 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	ccip "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/validate"
+	"github.com/smartcontractkit/chainlink/v2/core/services/streams"
 	"github.com/smartcontractkit/chainlink/v2/plugins"
 
 	pb "github.com/smartcontractkit/chainlink-protos/orchestrator/feedsmanager"
+
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
@@ -859,6 +861,15 @@ func (s *service) ApproveSpec(ctx context.Context, id int64, force bool) error {
 				if txerr != nil && !errors.Is(txerr, sql.ErrNoRows) {
 					return fmt.Errorf("failed while checking for existing ccip job: %w", txerr)
 				}
+			case job.Stream:
+				var existingJob job.Job
+				existingJob, txerr = tx.jobORM.FindJobByExternalJobID(ctx, j.ExternalJobID)
+				// Return an error if the repository errors. If there is a not found
+				// error we want to continue with approving the job.
+				if txerr != nil && !errors.Is(txerr, sql.ErrNoRows) {
+					return fmt.Errorf("failed while checking for existing ccip job: %w", txerr)
+				}
+				existingJobID = existingJob.ID
 			default:
 				return errors.Errorf("unsupported job type when approving job proposal specs: %s", j.Type)
 			}
@@ -1249,6 +1260,8 @@ func (s *service) generateJob(ctx context.Context, spec string) (*job.Job, error
 		js, err = workflows.ValidatedWorkflowJobSpec(ctx, spec)
 	case job.CCIP:
 		js, err = ccip.ValidatedCCIPSpec(spec)
+	case job.Stream:
+		js, err = streams.ValidatedStreamSpec(spec)
 	default:
 		return nil, errors.Errorf("unknown job type: %s", jobType)
 	}

--- a/core/services/job/mocks/orm.go
+++ b/core/services/job/mocks/orm.go
@@ -601,6 +601,63 @@ func (_c *ORM_FindJobIDByCapabilityNameAndVersion_Call) RunAndReturn(run func(co
 	return _c
 }
 
+// FindJobIDByStreamID provides a mock function with given fields: ctx, streamID
+func (_m *ORM) FindJobIDByStreamID(ctx context.Context, streamID uint32) (int32, error) {
+	ret := _m.Called(ctx, streamID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindJobIDByStreamID")
+	}
+
+	var r0 int32
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32) (int32, error)); ok {
+		return rf(ctx, streamID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint32) int32); ok {
+		r0 = rf(ctx, streamID)
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint32) error); ok {
+		r1 = rf(ctx, streamID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ORM_FindJobIDByStreamID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindJobIDByStreamID'
+type ORM_FindJobIDByStreamID_Call struct {
+	*mock.Call
+}
+
+// FindJobIDByStreamID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - streamID uint32
+func (_e *ORM_Expecter) FindJobIDByStreamID(ctx interface{}, streamID interface{}) *ORM_FindJobIDByStreamID_Call {
+	return &ORM_FindJobIDByStreamID_Call{Call: _e.mock.On("FindJobIDByStreamID", ctx, streamID)}
+}
+
+func (_c *ORM_FindJobIDByStreamID_Call) Run(run func(ctx context.Context, streamID uint32)) *ORM_FindJobIDByStreamID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint32))
+	})
+	return _c
+}
+
+func (_c *ORM_FindJobIDByStreamID_Call) Return(_a0 int32, _a1 error) *ORM_FindJobIDByStreamID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ORM_FindJobIDByStreamID_Call) RunAndReturn(run func(context.Context, uint32) (int32, error)) *ORM_FindJobIDByStreamID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FindJobIDByWorkflow provides a mock function with given fields: ctx, spec
 func (_m *ORM) FindJobIDByWorkflow(ctx context.Context, spec job.WorkflowSpec) (int32, error) {
 	ret := _m.Called(ctx, spec)


### PR DESCRIPTION
[MERC-6389](https://smartcontract-it.atlassian.net/browse/MERC-6389)

This PR allows CLO to propose Mercury LLO stream jobs. ([Corresponding CLO PR](https://github.com/smartcontractkit/feeds-manager/pull/3931).)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[MERC-6641]: https://smartcontract-it.atlassian.net/browse/MERC-6641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MERC-6389]: https://smartcontract-it.atlassian.net/browse/MERC-6389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ