### PR TITLE
fix(workflow/fetcher): validates response before use

### DIFF
--- a/.changeset/cyan-ladybugs-check.md
+++ b/.changeset/cyan-ladybugs-check.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+validates response from gateway in workflow/fetcher

--- a/core/services/gateway/handlers/capabilities/webapi.go
+++ b/core/services/gateway/handlers/capabilities/webapi.go
@@ -28,8 +28,6 @@ func (r Response) Validate() error {
 			return errors.New("executionError is true but response details (statusCode, headers, body) are populated")
 		}
 		return nil
-	} else if r.StatusCode == 0 {
-		return errors.New("statusCode must be set when executionError is false")
 	}
 
 	if r.StatusCode < 100 || r.StatusCode > 599 {

--- a/core/services/gateway/handlers/capabilities/webapi.go
+++ b/core/services/gateway/handlers/capabilities/webapi.go
@@ -1,5 +1,7 @@
 package capabilities
 
+import "errors"
+
 type Request struct {
 	URL       string            `json:"url"`                 // URL to query, only http and https protocols are supported.
 	Method    string            `json:"method,omitempty"`    // HTTP verb, defaults to GET.
@@ -14,6 +16,27 @@ type Response struct {
 	StatusCode     int               `json:"statusCode,omitempty"`   // HTTP status code
 	Headers        map[string]string `json:"headers,omitempty"`      // HTTP headers
 	Body           []byte            `json:"body,omitempty"`         // HTTP response body
+}
+
+// Validate ensures the Response struct is consistent.
+func (r Response) Validate() error {
+	if r.ExecutionError {
+		if r.ErrorMessage == "" {
+			return errors.New("executionError is true but errorMessage is empty")
+		}
+		if r.StatusCode != 0 || len(r.Headers) > 0 || len(r.Body) > 0 {
+			return errors.New("executionError is true but response details (statusCode, headers, body) are populated")
+		}
+		return nil
+	} else if r.StatusCode == 0 {
+		return errors.New("statusCode must be set when executionError is false")
+	}
+
+	if r.StatusCode < 100 || r.StatusCode > 599 {
+		return errors.New("statusCode must be a valid HTTP status code (100-599)")
+	}
+
+	return nil
 }
 
 type TriggerResponsePayload struct {

--- a/core/services/gateway/handlers/capabilities/webapi_test.go
+++ b/core/services/gateway/handlers/capabilities/webapi_test.go
@@ -1,0 +1,54 @@
+package capabilities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponseValidate(t *testing.T) {
+	tt := []struct {
+		name        string
+		response    Response
+		expectError string
+	}{
+		{
+			name:     "valid Response with ExecutionError",
+			response: Response{ExecutionError: true, ErrorMessage: "Some error"},
+		},
+		{
+			name:        "invalid Response with ExecutionError but no ErrorMessage",
+			response:    Response{ExecutionError: true},
+			expectError: "executionError is true but errorMessage is empty",
+		},
+		{
+			name:     "valid HTTP Response",
+			response: Response{StatusCode: 200},
+		},
+		{
+			name: "invalid status code",
+			response: Response{
+				Body: []byte("body"),
+			},
+			expectError: "statusCode must be set when executionError is false",
+		},
+		{
+			name:        "invalid HTTP Response with bad StatusCode",
+			response:    Response{StatusCode: 700},
+			expectError: "statusCode must be a valid HTTP status code (100-599)",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.response.Validate()
+
+			if tc.expectError != "" {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -98,10 +98,14 @@ func (s *FetcherService) Fetch(ctx context.Context, url string) ([]byte, error) 
 	}
 
 	s.lggr.Debugw("received gateway response")
+
 	var payload ghcapabilities.Response
-	err = json.Unmarshal(resp.Body.Payload, &payload)
-	if err != nil {
+	if err = json.Unmarshal(resp.Body.Payload, &payload); err != nil {
 		return nil, err
+	}
+
+	if err = payload.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid payload received from gateway message: %w", err)
 	}
 
 	if payload.ExecutionError {

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -93,11 +93,11 @@ func (s *FetcherService) Fetch(ctx context.Context, url string) ([]byte, error) 
 		return nil, err
 	}
 
-	if err := resp.Validate(); err != nil {
+	if err = resp.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid response from gateway: %w", err)
 	}
 
-	s.lggr.Debugw("received gateway response")
+	s.lggr.Debugw("received gateway response", "donID", resp.Body.DonId, "msgID", resp.Body.MessageId)
 
 	var payload ghcapabilities.Response
 	if err = json.Unmarshal(resp.Body.Payload, &payload); err != nil {

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -93,6 +93,10 @@ func (s *FetcherService) Fetch(ctx context.Context, url string) ([]byte, error) 
 		return nil, err
 	}
 
+	if err := resp.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid response from gateway: %w", err)
+	}
+
 	s.lggr.Debugw("received gateway response")
 	var payload ghcapabilities.Response
 	err = json.Unmarshal(resp.Body.Payload, &payload)

--- a/core/services/workflows/syncer/fetcher_test.go
+++ b/core/services/workflows/syncer/fetcher_test.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -11,10 +12,12 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/common"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/connector"
 	gcmocks "github.com/smartcontractkit/chainlink/v2/core/services/gateway/connector/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
 	ghcapabilities "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/matches"
 )
 
@@ -33,9 +36,11 @@ func TestNewFetcherService(t *testing.T) {
 	connector := gcmocks.NewGatewayConnector(t)
 	wrapper := &wrapper{c: connector}
 
-	url := "http://example.com"
-
-	msgID := strings.Join([]string{ghcapabilities.MethodWorkflowSyncer, hash(url)}, "/")
+	var (
+		url   = "http://example.com"
+		msgID = strings.Join([]string{ghcapabilities.MethodWorkflowSyncer, hash(url)}, "/")
+		donID = "don-id"
+	)
 
 	t.Run("OK-valid_request", func(t *testing.T) {
 		connector.EXPECT().AddHandler([]string{capabilities.MethodWorkflowSyncer}, mock.Anything).Return(nil)
@@ -44,11 +49,11 @@ func TestNewFetcherService(t *testing.T) {
 		require.NoError(t, fetcher.Start(ctx))
 		defer fetcher.Close()
 
-		gatewayResp := gatewayResponse(t, msgID)
+		gatewayResp := signGatewayResponse(t, gatewayResponse(t, msgID, donID))
 		connector.EXPECT().SignAndSendToGateway(mock.Anything, "gateway1", mock.Anything).Run(func(ctx context.Context, gatewayID string, msg *api.MessageBody) {
 			fetcher.och.HandleGatewayMessage(ctx, "gateway1", gatewayResp)
 		}).Return(nil).Times(1)
-		connector.EXPECT().DonID().Return("don-id")
+		connector.EXPECT().DonID().Return(donID)
 		connector.EXPECT().AwaitConnection(matches.AnyContext, "gateway1").Return(nil)
 		connector.EXPECT().GatewayIDs().Return([]string{"gateway1", "gateway2"})
 
@@ -57,6 +62,26 @@ func TestNewFetcherService(t *testing.T) {
 
 		expectedPayload := []byte("response body")
 		require.Equal(t, expectedPayload, payload)
+	})
+
+	t.Run("fails due to invalid gateway response", func(t *testing.T) {
+		connector.EXPECT().AddHandler([]string{capabilities.MethodWorkflowSyncer}, mock.Anything).Return(nil)
+
+		fetcher := NewFetcherService(lggr, wrapper)
+		require.NoError(t, fetcher.Start(ctx))
+		defer fetcher.Close()
+
+		gatewayResp := gatewayResponse(t, msgID, donID) // gateway response that is not signed
+		connector.EXPECT().SignAndSendToGateway(mock.Anything, "gateway1", mock.Anything).Run(func(ctx context.Context, gatewayID string, msg *api.MessageBody) {
+			fetcher.och.HandleGatewayMessage(ctx, "gateway1", gatewayResp)
+		}).Return(nil).Times(1)
+		connector.EXPECT().DonID().Return(donID)
+		connector.EXPECT().AwaitConnection(matches.AnyContext, "gateway1").Return(nil)
+		connector.EXPECT().GatewayIDs().Return([]string{"gateway1", "gateway2"})
+
+		_, err := fetcher.Fetch(ctx, url)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid response from gateway")
 	})
 
 	t.Run("NOK-response_payload_too_large", func(t *testing.T) {
@@ -85,7 +110,7 @@ func TestNewFetcherService(t *testing.T) {
 		connector.EXPECT().SignAndSendToGateway(mock.Anything, "gateway1", mock.Anything).Run(func(ctx context.Context, gatewayID string, msg *api.MessageBody) {
 			fetcher.och.HandleGatewayMessage(ctx, "gateway1", gatewayResponse)
 		}).Return(nil).Times(1)
-		connector.EXPECT().DonID().Return("don-id")
+		connector.EXPECT().DonID().Return(donID)
 		connector.EXPECT().AwaitConnection(matches.AnyContext, "gateway1").Return(nil)
 		connector.EXPECT().GatewayIDs().Return([]string{"gateway1", "gateway2"})
 
@@ -94,7 +119,8 @@ func TestNewFetcherService(t *testing.T) {
 	})
 }
 
-func gatewayResponse(t *testing.T, msgID string) *api.Message {
+// gatewayResponse creates an unsigned gateway response with a status code of 200 and a response body.
+func gatewayResponse(t *testing.T, msgID string, donID string) *api.Message {
 	headers := map[string]string{"Content-Type": "application/json"}
 	body := []byte("response body")
 	responsePayload, err := json.Marshal(ghcapabilities.Response{
@@ -107,8 +133,33 @@ func gatewayResponse(t *testing.T, msgID string) *api.Message {
 	return &api.Message{
 		Body: api.MessageBody{
 			MessageId: msgID,
+			DonId:     donID,
 			Method:    ghcapabilities.MethodWebAPITarget,
 			Payload:   responsePayload,
 		},
 	}
+}
+
+// signGatewayResponse signs the gateway response with a private key and arbitrarily sets the receiver
+// to the signer's address.  A signature and receiver are required for a valid gateway response.
+func signGatewayResponse(t *testing.T, msg *api.Message) *api.Message {
+	nodeKeys := common.NewTestNodes(t, 1)
+	s := &signer{pk: nodeKeys[0].PrivateKey}
+	signature, err := s.Sign(api.GetRawMessageBody(&msg.Body)...)
+	require.NoError(t, err)
+	msg.Signature = utils.StringToHex(string(signature))
+
+	signerBytes, err := msg.ExtractSigner()
+	require.NoError(t, err)
+
+	msg.Body.Receiver = utils.StringToHex(string(signerBytes))
+	return msg
+}
+
+type signer struct {
+	pk *ecdsa.PrivateKey
+}
+
+func (s *signer) Sign(data ...[]byte) ([]byte, error) {
+	return common.SignData(s.pk, data...)
 }

--- a/core/services/workflows/syncer/fetcher_test.go
+++ b/core/services/workflows/syncer/fetcher_test.go
@@ -64,6 +64,25 @@ func TestNewFetcherService(t *testing.T) {
 		require.Equal(t, expectedPayload, payload)
 	})
 
+	t.Run("fails with invalid payload response", func(t *testing.T) {
+		connector.EXPECT().AddHandler([]string{capabilities.MethodWorkflowSyncer}, mock.Anything).Return(nil)
+
+		fetcher := NewFetcherService(lggr, wrapper)
+		require.NoError(t, fetcher.Start(ctx))
+		defer fetcher.Close()
+
+		gatewayResp := signGatewayResponse(t, inconsistentPayload(t, msgID, donID))
+		connector.EXPECT().SignAndSendToGateway(mock.Anything, "gateway1", mock.Anything).Run(func(ctx context.Context, gatewayID string, msg *api.MessageBody) {
+			fetcher.och.HandleGatewayMessage(ctx, "gateway1", gatewayResp)
+		}).Return(nil).Times(1)
+		connector.EXPECT().DonID().Return(donID)
+		connector.EXPECT().AwaitConnection(matches.AnyContext, "gateway1").Return(nil)
+		connector.EXPECT().GatewayIDs().Return([]string{"gateway1", "gateway2"})
+
+		_, err := fetcher.Fetch(ctx, url)
+		require.Error(t, err)
+	})
+
 	t.Run("fails due to invalid gateway response", func(t *testing.T) {
 		connector.EXPECT().AddHandler([]string{capabilities.MethodWorkflowSyncer}, mock.Anything).Return(nil)
 
@@ -87,10 +106,9 @@ func TestNewFetcherService(t *testing.T) {
 	t.Run("NOK-response_payload_too_large", func(t *testing.T) {
 		headers := map[string]string{"Content-Type": "application/json"}
 		responsePayload, err := json.Marshal(ghcapabilities.Response{
-			StatusCode:     400,
-			Headers:        headers,
-			ErrorMessage:   "http: request body too large",
-			ExecutionError: true,
+			StatusCode:   400,
+			Headers:      headers,
+			ErrorMessage: "http: request body too large",
 		})
 		require.NoError(t, err)
 		gatewayResponse := &api.Message{
@@ -124,10 +142,26 @@ func gatewayResponse(t *testing.T, msgID string, donID string) *api.Message {
 	headers := map[string]string{"Content-Type": "application/json"}
 	body := []byte("response body")
 	responsePayload, err := json.Marshal(ghcapabilities.Response{
-		StatusCode:     200,
-		Headers:        headers,
-		Body:           body,
-		ExecutionError: false,
+		StatusCode: 200,
+		Headers:    headers,
+		Body:       body,
+	})
+	require.NoError(t, err)
+	return &api.Message{
+		Body: api.MessageBody{
+			MessageId: msgID,
+			DonId:     donID,
+			Method:    ghcapabilities.MethodWebAPITarget,
+			Payload:   responsePayload,
+		},
+	}
+}
+
+// inconsistentPayload creates an unsigned gateway response with an inconsistent payload.  The
+// ExecutionError is true, but there is no ErrorMessage, so it is invalid.
+func inconsistentPayload(t *testing.T, msgID string, donID string) *api.Message {
+	responsePayload, err := json.Marshal(ghcapabilities.Response{
+		ExecutionError: true,
 	})
 	require.NoError(t, err)
 	return &api.Message{


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

[CRE-92](https://smartcontract-it.atlassian.net/browse/CRE-92)

Calls `Validate()` on a response from the gateway before using.

```
2025-01-16T16:52:45.932-0500	debug	WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler	webapi/outgoing_connector_handler.go:82	sending request to gateway	{"version": "0.0.1@unset", "messageID": "workflow_syncer/87f2e66b7acad1ec9869cc1eaf74524fe0b4c5311c1619ee847bd1c81bb9c5e4"}
2025-01-16T16:52:45.932-0500	info	WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler	webapi/outgoing_connector_handler.go:101	selected gateway, awaiting connection	{"version": "0.0.1@unset", "messageID": "workflow_syncer/87f2e66b7acad1ec9869cc1eaf74524fe0b4c5311c1619ee847bd1c81bb9c5e4", "gatewayID": "por_gateway"}
2025-01-16T16:52:45.948-0500	debug	WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler	webapi/outgoing_connector_handler.go:129	handling gateway request	{"version": "0.0.1@unset", "gatewayID": "por_gateway", "method": "workflow_syncer", "messageID": "workflow_syncer/87f2e66b7acad1ec9869cc1eaf74524fe0b4c5311c1619ee847bd1c81bb9c5e4"}
2025-01-16T16:52:45.949-0500	debug	WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler	webapi/outgoing_connector_handler.go:113	received response from gateway	{"version": "0.0.1@unset", "messageID": "workflow_syncer/87f2e66b7acad1ec9869cc1eaf74524fe0b4c5311c1619ee847bd1c81bb9c5e4"}
2025-01-16T16:52:45.949-0500	debug	WorkflowRegistrySyncer.FetcherService	syncer/fetcher.go:100	received gateway response	{"version": "0.0.1@unset", "donID": "1", "msgID": "workflow_syncer/87f2e66b7acad1ec9869cc1eaf74524fe0b4c5311c1619ee847bd1c81bb9c5e4"}
2
```

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-92]: https://smartcontract-it.atlassian.net/browse/CRE-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ