### PR TITLE
Fix(core/scripts):  removes panic and adds node public keys to peer

### DIFF
--- a/.changeset/eight-meals-march.md
+++ b/.changeset/eight-meals-march.md
@@ -1,0 +1,7 @@
+---
+"chainlink": patch
+---
+
+Prevents a panic in test helper for confirming transaction
+and adds encrypted public key to a peer before calling addNodes
+on CapabilitiesRegistry

--- a/core/scripts/common/helpers.go
+++ b/core/scripts/common/helpers.go
@@ -298,6 +298,11 @@ func TenderlySimLink(simID string) string {
 
 // ConfirmTXMined confirms that the given transaction is mined and prints useful execution information.
 func ConfirmTXMined(context context.Context, client *ethclient.Client, transaction *types.Transaction, chainID int64, txInfo ...string) (receipt *types.Receipt) {
+	if transaction == nil {
+		fmt.Println("No transaction to confirm")
+		return
+	}
+
 	fmt.Println("Executing TX", ExplorerLink(chainID, transaction.Hash()), txInfo)
 	receipt, err := bind.WaitMined(context, client, transaction)
 	PanicErr(err)

--- a/core/scripts/keystone/src/88_capabilities_registry_helpers.go
+++ b/core/scripts/keystone/src/88_capabilities_registry_helpers.go
@@ -554,13 +554,23 @@ func peerToNode(nopID uint32, p peer) (kcr.CapabilitiesRegistryNodeParams, error
 		return kcr.CapabilitiesRegistryNodeParams{}, fmt.Errorf("failed to convert signer: %w", err)
 	}
 
+	epk := strings.TrimPrefix(p.EncryptionPublicKey, "0x")
+	epkB, err := hex.DecodeString(epk)
+	if err != nil {
+		return kcr.CapabilitiesRegistryNodeParams{}, fmt.Errorf("failed to convert encryptionPublicKey: %w", err)
+	}
+
+	var epkb [32]byte
+	copy(epkb[:], epkB)
+
 	var sigb [32]byte
 	copy(sigb[:], signerB)
 
 	return kcr.CapabilitiesRegistryNodeParams{
-		NodeOperatorId: nopID,
-		P2pId:          peerIDB,
-		Signer:         sigb,
+		NodeOperatorId:      nopID,
+		P2pId:               peerIDB,
+		Signer:              sigb,
+		EncryptionPublicKey: epkb,
 	}, nil
 }
 


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

The CapabilitiesRegistry contract requires that the peers have an `encryptionPublicKey` field or else the transaction will revert.  This PR adds the hardcoded node's EPK to create the node params before calling addNodes.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
