### PR TITLE
support build-tag style gates for testscripts

### DIFF
--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -1,0 +1,5 @@
+//go:build integration
+
+package main
+
+func init() { isIntegrationBuild = true }

--- a/main_test.go
+++ b/main_test.go
@@ -34,6 +34,8 @@ const (
 	//	-- testport.txt --
 	//	PORT
 	testPortName = "testport.txt"
+	// integrationBuildName acts like a build tag: //go:build integration
+	integrationBuildName = "go:build.integration"
 )
 
 func TestMain(m *testing.M) {
@@ -69,7 +71,15 @@ func TestScripts(t *testing.T) {
 	require.NoError(t, visitor.Walk())
 }
 
+// isIntegrationBuild is toggled true by a func init() with a //go:build integration gate
+var isIntegrationBuild = false
+
 func commonEnv(te *testscript.Env) error {
+	if _, err := os.Stat(integrationBuildName); err == nil && !isIntegrationBuild {
+		te.T().Skip("integration test")
+		return nil
+	}
+
 	te.Setenv("HOME", "$WORK/home")
 	te.Setenv("VERSION", static.Version)
 	te.Setenv("COMMIT_SHA", static.Sha)

--- a/testdata/scripts/health/multi-chain-loopp.txtar
+++ b/testdata/scripts/health/multi-chain-loopp.txtar
@@ -27,6 +27,7 @@ cp stdout compact.json
 exec jq . compact.json
 cmp stdout out-unhealthy.json
 
+-- go:build.integration --
 -- testdb.txt --
 CL_DATABASE_URL
 -- testport.txt --


### PR DESCRIPTION
Support a hook from testscripts that behaves like `//go:build integration`, in order to skip tests that require LOOPP binaries to be installed.