### PR TITLE
Migrating the workflows that are using CRIB and GAP V2 to the latest GHA versions

### DIFF
--- a/.github/actions/crib/action.yml
+++ b/.github/actions/crib/action.yml
@@ -21,9 +21,6 @@ inputs:
   api-gw-host-k8s:
     description: "API Gateway Host for K8s"
     required: true
-  k8s-api-endpoint:
-    description: "Kubernetes API endpoint"
-    required: true
   k8s-cluster-name:
     description: "Kubernetes cluster name"
     required: true
@@ -64,7 +61,12 @@ inputs:
     description: "Whether to run integration tests"
     required: false
     default: "true"
-
+  main-dns-zone:
+    description:
+      "The DNS zone is used for exposing services. It is required when using the
+      dynamic local proxy to prevent sending requests and exposing sensitive
+      information to random external endpoints. This ensures that the dynamic
+      local proxy is used only for the specific DNS zone."
 runs:
   using: "composite"
   steps:
@@ -110,7 +112,7 @@ runs:
         aws-role-duration-seconds: "1800"
 
     - name: Deploy and validate CRIB Environment for Core
-      uses: smartcontractkit/.github/actions/crib-deploy-environment@815e0d550527897746e889441407926d7e28169c # crib-deploy-environment@7.4.0
+      uses: smartcontractkit/.github/actions/crib-deploy-environment@265e28cc322771651688493303785323e3482b15 # crib-deploy-environment@8.2.1
       id: deploy-crib
       with:
         github-token: ${{ steps.token.outputs.access-token }}
@@ -118,7 +120,6 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         aws-role-arn: ${{ inputs.aws-role-arn }}
         ingress-base-domain: ${{ inputs.ingress-base-domain }}
-        k8s-api-endpoint: ${{ inputs.k8s-api-endpoint }}
         k8s-cluster-name: ${{ inputs.k8s-cluster-name }}
         chainlink-team: releng
         chainlink-product: crib
@@ -127,6 +128,7 @@ runs:
         product-image: ${{ inputs.crib-chainlink-docker-image-name }}
         product-image-tag: ${{ inputs.crib-chainlink-docker-image-tag }}
         ns-ttl: ${{ inputs.crib-cleanup-ttl }}
+        main-dns-zone: ${{ inputs.main-dns-zone }}
 
     - name: Set up Go
       uses: ./.github/actions/setup-go

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -33,7 +33,6 @@ jobs:
           aws-account-id: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           api-gw-host-crib: ${{ secrets.AWS_API_GW_HOST_CRIB_STAGE }}
           api-gw-host-k8s: ${{ secrets.AWS_API_GW_HOST_K8S_STAGE }}
-          k8s-api-endpoint: ${{ secrets.GAP_HOST_K8S_STAGE }}
           k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_STAGE }}
           aws-token-issuer-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-token-issuer-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
@@ -43,3 +42,4 @@ jobs:
           crib-alert-slack-webhook: ${{ secrets.CRIB_ALERT_SLACK_WEBHOOK }}
           crib-chainlink-docker-image-name: ${{ secrets.AWS_SDLC_ECR_HOSTNAME }}/chainlink
           crib-chainlink-docker-image-tag: develop
+          main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_STAGE }}

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -43,7 +43,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@80366cb090f714f9842da4ced1102f4a0e805f20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@fb79097de87a6391457ccc36f82387746d1cef55
     with:
       test_path: .github/e2e-tests.yml
       test_ids: ${{ inputs.testToRun}}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

Migrating some of the workflows that uses GAP v2 to the latest versions. 

Ticket: https://smartcontract-it.atlassian.net/browse/RE-3415

### Test

See: https://github.com/smartcontractkit/chainlink/actions/runs/12808706702/job/35712074674

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->
N/A
### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
N/A