### PR TITLE
fix(gateway): set default max read bytes on cfg

### DIFF
--- a/core/config/capabilities_config.go
+++ b/core/config/capabilities_config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 type CapabilitiesExternalRegistry interface {
@@ -15,6 +16,7 @@ type CapabilitiesWorkflowRegistry interface {
 	Address() string
 	NetworkID() string
 	ChainID() string
+	MaxArtifactsSize() utils.FileSize
 	RelayID() types.RelayID
 }
 

--- a/core/config/capabilities_config.go
+++ b/core/config/capabilities_config.go
@@ -16,7 +16,9 @@ type CapabilitiesWorkflowRegistry interface {
 	Address() string
 	NetworkID() string
 	ChainID() string
-	MaxArtifactsSize() utils.FileSize
+	MaxEncryptedSecretsSize() utils.FileSize
+	MaxBinarySize() utils.FileSize
+	MaxConfigSize() utils.FileSize
 	RelayID() types.RelayID
 }
 

--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -451,18 +451,12 @@ Address = '0x0' # Example
 NetworkID = 'evm' # Default
 # ChainID identifies the target chain id where the remote registry is located.
 ChainID = '1' # Default
-# MaxXXXSize is the maximum size of an artifact that can be fetched from the registry.
-#
-# Values must have suffixes with a unit like: `5120mb` (5,120 megabytes). If no unit suffix is provided, the value defaults to `b` (bytes). The list of valid unit suffixes are:
-#
-# - b (bytes)
-# - kb (kilobytes)
-# - mb (megabytes)
-# - gb (gigabytes)
-# - tb (terabytes)
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+# MaxBinarySize is the maximum size of a binary that can be fetched from the registry.
+MaxBinarySize = '20.00mb' # Default
+# MaxEncryptedSecretsSize is the maximum size of encrypted secrets that can be fetched from the given secrets url.
+MaxEncryptedSecretsSize = '26.40kb' # Default
+# MaxConfigSize is the maximum size of a config that can be fetched from the given config url.
+MaxConfigSize = '50.00kb' # Default
 
 [Capabilities.ExternalRegistry]
 # Address is the address for the capabilities registry contract.

--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -451,6 +451,16 @@ Address = '0x0' # Example
 NetworkID = 'evm' # Default
 # ChainID identifies the target chain id where the remote registry is located.
 ChainID = '1' # Default
+# MaxArtifactSize is the maximum size of an artifact that can be fetched from the registry.
+#
+# Values must have suffixes with a unit like: `5120mb` (5,120 megabytes). If no unit suffix is provided, the value defaults to `b` (bytes). The list of valid unit suffixes are:
+#
+# - b (bytes)
+# - kb (kilobytes)
+# - mb (megabytes)
+# - gb (gigabytes)
+# - tb (terabytes)
+MaxArtifactSize = '10mb'
 
 [Capabilities.ExternalRegistry]
 # Address is the address for the capabilities registry contract.

--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -451,7 +451,7 @@ Address = '0x0' # Example
 NetworkID = 'evm' # Default
 # ChainID identifies the target chain id where the remote registry is located.
 ChainID = '1' # Default
-# MaxArtifactSize is the maximum size of an artifact that can be fetched from the registry.
+# MaxXXXSize is the maximum size of an artifact that can be fetched from the registry.
 #
 # Values must have suffixes with a unit like: `5120mb` (5,120 megabytes). If no unit suffix is provided, the value defaults to `b` (bytes). The list of valid unit suffixes are:
 #
@@ -460,7 +460,9 @@ ChainID = '1' # Default
 # - mb (megabytes)
 # - gb (gigabytes)
 # - tb (terabytes)
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.ExternalRegistry]
 # Address is the address for the capabilities registry contract.

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -1456,9 +1456,10 @@ func (r *ExternalRegistry) setFrom(f *ExternalRegistry) {
 }
 
 type WorkflowRegistry struct {
-	Address   *string
-	NetworkID *string
-	ChainID   *string
+	Address          *string
+	NetworkID        *string
+	ChainID          *string
+	MaxArtifactsSize *utils.FileSize
 }
 
 func (r *WorkflowRegistry) setFrom(f *WorkflowRegistry) {
@@ -1472,6 +1473,10 @@ func (r *WorkflowRegistry) setFrom(f *WorkflowRegistry) {
 
 	if f.ChainID != nil {
 		r.ChainID = f.ChainID
+	}
+
+	if f.MaxArtifactsSize != nil {
+		r.MaxArtifactsSize = f.MaxArtifactsSize
 	}
 }
 

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -1456,10 +1456,12 @@ func (r *ExternalRegistry) setFrom(f *ExternalRegistry) {
 }
 
 type WorkflowRegistry struct {
-	Address          *string
-	NetworkID        *string
-	ChainID          *string
-	MaxArtifactsSize *utils.FileSize
+	Address                 *string
+	NetworkID               *string
+	ChainID                 *string
+	MaxBinarySize           *utils.FileSize
+	MaxEncryptedSecretsSize *utils.FileSize
+	MaxConfigSize           *utils.FileSize
 }
 
 func (r *WorkflowRegistry) setFrom(f *WorkflowRegistry) {
@@ -1475,8 +1477,16 @@ func (r *WorkflowRegistry) setFrom(f *WorkflowRegistry) {
 		r.ChainID = f.ChainID
 	}
 
-	if f.MaxArtifactsSize != nil {
-		r.MaxArtifactsSize = f.MaxArtifactsSize
+	if f.MaxBinarySize != nil {
+		r.MaxBinarySize = f.MaxBinarySize
+	}
+
+	if f.MaxEncryptedSecretsSize != nil {
+		r.MaxEncryptedSecretsSize = f.MaxEncryptedSecretsSize
+	}
+
+	if f.MaxConfigSize != nil {
+		r.MaxConfigSize = f.MaxConfigSize
 	}
 }
 

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -364,7 +364,11 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 				}
 
 				lggr := globalLogger.Named("WorkflowRegistrySyncer")
-				fetcher := syncer.NewFetcherService(lggr, gatewayConnectorWrapper,
+				fetcher := syncer.NewFetcherService(lggr, gatewayConnectorWrapper)
+
+				eventHandler := syncer.NewEventHandler(lggr, syncer.NewWorkflowRegistryDS(opts.DS, globalLogger),
+					fetcher.Fetch, workflowstore.NewDBStore(opts.DS, lggr, clockwork.NewRealClock()), opts.CapabilitiesRegistry,
+					custmsg.NewLabeler(), clockwork.NewRealClock(), keys[0],
 					syncer.WithMaxArtifactSize(
 						syncer.ArtifactConfig{
 							MaxBinarySize:  uint64(cfg.Capabilities().WorkflowRegistry().MaxBinarySize()),
@@ -373,10 +377,6 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 						},
 					),
 				)
-
-				eventHandler := syncer.NewEventHandler(lggr, syncer.NewWorkflowRegistryDS(opts.DS, globalLogger),
-					fetcher, workflowstore.NewDBStore(opts.DS, lggr, clockwork.NewRealClock()), opts.CapabilitiesRegistry,
-					custmsg.NewLabeler(), clockwork.NewRealClock(), keys[0])
 
 				globalLogger.Debugw("Creating WorkflowRegistrySyncer")
 				wfSyncer := syncer.NewWorkflowRegistry(

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -365,7 +365,13 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 
 				lggr := globalLogger.Named("WorkflowRegistrySyncer")
 				fetcher := syncer.NewFetcherService(lggr, gatewayConnectorWrapper,
-					syncer.WithMaxArtifactSize(uint64(cfg.Capabilities().WorkflowRegistry().MaxArtifactsSize())),
+					syncer.WithMaxArtifactSize(
+						syncer.ArtifactConfig{
+							MaxBinarySize:  uint64(cfg.Capabilities().WorkflowRegistry().MaxBinarySize()),
+							MaxSecretsSize: uint64(cfg.Capabilities().WorkflowRegistry().MaxEncryptedSecretsSize()),
+							MaxConfigSize:  uint64(cfg.Capabilities().WorkflowRegistry().MaxConfigSize()),
+						},
+					),
 				)
 
 				eventHandler := syncer.NewEventHandler(lggr, syncer.NewWorkflowRegistryDS(opts.DS, globalLogger),

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -364,7 +364,9 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 				}
 
 				lggr := globalLogger.Named("WorkflowRegistrySyncer")
-				fetcher := syncer.NewFetcherService(lggr, gatewayConnectorWrapper)
+				fetcher := syncer.NewFetcherService(lggr, gatewayConnectorWrapper,
+					syncer.WithMaxArtifactSize(uint64(cfg.Capabilities().WorkflowRegistry().MaxArtifactsSize())),
+				)
 
 				eventHandler := syncer.NewEventHandler(lggr, syncer.NewWorkflowRegistryDS(opts.DS, globalLogger),
 					fetcher.Fetch, workflowstore.NewDBStore(opts.DS, lggr, clockwork.NewRealClock()), opts.CapabilitiesRegistry,

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -369,7 +369,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 				)
 
 				eventHandler := syncer.NewEventHandler(lggr, syncer.NewWorkflowRegistryDS(opts.DS, globalLogger),
-					fetcher.Fetch, workflowstore.NewDBStore(opts.DS, lggr, clockwork.NewRealClock()), opts.CapabilitiesRegistry,
+					fetcher, workflowstore.NewDBStore(opts.DS, lggr, clockwork.NewRealClock()), opts.CapabilitiesRegistry,
 					custmsg.NewLabeler(), clockwork.NewRealClock(), keys[0])
 
 				globalLogger.Debugw("Creating WorkflowRegistrySyncer")

--- a/core/services/chainlink/config_capabilities.go
+++ b/core/services/chainlink/config_capabilities.go
@@ -4,6 +4,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 var _ config.Capabilities = (*capabilitiesConfig)(nil)
@@ -112,6 +113,10 @@ func (c *capabilitiesWorkflowRegistry) ChainID() string {
 
 func (c *capabilitiesWorkflowRegistry) Address() string {
 	return *c.c.Address
+}
+
+func (c *capabilitiesWorkflowRegistry) MaxArtifactsSize() utils.FileSize {
+	return *c.c.MaxArtifactsSize
 }
 
 type gatewayConnector struct {

--- a/core/services/chainlink/config_capabilities.go
+++ b/core/services/chainlink/config_capabilities.go
@@ -115,8 +115,16 @@ func (c *capabilitiesWorkflowRegistry) Address() string {
 	return *c.c.Address
 }
 
-func (c *capabilitiesWorkflowRegistry) MaxArtifactsSize() utils.FileSize {
-	return *c.c.MaxArtifactsSize
+func (c *capabilitiesWorkflowRegistry) MaxEncryptedSecretsSize() utils.FileSize {
+	return *c.c.MaxEncryptedSecretsSize
+}
+
+func (c *capabilitiesWorkflowRegistry) MaxBinarySize() utils.FileSize {
+	return *c.c.MaxBinarySize
+}
+
+func (c *capabilitiesWorkflowRegistry) MaxConfigSize() utils.FileSize {
+	return *c.c.MaxConfigSize
 }
 
 type gatewayConnector struct {

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -498,9 +498,9 @@ func TestConfig_Marshal(t *testing.T) {
 			Address:                 ptr(""),
 			ChainID:                 ptr("1"),
 			NetworkID:               ptr("evm"),
-			MaxBinarySize:           ptr(utils.FileSize(10 * utils.MB)),
-			MaxEncryptedSecretsSize: ptr(utils.FileSize(5 * utils.MB)),
-			MaxConfigSize:           ptr(utils.FileSize(5 * utils.MB)),
+			MaxBinarySize:           ptr(utils.FileSize(20 * utils.MB)),
+			MaxEncryptedSecretsSize: ptr(utils.FileSize(26.4 * utils.KB)),
+			MaxConfigSize:           ptr(utils.FileSize(50 * utils.KB)),
 		},
 		Dispatcher: toml.Dispatcher{
 			SupportedVersion:   ptr(1),

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -495,9 +495,10 @@ func TestConfig_Marshal(t *testing.T) {
 			NetworkID: ptr("evm"),
 		},
 		WorkflowRegistry: toml.WorkflowRegistry{
-			Address:   ptr(""),
-			ChainID:   ptr("1"),
-			NetworkID: ptr("evm"),
+			Address:          ptr(""),
+			ChainID:          ptr("1"),
+			NetworkID:        ptr("evm"),
+			MaxArtifactsSize: ptr(utils.FileSize(10 * utils.MB)),
 		},
 		Dispatcher: toml.Dispatcher{
 			SupportedVersion:   ptr(1),

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -495,10 +495,12 @@ func TestConfig_Marshal(t *testing.T) {
 			NetworkID: ptr("evm"),
 		},
 		WorkflowRegistry: toml.WorkflowRegistry{
-			Address:          ptr(""),
-			ChainID:          ptr("1"),
-			NetworkID:        ptr("evm"),
-			MaxArtifactsSize: ptr(utils.FileSize(10 * utils.MB)),
+			Address:                 ptr(""),
+			ChainID:                 ptr("1"),
+			NetworkID:               ptr("evm"),
+			MaxBinarySize:           ptr(utils.FileSize(10 * utils.MB)),
+			MaxEncryptedSecretsSize: ptr(utils.FileSize(5 * utils.MB)),
+			MaxConfigSize:           ptr(utils.FileSize(5 * utils.MB)),
 		},
 		Dispatcher: toml.Dispatcher{
 			SupportedVersion:   ptr(1),

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -274,7 +274,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -274,6 +274,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -274,9 +274,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -53,10 +53,7 @@ ServerPubKey = 'test-pub-key'
 Enabled = true
 ForwardToUrl = 'http://localhost:9898'
 JsonWrapperKey = 'event'
-Headers = [
-    'Authorization: token',
-    'X-SomeOther-Header: value with spaces | and a bar+*',
-]
+Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
 
 [Log]
 Level = 'crit'
@@ -174,10 +171,7 @@ TraceLogging = true
 [P2P.V2]
 Enabled = false
 AnnounceAddresses = ['a', 'b', 'c']
-DefaultBootstrappers = [
-    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10',
-    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99',
-]
+DefaultBootstrappers = ['12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10', '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99']
 DeltaDial = '1m0s'
 DeltaReconcile = '1s'
 ListenAddresses = ['foo', 'bar']
@@ -266,10 +260,7 @@ TraceLogging = true
 [Capabilities.Peering.V2]
 Enabled = false
 AnnounceAddresses = ['a', 'b', 'c']
-DefaultBootstrappers = [
-    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10',
-    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99',
-]
+DefaultBootstrappers = ['12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10', '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99']
 DeltaDial = '1m0s'
 DeltaReconcile = '2s'
 ListenAddresses = ['foo', 'bar']
@@ -293,9 +284,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = '11155111'

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -53,7 +53,10 @@ ServerPubKey = 'test-pub-key'
 Enabled = true
 ForwardToUrl = 'http://localhost:9898'
 JsonWrapperKey = 'event'
-Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
+Headers = [
+    'Authorization: token',
+    'X-SomeOther-Header: value with spaces | and a bar+*',
+]
 
 [Log]
 Level = 'crit'
@@ -171,7 +174,10 @@ TraceLogging = true
 [P2P.V2]
 Enabled = false
 AnnounceAddresses = ['a', 'b', 'c']
-DefaultBootstrappers = ['12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10', '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99']
+DefaultBootstrappers = [
+    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10',
+    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99',
+]
 DeltaDial = '1m0s'
 DeltaReconcile = '1s'
 ListenAddresses = ['foo', 'bar']
@@ -260,7 +266,10 @@ TraceLogging = true
 [Capabilities.Peering.V2]
 Enabled = false
 AnnounceAddresses = ['a', 'b', 'c']
-DefaultBootstrappers = ['12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10', '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99']
+DefaultBootstrappers = [
+    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10',
+    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99',
+]
 DeltaDial = '1m0s'
 DeltaReconcile = '2s'
 ListenAddresses = ['foo', 'bar']
@@ -284,6 +293,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = '11155111'

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -293,7 +293,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = '11155111'

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -47,7 +47,10 @@ UseBatchSend = true
 Enabled = true
 ForwardToUrl = 'http://localhost:9898'
 JsonWrapperKey = 'event'
-Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
+Headers = [
+    'Authorization: token',
+    'X-SomeOther-Header: value with spaces | and a bar+*',
+]
 
 [Log]
 Level = 'panic'
@@ -274,6 +277,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -47,10 +47,7 @@ UseBatchSend = true
 Enabled = true
 ForwardToUrl = 'http://localhost:9898'
 JsonWrapperKey = 'event'
-Headers = [
-    'Authorization: token',
-    'X-SomeOther-Header: value with spaces | and a bar+*',
-]
+Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
 
 [Log]
 Level = 'panic'
@@ -277,9 +274,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -277,7 +277,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -131,11 +131,12 @@ func (h *handler) handleWebAPIOutgoingMessage(ctx context.Context, msg *api.Mess
 
 	timeout := time.Duration(payload.TimeoutMs) * time.Millisecond
 	req := network.HTTPRequest{
-		Method:  payload.Method,
-		URL:     payload.URL,
-		Headers: payload.Headers,
-		Body:    payload.Body,
-		Timeout: timeout,
+		Method:           payload.Method,
+		URL:              payload.URL,
+		Headers:          payload.Headers,
+		Body:             payload.Body,
+		MaxResponseBytes: payload.MaxResponseBytes,
+		Timeout:          timeout,
 	}
 
 	// send response to node async

--- a/core/services/gateway/handlers/capabilities/webapi.go
+++ b/core/services/gateway/handlers/capabilities/webapi.go
@@ -3,12 +3,14 @@ package capabilities
 import "errors"
 
 type Request struct {
-	URL              string            `json:"url"`                 // URL to query, only http and https protocols are supported.
-	Method           string            `json:"method,omitempty"`    // HTTP verb, defaults to GET.
-	Headers          map[string]string `json:"headers,omitempty"`   // HTTP headers, defaults to empty.
-	Body             []byte            `json:"body,omitempty"`      // HTTP request body
-	TimeoutMs        uint32            `json:"timeoutMs,omitempty"` // Timeout in milliseconds
-	MaxResponseBytes uint32            `json:"maxBytes,omitempty"`  // Maximum number of bytes to read from the response body
+	URL       string            `json:"url"`                 // URL to query, only http and https protocols are supported.
+	Method    string            `json:"method,omitempty"`    // HTTP verb, defaults to GET.
+	Headers   map[string]string `json:"headers,omitempty"`   // HTTP headers, defaults to empty.
+	Body      []byte            `json:"body,omitempty"`      // HTTP request body
+	TimeoutMs uint32            `json:"timeoutMs,omitempty"` // Timeout in milliseconds
+
+	// Maximum number of bytes to read from the response body.  If the gateway max response size is smaller than this value, the gateway max response size will be used.
+	MaxResponseBytes uint32 `json:"maxBytes,omitempty"`
 }
 
 type Response struct {

--- a/core/services/gateway/handlers/capabilities/webapi.go
+++ b/core/services/gateway/handlers/capabilities/webapi.go
@@ -3,11 +3,12 @@ package capabilities
 import "errors"
 
 type Request struct {
-	URL       string            `json:"url"`                 // URL to query, only http and https protocols are supported.
-	Method    string            `json:"method,omitempty"`    // HTTP verb, defaults to GET.
-	Headers   map[string]string `json:"headers,omitempty"`   // HTTP headers, defaults to empty.
-	Body      []byte            `json:"body,omitempty"`      // HTTP request body
-	TimeoutMs uint32            `json:"timeoutMs,omitempty"` // Timeout in milliseconds
+	URL              string            `json:"url"`                 // URL to query, only http and https protocols are supported.
+	Method           string            `json:"method,omitempty"`    // HTTP verb, defaults to GET.
+	Headers          map[string]string `json:"headers,omitempty"`   // HTTP headers, defaults to empty.
+	Body             []byte            `json:"body,omitempty"`      // HTTP request body
+	TimeoutMs        uint32            `json:"timeoutMs,omitempty"` // Timeout in milliseconds
+	MaxResponseBytes uint32            `json:"maxBytes,omitempty"`  // Maximum number of bytes to read from the response body
 }
 
 type Response struct {

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -35,6 +35,7 @@ var (
 	defaultAllowedPorts     = []int{80, 443}
 	defaultAllowedSchemes   = []string{"http", "https"}
 	defaultMaxResponseBytes = uint32(30 * 1024 * 1024) // 30MB
+	defaultTimout           = 5 * time.Second
 )
 
 func (c *HTTPClientConfig) ApplyDefaults() {
@@ -48,6 +49,10 @@ func (c *HTTPClientConfig) ApplyDefaults() {
 
 	if c.MaxResponseBytes == 0 {
 		c.MaxResponseBytes = defaultMaxResponseBytes
+	}
+
+	if c.DefaultTimeout == 0 {
+		c.DefaultTimeout = defaultTimout
 	}
 
 	// safeurl automatically blocks internal IPs so no need
@@ -93,11 +98,13 @@ func NewHTTPClient(config HTTPClientConfig, lggr logger.Logger) (HTTPClient, err
 		EnableDebugLogging(true).
 		Build()
 
-	return &httpClient{
+	c := &httpClient{
 		config: config,
 		client: safeurl.Client(safeConfig),
 		lggr:   lggr,
-	}, nil
+	}
+
+	return c, nil
 }
 
 func disableRedirects(req *http.Request, via []*http.Request) error {
@@ -105,7 +112,13 @@ func disableRedirects(req *http.Request, via []*http.Request) error {
 }
 
 func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, req.Timeout)
+	to := req.Timeout
+	if to == 0 {
+		to = c.config.DefaultTimeout
+	}
+
+	c.lggr.Debugw("sending HTTP request with timeout", "url", req.URL, "request timeout", to)
+	timeoutCtx, cancel := context.WithTimeout(ctx, to)
 	defer cancel()
 	r, err := http.NewRequestWithContext(timeoutCtx, req.Method, req.URL, bytes.NewBuffer(req.Body))
 	if err != nil {
@@ -114,6 +127,7 @@ func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, 
 
 	resp, err := c.client.Do(r)
 	if err != nil {
+		c.lggr.Errorw("failed to send HTTP request", "url", req.URL, "err", err)
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -124,6 +138,7 @@ func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, 
 	reader := http.MaxBytesReader(nil, resp.Body, int64(n))
 	body, err := io.ReadAll(reader)
 	if err != nil {
+		c.lggr.Errorw("failed to read HTTP response body", "url", req.URL, "err", err)
 		return nil, err
 	}
 	headers := make(map[string]string)

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -55,11 +55,13 @@ func (c *HTTPClientConfig) ApplyDefaults() {
 }
 
 type HTTPRequest struct {
-	Method           string
-	URL              string
-	Headers          map[string]string
-	Body             []byte
-	Timeout          time.Duration
+	Method  string
+	URL     string
+	Headers map[string]string
+	Body    []byte
+	Timeout time.Duration
+
+	// Maximum number of bytes to read from the response body.  If 0, the default value is used.
 	MaxResponseBytes uint32
 }
 

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -32,8 +32,9 @@ type HTTPClientConfig struct {
 }
 
 var (
-	defaultAllowedPorts   = []int{80, 443}
-	defaultAllowedSchemes = []string{"http", "https"}
+	defaultAllowedPorts     = []int{80, 443}
+	defaultAllowedSchemes   = []string{"http", "https"}
+	defaultMaxResponseBytes = uint32(30 * 1024 * 1024) // 30MB
 )
 
 func (c *HTTPClientConfig) ApplyDefaults() {
@@ -45,17 +46,23 @@ func (c *HTTPClientConfig) ApplyDefaults() {
 		c.AllowedSchemes = defaultAllowedSchemes
 	}
 
+	if c.MaxResponseBytes == 0 {
+		c.MaxResponseBytes = defaultMaxResponseBytes
+	}
+
 	// safeurl automatically blocks internal IPs so no need
 	// to set defaults here.
 }
 
 type HTTPRequest struct {
-	Method  string
-	URL     string
-	Headers map[string]string
-	Body    []byte
-	Timeout time.Duration
+	Method           string
+	URL              string
+	Headers          map[string]string
+	Body             []byte
+	Timeout          time.Duration
+	MaxResponseBytes uint32
 }
+
 type HTTPResponse struct {
 	StatusCode int               // HTTP status code
 	Headers    map[string]string // HTTP headers
@@ -109,7 +116,10 @@ func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, 
 	}
 	defer resp.Body.Close()
 
-	reader := http.MaxBytesReader(nil, resp.Body, int64(c.config.MaxResponseBytes))
+	n := maxReadBytes(readSize{defaultSize: c.config.MaxResponseBytes, requestSize: req.MaxResponseBytes})
+	c.lggr.Debugw("max bytes to read from HTTP response", "bytes", n)
+
+	reader := http.MaxBytesReader(nil, resp.Body, int64(n))
 	body, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
@@ -127,4 +137,23 @@ func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, 
 		StatusCode: resp.StatusCode,
 		Body:       body,
 	}, nil
+}
+
+type readSize struct {
+	defaultSize uint32
+	requestSize uint32
+}
+
+func maxReadBytes(sizes readSize) uint32 {
+	if sizes.requestSize == 0 {
+		return sizes.defaultSize
+	}
+	return minUint32(sizes.defaultSize, sizes.requestSize)
+}
+
+func minUint32(a, b uint32) uint32 {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -12,6 +12,7 @@ import (
 	"github.com/doyensec/safeurl"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 // HTTPClient interfaces defines a method to send HTTP requests
@@ -34,7 +35,7 @@ type HTTPClientConfig struct {
 var (
 	defaultAllowedPorts     = []int{80, 443}
 	defaultAllowedSchemes   = []string{"http", "https"}
-	defaultMaxResponseBytes = uint32(30 * 1024 * 1024) // 30MB
+	defaultMaxResponseBytes = uint32(26.4 * utils.KB)
 	defaultTimout           = 5 * time.Second
 )
 

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -36,7 +36,7 @@ var (
 	defaultAllowedPorts     = []int{80, 443}
 	defaultAllowedSchemes   = []string{"http", "https"}
 	defaultMaxResponseBytes = uint32(26.4 * utils.KB)
-	defaultTimout           = 5 * time.Second
+	defaultTimeout          = 5 * time.Second
 )
 
 func (c *HTTPClientConfig) ApplyDefaults() {
@@ -53,7 +53,7 @@ func (c *HTTPClientConfig) ApplyDefaults() {
 	}
 
 	if c.DefaultTimeout == 0 {
-		c.DefaultTimeout = defaultTimout
+		c.DefaultTimeout = defaultTimeout
 	}
 
 	// safeurl automatically blocks internal IPs so no need
@@ -68,6 +68,7 @@ type HTTPRequest struct {
 	Timeout time.Duration
 
 	// Maximum number of bytes to read from the response body.  If 0, the default value is used.
+	// Does not override a request specific value gte 0.
 	MaxResponseBytes uint32
 }
 
@@ -99,13 +100,11 @@ func NewHTTPClient(config HTTPClientConfig, lggr logger.Logger) (HTTPClient, err
 		EnableDebugLogging(true).
 		Build()
 
-	c := &httpClient{
+	return &httpClient{
 		config: config,
 		client: safeurl.Client(safeConfig),
 		lggr:   lggr,
-	}
-
-	return c, nil
+	}, nil
 }
 
 func disableRedirects(req *http.Request, via []*http.Request) error {

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -36,7 +37,7 @@ func TestHTTPClient_Send(t *testing.T) {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 					_, err2 := w.Write([]byte("success"))
-					require.NoError(t, err2)
+					assert.NoError(t, err2)
 				}))
 			},
 			request: HTTPRequest{
@@ -431,7 +432,7 @@ func Test_ConfigApplyDefaults(t *testing.T) {
 		config := HTTPClientConfig{}
 		config.ApplyDefaults()
 		require.Equal(t, defaultMaxResponseBytes, config.MaxResponseBytes) // 30MB
-		require.Equal(t, 0*time.Second, config.DefaultTimeout)
+		require.Equal(t, defaultTimout, config.DefaultTimeout)
 		require.Equal(t, defaultAllowedPorts, config.AllowedPorts)
 		require.Equal(t, defaultAllowedSchemes, config.AllowedSchemes)
 	})

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -432,7 +432,7 @@ func Test_ConfigApplyDefaults(t *testing.T) {
 		config := HTTPClientConfig{}
 		config.ApplyDefaults()
 		require.Equal(t, defaultMaxResponseBytes, config.MaxResponseBytes) // 30MB
-		require.Equal(t, defaultTimout, config.DefaultTimeout)
+		require.Equal(t, defaultTimeout, config.DefaultTimeout)
 		require.Equal(t, defaultAllowedPorts, config.AllowedPorts)
 		require.Equal(t, defaultAllowedSchemes, config.AllowedSchemes)
 	})

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -23,11 +23,12 @@ func TestHTTPClient_Send(t *testing.T) {
 	lggr := logger.Test(t)
 	// Define test cases
 	tests := []struct {
-		name          string
-		setupServer   func() *httptest.Server
-		request       HTTPRequest
-		expectedError error
-		expectedResp  *HTTPResponse
+		name             string
+		setupServer      func() *httptest.Server
+		request          HTTPRequest
+		giveMaxRespBytes uint32
+		expectedError    error
+		expectedResp     *HTTPResponse
 	}{
 		{
 			name: "successful request",
@@ -96,7 +97,27 @@ func TestHTTPClient_Send(t *testing.T) {
 			},
 		},
 		{
-			name: "response too long",
+			name: "response too long with non-default config",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, err2 := w.Write(make([]byte, 2048))
+					require.NoError(t, err2)
+				}))
+			},
+			giveMaxRespBytes: 1024,
+			request: HTTPRequest{
+				Method:  "GET",
+				URL:     "/",
+				Headers: map[string]string{},
+				Body:    nil,
+				Timeout: 2 * time.Second,
+			},
+			expectedError: &http.MaxBytesError{},
+			expectedResp:  nil,
+		},
+		{
+			name: "success with long response and default config",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
@@ -111,8 +132,11 @@ func TestHTTPClient_Send(t *testing.T) {
 				Body:    nil,
 				Timeout: 2 * time.Second,
 			},
-			expectedError: &http.MaxBytesError{},
-			expectedResp:  nil,
+			expectedResp: &HTTPResponse{
+				StatusCode: http.StatusOK,
+				Headers:    map[string]string{"Content-Length": "2048"},
+				Body:       make([]byte, 2048),
+			},
 		},
 		{
 			name: "redirects are blocked",
@@ -153,7 +177,7 @@ func TestHTTPClient_Send(t *testing.T) {
 			require.NoError(t, err)
 
 			config := HTTPClientConfig{
-				MaxResponseBytes: 1024,
+				MaxResponseBytes: tt.giveMaxRespBytes,
 				DefaultTimeout:   5 * time.Second,
 				allowedIPs:       []string{hostname},
 				AllowedPorts:     []int{int(portInt)},
@@ -168,16 +192,17 @@ func TestHTTPClient_Send(t *testing.T) {
 			if tt.expectedError != nil {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tt.expectedError.Error())
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expectedResp.StatusCode, resp.StatusCode)
-				for k, v := range tt.expectedResp.Headers {
-					value, ok := resp.Headers[k]
-					require.True(t, ok)
-					require.Equal(t, v, value)
-				}
-				require.Equal(t, tt.expectedResp.Body, resp.Body)
+				return
 			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedResp.StatusCode, resp.StatusCode)
+			for k, v := range tt.expectedResp.Headers {
+				value, ok := resp.Headers[k]
+				require.True(t, ok)
+				require.Equal(t, v, value)
+			}
+			require.Equal(t, tt.expectedResp.Body, resp.Body)
 		})
 	}
 }
@@ -388,4 +413,26 @@ func TestHTTPClient_BlocksUnallowed(t *testing.T) {
 			require.ErrorContains(t, err, tt.expectedError)
 		})
 	}
+}
+
+func Test_ConfigApplyDefaults(t *testing.T) {
+	t.Parallel()
+	t.Run("successfully overrides defaults", func(t *testing.T) {
+		config := HTTPClientConfig{
+			MaxResponseBytes: 1024,
+			DefaultTimeout:   5 * time.Second,
+		}
+		config.ApplyDefaults()
+		require.Equal(t, uint32(1024), config.MaxResponseBytes)
+		require.Equal(t, 5*time.Second, config.DefaultTimeout)
+	})
+
+	t.Run("successfully sets default values", func(t *testing.T) {
+		config := HTTPClientConfig{}
+		config.ApplyDefaults()
+		require.Equal(t, defaultMaxResponseBytes, config.MaxResponseBytes) // 30MB
+		require.Equal(t, 0*time.Second, config.DefaultTimeout)
+		require.Equal(t, defaultAllowedPorts, config.AllowedPorts)
+		require.Equal(t, defaultAllowedSchemes, config.AllowedSchemes)
+	})
 }

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -61,7 +61,7 @@ func TestHTTPClient_Send(t *testing.T) {
 					time.Sleep(10 * time.Second)
 					w.WriteHeader(http.StatusOK)
 					_, err2 := w.Write([]byte("success"))
-					require.NoError(t, err2)
+					assert.NoError(t, err2)
 				}))
 			},
 			request: HTTPRequest{
@@ -80,7 +80,7 @@ func TestHTTPClient_Send(t *testing.T) {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusInternalServerError)
 					_, err2 := w.Write([]byte("error"))
-					require.NoError(t, err2)
+					assert.NoError(t, err2)
 				}))
 			},
 			request: HTTPRequest{
@@ -103,7 +103,7 @@ func TestHTTPClient_Send(t *testing.T) {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 					_, err2 := w.Write(make([]byte, 2048))
-					require.NoError(t, err2)
+					assert.NoError(t, err2)
 				}))
 			},
 			giveMaxRespBytes: 1024,
@@ -123,7 +123,7 @@ func TestHTTPClient_Send(t *testing.T) {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 					_, err2 := w.Write(make([]byte, 2048))
-					require.NoError(t, err2)
+					assert.NoError(t, err2)
 				}))
 			},
 			request: HTTPRequest{

--- a/core/services/relay/evm/capabilities/workflows/syncer/workflow_syncer_test.go
+++ b/core/services/relay/evm/capabilities/workflows/syncer/workflow_syncer_test.go
@@ -92,6 +92,12 @@ func (m *testWorkflowRegistryContractLoader) LoadWorkflows(ctx context.Context, 
 	}, nil
 }
 
+type mockFetcher func(ctx context.Context, cmd syncer.FetchMaxCmd) ([]byte, error)
+
+func (m mockFetcher) FetchMax(ctx context.Context, cmd syncer.FetchMaxCmd) ([]byte, error) {
+	return m(ctx, cmd)
+}
+
 func Test_EventHandlerStateSync(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	backendTH := testutils.NewEVMBackendTH(t)
@@ -308,9 +314,9 @@ func Test_SecretsWorker(t *testing.T) {
 		}
 		giveContents = "contents"
 		wantContents = "updated contents"
-		fetcherFn    = func(_ context.Context, _ string) ([]byte, error) {
+		fetcherFn    = mockFetcher(func(_ context.Context, _ syncer.FetchMaxCmd) ([]byte, error) {
 			return []byte(wantContents), nil
-		}
+		})
 	)
 
 	defer giveTicker.Stop()
@@ -407,9 +413,9 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyPaused(t *testing.T) {
 			BinaryURL: giveBinaryURL,
 		}
 		wantContents = "updated contents"
-		fetcherFn    = func(_ context.Context, _ string) ([]byte, error) {
+		fetcherFn    = mockFetcher(func(_ context.Context, _ syncer.FetchMaxCmd) ([]byte, error) {
 			return []byte(base64.StdEncoding.EncodeToString([]byte(wantContents))), nil
-		}
+		})
 	)
 
 	defer giveTicker.Stop()
@@ -504,9 +510,9 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyActivated(t *testing.T) {
 			BinaryURL: giveBinaryURL,
 		}
 		wantContents = "updated contents"
-		fetcherFn    = func(_ context.Context, _ string) ([]byte, error) {
+		fetcherFn    = mockFetcher(func(_ context.Context, _ syncer.FetchMaxCmd) ([]byte, error) {
 			return []byte(base64.StdEncoding.EncodeToString([]byte(wantContents))), nil
-		}
+		})
 	)
 
 	defer giveTicker.Stop()

--- a/core/services/relay/evm/capabilities/workflows/syncer/workflow_syncer_test.go
+++ b/core/services/relay/evm/capabilities/workflows/syncer/workflow_syncer_test.go
@@ -92,12 +92,6 @@ func (m *testWorkflowRegistryContractLoader) LoadWorkflows(ctx context.Context, 
 	}, nil
 }
 
-type mockFetcher func(ctx context.Context, cmd syncer.FetchMaxCmd) ([]byte, error)
-
-func (m mockFetcher) FetchMax(ctx context.Context, cmd syncer.FetchMaxCmd) ([]byte, error) {
-	return m(ctx, cmd)
-}
-
 func Test_EventHandlerStateSync(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	backendTH := testutils.NewEVMBackendTH(t)
@@ -314,9 +308,9 @@ func Test_SecretsWorker(t *testing.T) {
 		}
 		giveContents = "contents"
 		wantContents = "updated contents"
-		fetcherFn    = mockFetcher(func(_ context.Context, _ syncer.FetchMaxCmd) ([]byte, error) {
+		fetcherFn    = func(_ context.Context, _ string, _ uint32) ([]byte, error) {
 			return []byte(wantContents), nil
-		})
+		}
 	)
 
 	defer giveTicker.Stop()
@@ -413,9 +407,9 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyPaused(t *testing.T) {
 			BinaryURL: giveBinaryURL,
 		}
 		wantContents = "updated contents"
-		fetcherFn    = mockFetcher(func(_ context.Context, _ syncer.FetchMaxCmd) ([]byte, error) {
+		fetcherFn    = func(_ context.Context, _ string, _ uint32) ([]byte, error) {
 			return []byte(base64.StdEncoding.EncodeToString([]byte(wantContents))), nil
-		})
+		}
 	)
 
 	defer giveTicker.Stop()
@@ -510,9 +504,9 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyActivated(t *testing.T) {
 			BinaryURL: giveBinaryURL,
 		}
 		wantContents = "updated contents"
-		fetcherFn    = mockFetcher(func(_ context.Context, _ syncer.FetchMaxCmd) ([]byte, error) {
+		fetcherFn    = func(_ context.Context, _ string, _ uint32) ([]byte, error) {
 			return []byte(base64.StdEncoding.EncodeToString([]byte(wantContents))), nil
-		})
+		}
 	)
 
 	defer giveTicker.Stop()

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"strings"
 
@@ -17,7 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
 	ghcapabilities "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/common"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 type FetcherService struct {
@@ -25,47 +23,17 @@ type FetcherService struct {
 	lggr    logger.Logger
 	och     *webapi.OutgoingConnectorHandler
 	wrapper gatewayConnector
-	limits  *ArtifactConfig
 }
-
-type ArtifactConfig struct {
-	MaxConfigSize  uint64
-	MaxSecretsSize uint64
-	MaxBinarySize  uint64
-}
-
-type ArtifactType string
-
-var (
-	ArtifactTypeConfig  ArtifactType = "config"
-	ArtifactTypeSecrets ArtifactType = "secrets"
-	ArtifactTypeBinary  ArtifactType = "binary"
-	ArtifactTypeUnknown ArtifactType = "unknown"
-)
-
-// By default, if type is unknown, the largest artifact size is 26.4KB.  Configure the artifact size
-// via the ArtifactConfig to override this default.
-const defaultMaxArtifactSizeBytes = uint32(26.4 * utils.KB)
 
 type gatewayConnector interface {
 	GetGatewayConnector() connector.GatewayConnector
 }
 
-func WithMaxArtifactSize(cfg ArtifactConfig) func(*FetcherService) {
-	return func(fs *FetcherService) {
-		fs.limits = &cfg
-	}
-}
-
-func NewFetcherService(lggr logger.Logger, wrapper gatewayConnector, opts ...func(*FetcherService)) *FetcherService {
-	fs := &FetcherService{
+func NewFetcherService(lggr logger.Logger, wrapper gatewayConnector) *FetcherService {
+	return &FetcherService{
 		lggr:    lggr.Named("FetcherService"),
 		wrapper: wrapper,
 	}
-	for _, opt := range opts {
-		opt(fs)
-	}
-	return fs
 }
 
 func (s *FetcherService) Start(ctx context.Context) error {
@@ -115,28 +83,10 @@ func hash(url string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-type FetchMaxCmd struct {
-	URL          string       `json:"url"`
-	ArtifactType ArtifactType `json:"artifactType"`
-}
-
-type MaxFetcher interface {
-	FetchMax(ctx context.Context, cmd FetchMaxCmd) ([]byte, error)
-}
-
-func (s *FetcherService) FetchMax(ctx context.Context, cmd FetchMaxCmd) ([]byte, error) {
-	n, err := s.getMaxBytes(cmd.ArtifactType)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get max bytes for fetch: %w", err)
-	}
-	return s.fetch(ctx, cmd.URL, n)
-}
-
-func (s *FetcherService) Fetch(ctx context.Context, url string) ([]byte, error) {
-	return s.FetchMax(ctx, FetchMaxCmd{URL: url})
-}
-
-func (s *FetcherService) fetch(ctx context.Context, url string, n uint32) ([]byte, error) {
+// Fetch fetches the given URL and returns the response body.  n is the maximum number of bytes to
+// read from the response body.  Set n to zero to use the default size limit specified by the
+// configured gateway's http client, if any.
+func (s *FetcherService) Fetch(ctx context.Context, url string, n uint32) ([]byte, error) {
 	messageID := strings.Join([]string{ghcapabilities.MethodWorkflowSyncer, hash(url)}, "/")
 	resp, err := s.och.HandleSingleNodeRequest(ctx, messageID, ghcapabilities.Request{
 		URL:              url,
@@ -167,29 +117,4 @@ func (s *FetcherService) fetch(ctx context.Context, url string, n uint32) ([]byt
 	}
 
 	return payload.Body, nil
-}
-
-func (s *FetcherService) getMaxBytes(artifactType ArtifactType) (uint32, error) {
-	switch artifactType {
-	case ArtifactTypeConfig:
-		if s.limits != nil && s.limits.MaxConfigSize > 0 {
-			return safeSetUint32(s.limits.MaxConfigSize)
-		}
-	case ArtifactTypeSecrets:
-		if s.limits != nil && s.limits.MaxSecretsSize > 0 {
-			return safeSetUint32(s.limits.MaxSecretsSize)
-		}
-	case ArtifactTypeBinary:
-		if s.limits != nil && s.limits.MaxBinarySize > 0 {
-			return safeSetUint32(s.limits.MaxBinarySize)
-		}
-	}
-	return defaultMaxArtifactSizeBytes, nil
-}
-
-func safeSetUint32(n uint64) (uint32, error) {
-	if n > math.MaxUint32 {
-		return 0, fmt.Errorf("value %d is too large to fit in a uint32", n)
-	}
-	return uint32(n), nil
 }

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -45,13 +45,9 @@ type gatewayConnector interface {
 	GetGatewayConnector() connector.GatewayConnector
 }
 
-func WithMaxArtifactSize(maxArtifactSize uint64) func(*FetcherService) {
+func WithMaxArtifactSize(cfg ArtifactConfig) func(*FetcherService) {
 	return func(fs *FetcherService) {
-		fs.limits = &ArtifactConfig{
-			MaxConfigSize:  maxArtifactSize,
-			MaxSecretsSize: maxArtifactSize,
-			MaxBinarySize:  maxArtifactSize,
-		}
+		fs.limits = &cfg
 	}
 }
 

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -21,11 +21,25 @@ import (
 
 type FetcherService struct {
 	services.StateMachine
-	lggr            logger.Logger
-	och             *webapi.OutgoingConnectorHandler
-	wrapper         gatewayConnector
-	maxArtifactSize uint64
+	lggr    logger.Logger
+	och     *webapi.OutgoingConnectorHandler
+	wrapper gatewayConnector
+	limits  *ArtifactConfig
 }
+
+type ArtifactConfig struct {
+	MaxConfigSize  uint64
+	MaxSecretsSize uint64
+	MaxBinarySize  uint64
+}
+
+type ArtifactType string
+
+var (
+	ArtifactTypeConfig  ArtifactType = "config"
+	ArtifactTypeSecrets ArtifactType = "secrets"
+	ArtifactTypeBinary  ArtifactType = "binary"
+)
 
 type gatewayConnector interface {
 	GetGatewayConnector() connector.GatewayConnector
@@ -33,7 +47,11 @@ type gatewayConnector interface {
 
 func WithMaxArtifactSize(maxArtifactSize uint64) func(*FetcherService) {
 	return func(fs *FetcherService) {
-		fs.maxArtifactSize = maxArtifactSize
+		fs.limits = &ArtifactConfig{
+			MaxConfigSize:  maxArtifactSize,
+			MaxSecretsSize: maxArtifactSize,
+			MaxBinarySize:  maxArtifactSize,
+		}
 	}
 }
 
@@ -96,16 +114,54 @@ func hash(url string) string {
 }
 
 func (s *FetcherService) Fetch(ctx context.Context, url string) ([]byte, error) {
-	messageID := strings.Join([]string{ghcapabilities.MethodWorkflowSyncer, hash(url)}, "/")
+	return s.fetch(ctx, url, 0)
+}
 
-	if s.maxArtifactSize > 0 && s.maxArtifactSize > math.MaxUint32 {
-		return nil, fmt.Errorf("max artifact size is greater than maximum allowed size %d", math.MaxUint32)
+type FetchMaxCmd struct {
+	URL          string       `json:"url"`
+	ArtifactType ArtifactType `json:"artifactType"`
+}
+
+type MaxFetcher interface {
+	FetchMax(ctx context.Context, cmd FetchMaxCmd) ([]byte, error)
+}
+
+func (s *FetcherService) FetchMax(ctx context.Context, cmd FetchMaxCmd) ([]byte, error) {
+	if s.limits == nil {
+		s.lggr.Warn("FetcherService limits not set, allowing http client to set default limits")
+		return s.fetch(ctx, cmd.URL, 0)
 	}
 
+	var (
+		n   uint32
+		err error
+	)
+	switch cmd.ArtifactType {
+	case ArtifactTypeConfig:
+		n, err = safeSetUint32(s.limits.MaxConfigSize)
+	case ArtifactTypeSecrets:
+		n, err = safeSetUint32(s.limits.MaxSecretsSize)
+	case ArtifactTypeBinary:
+		n, err = safeSetUint32(s.limits.MaxBinarySize)
+	default:
+		err = fmt.Errorf("unknown artifact type: %s", cmd.ArtifactType)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to set fetch limit : %w", err)
+	}
+
+	s.lggr.Debugw("fetching artifact with max size", "url", cmd.URL, "artifactType", cmd.ArtifactType, "maxSize", n)
+
+	return s.fetch(ctx, cmd.URL, n)
+}
+
+func (s *FetcherService) fetch(ctx context.Context, url string, n uint32) ([]byte, error) {
+	messageID := strings.Join([]string{ghcapabilities.MethodWorkflowSyncer, hash(url)}, "/")
 	resp, err := s.och.HandleSingleNodeRequest(ctx, messageID, ghcapabilities.Request{
 		URL:              url,
 		Method:           http.MethodGet,
-		MaxResponseBytes: uint32(s.maxArtifactSize),
+		MaxResponseBytes: n,
 	})
 	if err != nil {
 		return nil, err
@@ -131,4 +187,11 @@ func (s *FetcherService) Fetch(ctx context.Context, url string) ([]byte, error) 
 	}
 
 	return payload.Body, nil
+}
+
+func safeSetUint32(n uint64) (uint32, error) {
+	if n > math.MaxUint32 {
+		return 0, fmt.Errorf("value %d is too large to fit in a uint32", n)
+	}
+	return uint32(n), nil
 }

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 
@@ -20,20 +21,31 @@ import (
 
 type FetcherService struct {
 	services.StateMachine
-	lggr    logger.Logger
-	och     *webapi.OutgoingConnectorHandler
-	wrapper gatewayConnector
+	lggr            logger.Logger
+	och             *webapi.OutgoingConnectorHandler
+	wrapper         gatewayConnector
+	maxArtifactSize uint64
 }
 
 type gatewayConnector interface {
 	GetGatewayConnector() connector.GatewayConnector
 }
 
-func NewFetcherService(lggr logger.Logger, wrapper gatewayConnector) *FetcherService {
-	return &FetcherService{
+func WithMaxArtifactSize(maxArtifactSize uint64) func(*FetcherService) {
+	return func(fs *FetcherService) {
+		fs.maxArtifactSize = maxArtifactSize
+	}
+}
+
+func NewFetcherService(lggr logger.Logger, wrapper gatewayConnector, opts ...func(*FetcherService)) *FetcherService {
+	fs := &FetcherService{
 		lggr:    lggr.Named("FetcherService"),
 		wrapper: wrapper,
 	}
+	for _, opt := range opts {
+		opt(fs)
+	}
+	return fs
 }
 
 func (s *FetcherService) Start(ctx context.Context) error {
@@ -85,9 +97,15 @@ func hash(url string) string {
 
 func (s *FetcherService) Fetch(ctx context.Context, url string) ([]byte, error) {
 	messageID := strings.Join([]string{ghcapabilities.MethodWorkflowSyncer, hash(url)}, "/")
+
+	if s.maxArtifactSize > 0 && s.maxArtifactSize > math.MaxUint32 {
+		return nil, fmt.Errorf("max artifact size is greater than maximum allowed size %d", math.MaxUint32)
+	}
+
 	resp, err := s.och.HandleSingleNodeRequest(ctx, messageID, ghcapabilities.Request{
-		URL:    url,
-		Method: http.MethodGet,
+		URL:              url,
+		Method:           http.MethodGet,
+		MaxResponseBytes: uint32(s.maxArtifactSize),
 	})
 	if err != nil {
 		return nil, err

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
 	ghcapabilities "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/common"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 type FetcherService struct {
@@ -42,7 +43,9 @@ var (
 	ArtifactTypeUnknown ArtifactType = "unknown"
 )
 
-const defaultMaxArtifactSizeBytes = uint32(10 * 1024 * 1024) // 10MB
+// By default, if type is unknown, the largest artifact size is 26.4KB.  Configure the artifact size
+// via the ArtifactConfig to override this default.
+const defaultMaxArtifactSizeBytes = uint32(26.4 * utils.KB)
 
 type gatewayConnector interface {
 	GetGatewayConnector() connector.GatewayConnector

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -39,7 +39,10 @@ var (
 	ArtifactTypeConfig  ArtifactType = "config"
 	ArtifactTypeSecrets ArtifactType = "secrets"
 	ArtifactTypeBinary  ArtifactType = "binary"
+	ArtifactTypeUnknown ArtifactType = "unknown"
 )
+
+const defaultMaxArtifactSizeBytes = uint32(10 * 1024 * 1024) // 10MB
 
 type gatewayConnector interface {
 	GetGatewayConnector() connector.GatewayConnector
@@ -109,10 +112,6 @@ func hash(url string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func (s *FetcherService) Fetch(ctx context.Context, url string) ([]byte, error) {
-	return s.fetch(ctx, url, 0)
-}
-
 type FetchMaxCmd struct {
 	URL          string       `json:"url"`
 	ArtifactType ArtifactType `json:"artifactType"`
@@ -123,33 +122,15 @@ type MaxFetcher interface {
 }
 
 func (s *FetcherService) FetchMax(ctx context.Context, cmd FetchMaxCmd) ([]byte, error) {
-	if s.limits == nil {
-		s.lggr.Warn("FetcherService limits not set, allowing http client to set default limits")
-		return s.fetch(ctx, cmd.URL, 0)
-	}
-
-	var (
-		n   uint32
-		err error
-	)
-	switch cmd.ArtifactType {
-	case ArtifactTypeConfig:
-		n, err = safeSetUint32(s.limits.MaxConfigSize)
-	case ArtifactTypeSecrets:
-		n, err = safeSetUint32(s.limits.MaxSecretsSize)
-	case ArtifactTypeBinary:
-		n, err = safeSetUint32(s.limits.MaxBinarySize)
-	default:
-		err = fmt.Errorf("unknown artifact type: %s", cmd.ArtifactType)
-	}
-
+	n, err := s.getMaxBytes(cmd.ArtifactType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set fetch limit : %w", err)
+		return nil, fmt.Errorf("failed to get max bytes for fetch: %w", err)
 	}
-
-	s.lggr.Debugw("fetching artifact with max size", "url", cmd.URL, "artifactType", cmd.ArtifactType, "maxSize", n)
-
 	return s.fetch(ctx, cmd.URL, n)
+}
+
+func (s *FetcherService) Fetch(ctx context.Context, url string) ([]byte, error) {
+	return s.FetchMax(ctx, FetchMaxCmd{URL: url})
 }
 
 func (s *FetcherService) fetch(ctx context.Context, url string, n uint32) ([]byte, error) {
@@ -183,6 +164,24 @@ func (s *FetcherService) fetch(ctx context.Context, url string, n uint32) ([]byt
 	}
 
 	return payload.Body, nil
+}
+
+func (s *FetcherService) getMaxBytes(artifactType ArtifactType) (uint32, error) {
+	switch artifactType {
+	case ArtifactTypeConfig:
+		if s.limits != nil && s.limits.MaxConfigSize > 0 {
+			return safeSetUint32(s.limits.MaxConfigSize)
+		}
+	case ArtifactTypeSecrets:
+		if s.limits != nil && s.limits.MaxSecretsSize > 0 {
+			return safeSetUint32(s.limits.MaxSecretsSize)
+		}
+	case ArtifactTypeBinary:
+		if s.limits != nil && s.limits.MaxBinarySize > 0 {
+			return safeSetUint32(s.limits.MaxBinarySize)
+		}
+	}
+	return defaultMaxArtifactSizeBytes, nil
 }
 
 func safeSetUint32(n uint64) (uint32, error) {

--- a/core/services/workflows/syncer/fetcher_test.go
+++ b/core/services/workflows/syncer/fetcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 
@@ -57,7 +58,7 @@ func TestNewFetcherService(t *testing.T) {
 		connector.EXPECT().AwaitConnection(matches.AnyContext, "gateway1").Return(nil)
 		connector.EXPECT().GatewayIDs().Return([]string{"gateway1", "gateway2"})
 
-		payload, err := fetcher.Fetch(ctx, url)
+		payload, err := fetcher.Fetch(ctx, url, 0)
 		require.NoError(t, err)
 
 		expectedPayload := []byte("response body")
@@ -79,7 +80,7 @@ func TestNewFetcherService(t *testing.T) {
 		connector.EXPECT().AwaitConnection(matches.AnyContext, "gateway1").Return(nil)
 		connector.EXPECT().GatewayIDs().Return([]string{"gateway1", "gateway2"})
 
-		_, err := fetcher.Fetch(ctx, url)
+		_, err := fetcher.Fetch(ctx, url, 0)
 		require.Error(t, err)
 	})
 
@@ -98,7 +99,7 @@ func TestNewFetcherService(t *testing.T) {
 		connector.EXPECT().AwaitConnection(matches.AnyContext, "gateway1").Return(nil)
 		connector.EXPECT().GatewayIDs().Return([]string{"gateway1", "gateway2"})
 
-		_, err := fetcher.Fetch(ctx, url)
+		_, err := fetcher.Fetch(ctx, url, 0)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "invalid response from gateway")
 	})
@@ -132,74 +133,9 @@ func TestNewFetcherService(t *testing.T) {
 		connector.EXPECT().AwaitConnection(matches.AnyContext, "gateway1").Return(nil)
 		connector.EXPECT().GatewayIDs().Return([]string{"gateway1", "gateway2"})
 
-		_, err = fetcher.Fetch(ctx, url)
+		_, err = fetcher.Fetch(ctx, url, math.MaxUint32)
 		require.Error(t, err, "execution error from gateway: http: request body too large")
 	})
-}
-
-func Test_getMaxBytes(t *testing.T) {
-	type testCase struct {
-		name             string
-		giveArtifactType ArtifactType
-		giveConfig       *ArtifactConfig
-		wantN            uint32
-		wantErr          string
-	}
-
-	tests := []testCase{
-		{
-			name:             "OK-config",
-			giveArtifactType: ArtifactTypeConfig,
-			wantN:            100,
-		},
-		{
-			name:             "OK-secrets",
-			giveArtifactType: ArtifactTypeSecrets,
-			wantN:            200,
-		},
-		{
-			name:             "OK-binary",
-			giveArtifactType: ArtifactTypeBinary,
-			wantN:            300,
-		},
-		{
-			name:  "OK-default",
-			wantN: defaultMaxArtifactSizeBytes,
-		},
-		{
-			name:             "NOK-value_too_large",
-			giveArtifactType: ArtifactTypeConfig,
-			giveConfig: &ArtifactConfig{
-				MaxConfigSize: 4294967296,
-			},
-			wantErr: "value 4294967296 is too large to fit in a uint32",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			limits := &ArtifactConfig{
-				MaxConfigSize:  100,
-				MaxSecretsSize: 200,
-				MaxBinarySize:  300,
-			}
-
-			if test.giveConfig != nil {
-				limits = test.giveConfig
-			}
-
-			fetcher := &FetcherService{limits: limits}
-			n, err := fetcher.getMaxBytes(test.giveArtifactType)
-			if test.wantErr != "" {
-				require.Error(t, err, test.wantErr)
-				require.ErrorContains(t, err, test.wantErr)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, test.wantN, n)
-		})
-	}
 }
 
 // gatewayResponse creates an unsigned gateway response with a status code of 200 and a response body.

--- a/core/services/workflows/syncer/fetcher_test.go
+++ b/core/services/workflows/syncer/fetcher_test.go
@@ -137,6 +137,71 @@ func TestNewFetcherService(t *testing.T) {
 	})
 }
 
+func Test_getMaxBytes(t *testing.T) {
+	type testCase struct {
+		name             string
+		giveArtifactType ArtifactType
+		giveConfig       *ArtifactConfig
+		wantN            uint32
+		wantErr          string
+	}
+
+	tests := []testCase{
+		{
+			name:             "OK-config",
+			giveArtifactType: ArtifactTypeConfig,
+			wantN:            100,
+		},
+		{
+			name:             "OK-secrets",
+			giveArtifactType: ArtifactTypeSecrets,
+			wantN:            200,
+		},
+		{
+			name:             "OK-binary",
+			giveArtifactType: ArtifactTypeBinary,
+			wantN:            300,
+		},
+		{
+			name:  "OK-default",
+			wantN: defaultMaxArtifactSizeBytes,
+		},
+		{
+			name:             "NOK-value_too_large",
+			giveArtifactType: ArtifactTypeConfig,
+			giveConfig: &ArtifactConfig{
+				MaxConfigSize: 4294967296,
+			},
+			wantErr: "value 4294967296 is too large to fit in a uint32",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			limits := &ArtifactConfig{
+				MaxConfigSize:  100,
+				MaxSecretsSize: 200,
+				MaxBinarySize:  300,
+			}
+
+			if test.giveConfig != nil {
+				limits = test.giveConfig
+			}
+
+			fetcher := &FetcherService{limits: limits}
+			n, err := fetcher.getMaxBytes(test.giveArtifactType)
+			if test.wantErr != "" {
+				require.Error(t, err, test.wantErr)
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.wantN, n)
+		})
+	}
+}
+
 // gatewayResponse creates an unsigned gateway response with a status code of 200 and a response body.
 func gatewayResponse(t *testing.T, msgID string, donID string) *api.Message {
 	headers := map[string]string{"Content-Type": "application/json"}

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -135,7 +135,7 @@ type engineFactoryFn func(ctx context.Context, wfid string, owner string, name s
 type eventHandler struct {
 	lggr                     logger.Logger
 	orm                      WorkflowRegistryDS
-	fetcher                  FetcherFunc
+	maxFetcher               MaxFetcher
 	workflowStore            store.Store
 	capRegistry              core.CapabilitiesRegistry
 	engineRegistry           *EngineRegistry
@@ -166,11 +166,17 @@ func WithEngineFactoryFn(efn engineFactoryFn) func(*eventHandler) {
 	}
 }
 
+func WithMaxFetcher(mf MaxFetcher) func(*eventHandler) {
+	return func(e *eventHandler) {
+		e.maxFetcher = mf
+	}
+}
+
 // NewEventHandler returns a new eventHandler instance.
 func NewEventHandler(
 	lggr logger.Logger,
 	orm ORM,
-	gateway FetcherFunc,
+	gateway MaxFetcher,
 	workflowStore store.Store,
 	capRegistry core.CapabilitiesRegistry,
 	emitter custmsg.MessageEmitter,
@@ -181,8 +187,8 @@ func NewEventHandler(
 	eh := &eventHandler{
 		lggr:                     lggr,
 		orm:                      orm,
-		fetcher:                  gateway,
 		workflowStore:            workflowStore,
+		maxFetcher:               gateway,
 		capRegistry:              capRegistry,
 		engineRegistry:           NewEngineRegistry(),
 		emitter:                  emitter,
@@ -411,7 +417,7 @@ func (h *eventHandler) workflowRegisteredEvent(
 	// Always fetch secrets from the SecretsURL
 	var secrets []byte
 	if payload.SecretsURL != "" {
-		secrets, err = h.fetcher(ctx, payload.SecretsURL)
+		secrets, err = h.maxFetcher.FetchMax(ctx, FetchMaxCmd{URL: payload.SecretsURL, ArtifactType: ArtifactTypeSecrets})
 		if err != nil {
 			return fmt.Errorf("failed to fetch secrets from %s : %w", payload.SecretsURL, err)
 		}
@@ -514,7 +520,7 @@ func (h *eventHandler) getWorkflowArtifacts(
 		binary, decodedBinary, config []byte
 		err                           error
 	)
-	if binary, err = h.fetcher(ctx, payload.BinaryURL); err != nil {
+	if binary, err = h.maxFetcher.FetchMax(ctx, FetchMaxCmd{URL: payload.BinaryURL, ArtifactType: ArtifactTypeBinary}); err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch binary from %s : %w", payload.BinaryURL, err)
 	}
 
@@ -523,7 +529,7 @@ func (h *eventHandler) getWorkflowArtifacts(
 	}
 
 	if payload.ConfigURL != "" {
-		if config, err = h.fetcher(ctx, payload.ConfigURL); err != nil {
+		if config, err = h.maxFetcher.FetchMax(ctx, FetchMaxCmd{URL: payload.ConfigURL, ArtifactType: ArtifactTypeConfig}); err != nil {
 			return nil, nil, fmt.Errorf("failed to fetch config from %s : %w", payload.ConfigURL, err)
 		}
 	}
@@ -679,7 +685,7 @@ func (h *eventHandler) forceUpdateSecretsEvent(
 	}
 
 	// Fetch the contents of the secrets file from the url via the fetcher
-	secrets, err := h.fetcher(ctx, url)
+	secrets, err := h.maxFetcher.FetchMax(ctx, FetchMaxCmd{URL: url, ArtifactType: ArtifactTypeSecrets})
 	if err != nil {
 		return "", err
 	}

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/workflowkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/store"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 var ErrNotImplemented = errors.New("not implemented")
@@ -130,12 +132,39 @@ func newLastFetchedAtMap() *lastFetchedAtMap {
 
 type engineFactoryFn func(ctx context.Context, wfid string, owner string, name string, config []byte, binary []byte) (services.Service, error)
 
+type ArtifactConfig struct {
+	MaxConfigSize  uint64
+	MaxSecretsSize uint64
+	MaxBinarySize  uint64
+}
+
+// By default, if type is unknown, the largest artifact size is 26.4KB.  Configure the artifact size
+// via the ArtifactConfig to override this default.
+const defaultMaxArtifactSizeBytes = 26.4 * utils.KB
+
+func (cfg *ArtifactConfig) ApplyDefaults() {
+	if cfg.MaxConfigSize == 0 {
+		cfg.MaxConfigSize = defaultMaxArtifactSizeBytes
+	}
+	if cfg.MaxSecretsSize == 0 {
+		cfg.MaxSecretsSize = defaultMaxArtifactSizeBytes
+	}
+	if cfg.MaxBinarySize == 0 {
+		cfg.MaxBinarySize = defaultMaxArtifactSizeBytes
+	}
+}
+
 // eventHandler is a handler for WorkflowRegistryEvent events.  Each event type has a corresponding
 // method that handles the event.
 type eventHandler struct {
-	lggr                     logger.Logger
-	orm                      WorkflowRegistryDS
-	maxFetcher               MaxFetcher
+	lggr logger.Logger
+	orm  WorkflowRegistryDS
+
+	// fetchFn is a function that fetches the contents of a URL with a limit on the size of the response.
+	fetchFn FetcherFunc
+
+	// limits sets max artifact sizes to fetch when handling events
+	limits                   *ArtifactConfig
 	workflowStore            store.Store
 	capRegistry              core.CapabilitiesRegistry
 	engineRegistry           *EngineRegistry
@@ -166,9 +195,9 @@ func WithEngineFactoryFn(efn engineFactoryFn) func(*eventHandler) {
 	}
 }
 
-func WithMaxFetcher(mf MaxFetcher) func(*eventHandler) {
-	return func(e *eventHandler) {
-		e.maxFetcher = mf
+func WithMaxArtifactSize(cfg ArtifactConfig) func(*eventHandler) {
+	return func(eh *eventHandler) {
+		eh.limits = &cfg
 	}
 }
 
@@ -176,7 +205,7 @@ func WithMaxFetcher(mf MaxFetcher) func(*eventHandler) {
 func NewEventHandler(
 	lggr logger.Logger,
 	orm ORM,
-	gateway MaxFetcher,
+	fetchFn FetcherFunc,
 	workflowStore store.Store,
 	capRegistry core.CapabilitiesRegistry,
 	emitter custmsg.MessageEmitter,
@@ -188,19 +217,22 @@ func NewEventHandler(
 		lggr:                     lggr,
 		orm:                      orm,
 		workflowStore:            workflowStore,
-		maxFetcher:               gateway,
 		capRegistry:              capRegistry,
+		fetchFn:                  fetchFn,
 		engineRegistry:           NewEngineRegistry(),
 		emitter:                  emitter,
 		lastFetchedAtMap:         newLastFetchedAtMap(),
 		clock:                    clock,
+		limits:                   &ArtifactConfig{},
 		secretsFreshnessDuration: defaultSecretsFreshnessDuration,
 		encryptionKey:            encryptionKey,
 	}
 	eh.engineFactory = eh.engineFactoryFn
+	eh.limits.ApplyDefaults()
 	for _, o := range opts {
 		o(eh)
 	}
+
 	return eh
 }
 
@@ -417,7 +449,7 @@ func (h *eventHandler) workflowRegisteredEvent(
 	// Always fetch secrets from the SecretsURL
 	var secrets []byte
 	if payload.SecretsURL != "" {
-		secrets, err = h.maxFetcher.FetchMax(ctx, FetchMaxCmd{URL: payload.SecretsURL, ArtifactType: ArtifactTypeSecrets})
+		secrets, err = h.fetchFn(ctx, payload.SecretsURL, safeUint32(h.limits.MaxSecretsSize))
 		if err != nil {
 			return fmt.Errorf("failed to fetch secrets from %s : %w", payload.SecretsURL, err)
 		}
@@ -520,7 +552,7 @@ func (h *eventHandler) getWorkflowArtifacts(
 		binary, decodedBinary, config []byte
 		err                           error
 	)
-	if binary, err = h.maxFetcher.FetchMax(ctx, FetchMaxCmd{URL: payload.BinaryURL, ArtifactType: ArtifactTypeBinary}); err != nil {
+	if binary, err = h.fetchFn(ctx, payload.BinaryURL, safeUint32(h.limits.MaxBinarySize)); err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch binary from %s : %w", payload.BinaryURL, err)
 	}
 
@@ -529,7 +561,7 @@ func (h *eventHandler) getWorkflowArtifacts(
 	}
 
 	if payload.ConfigURL != "" {
-		if config, err = h.maxFetcher.FetchMax(ctx, FetchMaxCmd{URL: payload.ConfigURL, ArtifactType: ArtifactTypeConfig}); err != nil {
+		if config, err = h.fetchFn(ctx, payload.ConfigURL, safeUint32(h.limits.MaxConfigSize)); err != nil {
 			return nil, nil, fmt.Errorf("failed to fetch config from %s : %w", payload.ConfigURL, err)
 		}
 	}
@@ -685,7 +717,7 @@ func (h *eventHandler) forceUpdateSecretsEvent(
 	}
 
 	// Fetch the contents of the secrets file from the url via the fetcher
-	secrets, err := h.maxFetcher.FetchMax(ctx, FetchMaxCmd{URL: url, ArtifactType: ArtifactTypeSecrets})
+	secrets, err := h.fetchFn(ctx, url, safeUint32(h.limits.MaxSecretsSize))
 	if err != nil {
 		return "", err
 	}
@@ -728,4 +760,11 @@ func logCustMsg(ctx context.Context, cma custmsg.MessageEmitter, msg string, log
 
 func newHandlerTypeError(data any) error {
 	return fmt.Errorf("invalid data type %T for event", data)
+}
+
+func safeUint32(n uint64) uint32 {
+	if n > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(n)
 }

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -40,12 +40,12 @@ type mockFetcher struct {
 	responseMap map[string]mockFetchResp
 }
 
-func (m *mockFetcher) FetchMax(_ context.Context, cmd FetchMaxCmd) ([]byte, error) {
-	return m.responseMap[cmd.URL].Body, m.responseMap[cmd.URL].Err
+func (m *mockFetcher) Fetch(_ context.Context, url string, n uint32) ([]byte, error) {
+	return m.responseMap[url].Body, m.responseMap[url].Err
 }
 
-func newMockFetcher(m map[string]mockFetchResp) MaxFetcher {
-	return (&mockFetcher{responseMap: m})
+func newMockFetcher(m map[string]mockFetchResp) FetcherFunc {
+	return (&mockFetcher{responseMap: m}).Fetch
 }
 
 type mockEngine struct {
@@ -70,12 +70,6 @@ func (m *mockEngine) HealthReport() map[string]error { return nil }
 
 func (m *mockEngine) Name() string { return "mockEngine" }
 
-type mockFetcherFunc func(ctx context.Context, cmd FetchMaxCmd) ([]byte, error)
-
-func (m mockFetcherFunc) FetchMax(ctx context.Context, cmd FetchMaxCmd) ([]byte, error) {
-	return m(ctx, cmd)
-}
-
 func Test_Handler(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	emitter := custmsg.NewLabeler()
@@ -95,9 +89,9 @@ func Test_Handler(t *testing.T) {
 			},
 		}
 
-		fetcher := mockFetcherFunc(func(_ context.Context, _ FetchMaxCmd) ([]byte, error) {
+		fetcher := func(_ context.Context, _ string, _ uint32) ([]byte, error) {
 			return []byte("contents"), nil
-		})
+		}
 		mockORM.EXPECT().GetSecretsURLByHash(matches.AnyContext, giveHash).Return(giveURL, nil)
 		mockORM.EXPECT().Update(matches.AnyContext, giveHash, "contents").Return(int64(1), nil)
 		h := NewEventHandler(lggr, mockORM, fetcher, nil, nil, emitter, clockwork.NewFakeClock(), workflowkey.Key{})
@@ -110,9 +104,9 @@ func Test_Handler(t *testing.T) {
 		ctx := testutils.Context(t)
 
 		giveEvent := WorkflowRegistryEvent{}
-		fetcher := mockFetcherFunc(func(_ context.Context, _ FetchMaxCmd) ([]byte, error) {
+		fetcher := func(_ context.Context, _ string, _ uint32) ([]byte, error) {
 			return []byte("contents"), nil
-		})
+		}
 
 		h := NewEventHandler(lggr, mockORM, fetcher, nil, nil, emitter, clockwork.NewFakeClock(), workflowkey.Key{})
 		err := h.Handle(ctx, giveEvent)
@@ -159,9 +153,9 @@ func Test_Handler(t *testing.T) {
 			},
 		}
 
-		fetcher := mockFetcherFunc(func(_ context.Context, _ FetchMaxCmd) ([]byte, error) {
+		fetcher := func(_ context.Context, _ string, _ uint32) ([]byte, error) {
 			return nil, assert.AnError
-		})
+		}
 		mockORM.EXPECT().GetSecretsURLByHash(matches.AnyContext, giveHash).Return(giveURL, nil)
 		h := NewEventHandler(lggr, mockORM, fetcher, nil, nil, emitter, clockwork.NewFakeClock(), workflowkey.Key{})
 		err = h.Handle(ctx, giveEvent)
@@ -185,9 +179,9 @@ func Test_Handler(t *testing.T) {
 			},
 		}
 
-		fetcher := mockFetcherFunc(func(_ context.Context, _ FetchMaxCmd) ([]byte, error) {
+		fetcher := func(_ context.Context, _ string, _ uint32) ([]byte, error) {
 			return []byte("contents"), nil
-		})
+		}
 		mockORM.EXPECT().GetSecretsURLByHash(matches.AnyContext, giveHash).Return(giveURL, nil)
 		mockORM.EXPECT().Update(matches.AnyContext, giveHash, "contents").Return(0, assert.AnError)
 		h := NewEventHandler(lggr, mockORM, fetcher, nil, nil, emitter, clockwork.NewFakeClock(), workflowkey.Key{})
@@ -426,7 +420,7 @@ type testCase struct {
 	GiveConfig      []byte
 	ConfigURL       string
 	WFOwner         []byte
-	fetcher         MaxFetcher
+	fetcher         FetcherFunc
 	Event           func([]byte) WorkflowRegistryWorkflowRegisteredV1
 	validationFn    func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler, wfOwner []byte, wfName string, wfID string)
 	engineFactoryFn func(ctx context.Context, wfid string, owner string, name string, config []byte, binary []byte) (services.Service, error)
@@ -819,7 +813,7 @@ func Test_Handler_SecretsFor(t *testing.T) {
 	h := NewEventHandler(
 		lggr,
 		orm,
-		fetcher,
+		fetcher.Fetch,
 		wfstore.NewDBStore(db, lggr, clockwork.NewFakeClock()),
 		capabilities.NewRegistry(lggr),
 		custmsg.NewLabeler(),
@@ -881,7 +875,7 @@ func Test_Handler_SecretsFor_RefreshesSecrets(t *testing.T) {
 	h := NewEventHandler(
 		lggr,
 		orm,
-		fetcher,
+		fetcher.Fetch,
 		wfstore.NewDBStore(db, lggr, clockwork.NewFakeClock()),
 		capabilities.NewRegistry(lggr),
 		custmsg.NewLabeler(),
@@ -944,7 +938,7 @@ func Test_Handler_SecretsFor_RefreshLogic(t *testing.T) {
 	h := NewEventHandler(
 		lggr,
 		orm,
-		fetcher,
+		fetcher.Fetch,
 		wfstore.NewDBStore(db, lggr, clockwork.NewFakeClock()),
 		capabilities.NewRegistry(lggr),
 		custmsg.NewLabeler(),

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -40,12 +40,12 @@ type mockFetcher struct {
 	responseMap map[string]mockFetchResp
 }
 
-func (m *mockFetcher) Fetch(_ context.Context, url string) ([]byte, error) {
-	return m.responseMap[url].Body, m.responseMap[url].Err
+func (m *mockFetcher) FetchMax(_ context.Context, cmd FetchMaxCmd) ([]byte, error) {
+	return m.responseMap[cmd.URL].Body, m.responseMap[cmd.URL].Err
 }
 
-func newMockFetcher(m map[string]mockFetchResp) FetcherFunc {
-	return (&mockFetcher{responseMap: m}).Fetch
+func newMockFetcher(m map[string]mockFetchResp) MaxFetcher {
+	return (&mockFetcher{responseMap: m})
 }
 
 type mockEngine struct {
@@ -70,6 +70,12 @@ func (m *mockEngine) HealthReport() map[string]error { return nil }
 
 func (m *mockEngine) Name() string { return "mockEngine" }
 
+type mockFetcherFunc func(ctx context.Context, cmd FetchMaxCmd) ([]byte, error)
+
+func (m mockFetcherFunc) FetchMax(ctx context.Context, cmd FetchMaxCmd) ([]byte, error) {
+	return m(ctx, cmd)
+}
+
 func Test_Handler(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	emitter := custmsg.NewLabeler()
@@ -89,9 +95,9 @@ func Test_Handler(t *testing.T) {
 			},
 		}
 
-		fetcher := func(_ context.Context, _ string) ([]byte, error) {
+		fetcher := mockFetcherFunc(func(_ context.Context, _ FetchMaxCmd) ([]byte, error) {
 			return []byte("contents"), nil
-		}
+		})
 		mockORM.EXPECT().GetSecretsURLByHash(matches.AnyContext, giveHash).Return(giveURL, nil)
 		mockORM.EXPECT().Update(matches.AnyContext, giveHash, "contents").Return(int64(1), nil)
 		h := NewEventHandler(lggr, mockORM, fetcher, nil, nil, emitter, clockwork.NewFakeClock(), workflowkey.Key{})
@@ -104,9 +110,9 @@ func Test_Handler(t *testing.T) {
 		ctx := testutils.Context(t)
 
 		giveEvent := WorkflowRegistryEvent{}
-		fetcher := func(_ context.Context, _ string) ([]byte, error) {
+		fetcher := mockFetcherFunc(func(_ context.Context, _ FetchMaxCmd) ([]byte, error) {
 			return []byte("contents"), nil
-		}
+		})
 
 		h := NewEventHandler(lggr, mockORM, fetcher, nil, nil, emitter, clockwork.NewFakeClock(), workflowkey.Key{})
 		err := h.Handle(ctx, giveEvent)
@@ -153,9 +159,9 @@ func Test_Handler(t *testing.T) {
 			},
 		}
 
-		fetcher := func(_ context.Context, _ string) ([]byte, error) {
+		fetcher := mockFetcherFunc(func(_ context.Context, _ FetchMaxCmd) ([]byte, error) {
 			return nil, assert.AnError
-		}
+		})
 		mockORM.EXPECT().GetSecretsURLByHash(matches.AnyContext, giveHash).Return(giveURL, nil)
 		h := NewEventHandler(lggr, mockORM, fetcher, nil, nil, emitter, clockwork.NewFakeClock(), workflowkey.Key{})
 		err = h.Handle(ctx, giveEvent)
@@ -179,9 +185,9 @@ func Test_Handler(t *testing.T) {
 			},
 		}
 
-		fetcher := func(_ context.Context, _ string) ([]byte, error) {
+		fetcher := mockFetcherFunc(func(_ context.Context, _ FetchMaxCmd) ([]byte, error) {
 			return []byte("contents"), nil
-		}
+		})
 		mockORM.EXPECT().GetSecretsURLByHash(matches.AnyContext, giveHash).Return(giveURL, nil)
 		mockORM.EXPECT().Update(matches.AnyContext, giveHash, "contents").Return(0, assert.AnError)
 		h := NewEventHandler(lggr, mockORM, fetcher, nil, nil, emitter, clockwork.NewFakeClock(), workflowkey.Key{})
@@ -420,7 +426,7 @@ type testCase struct {
 	GiveConfig      []byte
 	ConfigURL       string
 	WFOwner         []byte
-	fetcher         FetcherFunc
+	fetcher         MaxFetcher
 	Event           func([]byte) WorkflowRegistryWorkflowRegisteredV1
 	validationFn    func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler, wfOwner []byte, wfName string, wfID string)
 	engineFactoryFn func(ctx context.Context, wfid string, owner string, name string, config []byte, binary []byte) (services.Service, error)
@@ -813,7 +819,7 @@ func Test_Handler_SecretsFor(t *testing.T) {
 	h := NewEventHandler(
 		lggr,
 		orm,
-		fetcher.Fetch,
+		fetcher,
 		wfstore.NewDBStore(db, lggr, clockwork.NewFakeClock()),
 		capabilities.NewRegistry(lggr),
 		custmsg.NewLabeler(),
@@ -875,7 +881,7 @@ func Test_Handler_SecretsFor_RefreshesSecrets(t *testing.T) {
 	h := NewEventHandler(
 		lggr,
 		orm,
-		fetcher.Fetch,
+		fetcher,
 		wfstore.NewDBStore(db, lggr, clockwork.NewFakeClock()),
 		capabilities.NewRegistry(lggr),
 		custmsg.NewLabeler(),
@@ -938,7 +944,7 @@ func Test_Handler_SecretsFor_RefreshLogic(t *testing.T) {
 	h := NewEventHandler(
 		lggr,
 		orm,
-		fetcher.Fetch,
+		fetcher,
 		wfstore.NewDBStore(db, lggr, clockwork.NewFakeClock()),
 		capabilities.NewRegistry(lggr),
 		custmsg.NewLabeler(),

--- a/core/services/workflows/syncer/workflow_registry.go
+++ b/core/services/workflows/syncer/workflow_registry.go
@@ -90,7 +90,7 @@ type WorkflowLoadConfig struct {
 }
 
 // FetcherFunc is an abstraction for fetching the contents stored at a URL.
-type FetcherFunc func(ctx context.Context, url string) ([]byte, error)
+type FetcherFunc func(ctx context.Context, url string, n uint32) ([]byte, error)
 
 // ContractReader is a subset of types.ContractReader defined locally to enable mocking.
 type ContractReader interface {

--- a/core/web/resolver/testdata/config-empty-effective.toml
+++ b/core/web/resolver/testdata/config-empty-effective.toml
@@ -274,7 +274,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/web/resolver/testdata/config-empty-effective.toml
+++ b/core/web/resolver/testdata/config-empty-effective.toml
@@ -274,6 +274,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/web/resolver/testdata/config-empty-effective.toml
+++ b/core/web/resolver/testdata/config-empty-effective.toml
@@ -274,9 +274,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -53,10 +53,7 @@ ServerPubKey = 'test-pub-key-1'
 Enabled = true
 ForwardToUrl = 'http://localhost:9898'
 JsonWrapperKey = 'event'
-Headers = [
-    'Authorization: token',
-    'X-SomeOther-Header: value with spaces | and a bar+*',
-]
+Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
 
 [Log]
 Level = 'crit'
@@ -174,10 +171,7 @@ TraceLogging = true
 [P2P.V2]
 Enabled = false
 AnnounceAddresses = ['a', 'b', 'c']
-DefaultBootstrappers = [
-    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10',
-    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99',
-]
+DefaultBootstrappers = ['12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10', '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99']
 DeltaDial = '1m0s'
 DeltaReconcile = '1s'
 ListenAddresses = ['foo', 'bar']
@@ -266,10 +260,7 @@ TraceLogging = true
 [Capabilities.Peering.V2]
 Enabled = false
 AnnounceAddresses = ['a', 'b', 'c']
-DefaultBootstrappers = [
-    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10',
-    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99',
-]
+DefaultBootstrappers = ['12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10', '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99']
 DeltaDial = '1m0s'
 DeltaReconcile = '2s'
 ListenAddresses = ['foo', 'bar']
@@ -293,9 +284,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = '11155111'

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -293,7 +293,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = '11155111'

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -53,7 +53,10 @@ ServerPubKey = 'test-pub-key-1'
 Enabled = true
 ForwardToUrl = 'http://localhost:9898'
 JsonWrapperKey = 'event'
-Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
+Headers = [
+    'Authorization: token',
+    'X-SomeOther-Header: value with spaces | and a bar+*',
+]
 
 [Log]
 Level = 'crit'
@@ -171,7 +174,10 @@ TraceLogging = true
 [P2P.V2]
 Enabled = false
 AnnounceAddresses = ['a', 'b', 'c']
-DefaultBootstrappers = ['12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10', '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99']
+DefaultBootstrappers = [
+    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10',
+    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99',
+]
 DeltaDial = '1m0s'
 DeltaReconcile = '1s'
 ListenAddresses = ['foo', 'bar']
@@ -260,7 +266,10 @@ TraceLogging = true
 [Capabilities.Peering.V2]
 Enabled = false
 AnnounceAddresses = ['a', 'b', 'c']
-DefaultBootstrappers = ['12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10', '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99']
+DefaultBootstrappers = [
+    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10',
+    '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99',
+]
 DeltaDial = '1m0s'
 DeltaReconcile = '2s'
 ListenAddresses = ['foo', 'bar']
@@ -284,6 +293,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = '11155111'

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -47,7 +47,10 @@ UseBatchSend = true
 Enabled = true
 ForwardToUrl = 'http://localhost:9898'
 JsonWrapperKey = 'event'
-Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
+Headers = [
+    'Authorization: token',
+    'X-SomeOther-Header: value with spaces | and a bar+*',
+]
 
 [Log]
 Level = 'panic'
@@ -274,6 +277,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -47,10 +47,7 @@ UseBatchSend = true
 Enabled = true
 ForwardToUrl = 'http://localhost:9898'
 JsonWrapperKey = 'event'
-Headers = [
-    'Authorization: token',
-    'X-SomeOther-Header: value with spaces | and a bar+*',
-]
+Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
 
 [Log]
 Level = 'panic'
@@ -277,9 +274,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -277,7 +277,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1219,6 +1219,9 @@ but the host and port must be fully specified and cannot be empty. You can speci
 Address = '0x0' # Example
 NetworkID = 'evm' # Default
 ChainID = '1' # Default
+MaxBinarySize = '20.00mb' # Default
+MaxEncryptedSecretsSize = '26.40kb' # Default
+MaxConfigSize = '50.00kb' # Default
 ```
 
 
@@ -1239,6 +1242,24 @@ NetworkID identifies the target network where the remote registry is located.
 ChainID = '1' # Default
 ```
 ChainID identifies the target chain id where the remote registry is located.
+
+### MaxBinarySize
+```toml
+MaxBinarySize = '20.00mb' # Default
+```
+MaxBinarySize is the maximum size of a binary that can be fetched from the registry.
+
+### MaxEncryptedSecretsSize
+```toml
+MaxEncryptedSecretsSize = '26.40kb' # Default
+```
+MaxEncryptedSecretsSize is the maximum size of encrypted secrets that can be fetched from the given secrets url.
+
+### MaxConfigSize
+```toml
+MaxConfigSize = '50.00kb' # Default
+```
+MaxConfigSize is the maximum size of a config that can be fetched from the given config url.
 
 ## Capabilities.ExternalRegistry
 ```toml

--- a/testdata/scripts/config/merge_raw_configs.txtar
+++ b/testdata/scripts/config/merge_raw_configs.txtar
@@ -421,6 +421,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/config/merge_raw_configs.txtar
+++ b/testdata/scripts/config/merge_raw_configs.txtar
@@ -421,7 +421,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/config/merge_raw_configs.txtar
+++ b/testdata/scripts/config/merge_raw_configs.txtar
@@ -421,9 +421,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/default.txtar
+++ b/testdata/scripts/node/validate/default.txtar
@@ -286,9 +286,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/default.txtar
+++ b/testdata/scripts/node/validate/default.txtar
@@ -286,7 +286,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/default.txtar
+++ b/testdata/scripts/node/validate/default.txtar
@@ -286,6 +286,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -347,6 +347,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -347,9 +347,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -347,7 +347,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -330,7 +330,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -330,9 +330,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -330,6 +330,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -330,7 +330,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -330,9 +330,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -330,6 +330,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -330,7 +330,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -330,9 +330,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -330,6 +330,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/fallback-override.txtar
+++ b/testdata/scripts/node/validate/fallback-override.txtar
@@ -421,6 +421,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/fallback-override.txtar
+++ b/testdata/scripts/node/validate/fallback-override.txtar
@@ -421,7 +421,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/fallback-override.txtar
+++ b/testdata/scripts/node/validate/fallback-override.txtar
@@ -421,9 +421,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
+++ b/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
@@ -315,7 +315,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
+++ b/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
@@ -315,6 +315,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
+++ b/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
@@ -315,9 +315,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -320,7 +320,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -320,9 +320,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -320,6 +320,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -327,9 +327,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -327,7 +327,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -327,6 +327,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/warnings.txtar
+++ b/testdata/scripts/node/validate/warnings.txtar
@@ -309,6 +309,7 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
+MaxArtifactSize = '10mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/warnings.txtar
+++ b/testdata/scripts/node/validate/warnings.txtar
@@ -309,7 +309,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxArtifactSize = '10mb'
+MaxBinarySize = '10mb'
+MaxEncryptedSecretsSize = '5mb'
+MaxConfigSize = '5mb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''

--- a/testdata/scripts/node/validate/warnings.txtar
+++ b/testdata/scripts/node/validate/warnings.txtar
@@ -309,9 +309,9 @@ ChainID = '1'
 Address = ''
 NetworkID = 'evm'
 ChainID = '1'
-MaxBinarySize = '10mb'
-MaxEncryptedSecretsSize = '5mb'
-MaxConfigSize = '5mb'
+MaxBinarySize = '20.00mb'
+MaxEncryptedSecretsSize = '26.40kb'
+MaxConfigSize = '50.00kb'
 
 [Capabilities.GatewayConnector]
 ChainIDForNodeKey = ''


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

[CRE-91](https://smartcontract-it.atlassian.net/browse/CRE-91) impose limits on the size of artifacts that may be fetched by the gateway and sent back to a node.  three separate limits are set one each for binary, encrypted secrets and config.  The config values may be set by the WorkflowRegistry config.

Each limit is sent with the gateway request, if either the http client of the gateway has a smaller limit or the request has no limit, then the http client's default max response bytes will be used.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-91]: https://smartcontract-it.atlassian.net/browse/CRE-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ