### PR TITLE
Explicitly use protoc installed in the makefile.

### DIFF
--- a/.changeset/poor-adults-tie.md
+++ b/.changeset/poor-adults-tie.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#updated Explicitly use protoc installed in the makefile.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -108,6 +108,7 @@ abigen: ## Build & install abigen.
 
 .PHONY: generate
 generate: abigen codecgen mockery protoc gomods ## Execute all go:generate commands.
+	export PATH=$(HOME)/.local/bin:$(PATH) ## Make sure that go:generate uses protoc installed above
 	gomods -w go generate -x ./...
 	find . -type f -name .mockery.yaml -execdir mockery \; ## Execute mockery for all .mockery.yaml files
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -108,8 +108,8 @@ abigen: ## Build & install abigen.
 
 .PHONY: generate
 generate: abigen codecgen mockery protoc gomods ## Execute all go:generate commands.
-	export PATH=$(HOME)/.local/bin:$(PATH) ## Make sure that go:generate uses protoc installed above
-	gomods -w go generate -x ./...
+	## Make sure that go:generate uses protoc installed above
+	export PATH=$(HOME)/.local/bin:$(PATH); gomods -w go generate -x ./...
 	find . -type f -name .mockery.yaml -execdir mockery \; ## Execute mockery for all .mockery.yaml files
 
 .PHONY: rm-mocked

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -108,7 +108,7 @@ abigen: ## Build & install abigen.
 
 .PHONY: generate
 generate: abigen codecgen mockery protoc gomods ## Execute all go:generate commands.
-	## Make sure that go:generate uses protoc installed above
+	## Exporting PATH makes sure that go:generate uses the version of protoc installed by the protoc make command.
 	export PATH=$(HOME)/.local/bin:$(PATH); gomods -w go generate -x ./...
 	find . -type f -name .mockery.yaml -execdir mockery \; ## Execute mockery for all .mockery.yaml files
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -108,7 +108,7 @@ abigen: ## Build & install abigen.
 
 .PHONY: generate
 generate: abigen codecgen mockery protoc gomods ## Execute all go:generate commands.
-	## Exporting PATH makes sure that go:generate uses the version of protoc installed by the protoc make command.
+	## Updating PATH makes sure that go:generate uses the version of protoc installed by the protoc make command.
 	export PATH=$(HOME)/.local/bin:$(PATH); gomods -w go generate -x ./...
 	find . -type f -name .mockery.yaml -execdir mockery \; ## Execute mockery for all .mockery.yaml files
 


### PR DESCRIPTION
Before this change we interact with protoc as follows:
1.  install protoc at the specific version 25.1 in `core/scripts/install-protoc.sh`.
2. enable protoc by updating $PATH variable  in `core/scripts/install-protoc.sh`
3. call `gomods -w go generate -x ./...` and rely on `//go:generate protoc ...` directives to generate pb definitions.

The 2. Step above actually only works !inside! the script, hence not updating the $PATH for the later `//go:generate protoc...` invocation. This works on linux because protoc is installed in .local folder which is included in $PATH by default (https://unix.stackexchange.com/questions/316765/which-distributions-have-home-local-bin-in-path). But this does not work on MAC. This PR explicitly adds installed protoc folder to $PATH so that it is used in `//go:generate protoc...` calls. (On MAC the `make generate` command will use any `protoc` installed, e.g., `/opt/homebrew/bin/protoc`.)