### PR TITLE
core/chains/evm: simplify imports: reduce dependency on internal test utils & pgtest

### DIFF
--- a/core/chains/evm/forwarders/forwarder_manager_test.go
+++ b/core/chains/evm/forwarders/forwarder_manager_test.go
@@ -24,25 +24,18 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/authorized_forwarder"
-	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/authorized_receiver"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/operator_wrapper"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/evm/client"
-	evmtypes "github.com/smartcontractkit/chainlink/v2/evm/types"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	ubig "github.com/smartcontractkit/chainlink/v2/evm/utils/big"
 )
 
-var GetAuthorisedSendersABI = evmtypes.MustGetABI(authorized_receiver.AuthorizedReceiverABI).Methods["getAuthorizedSenders"]
-
-var SimpleOracleCallABI = evmtypes.MustGetABI(operator_wrapper.OperatorABI).Methods["getChainlinkToken"]
-
 func TestFwdMgr_MaybeForwardTransaction(t *testing.T) {
 	lggr := logger.Test(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 	owner := testutils.MustNewSimTransactor(t)
@@ -111,7 +104,7 @@ func TestFwdMgr_MaybeForwardTransaction(t *testing.T) {
 
 func TestFwdMgr_AccountUnauthorizedToForward_SkipsForwarding(t *testing.T) {
 	lggr := logger.Test(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	ctx := testutils.Context(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
@@ -161,7 +154,7 @@ func TestFwdMgr_AccountUnauthorizedToForward_SkipsForwarding(t *testing.T) {
 
 func TestFwdMgr_InvalidForwarderForOCR2FeedsStates(t *testing.T) {
 	lggr := logger.Test(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	ctx := testutils.Context(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)

--- a/core/chains/evm/forwarders/orm_test.go
+++ b/core/chains/evm/forwarders/orm_test.go
@@ -11,15 +11,14 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils/big"
 )
 
 // Tests the atomicity of cleanup function passed to DeleteForwarder, during DELETE operation
 func Test_DeleteForwarder(t *testing.T) {
 	t.Parallel()
-	orm := NewORM(pgtest.NewSqlxDB(t))
+	orm := NewORM(testutils.NewSqlxDB(t))
 	addr := testutils.NewAddress()
 	chainID := testutils.FixtureChainID
 	ctx := testutils.Context(t)

--- a/core/chains/evm/headtracker/head_broadcaster_test.go
+++ b/core/chains/evm/headtracker/head_broadcaster_test.go
@@ -22,10 +22,9 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker/types"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/evm/client/clienttest"
 	"github.com/smartcontractkit/chainlink/v2/evm/config/toml"
-	testutils2 "github.com/smartcontractkit/chainlink/v2/evm/testutils"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils/big"
@@ -38,7 +37,7 @@ func waitHeadBroadcasterToStart(t *testing.T, hb types.HeadBroadcaster) {
 	_, unsubscribe := hb.Subscribe(subscriber)
 	defer unsubscribe()
 
-	hb.BroadcastNewLongestChain(testutils2.Head(1))
+	hb.BroadcastNewLongestChain(testutils.Head(1))
 	g := gomega.NewWithT(t)
 	g.Eventually(subscriber.OnNewLongestChainCount).Should(gomega.Equal(int32(1)))
 }
@@ -47,10 +46,10 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewWithT(t)
 
-	evmCfg := testutils2.NewTestChainScopedConfig(t, func(c *toml.EVMConfig) {
+	evmCfg := testutils.NewTestChainScopedConfig(t, func(c *toml.EVMConfig) {
 		c.HeadTracker.SamplingInterval = &commonconfig.Duration{}
 	})
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	logger := logger.Test(t)
 
 	sub := commonmocks.NewSubscription(t)
@@ -63,7 +62,7 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 			chchHeaders <- chHead
 		}).
 		Return((<-chan *evmtypes.Head)(chHead), sub, nil)
-	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(testutils2.Head(1), nil)
+	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(testutils.Head(1), nil)
 
 	sub.On("Unsubscribe").Return()
 	sub.On("Err").Return(nil)
@@ -85,7 +84,7 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 	assert.Equal(t, (*evmtypes.Head)(nil), latest1)
 
 	headers := <-chchHeaders
-	h := evmtypes.Head{Number: 1, Hash: utils.NewHash(), ParentHash: utils.NewHash(), EVMChainID: big.New(testutils2.FixtureChainID)}
+	h := evmtypes.Head{Number: 1, Hash: utils.NewHash(), ParentHash: utils.NewHash(), EVMChainID: big.New(testutils.FixtureChainID)}
 	headers <- &h
 	g.Eventually(checker1.OnNewLongestChainCount).Should(gomega.Equal(int32(1)))
 
@@ -96,7 +95,7 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 
 	unsubscribe1()
 
-	headers <- &evmtypes.Head{Number: 2, Hash: utils.NewHash(), ParentHash: h.Hash, EVMChainID: big.New(testutils2.FixtureChainID)}
+	headers <- &evmtypes.Head{Number: 2, Hash: utils.NewHash(), ParentHash: h.Hash, EVMChainID: big.New(testutils.FixtureChainID)}
 	g.Eventually(checker2.OnNewLongestChainCount).Should(gomega.Equal(int32(1)))
 }
 
@@ -117,25 +116,25 @@ func TestHeadBroadcaster_BroadcastNewLongestChain(t *testing.T) {
 	_, unsubscribe1 := broadcaster.Subscribe(subscriber1)
 	_, unsubscribe2 := broadcaster.Subscribe(subscriber2)
 
-	broadcaster.BroadcastNewLongestChain(testutils2.Head(1))
+	broadcaster.BroadcastNewLongestChain(testutils.Head(1))
 	g.Eventually(subscriber1.OnNewLongestChainCount).Should(gomega.Equal(int32(1)))
 
 	unsubscribe1()
 
-	broadcaster.BroadcastNewLongestChain(testutils2.Head(2))
+	broadcaster.BroadcastNewLongestChain(testutils.Head(2))
 	g.Eventually(subscriber2.OnNewLongestChainCount).Should(gomega.Equal(int32(2)))
 
 	unsubscribe2()
 
 	subscriber3 := &mocks.MockHeadTrackable{}
 	_, unsubscribe3 := broadcaster.Subscribe(subscriber3)
-	broadcaster.BroadcastNewLongestChain(testutils2.Head(1))
+	broadcaster.BroadcastNewLongestChain(testutils.Head(1))
 	g.Eventually(subscriber3.OnNewLongestChainCount).Should(gomega.Equal(int32(1)))
 
 	unsubscribe3()
 
 	// no subscribers - shall do nothing
-	broadcaster.BroadcastNewLongestChain(testutils2.Head(0))
+	broadcaster.BroadcastNewLongestChain(testutils.Head(0))
 
 	err = broadcaster.Close()
 	require.NoError(t, err)
@@ -154,14 +153,14 @@ func TestHeadBroadcaster_TrackableCallbackTimeout(t *testing.T) {
 
 	waitHeadBroadcasterToStart(t, broadcaster)
 
-	slowAwaiter := testutils2.NewAwaiter()
-	fastAwaiter := testutils2.NewAwaiter()
+	slowAwaiter := testutils.NewAwaiter()
+	fastAwaiter := testutils.NewAwaiter()
 	slow := &sleepySubscriber{awaiter: slowAwaiter, delay: commonhtrk.TrackableCallbackTimeout * 2}
 	fast := &sleepySubscriber{awaiter: fastAwaiter, delay: commonhtrk.TrackableCallbackTimeout / 2}
 	_, unsubscribe1 := broadcaster.Subscribe(slow)
 	_, unsubscribe2 := broadcaster.Subscribe(fast)
 
-	broadcaster.BroadcastNewLongestChain(testutils2.Head(1))
+	broadcaster.BroadcastNewLongestChain(testutils.Head(1))
 	slowAwaiter.AwaitOrFail(t, tests.WaitTimeout(t))
 	fastAwaiter.AwaitOrFail(t, tests.WaitTimeout(t))
 
@@ -176,7 +175,7 @@ func TestHeadBroadcaster_TrackableCallbackTimeout(t *testing.T) {
 }
 
 type sleepySubscriber struct {
-	awaiter     testutils2.Awaiter
+	awaiter     testutils.Awaiter
 	delay       time.Duration
 	contextDone bool
 }

--- a/core/chains/evm/headtracker/head_saver_test.go
+++ b/core/chains/evm/headtracker/head_saver_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker"
 	httypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker/types"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
@@ -74,7 +73,7 @@ func configureSaver(t *testing.T, opts saverOpts) (httypes.HeadSaver, headtracke
 	if opts.headTrackerConfig == nil {
 		opts.headTrackerConfig = &headTrackerConfig{historyDepth: 6}
 	}
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	lggr := logger.Test(t)
 	htCfg := &config{finalityDepth: uint32(1)}
 	orm := headtracker.NewORM(*testutils.FixtureChainID, db)

--- a/core/chains/evm/headtracker/orm_test.go
+++ b/core/chains/evm/headtracker/orm_test.go
@@ -10,14 +10,13 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 )
 
 func TestORM_IdempotentInsertHead(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := headtracker.NewORM(*testutils.FixtureChainID, db)
 
 	// Returns nil when inserting first head
@@ -41,7 +40,7 @@ func TestORM_IdempotentInsertHead(t *testing.T) {
 func TestORM_TrimOldHeads(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := headtracker.NewORM(*testutils.FixtureChainID, db)
 
 	for i := 0; i < 10; i++ {
@@ -68,7 +67,7 @@ func TestORM_TrimOldHeads(t *testing.T) {
 func TestORM_HeadByHash(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := headtracker.NewORM(*testutils.FixtureChainID, db)
 
 	var hash common.Hash
@@ -89,7 +88,7 @@ func TestORM_HeadByHash(t *testing.T) {
 func TestORM_HeadByHash_NotFound(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := headtracker.NewORM(*testutils.FixtureChainID, db)
 
 	hash := testutils.Head(123).Hash
@@ -102,7 +101,7 @@ func TestORM_HeadByHash_NotFound(t *testing.T) {
 func TestORM_LatestHeads_NoRows(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := headtracker.NewORM(*testutils.FixtureChainID, db)
 
 	heads, err := orm.LatestHeads(tests.Context(t), 100)

--- a/core/chains/evm/log/broadcaster.go
+++ b/core/chains/evm/log/broadcaster.go
@@ -18,8 +18,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
+	"github.com/smartcontractkit/chainlink-framework/chains/headtracker"
 
-	httypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker/types"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated"
 	evmclient "github.com/smartcontractkit/chainlink/v2/evm/client"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/evm/types"
@@ -46,7 +46,7 @@ type (
 	Broadcaster interface {
 		utils.DependentAwaiter
 		services.Service
-		httypes.HeadTrackable
+		headtracker.HeadTrackable[*evmtypes.Head, common.Hash]
 
 		// ReplayFromBlock enqueues a replay from the provided block number. If forceBroadcast is
 		// set to true, the broadcaster will broadcast logs that were already marked consumed

--- a/core/chains/evm/log/integration_test.go
+++ b/core/chains/evm/log/integration_test.go
@@ -87,7 +87,7 @@ func TestBroadcaster_ResubscribesOnAddOrRemoveContract(t *testing.T) {
 	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight), nil)
 	helper.mockEth = mockEth
 
-	blockBackfillDepth := helper.config.EVM().BlockBackfillDepth()
+	blockBackfillDepth := helper.config.BlockBackfillDepth()
 
 	var backfillCount atomic.Int64
 
@@ -163,7 +163,7 @@ func TestBroadcaster_BackfillOnNodeStartAndOnReplay(t *testing.T) {
 	listener2 := helper.newLogListenerWithJob("two")
 	helper.register(listener2, newMockContract(t), uint32(2))
 
-	blockBackfillDepth := helper.config.EVM().BlockBackfillDepth()
+	blockBackfillDepth := helper.config.BlockBackfillDepth()
 
 	// the first backfill should use the height of last head saved to the db,
 	// minus maxNumConfirmations of subscribers and minus blockBackfillDepth
@@ -467,7 +467,7 @@ func TestBroadcaster_BackfillInBatches(t *testing.T) {
 	})
 	helper.mockEth = mockEth
 
-	blockBackfillDepth := helper.config.EVM().BlockBackfillDepth()
+	blockBackfillDepth := helper.config.BlockBackfillDepth()
 
 	var backfillCount atomic.Int64
 

--- a/core/chains/evm/log/orm_test.go
+++ b/core/chains/evm/log/orm_test.go
@@ -12,12 +12,11 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/log"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 )
 
 func TestORM_broadcasts(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
 	orm := log.NewORM(db, cltest.FixtureChainID)
@@ -80,7 +79,7 @@ func TestORM_broadcasts(t *testing.T) {
 
 func TestORM_pending(t *testing.T) {
 	ctx := testutils.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := log.NewORM(db, cltest.FixtureChainID)
 
 	num, err := orm.GetPendingMinBlock(ctx)
@@ -105,7 +104,7 @@ func TestORM_pending(t *testing.T) {
 
 func TestORM_MarkUnconsumed(t *testing.T) {
 	ctx := testutils.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
 	orm := log.NewORM(db, cltest.FixtureChainID)
@@ -202,7 +201,7 @@ func TestORM_Reinitialize(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			db := pgtest.NewSqlxDB(t)
+			db := testutils.NewSqlxDB(t)
 			ctx := testutils.Context(t)
 			orm := log.NewORM(db, cltest.FixtureChainID)
 

--- a/core/chains/evm/log/registrations_test.go
+++ b/core/chains/evm/log/registrations_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
 )
 

--- a/core/chains/evm/logpoller/helper_test.go
+++ b/core/chains/evm/logpoller/helper_test.go
@@ -23,10 +23,9 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/log_emitter"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/evm/config/chaintype"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/evm/types"
 )
 
@@ -94,7 +93,7 @@ func SetupTH(t testing.TB, opts logpoller.Opts) TestHarness {
 	lggr := logger.Test(t)
 	chainID := testutils.NewRandomEVMChainID()
 	chainID2 := testutils.NewRandomEVMChainID()
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 
 	o := logpoller.NewORM(chainID, db, lggr)
 	o2 := logpoller.NewORM(chainID2, db, lggr)

--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -30,9 +30,8 @@ import (
 
 	htMocks "github.com/smartcontractkit/chainlink/v2/common/headtracker/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/log_emitter"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/evm/client/clienttest"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
 )
@@ -64,7 +63,7 @@ func TestLogPoller_RegisterFilter(t *testing.T) {
 
 	lggr, observedLogs := logger.TestObserved(t, zapcore.WarnLevel)
 	chainID := testutils.NewRandomEVMChainID()
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	ctx := testutils.Context(t)
 
 	orm := NewORM(chainID, db, lggr)
@@ -208,7 +207,7 @@ func TestLogPoller_BackupPollerStartup(t *testing.T) {
 	addr := common.HexToAddress("0x2ab9a2dc53736b361b72d900cdf9f78f9406fbbc")
 	lggr, observedLogs := logger.TestObserved(t, zapcore.WarnLevel)
 	chainID := testutils.FixtureChainID
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := NewORM(chainID, db, lggr)
 	latestBlock := int64(4)
 	const finalityDepth = 2
@@ -302,7 +301,7 @@ func TestLogPoller_Replay(t *testing.T) {
 
 	lggr, observedLogs := logger.TestObserved(t, zapcore.ErrorLevel)
 	chainID := testutils.FixtureChainID
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := NewORM(chainID, db, lggr)
 
 	var head atomic.Pointer[evmtypes.Head]
@@ -606,7 +605,7 @@ func Test_latestBlockAndFinalityDepth(t *testing.T) {
 func Test_FetchBlocks(t *testing.T) {
 	lggr := logger.Test(t)
 	chainID := testutils.FixtureChainID
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := NewORM(chainID, db, lggr)
 	ctx := testutils.Context(t)
 
@@ -678,7 +677,7 @@ func Test_FetchBlocks(t *testing.T) {
 func Test_PollAndSaveLogs_BackfillFinalityViolation(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	lpOpts := Opts{
 		PollPeriod:               time.Second,
 		FinalityDepth:            3,

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -33,12 +33,11 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/log_emitter"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/testutils/heavyweight"
 	"github.com/smartcontractkit/chainlink/v2/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/evm/config/chaintype"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
 	ubig "github.com/smartcontractkit/chainlink/v2/evm/utils/big"
@@ -687,7 +686,7 @@ func TestLogPoller_SynchronizedWithGeth(t *testing.T) {
 	numChainInserts := 3
 	finalityDepth := 5
 	lggr := logger.Test(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 
 	owner := testutils.MustNewSimTransactor(t)
 	owner.GasPrice = big.NewInt(10e9)
@@ -1463,7 +1462,7 @@ func TestLogPoller_DBErrorHandling(t *testing.T) {
 	lggr, observedLogs := logger.TestObserved(t, zapcore.WarnLevel)
 	chainID1 := testutils.NewRandomEVMChainID()
 	chainID2 := testutils.NewRandomEVMChainID()
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	o := logpoller.NewORM(chainID1, db, lggr)
 
 	owner := testutils.MustNewSimTransactor(t)
@@ -1536,7 +1535,7 @@ func TestTooManyLogResults(t *testing.T) {
 	ec := evmtest.NewEthClientMockWithDefaultChain(t)
 	lggr, obs := logger.TestObserved(t, zapcore.DebugLevel)
 	chainID := testutils.NewRandomEVMChainID()
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 
 	o := logpoller.NewORM(chainID, db, lggr)
 
@@ -1964,7 +1963,7 @@ func TestFindLCA(t *testing.T) {
 	ec := evmtest.NewEthClientMockWithDefaultChain(t)
 	lggr := logger.Test(t)
 	chainID := testutils.NewRandomEVMChainID()
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 
 	orm := logpoller.NewORM(chainID, db, lggr)
 

--- a/core/chains/evm/logpoller/observability_test.go
+++ b/core/chains/evm/logpoller/observability_test.go
@@ -15,8 +15,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
 	ubig "github.com/smartcontractkit/chainlink/v2/evm/utils/big"
 )
@@ -170,7 +169,7 @@ func generateRandomLogs(chainId, count int) []Log {
 
 func createObservedORM(t *testing.T, chainId int64) *ObservedORM {
 	lggr := logger.Test(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	return NewObservedORM(big.NewInt(chainId), db, lggr)
 }
 

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -23,9 +23,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/testutils/heavyweight"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	"github.com/smartcontractkit/chainlink/v2/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
 	ubig "github.com/smartcontractkit/chainlink/v2/evm/utils/big"
@@ -704,7 +703,7 @@ func TestLogPollerFilters(t *testing.T) {
 	lggr := logger.Test(t)
 	chainID := testutils.NewRandomEVMChainID()
 
-	dbx := pgtest.NewSqlxDB(t)
+	dbx := testutils.NewSqlxDB(t)
 	orm := logpoller.NewORM(chainID, dbx, lggr)
 
 	event1 := EmitterABI.Events["Log1"].ID
@@ -1323,7 +1322,7 @@ func Test_ExecPagedQuery(t *testing.T) {
 	ctx := testutils.Context(t)
 	lggr := logger.Test(t)
 	chainID := testutils.NewRandomEVMChainID()
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	o := logpoller.NewORM(chainID, db, lggr)
 
 	m := mockQueryExecutor{}
@@ -2045,7 +2044,7 @@ func TestInsertLogsWithBlock(t *testing.T) {
 	ctx := testutils.Context(t)
 
 	// We need full db here, because we want to test transaction rollbacks.
-	// Using pgtest.NewSqlxDB(t) will run all tests in TXs which is not desired for this type of test
+	// Using testutils.NewSqlxDB(t) will run all tests in TXs which is not desired for this type of test
 	// (inner tx rollback will rollback outer tx, blocking rest of execution)
 	_, db := heavyweight.FullTestDBV2(t, nil)
 	o := logpoller.NewORM(chainID, db, logger.Test(t))

--- a/core/chains/evm/txmgr/broadcaster_test.go
+++ b/core/chains/evm/txmgr/broadcaster_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/testutils/heavyweight"
 	"github.com/smartcontractkit/chainlink/v2/evm/assets"
@@ -141,7 +140,7 @@ func TestEthBroadcaster_Lifecycle(t *testing.T) {
 
 // Failure to load next sequnce map should not fail Broadcaster startup
 func TestEthBroadcaster_LoadNextSequenceMapFailure_StartupSuccess(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
@@ -174,7 +173,7 @@ func TestEthBroadcaster_LoadNextSequenceMapFailure_StartupSuccess(t *testing.T) 
 }
 
 func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	ctx := tests.Context(t)
 	txStore := cltest.NewTestTxStore(t, db)
@@ -547,7 +546,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 }
 
 func TestEthBroadcaster_TransmitChecking(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	ctx := tests.Context(t)
 	txStore := cltest.NewTestTxStore(t, db)
@@ -693,7 +692,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_OptimisticLockingOnEthTx(t *testi
 }
 
 func TestEthBroadcaster_ProcessUnstartedEthTxs_Success_WithMultiplier(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		// Configured gas price changed
 		lm := decimal.RequireFromString("1.3")
@@ -747,7 +746,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 	ctx := tests.Context(t)
 
 	t.Run("cannot be more than one transaction per address in an unfinished state", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -782,7 +781,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 	})
 
 	t.Run("previous run assigned nonce but never broadcast", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -821,7 +820,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 	})
 
 	t.Run("previous run assigned nonce and broadcast but it fatally errored before we could save", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -858,7 +857,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 	})
 
 	t.Run("previous run assigned nonce and broadcast and is now in mempool", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -894,7 +893,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 	})
 
 	t.Run("previous run assigned nonce and broadcast and now the transaction has been confirmed", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -932,7 +931,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce and then failed to reach node for some reason and node is still down", func(t *testing.T) {
 		failedToReachNodeError := context.DeadlineExceeded
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -968,7 +967,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 	})
 
 	t.Run("previous run assigned nonce and broadcast transaction then crashed and rebooted with a different configured gas price", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -1036,7 +1035,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 	gasLimit := uint64(242)
 	encodedPayload := []byte{0, 1}
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	txStore := cltest.NewTestTxStore(t, db)
 
@@ -1522,7 +1521,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 		assert.True(t, retryable)
 
 		// TEARDOWN: Clear out the unsent tx before the next test
-		pgtest.MustExec(t, db, `DELETE FROM evm.txes WHERE nonce = $1`, localNextNonce)
+		testutils.MustExec(t, db, `DELETE FROM evm.txes WHERE nonce = $1`, localNextNonce)
 	})
 
 	t.Run("tx is left in progress and its attempt gets replaced with a new re-estimated attempt if node returns insufficient eth", func(t *testing.T) {
@@ -1553,7 +1552,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 		assert.Nil(t, attempt.BroadcastBeforeBlockNum)
 	})
 
-	pgtest.MustExec(t, db, `DELETE FROM evm.txes`)
+	testutils.MustExec(t, db, `DELETE FROM evm.txes`)
 
 	t.Run("eth tx is left in progress if nonce is too high", func(t *testing.T) {
 		localNextNonce := getLocalNextNonce(t, nonceTracker, fromAddress)
@@ -1581,7 +1580,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 		assert.Equal(t, txmgrtypes.TxAttemptInProgress, attempt.State)
 		assert.Nil(t, attempt.BroadcastBeforeBlockNum)
 
-		pgtest.MustExec(t, db, `DELETE FROM evm.txes`)
+		testutils.MustExec(t, db, `DELETE FROM evm.txes`)
 	})
 
 	t.Run("eth node returns underpriced transaction and bumping gas doesn't increase it in EIP-1559 mode", func(t *testing.T) {
@@ -1613,7 +1612,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 		require.Contains(t, err.Error(), "bumped gas tip cap of 1 wei is less than or equal to original gas tip cap of 1 wei")
 		assert.True(t, retryable)
 
-		pgtest.MustExec(t, db, `DELETE FROM evm.txes`)
+		testutils.MustExec(t, db, `DELETE FROM evm.txes`)
 	})
 
 	t.Run("eth node returns underpriced transaction in EIP-1559 mode, bumps until inclusion", func(t *testing.T) {
@@ -1651,7 +1650,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 		assert.False(t, retryable)
 
 		// TEARDOWN: Clear out the unsent tx before the next test
-		pgtest.MustExec(t, db, `DELETE FROM evm.txes WHERE nonce = $1`, localNextNonce)
+		testutils.MustExec(t, db, `DELETE FROM evm.txes WHERE nonce = $1`, localNextNonce)
 	})
 }
 
@@ -1661,7 +1660,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_GasEstimationError(t *testing.T) 
 	gasLimit := uint64(242)
 	encodedPayload := []byte{0, 1}
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	cfg.EVMConfigs()[0].GasEstimator.EstimateLimit = ptr(true) // Enabled gas limit estimation
 	limitMultiplier := float32(1.25)
@@ -1729,7 +1728,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_KeystoreErrors(t *testing.T) {
 	encodedPayload := []byte{0, 1}
 	localNonce := 0
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewGeneralConfig(t, nil)
 	txStore := cltest.NewTestTxStore(t, db)
 
@@ -1785,7 +1784,7 @@ func TestEthBroadcaster_Trigger(t *testing.T) {
 	t.Parallel()
 
 	// Simple sanity check to make sure it doesn't block
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 
 	cfg := configtest.NewGeneralConfig(t, nil)
 	txStore := cltest.NewTestTxStore(t, db)
@@ -1802,7 +1801,7 @@ func TestEthBroadcaster_Trigger(t *testing.T) {
 }
 
 func TestEthBroadcaster_SyncNonce(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	ctx := tests.Context(t)
 
 	lggr, observed := logger.TestObserved(t, zapcore.DebugLevel)
@@ -1845,7 +1844,7 @@ func TestEthBroadcaster_SyncNonce(t *testing.T) {
 func TestEthBroadcaster_NonceTracker_InProgressTx(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -1884,7 +1883,7 @@ func TestEthBroadcaster_NonceTracker_InProgressTx(t *testing.T) {
 func TestEthBroadcaster_HederaBroadcastValidation(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()

--- a/core/chains/evm/txmgr/confirmer_test.go
+++ b/core/chains/evm/txmgr/confirmer_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/evm/assets"
 	"github.com/smartcontractkit/chainlink/v2/evm/client"
@@ -107,7 +106,7 @@ func mustInsertConfirmedEthTx(t *testing.T, txStore txmgr.TestEvmTxStore, nonce 
 func TestEthConfirmer_Lifecycle(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	gconfig, config := newTestChainScopedConfig(t)
 	txStore := newTxStore(t, db)
 
@@ -187,7 +186,7 @@ func TestEthConfirmer_Lifecycle(t *testing.T) {
 func TestEthConfirmer_CheckForConfirmation(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].GasEstimator.PriceMax = assets.GWei(500)
 	})
@@ -416,7 +415,7 @@ func TestEthConfirmer_CheckForConfirmation(t *testing.T) {
 func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
@@ -710,7 +709,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 	t.Parallel()
 	lggr := logger.Test(t)
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 
 	t.Run("should retry previous attempt if connectivity check failed for legacy transactions", func(t *testing.T) {
@@ -815,7 +814,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 func TestEthConfirmer_RebroadcastWhereNecessary_MaxFeeScenario(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].GasEstimator.PriceMax = assets.GWei(500)
 	})
@@ -893,7 +892,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	currentHead := int64(30)
 
 	t.Run("does nothing if no transactions require bumping", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -903,7 +902,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("re-sends previous transaction on keystore error", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -932,7 +931,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("does nothing and continues on fatal error", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -951,7 +950,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("creates new attempt with higher gas price if transaction has an attempt older than threshold", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -978,7 +977,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("does nothing if there is an attempt without BroadcastBeforeBlockNum set", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -994,7 +993,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("creates new attempt with higher gas price if transaction is already in mempool (e.g. due to previous crash before we could save the new attempt)", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1021,7 +1020,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("saves new attempt even for transaction that has already been confirmed (nonce already used)", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1051,7 +1050,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("saves in-progress attempt on temporary error and returns error", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1102,7 +1101,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("re-bumps attempt if initial bump is underpriced because the bumped gas price is insufficiently higher than the previous one", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1133,7 +1132,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("resubmits at the old price and does not create a new attempt if one of the bumped transactions would exceed EVM.GasEstimator.PriceMax", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		priceMax := assets.GWei(30)
 		gcfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
@@ -1165,7 +1164,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("resubmits at the old price and does not create a new attempt if the current price is exactly EVM.GasEstimator.PriceMax", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		priceMax := assets.GWei(30)
 		gcfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
@@ -1196,7 +1195,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("EIP-1559: bumps using EIP-1559 rules when existing attempts are of type 0x2", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		gcfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			c.EVM[0].GasEstimator.BumpMin = assets.GWei(1)
@@ -1228,7 +1227,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("EIP-1559: resubmits at the old price and does not create a new attempt if one of the bumped EIP-1559 transactions would have its tip cap exceed EVM.GasEstimator.PriceMax", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		gcfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			c.EVM[0].GasEstimator.PriceMax = assets.NewWeiI(1)
@@ -1258,7 +1257,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	})
 
 	t.Run("EIP-1559: re-bumps attempt if initial bump is underpriced because the bumped gas price is insufficiently higher than the previous one", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		gcfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			c.EVM[0].GasEstimator.BumpMin = assets.GWei(1)
@@ -1296,7 +1295,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyUnderpriced_ThenGoesThrough(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].GasEstimator.PriceMax = assets.GWei(500)
 	})
@@ -1408,7 +1407,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyUnderpriced_ThenGoesTh
 
 func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 	t.Parallel()
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
@@ -1546,7 +1545,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyStuckError(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].GasEstimator.PriceMax = assets.GWei(500)
 	})
@@ -1598,7 +1597,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyStuckError(t *testing.
 func TestEthConfirmer_ForceRebroadcast(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -1698,7 +1697,7 @@ func TestEthConfirmer_ForceRebroadcast(t *testing.T) {
 func TestEthConfirmer_ProcessStuckTransactions(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
@@ -1746,7 +1745,7 @@ func TestEthConfirmer_ProcessStuckTransactions(t *testing.T) {
 		// Create attempts broadcasted autoPurgeThreshold block ago to ensure broadcast block num check is not being triggered
 		tx := mustInsertUnconfirmedTxWithBroadcastAttempts(t, txStore, nonce, fromAddress, autoPurgeMinAttempts, blockNum-int64(autoPurgeThreshold), marketGasPrice.Add(oneGwei))
 		// Update tx to signal callback once it is identified as terminally stuck
-		pgtest.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, signal_callback = TRUE WHERE id = $2`, uuid.New(), tx.ID)
+		testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, signal_callback = TRUE WHERE id = $2`, uuid.New(), tx.ID)
 		head := evmtypes.Head{
 			Hash:   testutils.NewHash(),
 			Number: blockNum,

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/evm/assets"
@@ -37,7 +36,7 @@ import (
 )
 
 func TestORM_TransactionsWithAttempts(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ctx := tests.Context(t)
@@ -82,7 +81,7 @@ func TestORM_TransactionsWithAttempts(t *testing.T) {
 }
 
 func TestORM_Transactions(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ctx := tests.Context(t)
@@ -121,7 +120,7 @@ func TestORM_Transactions(t *testing.T) {
 func TestORM(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db)
 	orm := cltest.NewTestTxStore(t, db)
 	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth())
@@ -188,7 +187,7 @@ func TestORM(t *testing.T) {
 }
 
 func TestORM_FindTxAttemptConfirmedByTxIDs(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	orm := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ctx := tests.Context(t)
@@ -238,7 +237,7 @@ func TestORM_FindTxAttemptConfirmedByTxIDs(t *testing.T) {
 func TestORM_FindTxAttemptsRequiringResend(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
@@ -325,7 +324,7 @@ func TestORM_FindTxAttemptsRequiringResend(t *testing.T) {
 func TestORM_UpdateBroadcastAts(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db)
 	orm := cltest.NewTestTxStore(t, db)
 	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth())
@@ -373,7 +372,7 @@ func TestORM_UpdateBroadcastAts(t *testing.T) {
 func TestORM_SetBroadcastBeforeBlockNum(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	_, cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -443,7 +442,7 @@ func TestORM_UpdateTxConfirmed(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -470,7 +469,7 @@ func TestORM_UpdateTxConfirmed(t *testing.T) {
 func TestORM_SaveFetchedReceipts(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -517,7 +516,7 @@ func TestORM_SaveFetchedReceipts(t *testing.T) {
 func TestORM_PreloadTxes(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -550,7 +549,7 @@ func TestORM_PreloadTxes(t *testing.T) {
 func TestORM_GetInProgressTxAttempts(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
@@ -570,14 +569,14 @@ func TestORM_GetInProgressTxAttempts(t *testing.T) {
 func TestORM_FindTxesPendingCallback(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
-	pgtest.MustExec(t, db, `SET CONSTRAINTS fk_pipeline_runs_pruning_key DEFERRED`)
-	pgtest.MustExec(t, db, `SET CONSTRAINTS pipeline_runs_pipeline_spec_id_fkey DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS fk_pipeline_runs_pruning_key DEFERRED`)
+	testutils.MustExec(t, db, `SET CONSTRAINTS pipeline_runs_pipeline_spec_id_fkey DEFERRED`)
 
 	h8 := &types.Head{
 		Number: 8,
@@ -598,41 +597,41 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	// Suspended run waiting for callback
 	run1 := cltest.MustInsertPipelineRun(t, db)
 	tr1 := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, run1.ID)
-	pgtest.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, run1.ID)
+	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, run1.ID)
 	etx1 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 1, fromAddress)
-	pgtest.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": true}'`)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": true}'`)
 	attempt1 := etx1.TxAttempts[0]
 	etxBlockNum := mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, attempt1.Hash).BlockNumber
-	pgtest.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &tr1.ID, minConfirmations, etx1.ID)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &tr1.ID, minConfirmations, etx1.ID)
 
 	// Callback to pipeline service completed. Should be ignored
 	run2 := cltest.MustInsertPipelineRunWithStatus(t, db, 0, pipeline.RunStatusCompleted, 0)
 	tr2 := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, run2.ID)
 	etx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 1, fromAddress)
-	pgtest.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
 	attempt2 := etx2.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, attempt2.Hash)
-	pgtest.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE, callback_completed = TRUE WHERE id = $3`, &tr2.ID, minConfirmations, etx2.ID)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE, callback_completed = TRUE WHERE id = $3`, &tr2.ID, minConfirmations, etx2.ID)
 
 	// Suspended run younger than minConfirmations. Should be ignored
 	run3 := cltest.MustInsertPipelineRun(t, db)
 	tr3 := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, run3.ID)
-	pgtest.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, run3.ID)
+	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, run3.ID)
 	etx3 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 5, 1, fromAddress)
-	pgtest.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
 	attempt3 := etx3.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number, head.Hash, attempt3.Hash)
-	pgtest.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &tr3.ID, minConfirmations, etx3.ID)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &tr3.ID, minConfirmations, etx3.ID)
 
 	// Tx not marked for callback. Should be ignore
 	etx4 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 6, 1, fromAddress)
 	attempt4 := etx4.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number, head.Hash, attempt4.Hash)
-	pgtest.MustExec(t, db, `UPDATE evm.txes SET min_confirmations = $1 WHERE id = $2`, minConfirmations, etx4.ID)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET min_confirmations = $1 WHERE id = $2`, minConfirmations, etx4.ID)
 
 	// Unconfirmed Tx without receipts. Should be ignored
 	etx5 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 7, 1, fromAddress)
-	pgtest.MustExec(t, db, `UPDATE evm.txes SET min_confirmations = $1 WHERE id = $2`, minConfirmations, etx5.ID)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET min_confirmations = $1 WHERE id = $2`, minConfirmations, etx5.ID)
 
 	// Search evm.txes table for tx requiring callback
 	receiptsPlus, err := txStore.FindTxesPendingCallback(tests.Context(t), head.Number, 0, ethClient.ConfiguredChainID())
@@ -642,7 +641,7 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	}
 
 	// Clear min_confirmations
-	pgtest.MustExec(t, db, `UPDATE evm.txes SET min_confirmations = NULL WHERE id = $1`, etx1.ID)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET min_confirmations = NULL WHERE id = $1`, etx1.ID)
 
 	// Search evm.txes table for tx requiring callback
 	receiptsPlus, err = txStore.FindTxesPendingCallback(tests.Context(t), head.Number, 0, ethClient.ConfiguredChainID())
@@ -659,7 +658,7 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 
 func Test_FindTxWithIdempotencyKey(t *testing.T) {
 	t.Parallel()
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	_, cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -689,7 +688,7 @@ func Test_FindTxWithIdempotencyKey(t *testing.T) {
 func TestORM_FindTxWithSequence(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -713,7 +712,7 @@ func TestORM_FindTxWithSequence(t *testing.T) {
 func TestORM_UpdateTxForRebroadcast(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -785,7 +784,7 @@ func TestORM_UpdateTxForRebroadcast(t *testing.T) {
 func TestORM_FindEarliestUnconfirmedBroadcastTime(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
@@ -808,7 +807,7 @@ func TestORM_FindEarliestUnconfirmedBroadcastTime(t *testing.T) {
 func TestORM_FindEarliestUnconfirmedTxAttemptBlock(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
@@ -839,7 +838,7 @@ func TestORM_SaveInsufficientEthAttempt(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -863,7 +862,7 @@ func TestORM_SaveSentAttempt(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -888,7 +887,7 @@ func TestORM_SaveConfirmedAttempt(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -913,7 +912,7 @@ func TestORM_DeleteInProgressAttempt(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -935,7 +934,7 @@ func TestORM_SaveInProgressAttempt(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -975,7 +974,7 @@ func TestORM_FindTxsRequiringGasBump(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
@@ -1014,7 +1013,7 @@ func TestORM_FindTxsRequiringGasBump(t *testing.T) {
 func TestEthConfirmer_FindTxsRequiringResubmissionDueToInsufficientEth(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
@@ -1059,8 +1058,8 @@ func TestEthConfirmer_FindTxsRequiringResubmissionDueToInsufficientEth(t *testin
 	})
 
 	t.Run("does not return confirmed or fatally errored eth_txes", func(t *testing.T) {
-		pgtest.MustExec(t, db, `UPDATE evm.txes SET state='confirmed' WHERE id = $1`, etx1.ID)
-		pgtest.MustExec(t, db, `UPDATE evm.txes SET state='fatal_error', nonce=NULL, error='foo', broadcast_at=NULL, initial_broadcast_at=NULL WHERE id = $1`, etx2.ID)
+		testutils.MustExec(t, db, `UPDATE evm.txes SET state='confirmed' WHERE id = $1`, etx1.ID)
+		testutils.MustExec(t, db, `UPDATE evm.txes SET state='fatal_error', nonce=NULL, error='foo', broadcast_at=NULL, initial_broadcast_at=NULL WHERE id = $1`, etx2.ID)
 
 		etxs, err := txStore.FindTxsRequiringResubmissionDueToInsufficientFunds(tests.Context(t), fromAddress, testutils.FixtureChainID)
 		require.NoError(t, err)
@@ -1076,7 +1075,7 @@ func TestORM_LoadEthTxesAttempts(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1129,7 +1128,7 @@ func TestORM_SaveReplacementInProgressAttempt(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1152,7 +1151,7 @@ func TestORM_SaveReplacementInProgressAttempt(t *testing.T) {
 func TestORM_FindNextUnstartedTransactionFromAddress(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
@@ -1179,7 +1178,7 @@ func TestORM_UpdateTxFatalErrorAndDeleteAttempts(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
@@ -1203,7 +1202,7 @@ func TestORM_UpdateTxAttemptInProgressToBroadcast(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1234,7 +1233,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1267,7 +1266,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 		require.ErrorContains(t, err, "tx removed")
 	})
 
-	db = pgtest.NewSqlxDB(t)
+	db = testutils.NewSqlxDB(t)
 	txStore = cltest.NewTestTxStore(t, db)
 	ethKeyStore = cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress = cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1321,7 +1320,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 func TestORM_GetTxInProgress(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1344,7 +1343,7 @@ func TestORM_GetTxInProgress(t *testing.T) {
 func TestORM_GetAbandonedTransactionsByBatch(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
@@ -1401,7 +1400,7 @@ func TestORM_GetAbandonedTransactionsByBatch(t *testing.T) {
 func TestORM_GetTxByID(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1423,7 +1422,7 @@ func TestORM_GetTxByID(t *testing.T) {
 func TestORM_GetFatalTransactions(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
@@ -1445,7 +1444,7 @@ func TestORM_GetFatalTransactions(t *testing.T) {
 func TestORM_HasInProgressTransaction(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
@@ -1469,7 +1468,7 @@ func TestORM_HasInProgressTransaction(t *testing.T) {
 func TestORM_CountUnconfirmedTransactions(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
@@ -1489,7 +1488,7 @@ func TestORM_CountUnconfirmedTransactions(t *testing.T) {
 func TestORM_CountTransactionsByState(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
@@ -1509,7 +1508,7 @@ func TestORM_CountTransactionsByState(t *testing.T) {
 func TestORM_CountUnstartedTransactions(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
@@ -1529,7 +1528,7 @@ func TestORM_CountUnstartedTransactions(t *testing.T) {
 func TestORM_CheckTxQueueCapacity(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
@@ -1624,7 +1623,7 @@ func TestORM_CheckTxQueueCapacity(t *testing.T) {
 func TestORM_CreateTransaction(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := newTxStore(t, db)
 	kst := cltest.NewKeyStore(t, db)
 
@@ -1723,7 +1722,7 @@ func TestORM_CreateTransaction(t *testing.T) {
 func TestORM_PruneUnstartedTxQueue(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := txmgr.NewTxStore(db, logger.Test(t))
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	evmtest.NewEthClientMockWithDefaultChain(t)
@@ -1751,7 +1750,7 @@ func TestORM_PruneUnstartedTxQueue(t *testing.T) {
 func TestORM_FindTxesWithAttemptsAndReceiptsByIdsAndState(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ctx := tests.Context(t)
@@ -1784,7 +1783,7 @@ func TestORM_FindAttemptsRequiringReceiptFetch(t *testing.T) {
 	blockNum := int64(100)
 
 	t.Run("finds confirmed transaction requiring receipt fetch", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		kst := cltest.NewKeyStore(t, db)
 		_, fromAddress := cltest.MustInsertRandomKey(t, kst.Eth())
@@ -1816,7 +1815,7 @@ func TestORM_FindAttemptsRequiringReceiptFetch(t *testing.T) {
 	})
 
 	t.Run("finds terminally stuck transaction requiring receipt fetch", func(t *testing.T) {
-		db := pgtest.NewSqlxDB(t)
+		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
 		kst := cltest.NewKeyStore(t, db)
 		_, fromAddress := cltest.MustInsertRandomKey(t, kst.Eth())
@@ -1849,7 +1848,7 @@ func TestORM_UpdateTxStatesToFinalizedUsingTxHashes(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	kst := cltest.NewKeyStore(t, db)
 	broadcast := time.Now()
@@ -1883,7 +1882,7 @@ func TestORM_FindReorgOrIncludedTxs(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	kst := cltest.NewKeyStore(t, db)
 	blockNum := int64(100)
@@ -1946,7 +1945,7 @@ func TestORM_UpdateTxFatalError(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	kst := cltest.NewKeyStore(t, db)
 	_, fromAddress := cltest.MustInsertRandomKey(t, kst.Eth())
@@ -1972,7 +1971,7 @@ func TestORM_UpdateTxFatalError(t *testing.T) {
 func TestORM_FindTxesByIDs(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -1996,7 +1995,7 @@ func TestORM_FindTxesByIDs(t *testing.T) {
 func TestORM_DeleteReceiptsByTxHash(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -2023,7 +2022,7 @@ func TestORM_DeleteReceiptsByTxHash(t *testing.T) {
 func TestORM_Abandon(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()

--- a/core/chains/evm/txmgr/nonce_tracker_test.go
+++ b/core/chains/evm/txmgr/nonce_tracker_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -17,9 +18,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	txstoremock "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/evm/client/clienttest"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	"github.com/smartcontractkit/chainlink/v2/evm/types"
 )
 
@@ -40,8 +40,8 @@ func TestNonceTracker_LoadSequenceMap(t *testing.T) {
 	enabledAddresses := []common.Address{addr1, addr2}
 
 	t.Run("set next nonce using entries from tx table", func(t *testing.T) {
-		randNonce1 := testutils.NewRandomPositiveInt64()
-		randNonce2 := testutils.NewRandomPositiveInt64()
+		randNonce1 := rand.Int63()
+		randNonce2 := rand.Int63()
 		txStore.On("FindLatestSequence", mock.Anything, addr1, chainID).Return(types.Nonce(randNonce1), nil).Once()
 		txStore.On("FindLatestSequence", mock.Anything, addr2, chainID).Return(types.Nonce(randNonce2), nil).Once()
 
@@ -59,8 +59,8 @@ func TestNonceTracker_LoadSequenceMap(t *testing.T) {
 		txStore.On("FindLatestSequence", mock.Anything, addr1, chainID).Return(emptyNonce, errors.New("no rows")).Once()
 		txStore.On("FindLatestSequence", mock.Anything, addr2, chainID).Return(emptyNonce, errors.New("no rows")).Once()
 
-		randNonce1 := testutils.NewRandomPositiveInt64()
-		randNonce2 := testutils.NewRandomPositiveInt64()
+		randNonce1 := rand.Int63()
+		randNonce2 := rand.Int63()
 		client.On("NonceAt", mock.Anything, addr1, mock.Anything).Return(uint64(randNonce1), nil).Once() //nolint:gosec // Disable G115: randNonce1 always positive
 		client.On("NonceAt", mock.Anything, addr2, mock.Anything).Return(uint64(randNonce2), nil).Once() //nolint:gosec // Disable G115: randNonce2 always positive
 
@@ -242,7 +242,7 @@ func TestNonceTracker_GenerateNextSequence(t *testing.T) {
 	addr := common.HexToAddress("0xd5e099c71b797516c10ed0f0d895f429c2781142")
 	enabledAddresses := []common.Address{addr}
 
-	randNonce := testutils.NewRandomPositiveInt64()
+	randNonce := rand.Int63()
 	txStore.On("FindLatestSequence", mock.Anything, addr, chainID).Return(types.Nonce(randNonce), nil).Once()
 	nonceTracker.LoadNextSequences(ctx, enabledAddresses)
 	seq, err := nonceTracker.GetNextSequence(ctx, addr)
@@ -261,7 +261,7 @@ func Test_SetNonceAfterInit(t *testing.T) {
 
 	ctx := tests.Context(t)
 	chainID := big.NewInt(0)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := txmgr.NewTxStore(db, logger.Test(t))
 
 	client := clienttest.NewClient(t)
@@ -271,7 +271,7 @@ func Test_SetNonceAfterInit(t *testing.T) {
 
 	addr := common.HexToAddress("0xd5e099c71b797516c10ed0f0d895f429c2781142")
 	enabledAddresses := []common.Address{addr}
-	randNonce := testutils.NewRandomPositiveInt64()
+	randNonce := rand.Int63()
 	client.On("NonceAt", mock.Anything, addr, mock.Anything).Return(uint64(0), errors.New("failed to retrieve nonce at startup")).Once()
 	client.On("NonceAt", mock.Anything, addr, mock.Anything).Return(uint64(randNonce), nil).Once() //nolint:gosec // Disable G115: randNonce always positive
 	nonceTracker.LoadNextSequences(ctx, enabledAddresses)

--- a/core/chains/evm/txmgr/reaper_test.go
+++ b/core/chains/evm/txmgr/reaper_test.go
@@ -14,7 +14,7 @@ import (
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 )
 
 func newReaperWithChainID(t *testing.T, db txmgrtypes.TxHistoryReaper[*big.Int], txConfig txmgrtypes.ReaperTransactionsConfig, cid *big.Int) *txmgr.Reaper {
@@ -41,7 +41,7 @@ func (r *reaperConfig) ReaperThreshold() time.Duration {
 func TestReaper_ReapTxes(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
@@ -93,7 +93,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 		// Didn't delete because eth_tx was not old enough
 		cltest.AssertCount(t, db, "evm.txes", 1)
 
-		pgtest.MustExec(t, db, `UPDATE evm.txes SET created_at=$1, state='finalized'`, oneDayAgo)
+		testutils.MustExec(t, db, `UPDATE evm.txes SET created_at=$1, state='finalized'`, oneDayAgo)
 
 		err = r.ReapTxes(42)
 		assert.NoError(t, err)
@@ -133,7 +133,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 		// Didn't delete because eth_tx was not old enough
 		cltest.AssertCount(t, db, "evm.txes", 1)
 
-		pgtest.MustExec(t, db, `UPDATE evm.txes SET created_at=$1`, oneDayAgo)
+		testutils.MustExec(t, db, `UPDATE evm.txes SET created_at=$1`, oneDayAgo)
 
 		err = r.ReapTxes(42)
 		assert.NoError(t, err)

--- a/core/chains/evm/txmgr/resender_test.go
+++ b/core/chains/evm/txmgr/resender_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/evm/client/clienttest"
 	"github.com/smartcontractkit/chainlink/v2/evm/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
@@ -29,7 +28,7 @@ import (
 func Test_EthResender_resendUnconfirmed(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	lggr := logger.Test(t)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -99,7 +98,7 @@ func Test_EthResender_resendUnconfirmed(t *testing.T) {
 func Test_EthResender_alertUnconfirmed(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	lggr, o := logger.TestObserved(t, zapcore.DebugLevel)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -137,7 +136,7 @@ func Test_EthResender_alertUnconfirmed(t *testing.T) {
 func Test_EthResender_Start(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	ccfg := testutils.NewTestChainScopedConfig(t, func(c *toml.EVMConfig) {
 		// This can be anything as long as it isn't zero
 		c.Transactions.ResendAfterThreshold = commonconfig.MustNewDuration(42 * time.Hour)

--- a/core/chains/evm/txmgr/stuck_tx_detector_test.go
+++ b/core/chains/evm/txmgr/stuck_tx_detector_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/evm/assets"
 	"github.com/smartcontractkit/chainlink/v2/evm/client/clienttest"
 	"github.com/smartcontractkit/chainlink/v2/evm/config/chaintype"
@@ -41,7 +40,7 @@ var (
 func TestStuckTxDetector_Disabled(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
@@ -64,7 +63,7 @@ func TestStuckTxDetector_Disabled(t *testing.T) {
 func TestStuckTxDetector_LoadPurgeBlockNumMap(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ctx := tests.Context(t)
@@ -108,7 +107,7 @@ func TestStuckTxDetector_LoadPurgeBlockNumMap(t *testing.T) {
 func TestStuckTxDetector_FindPotentialStuckTxs(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	_, config := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
@@ -186,7 +185,7 @@ func TestStuckTxDetector_FindPotentialStuckTxs(t *testing.T) {
 func TestStuckTxDetector_DetectStuckTransactionsHeuristic(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ctx := tests.Context(t)
@@ -294,7 +293,7 @@ func TestStuckTxDetector_DetectStuckTransactionsHeuristic(t *testing.T) {
 func TestStuckTxDetector_DetectStuckTransactionsZircuit(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ctx := tests.Context(t)
@@ -396,7 +395,7 @@ func TestStuckTxDetector_DetectStuckTransactionsZircuit(t *testing.T) {
 func TestStuckTxDetector_DetectStuckTransactionsZkEVM(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ctx := tests.Context(t)
@@ -488,7 +487,7 @@ func TestStuckTxDetector_DetectStuckTransactionsZkEVM(t *testing.T) {
 func TestStuckTxDetector_DetectStuckTransactionsScroll(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	ctx := tests.Context(t)

--- a/core/chains/evm/txmgr/tracker_test.go
+++ b/core/chains/evm/txmgr/tracker_test.go
@@ -14,14 +14,14 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/evm/client/clienttest"
 	"github.com/smartcontractkit/chainlink/v2/evm/keystore"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 	ubig "github.com/smartcontractkit/chainlink/v2/evm/utils/big"
 )
 
 func newTestEvmTrackerSetup(t *testing.T) (*txmgr.Tracker, txmgr.TestEvmTxStore, keystore.Eth, []common.Address) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	chainID := big.NewInt(0)

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/evm/assets"
 	evmclient "github.com/smartcontractkit/chainlink/v2/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/evm/client/clienttest"
@@ -93,7 +92,7 @@ func makeTestEvmTxm(
 
 func TestTxm_SendNativeToken_DoesNotSendToZero(t *testing.T) {
 	t.Parallel()
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 
 	from := utils.ZeroAddress
 	to := utils.ZeroAddress
@@ -116,7 +115,7 @@ func TestTxm_SendNativeToken_DoesNotSendToZero(t *testing.T) {
 func TestTxm_CreateTransaction(t *testing.T) {
 	t.Parallel()
 
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	kst := cltest.NewKeyStore(t, db)
 
@@ -240,7 +239,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 	})
 
 	t.Run("simulate transmit checker", func(t *testing.T) {
-		pgtest.MustExec(t, db, `DELETE FROM evm.txes`)
+		testutils.MustExec(t, db, `DELETE FROM evm.txes`)
 
 		checker := txmgr.TransmitCheckerSpec{
 			CheckerType: txmgr.TransmitCheckerTypeSimulate,
@@ -266,7 +265,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 	})
 
 	t.Run("meta and vrf checker", func(t *testing.T) {
-		pgtest.MustExec(t, db, `DELETE FROM evm.txes`)
+		testutils.MustExec(t, db, `DELETE FROM evm.txes`)
 		testDefaultSubID := uint64(2)
 		testDefaultMaxLink := "1000000000000000000"
 		testDefaultMaxEth := "2000000000000000000"
@@ -314,8 +313,8 @@ func TestTxm_CreateTransaction(t *testing.T) {
 	})
 
 	t.Run("forwards tx when a proper forwarder is set up", func(t *testing.T) {
-		pgtest.MustExec(t, db, `DELETE FROM evm.txes`)
-		pgtest.MustExec(t, db, `DELETE FROM evm.forwarders`)
+		testutils.MustExec(t, db, `DELETE FROM evm.txes`)
+		testutils.MustExec(t, db, `DELETE FROM evm.forwarders`)
 		evmConfig.MaxQueued = uint64(1)
 
 		// Create mock forwarder, mock authorizedsenders call.
@@ -396,7 +395,7 @@ func newMockTxStrategy(t *testing.T) *commontxmmocks.TxStrategy {
 }
 
 func TestTxm_CreateTransaction_OutOfEth(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	etKeyStore := cltest.NewKeyStore(t, db).Eth()
 
@@ -485,7 +484,7 @@ func TestTxm_CreateTransaction_OutOfEth(t *testing.T) {
 }
 
 func TestTxm_Lifecycle(t *testing.T) {
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	kst := ksmocks.NewEth(t)
@@ -541,7 +540,7 @@ func TestTxm_Reset(t *testing.T) {
 	t.Parallel()
 
 	// Lots of boilerplate setup since we actually want to test start/stop of EthBroadcaster/EthConfirmer
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	gcfg := configtest.NewTestGeneralConfig(t)
 	cfg := evmtest.NewChainScopedConfig(t, gcfg)
 	kst := cltest.NewKeyStore(t, db)
@@ -608,7 +607,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 	t.Parallel()
 
 	ctx := tests.Context(t)
-	db := pgtest.NewSqlxDB(t)
+	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	feeLimit := uint64(10_000)

--- a/core/gethwrappers/abigen_test.go
+++ b/core/gethwrappers/abigen_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/log_emitter"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/v2/evm/testutils"
 )
 
 // Test that the generated Deploy method fill all the required fields and returns the correct address.

--- a/core/internal/testutils/testutils.go
+++ b/core/internal/testutils/testutils.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/base64"
-	"flag"
 	"fmt"
 	"math"
 	"math/big"
@@ -50,6 +49,7 @@ var SimulatedChainID = big.NewInt(1337)
 
 // MustNewSimTransactor returns a transactor for interacting with the
 // geth simulated backend.
+// TODO use evm/testutils
 func MustNewSimTransactor(t testing.TB) *bind.TransactOpts {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -416,10 +416,6 @@ func AssertCount(t *testing.T, ds sqlutil.DataSource, tableName string, expected
 	err := ds.GetContext(ctx, &count, fmt.Sprintf(`SELECT count(*) FROM %s;`, tableName))
 	require.NoError(t, err)
 	require.Equal(t, expected, count)
-}
-
-func NewTestFlagSet() *flag.FlagSet {
-	return flag.NewFlagSet("test", flag.PanicOnError)
 }
 
 // Ptr takes pointer of anything

--- a/core/scripts/chaincli/handler/debug.go
+++ b/core/scripts/chaincli/handler/debug.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 
-	types2 "github.com/smartcontractkit/chainlink-common/pkg/types"
+	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 	commonhex "github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
 
@@ -270,7 +270,7 @@ func (k *Keeper) Debug(ctx context.Context, args []string) {
 
 	// handle data streams lookup
 	if checkResult.UpkeepFailureReason == uint8(encoding.UpkeepFailureReasonTargetCheckReverted) {
-		mc := &types2.MercuryCredentials{LegacyURL: k.cfg.DataStreamsLegacyURL, URL: k.cfg.DataStreamsURL, Username: k.cfg.DataStreamsID, Password: k.cfg.DataStreamsKey}
+		mc := &commontypes.MercuryCredentials{LegacyURL: k.cfg.DataStreamsLegacyURL, URL: k.cfg.DataStreamsURL, Username: k.cfg.DataStreamsID, Password: k.cfg.DataStreamsKey}
 		mercuryConfig := evm21.NewMercuryConfig(mc, core.StreamsCompatibleABI)
 		lggr, _ := logger.NewLogger()
 		blockSub := &blockSubscriber{k.client}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	types2 "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+	autotypes "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
@@ -50,33 +50,33 @@ func TestLogRecoverer_GetRecoverables(t *testing.T) {
 		{
 			"happy flow",
 			[]ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "2")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "2")},
 			},
 			[]ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "2")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "2")},
 			},
 			false,
 		},
 		{
 			"rate limiting",
 			[]ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "3", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "4", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "5", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "6", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "2")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "3", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "4", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "5", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "6", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "2")},
 			},
 			[]ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "3", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "4", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "5", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "2")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "3", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "4", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "5", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "2")},
 			},
 			false,
 		},
@@ -121,9 +121,9 @@ func TestLogRecoverer_Clean(t *testing.T) {
 		{
 			"clean expired",
 			[]ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "2")},
-				{WorkID: "3", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "3")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "2")},
+				{WorkID: "3", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "3")},
 			},
 			map[string]visitedRecord{
 				"1": visitedRecord{time.Now(), ocr2keepers.UpkeepPayload{
@@ -164,9 +164,9 @@ func TestLogRecoverer_Clean(t *testing.T) {
 				ocr2keepers.UnknownState,
 			},
 			[]ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "2")},
-				{WorkID: "4", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "4")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "2")},
+				{WorkID: "4", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "4")},
 			},
 			[]string{"1", "2", "4"},
 		},
@@ -583,7 +583,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if a filter is not found for the upkeep ID, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 			},
 			skipFilter: true,
 			expectErr:  true,
@@ -592,7 +592,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if an error is encountered fetching the latest block, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 0,
@@ -615,7 +615,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if an error is encountered fetching the tx receipt, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 0,
@@ -643,7 +643,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if the tx block is nil, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 0,
@@ -671,7 +671,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if a log trigger extension block number is 0, and the block number on the tx receipt is not recoverable, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 0,
@@ -701,7 +701,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if a log block is not recoverable, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 200,
@@ -731,7 +731,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if a log block has does not match, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 200,
@@ -763,7 +763,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if a log block is recoverable, when the upkeep state reader errors, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 80,
@@ -798,7 +798,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if a log block is recoverable, when the upkeep state reader returns a non recoverable state, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 80,
@@ -835,7 +835,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if a log block is recoverable, when the filter address is empty, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 80,
@@ -875,7 +875,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if a log block is recoverable, when the log poller returns an error fetching logs, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 80,
@@ -910,7 +910,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "if a log block is recoverable, when logs cannot be found for an upkeep ID, an error is returned",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: ocr2keepers.Trigger{
 					LogTriggerExtension: &ocr2keepers.LogTriggerExtension{
 						BlockNumber: 80,
@@ -949,7 +949,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "happy path with empty check data",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: func() ocr2keepers.Trigger {
 					t := ocr2keepers.NewTrigger(
 						ocr2keepers.BlockNumber(80),
@@ -1000,7 +1000,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 		{
 			name: "happy path with check data",
 			proposal: ocr2keepers.CoordinatedBlockProposal{
-				UpkeepID: core.GenUpkeepID(types2.LogTrigger, "123"),
+				UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123"),
 				Trigger: func() ocr2keepers.Trigger {
 					t := ocr2keepers.NewTrigger(
 						ocr2keepers.BlockNumber(80),
@@ -1061,7 +1061,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 				filterStore.AddActiveUpkeeps(upkeepFilter{
 					addr:     []byte("test"),
 					topics:   []common.Hash{common.HexToHash("0x1"), common.HexToHash("0x2"), common.HexToHash("0x3"), common.HexToHash("0x4")},
-					upkeepID: core.GenUpkeepID(types2.LogTrigger, "123").BigInt(),
+					upkeepID: core.GenUpkeepID(autotypes.LogTrigger, "123").BigInt(),
 				})
 			}
 
@@ -1111,34 +1111,34 @@ func TestLogRecoverer_pending(t *testing.T) {
 			name:         "add new and existing",
 			maxPerUpkeep: 10,
 			exist: []ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
 			},
 			new: []ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "2")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "2")},
 			},
 			errored: []bool{false, false},
 			want: []ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "2")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "2")},
 			},
 		},
 		{
 			name:         "exceed limits for upkeep",
 			maxPerUpkeep: 3,
 			exist: []ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "3", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "3", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
 			},
 			new: []ocr2keepers.UpkeepPayload{
-				{WorkID: "4", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
+				{WorkID: "4", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
 			},
 			errored: []bool{true},
 			want: []ocr2keepers.UpkeepPayload{
-				{WorkID: "1", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "2", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
-				{WorkID: "3", UpkeepID: core.GenUpkeepID(types2.LogTrigger, "1")},
+				{WorkID: "1", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "2", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
+				{WorkID: "3", UpkeepID: core.GenUpkeepID(autotypes.LogTrigger, "1")},
 			},
 		},
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/payload_builder_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/payload_builder_test.go
@@ -5,12 +5,11 @@ import (
 	"math/big"
 	"testing"
 
-	types2 "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
-
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
-	types "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -23,8 +22,8 @@ func TestNewPayloadBuilder(t *testing.T) {
 		name         string
 		activeList   ActiveUpkeepList
 		recoverer    logprovider.LogRecoverer
-		proposals    []types.CoordinatedBlockProposal
-		wantPayloads []types.UpkeepPayload
+		proposals    []automation.CoordinatedBlockProposal
+		wantPayloads []automation.UpkeepPayload
 	}{
 		{
 			name: "for log trigger upkeeps, new payloads are created",
@@ -33,43 +32,43 @@ func TestNewPayloadBuilder(t *testing.T) {
 					return true
 				},
 			},
-			proposals: []types.CoordinatedBlockProposal{
+			proposals: []automation.CoordinatedBlockProposal{
 				{
-					UpkeepID: core.GenUpkeepID(types2.LogTrigger, "abc"),
+					UpkeepID: core.GenUpkeepID(types.LogTrigger, "abc"),
 					WorkID:   "workID1",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 1,
 						BlockHash:   [32]byte{1},
 					},
 				},
 				{
-					UpkeepID: core.GenUpkeepID(types2.LogTrigger, "def"),
+					UpkeepID: core.GenUpkeepID(types.LogTrigger, "def"),
 					WorkID:   "workID2",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 2,
 						BlockHash:   [32]byte{2},
 					},
 				},
 			},
 			recoverer: &mockLogRecoverer{
-				GetProposalDataFn: func(ctx context.Context, proposal types.CoordinatedBlockProposal) ([]byte, error) {
+				GetProposalDataFn: func(ctx context.Context, proposal automation.CoordinatedBlockProposal) ([]byte, error) {
 					return []byte{1, 2, 3}, nil
 				},
 			},
-			wantPayloads: []types.UpkeepPayload{
+			wantPayloads: []automation.UpkeepPayload{
 				{
-					UpkeepID: core.GenUpkeepID(types2.LogTrigger, "abc"),
+					UpkeepID: core.GenUpkeepID(types.LogTrigger, "abc"),
 					WorkID:   "714f83255c5b562823725748c4a75777c9b78ea8c5ba72ea819926a1fecd389e",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 1,
 						BlockHash:   [32]byte{1},
 					},
 					CheckData: []byte{1, 2, 3},
 				},
 				{
-					UpkeepID: core.GenUpkeepID(types2.LogTrigger, "def"),
+					UpkeepID: core.GenUpkeepID(types.LogTrigger, "def"),
 					WorkID:   "3956daa0378d6a761fe972ee00fe98338f17fb6b7865c1d49a8a416cd85977b8",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 2,
 						BlockHash:   [32]byte{2},
 					},
@@ -81,54 +80,54 @@ func TestNewPayloadBuilder(t *testing.T) {
 			name: "for an inactive log trigger upkeep, an empty payload is added to the list of payloads",
 			activeList: &mockActiveUpkeepList{
 				IsActiveFn: func(id *big.Int) bool {
-					return core.GenUpkeepID(types2.LogTrigger, "ghi").BigInt().Cmp(id) != 0
+					return core.GenUpkeepID(types.LogTrigger, "ghi").BigInt().Cmp(id) != 0
 				},
 			},
-			proposals: []types.CoordinatedBlockProposal{
+			proposals: []automation.CoordinatedBlockProposal{
 				{
-					UpkeepID: core.GenUpkeepID(types2.LogTrigger, "abc"),
+					UpkeepID: core.GenUpkeepID(types.LogTrigger, "abc"),
 					WorkID:   "workID1",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 1,
 						BlockHash:   [32]byte{1},
 					},
 				},
 				{
-					UpkeepID: core.GenUpkeepID(types2.LogTrigger, "def"),
+					UpkeepID: core.GenUpkeepID(types.LogTrigger, "def"),
 					WorkID:   "workID2",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 2,
 						BlockHash:   [32]byte{2},
 					},
 				},
 				{
-					UpkeepID: core.GenUpkeepID(types2.LogTrigger, "ghi"),
+					UpkeepID: core.GenUpkeepID(types.LogTrigger, "ghi"),
 					WorkID:   "workID3",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 3,
 						BlockHash:   [32]byte{3},
 					},
 				},
 			},
 			recoverer: &mockLogRecoverer{
-				GetProposalDataFn: func(ctx context.Context, proposal types.CoordinatedBlockProposal) ([]byte, error) {
+				GetProposalDataFn: func(ctx context.Context, proposal automation.CoordinatedBlockProposal) ([]byte, error) {
 					return []byte{1, 2, 3}, nil
 				},
 			},
-			wantPayloads: []types.UpkeepPayload{
+			wantPayloads: []automation.UpkeepPayload{
 				{
-					UpkeepID: core.GenUpkeepID(types2.LogTrigger, "abc"),
+					UpkeepID: core.GenUpkeepID(types.LogTrigger, "abc"),
 					WorkID:   "714f83255c5b562823725748c4a75777c9b78ea8c5ba72ea819926a1fecd389e",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 1,
 						BlockHash:   [32]byte{1},
 					},
 					CheckData: []byte{1, 2, 3},
 				},
 				{
-					UpkeepID: core.GenUpkeepID(types2.LogTrigger, "def"),
+					UpkeepID: core.GenUpkeepID(types.LogTrigger, "def"),
 					WorkID:   "3956daa0378d6a761fe972ee00fe98338f17fb6b7865c1d49a8a416cd85977b8",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 2,
 						BlockHash:   [32]byte{2},
 					},
@@ -144,22 +143,22 @@ func TestNewPayloadBuilder(t *testing.T) {
 					return true
 				},
 			},
-			proposals: []types.CoordinatedBlockProposal{
+			proposals: []automation.CoordinatedBlockProposal{
 				{
-					UpkeepID: core.GenUpkeepID(types2.LogTrigger, "abc"),
+					UpkeepID: core.GenUpkeepID(types.LogTrigger, "abc"),
 					WorkID:   "workID1",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 1,
 						BlockHash:   [32]byte{1},
 					},
 				},
 			},
 			recoverer: &mockLogRecoverer{
-				GetProposalDataFn: func(ctx context.Context, proposal types.CoordinatedBlockProposal) ([]byte, error) {
+				GetProposalDataFn: func(ctx context.Context, proposal automation.CoordinatedBlockProposal) ([]byte, error) {
 					return nil, errors.New("recoverer boom")
 				},
 			},
-			wantPayloads: []types.UpkeepPayload{
+			wantPayloads: []automation.UpkeepPayload{
 				{},
 			},
 		},
@@ -170,21 +169,21 @@ func TestNewPayloadBuilder(t *testing.T) {
 					return true
 				},
 			},
-			proposals: []types.CoordinatedBlockProposal{
+			proposals: []automation.CoordinatedBlockProposal{
 				{
-					UpkeepID: core.GenUpkeepID(types2.ConditionTrigger, "def"),
+					UpkeepID: core.GenUpkeepID(types.ConditionTrigger, "def"),
 					WorkID:   "workID1",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 1,
 						BlockHash:   [32]byte{1},
 					},
 				},
 			},
-			wantPayloads: []types.UpkeepPayload{
+			wantPayloads: []automation.UpkeepPayload{
 				{
-					UpkeepID: core.GenUpkeepID(types2.ConditionTrigger, "def"),
+					UpkeepID: core.GenUpkeepID(types.ConditionTrigger, "def"),
 					WorkID:   "58f2f231792448679a75bac6efc2af4ba731901f0cb93a44a366525751cbabfb",
-					Trigger: types.Trigger{
+					Trigger: automation.Trigger{
 						BlockNumber: 1,
 						BlockHash:   [32]byte{1},
 					},
@@ -204,9 +203,9 @@ func TestNewPayloadBuilder(t *testing.T) {
 
 type mockLogRecoverer struct {
 	logprovider.LogRecoverer
-	GetProposalDataFn func(context.Context, types.CoordinatedBlockProposal) ([]byte, error)
+	GetProposalDataFn func(context.Context, automation.CoordinatedBlockProposal) ([]byte, error)
 }
 
-func (r *mockLogRecoverer) GetProposalData(ctx context.Context, p types.CoordinatedBlockProposal) ([]byte, error) {
+func (r *mockLogRecoverer) GetProposalData(ctx context.Context, p automation.CoordinatedBlockProposal) ([]byte, error) {
 	return r.GetProposalDataFn(ctx, p)
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry.go
@@ -23,7 +23,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
-	types2 "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+	autotypes "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
@@ -300,7 +300,7 @@ func (r *EvmRegistry) refreshActiveUpkeeps(ctx context.Context) error {
 			continue
 		}
 		switch core.GetUpkeepType(*uid) {
-		case types2.LogTrigger:
+		case autotypes.LogTrigger:
 			logTriggerIDs = append(logTriggerIDs, id)
 		default:
 		}
@@ -522,7 +522,7 @@ func (r *EvmRegistry) removeFromActive(ctx context.Context, id *big.Int) {
 	uid.FromBigInt(id)
 	trigger := core.GetUpkeepType(*uid)
 	switch trigger {
-	case types2.LogTrigger:
+	case autotypes.LogTrigger:
 		if err := r.logEventProvider.UnregisterFilter(ctx, id); err != nil {
 			r.lggr.Warnw("failed to unregister log filter", "upkeepID", id.String())
 		}
@@ -590,7 +590,7 @@ func (r *EvmRegistry) updateTriggerConfig(ctx context.Context, id *big.Int, cfg 
 	uid := &ocr2keepers.UpkeepIdentifier{}
 	uid.FromBigInt(id)
 	switch core.GetUpkeepType(*uid) {
-	case types2.LogTrigger:
+	case autotypes.LogTrigger:
 		if len(cfg) == 0 {
 			fetched, err := r.fetchTriggerConfig(ctx, id)
 			if err != nil {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline_test.go
@@ -16,11 +16,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	autotypes "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	types2 "github.com/smartcontractkit/chainlink-common/pkg/types"
+	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
-
-	types3 "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	ac "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/i_automation_v21_plus_common"
@@ -378,9 +377,9 @@ func TestRegistry_VerifyLogExists(t *testing.T) {
 
 func TestRegistry_CheckUpkeeps(t *testing.T) {
 	lggr := logger.Test(t)
-	uid0 := core.GenUpkeepID(types3.UpkeepType(0), "p0")
-	uid1 := core.GenUpkeepID(types3.UpkeepType(1), "p1")
-	uid2 := core.GenUpkeepID(types3.UpkeepType(1), "p2")
+	uid0 := core.GenUpkeepID(autotypes.UpkeepType(0), "p0")
+	uid1 := core.GenUpkeepID(autotypes.UpkeepType(1), "p1")
+	uid2 := core.GenUpkeepID(autotypes.UpkeepType(1), "p2")
 
 	extension1 := &ocr2keepers.LogTriggerExtension{
 		TxHash:      common.HexToHash("0xc8def8abdcf3a4eaaf6cc13bff3e4e2a7168d86ea41dbbf97451235aa76c3651"),
@@ -538,9 +537,9 @@ func TestRegistry_CheckUpkeeps(t *testing.T) {
 }
 
 func TestRegistry_SimulatePerformUpkeeps(t *testing.T) {
-	uid0 := core.GenUpkeepID(types3.UpkeepType(0), "p0")
-	uid1 := core.GenUpkeepID(types3.UpkeepType(1), "p1")
-	uid2 := core.GenUpkeepID(types3.UpkeepType(1), "p2")
+	uid0 := core.GenUpkeepID(autotypes.UpkeepType(0), "p0")
+	uid1 := core.GenUpkeepID(autotypes.UpkeepType(1), "p1")
+	uid2 := core.GenUpkeepID(autotypes.UpkeepType(1), "p2")
 
 	extension1 := &ocr2keepers.LogTriggerExtension{
 		TxHash:      common.HexToHash("0xc8def8abdcf3a4eaaf6cc13bff3e4e2a7168d86ea41dbbf97451235aa76c3651"),
@@ -692,7 +691,7 @@ func setupEVMRegistry(t *testing.T) *EvmRegistry {
 		headFunc:     func(ocr2keepers.BlockKey) {},
 		chLog:        make(chan logpoller.Log, 1000),
 		mercury: &MercuryConfig{
-			cred: &types2.MercuryCredentials{
+			cred: &commontypes.MercuryCredentials{
 				LegacyURL: "https://google.old.com",
 				URL:       "https://google.com",
 				Username:  "FakeClientID",

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_test.go
@@ -14,12 +14,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	types2 "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+	autotypes "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
-	types3 "github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker/types"
+	evmhttypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated"
@@ -258,7 +258,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 		{
 			name: "an error is returned when fetching indexed logs for IAutomationV21PlusCommonUpkeepUnpaused errors",
 			ids: []*big.Int{
-				core.GenUpkeepID(types2.LogTrigger, "abc").BigInt(),
+				core.GenUpkeepID(autotypes.LogTrigger, "abc").BigInt(),
 			},
 			logEventProvider: &mockLogEventProvider{
 				RefreshActiveUpkeepsFn: func(ctx context.Context, ids ...*big.Int) ([]*big.Int, error) {
@@ -281,8 +281,8 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 		{
 			name: "an error is returned when fetching indexed logs for IAutomationV21PlusCommonUpkeepTriggerConfigSet errors",
 			ids: []*big.Int{
-				core.GenUpkeepID(types2.LogTrigger, "abc").BigInt(),
-				core.GenUpkeepID(types2.ConditionTrigger, "abc").BigInt(),
+				core.GenUpkeepID(autotypes.LogTrigger, "abc").BigInt(),
+				core.GenUpkeepID(autotypes.ConditionTrigger, "abc").BigInt(),
 				big.NewInt(-1),
 			},
 			logEventProvider: &mockLogEventProvider{
@@ -306,8 +306,8 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 		{
 			name: "an error is returned when parsing the logs using the registry errors",
 			ids: []*big.Int{
-				core.GenUpkeepID(types2.LogTrigger, "abc").BigInt(),
-				core.GenUpkeepID(types2.ConditionTrigger, "abc").BigInt(),
+				core.GenUpkeepID(autotypes.LogTrigger, "abc").BigInt(),
+				core.GenUpkeepID(autotypes.ConditionTrigger, "abc").BigInt(),
 				big.NewInt(-1),
 			},
 			logEventProvider: &mockLogEventProvider{
@@ -335,8 +335,8 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 		{
 			name: "an error is returned when registering the filter errors",
 			ids: []*big.Int{
-				core.GenUpkeepID(types2.LogTrigger, "abc").BigInt(),
-				core.GenUpkeepID(types2.ConditionTrigger, "abc").BigInt(),
+				core.GenUpkeepID(autotypes.LogTrigger, "abc").BigInt(),
+				core.GenUpkeepID(autotypes.ConditionTrigger, "abc").BigInt(),
 				big.NewInt(-1),
 			},
 			logEventProvider: &mockLogEventProvider{
@@ -366,11 +366,11 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 					if log.BlockNumber == 1 {
 						return &autov2common.IAutomationV21PlusCommonUpkeepTriggerConfigSet{
 							TriggerConfig: []byte{1, 2, 3},
-							Id:            core.GenUpkeepID(types2.LogTrigger, "abc").BigInt(),
+							Id:            core.GenUpkeepID(autotypes.LogTrigger, "abc").BigInt(),
 						}, nil
 					}
 					return &autov2common.IAutomationV21PlusCommonUpkeepUnpaused{
-						Id: core.GenUpkeepID(types2.LogTrigger, "abc").BigInt(),
+						Id: core.GenUpkeepID(autotypes.LogTrigger, "abc").BigInt(),
 					}, nil
 				},
 				GetUpkeepTriggerConfigFn: func(opts *bind.CallOpts, upkeepId *big.Int) ([]byte, error) {
@@ -388,9 +388,9 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 		{
 			name: "log trigger upkeeps are refreshed without error",
 			ids: []*big.Int{
-				core.GenUpkeepID(types2.LogTrigger, "abc").BigInt(),
-				core.GenUpkeepID(types2.LogTrigger, "def").BigInt(),
-				core.GenUpkeepID(types2.ConditionTrigger, "abc").BigInt(),
+				core.GenUpkeepID(autotypes.LogTrigger, "abc").BigInt(),
+				core.GenUpkeepID(autotypes.LogTrigger, "def").BigInt(),
+				core.GenUpkeepID(autotypes.ConditionTrigger, "abc").BigInt(),
 				big.NewInt(-1),
 			},
 			logEventProvider: &mockLogEventProvider{
@@ -419,12 +419,12 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 				ParseLogFn: func(log coreTypes.Log) (generated.AbigenLog, error) {
 					if log.BlockNumber == 1 {
 						return &autov2common.IAutomationV21PlusCommonUpkeepTriggerConfigSet{
-							Id:            core.GenUpkeepID(types2.LogTrigger, "abc").BigInt(),
+							Id:            core.GenUpkeepID(autotypes.LogTrigger, "abc").BigInt(),
 							TriggerConfig: []byte{1, 2, 3},
 						}, nil
 					}
 					return &autov2common.IAutomationV21PlusCommonUpkeepUnpaused{
-						Id: core.GenUpkeepID(types2.LogTrigger, "def").BigInt(),
+						Id: core.GenUpkeepID(autotypes.LogTrigger, "def").BigInt(),
 					}, nil
 				},
 				GetUpkeepTriggerConfigFn: func(opts *bind.CallOpts, upkeepId *big.Int) ([]byte, error) {
@@ -442,7 +442,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 			ids: func() []*big.Int {
 				res := []*big.Int{}
 				for i := 0; i < logTriggerRefreshBatchSize*3; i++ {
-					res = append(res, core.GenUpkeepID(types2.LogTrigger, fmt.Sprintf("%d", i)).BigInt())
+					res = append(res, core.GenUpkeepID(autotypes.LogTrigger, fmt.Sprintf("%d", i)).BigInt())
 				}
 				return res
 			}(),
@@ -471,12 +471,12 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 				ParseLogFn: func(log coreTypes.Log) (generated.AbigenLog, error) {
 					if log.BlockNumber == 1 {
 						return &autov2common.IAutomationV21PlusCommonUpkeepTriggerConfigSet{
-							Id:            core.GenUpkeepID(types2.LogTrigger, "abc").BigInt(),
+							Id:            core.GenUpkeepID(autotypes.LogTrigger, "abc").BigInt(),
 							TriggerConfig: []byte{1, 2, 3},
 						}, nil
 					}
 					return &autov2common.IAutomationV21PlusCommonUpkeepUnpaused{
-						Id: core.GenUpkeepID(types2.LogTrigger, "def").BigInt(),
+						Id: core.GenUpkeepID(autotypes.LogTrigger, "def").BigInt(),
 					}, nil
 				},
 				GetUpkeepTriggerConfigFn: func(opts *bind.CallOpts, upkeepId *big.Int) ([]byte, error) {
@@ -494,7 +494,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 			ids: func() []*big.Int {
 				res := []*big.Int{}
 				for i := 0; i < logTriggerRefreshBatchSize+3; i++ {
-					res = append(res, core.GenUpkeepID(types2.LogTrigger, fmt.Sprintf("%d", i)).BigInt())
+					res = append(res, core.GenUpkeepID(autotypes.LogTrigger, fmt.Sprintf("%d", i)).BigInt())
 				}
 				return res
 			}(),
@@ -525,12 +525,12 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 				ParseLogFn: func(log coreTypes.Log) (generated.AbigenLog, error) {
 					if log.BlockNumber == 1 {
 						return &autov2common.IAutomationV21PlusCommonUpkeepTriggerConfigSet{
-							Id:            core.GenUpkeepID(types2.LogTrigger, "abc").BigInt(),
+							Id:            core.GenUpkeepID(autotypes.LogTrigger, "abc").BigInt(),
 							TriggerConfig: []byte{1, 2, 3},
 						}, nil
 					}
 					return &autov2common.IAutomationV21PlusCommonUpkeepUnpaused{
-						Id: core.GenUpkeepID(types2.LogTrigger, "def").BigInt(),
+						Id: core.GenUpkeepID(autotypes.LogTrigger, "def").BigInt(),
 					}, nil
 				},
 				GetUpkeepTriggerConfigFn: func(opts *bind.CallOpts, upkeepId *big.Int) ([]byte, error) {
@@ -547,7 +547,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := tests.Context(t)
 			lggr := logger.Test(t)
-			var hb types3.HeadBroadcaster
+			var hb evmhttypes.HeadBroadcaster
 			var lp logpoller.LogPoller
 
 			bs := NewBlockSubscriber(hb, lp, 1000, lggr)

--- a/core/services/ocrcommon/transmitter.go
+++ b/core/services/ocrcommon/transmitter.go
@@ -12,7 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/forwarders"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
-	types2 "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
+	evmtypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
 )
 
 type roundRobinKeystore interface {
@@ -94,7 +94,7 @@ func NewOCR2FeedsTransmitter(
 	checker txmgr.TransmitCheckerSpec,
 	chainID *big.Int,
 	ks keystore.Eth,
-	dualTransmissionConfig *types2.DualTransmissionConfig,
+	dualTransmissionConfig *evmtypes.DualTransmissionConfig,
 ) (Transmitter, error) {
 	// Ensure that a keystore is provided.
 	if ks == nil {

--- a/deployment/ccip/changeset/internal/deploy_home_chain.go
+++ b/deployment/ccip/changeset/internal/deploy_home_chain.go
@@ -17,13 +17,12 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
-	types2 "github.com/smartcontractkit/chainlink/deployment/common/types"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/ccip_home"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/offramp"
 	capabilities_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
-
 )
 
 const (
@@ -191,7 +190,7 @@ func BuildOCR3ConfigForCCIPHome(
 	dest deployment.Chain,
 	nodes deployment.Nodes,
 	rmnHomeAddress common.Address,
-	ocrParams types2.OCRParameters,
+	ocrParams commontypes.OCRParameters,
 	commitOffchainCfg *pluginconfig.CommitOffchainConfig,
 	execOffchainCfg *pluginconfig.ExecuteOffchainConfig,
 ) (map[types.PluginType]ccip_home.CCIPHomeOCR3Config, error) {

--- a/evm/testutils/evmtypes.go
+++ b/evm/testutils/evmtypes.go
@@ -6,9 +6,13 @@ import (
 	"math"
 	"math/big"
 	mrand "math/rand"
+	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
 
 	evmtypes "github.com/smartcontractkit/chainlink/v2/evm/types"
 	evmutils "github.com/smartcontractkit/chainlink/v2/evm/utils"
@@ -88,4 +92,14 @@ func NewLegacyTransaction(nonce uint64, to common.Address, value *big.Int, gasLi
 func NewAddressPtr() *common.Address {
 	a := common.BytesToAddress(randomBytes(20))
 	return &a
+}
+
+// MustNewSimTransactor returns a transactor for interacting with the
+// geth simulated backend.
+func MustNewSimTransactor(t testing.TB) *bind.TransactOpts {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	transactor, err := bind.NewKeyedTransactorWithChainID(key, SimulatedChainID)
+	require.NoError(t, err)
+	return transactor
 }

--- a/evm/testutils/sql.go
+++ b/evm/testutils/sql.go
@@ -1,0 +1,33 @@
+package testutils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/sqltest"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+)
+
+func NewSqlxDB(t testing.TB) *sqlx.DB {
+	SkipShortDB(t)
+	dbURL := os.Getenv("CL_DATABASE_URL")
+	if dbURL == "" {
+		t.Errorf("you must provide a CL_DATABASE_URL environment variable")
+		return nil
+	}
+	return sqltest.NewDB(t, dbURL)
+}
+
+// SkipShortDB skips tb during -short runs, and notes the DB dependency.
+func SkipShortDB(tb testing.TB) {
+	tests.SkipShort(tb, "DB dependency")
+}
+
+func MustExec(t *testing.T, ds sqlutil.DataSource, stmt string, args ...interface{}) {
+	require.NoError(t, utils.JustError(ds.ExecContext(Context(t), stmt, args...)))
+}

--- a/evm/testutils/testutils.go
+++ b/evm/testutils/testutils.go
@@ -1,0 +1,45 @@
+package testutils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+)
+
+// Context returns a context with the test's deadline, if available.
+func Context(tb testing.TB) context.Context {
+	return tests.Context(tb)
+}
+
+// DefaultWaitTimeout is the default wait timeout. If you have a *testing.T, use WaitTimeout instead.
+const DefaultWaitTimeout = 30 * time.Second
+
+// WaitTimeout returns a timeout based on the test's Deadline, if available.
+// Especially important to use in parallel tests, as their individual execution
+// can get paused for arbitrary amounts of time.
+func WaitTimeout(t *testing.T) time.Duration {
+	if d, ok := t.Deadline(); ok {
+		// 10% buffer for cleanup and scheduling delay
+		return time.Until(d) * 9 / 10
+	}
+	return DefaultWaitTimeout
+}
+
+// TestInterval is just a sensible poll interval that gives fast tests without
+// risk of spamming
+const TestInterval = 100 * time.Millisecond
+
+// AssertEventually calls assert.Eventually with default wait and tick durations.
+func AssertEventually(t *testing.T, f func() bool) bool {
+	return assert.Eventually(t, f, WaitTimeout(t), TestInterval/2)
+}
+
+// RequireEventually calls assert.Eventually with default wait and tick durations.
+func RequireEventually(t *testing.T, f func() bool) {
+	require.Eventually(t, f, WaitTimeout(t), TestInterval/2)
+}


### PR DESCRIPTION
Towards https://smartcontract-it.atlassian.net/browse/CRE-163
- remove import aliases
- replace `internal/testutils` with `evm/testutils`
- replace `pgtest` with `evm/testutils`