### PR TITLE
[CAPPL-320] use decoded workflowName when logged via beholder

### DIFF
--- a/core/capabilities/compute/compute.go
+++ b/core/capabilities/compute/compute.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -298,9 +299,19 @@ func (c *Compute) createFetcher() func(ctx context.Context, req *wasmpb.FetchReq
 			return nil, fmt.Errorf("workflow execution ID %q is invalid: %w", req.Metadata.WorkflowExecutionId, err)
 		}
 
+		// best effort to decode the workflow name
+		var workflowName string
+		decodedWorkflowName, err := hex.DecodeString(req.Metadata.WorkflowName)
+		if err != nil {
+			c.log.Errorf("failed to decode WorkflowName %q: %v", req.Metadata.WorkflowName, err)
+			workflowName = req.Metadata.WorkflowName
+		} else {
+			workflowName = string(decodedWorkflowName)
+		}
+
 		cma := c.emitter.With(
 			platform.KeyWorkflowID, req.Metadata.WorkflowId,
-			platform.KeyWorkflowName, req.Metadata.WorkflowName,
+			platform.KeyWorkflowName, workflowName,
 			platform.KeyWorkflowOwner, req.Metadata.WorkflowOwner,
 			platform.KeyWorkflowExecutionID, req.Metadata.WorkflowExecutionId,
 			timestampKey, time.Now().UTC().Format(time.RFC3339Nano),

--- a/core/capabilities/compute/compute.go
+++ b/core/capabilities/compute/compute.go
@@ -3,7 +3,6 @@ package compute
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -299,19 +298,9 @@ func (c *Compute) createFetcher() func(ctx context.Context, req *wasmpb.FetchReq
 			return nil, fmt.Errorf("workflow execution ID %q is invalid: %w", req.Metadata.WorkflowExecutionId, err)
 		}
 
-		// best effort to decode the workflow name
-		var workflowName string
-		decodedWorkflowName, err := hex.DecodeString(req.Metadata.WorkflowName)
-		if err != nil {
-			c.log.Errorf("failed to decode WorkflowName %q: %v", req.Metadata.WorkflowName, err)
-			workflowName = req.Metadata.WorkflowName
-		} else {
-			workflowName = string(decodedWorkflowName)
-		}
-
 		cma := c.emitter.With(
 			platform.KeyWorkflowID, req.Metadata.WorkflowId,
-			platform.KeyWorkflowName, workflowName,
+			platform.KeyWorkflowName, req.Metadata.DecodedWorkflowName,
 			platform.KeyWorkflowOwner, req.Metadata.WorkflowOwner,
 			platform.KeyWorkflowExecutionID, req.Metadata.WorkflowExecutionId,
 			timestampKey, time.Now().UTC().Format(time.RFC3339Nano),

--- a/core/capabilities/targets/write_target.go
+++ b/core/capabilities/targets/write_target.go
@@ -345,10 +345,21 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 				return capabilities.CapabilityResponse{}, nil
 			case commontypes.Failed, commontypes.Fatal:
 				cap.lggr.Error("Transaction failed", "request", request, "transaction", txID)
+
+				// best effort to decode the workflow name
+				var workflowName string
+				decodedWorkflowName, err := hex.DecodeString(request.Metadata.WorkflowName)
+				if err != nil {
+					cap.lggr.Errorf("failed to decode WorkflowName %q: %v", request.Metadata.WorkflowName, err)
+					workflowName = request.Metadata.WorkflowName
+				} else {
+					workflowName = string(decodedWorkflowName)
+				}
+
 				msg := "failed to submit transaction with ID: " + txID.String()
 				err = cap.emitter.With(
 					platform.KeyWorkflowID, request.Metadata.WorkflowID,
-					platform.KeyWorkflowName, request.Metadata.WorkflowName,
+					platform.KeyWorkflowName, workflowName,
 					platform.KeyWorkflowOwner, request.Metadata.WorkflowOwner,
 					platform.KeyWorkflowExecutionID, request.Metadata.WorkflowExecutionID,
 				).Emit(ctx, msg)

--- a/core/capabilities/targets/write_target.go
+++ b/core/capabilities/targets/write_target.go
@@ -346,20 +346,10 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 			case commontypes.Failed, commontypes.Fatal:
 				cap.lggr.Error("Transaction failed", "request", request, "transaction", txID)
 
-				// best effort to decode the workflow name
-				var workflowName string
-				decodedWorkflowName, err := hex.DecodeString(request.Metadata.WorkflowName)
-				if err != nil {
-					cap.lggr.Errorf("failed to decode WorkflowName %q: %v", request.Metadata.WorkflowName, err)
-					workflowName = request.Metadata.WorkflowName
-				} else {
-					workflowName = string(decodedWorkflowName)
-				}
-
 				msg := "failed to submit transaction with ID: " + txID.String()
 				err = cap.emitter.With(
 					platform.KeyWorkflowID, request.Metadata.WorkflowID,
-					platform.KeyWorkflowName, workflowName,
+					platform.KeyWorkflowName, request.Metadata.DecodedWorkflowName,
 					platform.KeyWorkflowOwner, request.Metadata.WorkflowOwner,
 					platform.KeyWorkflowExecutionID, request.Metadata.WorkflowExecutionID,
 				).Emit(ctx, msg)

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550
+	github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e
 	github.com/smartcontractkit/libocr v0.0.0-20241223215956-e5b78d8e3919
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1115,8 +1115,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000/go.mod h1:ncjd6mPZSRlelEqH/2KeLE1pU3UlqzBSn8RYkEoECzY=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250103152858-8973fd0c912b h1:UBXi9Yj8YSMHDDaxQLu273x1fWjyEL9xP58nuJsqZfg=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250103152858-8973fd0c912b/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550 h1:rRs74zjDJ7do5aYEXSU/sOnLnlbYCNqM8BrvEx/0NH8=
-github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
+github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e h1:8BStiP1F4W8AvjBRga0TYtjvAtkwN8oHYnHJztAlSF4=
+github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e h1:PRoeby6ZlTuTkv2f+7tVU4+zboTfRzI+beECynF4JQ0=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e/go.mod h1:mUh5/woemsVaHgTorA080hrYmO3syBCmPdnWc/5dOqk=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241216163550-fa030d178ba3 h1:aeiBdBHGY8QNftps+VqrIk6OnfeeOD5z4jrAabW4ZSc=

--- a/core/services/workflows/delegate.go
+++ b/core/services/workflows/delegate.go
@@ -81,7 +81,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 
 type noopSecretsFetcher struct{}
 
-func (n *noopSecretsFetcher) SecretsFor(ctx context.Context, workflowOwner, workflowName, workflowID string) (map[string]string, error) {
+func (n *noopSecretsFetcher) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, workflowID string) (map[string]string, error) {
 	return map[string]string{}, nil
 }
 

--- a/core/services/workflows/delegate.go
+++ b/core/services/workflows/delegate.go
@@ -81,7 +81,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 
 type noopSecretsFetcher struct{}
 
-func (n *noopSecretsFetcher) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, workflowID string) (map[string]string, error) {
+func (n *noopSecretsFetcher) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, decodedWorkflowName, workflowID string) (map[string]string, error) {
 	return map[string]string{}, nil
 }
 

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -96,7 +96,7 @@ func (sucm *stepUpdateManager) len() int64 {
 }
 
 type secretsFetcher interface {
-	SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, workflowID string) (map[string]string, error)
+	SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, decodedWorkflowName, workflowID string) (map[string]string, error)
 }
 
 // Engine handles the lifecycle of a single workflow and its executions.
@@ -432,6 +432,12 @@ func (e *Engine) registerTrigger(ctx context.Context, t *triggerCapability, trig
 
 	t.config.Store(tc)
 
+	workflowName, err := hex.DecodeString(e.workflow.hexName)
+	if err != nil {
+		e.logger.Warnw("failed to decode workflow name: %s, using encoded", err)
+		workflowName = []byte(e.workflow.hexName)
+	}
+
 	triggerRegRequest := capabilities.TriggerRegistrationRequest{
 		Metadata: capabilities.RequestMetadata{
 			WorkflowID:               e.workflow.id,
@@ -440,6 +446,7 @@ func (e *Engine) registerTrigger(ctx context.Context, t *triggerCapability, trig
 			WorkflowDonID:            e.localNode.WorkflowDON.ID,
 			WorkflowDonConfigVersion: e.localNode.WorkflowDON.ConfigVersion,
 			ReferenceID:              t.Ref,
+			DecodedWorkflowName:      string(workflowName),
 		},
 		Config:    t.config.Load(),
 		TriggerID: triggerID,
@@ -868,7 +875,13 @@ func (e *Engine) interpolateEnvVars(config map[string]any, env exec.Env) (*value
 // registry (for capability-level configuration). It doesn't perform any caching of the config values, since
 // the two registries perform their own caching.
 func (e *Engine) configForStep(ctx context.Context, lggr logger.Logger, step *step) (*values.Map, error) {
-	secrets, err := e.secretsFetcher.SecretsFor(ctx, e.workflow.owner, e.workflow.hexName, e.workflow.id)
+	workflowName, err := hex.DecodeString(e.workflow.hexName)
+	if err != nil {
+		e.logger.Warnw("failed to decode workflow name: %s, using encoded", err)
+		workflowName = []byte(e.workflow.hexName)
+	}
+
+	secrets, err := e.secretsFetcher.SecretsFor(ctx, e.workflow.owner, e.workflow.hexName, string(workflowName), e.workflow.id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch secrets: %w", err)
 	}
@@ -953,6 +966,12 @@ func (e *Engine) executeStep(ctx context.Context, lggr logger.Logger, msg stepRe
 		}
 	}
 
+	workflowName, err := hex.DecodeString(e.workflow.hexName)
+	if err != nil {
+		e.logger.Warnw("failed to decode workflow name: %s, using encoded", err)
+		workflowName = []byte(e.workflow.hexName)
+	}
+
 	tr := capabilities.CapabilityRequest{
 		Inputs: inputsMap,
 		Config: config,
@@ -964,6 +983,7 @@ func (e *Engine) executeStep(ctx context.Context, lggr logger.Logger, msg stepRe
 			WorkflowDonID:            e.localNode.WorkflowDON.ID,
 			WorkflowDonConfigVersion: e.localNode.WorkflowDON.ConfigVersion,
 			ReferenceID:              msg.stepRef,
+			DecodedWorkflowName:      string(workflowName),
 		},
 	}
 
@@ -981,6 +1001,12 @@ func (e *Engine) executeStep(ctx context.Context, lggr logger.Logger, msg stepRe
 }
 
 func (e *Engine) deregisterTrigger(ctx context.Context, t *triggerCapability, triggerIdx int) error {
+	workflowName, err := hex.DecodeString(e.workflow.hexName)
+	if err != nil {
+		e.logger.Warnw("failed to decode workflow name: %s, using encoded", err)
+		workflowName = []byte(e.workflow.hexName)
+	}
+
 	deregRequest := capabilities.TriggerRegistrationRequest{
 		Metadata: capabilities.RequestMetadata{
 			WorkflowID:               e.workflow.id,
@@ -989,6 +1015,7 @@ func (e *Engine) deregisterTrigger(ctx context.Context, t *triggerCapability, tr
 			WorkflowName:             e.workflow.hexName,
 			WorkflowOwner:            e.workflow.owner,
 			ReferenceID:              t.Ref,
+			DecodedWorkflowName:      string(workflowName),
 		},
 		TriggerID: generateTriggerId(e.workflow.id, triggerIdx),
 		Config:    t.config.Load(),

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -96,7 +96,7 @@ func (sucm *stepUpdateManager) len() int64 {
 }
 
 type secretsFetcher interface {
-	SecretsFor(ctx context.Context, workflowOwner, workflowName, workflowID string) (map[string]string, error)
+	SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, workflowID string) (map[string]string, error)
 }
 
 // Engine handles the lifecycle of a single workflow and its executions.

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -432,12 +432,6 @@ func (e *Engine) registerTrigger(ctx context.Context, t *triggerCapability, trig
 
 	t.config.Store(tc)
 
-	workflowName, err := hex.DecodeString(e.workflow.hexName)
-	if err != nil {
-		e.logger.Warnw("failed to decode workflow name: %s, using encoded", err)
-		workflowName = []byte(e.workflow.hexName)
-	}
-
 	triggerRegRequest := capabilities.TriggerRegistrationRequest{
 		Metadata: capabilities.RequestMetadata{
 			WorkflowID:               e.workflow.id,
@@ -446,7 +440,7 @@ func (e *Engine) registerTrigger(ctx context.Context, t *triggerCapability, trig
 			WorkflowDonID:            e.localNode.WorkflowDON.ID,
 			WorkflowDonConfigVersion: e.localNode.WorkflowDON.ConfigVersion,
 			ReferenceID:              t.Ref,
-			DecodedWorkflowName:      string(workflowName),
+			DecodedWorkflowName:      e.workflow.name,
 		},
 		Config:    t.config.Load(),
 		TriggerID: triggerID,
@@ -875,13 +869,7 @@ func (e *Engine) interpolateEnvVars(config map[string]any, env exec.Env) (*value
 // registry (for capability-level configuration). It doesn't perform any caching of the config values, since
 // the two registries perform their own caching.
 func (e *Engine) configForStep(ctx context.Context, lggr logger.Logger, step *step) (*values.Map, error) {
-	workflowName, err := hex.DecodeString(e.workflow.hexName)
-	if err != nil {
-		e.logger.Warnw("failed to decode workflow name: %s, using encoded", err)
-		workflowName = []byte(e.workflow.hexName)
-	}
-
-	secrets, err := e.secretsFetcher.SecretsFor(ctx, e.workflow.owner, e.workflow.hexName, string(workflowName), e.workflow.id)
+	secrets, err := e.secretsFetcher.SecretsFor(ctx, e.workflow.owner, e.workflow.hexName, e.workflow.name, e.workflow.id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch secrets: %w", err)
 	}
@@ -966,12 +954,6 @@ func (e *Engine) executeStep(ctx context.Context, lggr logger.Logger, msg stepRe
 		}
 	}
 
-	workflowName, err := hex.DecodeString(e.workflow.hexName)
-	if err != nil {
-		e.logger.Warnw("failed to decode workflow name: %s, using encoded", err)
-		workflowName = []byte(e.workflow.hexName)
-	}
-
 	tr := capabilities.CapabilityRequest{
 		Inputs: inputsMap,
 		Config: config,
@@ -983,7 +965,7 @@ func (e *Engine) executeStep(ctx context.Context, lggr logger.Logger, msg stepRe
 			WorkflowDonID:            e.localNode.WorkflowDON.ID,
 			WorkflowDonConfigVersion: e.localNode.WorkflowDON.ConfigVersion,
 			ReferenceID:              msg.stepRef,
-			DecodedWorkflowName:      string(workflowName),
+			DecodedWorkflowName:      e.workflow.name,
 		},
 	}
 
@@ -1001,12 +983,6 @@ func (e *Engine) executeStep(ctx context.Context, lggr logger.Logger, msg stepRe
 }
 
 func (e *Engine) deregisterTrigger(ctx context.Context, t *triggerCapability, triggerIdx int) error {
-	workflowName, err := hex.DecodeString(e.workflow.hexName)
-	if err != nil {
-		e.logger.Warnw("failed to decode workflow name: %s, using encoded", err)
-		workflowName = []byte(e.workflow.hexName)
-	}
-
 	deregRequest := capabilities.TriggerRegistrationRequest{
 		Metadata: capabilities.RequestMetadata{
 			WorkflowID:               e.workflow.id,
@@ -1015,7 +991,7 @@ func (e *Engine) deregisterTrigger(ctx context.Context, t *triggerCapability, tr
 			WorkflowName:             e.workflow.hexName,
 			WorkflowOwner:            e.workflow.owner,
 			ReferenceID:              t.Ref,
-			DecodedWorkflowName:      string(workflowName),
+			DecodedWorkflowName:      e.workflow.name,
 		},
 		TriggerID: generateTriggerId(e.workflow.id, triggerIdx),
 		Config:    t.config.Load(),
@@ -1322,6 +1298,7 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 	workflow.id = cfg.WorkflowID
 	workflow.owner = cfg.WorkflowOwner
 	workflow.hexName = hex.EncodeToString([]byte(cfg.WorkflowName))
+	workflow.name = cfg.WorkflowName
 
 	engine = &Engine{
 		cma:            cma,

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -153,7 +153,7 @@ func newTestEngineWithYAMLSpec(t *testing.T, reg *coreCap.Registry, spec string,
 
 type mockSecretsFetcher struct{}
 
-func (s mockSecretsFetcher) SecretsFor(ctx context.Context, workflowOwner, workflowName, workflowID string) (map[string]string, error) {
+func (s mockSecretsFetcher) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, workflowID string) (map[string]string, error) {
 	return map[string]string{}, nil
 }
 
@@ -1606,7 +1606,7 @@ type mockFetcher struct {
 	retval map[string]string
 }
 
-func (m *mockFetcher) SecretsFor(ctx context.Context, workflowOwner, workflowName, workflowID string) (map[string]string, error) {
+func (m *mockFetcher) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, workflowID string) (map[string]string, error) {
 	return m.retval, nil
 }
 

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -153,7 +153,7 @@ func newTestEngineWithYAMLSpec(t *testing.T, reg *coreCap.Registry, spec string,
 
 type mockSecretsFetcher struct{}
 
-func (s mockSecretsFetcher) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, workflowID string) (map[string]string, error) {
+func (s mockSecretsFetcher) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, decodedWorkflowName, workflowID string) (map[string]string, error) {
 	return map[string]string{}, nil
 }
 
@@ -1606,7 +1606,7 @@ type mockFetcher struct {
 	retval map[string]string
 }
 
-func (m *mockFetcher) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, workflowID string) (map[string]string, error) {
+func (m *mockFetcher) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, decodedWorkflowName, workflowID string) (map[string]string, error) {
 	return m.retval, nil
 }
 

--- a/core/services/workflows/models.go
+++ b/core/services/workflows/models.go
@@ -23,6 +23,7 @@ type workflow struct {
 	id      string
 	owner   string
 	hexName string
+	name    string
 	graph.Graph[string, *step]
 
 	triggers []*triggerCapability

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -224,7 +224,7 @@ func (h *eventHandler) refreshSecrets(ctx context.Context, workflowOwner, workfl
 	return updatedSecrets, nil
 }
 
-func (h *eventHandler) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, workflowID string) (map[string]string, error) {
+func (h *eventHandler) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, decodedWorkflowName, workflowID string) (map[string]string, error) {
 	secretsURLHash, secretsPayload, err := h.orm.GetContentsByWorkflowID(ctx, workflowID)
 	if err != nil {
 		// The workflow record was found, but secrets_id was empty.
@@ -243,21 +243,11 @@ func (h *eventHandler) SecretsFor(ctx context.Context, workflowOwner, hexWorkflo
 			msg := fmt.Sprintf("could not refresh secrets: proceeding with stale secrets for workflowID %s: %s", workflowID, innerErr)
 			h.lggr.Error(msg)
 
-			// best effort to decode the workflow name
-			var workflowName string
-			decodedWorkflowName, innerErr2 := hex.DecodeString(hexWorkflowName)
-			if innerErr2 != nil {
-				h.lggr.Errorf("failed to decode WorkflowName %q: %v", hexWorkflowName, innerErr2)
-				workflowName = hexWorkflowName
-			} else {
-				workflowName = string(decodedWorkflowName)
-			}
-
 			logCustMsg(
 				ctx,
 				h.emitter.With(
 					platform.KeyWorkflowID, workflowID,
-					platform.KeyWorkflowName, workflowName,
+					platform.KeyWorkflowName, decodedWorkflowName,
 					platform.KeyWorkflowOwner, workflowOwner,
 				),
 				msg,

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -224,7 +224,7 @@ func (h *eventHandler) refreshSecrets(ctx context.Context, workflowOwner, workfl
 	return updatedSecrets, nil
 }
 
-func (h *eventHandler) SecretsFor(ctx context.Context, workflowOwner, workflowName, workflowID string) (map[string]string, error) {
+func (h *eventHandler) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, workflowID string) (map[string]string, error) {
 	secretsURLHash, secretsPayload, err := h.orm.GetContentsByWorkflowID(ctx, workflowID)
 	if err != nil {
 		// The workflow record was found, but secrets_id was empty.
@@ -238,10 +238,21 @@ func (h *eventHandler) SecretsFor(ctx context.Context, workflowOwner, workflowNa
 
 	lastFetchedAt, ok := h.lastFetchedAtMap.Get(secretsURLHash)
 	if !ok || h.clock.Now().Sub(lastFetchedAt) > h.secretsFreshnessDuration {
-		updatedSecrets, innerErr := h.refreshSecrets(ctx, workflowOwner, workflowName, workflowID, secretsURLHash)
+		updatedSecrets, innerErr := h.refreshSecrets(ctx, workflowOwner, hexWorkflowName, workflowID, secretsURLHash)
 		if innerErr != nil {
 			msg := fmt.Sprintf("could not refresh secrets: proceeding with stale secrets for workflowID %s: %s", workflowID, innerErr)
 			h.lggr.Error(msg)
+
+			// best effort to decode the workflow name
+			var workflowName string
+			decodedWorkflowName, innerErr2 := hex.DecodeString(hexWorkflowName)
+			if innerErr2 != nil {
+				h.lggr.Errorf("failed to decode WorkflowName %q: %v", hexWorkflowName, innerErr2)
+				workflowName = hexWorkflowName
+			} else {
+				workflowName = string(decodedWorkflowName)
+			}
+
 			logCustMsg(
 				ctx,
 				h.emitter.With(

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -780,6 +780,7 @@ func Test_Handler_SecretsFor(t *testing.T) {
 	workflowOwner := hex.EncodeToString([]byte("anOwner"))
 	workflowName := "aName"
 	workflowID := "anID"
+	decodedWorkflowName := "decodedName"
 	encryptionKey, err := workflowkey.New()
 	require.NoError(t, err)
 
@@ -820,7 +821,7 @@ func Test_Handler_SecretsFor(t *testing.T) {
 		encryptionKey,
 	)
 
-	gotSecrets, err := h.SecretsFor(testutils.Context(t), workflowOwner, workflowName, workflowID)
+	gotSecrets, err := h.SecretsFor(testutils.Context(t), workflowOwner, workflowName, decodedWorkflowName, workflowID)
 	require.NoError(t, err)
 
 	expectedSecrets := map[string]string{
@@ -837,6 +838,7 @@ func Test_Handler_SecretsFor_RefreshesSecrets(t *testing.T) {
 	workflowOwner := hex.EncodeToString([]byte("anOwner"))
 	workflowName := "aName"
 	workflowID := "anID"
+	decodedWorkflowName := "decodedName"
 	encryptionKey, err := workflowkey.New()
 	require.NoError(t, err)
 
@@ -881,7 +883,7 @@ func Test_Handler_SecretsFor_RefreshesSecrets(t *testing.T) {
 		encryptionKey,
 	)
 
-	gotSecrets, err := h.SecretsFor(testutils.Context(t), workflowOwner, workflowName, workflowID)
+	gotSecrets, err := h.SecretsFor(testutils.Context(t), workflowOwner, workflowName, decodedWorkflowName, workflowID)
 	require.NoError(t, err)
 
 	expectedSecrets := map[string]string{
@@ -898,6 +900,7 @@ func Test_Handler_SecretsFor_RefreshLogic(t *testing.T) {
 	workflowOwner := hex.EncodeToString([]byte("anOwner"))
 	workflowName := "aName"
 	workflowID := "anID"
+	decodedWorkflowName := "decodedName"
 	encryptionKey, err := workflowkey.New()
 	require.NoError(t, err)
 
@@ -943,7 +946,7 @@ func Test_Handler_SecretsFor_RefreshLogic(t *testing.T) {
 		encryptionKey,
 	)
 
-	gotSecrets, err := h.SecretsFor(testutils.Context(t), workflowOwner, workflowName, workflowID)
+	gotSecrets, err := h.SecretsFor(testutils.Context(t), workflowOwner, workflowName, decodedWorkflowName, workflowID)
 	require.NoError(t, err)
 
 	expectedSecrets := map[string]string{
@@ -955,7 +958,7 @@ func Test_Handler_SecretsFor_RefreshLogic(t *testing.T) {
 	// SecretsFor should still succeed.
 	fetcher.responseMap[url] = mockFetchResp{}
 
-	gotSecrets, err = h.SecretsFor(testutils.Context(t), workflowOwner, workflowName, workflowID)
+	gotSecrets, err = h.SecretsFor(testutils.Context(t), workflowOwner, workflowName, decodedWorkflowName, workflowID)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedSecrets, gotSecrets)
@@ -963,7 +966,7 @@ func Test_Handler_SecretsFor_RefreshLogic(t *testing.T) {
 	// Now advance so that we hit the freshness limit
 	clock.Advance(48 * time.Hour)
 
-	_, err = h.SecretsFor(testutils.Context(t), workflowOwner, workflowName, workflowID)
+	_, err = h.SecretsFor(testutils.Context(t), workflowOwner, workflowName, decodedWorkflowName, workflowID)
 	assert.ErrorContains(t, err, "unexpected end of JSON input")
 }
 

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.36
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250103152858-8973fd0c912b
-	github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550
+	github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.13
 	github.com/smartcontractkit/libocr v0.0.0-20241223215956-e5b78d8e3919

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1385,8 +1385,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000/go.mod h1:ncjd6mPZSRlelEqH/2KeLE1pU3UlqzBSn8RYkEoECzY=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250103152858-8973fd0c912b h1:UBXi9Yj8YSMHDDaxQLu273x1fWjyEL9xP58nuJsqZfg=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250103152858-8973fd0c912b/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550 h1:rRs74zjDJ7do5aYEXSU/sOnLnlbYCNqM8BrvEx/0NH8=
-github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
+github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e h1:8BStiP1F4W8AvjBRga0TYtjvAtkwN8oHYnHJztAlSF4=
+github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e h1:PRoeby6ZlTuTkv2f+7tVU4+zboTfRzI+beECynF4JQ0=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e/go.mod h1:mUh5/woemsVaHgTorA080hrYmO3syBCmPdnWc/5dOqk=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241216163550-fa030d178ba3 h1:aeiBdBHGY8QNftps+VqrIk6OnfeeOD5z4jrAabW4ZSc=

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.34
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000
-	github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550
+	github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e
 	github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241216163550-fa030d178ba3
 	github.com/smartcontractkit/chainlink-feeds v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1150,8 +1150,8 @@ github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgB
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000 h1:6Zzr/R1j6P7bbvcUlt5WUIbItvrrGdGzIsiAzQezcwo=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000/go.mod h1:ncjd6mPZSRlelEqH/2KeLE1pU3UlqzBSn8RYkEoECzY=
-github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550 h1:rRs74zjDJ7do5aYEXSU/sOnLnlbYCNqM8BrvEx/0NH8=
-github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
+github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e h1:8BStiP1F4W8AvjBRga0TYtjvAtkwN8oHYnHJztAlSF4=
+github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e h1:PRoeby6ZlTuTkv2f+7tVU4+zboTfRzI+beECynF4JQ0=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e/go.mod h1:mUh5/woemsVaHgTorA080hrYmO3syBCmPdnWc/5dOqk=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241216163550-fa030d178ba3 h1:aeiBdBHGY8QNftps+VqrIk6OnfeeOD5z4jrAabW4ZSc=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.36
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000
-	github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550
+	github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.19

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1407,8 +1407,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000/go.mod h1:ncjd6mPZSRlelEqH/2KeLE1pU3UlqzBSn8RYkEoECzY=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250103152858-8973fd0c912b h1:UBXi9Yj8YSMHDDaxQLu273x1fWjyEL9xP58nuJsqZfg=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250103152858-8973fd0c912b/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550 h1:rRs74zjDJ7do5aYEXSU/sOnLnlbYCNqM8BrvEx/0NH8=
-github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
+github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e h1:8BStiP1F4W8AvjBRga0TYtjvAtkwN8oHYnHJztAlSF4=
+github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e h1:PRoeby6ZlTuTkv2f+7tVU4+zboTfRzI+beECynF4JQ0=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e/go.mod h1:mUh5/woemsVaHgTorA080hrYmO3syBCmPdnWc/5dOqk=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241216163550-fa030d178ba3 h1:aeiBdBHGY8QNftps+VqrIk6OnfeeOD5z4jrAabW4ZSc=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
-	github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550
+	github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.19
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.9
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1398,8 +1398,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20241218114855-f74219171000/go.mod h1:ncjd6mPZSRlelEqH/2KeLE1pU3UlqzBSn8RYkEoECzY=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250103152858-8973fd0c912b h1:UBXi9Yj8YSMHDDaxQLu273x1fWjyEL9xP58nuJsqZfg=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250103152858-8973fd0c912b/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550 h1:rRs74zjDJ7do5aYEXSU/sOnLnlbYCNqM8BrvEx/0NH8=
-github.com/smartcontractkit/chainlink-common v0.4.1-0.20241223143929-db7919d60550/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
+github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e h1:8BStiP1F4W8AvjBRga0TYtjvAtkwN8oHYnHJztAlSF4=
+github.com/smartcontractkit/chainlink-common v0.4.1-0.20250108194320-2ebd63bbb16e/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e h1:PRoeby6ZlTuTkv2f+7tVU4+zboTfRzI+beECynF4JQ0=
 github.com/smartcontractkit/chainlink-cosmos v0.5.2-0.20241202195413-82468150ac1e/go.mod h1:mUh5/woemsVaHgTorA080hrYmO3syBCmPdnWc/5dOqk=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20241216163550-fa030d178ba3 h1:aeiBdBHGY8QNftps+VqrIk6OnfeeOD5z4jrAabW4ZSc=


### PR DESCRIPTION
### Description

This pr introduces a fix to use a human readable hex decoded  workflow name whenever we log it via beholder
[CAPPL-320](https://smartcontract-it.atlassian.net/browse/CAPPL-320)

### Requires
- https://github.com/smartcontractkit/chainlink-common/pull/983

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CAPPL-320]: https://smartcontract-it.atlassian.net/browse/CAPPL-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ