### PR TITLE
RE-3259-add-gap-auth

### DIFF
--- a/deployment/environment/devenv/jd.go
+++ b/deployment/environment/devenv/jd.go
@@ -55,7 +55,7 @@ func gapTokenInterceptor(token string) grpc.UnaryClientInterceptor {
 		opts ...grpc.CallOption,
 	) error {
 		return invoker(
-			metadata.AppendToOutgoingContext(ctx, "x-authorization-github-jwt", token),
+			metadata.AppendToOutgoingContext(ctx, "x-authorization-github-jwt", "Bearer "+token),
 			method, req, reply, cc, opts...,
 		)
 	}
@@ -63,16 +63,24 @@ func gapTokenInterceptor(token string) grpc.UnaryClientInterceptor {
 
 func NewJDConnection(cfg JDConfig) (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{}
+	interceptors := []grpc.UnaryClientInterceptor{}
+
 	if cfg.Creds != nil {
 		opts = append(opts, grpc.WithTransportCredentials(cfg.Creds))
 	}
 	if cfg.Auth != nil {
-		opts = append(opts, grpc.WithUnaryInterceptor(authTokenInterceptor(cfg.Auth)))
+		interceptors = append(interceptors, authTokenInterceptor(cfg.Auth))
 	}
 	if cfg.GAP != "" {
-		opts = append(opts, grpc.WithUnaryInterceptor(gapTokenInterceptor(cfg.GAP)))
+		fmt.Println("Using GAP token from JDConfig")
+		interceptors = append(interceptors, gapTokenInterceptor(cfg.GAP))
 	}
-	opts = append(opts, grpc.WithAuthority(cfg.GRPC))
+
+	if len(interceptors) > 0 {
+		opts = append(opts, grpc.WithChainUnaryInterceptor(interceptors...))
+	}
+	// opts = append(opts, grpc.WithAuthority(cfg.GRPC))
+
 	conn, err := grpc.NewClient(cfg.GRPC, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect Job Distributor service. Err: %w", err)

--- a/deployment/environment/devenv/jd.go
+++ b/deployment/environment/devenv/jd.go
@@ -55,7 +55,7 @@ func gapTokenInterceptor(token string) grpc.UnaryClientInterceptor {
 		opts ...grpc.CallOption,
 	) error {
 		return invoker(
-			metadata.AppendToOutgoingContext(ctx, "x-authorization-github-jwt", "Bearer "+token),
+			metadata.AppendToOutgoingContext(ctx, "x-authorization-github-jwt", token),
 			method, req, reply, cc, opts...,
 		)
 	}

--- a/deployment/environment/devenv/jd.go
+++ b/deployment/environment/devenv/jd.go
@@ -20,6 +20,7 @@ type JDConfig struct {
 	WSRPC    string
 	Creds    credentials.TransportCredentials
 	Auth     oauth2.TokenSource
+	GAP      string
 	NodeInfo []NodeInfo
 }
 
@@ -44,6 +45,22 @@ func authTokenInterceptor(source oauth2.TokenSource) grpc.UnaryClientInterceptor
 	}
 }
 
+func gapTokenInterceptor(token string) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		return invoker(
+			metadata.AppendToOutgoingContext(ctx, "x-authorization-github-jwt", "Bearer "+token),
+			method, req, reply, cc, opts...,
+		)
+	}
+}
+
 func NewJDConnection(cfg JDConfig) (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{}
 	if cfg.Creds != nil {
@@ -52,6 +69,10 @@ func NewJDConnection(cfg JDConfig) (*grpc.ClientConn, error) {
 	if cfg.Auth != nil {
 		opts = append(opts, grpc.WithUnaryInterceptor(authTokenInterceptor(cfg.Auth)))
 	}
+	if cfg.GAP != "" {
+		opts = append(opts, grpc.WithUnaryInterceptor(gapTokenInterceptor(cfg.GAP)))
+	}
+	opts = append(opts, grpc.WithAuthority(cfg.GRPC))
 	conn, err := grpc.NewClient(cfg.GRPC, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect Job Distributor service. Err: %w", err)

--- a/deployment/environment/devenv/jd.go
+++ b/deployment/environment/devenv/jd.go
@@ -72,14 +72,12 @@ func NewJDConnection(cfg JDConfig) (*grpc.ClientConn, error) {
 		interceptors = append(interceptors, authTokenInterceptor(cfg.Auth))
 	}
 	if cfg.GAP != "" {
-		fmt.Println("Using GAP token from JDConfig")
 		interceptors = append(interceptors, gapTokenInterceptor(cfg.GAP))
 	}
 
 	if len(interceptors) > 0 {
 		opts = append(opts, grpc.WithChainUnaryInterceptor(interceptors...))
 	}
-	// opts = append(opts, grpc.WithAuthority(cfg.GRPC))
 
 	conn, err := grpc.NewClient(cfg.GRPC, opts...)
 	if err != nil {


### PR DESCRIPTION
[RE-3259](https://smartcontract-it.atlassian.net/browse/RE-3259)

Injects GAPv2 Auth header
 
### Requires
No dependency

### Supports
- https://github.com/smartcontractkit/chainlink-deployments/pull/238



[RE-3259]: https://smartcontract-it.atlassian.net/browse/RE-3259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ