### PR TITLE
Extend ChangesetOutput to include a list of ProposedJobs

### DIFF
--- a/deployment/ccip/changeset/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/cs_deploy_chain.go
@@ -58,6 +58,7 @@ func DeployChainContractsChangeset(env deployment.Environment, c DeployChainCont
 	return deployment.ChangesetOutput{
 		Proposals:   []timelock.MCMSWithTimelockProposal{},
 		AddressBook: newAddresses,
+		Jobs:        nil,
 		JobSpecs:    nil,
 	}, nil
 }

--- a/deployment/ccip/changeset/cs_home_chain.go
+++ b/deployment/ccip/changeset/cs_home_chain.go
@@ -49,6 +49,7 @@ func DeployHomeChainChangeset(env deployment.Environment, cfg DeployHomeChainCon
 		Proposals:   []timelock.MCMSWithTimelockProposal{},
 		AddressBook: ab,
 		JobSpecs:    nil,
+		Jobs:        nil,
 	}, nil
 }
 

--- a/deployment/ccip/changeset/cs_jobspec.go
+++ b/deployment/ccip/changeset/cs_jobspec.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
+
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -117,6 +118,7 @@ func CCIPCapabilityJobspecChangeset(env deployment.Environment, _ any) (deployme
 		Proposals:   []timelock.MCMSWithTimelockProposal{},
 		AddressBook: nil,
 		JobSpecs:    nodesToJobSpecs,
+		Jobs:        nil,
 	}, nil
 }
 

--- a/deployment/ccip/changeset/cs_jobspec_test.go
+++ b/deployment/ccip/changeset/cs_jobspec_test.go
@@ -21,6 +21,7 @@ func TestJobSpecChangeset(t *testing.T) {
 		Chains: 1,
 		Nodes:  4,
 	})
+	// TODO: Replace this with a changeset which proposes the jobs, and returns job ids.
 	output, err := changeset.CCIPCapabilityJobspecChangeset(e, nil)
 	require.NoError(t, err)
 	require.NotNil(t, output.JobSpecs)

--- a/deployment/ccip/changeset/cs_prerequisites.go
+++ b/deployment/ccip/changeset/cs_prerequisites.go
@@ -7,9 +7,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/maybe_revert_message_receiver"
@@ -53,6 +54,7 @@ func DeployPrerequisitesChangeset(env deployment.Environment, cfg DeployPrerequi
 		Proposals:   []timelock.MCMSWithTimelockProposal{},
 		AddressBook: ab,
 		JobSpecs:    nil,
+		Jobs:        nil,
 	}, nil
 }
 

--- a/deployment/changeset.go
+++ b/deployment/changeset.go
@@ -20,12 +20,22 @@ var (
 // If the configuration is unexpected type or format, the changeset should return ErrInvalidConfig.
 type ChangeSet[C any] func(e Environment, config C) (ChangesetOutput, error)
 
+// ProposedJob represents a job spec which has been proposed to a node, with the JobID returned by the
+// Job Distributor.
+type ProposedJob struct {
+	JobID string
+	Node  string
+	Spec  string
+}
+
 // ChangesetOutput is the output of a Changeset function.
 // Think of it like a state transition output.
 // The address book here should contain only new addresses created in
 // this changeset.
 type ChangesetOutput struct {
-	JobSpecs    map[string][]string
+	// Deprecated: Prefer Jobs instead.
+	JobSpecs    map[string][]string `deprecated:"true"`
+	Jobs        []ProposedJob
 	Proposals   []timelock.MCMSWithTimelockProposal
 	AddressBook AddressBook
 }

--- a/deployment/common/changeset/save_existing.go
+++ b/deployment/common/changeset/save_existing.go
@@ -61,5 +61,6 @@ func SaveExistingContractsChangeset(env deployment.Environment, cfg ExistingCont
 		Proposals:   []timelock.MCMSWithTimelockProposal{},
 		AddressBook: ab,
 		JobSpecs:    nil,
+		Jobs:        nil,
 	}, nil
 }

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -52,6 +52,7 @@ func ApplyChangesets(t *testing.T, e deployment.Environment, timelockContractsPe
 			addresses = currentEnv.ExistingAddresses
 		}
 		if out.JobSpecs != nil {
+			// TODO: Delete this when out.JobSpecs are no longer in use.
 			ctx := testcontext.Get(t)
 			for nodeID, jobs := range out.JobSpecs {
 				for _, job := range jobs {
@@ -66,6 +67,9 @@ func ApplyChangesets(t *testing.T, e deployment.Environment, timelockContractsPe
 					}
 				}
 			}
+		}
+		if out.Jobs != nil {
+			// do nothing, as these jobs auto-accept.
 		}
 		if out.Proposals != nil {
 			for _, prop := range out.Proposals {


### PR DESCRIPTION
Extend ChangesetOutput to include a ProposedJobs slice, which contains the job spec, the node id, and the job id (as returned from the propose API of JD). Also, mark JobSpecs as deprecated. Once we remove all JobSpecs use, we can remove that field.

[DPA-1518](https://smartcontract-it.atlassian.net/browse/DPA-1518)


[DPA-1518]: https://smartcontract-it.atlassian.net/browse/DPA-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ