### PR TITLE
typo-Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ go test ./...
 #### Notes
 
 - The `parallel` flag can be used to limit CPU usage, for running tests in the background (`-parallel=4`) - the default is `GOMAXPROCS`
-- The `p` flag can be used to limit the number of _packages_ tested concurrently, if they are interferring with one another (`-p=1`)
+- The `p` flag can be used to limit the number of _packages_ tested concurrently, if they are interfering with one another (`-p=1`)
 - The `-short` flag skips tests which depend on the database, for quickly spot checking simpler tests in around one minute
 
 #### Race Detector


### PR DESCRIPTION
# Fix: Corrected typo in README.md

## Changes
1. **File**: `README.md`
   - Corrected "interferring" to "interfering".
   
   - **Before**:
     ```markdown
      interferring 
     ```
   - **After**:
     ```markdown
      interfering 
     ```

## Purpose
- Enhanced documentation clarity by correcting the typographical error.
- Improved the readability and professionalism of the README file.
