### PR TITLE
Update abandon tx functionality to drop related attempts

### DIFF
--- a/.changeset/gorgeous-ants-promise.md
+++ b/.changeset/gorgeous-ants-promise.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Updated TXM abandon transaction functionality to drop related attempts. #updated


### PR DESCRIPTION
[BCFR-1078](https://smartcontract-it.atlassian.net/browse/BCFR-1078)

### Context
The abandon transaction functionality marks `unstarted`, `in_progress`, and `unconfirmed` transactions as `fatal_error` and clears out any assigned nonces. However, attempts for `in_progress` or `unconfirmed` transactions remained in the db even though these attempts aren't needed for any other TXM process. This was causing a conflict with purged transactions that are marked as fatal with attempts that still need to be bumped and confirmed. The only difference is that purge transactions maintain their nonces

### Changes
- The abandon transaction functionality was updated to drop attempts when transactions are initially marked as fatal and the nonce is removed.
- The query to find attempts that require a receipt fetch was updated to include a nonce null check.

[BCFR-1078]: https://smartcontract-it.atlassian.net/browse/BCFR-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ