### PR TITLE
Add panic recovery to mercury wsrpc client

### DIFF
--- a/.changeset/eleven-cheetahs-care.md
+++ b/.changeset/eleven-cheetahs-care.md
@@ -1,0 +1,7 @@
+---
+"chainlink": patch
+---
+
+Add panic recovery to wsrpc mercury client
+
+- Should help to make nodes running wsrpc v0.8.2 more stable #bugfix

--- a/core/services/relay/evm/mercury/wsrpc/mocks/mocks.go
+++ b/core/services/relay/evm/mercury/wsrpc/mocks/mocks.go
@@ -29,9 +29,10 @@ func (m *MockWSRPCClient) ServerURL() string { return "mock server url" }
 func (m *MockWSRPCClient) RawClient() pb.MercuryClient { return nil }
 
 type MockConn struct {
-	State  grpc_connectivity.State
-	Ready  bool
-	Closed bool
+	State   grpc_connectivity.State
+	Ready   bool
+	Closed  bool
+	InvokeF func(ctx context.Context, method string, args interface{}, reply interface{}) error
 }
 
 func (m *MockConn) Close() error {
@@ -42,3 +43,7 @@ func (m MockConn) WaitForReady(ctx context.Context) bool {
 	return m.Ready
 }
 func (m MockConn) GetState() grpc_connectivity.State { return m.State }
+
+func (m MockConn) Invoke(ctx context.Context, method string, args interface{}, reply interface{}) error {
+	return m.InvokeF(ctx, method, args, reply)
+}

--- a/core/services/relay/evm/mercury/wsrpc/pool.go
+++ b/core/services/relay/evm/mercury/wsrpc/pool.go
@@ -60,7 +60,7 @@ func (conn *connection) checkout(ctx context.Context) (cco *clientCheckout, err 
 // not thread-safe, access must be serialized
 func (conn *connection) ensureStartedClient(ctx context.Context) error {
 	if len(conn.checkouts) == 0 {
-		conn.Client = conn.pool.newClient(conn.lggr, conn.clientPrivKey, conn.serverPubKey, conn.serverURL, conn.pool.cacheSet)
+		conn.Client = conn.pool.newClient(ClientOpts{conn.lggr, conn.clientPrivKey, conn.serverPubKey, conn.serverURL, conn.pool.cacheSet, nil})
 		return conn.Client.Start(ctx)
 	}
 	return nil
@@ -121,7 +121,7 @@ type pool struct {
 	connections map[string]map[credentials.StaticSizedPublicKey]*connection
 
 	// embedding newClient makes testing/mocking easier
-	newClient func(lggr logger.Logger, privKey csakey.KeyV2, serverPubKey []byte, serverURL string, cacheSet cache.CacheSet) Client
+	newClient func(opts ClientOpts) Client
 
 	mu sync.RWMutex
 

--- a/core/services/relay/evm/mercury/wsrpc/pool_test.go
+++ b/core/services/relay/evm/mercury/wsrpc/pool_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/csakey"
-	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/wsrpc/cache"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/wsrpc/pb"
 )
 
@@ -64,10 +63,10 @@ func Test_Pool(t *testing.T) {
 			serverURL := "example.com:443/ws"
 
 			client := newMockClient(lggr)
-			p.newClient = func(lggr logger.Logger, cprivk csakey.KeyV2, spubk []byte, surl string, cs cache.CacheSet) Client {
-				assert.Equal(t, clientPrivKey, cprivk)
-				assert.Equal(t, serverPubKey, spubk)
-				assert.Equal(t, serverURL, surl)
+			p.newClient = func(opts ClientOpts) Client {
+				assert.Equal(t, clientPrivKey, opts.ClientPrivKey)
+				assert.Equal(t, serverPubKey, opts.ServerPubKey)
+				assert.Equal(t, serverURL, opts.ServerURL)
 				return client
 			}
 
@@ -110,8 +109,8 @@ func Test_Pool(t *testing.T) {
 				"example.invalid:8000/ws",
 			}
 
-			p.newClient = func(lggr logger.Logger, cprivk csakey.KeyV2, spubk []byte, surl string, cs cache.CacheSet) Client {
-				return newMockClient(lggr)
+			p.newClient = func(opts ClientOpts) Client {
+				return newMockClient(opts.Logger)
 			}
 
 			// conn 1
@@ -226,8 +225,8 @@ func Test_Pool(t *testing.T) {
 		}
 
 		var clients []*mockClient
-		p.newClient = func(lggr logger.Logger, cprivk csakey.KeyV2, spubk []byte, surl string, cs cache.CacheSet) Client {
-			c := newMockClient(lggr)
+		p.newClient = func(opts ClientOpts) Client {
+			c := newMockClient(opts.Logger)
 			clients = append(clients, c)
 			return c
 		}


### PR DESCRIPTION
Wraps calls to Transmit and LatestReport with automatic recovers,
triggering a redial of the underlying connection.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
