### PR TITLE
Fix Mercury Transmitter context cancellation

### DIFF
--- a/core/services/relay/evm/mercury/transmitter.go
+++ b/core/services/relay/evm/mercury/transmitter.go
@@ -236,7 +236,7 @@ func (s *server) runQueueLoop(stopCh services.StopChan, wg *sync.WaitGroup, feed
 		}
 		res, err := func(ctx context.Context) (*pb.TransmitResponse, error) {
 			ctx, cancel := context.WithTimeout(ctx, utils.WithJitter(s.transmitTimeout))
-			cancel()
+			defer cancel()
 			return s.c.Transmit(ctx, t.Req)
 		}(ctx)
 		if ctx.Err() != nil {


### PR DESCRIPTION
This reverts the issue with the jitter timeout on the Mercury Transmitter. It was causing the transmitter queue to get stuck and grow until we hit the limit.
