### PR TITLE
Increase default timeout of remote Executable requests

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -398,7 +398,8 @@ func (w *launcher) addToRegistryAndSetDispatcher(ctx context.Context, capability
 }
 
 var (
-	defaultTargetRequestTimeout = time.Minute
+	// TODO: make this configurable
+	defaultTargetRequestTimeout = 8 * time.Minute
 )
 
 func (w *launcher) exposeCapabilities(ctx context.Context, myPeerID p2ptypes.PeerID, don registrysyncer.DON, state *registrysyncer.LocalRegistry, remoteWorkflowDONs []registrysyncer.DON) error {

--- a/core/capabilities/remote/executable/endtoend_test.go
+++ b/core/capabilities/remote/executable/endtoend_test.go
@@ -102,7 +102,7 @@ func Test_RemoteExecutableCapability_RandomCapabilityError(t *testing.T) {
 
 	methods = append(methods, func(ctx context.Context, caller commoncap.ExecutableCapability) {
 		executeCapability(ctx, t, caller, transmissionSchedule, func(t *testing.T, responseCh commoncap.CapabilityResponse, responseError error) {
-			assert.Equal(t, "error executing request: request expired", responseError.Error())
+			assert.Equal(t, "error executing request: request expired by executable client", responseError.Error())
 		})
 	})
 


### PR DESCRIPTION
Remote Target executions are based on _deltaStage_ parameter specified in the workflow spec.
Target capability nodes (e.g. chain writers) are invoked one-by-one with deltaStage seconds between invocations.

This timeout is the maximum total time all target invocations can take.
For example, with the old one minute setting, and a workflow using deltaStage=45sec, the invocations will look as follows:
1. First writer called at 0:00
2. Second writer called at 0:45
3. Timeout at 1:00

Workflow Engine requires F+1 target executions to complete successfully. When F=5, and timeout set to 1 min, it never has a chance to do so. 

Bumping to a larger value, which is closer to max workflow execution time (10 mins). Should give us plenty of headroom for DONs with F=5 and deltaStage up to 1 min.