### PR TITLE
Add config to toggle the TXM

### DIFF
--- a/.changeset/wild-cats-think.md
+++ b/.changeset/wild-cats-think.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Added the `TXMEnabled` config to enable or disable the TXM. #added

--- a/.changeset/wild-cats-think.md
+++ b/.changeset/wild-cats-think.md
@@ -2,4 +2,4 @@
 "chainlink": minor
 ---
 
-Added the `TransactionManagerEnabled` config to enable or disable the transaction manager. #added
+Added the `EVM.Transactions.Enabled` config to enable or disable the transaction manager. #added

--- a/.changeset/wild-cats-think.md
+++ b/.changeset/wild-cats-think.md
@@ -2,4 +2,4 @@
 "chainlink": minor
 ---
 
-Added the `TXMEnabled` config to enable or disable the TXM. #added
+Added the `TransactionManagerEnabled` config to enable or disable the transaction manager. #added

--- a/core/chains/evm/config/chain_scoped.go
+++ b/core/chains/evm/config/chain_scoped.go
@@ -192,6 +192,6 @@ func (e *EVMConfig) NoNewFinalizedHeadsThreshold() time.Duration {
 	return e.C.NoNewFinalizedHeadsThreshold.Duration()
 }
 
-func (e *EVMConfig) TXMEnabled() bool {
-	return *e.C.TXMEnabled
+func (e *EVMConfig) TransactionManagerEnabled() bool {
+	return *e.C.TransactionManagerEnabled
 }

--- a/core/chains/evm/config/chain_scoped.go
+++ b/core/chains/evm/config/chain_scoped.go
@@ -191,3 +191,7 @@ func (e *EVMConfig) FinalizedBlockOffset() uint32 {
 func (e *EVMConfig) NoNewFinalizedHeadsThreshold() time.Duration {
 	return e.C.NoNewFinalizedHeadsThreshold.Duration()
 }
+
+func (e *EVMConfig) TXMEnabled() bool {
+	return *e.C.TXMEnabled
+}

--- a/core/chains/evm/config/chain_scoped.go
+++ b/core/chains/evm/config/chain_scoped.go
@@ -191,7 +191,3 @@ func (e *EVMConfig) FinalizedBlockOffset() uint32 {
 func (e *EVMConfig) NoNewFinalizedHeadsThreshold() time.Duration {
 	return e.C.NoNewFinalizedHeadsThreshold.Duration()
 }
-
-func (e *EVMConfig) TransactionManagerEnabled() bool {
-	return *e.C.TransactionManagerEnabled
-}

--- a/core/chains/evm/config/chain_scoped_transactions.go
+++ b/core/chains/evm/config/chain_scoped_transactions.go
@@ -11,6 +11,10 @@ type transactionsConfig struct {
 	c toml.Transactions
 }
 
+func (t *transactionsConfig) Enabled() bool {
+	return *t.c.Enabled
+}
+
 func (t *transactionsConfig) ForwardersEnabled() bool {
 	return *t.c.ForwardersEnabled
 }

--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -49,6 +49,7 @@ type EVM interface {
 	NodeNoNewHeadsThreshold() time.Duration
 	FinalizedBlockOffset() uint32
 	NoNewFinalizedHeadsThreshold() time.Duration
+	TXMEnabled() bool
 
 	IsEnabled() bool
 	TOMLString() (string, error)

--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -49,7 +49,7 @@ type EVM interface {
 	NodeNoNewHeadsThreshold() time.Duration
 	FinalizedBlockOffset() uint32
 	NoNewFinalizedHeadsThreshold() time.Duration
-	TXMEnabled() bool
+	TransactionManagerEnabled() bool
 
 	IsEnabled() bool
 	TOMLString() (string, error)

--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -49,7 +49,6 @@ type EVM interface {
 	NodeNoNewHeadsThreshold() time.Duration
 	FinalizedBlockOffset() uint32
 	NoNewFinalizedHeadsThreshold() time.Duration
-	TransactionManagerEnabled() bool
 
 	IsEnabled() bool
 	TOMLString() (string, error)
@@ -104,6 +103,7 @@ type ClientErrors interface {
 }
 
 type Transactions interface {
+	Enabled() bool
 	ForwardersEnabled() bool
 	ReaperInterval() time.Duration
 	ResendAfterThreshold() time.Duration

--- a/core/chains/evm/config/config_test.go
+++ b/core/chains/evm/config/config_test.go
@@ -221,18 +221,18 @@ func TestChainScopedConfig(t *testing.T) {
 		})
 	})
 
-	t.Run("TXMEnabled", func(t *testing.T) {
-		t.Run("turn on TXMEnabled by default", func(t *testing.T) {
-			assert.True(t, cfg.EVM().TXMEnabled())
+	t.Run("TransactionManagerEnabled", func(t *testing.T) {
+		t.Run("turn on TransactionManagerEnabled by default", func(t *testing.T) {
+			assert.True(t, cfg.EVM().TransactionManagerEnabled())
 		})
 
-		t.Run("verify TXMEnabled is set correctly", func(t *testing.T) {
+		t.Run("verify TransactionManagerEnabled is set correctly", func(t *testing.T) {
 			val := false
 			cfg3 := testutils.NewTestChainScopedConfig(t, func(c *toml.EVMConfig) {
-				c.TXMEnabled = ptr(val)
+				c.TransactionManagerEnabled = ptr(val)
 			})
 
-			assert.False(t, cfg3.EVM().TXMEnabled())
+			assert.False(t, cfg3.EVM().TransactionManagerEnabled())
 		})
 	})
 }

--- a/core/chains/evm/config/config_test.go
+++ b/core/chains/evm/config/config_test.go
@@ -221,18 +221,18 @@ func TestChainScopedConfig(t *testing.T) {
 		})
 	})
 
-	t.Run("TransactionManagerEnabled", func(t *testing.T) {
-		t.Run("turn on TransactionManagerEnabled by default", func(t *testing.T) {
-			assert.True(t, cfg.EVM().TransactionManagerEnabled())
+	t.Run("EVM.Transactions.Enabled", func(t *testing.T) {
+		t.Run("turn on EVM.Transactions.Enabled by default", func(t *testing.T) {
+			assert.True(t, cfg.EVM().Transactions().Enabled())
 		})
 
-		t.Run("verify TransactionManagerEnabled is set correctly", func(t *testing.T) {
+		t.Run("verify EVM.Transactions.Enabled is set correctly", func(t *testing.T) {
 			val := false
 			cfg3 := testutils.NewTestChainScopedConfig(t, func(c *toml.EVMConfig) {
-				c.TransactionManagerEnabled = ptr(val)
+				c.Transactions.Enabled = ptr(val)
 			})
 
-			assert.False(t, cfg3.EVM().TransactionManagerEnabled())
+			assert.False(t, cfg3.EVM().Transactions().Enabled())
 		})
 	})
 }

--- a/core/chains/evm/config/config_test.go
+++ b/core/chains/evm/config/config_test.go
@@ -223,7 +223,7 @@ func TestChainScopedConfig(t *testing.T) {
 
 	t.Run("TXMEnabled", func(t *testing.T) {
 		t.Run("turn on TXMEnabled by default", func(t *testing.T) {
-			assert.Equal(t, true, cfg.EVM().TXMEnabled())
+			assert.True(t, cfg.EVM().TXMEnabled())
 		})
 
 		t.Run("verify TXMEnabled is set correctly", func(t *testing.T) {
@@ -232,7 +232,7 @@ func TestChainScopedConfig(t *testing.T) {
 				c.TXMEnabled = ptr(val)
 			})
 
-			assert.Equal(t, false, cfg3.EVM().TXMEnabled())
+			assert.False(t, cfg3.EVM().TXMEnabled())
 		})
 	})
 }

--- a/core/chains/evm/config/config_test.go
+++ b/core/chains/evm/config/config_test.go
@@ -219,9 +219,20 @@ func TestChainScopedConfig(t *testing.T) {
 
 			assert.Equal(t, false, cfg3.EVM().LogBroadcasterEnabled())
 		})
+	})
 
-		t.Run("use Noop logBroadcaster when LogBroadcaster is disabled", func(t *testing.T) {
+	t.Run("TXMEnabled", func(t *testing.T) {
+		t.Run("turn on TXMEnabled by default", func(t *testing.T) {
+			assert.Equal(t, true, cfg.EVM().TXMEnabled())
+		})
 
+		t.Run("verify TXMEnabled is set correctly", func(t *testing.T) {
+			val := false
+			cfg3 := testutils.NewTestChainScopedConfig(t, func(c *toml.EVMConfig) {
+				c.TXMEnabled = ptr(val)
+			})
+
+			assert.Equal(t, false, cfg3.EVM().TXMEnabled())
 		})
 	})
 }

--- a/core/chains/evm/config/toml/config.go
+++ b/core/chains/evm/config/toml/config.go
@@ -386,7 +386,6 @@ type Chain struct {
 	RPCBlockQueryDelay           *uint16
 	FinalizedBlockOffset         *uint32
 	NoNewFinalizedHeadsThreshold *commonconfig.Duration
-	TransactionManagerEnabled    *bool
 
 	Transactions   Transactions      `toml:",omitempty"`
 	BalanceMonitor BalanceMonitor    `toml:",omitempty"`
@@ -473,6 +472,7 @@ func (c *Chain) ValidateConfig() (err error) {
 }
 
 type Transactions struct {
+	Enabled              *bool
 	ForwardersEnabled    *bool
 	MaxInFlight          *uint32
 	MaxQueued            *uint32
@@ -484,6 +484,9 @@ type Transactions struct {
 }
 
 func (t *Transactions) setFrom(f *Transactions) {
+	if v := f.Enabled; v != nil {
+		t.Enabled = v
+	}
 	if v := f.ForwardersEnabled; v != nil {
 		t.ForwardersEnabled = v
 	}

--- a/core/chains/evm/config/toml/config.go
+++ b/core/chains/evm/config/toml/config.go
@@ -386,6 +386,7 @@ type Chain struct {
 	RPCBlockQueryDelay           *uint16
 	FinalizedBlockOffset         *uint32
 	NoNewFinalizedHeadsThreshold *commonconfig.Duration
+	TXMEnabled                   *bool
 
 	Transactions   Transactions      `toml:",omitempty"`
 	BalanceMonitor BalanceMonitor    `toml:",omitempty"`

--- a/core/chains/evm/config/toml/config.go
+++ b/core/chains/evm/config/toml/config.go
@@ -386,7 +386,7 @@ type Chain struct {
 	RPCBlockQueryDelay           *uint16
 	FinalizedBlockOffset         *uint32
 	NoNewFinalizedHeadsThreshold *commonconfig.Duration
-	TXMEnabled                   *bool
+	TransactionManagerEnabled    *bool
 
 	Transactions   Transactions      `toml:",omitempty"`
 	BalanceMonitor BalanceMonitor    `toml:",omitempty"`

--- a/core/chains/evm/config/toml/defaults.go
+++ b/core/chains/evm/config/toml/defaults.go
@@ -239,9 +239,6 @@ func (c *Chain) SetFrom(f *Chain) {
 	if v := f.NoNewFinalizedHeadsThreshold; v != nil {
 		c.NoNewFinalizedHeadsThreshold = v
 	}
-	if v := f.TransactionManagerEnabled; v != nil {
-		c.TransactionManagerEnabled = v
-	}
 
 	c.Transactions.setFrom(&f.Transactions)
 	c.BalanceMonitor.setFrom(&f.BalanceMonitor)

--- a/core/chains/evm/config/toml/defaults.go
+++ b/core/chains/evm/config/toml/defaults.go
@@ -236,9 +236,11 @@ func (c *Chain) SetFrom(f *Chain) {
 	if v := f.FinalizedBlockOffset; v != nil {
 		c.FinalizedBlockOffset = v
 	}
-
 	if v := f.NoNewFinalizedHeadsThreshold; v != nil {
 		c.NoNewFinalizedHeadsThreshold = v
+	}
+	if v := f.TXMEnabled; v != nil {
+		c.TXMEnabled = v
 	}
 
 	c.Transactions.setFrom(&f.Transactions)

--- a/core/chains/evm/config/toml/defaults.go
+++ b/core/chains/evm/config/toml/defaults.go
@@ -239,8 +239,8 @@ func (c *Chain) SetFrom(f *Chain) {
 	if v := f.NoNewFinalizedHeadsThreshold; v != nil {
 		c.NoNewFinalizedHeadsThreshold = v
 	}
-	if v := f.TXMEnabled; v != nil {
-		c.TXMEnabled = v
+	if v := f.TransactionManagerEnabled; v != nil {
+		c.TransactionManagerEnabled = v
 	}
 
 	c.Transactions.setFrom(&f.Transactions)

--- a/core/chains/evm/config/toml/defaults/fallback.toml
+++ b/core/chains/evm/config/toml/defaults/fallback.toml
@@ -17,7 +17,7 @@ RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0'
 LogBroadcasterEnabled = true
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false

--- a/core/chains/evm/config/toml/defaults/fallback.toml
+++ b/core/chains/evm/config/toml/defaults/fallback.toml
@@ -17,6 +17,7 @@ RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0'
 LogBroadcasterEnabled = true
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false

--- a/core/chains/evm/config/toml/defaults/fallback.toml
+++ b/core/chains/evm/config/toml/defaults/fallback.toml
@@ -17,9 +17,9 @@ RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0'
 LogBroadcasterEnabled = true
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250

--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -247,10 +247,10 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 	// note: gas estimator is started as a part of the txm
 	var txm txmgr.TxManager
 	var gasEstimator gas.EvmFeeEstimator
-	//nolint:gocritic // ignoring styling issue
+	//nolint:gocritic // ignoring suggestion to convert to switch statement
 	if !opts.AppConfig.EVMRPCEnabled() {
 		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("Ethereum is disabled for chain %d", chainID)}
-	} else if !cfg.EVM().TXMEnabled() {
+	} else if !cfg.EVM().TransactionManagerEnabled() {
 		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("TXM disabled for chain %d", chainID)}
 	} else {
 		var err error

--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -245,8 +245,8 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 	}
 
 	// initialize gas estimator
-	var gasEstimator gas.EvmFeeEstimator
-	if gasEstimator, err = newGasEstimator(cfg.EVM(), client, l, opts, clientsByChainID); err != nil {
+	gasEstimator, err := newGasEstimator(cfg.EVM(), client, l, opts, clientsByChainID)
+	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate gas estimator for chain with ID %s: %w", chainID, err)
 	}
 

--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -256,7 +256,7 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 		var err error
 		txm, gasEstimator, err = newEvmTxm(opts.DS, cfg.EVM(), opts.AppConfig.Database(), opts.AppConfig.Database().Listener(), client, l, logPoller, opts, headTracker, clientsByChainID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to instantiate EvmTxm for chain with ID %s: %w", chainID.String(), err)
+			return nil, fmt.Errorf("failed to instantiate EvmTxm for chain with ID %s: %w", chainID, err)
 		}
 	}
 

--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -247,6 +247,7 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 	// note: gas estimator is started as a part of the txm
 	var txm txmgr.TxManager
 	var gasEstimator gas.EvmFeeEstimator
+	//nolint // ignoring styling issue
 	if !opts.AppConfig.EVMRPCEnabled() {
 		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("Ethereum is disabled for chain %d", chainID)}
 	} else if !cfg.EVM().TXMEnabled() {

--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -247,7 +247,7 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 	// note: gas estimator is started as a part of the txm
 	var txm txmgr.TxManager
 	var gasEstimator gas.EvmFeeEstimator
-	//nolint // ignoring styling issue
+	//nolint:gocritic // ignoring styling issue
 	if !opts.AppConfig.EVMRPCEnabled() {
 		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("Ethereum is disabled for chain %d", chainID)}
 	} else if !cfg.EVM().TXMEnabled() {

--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -255,7 +255,7 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 	//nolint:gocritic // ignoring suggestion to convert to switch statement
 	if !opts.AppConfig.EVMRPCEnabled() {
 		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("Ethereum is disabled for chain %d", chainID)}
-	} else if !cfg.EVM().TransactionManagerEnabled() {
+	} else if !cfg.EVM().Transactions().Enabled() {
 		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("TXM disabled for chain %d", chainID)}
 	} else {
 		txm, err = newEvmTxm(opts.DS, cfg.EVM(), opts.AppConfig.Database(), opts.AppConfig.Database().Listener(), client, l, logPoller, opts, headTracker, gasEstimator)

--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -245,9 +245,18 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 	}
 
 	// note: gas estimator is started as a part of the txm
-	txm, gasEstimator, err := newEvmTxm(opts.DS, cfg.EVM(), opts.AppConfig.EVMRPCEnabled(), opts.AppConfig.Database(), opts.AppConfig.Database().Listener(), client, l, logPoller, opts, headTracker, clientsByChainID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate EvmTxm for chain with ID %s: %w", chainID.String(), err)
+	var txm txmgr.TxManager
+	var gasEstimator gas.EvmFeeEstimator
+	if !opts.AppConfig.EVMRPCEnabled() {
+		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("Ethereum is disabled for chain %d", chainID)}
+	} else if !cfg.EVM().TXMEnabled() {
+		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("TXM disabled for chain %d", chainID)}
+	} else {
+		var err error
+		txm, gasEstimator, err = newEvmTxm(opts.DS, cfg.EVM(), opts.AppConfig.Database(), opts.AppConfig.Database().Listener(), client, l, logPoller, opts, headTracker, clientsByChainID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to instantiate EvmTxm for chain with ID %s: %w", chainID.String(), err)
+		}
 	}
 
 	headBroadcaster.Subscribe(txm)

--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -244,9 +244,14 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 		}
 	}
 
+	// initialize gas estimator
+	gasEstimator, err := newGasEstimator(cfg.EVM(), client, l, opts, clientsByChainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to instantiate gas estimator for chain with ID %s: %w", chainID, err)
+	}
+
 	// note: gas estimator is started as a part of the txm
 	var txm txmgr.TxManager
-	var gasEstimator gas.EvmFeeEstimator
 	//nolint:gocritic // ignoring suggestion to convert to switch statement
 	if !opts.AppConfig.EVMRPCEnabled() {
 		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("Ethereum is disabled for chain %d", chainID)}
@@ -254,7 +259,7 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("TXM disabled for chain %d", chainID)}
 	} else {
 		var err error
-		txm, gasEstimator, err = newEvmTxm(opts.DS, cfg.EVM(), opts.AppConfig.Database(), opts.AppConfig.Database().Listener(), client, l, logPoller, opts, headTracker, clientsByChainID)
+		txm, err = newEvmTxm(opts.DS, cfg.EVM(), opts.AppConfig.Database(), opts.AppConfig.Database().Listener(), client, l, logPoller, opts, headTracker, gasEstimator)
 		if err != nil {
 			return nil, fmt.Errorf("failed to instantiate EvmTxm for chain with ID %s: %w", chainID, err)
 		}

--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -194,10 +194,10 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 	chainID := cfg.EVM().ChainID()
 	l := opts.Logger
 	var client evmclient.Client
+	var err error
 	if !opts.AppConfig.EVMRPCEnabled() {
 		client = evmclient.NewNullClient(chainID, l)
 	} else if opts.GenEthClient == nil {
-		var err error
 		client, err = evmclient.NewEvmClient(cfg.EVM().NodePool(), cfg.EVM(), cfg.EVM().NodePool().Errors(), l, chainID, nodes, cfg.EVM().ChainType())
 		if err != nil {
 			return nil, err
@@ -245,8 +245,8 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 	}
 
 	// initialize gas estimator
-	gasEstimator, err := newGasEstimator(cfg.EVM(), client, l, opts, clientsByChainID)
-	if err != nil {
+	var gasEstimator gas.EvmFeeEstimator
+	if gasEstimator, err = newGasEstimator(cfg.EVM(), client, l, opts, clientsByChainID); err != nil {
 		return nil, fmt.Errorf("failed to instantiate gas estimator for chain with ID %s: %w", chainID, err)
 	}
 
@@ -258,7 +258,6 @@ func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Nod
 	} else if !cfg.EVM().TransactionManagerEnabled() {
 		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("TXM disabled for chain %d", chainID)}
 	} else {
-		var err error
 		txm, err = newEvmTxm(opts.DS, cfg.EVM(), opts.AppConfig.Database(), opts.AppConfig.Database().Listener(), client, l, logPoller, opts, headTracker, gasEstimator)
 		if err != nil {
 			return nil, fmt.Errorf("failed to instantiate EvmTxm for chain with ID %s: %w", chainID, err)

--- a/core/chains/legacyevm/evm_txm.go
+++ b/core/chains/legacyevm/evm_txm.go
@@ -24,9 +24,8 @@ func newEvmTxm(
 	logPoller logpoller.LogPoller,
 	opts ChainRelayOpts,
 	headTracker httypes.HeadTracker,
-	clientsByChainID map[string]rollups.DAClient,
-) (txm txmgr.TxManager,
 	estimator gas.EvmFeeEstimator,
+) (txm txmgr.TxManager,
 	err error,
 ) {
 	chainID := cfg.ChainID()
@@ -39,15 +38,6 @@ func newEvmTxm(
 		"nonceAutoSync", cfg.NonceAutoSync(),
 		"limitDefault", cfg.GasEstimator().LimitDefault(),
 	)
-
-	// build estimator from factory
-	if opts.GenGasEstimator == nil {
-		if estimator, err = gas.NewEstimator(lggr, client, cfg.ChainType(), chainID, cfg.GasEstimator(), clientsByChainID); err != nil {
-			return nil, nil, fmt.Errorf("failed to initialize estimator: %w", err)
-		}
-	} else {
-		estimator = opts.GenGasEstimator(chainID)
-	}
 
 	if opts.GenTxManager == nil {
 		txm, err = txmgr.NewTxm(
@@ -66,6 +56,26 @@ func newEvmTxm(
 			headTracker)
 	} else {
 		txm = opts.GenTxManager(chainID)
+	}
+	return
+}
+
+func newGasEstimator(
+	cfg evmconfig.EVM,
+	client evmclient.Client,
+	lggr logger.Logger,
+	opts ChainRelayOpts,
+	clientsByChainID map[string]rollups.DAClient,
+) (estimator gas.EvmFeeEstimator, err error) {
+	lggr = lggr.Named("GasEstimator")
+	chainID := cfg.ChainID()
+	// build estimator from factory
+	if opts.GenGasEstimator == nil {
+		if estimator, err = gas.NewEstimator(lggr, client, cfg.ChainType(), chainID, cfg.GasEstimator(), clientsByChainID); err != nil {
+			return nil, fmt.Errorf("failed to initialize estimator: %w", err)
+		}
+	} else {
+		estimator = opts.GenGasEstimator(chainID)
 	}
 	return
 }

--- a/core/chains/legacyevm/evm_txm.go
+++ b/core/chains/legacyevm/evm_txm.go
@@ -67,7 +67,7 @@ func newGasEstimator(
 	opts ChainRelayOpts,
 	clientsByChainID map[string]rollups.DAClient,
 ) (estimator gas.EvmFeeEstimator, err error) {
-	lggr = lggr.Named("GasEstimator")
+	lggr = lggr.Named("Txm")
 	chainID := cfg.ChainID()
 	// build estimator from factory
 	if opts.GenGasEstimator == nil {

--- a/core/chains/legacyevm/evm_txm.go
+++ b/core/chains/legacyevm/evm_txm.go
@@ -17,7 +17,6 @@ import (
 func newEvmTxm(
 	ds sqlutil.DataSource,
 	cfg evmconfig.EVM,
-	evmRPCEnabled bool,
 	databaseConfig txmgr.DatabaseConfig,
 	listenerConfig txmgr.ListenerConfig,
 	client evmclient.Client,
@@ -31,10 +30,6 @@ func newEvmTxm(
 	err error,
 ) {
 	chainID := cfg.ChainID()
-	if !evmRPCEnabled {
-		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("Ethereum is disabled for chain %d", chainID)}
-		return txm, nil, nil
-	}
 
 	lggr = lggr.Named("Txm")
 	lggr.Infow("Initializing EVM transaction manager",

--- a/core/config/docs/chains-evm.toml
+++ b/core/config/docs/chains-evm.toml
@@ -104,7 +104,7 @@ LogBroadcasterEnabled = true # Default
 #
 # Set to zero to disable.
 NoNewFinalizedHeadsThreshold = '0' # Default
-# TXMEnabled is a feature flag for the Transaction Manager
+# TXMEnabled is a feature flag for the Transaction Manager. This flag also enables or disables the gas estimator since it is dependent on the TXM to start it.
 TXMEnabled = true # Default
 
 [EVM.Transactions]

--- a/core/config/docs/chains-evm.toml
+++ b/core/config/docs/chains-evm.toml
@@ -104,6 +104,8 @@ LogBroadcasterEnabled = true # Default
 #
 # Set to zero to disable.
 NoNewFinalizedHeadsThreshold = '0' # Default
+# TXMEnabled is a feature flag for the Transaction Manager
+TXMEnabled = true # Default
 
 [EVM.Transactions]
 # ForwardersEnabled enables or disables sending transactions through forwarder contracts.

--- a/core/config/docs/chains-evm.toml
+++ b/core/config/docs/chains-evm.toml
@@ -104,10 +104,10 @@ LogBroadcasterEnabled = true # Default
 #
 # Set to zero to disable.
 NoNewFinalizedHeadsThreshold = '0' # Default
-# TransactionManagerEnabled is a feature flag for the Transaction Manager. This flag also enables or disables the gas estimator since it is dependent on the TXM to start it.
-TransactionManagerEnabled = true # Default
 
 [EVM.Transactions]
+# Enabled is a feature flag for the Transaction Manager. This flag also enables or disables the gas estimator since it is dependent on the TXM to start it.
+Enabled = true # Default
 # ForwardersEnabled enables or disables sending transactions through forwarder contracts.
 ForwardersEnabled = false # Default
 # MaxInFlight controls how many transactions are allowed to be "in-flight" i.e. broadcast but unconfirmed at any one time. You can consider this a form of transaction throttling.

--- a/core/config/docs/chains-evm.toml
+++ b/core/config/docs/chains-evm.toml
@@ -104,8 +104,8 @@ LogBroadcasterEnabled = true # Default
 #
 # Set to zero to disable.
 NoNewFinalizedHeadsThreshold = '0' # Default
-# TXMEnabled is a feature flag for the Transaction Manager. This flag also enables or disables the gas estimator since it is dependent on the TXM to start it.
-TXMEnabled = true # Default
+# TransactionManagerEnabled is a feature flag for the Transaction Manager. This flag also enables or disables the gas estimator since it is dependent on the TXM to start it.
+TransactionManagerEnabled = true # Default
 
 [EVM.Transactions]
 # ForwardersEnabled enables or disables sending transactions through forwarder contracts.

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -586,7 +586,6 @@ func TestConfig_Marshal(t *testing.T) {
 				FinalityTagEnabled:        ptr[bool](true),
 				FlagsContractAddress:      mustAddress("0xae4E781a6218A8031764928E88d457937A954fC3"),
 				FinalizedBlockOffset:      ptr[uint32](16),
-				TransactionManagerEnabled: ptr(true),
 
 				GasEstimator: evmcfg.GasEstimator{
 					Mode:               ptr("SuggestedPrice"),
@@ -655,6 +654,7 @@ func TestConfig_Marshal(t *testing.T) {
 				NoNewFinalizedHeadsThreshold: &hour,
 
 				Transactions: evmcfg.Transactions{
+					Enabled:              ptr(true),
 					MaxInFlight:          ptr[uint32](19),
 					MaxQueued:            ptr[uint32](99),
 					ReaperInterval:       &minute,
@@ -1117,9 +1117,9 @@ RPCDefaultBatchSize = 17
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 16
 NoNewFinalizedHeadsThreshold = '1h0m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = true
 MaxInFlight = 19
 MaxQueued = 99

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -1117,6 +1117,7 @@ RPCDefaultBatchSize = 17
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 16
 NoNewFinalizedHeadsThreshold = '1h0m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = true

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -579,13 +579,13 @@ func TestConfig_Marshal(t *testing.T) {
 				BalanceMonitor: evmcfg.BalanceMonitor{
 					Enabled: ptr(true),
 				},
-				BlockBackfillDepth:        ptr[uint32](100),
-				BlockBackfillSkip:         ptr(true),
-				ChainType:                 chaintype.NewConfig("Optimism"),
-				FinalityDepth:             ptr[uint32](42),
-				FinalityTagEnabled:        ptr[bool](true),
-				FlagsContractAddress:      mustAddress("0xae4E781a6218A8031764928E88d457937A954fC3"),
-				FinalizedBlockOffset:      ptr[uint32](16),
+				BlockBackfillDepth:   ptr[uint32](100),
+				BlockBackfillSkip:    ptr(true),
+				ChainType:            chaintype.NewConfig("Optimism"),
+				FinalityDepth:        ptr[uint32](42),
+				FinalityTagEnabled:   ptr[bool](true),
+				FlagsContractAddress: mustAddress("0xae4E781a6218A8031764928E88d457937A954fC3"),
+				FinalizedBlockOffset: ptr[uint32](16),
 
 				GasEstimator: evmcfg.GasEstimator{
 					Mode:               ptr("SuggestedPrice"),

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -579,14 +579,14 @@ func TestConfig_Marshal(t *testing.T) {
 				BalanceMonitor: evmcfg.BalanceMonitor{
 					Enabled: ptr(true),
 				},
-				BlockBackfillDepth:   ptr[uint32](100),
-				BlockBackfillSkip:    ptr(true),
-				ChainType:            chaintype.NewConfig("Optimism"),
-				FinalityDepth:        ptr[uint32](42),
-				FinalityTagEnabled:   ptr[bool](true),
-				FlagsContractAddress: mustAddress("0xae4E781a6218A8031764928E88d457937A954fC3"),
-				FinalizedBlockOffset: ptr[uint32](16),
-				TXMEnabled:           ptr(true),
+				BlockBackfillDepth:        ptr[uint32](100),
+				BlockBackfillSkip:         ptr(true),
+				ChainType:                 chaintype.NewConfig("Optimism"),
+				FinalityDepth:             ptr[uint32](42),
+				FinalityTagEnabled:        ptr[bool](true),
+				FlagsContractAddress:      mustAddress("0xae4E781a6218A8031764928E88d457937A954fC3"),
+				FinalizedBlockOffset:      ptr[uint32](16),
+				TransactionManagerEnabled: ptr(true),
 
 				GasEstimator: evmcfg.GasEstimator{
 					Mode:               ptr("SuggestedPrice"),
@@ -1117,7 +1117,7 @@ RPCDefaultBatchSize = 17
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 16
 NoNewFinalizedHeadsThreshold = '1h0m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = true

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -586,6 +586,7 @@ func TestConfig_Marshal(t *testing.T) {
 				FinalityTagEnabled:   ptr[bool](true),
 				FlagsContractAddress: mustAddress("0xae4E781a6218A8031764928E88d457937A954fC3"),
 				FinalizedBlockOffset: ptr[uint32](16),
+				TXMEnabled:           ptr(true),
 
 				GasEstimator: evmcfg.GasEstimator{
 					Mode:               ptr("SuggestedPrice"),

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -335,9 +335,9 @@ RPCDefaultBatchSize = 17
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 16
 NoNewFinalizedHeadsThreshold = '1h0m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = true
 MaxInFlight = 19
 MaxQueued = 99

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -335,7 +335,7 @@ RPCDefaultBatchSize = 17
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 16
 NoNewFinalizedHeadsThreshold = '1h0m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = true

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -335,6 +335,7 @@ RPCDefaultBatchSize = 17
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 16
 NoNewFinalizedHeadsThreshold = '1h0m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = true

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -318,6 +318,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 12
 NoNewFinalizedHeadsThreshold = '9m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false
@@ -428,6 +429,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false
@@ -532,6 +534,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '6m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -318,9 +318,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 12
 NoNewFinalizedHeadsThreshold = '9m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -429,9 +429,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -534,9 +534,9 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '6m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 5000

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -318,7 +318,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 12
 NoNewFinalizedHeadsThreshold = '9m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false
@@ -429,7 +429,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false
@@ -534,7 +534,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '6m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -335,7 +335,7 @@ RPCDefaultBatchSize = 17
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = true

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -335,9 +335,9 @@ RPCDefaultBatchSize = 17
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = true
 MaxInFlight = 19
 MaxQueued = 99

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -335,6 +335,7 @@ RPCDefaultBatchSize = 17
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = true

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -318,6 +318,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false
@@ -428,6 +429,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false
@@ -532,6 +534,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '6m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -318,9 +318,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -429,9 +429,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -534,9 +534,9 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '6m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 5000

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -318,7 +318,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false
@@ -429,7 +429,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false
@@ -534,7 +534,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '6m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2032,6 +2032,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2136,6 +2137,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2240,6 +2242,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2344,6 +2347,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2449,6 +2453,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '13m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2557,6 +2562,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2661,6 +2667,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2766,6 +2773,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2870,6 +2878,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '45s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2973,6 +2982,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3076,6 +3086,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3180,6 +3191,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '40s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3285,6 +3297,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '2m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3389,6 +3402,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3493,6 +3507,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '6m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3597,6 +3612,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 15
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3702,6 +3718,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 15
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3807,6 +3824,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h10m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3915,6 +3933,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4019,6 +4038,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4127,6 +4147,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4234,6 +4255,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4338,6 +4360,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4442,6 +4465,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4549,6 +4573,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4657,6 +4682,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4765,6 +4791,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h30m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4873,6 +4900,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4976,6 +5004,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5080,6 +5109,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5184,6 +5214,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 15
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5289,6 +5320,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '40s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5393,6 +5425,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '40s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5497,6 +5530,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h10m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5605,6 +5639,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '45m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5712,6 +5747,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5817,6 +5853,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '2h0m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5925,6 +5962,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6029,6 +6067,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6133,6 +6172,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6241,6 +6281,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6346,6 +6387,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6450,6 +6492,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h30m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6557,6 +6600,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6661,6 +6705,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6769,6 +6814,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '2m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6874,6 +6920,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6982,6 +7029,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7090,6 +7138,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7197,6 +7246,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '1m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7301,6 +7351,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '1m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7405,6 +7456,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '1m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7509,6 +7561,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '45m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7614,6 +7667,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7725,6 +7779,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7834,6 +7889,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7937,6 +7993,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8042,6 +8099,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8148,6 +8206,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8252,6 +8311,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h50m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8360,6 +8420,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8463,6 +8524,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '12m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8566,6 +8628,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '5m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8670,6 +8733,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8778,6 +8842,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '12m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8887,6 +8952,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8995,6 +9061,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9102,6 +9169,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9209,6 +9277,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9318,6 +9387,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9427,6 +9497,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h50m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9535,6 +9606,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9639,6 +9711,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9747,6 +9820,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9851,6 +9925,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
+TXMEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -10134,6 +10209,12 @@ NoNewFinalizedHeadsThreshold controls how long to wait for new finalized block b
 out-of-sync. Only applicable if `FinalityTagEnabled=true`
 
 Set to zero to disable.
+
+### TXMEnabled
+```toml
+TXMEnabled = true # Default
+```
+TXMEnabled is a feature flag for the Transaction Manager
 
 ## EVM.Transactions
 ```toml

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -10214,7 +10214,7 @@ Set to zero to disable.
 ```toml
 TXMEnabled = true # Default
 ```
-TXMEnabled is a feature flag for the Transaction Manager
+TXMEnabled is a feature flag for the Transaction Manager. This flag also enables or disables the gas estimator since it is dependent on the TXM to start it.
 
 ## EVM.Transactions
 ```toml

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2032,9 +2032,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -2137,9 +2137,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -2242,9 +2242,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -2347,9 +2347,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -2453,9 +2453,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '13m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -2562,9 +2562,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -2667,9 +2667,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -2773,9 +2773,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -2878,9 +2878,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '45s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -2982,9 +2982,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -3086,9 +3086,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -3191,9 +3191,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '40s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -3297,9 +3297,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '2m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -3402,9 +3402,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -3507,9 +3507,9 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '6m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 5000
@@ -3612,9 +3612,9 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 15
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -3718,9 +3718,9 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 15
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -3824,9 +3824,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h10m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -3933,9 +3933,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -4038,9 +4038,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -4147,9 +4147,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -4255,9 +4255,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -4360,9 +4360,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -4465,9 +4465,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -4573,9 +4573,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -4682,9 +4682,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -4791,9 +4791,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h30m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -4900,9 +4900,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -5004,9 +5004,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -5109,9 +5109,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -5214,9 +5214,9 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 15
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -5320,9 +5320,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '40s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -5425,9 +5425,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '40s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -5530,9 +5530,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h10m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -5639,9 +5639,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '45m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -5747,9 +5747,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -5853,9 +5853,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '2h0m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -5962,9 +5962,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -6067,9 +6067,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -6172,9 +6172,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -6281,9 +6281,9 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -6387,9 +6387,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -6492,9 +6492,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h30m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -6600,9 +6600,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -6705,9 +6705,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -6814,9 +6814,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '2m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -6920,9 +6920,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -7029,9 +7029,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -7138,9 +7138,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -7246,9 +7246,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '1m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -7351,9 +7351,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '1m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -7456,9 +7456,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '1m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -7561,9 +7561,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '45m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -7667,9 +7667,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -7779,9 +7779,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -7889,9 +7889,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -7993,9 +7993,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -8099,9 +8099,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -8206,9 +8206,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -8311,9 +8311,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h50m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -8420,9 +8420,9 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 5000
@@ -8524,9 +8524,9 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '12m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 5000
@@ -8628,9 +8628,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '5m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -8733,9 +8733,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -8842,9 +8842,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '12m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -8952,9 +8952,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -9061,9 +9061,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -9169,9 +9169,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -9277,9 +9277,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -9387,9 +9387,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -9497,9 +9497,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h50m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -9606,9 +9606,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -9711,9 +9711,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -9820,9 +9820,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -9925,9 +9925,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TransactionManagerEnabled = true
 
 [Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250
@@ -10210,15 +10210,10 @@ out-of-sync. Only applicable if `FinalityTagEnabled=true`
 
 Set to zero to disable.
 
-### TransactionManagerEnabled
-```toml
-TransactionManagerEnabled = true # Default
-```
-TransactionManagerEnabled is a feature flag for the Transaction Manager. This flag also enables or disables the gas estimator since it is dependent on the TXM to start it.
-
 ## EVM.Transactions
 ```toml
 [EVM.Transactions]
+Enabled = true # Default
 ForwardersEnabled = false # Default
 MaxInFlight = 16 # Default
 MaxQueued = 250 # Default
@@ -10227,6 +10222,12 @@ ReaperThreshold = '168h' # Default
 ResendAfterThreshold = '1m' # Default
 ```
 
+
+### Enabled
+```toml
+Enabled = true # Default
+```
+Enabled is a feature flag for the Transaction Manager. This flag also enables or disables the gas estimator since it is dependent on the TXM to start it.
 
 ### ForwardersEnabled
 ```toml

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2032,7 +2032,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2137,7 +2137,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2242,7 +2242,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2347,7 +2347,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2453,7 +2453,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '13m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2562,7 +2562,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2667,7 +2667,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2773,7 +2773,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2878,7 +2878,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '45s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -2982,7 +2982,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3086,7 +3086,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3191,7 +3191,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '40s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3297,7 +3297,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '2m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3402,7 +3402,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3507,7 +3507,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '6m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3612,7 +3612,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 15
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3718,7 +3718,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 15
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3824,7 +3824,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h10m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -3933,7 +3933,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4038,7 +4038,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4147,7 +4147,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4255,7 +4255,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4360,7 +4360,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4465,7 +4465,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4573,7 +4573,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4682,7 +4682,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4791,7 +4791,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h30m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -4900,7 +4900,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5004,7 +5004,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5109,7 +5109,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5214,7 +5214,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 15
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5320,7 +5320,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '40s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5425,7 +5425,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '40s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5530,7 +5530,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h10m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5639,7 +5639,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '45m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5747,7 +5747,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5853,7 +5853,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '2h0m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -5962,7 +5962,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6067,7 +6067,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6172,7 +6172,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6281,7 +6281,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6387,7 +6387,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6492,7 +6492,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h30m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6600,7 +6600,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6705,7 +6705,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6814,7 +6814,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '2m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -6920,7 +6920,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7029,7 +7029,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7138,7 +7138,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7246,7 +7246,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '1m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7351,7 +7351,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '1m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7456,7 +7456,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '1m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7561,7 +7561,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '45m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7667,7 +7667,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7779,7 +7779,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7889,7 +7889,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -7993,7 +7993,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8099,7 +8099,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8206,7 +8206,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8311,7 +8311,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h50m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8420,7 +8420,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8524,7 +8524,7 @@ RPCDefaultBatchSize = 100
 RPCBlockQueryDelay = 10
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '12m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8628,7 +8628,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '5m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8733,7 +8733,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8842,7 +8842,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '12m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -8952,7 +8952,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9061,7 +9061,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9169,7 +9169,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9277,7 +9277,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9387,7 +9387,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9497,7 +9497,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '1h50m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9606,7 +9606,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9711,7 +9711,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '15m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9820,7 +9820,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -9925,7 +9925,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [Transactions]
 ForwardersEnabled = false
@@ -10210,11 +10210,11 @@ out-of-sync. Only applicable if `FinalityTagEnabled=true`
 
 Set to zero to disable.
 
-### TXMEnabled
+### TransactionManagerEnabled
 ```toml
-TXMEnabled = true # Default
+TransactionManagerEnabled = true # Default
 ```
-TXMEnabled is a feature flag for the Transaction Manager. This flag also enables or disables the gas estimator since it is dependent on the TXM to start it.
+TransactionManagerEnabled is a feature flag for the Transaction Manager. This flag also enables or disables the gas estimator since it is dependent on the TXM to start it.
 
 ## EVM.Transactions
 ```toml

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -391,7 +391,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -391,6 +391,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -391,9 +391,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -374,6 +374,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -374,9 +374,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -374,7 +374,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -374,6 +374,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -374,9 +374,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -374,7 +374,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -374,6 +374,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -374,9 +374,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -374,7 +374,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -364,9 +364,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -364,6 +364,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -364,7 +364,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -371,6 +371,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
+TXMEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -371,7 +371,7 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TXMEnabled = true
+TransactionManagerEnabled = true
 
 [EVM.Transactions]
 ForwardersEnabled = false

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -371,9 +371,9 @@ RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
 NoNewFinalizedHeadsThreshold = '9m0s'
-TransactionManagerEnabled = true
 
 [EVM.Transactions]
+Enabled = true
 ForwardersEnabled = false
 MaxInFlight = 16
 MaxQueued = 250


### PR DESCRIPTION
[MERC-6516](https://smartcontract-it.atlassian.net/browse/MERC-6516)

Added the `TransactionManagerEnabled` config to enable or disable the TXM. This toggle was added so a product that only needs read-only access (i.e client, head tracker, log poller) can disable the unused component.

[MERC-6516]: https://smartcontract-it.atlassian.net/browse/MERC-6516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ