### PR TITLE
Contract Reader Handle Empty Bytes

### DIFF
--- a/core/services/relay/evm/chain_reader.go
+++ b/core/services/relay/evm/chain_reader.go
@@ -199,7 +199,11 @@ func (cr *chainReader) GetLatestValue(ctx context.Context, readName string, conf
 	ptrToValue, isValue := returnVal.(*values.Value)
 	if !isValue {
 		_, err = binding.GetLatestValueWithHeadData(ctx, common.HexToAddress(address), confidenceLevel, params, returnVal)
-		return err
+		if err != nil {
+			return err
+		}
+
+		return nil
 	}
 
 	contractType, err := cr.CreateContractType(readName, false)


### PR DESCRIPTION
In some cases, a contract call will return an empty result `0x`, which decodes to an empty set of bytes. The codec can't decode this empty set except in specific cases where a slice of bytes is the expected result.

This commit adds a short-circuit to decoding an empty result where the return value is unaltered.