### PR TITLE
fix: add context to golang ci lint notifications

### DIFF
--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -18,6 +18,11 @@ inputs:
     description: Set where the go module file is located at
     default: "go.sum"
 
+outputs:
+  golang-report-artifact-url:
+    description: The URL to the uploaded artifact
+    value: ${{ steps.upload-artifact.outputs.artifact_url }}
+
 runs:
   using: composite
   steps:
@@ -100,6 +105,7 @@ runs:
 
     - name: Store Golangci-lint report artifact
       if: always()
+      id: upload-artifact
       uses: actions/upload-artifact@v4.4.3
       with:
         # Use a unique suffix for each lint report artifact to avoid duplication errors

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -156,7 +156,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
         with:
           channel-id: "#team-core"
-          slack-message: "golangci-lint failed: \n${{ format('https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id) }}"
+          slack-message: "golangci-lint failed (${{ matrix.modules }}): \n${{ format('https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id) }}"
   
   # Fails if any golangci-lint matrix jobs fails and silently succeeds otherwise
   # Consolidates golangci-lint matrix job results under one required `lint` check

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -146,6 +146,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Golang Lint (${{ matrix.modules }})
+        id: golang-lint
         uses: ./.github/actions/golangci-lint
         with: 
           go-directory: ${{ matrix.modules }}
@@ -156,7 +157,10 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
         with:
           channel-id: "#team-core"
-          slack-message: "golangci-lint failed (${{ matrix.modules }}): \n${{ format('https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id) }}"
+          slack-message: |
+            "golangci-lint failed (${{ matrix.modules }})
+                - Run: ${{ format('https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id) }}"
+                - Report: ${{ steps.golang-lint.outputs.golang-report-artifact-url }}"
   
   # Fails if any golangci-lint matrix jobs fails and silently succeeds otherwise
   # Consolidates golangci-lint matrix job results under one required `lint` check


### PR DESCRIPTION
### Changes

- Adds the module to slack message upon GoLangCI lint failure.
- Adds the artifact url to the slack message as well

Due to constraints, modules is based on the path, and is currently one of:
```
[
  ".",
  "tools/goreleaser-config",
  "core/scripts",
  "core/scripts/ccip/manual-execution",
  "dashboard-lib",
  "integration-tests",
  "integration-tests/load",
  "deployment"
]
```