### PR TITLE
cribbit.sh removed

### DIFF
--- a/core/scripts/keystone/README.md
+++ b/core/scripts/keystone/README.md
@@ -51,7 +51,7 @@ If you want to redeploy all resources, then you'll want to do the following:
 ```bash
 # From /crib
 devspace purge --profile keystone # Remove all k8s resources
-./cribbit.sh crib-<new-namespace> # Purge currently leaves some hanging resources, make a new namespace
+DEVSPACE_NAMESPACE=crib-<new-namespace> crib init # Purge currently leaves some hanging resources, make a new namespace
 devspace deploy --profile keysone --clean # Wipe any keystone related persisted data, like artefacts and caches.
 ```
 

--- a/integration-tests/crib/README.md
+++ b/integration-tests/crib/README.md
@@ -6,7 +6,7 @@ It runs OCRv1 and reboots the environment confirming integration with environmen
 Go to the [CRIB](https://github.com/smartcontractkit/crib) repository and spin up a cluster.
 
 ```shell
-./scripts/cribbit.sh crib-oh-my-crib
+DEVSPACE_NAMESPACE=crib-oh-my-crib crib init
 devspace deploy --debug --profile local-dev-simulated-core-ocr1
 ```
 


### PR DESCRIPTION
cribbit.sh is ~~deprecated and will be~~ removed as part of https://smartcontract-it.atlassian.net/browse/CRIB-565