### PR TITLE
[CRE-45] Check for duplicated cache modules

### DIFF
--- a/core/capabilities/compute/cache.go
+++ b/core/capabilities/compute/cache.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 )
@@ -41,9 +42,10 @@ type moduleCache struct {
 	clock      clockwork.Clock
 	reapTicker <-chan time.Time
 	onReaper   chan struct{}
+	log        logger.Logger
 }
 
-func newModuleCache(clock clockwork.Clock, tick, timeout time.Duration, evictAfterSize int) *moduleCache {
+func newModuleCache(clock clockwork.Clock, tick, timeout time.Duration, evictAfterSize int, log logger.Logger) *moduleCache {
 	return &moduleCache{
 		m:              map[string]*module{},
 		tickInterval:   tick,
@@ -52,6 +54,7 @@ func newModuleCache(clock clockwork.Clock, tick, timeout time.Duration, evictAft
 		clock:          clock,
 		reapTicker:     clock.NewTicker(tick).Chan(),
 		stopChan:       make(chan struct{}),
+		log:            log,
 	}
 }
 
@@ -85,6 +88,12 @@ func (mc *moduleCache) reapLoop() {
 func (mc *moduleCache) add(id string, mod *module) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
+
+	if mc.m[id] != nil {
+		mc.log.Warnf("module with id %q already exists in cache, skipping...", id)
+		return
+	}
+
 	mod.lastFetchedAt = mc.clock.Now()
 	mc.m[id] = mod
 	moduleCacheAddition.Inc()

--- a/core/capabilities/compute/cache.go
+++ b/core/capabilities/compute/cache.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 )
@@ -42,10 +42,9 @@ type moduleCache struct {
 	clock      clockwork.Clock
 	reapTicker <-chan time.Time
 	onReaper   chan struct{}
-	log        logger.Logger
 }
 
-func newModuleCache(clock clockwork.Clock, tick, timeout time.Duration, evictAfterSize int, log logger.Logger) *moduleCache {
+func newModuleCache(clock clockwork.Clock, tick, timeout time.Duration, evictAfterSize int) *moduleCache {
 	return &moduleCache{
 		m:              map[string]*module{},
 		tickInterval:   tick,
@@ -54,7 +53,6 @@ func newModuleCache(clock clockwork.Clock, tick, timeout time.Duration, evictAft
 		clock:          clock,
 		reapTicker:     clock.NewTicker(tick).Chan(),
 		stopChan:       make(chan struct{}),
-		log:            log,
 	}
 }
 
@@ -85,18 +83,18 @@ func (mc *moduleCache) reapLoop() {
 	}
 }
 
-func (mc *moduleCache) add(id string, mod *module) {
+func (mc *moduleCache) add(id string, mod *module) error {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 
 	if mc.m[id] != nil {
-		mc.log.Warnf("module with id %q already exists in cache, skipping...", id)
-		return
+		return fmt.Errorf("module with id %q already exists in cache", id)
 	}
 
 	mod.lastFetchedAt = mc.clock.Now()
 	mc.m[id] = mod
 	moduleCacheAddition.Inc()
+	return nil
 }
 
 func (mc *moduleCache) get(id string) (*module, bool) {

--- a/core/capabilities/compute/cache_test.go
+++ b/core/capabilities/compute/cache_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
@@ -29,9 +28,8 @@ func TestCache(t *testing.T) {
 	tick := 1 * time.Second
 	timeout := 1 * time.Second
 	reapTicker := make(chan time.Time)
-	lggr := logger.TestLogger(t)
 
-	cache := newModuleCache(clock, tick, timeout, 0, lggr)
+	cache := newModuleCache(clock, tick, timeout, 0)
 	cache.onReaper = make(chan struct{}, 1)
 	cache.reapTicker = reapTicker
 	cache.start()
@@ -39,7 +37,7 @@ func TestCache(t *testing.T) {
 
 	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
 	hmod, err := host.NewModule(&host.ModuleConfig{
-		Logger:         lggr,
+		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
 	}, binary)
 	require.NoError(t, err)
@@ -70,9 +68,8 @@ func TestCache_EvictAfterSize(t *testing.T) {
 	tick := 1 * time.Second
 	timeout := 1 * time.Second
 	reapTicker := make(chan time.Time)
-	lggr := logger.TestLogger(t)
 
-	cache := newModuleCache(clock, tick, timeout, 1, lggr)
+	cache := newModuleCache(clock, tick, timeout, 1)
 	cache.onReaper = make(chan struct{}, 1)
 	cache.reapTicker = reapTicker
 	cache.start()
@@ -80,7 +77,7 @@ func TestCache_EvictAfterSize(t *testing.T) {
 
 	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
 	hmod, err := host.NewModule(&host.ModuleConfig{
-		Logger:         lggr,
+		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
 	}, binary)
 	require.NoError(t, err)
@@ -114,9 +111,8 @@ func TestCache_AddDuplicatedModule(t *testing.T) {
 	tick := 1 * time.Second
 	timeout := 1 * time.Second
 	reapTicker := make(chan time.Time)
-	lggr, logs := logger.TestLoggerObserved(t, zapcore.WarnLevel)
 
-	cache := newModuleCache(clock, tick, timeout, 0, lggr)
+	cache := newModuleCache(clock, tick, timeout, 0)
 	cache.onReaper = make(chan struct{}, 1)
 	cache.reapTicker = reapTicker
 	cache.start()
@@ -124,7 +120,7 @@ func TestCache_AddDuplicatedModule(t *testing.T) {
 
 	simpleBinary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
 	shmod, err := host.NewModule(&host.ModuleConfig{
-		Logger:         lggr,
+		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
 	}, simpleBinary)
 	require.NoError(t, err)
@@ -134,17 +130,17 @@ func TestCache_AddDuplicatedModule(t *testing.T) {
 	smod := &module{
 		module: shmod,
 	}
-	cache.add(duplicatedID, smod)
+	err = cache.add(duplicatedID, smod)
+	require.NoError(t, err)
 
 	got, ok := cache.get(duplicatedID)
 	assert.True(t, ok)
 	assert.Equal(t, got, smod)
-	assert.Empty(t, logs.All())
 
 	// Adding a different module but with the same id should not overwrite the existing module
 	fetchBinary := wasmtest.CreateTestBinary(fetchBinaryCmd, fetchBinaryLocation, false, t)
 	fhmod, err := host.NewModule(&host.ModuleConfig{
-		Logger:         lggr,
+		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
 	}, fetchBinary)
 	require.NoError(t, err)
@@ -152,15 +148,11 @@ func TestCache_AddDuplicatedModule(t *testing.T) {
 	fmod := &module{
 		module: fhmod,
 	}
-	cache.add(duplicatedID, fmod)
+	err = cache.add(duplicatedID, fmod)
+	require.ErrorContains(t, err, fmt.Sprintf("module with id %q already exists in cache", duplicatedID))
 
 	// validate that the module is still the same
 	got, ok = cache.get(duplicatedID)
 	assert.True(t, ok)
 	assert.Equal(t, got, smod)
-
-	// validate that the log was emitted
-	assert.Equal(t, 1, len(logs.All()))
-	expectedLog := fmt.Sprintf("module with id %q already exists in cache, skipping...", duplicatedID)
-	assert.Equal(t, expectedLog, logs.All()[0].Entry.Message)
 }

--- a/core/capabilities/compute/cache_test.go
+++ b/core/capabilities/compute/cache_test.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
@@ -16,8 +18,8 @@ import (
 )
 
 const (
-	binaryLocation = "test/simple/cmd/testmodule.wasm"
-	binaryCmd      = "core/capabilities/compute/test/simple/cmd"
+	simpleBinaryLocation = "test/simple/cmd/testmodule.wasm"
+	simpleBinaryCmd      = "core/capabilities/compute/test/simple/cmd"
 )
 
 // Verify that cache evicts an expired module.
@@ -27,16 +29,17 @@ func TestCache(t *testing.T) {
 	tick := 1 * time.Second
 	timeout := 1 * time.Second
 	reapTicker := make(chan time.Time)
+	lggr := logger.TestLogger(t)
 
-	cache := newModuleCache(clock, tick, timeout, 0)
+	cache := newModuleCache(clock, tick, timeout, 0, lggr)
 	cache.onReaper = make(chan struct{}, 1)
 	cache.reapTicker = reapTicker
 	cache.start()
 	defer cache.close()
 
-	binary := wasmtest.CreateTestBinary(binaryCmd, binaryLocation, false, t)
+	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
 	hmod, err := host.NewModule(&host.ModuleConfig{
-		Logger:         logger.TestLogger(t),
+		Logger:         lggr,
 		IsUncompressed: true,
 	}, binary)
 	require.NoError(t, err)
@@ -67,16 +70,17 @@ func TestCache_EvictAfterSize(t *testing.T) {
 	tick := 1 * time.Second
 	timeout := 1 * time.Second
 	reapTicker := make(chan time.Time)
+	lggr := logger.TestLogger(t)
 
-	cache := newModuleCache(clock, tick, timeout, 1)
+	cache := newModuleCache(clock, tick, timeout, 1, lggr)
 	cache.onReaper = make(chan struct{}, 1)
 	cache.reapTicker = reapTicker
 	cache.start()
 	defer cache.close()
 
-	binary := wasmtest.CreateTestBinary(binaryCmd, binaryLocation, false, t)
+	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
 	hmod, err := host.NewModule(&host.ModuleConfig{
-		Logger:         logger.TestLogger(t),
+		Logger:         lggr,
 		IsUncompressed: true,
 	}, binary)
 	require.NoError(t, err)
@@ -102,4 +106,61 @@ func TestCache_EvictAfterSize(t *testing.T) {
 	}
 	_, ok = cache.get(id)
 	assert.True(t, ok)
+}
+
+func TestCache_AddDuplicatedModule(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+	tick := 1 * time.Second
+	timeout := 1 * time.Second
+	reapTicker := make(chan time.Time)
+	lggr, logs := logger.TestLoggerObserved(t, zapcore.WarnLevel)
+
+	cache := newModuleCache(clock, tick, timeout, 0, lggr)
+	cache.onReaper = make(chan struct{}, 1)
+	cache.reapTicker = reapTicker
+	cache.start()
+	defer cache.close()
+
+	simpleBinary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
+	shmod, err := host.NewModule(&host.ModuleConfig{
+		Logger:         lggr,
+		IsUncompressed: true,
+	}, simpleBinary)
+	require.NoError(t, err)
+
+	// we will use the same id for both modules, but should only be associated to the simple module
+	duplicatedID := uuid.New().String()
+	smod := &module{
+		module: shmod,
+	}
+	cache.add(duplicatedID, smod)
+
+	got, ok := cache.get(duplicatedID)
+	assert.True(t, ok)
+	assert.Equal(t, got, smod)
+	assert.Empty(t, logs.All())
+
+	// Adding a different module but with the same id should not overwrite the existing module
+	fetchBinary := wasmtest.CreateTestBinary(fetchBinaryCmd, fetchBinaryLocation, false, t)
+	fhmod, err := host.NewModule(&host.ModuleConfig{
+		Logger:         lggr,
+		IsUncompressed: true,
+	}, fetchBinary)
+	require.NoError(t, err)
+
+	fmod := &module{
+		module: fhmod,
+	}
+	cache.add(duplicatedID, fmod)
+
+	// validate that the module is still the same
+	got, ok = cache.get(duplicatedID)
+	assert.True(t, ok)
+	assert.Equal(t, got, smod)
+
+	// validate that the log was emitted
+	assert.Equal(t, 1, len(logs.All()))
+	expectedLog := fmt.Sprintf("module with id %q already exists in cache, skipping...", duplicatedID)
+	assert.Equal(t, expectedLog, logs.All()[0].Entry.Message)
 }

--- a/core/capabilities/compute/compute.go
+++ b/core/capabilities/compute/compute.go
@@ -199,7 +199,7 @@ func (c *Compute) initModule(id string, cfg *host.ModuleConfig, binary []byte, r
 	m := &module{module: mod}
 	err = c.modules.add(id, m)
 	if err != nil {
-		c.log.Errorf("failed to add module to cache: %s", err.Error())
+		c.log.Warnf("failed to add module to cache: %s", err.Error())
 	}
 	return m, nil
 }

--- a/core/capabilities/compute/compute.go
+++ b/core/capabilities/compute/compute.go
@@ -389,7 +389,7 @@ func NewAction(
 			emitter:                  labeler,
 			metrics:                  metricsLabeler,
 			registry:                 registry,
-			modules:                  newModuleCache(clockwork.NewRealClock(), 1*time.Minute, 10*time.Minute, 3),
+			modules:                  newModuleCache(clockwork.NewRealClock(), 1*time.Minute, 10*time.Minute, 3, lggr),
 			transformer:              NewTransformer(lggr, labeler),
 			outgoingConnectorHandler: handler,
 			idGenerator:              idGenerator,

--- a/core/capabilities/compute/compute.go
+++ b/core/capabilities/compute/compute.go
@@ -197,7 +197,10 @@ func (c *Compute) initModule(id string, cfg *host.ModuleConfig, binary []byte, r
 	computeWASMInit.WithLabelValues(requestMetadata.WorkflowID, requestMetadata.ReferenceID).Observe(float64(initDuration))
 
 	m := &module{module: mod}
-	c.modules.add(id, m)
+	err = c.modules.add(id, m)
+	if err != nil {
+		c.log.Errorf("failed to add module to cache: %s", err.Error())
+	}
 	return m, nil
 }
 
@@ -389,7 +392,7 @@ func NewAction(
 			emitter:                  labeler,
 			metrics:                  metricsLabeler,
 			registry:                 registry,
-			modules:                  newModuleCache(clockwork.NewRealClock(), 1*time.Minute, 10*time.Minute, 3, lggr),
+			modules:                  newModuleCache(clockwork.NewRealClock(), 1*time.Minute, 10*time.Minute, 3),
 			transformer:              NewTransformer(lggr, labeler),
 			outgoingConnectorHandler: handler,
 			idGenerator:              idGenerator,

--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -91,7 +91,7 @@ func TestComputeExecuteMissingConfig(t *testing.T) {
 	th := setup(t, defaultConfig)
 	require.NoError(t, th.compute.Start(tests.Context(t)))
 
-	binary := wasmtest.CreateTestBinary(binaryCmd, binaryLocation, true, t)
+	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, true, t)
 
 	config, err := values.WrapMap(map[string]any{
 		"binary": binary,
@@ -134,7 +134,7 @@ func TestComputeExecute(t *testing.T) {
 
 	require.NoError(t, th.compute.Start(tests.Context(t)))
 
-	binary := wasmtest.CreateTestBinary(binaryCmd, binaryLocation, true, t)
+	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, true, t)
 
 	config, err := values.WrapMap(map[string]any{
 		"config": []byte(""),


### PR DESCRIPTION
### Description

This pr introduces a fix in which if a cached module already exists for a given ID, it will not overwrite it, instead it will log the warn and keep the existing one.
[CRE-45](https://smartcontract-it.atlassian.net/browse/CRE-45)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-45]: https://smartcontract-it.atlassian.net/browse/CRE-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ