### PR TITLE
bump foundry to stable v0.3.0

### DIFF
--- a/.github/actions/install-solidity-foundry/action.yml
+++ b/.github/actions/install-solidity-foundry/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        foundry_version=$(grep -Eo "foundryup --version [^ ]+" GNUmakefile | awk '{print $3}')
+        foundry_version=$(grep -Eo "foundryup --install [^ ]+" GNUmakefile | awk '{print $3}')
         if [ -z "$foundry_version" ]; then
           echo "::error::Foundry version not found in GNUmakefile"
           exit 1
@@ -26,6 +26,6 @@ runs:
         echo "foundry-version=$foundry_version" >> $GITHUB_OUTPUT
 
     - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@8f1998e9878d786675189ef566a2e4bf24869773 # v1.2.0
+      uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
       with:
         version: ${{ steps.extract-foundry-version.outputs.foundry-version }}

--- a/contracts/GNUmakefile
+++ b/contracts/GNUmakefile
@@ -43,7 +43,7 @@ mockery: $(mockery) ## Install mockery.
 
 .PHONY: foundry
 foundry: ## Install foundry.
-	foundryup --version nightly-aa69ed1e46dd61fbf9d73399396a4db4dd527431
+	foundryup --install v0.3.0
 
 .PHONY: foundry-refresh
 foundry-refresh: foundry


### PR DESCRIPTION
Foundry finally released a new stable version. It might require a new version of foundryup to install.

Use `curl -L https://foundry.paradigm.xyz | bash` to update foundryup and then use `make foundry` to update Foundry.