### PR TITLE
Revert "core/internal/features/ocr2: parallelize subtests..."

### DIFF
--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -77,7 +77,6 @@ func setup(t *testing.T, config Config) testHarness {
 }
 
 func TestComputeStartAddsToRegistry(t *testing.T) {
-	t.Parallel()
 	th := setup(t, defaultConfig)
 
 	require.NoError(t, th.compute.Start(tests.Context(t)))
@@ -110,7 +109,6 @@ func TestComputeExecuteMissingConfig(t *testing.T) {
 }
 
 func TestComputeExecuteMissingBinary(t *testing.T) {
-	t.Parallel()
 	th := setup(t, defaultConfig)
 
 	require.NoError(t, th.compute.Start(tests.Context(t)))

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -999,7 +999,7 @@ func WaitForPipeline(t testing.TB, nodeID int, jobID int32, expectedPipelineRuns
 	t.Helper()
 
 	var pr []pipeline.Run
-	if !gomega.NewWithT(t).Eventually(func() bool {
+	gomega.NewWithT(t).Eventually(func() bool {
 		prs, _, err := jo.PipelineRuns(testutils.Context(t), &jobID, 0, 1000)
 		require.NoError(t, err)
 
@@ -1029,9 +1029,7 @@ func WaitForPipeline(t testing.TB, nodeID int, jobID int32, expectedPipelineRuns
 			jobID,
 			len(pr),
 		),
-	) {
-		t.Fatal()
-	}
+	)
 	return pr
 }
 

--- a/core/internal/features/ocr2/features_ocr2_helper.go
+++ b/core/internal/features/ocr2/features_ocr2_helper.go
@@ -35,7 +35,6 @@ import (
 	ocrtypes2 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrbootstrap"
 
@@ -202,7 +201,6 @@ func RunTestIntegrationOCR2(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			owner, b, ocrContractAddress, ocrContract := SetupOCR2Contracts(t)
 
 			lggr := logger.TestLogger(t)
@@ -558,7 +556,7 @@ updateInterval = "1m"
 							return
 						}
 						// Want at least 2 runs so we see all the metadata.
-						pr := cltest.WaitForPipelineComplete(t, ic, jids[ic], len(completedRuns)+2, 7, apps[ic].JobORM(), tests.WaitTimeout(t), 5*time.Second)
+						pr := cltest.WaitForPipelineComplete(t, ic, jids[ic], len(completedRuns)+2, 7, apps[ic].JobORM(), 2*time.Minute, 5*time.Second)
 						jb, err2 := pr[0].Outputs.MarshalJSON()
 						if !assert.NoError(t, err2) {
 							return
@@ -570,13 +568,11 @@ updateInterval = "1m"
 
 				// Trail #1: 4 oracles reporting 0, 10, 20, 30. Answer should be 20 (results[4/2]).
 				// Trial #2: 4 oracles reporting 0, 20, 40, 60. Answer should be 40 (results[4/2]).
-				if !gomega.NewGomegaWithT(t).Eventually(func() string {
+				gomega.NewGomegaWithT(t).Eventually(func() string {
 					answer, err2 := ocrContract.LatestAnswer(nil)
 					require.NoError(t, err2)
 					return answer.String()
-				}, tests.WaitTimeout(t), 200*time.Millisecond).Should(gomega.Equal(strconv.Itoa(2 * retVal))) {
-					t.Fatal()
-				}
+				}, 1*time.Minute, 200*time.Millisecond).Should(gomega.Equal(strconv.Itoa(2 * retVal)))
 
 				for _, app := range apps {
 					jobs, _, err2 := app.JobORM().FindJobs(ctx, 0, 1000)


### PR DESCRIPTION
Reverts changes from #14754 /  ec35d77281f8df4d3021c7c94124cc32a2ac5f92.

### Motivation

We've been seeing a lot of failures from `http://github.com/smartcontractkit/chainlink/v2/core/internal/features/ocr2/plugins`. This change may have caused some instability with the go-conditional-tests.


More information: https://smartcontract-it.atlassian.net/browse/RE-3313?focusedCommentId=338207

### Testing

I tested partial reverts of these changes: https://github.com/smartcontractkit/chainlink/pull/15795

The full revert was the most consistent - https://github.com/smartcontractkit/chainlink/actions/runs/12435970239/job/34727487863?pr=15792

---

RE-3313
