### PR TITLE
ccip: Remove unnecessary generics.

### DIFF
--- a/core/capabilities/ccip/ocrimpls/contract_transmitter.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter.go
@@ -17,19 +17,19 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 )
 
-type toCalldataFunc func(
+type ToCalldataFunc func(
 	rawReportCtx [2][32]byte,
-	report ocr3types.ReportWithInfo[[]byte],
+	report []byte,
 	rs, ss [][32]byte,
 	vs [32]byte,
-) (any, error)
+) any
 
 func ToCommitCalldata(
 	rawReportCtx [2][32]byte,
-	report ocr3types.ReportWithInfo[[]byte],
+	report []byte,
 	rs, ss [][32]byte,
 	vs [32]byte,
-) (any, error) {
+) any {
 	// Note that the name of the struct field is very important, since the encoder used
 	// by the chainwriter uses mapstructure, which will use the struct field name to map
 	// to the argument name in the function call.
@@ -47,19 +47,19 @@ func ToCommitCalldata(
 		RawVs         [32]byte
 	}{
 		ReportContext: rawReportCtx,
-		Report:        report.Report,
+		Report:        report,
 		Rs:            rs,
 		Ss:            ss,
 		RawVs:         vs,
-	}, nil
+	}
 }
 
 func ToExecCalldata(
 	rawReportCtx [2][32]byte,
-	report ocr3types.ReportWithInfo[[]byte],
+	report []byte,
 	rs, ss [][32]byte,
 	vs [32]byte,
-) (any, error) {
+) any {
 	// Note that the name of the struct field is very important, since the encoder used
 	// by the chainwriter uses mapstructure, which will use the struct field name to map
 	// to the argument name in the function call.
@@ -74,8 +74,8 @@ func ToExecCalldata(
 		Report        []byte
 	}{
 		ReportContext: rawReportCtx,
-		Report:        report.Report,
-	}, nil
+		Report:        report,
+	}
 }
 
 var _ ocr3types.ContractTransmitter[[]byte] = &commitTransmitter{}
@@ -86,7 +86,7 @@ type commitTransmitter struct {
 	contractName   string
 	method         string
 	offrampAddress string
-	toCalldataFn   toCalldataFunc
+	toCalldataFn   ToCalldataFunc
 }
 
 func XXXNewContractTransmitterTestsOnly(
@@ -95,7 +95,7 @@ func XXXNewContractTransmitterTestsOnly(
 	contractName string,
 	method string,
 	offrampAddress string,
-	toCalldataFn toCalldataFunc,
+	toCalldataFn ToCalldataFunc,
 ) ocr3types.ContractTransmitter[[]byte] {
 	return &commitTransmitter{
 		cw:             cw,
@@ -176,10 +176,7 @@ func (c *commitTransmitter) Transmit(
 	}
 
 	// chain writer takes in the raw calldata and packs it on its own.
-	args, err := c.toCalldataFn(rawReportCtx, reportWithInfo, rs, ss, vs)
-	if err != nil {
-		return fmt.Errorf("failed to generate call data: %w", err)
-	}
+	args := c.toCalldataFn(rawReportCtx, reportWithInfo.Report, rs, ss, vs)
 
 	// TODO: no meta fields yet, what should we add?
 	// probably whats in the info part of the report?

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	"github.com/google/uuid"
+
 	"github.com/smartcontractkit/libocr/offchainreporting2/chains/evmutil"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -16,9 +17,19 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 )
 
-type ToCalldataFunc func(rawReportCtx [2][32]byte, report []byte, rs, ss [][32]byte, vs [32]byte) any
+type toCalldataFunc func(
+	rawReportCtx [2][32]byte,
+	report ocr3types.ReportWithInfo[[]byte],
+	rs, ss [][32]byte,
+	vs [32]byte,
+) (any, error)
 
-func ToCommitCalldata(rawReportCtx [2][32]byte, report []byte, rs, ss [][32]byte, vs [32]byte) any {
+func ToCommitCalldata(
+	rawReportCtx [2][32]byte,
+	report ocr3types.ReportWithInfo[[]byte],
+	rs, ss [][32]byte,
+	vs [32]byte,
+) (any, error) {
 	// Note that the name of the struct field is very important, since the encoder used
 	// by the chainwriter uses mapstructure, which will use the struct field name to map
 	// to the argument name in the function call.
@@ -36,14 +47,19 @@ func ToCommitCalldata(rawReportCtx [2][32]byte, report []byte, rs, ss [][32]byte
 		RawVs         [32]byte
 	}{
 		ReportContext: rawReportCtx,
-		Report:        report,
+		Report:        report.Report,
 		Rs:            rs,
 		Ss:            ss,
 		RawVs:         vs,
-	}
+	}, nil
 }
 
-func ToExecCalldata(rawReportCtx [2][32]byte, report []byte, _, _ [][32]byte, _ [32]byte) any {
+func ToExecCalldata(
+	rawReportCtx [2][32]byte,
+	report ocr3types.ReportWithInfo[[]byte],
+	rs, ss [][32]byte,
+	vs [32]byte,
+) (any, error) {
 	// Note that the name of the struct field is very important, since the encoder used
 	// by the chainwriter uses mapstructure, which will use the struct field name to map
 	// to the argument name in the function call.
@@ -58,30 +74,30 @@ func ToExecCalldata(rawReportCtx [2][32]byte, report []byte, _, _ [][32]byte, _ 
 		Report        []byte
 	}{
 		ReportContext: rawReportCtx,
-		Report:        report,
-	}
+		Report:        report.Report,
+	}, nil
 }
 
-var _ ocr3types.ContractTransmitter[[]byte] = &commitTransmitter[[]byte]{}
+var _ ocr3types.ContractTransmitter[[]byte] = &commitTransmitter{}
 
-type commitTransmitter[RI any] struct {
+type commitTransmitter struct {
 	cw             commontypes.ContractWriter
 	fromAccount    ocrtypes.Account
 	contractName   string
 	method         string
 	offrampAddress string
-	toCalldataFn   ToCalldataFunc
+	toCalldataFn   toCalldataFunc
 }
 
-func XXXNewContractTransmitterTestsOnly[RI any](
+func XXXNewContractTransmitterTestsOnly(
 	cw commontypes.ContractWriter,
 	fromAccount ocrtypes.Account,
 	contractName string,
 	method string,
 	offrampAddress string,
-	toCalldataFn ToCalldataFunc,
-) ocr3types.ContractTransmitter[RI] {
-	return &commitTransmitter[RI]{
+	toCalldataFn toCalldataFunc,
+) ocr3types.ContractTransmitter[[]byte] {
+	return &commitTransmitter{
 		cw:             cw,
 		fromAccount:    fromAccount,
 		contractName:   contractName,
@@ -91,12 +107,12 @@ func XXXNewContractTransmitterTestsOnly[RI any](
 	}
 }
 
-func NewCommitContractTransmitter[RI any](
+func NewCommitContractTransmitter(
 	cw commontypes.ContractWriter,
 	fromAccount ocrtypes.Account,
 	offrampAddress string,
-) ocr3types.ContractTransmitter[RI] {
-	return &commitTransmitter[RI]{
+) ocr3types.ContractTransmitter[[]byte] {
+	return &commitTransmitter{
 		cw:             cw,
 		fromAccount:    fromAccount,
 		contractName:   consts.ContractNameOffRamp,
@@ -106,12 +122,12 @@ func NewCommitContractTransmitter[RI any](
 	}
 }
 
-func NewExecContractTransmitter[RI any](
+func NewExecContractTransmitter(
 	cw commontypes.ContractWriter,
 	fromAccount ocrtypes.Account,
 	offrampAddress string,
-) ocr3types.ContractTransmitter[RI] {
-	return &commitTransmitter[RI]{
+) ocr3types.ContractTransmitter[[]byte] {
+	return &commitTransmitter{
 		cw:             cw,
 		fromAccount:    fromAccount,
 		contractName:   consts.ContractNameOffRamp,
@@ -122,16 +138,16 @@ func NewExecContractTransmitter[RI any](
 }
 
 // FromAccount implements ocr3types.ContractTransmitter.
-func (c *commitTransmitter[RI]) FromAccount(context.Context) (ocrtypes.Account, error) {
+func (c *commitTransmitter) FromAccount(context.Context) (ocrtypes.Account, error) {
 	return c.fromAccount, nil
 }
 
 // Transmit implements ocr3types.ContractTransmitter.
-func (c *commitTransmitter[RI]) Transmit(
+func (c *commitTransmitter) Transmit(
 	ctx context.Context,
 	configDigest ocrtypes.ConfigDigest,
 	seqNr uint64,
-	reportWithInfo ocr3types.ReportWithInfo[RI],
+	reportWithInfo ocr3types.ReportWithInfo[[]byte],
 	sigs []ocrtypes.AttributedOnchainSignature,
 ) error {
 	var rs [][32]byte
@@ -160,7 +176,10 @@ func (c *commitTransmitter[RI]) Transmit(
 	}
 
 	// chain writer takes in the raw calldata and packs it on its own.
-	args := c.toCalldataFn(rawReportCtx, reportWithInfo.Report, rs, ss, vs)
+	args, err := c.toCalldataFn(rawReportCtx, reportWithInfo, rs, ss, vs)
+	if err != nil {
+		return fmt.Errorf("failed to generate call data: %w", err)
+	}
 
 	// TODO: no meta fields yet, what should we add?
 	// probably whats in the info part of the report?

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
@@ -103,7 +103,7 @@ func testTransmitter(
 	report []byte,
 ) {
 	ctx := tests.Context(t)
-	uni := newTestUniverse[[]byte](t, nil)
+	uni := newTestUniverse(t, nil)
 
 	c, err := uni.wrapper.LatestConfigDetails(nil, pluginType)
 	require.NoError(t, err, "failed to get latest config details")
@@ -178,28 +178,28 @@ func testTransmitter(
 	require.Equal(t, seqNr, events[0].SequenceNumber, "seq num mismatch")
 }
 
-type testUniverse[RI any] struct {
+type testUniverse struct {
 	simClient              *client.SimulatedBackendClient
 	backend                *simulated.Backend
 	deployer               *bind.TransactOpts
 	transmitters           []common.Address
 	signers                []common.Address
 	wrapper                *multi_ocr3_helper.MultiOCR3Helper
-	transmitterWithSigs    ocr3types.ContractTransmitter[RI]
-	transmitterWithoutSigs ocr3types.ContractTransmitter[RI]
-	keyrings               []ocr3types.OnchainKeyring[RI]
+	transmitterWithSigs    ocr3types.ContractTransmitter[[]byte]
+	transmitterWithoutSigs ocr3types.ContractTransmitter[[]byte]
+	keyrings               []ocr3types.OnchainKeyring[[]byte]
 	f                      uint8
 	db                     *sqlx.DB
 	txm                    txmgr.TxManager
 	gasEstimator           gas.EvmFeeEstimator
 }
 
-type keyringsAndSigners[RI any] struct {
-	keyrings []ocr3types.OnchainKeyring[RI]
+type keyringsAndSigners struct {
+	keyrings []ocr3types.OnchainKeyring[[]byte]
 	signers  []common.Address
 }
 
-func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniverse[RI] {
+func newTestUniverse(t *testing.T, ks *keyringsAndSigners) *testUniverse {
 	t.Helper()
 
 	db := pgtest.NewSqlxDB(t)
@@ -233,7 +233,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 	// create the oracle identities for setConfig
 	// need to create at least 4 identities otherwise setConfig will fail
 	var (
-		keyrings []ocr3types.OnchainKeyring[RI]
+		keyrings []ocr3types.OnchainKeyring[[]byte]
 		signers  []common.Address
 	)
 	if ks != nil {
@@ -243,7 +243,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 		for i := 0; i < 4; i++ {
 			kb, err2 := ocr2key.New(kschaintype.EVM)
 			require.NoError(t, err2, "failed to create key")
-			kr := ocrimpls.NewOnchainKeyring[RI](kb, logger.TestLogger(t))
+			kr := ocrimpls.NewOnchainKeyring(kb, logger.TestLogger(t))
 			signers = append(signers, common.BytesToAddress(kr.PublicKey()))
 			keyrings = append(keyrings, kr)
 		}
@@ -309,7 +309,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 	require.NoError(t, chainWriter.Start(testutils.Context(t)), "failed to start chain writer")
 	t.Cleanup(func() { require.NoError(t, chainWriter.Close()) })
 
-	transmitterWithSigs := ocrimpls.XXXNewContractTransmitterTestsOnly[RI](
+	transmitterWithSigs := ocrimpls.XXXNewContractTransmitterTestsOnly(
 		chainWriter,
 		ocrtypes.Account(transmitters[0].Hex()),
 		contractName,
@@ -317,7 +317,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 		ocr3HelperAddr.Hex(),
 		ocrimpls.ToCommitCalldata,
 	)
-	transmitterWithoutSigs := ocrimpls.XXXNewContractTransmitterTestsOnly[RI](
+	transmitterWithoutSigs := ocrimpls.XXXNewContractTransmitterTestsOnly(
 		chainWriter,
 		ocrtypes.Account(transmitters[0].Hex()),
 		contractName,
@@ -326,7 +326,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 		ocrimpls.ToExecCalldata,
 	)
 
-	return &testUniverse[RI]{
+	return &testUniverse{
 		simClient:              simClient,
 		backend:                backend,
 		deployer:               owner,
@@ -343,7 +343,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 	}
 }
 
-func (uni testUniverse[RI]) SignReport(t *testing.T, configDigest ocrtypes.ConfigDigest, rwi ocr3types.ReportWithInfo[RI], seqNum uint64) []ocrtypes.AttributedOnchainSignature {
+func (uni testUniverse) SignReport(t *testing.T, configDigest ocrtypes.ConfigDigest, rwi ocr3types.ReportWithInfo[[]byte], seqNum uint64) []ocrtypes.AttributedOnchainSignature {
 	var attributedSigs []ocrtypes.AttributedOnchainSignature
 	for i := uint8(0); i < uni.f+1; i++ {
 		t.Log("signing report with", hexutil.Encode(uni.keyrings[i].PublicKey()))
@@ -357,7 +357,7 @@ func (uni testUniverse[RI]) SignReport(t *testing.T, configDigest ocrtypes.Confi
 	return attributedSigs
 }
 
-func (uni testUniverse[RI]) TransmittedEvents(t *testing.T) []*multi_ocr3_helper.MultiOCR3HelperTransmitted {
+func (uni testUniverse) TransmittedEvents(t *testing.T) []*multi_ocr3_helper.MultiOCR3HelperTransmitted {
 	iter, err := uni.wrapper.FilterTransmitted(&bind.FilterOpts{
 		Start: 0,
 	}, nil)

--- a/core/capabilities/ccip/ocrimpls/keyring.go
+++ b/core/capabilities/ccip/ocrimpls/keyring.go
@@ -2,6 +2,7 @@ package ocrimpls
 
 import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
@@ -17,30 +18,30 @@ type OCR3SignerVerifierExtra interface {
 	MaxSignatureLength() int
 }
 
-var _ ocr3types.OnchainKeyring[[]byte] = &ocr3Keyring[[]byte]{}
+var _ ocr3types.OnchainKeyring[[]byte] = &ocr3Keyring{}
 
 // ocr3Keyring is an adapter that exposes ocr3 onchain keyring.
-type ocr3Keyring[RI any] struct {
+type ocr3Keyring struct {
 	core OCR3SignerVerifierExtra
 	lggr logger.Logger
 }
 
-func NewOnchainKeyring[RI any](keyring OCR3SignerVerifierExtra, lggr logger.Logger) *ocr3Keyring[RI] {
-	return &ocr3Keyring[RI]{
+func NewOnchainKeyring(keyring OCR3SignerVerifierExtra, lggr logger.Logger) *ocr3Keyring {
+	return &ocr3Keyring{
 		core: keyring,
 		lggr: lggr.Named("OCR3Keyring"),
 	}
 }
 
-func (w *ocr3Keyring[RI]) PublicKey() types.OnchainPublicKey {
+func (w *ocr3Keyring) PublicKey() types.OnchainPublicKey {
 	return w.core.PublicKey()
 }
 
-func (w *ocr3Keyring[RI]) MaxSignatureLength() int {
+func (w *ocr3Keyring) MaxSignatureLength() int {
 	return w.core.MaxSignatureLength()
 }
 
-func (w *ocr3Keyring[RI]) Sign(configDigest types.ConfigDigest, seqNr uint64, r ocr3types.ReportWithInfo[RI]) (signature []byte, err error) {
+func (w *ocr3Keyring) Sign(configDigest types.ConfigDigest, seqNr uint64, r ocr3types.ReportWithInfo[[]byte]) (signature []byte, err error) {
 	w.lggr.Debugw(
 		"signing report",
 		"configDigest", configDigest.Hex(),
@@ -50,7 +51,7 @@ func (w *ocr3Keyring[RI]) Sign(configDigest types.ConfigDigest, seqNr uint64, r 
 	return w.core.Sign3(configDigest, seqNr, r.Report)
 }
 
-func (w *ocr3Keyring[RI]) Verify(key types.OnchainPublicKey, configDigest types.ConfigDigest, seqNr uint64, r ocr3types.ReportWithInfo[RI], signature []byte) bool {
+func (w *ocr3Keyring) Verify(key types.OnchainPublicKey, configDigest types.ConfigDigest, seqNr uint64, r ocr3types.ReportWithInfo[[]byte], signature []byte) bool {
 	w.lggr.Debugw("verifying report",
 		"configDigest", configDigest.Hex(),
 		"seqNr", seqNr,

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -152,7 +152,7 @@ func (i *pluginOracleCreator) Create(ctx context.Context, donID uint32, config c
 	if !ok {
 		return nil, fmt.Errorf("no OCR key bundle found for chain family %s, forgot to create one?", destChainFamily)
 	}
-	onchainKeyring := ocrimpls.NewOnchainKeyring[[]byte](keybundle, i.lggr)
+	onchainKeyring := ocrimpls.NewOnchainKeyring(keybundle, i.lggr)
 
 	// build the contract transmitter
 	// assume that we are using the first account in the keybundle as the from account
@@ -271,7 +271,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 			rmnCrypto,
 		)
 		factory = promwrapper.NewReportingPluginFactory[[]byte](factory, i.lggr, chainID, "CCIPCommit")
-		transmitter = ocrimpls.NewCommitContractTransmitter[[]byte](destChainWriter,
+		transmitter = ocrimpls.NewCommitContractTransmitter(destChainWriter,
 			ocrtypes.Account(destFromAccounts[0]),
 			hexutil.Encode(config.Config.OfframpAddress), // TODO: this works for evm only, how about non-evm?
 		)
@@ -292,7 +292,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 			chainWriters,
 		)
 		factory = promwrapper.NewReportingPluginFactory[[]byte](factory, i.lggr, chainID, "CCIPExec")
-		transmitter = ocrimpls.NewExecContractTransmitter[[]byte](destChainWriter,
+		transmitter = ocrimpls.NewExecContractTransmitter(destChainWriter,
 			ocrtypes.Account(destFromAccounts[0]),
 			hexutil.Encode(config.Config.OfframpAddress), // TODO: this works for evm only, how about non-evm?
 		)


### PR DESCRIPTION
The generic `ReportInfo[RI]` type only allows a single type for `RI`. Rather than propogate the generics boilerplate everywhere, hard code it to the only allowable value.