### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"cmp"
 	"fmt"
 	"net/url"
@@ -222,7 +223,7 @@ func NewApp(s *Shell) *cli.App {
 				},
 			},
 			Before: func(c *cli.Context) error {
-				errNoDuplicateFlags := fmt.Errorf("multiple commands with --config or --secrets flags. only one command may specify these flags. when secrets are used, they must be specific together in the same command")
+				errNoDuplicateFlags := errors.New("multiple commands with --config or --secrets flags. only one command may specify these flags. when secrets are used, they must be specific together in the same command")
 				if c.IsSet("config") {
 					if s.configFilesIsSet || s.secretsFileIsSet {
 						return errNoDuplicateFlags


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters