### PR TITLE
[CAPPL-324] rehydrate artifacts from db if they haven't changed

### DIFF
--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -400,6 +400,7 @@ func (h *eventHandler) workflowRegisteredEvent(
 	ctx context.Context,
 	payload WorkflowRegistryWorkflowRegisteredV1,
 ) error {
+	// Fetch the workflow artifacts from the database or download them from the specified URLs
 	decodedBinary, config, err := h.getWorkflowArtifacts(ctx, payload)
 	if err != nil {
 		return err
@@ -492,48 +493,29 @@ func (h *eventHandler) getWorkflowArtifacts(
 	ctx context.Context,
 	payload WorkflowRegistryWorkflowRegisteredV1,
 ) ([]byte, []byte, error) {
-	spec, err := h.orm.GetWorkflowSpec(ctx, hex.EncodeToString(payload.WorkflowOwner), payload.WorkflowName)
+	spec, err := h.orm.GetWorkflowSpecByID(ctx, hex.EncodeToString(payload.WorkflowID[:]))
 	if err != nil {
-		return h.fetchAndDecodeWorkflowArtifacts(ctx, payload)
-	}
+		binary, err2 := h.fetcher(ctx, payload.BinaryURL)
+		if err2 != nil {
+			return nil, nil, fmt.Errorf("failed to fetch binary from %s : %w", payload.BinaryURL, err)
+		}
 
-	// there is an update in the BinaryURL or ConfigURL, lets fetch it
-	if spec.ConfigURL != payload.ConfigURL || spec.BinaryURL != payload.BinaryURL {
-		return h.fetchAndDecodeWorkflowArtifacts(ctx, payload)
+		decodedBinary, err2 := base64.StdEncoding.DecodeString(string(binary))
+		if err2 != nil {
+			return nil, nil, fmt.Errorf("failed to decode binary: %w", err)
+		}
+
+		var config []byte
+		if payload.ConfigURL != "" {
+			config, err2 = h.fetcher(ctx, payload.ConfigURL)
+			if err2 != nil {
+				return nil, nil, fmt.Errorf("failed to fetch config from %s : %w", payload.ConfigURL, err)
+			}
+		}
+		return decodedBinary, config, nil
 	}
 
 	// there is no update in the BinaryURL or ConfigURL, lets decode the stored artifacts
-	return h.decodeStoredWorkflowArtifacts(spec)
-}
-
-func (h *eventHandler) fetchAndDecodeWorkflowArtifacts(
-	ctx context.Context,
-	payload WorkflowRegistryWorkflowRegisteredV1,
-) ([]byte, []byte, error) {
-	binary, err := h.fetcher(ctx, payload.BinaryURL)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to fetch binary from %s : %w", payload.BinaryURL, err)
-	}
-
-	decodedBinary, err := base64.StdEncoding.DecodeString(string(binary))
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to decode binary: %w", err)
-	}
-
-	var config []byte
-	if payload.ConfigURL != "" {
-		config, err = h.fetcher(ctx, payload.ConfigURL)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch config from %s : %w", payload.ConfigURL, err)
-		}
-	}
-
-	return decodedBinary, config, nil
-}
-
-func (h *eventHandler) decodeStoredWorkflowArtifacts(
-	spec *job.WorkflowSpec,
-) ([]byte, []byte, error) {
 	decodedBinary, err := hex.DecodeString(spec.Workflow)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to decode stored workflow spec: %w", err)

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -400,25 +400,12 @@ func (h *eventHandler) workflowRegisteredEvent(
 	ctx context.Context,
 	payload WorkflowRegistryWorkflowRegisteredV1,
 ) error {
-	// Download the contents of binaryURL, configURL and secretsURL and cache them locally.
-	binary, err := h.fetcher(ctx, payload.BinaryURL)
+	decodedBinary, config, err := h.getWorkflowArtifacts(ctx, payload)
 	if err != nil {
-		return fmt.Errorf("failed to fetch binary from %s : %w", payload.BinaryURL, err)
+		return err
 	}
 
-	decodedBinary, err := base64.StdEncoding.DecodeString(string(binary))
-	if err != nil {
-		return fmt.Errorf("failed to decode binary: %w", err)
-	}
-
-	var config []byte
-	if payload.ConfigURL != "" {
-		config, err = h.fetcher(ctx, payload.ConfigURL)
-		if err != nil {
-			return fmt.Errorf("failed to fetch config from %s : %w", payload.ConfigURL, err)
-		}
-	}
-
+	// Always fetch secrets from the SecretsURL
 	var secrets []byte
 	if payload.SecretsURL != "" {
 		secrets, err = h.fetcher(ctx, payload.SecretsURL)
@@ -497,6 +484,61 @@ func (h *eventHandler) workflowRegisteredEvent(
 	h.engineRegistry.Add(wfID, engine)
 
 	return nil
+}
+
+// getWorkflowArtifacts retrieves the workflow artifacts from the database if they exist,
+// or downloads them from the specified URLs if they are not found in the database.
+func (h *eventHandler) getWorkflowArtifacts(
+	ctx context.Context,
+	payload WorkflowRegistryWorkflowRegisteredV1,
+) ([]byte, []byte, error) {
+	spec, err := h.orm.GetWorkflowSpec(ctx, hex.EncodeToString(payload.WorkflowOwner), payload.WorkflowName)
+	if err != nil {
+		return h.fetchAndDecodeWorkflowArtifacts(ctx, payload)
+	}
+
+	// there is an update in the BinaryURL or ConfigURL, lets fetch it
+	if spec.ConfigURL != payload.ConfigURL || spec.BinaryURL != payload.BinaryURL {
+		return h.fetchAndDecodeWorkflowArtifacts(ctx, payload)
+	}
+
+	// there is no update in the BinaryURL or ConfigURL, lets decode the stored artifacts
+	return h.decodeStoredWorkflowArtifacts(spec)
+}
+
+func (h *eventHandler) fetchAndDecodeWorkflowArtifacts(
+	ctx context.Context,
+	payload WorkflowRegistryWorkflowRegisteredV1,
+) ([]byte, []byte, error) {
+	binary, err := h.fetcher(ctx, payload.BinaryURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch binary from %s : %w", payload.BinaryURL, err)
+	}
+
+	decodedBinary, err := base64.StdEncoding.DecodeString(string(binary))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decode binary: %w", err)
+	}
+
+	var config []byte
+	if payload.ConfigURL != "" {
+		config, err = h.fetcher(ctx, payload.ConfigURL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to fetch config from %s : %w", payload.ConfigURL, err)
+		}
+	}
+
+	return decodedBinary, config, nil
+}
+
+func (h *eventHandler) decodeStoredWorkflowArtifacts(
+	spec *job.WorkflowSpec,
+) ([]byte, []byte, error) {
+	decodedBinary, err := hex.DecodeString(spec.Workflow)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decode stored workflow spec: %w", err)
+	}
+	return decodedBinary, []byte(spec.Config), nil
 }
 
 func (h *eventHandler) engineFactoryFn(ctx context.Context, id string, owner string, name string, config []byte, binary []byte) (services.Service, error) {

--- a/core/services/workflows/syncer/mocks/orm.go
+++ b/core/services/workflows/syncer/mocks/orm.go
@@ -540,6 +540,65 @@ func (_c *ORM_GetWorkflowSpec_Call) RunAndReturn(run func(context.Context, strin
 	return _c
 }
 
+// GetWorkflowSpecByID provides a mock function with given fields: ctx, id
+func (_m *ORM) GetWorkflowSpecByID(ctx context.Context, id string) (*job.WorkflowSpec, error) {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWorkflowSpecByID")
+	}
+
+	var r0 *job.WorkflowSpec
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*job.WorkflowSpec, error)); ok {
+		return rf(ctx, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *job.WorkflowSpec); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*job.WorkflowSpec)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ORM_GetWorkflowSpecByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetWorkflowSpecByID'
+type ORM_GetWorkflowSpecByID_Call struct {
+	*mock.Call
+}
+
+// GetWorkflowSpecByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *ORM_Expecter) GetWorkflowSpecByID(ctx interface{}, id interface{}) *ORM_GetWorkflowSpecByID_Call {
+	return &ORM_GetWorkflowSpecByID_Call{Call: _e.mock.On("GetWorkflowSpecByID", ctx, id)}
+}
+
+func (_c *ORM_GetWorkflowSpecByID_Call) Run(run func(ctx context.Context, id string)) *ORM_GetWorkflowSpecByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *ORM_GetWorkflowSpecByID_Call) Return(_a0 *job.WorkflowSpec, _a1 error) *ORM_GetWorkflowSpecByID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ORM_GetWorkflowSpecByID_Call) RunAndReturn(run func(context.Context, string) (*job.WorkflowSpec, error)) *ORM_GetWorkflowSpecByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Update provides a mock function with given fields: ctx, secretsURL, contents
 func (_m *ORM) Update(ctx context.Context, secretsURL string, contents string) (int64, error) {
 	ret := _m.Called(ctx, secretsURL, contents)

--- a/core/services/workflows/syncer/orm.go
+++ b/core/services/workflows/syncer/orm.go
@@ -52,6 +52,9 @@ type WorkflowSpecsDS interface {
 
 	// DeleteWorkflowSpec deletes the workflow spec for the given owner and name.
 	DeleteWorkflowSpec(ctx context.Context, owner, name string) error
+
+	// GetWorkflowSpecByID returns the workflow spec for the given workflowID.
+	GetWorkflowSpecByID(ctx context.Context, id string) (*job.WorkflowSpec, error)
 }
 
 type ORM interface {
@@ -360,6 +363,22 @@ func (orm *orm) GetWorkflowSpec(ctx context.Context, owner, name string) (*job.W
 
 	var spec job.WorkflowSpec
 	err := orm.ds.GetContext(ctx, &spec, query, owner, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &spec, nil
+}
+
+func (orm *orm) GetWorkflowSpecByID(ctx context.Context, id string) (*job.WorkflowSpec, error) {
+	query := `
+		SELECT *
+		FROM workflow_specs
+		WHERE workflow_id = $1
+	`
+
+	var spec job.WorkflowSpec
+	err := orm.ds.GetContext(ctx, &spec, query, id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

This fix introduces a modification in the way we fetch the artifacts (binary and config). Basically we only want to download them from the provided URLs if they have changed and fetch them from the DB if they haven't. We control if they changed or not by fetching them by the workflowID that is generated based on the content of these artifacts.

[CAPPL-324](https://smartcontract-it.atlassian.net/browse/CAPPL-324)


### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CAPPL-324]: https://smartcontract-it.atlassian.net/browse/CAPPL-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ