### PR TITLE
update price min for bsc to 1 gwei

### DIFF
--- a/ccip/config/evm/BSC_Mainnet.toml
+++ b/ccip/config/evm/BSC_Mainnet.toml
@@ -12,9 +12,7 @@ RPCBlockQueryDelay = 2
 NoNewFinalizedHeadsThreshold = '45s'
 
 [GasEstimator]
-PriceDefault = '5 gwei'
-# Set to the BSC node's default Eth.Miner.GasPrice config
-PriceMin = '3 gwei'
+PriceDefault = '1 gwei'
 # 15s delay since feeds update every minute in volatile situations
 BumpThreshold = 5
 

--- a/ccip/config/evm/BSC_Mainnet.toml
+++ b/ccip/config/evm/BSC_Mainnet.toml
@@ -4,25 +4,3 @@
 ChainID = '56'
 # Keeping this >> 11 because it's not expensive and gives us a safety margin
 FinalityDepth = 50
-FinalityTagEnabled = true
-LinkContractAddress = '0x404460C6A5EdE2D891e8297795264fDe62ADBB75'
-LogPollInterval = '3s'
-NoNewHeadsThreshold = '30s'
-RPCBlockQueryDelay = 2
-NoNewFinalizedHeadsThreshold = '45s'
-
-[GasEstimator]
-PriceDefault = '1 gwei'
-# 15s delay since feeds update every minute in volatile situations
-BumpThreshold = 5
-
-[GasEstimator.BlockHistory]
-BlockHistorySize = 24
-
-[OCR]
-DatabaseTimeout = '2s'
-ContractTransmitterTransmitTimeout = '2s'
-ObservationGracePeriod = '500ms'
-
-[NodePool]
-SyncThreshold = 10

--- a/ccip/config/evm/BSC_Testnet.toml
+++ b/ccip/config/evm/BSC_Testnet.toml
@@ -12,7 +12,7 @@ RPCBlockQueryDelay = 2
 NoNewFinalizedHeadsThreshold = '40s'
 
 [GasEstimator]
-PriceDefault = '5 gwei'
+PriceDefault = '1 gwei'
 # 15s delay since feeds update every minute in volatile situations
 BumpThreshold = 5
 

--- a/ccip/config/evm/BSC_Testnet.toml
+++ b/ccip/config/evm/BSC_Testnet.toml
@@ -4,30 +4,3 @@
 ChainID = '97'
 # Keeping this >> 11 because it's not expensive and gives us a safety margin
 FinalityDepth = 50
-FinalityTagEnabled = true
-LinkContractAddress = '0x84b9B910527Ad5C03A9Ca831909E21e236EA7b06'
-LogPollInterval = '3s'
-NoNewHeadsThreshold = '30s'
-RPCBlockQueryDelay = 2
-NoNewFinalizedHeadsThreshold = '40s'
-
-[GasEstimator]
-PriceDefault = '1 gwei'
-# 15s delay since feeds update every minute in volatile situations
-BumpThreshold = 5
-
-[GasEstimator.BlockHistory]
-BlockHistorySize = 24
-
-[HeadTracker]
-HistoryDepth = 100
-SamplingInterval = '1s'
-FinalityTagBypass = false
-
-[OCR]
-DatabaseTimeout = '2s'
-ContractTransmitterTransmitTimeout = '2s'
-ObservationGracePeriod = '500ms'
-
-[NodePool]
-SyncThreshold = 10

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2989,9 +2989,9 @@ Enabled = true
 
 [GasEstimator]
 Mode = 'BlockHistory'
-PriceDefault = '5 gwei'
+PriceDefault = '1 gwei'
 PriceMax = '115792089237316195423570985008687907853269984665.640564039457584007913129639935 tether'
-PriceMin = '3 gwei'
+PriceMin = '1 gwei'
 LimitDefault = 500000
 LimitMax = 500000
 LimitMultiplier = '1'
@@ -3418,7 +3418,7 @@ Enabled = true
 
 [GasEstimator]
 Mode = 'BlockHistory'
-PriceDefault = '5 gwei'
+PriceDefault = '1 gwei'
 PriceMax = '115792089237316195423570985008687907853269984665.640564039457584007913129639935 tether'
 PriceMin = '1 gwei'
 LimitDefault = 500000

--- a/evm/config/toml/defaults/BSC_Mainnet.toml
+++ b/evm/config/toml/defaults/BSC_Mainnet.toml
@@ -11,9 +11,7 @@ FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '45s'
 
 [GasEstimator]
-PriceDefault = '5 gwei'
-# Set to the BSC node's default Eth.Miner.GasPrice config
-PriceMin = '3 gwei'
+PriceDefault = '1 gwei'
 # 15s delay since feeds update every minute in volatile situations
 BumpThreshold = 5
 

--- a/evm/config/toml/defaults/BSC_Testnet.toml
+++ b/evm/config/toml/defaults/BSC_Testnet.toml
@@ -11,7 +11,7 @@ FinalizedBlockOffset = 2
 NoNewFinalizedHeadsThreshold = '40s'
 
 [GasEstimator]
-PriceDefault = '5 gwei'
+PriceDefault = '1 gwei'
 # 15s delay since feeds update every minute in volatile situations
 BumpThreshold = 5
 


### PR DESCRIPTION
Removed 3gwei PriceMin to get the fallback of 1gwei & updated price default to 1 gwei 
context: BSC reduced the minimum gasPrice requirement to 1gwei from 3gwei [ref](https://github.com/bnb-chain/bsc/releases/tag/v1.4.16). So setting the configs to reflect the reduced minimum & to bring down the BSC operational costs