### PR TITLE
Fix restore of config in blue-green mode

### DIFF
--- a/core/services/llo/delegate.go
+++ b/core/services/llo/delegate.go
@@ -69,12 +69,12 @@ type DelegateConfig struct {
 	// One Oracle will be started for each ContractConfigTracker
 	ContractConfigTrackers []ocr2types.ContractConfigTracker
 	ContractTransmitter    ocr3types.ContractTransmitter[llotypes.ReportInfo]
-	Database               ocr3types.Database
 	OCR3MonitoringEndpoint ocrcommontypes.MonitoringEndpoint
 	OffchainConfigDigester ocr2types.OffchainConfigDigester
 	OffchainKeyring        ocr2types.OffchainKeyring
 	OnchainKeyring         ocr3types.OnchainKeyring[llotypes.ReportInfo]
 	LocalConfig            ocr2types.LocalConfig
+	NewOCR3DB              func(pluginID int32) ocr3types.Database
 }
 
 func NewDelegate(cfg DelegateConfig) (job.ServiceCtx, error) {
@@ -146,7 +146,7 @@ func (d *delegate) Start(ctx context.Context) error {
 				V2Bootstrappers:              d.cfg.V2Bootstrappers,
 				ContractConfigTracker:        configTracker,
 				ContractTransmitter:          d.cfg.ContractTransmitter,
-				Database:                     d.cfg.Database,
+				Database:                     d.cfg.NewOCR3DB(int32(i)), // //nolint:gosec // G115 // impossible due to check on line 119
 				LocalConfig:                  d.cfg.LocalConfig,
 				Logger:                       ocrLogger,
 				MonitoringEndpoint:           d.cfg.OCR3MonitoringEndpoint,

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -1056,7 +1056,6 @@ func (d *Delegate) newServicesLLO(
 		V2Bootstrappers:              bootstrapPeers,
 		ContractTransmitter:          provider.ContractTransmitter(),
 		ContractConfigTrackers:       provider.ContractConfigTrackers(),
-		Database:                     ocrDB,
 		LocalConfig:                  lc,
 		OCR3MonitoringEndpoint:       d.monitoringEndpointGen.GenMonitoringEndpoint(rid.Network, rid.ChainID, telemetryContractID, synchronization.OCR3Mercury),
 		OffchainConfigDigester:       provider.OffchainConfigDigester(),
@@ -1065,6 +1064,9 @@ func (d *Delegate) newServicesLLO(
 
 		// Enable verbose logging if either Mercury.VerboseLogging is on or OCR2.TraceLogging is on
 		ReportingPluginConfig: datastreamsllo.Config{VerboseLogging: d.cfg.Mercury().VerboseLogging() || d.cfg.OCR2().TraceLogging()},
+		NewOCR3DB: func(pluginID int32) ocr3types.Database {
+			return NewDB(d.ds, spec.ID, pluginID, lggr)
+		},
 	}
 	oracle, err := llo.NewDelegate(cfg)
 	if err != nil {


### PR DESCRIPTION
The OCR3 database must be scoped to each instance, not to the job,
otherwise we can restore the wrong config on node restart.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
