### PR TITLE
[DPA-1357]: fix: include OCR secrets as part of deployment.Environment

### DIFF
--- a/.changeset/hot-islands-dress.md
+++ b/.changeset/hot-islands-dress.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal refactor: inject ocr secrets via env instead of config

--- a/core/scripts/keystone/src/88_gen_ocr3_config.go
+++ b/core/scripts/keystone/src/88_gen_ocr3_config.go
@@ -13,9 +13,8 @@ func mustReadConfig(fileName string) (output ksdeploy.TopLevelConfigSource) {
 func generateOCR3Config(nodeList string, configFile string, chainID int64, pubKeysPath string) ksdeploy.OCR2OracleConfig {
 	topLevelCfg := mustReadConfig(configFile)
 	cfg := topLevelCfg.OracleConfig
-	cfg.OCRSecrets = deployment.XXXGenerateTestOCRSecrets()
 	nca := downloadNodePubKeys(nodeList, chainID, pubKeysPath)
-	c, err := ksdeploy.GenerateOCR3Config(cfg, nca)
+	c, err := ksdeploy.GenerateOCR3Config(cfg, nca, deployment.XXXGenerateTestOCRSecrets())
 	helpers.PanicErr(err)
 	return c
 }

--- a/deployment/ccip/changeset/cs_active_candidate.go
+++ b/deployment/ccip/changeset/cs_active_candidate.go
@@ -137,7 +137,7 @@ func SetCandidatePluginChangeset(
 	}
 
 	newDONArgs, err := internal.BuildOCR3ConfigForCCIPHome(
-		cfg.OCRSecrets,
+		e.OCRSecrets,
 		state.Chains[cfg.NewChainSelector].OffRamp,
 		e.Chains[cfg.NewChainSelector],
 		nodes.NonBootstraps(),

--- a/deployment/ccip/changeset/cs_active_candidate_test.go
+++ b/deployment/ccip/changeset/cs_active_candidate_test.go
@@ -144,7 +144,7 @@ func TestActiveCandidate(t *testing.T) {
 		nil,
 	)
 	ocr3ConfigMap, err := internal.BuildOCR3ConfigForCCIPHome(
-		deployment.XXXGenerateTestOCRSecrets(),
+		e.OCRSecrets,
 		state.Chains[tenv.FeedChainSel].OffRamp,
 		e.Chains[tenv.FeedChainSel],
 		nodes.NonBootstraps(),

--- a/deployment/ccip/changeset/cs_add_chain.go
+++ b/deployment/ccip/changeset/cs_add_chain.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/internal"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
@@ -142,7 +143,6 @@ type AddDonAndSetCandidateChangesetConfig struct {
 	PluginType        types.PluginType
 	NodeIDs           []string
 	CCIPOCRParams     CCIPOCRParams
-	OCRSecrets        deployment.OCRSecrets
 }
 
 func (a AddDonAndSetCandidateChangesetConfig) Validate(e deployment.Environment, state CCIPOnChainState) (deployment.Nodes, error) {
@@ -191,7 +191,7 @@ func (a AddDonAndSetCandidateChangesetConfig) Validate(e deployment.Environment,
 		return nil, fmt.Errorf("invalid ccip ocr params: %w", err)
 	}
 
-	if a.OCRSecrets.IsEmpty() {
+	if e.OCRSecrets.IsEmpty() {
 		return nil, fmt.Errorf("OCR secrets must be set")
 	}
 
@@ -215,7 +215,7 @@ func AddDonAndSetCandidateChangeset(
 	}
 
 	newDONArgs, err := internal.BuildOCR3ConfigForCCIPHome(
-		cfg.OCRSecrets,
+		e.OCRSecrets,
 		state.Chains[cfg.NewChainSelector].OffRamp,
 		e.Chains[cfg.NewChainSelector],
 		nodes.NonBootstraps(),

--- a/deployment/ccip/changeset/cs_add_chain_test.go
+++ b/deployment/ccip/changeset/cs_add_chain_test.go
@@ -84,7 +84,6 @@ func TestAddChainInbound(t *testing.T) {
 		HomeChainSel:       e.HomeChainSel,
 		FeedChainSel:       e.FeedChainSel,
 		ChainConfigByChain: chainConfig,
-		OCRSecrets:         deployment.XXXGenerateTestOCRSecrets(),
 	})
 	require.NoError(t, err)
 
@@ -191,7 +190,6 @@ func TestAddChainInbound(t *testing.T) {
 				NewChainSelector:  newChain,
 				PluginType:        types.PluginTypeCCIPCommit,
 				NodeIDs:           nodeIDs,
-				OCRSecrets:        deployment.XXXGenerateTestOCRSecrets(),
 				CCIPOCRParams: DefaultOCRParams(
 					e.FeedChainSel,
 					tokenConfig.GetTokenInfo(logger.TestLogger(t), state.Chains[newChain].LinkToken, state.Chains[newChain].Weth9),
@@ -207,7 +205,6 @@ func TestAddChainInbound(t *testing.T) {
 				NewChainSelector:  newChain,
 				PluginType:        types.PluginTypeCCIPExec,
 				NodeIDs:           nodeIDs,
-				OCRSecrets:        deployment.XXXGenerateTestOCRSecrets(),
 				CCIPOCRParams: DefaultOCRParams(
 					e.FeedChainSel,
 					tokenConfig.GetTokenInfo(logger.TestLogger(t), state.Chains[newChain].LinkToken, state.Chains[newChain].Weth9),

--- a/deployment/ccip/changeset/cs_initial_add_chain.go
+++ b/deployment/ccip/changeset/cs_initial_add_chain.go
@@ -76,7 +76,6 @@ type NewChainsConfig struct {
 	// Common to all chains
 	HomeChainSel uint64
 	FeedChainSel uint64
-	OCRSecrets   deployment.OCRSecrets
 	// Per chain config
 	ChainConfigByChain map[uint64]CCIPOCRParams
 }
@@ -95,9 +94,6 @@ func (c NewChainsConfig) Validate() error {
 	}
 	if err := deployment.IsValidChainSelector(c.FeedChainSel); err != nil {
 		return fmt.Errorf("invalid feed chain selector: %d - %w", c.FeedChainSel, err)
-	}
-	if c.OCRSecrets.IsEmpty() {
-		return fmt.Errorf("no OCR secrets provided")
 	}
 	// Validate chain config
 	for chain, cfg := range c.ChainConfigByChain {
@@ -166,7 +162,7 @@ func configureChain(
 	e deployment.Environment,
 	c NewChainsConfig,
 ) error {
-	if c.OCRSecrets.IsEmpty() {
+	if e.OCRSecrets.IsEmpty() {
 		return fmt.Errorf("OCR secrets are empty")
 	}
 	nodes, err := deployment.NodeInfo(e.NodeIDs, e.Offchain)
@@ -217,7 +213,7 @@ func configureChain(
 		// For each chain, we create a DON on the home chain (2 OCR instances)
 		if err := addDON(
 			e.Logger,
-			c.OCRSecrets,
+			e.OCRSecrets,
 			capReg,
 			ccipHome,
 			rmnHome.Address(),

--- a/deployment/ccip/changeset/test_helpers.go
+++ b/deployment/ccip/changeset/test_helpers.go
@@ -379,7 +379,6 @@ func NewMemoryEnvironmentWithJobsAndContracts(t *testing.T, lggr logger.Logger, 
 			Config: NewChainsConfig{
 				HomeChainSel:       e.HomeChainSel,
 				FeedChainSel:       e.FeedChainSel,
-				OCRSecrets:         deployment.XXXGenerateTestOCRSecrets(),
 				ChainConfigByChain: chainConfigs,
 			},
 		},

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -90,6 +90,7 @@ func ApplyChangesets(t *testing.T, e deployment.Environment, timelocksPerChain m
 			Chains:            e.Chains,
 			NodeIDs:           e.NodeIDs,
 			Offchain:          e.Offchain,
+			OCRSecrets:        e.OCRSecrets,
 		}
 	}
 	return currentEnv, nil

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -98,6 +98,7 @@ type Environment struct {
 	NodeIDs           []string
 	Offchain          OffchainClient
 	GetContext        func() context.Context
+	OCRSecrets        OCRSecrets
 }
 
 func NewEnvironment(
@@ -108,6 +109,7 @@ func NewEnvironment(
 	nodeIDs []string,
 	offchain OffchainClient,
 	ctx func() context.Context,
+	secrets OCRSecrets,
 ) *Environment {
 	return &Environment{
 		Name:              name,
@@ -117,6 +119,7 @@ func NewEnvironment(
 		NodeIDs:           nodeIDs,
 		Offchain:          offchain,
 		GetContext:        ctx,
+		OCRSecrets:        secrets,
 	}
 }
 

--- a/deployment/environment/devenv/environment.go
+++ b/deployment/environment/devenv/environment.go
@@ -52,5 +52,6 @@ func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config Envir
 		nodeIDs,
 		offChain,
 		ctx,
+		deployment.XXXGenerateTestOCRSecrets(),
 	), jd.don, nil
 }

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -142,6 +142,7 @@ func NewMemoryEnvironmentFromChainsNodes(
 		nodeIDs, // Note these have the p2p_ prefix.
 		NewMemoryJobClient(nodes),
 		ctx,
+		deployment.XXXGenerateTestOCRSecrets(),
 	)
 }
 
@@ -161,5 +162,6 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 		nodeIDs,
 		NewMemoryJobClient(nodes),
 		func() context.Context { return tests.Context(t) },
+		deployment.XXXGenerateTestOCRSecrets(),
 	)
 }

--- a/deployment/keystone/changeset/configure_contracts.go
+++ b/deployment/keystone/changeset/configure_contracts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	kslib "github.com/smartcontractkit/chainlink/deployment/keystone"
 )
@@ -14,7 +15,7 @@ var _ deployment.ChangeSet[InitialContractsCfg] = ConfigureInitialContractsChang
 type InitialContractsCfg struct {
 	RegistryChainSel uint64
 	Dons             []kslib.DonCapabilities
-	OCR3Config       *kslib.OracleConfigWithSecrets
+	OCR3Config       *kslib.OracleConfig
 }
 
 func ConfigureInitialContractsChangeset(e deployment.Environment, cfg InitialContractsCfg) (deployment.ChangesetOutput, error) {

--- a/deployment/keystone/changeset/deploy_ocr3.go
+++ b/deployment/keystone/changeset/deploy_ocr3.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	kslib "github.com/smartcontractkit/chainlink/deployment/keystone"
 )
@@ -33,7 +34,7 @@ var _ deployment.ChangeSet[ConfigureOCR3Config] = ConfigureOCR3Contract
 type ConfigureOCR3Config struct {
 	ChainSel             uint64
 	NodeIDs              []string
-	OCR3Config           *kslib.OracleConfigWithSecrets
+	OCR3Config           *kslib.OracleConfig
 	DryRun               bool
 	WriteGeneratedConfig io.Writer // if not nil, write the generated config to this writer as JSON [OCR2OracleConfig]
 

--- a/deployment/keystone/changeset/deploy_ocr3_test.go
+++ b/deployment/keystone/changeset/deploy_ocr3_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	kslib "github.com/smartcontractkit/chainlink/deployment/keystone"
@@ -48,12 +48,9 @@ func TestConfigureOCR3(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 
-	c := kslib.OracleConfigWithSecrets{
-		OracleConfig: kslib.OracleConfig{
-			MaxFaultyOracles:    1,
-			DeltaProgressMillis: 12345,
-		},
-		OCRSecrets: deployment.XXXGenerateTestOCRSecrets(),
+	c := kslib.OracleConfig{
+		MaxFaultyOracles:    1,
+		DeltaProgressMillis: 12345,
 	}
 
 	t.Run("no mcms", func(t *testing.T) {

--- a/deployment/keystone/changeset/helpers_test.go
+++ b/deployment/keystone/changeset/helpers_test.go
@@ -7,16 +7,19 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sort"
-
-	"math"
 	"testing"
 
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"golang.org/x/exp/maps"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -26,9 +29,6 @@ import (
 	kschangeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	kcr "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-	"golang.org/x/exp/maps"
 )
 
 func TestSetupTestEnv(t *testing.T) {
@@ -215,11 +215,8 @@ func SetupTestEnv(t *testing.T, c TestConfig) TestEnv {
 	err = env.ExistingAddresses.Merge(e.ExistingAddresses)
 	require.NoError(t, err)
 
-	var ocr3Config = keystone.OracleConfigWithSecrets{
-		OracleConfig: keystone.OracleConfig{
-			MaxFaultyOracles: len(wfNodes) / 3,
-		},
-		OCRSecrets: deployment.XXXGenerateTestOCRSecrets(),
+	var ocr3Config = keystone.OracleConfig{
+		MaxFaultyOracles: len(wfNodes) / 3,
 	}
 	var allDons = []keystone.DonCapabilities{wfDon, cwDon, assetDon}
 

--- a/deployment/keystone/deploy.go
+++ b/deployment/keystone/deploy.go
@@ -44,8 +44,8 @@ type ConfigureContractsRequest struct {
 	RegistryChainSel uint64
 	Env              *deployment.Environment
 
-	Dons       []DonCapabilities        // externally sourced based on the environment
-	OCR3Config *OracleConfigWithSecrets // TODO: probably should be a map of don to config; but currently we only have one wf don therefore one config
+	Dons       []DonCapabilities // externally sourced based on the environment
+	OCR3Config *OracleConfig     // TODO: probably should be a map of don to config; but currently we only have one wf don therefore one config
 
 	// TODO rm this option; unused
 	DoContractDeploy bool // if false, the contracts are assumed to be deployed and the address book is used
@@ -304,7 +304,7 @@ func ConfigureRegistry(ctx context.Context, lggr logger.Logger, req ConfigureCon
 
 // Depreciated: use changeset.ConfigureOCR3Contract instead
 // ocr3 contract on the registry chain for the wf dons
-func ConfigureOCR3Contract(env *deployment.Environment, chainSel uint64, dons []RegisteredDon, cfg *OracleConfigWithSecrets) error {
+func ConfigureOCR3Contract(env *deployment.Environment, chainSel uint64, dons []RegisteredDon, cfg *OracleConfig) error {
 	registryChain, ok := env.Chains[chainSel]
 	if !ok {
 		return fmt.Errorf("chain %d not found in environment", chainSel)
@@ -338,6 +338,7 @@ func ConfigureOCR3Contract(env *deployment.Environment, chainSel uint64, dons []
 			contract:    contract,
 			nodes:       don.Nodes,
 			contractSet: &contracts,
+			ocrSecrets:  env.OCRSecrets,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to configure OCR3 contract for don %s: %w", don.Name, err)
@@ -354,7 +355,7 @@ type ConfigureOCR3Resp struct {
 type ConfigureOCR3Config struct {
 	ChainSel   uint64
 	NodeIDs    []string
-	OCR3Config *OracleConfigWithSecrets
+	OCR3Config *OracleConfig
 	DryRun     bool
 
 	UseMCMS bool
@@ -398,6 +399,7 @@ func ConfigureOCR3ContractFromJD(env *deployment.Environment, cfg ConfigureOCR3C
 		dryRun:      cfg.DryRun,
 		contractSet: &contracts,
 		useMCMS:     cfg.UseMCMS,
+		ocrSecrets:  env.OCRSecrets,
 	})
 	if err != nil {
 		return nil, err

--- a/deployment/keystone/deploy_test.go
+++ b/deployment/keystone/deploy_test.go
@@ -107,6 +107,7 @@ func TestDeployCLO(t *testing.T) {
 		Offchain:          clo.NewJobClient(lggr, clo.JobClientConfig{Nops: allNops}),
 		Chains:            allChains,
 		Logger:            lggr,
+		OCRSecrets:        deployment.XXXGenerateTestOCRSecrets(),
 	}
 	// assume that all the nodes in the provided input nops are part of the don
 	for _, nop := range allNops {
@@ -119,11 +120,8 @@ func TestDeployCLO(t *testing.T) {
 	registryChainSel, err := chainsel.SelectorFromChainId(11155111)
 	require.NoError(t, err)
 
-	var ocr3Config = keystone.OracleConfigWithSecrets{
-		OracleConfig: keystone.OracleConfig{
-			MaxFaultyOracles: len(wfNops) / 3,
-		},
-		OCRSecrets: deployment.XXXGenerateTestOCRSecrets(),
+	var ocr3Config = keystone.OracleConfig{
+		MaxFaultyOracles: len(wfNops) / 3,
 	}
 
 	ctx := tests.Context(t)

--- a/deployment/keystone/ocr3config_test.go
+++ b/deployment/keystone/ocr3config_test.go
@@ -85,11 +85,12 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 	err := json.Unmarshal([]byte(ocr3Cfg), &cfg)
 	require.NoError(t, err)
 	r := configureOCR3Request{
-		cfg:   &OracleConfigWithSecrets{OracleConfig: cfg, OCRSecrets: deployment.XXXGenerateTestOCRSecrets()},
+		cfg:   &cfg,
 		nodes: nodes,
 		chain: deployment.Chain{
 			Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 		},
+		ocrSecrets: deployment.XXXGenerateTestOCRSecrets(),
 	}
 	got, err := r.generateOCR3Config()
 	require.NoError(t, err)

--- a/integration-tests/testsetups/ccip/test_helpers.go
+++ b/integration-tests/testsetups/ccip/test_helpers.go
@@ -244,7 +244,6 @@ func NewLocalDevEnvironment(
 			Config: changeset.NewChainsConfig{
 				HomeChainSel:       homeChainSel,
 				FeedChainSel:       feedSel,
-				OCRSecrets:         deployment.XXXGenerateTestOCRSecrets(),
 				ChainConfigByChain: chainConfigs,
 			},
 		},


### PR DESCRIPTION
There are many cases where a changeset requires access to the OCR secrets and because it is not accessible via `deployment.Environment`, users are left no choice but to pass secrets as config in a changesets. By plumbing OCR secrets in `deployment.Environment`, user will no longer need to do the workaround.

Update code to use OCR secrets from the env instead of from requests/config

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1357

Used by: https://github.com/smartcontractkit/chainlink-deployments/pull/253
