### PR TITLE
Increase Automation GasLimit on ZKsync to 6M [SHIP-2804]

### DIFF
--- a/.changeset/spotty-knives-smile.md
+++ b/.changeset/spotty-knives-smile.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Increase GasLimit for Automation on ZKsync to 6M #nops

--- a/core/chains/evm/config/toml/defaults/zkSync_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/zkSync_Mainnet.toml
@@ -16,3 +16,6 @@ OracleType = 'zksync'
 
 [HeadTracker]
 HistoryDepth = 50
+
+[OCR2.Automation]
+GasLimit = 6_000_000

--- a/core/chains/evm/config/toml/defaults/zkSync_Sepolia.toml
+++ b/core/chains/evm/config/toml/defaults/zkSync_Sepolia.toml
@@ -16,3 +16,6 @@ OracleType = 'zksync'
 
 [HeadTracker]
 HistoryDepth = 50
+
+[OCR2.Automation]
+GasLimit = 6_000_000

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -4518,7 +4518,7 @@ ObservationGracePeriod = '1s'
 
 [OCR2]
 [OCR2.Automation]
-GasLimit = 5400000
+GasLimit = 6000000
 
 [Workflow]
 GasLimitDefault = 400000
@@ -4625,7 +4625,7 @@ ObservationGracePeriod = '1s'
 
 [OCR2]
 [OCR2.Automation]
-GasLimit = 5400000
+GasLimit = 6000000
 
 [Workflow]
 GasLimitDefault = 400000


### PR DESCRIPTION
This PR increases the default GasLimit used for CLA transmits from 5.4M to 6M.