### PR TITLE
core/services/relay/evm/capabilities: extend timeout for TestLogEventTriggerEVMHappyPath flake

### DIFF
--- a/core/services/relay/evm/capabilities/log_event_trigger_test.go
+++ b/core/services/relay/evm/capabilities/log_event_trigger_test.go
@@ -3,7 +3,6 @@ package logevent_test
 import (
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -13,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	commonmocks "github.com/smartcontractkit/chainlink-common/pkg/types/core/mocks"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/triggers/logevent"
 	coretestutils "github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/capabilities/testutils"
@@ -135,7 +135,7 @@ func emitLogTxnAndWaitForLog(t *testing.T,
 
 	for _, expectedLogVal := range expectedLogVals {
 		// Wait for logs with a timeout
-		_, output, err := testutils.WaitForLog(th.BackendTH.Lggr, log1Ch, 15*time.Second)
+		_, output, err := testutils.WaitForLog(th.BackendTH.Lggr, log1Ch, tests.WaitTimeout(t))
 		require.NoError(t, err)
 		th.BackendTH.Lggr.Infow("EmitLog", "output", output)
 


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-3462
https://smartcontract-it.atlassian.net/browse/BCF-3447

This fix also affects `TestLogEventTriggerCursorNewLogs`
```
--- FAIL: TestLogEventTriggerEVMHappyPath (188.06s)
    logger.go:146: 2025-01-03T16:37:48.603Z	INFO	LogEventTriggerCapabilityService	logevent/service.go:139	Starting LogEventTriggerCapabilityService	{"version": "unset@unset"}
    logger.go:146: 2025-01-03T16:37:48.611Z	INFO	LogEventTriggerCapabilityService	logevent/service.go:116	RegisterTrigger	{"version": "unset@unset", "triggerId": "logeventtrigger_log1", "WorkflowID": ""}
    logger.go:146: 2025-01-03T16:37:48.611Z	DEBUG	LogPoller	logpoller/log_poller.go:1104	Latest blocks read from chain	{"version": "unset@unset", "latest": 3, "finalized": 1}
    logger.go:146: 2025-01-03T16:37:48.612Z	DEBUG	LogPoller	logpoller/log_poller.go:997	Polling for logs	{"version": "unset@unset", "currentBlockNumber": 1}
    logger.go:146: 2025-01-03T16:37:48.613Z	DEBUG	LogPoller	logpoller/log_poller.go:1104	Latest blocks read from chain	{"version": "unset@unset", "latest": 3, "finalized": 1}
    logger.go:146: 2025-01-03T16:37:48.614Z	INFO	LogPoller	logpoller/log_poller.go:959	Do not have previous block, first poll ever on new chain or after backfill	{"version": "unset@unset", "currentBlockNumber": 1}
    logger.go:146: 2025-01-03T16:37:48.615Z	DEBUG	LogPoller	logpoller/log_poller.go:1064	Unfinalized log query	{"version": "unset@unset", "logs": 0, "currentBlockNumber": 1, "blockHash": "0x747b40554862ff028bb55119cb00f34916069a23b7e6caa0c651f960d27ec270", "timestamp": "2025-01-02T16:37:48.000Z"}
    logger.go:146: 2025-01-03T16:37:49.611Z	INFO	LogEventTriggerCapabilityService.LogEventTrigger.	logevent/trigger.go:144	Polling event logs from ContractReader using QueryKey at	{"version": "unset@unset", "time": "2025-01-03T16:37:49.611Z", "startBlockNum": 0, "cursor": ""}
    log_event_trigger_test.go:139: 
        	Error Trace:	/home/runner/work/chainlink/chainlink/core/services/relay/evm/capabilities/log_event_trigger_test.go:139
        	            				/home/runner/work/chainlink/chainlink/core/services/relay/evm/capabilities/log_event_trigger_test.go:64
        	Error:      	Received unexpected error:
        	            	timeout waiting for Log1 event from ContractReader
        	Test:       	TestLogEventTriggerEVMHappyPath
    logger.go:146: 2025-01-03T16:38:03.614Z	INFO	LogEventTriggerCapabilityService	logevent/service.go:149	Stopping LogEventTriggerCapabilityService	{"version": "unset@unset"}
    logger.go:146: 2025-01-03T16:40:56.642Z	INFO	LogEventTriggerCapabilityService.LogEventTrigger.	logevent/trigger.go:138	Closing trigger server for (waiting for waitGroup)	{"version": "unset@unset", "ChainID": "1337", "ContractName": "LogEmitter", "ContractAddress": "0x78Dc4B49F81Eed7F64C387677102c43BE5245a9a", "ContractEventName": "Log1"}
    logger.go:146: 2025-01-03T16:40:56.642Z	DEBUG	LogPoller	logpoller/log_poller.go:1064	Unfinalized log query	{"version": "unset@unset", "logs": 0, "currentBlockNumber": 2, "blockHash": "0x8e6bfc6ad47bfa2c9a127e6ebc7fb26bd790e3d9c01013bbbd711c6797498e50", "timestamp": "2025-01-03T16:37:48.000Z"}
    logger.go:146: 2025-01-03T16:40:56.643Z	WARN	LogPoller	logpoller/log_poller.go:935	Unable to get currentBlock	{"version": "unset@unset", "err": "context canceled", "currentBlockNumber": 3}
    logger.go:146: 2025-01-03T16:40:56.643Z	ERROR	LogPoller	logpoller/log_poller.go:1051	Unable to get current block	{"version": "unset@unset", "err": "context canceled"}
        github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller.(*logPoller).PollAndSaveLogs
        	/home/runner/work/chainlink/chainlink/core/chains/evm/logpoller/log_poller.go:1051
        github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller.(*logPoller).run
        	/home/runner/work/chainlink/chainlink/core/chains/evm/logpoller/log_poller.go:652
FAIL
FAIL	github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/capabilities	[188](https://github.com/smartcontractkit/chainlink/actions/runs/12600768168/job/35120522349#step:15:189).406s
```