### PR TITLE
fix: lint report artifact url

### DIFF
--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -21,7 +21,7 @@ inputs:
 outputs:
   golang-report-artifact-url:
     description: The URL to the uploaded artifact
-    value: ${{ steps.upload-artifact.outputs.artifact_url }}
+    value: ${{ steps.upload-artifact.outputs.artifact-url }}
 
 runs:
   using: composite


### PR DESCRIPTION
### Changes

- Fixes the artifact url which output from #15979.
    - `artifact-url` vs. `artifact_url`.

https://github.com/actions/upload-artifact?tab=readme-ov-file#outputs

