### PR TITLE
expand extra parameters

### DIFF
--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -14,7 +14,7 @@ echo ""
 if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
   EXTRA_FLAGS="-covermode=atomic -coverpkg=./... -coverprofile=coverage.txt"
 fi
-go test ./... "$EXTRA_FLAGS" | tee $OUTPUT_FILE | grep -Ev '\[no test files\]|\[no tests to run\]'
+go test ./... $EXTRA_FLAGS | tee $OUTPUT_FILE | grep -Ev '\[no test files\]|\[no tests to run\]'
 EXITCODE=${PIPESTATUS[0]}
 
 # Assert no known sensitive strings present in test logger output

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -11,7 +11,7 @@ echo ""
 if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
   EXTRA_FLAGS="-covermode=atomic -coverpkg=./... -coverprofile=coverage.txt"
 fi
-go test "$EXTRA_FLAGS" $1 | tee $OUTPUT_FILE | grep -Ev '\[no test files\]|\[no tests to run\]'
+go test $EXTRA_FLAGS $1 | tee $OUTPUT_FILE | grep -Ev '\[no test files\]|\[no tests to run\]'
 EXITCODE=${PIPESTATUS[0]}
 
 # Assert no known sensitive strings present in test logger output

--- a/tools/bin/go_core_tests_integration
+++ b/tools/bin/go_core_tests_integration
@@ -23,7 +23,7 @@ if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
   # COVERPKG_DIRS=$(echo "$INTEGRATION_TEST_DIRS $ALL_IMPORTS" | grep "smartcontractkit/chainlink" | tr '\n' ',')
   EXTRA_FLAGS="-covermode=atomic -coverpkg=./... -coverprofile=coverage.txt"
 fi
-go test -tags integration "$EXTRA_FLAGS" $INTEGRATION_TEST_DIRS_SPACE_DELIMITED | tee $OUTPUT_FILE | grep -Ev '\[no test files\]|\[no tests to run\]'
+go test -tags integration $EXTRA_FLAGS $INTEGRATION_TEST_DIRS_SPACE_DELIMITED | tee $OUTPUT_FILE | grep -Ev '\[no test files\]|\[no tests to run\]'
 EXITCODE=${PIPESTATUS[0]}
 
 # Assert no known sensitive strings present in test logger output


### PR DESCRIPTION
extra parameters were incorrectly quoted and due to that were not expanded. Instead, they were all treated as a single string and thus made `go test` fail.