### PR TITLE
Increase Zircuit NoNewFinalizedHeadsThreshold

### DIFF
--- a/.changeset/yellow-spies-fail.md
+++ b/.changeset/yellow-spies-fail.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Increase Zircuit's NoNewFinalizedHeadsThreshold to 40 minutes #nops

--- a/core/chains/evm/config/toml/defaults/Zircuit_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Zircuit_Mainnet.toml
@@ -5,7 +5,7 @@ FinalityDepth = 1000
 LinkContractAddress = '0x5D6d033B4FbD2190D99D930719fAbAcB64d2439a'
 LogPollInterval = "2s"
 NoNewHeadsThreshold = "40s"
-NoNewFinalizedHeadsThreshold = "15m"
+NoNewFinalizedHeadsThreshold = "40m"
 
 [GasEstimator]
 EIP1559DynamicFees = true

--- a/core/chains/evm/config/toml/defaults/Zircuit_Sepolia.toml
+++ b/core/chains/evm/config/toml/defaults/Zircuit_Sepolia.toml
@@ -5,7 +5,7 @@ FinalityDepth = 1000
 LinkContractAddress = '0xDEE94506570cA186BC1e3516fCf4fd719C312cCD'
 LogPollInterval = "2s"
 NoNewHeadsThreshold = "40s"
-NoNewFinalizedHeadsThreshold = "15m"
+NoNewFinalizedHeadsThreshold = "40m"
 
 [GasEstimator]
 EIP1559DynamicFees = true

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -9862,7 +9862,7 @@ LogBroadcasterEnabled = true
 RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
-NoNewFinalizedHeadsThreshold = '15m0s'
+NoNewFinalizedHeadsThreshold = '40m0s'
 
 [Transactions]
 Enabled = true
@@ -9977,7 +9977,7 @@ LogBroadcasterEnabled = true
 RPCDefaultBatchSize = 250
 RPCBlockQueryDelay = 1
 FinalizedBlockOffset = 0
-NoNewFinalizedHeadsThreshold = '15m0s'
+NoNewFinalizedHeadsThreshold = '40m0s'
 
 [Transactions]
 Enabled = true


### PR DESCRIPTION
We're seeing finalization times ranging from 13-40 minutes on both mainnet and testnet:
![image](https://github.com/user-attachments/assets/86086294-0ec5-4be3-a0e1-7084bfb323eb)

This leads to CRIT logs:
```
RPC's finalized state is out of sync; no new finalized heads received for 15m0s
```
Increase `NoNewFinalizedHeadsThreshold` to `40m` accordingly.