### PR TITLE
[CAPPL-411] do not fail when deleting non existing workflow spec

### DIFF
--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -642,7 +643,8 @@ func (h *eventHandler) workflowDeletedEvent(
 		return err
 	}
 
-	if err := h.orm.DeleteWorkflowSpec(ctx, hex.EncodeToString(payload.WorkflowOwner), payload.WorkflowName); err != nil {
+	err := h.orm.DeleteWorkflowSpec(ctx, hex.EncodeToString(payload.WorkflowOwner), payload.WorkflowName)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("failed to delete workflow spec: %w", err)
 	}
 	return nil

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -644,9 +644,14 @@ func (h *eventHandler) workflowDeletedEvent(
 	}
 
 	err := h.orm.DeleteWorkflowSpec(ctx, hex.EncodeToString(payload.WorkflowOwner), payload.WorkflowName)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			h.lggr.Warnw("workflow spec not found", "workflowID", hex.EncodeToString(payload.WorkflowID[:]))
+			return nil
+		}
 		return fmt.Errorf("failed to delete workflow spec: %w", err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
### Description
This fix prevents the deletion event handler from failing whenever it tries to delete a non existing workflow spec from the DB
[CAPPL-411](https://smartcontract-it.atlassian.net/browse/CAPPL-411)


### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CAPPL-411]: https://smartcontract-it.atlassian.net/browse/CAPPL-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ