### PR TITLE
core/services/relay/evm: fix TestChainComponents race

### DIFF
--- a/core/services/relay/evm/chain_components_test.go
+++ b/core/services/relay/evm/chain_components_test.go
@@ -273,7 +273,6 @@ func (h *helper) Backend() bind.ContractBackend {
 	if h.sim == nil {
 		h.sim = simulated.NewBackend(
 			evmtypes.GenesisAlloc{h.accounts[0].From: {Balance: big.NewInt(math.MaxInt64)}, h.accounts[1].From: {Balance: big.NewInt(math.MaxInt64)}}, simulated.WithBlockGasLimit(commonGasLimitOnEvms*5000))
-		cltest.Mine(h.sim, 1*time.Second)
 	}
 
 	return h.sim.Client()


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Read at 0x00c00154d740 by goroutine 5254:
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).sealBlock()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/eth/catalyst/simulated_beacon.go:153 +0x72
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).Commit()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/eth/catalyst/simulated_beacon.go:281 +0xfa
  github.com/ethereum/go-ethereum/ethclient/simulated.(*Backend).Commit()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/ethclient/simulated/backend.go:160 +0x52
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm_test.(*helper).Commit()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/chain_components_test.go:283 +0x1d
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting.(*EVMChainComponentsInterfaceTester[go.shape.*uint8]).deployNewContract()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/evmtesting/chain_components_interface_tester.go:467 +0x1c9
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting.(*EVMChainComponentsInterfaceTester[go.shape.*uint8]).deployNewContracts()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/evmtesting/chain_components_interface_tester.go:452 +0x158
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting.(*EVMChainComponentsInterfaceTester[go.shape.*uint8]).Setup()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/evmtesting/chain_components_interface_tester.go:103 +0x556
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting.(*EVMChainComponentsInterfaceTester[*testing.T]).Setup()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/evmtesting/chain_components_interface_tester.go:83 +0x44
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.RunTests[go.shape.*uint8].func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.1-0.20241125150608-97ceadb2072d/pkg/types/interfacetests/utils.go:62 +0x4c
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:[17](https://github.com/smartcontractkit/chainlink/actions/runs/12142456241/job/33856999219#step:17:18)43 +0x44

Previous write at 0x00c00154d740 by goroutine 939:
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).sealBlock()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/eth/catalyst/simulated_beacon.go:232 +0x14[18](https://github.com/smartcontractkit/chainlink/actions/runs/12142456241/job/33856999219#step:17:19)
  github.com/ethereum/go-ethereum/eth/catalyst.(*SimulatedBeacon).Commit()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/eth/catalyst/simulated_beacon.go:281 +0xfa
  github.com/ethereum/go-ethereum/ethclient/simulated.(*Backend).Commit()
      /home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.11/ethclient/simulated/backend.go:160 +0x49
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.Mine.func1()
      /home/runner/work/chainlink/chainlink/core/internal/cltest/simulated_backend.go:105 +0x241

Goroutine 5254 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x825
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.RunTests[go.shape.*uint8]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.1-0.[20](https://github.com/smartcontractkit/chainlink/actions/runs/12142456241/job/33856999219#step:17:21)241125150608-97ceadb2072d/pkg/types/interfacetests/utils.go:61 +0x26a
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.runContractReaderGetLatestValueInterfaceTests[go.shape.*uint8]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.1-0.20241125150608-97ceadb2072d/pkg/types/interfacetests/chain_components_interface_tests.go:443 +0xcea
  github.com/smartcontractkit/chainlink-common/pkg/types/interfacetests.RunContractReaderInterfaceTests[go.shape.*uint8].func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.3.1-0.20241125150608-97ceadb2072d/pkg/types/interfacetests/chain_components_interface_tests.go:103 +0x79
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44

Goroutine 939 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.Mine()
      /home/runner/work/chainlink/chainlink/core/internal/cltest/simulated_backend.go:100 +0x1e4
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm_test.(*helper).Backend()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/chain_components_test.go:276 +0x468
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm_test.(*helper).Init()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/chain_components_test.go:235 +0x105
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/evmtesting.(*EVMChainComponentsInterfaceTester[go.shape.*uint8]).Init()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/evmtesting/chain_components_interface_tester.go:479 +0x55
  github.com/smartcontractkit/chainlink/v2/core/services/relay/evm_test.TestChainComponents()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/chain_components_test.go:[21](https://github.com/smartcontractkit/chainlink/actions/runs/12142456241/job/33856999219#step:17:22)0 +0x149
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x[22](https://github.com/smartcontractkit/chainlink/actions/runs/12142456241/job/33856999219#step:17:23)6
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44
==================
```