### PR TITLE
feat(keystone): add capabilities and add nops as mcms proposals

### DIFF
--- a/deployment/keystone/changeset/internal/append_node_capabilities.go
+++ b/deployment/keystone/changeset/internal/append_node_capabilities.go
@@ -49,7 +49,7 @@ func AppendNodeCapabilitiesImpl(lggr logger.Logger, req *AppendNodeCapabilitiesR
 	for _, cap := range req.P2pToCapabilities {
 		capabilities = append(capabilities, cap...)
 	}
-	op, err := AddCapabilities(lggr, req.ContractSet, req.Chain, capabilities, req.UseMCMS)
+	op, err := AddCapabilities(lggr, req.ContractSet.CapabilitiesRegistry, req.Chain, capabilities, req.UseMCMS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add capabilities: %w", err)
 	}

--- a/deployment/keystone/changeset/internal/deploy.go
+++ b/deployment/keystone/changeset/internal/deploy.go
@@ -416,10 +416,14 @@ type RegisterCapabilitiesRequest struct {
 	Env                   *deployment.Environment
 	RegistryChainSelector uint64
 	DonToCapabilities     map[string][]capabilities_registry.CapabilitiesRegistryCapability
+
+	// if UseMCMS is true, a batch proposal is returned and no transaction is confirmed on chain.
+	UseMCMS bool
 }
 
 type RegisterCapabilitiesResponse struct {
 	DonToCapabilities map[string][]RegisteredCapability
+	Ops               *timelock.BatchChainOperation
 }
 
 type RegisteredCapability struct {
@@ -492,11 +496,14 @@ func RegisterCapabilities(lggr logger.Logger, req RegisterCapabilitiesRequest) (
 		lggr.Warn("no new capabilities to register")
 		return &RegisterCapabilitiesResponse{}, nil
 	}
-	// not using mcms; ignore proposals
-	_, err = AddCapabilities(lggr, &contracts, registryChain, capabilities, false)
+
+	ops, err := AddCapabilities(lggr, &contracts, registryChain, capabilities, req.UseMCMS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add capabilities: %w", err)
 	}
+
+	resp.Ops = ops
+
 	return resp, nil
 }
 
@@ -504,10 +511,12 @@ type RegisterNOPSRequest struct {
 	Env                   *deployment.Environment
 	RegistryChainSelector uint64
 	Nops                  []capabilities_registry.CapabilitiesRegistryNodeOperator
+	UseMCMS               bool
 }
 
 type RegisterNOPSResponse struct {
 	Nops []*capabilities_registry.CapabilitiesRegistryNodeOperatorAdded
+	Ops  *timelock.BatchChainOperation
 }
 
 func RegisterNOPS(ctx context.Context, lggr logger.Logger, req RegisterNOPSRequest) (*RegisterNOPSResponse, error) {
@@ -550,6 +559,22 @@ func RegisterNOPS(ctx context.Context, lggr logger.Logger, req RegisterNOPSReque
 		err = deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to call AddNodeOperators: %w", err)
 	}
+
+	if req.UseMCMS {
+		resp.Ops = &timelock.BatchChainOperation{
+			ChainIdentifier: mcms.ChainIdentifier(registryChain.Selector),
+			Batch: []mcms.Operation{
+				{
+					To:    registry.Address(),
+					Data:  tx.Data(),
+					Value: big.NewInt(0),
+				},
+			},
+		}
+
+		return resp, nil
+	}
+
 	// for some reason that i don't understand, the confirm must be called before the WaitMined or the latter will hang
 	// (at least for a simulated backend chain)
 	_, err = registryChain.Confirm(tx)

--- a/deployment/keystone/changeset/internal/deploy.go
+++ b/deployment/keystone/changeset/internal/deploy.go
@@ -658,9 +658,11 @@ type RegisterNodesRequest struct {
 	DonToNodes            map[string][]deployment.Node
 	DonToCapabilities     map[string][]RegisteredCapability
 	Nops                  []*capabilities_registry.CapabilitiesRegistryNodeOperatorAdded
+	UseMCMS               bool
 }
 type RegisterNodesResponse struct {
 	nodeIDToParams map[string]capabilities_registry.CapabilitiesRegistryNodeParams
+	Ops            *timelock.BatchChainOperation
 }
 
 // registerNodes registers the nodes with the registry. it assumes that the deployer key in the Chain
@@ -766,6 +768,18 @@ func RegisterNodes(lggr logger.Logger, req *RegisterNodesRequest) (*RegisterNode
 	}
 	lggr.Debugw("unique node params to add", "count", len(uniqueNodeParams), "params", uniqueNodeParams)
 
+	if req.UseMCMS {
+		ops, err := addNodesMCMSProposal(registry, uniqueNodeParams, registryChain)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate proposal to add nodes: %w", err)
+		}
+
+		return &RegisterNodesResponse{
+			nodeIDToParams: nodeIDToParams,
+			Ops:            ops,
+		}, nil
+	}
+
 	tx, err := registry.AddNodes(registryChain.DeployerKey, uniqueNodeParams)
 	if err != nil {
 		err = deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)
@@ -802,6 +816,26 @@ func RegisterNodes(lggr logger.Logger, req *RegisterNodesRequest) (*RegisterNode
 
 	return &RegisterNodesResponse{
 		nodeIDToParams: nodeIDToParams,
+	}, nil
+}
+
+// addNodesMCMSProposal generates a single call to AddNodes for all the node params at once.
+func addNodesMCMSProposal(registry *capabilities_registry.CapabilitiesRegistry, params []capabilities_registry.CapabilitiesRegistryNodeParams, regChain deployment.Chain) (*timelock.BatchChainOperation, error) {
+	tx, err := registry.AddNodes(deployment.SimTransactOpts(), params)
+	if err != nil {
+		err = deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)
+		return nil, fmt.Errorf("failed to simulate call to AddNodes: %w", err)
+	}
+
+	return &timelock.BatchChainOperation{
+		ChainIdentifier: mcms.ChainIdentifier(regChain.Selector),
+		Batch: []mcms.Operation{
+			{
+				To:    registry.Address(),
+				Data:  tx.Data(),
+				Value: big.NewInt(0),
+			},
+		},
 	}, nil
 }
 

--- a/deployment/keystone/changeset/internal/deploy.go
+++ b/deployment/keystone/changeset/internal/deploy.go
@@ -801,10 +801,12 @@ type RegisterDonsRequest struct {
 	NodeIDToP2PID     map[string][32]byte
 	DonToCapabilities map[string][]RegisteredCapability
 	DonsToRegister    []DONToRegister
+	UseMCMS           bool
 }
 
 type RegisterDonsResponse struct {
 	DonInfos map[string]capabilities_registry.CapabilitiesRegistryDONInfo
+	Ops      *timelock.BatchChainOperation
 }
 
 func sortedHash(p2pids [][32]byte) string {
@@ -840,6 +842,7 @@ func RegisterDons(lggr logger.Logger, req RegisterDonsRequest) (*RegisterDonsRes
 	}
 	lggr.Infow("fetched existing DONs...", "len", len(donInfos), "lenByNodesHash", len(existingDONs))
 
+	mcmsOps := make([]mcms.Operation, 0, len(req.DonsToRegister))
 	for _, don := range req.DonsToRegister {
 		var p2pIds [][32]byte
 		for _, n := range don.Nodes {
@@ -888,6 +891,17 @@ func RegisterDons(lggr logger.Logger, req RegisterDonsRequest) (*RegisterDonsRes
 			err = deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)
 			return nil, fmt.Errorf("failed to call AddDON for don '%s' p2p2Id hash %s capability %v: %w", don.Name, p2pSortedHash, cfgs, err)
 		}
+
+		if req.UseMCMS {
+			op := mcms.Operation{
+				To:    registry.Address(),
+				Data:  tx.Data(),
+				Value: big.NewInt(0),
+			}
+			mcmsOps = append(mcmsOps, op)
+			continue
+		}
+
 		_, err = registryChain.Confirm(tx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to confirm AddDON transaction %s for don %s: %w", tx.Hash().String(), don.Name, err)
@@ -895,6 +909,16 @@ func RegisterDons(lggr logger.Logger, req RegisterDonsRequest) (*RegisterDonsRes
 		lggr.Debugw("registered DON", "don", don.Name, "p2p sorted hash", p2pSortedHash, "cgs", cfgs, "wfSupported", wfSupported, "f", don.F)
 		addedDons++
 	}
+
+	if req.UseMCMS {
+		return &RegisterDonsResponse{
+			Ops: &timelock.BatchChainOperation{
+				ChainIdentifier: mcms.ChainIdentifier(registryChain.Selector),
+				Batch:           mcmsOps,
+			},
+		}, nil
+	}
+
 	lggr.Debugf("Registered all DONs (new=%d), waiting for registry to update", addedDons)
 
 	// occasionally the registry does not return the expected number of DONS immediately after the txns above

--- a/deployment/keystone/changeset/internal/deploy.go
+++ b/deployment/keystone/changeset/internal/deploy.go
@@ -555,29 +555,20 @@ func RegisterNOPS(ctx context.Context, lggr logger.Logger, req RegisterNOPSReque
 		return resp, nil
 	}
 
-	txOpts := registryChain.DeployerKey
 	if req.UseMCMS {
-		txOpts = deployment.SimTransactOpts()
+		ops, err := addNOPsMCMSProposal(registry, nops, registryChain)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate proposal to add node operators: %w", err)
+		}
+
+		resp.Ops = ops
+		return resp, nil
 	}
-	tx, err := registry.AddNodeOperators(txOpts, nops)
+
+	tx, err := registry.AddNodeOperators(registryChain.DeployerKey, nops)
 	if err != nil {
 		err = deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to call AddNodeOperators: %w", err)
-	}
-
-	if req.UseMCMS {
-		resp.Ops = &timelock.BatchChainOperation{
-			ChainIdentifier: mcms.ChainIdentifier(registryChain.Selector),
-			Batch: []mcms.Operation{
-				{
-					To:    registry.Address(),
-					Data:  tx.Data(),
-					Value: big.NewInt(0),
-				},
-			},
-		}
-
-		return resp, nil
 	}
 
 	// for some reason that i don't understand, the confirm must be called before the WaitMined or the latter will hang
@@ -603,6 +594,25 @@ func RegisterNOPS(ctx context.Context, lggr logger.Logger, req RegisterNOPSReque
 	}
 
 	return resp, nil
+}
+
+func addNOPsMCMSProposal(registry *capabilities_registry.CapabilitiesRegistry, nops []capabilities_registry.CapabilitiesRegistryNodeOperator, regChain deployment.Chain) (*timelock.BatchChainOperation, error) {
+	tx, err := registry.AddNodeOperators(deployment.SimTransactOpts(), nops)
+	if err != nil {
+		err = deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)
+		return nil, fmt.Errorf("failed to call AddNodeOperators: %w", err)
+	}
+
+	return &timelock.BatchChainOperation{
+		ChainIdentifier: mcms.ChainIdentifier(regChain.Selector),
+		Batch: []mcms.Operation{
+			{
+				To:    registry.Address(),
+				Data:  tx.Data(),
+				Value: big.NewInt(0),
+			},
+		},
+	}, nil
 }
 
 func DefaultCapConfig(capType uint8, nNodes int) *capabilitiespb.CapabilityConfig {

--- a/deployment/keystone/changeset/internal/deploy.go
+++ b/deployment/keystone/changeset/internal/deploy.go
@@ -497,7 +497,7 @@ func RegisterCapabilities(lggr logger.Logger, req RegisterCapabilitiesRequest) (
 		return &RegisterCapabilitiesResponse{}, nil
 	}
 
-	ops, err := AddCapabilities(lggr, &contracts, registryChain, capabilities, req.UseMCMS)
+	ops, err := AddCapabilities(lggr, contracts.CapabilitiesRegistry, registryChain, capabilities, req.UseMCMS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add capabilities: %w", err)
 	}
@@ -554,7 +554,12 @@ func RegisterNOPS(ctx context.Context, lggr logger.Logger, req RegisterNOPSReque
 		lggr.Debug("no new node operators to register")
 		return resp, nil
 	}
-	tx, err := registry.AddNodeOperators(registryChain.DeployerKey, nops)
+
+	txOpts := registryChain.DeployerKey
+	if req.UseMCMS {
+		txOpts = deployment.SimTransactOpts()
+	}
+	tx, err := registry.AddNodeOperators(txOpts, nops)
 	if err != nil {
 		err = deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to call AddNodeOperators: %w", err)
@@ -750,6 +755,7 @@ func RegisterNodes(lggr logger.Logger, req *RegisterNodesRequest) (*RegisterNode
 		uniqueNodeParams = append(uniqueNodeParams, v)
 	}
 	lggr.Debugw("unique node params to add", "count", len(uniqueNodeParams), "params", uniqueNodeParams)
+
 	tx, err := registry.AddNodes(registryChain.DeployerKey, uniqueNodeParams)
 	if err != nil {
 		err = deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)
@@ -783,6 +789,7 @@ func RegisterNodes(lggr logger.Logger, req *RegisterNodesRequest) (*RegisterNode
 			return nil, fmt.Errorf("failed to confirm AddNode confirm transaction %s: %w", tx.Hash().String(), err)
 		}
 	}
+
 	return &RegisterNodesResponse{
 		nodeIDToParams: nodeIDToParams,
 	}, nil

--- a/deployment/keystone/changeset/internal/deploy.go
+++ b/deployment/keystone/changeset/internal/deploy.go
@@ -911,9 +911,11 @@ func RegisterDons(lggr logger.Logger, req RegisterDonsRequest) (*RegisterDonsRes
 		p2pIdsToDon[p2pSortedHash] = don.Name
 
 		if _, ok := existingDONs[p2pSortedHash]; ok {
-			lggr.Debugw("don already exists, ignoring", "don", don, "p2p sorted hash", p2pSortedHash)
+			lggr.Debugw("don already exists, ignoring", "don", don.Name, "p2p sorted hash", p2pSortedHash)
 			continue
 		}
+
+		lggr.Debugw("registering DON", "don", don.Name, "p2p sorted hash", p2pSortedHash)
 
 		caps, ok := req.DonToCapabilities[don.Name]
 		if !ok {
@@ -937,13 +939,19 @@ func RegisterDons(lggr logger.Logger, req RegisterDonsRequest) (*RegisterDonsRes
 			})
 		}
 
-		tx, err := registry.AddDON(registryChain.DeployerKey, p2pIds, cfgs, true, wfSupported, don.F)
+		txOpts := registryChain.DeployerKey
+		if req.UseMCMS {
+			txOpts = deployment.SimTransactOpts()
+		}
+
+		tx, err := registry.AddDON(txOpts, p2pIds, cfgs, true, wfSupported, don.F)
 		if err != nil {
 			err = deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)
 			return nil, fmt.Errorf("failed to call AddDON for don '%s' p2p2Id hash %s capability %v: %w", don.Name, p2pSortedHash, cfgs, err)
 		}
 
 		if req.UseMCMS {
+			lggr.Debugw("adding mcms op for DON", "don", don.Name)
 			op := mcms.Operation{
 				To:    registry.Address(),
 				Data:  tx.Data(),
@@ -1006,6 +1014,7 @@ func RegisterDons(lggr logger.Logger, req RegisterDonsRequest) (*RegisterDonsRes
 		lggr.Debugw("adding don info to the response (keyed by DON name)", "don", donName)
 		resp.DonInfos[donName] = donInfos[i]
 	}
+
 	return &resp, nil
 }
 

--- a/deployment/keystone/changeset/internal/deploy_test.go
+++ b/deployment/keystone/changeset/internal/deploy_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 	kstest "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal/test"
 	kcr "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-	"github.com/test-go/testify/require"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_RegisterNOPS(t *testing.T) {
@@ -114,5 +115,89 @@ func Test_RegisterNodes(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Ops)
 		require.Len(t, resp.Ops.Batch, 1)
+	})
+}
+
+func Test_RegisterDons(t *testing.T) {
+	var (
+		useMCMS   bool
+		lggr      = logger.Test(t)
+		setupResp = kstest.SetupTestRegistry(t, lggr, &kstest.SetupTestRegistryRequest{})
+		registry  = setupResp.Registry
+		chain     = setupResp.Chain
+	)
+	t.Run("success create add DONs mcms proposal", func(t *testing.T) {
+		useMCMS = true
+		env := &deployment.Environment{
+			Logger: lggr,
+			Chains: map[uint64]deployment.Chain{
+				chain.Selector: chain,
+			},
+			ExistingAddresses: deployment.NewMemoryAddressBookFromMap(map[uint64]map[string]deployment.TypeAndVersion{
+				chain.Selector: {
+					registry.Address().String(): deployment.TypeAndVersion{
+						Type:    internal.CapabilitiesRegistry,
+						Version: deployment.Version1_0_0,
+					},
+				},
+			}),
+		}
+		resp, err := internal.RegisterDons(lggr, internal.RegisterDonsRequest{
+			Env:                   env,
+			RegistryChainSelector: chain.Selector,
+			DonToCapabilities: map[string][]internal.RegisteredCapability{
+				"test-don": {},
+			},
+			DonsToRegister: []internal.DONToRegister{
+				{
+					Name: "test-don",
+					F:    2,
+				},
+			},
+			UseMCMS: useMCMS,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp.Ops)
+		require.Len(t, resp.Ops.Batch, 1)
+	})
+
+	t.Run("success create add DONs mcms proposal with multiple DONs", func(t *testing.T) {
+		useMCMS = true
+		env := &deployment.Environment{
+			Logger: lggr,
+			Chains: map[uint64]deployment.Chain{
+				chain.Selector: chain,
+			},
+			ExistingAddresses: deployment.NewMemoryAddressBookFromMap(map[uint64]map[string]deployment.TypeAndVersion{
+				chain.Selector: {
+					registry.Address().String(): deployment.TypeAndVersion{
+						Type:    internal.CapabilitiesRegistry,
+						Version: deployment.Version1_0_0,
+					},
+				},
+			}),
+		}
+		resp, err := internal.RegisterDons(lggr, internal.RegisterDonsRequest{
+			Env:                   env,
+			RegistryChainSelector: chain.Selector,
+			DonToCapabilities: map[string][]internal.RegisteredCapability{
+				"test-don-1": {},
+				"test-don-2": {},
+			},
+			DonsToRegister: []internal.DONToRegister{
+				{
+					Name: "test-don-1",
+					F:    2,
+				},
+				{
+					Name: "test-don-2",
+					F:    2,
+				},
+			},
+			UseMCMS: useMCMS,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp.Ops)
+		require.Len(t, resp.Ops.Batch, 2)
 	})
 }

--- a/deployment/keystone/changeset/internal/deploy_test.go
+++ b/deployment/keystone/changeset/internal/deploy_test.go
@@ -81,3 +81,38 @@ func Test_AddCapabilities(t *testing.T) {
 		require.Nil(t, ops)
 	})
 }
+
+func Test_RegisterNodes(t *testing.T) {
+	var (
+		useMCMS   bool
+		lggr      = logger.Test(t)
+		setupResp = kstest.SetupTestRegistry(t, lggr, &kstest.SetupTestRegistryRequest{})
+		registry  = setupResp.Registry
+		chain     = setupResp.Chain
+	)
+	t.Run("success create add nodes mcms proposal", func(t *testing.T) {
+		useMCMS = true
+		env := &deployment.Environment{
+			Logger: lggr,
+			Chains: map[uint64]deployment.Chain{
+				chain.Selector: chain,
+			},
+			ExistingAddresses: deployment.NewMemoryAddressBookFromMap(map[uint64]map[string]deployment.TypeAndVersion{
+				chain.Selector: {
+					registry.Address().String(): deployment.TypeAndVersion{
+						Type:    internal.CapabilitiesRegistry,
+						Version: deployment.Version1_0_0,
+					},
+				},
+			}),
+		}
+		resp, err := internal.RegisterNodes(lggr, &internal.RegisterNodesRequest{
+			Env:                   env,
+			RegistryChainSelector: chain.Selector,
+			UseMCMS:               useMCMS,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp.Ops)
+		require.Len(t, resp.Ops.Batch, 1)
+	})
+}

--- a/deployment/keystone/changeset/internal/deploy_test.go
+++ b/deployment/keystone/changeset/internal/deploy_test.go
@@ -1,9 +1,11 @@
 package internal_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 	kstest "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal/test"
 	kcr "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
@@ -11,7 +13,43 @@ import (
 )
 
 func Test_RegisterNOPS(t *testing.T) {
-	t.Skip()
+	var (
+		useMCMS   bool
+		lggr      = logger.Test(t)
+		setupResp = kstest.SetupTestRegistry(t, lggr, &kstest.SetupTestRegistryRequest{})
+		registry  = setupResp.Registry
+		chain     = setupResp.Chain
+		nops      = make([]kcr.CapabilitiesRegistryNodeOperator, 0)
+	)
+	t.Run("success create add NOPs mcms proposal", func(t *testing.T) {
+		nops = append(nops, kcr.CapabilitiesRegistryNodeOperator{
+			Name: "test-nop",
+		})
+		useMCMS = true
+		env := &deployment.Environment{
+			Logger: lggr,
+			Chains: map[uint64]deployment.Chain{
+				chain.Selector: chain,
+			},
+			ExistingAddresses: deployment.NewMemoryAddressBookFromMap(map[uint64]map[string]deployment.TypeAndVersion{
+				chain.Selector: {
+					registry.Address().String(): deployment.TypeAndVersion{
+						Type:    internal.CapabilitiesRegistry,
+						Version: deployment.Version1_0_0,
+					},
+				},
+			}),
+		}
+		resp, err := internal.RegisterNOPS(context.TODO(), lggr, internal.RegisterNOPSRequest{
+			Env:                   env,
+			RegistryChainSelector: chain.Selector,
+			Nops:                  nops,
+			UseMCMS:               useMCMS,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp.Ops)
+		require.Len(t, resp.Ops.Batch, 1)
+	})
 }
 
 func Test_AddCapabilities(t *testing.T) {

--- a/deployment/keystone/changeset/internal/deploy_test.go
+++ b/deployment/keystone/changeset/internal/deploy_test.go
@@ -1,0 +1,45 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
+	kstest "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal/test"
+	kcr "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+	"github.com/test-go/testify/require"
+)
+
+func Test_RegisterNOPS(t *testing.T) {
+	t.Skip()
+}
+
+func Test_AddCapabilities(t *testing.T) {
+	var (
+		useMCMS      bool
+		lggr         = logger.Test(t)
+		setupResp    = kstest.SetupTestRegistry(t, lggr, &kstest.SetupTestRegistryRequest{})
+		registry     = setupResp.Registry
+		chain        = setupResp.Chain
+		capabilities = make([]kcr.CapabilitiesRegistryCapability, 0)
+	)
+
+	t.Run("successfully create mcms proposal", func(t *testing.T) {
+		useMCMS = true
+		capabilities = append(capabilities, kcr.CapabilitiesRegistryCapability{
+			LabelledName:   "cap1",
+			Version:        "1.0.0",
+			CapabilityType: 0,
+		})
+		ops, err := internal.AddCapabilities(lggr, registry, chain, capabilities, useMCMS)
+		require.NoError(t, err)
+		require.NotNil(t, ops)
+		require.Len(t, ops.Batch, 1)
+	})
+
+	t.Run("does nothing if no capabilities", func(t *testing.T) {
+		ops, err := internal.AddCapabilities(lggr, registry, chain, nil, useMCMS)
+		require.NoError(t, err)
+		require.Nil(t, ops)
+	})
+}

--- a/deployment/keystone/changeset/internal/update_node_capabilities.go
+++ b/deployment/keystone/changeset/internal/update_node_capabilities.go
@@ -38,7 +38,7 @@ func UpdateNodeCapabilitiesImpl(lggr logger.Logger, req *UpdateNodeCapabilitiesI
 	for _, cap := range req.P2pToCapabilities {
 		capabilities = append(capabilities, cap...)
 	}
-	op, err := AddCapabilities(lggr, req.ContractSet, req.Chain, capabilities, req.UseMCMS)
+	op, err := AddCapabilities(lggr, req.ContractSet.CapabilitiesRegistry, req.Chain, capabilities, req.UseMCMS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add capabilities: %w", err)
 	}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

the CapabilityRegistry for a chain is eventually transferred to a MCMS.  this PR enables the creation of changesets that generate MCMS proposals for `AddNOPs`, `AddNodes`, `AddDONs` and `AddCapabilities` calls.

transaction data is generated using a simulated signer.  unit tests are added yet scoped to just the MCMS proposal generation.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
