### PR TITLE
deployment/ccip/changeset: use singular GetChainConfig

### DIFF
--- a/deployment/ccip/changeset/cs_add_chain.go
+++ b/deployment/ccip/changeset/cs_add_chain.go
@@ -169,21 +169,14 @@ func (a AddDonAndSetCandidateChangesetConfig) Validate(e deployment.Environment,
 	}
 
 	// check that chain config is set up for the new chain
-	// TODO: feels like we should just have a getter for a particular chain, this pagination
-	// logic seems a bit out of place here.
-	allConfigs, err := state.Chains[a.HomeChainSelector].CCIPHome.GetAllChainConfigs(nil, big.NewInt(0), big.NewInt(100))
+	chainConfig, err := state.Chains[a.HomeChainSelector].CCIPHome.GetChainConfig(nil, a.NewChainSelector)
 	if err != nil {
 		return nil, fmt.Errorf("get all chain configs: %w", err)
 	}
-	var found bool
-	for _, chainConfig := range allConfigs {
-		if chainConfig.ChainSelector == a.NewChainSelector {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return nil, fmt.Errorf("chain config not set for chain %d", a.NewChainSelector)
+
+	// FChain should never be zero if a chain config is set in CCIPHome
+	if chainConfig.FChain == 0 {
+		return nil, fmt.Errorf("chain config not set up for new chain")
 	}
 
 	err = a.CCIPOCRParams.Validate()

--- a/deployment/ccip/changeset/cs_add_chain.go
+++ b/deployment/ccip/changeset/cs_add_chain.go
@@ -176,7 +176,7 @@ func (a AddDonAndSetCandidateChangesetConfig) Validate(e deployment.Environment,
 
 	// FChain should never be zero if a chain config is set in CCIPHome
 	if chainConfig.FChain == 0 {
-		return nil, fmt.Errorf("chain config not set up for new chain")
+		return nil, fmt.Errorf("chain config not set up for new chain %d", a.NewChainSelector)
 	}
 
 	err = a.CCIPOCRParams.Validate()


### PR DESCRIPTION
Use the singular GetChainConfig method on CCIPHome to get the chain config of a particular chain instead of GetAllChainConfigs.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
