### PR TITLE
Allow to set default flakeguard runner

### DIFF
--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -73,7 +73,7 @@ env:
   RUN_WITH_SHUFFLE: ${{ fromJSON(inputs.extraArgs)['run_with_shuffle'] || 'false' }} # Whether to run tests with -shuffle flag.
   SHUFFLE_SEED: ${{ fromJSON(inputs.extraArgs)['shuffle_seed'] || '999' }} # The seed to use when -shuffle flag is enabled. Requires RUN_WITH_SHUFFLE to be true.
   ALL_TESTS_RUNNER: ${{ fromJSON(inputs.extraArgs)['all_tests_runner'] || 'ubuntu22.04-32cores-128GB' }} # The runner to use for running all tests.
-  DEFAULT_RUNNER: 'ubuntu-latest' # The default runner to use for running tests.
+  DEFAULT_RUNNER: ${{ fromJSON(inputs.extraArgs)['default_tests_runner'] || 'ubuntu-latest' }} # The runner to use for running custom tests (e.g. in PRs).
   UPLOAD_ALL_TEST_RESULTS: ${{ fromJSON(inputs.extraArgs)['upload_all_test_results'] || 'false' }} # Whether to upload all test results as artifacts.
   OMIT_TEST_OUTPUTS_ON_SUCCESS: ${{ fromJSON(inputs.extraArgs)['omit_test_outputs_on_success'] || 'true' }}
 


### PR DESCRIPTION
Allow to change default flakeguard runner which is `ubuntu-latest` by default. 

To do it call `./.github/workflows/flakeguard.yml` workflow with `default_tests_runner` in `extraArgs`. E.g. 

```
  trigger-flaky-test-detection-for-deployment-project:
    name: Flakeguard Deployment Project
    uses: ./.github/workflows/flakeguard.yml
    needs: [detect-changes]
    if: ${{ needs.detect-changes.outputs.deployment-changes == 'true'}}
    with:
      repoUrl: 'https://github.com/smartcontractkit/chainlink'
      projectPath: 'deployment'
      baseRef: ${{ github.base_ref }}
      headRef: ${{ github.head_ref }}
      maxPassRatio: '1.0'
      findByTestFilesDiff: true
      findByAffectedPackages: false
      slackNotificationAfterTestsChannelId: 'C07TRF65CNS' #flaky-test-detector-notifications
      extraArgs: '{ "skipped_tests": "TestAddLane", "run_with_race": "true", "print_failed_tests": "true", "test_repeat_count": "3", "omit_test_outputs_on_success": "true", "default_tests_runner": "<CUSTOM-RUNNER>" }'
    secrets:
      SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      FLAKEGUARD_SPLUNK_ENDPOINT: ${{ secrets.FLAKEGUARD_SPLUNK_ENDPOINT }}
      FLAKEGUARD_SPLUNK_HEC: ${{ secrets.FLAKEGUARD_SPLUNK_HEC }}
```