### PR TITLE
Add logic to calculate gas deviation based on fitted curve

### DIFF
--- a/.changeset/young-terms-prove.md
+++ b/.changeset/young-terms-prove.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#added a new way to calculate CCIP gas deviation thresholds using a sliding curve approach

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
@@ -88,7 +88,10 @@ func DeviatesOnGasCurve(xNew, xOld, noDeviationLowerBound *big.Int, ppb int64) b
 	xNewFloat := new(big.Float).SetInt(xNew)
 	xNewFloat64, _ := xNewFloat.Float64()
 
-	// Calculate the deviation threshold percentage with xNew using the formula: y = (10e11) / (x^0.665)
+	// Calculate the deviation threshold percentage with xNew using the formula: y = (10e11) / (xNew^0.665)
+	// We use xNew to generate the threshold so that when going from cheap --> expensive, xNew generates a smaller
+	// deviation threshold so we are more likely to update the gas price on chain. When going from expensive --> cheap,
+	// xNew generates a larger deviation threshold since it's not as urgent to update the gas price on chain.
 	const constantFactor = 10e11
 	const exponent = 0.665
 	xNewPower := math.Pow(xNewFloat64, exponent)

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
@@ -96,8 +96,8 @@ func DeviatesOnCurve(xNew, xOld, noDeviationLowerBound *big.Int, ppb int64) bool
 	return Deviates(xNew, xOld, curveThresholdPPB)
 }
 
-// calculateCurveThresholdPPB calculates the deviation threshold percentage with xNew using the formula:
-// y = (10e11) / (xNew^0.665).
+// calculateCurveThresholdPPB calculates the deviation threshold percentage with x using the formula:
+// y = (10e11) / (x^0.665).
 func calculateCurveThresholdPPB(x float64) int64 {
 	const constantFactor = 10e11
 	const exponent = 0.665

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	// DESTINATION_ETH_PPB_GATE is the deviation threshold when writing to ethereum's PriceRegistry
-	EthereumThresholdGatePPB = 4e9
+	// CurveBasedDeviationPPB is the deviation threshold when writing to ethereum's PriceRegistry and is the trigger for
+	// using curve-based deviation logic.
+	CurveBasedDeviationPPB = 4e9
 )
 
 // ContiguousReqs checks if seqNrs contains all numbers from min to max.
@@ -70,13 +71,13 @@ func Deviates(x1, x2 *big.Int, ppb int64) bool {
 	return diff.CmpAbs(big.NewInt(ppb)) > 0 // abs(diff) > ppb
 }
 
-// DeviatesOnGasCurve calculates a deviation threshold on the fly using xNew. For now it's only used for gas price
+// DeviatesOnCurve calculates a deviation threshold on the fly using xNew. For now it's only used for gas price
 // deviation calculation. It's important to make sure the order of xNew and xOld is correct when passed into this
 // function to get an accurate deviation threshold.
-func DeviatesOnGasCurve(xNew, xOld, noDeviationLowerBound *big.Int, ppb int64) bool {
+func DeviatesOnCurve(xNew, xOld, noDeviationLowerBound *big.Int, ppb int64) bool {
 	// This is a temporary gating mechanism that ensures we only apply the gas curve deviation logic to eth-bound price
 	// updates. If ppb from config is not equal to 4000000000, do not apply the gas curve.
-	if ppb != EthereumThresholdGatePPB {
+	if ppb != CurveBasedDeviationPPB {
 		return Deviates(xOld, xNew, ppb)
 	}
 
@@ -88,19 +89,24 @@ func DeviatesOnGasCurve(xNew, xOld, noDeviationLowerBound *big.Int, ppb int64) b
 	xNewFloat := new(big.Float).SetInt(xNew)
 	xNewFloat64, _ := xNewFloat.Float64()
 
-	// Calculate the deviation threshold percentage with xNew using the formula: y = (10e11) / (xNew^0.665)
 	// We use xNew to generate the threshold so that when going from cheap --> expensive, xNew generates a smaller
 	// deviation threshold so we are more likely to update the gas price on chain. When going from expensive --> cheap,
 	// xNew generates a larger deviation threshold since it's not as urgent to update the gas price on chain.
+	curveThresholdPPB := calculateCurveThresholdPPB(xNewFloat64)
+	return Deviates(xNew, xOld, curveThresholdPPB)
+}
+
+// calculateCurveThresholdPPB calculates the deviation threshold percentage with xNew using the formula:
+// y = (10e11) / (xNew^0.665).
+func calculateCurveThresholdPPB(x float64) int64 {
 	const constantFactor = 10e11
 	const exponent = 0.665
-	xNewPower := math.Pow(xNewFloat64, exponent)
-	threshold := constantFactor / xNewPower
+	xPower := math.Pow(x, exponent)
+	threshold := constantFactor / xPower
 
-	// Convert percentage to PPB
+	// Convert curve output percentage to PPB
 	thresholdPPB := int64(threshold * 1e7)
-
-	return Deviates(xNew, xOld, thresholdPPB)
+	return thresholdPPB
 }
 
 func MergeEpochAndRound(epoch uint32, round uint8) uint64 {

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
@@ -97,7 +97,14 @@ func DeviatesOnCurve(xNew, xOld, noDeviationLowerBound *big.Int, ppb int64) bool
 }
 
 // calculateCurveThresholdPPB calculates the deviation threshold percentage with x using the formula:
-// y = (10e11) / (x^0.665).
+// y = (10e11) / (x^0.665). This sliding scale curve was created by collecting several thousands of historical
+// PriceRegistry gas price update samples from chains with volatile gas prices like Zircuit and Mode and then using that
+// historical data to define thresholds of gas deviations that were acceptable given their USD value. The gas prices
+// (X coordinates) and these new thresholds (Y coordinates) were used to fit this sliding scale curve that returns large
+// thresholds at low gas prices and smaller thresholds at higher gas prices. Constructing the curve in USD terms allows
+// us to more easily reason about these thresholds and also better translates to non-evm chains. For example, when the
+// per unit gas price is 0.000006 USD, (6e12 USDgwei), the curve will output a threshold of around 3,000%. However, when
+// the per unit gas price is 0.005 USD (5e15 USDgwei), the curve will output a threshold of only ~30%.
 func calculateCurveThresholdPPB(x float64) int64 {
 	const constantFactor = 10e11
 	const exponent = 0.665

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
@@ -8,6 +8,11 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
+const (
+	// DESTINATION_ETH_PPB_GATE is the deviation threshold when writing to ethereum's PriceRegistry
+	ETHEREUM_THRESHOLD_GATE_PPB = 4e9
+)
+
 // ContiguousReqs checks if seqNrs contains all numbers from min to max.
 func ContiguousReqs(lggr logger.Logger, min, max uint64, seqNrs []uint64) bool {
 	if int(max-min+1) != len(seqNrs) {
@@ -68,26 +73,31 @@ func Deviates(x1, x2 *big.Int, ppb int64) bool {
 // DeviatesOnGasCurve calculates a deviation threshold on the fly using xNew. For now it's only used for gas price
 // deviation calculation. It's important to make sure the order of xNew and xOld is correct when passed into this
 // function to get an accurate deviation threshold.
-func DeviatesOnGasCurve(xNew, xOld *big.Int, ppb int64) bool {
-	// If ppb from config is not equal to 4000000000, do not apply the gas curve. This is a temporary gating mechanism
-	// that ensures we only apply the gas curve deviation logic to eth-bound price updates.
-	if ppb != 4000000000 {
+func DeviatesOnGasCurve(xNew, xOld, noDeviationLowerBound *big.Int, ppb int64) bool {
+	// This is a temporary gating mechanism that ensures we only apply the gas curve deviation logic to eth-bound price
+	// updates. If ppb from config is not equal to 4000000000, do not apply the gas curve.
+	if ppb != ETHEREUM_THRESHOLD_GATE_PPB {
 		return Deviates(xOld, xNew, ppb)
+	}
+
+	// If xNew < noDeviationLowerBound, Deviates should never be true
+	if xNew.Cmp(noDeviationLowerBound) < 0 {
+		return false
 	}
 
 	xNewFloat := new(big.Float).SetInt(xNew)
 	xNewFloat64, _ := xNewFloat.Float64()
 
-	// Calculate the deviation threshold percentage with xNew using the formula: y = (5.64e10) / (x^0.654)
-	const constantFactor = 5.64e10
-	const exponent = 0.654
+	// Calculate the deviation threshold percentage with xNew using the formula: y = (10e11) / (x^0.665)
+	const constantFactor = 10e11
+	const exponent = 0.665
 	xNewPower := math.Pow(xNewFloat64, exponent)
 	threshold := constantFactor / xNewPower
 
 	// Convert percentage to PPB
 	thresholdPPB := int64(threshold * 1e7)
 
-	return Deviates(xOld, xNew, thresholdPPB)
+	return Deviates(xNew, xOld, thresholdPPB)
 }
 
 func MergeEpochAndRound(epoch uint32, round uint8) uint64 {

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// DESTINATION_ETH_PPB_GATE is the deviation threshold when writing to ethereum's PriceRegistry
-	ETHEREUM_THRESHOLD_GATE_PPB = 4e9
+	EthereumThresholdGatePPB = 4e9
 )
 
 // ContiguousReqs checks if seqNrs contains all numbers from min to max.
@@ -76,7 +76,7 @@ func Deviates(x1, x2 *big.Int, ppb int64) bool {
 func DeviatesOnGasCurve(xNew, xOld, noDeviationLowerBound *big.Int, ppb int64) bool {
 	// This is a temporary gating mechanism that ensures we only apply the gas curve deviation logic to eth-bound price
 	// updates. If ppb from config is not equal to 4000000000, do not apply the gas curve.
-	if ppb != ETHEREUM_THRESHOLD_GATE_PPB {
+	if ppb != EthereumThresholdGatePPB {
 		return Deviates(xOld, xNew, ppb)
 	}
 

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
@@ -1,6 +1,7 @@
 package ccipcalc
 
 import (
+	"math"
 	"math/big"
 	"sort"
 
@@ -62,6 +63,31 @@ func Deviates(x1, x2 *big.Int, ppb int64) bool {
 		diff.Div(diff, x1)
 	}
 	return diff.CmpAbs(big.NewInt(ppb)) > 0 // abs(diff) > ppb
+}
+
+// DeviatesOnGasCurve calculates a deviation threshold on the fly using xNew. For now it's only used for gas price
+// deviation calculation. It's important to make sure the order of xNew and xOld is correct when passed into this
+// function to get an accurate deviation threshold.
+func DeviatesOnGasCurve(xNew, xOld *big.Int, ppb int64) bool {
+	// If ppb from config is not equal to 4000000000, do not apply the gas curve. This is a temporary gating mechanism
+	// that ensures we only apply the gas curve deviation logic to eth-bound price updates.
+	if ppb != 4000000000 {
+		return Deviates(xOld, xNew, ppb)
+	}
+
+	xNewFloat := new(big.Float).SetInt(xNew)
+	xNewFloat64, _ := xNewFloat.Float64()
+
+	// Calculate the deviation threshold percentage with xNew using the formula: y = (5.64e10) / (x^0.654)
+	const constantFactor = 5.64e10
+	const exponent = 0.654
+	xNewPower := math.Pow(xNewFloat64, exponent)
+	threshold := constantFactor / xNewPower
+
+	// Convert percentage to PPB
+	thresholdPPB := int64(threshold * 1e7)
+
+	return Deviates(xOld, xNew, thresholdPPB)
 }
 
 func MergeEpochAndRound(epoch uint32, round uint8) uint64 {

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
@@ -233,37 +233,37 @@ func TestDeviatesOnGasCurve(t *testing.T) {
 	}{
 		{
 			name: "base case deviates from increase",
-			args: args{xNew: big.NewInt(4e14), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			args: args{xNew: big.NewInt(4e14), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: EthereumThresholdGatePPB},
 			want: true,
 		},
 		{
 			name: "base case deviates from decrease",
-			args: args{xNew: big.NewInt(1e13), xOld: big.NewInt(4e15), noDev: big.NewInt(1), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			args: args{xNew: big.NewInt(1e13), xOld: big.NewInt(4e15), noDev: big.NewInt(1), ppb: EthereumThresholdGatePPB},
 			want: true,
 		},
 		{
 			name: "does not deviate when equal",
-			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: EthereumThresholdGatePPB},
 			want: false,
 		},
 		{
 			name: "does not deviate with small difference when xNew is bigger",
-			args: args{xNew: big.NewInt(3e14 + 1), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			args: args{xNew: big.NewInt(3e14 + 1), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: EthereumThresholdGatePPB},
 			want: false,
 		},
 		{
 			name: "does not deviate with small difference when xOld is bigger",
-			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14 + 1), noDev: big.NewInt(3e13), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14 + 1), noDev: big.NewInt(3e13), ppb: EthereumThresholdGatePPB},
 			want: false,
 		},
 		{
-			name: "deviates when ppb is not equal to ETHEREUM_THRESHOLD_GATE_PPB",
+			name: "deviates when ppb is not equal to EthereumThresholdGatePPB",
 			args: args{xNew: big.NewInt(1e9), xOld: big.NewInt(2e9), noDev: big.NewInt(1), ppb: 1},
 			want: true,
 		},
 		{
 			name: "does not deviate when xNew is below noDeviationLowerBound",
-			args: args{xNew: big.NewInt(2e13), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			args: args{xNew: big.NewInt(2e13), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: EthereumThresholdGatePPB},
 			want: false,
 		},
 		// thresholdPPB = (10e11) / (xNew^0.665) * 1e7
@@ -271,12 +271,12 @@ func TestDeviatesOnGasCurve(t *testing.T) {
 		// Deviates = abs(diff) > thresholdPPB
 		{
 			name: "xNew is just below deviation threshold and does deviate",
-			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12), noDev: big.NewInt(1), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12), noDev: big.NewInt(1), ppb: EthereumThresholdGatePPB},
 			want: false,
 		},
 		{
 			name: "xNew is just above deviation threshold and does deviate",
-			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12 - 30), noDev: big.NewInt(1), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12 - 30), noDev: big.NewInt(1), ppb: EthereumThresholdGatePPB},
 			want: true,
 		},
 	}

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
@@ -218,3 +218,75 @@ func TestDeviates(t *testing.T) {
 		})
 	}
 }
+
+func TestDeviatesOnGasCurve(t *testing.T) {
+	type args struct {
+		xNew  *big.Int
+		xOld  *big.Int
+		noDev *big.Int
+		ppb   int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "base case deviates from increase",
+			args: args{xNew: big.NewInt(4e14), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			want: true,
+		},
+		{
+			name: "base case deviates from decrease",
+			args: args{xNew: big.NewInt(1e13), xOld: big.NewInt(4e15), noDev: big.NewInt(1), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			want: true,
+		},
+		{
+			name: "does not deviate when equal",
+			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			want: false,
+		},
+		{
+			name: "does not deviate with small difference when xNew is bigger",
+			args: args{xNew: big.NewInt(3e14 + 1), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			want: false,
+		},
+		{
+			name: "does not deviate with small difference when xOld is bigger",
+			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14 + 1), noDev: big.NewInt(3e13), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			want: false,
+		},
+		{
+			name: "deviates when ppb is not equal to ETHEREUM_THRESHOLD_GATE_PPB",
+			args: args{xNew: big.NewInt(1e9), xOld: big.NewInt(2e9), noDev: big.NewInt(1), ppb: 1},
+			want: true,
+		},
+		{
+			name: "does not deviate when xNew is below noDeviationLowerBound",
+			args: args{xNew: big.NewInt(2e13), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			want: false,
+		},
+		// thresholdPPB = (10e11) / (xNew^0.665) * 1e7
+		// diff = (xNew - xOld) / min(xNew, xOld) * 1e9
+		// Deviates = abs(diff) > thresholdPPB
+		{
+			name: "xNew is just below deviation threshold and does deviate",
+			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12), noDev: big.NewInt(1), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			want: false,
+		},
+		{
+			name: "xNew is just above deviation threshold and does deviate",
+			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12 - 30), noDev: big.NewInt(1), ppb: ETHEREUM_THRESHOLD_GATE_PPB},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(
+				t,
+				tt.want,
+				DeviatesOnGasCurve(tt.args.xNew, tt.args.xOld, tt.args.noDev, tt.args.ppb),
+				"DeviatesOnGasCurve(%v, %v, %v, %v)", tt.args.xNew, tt.args.xOld, tt.args.noDev, tt.args.ppb)
+		})
+	}
+}

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
@@ -1,6 +1,7 @@
 package ccipcalc
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 	"testing"
@@ -233,37 +234,37 @@ func TestDeviatesOnGasCurve(t *testing.T) {
 	}{
 		{
 			name: "base case deviates from increase",
-			args: args{xNew: big.NewInt(4e14), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: EthereumThresholdGatePPB},
+			args: args{xNew: big.NewInt(4e14), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
 			want: true,
 		},
 		{
 			name: "base case deviates from decrease",
-			args: args{xNew: big.NewInt(1e13), xOld: big.NewInt(4e15), noDev: big.NewInt(1), ppb: EthereumThresholdGatePPB},
+			args: args{xNew: big.NewInt(1e13), xOld: big.NewInt(4e15), noDev: big.NewInt(1), ppb: CurveBasedDeviationPPB},
 			want: true,
 		},
 		{
 			name: "does not deviate when equal",
-			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: EthereumThresholdGatePPB},
+			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
 			want: false,
 		},
 		{
 			name: "does not deviate with small difference when xNew is bigger",
-			args: args{xNew: big.NewInt(3e14 + 1), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: EthereumThresholdGatePPB},
+			args: args{xNew: big.NewInt(3e14 + 1), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
 			want: false,
 		},
 		{
 			name: "does not deviate with small difference when xOld is bigger",
-			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14 + 1), noDev: big.NewInt(3e13), ppb: EthereumThresholdGatePPB},
+			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14 + 1), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
 			want: false,
 		},
 		{
-			name: "deviates when ppb is not equal to EthereumThresholdGatePPB",
+			name: "deviates when ppb is not equal to CurveBasedDeviationPPB",
 			args: args{xNew: big.NewInt(1e9), xOld: big.NewInt(2e9), noDev: big.NewInt(1), ppb: 1},
 			want: true,
 		},
 		{
 			name: "does not deviate when xNew is below noDeviationLowerBound",
-			args: args{xNew: big.NewInt(2e13), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: EthereumThresholdGatePPB},
+			args: args{xNew: big.NewInt(2e13), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
 			want: false,
 		},
 		// thresholdPPB = (10e11) / (xNew^0.665) * 1e7
@@ -271,12 +272,12 @@ func TestDeviatesOnGasCurve(t *testing.T) {
 		// Deviates = abs(diff) > thresholdPPB
 		{
 			name: "xNew is just below deviation threshold and does deviate",
-			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12), noDev: big.NewInt(1), ppb: EthereumThresholdGatePPB},
+			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12), noDev: big.NewInt(1), ppb: CurveBasedDeviationPPB},
 			want: false,
 		},
 		{
 			name: "xNew is just above deviation threshold and does deviate",
-			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12 - 30), noDev: big.NewInt(1), ppb: EthereumThresholdGatePPB},
+			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12 - 30), noDev: big.NewInt(1), ppb: CurveBasedDeviationPPB},
 			want: true,
 		},
 	}
@@ -285,8 +286,75 @@ func TestDeviatesOnGasCurve(t *testing.T) {
 			assert.Equalf(
 				t,
 				tt.want,
-				DeviatesOnGasCurve(tt.args.xNew, tt.args.xOld, tt.args.noDev, tt.args.ppb),
-				"DeviatesOnGasCurve(%v, %v, %v, %v)", tt.args.xNew, tt.args.xOld, tt.args.noDev, tt.args.ppb)
+				DeviatesOnCurve(tt.args.xNew, tt.args.xOld, tt.args.noDev, tt.args.ppb),
+				"DeviatesOnCurve(%v, %v, %v, %v)", tt.args.xNew, tt.args.xOld, tt.args.noDev, tt.args.ppb)
+		})
+	}
+}
+
+func TestCalculateCurveThresholdPPB(t *testing.T) {
+	tests := []struct {
+		x             float64
+		ppbLowerBound int64
+		ppbUpperBound int64
+	}{
+		{
+			x:             500_000,
+			ppbLowerBound: 1_000_000_000_000_000, // 100,000,000%
+			ppbUpperBound: 3_000_000_000_000_000, // 300,000,000%
+		},
+		{
+			x:             50_000_000,
+			ppbLowerBound: 70_000_000_000_000, // 7,000,000%
+			ppbUpperBound: 90_000_000_000_000, // 9,000,000%
+		},
+		{
+			x:             350_000_000,
+			ppbLowerBound: 20_000_000_000_000, // 2,000,000%
+			ppbUpperBound: 30_000_000_000_000, // 3,000,000%
+		},
+		{
+			x:             200_000_000_000,
+			ppbLowerBound: 300_000_000_000, // 30,000%
+			ppbUpperBound: 400_000_000_000, // 40,000%
+		},
+		{
+			x:             6_000_000_000_000,
+			ppbLowerBound: 30_000_000_000, // 3,000%
+			ppbUpperBound: 40000000000,    // 4,000%
+		},
+		{
+			x:             50_000_000_000_000,
+			ppbLowerBound: 7_000_000_000, // 700%
+			ppbUpperBound: 8_000_000_000, // 800%
+		},
+		{
+			x:             225_000_000_000_000,
+			ppbLowerBound: 2_000_000_000, // 200%
+			ppbUpperBound: 3_000_000_000, // 300%
+		},
+		{
+			x:             5_000_000_000_000_000,
+			ppbLowerBound: 300_000_000, // 30%
+			ppbUpperBound: 400_000_000, // 40%
+		},
+		{
+			x:             70_000_000_000_000_000,
+			ppbLowerBound: 60_000_000, // 6%
+			ppbUpperBound: 70_000_000, // 7%
+		},
+		{
+			x:             500_000_000_000_000_000,
+			ppbLowerBound: 10_000_000, // 1%
+			ppbUpperBound: 20_000_000, // 2%
+		},
+	}
+	for _, tt := range tests {
+		// convert tt.x to string
+		t.Run(fmt.Sprintf("%f", tt.x), func(t *testing.T) {
+			thresholdPPB := calculateCurveThresholdPPB(tt.x)
+			assert.GreaterOrEqual(t, thresholdPPB, tt.ppbLowerBound)
+			assert.LessOrEqual(t, thresholdPPB, tt.ppbUpperBound)
 		})
 	}
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
@@ -220,7 +220,7 @@ func TestDeviates(t *testing.T) {
 	}
 }
 
-func TestDeviatesOnGasCurve(t *testing.T) {
+func TestDeviatesOnCurve(t *testing.T) {
 	type args struct {
 		xNew  *big.Int
 		xOld  *big.Int
@@ -350,7 +350,6 @@ func TestCalculateCurveThresholdPPB(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		// convert tt.x to string
 		t.Run(fmt.Sprintf("%f", tt.x), func(t *testing.T) {
 			thresholdPPB := calculateCurveThresholdPPB(tt.x)
 			assert.GreaterOrEqual(t, thresholdPPB, tt.ppbLowerBound)

--- a/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
@@ -16,12 +16,12 @@ import (
 
 const (
 	// ExecNoDeviationThresholdUSD is the lower bound no deviation threshold for exec gas. If the exec gas price is
-	// less than this value, we should never trigger a deviation. 0.00003 USD.
-	ExecNoDeviationThresholdUSD = 3e13
+	// less than this value, we should never trigger a deviation. This is set to 10 gwei in USD terms.
+	ExecNoDeviationThresholdUSD = 10e9
 
 	// DANoDeviationThresholdUSD is the lower bound no deviation threshold for DA gas. If the DA gas price is less
-	// than this value, we should never trigger a deviation. 0.00006 USD.
-	DANoDeviationThresholdUSD = 6e13
+	// than this value, we should never trigger a deviation. This is set to 20 gwei in USD terms.
+	DANoDeviationThresholdUSD = 20e9
 )
 
 type DAGasPriceEstimator struct {

--- a/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
@@ -14,6 +14,16 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 )
 
+const (
+	// EXEC_NO_DEVIATION_THRESHOLD_USD is the lower bound no deviation threshold for exec gas. If the exec gas price is
+	// less than this value, we should never trigger a deviation. 0.00003 USD.
+	EXEC_NO_DEVIATION_THRESHOLD_USD = 3e13
+
+	// DA_NO_DEVIATION_THRESHOLD_USD is the lower bound no deviation threshold for DA gas. If the DA gas price is less
+	// than this value, we should never trigger a deviation. 0.00006 USD.
+	DA_NO_DEVIATION_THRESHOLD_USD = 6e13
+)
+
 type DAGasPriceEstimator struct {
 	execEstimator       GasPriceEstimator
 	l1Oracle            rollups.L1Oracle
@@ -135,7 +145,7 @@ func (g DAGasPriceEstimator) Deviates(ctx context.Context, p1, p2 *big.Int) (boo
 		return execDeviates, nil
 	}
 
-	return ccipcalc.DeviatesOnGasCurve(p1DAGasPrice, p2DAGasPrice, g.daDeviationPPB), nil
+	return ccipcalc.DeviatesOnGasCurve(p1DAGasPrice, p2DAGasPrice, big.NewInt(DA_NO_DEVIATION_THRESHOLD_USD), g.daDeviationPPB), nil
 }
 
 func (g DAGasPriceEstimator) EstimateMsgCostUSD(ctx context.Context, p *big.Int, wrappedNativePrice *big.Int, msg cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta) (*big.Int, error) {

--- a/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
@@ -15,13 +15,13 @@ import (
 )
 
 const (
-	// EXEC_NO_DEVIATION_THRESHOLD_USD is the lower bound no deviation threshold for exec gas. If the exec gas price is
+	// ExecNoDeviationThresholdUSD is the lower bound no deviation threshold for exec gas. If the exec gas price is
 	// less than this value, we should never trigger a deviation. 0.00003 USD.
-	EXEC_NO_DEVIATION_THRESHOLD_USD = 3e13
+	ExecNoDeviationThresholdUSD = 3e13
 
-	// DA_NO_DEVIATION_THRESHOLD_USD is the lower bound no deviation threshold for DA gas. If the DA gas price is less
+	// DANoDeviationThresholdUSD is the lower bound no deviation threshold for DA gas. If the DA gas price is less
 	// than this value, we should never trigger a deviation. 0.00006 USD.
-	DA_NO_DEVIATION_THRESHOLD_USD = 6e13
+	DANoDeviationThresholdUSD = 6e13
 )
 
 type DAGasPriceEstimator struct {
@@ -145,7 +145,7 @@ func (g DAGasPriceEstimator) Deviates(ctx context.Context, p1, p2 *big.Int) (boo
 		return execDeviates, nil
 	}
 
-	return ccipcalc.DeviatesOnGasCurve(p1DAGasPrice, p2DAGasPrice, big.NewInt(DA_NO_DEVIATION_THRESHOLD_USD), g.daDeviationPPB), nil
+	return ccipcalc.DeviatesOnGasCurve(p1DAGasPrice, p2DAGasPrice, big.NewInt(DANoDeviationThresholdUSD), g.daDeviationPPB), nil
 }
 
 func (g DAGasPriceEstimator) EstimateMsgCostUSD(ctx context.Context, p *big.Int, wrappedNativePrice *big.Int, msg cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta) (*big.Int, error) {

--- a/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
@@ -15,10 +15,6 @@ import (
 )
 
 const (
-	// ExecNoDeviationThresholdUSD is the lower bound no deviation threshold for exec gas. If the exec gas price is
-	// less than this value, we should never trigger a deviation. This is set to 10 gwei in USD terms.
-	ExecNoDeviationThresholdUSD = 10e9
-
 	// DANoDeviationThresholdUSD is the lower bound no deviation threshold for DA gas. If the DA gas price is less
 	// than this value, we should never trigger a deviation. This is set to 20 gwei in USD terms.
 	DANoDeviationThresholdUSD = 20e9
@@ -145,7 +141,7 @@ func (g DAGasPriceEstimator) Deviates(ctx context.Context, p1, p2 *big.Int) (boo
 		return execDeviates, nil
 	}
 
-	return ccipcalc.DeviatesOnGasCurve(p1DAGasPrice, p2DAGasPrice, big.NewInt(DANoDeviationThresholdUSD), g.daDeviationPPB), nil
+	return ccipcalc.DeviatesOnCurve(p1DAGasPrice, p2DAGasPrice, big.NewInt(DANoDeviationThresholdUSD), g.daDeviationPPB), nil
 }
 
 func (g DAGasPriceEstimator) EstimateMsgCostUSD(ctx context.Context, p *big.Int, wrappedNativePrice *big.Int, msg cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta) (*big.Int, error) {

--- a/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/rollups"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
@@ -134,7 +135,7 @@ func (g DAGasPriceEstimator) Deviates(ctx context.Context, p1, p2 *big.Int) (boo
 		return execDeviates, nil
 	}
 
-	return ccipcalc.Deviates(p1DAGasPrice, p2DAGasPrice, g.daDeviationPPB), nil
+	return ccipcalc.DeviatesOnGasCurve(p1DAGasPrice, p2DAGasPrice, g.daDeviationPPB), nil
 }
 
 func (g DAGasPriceEstimator) EstimateMsgCostUSD(ctx context.Context, p *big.Int, wrappedNativePrice *big.Int, msg cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta) (*big.Int, error) {

--- a/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
@@ -6,6 +6,9 @@ import (
 	"math/big"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 	"github.com/smartcontractkit/chainlink/v2/evm/assets"
@@ -51,7 +54,7 @@ func (g ExecGasPriceEstimator) Median(ctx context.Context, gasPrices []*big.Int)
 }
 
 func (g ExecGasPriceEstimator) Deviates(ctx context.Context, p1 *big.Int, p2 *big.Int) (bool, error) {
-	return ccipcalc.Deviates(p1, p2, g.deviationPPB), nil
+	return ccipcalc.DeviatesOnGasCurve(p1, p2, g.deviationPPB), nil
 }
 
 func (g ExecGasPriceEstimator) EstimateMsgCostUSD(ctx context.Context, p *big.Int, wrappedNativePrice *big.Int, msg cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta) (*big.Int, error) {

--- a/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
@@ -14,6 +14,12 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/evm/assets"
 )
 
+const (
+	// ExecNoDeviationThresholdUSD is the lower bound no deviation threshold for exec gas. If the exec gas price is
+	// less than this value, we should never trigger a deviation. This is set to 10 gwei in USD terms.
+	ExecNoDeviationThresholdUSD = 10e9
+)
+
 type ExecGasPriceEstimator struct {
 	estimator    gas.EvmFeeEstimator
 	maxGasPrice  *big.Int
@@ -54,7 +60,7 @@ func (g ExecGasPriceEstimator) Median(ctx context.Context, gasPrices []*big.Int)
 }
 
 func (g ExecGasPriceEstimator) Deviates(ctx context.Context, p1 *big.Int, p2 *big.Int) (bool, error) {
-	return ccipcalc.DeviatesOnGasCurve(p1, p2, big.NewInt(ExecNoDeviationThresholdUSD), g.deviationPPB), nil
+	return ccipcalc.DeviatesOnCurve(p1, p2, big.NewInt(ExecNoDeviationThresholdUSD), g.deviationPPB), nil
 }
 
 func (g ExecGasPriceEstimator) EstimateMsgCostUSD(ctx context.Context, p *big.Int, wrappedNativePrice *big.Int, msg cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta) (*big.Int, error) {

--- a/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
@@ -7,8 +7,6 @@ import (
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
-
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 	"github.com/smartcontractkit/chainlink/v2/evm/assets"

--- a/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
@@ -54,7 +54,7 @@ func (g ExecGasPriceEstimator) Median(ctx context.Context, gasPrices []*big.Int)
 }
 
 func (g ExecGasPriceEstimator) Deviates(ctx context.Context, p1 *big.Int, p2 *big.Int) (bool, error) {
-	return ccipcalc.DeviatesOnGasCurve(p1, p2, big.NewInt(EXEC_NO_DEVIATION_THRESHOLD_USD), g.deviationPPB), nil
+	return ccipcalc.DeviatesOnGasCurve(p1, p2, big.NewInt(ExecNoDeviationThresholdUSD), g.deviationPPB), nil
 }
 
 func (g ExecGasPriceEstimator) EstimateMsgCostUSD(ctx context.Context, p *big.Int, wrappedNativePrice *big.Int, msg cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta) (*big.Int, error) {

--- a/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
@@ -54,7 +54,7 @@ func (g ExecGasPriceEstimator) Median(ctx context.Context, gasPrices []*big.Int)
 }
 
 func (g ExecGasPriceEstimator) Deviates(ctx context.Context, p1 *big.Int, p2 *big.Int) (bool, error) {
-	return ccipcalc.DeviatesOnGasCurve(p1, p2, g.deviationPPB), nil
+	return ccipcalc.DeviatesOnGasCurve(p1, p2, big.NewInt(EXEC_NO_DEVIATION_THRESHOLD_USD), g.deviationPPB), nil
 }
 
 func (g ExecGasPriceEstimator) EstimateMsgCostUSD(ctx context.Context, p *big.Int, wrappedNativePrice *big.Int, msg cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta) (*big.Int, error) {


### PR DESCRIPTION
## Description
- Adds a new function `DeviatesOnCurve()` to CCIP calc to have a more flexible gas deviation threshold based on a sliding log scale
- This new gas curve function will output larger deviation thresholds for smaller (in USD terms) gas prices, and smaller deviation thresholds for higher gas prices

## Motivation
- It doesn't provide much value to publish a gas update when the gas price changes from $0.00000001 to $0.00000004, all it does it cause us to spend more on publishing these gas updates