### PR TITLE
Fixing cross compilation issue in CRIB

### DIFF
--- a/tools/bin/goreleaser_utils
+++ b/tools/bin/goreleaser_utils
@@ -27,8 +27,10 @@ before_hook() {
   # linux_arm64, rather than being suffixless on native platforms
   if [ "$GOARCH" = "arm64" ]; then
     if [ -d "$BIN_DIR/linux_arm64" ]; then
+      cp "$BIN_DIR/linux_arm64"/chainlink* "$PLUGIN_DIR"
+    elif [ -d "$BIN_DIR/linux_arm64_v8.0" ]; then
       cp "$BIN_DIR/linux_arm64_v8.0"/chainlink* "$PLUGIN_DIR"
-    else 
+    else
       cp "$BIN_DIR"/chainlink* "$PLUGIN_DIR"
     fi
     # Call patchelf --set-interpreter on all plugins


### PR DESCRIPTION
Cherry-picked the fix by @HenryNguyen5  from https://github.com/smartcontractkit/chainlink/pull/14326 into develop, so `devspace run core-kind` works again.

Part of https://smartcontract-it.atlassian.net/browse/CRIB-583