### PR TITLE
fix: add compute hashed capability id and change f to 1

### DIFF
--- a/core/scripts/keystone/src/05_deploy_initialize_capabilities_registry.go
+++ b/core/scripts/keystone/src/05_deploy_initialize_capabilities_registry.go
@@ -294,7 +294,7 @@ func (c *deployAndInitializeCapabilitiesRegistryCommand) Run(args []string) {
 			panic(innerErr)
 		}
 
-		n.HashedCapabilityIds = [][32]byte{ocrid, ctid}
+		n.HashedCapabilityIds = [][32]byte{ocrid, ctid, aid}
 		nodes = append(nodes, n)
 	}
 
@@ -337,7 +337,7 @@ func (c *deployAndInitializeCapabilitiesRegistryCommand) Run(args []string) {
 			Config:       ccfgb,
 		},
 	}
-	_, err = reg.AddDON(env.Owner, ps, cfgs, true, true, 2)
+	_, err = reg.AddDON(env.Owner, ps, cfgs, true, true, 1)
 	if err != nil {
 		log.Printf("workflowDON: failed to AddDON: %s", err)
 	}


### PR DESCRIPTION
### Description

- add the compute hashed capability id 
- change f to 1 to make it work on a 4 nodes don, because It validates specifically that there are 3f+1 nodes

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
