### PR TITLE
fix: add job link to race test notifications

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -207,6 +207,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4.2.1
@@ -288,7 +289,14 @@ jobs:
       - name: Print Races
         id: print-races
         if: ${{ failure() && matrix.type.cmd == 'go_core_race_tests' && needs.filter.outputs.should-run-ci-core == 'true' }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          run_url=$(gh run --repo "$GH_REPO" view "$GH_RUN_ID" --json jobs --jq '.jobs[] | select(.name | contains("${{ matrix.type.cmd }}")) | .url')
+          echo "run_url=$run_url" >> $GITHUB_OUTPUT
+
           find race.* | xargs cat > race.txt
           if [[ -s race.txt ]]; then
             cat race.txt
@@ -329,7 +337,8 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
         with:
           channel-id: "#topic-data-races"
-          slack-message: "Race tests failed: \n${{ format('https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id) }}"
+          slack-message: |
+            Race Tests Failed: ${{ steps.print-races.outputs.run_url }}
 
   core-scripts-tests:
     name: test-scripts


### PR DESCRIPTION
### Changes

Include the job link in race test failure notifications

### Notes

Github doesn't natively support getting the job id, and it is especially bad within matrix jobs.

```
gh run --repo $GH_REPO view $GH_RUN_ID --json jobs --jq '.jobs[] | select(.name | contains("${{ matrix.type.cmd }}")) | .url'
```

This command was adapted from: https://stackoverflow.com/questions/59073850/github-actions-get-url-of-test-build, this works because we know a substring of our race tests job so we can do `select(.name | contains("${{ matrix.type.cmd }}")`.

### Testing

Echo'd the run_url here: https://github.com/smartcontractkit/chainlink/actions/runs/12896302500/job/35959051383?pr=16018#step:4:14



---

RE-3429
