### PR TITLE
fix: ci-core use all modules for scheduled runs

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -112,9 +112,17 @@ jobs:
       - name: Resolve affected files to affected modules
         id: resolved-modules
         shell: bash
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Ensure the step uses `with.list-files: json` to get the list of files in JSON format
-          bash ./.github/scripts/map-affected-files-to-modules.sh '${{ steps.match-every.outputs.all_files }}'
+          # if scheduled, run for all modules. Otherwise, run for only affected modules.
+          if [[ "$GH_EVENT_NAME" == "schedule" ]]; then
+            json_array=$(find . -name 'go.mod' -exec dirname {} \; | sed 's|^./||' | uniq |  jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "module_names=$json_array" >> "$GITHUB_OUTPUT"            
+          else
+            # Ensure the step uses `with.list-files: json` to get the list of files in JSON format
+            bash ./.github/scripts/map-affected-files-to-modules.sh '${{ steps.match-every.outputs.all_files }}'
+          fi
   
   golangci:
     name: GolangCI Lint


### PR DESCRIPTION
### Changes

Update `ci-core - detect changes` to resolve to all modules for scheduled events.

### Motivation

https://github.com/smartcontractkit/chainlink/actions/runs/12828691642/job/35773270097

The step was failing to resolve changed files to affected modules during scheduled runs because it was listing all files. This argument was too large. Instead of invoking the shell script during scheduled runs, it resolves to all modules.

### Testing

https://github.com/smartcontractkit/chainlink/actions/runs/12837313249/job/35800734272?pr=15976
- Ran with the shell one liner, it resolved to all modules
