### PR TITLE
common/types: move ChainStatusWithID and rename to NetworkChainStatus

### DIFF
--- a/common/types/chain.go
+++ b/common/types/chain.go
@@ -2,8 +2,6 @@ package types
 
 import (
 	"fmt"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
 // Sequence represents the base type, for any chain's sequence object.
@@ -16,10 +14,3 @@ type Sequence interface {
 // ID represents the base type, for any chain's ID.
 // It should be convertible to a string, that can uniquely identify this chain
 type ID fmt.Stringer
-
-// ChainStatusWithID compose of ChainStatus and RelayID. This is useful for
-// storing the Network associated with the ChainStatus.
-type ChainStatusWithID struct {
-	types.ChainStatus
-	types.RelayID
-}

--- a/core/services/chainlink/mocks/relayer_chain_interoperators.go
+++ b/core/services/chainlink/mocks/relayer_chain_interoperators.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"slices"
 
-	commonTypes "github.com/smartcontractkit/chainlink/v2/common/types"
 	services2 "github.com/smartcontractkit/chainlink/v2/core/services"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 
@@ -70,6 +69,6 @@ func (f *FakeRelayerChainInteroperators) ChainStatus(ctx context.Context, id typ
 	panic("unimplemented")
 }
 
-func (f *FakeRelayerChainInteroperators) ChainStatuses(ctx context.Context, offset, limit int) ([]commonTypes.ChainStatusWithID, int, error) {
+func (f *FakeRelayerChainInteroperators) ChainStatuses(ctx context.Context, offset, limit int) ([]chainlink.NetworkChainStatus, int, error) {
 	panic("unimplemented")
 }

--- a/core/services/chainlink/relayer_chain_interoperators.go
+++ b/core/services/chainlink/relayer_chain_interoperators.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 
-	commonTypes "github.com/smartcontractkit/chainlink/v2/common/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink/v2/core/services"
@@ -52,9 +51,15 @@ type LegacyChainer interface {
 	LegacyCosmosChains() LegacyCosmosContainer
 }
 
+// NetworkChainStatus is a ChainStatus from a particlar Network.
+type NetworkChainStatus struct {
+	Network string
+	types.ChainStatus
+}
+
 type ChainStatuser interface {
 	ChainStatus(ctx context.Context, id types.RelayID) (types.ChainStatus, error)
-	ChainStatuses(ctx context.Context, offset, limit int) ([]commonTypes.ChainStatusWithID, int, error)
+	ChainStatuses(ctx context.Context, offset, limit int) ([]NetworkChainStatus, int, error)
 }
 
 // NodesStatuser is an interface for node configuration and state.
@@ -279,9 +284,9 @@ func (rs *CoreRelayerChainInteroperators) ChainStatus(ctx context.Context, id ty
 	return lr.GetChainStatus(ctx)
 }
 
-func (rs *CoreRelayerChainInteroperators) ChainStatuses(ctx context.Context, offset, limit int) ([]commonTypes.ChainStatusWithID, int, error) {
+func (rs *CoreRelayerChainInteroperators) ChainStatuses(ctx context.Context, offset, limit int) ([]NetworkChainStatus, int, error) {
 	var (
-		stats    []commonTypes.ChainStatusWithID
+		stats    []NetworkChainStatus
 		totalErr error
 	)
 	rs.mu.Lock()
@@ -301,7 +306,7 @@ func (rs *CoreRelayerChainInteroperators) ChainStatuses(ctx context.Context, off
 			totalErr = errors.Join(totalErr, err)
 			continue
 		}
-		stats = append(stats, commonTypes.ChainStatusWithID{ChainStatus: stat, RelayID: rid})
+		stats = append(stats, NetworkChainStatus{ChainStatus: stat, Network: rid.Network})
 	}
 
 	if totalErr != nil {

--- a/core/web/chains_controller.go
+++ b/core/web/chains_controller.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
-	commonTypes "github.com/smartcontractkit/chainlink/v2/common/types"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/logger/audit"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -33,7 +32,7 @@ func (e errChainDisabled) Error() string {
 
 type chainsController struct {
 	chainStats  chainlink.RelayerChainInteroperators
-	newResource func(commonTypes.ChainStatusWithID) presenters.ChainResource
+	newResource func(chainlink.NetworkChainStatus) presenters.ChainResource
 	lggr        logger.Logger
 	auditLogger audit.AuditLogger
 }
@@ -71,7 +70,7 @@ func (cc *chainsController) Index(c *gin.Context, size, page, offset int) {
 func (cc *chainsController) Show(c *gin.Context) {
 	relayID := types.RelayID{Network: c.Param("network"), ChainID: c.Param("ID")}
 	chain, err := cc.chainStats.ChainStatus(c.Request.Context(), relayID)
-	status := commonTypes.ChainStatusWithID{ChainStatus: chain, RelayID: relayID}
+	status := chainlink.NetworkChainStatus{ChainStatus: chain, Network: relayID.Network}
 	if err != nil {
 		jsonAPIError(c, http.StatusBadRequest, err)
 		return

--- a/core/web/loader/chain.go
+++ b/core/web/loader/chain.go
@@ -8,7 +8,6 @@ import (
 
 	commonTypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 
-	"github.com/smartcontractkit/chainlink/v2/common/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
@@ -28,7 +27,7 @@ func (b *chainBatcher) loadByIDs(ctx context.Context, keys dataloader.Keys) []*d
 		keyOrder[key.String()] = ix
 	}
 
-	var cs []types.ChainStatusWithID
+	var cs []chainlink.NetworkChainStatus
 	relayersMap, err := b.app.GetRelayers().GetIDToRelayerMap()
 	if err != nil {
 		return []*dataloader.Result{{Data: nil, Error: err}}
@@ -41,9 +40,9 @@ func (b *chainBatcher) loadByIDs(ctx context.Context, keys dataloader.Keys) []*d
 		}
 
 		if slices.Contains(chainIDs, s.ID) {
-			cs = append(cs, types.ChainStatusWithID{
+			cs = append(cs, chainlink.NetworkChainStatus{
 				ChainStatus: s,
-				RelayID:     k,
+				Network:     k.Network,
 			})
 		}
 	}
@@ -94,9 +93,9 @@ func (b *chainBatcher) loadByRelayIDs(ctx context.Context, keys dataloader.Keys)
 			continue
 		}
 
-		results = append(results, &dataloader.Result{Data: types.ChainStatusWithID{
+		results = append(results, &dataloader.Result{Data: chainlink.NetworkChainStatus{
 			ChainStatus: status,
-			RelayID:     relay,
+			Network:     relay.Network,
 		}, Error: err})
 	}
 

--- a/core/web/loader/getters.go
+++ b/core/web/loader/getters.go
@@ -7,9 +7,9 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
-	commonTypes "github.com/smartcontractkit/chainlink/v2/common/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/feeds"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
@@ -21,7 +21,7 @@ var ErrInvalidType = errors.New("invalid type")
 
 // GetChainByID fetches the chain by it's id.
 // Deprecated: use GetChainByRelayID.
-func GetChainByID(ctx context.Context, id string) (*commonTypes.ChainStatusWithID, error) {
+func GetChainByID(ctx context.Context, id string) (*chainlink.NetworkChainStatus, error) {
 	ldr := For(ctx)
 
 	thunk := ldr.ChainsByIDLoader.Load(ctx, dataloader.StringKey(id))
@@ -30,7 +30,7 @@ func GetChainByID(ctx context.Context, id string) (*commonTypes.ChainStatusWithI
 		return nil, err
 	}
 
-	chain, ok := result.(commonTypes.ChainStatusWithID)
+	chain, ok := result.(chainlink.NetworkChainStatus)
 	if !ok {
 		return nil, ErrInvalidType
 	}
@@ -39,7 +39,7 @@ func GetChainByID(ctx context.Context, id string) (*commonTypes.ChainStatusWithI
 }
 
 // GetChainByRelayID fetches the chain by it's relayId.
-func GetChainByRelayID(ctx context.Context, id string) (*commonTypes.ChainStatusWithID, error) {
+func GetChainByRelayID(ctx context.Context, id string) (*chainlink.NetworkChainStatus, error) {
 	ldr := For(ctx)
 
 	thunk := ldr.ChainsByRelayIDLoader.Load(ctx, dataloader.StringKey(id))
@@ -48,7 +48,7 @@ func GetChainByRelayID(ctx context.Context, id string) (*commonTypes.ChainStatus
 		return nil, err
 	}
 
-	chain, ok := result.(commonTypes.ChainStatusWithID)
+	chain, ok := result.(chainlink.NetworkChainStatus)
 	if !ok {
 		return nil, ErrInvalidType
 	}

--- a/core/web/loader/loader_test.go
+++ b/core/web/loader/loader_test.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/common/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	evmtxmgrmocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/mocks"
 	evmutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 
 	ubig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils/big"
@@ -73,17 +73,17 @@ func TestLoader_Chains(t *testing.T) {
 	assert.Len(t, results, 3)
 
 	require.NoError(t, err)
-	want2 := types.ChainStatusWithID{
+	want2 := chainlink.NetworkChainStatus{
 		ChainStatus: commontypes.ChainStatus{ID: "2", Enabled: true, Config: config2},
-		RelayID:     commontypes.RelayID{Network: relay.NetworkEVM, ChainID: "2"},
+		Network:     relay.NetworkEVM,
 	}
-	assert.Equal(t, want2, results[0].Data.(types.ChainStatusWithID))
+	assert.Equal(t, want2, results[0].Data.(chainlink.NetworkChainStatus))
 
-	want1 := types.ChainStatusWithID{
+	want1 := chainlink.NetworkChainStatus{
 		ChainStatus: commontypes.ChainStatus{ID: "1", Enabled: true, Config: config1},
-		RelayID:     commontypes.RelayID{Network: relay.NetworkEVM, ChainID: "1"},
+		Network:     relay.NetworkEVM,
 	}
-	assert.Equal(t, want1, results[1].Data.(types.ChainStatusWithID))
+	assert.Equal(t, want1, results[1].Data.(chainlink.NetworkChainStatus))
 	assert.Nil(t, results[2].Data)
 	assert.Error(t, results[2].Error)
 	assert.ErrorIs(t, results[2].Error, chains.ErrNotFound)
@@ -148,15 +148,15 @@ func TestLoader_ChainsRelayID_HandleDuplicateIDAcrossNetworks(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Equal(t, types.ChainStatusWithID{
+	assert.Equal(t, chainlink.NetworkChainStatus{
 		ChainStatus: commontypes.ChainStatus{ID: "2", Enabled: true, Config: config2},
-		RelayID:     evm2,
-	}, results[0].Data.(types.ChainStatusWithID))
+		Network:     evm2.Network,
+	}, results[0].Data.(chainlink.NetworkChainStatus))
 
-	assert.Equal(t, types.ChainStatusWithID{
+	assert.Equal(t, chainlink.NetworkChainStatus{
 		ChainStatus: commontypes.ChainStatus{ID: "1", Enabled: true, Config: config1},
-		RelayID:     evm1,
-	}, results[1].Data.(types.ChainStatusWithID))
+		Network:     evm1.Network,
+	}, results[1].Data.(chainlink.NetworkChainStatus))
 	assert.Nil(t, results[2].Data)
 	require.Error(t, results[2].Error)
 	require.ErrorIs(t, results[2].Error, chains.ErrNotFound)

--- a/core/web/presenters/chain.go
+++ b/core/web/presenters/chain.go
@@ -2,7 +2,7 @@ package presenters
 
 import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-	commonTypes "github.com/smartcontractkit/chainlink/v2/common/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
 type ChainResource struct {
@@ -18,10 +18,10 @@ func (r ChainResource) GetName() string {
 }
 
 // NewChainResource returns a new ChainResource for chain.
-func NewChainResource(chain commonTypes.ChainStatusWithID) ChainResource {
+func NewChainResource(chain chainlink.NetworkChainStatus) ChainResource {
 	return ChainResource{
-		JAID:    NewJAID(chain.RelayID.ChainID),
-		Network: chain.RelayID.Network,
+		JAID:    NewJAID(chain.ID),
+		Network: chain.Network,
 		Config:  chain.Config,
 		Enabled: chain.Enabled,
 	}

--- a/core/web/resolver/chain.go
+++ b/core/web/resolver/chain.go
@@ -3,19 +3,19 @@ package resolver
 import (
 	"github.com/graph-gophers/graphql-go"
 
-	"github.com/smartcontractkit/chainlink/v2/common/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
 // ChainResolver resolves the Chain type.
 type ChainResolver struct {
-	chain types.ChainStatusWithID
+	chain chainlink.NetworkChainStatus
 }
 
-func NewChain(chain types.ChainStatusWithID) *ChainResolver {
+func NewChain(chain chainlink.NetworkChainStatus) *ChainResolver {
 	return &ChainResolver{chain: chain}
 }
 
-func NewChains(chains []types.ChainStatusWithID) []*ChainResolver {
+func NewChains(chains []chainlink.NetworkChainStatus) []*ChainResolver {
 	var resolvers []*ChainResolver
 	for _, c := range chains {
 		resolvers = append(resolvers, NewChain(c))
@@ -45,11 +45,11 @@ func (r *ChainResolver) Network() string {
 }
 
 type ChainPayloadResolver struct {
-	chain types.ChainStatusWithID
+	chain chainlink.NetworkChainStatus
 	NotFoundErrorUnionType
 }
 
-func NewChainPayload(chain types.ChainStatusWithID, err error) *ChainPayloadResolver {
+func NewChainPayload(chain chainlink.NetworkChainStatus, err error) *ChainPayloadResolver {
 	e := NotFoundErrorUnionType{err: err, message: "chain not found", isExpectedErrorFn: nil}
 
 	return &ChainPayloadResolver{chain: chain, NotFoundErrorUnionType: e}
@@ -64,11 +64,11 @@ func (r *ChainPayloadResolver) ToChain() (*ChainResolver, bool) {
 }
 
 type ChainsPayloadResolver struct {
-	chains []types.ChainStatusWithID
+	chains []chainlink.NetworkChainStatus
 	total  int32
 }
 
-func NewChainsPayload(chains []types.ChainStatusWithID, total int32) *ChainsPayloadResolver {
+func NewChainsPayload(chains []chainlink.NetworkChainStatus, total int32) *ChainsPayloadResolver {
 	return &ChainsPayloadResolver{chains: chains, total: total}
 }
 


### PR DESCRIPTION
`ChainStatusWithID` is a core type that doesn't belong in the `common/` subtree, which is for chain-agnostic code that will be moved to `chainlink-framework/`.

It was also defined in a redundant way, with two Network fields.