### PR TITLE
Use both TXMv1 and TXMv2 for OEV

### DIFF
--- a/core/chains/legacyevm/evm_txm.go
+++ b/core/chains/legacyevm/evm_txm.go
@@ -54,7 +54,7 @@ func newEvmTxm(
 				opts.KeyStore,
 				estimator,
 			)
-			if cfg.Transactions().TransactionManagerV2().DualBroadcast() != nil && *cfg.Transactions().TransactionManagerV2().DualBroadcast() {
+			if cfg.Transactions().TransactionManagerV2().DualBroadcast() == nil || !*cfg.Transactions().TransactionManagerV2().DualBroadcast() {
 				return txmv2, err
 			}
 		}


### PR DESCRIPTION
This change was reverted at some point. If TXMv2 is enabled and DualBroadcast is nil or false, we return TXMv2 immediately. If TXMv2 is disabled we return TXMv2. If TXMv2 is enabled and DualBroadcast is true, we need to initialize both TXMs and inject TXMv2 in TXMv1 as per our previous custom release.