### PR TITLE
CCIP-4753: Defining the timer based on test timeout

### DIFF
--- a/deployment/ccip/changeset/test_assertions.go
+++ b/deployment/ccip/changeset/test_assertions.go
@@ -486,7 +486,7 @@ func ConfirmExecWithSeqNrs(
 		return nil, errors.New("no expected sequence numbers provided")
 	}
 
-	timer := time.NewTimer(8 * time.Minute)
+	timer := time.NewTimer(tests.WaitTimeout(t))
 	defer timer.Stop()
 	tick := time.NewTicker(3 * time.Second)
 	defer tick.Stop()


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message

--> 
[CCIP-4753](https://smartcontract-it.atlassian.net/browse/CCIP4753)

ExecutionStatusChanged event are expected to happen within 8 mins might not the case for prod testnet or mainnet. The timeout is set as per test timeout instead of hard coded 8 mins. 

### Supports
https://github.com/smartcontractkit/chainlink-deployments/pull/412


[CCIP-4753]: https://smartcontract-it.atlassian.net/browse/CCIP-4753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ