### PR TITLE
core/services: log ocr2 job type

### DIFF
--- a/core/services/job/kv_orm.go
+++ b/core/services/job/kv_orm.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // KVStore is a simple KV store that can store and retrieve serializable data.
@@ -18,17 +17,14 @@ type KVStore interface {
 type kVStore struct {
 	jobID int32
 	ds    sqlutil.DataSource
-	lggr  logger.SugaredLogger
 }
 
 var _ KVStore = (*kVStore)(nil)
 
-func NewKVStore(jobID int32, ds sqlutil.DataSource, lggr logger.Logger) kVStore {
-	namedLogger := logger.Sugared(lggr.Named("JobORM"))
+func NewKVStore(jobID int32, ds sqlutil.DataSource) kVStore {
 	return kVStore{
 		jobID: jobID,
 		ds:    ds,
-		lggr:  namedLogger,
 	}
 }
 

--- a/core/services/job/kv_orm_test.go
+++ b/core/services/job/kv_orm_test.go
@@ -28,13 +28,11 @@ func TestJobKVStore(t *testing.T) {
 	config := configtest.NewTestGeneralConfig(t)
 	db := pgtest.NewSqlxDB(t)
 
-	lggr := logger.TestLogger(t)
-
 	pipelineORM := pipeline.NewORM(db, logger.TestLogger(t), config.JobPipeline().MaxSuccessfulRuns())
 	bridgesORM := bridges.NewORM(db)
 
 	jobID := int32(1337)
-	kvStore := job.NewKVStore(jobID, db, lggr)
+	kvStore := job.NewKVStore(jobID, db)
 	jobORM := NewTestORM(t, db, pipelineORM, bridgesORM, cltest.NewKeyStore(t, db))
 
 	jb, err := directrequest.ValidatedDirectRequestSpec(testspecs.GetDirectRequestSpec())

--- a/core/services/standardcapabilities/delegate.go
+++ b/core/services/standardcapabilities/delegate.go
@@ -105,7 +105,7 @@ func (d *Delegate) BeforeJobCreated(job job.Job) {
 func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.ServiceCtx, error) {
 	log := d.logger.Named("StandardCapabilities").Named(spec.StandardCapabilitiesSpec.GetID())
 
-	kvStore := job.NewKVStore(spec.ID, d.ds, log)
+	kvStore := job.NewKVStore(spec.ID, d.ds)
 	telemetryService := generic.NewTelemetryAdapter(d.monitoringEndpointGen)
 	errorLog := &ErrorLog{jobID: spec.ID, recordError: d.jobORM.RecordError}
 	pr := generic.NewPipelineRunnerAdapter(log, spec, d.pipelineRunner)


### PR DESCRIPTION
Add job type to ocr2 logger name and remove unused logger from `kVStore`.
```diff
-logger=OCR2.ec912c2c-d933-4155-9325-daaf1168d5fa
+logger=OCR2.<job-type>.ec912c2c-d933-4155-9325-daaf1168d5fa
```