### PR TITLE
fix: typo for contracts changeset validation

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -182,7 +182,7 @@ jobs:
               - added|modified: 'contracts/.changeset/*.md'
 
       - name: Setup node
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/setup-nodejs
         if: ${{ steps.files-changed.outputs.contracts-changeset == 'true' }}
       
       - name: Validate changeset files


### PR DESCRIPTION
Fix pathing to `setup-nodejs` action for contracts changesets.

- https://github.com/smartcontractkit/chainlink/pull/15468
- RE-3165
