### PR TITLE
chore: update actions/cache to v4

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -57,7 +57,7 @@ runs:
     # If multiple jobs call actions/cache, then only one will get priority to create upon a cache miss.
     # We will only restore the cache by default (by calling actions/cache/restore) and let the
     # `go-mod-cache.yml` workflow handle the creation.
-    - uses: actions/cache/restore@v4.1.1
+    - uses: actions/cache/restore@v4
       if: ${{ inputs.restore-module-cache-only == 'true' }}
       name: Cache Go Modules
       with:
@@ -71,7 +71,7 @@ runs:
 
     # If this is called, then it will create the cache entry upon a cache miss.
     # The cache is created after a cache miss, and after job completes successfully.
-    - uses: actions/cache@v4.1.1
+    - uses: actions/cache@v4
       if: ${{ inputs.restore-module-cache-only != 'true' }}
       name: Cache Go Modules
       with:
@@ -83,7 +83,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
 
-    - uses: actions/cache/restore@v4.1.1
+    - uses: actions/cache/restore@v4
       name: Cache Go Build Outputs (restore)
       # For certain events, we don't necessarily want to create a build cache, but we will benefit from restoring from one. 
       if: ${{ inputs.only-modules == 'false' && (github.event_name == 'merge_group' || inputs.restore-build-cache-only == 'true') }}
@@ -97,7 +97,7 @@ runs:
           ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-
           ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-
 
-    - uses: actions/cache@v4.1.1
+    - uses: actions/cache@v4
       # don't save cache on merge queue events
       if: ${{ inputs.only-modules == 'false' && (github.event_name != 'merge_group' && inputs.restore-build-cache-only == 'false') }}
       name: Cache Go Build Outputs

--- a/.github/actions/setup-hardhat/action.yaml
+++ b/.github/actions/setup-hardhat/action.yaml
@@ -11,13 +11,13 @@ runs:
   using: composite
   steps:
     - name: Cache Compilers
-      uses: actions/cache@v4.1.1
+      uses: actions/cache@v4
       with:
         path: ~/.cache/hardhat-nodejs/
         key: contracts-compilers-${{ runner.os }}-${{ inputs.cache-version }}-${{ hashFiles('contracts/pnpm-lock.yaml', 'contracts/hardhat.config.ts') }}
 
     - name: Cache contracts build outputs
-      uses: actions/cache@v4.1.1
+      uses: actions/cache@v4
       with:
         path: |
           contracts/cache/

--- a/.github/actions/setup-solana/action.yml
+++ b/.github/actions/setup-solana/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-      - uses: actions/cache@v4.1.1
+      - uses: actions/cache@v4
         id: cache
         name: Cache solana CLI
         with:

--- a/.github/actions/setup-wasmd/action.yml
+++ b/.github/actions/setup-wasmd/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-      - uses: actions/cache@v4.1.1
+      - uses: actions/cache@v4
         id: cache
         name: Cache wasmd-build
         with:

--- a/.github/workflows/build-publish-develop-pr.yml
+++ b/.github/workflows/build-publish-develop-pr.yml
@@ -98,7 +98,7 @@ jobs:
           role-session-name: "split-${{ matrix.goarch }}"
 
       - id: cache
-        uses: actions/cache@v4.1.1
+        uses: actions/cache@v4
         with:
           path: dist/${{ matrix.dist_name }}
           key: chainlink-${{ matrix.goarch }}-${{ github.sha }}
@@ -134,13 +134,13 @@ jobs:
           mask-aws-account-id: true
           role-session-name: "merge"
 
-      - uses: actions/cache/restore@v4.1.1
+      - uses: actions/cache/restore@v4
         with:
           path: dist/linux_amd64_v1
           key: chainlink-amd64-${{ github.sha }}
           fail-on-cache-miss: true
 
-      - uses: actions/cache/restore@v4.1.1
+      - uses: actions/cache/restore@v4
         with:
           path: dist/linux_arm64_v8.0
           key: chainlink-arm64-${{ github.sha }}


### PR DESCRIPTION
### Changes

Upgrade all `actions/cache` version to `v4`.

### Motivation

https://github.com/actions/cache/discussions/1510

> The new service will gradually roll out as of February 1st, 2025. The legacy service will also be sunset on the same date. Changes in these release are fully backward compatible.
> 
> We are deprecating some versions of this action. We recommend upgrading to version v4 or v3 as soon as possible before February 1st, 2025. (Upgrade instructions below).
> 
> If you are using pinned SHAs, please use the SHAs of versions v4.2.0 or v3.4.0
> 
> If you do not upgrade, all workflow runs using any of the deprecated [actions/cache](https://github.com/actions/cache) will fail.

---

RE-3330