### PR TITLE
integration-tests/smoke/ccip: bump down ccip_batching_test batch size to 5 from 25

### DIFF
--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -53,7 +53,7 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
-    test_cmd: cd integration-tests/smoke/ccip && go test ccip_batching_test.go -timeout 12m -test.parallel=2 -count=1 -json
+    test_cmd: cd integration-tests/smoke/ccip && go test ccip_batching_test.go -timeout 18m -test.parallel=2 -count=1 -json
   
   - id: smoke/ccip/ccip_add_chain_test.go:*
     path: integration-tests/smoke/ccip/ccip_add_chain_test.go

--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -53,7 +53,7 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
-    test_cmd: cd integration-tests/smoke/ccip && go test ccip_batching_test.go -timeout 18m -test.parallel=2 -count=1 -json
+    test_cmd: cd integration-tests/smoke/ccip && go test ccip_batching_test.go -timeout 25m -test.parallel=2 -count=1 -json
   
   - id: smoke/ccip/ccip_add_chain_test.go:*
     path: integration-tests/smoke/ccip/ccip_add_chain_test.go

--- a/integration-tests/smoke/ccip/ccip_batching_test.go
+++ b/integration-tests/smoke/ccip/ccip_batching_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	numMessages = 15
+	numMessages = 5
 )
 
 type batchTestSetup struct {

--- a/integration-tests/smoke/ccip/ccip_batching_test.go
+++ b/integration-tests/smoke/ccip/ccip_batching_test.go
@@ -71,8 +71,6 @@ func newBatchTestSetup(t *testing.T) batchTestSetup {
 }
 
 func Test_CCIPBatching_MaxBatchSizeEVM(t *testing.T) {
-	t.Parallel()
-
 	ctx := testhelpers.Context(t)
 	setup := newBatchTestSetup(t)
 	sourceChain1, sourceChain2, destChain, e, state := setup.sourceChain1, setup.sourceChain2, setup.destChain, setup.e, setup.state
@@ -137,10 +135,6 @@ func Test_CCIPBatching_MaxBatchSizeEVM(t *testing.T) {
 }
 
 func Test_CCIPBatching_MultiSource(t *testing.T) {
-	// t.Skip("Exec not working, boosting not working correctly")
-
-	t.Parallel()
-
 	// Setup 3 chains, with 2 lanes going to the dest.
 	ctx := testhelpers.Context(t)
 	setup := newBatchTestSetup(t)
@@ -266,8 +260,6 @@ func Test_CCIPBatching_MultiSource(t *testing.T) {
 }
 
 func Test_CCIPBatching_SingleSource(t *testing.T) {
-	t.Parallel()
-
 	// Setup 3 chains, with 2 lanes going to the dest.
 	ctx := testhelpers.Context(t)
 	setup := newBatchTestSetup(t)

--- a/integration-tests/smoke/ccip/ccip_batching_test.go
+++ b/integration-tests/smoke/ccip/ccip_batching_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	numMessages = 25
+	numMessages = 15
 )
 
 type batchTestSetup struct {


### PR DESCRIPTION
The exec part of the test seems a bit slow still, we were flaking and executing > 20 messages but < 25 messages. 

As such, drop the batch size to 5 messages.