### PR TITLE
Fix check for AWS Secret key in run-e2e-tests workflow

### DIFF
--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       test_path: .github/e2e-tests.yml
       test_ids: '${{ inputs.testType }}/automation_test.go:TestAutomationBenchmark'

--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       test_path: .github/e2e-tests.yml
       test_ids: '${{ inputs.testType }}/automation_test.go:TestAutomationBenchmark'

--- a/.github/workflows/automation-load-tests.yml
+++ b/.github/workflows/automation-load-tests.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       test_path: .github/e2e-tests.yml
       test_ids: 'load/automationv2_1/automationv2_1_test.go:TestLogTrigger'

--- a/.github/workflows/automation-load-tests.yml
+++ b/.github/workflows/automation-load-tests.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       test_path: .github/e2e-tests.yml
       test_ids: 'load/automationv2_1/automationv2_1_test.go:TestLogTrigger'

--- a/.github/workflows/automation-nightly-tests.yml
+++ b/.github/workflows/automation-nightly-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd # ctf-run-tests@0.2.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d # ctf-run-tests@0.2.0
     with:
       test_path: .github/e2e-tests.yml
       test_trigger: Automation Nightly Tests

--- a/.github/workflows/automation-nightly-tests.yml
+++ b/.github/workflows/automation-nightly-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d # ctf-run-tests@0.2.0
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd # ctf-run-tests@0.2.0
     with:
       test_path: .github/e2e-tests.yml
       test_trigger: Automation Nightly Tests

--- a/.github/workflows/automation-ondemand-tests.yml
+++ b/.github/workflows/automation-ondemand-tests.yml
@@ -168,7 +168,7 @@ jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       test_path: .github/e2e-tests.yml
       test_list: ${{ needs.set-tests-to-run.outputs.test_list }}

--- a/.github/workflows/automation-ondemand-tests.yml
+++ b/.github/workflows/automation-ondemand-tests.yml
@@ -168,7 +168,7 @@ jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       test_path: .github/e2e-tests.yml
       test_list: ${{ needs.set-tests-to-run.outputs.test_list }}

--- a/.github/workflows/ccip-chaos-tests.yml
+++ b/.github/workflows/ccip-chaos-tests.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       test_path: .github/e2e-tests.yml
       chainlink_version: ${{ github.sha }}

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       test_path: .github/e2e-tests.yml
       test_trigger: E2E CCIP Load Tests

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       test_path: .github/e2e-tests.yml
       test_trigger: E2E CCIP Load Tests

--- a/.github/workflows/integration-chaos-tests.yml
+++ b/.github/workflows/integration-chaos-tests.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   run-e2e-tests-workflow-dispatch:
     name: Run E2E Tests (Workflow Dispatch)
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     if: github.event_name == 'workflow_dispatch'
     with:
       test_path: .github/e2e-tests.yml
@@ -48,7 +48,7 @@ jobs:
 
   run-e2e-tests-workflow:
     name: Run E2E Tests (Push and Sechedule)
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     if: github.event_name != 'workflow_dispatch'
     with:
       test_path: .github/e2e-tests.yml

--- a/.github/workflows/integration-chaos-tests.yml
+++ b/.github/workflows/integration-chaos-tests.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   run-e2e-tests-workflow-dispatch:
     name: Run E2E Tests (Workflow Dispatch)
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     if: github.event_name == 'workflow_dispatch'
     with:
       test_path: .github/e2e-tests.yml
@@ -48,7 +48,7 @@ jobs:
 
   run-e2e-tests-workflow:
     name: Run E2E Tests (Push and Sechedule)
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     if: github.event_name != 'workflow_dispatch'
     with:
       test_path: .github/e2e-tests.yml

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -175,7 +175,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -217,7 +217,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -263,7 +263,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -175,7 +175,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -217,7 +217,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -263,7 +263,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || github.sha }}

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -43,7 +43,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       test_path: .github/e2e-tests.yml
       test_ids: ${{ inputs.testToRun}}

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -43,7 +43,7 @@ on:
 jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       test_path: .github/e2e-tests.yml
       test_ids: ${{ inputs.testToRun}}

--- a/.github/workflows/on-demand-vrfv2-performance-test.yml
+++ b/.github/workflows/on-demand-vrfv2-performance-test.yml
@@ -71,7 +71,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2-performance-test.yml
+++ b/.github/workflows/on-demand-vrfv2-performance-test.yml
@@ -71,7 +71,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2-smoke-tests.yml
+++ b/.github/workflows/on-demand-vrfv2-smoke-tests.yml
@@ -74,7 +74,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2-smoke-tests.yml
+++ b/.github/workflows/on-demand-vrfv2-smoke-tests.yml
@@ -74,7 +74,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2plus-performance-test.yml
+++ b/.github/workflows/on-demand-vrfv2plus-performance-test.yml
@@ -71,7 +71,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2plus-performance-test.yml
+++ b/.github/workflows/on-demand-vrfv2plus-performance-test.yml
@@ -71,7 +71,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2plus-smoke-tests.yml
+++ b/.github/workflows/on-demand-vrfv2plus-smoke-tests.yml
@@ -74,7 +74,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/on-demand-vrfv2plus-smoke-tests.yml
+++ b/.github/workflows/on-demand-vrfv2plus-smoke-tests.yml
@@ -74,7 +74,7 @@ jobs:
   run-e2e-tests-workflow:
     name: Run E2E Tests
     needs: set-tests-to-run
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       custom_test_list_json: ${{ needs.set-tests-to-run.outputs.test_list }}
       chainlink_version: ${{ inputs.chainlink_version }}

--- a/.github/workflows/run-nightly-e2e-tests.yml
+++ b/.github/workflows/run-nightly-e2e-tests.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       chainlink_version: ${{ inputs.chainlink_version || 'develop' }}
       test_path: .github/e2e-tests.yml

--- a/.github/workflows/run-nightly-e2e-tests.yml
+++ b/.github/workflows/run-nightly-e2e-tests.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       chainlink_version: ${{ inputs.chainlink_version || 'develop' }}
       test_path: .github/e2e-tests.yml

--- a/.github/workflows/run-selected-e2e-tests.yml
+++ b/.github/workflows/run-selected-e2e-tests.yml
@@ -35,7 +35,7 @@ run-name: ${{ inputs.workflow_run_name }}
 jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@d02f6b5bf665d9ce4cb9654a2454ae34a1e3a23d
     with:
       chainlink_version: ${{ github.event.inputs.chainlink_version }}
       test_path: .github/e2e-tests.yml

--- a/.github/workflows/run-selected-e2e-tests.yml
+++ b/.github/workflows/run-selected-e2e-tests.yml
@@ -35,7 +35,7 @@ run-name: ${{ inputs.workflow_run_name }}
 jobs:
   call-run-e2e-tests-workflow:
     name: Run E2E Tests
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@61acf908014e2fe42c04f2a507c79f97eb5f8c4d
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70e8b4e72240b1d53c76b55163b5bc2149efd1cd
     with:
       chainlink_version: ${{ github.event.inputs.chainlink_version }}
       test_path: .github/e2e-tests.yml


### PR DESCRIPTION
This PR bumps e2e workflow to include this change: https://github.com/smartcontractkit/.github/pull/837