### PR TITLE
Refactor beholder entity

### DIFF
--- a/core/chains/evm/txm/metrics.go
+++ b/core/chains/evm/txm/metrics.go
@@ -112,7 +112,7 @@ func (m *txmMetrics) EmitTxMessage(ctx context.Context, tx common.Hash, fromAddr
 		ctx,
 		messageBytes,
 		"beholder_domain", "svr",
-		"beholder_entity", "TxMessage",
+		"beholder_entity", "pb.TxMessage",
 		"beholder_data_schema", "/beholder-tx-message/versions/1",
 	)
 


### PR DESCRIPTION
Context in this [Slack thread](https://chainlink-core.slack.com/archives/C06QQCU1SGH/p1736533777878599)

Following the new convention, refactor the beholder entity `TxMessage` to `pb.TxMessage`
