### PR TITLE
Improve deployer group

### DIFF
--- a/deployment/ccip/changeset/cs_accept_admin_role.go
+++ b/deployment/ccip/changeset/cs_accept_admin_role.go
@@ -35,8 +35,7 @@ func AcceptAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistryCh
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	deploymentContext := NewDeploymentContext("accept admin role for tokens on token admin registries")
-	deployerGroup := NewDeployerGroup(env, state, deploymentContext, c.MCMS)
+	deployerGroup := NewDeployerGroup(env, state, c.MCMS).WithDeploymentContext("accept admin role for tokens on token admin registries")
 
 	for chainSelector, tokenSymbolToPoolInfo := range c.Pools {
 		chain := env.Chains[chainSelector]

--- a/deployment/ccip/changeset/cs_accept_admin_role.go
+++ b/deployment/ccip/changeset/cs_accept_admin_role.go
@@ -34,7 +34,9 @@ func AcceptAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistryCh
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deployerGroup := NewDeployerGroup(env, state, c.MCMS)
+
+	deploymentContext := NewDeploymentContext("accept admin role for tokens on token admin registries")
+	deployerGroup := NewDeployerGroup(env, state, deploymentContext, c.MCMS)
 
 	for chainSelector, tokenSymbolToPoolInfo := range c.Pools {
 		chain := env.Chains[chainSelector]
@@ -55,5 +57,5 @@ func AcceptAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistryCh
 		}
 	}
 
-	return deployerGroup.Enact("accept admin role for tokens on token admin registries")
+	return deployerGroup.Enact()
 }

--- a/deployment/ccip/changeset/cs_configure_token_pools.go
+++ b/deployment/ccip/changeset/cs_configure_token_pools.go
@@ -173,7 +173,9 @@ func ConfigureTokenPoolContractsChangeset(env deployment.Environment, c Configur
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deployerGroup := NewDeployerGroup(env, state, c.MCMS)
+
+	deploymentContext := NewDeploymentContext(fmt.Sprintf("configure %s token pools", c.TokenSymbol))
+	deployerGroup := NewDeployerGroup(env, state, deploymentContext, c.MCMS)
 
 	for chainSelector := range c.PoolUpdates {
 		chain := env.Chains[chainSelector]
@@ -188,7 +190,7 @@ func ConfigureTokenPoolContractsChangeset(env deployment.Environment, c Configur
 		}
 	}
 
-	return deployerGroup.Enact(fmt.Sprintf("configure %s token pools", c.TokenSymbol))
+	return deployerGroup.Enact()
 }
 
 // configureTokenPool creates all transactions required to configure the desired token pool on a chain,

--- a/deployment/ccip/changeset/cs_configure_token_pools.go
+++ b/deployment/ccip/changeset/cs_configure_token_pools.go
@@ -174,8 +174,7 @@ func ConfigureTokenPoolContractsChangeset(env deployment.Environment, c Configur
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	deploymentContext := NewDeploymentContext(fmt.Sprintf("configure %s token pools", c.TokenSymbol))
-	deployerGroup := NewDeployerGroup(env, state, deploymentContext, c.MCMS)
+	deployerGroup := NewDeployerGroup(env, state, c.MCMS).WithDeploymentContext(fmt.Sprintf("configure %s token pools", c.TokenSymbol))
 
 	for chainSelector := range c.PoolUpdates {
 		chain := env.Chains[chainSelector]

--- a/deployment/ccip/changeset/cs_propose_admin_role.go
+++ b/deployment/ccip/changeset/cs_propose_admin_role.go
@@ -38,7 +38,8 @@ func ProposeAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistryC
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deployerGroup := NewDeployerGroup(env, state, c.MCMS)
+	deploymentContext := NewDeploymentContext("propose admin role for tokens on token admin registries")
+	deployerGroup := NewDeployerGroup(env, state, deploymentContext, c.MCMS)
 
 	for chainSelector, tokenSymbolToPoolInfo := range c.Pools {
 		chain := env.Chains[chainSelector]
@@ -66,5 +67,5 @@ func ProposeAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistryC
 		}
 	}
 
-	return deployerGroup.Enact("propose admin role for tokens on token admin registries")
+	return deployerGroup.Enact()
 }

--- a/deployment/ccip/changeset/cs_propose_admin_role.go
+++ b/deployment/ccip/changeset/cs_propose_admin_role.go
@@ -38,8 +38,8 @@ func ProposeAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistryC
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deploymentContext := NewDeploymentContext("propose admin role for tokens on token admin registries")
-	deployerGroup := NewDeployerGroup(env, state, deploymentContext, c.MCMS)
+
+	deployerGroup := NewDeployerGroup(env, state, c.MCMS).WithDeploymentContext("propose admin role for tokens on token admin registries")
 
 	for chainSelector, tokenSymbolToPoolInfo := range c.Pools {
 		chain := env.Chains[chainSelector]

--- a/deployment/ccip/changeset/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/cs_rmn_curse_uncurse.go
@@ -219,7 +219,8 @@ func RMNCurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployment
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deployerGroup := NewDeployerGroup(e, state, cfg.MCMS)
+	deploymentContext := NewDeploymentContext("proposal to curse RMNs: " + cfg.Reason)
+	deployerGroup := NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
 
 	// Generate curse actions
 	var curseActions []RMNCurseAction
@@ -263,7 +264,7 @@ func RMNCurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployment
 		}
 	}
 
-	return deployerGroup.Enact("proposal to curse RMNs: " + cfg.Reason)
+	return deployerGroup.Enact()
 }
 
 // RMNUncurseChangeset creates a new changeset for uncursing chains or lanes on RMNRemote contracts.
@@ -289,7 +290,8 @@ func RMNUncurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployme
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deployerGroup := NewDeployerGroup(e, state, cfg.MCMS)
+	deploymentContext := NewDeploymentContext("proposal to uncurse RMNs: " + cfg.Reason)
+	deployerGroup := NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
 
 	// Generate curse actions
 	var curseActions []RMNCurseAction
@@ -335,5 +337,5 @@ func RMNUncurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployme
 		}
 	}
 
-	return deployerGroup.Enact("proposal to uncurse RMNs: %s" + cfg.Reason)
+	return deployerGroup.Enact()
 }

--- a/deployment/ccip/changeset/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/cs_rmn_curse_uncurse.go
@@ -219,8 +219,8 @@ func RMNCurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployment
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deploymentContext := NewDeploymentContext("proposal to curse RMNs: " + cfg.Reason)
-	deployerGroup := NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
+
+	deployerGroup := NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("proposal to curse RMNs: " + cfg.Reason)
 
 	// Generate curse actions
 	var curseActions []RMNCurseAction
@@ -290,8 +290,8 @@ func RMNUncurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployme
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deploymentContext := NewDeploymentContext("proposal to uncurse RMNs: " + cfg.Reason)
-	deployerGroup := NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
+
+	deployerGroup := NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("proposal to uncurse RMNs: " + cfg.Reason)
 
 	// Generate curse actions
 	var curseActions []RMNCurseAction

--- a/deployment/ccip/changeset/cs_set_pool.go
+++ b/deployment/ccip/changeset/cs_set_pool.go
@@ -34,8 +34,8 @@ func SetPoolChangeset(env deployment.Environment, c TokenAdminRegistryChangesetC
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deploymentContext := NewDeploymentContext("set pool for tokens on token admin registries")
-	deployerGroup := NewDeployerGroup(env, state, deploymentContext, c.MCMS)
+
+	deployerGroup := NewDeployerGroup(env, state, c.MCMS).WithDeploymentContext("set pool for tokens on token admin registries")
 
 	for chainSelector, tokenSymbolToPoolInfo := range c.Pools {
 		chain := env.Chains[chainSelector]

--- a/deployment/ccip/changeset/cs_set_pool.go
+++ b/deployment/ccip/changeset/cs_set_pool.go
@@ -34,7 +34,8 @@ func SetPoolChangeset(env deployment.Environment, c TokenAdminRegistryChangesetC
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deployerGroup := NewDeployerGroup(env, state, c.MCMS)
+	deploymentContext := NewDeploymentContext("set pool for tokens on token admin registries")
+	deployerGroup := NewDeployerGroup(env, state, deploymentContext, c.MCMS)
 
 	for chainSelector, tokenSymbolToPoolInfo := range c.Pools {
 		chain := env.Chains[chainSelector]
@@ -55,5 +56,5 @@ func SetPoolChangeset(env deployment.Environment, c TokenAdminRegistryChangesetC
 		}
 	}
 
-	return deployerGroup.Enact("set pool for tokens on token admin registries")
+	return deployerGroup.Enact()
 }

--- a/deployment/ccip/changeset/cs_transfer_admin_role.go
+++ b/deployment/ccip/changeset/cs_transfer_admin_role.go
@@ -40,8 +40,7 @@ func TransferAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistry
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	deploymentContext := NewDeploymentContext("transfer admin role for tokens on token admin registries")
-	deployerGroup := NewDeployerGroup(env, state, deploymentContext, c.MCMS)
+	deployerGroup := NewDeployerGroup(env, state, c.MCMS).WithDeploymentContext("transfer admin role for tokens on token admin registries")
 
 	for chainSelector, tokenSymbolToPoolInfo := range c.Pools {
 		chain := env.Chains[chainSelector]

--- a/deployment/ccip/changeset/cs_transfer_admin_role.go
+++ b/deployment/ccip/changeset/cs_transfer_admin_role.go
@@ -39,7 +39,9 @@ func TransferAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistry
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deployerGroup := NewDeployerGroup(env, state, c.MCMS)
+
+	deploymentContext := NewDeploymentContext("transfer admin role for tokens on token admin registries")
+	deployerGroup := NewDeployerGroup(env, state, deploymentContext, c.MCMS)
 
 	for chainSelector, tokenSymbolToPoolInfo := range c.Pools {
 		chain := env.Chains[chainSelector]
@@ -60,5 +62,5 @@ func TransferAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistry
 		}
 	}
 
-	return deployerGroup.Enact("transfer admin role for tokens on token admin registries")
+	return deployerGroup.Enact()
 }

--- a/deployment/ccip/changeset/cs_update_rmn_config.go
+++ b/deployment/ccip/changeset/cs_update_rmn_config.go
@@ -565,7 +565,9 @@ func SetRMNHomeDynamicConfigChangeset(e deployment.Environment, cfg SetRMNHomeDy
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deployerGroup := NewDeployerGroup(e, state, cfg.MCMS)
+
+	deploymentContext := NewDeploymentContext("set RMNHome dynamic config")
+	deployerGroup := NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
 
 	chain, exists := e.Chains[cfg.HomeChainSelector]
 	if !exists {
@@ -588,7 +590,7 @@ func SetRMNHomeDynamicConfigChangeset(e deployment.Environment, cfg SetRMNHomeDy
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to set RMNHome dynamic config for chain %s: %w", chain.String(), err)
 	}
 
-	return deployerGroup.Enact("Set RMNHome dynamic config")
+	return deployerGroup.Enact()
 }
 
 type RevokeCandidateConfig struct {
@@ -635,7 +637,9 @@ func RevokeRMNHomeCandidateConfigChangeset(e deployment.Environment, cfg RevokeC
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	deployerGroup := NewDeployerGroup(e, state, cfg.MCMS)
+
+	deploymentContext := NewDeploymentContext("Revoke candidate config")
+	deployerGroup := NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
 
 	chain, exists := e.Chains[cfg.HomeChainSelector]
 	if !exists {
@@ -657,7 +661,7 @@ func RevokeRMNHomeCandidateConfigChangeset(e deployment.Environment, cfg RevokeC
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to revoke candidate config for chain %s: %w", chain.String(), err)
 	}
 
-	return deployerGroup.Enact("Revoke candidate config")
+	return deployerGroup.Enact()
 }
 
 func SetRMNRemoteConfigChangeset(e deployment.Environment, config SetRMNRemoteConfig) (deployment.ChangesetOutput, error) {

--- a/deployment/ccip/changeset/cs_update_rmn_config.go
+++ b/deployment/ccip/changeset/cs_update_rmn_config.go
@@ -566,8 +566,7 @@ func SetRMNHomeDynamicConfigChangeset(e deployment.Environment, cfg SetRMNHomeDy
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	deploymentContext := NewDeploymentContext("set RMNHome dynamic config")
-	deployerGroup := NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
+	deployerGroup := NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("set RMNHome dynamic config")
 
 	chain, exists := e.Chains[cfg.HomeChainSelector]
 	if !exists {
@@ -638,8 +637,7 @@ func RevokeRMNHomeCandidateConfigChangeset(e deployment.Environment, cfg RevokeC
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	deploymentContext := NewDeploymentContext("Revoke candidate config")
-	deployerGroup := NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
+	deployerGroup := NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("revoke candidate config")
 
 	chain, exists := e.Chains[cfg.HomeChainSelector]
 	if !exists {

--- a/deployment/ccip/changeset/deployer_group.go
+++ b/deployment/ccip/changeset/deployer_group.go
@@ -52,6 +52,25 @@ func (d *DeploymentContext) Fork(description string) *DeploymentContext {
 	}
 }
 
+type DeployerGroupWithContext interface {
+	WithDeploymentContext(description string) *DeployerGroup
+}
+
+type deployerGroupBuilder struct {
+	e         deployment.Environment
+	state     CCIPOnChainState
+	mcmConfig *MCMSConfig
+}
+
+func (d *deployerGroupBuilder) WithDeploymentContext(description string) *DeployerGroup {
+	return &DeployerGroup{
+		e:                 d.e,
+		mcmConfig:         d.mcmConfig,
+		state:             d.state,
+		deploymentContext: NewDeploymentContext(description),
+	}
+}
+
 // DeployerGroup is an abstraction that lets developers write their changeset
 // without needing to know if it's executed using a DeployerKey or an MCMS proposal.
 //
@@ -64,16 +83,15 @@ func (d *DeploymentContext) Fork(description string) *DeploymentContext {
 //	state.Chains[selector].RMNRemote.Curse()
 //	# Execute the transaction or create the proposal
 //	deployerGroup.Enact("Curse RMNRemote")
-func NewDeployerGroup(e deployment.Environment, state CCIPOnChainState, deploymentContext *DeploymentContext, mcmConfig *MCMSConfig) *DeployerGroup {
-	return &DeployerGroup{
-		e:                 e,
-		mcmConfig:         mcmConfig,
-		state:             state,
-		deploymentContext: deploymentContext,
+func NewDeployerGroup(e deployment.Environment, state CCIPOnChainState, mcmConfig *MCMSConfig) DeployerGroupWithContext {
+	return &deployerGroupBuilder{
+		e:         e,
+		mcmConfig: mcmConfig,
+		state:     state,
 	}
 }
 
-func (d *DeployerGroup) WithNewDeploymentContext(description string) *DeployerGroup {
+func (d *DeployerGroup) WithDeploymentContext(description string) *DeployerGroup {
 	return &DeployerGroup{
 		e:                 d.e,
 		mcmConfig:         d.mcmConfig,
@@ -135,14 +153,13 @@ func (d *DeployerGroup) GetDeployer(chain uint64) (*bind.TransactOpts, error) {
 
 		currentNonce := big.NewInt(0).Add(startingNonce, txCount)
 
-		// Update the nonce to consider the transactions that have been sent
-		sim.Nonce = big.NewInt(0).Add(currentNone, big.NewInt(1))
-
 		tx, err := oldSigner(a, t)
 		if err != nil {
 			return nil, err
 		}
 		dc.transactions[chain] = append(dc.transactions[chain], tx)
+		// Update the nonce to consider the transactions that have been sent
+		sim.Nonce = big.NewInt(0).Add(currentNonce, big.NewInt(1))
 		return tx, nil
 	}
 	return sim, nil
@@ -198,6 +215,11 @@ func (d *DeployerGroup) enactMcms() (deployment.ChangesetOutput, error) {
 				ChainIdentifier: mcms.ChainIdentifier(selector),
 				Batch:           mcmOps,
 			})
+		}
+
+		if len(batches) == 0 {
+			d.e.Logger.Warnf("No batch was produced from deployment context skipping proposal: %s", dc.description)
+			continue
 		}
 
 		timelocksPerChain := BuildTimelockAddressPerChain(d.e, d.state)

--- a/deployment/ccip/changeset/deployer_group.go
+++ b/deployment/ccip/changeset/deployer_group.go
@@ -239,7 +239,7 @@ func (d *DeployerGroup) enactMcms() (deployment.ChangesetOutput, error) {
 		if len(proposals) > 0 {
 			previousProposal := proposals[len(proposals)-1]
 			for chain, metadata := range previousProposal.ChainMetadata {
-				nextStartingOp := metadata.StartingOpCount + uint64(getBatchCountForChain(uint64(chain), prop))
+				nextStartingOp := metadata.StartingOpCount + getBatchCountForChain(chain, prop)
 				prop.ChainMetadata[chain] = mcms.ChainMetadata{
 					StartingOpCount: nextStartingOp,
 					MCMAddress:      prop.ChainMetadata[chain].MCMAddress,
@@ -259,14 +259,14 @@ func (d *DeployerGroup) enactMcms() (deployment.ChangesetOutput, error) {
 	}, nil
 }
 
-func getBatchCountForChain(chain uint64, m *timelock.MCMSWithTimelockProposal) int {
+func getBatchCountForChain(chain mcms.ChainIdentifier, m *timelock.MCMSWithTimelockProposal) uint64 {
 	batches := make([]timelock.BatchChainOperation, 0)
 	for _, t := range m.Transactions {
-		if uint64(t.ChainIdentifier) == chain {
+		if t.ChainIdentifier == chain {
 			batches = append(batches, t)
 		}
 	}
-	return len(batches)
+	return uint64(len(batches))
 }
 
 func (d *DeployerGroup) enactDeployer() (deployment.ChangesetOutput, error) {

--- a/deployment/ccip/changeset/deployer_group.go
+++ b/deployment/ccip/changeset/deployer_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -23,10 +24,32 @@ type MCMSConfig struct {
 }
 
 type DeployerGroup struct {
-	e            deployment.Environment
-	state        CCIPOnChainState
-	mcmConfig    *MCMSConfig
-	transactions map[uint64][]*types.Transaction
+	e                 deployment.Environment
+	state             CCIPOnChainState
+	mcmConfig         *MCMSConfig
+	deploymentContext *DeploymentContext
+}
+
+type DeploymentContext struct {
+	description    string
+	transactions   map[uint64][]*types.Transaction
+	previousConfig *DeploymentContext
+}
+
+func NewDeploymentContext(description string) *DeploymentContext {
+	return &DeploymentContext{
+		description:    description,
+		transactions:   make(map[uint64][]*types.Transaction),
+		previousConfig: nil,
+	}
+}
+
+func (d *DeploymentContext) Fork(description string) *DeploymentContext {
+	return &DeploymentContext{
+		description:    description,
+		transactions:   make(map[uint64][]*types.Transaction),
+		previousConfig: d,
+	}
 }
 
 // DeployerGroup is an abstraction that lets developers write their changeset
@@ -41,12 +64,21 @@ type DeployerGroup struct {
 //	state.Chains[selector].RMNRemote.Curse()
 //	# Execute the transaction or create the proposal
 //	deployerGroup.Enact("Curse RMNRemote")
-func NewDeployerGroup(e deployment.Environment, state CCIPOnChainState, mcmConfig *MCMSConfig) *DeployerGroup {
+func NewDeployerGroup(e deployment.Environment, state CCIPOnChainState, deploymentContext *DeploymentContext, mcmConfig *MCMSConfig) *DeployerGroup {
 	return &DeployerGroup{
-		e:            e,
-		mcmConfig:    mcmConfig,
-		state:        state,
-		transactions: make(map[uint64][]*types.Transaction),
+		e:                 e,
+		mcmConfig:         mcmConfig,
+		state:             state,
+		deploymentContext: deploymentContext,
+	}
+}
+
+func (d *DeployerGroup) WithNewDeploymentContext(description string) *DeployerGroup {
+	return &DeployerGroup{
+		e:                 d.e,
+		mcmConfig:         d.mcmConfig,
+		state:             d.state,
+		deploymentContext: d.deploymentContext.Fork(description),
 	}
 }
 
@@ -94,77 +126,141 @@ func (d *DeployerGroup) GetDeployer(chain uint64) (*bind.TransactOpts, error) {
 		startingNonce = new(big.Int).SetUint64(nonce)
 	}
 
+	dc := d.deploymentContext
 	sim.Signer = func(a common.Address, t *types.Transaction) (*types.Transaction, error) {
+		txCount, err := d.getTransactionCount(chain)
+		if err != nil {
+			return nil, err
+		}
+
+		currentNone := big.NewInt(0).Add(startingNonce, txCount)
+
 		// Update the nonce to consider the transactions that have been sent
-		sim.Nonce = big.NewInt(0).Add(startingNonce, big.NewInt(int64(len(d.transactions[chain]))+1))
+		sim.Nonce = big.NewInt(0).Add(currentNone, big.NewInt(1))
 
 		tx, err := oldSigner(a, t)
 		if err != nil {
 			return nil, err
 		}
-		d.transactions[chain] = append(d.transactions[chain], tx)
+		dc.transactions[chain] = append(dc.transactions[chain], tx)
 		return tx, nil
 	}
 	return sim, nil
 }
 
-func (d *DeployerGroup) Enact(deploymentDescription string) (deployment.ChangesetOutput, error) {
+func (d *DeployerGroup) getContextChainInOrder() []*DeploymentContext {
+	contexts := make([]*DeploymentContext, 0)
+	for c := d.deploymentContext; c != nil; c = c.previousConfig {
+		contexts = append(contexts, c)
+	}
+	slices.Reverse(contexts)
+	return contexts
+}
+
+func (d *DeployerGroup) getTransactions() map[uint64][]*types.Transaction {
+	transactions := make(map[uint64][]*types.Transaction)
+	for _, c := range d.getContextChainInOrder() {
+		for k, v := range c.transactions {
+			transactions[k] = append(transactions[k], v...)
+		}
+	}
+	return transactions
+}
+
+func (d *DeployerGroup) getTransactionCount(chain uint64) (*big.Int, error) {
+	txs := d.getTransactions()
+	return big.NewInt(int64(len(txs[chain]))), nil
+}
+
+func (d *DeployerGroup) Enact() (deployment.ChangesetOutput, error) {
 	if d.mcmConfig != nil {
-		return d.enactMcms(deploymentDescription)
+		return d.enactMcms()
 	}
 
 	return d.enactDeployer()
 }
 
-func (d *DeployerGroup) enactMcms(deploymentDescription string) (deployment.ChangesetOutput, error) {
-	batches := make([]timelock.BatchChainOperation, 0)
-	for selector, txs := range d.transactions {
-		mcmOps := make([]mcms.Operation, len(txs))
-		for i, tx := range txs {
-			mcmOps[i] = mcms.Operation{
-				To:    *tx.To(),
-				Data:  tx.Data(),
-				Value: tx.Value(),
+func (d *DeployerGroup) enactMcms() (deployment.ChangesetOutput, error) {
+	contexts := d.getContextChainInOrder()
+	proposals := make([]timelock.MCMSWithTimelockProposal, 0)
+	for _, dc := range contexts {
+		batches := make([]timelock.BatchChainOperation, 0)
+		for selector, txs := range dc.transactions {
+			mcmOps := make([]mcms.Operation, len(txs))
+			for i, tx := range txs {
+				mcmOps[i] = mcms.Operation{
+					To:    *tx.To(),
+					Data:  tx.Data(),
+					Value: tx.Value(),
+				}
+			}
+			batches = append(batches, timelock.BatchChainOperation{
+				ChainIdentifier: mcms.ChainIdentifier(selector),
+				Batch:           mcmOps,
+			})
+		}
+
+		timelocksPerChain := BuildTimelockAddressPerChain(d.e, d.state)
+
+		proposerMCMSes := BuildProposerPerChain(d.e, d.state)
+
+		prop, err := proposalutils.BuildProposalFromBatches(
+			timelocksPerChain,
+			proposerMCMSes,
+			batches,
+			dc.description,
+			d.mcmConfig.MinDelay,
+		)
+
+		// Update the proposal metadata to incorporate the startingOpCount
+		// from the previous proposal
+		if len(proposals) > 0 {
+			previousProposal := proposals[len(proposals)-1]
+			for chain, metadata := range previousProposal.ChainMetadata {
+				nextStartingOp := metadata.StartingOpCount + uint64(getBatchCountForChain(uint64(chain), prop))
+				prop.ChainMetadata[chain] = mcms.ChainMetadata{
+					StartingOpCount: nextStartingOp,
+					MCMAddress:      prop.ChainMetadata[chain].MCMAddress,
+				}
 			}
 		}
-		batches = append(batches, timelock.BatchChainOperation{
-			ChainIdentifier: mcms.ChainIdentifier(selector),
-			Batch:           mcmOps,
-		})
-	}
 
-	timelocksPerChain := BuildTimelockAddressPerChain(d.e, d.state)
+		if err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal %w", err)
+		}
 
-	proposerMCMSes := BuildProposerPerChain(d.e, d.state)
-
-	prop, err := proposalutils.BuildProposalFromBatches(
-		timelocksPerChain,
-		proposerMCMSes,
-		batches,
-		deploymentDescription,
-		d.mcmConfig.MinDelay,
-	)
-
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal %w", err)
+		proposals = append(proposals, *prop)
 	}
 
 	return deployment.ChangesetOutput{
-		Proposals: []timelock.MCMSWithTimelockProposal{*prop},
+		Proposals: proposals,
 	}, nil
 }
 
-func (d *DeployerGroup) enactDeployer() (deployment.ChangesetOutput, error) {
-	for selector, txs := range d.transactions {
-		for _, tx := range txs {
-			err := d.e.Chains[selector].Client.SendTransaction(context.Background(), tx)
-			if err != nil {
-				return deployment.ChangesetOutput{}, fmt.Errorf("failed to send transaction: %w", err)
-			}
+func getBatchCountForChain(chain uint64, m *timelock.MCMSWithTimelockProposal) int {
+	batches := make([]timelock.BatchChainOperation, 0)
+	for _, t := range m.Transactions {
+		if uint64(t.ChainIdentifier) == chain {
+			batches = append(batches, t)
+		}
+	}
+	return len(batches)
+}
 
-			_, err = d.e.Chains[selector].Confirm(tx)
-			if err != nil {
-				return deployment.ChangesetOutput{}, fmt.Errorf("waiting for tx to be mined failed: %w", err)
+func (d *DeployerGroup) enactDeployer() (deployment.ChangesetOutput, error) {
+	contexts := d.getContextChainInOrder()
+	for _, c := range contexts {
+		for selector, txs := range c.transactions {
+			for _, tx := range txs {
+				err := d.e.Chains[selector].Client.SendTransaction(context.Background(), tx)
+				if err != nil {
+					return deployment.ChangesetOutput{}, fmt.Errorf("failed to send transaction: %w", err)
+				}
+
+				_, err = d.e.Chains[selector].Confirm(tx)
+				if err != nil {
+					return deployment.ChangesetOutput{}, fmt.Errorf("waiting for tx to be mined failed: %w", err)
+				}
 			}
 		}
 	}

--- a/deployment/ccip/changeset/deployer_group.go
+++ b/deployment/ccip/changeset/deployer_group.go
@@ -133,7 +133,7 @@ func (d *DeployerGroup) GetDeployer(chain uint64) (*bind.TransactOpts, error) {
 			return nil, err
 		}
 
-		currentNone := big.NewInt(0).Add(startingNonce, txCount)
+		currentNonce := big.NewInt(0).Add(startingNonce, txCount)
 
 		// Update the nonce to consider the transactions that have been sent
 		sim.Nonce = big.NewInt(0).Add(currentNone, big.NewInt(1))

--- a/deployment/ccip/changeset/deployer_group_test.go
+++ b/deployment/ccip/changeset/deployer_group_test.go
@@ -34,6 +34,20 @@ type dummyDeployerGroupChangesetConfig struct {
 	MCMS     *changeset.MCMSConfig
 }
 
+type dummyEmptyBatchChangesetConfig struct {
+	MCMS *changeset.MCMSConfig
+}
+
+func dummyEmptyBatchChangeset(e deployment.Environment, cfg dummyEmptyBatchChangesetConfig) (deployment.ChangesetOutput, error) {
+	state, err := changeset.LoadOnchainState(e)
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
+	group := changeset.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("empty batch")
+	return group.Enact()
+}
+
 func dummyDeployerGroupGrantMintChangeset(e deployment.Environment, cfg dummyDeployerGroupChangesetConfig) (deployment.ChangesetOutput, error) {
 	state, err := changeset.LoadOnchainState(e)
 	if err != nil {
@@ -42,8 +56,7 @@ func dummyDeployerGroupGrantMintChangeset(e deployment.Environment, cfg dummyDep
 
 	token := state.Chains[cfg.selector].LinkToken
 
-	deploymentContext := changeset.NewDeploymentContext("grant mint role")
-	group := changeset.NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
+	group := changeset.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("grant mint role")
 	deployer, err := group.GetDeployer(cfg.selector)
 	if err != nil {
 		return deployment.ChangesetOutput{}, err
@@ -65,8 +78,7 @@ func dummyDeployerGroupMintChangeset(e deployment.Environment, cfg dummyDeployer
 
 	token := state.Chains[cfg.selector].LinkToken
 
-	deploymentContext := changeset.NewDeploymentContext("mint tokens")
-	group := changeset.NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
+	group := changeset.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("mint tokens")
 	deployer, err := group.GetDeployer(cfg.selector)
 	if err != nil {
 		return deployment.ChangesetOutput{}, err
@@ -88,7 +100,7 @@ func dummyDeployerGroupGrantMintMultiChainChangeset(e deployment.Environment, cf
 		return deployment.ChangesetOutput{}, err
 	}
 
-	group := changeset.NewDeployerGroup(e, state, changeset.NewDeploymentContext("grant mint role"), cfg.MCMS)
+	group := changeset.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("grant mint role")
 	for _, mint := range cfg.mints {
 		selector := e.AllChainSelectors()[mint.selectorIndex]
 		token := state.Chains[selector].LinkToken
@@ -121,9 +133,9 @@ func dummyDeployerGroupMintMultiDeploymentContextChangeset(e deployment.Environm
 		token := state.Chains[selector].LinkToken
 
 		if group == nil {
-			group = changeset.NewDeployerGroup(e, state, changeset.NewDeploymentContext(fmt.Sprintf("mint tokens %d", i+1)), cfg.MCMS)
+			group = changeset.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext(fmt.Sprintf("mint tokens %d", i+1))
 		} else {
-			group = group.WithNewDeploymentContext(fmt.Sprintf("mint tokens %d", i+1))
+			group = group.WithDeploymentContext(fmt.Sprintf("mint tokens %d", i+1))
 		}
 		deployer, err = group.GetDeployer(selector)
 		if err != nil {
@@ -398,4 +410,18 @@ func TestDeployerGroupMultipleProposalsMCMS(t *testing.T) {
 	}
 
 	require.Equal(t, sumOfMints, amount)
+}
+
+func TestEmptyBatch(t *testing.T) {
+	e, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithNumOfChains(2))
+
+	cfg := dummyEmptyBatchChangesetConfig{
+		MCMS: &changeset.MCMSConfig{
+			MinDelay: 0,
+		},
+	}
+
+	result, err := dummyEmptyBatchChangeset(e.Env, cfg)
+	require.NoError(t, err)
+	require.Len(t, result.Proposals, 0)
 }

--- a/deployment/ccip/changeset/deployer_group_test.go
+++ b/deployment/ccip/changeset/deployer_group_test.go
@@ -1,17 +1,31 @@
 package changeset_test
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/mcms"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 )
+
+type mintConfig struct {
+	selectorIndex uint64
+	amount        *big.Int
+}
+
+type dummyMultiChainDeployerGroupChangesetConfig struct {
+	address common.Address
+	mints   []mintConfig
+	MCMS    *changeset.MCMSConfig
+}
 
 type dummyDeployerGroupChangesetConfig struct {
 	selector uint64
@@ -28,7 +42,8 @@ func dummyDeployerGroupGrantMintChangeset(e deployment.Environment, cfg dummyDep
 
 	token := state.Chains[cfg.selector].LinkToken
 
-	group := changeset.NewDeployerGroup(e, state, cfg.MCMS)
+	deploymentContext := changeset.NewDeploymentContext("grant mint role")
+	group := changeset.NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
 	deployer, err := group.GetDeployer(cfg.selector)
 	if err != nil {
 		return deployment.ChangesetOutput{}, err
@@ -39,7 +54,7 @@ func dummyDeployerGroupGrantMintChangeset(e deployment.Environment, cfg dummyDep
 		return deployment.ChangesetOutput{}, err
 	}
 
-	return group.Enact("Grant mint role")
+	return group.Enact()
 }
 
 func dummyDeployerGroupMintChangeset(e deployment.Environment, cfg dummyDeployerGroupChangesetConfig) (deployment.ChangesetOutput, error) {
@@ -50,7 +65,8 @@ func dummyDeployerGroupMintChangeset(e deployment.Environment, cfg dummyDeployer
 
 	token := state.Chains[cfg.selector].LinkToken
 
-	group := changeset.NewDeployerGroup(e, state, cfg.MCMS)
+	deploymentContext := changeset.NewDeploymentContext("mint tokens")
+	group := changeset.NewDeployerGroup(e, state, deploymentContext, cfg.MCMS)
 	deployer, err := group.GetDeployer(cfg.selector)
 	if err != nil {
 		return deployment.ChangesetOutput{}, err
@@ -63,7 +79,64 @@ func dummyDeployerGroupMintChangeset(e deployment.Environment, cfg dummyDeployer
 		}
 	}
 
-	return group.Enact("Mint tokens")
+	return group.Enact()
+}
+
+func dummyDeployerGroupGrantMintMultiChainChangeset(e deployment.Environment, cfg dummyMultiChainDeployerGroupChangesetConfig) (deployment.ChangesetOutput, error) {
+	state, err := changeset.LoadOnchainState(e)
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
+	group := changeset.NewDeployerGroup(e, state, changeset.NewDeploymentContext("grant mint role"), cfg.MCMS)
+	for _, mint := range cfg.mints {
+		selector := e.AllChainSelectors()[mint.selectorIndex]
+		token := state.Chains[selector].LinkToken
+
+		deployer, err := group.GetDeployer(selector)
+		if err != nil {
+			return deployment.ChangesetOutput{}, err
+		}
+
+		_, err = token.GrantMintRole(deployer, deployer.From)
+		if err != nil {
+			return deployment.ChangesetOutput{}, err
+		}
+	}
+
+	return group.Enact()
+}
+
+func dummyDeployerGroupMintMultiDeploymentContextChangeset(e deployment.Environment, cfg dummyMultiChainDeployerGroupChangesetConfig) (deployment.ChangesetOutput, error) {
+	state, err := changeset.LoadOnchainState(e)
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
+	var group *changeset.DeployerGroup
+	var deployer *bind.TransactOpts
+
+	for i, mint := range cfg.mints {
+		selector := e.AllChainSelectors()[mint.selectorIndex]
+		token := state.Chains[selector].LinkToken
+
+		if group == nil {
+			group = changeset.NewDeployerGroup(e, state, changeset.NewDeploymentContext(fmt.Sprintf("mint tokens %d", i+1)), cfg.MCMS)
+		} else {
+			group = group.WithNewDeploymentContext(fmt.Sprintf("mint tokens %d", i+1))
+		}
+		deployer, err = group.GetDeployer(selector)
+		if err != nil {
+			return deployment.ChangesetOutput{}, err
+		}
+
+		_, err = token.Mint(deployer, cfg.address, mint.amount)
+		if err != nil {
+			return deployment.ChangesetOutput{}, err
+		}
+	}
+
+	return group.Enact()
 }
 
 type deployerGroupTestCase struct {
@@ -190,4 +263,139 @@ func TestDeployerGroupMCMS(t *testing.T) {
 			require.Equal(t, sumOfMints, amount)
 		})
 	}
+}
+
+func TestDeployerGroupGenerateMultipleProposals(t *testing.T) {
+	tc := dummyMultiChainDeployerGroupChangesetConfig{
+		address: common.HexToAddress("0x455E5AA18469bC6ccEF49594645666C587A3a71B"),
+		mints: []mintConfig{
+			{
+				selectorIndex: 0,
+				amount:        big.NewInt(1),
+			},
+			{
+				selectorIndex: 0,
+				amount:        big.NewInt(2),
+			},
+			{
+				selectorIndex: 1,
+				amount:        big.NewInt(4),
+			},
+		},
+		MCMS: &changeset.MCMSConfig{
+			MinDelay: 0,
+		},
+	}
+	e, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithNumOfChains(2))
+	state, err := changeset.LoadOnchainState(e.Env)
+	require.NoError(t, err)
+
+	timelocksPerChain := changeset.BuildTimelockPerChain(e.Env, state)
+
+	contractsByChain := make(map[uint64][]common.Address)
+	for _, chain := range e.Env.AllChainSelectors() {
+		contractsByChain[chain] = []common.Address{state.Chains[chain].LinkToken.Address()}
+	}
+
+	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
+		{
+			Changeset: commonchangeset.WrapChangeSet(commonchangeset.TransferToMCMSWithTimelock),
+			Config: commonchangeset.TransferToMCMSWithTimelockConfig{
+				ContractsByChain: contractsByChain,
+				MinDelay:         0,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
+		{
+			Changeset: commonchangeset.WrapChangeSet(dummyDeployerGroupGrantMintMultiChainChangeset),
+			Config:    tc,
+		},
+	})
+	require.NoError(t, err)
+
+	cs, err := dummyDeployerGroupMintMultiDeploymentContextChangeset(e.Env, tc)
+	require.NoError(t, err)
+	require.Len(t, cs.Proposals, len(tc.mints))
+	require.Equal(t, "mint tokens 1", cs.Proposals[0].Description)
+	require.Equal(t, "mint tokens 2", cs.Proposals[1].Description)
+	require.Equal(t, "mint tokens 3", cs.Proposals[2].Description)
+	require.Equal(t, cs.Proposals[0].ChainMetadata[mcms.ChainIdentifier(e.Env.AllChainSelectors()[tc.mints[0].selectorIndex])].StartingOpCount, uint64(2))
+	require.Equal(t, cs.Proposals[1].ChainMetadata[mcms.ChainIdentifier(e.Env.AllChainSelectors()[tc.mints[1].selectorIndex])].StartingOpCount, uint64(3))
+	require.Equal(t, cs.Proposals[2].ChainMetadata[mcms.ChainIdentifier(e.Env.AllChainSelectors()[tc.mints[2].selectorIndex])].StartingOpCount, uint64(2))
+}
+
+func TestDeployerGroupMultipleProposalsMCMS(t *testing.T) {
+	cfg := dummyMultiChainDeployerGroupChangesetConfig{
+		address: common.HexToAddress("0x455E5AA18469bC6ccEF49594645666C587A3a71B"),
+		mints: []mintConfig{
+			{
+				selectorIndex: 0,
+				amount:        big.NewInt(1),
+			},
+			{
+				selectorIndex: 0,
+				amount:        big.NewInt(2),
+			},
+		},
+		MCMS: &changeset.MCMSConfig{
+			MinDelay: 0,
+		},
+	}
+
+	e, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithNumOfChains(2))
+
+	state, err := changeset.LoadOnchainState(e.Env)
+	require.NoError(t, err)
+
+	timelocksPerChain := changeset.BuildTimelockPerChain(e.Env, state)
+
+	contractsByChain := make(map[uint64][]common.Address)
+	for _, chain := range e.Env.AllChainSelectors() {
+		contractsByChain[chain] = []common.Address{state.Chains[chain].LinkToken.Address()}
+	}
+
+	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
+		{
+			Changeset: commonchangeset.WrapChangeSet(commonchangeset.TransferToMCMSWithTimelock),
+			Config: commonchangeset.TransferToMCMSWithTimelockConfig{
+				ContractsByChain: contractsByChain,
+				MinDelay:         0,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
+		{
+			Changeset: commonchangeset.WrapChangeSet(dummyDeployerGroupGrantMintMultiChainChangeset),
+			Config:    cfg,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
+		{
+			Changeset: commonchangeset.WrapChangeSet(dummyDeployerGroupMintMultiDeploymentContextChangeset),
+			Config:    cfg,
+		},
+	})
+	require.NoError(t, err)
+
+	state, err = changeset.LoadOnchainState(e.Env)
+	require.NoError(t, err)
+
+	token := state.Chains[e.HomeChainSel].LinkToken
+
+	amount, err := token.BalanceOf(nil, cfg.address)
+	require.NoError(t, err)
+
+	sumOfMints := big.NewInt(0)
+	for _, mint := range cfg.mints {
+		sumOfMints = sumOfMints.Add(sumOfMints, mint.amount)
+	}
+
+	require.Equal(t, sumOfMints, amount)
 }

--- a/deployment/ccip/changeset/deployer_group_test.go
+++ b/deployment/ccip/changeset/deployer_group_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/mcms"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
@@ -334,9 +335,9 @@ func TestDeployerGroupGenerateMultipleProposals(t *testing.T) {
 	require.Equal(t, "mint tokens 1", cs.Proposals[0].Description)
 	require.Equal(t, "mint tokens 2", cs.Proposals[1].Description)
 	require.Equal(t, "mint tokens 3", cs.Proposals[2].Description)
-	require.Equal(t, cs.Proposals[0].ChainMetadata[mcms.ChainIdentifier(e.Env.AllChainSelectors()[tc.mints[0].selectorIndex])].StartingOpCount, uint64(2))
-	require.Equal(t, cs.Proposals[1].ChainMetadata[mcms.ChainIdentifier(e.Env.AllChainSelectors()[tc.mints[1].selectorIndex])].StartingOpCount, uint64(3))
-	require.Equal(t, cs.Proposals[2].ChainMetadata[mcms.ChainIdentifier(e.Env.AllChainSelectors()[tc.mints[2].selectorIndex])].StartingOpCount, uint64(2))
+	require.Equal(t, uint64(2), cs.Proposals[0].ChainMetadata[mcms.ChainIdentifier(e.Env.AllChainSelectors()[tc.mints[0].selectorIndex])].StartingOpCount)
+	require.Equal(t, uint64(3), cs.Proposals[1].ChainMetadata[mcms.ChainIdentifier(e.Env.AllChainSelectors()[tc.mints[1].selectorIndex])].StartingOpCount)
+	require.Equal(t, uint64(2), cs.Proposals[2].ChainMetadata[mcms.ChainIdentifier(e.Env.AllChainSelectors()[tc.mints[2].selectorIndex])].StartingOpCount)
 }
 
 func TestDeployerGroupMultipleProposalsMCMS(t *testing.T) {
@@ -423,5 +424,5 @@ func TestEmptyBatch(t *testing.T) {
 
 	result, err := dummyEmptyBatchChangeset(e.Env, cfg)
 	require.NoError(t, err)
-	require.Len(t, result.Proposals, 0)
+	require.Empty(t, result.Proposals)
 }


### PR DESCRIPTION
Improve deployer group
    
- Increase coverage for deployer group test
- Add mutli proposal support

This pull request introduces a new `DeploymentContext` to the `DeployerGroup` class and updates various changeset functions to utilize this context for better management of deployment descriptions and transactions. The most important changes include the addition of the `DeploymentContext` struct, modifications to the `DeployerGroup` methods to support this new context, and updates to the changeset functions to leverage the new context.

### Introduction of `DeploymentContext`:

* [`deployment/ccip/changeset/deployer_group.go`](diffhunk://#diff-6e11d25caefb9c749fd2eb67adf89a14e8698c5651849fd5055419ef2c76e2a9R30-R52): Added `DeploymentContext` struct and methods to manage deployment descriptions and transactions. Updated `DeployerGroup` to include a `deploymentContext` field and modified its constructor and methods accordingly. [[1]](diffhunk://#diff-6e11d25caefb9c749fd2eb67adf89a14e8698c5651849fd5055419ef2c76e2a9R30-R52) [[2]](diffhunk://#diff-6e11d25caefb9c749fd2eb67adf89a14e8698c5651849fd5055419ef2c76e2a9L44-R81) [[3]](diffhunk://#diff-6e11d25caefb9c749fd2eb67adf89a14e8698c5651849fd5055419ef2c76e2a9R129-R188) [[4]](diffhunk://#diff-6e11d25caefb9c749fd2eb67adf89a14e8698c5651849fd5055419ef2c76e2a9L144-R253) [[5]](diffhunk://#diff-6e11d25caefb9c749fd2eb67adf89a14e8698c5651849fd5055419ef2c76e2a9R266)

### Changeset function updates:

* [`deployment/ccip/changeset/cs_accept_admin_role.go`](diffhunk://#diff-6a7f95aa8bcfcc9508a33a80ea85690673e828fafa8cb64501c4b92ec7125f40L37-R39): Updated `AcceptAdminRoleChangeset` to use `DeploymentContext` for managing deployment descriptions. [[1]](diffhunk://#diff-6a7f95aa8bcfcc9508a33a80ea85690673e828fafa8cb64501c4b92ec7125f40L37-R39) [[2]](diffhunk://#diff-6a7f95aa8bcfcc9508a33a80ea85690673e828fafa8cb64501c4b92ec7125f40L58-R60)
* [`deployment/ccip/changeset/cs_configure_token_pools.go`](diffhunk://#diff-3fc369bb938fcc2d80418d5918762b81aabd0a63162eb147c20a0730829bd8ddL176-R178): Updated `ConfigureTokenPoolContractsChangeset` to use `DeploymentContext` for managing deployment descriptions. [[1]](diffhunk://#diff-3fc369bb938fcc2d80418d5918762b81aabd0a63162eb147c20a0730829bd8ddL176-R178) [[2]](diffhunk://#diff-3fc369bb938fcc2d80418d5918762b81aabd0a63162eb147c20a0730829bd8ddL191-R193)
* [`deployment/ccip/changeset/cs_propose_admin_role.go`](diffhunk://#diff-6a2ffae0f03442563b7b91f1ff6c96b504cbeedc80f9943eb275e751bf86e559L41-R42): Updated `ProposeAdminRoleChangeset` to use `DeploymentContext` for managing deployment descriptions. [[1]](diffhunk://#diff-6a2ffae0f03442563b7b91f1ff6c96b504cbeedc80f9943eb275e751bf86e559L41-R42) [[2]](diffhunk://#diff-6a2ffae0f03442563b7b91f1ff6c96b504cbeedc80f9943eb275e751bf86e559L69-R70)
* [`deployment/ccip/changeset/cs_rmn_curse_uncurse.go`](diffhunk://#diff-7c5bdefcbaa8996427881852bfb5729a32b2adc4ce8b23fe6bbabea658f58610L222-R223): Updated `RMNCurseChangeset` and `RMNUncurseChangeset` to use `DeploymentContext` for managing deployment descriptions. [[1]](diffhunk://#diff-7c5bdefcbaa8996427881852bfb5729a32b2adc4ce8b23fe6bbabea658f58610L222-R223) [[2]](diffhunk://#diff-7c5bdefcbaa8996427881852bfb5729a32b2adc4ce8b23fe6bbabea658f58610L266-R267) [[3]](diffhunk://#diff-7c5bdefcbaa8996427881852bfb5729a32b2adc4ce8b23fe6bbabea658f58610L292-R294) [[4]](diffhunk://#diff-7c5bdefcbaa8996427881852bfb5729a32b2adc4ce8b23fe6bbabea658f58610L338-R340)
* [`deployment/ccip/changeset/cs_set_pool.go`](diffhunk://#diff-5bcb22ec43a576fdfaf850169c425399d61a06b932f6e8df37089c3eb7496327L37-R38): Updated `SetPoolChangeset` to use `DeploymentContext` for managing deployment descriptions. [[1]](diffhunk://#diff-5bcb22ec43a576fdfaf850169c425399d61a06b932f6e8df37089c3eb7496327L37-R38) [[2]](diffhunk://#diff-5bcb22ec43a576fdfaf850169c425399d61a06b932f6e8df37089c3eb7496327L58-R59)
* [`deployment/ccip/changeset/cs_transfer_admin_role.go`](diffhunk://#diff-13c0ec5c103b573d958f17e23513c9b371ad0de0ad43355cc1c938b27d504745L42-R44): Updated `TransferAdminRoleChangeset` to use `DeploymentContext` for managing deployment descriptions. [[1]](diffhunk://#diff-13c0ec5c103b573d958f17e23513c9b371ad0de0ad43355cc1c938b27d504745L42-R44) [[2]](diffhunk://#diff-13c0ec5c103b573d958f17e23513c9b371ad0de0ad43355cc1c938b27d504745L63-R65)
* [`deployment/ccip/changeset/cs_update_rmn_config.go`](diffhunk://#diff-f6eeb14804b5d16769abc3f48ad18187965263d5e5d29345e4079e85199de731L568-R570): Updated `SetRMNHomeDynamicConfigChangeset` and `RevokeRMNHomeCandidateConfigChangeset` to use `DeploymentContext` for managing deployment descriptions. [[1]](diffhunk://#diff-f6eeb14804b5d16769abc3f48ad18187965263d5e5d29345e4079e85199de731L568-R570) [[2]](diffhunk://#diff-f6eeb14804b5d16769abc3f48ad18187965263d5e5d29345e4079e85199de731L591-R593) [[3]](diffhunk://#diff-f6eeb14804b5d16769abc3f48ad18187965263d5e5d29345e4079e85199de731L638-R642) [[4]](diffhunk://#diff-f6eeb14804b5d16769abc3f48ad18187965263d5e5d29345e4079e85199de731L660-R664)

### Test updates:

* [`deployment/ccip/changeset/deployer_group_test.go`](diffhunk://#diff-d254edf85c72bfef3f746264098561b694acef83a6356c80a5a3c31b677613efR4-R29): Updated tests to include `DeploymentContext` in the `DeployerGroup` initialization and validate the new context functionality. [[1]](diffhunk://#diff-d254edf85c72bfef3f746264098561b694acef83a6356c80a5a3c31b677613efR4-R29) [[2]](diffhunk://#diff-d254edf85c72bfef3f746264098561b694acef83a6356c80a5a3c31b677613efL31-R46) [[3]](diffhunk://#diff-d254edf85c72bfef3f746264098561b694acef83a6356c80a5a3c31b677613efL42-R57)

These changes enhance the management of deployment descriptions and transactions, providing a more structured and maintainable approach to handling changesets.