### PR TITLE
ccip: minimal interface changes to get byte slices into calldata func.

### DIFF
--- a/core/capabilities/ccip/ocrimpls/contract_transmitter.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	"github.com/google/uuid"
+
 	"github.com/smartcontractkit/libocr/offchainreporting2/chains/evmutil"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -16,9 +17,19 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 )
 
-type ToCalldataFunc func(rawReportCtx [2][32]byte, report []byte, rs, ss [][32]byte, vs [32]byte) any
+type ToCalldataFunc func(
+	rawReportCtx [2][32]byte,
+	report ocr3types.ReportWithInfo[[]byte],
+	rs, ss [][32]byte,
+	vs [32]byte,
+) (any, error)
 
-func ToCommitCalldata(rawReportCtx [2][32]byte, report []byte, rs, ss [][32]byte, vs [32]byte) any {
+func ToCommitCalldata(
+	rawReportCtx [2][32]byte,
+	report ocr3types.ReportWithInfo[[]byte],
+	rs, ss [][32]byte,
+	vs [32]byte,
+) (any, error) {
 	// Note that the name of the struct field is very important, since the encoder used
 	// by the chainwriter uses mapstructure, which will use the struct field name to map
 	// to the argument name in the function call.
@@ -36,14 +47,19 @@ func ToCommitCalldata(rawReportCtx [2][32]byte, report []byte, rs, ss [][32]byte
 		RawVs         [32]byte
 	}{
 		ReportContext: rawReportCtx,
-		Report:        report,
+		Report:        report.Report,
 		Rs:            rs,
 		Ss:            ss,
 		RawVs:         vs,
-	}
+	}, nil
 }
 
-func ToExecCalldata(rawReportCtx [2][32]byte, report []byte, _, _ [][32]byte, _ [32]byte) any {
+func ToExecCalldata(
+	rawReportCtx [2][32]byte,
+	report ocr3types.ReportWithInfo[[]byte],
+	_, _ [][32]byte,
+	_ [32]byte,
+) (any, error) {
 	// Note that the name of the struct field is very important, since the encoder used
 	// by the chainwriter uses mapstructure, which will use the struct field name to map
 	// to the argument name in the function call.
@@ -58,13 +74,13 @@ func ToExecCalldata(rawReportCtx [2][32]byte, report []byte, _, _ [][32]byte, _ 
 		Report        []byte
 	}{
 		ReportContext: rawReportCtx,
-		Report:        report,
-	}
+		Report:        report.Report,
+	}, nil
 }
 
-var _ ocr3types.ContractTransmitter[[]byte] = &commitTransmitter[[]byte]{}
+var _ ocr3types.ContractTransmitter[[]byte] = &commitTransmitter{}
 
-type commitTransmitter[RI any] struct {
+type commitTransmitter struct {
 	cw             commontypes.ContractWriter
 	fromAccount    ocrtypes.Account
 	contractName   string
@@ -73,15 +89,15 @@ type commitTransmitter[RI any] struct {
 	toCalldataFn   ToCalldataFunc
 }
 
-func XXXNewContractTransmitterTestsOnly[RI any](
+func XXXNewContractTransmitterTestsOnly(
 	cw commontypes.ContractWriter,
 	fromAccount ocrtypes.Account,
 	contractName string,
 	method string,
 	offrampAddress string,
 	toCalldataFn ToCalldataFunc,
-) ocr3types.ContractTransmitter[RI] {
-	return &commitTransmitter[RI]{
+) ocr3types.ContractTransmitter[[]byte] {
+	return &commitTransmitter{
 		cw:             cw,
 		fromAccount:    fromAccount,
 		contractName:   contractName,
@@ -91,12 +107,12 @@ func XXXNewContractTransmitterTestsOnly[RI any](
 	}
 }
 
-func NewCommitContractTransmitter[RI any](
+func NewCommitContractTransmitter(
 	cw commontypes.ContractWriter,
 	fromAccount ocrtypes.Account,
 	offrampAddress string,
-) ocr3types.ContractTransmitter[RI] {
-	return &commitTransmitter[RI]{
+) ocr3types.ContractTransmitter[[]byte] {
+	return &commitTransmitter{
 		cw:             cw,
 		fromAccount:    fromAccount,
 		contractName:   consts.ContractNameOffRamp,
@@ -106,12 +122,12 @@ func NewCommitContractTransmitter[RI any](
 	}
 }
 
-func NewExecContractTransmitter[RI any](
+func NewExecContractTransmitter(
 	cw commontypes.ContractWriter,
 	fromAccount ocrtypes.Account,
 	offrampAddress string,
-) ocr3types.ContractTransmitter[RI] {
-	return &commitTransmitter[RI]{
+) ocr3types.ContractTransmitter[[]byte] {
+	return &commitTransmitter{
 		cw:             cw,
 		fromAccount:    fromAccount,
 		contractName:   consts.ContractNameOffRamp,
@@ -122,16 +138,16 @@ func NewExecContractTransmitter[RI any](
 }
 
 // FromAccount implements ocr3types.ContractTransmitter.
-func (c *commitTransmitter[RI]) FromAccount(context.Context) (ocrtypes.Account, error) {
+func (c *commitTransmitter) FromAccount(context.Context) (ocrtypes.Account, error) {
 	return c.fromAccount, nil
 }
 
 // Transmit implements ocr3types.ContractTransmitter.
-func (c *commitTransmitter[RI]) Transmit(
+func (c *commitTransmitter) Transmit(
 	ctx context.Context,
 	configDigest ocrtypes.ConfigDigest,
 	seqNr uint64,
-	reportWithInfo ocr3types.ReportWithInfo[RI],
+	reportWithInfo ocr3types.ReportWithInfo[[]byte],
 	sigs []ocrtypes.AttributedOnchainSignature,
 ) error {
 	var rs [][32]byte
@@ -160,7 +176,10 @@ func (c *commitTransmitter[RI]) Transmit(
 	}
 
 	// chain writer takes in the raw calldata and packs it on its own.
-	args := c.toCalldataFn(rawReportCtx, reportWithInfo.Report, rs, ss, vs)
+	args, err := c.toCalldataFn(rawReportCtx, reportWithInfo, rs, ss, vs)
+	if err != nil {
+		return fmt.Errorf("failed to generate call data: %w", err)
+	}
 
 	// TODO: no meta fields yet, what should we add?
 	// probably whats in the info part of the report?

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
@@ -103,7 +103,7 @@ func testTransmitter(
 	report []byte,
 ) {
 	ctx := tests.Context(t)
-	uni := newTestUniverse[[]byte](t, nil)
+	uni := newTestUniverse(t, nil)
 
 	c, err := uni.wrapper.LatestConfigDetails(nil, pluginType)
 	require.NoError(t, err, "failed to get latest config details")
@@ -199,7 +199,7 @@ type keyringsAndSigners[RI any] struct {
 	signers  []common.Address
 }
 
-func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniverse[RI] {
+func newTestUniverse(t *testing.T, ks *keyringsAndSigners[[]byte]) *testUniverse[[]byte] {
 	t.Helper()
 
 	db := pgtest.NewSqlxDB(t)
@@ -233,7 +233,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 	// create the oracle identities for setConfig
 	// need to create at least 4 identities otherwise setConfig will fail
 	var (
-		keyrings []ocr3types.OnchainKeyring[RI]
+		keyrings []ocr3types.OnchainKeyring[[]byte]
 		signers  []common.Address
 	)
 	if ks != nil {
@@ -243,7 +243,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 		for i := 0; i < 4; i++ {
 			kb, err2 := ocr2key.New(kschaintype.EVM)
 			require.NoError(t, err2, "failed to create key")
-			kr := ocrimpls.NewOnchainKeyring[RI](kb, logger.TestLogger(t))
+			kr := ocrimpls.NewOnchainKeyring[[]byte](kb, logger.TestLogger(t))
 			signers = append(signers, common.BytesToAddress(kr.PublicKey()))
 			keyrings = append(keyrings, kr)
 		}
@@ -309,7 +309,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 	require.NoError(t, chainWriter.Start(testutils.Context(t)), "failed to start chain writer")
 	t.Cleanup(func() { require.NoError(t, chainWriter.Close()) })
 
-	transmitterWithSigs := ocrimpls.XXXNewContractTransmitterTestsOnly[RI](
+	transmitterWithSigs := ocrimpls.XXXNewContractTransmitterTestsOnly(
 		chainWriter,
 		ocrtypes.Account(transmitters[0].Hex()),
 		contractName,
@@ -317,7 +317,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 		ocr3HelperAddr.Hex(),
 		ocrimpls.ToCommitCalldata,
 	)
-	transmitterWithoutSigs := ocrimpls.XXXNewContractTransmitterTestsOnly[RI](
+	transmitterWithoutSigs := ocrimpls.XXXNewContractTransmitterTestsOnly(
 		chainWriter,
 		ocrtypes.Account(transmitters[0].Hex()),
 		contractName,
@@ -326,7 +326,7 @@ func newTestUniverse[RI any](t *testing.T, ks *keyringsAndSigners[RI]) *testUniv
 		ocrimpls.ToExecCalldata,
 	)
 
-	return &testUniverse[RI]{
+	return &testUniverse[[]byte]{
 		simClient:              simClient,
 		backend:                backend,
 		deployer:               owner,

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -271,7 +271,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 			rmnCrypto,
 		)
 		factory = promwrapper.NewReportingPluginFactory[[]byte](factory, i.lggr, chainID, "CCIPCommit")
-		transmitter = ocrimpls.NewCommitContractTransmitter[[]byte](destChainWriter,
+		transmitter = ocrimpls.NewCommitContractTransmitter(destChainWriter,
 			ocrtypes.Account(destFromAccounts[0]),
 			hexutil.Encode(config.Config.OfframpAddress), // TODO: this works for evm only, how about non-evm?
 		)
@@ -292,7 +292,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 			chainWriters,
 		)
 		factory = promwrapper.NewReportingPluginFactory[[]byte](factory, i.lggr, chainID, "CCIPExec")
-		transmitter = ocrimpls.NewExecContractTransmitter[[]byte](destChainWriter,
+		transmitter = ocrimpls.NewExecContractTransmitter(destChainWriter,
 			ocrtypes.Account(destFromAccounts[0]),
 			hexutil.Encode(config.Config.OfframpAddress), // TODO: this works for evm only, how about non-evm?
 		)


### PR DESCRIPTION
In order to process report-info as a byte slice, the generics must be removed. Attempt a minimal set of changes to remove generics and get the full report info object into the calldata handlers.