### PR TITLE
Migrate to Larger Runners for CCIP v1.6 RMN Tests

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -980,7 +980,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_TwoMessagesOnTwoLanesIncludingBatching$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-22.04-large
+    runs_on: macos-15-xlarge
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -996,7 +996,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_MultipleMessagesOnOneLaneNoWaitForExec$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-22.04-large
+    runs_on: macos-15-xlarge
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1012,7 +1012,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_NotEnoughObservers$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-22.04-large
+    runs_on: macos-15-xlarge
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1028,7 +1028,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_DifferentSigners$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-22.04-large
+    runs_on: macos-15-xlarge
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1044,7 +1044,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_NotEnoughSigners$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-22.04-large
+    runs_on: macos-15-xlarge
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1060,7 +1060,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_DifferentRmnNodesForDifferentChains$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-22.04-large
+    runs_on: macos-15-xlarge
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1076,7 +1076,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_TwoMessagesOneSourceChainCursed$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-22.04-large
+    runs_on: macos-15-xlarge
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1092,7 +1092,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_GlobalCurseTwoMessagesOnTwoLanes$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-22.04-large
+    runs_on: macos-15-xlarge
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -980,7 +980,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_TwoMessagesOnTwoLanesIncludingBatching$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-latest
+    runs_on: ubuntu-22.04-large
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -996,7 +996,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_MultipleMessagesOnOneLaneNoWaitForExec$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-latest
+    runs_on: ubuntu-22.04-large
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1012,7 +1012,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_NotEnoughObservers$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-latest
+    runs_on: ubuntu-22.04-large
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1028,7 +1028,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_DifferentSigners$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-latest
+    runs_on: ubuntu-22.04-large
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1044,7 +1044,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_NotEnoughSigners$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-latest
+    runs_on: ubuntu-22.04-large
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1060,7 +1060,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_DifferentRmnNodesForDifferentChains$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-latest
+    runs_on: ubuntu-22.04-large
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1076,7 +1076,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_TwoMessagesOneSourceChainCursed$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-latest
+    runs_on: ubuntu-22.04-large
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1092,7 +1092,7 @@ runner-test-matrix:
   - id: smoke/ccip/ccip_rmn_test.go:^TestRMN_GlobalCurseTwoMessagesOnTwoLanes$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
-    runs_on: ubuntu-latest
+    runs_on: ubuntu-22.04-large
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests


### PR DESCRIPTION
# Migrate to Larger Runners for CCIP v1.6 RMN Tests

## Background
The "RMN Tests" in our GitHub Actions workflow often require spinning up multiple Docker containers. On `ubuntu-latest`, the limited resources (CPU, memory, and disk space) occasionally caused tests to fail due to resource exhaustion with timeouts or random networking errors.

## Change Summary
This PR updates the GitHub Actions workflow to use a larger runner (`ubuntu-22.04-large`). These runners provide more resources. This ensures the workflow can run more reliably the RMN Tests without failures caused by resource constraints.

## Changes Made
1. Updated `runs-on` in the workflow file:
   ```yaml
   runs-on: ubuntu-22.04-large
