### PR TITLE
fix(deployment): enables multiple ocr3 contracts per chain

### DIFF
--- a/deployment/address_book_test.go
+++ b/deployment/address_book_test.go
@@ -72,6 +72,35 @@ func TestAddressBook_Save(t *testing.T) {
 	})
 }
 
+func TestAddressBook_AddressesForChain(t *testing.T) {
+	ab := NewMemoryAddressBook()
+	ocr3Cap100 := NewTypeAndVersion("OCR3Capability", Version1_0_0)
+	copyOCR3Cap100 := NewTypeAndVersion("OCR3Capability", Version1_0_0)
+
+	addr1 := common.HexToAddress("0x1").String()
+	addr2 := common.HexToAddress("0x2").String()
+
+	err := ab.Save(chainsel.TEST_90000001.Selector, addr1, ocr3Cap100)
+	require.NoError(t, err)
+
+	err = ab.Save(chainsel.TEST_90000001.Selector, addr2, copyOCR3Cap100)
+	require.NoError(t, err)
+
+	addresses, err := ab.AddressesForChain(chainsel.TEST_90000001.Selector,
+		func(m map[string]TypeAndVersion) {
+			for k, v := range m {
+				if v.Type == "OCR3Capability" {
+					if k != addr1 {
+						delete(m, k)
+					}
+				}
+			}
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, addresses, 1)
+}
+
 func TestAddressBook_Merge(t *testing.T) {
 	onRamp100 := NewTypeAndVersion("OnRamp", Version1_0_0)
 	onRamp110 := NewTypeAndVersion("OnRamp", Version1_1_0)

--- a/deployment/keystone/changeset/deploy_ocr3.go
+++ b/deployment/keystone/changeset/deploy_ocr3.go
@@ -37,6 +37,7 @@ var _ deployment.ChangeSet[ConfigureOCR3Config] = ConfigureOCR3Contract
 type ConfigureOCR3Config struct {
 	ChainSel             uint64
 	NodeIDs              []string
+	OCR3ContractAddr     *string
 	OCR3Config           *kslib.OracleConfig
 	DryRun               bool
 	WriteGeneratedConfig io.Writer // if not nil, write the generated config to this writer as JSON [OCR2OracleConfig]
@@ -55,6 +56,7 @@ func ConfigureOCR3Contract(env deployment.Environment, cfg ConfigureOCR3Config) 
 		NodeIDs:    cfg.NodeIDs,
 		OCR3Config: cfg.OCR3Config,
 		DryRun:     cfg.DryRun,
+		OCR3Addr:   cfg.OCR3ContractAddr,
 		UseMCMS:    cfg.UseMCMS(),
 	})
 	if err != nil {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

it is possible to deploy multiple OCR contracts per chain for workflow dons yet the behavior of fetching a `ContractSet` from an address book is non-deterministic in this case.  this PR allows `AddressBook` clients to pass an address filterer that will be applied to the addresses fetched for the chain prior to transforming them into a `ContractSet`.

modifies the `keystone` package to use an address filterer that removes all OCR3Capability contracts from an address book that don't match a specified address.  the specified address should be passed as config to a changeset to configure OCR3.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
