### PR TITLE
core/services/chainlink: wrap cosmos relayer with ServerAdapter

### DIFF
--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -328,7 +328,7 @@ func (r *RelayerFactory) NewCosmos(config CosmosFactoryConfig) (map[types.RelayI
 				return nil, fmt.Errorf("failed to load Cosmos chain %q: %w", relayID, err)
 			}
 
-			relayers[relayID] = cosmos.NewRelayer(lggr, chain)
+			relayers[relayID] = relay.NewServerAdapter(cosmos.NewRelayer(lggr, chain))
 		}
 	}
 	return relayers, nil


### PR DESCRIPTION
Fixing: `plugin provider is not supported for cosmos`