### PR TITLE
Fix nightly flakeguard job

### DIFF
--- a/.github/workflows/flakeguard-nightly.yml
+++ b/.github/workflows/flakeguard-nightly.yml
@@ -1,0 +1,21 @@
+name: Flakeguard Nightly
+
+on:
+  schedule:
+    # Run every night at 3:00 AM UTC
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  trigger-flaky-test-detection:
+    name: Find Flaky Tests
+    uses: ./.github/workflows/flakeguard.yml
+    with:
+      repoUrl: 'https://github.com/smartcontractkit/chainlink'
+      baseRef: 'origin/develop'
+      projectPath: '.'
+      maxPassRatio: '1.0'
+      runAllTests: 'true'
+      extraArgs: '{ "skipped_tests": "TestChainComponents", "test_repeat_count": "5", "all_tests_runner": "ubuntu22.04-32cores-128GB", "all_tests_runner_count": "3", "run_with_race": "false" }'
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}

--- a/.github/workflows/flakeguard-nightly.yml
+++ b/.github/workflows/flakeguard-nightly.yml
@@ -1,7 +1,6 @@
 name: Flakeguard Nightly
 
 on:
-  push:
   schedule:
     # Run every night at 3:00 AM UTC
     - cron: '0 3 * * *'
@@ -16,7 +15,7 @@ jobs:
       baseRef: 'origin/develop'
       projectPath: '.'
       maxPassRatio: '1.0'
-      runAllTests: 'true'
+      runAllTests: true
       extraArgs: '{ "skipped_tests": "TestChainComponents", "test_repeat_count": "5", "all_tests_runner": "ubuntu22.04-32cores-128GB", "all_tests_runner_count": "3", "run_with_race": "false" }'
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}

--- a/.github/workflows/flakeguard-nightly.yml
+++ b/.github/workflows/flakeguard-nightly.yml
@@ -1,6 +1,7 @@
 name: Flakeguard Nightly
 
 on:
+  push:
   schedule:
     # Run every night at 3:00 AM UTC
     - cron: '0 3 * * *'

--- a/.github/workflows/flakeguard-nightly.yml
+++ b/.github/workflows/flakeguard-nightly.yml
@@ -17,5 +17,6 @@ jobs:
       maxPassRatio: '1.0'
       runAllTests: true
       extraArgs: '{ "skipped_tests": "TestChainComponents", "test_repeat_count": "5", "all_tests_runner": "ubuntu22.04-32cores-128GB", "all_tests_runner_count": "3", "run_with_race": "false" }'
+      slackNotificationAfterTestsChannelId: 'C07TRF65CNS' #flaky-test-detector-notifications
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}

--- a/.github/workflows/flakeguard-on-demand.yml
+++ b/.github/workflows/flakeguard-on-demand.yml
@@ -1,9 +1,6 @@
 name: Flakeguard On Demand
 
 on:
-  schedule:
-    # Run every night at 3:00 AM UTC
-    - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
       repoUrl:

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -418,7 +418,7 @@ jobs:
           script: |
             const fs = require('fs');
             const prNumber = context.payload.pull_request.number;
-            const commentBody = fs.readFileSync('../all_tests.md', 'utf8');
+            const commentBody = fs.readFileSync('all_tests.md', 'utf8');
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install flakeguard
         shell: bash
-        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@04bfae2602c015036f366a8dd4e7a619096cc516 # flakguard@0.1.0
+        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@f03577def97a20a38c0e1de1cbe7fc98d416dd86 # flakguard@0.1.0
 
       - name: Find new or updated test packages
         if: ${{ inputs.runAllTests == false }}
@@ -259,7 +259,7 @@ jobs:
 
       - name: Install flakeguard
         shell: bash
-        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@04bfae2602c015036f366a8dd4e7a619096cc516 # flakguard@0.1.0
+        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@f03577def97a20a38c0e1de1cbe7fc98d416dd86 # flakguard@0.1.0
 
       - name: Run tests with flakeguard
         shell: bash
@@ -306,7 +306,7 @@ jobs:
             
       - name: Install flakeguard
         shell: bash
-        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@04bfae2602c015036f366a8dd4e7a619096cc516 # flakguard@0.1.0
+        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@f03577def97a20a38c0e1de1cbe7fc98d416dd86 # flakguard@0.1.0
                 
       - name: Set combined test results
         id: set_test_results

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -283,6 +283,11 @@ jobs:
     outputs:
       test_results: ${{ steps.set_test_results.outputs.results }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          ref: ${{ env.GIT_HEAD_REF }}
+
       - name: Set Pretty Project Path
         id: set_project_path_pretty
         run: |
@@ -295,7 +300,7 @@ jobs:
       - name: Download all test result artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          path: test_results
+          path: ci_test_results
           pattern:
             test-result-${{ needs.get-tests.outputs.workflow_id }}-*
             
@@ -308,8 +313,9 @@ jobs:
         shell: bash
         run: |
           set -e  # Exit immediately if a command exits with a non-zero status.
-          if [ -d "test_results" ]; then
-            cd test_results
+          
+          if [ -d "ci_test_results" ]; then
+            cd ci_test_results
             ls -R .
 
             # Fix flakeguard binary path
@@ -325,7 +331,7 @@ jobs:
             echo "all_tests_count=$ALL_TESTS_COUNT" >> "$GITHUB_OUTPUT"
 
             # Use flakeguard to filter and output failed tests based on MaxPassRatio
-            flakeguard aggregate-results --filter-failed=true --max-pass-ratio=${{ inputs.maxPassRatio }} --results-path . --output-results ../failed_tests.json --output-logs ../failed_test_logs.json --project-path=${{ inputs.projectPath }} --codeowners-path=.github/CODEOWNERS
+            flakeguard aggregate-results --filter-failed=true --max-pass-ratio=${{ inputs.maxPassRatio }} --results-path . --output-results ../failed_tests.json --output-logs ../failed_test_logs.json --project-path=${{ inputs.projectPath }} --codeowners-path=${{ github.workspace }}/.github/CODEOWNERS
 
             # Count failed tests
             if [ -f "../failed_tests.json" ]; then

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -323,7 +323,7 @@ jobs:
             export PATH
 
             # Use flakeguard to aggregate all test results
-            flakeguard aggregate-results --results-path . --output-results ../all_tests.json
+            flakeguard aggregate-results --results-path . --output-results ../all_tests.json --project-path=${{ github.workspace }}/${{ inputs.projectPath }} --codeowners-path=${{ github.workspace }}/.github/CODEOWNERS
 
             # Count all tests
             ALL_TESTS_COUNT=$(jq '.Results | length' ../all_tests.json)
@@ -331,7 +331,7 @@ jobs:
             echo "all_tests_count=$ALL_TESTS_COUNT" >> "$GITHUB_OUTPUT"
 
             # Use flakeguard to filter and output failed tests based on MaxPassRatio
-            flakeguard aggregate-results --filter-failed=true --max-pass-ratio=${{ inputs.maxPassRatio }} --results-path . --output-results ../failed_tests.json --output-logs ../failed_test_logs.json --project-path=${{ inputs.projectPath }} --codeowners-path=${{ github.workspace }}/.github/CODEOWNERS
+            flakeguard aggregate-results --filter-failed=true --max-pass-ratio=${{ inputs.maxPassRatio }} --results-path . --output-results ../failed_tests.json --output-logs ../failed_test_logs.json --project-path=${{ github.workspace }}/${{ inputs.projectPath }} --codeowners-path=${{ github.workspace }}/.github/CODEOWNERS
 
             # Count failed tests
             if [ -f "../failed_tests.json" ]; then

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -342,7 +342,7 @@ jobs:
           fi   
 
       - name: Tests Summary
-        if: always()
+        if: ${{ fromJson(steps.set_test_results.outputs.all_tests_count) > 0 }}
         run: |
           FILE_SIZE=$(wc -c < all_tests.md)
                     echo "File size: $FILE_SIZE bytes"


### PR DESCRIPTION
This PR introduces a dedicated workflow for running "Flakeguard Nightly" on a scheduled basis.

Key changes:
- Added a new workflow specifically designed for nightly runs with explicit parameters tailored for scheduled execution.
- The “Flakeguard On Demand” workflow is now exclusively reserved for on-demand runs and will no longer be used for scheduled runs.

Note: `workflow_dispatch` defaults in the “Flakeguard On Demand” workflow cannot be used as parameters for scheduled jobs.
