### PR TITLE
CCIP-4320 ccip changeset parametrize

### DIFF
--- a/deployment/ccip/changeset/cs_ccip_home.go
+++ b/deployment/ccip/changeset/cs_ccip_home.go
@@ -33,6 +33,34 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 )
 
+const (
+	// ========= Changeset Defaults =========
+	FirstBlockAge                           = 8 * time.Hour
+	RemoteGasPriceBatchWriteFrequency       = 30 * time.Minute
+	TokenPriceBatchWriteFrequency           = 30 * time.Minute
+	BatchGasLimit                           = 6_500_000
+	RelativeBoostPerWaitHour                = 0.5
+	InflightCacheExpiry                     = 10 * time.Minute
+	RootSnoozeTime                          = 30 * time.Minute
+	BatchingStrategyID                      = 0
+	DeltaProgress                           = 30 * time.Second
+	DeltaResend                             = 10 * time.Second
+	DeltaInitial                            = 20 * time.Second
+	DeltaRound                              = 2 * time.Second
+	DeltaGrace                              = 2 * time.Second
+	DeltaCertifiedCommitRequest             = 10 * time.Second
+	DeltaStage                              = 10 * time.Second
+	Rmax                                    = 3
+	MaxDurationQuery                        = 500 * time.Millisecond
+	MaxDurationObservation                  = 5 * time.Second
+	MaxDurationShouldAcceptAttestedReport   = 10 * time.Second
+	MaxDurationShouldTransmitAcceptedReport = 10 * time.Second
+	GasPriceDeviationPPB                    = 1000
+	DAGasPriceDeviationPPB                  = 0
+	OptimisticConfirmations                 = 1
+	// ======================================
+)
+
 var (
 	_ deployment.ChangeSet[AddDonAndSetCandidateChangesetConfig] = AddDonAndSetCandidateChangeset
 	_ deployment.ChangeSet[PromoteCandidateChangesetConfig]      = PromoteCandidateChangeset
@@ -191,8 +219,8 @@ func WithDefaultCommitOffChainConfig(feedChainSel uint64, tokenInfo map[ccipocr3
 	return func(params *CCIPOCRParams) {
 		if params.CommitOffChainConfig == nil {
 			params.CommitOffChainConfig = &pluginconfig.CommitOffchainConfig{
-				RemoteGasPriceBatchWriteFrequency:  *config.MustNewDuration(internal.RemoteGasPriceBatchWriteFrequency),
-				TokenPriceBatchWriteFrequency:      *config.MustNewDuration(internal.TokenPriceBatchWriteFrequency),
+				RemoteGasPriceBatchWriteFrequency:  *config.MustNewDuration(RemoteGasPriceBatchWriteFrequency),
+				TokenPriceBatchWriteFrequency:      *config.MustNewDuration(TokenPriceBatchWriteFrequency),
 				TokenInfo:                          tokenInfo,
 				PriceFeedChainSelector:             ccipocr3.ChainSelector(feedChainSel),
 				NewMsgScanBatchSize:                merklemulti.MaxNumberTreeLeaves,
@@ -218,12 +246,12 @@ func WithDefaultExecuteOffChainConfig(tokenDataObservers []pluginconfig.TokenDat
 	return func(params *CCIPOCRParams) {
 		if params.ExecuteOffChainConfig == nil {
 			params.ExecuteOffChainConfig = &pluginconfig.ExecuteOffchainConfig{
-				BatchGasLimit:             internal.BatchGasLimit,
-				RelativeBoostPerWaitHour:  internal.RelativeBoostPerWaitHour,
-				InflightCacheExpiry:       *config.MustNewDuration(internal.InflightCacheExpiry),
-				RootSnoozeTime:            *config.MustNewDuration(internal.RootSnoozeTime),
-				MessageVisibilityInterval: *config.MustNewDuration(internal.FirstBlockAge),
-				BatchingStrategyID:        internal.BatchingStrategyID,
+				BatchGasLimit:             BatchGasLimit,
+				RelativeBoostPerWaitHour:  RelativeBoostPerWaitHour,
+				InflightCacheExpiry:       *config.MustNewDuration(InflightCacheExpiry),
+				RootSnoozeTime:            *config.MustNewDuration(RootSnoozeTime),
+				MessageVisibilityInterval: *config.MustNewDuration(FirstBlockAge),
+				BatchingStrategyID:        BatchingStrategyID,
 				TokenDataObservers:        tokenDataObservers,
 			}
 		} else if tokenDataObservers != nil {
@@ -238,18 +266,18 @@ func DeriveCCIPOCRParams(
 ) CCIPOCRParams {
 	params := CCIPOCRParams{
 		OCRParameters: commontypes.OCRParameters{
-			DeltaProgress:                           internal.DeltaProgress,
-			DeltaResend:                             internal.DeltaResend,
-			DeltaInitial:                            internal.DeltaInitial,
-			DeltaRound:                              internal.DeltaRound,
-			DeltaGrace:                              internal.DeltaGrace,
-			DeltaCertifiedCommitRequest:             internal.DeltaCertifiedCommitRequest,
-			DeltaStage:                              internal.DeltaStage,
-			Rmax:                                    internal.Rmax,
-			MaxDurationQuery:                        internal.MaxDurationQuery,
-			MaxDurationObservation:                  internal.MaxDurationObservation,
-			MaxDurationShouldAcceptAttestedReport:   internal.MaxDurationShouldAcceptAttestedReport,
-			MaxDurationShouldTransmitAcceptedReport: internal.MaxDurationShouldTransmitAcceptedReport,
+			DeltaProgress:                           DeltaProgress,
+			DeltaResend:                             DeltaResend,
+			DeltaInitial:                            DeltaInitial,
+			DeltaRound:                              DeltaRound,
+			DeltaGrace:                              DeltaGrace,
+			DeltaCertifiedCommitRequest:             DeltaCertifiedCommitRequest,
+			DeltaStage:                              DeltaStage,
+			Rmax:                                    Rmax,
+			MaxDurationQuery:                        MaxDurationQuery,
+			MaxDurationObservation:                  MaxDurationObservation,
+			MaxDurationShouldAcceptAttestedReport:   MaxDurationShouldAcceptAttestedReport,
+			MaxDurationShouldTransmitAcceptedReport: MaxDurationShouldTransmitAcceptedReport,
 		},
 	}
 	for _, opt := range opts {

--- a/deployment/ccip/changeset/cs_ccip_home_test.go
+++ b/deployment/ccip/changeset/cs_ccip_home_test.go
@@ -51,8 +51,13 @@ func TestInvalidOCR3Params(t *testing.T) {
 		{
 			Changeset: commonchangeset.WrapChangeSet(changeset.DeployChainContractsChangeset),
 			Config: changeset.DeployChainContractsConfig{
-				ChainSelectors:    []uint64{chain1},
 				HomeChainSelector: e.HomeChainSel,
+				ContractParamsPerChain: map[uint64]changeset.ContractParams{
+					chain1: {
+						FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
+						OffRampParams:   changeset.DefaultOffRampParams(),
+					},
+				},
 			},
 		},
 	})
@@ -557,9 +562,9 @@ func Test_UpdateChainConfigs(t *testing.T) {
 						RemoteChainAdds: map[uint64]changeset.ChainConfig{
 							otherChain: {
 								EncodableChainConfig: chainconfig.ChainConfig{
-									GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(internal.GasPriceDeviationPPB)},
-									DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(internal.DAGasPriceDeviationPPB)},
-									OptimisticConfirmations: internal.OptimisticConfirmations,
+									GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(testhelpers.GasPriceDeviationPPB)},
+									DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(testhelpers.DAGasPriceDeviationPPB)},
+									OptimisticConfirmations: testhelpers.OptimisticConfirmations,
 								},
 								FChain:  otherChainConfig.FChain,
 								Readers: otherChainConfig.Readers,

--- a/deployment/ccip/changeset/cs_ccip_home_test.go
+++ b/deployment/ccip/changeset/cs_ccip_home_test.go
@@ -52,7 +52,7 @@ func TestInvalidOCR3Params(t *testing.T) {
 			Changeset: commonchangeset.WrapChangeSet(changeset.DeployChainContractsChangeset),
 			Config: changeset.DeployChainContractsConfig{
 				HomeChainSelector: e.HomeChainSel,
-				ContractParamsPerChain: map[uint64]changeset.ContractParams{
+				ContractParamsPerChain: map[uint64]changeset.ChainContractParams{
 					chain1: {
 						FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
 						OffRampParams:   changeset.DefaultOffRampParams(),
@@ -562,9 +562,9 @@ func Test_UpdateChainConfigs(t *testing.T) {
 						RemoteChainAdds: map[uint64]changeset.ChainConfig{
 							otherChain: {
 								EncodableChainConfig: chainconfig.ChainConfig{
-									GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(testhelpers.GasPriceDeviationPPB)},
-									DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(testhelpers.DAGasPriceDeviationPPB)},
-									OptimisticConfirmations: testhelpers.OptimisticConfirmations,
+									GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(changeset.GasPriceDeviationPPB)},
+									DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(changeset.DAGasPriceDeviationPPB)},
+									OptimisticConfirmations: changeset.OptimisticConfirmations,
 								},
 								FChain:  otherChainConfig.FChain,
 								Readers: otherChainConfig.Readers,

--- a/deployment/ccip/changeset/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/cs_deploy_chain.go
@@ -39,7 +39,7 @@ func DeployChainContractsChangeset(env deployment.Environment, c DeployChainCont
 		return deployment.ChangesetOutput{}, fmt.Errorf("invalid DeployChainContractsConfig: %w", err)
 	}
 	newAddresses := deployment.NewMemoryAddressBook()
-	err := deployChainContractsForChains(env, newAddresses, c.HomeChainSelector, c.ChainSelectors)
+	err := deployChainContractsForChains(env, newAddresses, c.HomeChainSelector, c.ContractParamsPerChain)
 	if err != nil {
 		env.Logger.Errorw("Failed to deploy CCIP contracts", "err", err, "newAddresses", newAddresses)
 		return deployment.ChangesetOutput{AddressBook: newAddresses}, deployment.MaybeDataErr(err)
@@ -52,27 +52,108 @@ func DeployChainContractsChangeset(env deployment.Environment, c DeployChainCont
 }
 
 type DeployChainContractsConfig struct {
-	ChainSelectors    []uint64
-	HomeChainSelector uint64
+	HomeChainSelector      uint64
+	ContractParamsPerChain map[uint64]ContractParams
 }
 
 func (c DeployChainContractsConfig) Validate() error {
-	for _, cs := range c.ChainSelectors {
+	if err := deployment.IsValidChainSelector(c.HomeChainSelector); err != nil {
+		return fmt.Errorf("invalid home chain selector: %d - %w", c.HomeChainSelector, err)
+	}
+	for cs, args := range c.ContractParamsPerChain {
 		if err := deployment.IsValidChainSelector(cs); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", cs, err)
 		}
-	}
-	if err := deployment.IsValidChainSelector(c.HomeChainSelector); err != nil {
-		return fmt.Errorf("invalid home chain selector: %d - %w", c.HomeChainSelector, err)
+		if err := args.Validate(); err != nil {
+			return fmt.Errorf("invalid contract args for chain %d: %w", cs, err)
+		}
 	}
 	return nil
 }
 
-func deployChainContractsForChains(
-	e deployment.Environment,
-	ab deployment.AddressBook,
-	homeChainSel uint64,
-	chainsToDeploy []uint64) error {
+type ContractParams struct {
+	FeeQuoterParams FeeQuoterParams
+	OffRampParams   OffRampParams
+}
+
+func (c ContractParams) Validate() error {
+	if err := c.FeeQuoterParams.Validate(); err != nil {
+		return fmt.Errorf("invalid FeeQuoterParams: %w", err)
+	}
+	if err := c.OffRampParams.Validate(); err != nil {
+		return fmt.Errorf("invalid OffRampParams: %w", err)
+	}
+	return nil
+}
+
+type FeeQuoterParams struct {
+	MaxFeeJuelsPerMsg              *big.Int
+	TokenPriceStalenessThreshold   uint32
+	LinkPremiumMultiplierWeiPerEth uint64
+	WethPremiumMultiplierWeiPerEth uint64
+}
+
+func (c FeeQuoterParams) Validate() error {
+	if c.MaxFeeJuelsPerMsg == nil {
+		return errors.New("MaxFeeJuelsPerMsg is nil")
+	}
+	if c.MaxFeeJuelsPerMsg.Cmp(big.NewInt(0)) <= 0 {
+		return errors.New("MaxFeeJuelsPerMsg must be positive")
+	}
+	if c.TokenPriceStalenessThreshold == 0 {
+		return errors.New("TokenPriceStalenessThreshold can't be 0")
+	}
+	return nil
+}
+
+func DefaultFeeQuoterParams() FeeQuoterParams {
+	return FeeQuoterParams{
+		MaxFeeJuelsPerMsg:              big.NewInt(0).Mul(big.NewInt(2e2), big.NewInt(1e18)),
+		TokenPriceStalenessThreshold:   uint32(24 * 60 * 60),
+		LinkPremiumMultiplierWeiPerEth: 9e17, // 0.9 ETH,
+		WethPremiumMultiplierWeiPerEth: 1e18, // 1.0 ETH,
+	}
+}
+
+type OffRampParams struct {
+	GasForCallExactCheck                    uint16
+	PermissionLessExecutionThresholdSeconds uint32
+	IsRMNVerificationDisabled               bool
+}
+
+func (c OffRampParams) Validate() error {
+	if c.GasForCallExactCheck == 0 {
+		return errors.New("GasForCallExactCheck is 0")
+	}
+	if c.PermissionLessExecutionThresholdSeconds == 0 {
+		return errors.New("PermissionLessExecutionThresholdSeconds is 0")
+	}
+	return nil
+}
+
+func DefaultOffRampParams() OffRampParams {
+	return OffRampParams{
+		GasForCallExactCheck:                    uint16(5000),
+		PermissionLessExecutionThresholdSeconds: uint32(24 * 60 * 60),
+		IsRMNVerificationDisabled:               true,
+	}
+}
+
+func DeriveContractParams(opts ...interface{}) (*ContractParams, error) {
+	params := &ContractParams{}
+	for _, opt := range opts {
+		if f, ok := opt.(FeeQuoterParams); ok {
+			params.FeeQuoterParams = f
+		} else if f, ok := opt.(OffRampParams); ok {
+			params.OffRampParams = f
+		} else {
+			return nil, fmt.Errorf("unknown option type: %T", opt)
+		}
+	}
+	return params, nil
+}
+
+func deployChainContractsForChains(e deployment.Environment, ab deployment.AddressBook, homeChainSel uint64, contractParamsPerChain map[uint64]ContractParams) error {
 	existingState, err := LoadOnchainState(e)
 	if err != nil {
 		e.Logger.Errorw("Failed to load existing onchain state", "err")
@@ -114,7 +195,7 @@ func deployChainContractsForChains(
 		return errors.New("rmn home not found")
 	}
 	deployGrp := errgroup.Group{}
-	for _, chainSel := range chainsToDeploy {
+	for chainSel, contractParams := range contractParamsPerChain {
 		chain, ok := e.Chains[chainSel]
 		if !ok {
 			return fmt.Errorf("chain %d not found", chainSel)
@@ -130,7 +211,7 @@ func deployChainContractsForChains(
 		}
 		deployGrp.Go(
 			func() error {
-				err := deployChainContracts(e, chain, ab, rmnHome)
+				err := deployChainContracts(e, chain, ab, rmnHome, contractParams)
 				if err != nil {
 					e.Logger.Errorw("Failed to deploy chain contracts", "chain", chainSel, "err", err)
 					return fmt.Errorf("failed to deploy chain contracts for chain %d: %w", chainSel, err)
@@ -145,12 +226,7 @@ func deployChainContractsForChains(
 	return nil
 }
 
-func deployChainContracts(
-	e deployment.Environment,
-	chain deployment.Chain,
-	ab deployment.AddressBook,
-	rmnHome *rmn_home.RMNHome,
-) error {
+func deployChainContracts(e deployment.Environment, chain deployment.Chain, ab deployment.AddressBook, rmnHome *rmn_home.RMNHome, contractParams ContractParams) error {
 	// check for existing contracts
 	state, err := LoadOnchainState(e)
 	if err != nil {
@@ -290,9 +366,9 @@ func deployChainContracts(
 					chain.DeployerKey,
 					chain.Client,
 					fee_quoter.FeeQuoterStaticConfig{
-						MaxFeeJuelsPerMsg:            big.NewInt(0).Mul(big.NewInt(2e2), big.NewInt(1e18)),
+						MaxFeeJuelsPerMsg:            contractParams.FeeQuoterParams.MaxFeeJuelsPerMsg,
 						LinkToken:                    linkTokenContractAddr,
-						TokenPriceStalenessThreshold: uint32(24 * 60 * 60),
+						TokenPriceStalenessThreshold: contractParams.FeeQuoterParams.TokenPriceStalenessThreshold,
 					},
 					[]common.Address{state.Chains[chain.Selector].Timelock.Address()}, // timelock should be able to update, ramps added after
 					[]common.Address{weth9Contract.Address(), linkTokenContractAddr},  // fee tokens
@@ -300,11 +376,11 @@ func deployChainContracts(
 					[]fee_quoter.FeeQuoterTokenTransferFeeConfigArgs{}, // TODO: tokens
 					[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs{
 						{
-							PremiumMultiplierWeiPerEth: 9e17, // 0.9 ETH
+							PremiumMultiplierWeiPerEth: contractParams.FeeQuoterParams.LinkPremiumMultiplierWeiPerEth,
 							Token:                      linkTokenContractAddr,
 						},
 						{
-							PremiumMultiplierWeiPerEth: 1e18,
+							PremiumMultiplierWeiPerEth: contractParams.FeeQuoterParams.WethPremiumMultiplierWeiPerEth,
 							Token:                      weth9Contract.Address(),
 						},
 					},
@@ -362,15 +438,15 @@ func deployChainContracts(
 					chain.Client,
 					offramp.OffRampStaticConfig{
 						ChainSelector:        chain.Selector,
-						GasForCallExactCheck: 5_000,
+						GasForCallExactCheck: contractParams.OffRampParams.GasForCallExactCheck,
 						RmnRemote:            RMNProxy.Address(),
 						NonceManager:         nmContract.Address(),
 						TokenAdminRegistry:   tokenAdminReg.Address(),
 					},
 					offramp.OffRampDynamicConfig{
 						FeeQuoter:                               feeQuoterContract.Address(),
-						PermissionLessExecutionThresholdSeconds: uint32(86400),
-						IsRMNVerificationDisabled:               true,
+						PermissionLessExecutionThresholdSeconds: contractParams.OffRampParams.PermissionLessExecutionThresholdSeconds,
+						IsRMNVerificationDisabled:               contractParams.OffRampParams.IsRMNVerificationDisabled,
 					},
 					[]offramp.OffRampSourceChainConfigArgs{},
 				)

--- a/deployment/ccip/changeset/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/cs_deploy_chain.go
@@ -53,7 +53,7 @@ func DeployChainContractsChangeset(env deployment.Environment, c DeployChainCont
 
 type DeployChainContractsConfig struct {
 	HomeChainSelector      uint64
-	ContractParamsPerChain map[uint64]ContractParams
+	ContractParamsPerChain map[uint64]ChainContractParams
 }
 
 func (c DeployChainContractsConfig) Validate() error {
@@ -71,12 +71,12 @@ func (c DeployChainContractsConfig) Validate() error {
 	return nil
 }
 
-type ContractParams struct {
+type ChainContractParams struct {
 	FeeQuoterParams FeeQuoterParams
 	OffRampParams   OffRampParams
 }
 
-func (c ContractParams) Validate() error {
+func (c ChainContractParams) Validate() error {
 	if err := c.FeeQuoterParams.Validate(); err != nil {
 		return fmt.Errorf("invalid FeeQuoterParams: %w", err)
 	}
@@ -86,11 +86,22 @@ func (c ContractParams) Validate() error {
 	return nil
 }
 
+type FeeQuoterParamsOld struct {
+	MaxFeeJuelsPerMsg              *big.Int
+	TokenPriceStalenessThreshold   uint32
+	LinkPremiumMultiplierWeiPerEth uint64
+	WethPremiumMultiplierWeiPerEth uint64
+}
+
 type FeeQuoterParams struct {
 	MaxFeeJuelsPerMsg              *big.Int
 	TokenPriceStalenessThreshold   uint32
 	LinkPremiumMultiplierWeiPerEth uint64
 	WethPremiumMultiplierWeiPerEth uint64
+	MorePremiumMultiplierWeiPerEth []fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs
+	TokenPriceFeedUpdates          []fee_quoter.FeeQuoterTokenPriceFeedUpdate
+	TokenTransferFeeConfigArgs     []fee_quoter.FeeQuoterTokenTransferFeeConfigArgs
+	DestChainConfigArgs            []fee_quoter.FeeQuoterDestChainConfigArgs
 }
 
 func (c FeeQuoterParams) Validate() error {
@@ -110,8 +121,12 @@ func DefaultFeeQuoterParams() FeeQuoterParams {
 	return FeeQuoterParams{
 		MaxFeeJuelsPerMsg:              big.NewInt(0).Mul(big.NewInt(2e2), big.NewInt(1e18)),
 		TokenPriceStalenessThreshold:   uint32(24 * 60 * 60),
-		LinkPremiumMultiplierWeiPerEth: 9e17, // 0.9 ETH,
-		WethPremiumMultiplierWeiPerEth: 1e18, // 1.0 ETH,
+		LinkPremiumMultiplierWeiPerEth: 9e17, // 0.9 ETH
+		WethPremiumMultiplierWeiPerEth: 1e18, // 1.0 ETH
+		TokenPriceFeedUpdates:          []fee_quoter.FeeQuoterTokenPriceFeedUpdate{},
+		TokenTransferFeeConfigArgs:     []fee_quoter.FeeQuoterTokenTransferFeeConfigArgs{},
+		MorePremiumMultiplierWeiPerEth: []fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs{},
+		DestChainConfigArgs:            []fee_quoter.FeeQuoterDestChainConfigArgs{},
 	}
 }
 
@@ -139,21 +154,7 @@ func DefaultOffRampParams() OffRampParams {
 	}
 }
 
-func DeriveContractParams(opts ...interface{}) (*ContractParams, error) {
-	params := &ContractParams{}
-	for _, opt := range opts {
-		if f, ok := opt.(FeeQuoterParams); ok {
-			params.FeeQuoterParams = f
-		} else if f, ok := opt.(OffRampParams); ok {
-			params.OffRampParams = f
-		} else {
-			return nil, fmt.Errorf("unknown option type: %T", opt)
-		}
-	}
-	return params, nil
-}
-
-func deployChainContractsForChains(e deployment.Environment, ab deployment.AddressBook, homeChainSel uint64, contractParamsPerChain map[uint64]ContractParams) error {
+func deployChainContractsForChains(e deployment.Environment, ab deployment.AddressBook, homeChainSel uint64, contractParamsPerChain map[uint64]ChainContractParams) error {
 	existingState, err := LoadOnchainState(e)
 	if err != nil {
 		e.Logger.Errorw("Failed to load existing onchain state", "err")
@@ -226,7 +227,7 @@ func deployChainContractsForChains(e deployment.Environment, ab deployment.Addre
 	return nil
 }
 
-func deployChainContracts(e deployment.Environment, chain deployment.Chain, ab deployment.AddressBook, rmnHome *rmn_home.RMNHome, contractParams ContractParams) error {
+func deployChainContracts(e deployment.Environment, chain deployment.Chain, ab deployment.AddressBook, rmnHome *rmn_home.RMNHome, contractParams ChainContractParams) error {
 	// check for existing contracts
 	state, err := LoadOnchainState(e)
 	if err != nil {
@@ -322,7 +323,7 @@ func deployChainContracts(e deployment.Environment, chain deployment.Chain, ab d
 				routerAddr, tx2, routerC, err2 := router.DeployRouter(
 					chain.DeployerKey,
 					chain.Client,
-					weth9Contract.Address(),
+					chainState.Weth9.Address(),
 					RMNProxy.Address(),
 				)
 				return deployment.ContractDeploy[*router.Router]{
@@ -372,9 +373,9 @@ func deployChainContracts(e deployment.Environment, chain deployment.Chain, ab d
 					},
 					[]common.Address{state.Chains[chain.Selector].Timelock.Address()}, // timelock should be able to update, ramps added after
 					[]common.Address{weth9Contract.Address(), linkTokenContractAddr},  // fee tokens
-					[]fee_quoter.FeeQuoterTokenPriceFeedUpdate{},
-					[]fee_quoter.FeeQuoterTokenTransferFeeConfigArgs{}, // TODO: tokens
-					[]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs{
+					contractParams.FeeQuoterParams.TokenPriceFeedUpdates,
+					contractParams.FeeQuoterParams.TokenTransferFeeConfigArgs,
+					append([]fee_quoter.FeeQuoterPremiumMultiplierWeiPerEthArgs{
 						{
 							PremiumMultiplierWeiPerEth: contractParams.FeeQuoterParams.LinkPremiumMultiplierWeiPerEth,
 							Token:                      linkTokenContractAddr,
@@ -383,8 +384,8 @@ func deployChainContracts(e deployment.Environment, chain deployment.Chain, ab d
 							PremiumMultiplierWeiPerEth: contractParams.FeeQuoterParams.WethPremiumMultiplierWeiPerEth,
 							Token:                      weth9Contract.Address(),
 						},
-					},
-					[]fee_quoter.FeeQuoterDestChainConfigArgs{},
+					}, contractParams.FeeQuoterParams.MorePremiumMultiplierWeiPerEth...),
+					contractParams.FeeQuoterParams.DestChainConfigArgs,
 				)
 				return deployment.ContractDeploy[*fee_quoter.FeeQuoter]{
 					Address: prAddr, Contract: pr, Tx: tx2, Tv: deployment.NewTypeAndVersion(FeeQuoter, deployment.Version1_6_0_dev), Err: err2,

--- a/deployment/ccip/changeset/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/cs_deploy_chain_test.go
@@ -32,8 +32,13 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 	require.NoError(t, err)
 	p2pIds := nodes.NonBootstraps().PeerIDs()
 	cfg := make(map[uint64]commontypes.MCMSWithTimelockConfig)
+	contractParams := make(map[uint64]changeset.ContractParams)
 	for _, chain := range e.AllChainSelectors() {
 		cfg[chain] = proposalutils.SingleGroupTimelockConfig(t)
+		contractParams[chain] = changeset.ContractParams{
+			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
+			OffRampParams:   changeset.DefaultOffRampParams(),
+		}
 	}
 	prereqCfg := make([]changeset.DeployPrerequisiteConfigPerChain, 0)
 	for _, chain := range e.AllChainSelectors() {
@@ -71,8 +76,8 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 		{
 			Changeset: commonchangeset.WrapChangeSet(changeset.DeployChainContractsChangeset),
 			Config: changeset.DeployChainContractsConfig{
-				ChainSelectors:    selectors,
-				HomeChainSelector: homeChainSel,
+				HomeChainSelector:      homeChainSel,
+				ContractParamsPerChain: contractParams,
 			},
 		},
 	})

--- a/deployment/ccip/changeset/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/cs_deploy_chain_test.go
@@ -32,10 +32,10 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 	require.NoError(t, err)
 	p2pIds := nodes.NonBootstraps().PeerIDs()
 	cfg := make(map[uint64]commontypes.MCMSWithTimelockConfig)
-	contractParams := make(map[uint64]changeset.ContractParams)
+	contractParams := make(map[uint64]changeset.ChainContractParams)
 	for _, chain := range e.AllChainSelectors() {
 		cfg[chain] = proposalutils.SingleGroupTimelockConfig(t)
-		contractParams[chain] = changeset.ContractParams{
+		contractParams[chain] = changeset.ChainContractParams{
 			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
 			OffRampParams:   changeset.DefaultOffRampParams(),
 		}

--- a/deployment/ccip/changeset/internal/deploy_home_chain.go
+++ b/deployment/ccip/changeset/internal/deploy_home_chain.go
@@ -49,10 +49,6 @@ const (
 	MaxDurationObservation                  = 5 * time.Second
 	MaxDurationShouldAcceptAttestedReport   = 10 * time.Second
 	MaxDurationShouldTransmitAcceptedReport = 10 * time.Second
-
-	GasPriceDeviationPPB    = 1000
-	DAGasPriceDeviationPPB  = 0
-	OptimisticConfirmations = 1
 )
 
 var (

--- a/deployment/ccip/changeset/internal/deploy_home_chain.go
+++ b/deployment/ccip/changeset/internal/deploy_home_chain.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -28,27 +27,6 @@ import (
 const (
 	CapabilityLabelledName = "ccip"
 	CapabilityVersion      = "v1.0.0"
-
-	FirstBlockAge                           = 8 * time.Hour
-	RemoteGasPriceBatchWriteFrequency       = 30 * time.Minute
-	TokenPriceBatchWriteFrequency           = 30 * time.Minute
-	BatchGasLimit                           = 6_500_000
-	RelativeBoostPerWaitHour                = 0.5
-	InflightCacheExpiry                     = 10 * time.Minute
-	RootSnoozeTime                          = 30 * time.Minute
-	BatchingStrategyID                      = 0
-	DeltaProgress                           = 30 * time.Second
-	DeltaResend                             = 10 * time.Second
-	DeltaInitial                            = 20 * time.Second
-	DeltaRound                              = 2 * time.Second
-	DeltaGrace                              = 2 * time.Second
-	DeltaCertifiedCommitRequest             = 10 * time.Second
-	DeltaStage                              = 10 * time.Second
-	Rmax                                    = 3
-	MaxDurationQuery                        = 500 * time.Millisecond
-	MaxDurationObservation                  = 5 * time.Second
-	MaxDurationShouldAcceptAttestedReport   = 10 * time.Second
-	MaxDurationShouldTransmitAcceptedReport = 10 * time.Second
 )
 
 var (

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -36,10 +36,6 @@ const (
 	Memory      EnvType = "in-memory"
 	Docker      EnvType = "docker"
 	ENVTESTTYPE         = "CCIP_V16_TEST_ENV"
-
-	GasPriceDeviationPPB    = 1000
-	DAGasPriceDeviationPPB  = 0
-	OptimisticConfirmations = 1
 )
 
 type TestConfigs struct {
@@ -499,9 +495,9 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 			},
 		})
 	}
-	allContractParams := make(map[uint64]changeset.ContractParams)
+	allContractParams := make(map[uint64]changeset.ChainContractParams)
 	for _, chain := range allChains {
-		allContractParams[chain] = changeset.ContractParams{
+		allContractParams[chain] = changeset.ChainContractParams{
 			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
 			OffRampParams:   changeset.DefaultOffRampParams(),
 		}
@@ -577,9 +573,9 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 			Readers: nodeInfo.NonBootstraps().PeerIDs(),
 			FChain:  uint8(len(nodeInfo.NonBootstraps().PeerIDs()) / 3),
 			EncodableChainConfig: chainconfig.ChainConfig{
-				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(GasPriceDeviationPPB)},
-				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(DAGasPriceDeviationPPB)},
-				OptimisticConfirmations: OptimisticConfirmations,
+				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(changeset.GasPriceDeviationPPB)},
+				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(changeset.DAGasPriceDeviationPPB)},
+				OptimisticConfirmations: changeset.OptimisticConfirmations,
 			},
 		}
 	}

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -21,7 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -37,6 +36,10 @@ const (
 	Memory      EnvType = "in-memory"
 	Docker      EnvType = "docker"
 	ENVTESTTYPE         = "CCIP_V16_TEST_ENV"
+
+	GasPriceDeviationPPB    = 1000
+	DAGasPriceDeviationPPB  = 0
+	OptimisticConfirmations = 1
 )
 
 type TestConfigs struct {
@@ -496,11 +499,18 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 			},
 		})
 	}
+	allContractParams := make(map[uint64]changeset.ContractParams)
+	for _, chain := range allChains {
+		allContractParams[chain] = changeset.ContractParams{
+			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
+			OffRampParams:   changeset.DefaultOffRampParams(),
+		}
+	}
 	apps = append(apps, commonchangeset.ChangesetApplication{
 		Changeset: commonchangeset.WrapChangeSet(changeset.DeployChainContractsChangeset),
 		Config: changeset.DeployChainContractsConfig{
-			ChainSelectors:    allChains,
-			HomeChainSelector: e.HomeChainSel,
+			HomeChainSelector:      e.HomeChainSel,
+			ContractParamsPerChain: allContractParams,
 		},
 	})
 	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, nil, apps)
@@ -567,9 +577,9 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 			Readers: nodeInfo.NonBootstraps().PeerIDs(),
 			FChain:  uint8(len(nodeInfo.NonBootstraps().PeerIDs()) / 3),
 			EncodableChainConfig: chainconfig.ChainConfig{
-				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(internal.GasPriceDeviationPPB)},
-				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(internal.DAGasPriceDeviationPPB)},
-				OptimisticConfirmations: internal.OptimisticConfirmations,
+				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(GasPriceDeviationPPB)},
+				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(DAGasPriceDeviationPPB)},
+				OptimisticConfirmations: OptimisticConfirmations,
 			},
 		}
 	}

--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -103,7 +103,7 @@ func DeployCCIPAndAddLanes(ctx context.Context, lggr logger.Logger, envConfig de
 	if err != nil {
 		return DeployCCIPOutput{}, fmt.Errorf("failed to get node info from env: %w", err)
 	}
-	contractParams := make(map[uint64]changeset.ContractParams)
+	contractParams := make(map[uint64]changeset.ChainContractParams)
 	for _, chain := range chainSelectors {
 		chainConfigs[chain] = changeset.ChainConfig{
 			Readers: nodeInfo.NonBootstraps().PeerIDs(),
@@ -114,7 +114,7 @@ func DeployCCIPAndAddLanes(ctx context.Context, lggr logger.Logger, envConfig de
 				OptimisticConfirmations: 1,
 			},
 		}
-		contractParams[chain] = changeset.ContractParams{
+		contractParams[chain] = changeset.ChainContractParams{
 			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
 			OffRampParams:   changeset.DefaultOffRampParams(),
 		}

--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -103,6 +103,7 @@ func DeployCCIPAndAddLanes(ctx context.Context, lggr logger.Logger, envConfig de
 	if err != nil {
 		return DeployCCIPOutput{}, fmt.Errorf("failed to get node info from env: %w", err)
 	}
+	contractParams := make(map[uint64]changeset.ContractParams)
 	for _, chain := range chainSelectors {
 		chainConfigs[chain] = changeset.ChainConfig{
 			Readers: nodeInfo.NonBootstraps().PeerIDs(),
@@ -112,6 +113,10 @@ func DeployCCIPAndAddLanes(ctx context.Context, lggr logger.Logger, envConfig de
 				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(1_000_000)},
 				OptimisticConfirmations: 1,
 			},
+		}
+		contractParams[chain] = changeset.ContractParams{
+			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
+			OffRampParams:   changeset.DefaultOffRampParams(),
 		}
 	}
 
@@ -141,8 +146,8 @@ func DeployCCIPAndAddLanes(ctx context.Context, lggr logger.Logger, envConfig de
 		{
 			Changeset: commonchangeset.WrapChangeSet(changeset.DeployChainContractsChangeset),
 			Config: changeset.DeployChainContractsConfig{
-				ChainSelectors:    chainSelectors,
-				HomeChainSelector: homeChainSel,
+				HomeChainSelector:      homeChainSel,
+				ContractParamsPerChain: contractParams,
 			},
 		},
 		{

--- a/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
@@ -372,10 +372,15 @@ func TestSetRMNRemoteOnRMNProxy(t *testing.T) {
 		contractsByChain[chain] = []common.Address{rmnProxy.Address()}
 	}
 	timelockContractsPerChain := make(map[uint64]*proposalutils.TimelockExecutionContracts)
+	allContractParams := make(map[uint64]changeset.ContractParams)
 	for _, chain := range allChains {
 		timelockContractsPerChain[chain] = &proposalutils.TimelockExecutionContracts{
 			Timelock:  state.Chains[chain].Timelock,
 			CallProxy: state.Chains[chain].CallProxy,
+		}
+		allContractParams[chain] = changeset.ContractParams{
+			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
+			OffRampParams:   changeset.DefaultOffRampParams(),
 		}
 	}
 	envNodes, err := deployment.NodeInfo(e.Env.NodeIDs, e.Env.Offchain)
@@ -405,8 +410,8 @@ func TestSetRMNRemoteOnRMNProxy(t *testing.T) {
 		{
 			Changeset: commonchangeset.WrapChangeSet(changeset.DeployChainContractsChangeset),
 			Config: changeset.DeployChainContractsConfig{
-				ChainSelectors:    allChains,
-				HomeChainSelector: e.HomeChainSel,
+				HomeChainSelector:      e.HomeChainSel,
+				ContractParamsPerChain: allContractParams,
 			},
 		},
 		{

--- a/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
@@ -372,13 +372,13 @@ func TestSetRMNRemoteOnRMNProxy(t *testing.T) {
 		contractsByChain[chain] = []common.Address{rmnProxy.Address()}
 	}
 	timelockContractsPerChain := make(map[uint64]*proposalutils.TimelockExecutionContracts)
-	allContractParams := make(map[uint64]changeset.ContractParams)
+	allContractParams := make(map[uint64]changeset.ChainContractParams)
 	for _, chain := range allChains {
 		timelockContractsPerChain[chain] = &proposalutils.TimelockExecutionContracts{
 			Timelock:  state.Chains[chain].Timelock,
 			CallProxy: state.Chains[chain].CallProxy,
 		}
-		allContractParams[chain] = changeset.ContractParams{
+		allContractParams[chain] = changeset.ChainContractParams{
 			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
 			OffRampParams:   changeset.DefaultOffRampParams(),
 		}


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/CCIP-4320
Parametrize CCIP changesets
1) Move hardcoded inputs from cs_deploy_chain.go to created ContractParams input
2) Move `GasPriceDeviationPPB`	`DAGasPriceDeviationPPB` `OptimisticConfirmations`in deploy_home_chain to testhelpers (used in deployment/environment/crib and in unit tests)
3) Actualize tests

Still has constants in [internal/deploy_home_chain.go](https://github.com/smartcontractkit/chainlink/blob/d6aeee8db895819eff623df0f5342b410ae18a66/deployment/ccip/changeset/internal/deploy_home_chain.go#L28) but they are used as a defaults in changesets