### PR TITLE
[CAPP-312] handle unconfirmed/confirmed transactions

### DIFF
--- a/core/capabilities/targets/write_target.go
+++ b/core/capabilities/targets/write_target.go
@@ -44,6 +44,13 @@ type WriteTarget struct {
 	bound bool
 }
 
+const (
+	TransmissionStateNotAttempted uint8 = iota
+	TransmissionStateSucceeded
+	TransmissionStateInvalidReceiver
+	TransmissionStateFailed
+)
+
 type TransmissionInfo struct {
 	GasLimit        *big.Int
 	InvalidReceiver bool
@@ -243,30 +250,21 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 	}
 
 	// Check whether value was already transmitted on chain
-	queryInputs := struct {
-		Receiver            string
-		WorkflowExecutionID []byte
-		ReportId            []byte
-	}{
-		Receiver:            request.Config.Address,
-		WorkflowExecutionID: rawExecutionID,
-		ReportId:            request.Inputs.SignedReport.ID,
-	}
-	var transmissionInfo TransmissionInfo
-	if err = cap.cr.GetLatestValue(ctx, cap.binding.ReadIdentifier("getTransmissionInfo"), primitives.Unconfirmed, queryInputs, &transmissionInfo); err != nil {
-		return capabilities.CapabilityResponse{}, fmt.Errorf("failed to getTransmissionInfo latest value: %w", err)
+	transmissionInfo, err := cap.getTransmissionInfo(ctx, request, rawExecutionID)
+	if err != nil {
+		return capabilities.CapabilityResponse{}, err
 	}
 
 	switch {
-	case transmissionInfo.State == 0: // NOT_ATTEMPTED
+	case transmissionInfo.State == TransmissionStateNotAttempted:
 		cap.lggr.Infow("non-empty report - transmission not attempted - attempting to push to txmgr", "request", request, "reportLen", len(request.Inputs.SignedReport.Report), "reportContextLen", len(request.Inputs.SignedReport.Context), "nSignatures", len(request.Inputs.SignedReport.Signatures), "executionID", request.Metadata.WorkflowExecutionID)
-	case transmissionInfo.State == 1: // SUCCEEDED
+	case transmissionInfo.State == TransmissionStateSucceeded:
 		cap.lggr.Infow("returning without a transmission attempt - report already onchain ", "executionID", request.Metadata.WorkflowExecutionID)
 		return capabilities.CapabilityResponse{}, nil
-	case transmissionInfo.State == 2: // INVALID_RECEIVER
+	case transmissionInfo.State == TransmissionStateInvalidReceiver:
 		cap.lggr.Infow("returning without a transmission attempt - transmission already attempted, receiver was marked as invalid", "executionID", request.Metadata.WorkflowExecutionID)
 		return capabilities.CapabilityResponse{}, nil
-	case transmissionInfo.State == 3: // FAILED
+	case transmissionInfo.State == TransmissionStateFailed:
 		receiverGasMinimum := cap.receiverGasMinimum
 		if request.Config.GasLimit != nil {
 			receiverGasMinimum = *request.Config.GasLimit - ForwarderContractLogicGasCost
@@ -340,6 +338,32 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 				continue
 			}
 			switch txStatus {
+			case commontypes.Unconfirmed:
+				transmissionInfo, err := cap.getTransmissionInfo(ctx, request, rawExecutionID)
+				if err != nil {
+					return capabilities.CapabilityResponse{}, err
+				}
+
+				// This is contraintuitive, but the tx manager is currently returning unconfirmed whenever the tx is confirmed
+				// current implementation here: https://github.com/smartcontractkit/chainlink-framework/blob/main/chains/txmgr/txmgr.go#L697
+				// so we need to check if we where able to write to the consumer contract to determine if the transaction was successful
+				if transmissionInfo.State == TransmissionStateSucceeded {
+					cap.lggr.Debugw("Transaction confirmed", "request", request, "transaction", txID)
+					return capabilities.CapabilityResponse{}, nil
+				} else {
+					cap.lggr.Errorw("Transaction written to the forwarder, but failed to be written to the consumer contract", "request", request, "transaction", txID)
+					msg := "failed to submit transaction with ID: " + txID.String()
+					err = cap.emitter.With(
+						platform.KeyWorkflowID, request.Metadata.WorkflowID,
+						platform.KeyWorkflowName, request.Metadata.DecodedWorkflowName,
+						platform.KeyWorkflowOwner, request.Metadata.WorkflowOwner,
+						platform.KeyWorkflowExecutionID, request.Metadata.WorkflowExecutionID,
+					).Emit(ctx, msg)
+					if err != nil {
+						cap.lggr.Errorf("failed to send custom message with msg: %s, err: %v", msg, err)
+					}
+					return capabilities.CapabilityResponse{}, fmt.Errorf("submitted transaction failed: %w", err)
+				}
 			case commontypes.Finalized:
 				cap.lggr.Debugw("Transaction finalized", "request", request, "transaction", txID)
 				return capabilities.CapabilityResponse{}, nil
@@ -370,4 +394,21 @@ func (cap *WriteTarget) RegisterToWorkflow(ctx context.Context, request capabili
 
 func (cap *WriteTarget) UnregisterFromWorkflow(ctx context.Context, request capabilities.UnregisterFromWorkflowRequest) error {
 	return nil
+}
+
+func (cap *WriteTarget) getTransmissionInfo(ctx context.Context, request Request, rawExecutionID []byte) (*TransmissionInfo, error) {
+	queryInputs := struct {
+		Receiver            string
+		WorkflowExecutionID []byte
+		ReportId            []byte
+	}{
+		Receiver:            request.Config.Address,
+		WorkflowExecutionID: rawExecutionID,
+		ReportId:            request.Inputs.SignedReport.ID,
+	}
+	var transmissionInfo TransmissionInfo
+	if err := cap.cr.GetLatestValue(ctx, cap.binding.ReadIdentifier("getTransmissionInfo"), primitives.Unconfirmed, queryInputs, &transmissionInfo); err != nil {
+		return nil, fmt.Errorf("failed to getTransmissionInfo latest value: %w", err)
+	}
+	return &transmissionInfo, nil
 }

--- a/core/capabilities/targets/write_target.go
+++ b/core/capabilities/targets/write_target.go
@@ -338,13 +338,14 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 				continue
 			}
 			switch txStatus {
+			// TxStatus Unconfirmed actually means "Confirmed" for the transaction manager, i.e. the transaction has landed on chain but isn't finalized.
 			case commontypes.Unconfirmed:
-				transmissionInfo, err := cap.getTransmissionInfo(ctx, request, rawExecutionID)
+				transmissionInfo, err = cap.getTransmissionInfo(ctx, request, rawExecutionID)
 				if err != nil {
 					return capabilities.CapabilityResponse{}, err
 				}
 
-				// This is contraintuitive, but the tx manager is currently returning unconfirmed whenever the tx is confirmed
+				// This is counterintuitive, but the tx manager is currently returning unconfirmed whenever the tx is confirmed
 				// current implementation here: https://github.com/smartcontractkit/chainlink-framework/blob/main/chains/txmgr/txmgr.go#L697
 				// so we need to check if we where able to write to the consumer contract to determine if the transaction was successful
 				if transmissionInfo.State == TransmissionStateSucceeded {
@@ -400,11 +401,11 @@ func (cap *WriteTarget) getTransmissionInfo(ctx context.Context, request Request
 	queryInputs := struct {
 		Receiver            string
 		WorkflowExecutionID []byte
-		ReportId            []byte
+		ReportID            []byte
 	}{
 		Receiver:            request.Config.Address,
 		WorkflowExecutionID: rawExecutionID,
-		ReportId:            request.Inputs.SignedReport.ID,
+		ReportID:            request.Inputs.SignedReport.ID,
 	}
 	var transmissionInfo TransmissionInfo
 	if err := cap.cr.GetLatestValue(ctx, cap.binding.ReadIdentifier("getTransmissionInfo"), primitives.Unconfirmed, queryInputs, &transmissionInfo); err != nil {

--- a/core/capabilities/targets/write_target.go
+++ b/core/capabilities/targets/write_target.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -354,7 +355,7 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 					cap.lggr.Debugw("Transaction confirmed", "request", request, "transaction", txID)
 					return capabilities.CapabilityResponse{}, nil
 				} else {
-					cap.lggr.Errorw("Transaction written to the forwarder, but failed to be written to the consumer contract", "request", request, "transaction", txID)
+					cap.lggr.Errorw("Transaction written to the forwarder, but failed to be written to the consumer contract", "request", request, "transaction", txID, "transmissionState", transmissionInfo.State)
 					msg := "failed to submit transaction with ID: " + txID.String()
 					err = cap.emitter.With(
 						platform.KeyWorkflowID, request.Metadata.WorkflowID,
@@ -365,7 +366,7 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 					if err != nil {
 						cap.lggr.Errorf("failed to send custom message with msg: %s, err: %v", msg, err)
 					}
-					return capabilities.CapabilityResponse{}, fmt.Errorf("submitted transaction failed: %w", err)
+					return capabilities.CapabilityResponse{}, errors.New("submitted transaction failed")
 				}
 			case commontypes.Finalized:
 				cap.lggr.Debugw("Transaction finalized", "request", request, "transaction", txID)
@@ -383,7 +384,7 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 				if err != nil {
 					cap.lggr.Errorf("failed to send custom message with msg: %s, err: %v", msg, err)
 				}
-				return capabilities.CapabilityResponse{}, fmt.Errorf("submitted transaction failed: %w", err)
+				return capabilities.CapabilityResponse{}, errors.New("submitted transaction failed")
 			default:
 				cap.lggr.Debugw("Unexpected transaction status", "request", request, "transaction", txID, "status", txStatus)
 			}

--- a/core/capabilities/targets/write_target.go
+++ b/core/capabilities/targets/write_target.go
@@ -338,6 +338,8 @@ func (cap *WriteTarget) Execute(ctx context.Context, rawRequest capabilities.Cap
 				continue
 			}
 			switch txStatus {
+			case commontypes.Pending:
+				cap.lggr.Debugw("Transaction pending, retrying...", "request", request, "transaction", txID)
 			// TxStatus Unconfirmed actually means "Confirmed" for the transaction manager, i.e. the transaction has landed on chain but isn't finalized.
 			case commontypes.Unconfirmed:
 				transmissionInfo, err = cap.getTransmissionInfo(ctx, request, rawExecutionID)

--- a/core/capabilities/targets/write_target_test.go
+++ b/core/capabilities/targets/write_target_test.go
@@ -23,9 +23,21 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
-func TestWriteTarget(t *testing.T) {
+type testHarness struct {
+	ctx           context.Context
+	lggr          logger.Logger
+	cw            *mocks.ContractWriter
+	cr            *mocks.ContractValueGetter
+	config        *values.Map
+	validInputs   *values.Map
+	validMetadata capabilities.RequestMetadata
+	writeTarget   *targets.WriteTarget
+	forwarderAddr string
+	binding       types.BoundContract
+}
+
+func setup(t *testing.T) testHarness {
 	lggr := logger.TestLogger(t)
-	ctx := context.Background()
 
 	cw := mocks.NewContractWriter(t)
 	cr := mocks.NewContractValueGetter(t)
@@ -85,7 +97,22 @@ func TestWriteTarget(t *testing.T) {
 
 	cr.On("Bind", mock.Anything, []types.BoundContract{binding}).Return(nil)
 
-	cr.EXPECT().GetLatestValue(mock.Anything, binding.ReadIdentifier("getTransmissionInfo"), mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(_ context.Context, _ string, _ primitives.ConfidenceLevel, _, retVal any) {
+	return testHarness{
+		ctx:           testutils.Context(t),
+		lggr:          lggr,
+		cw:            cw,
+		cr:            cr,
+		config:        config,
+		validInputs:   validInputs,
+		validMetadata: validMetadata,
+		writeTarget:   writeTarget,
+		forwarderAddr: forwarderAddr,
+		binding:       binding,
+	}
+}
+func TestWriteTarget(t *testing.T) {
+	th := setup(t)
+	th.cr.EXPECT().GetLatestValue(mock.Anything, th.binding.ReadIdentifier("getTransmissionInfo"), mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(_ context.Context, _ string, _ primitives.ConfidenceLevel, _, retVal any) {
 		transmissionInfo := retVal.(*targets.TransmissionInfo)
 		*transmissionInfo = targets.TransmissionInfo{
 			GasLimit:        big.NewInt(0),
@@ -96,93 +123,91 @@ func TestWriteTarget(t *testing.T) {
 			Transmitter:     common.HexToAddress("0x0"),
 		}
 	})
-
-	cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, forwarderAddr, mock.Anything, mock.Anything).Return(nil).Once()
-
 	t.Run("succeeds with valid report", func(t *testing.T) {
 		req := capabilities.CapabilityRequest{
-			Metadata: validMetadata,
-			Config:   config,
-			Inputs:   validInputs,
+			Metadata: th.validMetadata,
+			Config:   th.config,
+			Inputs:   th.validInputs,
 		}
-		cw.On("GetTransactionStatus", mock.Anything, mock.Anything).Return(types.Finalized, nil).Once()
+		th.cw.On("GetTransactionStatus", mock.Anything, mock.Anything).Return(types.Finalized, nil).Once()
+		th.cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, th.forwarderAddr, mock.Anything, mock.Anything).Return(nil).Once()
 
-		response, err2 := writeTarget.Execute(ctx, req)
+		response, err2 := th.writeTarget.Execute(th.ctx, req)
 		require.NoError(t, err2)
 		require.NotNil(t, response)
 	})
 
 	t.Run("fails when ChainWriter's SubmitTransaction returns error", func(t *testing.T) {
 		req := capabilities.CapabilityRequest{
-			Metadata: validMetadata,
-			Config:   config,
-			Inputs:   validInputs,
+			Metadata: th.validMetadata,
+			Config:   th.config,
+			Inputs:   th.validInputs,
 		}
-		cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, forwarderAddr, mock.Anything, mock.Anything).Return(errors.New("writer error"))
+		th.cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, th.forwarderAddr, mock.Anything, mock.Anything).Return(errors.New("writer error"))
 
-		_, err = writeTarget.Execute(ctx, req)
+		_, err := th.writeTarget.Execute(th.ctx, req)
 		require.Error(t, err)
 	})
 
 	t.Run("passes gas limit set on config to the chain writer", func(t *testing.T) {
 		configGasLimit, err2 := values.NewMap(map[string]any{
-			"Address":  forwarderAddr,
+			"Address":  th.forwarderAddr,
 			"GasLimit": 500000,
 		})
 		require.NoError(t, err2)
 		req := capabilities.CapabilityRequest{
-			Metadata: validMetadata,
+			Metadata: th.validMetadata,
 			Config:   configGasLimit,
-			Inputs:   validInputs,
+			Inputs:   th.validInputs,
 		}
 
 		meta := types.TxMeta{WorkflowExecutionID: &req.Metadata.WorkflowExecutionID, GasLimit: big.NewInt(500000)}
-		cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, forwarderAddr, &meta, mock.Anything).Return(types.ErrSettingTransactionGasLimitNotSupported)
+		th.cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, th.forwarderAddr, &meta, mock.Anything).Return(types.ErrSettingTransactionGasLimitNotSupported)
 
-		_, err2 = writeTarget.Execute(ctx, req)
+		_, err2 = th.writeTarget.Execute(th.ctx, req)
 		require.Error(t, err2)
 	})
 
 	t.Run("retries without gas limit when ChainWriter's SubmitTransaction returns error due to gas limit not supported", func(t *testing.T) {
 		configGasLimit, err2 := values.NewMap(map[string]any{
-			"Address":  forwarderAddr,
+			"Address":  th.forwarderAddr,
 			"GasLimit": 500000,
 		})
 		require.NoError(t, err2)
 		req := capabilities.CapabilityRequest{
-			Metadata: validMetadata,
+			Metadata: th.validMetadata,
 			Config:   configGasLimit,
-			Inputs:   validInputs,
+			Inputs:   th.validInputs,
 		}
 
 		meta := types.TxMeta{WorkflowExecutionID: &req.Metadata.WorkflowExecutionID, GasLimit: big.NewInt(500000)}
-		cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, forwarderAddr, &meta, mock.Anything).Return(types.ErrSettingTransactionGasLimitNotSupported)
+		th.cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, th.forwarderAddr, &meta, mock.Anything).Return(types.ErrSettingTransactionGasLimitNotSupported)
 		meta = types.TxMeta{WorkflowExecutionID: &req.Metadata.WorkflowExecutionID}
-		cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, forwarderAddr, &meta, mock.Anything).Return(nil)
+		th.cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, th.forwarderAddr, &meta, mock.Anything).Return(nil)
 
-		configGasLimit, err = values.NewMap(map[string]any{
-			"Address": forwarderAddr,
+		configGasLimit, err := values.NewMap(map[string]any{
+			"Address": th.forwarderAddr,
 		})
 		require.NoError(t, err)
 		req = capabilities.CapabilityRequest{
-			Metadata: validMetadata,
+			Metadata: th.validMetadata,
 			Config:   configGasLimit,
-			Inputs:   validInputs,
+			Inputs:   th.validInputs,
 		}
 
-		_, err2 = writeTarget.Execute(ctx, req)
+		_, err2 = th.writeTarget.Execute(th.ctx, req)
 		require.Error(t, err2)
 	})
 
 	t.Run("fails when ChainReader's GetLatestValue returns error", func(t *testing.T) {
 		req := capabilities.CapabilityRequest{
-			Metadata: validMetadata,
-			Config:   config,
-			Inputs:   validInputs,
+			Metadata: th.validMetadata,
+			Config:   th.config,
+			Inputs:   th.validInputs,
 		}
-		cr.EXPECT().GetLatestValue(mock.Anything, binding.ReadIdentifier("getTransmissionInfo"), mock.Anything, mock.Anything, mock.Anything).Return(errors.New("reader error"))
+		th.cr.EXPECT().GetLatestValue(mock.Anything, th.binding.ReadIdentifier("getTransmissionInfo"), mock.Anything, mock.Anything, mock.Anything).Return(errors.New("reader error"))
 
-		_, err = writeTarget.Execute(ctx, req)
+		_, err := th.writeTarget.Execute(th.ctx, req)
 		require.Error(t, err)
 	})
 
@@ -197,32 +222,35 @@ func TestWriteTarget(t *testing.T) {
 				WorkflowID: "test-id",
 			},
 			Config: invalidConfig,
-			Inputs: validInputs,
+			Inputs: th.validInputs,
 		}
-		_, err2 = writeTarget.Execute(ctx, req)
+		_, err2 = th.writeTarget.Execute(th.ctx, req)
 		require.Error(t, err2)
 	})
 
 	t.Run("fails with nil config", func(t *testing.T) {
 		req := capabilities.CapabilityRequest{
-			Metadata: validMetadata,
+			Metadata: th.validMetadata,
 			Config:   nil,
-			Inputs:   validInputs,
+			Inputs:   th.validInputs,
 		}
-		_, err2 := writeTarget.Execute(ctx, req)
+		_, err2 := th.writeTarget.Execute(th.ctx, req)
 		require.Error(t, err2)
 	})
 
 	t.Run("fails with nil inputs", func(t *testing.T) {
 		req := capabilities.CapabilityRequest{
-			Metadata: validMetadata,
-			Config:   config,
+			Metadata: th.validMetadata,
+			Config:   th.config,
 			Inputs:   nil,
 		}
-		_, err2 := writeTarget.Execute(ctx, req)
+		_, err2 := th.writeTarget.Execute(th.ctx, req)
 		require.Error(t, err2)
 	})
+}
 
+func TestWriteTarget_ValidateRequest(t *testing.T) {
+	th := setup(t)
 	tests := []struct {
 		name          string
 		modifyRequest func(*capabilities.CapabilityRequest)
@@ -247,13 +275,13 @@ func TestWriteTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := capabilities.CapabilityRequest{
-				Metadata: validMetadata,
-				Config:   config,
-				Inputs:   validInputs,
+				Metadata: th.validMetadata,
+				Config:   th.config,
+				Inputs:   th.validInputs,
 			}
 			tt.modifyRequest(&req)
 
-			_, err := writeTarget.Execute(ctx, req)
+			_, err := th.writeTarget.Execute(th.ctx, req)
 			if tt.expectedError == "" {
 				require.NoError(t, err)
 			} else {
@@ -262,4 +290,85 @@ func TestWriteTarget(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWriteTarget_UnconfirmedTransaction(t *testing.T) {
+	t.Run("succeeds when transaction is unconfirmed but transmission succeeded ", func(t *testing.T) {
+		th := setup(t)
+		th.cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, th.forwarderAddr, mock.Anything, mock.Anything).Return(nil).Once()
+		callCount := 0
+		th.cr.On("GetLatestValue", mock.Anything, th.binding.ReadIdentifier("getTransmissionInfo"), mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			transmissionInfo := args.Get(4).(*targets.TransmissionInfo)
+			if callCount == 0 {
+				*transmissionInfo = targets.TransmissionInfo{
+					GasLimit:        big.NewInt(0),
+					InvalidReceiver: false,
+					State:           targets.TransmissionStateNotAttempted,
+					Success:         false,
+					TransmissionId:  [32]byte{},
+					Transmitter:     common.HexToAddress("0x0"),
+				}
+			} else {
+				*transmissionInfo = targets.TransmissionInfo{
+					GasLimit:        big.NewInt(0),
+					InvalidReceiver: false,
+					State:           targets.TransmissionStateSucceeded,
+					Success:         false,
+					TransmissionId:  [32]byte{},
+					Transmitter:     common.HexToAddress("0x0"),
+				}
+			}
+			callCount++
+		})
+		req := capabilities.CapabilityRequest{
+			Metadata: th.validMetadata,
+			Config:   th.config,
+			Inputs:   th.validInputs,
+		}
+
+		th.cw.On("GetTransactionStatus", mock.Anything, mock.Anything).Return(types.Unconfirmed, nil).Once()
+
+		response, err2 := th.writeTarget.Execute(th.ctx, req)
+		require.NoError(t, err2)
+		require.NotNil(t, response)
+	})
+
+	t.Run("transaction written to the forwarder, but failed to be written to the consumer contract", func(t *testing.T) {
+		th := setup(t)
+		th.cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, th.forwarderAddr, mock.Anything, mock.Anything).Return(nil).Once()
+		callCount := 0
+		th.cr.On("GetLatestValue", mock.Anything, th.binding.ReadIdentifier("getTransmissionInfo"), mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			transmissionInfo := args.Get(4).(*targets.TransmissionInfo)
+			if callCount == 0 {
+				*transmissionInfo = targets.TransmissionInfo{
+					GasLimit:        big.NewInt(0),
+					InvalidReceiver: false,
+					State:           targets.TransmissionStateNotAttempted,
+					Success:         false,
+					TransmissionId:  [32]byte{},
+					Transmitter:     common.HexToAddress("0x0"),
+				}
+			} else {
+				*transmissionInfo = targets.TransmissionInfo{
+					GasLimit:        big.NewInt(0),
+					InvalidReceiver: false,
+					State:           targets.TransmissionStateFailed,
+					Success:         false,
+					TransmissionId:  [32]byte{},
+					Transmitter:     common.HexToAddress("0x0"),
+				}
+			}
+			callCount++
+		})
+		req := capabilities.CapabilityRequest{
+			Metadata: th.validMetadata,
+			Config:   th.config,
+			Inputs:   th.validInputs,
+		}
+
+		th.cw.On("GetTransactionStatus", mock.Anything, mock.Anything).Return(types.Unconfirmed, nil).Once()
+		_, err2 := th.writeTarget.Execute(th.ctx, req)
+		require.Error(t, err2)
+		require.Contains(t, err2.Error(), "submitted transaction failed")
+	})
 }

--- a/core/capabilities/targets/write_target_test.go
+++ b/core/capabilities/targets/write_target_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 type testHarness struct {
-	ctx           context.Context
 	lggr          logger.Logger
 	cw            *mocks.ContractWriter
 	cr            *mocks.ContractValueGetter
@@ -98,7 +97,6 @@ func setup(t *testing.T) testHarness {
 	cr.On("Bind", mock.Anything, []types.BoundContract{binding}).Return(nil)
 
 	return testHarness{
-		ctx:           testutils.Context(t),
 		lggr:          lggr,
 		cw:            cw,
 		cr:            cr,
@@ -132,7 +130,8 @@ func TestWriteTarget(t *testing.T) {
 		th.cw.On("GetTransactionStatus", mock.Anything, mock.Anything).Return(types.Finalized, nil).Once()
 		th.cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, th.forwarderAddr, mock.Anything, mock.Anything).Return(nil).Once()
 
-		response, err2 := th.writeTarget.Execute(th.ctx, req)
+		ctx := testutils.Context(t)
+		response, err2 := th.writeTarget.Execute(ctx, req)
 		require.NoError(t, err2)
 		require.NotNil(t, response)
 	})
@@ -145,7 +144,8 @@ func TestWriteTarget(t *testing.T) {
 		}
 		th.cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, th.forwarderAddr, mock.Anything, mock.Anything).Return(errors.New("writer error"))
 
-		_, err := th.writeTarget.Execute(th.ctx, req)
+		ctx := testutils.Context(t)
+		_, err := th.writeTarget.Execute(ctx, req)
 		require.Error(t, err)
 	})
 
@@ -164,7 +164,8 @@ func TestWriteTarget(t *testing.T) {
 		meta := types.TxMeta{WorkflowExecutionID: &req.Metadata.WorkflowExecutionID, GasLimit: big.NewInt(500000)}
 		th.cw.On("SubmitTransaction", mock.Anything, "forwarder", "report", mock.Anything, mock.Anything, th.forwarderAddr, &meta, mock.Anything).Return(types.ErrSettingTransactionGasLimitNotSupported)
 
-		_, err2 = th.writeTarget.Execute(th.ctx, req)
+		ctx := testutils.Context(t)
+		_, err2 = th.writeTarget.Execute(ctx, req)
 		require.Error(t, err2)
 	})
 
@@ -195,7 +196,8 @@ func TestWriteTarget(t *testing.T) {
 			Inputs:   th.validInputs,
 		}
 
-		_, err2 = th.writeTarget.Execute(th.ctx, req)
+		ctx := testutils.Context(t)
+		_, err2 = th.writeTarget.Execute(ctx, req)
 		require.Error(t, err2)
 	})
 
@@ -207,7 +209,8 @@ func TestWriteTarget(t *testing.T) {
 		}
 		th.cr.EXPECT().GetLatestValue(mock.Anything, th.binding.ReadIdentifier("getTransmissionInfo"), mock.Anything, mock.Anything, mock.Anything).Return(errors.New("reader error"))
 
-		_, err := th.writeTarget.Execute(th.ctx, req)
+		ctx := testutils.Context(t)
+		_, err := th.writeTarget.Execute(ctx, req)
 		require.Error(t, err)
 	})
 
@@ -224,7 +227,8 @@ func TestWriteTarget(t *testing.T) {
 			Config: invalidConfig,
 			Inputs: th.validInputs,
 		}
-		_, err2 = th.writeTarget.Execute(th.ctx, req)
+		ctx := testutils.Context(t)
+		_, err2 = th.writeTarget.Execute(ctx, req)
 		require.Error(t, err2)
 	})
 
@@ -234,7 +238,8 @@ func TestWriteTarget(t *testing.T) {
 			Config:   nil,
 			Inputs:   th.validInputs,
 		}
-		_, err2 := th.writeTarget.Execute(th.ctx, req)
+		ctx := testutils.Context(t)
+		_, err2 := th.writeTarget.Execute(ctx, req)
 		require.Error(t, err2)
 	})
 
@@ -244,7 +249,8 @@ func TestWriteTarget(t *testing.T) {
 			Config:   th.config,
 			Inputs:   nil,
 		}
-		_, err2 := th.writeTarget.Execute(th.ctx, req)
+		ctx := testutils.Context(t)
+		_, err2 := th.writeTarget.Execute(ctx, req)
 		require.Error(t, err2)
 	})
 }
@@ -281,7 +287,8 @@ func TestWriteTarget_ValidateRequest(t *testing.T) {
 			}
 			tt.modifyRequest(&req)
 
-			_, err := th.writeTarget.Execute(th.ctx, req)
+			ctx := testutils.Context(t)
+			_, err := th.writeTarget.Execute(ctx, req)
 			if tt.expectedError == "" {
 				require.NoError(t, err)
 			} else {
@@ -328,7 +335,8 @@ func TestWriteTarget_UnconfirmedTransaction(t *testing.T) {
 
 		th.cw.On("GetTransactionStatus", mock.Anything, mock.Anything).Return(types.Unconfirmed, nil).Once()
 
-		response, err2 := th.writeTarget.Execute(th.ctx, req)
+		ctx := testutils.Context(t)
+		response, err2 := th.writeTarget.Execute(ctx, req)
 		require.NoError(t, err2)
 		require.NotNil(t, response)
 	})
@@ -367,7 +375,8 @@ func TestWriteTarget_UnconfirmedTransaction(t *testing.T) {
 		}
 
 		th.cw.On("GetTransactionStatus", mock.Anything, mock.Anything).Return(types.Unconfirmed, nil).Once()
-		_, err2 := th.writeTarget.Execute(th.ctx, req)
+		ctx := testutils.Context(t)
+		_, err2 := th.writeTarget.Execute(ctx, req)
 		require.Error(t, err2)
 		require.Contains(t, err2.Error(), "submitted transaction failed")
 	})


### PR DESCRIPTION
### Description
This pr aims to fix the misleading  log `"msg": "Unexpected transaction status"` by handling two cases that where not handled before when getting the status of a tx from the tx manager:

- **Unconfirmed**: This is actually confirmed, from a TXM perspective the tx landed on-chain, but seems that due an alignment between on the concept of `unconfirmed` between ChainReader and ChainWriter this is returned. The decision was to treat the `Unconfirmed` as "We know the tx is confirmed and landed on-chain".

- **Pending**: Transactions with pending status where also not handled and as a consequence we logging "Unexpected transaction status", when we should actually log: "Transaction pending, retrying..." , there is no logic change, only a more accurate log message.

In the ticket comments you can find links to the respective conversations on slack

[CAPP-312](https://smartcontract-it.atlassian.net/browse/CAPP-312)


### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
