### PR TITLE
temp fix to chainreader error when no workflows

### DIFF
--- a/core/capabilities/remote/executable/request/client_request_test.go
+++ b/core/capabilities/remote/executable/request/client_request_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -24,6 +25,13 @@ const (
 	workflowID1          = "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
 	workflowExecutionID1 = "95ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0abbadeed"
 )
+
+func Test_Hex(t *testing.T) {
+	b := []byte{}
+
+	strResult := hexutil.Encode(b)
+	assert.Equal(t, "", strResult)
+}
 
 func Test_ClientRequest_MessageValidation(t *testing.T) {
 	lggr := logger.TestLogger(t)

--- a/core/capabilities/remote/executable/request/client_request_test.go
+++ b/core/capabilities/remote/executable/request/client_request_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -25,13 +24,6 @@ const (
 	workflowID1          = "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
 	workflowExecutionID1 = "95ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0abbadeed"
 )
-
-func Test_Hex(t *testing.T) {
-	b := []byte{}
-
-	strResult := hexutil.Encode(b)
-	assert.Equal(t, "", strResult)
-}
 
 func Test_ClientRequest_MessageValidation(t *testing.T) {
 	lggr := logger.TestLogger(t)

--- a/core/services/workflows/syncer/workflow_registry.go
+++ b/core/services/workflows/syncer/workflow_registry.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"strings"
 	"sync"
 	"time"
 
@@ -222,8 +223,11 @@ func (w *workflowRegistry) Start(_ context.Context) error {
 			w.lggr.Debugw("Loading initial workflows for DON", "DON", don.ID)
 			loadWorkflowsHead, err := w.initialWorkflowsStateLoader.LoadWorkflows(ctx, don)
 			if err != nil {
-				w.lggr.Errorw("failed to load workflows", "err", err)
-				return
+				// TODO - this is a temporary fix to handle the case where the contract is empty, to track: https://smartcontract-it.atlassian.net/browse/CAPPL-393
+				if !strings.Contains(err.Error(), "attempting to unmarshal an empty string while arguments are expected") {
+					w.lggr.Errorw("failed to load workflows", "err", err)
+					return
+				}
 			}
 
 			reader, err := w.getContractReader(ctx)

--- a/core/services/workflows/syncer/workflow_registry.go
+++ b/core/services/workflows/syncer/workflow_registry.go
@@ -223,10 +223,15 @@ func (w *workflowRegistry) Start(_ context.Context) error {
 			w.lggr.Debugw("Loading initial workflows for DON", "DON", don.ID)
 			loadWorkflowsHead, err := w.initialWorkflowsStateLoader.LoadWorkflows(ctx, don)
 			if err != nil {
-				// TODO - this is a temporary fix to handle the case where the contract is empty, to track: https://smartcontract-it.atlassian.net/browse/CAPPL-393
+				// TODO - this is a temporary fix to handle the case where the chainreader errors because the contract
+				// contains no workflows.  To track: https://smartcontract-it.atlassian.net/browse/CAPPL-393
 				if !strings.Contains(err.Error(), "attempting to unmarshal an empty string while arguments are expected") {
 					w.lggr.Errorw("failed to load workflows", "err", err)
 					return
+				}
+
+				loadWorkflowsHead = &types.Head{
+					Height: "0",
 				}
 			}
 


### PR DESCRIPTION
It appears that chainreader errors when getWorkflowForDon returns an empty collection as does not handle the return type (empty []byte) correctly when decoding to the passed type.   This PR is a temporary workaround for that issue in the workflow registry syncer initial load.