### PR TITLE
Add chaintype.ChainZircuit to chaintypes with rollup support in L1 oracle

### DIFF
--- a/.changeset/five-beds-wait.md
+++ b/.changeset/five-beds-wait.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix Add chaintype.ChainZircuit to chaintypes with rollup support in L1 oracle to prevent a nil L1 oracle being used for Zircuit's gas estimator

--- a/core/chains/evm/gas/rollups/l1_oracle.go
+++ b/core/chains/evm/gas/rollups/l1_oracle.go
@@ -50,14 +50,15 @@ const (
 	PollPeriod = 6 * time.Second
 )
 
+// Sort alphabetically
 var supportedChainTypes = []chaintype.ChainType{
 	chaintype.ChainArbitrum,
-	chaintype.ChainOptimismBedrock,
 	chaintype.ChainKroma,
-	chaintype.ChainScroll,
-	chaintype.ChainZkSync,
 	chaintype.ChainMantle,
+	chaintype.ChainOptimismBedrock,
+	chaintype.ChainScroll,
 	chaintype.ChainZircuit,
+	chaintype.ChainZkSync,
 }
 
 func IsRollupWithL1Support(chainType chaintype.ChainType) bool {

--- a/core/chains/evm/gas/rollups/l1_oracle.go
+++ b/core/chains/evm/gas/rollups/l1_oracle.go
@@ -50,7 +50,15 @@ const (
 	PollPeriod = 6 * time.Second
 )
 
-var supportedChainTypes = []chaintype.ChainType{chaintype.ChainArbitrum, chaintype.ChainOptimismBedrock, chaintype.ChainKroma, chaintype.ChainScroll, chaintype.ChainZkSync, chaintype.ChainMantle}
+var supportedChainTypes = []chaintype.ChainType{
+	chaintype.ChainArbitrum,
+	chaintype.ChainOptimismBedrock,
+	chaintype.ChainKroma,
+	chaintype.ChainScroll,
+	chaintype.ChainZkSync,
+	chaintype.ChainMantle,
+	chaintype.ChainZircuit,
+}
 
 func IsRollupWithL1Support(chainType chaintype.ChainType) bool {
 	return slices.Contains(supportedChainTypes, chainType)


### PR DESCRIPTION
## Motivation
- Zircuit's chaintype was recently changed from `optimismBedrock` to `zircuit`
- This means `IsRollupWithL1Support()` started returning false for zircuit
- Which in turn meant no L1 oracle was created for Zircuit 

## Solution
- Add zircuit to `supportedChainTypes`