### PR TITLE
fix: install toolchain version

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -29,10 +29,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Get Go Version
+      shell: bash
+      id: go-version
+      run: |
+        version=$(sed -ne '/^toolchain /s/^toolchain go//p' ${{ inputs.go-version-file }})
+        if [ -z "$version" ]; then
+          version=$(sed -ne '/^go /s/^go //p' ${{ inputs.go-version-file }})
+          echo "Toolchain version not found in ${{ inputs.go-version-file }}, using go directive instead."
+        fi
+        echo "Go Version: $version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Set up Go
       uses: actions/setup-go@v5.0.2
       with:
-        go-version-file: ${{ inputs.go-version-file }}
+        go-version: ${{ steps.go-version.outputs.version }}
         cache: false
         check-latest: true
 


### PR DESCRIPTION
### Changes

- Install the go version specified by the `toolchain` directive if it exists.

### Motivation

This is the cause for the errors seen during go mod cache restores for all of our workflows.

Basically the `actions/setup-go` action doesn't install the provided toolchain version, so when executing a `go` command later, it fetches the toolchain version and adds the toolchain's modules to the go mod cache. When we go to restore the cache, it can't overwrite the modules which are already present.

Related: https://github.com/actions/setup-go/issues/424

---

RE-3325
