### PR TITLE
chore: rename ci-core-partial workflow

### DIFF
--- a/.github/workflows/ci-core-partial.yml
+++ b/.github/workflows/ci-core-partial.yml
@@ -1,4 +1,4 @@
-name: Core Unit Tests
+name: Experimental Test Optimization
 
 on:
   push:


### PR DESCRIPTION
### Changes

Rename "Core Unit Tests" to better describe that this test isn't mandatory yet.

---

RE-3313
