### PR TITLE
integration-tests/smoke/ccip: drop numMessages

### DIFF
--- a/integration-tests/smoke/ccip/ccip_batching_test.go
+++ b/integration-tests/smoke/ccip/ccip_batching_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	numMessages = 40
+	numMessages = 25
 )
 
 type batchTestSetup struct {


### PR DESCRIPTION
The Test_CCIPBatching test is flaking due to the high
number of messages being sent. This change drops the
number of messages to 25 to avoid timeouts.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
