### PR TITLE
chore: add deployment automation team as code owner of the deployment…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -139,8 +139,7 @@ core/scripts/gateway @smartcontractkit/dev-services
 /integration-tests/**/*ccip* @smartcontractkit/ccip-offchain @smartcontractkit/core
 
 # Deployment tooling
-# Initially the common structures owned by CCIP
-/deployment @smartcontractkit/ccip @smartcontractkit/keystone @smartcontractkit/core
+/deployment @smartcontractkit/ccip @smartcontractkit/keystone @smartcontractkit/core @smartcontractkit/deployment-automation
 /deployment/ccip @smartcontractkit/ccip @smartcontractkit/core
 /deployment/keystone @smartcontractkit/keystone @smartcontractkit/core
 # TODO: As more products add their deployment logic here, add the team as an owner


### PR DESCRIPTION
Adds Deployment Automation team as code owners of the chainlink deployments `deploment/` module
