### PR TITLE
make gomodslocalupdate

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -147,7 +147,7 @@ testdb-user-only: ## Prepares the test database with user only.
 
 .PHONY: gomods
 gomods: ## Install gomods
-	go install github.com/jmank88/gomods@v0.1.4
+	go install github.com/jmank88/gomods@v0.1.5
 
 .PHONY: gomodslocalupdate
 gomodslocalupdate: gomods ## Run gomod-local-update

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -12,8 +12,8 @@ replace github.com/smartcontractkit/chainlink/deployment => ../../deployment
 // Using a separate `require` here to avoid surrounding line changes
 // creating potential merge conflicts.
 require (
-	github.com/smartcontractkit/chainlink/deployment v0.0.0-20241206210521-125d98cdaf66
-	github.com/smartcontractkit/chainlink/v2 v2.14.0-mercury-20240807.0.20241106193309-5560cd76211a
+	github.com/smartcontractkit/chainlink/deployment v0.0.0-20250120230622-566643da09fd
+	github.com/smartcontractkit/chainlink/v2 v2.0.0-20250120230622-566643da09fd
 )
 
 require (

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -9,7 +9,7 @@ replace github.com/smartcontractkit/chainlink/v2 => ../
 
 // Using a separate inline `require` here to avoid surrounding line changes
 // creating potential merge conflicts.
-require github.com/smartcontractkit/chainlink/v2 v2.0.0-20241212011003-de1a8f5e5b42
+require github.com/smartcontractkit/chainlink/v2 v2.0.0-20250120230622-566643da09fd
 
 require (
 	github.com/Khan/genqlient v0.7.0

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -12,8 +12,8 @@ replace github.com/smartcontractkit/chainlink/deployment => ../deployment
 // Using a separate `require` here to avoid surrounding line changes
 // creating potential merge conflicts.
 require (
-	github.com/smartcontractkit/chainlink/deployment v0.0.0-20241212011003-de1a8f5e5b42
-	github.com/smartcontractkit/chainlink/v2 v2.0.0-20241212011003-de1a8f5e5b42
+	github.com/smartcontractkit/chainlink/deployment v0.0.0-20250120230622-566643da09fd
+	github.com/smartcontractkit/chainlink/v2 v2.0.0-20250120230622-566643da09fd
 )
 
 require (

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -14,9 +14,9 @@ replace github.com/smartcontractkit/chainlink/integration-tests => ../
 // Using a separate `require` here to avoid surrounding line changes
 // creating potential merge conflicts.
 require (
-	github.com/smartcontractkit/chainlink/deployment v0.0.0-20241212011003-de1a8f5e5b42
-	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20241212011003-de1a8f5e5b42
-	github.com/smartcontractkit/chainlink/v2 v2.0.0-20241212011003-de1a8f5e5b42
+	github.com/smartcontractkit/chainlink/deployment v0.0.0-20250120230622-566643da09fd
+	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20250120230622-566643da09fd
+	github.com/smartcontractkit/chainlink/v2 v2.0.0-20250120230622-566643da09fd
 )
 
 require (


### PR DESCRIPTION
Run `make gomodslocalupdate` to update local `replace`s to the latest develop hash, so that imports "just work".