### PR TITLE
unconditionally track bridge task latency

### DIFF
--- a/.changeset/cuddly-hats-help.md
+++ b/.changeset/cuddly-hats-help.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-#changed Unconditionally track bridge task latency
+Unconditionally track bridge task latency #changed

--- a/.changeset/cuddly-hats-help.md
+++ b/.changeset/cuddly-hats-help.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Unconditionally track bridge task latency

--- a/.changeset/cuddly-hats-help.md
+++ b/.changeset/cuddly-hats-help.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-Unconditionally track bridge task latency
+#changed Unconditionally track bridge task latency

--- a/core/services/pipeline/common_http.go
+++ b/core/services/pipeline/common_http.go
@@ -110,3 +110,21 @@ func httpRequestCtx(ctx context.Context, t Task, cfg Config) (requestCtx context
 	}
 	return
 }
+
+// statusCodeGroup maps to course status code group (e.g. 2xx, 4xx, 5xx) to reduce metric cardinality.
+func statusCodeGroup(status int) string {
+	switch {
+	case status >= 100 && status < 200:
+		return "1xx"
+	case status >= 200 && status < 300:
+		return "2xx"
+	case status >= 300 && status < 400:
+		return "3xx"
+	case status >= 400 && status < 500:
+		return "4xx"
+	case status >= 500 && status < 600:
+		return "5xx"
+	default:
+		return "unknown"
+	}
+}

--- a/core/services/pipeline/task.bridge.go
+++ b/core/services/pipeline/task.bridge.go
@@ -28,9 +28,9 @@ import (
 var (
 	promBridgeLatency = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "bridge_latency_seconds",
-		Help: "Bridge latency in seconds scoped by name",
+		Help: "Bridge latency in seconds scoped by name and response status code",
 	},
-		[]string{"name"},
+		[]string{"name", "status_code_group"},
 	)
 	promBridgeErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "bridge_errors_total",
@@ -187,7 +187,7 @@ func (t *BridgeTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inp
 	var cachedResponse bool
 	responseBytes, statusCode, headers, start, finish, err := makeHTTPRequest(requestCtx, lggr, "POST", url, reqHeaders, requestData, t.httpClient, t.config.DefaultHTTPLimit())
 	elapsed := finish.Sub(start)
-	promBridgeLatency.WithLabelValues(t.Name).Set(elapsed.Seconds())
+	promBridgeLatency.WithLabelValues(t.Name, statusCodeGroup(statusCode)).Set(elapsed.Seconds())
 
 	defer func() {
 		telemetryCh := GetTelemetryCh(ctx)

--- a/core/services/pipeline/task.bridge.go
+++ b/core/services/pipeline/task.bridge.go
@@ -187,6 +187,7 @@ func (t *BridgeTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inp
 	var cachedResponse bool
 	responseBytes, statusCode, headers, start, finish, err := makeHTTPRequest(requestCtx, lggr, "POST", url, reqHeaders, requestData, t.httpClient, t.config.DefaultHTTPLimit())
 	elapsed := finish.Sub(start)
+	promBridgeLatency.WithLabelValues(t.Name).Set(elapsed.Seconds())
 
 	defer func() {
 		telemetryCh := GetTelemetryCh(ctx)
@@ -250,8 +251,6 @@ func (t *BridgeTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inp
 			"url", url.String(),
 		)
 		cachedResponse = true
-	} else {
-		promBridgeLatency.WithLabelValues(t.Name).Set(elapsed.Seconds())
 	}
 
 	if t.Async == "true" {


### PR DESCRIPTION
unconditionally track bridge task latency - this will show latency regardless if there are errors or successes. In the current state this metric collection behavior masks when a bridge will timeout or struggle and return with an error

Added course grouping on HTTP status codes 