### PR TITLE
add solana contracts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ benchmark_report.csv
 benchmark_summary.json
 secrets.toml
 tmp_laneconfig/
+solana_contracts
 
 # goreleaser builds
 cosign.*


### PR DESCRIPTION
For local testing, we will have contracts locally and don't want to accidentally commit them. https://github.com/smartcontractkit/chainlink/blob/8830defafe2b5e7418f4da1b2a23048fc3f1ceeb/deployment/environment/memory/environment.go#L46

### Requires

### Supports
