### PR TITLE
TT-1966 Allow Flakeguard to rerun selected test and check for flakiness

### DIFF
--- a/.github/workflows/flakeguard-validate-tests.yml
+++ b/.github/workflows/flakeguard-validate-tests.yml
@@ -1,6 +1,7 @@
 name: Flakeguard Validate Tests
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       testPackages:

--- a/.github/workflows/flakeguard-validate-tests.yml
+++ b/.github/workflows/flakeguard-validate-tests.yml
@@ -42,5 +42,3 @@ jobs:
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # FLAKEGUARD_SPLUNK_ENDPOINT: ${{ secrets.FLAKEGUARD_SPLUNK_ENDPOINT }}
-      # FLAKEGUARD_SPLUNK_HEC: ${{ secrets.FLAKEGUARD_SPLUNK_HEC }}

--- a/.github/workflows/flakeguard-validate-tests.yml
+++ b/.github/workflows/flakeguard-validate-tests.yml
@@ -32,10 +32,11 @@ jobs:
       maxPassRatio: '1.0' 
       extraArgs: >-
         {
-          "runCustomTestPackages": "${{ inputs.testPackages }}",
+          "run_custom_test_packages": "${{ inputs.testPackages }}",
           "test_repeat_count": "${{ inputs.testRepeatCount }}",
-          "skipped_tests": "",
-          "run_with_race": "${{ inputs.runTestsWithRace }}"
+          "run_with_race": "${{ inputs.runTestsWithRace }}",
+          "default_tests_runner": "ubuntu22.04-8cores-32GB",
+          "skipped_tests": ""
         }
 
     secrets:

--- a/.github/workflows/flakeguard-validate-tests.yml
+++ b/.github/workflows/flakeguard-validate-tests.yml
@@ -1,7 +1,6 @@
 name: Flakeguard Validate Tests
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       testPackages:

--- a/.github/workflows/flakeguard-validate-tests.yml
+++ b/.github/workflows/flakeguard-validate-tests.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: '5'
+      testRunner:
+        description: 'The default tests runner to use.'
+        required: false
+        type: string
+        default: 'ubuntu-20.04'
       runTestsWithRace:
         description: 'Run tests with the race detector enabled.'
         required: false
@@ -34,7 +39,7 @@ jobs:
           "run_custom_test_packages": "${{ inputs.testPackages }}",
           "test_repeat_count": "${{ inputs.testRepeatCount }}",
           "run_with_race": "${{ inputs.runTestsWithRace }}",
-          "default_tests_runner": "ubuntu22.04-8cores-32GB",
+          "default_tests_runner": "${{ inputs.testRunner }}",
           "skipped_tests": ""
         }
 

--- a/.github/workflows/flakeguard-validate-tests.yml
+++ b/.github/workflows/flakeguard-validate-tests.yml
@@ -24,7 +24,6 @@ jobs:
     name: Run Custom Tests with Flakeguard
     uses: ./.github/workflows/flakeguard.yml
     with:
-      # Minimal required inputs for your reusable workflow
       repoUrl: 'https://github.com/smartcontractkit/chainlink'
       projectPath: '.'
       runAllTests: false

--- a/.github/workflows/flakeguard-validate-tests.yml
+++ b/.github/workflows/flakeguard-validate-tests.yml
@@ -1,0 +1,45 @@
+name: Flakeguard Validate Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      testPackages:
+        description: 'A comma-separated list of test packages to run.'
+        required: true
+        type: string
+        default: 'github.com/smartcontractkit/chainlink/v2/core/cmd'
+      testRepeatCount:
+        description: 'The number of times to repeat the tests.'
+        required: false
+        type: string
+        default: '5'
+      runTestsWithRace:
+        description: 'Run tests with the race detector enabled.'
+        required: false
+        type: string
+        default: 'true'
+
+jobs:
+  run-custom-tests:
+    name: Run Custom Tests with Flakeguard
+    uses: ./.github/workflows/flakeguard.yml
+    with:
+      # Minimal required inputs for your reusable workflow
+      repoUrl: 'https://github.com/smartcontractkit/chainlink'
+      projectPath: '.'
+      runAllTests: false
+      # All tests have to pass
+      maxPassRatio: '1.0' 
+      extraArgs: >-
+        {
+          "runCustomTestPackages": "${{ inputs.testPackages }}",
+          "test_repeat_count": "${{ inputs.testRepeatCount }}",
+          "skipped_tests": "",
+          "run_with_race": "${{ inputs.runTestsWithRace }}"
+        }
+
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # FLAKEGUARD_SPLUNK_ENDPOINT: ${{ secrets.FLAKEGUARD_SPLUNK_ENDPOINT }}
+      # FLAKEGUARD_SPLUNK_HEC: ${{ secrets.FLAKEGUARD_SPLUNK_HEC }}

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -57,10 +57,10 @@ on:
         required: true
       FLAKEGUARD_SPLUNK_ENDPOINT:
         description: "The Splunk HTTP Event Collector (HEC) endpoint."
-        required: true
+        required: false
       FLAKEGUARD_SPLUNK_HEC:
         description: "The Splunk HTTP Event Collector (HEC) token."
-        required: true
+        required: false
 
 env:
   GIT_BASE_REF: ${{ inputs.baseRef }}
@@ -71,6 +71,7 @@ env:
   TEST_REPEAT_COUNT: ${{ fromJSON(inputs.extraArgs)['test_repeat_count'] || '5' }} # The number of times each runner should run a test to detect flaky tests.
   RUN_WITH_RACE: ${{ fromJSON(inputs.extraArgs)['run_with_race'] || 'true' }} # Whether to run tests with -race flag.
   RUN_WITH_SHUFFLE: ${{ fromJSON(inputs.extraArgs)['run_with_shuffle'] || 'false' }} # Whether to run tests with -shuffle flag.
+  RUN_CUSTOM_TEST_PACKAGES: ${{ fromJSON(inputs.extraArgs)['runCustomTestPackages'] || '' }} # Comma-separated custom test packages to run.
   SHUFFLE_SEED: ${{ fromJSON(inputs.extraArgs)['shuffle_seed'] || '999' }} # The seed to use when -shuffle flag is enabled. Requires RUN_WITH_SHUFFLE to be true.
   ALL_TESTS_RUNNER: ${{ fromJSON(inputs.extraArgs)['all_tests_runner'] || 'ubuntu22.04-32cores-128GB' }} # The runner to use for running all tests.
   DEFAULT_RUNNER: ${{ fromJSON(inputs.extraArgs)['default_tests_runner'] || 'ubuntu-latest' }} # The runner to use for running custom tests (e.g. in PRs).
@@ -135,7 +136,7 @@ jobs:
         run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@96581547bab07e3982df522dd4343c998619ca77 # flakguard@0.1.0
 
       - name: Find new or updated test packages
-        if: ${{ inputs.runAllTests == false }}
+        if: ${{ inputs.runAllTests == false && env.RUN_CUSTOM_TEST_PACKAGES == '' }}
         id: get-tests
         shell: bash
         env:
@@ -153,7 +154,7 @@ jobs:
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
       - name: Find changed test files 
-        if: ${{ inputs.runAllTests == false }}
+        if: ${{ inputs.runAllTests == false && env.RUN_CUSTOM_TEST_PACKAGES == '' }}
         id: find-changed-test-files
         shell: bash
         env:
@@ -173,7 +174,11 @@ jobs:
         shell: bash
         env:
           GH_INPUTS_RUN_ALL_TESTS: ${{ inputs.runAllTests }}
+          RUN_CUSTOM_TEST_PACKAGES: ${{ env.RUN_CUSTOM_TEST_PACKAGES }}
         run: |
+          # ---------------------------------------------------------
+          # Run all tests if RUN_ALL_TESTS is set
+          # ---------------------------------------------------------
           if [[ "$GH_INPUTS_RUN_ALL_TESTS" == "true" ]]; then
             # Use ALL_TESTS_RUNNER for a specified number of groups, each with "./..." to run all tests
             ALL_TESTS_RUNNER_COUNT=${{ env.ALL_TESTS_RUNNER_COUNT }}
@@ -189,6 +194,30 @@ jobs:
             exit 0
           fi
 
+          # ---------------------------------------------------------
+          # If RUN_CUSTOM_TEST_PACKAGES is set, skip diff-based logic and run the specified packages
+          # ---------------------------------------------------------
+          if [[ -n "$RUN_CUSTOM_TEST_PACKAGES" ]]; then
+            IFS=',' read -ra cpkgs <<< "$RUN_CUSTOM_TEST_PACKAGES"
+            groups=()
+
+            for pkg in "${cpkgs[@]}"; do
+              # Trim whitespace around package name
+              pkg=$(echo "$pkg" | xargs)
+              groups+=("{\"testPackages\":\"$pkg\",\"runs_on\":\"${{ env.DEFAULT_RUNNER }}\"}")
+            done
+
+            json_groups=$(printf '%s\n' "${groups[@]}" | jq -s .)
+            echo "$json_groups"
+            echo "matrix<<EOF" >> $GITHUB_OUTPUT
+            echo "$json_groups" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # -------------------------------------------
+          # Otherwise, use the normal find & split logic
+          # -------------------------------------------
           PACKAGES=(${{ steps.get-tests.outputs.packages }})
           DESIRED_GROUP_COUNT=$((${{ env.DEFAULT_MAX_RUNNER_COUNT }}))
           TOTAL_PACKAGES=${#PACKAGES[@]}

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -71,7 +71,7 @@ env:
   TEST_REPEAT_COUNT: ${{ fromJSON(inputs.extraArgs)['test_repeat_count'] || '5' }} # The number of times each runner should run a test to detect flaky tests.
   RUN_WITH_RACE: ${{ fromJSON(inputs.extraArgs)['run_with_race'] || 'true' }} # Whether to run tests with -race flag.
   RUN_WITH_SHUFFLE: ${{ fromJSON(inputs.extraArgs)['run_with_shuffle'] || 'false' }} # Whether to run tests with -shuffle flag.
-  RUN_CUSTOM_TEST_PACKAGES: ${{ fromJSON(inputs.extraArgs)['runCustomTestPackages'] || '' }} # Comma-separated custom test packages to run.
+  RUN_CUSTOM_TEST_PACKAGES: ${{ fromJSON(inputs.extraArgs)['run_custom_test_packages'] || '' }} # Comma-separated custom test packages to run.
   SHUFFLE_SEED: ${{ fromJSON(inputs.extraArgs)['shuffle_seed'] || '999' }} # The seed to use when -shuffle flag is enabled. Requires RUN_WITH_SHUFFLE to be true.
   ALL_TESTS_RUNNER: ${{ fromJSON(inputs.extraArgs)['all_tests_runner'] || 'ubuntu22.04-32cores-128GB' }} # The runner to use for running all tests.
   DEFAULT_RUNNER: ${{ fromJSON(inputs.extraArgs)['default_tests_runner'] || 'ubuntu-latest' }} # The runner to use for running custom tests (e.g. in PRs).

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -203,10 +203,13 @@ test-short: ## Run 'go test -short' and suppress uninteresting output
 run_flakeguard_validate_tests:
 	@read -p "Enter a comma-separated list of test packages (e.g., package1,package2): " PKGS; \
 	 read -p "Enter the number of times to rerun the tests (e.g., 5): " REPS; \
+	 read -p "Enter the test runner (default: ubuntu-20.04): " RUNNER; \
+	 RUNNER=$${RUNNER:-ubuntu-20.04}; \
 	 gh workflow run flakeguard-validate-tests.yml \
 	   -f testPackages="$${PKGS}" \
 	   -f testRepeatCount="$${REPS}" \
-	   -f runTestsWithRace="true"
+	   -f runTestsWithRace="true" \
+	   -f testRunner="$${RUNNER}"
 
 help:
 	@echo ""

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -199,6 +199,15 @@ modgraph:
 test-short: ## Run 'go test -short' and suppress uninteresting output
 	go test -short ./... | grep -v "\[no test files\]" | grep -v "\(cached\)"
 
+.PHONY: run_flakeguard_validate_tests
+run_flakeguard_validate_tests:
+	@read -p "Enter a comma-separated list of test packages (e.g., package1,package2): " PKGS; \
+	 read -p "Enter the number of times to rerun the tests (e.g., 5): " REPS; \
+	 gh workflow run flakeguard-validate-tests.yml \
+	   -f testPackages="$${PKGS}" \
+	   -f testRepeatCount="$${REPS}" \
+	   -f runTestsWithRace="true"
+
 help:
 	@echo ""
 	@echo "         .__           .__       .__  .__        __"

--- a/core/web/resolver/spec_test.go
+++ b/core/web/resolver/spec_test.go
@@ -43,7 +43,7 @@ func TestResolver_CronSpec(t *testing.T) {
 					Type: job.Cron,
 					CronSpec: &job.CronSpec{
 						CronSchedule: "CRON_TZ=UTC 0 0 1 1 *",
-						EVMChainID:   ubig.NewI(42),
+						EVMChainID:   ubig.NewI(45),
 						CreatedAt:    f.Timestamp(),
 					},
 				}, nil)

--- a/core/web/resolver/spec_test.go
+++ b/core/web/resolver/spec_test.go
@@ -43,7 +43,7 @@ func TestResolver_CronSpec(t *testing.T) {
 					Type: job.Cron,
 					CronSpec: &job.CronSpec{
 						CronSchedule: "CRON_TZ=UTC 0 0 1 1 *",
-						EVMChainID:   ubig.NewI(45),
+						EVMChainID:   ubig.NewI(42),
 						CreatedAt:    f.Timestamp(),
 					},
 				}, nil)


### PR DESCRIPTION
Example run: https://github.com/smartcontractkit/chainlink/actions/runs/13008623765

CMD to run Flakeguard for a test package(s) to validate if it is not flaky:

```
gh workflow run flakeguard-validate-tests.yml \
  --ref "TT-1966-Allow-FlakeGuard-to-rerun-selected-test-and-check-for-flakiness" \
  -f testPackages="github.com/smartcontractkit/chainlink/v2/core/cmd,github.com/smartcontractkit/chainlink/v2/core/web/resolver" \
  -f testRepeatCount="2"
```
