### PR TITLE
[CAPPL-402] correctly propagate errors on fetcher

### DIFF
--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -100,5 +100,9 @@ func (s *FetcherService) Fetch(ctx context.Context, url string) ([]byte, error) 
 		return nil, err
 	}
 
+	if payload.ExecutionError {
+		return nil, fmt.Errorf("execution error from gateway: %s", payload.ErrorMessage)
+	}
+
 	return payload.Body, nil
 }

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -497,19 +497,19 @@ func (h *eventHandler) getWorkflowArtifacts(
 	if err != nil {
 		binary, err2 := h.fetcher(ctx, payload.BinaryURL)
 		if err2 != nil {
-			return nil, nil, fmt.Errorf("failed to fetch binary from %s : %w", payload.BinaryURL, err)
+			return nil, nil, fmt.Errorf("failed to fetch binary from %s : %w", payload.BinaryURL, err2)
 		}
 
 		decodedBinary, err2 := base64.StdEncoding.DecodeString(string(binary))
 		if err2 != nil {
-			return nil, nil, fmt.Errorf("failed to decode binary: %w", err)
+			return nil, nil, fmt.Errorf("failed to decode binary: %w", err2)
 		}
 
 		var config []byte
 		if payload.ConfigURL != "" {
 			config, err2 = h.fetcher(ctx, payload.ConfigURL)
 			if err2 != nil {
-				return nil, nil, fmt.Errorf("failed to fetch config from %s : %w", payload.ConfigURL, err)
+				return nil, nil, fmt.Errorf("failed to fetch config from %s : %w", payload.ConfigURL, err2)
 			}
 		}
 		return decodedBinary, config, nil


### PR DESCRIPTION
### Description
Whenever the fetcher was failing to download the artifacts (EG: response payload too big) we where not checking for the error in the payload, aside from that we were also logging the wrong error.

[CAPPL-402](https://smartcontract-it.atlassian.net/browse/CAPPL-402)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CAPPL-402]: https://smartcontract-it.atlassian.net/browse/CAPPL-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ