### PR TITLE
Executable capability registration logic update to match that of trigger capability plus expand test suite to test behaviour

### DIFF
--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -76,7 +76,6 @@ func Test_Client_DonTopologies(t *testing.T) {
 
 	testClient(t, remoteExecutableConfig, 10, responseTimeOut, 10, 9,
 		capability, method)
-
 }
 
 func Test_Client_TransmissionSchedules(t *testing.T) {
@@ -176,8 +175,8 @@ func Test_Client_ContextCanceledBeforeQuorumReached(t *testing.T) {
 	require.NoError(t, err)
 
 	cancel()
-	testClient(t, 2, 20*time.Second, 2, 2,
-		capability,
+	testClient(t, &commoncap.RemoteExecutableConfig{}, 2, 20*time.Second, 2, 2,
+		func() commoncap.ExecutableCapability { return capability },
 		func(caller commoncap.ExecutableCapability) {
 			executeInputs, err := values.NewMap(map[string]any{"executeValue1": "aValue1"})
 			require.NoError(t, err)
@@ -392,7 +391,6 @@ type clientTestServer struct {
 func newTestServer(lggr logger.Logger, peerID p2ptypes.PeerID, capInfo commoncap.CapabilityInfo,
 	registrationExpiry time.Duration, dispatcher remotetypes.Dispatcher, workflowDonInfo commoncap.DON,
 	executableCapability commoncap.ExecutableCapability) *clientTestServer {
-
 	target := &executable.TargetAdapter{Capability: executableCapability}
 
 	workflowDONs := map[uint32]commoncap.DON{

--- a/core/capabilities/remote/executable/endtoend_test.go
+++ b/core/capabilities/remote/executable/endtoend_test.go
@@ -514,7 +514,6 @@ func setupDons(t *testing.T,
 
 	wfDon := newWorkflowDon(broker)
 	for i := 0; i < numWorkflowPeers; i++ {
-
 		node := newClientNode(workflowPeers[i], broker, remoteExecutableConfig, capInfo, capDonInfo, workflowDonInfo, workflowNodeTimeout, lggr)
 		wfDon.AddNode(node)
 		servicetest.Run(t, node)

--- a/core/capabilities/remote/executable/endtoend_test.go
+++ b/core/capabilities/remote/executable/endtoend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -25,6 +26,346 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
+
+func Test_RemoteExecutionCapability_DonTopologies(t *testing.T) {
+	ctx := testutils.Context(t)
+
+	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
+		require.NoError(t, responseError)
+		mp, err := response.Value.Unwrap()
+		require.NoError(t, err)
+		assert.Equal(t, "aValue1", mp.(map[string]any)["response"].(string))
+	}
+
+	transmissionSchedule, err := values.NewMap(map[string]any{
+		"schedule":   transmission.Schedule_OneAtATime,
+		"deltaStage": "10ms",
+	})
+	require.NoError(t, err)
+
+	timeOut := 10 * time.Minute
+
+	capability := &TestCapability{}
+
+	var methods []func(ctx context.Context, caller commoncap.ExecutableCapability)
+
+	methods = append(methods, func(ctx context.Context, caller commoncap.ExecutableCapability) {
+		executeCapability(ctx, t, caller, transmissionSchedule, responseTest)
+	})
+
+	capabilityFactory := func() commoncap.ExecutableCapability { return capability }
+	remoteExecutableConfig := &commoncap.RemoteExecutableConfig{}
+
+	for _, method := range methods {
+		// Test scenarios where the number of submissions is greater than or equal to F + 1
+		wfDon, _ := setupDons(t, remoteExecutableConfig, capabilityFactory, 1, 0, timeOut, 1, 0, timeOut)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
+
+		wfDon, _ = setupDons(t, remoteExecutableConfig, capabilityFactory, 4, 3, timeOut, 1, 0, timeOut)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
+		wfDon, _ = setupDons(t, remoteExecutableConfig, capabilityFactory, 10, 3, timeOut, 1, 0, timeOut)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
+
+		wfDon, _ = setupDons(t, remoteExecutableConfig, capabilityFactory, 1, 0, timeOut, 1, 0, timeOut)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
+		wfDon, _ = setupDons(t, remoteExecutableConfig, capabilityFactory, 1, 0, timeOut, 4, 3, timeOut)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
+		wfDon, _ = setupDons(t, remoteExecutableConfig, capabilityFactory, 1, 0, timeOut, 10, 3, timeOut)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
+
+		wfDon, _ = setupDons(t, remoteExecutableConfig, capabilityFactory, 4, 3, timeOut, 4, 3, timeOut)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
+		wfDon, _ = setupDons(t, remoteExecutableConfig, capabilityFactory, 10, 3, timeOut, 10, 3, timeOut)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
+		wfDon, _ = setupDons(t, remoteExecutableConfig, capabilityFactory, 10, 9, timeOut, 10, 9, timeOut)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
+	}
+}
+
+func Test_RemoteExecutionCapability_RegisterAndUnregisterWorkflow(t *testing.T) {
+	ctx := testutils.Context(t)
+
+	timeOut := 10 * time.Minute
+
+	remoteExecutableConfig := &commoncap.RemoteExecutableConfig{
+		RequestHashExcludedAttributes: []string{},
+		RegistrationRefresh:           100 * time.Millisecond,
+		RegistrationExpiry:            1 * time.Second,
+	}
+
+	var serverSideCapabilities []commoncap.ExecutableCapability
+
+	wfDon, _ := setupDons(t, remoteExecutableConfig, func() commoncap.ExecutableCapability {
+		testCapability := &TestCapability{}
+		serverSideCapabilities = append(serverSideCapabilities, testCapability)
+		return testCapability
+	}, 4, 1, timeOut, 4, 1, timeOut)
+
+	registerRequest := commoncap.RegisterToWorkflowRequest{
+		Metadata: commoncap.RegistrationMetadata{
+			WorkflowID:    workflowID1,
+			ReferenceID:   stepReferenceID1,
+			WorkflowOwner: workflowOwnerID,
+		},
+	}
+
+	unregisterRequest := commoncap.UnregisterFromWorkflowRequest{
+		Metadata: commoncap.RegistrationMetadata{
+			WorkflowID:    workflowID1,
+			ReferenceID:   stepReferenceID1,
+			WorkflowOwner: workflowOwnerID,
+		},
+	}
+
+	workflowNodes := wfDon.GetNodes()
+
+	// Call RegisterToWorkflow on 2 clients
+	err := workflowNodes[0].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+	err = workflowNodes[1].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+
+	// wait a couple of refresh intervals
+	time.Sleep(2 * remoteExecutableConfig.RegistrationRefresh)
+
+	// Should have no registrations on any server side capabilities
+	for _, capability := range serverSideCapabilities {
+		assert.Empty(t, capability.(*TestCapability).GetRegisterRequests())
+	}
+
+	// Subscribe the remaining 2 clients to the same workflow
+	err = workflowNodes[2].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+	err = workflowNodes[3].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+
+	// Should eventually have 1 registration on each server side capability
+	for _, capability := range serverSideCapabilities {
+		require.Eventually(t, func() bool {
+			return len(capability.(*TestCapability).GetRegisterRequests()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+
+	// Unregister a client (leaving f+1 clients registered)
+	err = workflowNodes[0].UnregisterFromWorkflow(ctx, unregisterRequest)
+	require.NoError(t, err)
+
+	// wait a couple of expiry intervals
+	time.Sleep(2 * remoteExecutableConfig.RegistrationExpiry)
+
+	// Should have no unregistration requests on any server side capabilities
+	for _, capability := range serverSideCapabilities {
+		assert.Empty(t, capability.(*TestCapability).GetUnregisterRequests())
+	}
+
+	// Unregister another client (leaving less than f+1 clients registered)
+	err = workflowNodes[1].UnregisterFromWorkflow(ctx, unregisterRequest)
+	require.NoError(t, err)
+
+	// Should eventually have 1 unregistration on each server side capability
+	for _, capability := range serverSideCapabilities {
+		require.Eventually(t, func() bool {
+			return len(capability.(*TestCapability).GetUnregisterRequests()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+
+	// Unregister the remaining clients
+	err = workflowNodes[2].UnregisterFromWorkflow(ctx, unregisterRequest)
+	require.NoError(t, err)
+	err = workflowNodes[3].UnregisterFromWorkflow(ctx, unregisterRequest)
+	require.NoError(t, err)
+
+	// wait a couple of expiry intervals
+	time.Sleep(2 * remoteExecutableConfig.RegistrationExpiry)
+
+	// confirm there is still only 1 unregister request on each server side capability
+	for _, capability := range serverSideCapabilities {
+		assert.Len(t, capability.(*TestCapability).GetUnregisterRequests(), 1)
+	}
+
+	// re-register all the clients
+	for i := 0; i < len(workflowNodes); i++ {
+		err = workflowNodes[i].RegisterToWorkflow(ctx, registerRequest)
+		require.NoError(t, err)
+	}
+
+	// Should eventually have 2 registration requests on each server side capability
+	for _, capability := range serverSideCapabilities {
+		require.Eventually(t, func() bool {
+			return len(capability.(*TestCapability).GetRegisterRequests()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+}
+
+func Test_RemoteExecutionCapability_RegisterAndUnregister_CapabilityNodeRestart(t *testing.T) {
+	ctx := testutils.Context(t)
+
+	timeOut := 10 * time.Minute
+
+	remoteExecutableConfig := &commoncap.RemoteExecutableConfig{
+		RequestHashExcludedAttributes: []string{},
+		RegistrationRefresh:           100 * time.Millisecond,
+		RegistrationExpiry:            1 * time.Second,
+	}
+
+	wfDon, capDon := setupDons(t, remoteExecutableConfig, func() commoncap.ExecutableCapability {
+		testCapability := &TestCapability{}
+		return testCapability
+	}, 4, 1, timeOut, 4, 1, timeOut)
+
+	registerRequest := commoncap.RegisterToWorkflowRequest{
+		Metadata: commoncap.RegistrationMetadata{
+			WorkflowID:    workflowID1,
+			ReferenceID:   stepReferenceID1,
+			WorkflowOwner: workflowOwnerID,
+		},
+	}
+
+	workflowNodes := wfDon.GetNodes()
+
+	// Call RegisterToWorkflow on all clients
+	err := workflowNodes[0].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+	err = workflowNodes[1].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+	err = workflowNodes[2].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+	err = workflowNodes[3].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+
+	// Should eventually have 1 registration on each server side capability
+	for _, node := range capDon.GetNodes() {
+		require.Eventually(t, func() bool {
+			return len(node.GetUnderlyingCapability().(*TestCapability).GetRegisterRequests()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+
+	// Stop a single capability node
+	capNodes := capDon.GetNodes()
+	err = capNodes[0].Close()
+	require.NoError(t, err)
+
+	// Verify still have 1 registration on each server side capability
+	for _, node := range capNodes {
+		require.Eventually(t, func() bool {
+			return len(node.GetUnderlyingCapability().(*TestCapability).GetRegisterRequests()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+
+	// Restart the stopped capability node
+	err = capNodes[0].Start(ctx)
+	require.NoError(t, err)
+
+	// The restarted nodes capability should eventually have 2 registrations, the latter one corresponding to the re-registration after restart
+	require.Eventually(t, func() bool {
+		return len(capNodes[0].GetUnderlyingCapability().(*TestCapability).GetRegisterRequests()) == 2
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func Test_RemoteExecutionCapability_RegisterAndUnregister_WorkflowNodeRestart(t *testing.T) {
+	ctx := testutils.Context(t)
+
+	timeOut := 10 * time.Minute
+
+	remoteExecutableConfig := &commoncap.RemoteExecutableConfig{
+		RequestHashExcludedAttributes: []string{},
+		RegistrationRefresh:           100 * time.Millisecond,
+		RegistrationExpiry:            1 * time.Second,
+	}
+
+	wfDon, capDon := setupDons(t, remoteExecutableConfig, func() commoncap.ExecutableCapability {
+		testCapability := &TestCapability{}
+		return testCapability
+	}, 4, 1, timeOut, 4, 1, timeOut)
+
+	registerRequest := commoncap.RegisterToWorkflowRequest{
+		Metadata: commoncap.RegistrationMetadata{
+			WorkflowID:    workflowID1,
+			ReferenceID:   stepReferenceID1,
+			WorkflowOwner: workflowOwnerID,
+		},
+	}
+
+	workflowNodes := wfDon.GetNodes()
+
+	// Call RegisterToWorkflow on all clients
+	err := workflowNodes[0].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+	err = workflowNodes[1].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+	err = workflowNodes[2].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+	err = workflowNodes[3].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+
+	// Should eventually have 1 registration on each server side capability
+	for _, node := range capDon.GetNodes() {
+		require.Eventually(t, func() bool {
+			return len(node.GetUnderlyingCapability().(*TestCapability).GetRegisterRequests()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+
+	// Stop a single workflow node
+	wfNodes := wfDon.GetNodes()
+	err = wfNodes[0].Close()
+	require.NoError(t, err)
+
+	// sleep for a couple of registration expiry intervals
+	time.Sleep(2 * remoteExecutableConfig.RegistrationExpiry)
+
+	// Verify no unregister requests on any capability nodes
+	for _, node := range capDon.GetNodes() {
+		require.Eventually(t, func() bool {
+			return len(node.GetUnderlyingCapability().(*TestCapability).GetUnregisterRequests()) == 0
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+
+	// Restart the stopped workflow node
+	err = wfNodes[0].Start(ctx)
+	require.NoError(t, err)
+
+	// sleep for a couple of refresh intervals
+	time.Sleep(2 * remoteExecutableConfig.RegistrationRefresh)
+
+	// Verify still have 1 registration on each server side capability
+	for _, node := range capDon.GetNodes() {
+		require.Eventually(t, func() bool {
+			return len(node.GetUnderlyingCapability().(*TestCapability).GetRegisterRequests()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+
+	// Stop 2 of the workflow nodes
+	err = wfNodes[1].Close()
+	require.NoError(t, err)
+	err = wfNodes[2].Close()
+	require.NoError(t, err)
+
+	// Eventually all capability nodes should have 1 unregister request
+	for _, node := range capDon.GetNodes() {
+		require.Eventually(t, func() bool {
+			return len(node.GetUnderlyingCapability().(*TestCapability).GetUnregisterRequests()) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+
+	// Restart the stopped workflow nodes and register to workflow
+	err = wfNodes[1].Start(ctx)
+	require.NoError(t, err)
+	err = wfNodes[2].Start(ctx)
+	require.NoError(t, err)
+
+	err = workflowNodes[1].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+	err = workflowNodes[2].RegisterToWorkflow(ctx, registerRequest)
+	require.NoError(t, err)
+
+	// Eventually all capability nodes show have 2 register requests, the latter one corresponding to the re-registration
+	// after restart of the workflow nodes
+	for _, node := range capDon.GetNodes() {
+		require.Eventually(t, func() bool {
+			return len(node.GetUnderlyingCapability().(*TestCapability).GetRegisterRequests()) == 2
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+}
 
 func Test_RemoteExecutableCapability_TransmissionSchedules(t *testing.T) {
 	ctx := testutils.Context(t)
@@ -49,7 +390,8 @@ func Test_RemoteExecutableCapability_TransmissionSchedules(t *testing.T) {
 	method := func(ctx context.Context, caller commoncap.ExecutableCapability) {
 		executeCapability(ctx, t, caller, transmissionSchedule, responseTest)
 	}
-	testRemoteExecutableCapability(ctx, t, capability, 10, 9, timeOut, 10, 9, timeOut, method)
+	wfDon, _ := setupDons(t, &commoncap.RemoteExecutableConfig{}, func() commoncap.ExecutableCapability { return capability }, 10, 9, timeOut, 10, 9, timeOut)
+	wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
 
 	transmissionSchedule, err = values.NewMap(map[string]any{
 		"schedule":   transmission.Schedule_AllAtOnce,
@@ -60,7 +402,8 @@ func Test_RemoteExecutableCapability_TransmissionSchedules(t *testing.T) {
 		executeCapability(ctx, t, caller, transmissionSchedule, responseTest)
 	}
 
-	testRemoteExecutableCapability(ctx, t, capability, 10, 9, timeOut, 10, 9, timeOut, method)
+	wfDon, _ = setupDons(t, &commoncap.RemoteExecutableConfig{}, func() commoncap.ExecutableCapability { return capability }, 10, 9, timeOut, 10, 9, timeOut)
+	wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
 }
 
 func Test_RemoteExecutionCapability_CapabilityError(t *testing.T) {
@@ -83,7 +426,8 @@ func Test_RemoteExecutionCapability_CapabilityError(t *testing.T) {
 	})
 
 	for _, method := range methods {
-		testRemoteExecutableCapability(ctx, t, capability, 10, 9, 10*time.Minute, 10, 9, 10*time.Minute, method)
+		wfDon, _ := setupDons(t, &commoncap.RemoteExecutableConfig{}, func() commoncap.ExecutableCapability { return capability }, 10, 9, 10*time.Minute, 10, 9, 10*time.Minute)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
 	}
 }
 
@@ -107,14 +451,15 @@ func Test_RemoteExecutableCapability_RandomCapabilityError(t *testing.T) {
 	})
 
 	for _, method := range methods {
-		testRemoteExecutableCapability(ctx, t, capability, 10, 9, 1*time.Second, 10, 9, 10*time.Minute,
-			method)
+		wfDon, _ := setupDons(t, &commoncap.RemoteExecutableConfig{}, func() commoncap.ExecutableCapability { return capability }, 10, 9, 1*time.Second, 10, 9, 10*time.Minute)
+		wfDon.ExecuteMethodInParallelOnAllNodes(ctx, method)
 	}
 }
 
-func testRemoteExecutableCapability(ctx context.Context, t *testing.T, underlying commoncap.ExecutableCapability, numWorkflowPeers int, workflowDonF uint8, workflowNodeTimeout time.Duration,
-	numCapabilityPeers int, capabilityDonF uint8, capabilityNodeResponseTimeout time.Duration,
-	method func(ctx context.Context, caller commoncap.ExecutableCapability)) {
+func setupDons(t *testing.T,
+	remoteExecutableConfig *commoncap.RemoteExecutableConfig,
+	capabilityFactory func() commoncap.ExecutableCapability, numWorkflowPeers int, workflowDonF uint8, workflowNodeTimeout time.Duration,
+	numCapabilityPeers int, capabilityDonF uint8, capabilityNodeResponseTimeout time.Duration) (*workflowDon, *capabilityDon) {
 	lggr := logger.TestLogger(t)
 
 	capabilityPeers := make([]p2ptypes.PeerID, numCapabilityPeers)
@@ -154,44 +499,250 @@ func testRemoteExecutableCapability(ctx context.Context, t *testing.T, underlyin
 	}
 
 	broker := newTestAsyncMessageBroker(t, 1000)
+	servicetest.Run(t, broker)
 
 	workflowDONs := map[uint32]commoncap.DON{
 		workflowDonInfo.ID: workflowDonInfo,
 	}
 
-	capabilityNodes := make([]remotetypes.Receiver, numCapabilityPeers)
+	capDon := newCapabilityDon()
 	for i := 0; i < numCapabilityPeers; i++ {
-		capabilityPeer := capabilityPeers[i]
-		capabilityDispatcher := broker.NewDispatcherForNode(capabilityPeer)
-		capabilityNode := executable.NewServer(&commoncap.RemoteExecutableConfig{RequestHashExcludedAttributes: []string{}}, capabilityPeer, underlying, capInfo, capDonInfo, workflowDONs, capabilityDispatcher,
-			capabilityNodeResponseTimeout, lggr)
-		servicetest.Run(t, capabilityNode)
-		broker.RegisterReceiverNode(capabilityPeer, capabilityNode)
-		capabilityNodes[i] = capabilityNode
+		node := newServerNode(capabilityPeers[i], broker, remoteExecutableConfig, capabilityFactory(), capInfo, capDonInfo, workflowDONs, capabilityNodeResponseTimeout, lggr)
+		capDon.AddNode(node)
+		servicetest.Run(t, node)
 	}
 
-	workflowNodes := make([]commoncap.ExecutableCapability, numWorkflowPeers)
+	wfDon := newWorkflowDon(broker)
 	for i := 0; i < numWorkflowPeers; i++ {
-		workflowPeerDispatcher := broker.NewDispatcherForNode(workflowPeers[i])
-		workflowNode := executable.NewClient(capInfo, workflowDonInfo, workflowPeerDispatcher, workflowNodeTimeout, lggr)
-		servicetest.Run(t, workflowNode)
-		broker.RegisterReceiverNode(workflowPeers[i], workflowNode)
-		workflowNodes[i] = workflowNode
+
+		node := newClientNode(workflowPeers[i], broker, remoteExecutableConfig, capInfo, capDonInfo, workflowDonInfo, workflowNodeTimeout, lggr)
+		wfDon.AddNode(node)
+		servicetest.Run(t, node)
 	}
 
-	servicetest.Run(t, broker)
+	return wfDon, capDon
+}
 
+type workflowNode interface {
+	commoncap.ExecutableCapability
+	Start(ctx context.Context) error
+	Close() error
+}
+
+type client interface {
+	remotetypes.Receiver
+	commoncap.ExecutableCapability
+	Start(ctx context.Context) error
+	Close() error
+}
+
+type clientNode struct {
+	client     client
+	nodePeerID p2ptypes.PeerID
+	broker     *testAsyncMessageBroker
+
+	remoteExecutableConfig *commoncap.RemoteExecutableConfig
+	remoteCapabilityInfo   commoncap.CapabilityInfo
+	remoteDonInfo          commoncap.DON
+	localDonInfo           commoncap.DON
+	requestTimeout         time.Duration
+	mux                    sync.Mutex
+	running                bool
+	lggr                   logger.Logger
+}
+
+func newClientNode(nodePeerID p2ptypes.PeerID, broker *testAsyncMessageBroker, remoteExecutableConfig *commoncap.RemoteExecutableConfig,
+	remoteCapabilityInfo commoncap.CapabilityInfo,
+	remoteDonInfo commoncap.DON,
+	localDonInfo commoncap.DON,
+	requestTimeout time.Duration,
+	lggr logger.Logger) *clientNode {
+	return &clientNode{
+		nodePeerID:             nodePeerID,
+		broker:                 broker,
+		remoteExecutableConfig: remoteExecutableConfig,
+		remoteCapabilityInfo:   remoteCapabilityInfo,
+		remoteDonInfo:          remoteDonInfo,
+		localDonInfo:           localDonInfo,
+		requestTimeout:         requestTimeout,
+		lggr:                   lggr,
+	}
+}
+
+func (w *clientNode) Start(ctx context.Context) error {
+	w.mux.Lock()
+	defer w.mux.Unlock()
+	if !w.running {
+		w.client = executable.NewClient(w.remoteExecutableConfig, w.remoteCapabilityInfo, w.remoteDonInfo, w.localDonInfo, w.broker.NewDispatcherForNode(w.nodePeerID), w.requestTimeout, w.lggr)
+		w.broker.RegisterReceiverNode(w.nodePeerID, w.client)
+		if err := w.client.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start client: %w", err)
+		}
+		w.running = true
+	}
+
+	return nil
+}
+
+func (w *clientNode) Close() error {
+	w.mux.Lock()
+	defer w.mux.Unlock()
+	if w.running {
+		w.broker.RemoveReceiverNode(w.nodePeerID)
+		if err := w.client.Close(); err != nil {
+			return fmt.Errorf("failed to close client: %w", err)
+		}
+		w.running = false
+	}
+
+	return nil
+}
+
+func (w *clientNode) Execute(ctx context.Context, request commoncap.CapabilityRequest) (commoncap.CapabilityResponse, error) {
+	return w.client.Execute(ctx, request)
+}
+
+func (w *clientNode) RegisterToWorkflow(ctx context.Context, request commoncap.RegisterToWorkflowRequest) error {
+	return w.client.RegisterToWorkflow(ctx, request)
+}
+
+func (w *clientNode) UnregisterFromWorkflow(ctx context.Context, request commoncap.UnregisterFromWorkflowRequest) error {
+	return w.client.UnregisterFromWorkflow(ctx, request)
+}
+
+func (w *clientNode) Info(ctx context.Context) (commoncap.CapabilityInfo, error) {
+	return w.client.Info(ctx)
+}
+
+type workflowDon struct {
+	nodes []workflowNode
+}
+
+func newWorkflowDon(broker *testAsyncMessageBroker) *workflowDon {
+	return &workflowDon{
+		nodes: make([]workflowNode, 0),
+	}
+}
+
+func (w *workflowDon) ExecuteMethodInParallelOnAllNodes(ctx context.Context, method func(ctx context.Context, caller commoncap.ExecutableCapability)) {
 	wg := &sync.WaitGroup{}
-	wg.Add(len(workflowNodes))
+	wg.Add(len(w.nodes))
 
-	for _, caller := range workflowNodes {
+	for _, node := range w.nodes {
 		go func(caller commoncap.ExecutableCapability) {
 			defer wg.Done()
 			method(ctx, caller)
-		}(caller)
+		}(node)
 	}
 
 	wg.Wait()
+}
+
+func (w *workflowDon) AddNode(wfNode workflowNode) {
+	w.nodes = append(w.nodes, wfNode)
+}
+
+func (w *workflowDon) GetNodes() []workflowNode {
+	return w.nodes
+}
+
+type server interface {
+	remotetypes.Receiver
+	Start(ctx context.Context) error
+	Close() error
+}
+
+type serverNode struct {
+	server     server
+	nodePeerID p2ptypes.PeerID
+	broker     *testAsyncMessageBroker
+
+	remoteExecutableConfig *commoncap.RemoteExecutableConfig
+	underlying             commoncap.ExecutableCapability
+	capInfo                commoncap.CapabilityInfo
+	localDonInfo           commoncap.DON
+	workflowDONs           map[uint32]commoncap.DON
+	requestTimeout         time.Duration
+	mux                    sync.Mutex
+	running                bool
+	lggr                   logger.Logger
+}
+
+func newServerNode(nodePeerID p2ptypes.PeerID, broker *testAsyncMessageBroker, remoteExecutableConfig *commoncap.RemoteExecutableConfig,
+	underlying commoncap.ExecutableCapability,
+	capInfo commoncap.CapabilityInfo,
+	localDonInfo commoncap.DON,
+	workflowDONs map[uint32]commoncap.DON,
+	requestTimeout time.Duration,
+	lggr logger.Logger) *serverNode {
+	return &serverNode{
+		nodePeerID:             nodePeerID,
+		broker:                 broker,
+		remoteExecutableConfig: remoteExecutableConfig,
+		underlying:             underlying,
+		capInfo:                capInfo,
+		localDonInfo:           localDonInfo,
+		workflowDONs:           workflowDONs,
+		requestTimeout:         requestTimeout,
+		lggr:                   lggr,
+	}
+}
+
+func (w *serverNode) GetUnderlyingCapability() commoncap.ExecutableCapability {
+	return w.underlying
+}
+
+func (w *serverNode) Start(ctx context.Context) error {
+	w.mux.Lock()
+	defer w.mux.Unlock()
+	if !w.running {
+		w.server = executable.NewServer(w.remoteExecutableConfig, w.nodePeerID, w.underlying, w.capInfo, w.localDonInfo, w.workflowDONs, w.broker.NewDispatcherForNode(w.nodePeerID),
+			w.requestTimeout, w.lggr)
+		w.broker.RegisterReceiverNode(w.nodePeerID, w.server)
+		if err := w.server.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start server: %w", err)
+		}
+		w.running = true
+	}
+	return nil
+}
+
+func (w *serverNode) Close() error {
+	w.mux.Lock()
+	defer w.mux.Unlock()
+	if w.running {
+		w.broker.RemoveReceiverNode(w.nodePeerID)
+		if err := w.server.Close(); err != nil {
+			return fmt.Errorf("failed to close server: %w", err)
+		}
+		w.running = false
+	}
+
+	return nil
+}
+
+type capabilityNode interface {
+	Start(ctx context.Context) error
+	Close() error
+	GetUnderlyingCapability() commoncap.ExecutableCapability
+}
+
+type capabilityDon struct {
+	nodes []capabilityNode
+}
+
+func newCapabilityDon() *capabilityDon {
+	return &capabilityDon{
+		nodes: make([]capabilityNode, 0),
+	}
+}
+
+func (c *capabilityDon) AddNode(node capabilityNode) {
+	c.nodes = append(c.nodes, node)
+}
+
+func (c *capabilityDon) GetNodes() []capabilityNode {
+	return c.nodes
 }
 
 type testAsyncMessageBroker struct {
@@ -199,8 +750,8 @@ type testAsyncMessageBroker struct {
 	eng *services.Engine
 	t   *testing.T
 
-	nodes map[p2ptypes.PeerID]remotetypes.Receiver
-
+	mux    sync.Mutex
+	nodes  map[p2ptypes.PeerID]remotetypes.Receiver
 	sendCh chan *remotetypes.MessageBody
 }
 
@@ -226,12 +777,14 @@ func (a *testAsyncMessageBroker) start(ctx context.Context) error {
 			case msg := <-a.sendCh:
 				receiverID := toPeerID(msg.Receiver)
 
-				receiver, ok := a.nodes[receiverID]
-				if !ok {
-					panic("server not found for peer id")
-				}
+				var receiver remotetypes.Receiver
+				a.mux.Lock()
+				receiver = a.nodes[receiverID]
+				a.mux.Unlock()
 
-				receiver.Receive(tests.Context(a.t), msg)
+				if receiver != nil {
+					receiver.Receive(tests.Context(a.t), msg)
+				}
 			}
 		}
 	})
@@ -246,11 +799,19 @@ func (a *testAsyncMessageBroker) NewDispatcherForNode(nodePeerID p2ptypes.PeerID
 }
 
 func (a *testAsyncMessageBroker) RegisterReceiverNode(nodePeerID p2ptypes.PeerID, node remotetypes.Receiver) {
+	a.mux.Lock()
+	defer a.mux.Unlock()
 	if _, ok := a.nodes[nodePeerID]; ok {
 		panic("node already registered")
 	}
 
 	a.nodes[nodePeerID] = node
+}
+
+func (a *testAsyncMessageBroker) RemoveReceiverNode(nodePeerID p2ptypes.PeerID) {
+	a.mux.Lock()
+	defer a.mux.Unlock()
+	delete(a.nodes, nodePeerID)
 }
 
 func (a *testAsyncMessageBroker) Send(msg *remotetypes.MessageBody) {
@@ -311,19 +872,14 @@ func (t abstractTestCapability) Info(ctx context.Context) (commoncap.CapabilityI
 	return commoncap.CapabilityInfo{}, nil
 }
 
-func (t abstractTestCapability) RegisterToWorkflow(ctx context.Context, request commoncap.RegisterToWorkflowRequest) error {
-	return nil
-}
-
-func (t abstractTestCapability) UnregisterFromWorkflow(ctx context.Context, request commoncap.UnregisterFromWorkflowRequest) error {
-	return nil
-}
-
 type TestCapability struct {
 	abstractTestCapability
+	registerRequests   []commoncap.RegisterToWorkflowRequest
+	unregisterRequests []commoncap.UnregisterFromWorkflowRequest
+	mu                 sync.Mutex
 }
 
-func (t TestCapability) Execute(ctx context.Context, request commoncap.CapabilityRequest) (commoncap.CapabilityResponse, error) {
+func (t *TestCapability) Execute(ctx context.Context, request commoncap.CapabilityRequest) (commoncap.CapabilityResponse, error) {
 	value := request.Inputs.Underlying["executeValue1"]
 	response, err := values.NewMap(map[string]any{"response": value})
 	if err != nil {
@@ -334,20 +890,67 @@ func (t TestCapability) Execute(ctx context.Context, request commoncap.Capabilit
 	}, nil
 }
 
-type TestErrorCapability struct {
-	abstractTestCapability
+func (t *TestCapability) RegisterToWorkflow(ctx context.Context, request commoncap.RegisterToWorkflowRequest) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.registerRequests = append(t.registerRequests, request)
+	return nil
 }
 
-func (t TestErrorCapability) Execute(ctx context.Context, request commoncap.CapabilityRequest) (commoncap.CapabilityResponse, error) {
+func (t *TestCapability) UnregisterFromWorkflow(ctx context.Context, request commoncap.UnregisterFromWorkflowRequest) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.unregisterRequests = append(t.unregisterRequests, request)
+	return nil
+}
+
+func (t *TestCapability) GetRegisterRequests() []commoncap.RegisterToWorkflowRequest {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.registerRequests
+}
+
+func (t *TestCapability) GetUnregisterRequests() []commoncap.UnregisterFromWorkflowRequest {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.unregisterRequests
+}
+
+type TestErrorCapability struct {
+	abstractTestCapability
+	registerRequests   []commoncap.RegisterToWorkflowRequest
+	unregisterRequests []commoncap.UnregisterFromWorkflowRequest
+	mu                 sync.Mutex
+}
+
+func (t *TestErrorCapability) Execute(ctx context.Context, request commoncap.CapabilityRequest) (commoncap.CapabilityResponse, error) {
 	return commoncap.CapabilityResponse{}, errors.New("an error")
 }
 
-func (t TestErrorCapability) RegisterToWorkflow(ctx context.Context, request commoncap.RegisterToWorkflowRequest) error {
-	return errors.New("an error")
+func (t *TestErrorCapability) RegisterToWorkflow(ctx context.Context, request commoncap.RegisterToWorkflowRequest) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.registerRequests = append(t.registerRequests, request)
+	return nil
 }
 
-func (t TestErrorCapability) UnregisterFromWorkflow(ctx context.Context, request commoncap.UnregisterFromWorkflowRequest) error {
-	return errors.New("an error")
+func (t *TestErrorCapability) UnregisterFromWorkflow(ctx context.Context, request commoncap.UnregisterFromWorkflowRequest) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.unregisterRequests = append(t.unregisterRequests, request)
+	return nil
+}
+
+func (t *TestErrorCapability) GetRegisterRequests() []commoncap.RegisterToWorkflowRequest {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.registerRequests
+}
+
+func (t *TestErrorCapability) GetUnregisterRequests() []commoncap.UnregisterFromWorkflowRequest {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.unregisterRequests
 }
 
 type TestRandomErrorCapability struct {

--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -398,7 +398,6 @@ func newServerTestClient(lggr logger.Logger, peerID p2ptypes.PeerID, registratio
 	capabilityDonInfo commoncap.DON,
 	workflowDonInfo commoncap.DON,
 	dispatcher remotetypes.Dispatcher) *serverTestClient {
-
 	registrationClient := registration.NewClient(lggr, remotetypes.MethodRegisterToWorkflow, registrationRefresh, capInfo, capabilityDonInfo, workflowDonInfo, dispatcher, "serverTestClient")
 
 	return &serverTestClient{lggr: lggr, peerID: peerID, dispatcher: dispatcher, capabilityDonInfo: capabilityDonInfo,

--- a/core/capabilities/remote/executable/server_test.go
+++ b/core/capabilities/remote/executable/server_test.go
@@ -2,6 +2,7 @@ package executable_test
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -12,8 +13,10 @@ import (
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/registration"
 	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -26,7 +29,7 @@ func Test_Server_ExcludesNonDeterministicInputAttributes(t *testing.T) {
 	numCapabilityPeers := 4
 
 	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{RequestHashExcludedAttributes: []string{"signed_report.Signatures"}},
-		&TestCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute)
+		func() commoncap.ExecutableCapability { return &TestCapability{} }, 10, 9, numCapabilityPeers, 3, 10*time.Minute)
 
 	for idx, caller := range callers {
 		rawInputs := map[string]any{
@@ -61,7 +64,7 @@ func Test_Server_Execute_RespondsAfterSufficientRequests(t *testing.T) {
 
 	numCapabilityPeers := 4
 
-	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute)
+	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, func() commoncap.ExecutableCapability { return &TestCapability{} }, 10, 9, numCapabilityPeers, 3, 10*time.Minute)
 
 	for _, caller := range callers {
 		_, err := caller.Execute(context.Background(),
@@ -83,14 +86,25 @@ func Test_Server_Execute_RespondsAfterSufficientRequests(t *testing.T) {
 	closeServices(t, srvcs)
 }
 
-func Test_Server_RegisterToWorkflow_RespondsAfterSufficientRequests(t *testing.T) {
+func Test_Server_RegisterToWorkflow(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	numCapabilityPeers := 4
 
-	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute)
+	remoteExecutableConfig := &commoncap.RemoteExecutableConfig{}
+	remoteExecutableConfig.RegistrationRefresh = 100 * time.Millisecond
 
-	for _, caller := range callers {
+	var testCapabilities []*TestCapability
+
+	clients, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{RegistrationRefresh: 100 * time.Millisecond},
+		func() commoncap.ExecutableCapability {
+			testCap := &TestCapability{}
+			testCapabilities = append(testCapabilities, testCap)
+			return testCap
+		},
+		10, 4, numCapabilityPeers, 3, 10*time.Minute)
+
+	for _, caller := range clients {
 		err := caller.RegisterToWorkflow(context.Background(), commoncap.RegisterToWorkflowRequest{
 			Metadata: commoncap.RegistrationMetadata{
 				WorkflowID:    workflowID1,
@@ -102,12 +116,23 @@ func Test_Server_RegisterToWorkflow_RespondsAfterSufficientRequests(t *testing.T
 		require.NoError(t, err)
 	}
 
-	for _, caller := range callers {
-		for i := 0; i < numCapabilityPeers; i++ {
-			msg := <-caller.receivedMessages
-			assert.Equal(t, remotetypes.Error_OK, msg.Error)
+	require.Eventually(t, func() bool {
+		for _, testCapability := range testCapabilities {
+			if len(testCapability.GetRegisterRequests()) != 1 {
+				return false
+			}
 		}
+
+		return true
+	}, 10*time.Second, 100*time.Millisecond, "expected one registration request to be received")
+
+	// a short sleep to allow the registration refresh mechanism to run, then check that there is still one registration request
+	time.Sleep(200 * time.Millisecond)
+
+	for _, testCapability := range testCapabilities {
+		assert.Len(t, testCapability.GetRegisterRequests(), 1)
 	}
+
 	closeServices(t, srvcs)
 }
 
@@ -116,9 +141,20 @@ func Test_Server_RegisterToWorkflow_Error(t *testing.T) {
 
 	numCapabilityPeers := 4
 
-	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestErrorCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute)
+	remoteExecutableConfig := &commoncap.RemoteExecutableConfig{}
+	remoteExecutableConfig.RegistrationRefresh = 100 * time.Millisecond
 
-	for _, caller := range callers {
+	var testCapabilities []*TestErrorCapability
+
+	clients, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{RegistrationRefresh: 100 * time.Millisecond},
+		func() commoncap.ExecutableCapability {
+			testCap := &TestErrorCapability{}
+			testCapabilities = append(testCapabilities, testCap)
+			return testCap
+		},
+		10, 4, numCapabilityPeers, 3, 10*time.Minute)
+
+	for _, caller := range clients {
 		err := caller.RegisterToWorkflow(context.Background(), commoncap.RegisterToWorkflowRequest{
 			Metadata: commoncap.RegistrationMetadata{
 				WorkflowID:    workflowID1,
@@ -130,39 +166,82 @@ func Test_Server_RegisterToWorkflow_Error(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	for _, caller := range callers {
-		for i := 0; i < numCapabilityPeers; i++ {
-			msg := <-caller.receivedMessages
-			assert.Equal(t, remotetypes.Error_INTERNAL_ERROR, msg.Error)
+	// As the registration errors, the client should retry the registration request repeatedly
+	require.Eventually(t, func() bool {
+		for _, testCapability := range testCapabilities {
+			if len(testCapability.GetRegisterRequests()) > 2 {
+				return false
+			}
 		}
-	}
+
+		return true
+	}, 10*time.Second, 100*time.Millisecond, "expected more than 2 registration requests to be received")
+
 	closeServices(t, srvcs)
 }
 
-func Test_Server_UnregisterFromWorkflow_RespondsAfterSufficientRequests(t *testing.T) {
+func Test_Server_UnregisterFromWorkflowIsCalledWhenClientsAreShutdown(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	numCapabilityPeers := 4
 
-	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestCapability{}, 10, 9, numCapabilityPeers, 3, 10*time.Minute)
+	remoteExecutableConfig := &commoncap.RemoteExecutableConfig{}
+	remoteExecutableConfig.RegistrationRefresh = 100 * time.Millisecond
 
-	for _, caller := range callers {
-		err := caller.UnregisterFromWorkflow(context.Background(), commoncap.UnregisterFromWorkflowRequest{
+	var testCapabilities []*TestCapability
+
+	clients, srvcs := testRemoteExecutableCapabilityServer(ctx, t,
+		&commoncap.RemoteExecutableConfig{RegistrationRefresh: 50 * time.Millisecond, RegistrationExpiry: 500 * time.Millisecond},
+		func() commoncap.ExecutableCapability {
+			testCap := &TestCapability{}
+			testCapabilities = append(testCapabilities, testCap)
+			return testCap
+		},
+		10, 4, numCapabilityPeers, 3, 10*time.Minute)
+
+	for _, caller := range clients {
+		err := caller.RegisterToWorkflow(context.Background(), commoncap.RegisterToWorkflowRequest{
 			Metadata: commoncap.RegistrationMetadata{
 				WorkflowID:    workflowID1,
 				ReferenceID:   stepReferenceID1,
 				WorkflowOwner: workflowOwnerID,
 			},
 		})
+
 		require.NoError(t, err)
 	}
 
-	for _, caller := range callers {
-		for i := 0; i < numCapabilityPeers; i++ {
-			msg := <-caller.receivedMessages
-			assert.Equal(t, remotetypes.Error_OK, msg.Error)
+	require.Eventually(t, func() bool {
+		for _, testCapability := range testCapabilities {
+			if len(testCapability.GetRegisterRequests()) != 1 {
+				return false
+			}
 		}
+
+		return true
+	}, 10*time.Second, 100*time.Millisecond, "expected one registration request to be received")
+
+	for _, client := range clients {
+		require.NoError(t, client.Close())
 	}
+
+	require.Eventually(t, func() bool {
+		for _, testCapability := range testCapabilities {
+			if len(testCapability.GetUnregisterRequests()) != 1 {
+				return false
+			}
+		}
+
+		return true
+	}, 10*time.Second, 100*time.Millisecond, "expected one registration request to be received")
+
+	// a short sleep greater than the expiry time then check that there is still only one unregistration request
+	time.Sleep(1 * time.Second)
+
+	for _, testCapability := range testCapabilities {
+		assert.Len(t, testCapability.GetUnregisterRequests(), 1)
+	}
+
 	closeServices(t, srvcs)
 }
 
@@ -171,7 +250,8 @@ func Test_Server_InsufficientCallers(t *testing.T) {
 
 	numCapabilityPeers := 4
 
-	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestCapability{}, 10, 10, numCapabilityPeers, 3, 100*time.Millisecond)
+	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{},
+		func() commoncap.ExecutableCapability { return &TestCapability{} }, 10, 10, numCapabilityPeers, 3, 100*time.Millisecond)
 
 	for _, caller := range callers {
 		_, err := caller.Execute(context.Background(),
@@ -198,7 +278,8 @@ func Test_Server_CapabilityError(t *testing.T) {
 
 	numCapabilityPeers := 4
 
-	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{}, &TestErrorCapability{}, 10, 9, numCapabilityPeers, 3, 100*time.Millisecond)
+	callers, srvcs := testRemoteExecutableCapabilityServer(ctx, t, &commoncap.RemoteExecutableConfig{},
+		func() commoncap.ExecutableCapability { return &TestErrorCapability{} }, 10, 9, numCapabilityPeers, 3, 100*time.Millisecond)
 
 	for _, caller := range callers {
 		_, err := caller.Execute(context.Background(),
@@ -222,7 +303,7 @@ func Test_Server_CapabilityError(t *testing.T) {
 
 func testRemoteExecutableCapabilityServer(ctx context.Context, t *testing.T,
 	config *commoncap.RemoteExecutableConfig,
-	underlying commoncap.ExecutableCapability,
+	capabilityFactory func() commoncap.ExecutableCapability,
 	numWorkflowPeers int, workflowDonF uint8,
 	numCapabilityPeers int, capabilityDonF uint8, capabilityNodeResponseTimeout time.Duration) ([]*serverTestClient, []services.Service) {
 	lggr := logger.TestLogger(t)
@@ -272,7 +353,7 @@ func testRemoteExecutableCapabilityServer(ctx context.Context, t *testing.T,
 	for i := 0; i < numCapabilityPeers; i++ {
 		capabilityPeer := capabilityPeers[i]
 		capabilityDispatcher := broker.NewDispatcherForNode(capabilityPeer)
-		capabilityNode := executable.NewServer(config, capabilityPeer, underlying, capInfo, capDonInfo, workflowDONs, capabilityDispatcher,
+		capabilityNode := executable.NewServer(config, capabilityPeer, capabilityFactory(), capInfo, capDonInfo, workflowDONs, capabilityDispatcher,
 			capabilityNodeResponseTimeout, lggr)
 		require.NoError(t, capabilityNode.Start(ctx))
 		broker.RegisterReceiverNode(capabilityPeer, capabilityNode)
@@ -283,9 +364,10 @@ func testRemoteExecutableCapabilityServer(ctx context.Context, t *testing.T,
 	workflowNodes := make([]*serverTestClient, numWorkflowPeers)
 	for i := 0; i < numWorkflowPeers; i++ {
 		workflowPeerDispatcher := broker.NewDispatcherForNode(workflowPeers[i])
-		workflowNode := newServerTestClient(workflowPeers[i], capDonInfo, workflowPeerDispatcher)
+		workflowNode := newServerTestClient(lggr, workflowPeers[i], config.RegistrationRefresh, capInfo, capDonInfo, workflowDonInfo, workflowPeerDispatcher)
 		broker.RegisterReceiverNode(workflowPeers[i], workflowNode)
 		workflowNodes[i] = workflowNode
+		servicetest.Run(t, workflowNode)
 	}
 
 	return workflowNodes, srvcs
@@ -298,25 +380,53 @@ func closeServices(t *testing.T, srvcs []services.Service) {
 }
 
 type serverTestClient struct {
-	peerID            p2ptypes.PeerID
-	dispatcher        remotetypes.Dispatcher
-	capabilityDonInfo commoncap.DON
-	receivedMessages  chan *remotetypes.MessageBody
-	callerDonID       string
+	services.StateMachine
+	lggr               logger.Logger
+	peerID             p2ptypes.PeerID
+	dispatcher         remotetypes.Dispatcher
+	capabilityDonInfo  commoncap.DON
+	receivedMessages   chan *remotetypes.MessageBody
+	callerDonID        string
+	registrationClient *registration.Client
 }
 
 func (r *serverTestClient) Receive(_ context.Context, msg *remotetypes.MessageBody) {
 	r.receivedMessages <- msg
 }
 
-func newServerTestClient(peerID p2ptypes.PeerID, capabilityDonInfo commoncap.DON,
+func newServerTestClient(lggr logger.Logger, peerID p2ptypes.PeerID, registrationRefresh time.Duration, capInfo commoncap.CapabilityInfo,
+	capabilityDonInfo commoncap.DON,
+	workflowDonInfo commoncap.DON,
 	dispatcher remotetypes.Dispatcher) *serverTestClient {
-	return &serverTestClient{peerID: peerID, dispatcher: dispatcher, capabilityDonInfo: capabilityDonInfo,
-		receivedMessages: make(chan *remotetypes.MessageBody, 100), callerDonID: "workflow-don"}
+
+	registrationClient := registration.NewClient(lggr, remotetypes.MethodRegisterToWorkflow, registrationRefresh, capInfo, capabilityDonInfo, workflowDonInfo, dispatcher, "serverTestClient")
+
+	return &serverTestClient{lggr: lggr, peerID: peerID, dispatcher: dispatcher, capabilityDonInfo: capabilityDonInfo,
+		receivedMessages: make(chan *remotetypes.MessageBody, 100), callerDonID: "workflow-don",
+		registrationClient: registrationClient}
 }
 
 func (r *serverTestClient) Info(ctx context.Context) (commoncap.CapabilityInfo, error) {
 	panic("not implemented")
+}
+
+func (r *serverTestClient) Start(ctx context.Context) error {
+	return r.StartOnce(r.peerID.String(), func() error {
+		if err := r.registrationClient.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start capability register: %w", err)
+		}
+		return nil
+	})
+}
+
+func (r *serverTestClient) Close() error {
+	r.IfNotStopped(func() {
+		if err := r.registrationClient.Close(); err != nil {
+			r.lggr.Errorf("failed to close capability register: %v", err)
+		}
+	})
+
+	return nil
 }
 
 func (r *serverTestClient) RegisterToWorkflow(ctx context.Context, req commoncap.RegisterToWorkflowRequest) error {
@@ -325,52 +435,16 @@ func (r *serverTestClient) RegisterToWorkflow(ctx context.Context, req commoncap
 		return err
 	}
 
-	messageID := remotetypes.MethodRegisterToWorkflow + ":" + req.Metadata.WorkflowID
-
-	for _, node := range r.capabilityDonInfo.Members {
-		message := &remotetypes.MessageBody{
-			CapabilityId:    "capability-id",
-			CapabilityDonId: 1,
-			CallerDonId:     2,
-			Method:          remotetypes.MethodRegisterToWorkflow,
-			Payload:         rawRequest,
-			MessageId:       []byte(messageID),
-			Sender:          r.peerID[:],
-			Receiver:        node[:],
-		}
-
-		if err = r.dispatcher.Send(node, message); err != nil {
-			return err
-		}
+	err = r.registrationClient.RegisterWorkflow(req.Metadata.WorkflowID, rawRequest)
+	if err != nil {
+		return err
 	}
 
 	return nil
 }
 
 func (r *serverTestClient) UnregisterFromWorkflow(ctx context.Context, req commoncap.UnregisterFromWorkflowRequest) error {
-	rawRequest, err := pb.MarshalUnregisterFromWorkflowRequest(req)
-	if err != nil {
-		return err
-	}
-
-	messageID := remotetypes.MethodUnregisterFromWorkflow + ":" + req.Metadata.WorkflowID
-
-	for _, node := range r.capabilityDonInfo.Members {
-		message := &remotetypes.MessageBody{
-			CapabilityId:    "capability-id",
-			CapabilityDonId: 1,
-			CallerDonId:     2,
-			Method:          remotetypes.MethodUnregisterFromWorkflow,
-			Payload:         rawRequest,
-			MessageId:       []byte(messageID),
-			Sender:          r.peerID[:],
-			Receiver:        node[:],
-		}
-
-		if err = r.dispatcher.Send(node, message); err != nil {
-			return err
-		}
-	}
+	r.registrationClient.UnregisterWorkflow(req.Metadata.WorkflowID)
 
 	return nil
 }

--- a/core/capabilities/remote/registration/client.go
+++ b/core/capabilities/remote/registration/client.go
@@ -1,0 +1,138 @@
+package registration
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+)
+
+type clientRegistration struct {
+	registrationRequest []byte
+}
+
+type registerDispatcher interface {
+	Send(peerID p2ptypes.PeerID, msgBody *types.MessageBody) error
+}
+
+// Client is a shim for remote capabilities that support registration to a workflow.  It polls the Server to ensure
+// the registration stays live.  In the current implementation the Server shim will unregister any workflow that has
+// not been re-registered within the registrationExpiry interval.
+type Client struct {
+	services.StateMachine
+	lggr                logger.Logger
+	registrationMethod  string
+	registrationRefresh time.Duration
+	capInfo             commoncap.CapabilityInfo
+	capDonInfo          commoncap.DON
+	localDonInfo        commoncap.DON
+	dispatcher          registerDispatcher
+	registeredWorkflows map[string]*clientRegistration
+	mu                  sync.RWMutex
+	stopCh              services.StopChan
+	wg                  sync.WaitGroup
+}
+
+func NewClient(lggr logger.Logger, registrationMethod string, registrationRefresh time.Duration, capInfo commoncap.CapabilityInfo, capDonInfo commoncap.DON,
+	localDonInfo commoncap.DON, dispatcher registerDispatcher, registryType string) *Client {
+	return &Client{
+		lggr:                lggr.Named(registryType),
+		registrationMethod:  registrationMethod,
+		registrationRefresh: registrationRefresh,
+		capInfo:             capInfo,
+		capDonInfo:          capDonInfo,
+		localDonInfo:        localDonInfo,
+		dispatcher:          dispatcher,
+		registeredWorkflows: make(map[string]*clientRegistration),
+		stopCh:              make(services.StopChan),
+	}
+}
+
+func (r *Client) Start(_ context.Context) error {
+	return r.StartOnce(r.lggr.Name(), func() error {
+		r.wg.Add(1)
+		go func() {
+			defer r.wg.Done()
+			r.registrationLoop()
+		}()
+		r.lggr.Info("started")
+		return nil
+	})
+}
+
+func (r *Client) Close() error {
+	return r.StopOnce(r.lggr.Name(), func() error {
+		close(r.stopCh)
+		r.wg.Wait()
+		r.lggr.Info("closed")
+		return nil
+	})
+}
+
+func (r *Client) RegisterWorkflow(workflowID string, request []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.lggr.Infow("register workflow called", "capabilityId", r.capInfo.ID, "donId", r.capDonInfo.ID, "workflowID", workflowID)
+	regState, ok := r.registeredWorkflows[workflowID]
+	if !ok {
+		regState = &clientRegistration{
+			registrationRequest: request,
+		}
+		r.registeredWorkflows[workflowID] = regState
+	} else {
+		regState.registrationRequest = request
+		r.lggr.Warnw("re-registering workflow", "capabilityId", r.capInfo.ID, "donId", r.capDonInfo.ID, "workflowID", workflowID)
+	}
+
+	return nil
+}
+
+func (r *Client) UnregisterWorkflow(workflowID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.lggr.Infow("unregister workflow called", "capabilityId", r.capInfo.ID, "donId", r.capDonInfo.ID, "workflowID", workflowID)
+	delete(r.registeredWorkflows, workflowID)
+	// Registrations will quickly expire on all remote nodes so it is currently considered unnecessary to send
+	// unregister messages to the nodes
+}
+
+func (r *Client) registrationLoop() {
+	ticker := time.NewTicker(r.registrationRefresh)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		case <-ticker.C:
+			r.mu.RLock()
+			r.lggr.Infow("register for remote capability", "capabilityId", r.capInfo.ID, "donId", r.capDonInfo.ID, "nMembers", len(r.capDonInfo.Members), "nWorkflows", len(r.registeredWorkflows))
+			if len(r.registeredWorkflows) == 0 {
+				r.lggr.Infow("no workflows to register")
+			}
+			for _, registration := range r.registeredWorkflows {
+				// NOTE: send to all by default, introduce different strategies later (KS-76)
+				for _, peerID := range r.capDonInfo.Members {
+					m := &types.MessageBody{
+						CapabilityId:    r.capInfo.ID,
+						CapabilityDonId: r.capDonInfo.ID,
+						CallerDonId:     r.localDonInfo.ID,
+						Method:          r.registrationMethod,
+						Payload:         registration.registrationRequest,
+					}
+					err := r.dispatcher.Send(peerID, m)
+					if err != nil {
+						r.lggr.Errorw("failed to send message", "capabilityId", r.capInfo.ID, "donId", r.capDonInfo.ID, "peerId", peerID, "err", err)
+					}
+				}
+			}
+			r.mu.RUnlock()
+		}
+	}
+}

--- a/core/capabilities/remote/registration/client_test.go
+++ b/core/capabilities/remote/registration/client_test.go
@@ -1,0 +1,92 @@
+package registration
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	types2 "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+
+	libocrtypes "github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+func TestClient_RegisterWorkflow(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	dispatcher := NewMockDispatcher()
+	peer1 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '1'}
+	peer2 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '2'}
+
+	client := NewClient(lggr, types.MethodRegisterTrigger, 10*time.Millisecond, capabilities.CapabilityInfo{}, capabilities.DON{Members: []libocrtypes.PeerID{peer1, peer2}}, capabilities.DON{}, dispatcher, "test")
+	servicetest.Run(t, client)
+
+	err := client.RegisterWorkflow("workflow1", []byte("registerrequest"))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		messages := dispatcher.GetMessages()
+
+		// Check sent to both peers with the same number of requests
+		if len(messages[peer1]) >= 3 {
+			return len(messages[peer1]) == len(messages[peer2])
+		}
+		return false
+	}, 60*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, "registerrequest", string(dispatcher.GetMessages()[peer1][0].Payload))
+}
+
+func TestClient_UnregisterWorkflow(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	dispatcher := NewMockDispatcher()
+
+	peer1 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '1'}
+	client := NewClient(lggr, types.MethodRegisterTrigger, 10*time.Millisecond, capabilities.CapabilityInfo{}, capabilities.DON{Members: []libocrtypes.PeerID{peer1}}, capabilities.DON{}, dispatcher, "test")
+	servicetest.Run(t, client)
+
+	err := client.RegisterWorkflow("workflow1", []byte("request"))
+	require.NoError(t, err)
+
+	client.UnregisterWorkflow("workflow1")
+
+	initialCount := len(dispatcher.GetMessages()[peer1])
+	time.Sleep(100 * time.Microsecond)
+	// If it has been unregistered then no new registration requests should be sent
+	finalCount := len(dispatcher.GetMessages()[peer1])
+	assert.Equal(t, initialCount, finalCount)
+}
+
+type MockDispatcher struct {
+	mu       sync.Mutex
+	messages map[types2.PeerID][]*types.MessageBody
+}
+
+func NewMockDispatcher() *MockDispatcher {
+	return &MockDispatcher{
+		messages: make(map[types2.PeerID][]*types.MessageBody),
+	}
+}
+
+func (m *MockDispatcher) Send(peerID types2.PeerID, msgBody *types.MessageBody) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages[peerID] = append(m.messages[peerID], msgBody)
+	return nil
+}
+
+func (m *MockDispatcher) GetMessages() map[types2.PeerID][]*types.MessageBody {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	mapCopy := make(map[types2.PeerID][]*types.MessageBody)
+	for k, v := range m.messages {
+		mapCopy[k] = append([]*types.MessageBody(nil), v...)
+	}
+	return mapCopy
+}

--- a/core/capabilities/remote/registration/server.go
+++ b/core/capabilities/remote/registration/server.go
@@ -1,0 +1,168 @@
+package registration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/validation"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+)
+
+type Key struct {
+	CallerDonID   uint32
+	WorkflowID    string
+	StepReference string
+}
+
+type serverRegistration struct {
+	registrationRequest []byte
+}
+
+type target interface {
+	Register(ctx context.Context, key Key, registerRequest []byte) error
+	Unregister(ctx context.Context, registerRequest []byte) error
+}
+
+// Server is a shim for remote capabilities that support registration to a workflow.  It aggregates registration requests
+// and invokes the register method on the target capability when the minimum number of registrations are received (2f+1).
+// The server will also periodically clean up expired registrations.  A registration is considered expired if it has not
+// been aggregated within the registrationExpiry period, when a registration is expired unregister is called on the target
+type Server struct {
+	lggr               logger.Logger
+	capInfo            commoncap.CapabilityInfo
+	registrationExpiry time.Duration
+	target             target
+	registrations      map[Key]*serverRegistration
+	messageCache       *messagecache.MessageCache[Key, p2ptypes.PeerID]
+	membersCache       map[uint32]map[p2ptypes.PeerID]bool
+	workflowDONs       map[uint32]commoncap.DON
+
+	stopCh services.StopChan
+	wg     sync.WaitGroup
+
+	mu sync.RWMutex
+}
+
+func NewServer(lggr logger.Logger, target target, capInfo commoncap.CapabilityInfo, registrationExpiry time.Duration, workflowDONs map[uint32]commoncap.DON, serverType string) *Server {
+	membersCache := make(map[uint32]map[p2ptypes.PeerID]bool)
+	for id, don := range workflowDONs {
+		cache := make(map[p2ptypes.PeerID]bool)
+		for _, member := range don.Members {
+			cache[member] = true
+		}
+		membersCache[id] = cache
+	}
+
+	return &Server{
+		lggr:               lggr.Named(serverType),
+		capInfo:            capInfo,
+		target:             target,
+		registrationExpiry: registrationExpiry,
+		stopCh:             make(services.StopChan),
+		registrations:      make(map[Key]*serverRegistration),
+		messageCache:       messagecache.New[Key, p2ptypes.PeerID](),
+		membersCache:       membersCache,
+		workflowDONs:       workflowDONs,
+	}
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.registrationCleanupLoop()
+	}()
+
+	s.lggr.Info("started")
+	return nil
+}
+
+func (s *Server) Close() error {
+	close(s.stopCh)
+	s.wg.Wait()
+	s.lggr.Info("closed")
+	return nil
+}
+
+func (s *Server) Register(ctx context.Context, msg *types.MessageBody, sender p2ptypes.PeerID, workflowID string, stepReference string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	callerDon, ok := s.workflowDONs[msg.CallerDonId]
+	if !ok {
+		return errors.New("received a message from unsupported workflow DON")
+	}
+	if !s.membersCache[msg.CallerDonId][sender] {
+		return errors.New("sender not a member of its workflow DON")
+	}
+	if err := validation.ValidateWorkflowOrExecutionID(workflowID); err != nil {
+		return fmt.Errorf("received request with invalid workflow ID: %w", err)
+	}
+
+	s.lggr.Debugw("received registration", "capabilityId", s.capInfo.ID, "workflowId", workflowID, "sender", sender)
+	key := Key{CallerDonID: msg.CallerDonId, WorkflowID: workflowID, StepReference: stepReference}
+	nowMs := time.Now().UnixMilli()
+	s.messageCache.Insert(key, sender, nowMs, msg.Payload)
+	_, exists := s.registrations[key]
+	if exists {
+		s.lggr.Debugw("registration already exists", "capabilityId", s.capInfo.ID, "workflowId", workflowID)
+		return nil
+	}
+	// NOTE: require 2F+1 by default, introduce different strategies later (KS-76)
+	minRequired := uint32(2*callerDon.F + 1)
+	ready, payloads := s.messageCache.Ready(key, minRequired, nowMs-s.registrationExpiry.Milliseconds(), false)
+	if !ready {
+		s.lggr.Debugw("not ready to aggregate yet", "capabilityId", s.capInfo.ID, "workflowId", workflowID, "minRequired", minRequired)
+		return nil
+	}
+	aggregated, err := aggregation.AggregateModeRaw(payloads, uint32(callerDon.F+1))
+	if err != nil {
+		return fmt.Errorf("failed to aggregate registrations: %w", err)
+	}
+	err = s.target.Register(ctx, key, aggregated)
+	if err != nil {
+		return fmt.Errorf("failed to register request on target: %w", err)
+	}
+
+	s.registrations[key] = &serverRegistration{
+		registrationRequest: aggregated,
+	}
+	s.lggr.Debugw("updated registration", "capabilityId", s.capInfo.ID, "workflowId", workflowID)
+	return nil
+}
+
+func (s *Server) registrationCleanupLoop() {
+	ticker := time.NewTicker(s.registrationExpiry)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			now := time.Now().UnixMilli()
+			s.mu.Lock()
+			for key, req := range s.registrations {
+				callerDon := s.workflowDONs[key.CallerDonID]
+				ready, _ := s.messageCache.Ready(key, uint32(2*callerDon.F+1), now-s.registrationExpiry.Milliseconds(), false)
+				if !ready {
+					s.lggr.Infow("registration expired", "capabilityId", s.capInfo.ID, "callerDonID", key.CallerDonID, "workflowId", key.WorkflowID)
+					ctx, cancel := s.stopCh.NewCtx()
+					err := s.target.Unregister(ctx, req.registrationRequest)
+					cancel()
+					s.lggr.Infow("unregistered", "capabilityId", s.capInfo.ID, "callerDonID", key.CallerDonID, "workflowId", key.WorkflowID, "err", err)
+					delete(s.registrations, key)
+					s.messageCache.Delete(key)
+				}
+			}
+			s.mu.Unlock()
+		}
+	}
+}

--- a/core/capabilities/remote/registration/server.go
+++ b/core/capabilities/remote/registration/server.go
@@ -69,7 +69,7 @@ func NewServer(lggr logger.Logger, target target, capInfo commoncap.CapabilityIn
 		registrationExpiry: registrationExpiry,
 		stopCh:             make(services.StopChan),
 		registrations:      make(map[Key]*serverRegistration),
-		messageCache:       messagecache.New[Key, p2ptypes.PeerID](),
+		messageCache:       messagecache.NewMessageCache[Key, p2ptypes.PeerID](),
 		membersCache:       membersCache,
 		workflowDONs:       workflowDONs,
 	}

--- a/core/capabilities/remote/registration/server_test.go
+++ b/core/capabilities/remote/registration/server_test.go
@@ -1,0 +1,123 @@
+package registration
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+
+	libocrtypes "github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+func TestServer_Register(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	target := &mockTarget{}
+
+	peer1 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '1'}
+	peer2 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '2'}
+	peer3 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '3'}
+	peer4 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '4'}
+	peer5 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '5'}
+
+	workflowID1 := "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
+
+	capInfo := capabilities.CapabilityInfo{ID: "test-capability"}
+	registrationExpiry := 60 * time.Second
+	workflowDONs := make(map[uint32]capabilities.DON)
+	workflowDONs[1] = capabilities.DON{F: 1, Members: []p2ptypes.PeerID{peer1, peer2, peer3, peer4, peer5}}
+
+	srv := NewServer(lggr, target, capInfo, registrationExpiry, workflowDONs, "test-server")
+	servicetest.Run(t, srv)
+
+	msg := &types.MessageBody{CallerDonId: 1, Payload: []byte("test-payload")}
+	err := srv.Register(context.Background(), msg, peer1, workflowID1, "step1")
+	require.NoError(t, err)
+	assert.Empty(t, target.GetRegisterRequests())
+
+	err = srv.Register(context.Background(), msg, peer2, workflowID1, "step1")
+	require.NoError(t, err)
+	assert.Empty(t, target.GetRegisterRequests())
+
+	err = srv.Register(context.Background(), msg, peer3, workflowID1, "step1")
+	require.NoError(t, err)
+	// 2F+1 requests have been sent so register on the target should be called
+	assert.Len(t, target.GetRegisterRequests(), 1)
+
+	// Sending more requests should not result in the target receiving more register calls
+	err = srv.Register(context.Background(), msg, peer4, workflowID1, "step1")
+	require.NoError(t, err)
+	err = srv.Register(context.Background(), msg, peer5, workflowID1, "step1")
+	require.NoError(t, err)
+
+	assert.Len(t, target.registerRequests, 1)
+}
+
+func TestServer_Unregister(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	target := &mockTarget{}
+
+	peer1 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '1'}
+	peer2 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '2'}
+	peer3 := libocrtypes.PeerID{'p', 'e', 'e', 'r', '3'}
+
+	workflowID1 := "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
+
+	capInfo := capabilities.CapabilityInfo{ID: "test-capability"}
+	registrationExpiry := 10 * time.Millisecond
+	workflowDONs := make(map[uint32]capabilities.DON)
+	workflowDONs[1] = capabilities.DON{F: 1, Members: []p2ptypes.PeerID{peer1, peer2, peer3}}
+
+	srv := NewServer(lggr, target, capInfo, registrationExpiry, workflowDONs, "test-server")
+	servicetest.Run(t, srv)
+
+	msg := &types.MessageBody{CallerDonId: 1, Payload: []byte("test-payload")}
+	err := srv.Register(context.Background(), msg, peer1, workflowID1, "step1")
+	require.NoError(t, err)
+	err = srv.Register(context.Background(), msg, peer2, workflowID1, "step1")
+	require.NoError(t, err)
+	err = srv.Register(context.Background(), msg, peer3, workflowID1, "step1")
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool { return len(target.GetUnregisterRequests()) == 1 }, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+type mockTarget struct {
+	registerRequests   [][]byte
+	unregisterRequests [][]byte
+	mux                sync.Mutex
+}
+
+func (m *mockTarget) Register(ctx context.Context, key Key, registerRequest []byte) error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	m.registerRequests = append(m.registerRequests, registerRequest)
+	return nil
+}
+
+func (m *mockTarget) Unregister(ctx context.Context, registerRequest []byte) error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	m.unregisterRequests = append(m.unregisterRequests, registerRequest)
+	return nil
+}
+
+func (m *mockTarget) GetRegisterRequests() [][]byte {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	return m.registerRequests
+}
+
+func (m *mockTarget) GetUnregisterRequests() [][]byte {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	return m.unregisterRequests
+}

--- a/core/capabilities/remote/trigger_subscriber.go
+++ b/core/capabilities/remote/trigger_subscriber.go
@@ -81,7 +81,7 @@ func NewTriggerSubscriber(config *commoncap.RemoteTriggerConfig, capInfo commonc
 		capInfo:            capInfo,
 		capDonMembers:      capDonMembers,
 		aggregator:         aggregator,
-		messageCache:       messagecache.New[triggerEventKey, p2ptypes.PeerID](),
+		messageCache:       messagecache.NewMessageCache[triggerEventKey, p2ptypes.PeerID](),
 		stopCh:             make(services.StopChan),
 		lggr:               lggr.Named("TriggerSubscriber"),
 		registrationClient: registration.NewClient(lggr, types.MethodRegisterTrigger, config.RegistrationRefresh, capInfo, capDonInfo, localDonInfo, dispatcher, "TriggerSubscriber"),


### PR DESCRIPTION
Reuse the registration logic from trigger capabiliies in executable capabilties and expand the test cases to contain workflow/capability node bouncing and registration tests to ensure registration logic behaves as expected.

https://smartcontract-it.atlassian.net/browse/CAPPL-314

depends on

- https://github.com/smartcontractkit/chainlink-common/pull/968