### PR TITLE
[DO NOT MERGE] CCIP Release branch 2.20-ccip1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.20.0",
+  "version": "2.20.0-ccip1.5.17",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Release branch for CCIP1.5 built on top of Core 2.20

It's built on top of [release/2.20.0](https://github.com/smartcontractkit/chainlink/tree/release/2.20.0) and should be updated whenever parent is changed 

Additional cherry-picks/changes not present in the parent:
* Bumping chain-selectors to 1.0.36 https://github.com/smartcontractkit/chainlink/pull/16026
* Fixing configuration for chainType for CCIP https://github.com/smartcontractkit/chainlink/pull/16024
* `package.json` bump that should never be merged 