### PR TITLE
Add missing backend.Commit() to log emitter deployment

### DIFF
--- a/core/chains/evm/logpoller/helper_test.go
+++ b/core/chains/evm/logpoller/helper_test.go
@@ -120,6 +120,7 @@ func SetupTH(t testing.TB, opts logpoller.Opts) TestHarness {
 	lp := logpoller.NewLogPoller(o, esc, lggr, headTracker, opts)
 	emitterAddress1, _, emitter1, err := log_emitter.DeployLogEmitter(owner, backend.Client())
 	require.NoError(t, err)
+	backend.Commit()
 	emitterAddress2, _, emitter2, err := log_emitter.DeployLogEmitter(owner, backend.Client())
 	require.NoError(t, err)
 	backend.Commit()


### PR DESCRIPTION
There have been a few LogPoller flakes lately due to this.  Looks like calling `Commit()` between each call to a gethwrapper function is required for the latest version of simulated geth to avoid a race where it can send two tx's in a row with the same nonce before it's incremented.

[BCFR-1081](https://smartcontract-it.atlassian.net/browse/BCFR-1081)

[BCFR-1081]: https://smartcontract-it.atlassian.net/browse/BCFR-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ