### PR TITLE
CCIP-4883: Sending continuous request while migration

### DIFF
--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -110,7 +110,8 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	wg.Add(1)
 	// send continuous messages in real router until done is closed
 	go func() {
-		initialBlock, v1_5Msgs, v1_6Msgs = SendMessages(t, &e, &state, pairs[0].SourceChainSelector, pairs[0].DestChainSelector, done)
+		initialBlock, v1_5Msgs, v1_6Msgs = SendContinuousMessages(
+			t, &e, &state, pairs[0].SourceChainSelector, pairs[0].DestChainSelector, done)
 		wg.Done()
 	}()
 	// send a message from the other lane src2 -> dest
@@ -377,7 +378,7 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 }
 
 // SendMessages sends messages from src to dest until done is closed
-func SendMessages(
+func SendContinuousMessages(
 	t *testing.T,
 	e *testhelpers.DeployedEnv,
 	state *changeset.CCIPOnChainState,
@@ -393,7 +394,7 @@ func SendMessages(
 	for {
 		select {
 		case <-ticker.C:
-			msg := sendMessage(t, e, state, src, dest)
+			msg := sendMessageInRealRouter(t, e, state, src, dest)
 			switch msg := msg.(type) {
 			case *evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested:
 				v1_5Msgs = append(v1_5Msgs, msg)
@@ -414,8 +415,8 @@ func SendMessages(
 	}
 }
 
-// sendMessage sends a message and filter the log topic to identify the event type nad parse the event data.
-func sendMessage(
+// sendMessageInRealRouter sends a message and filter the log topic to identify the event type nad parse the event data.
+func sendMessageInRealRouter(
 	t *testing.T,
 	e *testhelpers.DeployedEnv,
 	state *changeset.CCIPOnChainState,

--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -2,34 +2,37 @@ package ccip
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
+	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
-
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	v1_5testhelpers "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/v1_5"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
-
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_onramp"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/onramp"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/rmn_contract"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/router"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
 )
 
 func TestMigrateFromV1_5ToV1_6(t *testing.T) {
-	t.Skipf("Skipping test due to flakiness. " +
-		"This test getting face lifted in this ticket CCIP-4883 and will resolve the flakiness part of it.")
-
 	// Deploy CCIP 1.5 with 3 chains and 4 nodes + 1 bootstrap
-	// Deploy 1.5 contracts (excluding pools to start, but including MCMS) .
+	// Deploy 1.5 contracts (excluding pools to start, but including MCMS)
+	const msgInterval = 10 * time.Second
 	e, _, tEnv := testsetups.NewIntegrationEnvironment(
 		t,
 		testhelpers.WithPrerequisiteDeploymentOnly(
@@ -98,27 +101,20 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	require.NoError(t, err)
 	tEnv.UpdateDeployedEnvironment(e)
 	// ensure that all lanes are functional
-	for _, pair := range pairs {
-		sentEvent, err := v1_5testhelpers.SendRequest(t, e.Env, state,
-			testhelpers.WithSourceChain(pair.SourceChainSelector),
-			testhelpers.WithDestChain(pair.DestChainSelector),
-			testhelpers.WithTestRouter(false),
-			testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
-				Receiver:     common.LeftPadBytes(state.Chains[pair.DestChainSelector].Receiver.Address().Bytes(), 32),
-				Data:         []byte("hello"),
-				TokenAmounts: nil,
-				FeeToken:     common.HexToAddress("0x0"),
-				ExtraArgs:    nil,
-			}),
-		)
-		require.NoError(t, err)
-		require.NotNil(t, sentEvent)
-		destChain := e.Env.Chains[pair.DestChainSelector]
-		destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
-		require.NoError(t, err)
-		v1_5testhelpers.WaitForCommit(t, e.Env.Chains[pair.SourceChainSelector], destChain, state.Chains[dest].CommitStore[src1], sentEvent.Message.SequenceNumber)
-		v1_5testhelpers.WaitForExecute(t, e.Env.Chains[pair.SourceChainSelector], destChain, state.Chains[dest].EVM2EVMOffRamp[src1], []uint64{sentEvent.Message.SequenceNumber}, destStartBlock.Number.Uint64())
-	}
+	stopMsgs := make(chan bool)     // channel to stop sending messages in real router
+	switchTov1_6 := make(chan bool) // channel to switchTov1_6 to switch to 1.6
+	var wg sync.WaitGroup           // wait group to wait for all the messages to be delivered
+	// send continuous messages from src1 -> dest until stopMsgs is closed
+	sendContinuousMessagesInRealRouter(t, &e, &state, pairs[0], &wg, stopMsgs, switchTov1_6, msgInterval)
+	// send a message from the other lane src2 -> dest
+	sentEvent := sendMsgInV1_5(t, e, state, src2, dest)
+	destChain := e.Env.Chains[dest]
+	destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
+	require.NoError(t, err)
+	v1_5testhelpers.WaitForCommit(t, e.Env.Chains[src2], destChain, state.Chains[dest].CommitStore[src1],
+		sentEvent.Message.SequenceNumber)
+	v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src2], destChain, state.Chains[dest].EVM2EVMOffRamp[src1],
+		[]uint64{sentEvent.Message.SequenceNumber}, destStartBlock.Number.Uint64())
 
 	// now that all 1.5 lanes work transfer ownership of the contracts to MCMS
 	contractsByChain := make(map[uint64][]common.Address)
@@ -221,23 +217,9 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	startBlocks[dest] = &block
 	expectedSeqNumExec := make(map[testhelpers.SourceDestPair][]uint64)
 	expectedSeqNums := make(map[testhelpers.SourceDestPair]uint64)
-	msgSentEvent, err := testhelpers.DoSendRequest(
-		t, e.Env, state,
-		testhelpers.WithSourceChain(src1),
-		testhelpers.WithDestChain(dest),
-		testhelpers.WithTestRouter(true),
-		// Send traffic across single 1.6 lane with a DIFFERENT ( very important to not mess with real sender nonce) sender
-		// from test router to ensure 1.6 is working.
-		testhelpers.WithSender(e.Users[src1][1]),
-		testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
-			Receiver:     common.LeftPadBytes(state.Chains[dest].Receiver.Address().Bytes(), 32),
-			Data:         []byte("hello"),
-			TokenAmounts: nil,
-			FeeToken:     common.HexToAddress("0x0"),
-			ExtraArgs:    nil,
-		}))
-	require.NoError(t, err)
-
+	// Send traffic across single 1.6 lane with a DIFFERENT ( very important to not mess with real sender nonce) sender
+	// from test router to ensure 1.6 is working.
+	msgSentEvent := sendMsgInV1_6(t, e, state, src1, dest, e.Users[src1][1], true)
 	expectedSeqNumExec[testhelpers.SourceDestPair{
 		SourceChainSelector: src1,
 		DestChainSelector:   dest,
@@ -249,29 +231,12 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 
 	// This sleep is needed so that plugins come up and start indexing logs.
 	// Otherwise test will flake.
-	time.Sleep(15 * time.Second)
+	time.Sleep(30 * time.Second)
 	testhelpers.ReplayLogs(t, e.Env.Offchain, map[uint64]uint64{
 		src1: msgSentEvent.Raw.BlockNumber,
 	})
 	testhelpers.ConfirmCommitForAllWithExpectedSeqNums(t, e.Env, state, expectedSeqNums, startBlocks)
 	testhelpers.ConfirmExecWithSeqNrsForAll(t, e.Env, state, expectedSeqNumExec, startBlocks)
-
-	// send a message from real router, the send requested event should be received in 1.5 onRamp
-	// the request should get delivered to 1.5 offRamp
-	sentEventBeforeSwitch, err := v1_5testhelpers.SendRequest(t, e.Env, state,
-		testhelpers.WithSourceChain(src1),
-		testhelpers.WithDestChain(dest),
-		testhelpers.WithTestRouter(false),
-		testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
-			Receiver:     common.LeftPadBytes(state.Chains[dest].Receiver.Address().Bytes(), 32),
-			Data:         []byte("hello"),
-			TokenAmounts: nil,
-			FeeToken:     common.HexToAddress("0x0"),
-			ExtraArgs:    nil,
-		}),
-	)
-	require.NoError(t, err)
-	require.NotNil(t, sentEventBeforeSwitch)
 
 	// now that the 1.6 lane is working, we can enable the real router
 	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commonchangeset.ChangesetApplication{
@@ -329,37 +294,275 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// send a message from real router the send requested event should be received in 1.6 onRamp
-	// the request should get delivered to 1.6 offRamp
-	destStartBlock, err := e.Env.Chains[dest].Client.HeaderByNumber(context.Background(), nil)
-	require.NoError(t, err)
-	sentEventAfterSwitch, err := testhelpers.DoSendRequest(
-		t, e.Env, state,
-		testhelpers.WithSourceChain(src1),
-		testhelpers.WithDestChain(dest),
-		testhelpers.WithTestRouter(false),
-		testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
+	// As the real router are getting continuous messages, after this switch v1.6 OnRamp should start receiving the messages.
+	// and the request should get delivered to 1.6 offRamp
+	switchTov1_6 <- true // Signal to look for messages in 1.6 OnRamp
+
+	// confirm that the other lane src2->dest is still working with v1.5
+	sentEventOnOtherLane := sendMsgInV1_5(t, e, state, src2, dest)
+	v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src2], e.Env.Chains[dest], state.Chains[dest].EVM2EVMOffRamp[src2],
+		[]uint64{sentEventOnOtherLane.Message.SequenceNumber}, destStartBlock.Number.Uint64())
+
+	// stop the continuous messages in real router and wait for all the executions to confirm
+	stopMsgs <- true
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	},
+		tests.WaitTimeout(t),
+		2*time.Second,
+		"all executions did not confirm",
+	)
+}
+
+type msgEvent struct {
+	tx       common.Hash
+	blockNum uint64
+}
+
+// sendContinuousMessagesInRealRouter sends continuous messages from the source chain to the destination chain until stopped.
+func sendContinuousMessagesInRealRouter(
+	t *testing.T,
+	e *testhelpers.DeployedEnv,
+	state *changeset.CCIPOnChainState,
+	pair testhelpers.SourceDestPair,
+	wg *sync.WaitGroup,
+	stopMsgs, signal chan bool,
+	interval time.Duration,
+) {
+	ticker := time.NewTicker(interval)
+	var (
+		mu sync.Mutex
+	)
+	type msgSentCheck struct {
+		src, dest, seqNr, startBlockNumber uint64
+	}
+	statusTracker := make(map[uint64]int)
+	msgPipeline := make(chan msgEvent, 100) // channel to send the message tx and block number to check msg sent event
+	// channel to send the message sent event to check for commit & execute in
+	performMsgCheckInV1_5 := make(chan msgSentCheck, 100)
+	// channel to send the message sent event to check for commit & execute
+	performMsgCheckInV1_6 := make(chan msgSentCheck, 100)
+	// Go routine to send the messages continuously until stopMsgs is closed
+	go func() {
+		defer ticker.Stop()
+		sendMessageWithoutCapturingSentEvent(t, e, state, pair.SourceChainSelector, pair.DestChainSelector, msgPipeline)
+		for {
+			select {
+			case <-stopMsgs:
+				close(msgPipeline)
+				return
+			case <-ticker.C:
+				sendMessageWithoutCapturingSentEvent(t, e, state, pair.SourceChainSelector, pair.DestChainSelector, msgPipeline)
+			}
+		}
+	}()
+
+	// function to listen to the message sent event in v1.6 onRamp
+	listenV1_6OnRamp := func(input msgEvent) {
+		defer wg.Done()
+		// filter the message sent event in 1.6 onRamp
+		it, err := state.Chains[pair.SourceChainSelector].OnRamp.FilterCCIPMessageSent(&bind.FilterOpts{
+			Start:   input.blockNum,
+			End:     &input.blockNum,
+			Context: context.Background(),
+		}, []uint64{pair.DestChainSelector}, []uint64{})
+		if err != nil {
+			t.Errorf("failed to get msg sent filter iterator")
+		}
+		if !it.Next() {
+			t.Errorf("failed to get next event")
+		}
+		t.Logf("CCIP message (id %x) sent from chain selector %d to chain selector %d tx %s seqNum %d sender %s",
+			it.Event.Message.Header.MessageId[:],
+			pair.SourceChainSelector,
+			pair.DestChainSelector,
+			input.tx.String(),
+			it.Event.Message.Header.SequenceNumber,
+			it.Event.Message.Sender.String(),
+		)
+		destChain := e.Env.Chains[pair.DestChainSelector]
+		destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
+		if err != nil {
+			t.Errorf("failed to get header by number")
+		}
+		mu.Lock()
+		statusTracker[it.Event.Message.Header.SequenceNumber] = testhelpers.EXECUTION_STATE_INPROGRESS
+		mu.Unlock()
+		performMsgCheckInV1_6 <- msgSentCheck{
+			src:              pair.SourceChainSelector,
+			dest:             pair.DestChainSelector,
+			seqNr:            it.Event.Message.Header.SequenceNumber,
+			startBlockNumber: destStartBlock.Number.Uint64(),
+		}
+	}
+	// function to listen to the message sent event in v1.5 onRamp
+	listenV1_5OnRamp := func(input msgEvent) {
+		defer wg.Done()
+		// filter the message sent event in 1.5 onRamp
+		it, err := state.Chains[pair.SourceChainSelector].EVM2EVMOnRamp[pair.DestChainSelector].FilterCCIPSendRequested(&bind.FilterOpts{
+			Start:   input.blockNum,
+			End:     &input.blockNum,
+			Context: context.Background(),
+		})
+		if err != nil {
+			t.Errorf("failed to get msg sent filter iterator")
+		}
+		if !it.Next() {
+			t.Errorf("failed to get next event")
+		}
+		t.Logf("CCIP message (id %x) sent from chain selector %d to chain selector %d tx %s seqNum %d sender %s",
+			it.Event.Message.MessageId[:],
+			pair.SourceChainSelector,
+			pair.DestChainSelector,
+			input.tx.String(),
+			it.Event.Message.SequenceNumber,
+			it.Event.Message.Sender.String(),
+		)
+		destChain := e.Env.Chains[pair.DestChainSelector]
+		destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
+		if err != nil {
+			t.Errorf("failed to get header by number")
+		}
+		mu.Lock()
+		statusTracker[it.Event.Message.SequenceNumber] = testhelpers.EXECUTION_STATE_INPROGRESS
+		mu.Unlock()
+		performMsgCheckInV1_5 <- msgSentCheck{
+			src:              pair.SourceChainSelector,
+			dest:             pair.DestChainSelector,
+			seqNr:            it.Event.Message.SequenceNumber,
+			startBlockNumber: destStartBlock.Number.Uint64(),
+		}
+	}
+
+	// Process the msg event in real router
+	go func() {
+		switchSignal := false
+		defer close(performMsgCheckInV1_5)
+		defer close(performMsgCheckInV1_6)
+		for input := range msgPipeline {
+			wg.Add(1)
+			select {
+			case <-signal:
+				switchSignal = true
+				go listenV1_6OnRamp(input)
+			default:
+				if switchSignal {
+					go listenV1_6OnRamp(input)
+				} else {
+					go listenV1_5OnRamp(input)
+				}
+			}
+		}
+	}()
+
+	// Verify message sent in v1.5
+	go func() {
+		for input := range performMsgCheckInV1_5 {
+			wg.Add(1)
+			go func(input msgSentCheck) {
+				defer wg.Done()
+				v1_5testhelpers.WaitForCommit(t, e.Env.Chains[input.src], e.Env.Chains[input.dest],
+					state.Chains[input.dest].CommitStore[input.src], input.seqNr)
+				v1_5testhelpers.WaitForExecute(t, e.Env.Chains[input.src], e.Env.Chains[input.dest],
+					state.Chains[pair.DestChainSelector].EVM2EVMOffRamp[pair.SourceChainSelector],
+					[]uint64{input.seqNr}, input.startBlockNumber)
+				mu.Lock()
+				statusTracker[input.seqNr] = testhelpers.EXECUTION_STATE_SUCCESS
+				mu.Unlock()
+			}(input)
+		}
+	}()
+
+	// verify message sent in v1.6
+	go func() {
+		for input := range performMsgCheckInV1_6 {
+			wg.Add(1)
+			go func(input msgSentCheck) {
+				defer wg.Done()
+				_, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
+					t,
+					input.src,
+					e.Env.Chains[input.dest],
+					state.Chains[input.dest].OffRamp,
+					&input.startBlockNumber,
+					ccipocr3.SeqNumRange{
+						ccipocr3.SeqNum(input.seqNr),
+						ccipocr3.SeqNum(input.seqNr),
+					},
+					true,
+				)
+				if err != nil {
+					t.Errorf("failed to confirm commit")
+				}
+				_, err = testhelpers.ConfirmExecWithSeqNrs(
+					t,
+					input.src,
+					e.Env.Chains[input.dest],
+					state.Chains[input.dest].OffRamp,
+					&input.startBlockNumber,
+					[]uint64{input.seqNr},
+				)
+				if err != nil {
+					t.Errorf("failed to confirm execute")
+				}
+				mu.Lock()
+				statusTracker[input.seqNr] = testhelpers.EXECUTION_STATE_SUCCESS
+				mu.Unlock()
+			}(input)
+		}
+	}()
+}
+
+func sendMessageWithoutCapturingSentEvent(
+	t *testing.T,
+	e *testhelpers.DeployedEnv,
+	state *changeset.CCIPOnChainState,
+	src, dest uint64,
+	msgPipeline chan msgEvent,
+) {
+	cfg := &testhelpers.CCIPSendReqConfig{
+		SourceChain:  src,
+		DestChain:    dest,
+		Sender:       e.Env.Chains[src].DeployerKey,
+		IsTestRouter: false,
+		Evm2AnyMessage: router.ClientEVM2AnyMessage{
 			Receiver:     common.LeftPadBytes(state.Chains[dest].Receiver.Address().Bytes(), 32),
 			Data:         []byte("hello"),
 			TokenAmounts: nil,
 			FeeToken:     common.HexToAddress("0x0"),
 			ExtraArgs:    nil,
-		}))
-	require.NoError(t, err)
-	// verify that before switch message is received in 1.5 offRamp
-	v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src1], e.Env.Chains[dest], state.Chains[dest].EVM2EVMOffRamp[src1],
-		[]uint64{sentEventBeforeSwitch.Message.SequenceNumber}, destStartBlock.Number.Uint64())
+		},
+	}
+	t.Logf("Sending CCIP request from chain selector %d to chain selector %d from sender %s",
+		cfg.SourceChain, cfg.DestChain, cfg.Sender.From.String())
 
-	// verify that after switch message is received in 1.6 offRamp
-	expectedSeqNumExec[testhelpers.SourceDestPair{
-		SourceChainSelector: src1,
-		DestChainSelector:   dest,
-	}] = []uint64{sentEventAfterSwitch.SequenceNumber}
-	testhelpers.ConfirmExecWithSeqNrsForAll(t, e.Env, state, expectedSeqNumExec, startBlocks)
+	tx, blockNum, err := testhelpers.CCIPSendRequest(e.Env, *state, cfg)
+	if err != nil {
+		t.Errorf("failed to send message: %v", err)
+	}
+	msgPipeline <- msgEvent{
+		tx:       tx.Hash(),
+		blockNum: blockNum,
+	}
+}
 
-	// confirm that the other lane src2->dest is still working with v1.5
-	sentEventOnOtherLane, err := v1_5testhelpers.SendRequest(t, e.Env, state,
-		testhelpers.WithSourceChain(src2),
+func sendMsgInV1_5(
+	t *testing.T,
+	e testhelpers.DeployedEnv,
+	state changeset.CCIPOnChainState,
+	src, dest uint64) *evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested {
+	sentEvent, err := v1_5testhelpers.SendRequest(t, e.Env, state,
+		testhelpers.WithSourceChain(src),
 		testhelpers.WithDestChain(dest),
 		testhelpers.WithTestRouter(false),
 		testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
@@ -371,7 +574,31 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 		}),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, sentEventOnOtherLane)
-	v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src2], e.Env.Chains[dest], state.Chains[dest].EVM2EVMOffRamp[src2],
-		[]uint64{sentEventOnOtherLane.Message.SequenceNumber}, destStartBlock.Number.Uint64())
+	require.NotNil(t, sentEvent)
+	return sentEvent
+}
+
+func sendMsgInV1_6(
+	t *testing.T,
+	e testhelpers.DeployedEnv,
+	state changeset.CCIPOnChainState,
+	src, dest uint64,
+	sender *bind.TransactOpts,
+	isTestRouter bool,
+) *onramp.OnRampCCIPMessageSent {
+	sentEvent, err := testhelpers.DoSendRequest(
+		t, e.Env, state,
+		testhelpers.WithSourceChain(src),
+		testhelpers.WithDestChain(dest),
+		testhelpers.WithTestRouter(isTestRouter),
+		testhelpers.WithSender(sender),
+		testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
+			Receiver:     common.LeftPadBytes(state.Chains[dest].Receiver.Address().Bytes(), 32),
+			Data:         []byte("hello"),
+			TokenAmounts: nil,
+			FeeToken:     common.HexToAddress("0x0"),
+			ExtraArgs:    nil,
+		}))
+	require.NoError(t, err)
+	return sentEvent
 }

--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -29,6 +29,23 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
 )
 
+// TestMigrateFromV1_5ToV1_6 tests the migration from v1.5 to v1.6
+// The test steps are as follows:
+// 1. Deploy CCIP 1.5 with 3 chains and 4 nodes + 1 bootstrap
+// 2. Deploy 1.5 contracts (excluding pools to start, but including MCMS)
+// 3. Wire up all lanes
+// 4. PermaBless the commit stores
+// 5. Send continuous messages from src1 -> dest in real router until stopMsgs is closed
+// 6. Send a message from the other lane src2 -> dest
+// 6. Transfer ownership of the contracts to MCMS
+// 7. Add 1.6 contracts to the environment and send 1.6 jobs
+// 8. Set RMNProxy to point to RMNRemote
+// 9. Update nonce managers
+// 10. Enable a single 1.6 lane with test router
+// 11. Send traffic across single 1.6 src1 > dest lane with a DIFFERENT sender from test router to ensure 1.6 is working
+// 12. Enable the real router and verify sender nonce in 1.6 OnRamp event is plus one to sender nonce in 1.5 OnRamp
+// 13. Confirm that the other lane src2->dest is still working with v1.5
+// 14. Stop the continuous messages in real router and wait for all the executions to confirm
 func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	// Deploy CCIP 1.5 with 3 chains and 4 nodes + 1 bootstrap
 	// Deploy 1.5 contracts (excluding pools to start, but including MCMS)
@@ -330,6 +347,16 @@ type msgEvent struct {
 }
 
 // sendContinuousMessagesInRealRouter sends continuous messages from the source chain to the destination chain until stopped.
+// The process is as follows:
+//  1. Send a message once and then send messages based on the interval in real router until signal to stop the message is received.
+//  2. Listen to the message sent event in 1.5 onRamp until the switch signal is received
+//     and send the message sequence number and block number to check for commit & execute through performMsgCheckInV1_5 channel.
+//  3. Separate Go routines listens to the channel performMsgCheckInV1_5 and performMsgCheckInV1_6 to perform
+//     commit and execute in 1.5 and 1.6 version offRamps respectively.
+//  4. Start listening to the message sent event in 1.6 onRamp after the switch signal is received and send the message
+//     sequence number and block number to check for commit & execute through performMsgCheckInV1_6 channel.
+//  5. In the test, wait for all the go routines to complete to confirm all the messages are delivered.
+//  6. Assert sender nonce in 1.6 OnRamp event is plus one to sender nonce in 1.5 OnRamp .
 func sendContinuousMessagesInRealRouter(
 	t *testing.T,
 	e *testhelpers.DeployedEnv,
@@ -340,25 +367,25 @@ func sendContinuousMessagesInRealRouter(
 	interval time.Duration,
 ) {
 	ticker := time.NewTicker(interval)
-	var (
-		mu sync.Mutex
-	)
 	type msgSentCheck struct {
 		src, dest, seqNr, startBlockNumber uint64
 	}
-	statusTracker := make(map[uint64]int)
 	msgPipeline := make(chan msgEvent, 100) // channel to send the message tx and block number to check msg sent event
 	// channel to send the message sent event to check for commit & execute in
 	performMsgCheckInV1_5 := make(chan msgSentCheck, 100)
 	// channel to send the message sent event to check for commit & execute
 	performMsgCheckInV1_6 := make(chan msgSentCheck, 100)
+	performNonceCheck := false
+
 	// Go routine to send the messages continuously until stopMsgs is closed
 	go func() {
 		defer ticker.Stop()
+		// send once and further send messages based on the interval
+		// the below function sends the message and adds the message sent event to the msgPipeline
 		sendMessageWithoutCapturingSentEvent(t, e, state, pair.SourceChainSelector, pair.DestChainSelector, msgPipeline)
 		for {
 			select {
-			case <-stopMsgs:
+			case <-stopMsgs: // stop sending messages and close the msgPipeline
 				close(msgPipeline)
 				return
 			case <-ticker.C:
@@ -395,9 +422,21 @@ func sendContinuousMessagesInRealRouter(
 		if err != nil {
 			t.Errorf("failed to get header by number")
 		}
-		mu.Lock()
-		statusTracker[it.Event.Message.Header.SequenceNumber] = testhelpers.EXECUTION_STATE_INPROGRESS
-		mu.Unlock()
+		if performNonceCheck {
+			lastnonce, err := state.Chains[pair.SourceChainSelector].EVM2EVMOnRamp[pair.DestChainSelector].GetSenderNonce(
+				nil,
+				e.Env.Chains[pair.SourceChainSelector].DeployerKey.From,
+			)
+			if err != nil {
+				t.Errorf("failed to get sender nonce in 1.5 OnRamp")
+			}
+			// assert sender nonce in 1.6 OnRamp event is plus one to sender nonce in 1.5 OnRamp
+			if lastnonce+1 != it.Event.Message.Header.Nonce {
+				t.Errorf("sender nonce in 1.6 OnRamp event is not plus one to sender nonce in 1.5 OnRamp")
+			}
+			performNonceCheck = false
+		}
+		// channel to send the message sequence number and block number to check for commit & execute
 		performMsgCheckInV1_6 <- msgSentCheck{
 			src:              pair.SourceChainSelector,
 			dest:             pair.DestChainSelector,
@@ -420,6 +459,7 @@ func sendContinuousMessagesInRealRouter(
 		if !it.Next() {
 			t.Errorf("failed to get next event")
 		}
+
 		t.Logf("CCIP message (id %x) sent from chain selector %d to chain selector %d tx %s seqNum %d sender %s",
 			it.Event.Message.MessageId[:],
 			pair.SourceChainSelector,
@@ -433,9 +473,7 @@ func sendContinuousMessagesInRealRouter(
 		if err != nil {
 			t.Errorf("failed to get header by number")
 		}
-		mu.Lock()
-		statusTracker[it.Event.Message.SequenceNumber] = testhelpers.EXECUTION_STATE_INPROGRESS
-		mu.Unlock()
+		// channel to send the message sequence number and block number to check for commit & execute
 		performMsgCheckInV1_5 <- msgSentCheck{
 			src:              pair.SourceChainSelector,
 			dest:             pair.DestChainSelector,
@@ -446,19 +484,24 @@ func sendContinuousMessagesInRealRouter(
 
 	// Process the msg event in real router
 	go func() {
+		// switchSignal is used to switch to 1.6 onRamp after the signal is received until then it listens to 1.5 onRamp
 		switchSignal := false
 		defer close(performMsgCheckInV1_5)
 		defer close(performMsgCheckInV1_6)
+		defer close(signal)
 		for input := range msgPipeline {
 			wg.Add(1)
 			select {
 			case <-signal:
+				// switch to 1.6 onRamp
 				switchSignal = true
+				performNonceCheck = true
 				go listenV1_6OnRamp(input)
 			default:
 				if switchSignal {
 					go listenV1_6OnRamp(input)
 				} else {
+					// listen to 1.5 onRamp until switchSignal is set to true
 					go listenV1_5OnRamp(input)
 				}
 			}
@@ -467,6 +510,8 @@ func sendContinuousMessagesInRealRouter(
 
 	// Verify message sent in v1.5
 	go func() {
+		// range over performMsgCheckInV1_5 channel to verify the commit and execute in 1.5 offRamp
+		// this channel will be populated when there is msg sent event in 1.5 onRamp
 		for input := range performMsgCheckInV1_5 {
 			wg.Add(1)
 			go func(input msgSentCheck) {
@@ -476,19 +521,19 @@ func sendContinuousMessagesInRealRouter(
 				v1_5testhelpers.WaitForExecute(t, e.Env.Chains[input.src], e.Env.Chains[input.dest],
 					state.Chains[pair.DestChainSelector].EVM2EVMOffRamp[pair.SourceChainSelector],
 					[]uint64{input.seqNr}, input.startBlockNumber)
-				mu.Lock()
-				statusTracker[input.seqNr] = testhelpers.EXECUTION_STATE_SUCCESS
-				mu.Unlock()
 			}(input)
 		}
 	}()
 
 	// verify message sent in v1.6
 	go func() {
+		// range over performMsgCheckInV1_6 channel to verify the commit and execute in 1.6 offRamp
+		// this channel will be populated when there is msg sent event in 1.6 onRamp
 		for input := range performMsgCheckInV1_6 {
 			wg.Add(1)
 			go func(input msgSentCheck) {
 				defer wg.Done()
+				// confirm commit in 1.6 offRamp
 				_, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 					t,
 					input.src,
@@ -504,6 +549,7 @@ func sendContinuousMessagesInRealRouter(
 				if err != nil {
 					t.Errorf("failed to confirm commit")
 				}
+				// confirm execute in 1.6 offRamp
 				_, err = testhelpers.ConfirmExecWithSeqNrs(
 					t,
 					input.src,
@@ -515,14 +561,12 @@ func sendContinuousMessagesInRealRouter(
 				if err != nil {
 					t.Errorf("failed to confirm execute")
 				}
-				mu.Lock()
-				statusTracker[input.seqNr] = testhelpers.EXECUTION_STATE_SUCCESS
-				mu.Unlock()
 			}(input)
 		}
 	}()
 }
 
+// sendMessageWithoutCapturingSentEvent sends a message from the source chain to the destination chain without capturing the message sent event.
 func sendMessageWithoutCapturingSentEvent(
 	t *testing.T,
 	e *testhelpers.DeployedEnv,
@@ -550,12 +594,16 @@ func sendMessageWithoutCapturingSentEvent(
 	if err != nil {
 		t.Errorf("failed to send message: %v", err)
 	}
+	// send the message tx and block number to msgPipeline channel which looks for the message sent event in the onRamp.
+	// initially it will look for the message sent event in 1.5 onRamp and
+	// after switchSignal is set to true, it will look for the message sent event in 1.6 onRamp
 	msgPipeline <- msgEvent{
 		tx:       tx.Hash(),
 		blockNum: blockNum,
 	}
 }
 
+// sendMsgInV1_5 sends a message and filter the message sent event in 1.5 onRamp.
 func sendMsgInV1_5(
 	t *testing.T,
 	e testhelpers.DeployedEnv,
@@ -578,6 +626,7 @@ func sendMsgInV1_5(
 	return sentEvent
 }
 
+// sendMsgInV1_6 sends a message and filter the message sent event in 1.6 onRamp.
 func sendMsgInV1_6(
 	t *testing.T,
 	e testhelpers.DeployedEnv,

--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -6,15 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
-	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
@@ -26,30 +24,14 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/onramp"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/rmn_contract"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/router"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
 )
 
 // TestMigrateFromV1_5ToV1_6 tests the migration from v1.5 to v1.6
-// The test steps are as follows:
-// 1. Deploy CCIP 1.5 with 3 chains and 4 nodes + 1 bootstrap
-// 2. Deploy 1.5 contracts (excluding pools to start, but including MCMS)
-// 3. Wire up all lanes
-// 4. PermaBless the commit stores
-// 5. Send continuous messages from src1 -> dest in real router until stopMsgs is closed
-// 6. Send a message from the other lane src2 -> dest
-// 6. Transfer ownership of the contracts to MCMS
-// 7. Add 1.6 contracts to the environment and send 1.6 jobs
-// 8. Set RMNProxy to point to RMNRemote
-// 9. Update nonce managers
-// 10. Enable a single 1.6 lane with test router
-// 11. Send traffic across single 1.6 src1 > dest lane with a DIFFERENT sender from test router to ensure 1.6 is working
-// 12. Enable the real router and verify sender nonce in 1.6 OnRamp event is plus one to sender nonce in 1.5 OnRamp
-// 13. Confirm that the other lane src2->dest is still working with v1.5
-// 14. Stop the continuous messages in real router and wait for all the executions to confirm
 func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	// Deploy CCIP 1.5 with 3 chains and 4 nodes + 1 bootstrap
-	// Deploy 1.5 contracts (excluding pools to start, but including MCMS)
-	const msgInterval = 10 * time.Second
+	// Deploy 1.5 contracts (excluding pools to start, but including MCMS) .
 	e, _, tEnv := testsetups.NewIntegrationEnvironment(
 		t,
 		testhelpers.WithPrerequisiteDeploymentOnly(
@@ -118,19 +100,40 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	require.NoError(t, err)
 	tEnv.UpdateDeployedEnvironment(e)
 	// ensure that all lanes are functional
-	stopMsgs := make(chan bool)     // channel to stop sending messages in real router
-	switchTov1_6 := make(chan bool) // channel to switchTov1_6 to switch to 1.6
-	var wg sync.WaitGroup           // wait group to wait for all the messages to be delivered
-	// send continuous messages from src1 -> dest until stopMsgs is closed
-	sendContinuousMessagesInRealRouter(t, &e, &state, pairs[0], &wg, stopMsgs, switchTov1_6, msgInterval)
+	var (
+		done                                = make(chan bool) // channel to stop sending messages in real router
+		wg                                  sync.WaitGroup    // wait group to wait for all the messages to be delivered
+		v1_5Msgs                            = make([]*evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested, 0)
+		v1_6Msgs                            = make([]*onramp.OnRampCCIPMessageSent, 0)
+		initialBlock, lastNonce, firstNonce uint64
+	)
+	wg.Add(1)
+	// send continuous messages in real router until done is closed
+	go func() {
+		initialBlock, v1_5Msgs, v1_6Msgs = SendMessages(t, &e, &state, pairs[0].SourceChainSelector, pairs[0].DestChainSelector, done)
+		wg.Done()
+	}()
 	// send a message from the other lane src2 -> dest
-	sentEvent := sendMsgInV1_5(t, e, state, src2, dest)
+	sentEvent, err := v1_5testhelpers.SendRequest(t, e.Env, state,
+		testhelpers.WithSourceChain(src2),
+		testhelpers.WithDestChain(dest),
+		testhelpers.WithTestRouter(false),
+		testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
+			Receiver:     common.LeftPadBytes(state.Chains[dest].Receiver.Address().Bytes(), 32),
+			Data:         []byte("hello"),
+			TokenAmounts: nil,
+			FeeToken:     common.HexToAddress("0x0"),
+			ExtraArgs:    nil,
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sentEvent)
 	destChain := e.Env.Chains[dest]
 	destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
 	require.NoError(t, err)
-	v1_5testhelpers.WaitForCommit(t, e.Env.Chains[src2], destChain, state.Chains[dest].CommitStore[src1],
+	v1_5testhelpers.WaitForCommit(t, e.Env.Chains[src2], destChain, state.Chains[dest].CommitStore[src2],
 		sentEvent.Message.SequenceNumber)
-	v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src2], destChain, state.Chains[dest].EVM2EVMOffRamp[src1],
+	v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src2], destChain, state.Chains[dest].EVM2EVMOffRamp[src2],
 		[]uint64{sentEvent.Message.SequenceNumber}, destStartBlock.Number.Uint64())
 
 	// now that all 1.5 lanes work transfer ownership of the contracts to MCMS
@@ -234,9 +237,23 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	startBlocks[dest] = &block
 	expectedSeqNumExec := make(map[testhelpers.SourceDestPair][]uint64)
 	expectedSeqNums := make(map[testhelpers.SourceDestPair]uint64)
-	// Send traffic across single 1.6 lane with a DIFFERENT ( very important to not mess with real sender nonce) sender
-	// from test router to ensure 1.6 is working.
-	msgSentEvent := sendMsgInV1_6(t, e, state, src1, dest, e.Users[src1][1], true)
+	msgSentEvent, err := testhelpers.DoSendRequest(
+		t, e.Env, state,
+		testhelpers.WithSourceChain(src1),
+		testhelpers.WithDestChain(dest),
+		testhelpers.WithTestRouter(true),
+		// Send traffic across single 1.6 lane with a DIFFERENT ( very important to not mess with real sender nonce) sender
+		// from test router to ensure 1.6 is working.
+		testhelpers.WithSender(e.Users[src1][1]),
+		testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
+			Receiver:     common.LeftPadBytes(state.Chains[dest].Receiver.Address().Bytes(), 32),
+			Data:         []byte("hello"),
+			TokenAmounts: nil,
+			FeeToken:     common.HexToAddress("0x0"),
+			ExtraArgs:    nil,
+		}))
+	require.NoError(t, err)
+
 	expectedSeqNumExec[testhelpers.SourceDestPair{
 		SourceChainSelector: src1,
 		DestChainSelector:   dest,
@@ -310,270 +327,102 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-
-	// As the real router are getting continuous messages, after this switch v1.6 OnRamp should start receiving the messages.
-	// and the request should get delivered to 1.6 offRamp
-	switchTov1_6 <- true // Signal to look for messages in 1.6 OnRamp
-
 	// confirm that the other lane src2->dest is still working with v1.5
-	sentEventOnOtherLane := sendMsgInV1_5(t, e, state, src2, dest)
+	sentEventOnOtherLane, err := v1_5testhelpers.SendRequest(t, e.Env, state,
+		testhelpers.WithSourceChain(src2),
+		testhelpers.WithDestChain(dest),
+		testhelpers.WithTestRouter(false),
+		testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
+			Receiver:     common.LeftPadBytes(state.Chains[dest].Receiver.Address().Bytes(), 32),
+			Data:         []byte("hello"),
+			TokenAmounts: nil,
+			FeeToken:     common.HexToAddress("0x0"),
+			ExtraArgs:    nil,
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sentEvent)
+
 	v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src2], e.Env.Chains[dest], state.Chains[dest].EVM2EVMOffRamp[src2],
 		[]uint64{sentEventOnOtherLane.Message.SequenceNumber}, destStartBlock.Number.Uint64())
 
-	// stop the continuous messages in real router and wait for all the executions to confirm
-	stopMsgs <- true
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-	require.Eventually(t, func() bool {
-		select {
-		case <-done:
-			return true
-		default:
-			return false
+	// stop the continuous messages in real router
+	close(done) // stop sending messages in real router
+	wg.Wait()
+	// start validating the messages sent in 1.5 and 1.6
+	for _, msg := range v1_5Msgs {
+		v1_5testhelpers.WaitForCommit(t, e.Env.Chains[src1], destChain, state.Chains[dest].CommitStore[src1],
+			msg.Message.SequenceNumber)
+		v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src1], destChain, state.Chains[dest].EVM2EVMOffRamp[src1],
+			[]uint64{msg.Message.SequenceNumber}, initialBlock)
+		lastNonce = msg.Message.Nonce
+	}
+	for _, msg := range v1_6Msgs {
+		if firstNonce == 0 {
+			firstNonce = msg.Message.Header.Nonce
 		}
-	},
-		tests.WaitTimeout(t),
-		2*time.Second,
-		"all executions did not confirm",
-	)
+		expectedSeqNumExec[testhelpers.SourceDestPair{
+			SourceChainSelector: src1,
+			DestChainSelector:   dest,
+		}] = []uint64{msg.Message.Header.SequenceNumber}
+		expectedSeqNums[testhelpers.SourceDestPair{
+			SourceChainSelector: src1,
+			DestChainSelector:   dest,
+		}] = msg.Message.Header.SequenceNumber
+	}
+	startBlocks[dest] = &initialBlock
+	testhelpers.ConfirmCommitForAllWithExpectedSeqNums(t, e.Env, state, expectedSeqNums, startBlocks)
+	testhelpers.ConfirmExecWithSeqNrsForAll(t, e.Env, state, expectedSeqNumExec, startBlocks)
+	require.Equal(t, lastNonce+1, firstNonce, "sender nonce in 1.6 OnRamp event is not plus one to sender nonce in 1.5 OnRamp")
 }
 
-type msgEvent struct {
-	tx       common.Hash
-	blockNum uint64
-}
-
-// sendContinuousMessagesInRealRouter sends continuous messages from the source chain to the destination chain until stopped.
-// The process is as follows:
-//  1. Send a message once and then send messages based on the interval in real router until signal to stop the message is received.
-//  2. Listen to the message sent event in 1.5 onRamp until the switch signal is received
-//     and send the message sequence number and block number to check for commit & execute through performMsgCheckInV1_5 channel.
-//  3. Separate Go routines listens to the channel performMsgCheckInV1_5 and performMsgCheckInV1_6 to perform
-//     commit and execute in 1.5 and 1.6 version offRamps respectively.
-//  4. Start listening to the message sent event in 1.6 onRamp after the switch signal is received and send the message
-//     sequence number and block number to check for commit & execute through performMsgCheckInV1_6 channel.
-//  5. In the test, wait for all the go routines to complete to confirm all the messages are delivered.
-//  6. Assert sender nonce in 1.6 OnRamp event is plus one to sender nonce in 1.5 OnRamp .
-func sendContinuousMessagesInRealRouter(
-	t *testing.T,
-	e *testhelpers.DeployedEnv,
-	state *changeset.CCIPOnChainState,
-	pair testhelpers.SourceDestPair,
-	wg *sync.WaitGroup,
-	stopMsgs, signal chan bool,
-	interval time.Duration,
-) {
-	ticker := time.NewTicker(interval)
-	type msgSentCheck struct {
-		src, dest, seqNr, startBlockNumber uint64
-	}
-	msgPipeline := make(chan msgEvent, 100) // channel to send the message tx and block number to check msg sent event
-	// channel to send the message sent event to check for commit & execute in
-	performMsgCheckInV1_5 := make(chan msgSentCheck, 100)
-	// channel to send the message sent event to check for commit & execute
-	performMsgCheckInV1_6 := make(chan msgSentCheck, 100)
-	performNonceCheck := false
-
-	// Go routine to send the messages continuously until stopMsgs is closed
-	go func() {
-		defer ticker.Stop()
-		// send once and further send messages based on the interval
-		// the below function sends the message and adds the message sent event to the msgPipeline
-		sendMessageWithoutCapturingSentEvent(t, e, state, pair.SourceChainSelector, pair.DestChainSelector, msgPipeline)
-		for {
-			select {
-			case <-stopMsgs: // stop sending messages and close the msgPipeline
-				close(msgPipeline)
-				return
-			case <-ticker.C:
-				sendMessageWithoutCapturingSentEvent(t, e, state, pair.SourceChainSelector, pair.DestChainSelector, msgPipeline)
-			}
-		}
-	}()
-
-	// function to listen to the message sent event in v1.6 onRamp
-	listenV1_6OnRamp := func(input msgEvent) {
-		defer wg.Done()
-		// filter the message sent event in 1.6 onRamp
-		it, err := state.Chains[pair.SourceChainSelector].OnRamp.FilterCCIPMessageSent(&bind.FilterOpts{
-			Start:   input.blockNum,
-			End:     &input.blockNum,
-			Context: context.Background(),
-		}, []uint64{pair.DestChainSelector}, []uint64{})
-		if err != nil {
-			t.Errorf("failed to get msg sent filter iterator")
-		}
-		if !it.Next() {
-			t.Errorf("failed to get next event")
-		}
-		t.Logf("CCIP message (id %x) sent from chain selector %d to chain selector %d tx %s seqNum %d sender %s",
-			it.Event.Message.Header.MessageId[:],
-			pair.SourceChainSelector,
-			pair.DestChainSelector,
-			input.tx.String(),
-			it.Event.Message.Header.SequenceNumber,
-			it.Event.Message.Sender.String(),
-		)
-		destChain := e.Env.Chains[pair.DestChainSelector]
-		destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
-		if err != nil {
-			t.Errorf("failed to get header by number")
-		}
-		if performNonceCheck {
-			lastnonce, err := state.Chains[pair.SourceChainSelector].EVM2EVMOnRamp[pair.DestChainSelector].GetSenderNonce(
-				nil,
-				e.Env.Chains[pair.SourceChainSelector].DeployerKey.From,
-			)
-			if err != nil {
-				t.Errorf("failed to get sender nonce in 1.5 OnRamp")
-			}
-			// assert sender nonce in 1.6 OnRamp event is plus one to sender nonce in 1.5 OnRamp
-			if lastnonce+1 != it.Event.Message.Header.Nonce {
-				t.Errorf("sender nonce in 1.6 OnRamp event is not plus one to sender nonce in 1.5 OnRamp")
-			}
-			performNonceCheck = false
-		}
-		// channel to send the message sequence number and block number to check for commit & execute
-		performMsgCheckInV1_6 <- msgSentCheck{
-			src:              pair.SourceChainSelector,
-			dest:             pair.DestChainSelector,
-			seqNr:            it.Event.Message.Header.SequenceNumber,
-			startBlockNumber: destStartBlock.Number.Uint64(),
-		}
-	}
-	// function to listen to the message sent event in v1.5 onRamp
-	listenV1_5OnRamp := func(input msgEvent) {
-		defer wg.Done()
-		// filter the message sent event in 1.5 onRamp
-		it, err := state.Chains[pair.SourceChainSelector].EVM2EVMOnRamp[pair.DestChainSelector].FilterCCIPSendRequested(&bind.FilterOpts{
-			Start:   input.blockNum,
-			End:     &input.blockNum,
-			Context: context.Background(),
-		})
-		if err != nil {
-			t.Errorf("failed to get msg sent filter iterator")
-		}
-		if !it.Next() {
-			t.Errorf("failed to get next event")
-		}
-
-		t.Logf("CCIP message (id %x) sent from chain selector %d to chain selector %d tx %s seqNum %d sender %s",
-			it.Event.Message.MessageId[:],
-			pair.SourceChainSelector,
-			pair.DestChainSelector,
-			input.tx.String(),
-			it.Event.Message.SequenceNumber,
-			it.Event.Message.Sender.String(),
-		)
-		destChain := e.Env.Chains[pair.DestChainSelector]
-		destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
-		if err != nil {
-			t.Errorf("failed to get header by number")
-		}
-		// channel to send the message sequence number and block number to check for commit & execute
-		performMsgCheckInV1_5 <- msgSentCheck{
-			src:              pair.SourceChainSelector,
-			dest:             pair.DestChainSelector,
-			seqNr:            it.Event.Message.SequenceNumber,
-			startBlockNumber: destStartBlock.Number.Uint64(),
-		}
-	}
-
-	// Process the msg event in real router
-	go func() {
-		// switchSignal is used to switch to 1.6 onRamp after the signal is received until then it listens to 1.5 onRamp
-		switchSignal := false
-		defer close(performMsgCheckInV1_5)
-		defer close(performMsgCheckInV1_6)
-		defer close(signal)
-		for input := range msgPipeline {
-			wg.Add(1)
-			select {
-			case <-signal:
-				// switch to 1.6 onRamp
-				switchSignal = true
-				performNonceCheck = true
-				go listenV1_6OnRamp(input)
-			default:
-				if switchSignal {
-					go listenV1_6OnRamp(input)
-				} else {
-					// listen to 1.5 onRamp until switchSignal is set to true
-					go listenV1_5OnRamp(input)
-				}
-			}
-		}
-	}()
-
-	// Verify message sent in v1.5
-	go func() {
-		// range over performMsgCheckInV1_5 channel to verify the commit and execute in 1.5 offRamp
-		// this channel will be populated when there is msg sent event in 1.5 onRamp
-		for input := range performMsgCheckInV1_5 {
-			wg.Add(1)
-			go func(input msgSentCheck) {
-				defer wg.Done()
-				v1_5testhelpers.WaitForCommit(t, e.Env.Chains[input.src], e.Env.Chains[input.dest],
-					state.Chains[input.dest].CommitStore[input.src], input.seqNr)
-				v1_5testhelpers.WaitForExecute(t, e.Env.Chains[input.src], e.Env.Chains[input.dest],
-					state.Chains[pair.DestChainSelector].EVM2EVMOffRamp[pair.SourceChainSelector],
-					[]uint64{input.seqNr}, input.startBlockNumber)
-			}(input)
-		}
-	}()
-
-	// verify message sent in v1.6
-	go func() {
-		// range over performMsgCheckInV1_6 channel to verify the commit and execute in 1.6 offRamp
-		// this channel will be populated when there is msg sent event in 1.6 onRamp
-		for input := range performMsgCheckInV1_6 {
-			wg.Add(1)
-			go func(input msgSentCheck) {
-				defer wg.Done()
-				// confirm commit in 1.6 offRamp
-				_, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
-					t,
-					input.src,
-					e.Env.Chains[input.dest],
-					state.Chains[input.dest].OffRamp,
-					&input.startBlockNumber,
-					ccipocr3.SeqNumRange{
-						ccipocr3.SeqNum(input.seqNr),
-						ccipocr3.SeqNum(input.seqNr),
-					},
-					true,
-				)
-				if err != nil {
-					t.Errorf("failed to confirm commit")
-				}
-				// confirm execute in 1.6 offRamp
-				_, err = testhelpers.ConfirmExecWithSeqNrs(
-					t,
-					input.src,
-					e.Env.Chains[input.dest],
-					state.Chains[input.dest].OffRamp,
-					&input.startBlockNumber,
-					[]uint64{input.seqNr},
-				)
-				if err != nil {
-					t.Errorf("failed to confirm execute")
-				}
-			}(input)
-		}
-	}()
-}
-
-// sendMessageWithoutCapturingSentEvent sends a message from the source chain to the destination chain without capturing the message sent event.
-func sendMessageWithoutCapturingSentEvent(
+// SendMessages sends messages from src to dest until done is closed
+func SendMessages(
 	t *testing.T,
 	e *testhelpers.DeployedEnv,
 	state *changeset.CCIPOnChainState,
 	src, dest uint64,
-	msgPipeline chan msgEvent,
-) {
+	done chan bool,
+) (uint64, []*evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested, []*onramp.OnRampCCIPMessageSent) {
+	var (
+		ticker           = time.NewTicker(10 * time.Second)
+		initialDestBlock uint64
+		v1_6Msgs         []*onramp.OnRampCCIPMessageSent
+		v1_5Msgs         []*evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested
+	)
+	for {
+		select {
+		case <-ticker.C:
+			msg := sendMessage(t, e, state, src, dest)
+			switch msg := msg.(type) {
+			case *evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested:
+				v1_5Msgs = append(v1_5Msgs, msg)
+				if initialDestBlock == 0 {
+					destChain := e.Env.Chains[dest]
+					destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
+					if err != nil {
+						t.Errorf("failed to get block header")
+					}
+					initialDestBlock = destStartBlock.Number.Uint64()
+				}
+			case *onramp.OnRampCCIPMessageSent:
+				v1_6Msgs = append(v1_6Msgs, msg)
+			}
+		case <-done:
+			return initialDestBlock, v1_5Msgs, v1_6Msgs
+		}
+	}
+}
+
+// sendMessage sends a message and filter the log topic to identify the event type nad parse the event data.
+func sendMessage(
+	t *testing.T,
+	e *testhelpers.DeployedEnv,
+	state *changeset.CCIPOnChainState,
+	src, dest uint64,
+) any {
+	evm2EVMOnRampABI := abihelpers.MustParseABI(evm_2_evm_onramp.EVM2EVMOnRampABI)
+	onRampABI := abihelpers.MustParseABI(onramp.OnRampABI)
 	cfg := &testhelpers.CCIPSendReqConfig{
 		SourceChain:  src,
 		DestChain:    dest,
@@ -590,64 +439,33 @@ func sendMessageWithoutCapturingSentEvent(
 	t.Logf("Sending CCIP request from chain selector %d to chain selector %d from sender %s",
 		cfg.SourceChain, cfg.DestChain, cfg.Sender.From.String())
 
-	tx, blockNum, err := testhelpers.CCIPSendRequest(e.Env, *state, cfg)
+	tx, _, err := testhelpers.CCIPSendRequest(e.Env, *state, cfg)
 	if err != nil {
 		t.Errorf("failed to send message: %v", err)
 	}
-	// send the message tx and block number to msgPipeline channel which looks for the message sent event in the onRamp.
-	// initially it will look for the message sent event in 1.5 onRamp and
-	// after switchSignal is set to true, it will look for the message sent event in 1.6 onRamp
-	msgPipeline <- msgEvent{
-		tx:       tx.Hash(),
-		blockNum: blockNum,
+	receipt, err := e.Env.Chains[src].Client.TransactionReceipt(context.Background(), tx.Hash())
+	if err != nil {
+		t.Errorf("failed to get transaction receipt: %v", err)
 	}
-}
-
-// sendMsgInV1_5 sends a message and filter the message sent event in 1.5 onRamp.
-func sendMsgInV1_5(
-	t *testing.T,
-	e testhelpers.DeployedEnv,
-	state changeset.CCIPOnChainState,
-	src, dest uint64) *evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested {
-	sentEvent, err := v1_5testhelpers.SendRequest(t, e.Env, state,
-		testhelpers.WithSourceChain(src),
-		testhelpers.WithDestChain(dest),
-		testhelpers.WithTestRouter(false),
-		testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
-			Receiver:     common.LeftPadBytes(state.Chains[dest].Receiver.Address().Bytes(), 32),
-			Data:         []byte("hello"),
-			TokenAmounts: nil,
-			FeeToken:     common.HexToAddress("0x0"),
-			ExtraArgs:    nil,
-		}),
-	)
-	require.NoError(t, err)
-	require.NotNil(t, sentEvent)
-	return sentEvent
-}
-
-// sendMsgInV1_6 sends a message and filter the message sent event in 1.6 onRamp.
-func sendMsgInV1_6(
-	t *testing.T,
-	e testhelpers.DeployedEnv,
-	state changeset.CCIPOnChainState,
-	src, dest uint64,
-	sender *bind.TransactOpts,
-	isTestRouter bool,
-) *onramp.OnRampCCIPMessageSent {
-	sentEvent, err := testhelpers.DoSendRequest(
-		t, e.Env, state,
-		testhelpers.WithSourceChain(src),
-		testhelpers.WithDestChain(dest),
-		testhelpers.WithTestRouter(isTestRouter),
-		testhelpers.WithSender(sender),
-		testhelpers.WithEvm2AnyMessage(router.ClientEVM2AnyMessage{
-			Receiver:     common.LeftPadBytes(state.Chains[dest].Receiver.Address().Bytes(), 32),
-			Data:         []byte("hello"),
-			TokenAmounts: nil,
-			FeeToken:     common.HexToAddress("0x0"),
-			ExtraArgs:    nil,
-		}))
-	require.NoError(t, err)
-	return sentEvent
+	// filter the log topic to identify the event type and parse the event data
+	for _, lg := range receipt.Logs {
+		if lg.Topics[0].Hex() == evm2EVMOnRampABI.Events["CCIPSendRequested"].ID.Hex() {
+			unpackedMsg, err := evm2EVMOnRampABI.Events["CCIPSendRequested"].Inputs.Unpack(lg.Data)
+			if err != nil {
+				t.Errorf("failed to unpack ccip send requested event")
+			}
+			return &evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested{
+				Message: *abi.ConvertType(unpackedMsg[0], new(evm_2_evm_onramp.InternalEVM2EVMMessage)).(*evm_2_evm_onramp.InternalEVM2EVMMessage),
+			}
+		} else if lg.Topics[0].Hex() == onRampABI.Events["CCIPMessageSent"].ID.Hex() {
+			unpackedMsg, err := onRampABI.Events["CCIPMessageSent"].Inputs.Unpack(lg.Data)
+			if err != nil {
+				t.Errorf("failed to unpack ccip message sent event")
+			}
+			return &onramp.OnRampCCIPMessageSent{
+				Message: *abi.ConvertType(unpackedMsg[0], new(onramp.InternalEVM2AnyRampMessage)).(*onramp.InternalEVM2AnyRampMessage),
+			}
+		}
+	}
+	return nil
 }

--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -28,6 +28,11 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/evm/utils"
 )
 
+var (
+	evm2EVMOnRampABI = abihelpers.MustParseABI(evm_2_evm_onramp.EVM2EVMOnRampABI)
+	onRampABI        = abihelpers.MustParseABI(onramp.OnRampABI)
+)
+
 // TestMigrateFromV1_5ToV1_6 tests the migration from v1.5 to v1.6
 func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	// Deploy CCIP 1.5 with 3 chains and 4 nodes + 1 bootstrap
@@ -110,9 +115,9 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	wg.Add(1)
 	// send continuous messages in real router until done is closed
 	go func() {
-		initialBlock, v1_5Msgs, v1_6Msgs = SendContinuousMessages(
+		defer wg.Done()
+		initialBlock, v1_5Msgs, v1_6Msgs = sendContinuousMessages(
 			t, &e, &state, pairs[0].SourceChainSelector, pairs[0].DestChainSelector, done)
-		wg.Done()
 	}()
 	// send a message from the other lane src2 -> dest
 	sentEvent, err := v1_5testhelpers.SendRequest(t, e.Env, state,
@@ -378,7 +383,7 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 }
 
 // SendMessages sends messages from src to dest until done is closed
-func SendContinuousMessages(
+func sendContinuousMessages(
 	t *testing.T,
 	e *testhelpers.DeployedEnv,
 	state *changeset.CCIPOnChainState,
@@ -395,6 +400,10 @@ func SendContinuousMessages(
 		select {
 		case <-ticker.C:
 			msg := sendMessageInRealRouter(t, e, state, src, dest)
+			if msg == nil {
+				t.Errorf("failed to send message in real router")
+				continue
+			}
 			switch msg := msg.(type) {
 			case *evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested:
 				v1_5Msgs = append(v1_5Msgs, msg)
@@ -422,8 +431,6 @@ func sendMessageInRealRouter(
 	state *changeset.CCIPOnChainState,
 	src, dest uint64,
 ) any {
-	evm2EVMOnRampABI := abihelpers.MustParseABI(evm_2_evm_onramp.EVM2EVMOnRampABI)
-	onRampABI := abihelpers.MustParseABI(onramp.OnRampABI)
 	cfg := &testhelpers.CCIPSendReqConfig{
 		SourceChain:  src,
 		DestChain:    dest,


### PR DESCRIPTION
Have added logic to fire continuous msgs in real router until it requested to stop. Such msgs are asserted for expected events immediate to successful sent.

Have also addressed the flakiness.
