### PR TITLE
Gracefully fail if CL_DATABASE_URL is not set

### DIFF
--- a/.changeset/beige-geckos-explode.md
+++ b/.changeset/beige-geckos-explode.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#updated Gracefully fail if CL_DATABASE_URL is not set.

--- a/core/services/chainlink/config_database.go
+++ b/core/services/chainlink/config_database.go
@@ -107,6 +107,9 @@ func (d *databaseConfig) DefaultQueryTimeout() time.Duration {
 }
 
 func (d *databaseConfig) URL() url.URL {
+	if d.s.URL == nil {
+		return url.URL{}
+	}
 	return *d.s.URL.URL()
 }
 


### PR DESCRIPTION
Before this change running an integration test without CL_DATABASE_URL results in panic:

```
--- FAIL: Test_CCIPBatching_SingleSource (0.06s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
```

After this change we get a verbose message:
```
        	Error:      	Received unexpected error:
        	            	path missing from database URL
        	Test:       	Test_CCIPBatching_SingleSource
```