### PR TITLE
[ship-3971] remove ws dep ccip

### DIFF
--- a/go.md
+++ b/go.md
@@ -173,6 +173,8 @@ flowchart LR
 	click chainlink-testing-framework/lib href "https://github.com/smartcontractkit/chainlink-testing-framework"
 	chainlink-testing-framework/lib/grafana
 	click chainlink-testing-framework/lib/grafana href "https://github.com/smartcontractkit/chainlink-testing-framework"
+	chainlink-testing-framework/sentinel --> chainlink-testing-framework/lib
+	click chainlink-testing-framework/sentinel href "https://github.com/smartcontractkit/chainlink-testing-framework"
 	chainlink-testing-framework/seth
 	click chainlink-testing-framework/seth href "https://github.com/smartcontractkit/chainlink-testing-framework"
 	chainlink-testing-framework/wasp --> chainlink-testing-framework/lib/grafana
@@ -186,6 +188,7 @@ flowchart LR
 	chainlink/deployment --> mcms
 	click chainlink/deployment href "https://github.com/smartcontractkit/chainlink"
 	chainlink/integration-tests --> chainlink-testing-framework/havoc
+	chainlink/integration-tests --> chainlink-testing-framework/sentinel
 	chainlink/integration-tests --> chainlink-testing-framework/wasp
 	chainlink/integration-tests --> chainlink/deployment
 	click chainlink/integration-tests href "https://github.com/smartcontractkit/chainlink"
@@ -251,6 +254,7 @@ flowchart LR
 		 chainlink-testing-framework/havoc
 		 chainlink-testing-framework/lib
 		 chainlink-testing-framework/lib/grafana
+		 chainlink-testing-framework/sentinel
 		 chainlink-testing-framework/seth
 		 chainlink-testing-framework/wasp
 	end

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -3619,13 +3619,7 @@ func (lane *CCIPLane) StartEventWatchers() error {
 		for {
 			select {
 			case e := <-messageReceivedEvent:
-				messageID := string(e.MessageId[:])
-				messageContent := e.Data
-				messageSender := string(e.Sender)
-				log.Info().Msgf("Message event received for message id: 0x%x", messageID)
-				log.Info().Msgf("Message event received with content: %+v", string(messageContent))
-				log.Info().Msgf("Message event received with sender: 0x%x", messageSender[len(messageSender)-20:])
-				lane.Dest.MessageReceivedWatcher.Store(messageID, messageContent)
+				processMessageReceivedEvent(lane, e)
 			case <-lane.Context.Done():
 				return
 			}
@@ -3764,6 +3758,16 @@ func processExecutionStateChangedEvent(lane *CCIPLane, e *evm_2_evm_offramp.EVM2
 	lane.Dest.ExecStateChangedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ExecStateChangedWatcher)
 }
 
+func processMessageReceivedEvent(lane *CCIPLane, e *maybe_revert_message_receiver.MaybeRevertMessageReceiverMessageReceived) {
+	messageID := string(e.MessageId[:])
+	messageContent := e.Data
+	messageSender := string(e.Sender)
+	log.Info().Msgf("Message event received for message id: 0x%x", messageID)
+	log.Info().Msgf("Message event received with content: %+v", string(messageContent))
+	log.Info().Msgf("Message event received with sender: 0x%x", messageSender[len(messageSender)-20:])
+	lane.Dest.MessageReceivedWatcher.Store(messageID, messageContent)
+}
+
 func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator) error {
 	lane.Logger.Info().Msg("Starting event watchers, Polling")
 	if lane.Source.Common.ChainClient.GetNetworkConfig().FinalityDepth == 0 {
@@ -3783,11 +3787,6 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 		return err
 	}
 	go func() {
-		defer func() {
-			if err := sc.Sentinel.Unsubscribe(lane.SourceChain.GetChainID().Int64(), lane.Source.OnRamp.EthAddress, evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested{}.Topic(), sendReqEventSub); err != nil {
-				lane.Logger.Error().Err(err).Msg("failed to unsubscribe from CCIPSendRequested event")
-			}
-		}()
 		for {
 			select {
 			case <-sc.Ctx.Done():
@@ -3816,11 +3815,6 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 		return errors.New("failed to subscribe to ReportAccepted event")
 	}
 	go func() {
-		defer func() {
-			if err := sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.CommitStore.EthAddress, commit_store.CommitStoreReportAccepted{}.Topic(), reportAcceptedSub); err != nil {
-				lane.Logger.Error().Err(err).Msg("failed to unsubscribe from ReportAccepted event")
-			}
-		}()
 		for {
 			select {
 			case <-sc.Ctx.Done():
@@ -3861,11 +3855,6 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 		}
 
 		go func() {
-			defer func() {
-				if err := sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.Common.ARM.EthAddress, rmn_contract.RMNContractTaggedRootBlessed{}.Topic(), reportBlessedEventSub); err != nil {
-					lane.Logger.Error().Err(err).Msg("failed to unsubscribe from TaggedRootBlessed event")
-				}
-			}()
 			for {
 				select {
 				case <-sc.Ctx.Done():
@@ -3906,11 +3895,6 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 	}
 
 	go func() {
-		defer func() {
-			if err := sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.OffRamp.EthAddress, evm_2_evm_offramp.EVM2EVMOffRampExecutionStateChanged{}.Topic(), execStateChangedEventSub); err != nil {
-				lane.Logger.Error().Err(err).Msg("failed to unsubscribe from ExecutionStateChanged event")
-			}
-		}()
 		for {
 			select {
 			case <-sc.Ctx.Done():
@@ -3933,6 +3917,33 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 					continue
 				}
 				processExecutionStateChangedEvent(lane, e)
+			case <-lane.Context.Done():
+				return
+			}
+		}
+	}()
+	messageReceivedSub, err := sc.Sentinel.Subscribe(
+		lane.DestChain.GetChainID().Int64(),
+		lane.Dest.ReceiverDapp.EthAddress,
+		maybe_revert_message_receiver.MaybeRevertMessageReceiverMessageReceived{}.Topic(),
+	)
+	if err != nil {
+		log.Error().Err(err).Msg("error in setting up polling to MaybeRevertMessageReceiverMessageReceived event")
+		return err
+	}
+	go func() {
+		for {
+			select {
+			case <-sc.Ctx.Done():
+				return
+			case event, ok := <-messageReceivedSub:
+				if !ok {
+					lane.Logger.Info().Msg("Sentinel log channel closed. Exiting goroutine.")
+					return
+				}
+				typesLog, _ := sentinel.ConvertAPILogToTypesLog(event)
+				e, _ := lane.Dest.ReceiverDapp.Instance.MaybeRevertMessageReceiverFilterer.ParseMessageReceived(*typesLog)
+				processMessageReceivedEvent(lane, e)
 			case <-lane.Context.Done():
 				return
 			}

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -3574,38 +3574,7 @@ func (lane *CCIPLane) StartEventWatchers() error {
 		for {
 			select {
 			case e := <-sendReqEventLatest:
-				lane.Logger.Info().Msgf("CCIPSendRequested event received for seq number %d", e.Message.SequenceNumber)
-				eventsForTx, ok := lane.Source.CCIPSendRequestedWatcher.Load(e.Raw.TxHash.Hex())
-				if ok {
-					lane.Source.CCIPSendRequestedWatcher.Store(e.Raw.TxHash.Hex(), append(eventsForTx.([]*contracts.SendReqEventData),
-						&contracts.SendReqEventData{
-							MessageId:      e.Message.MessageId,
-							SequenceNumber: e.Message.SequenceNumber,
-							DataLength:     len(e.Message.Data),
-							NoOfTokens:     len(e.Message.TokenAmounts),
-							LogInfo: contracts.LogInfo{
-								BlockNumber: e.Raw.BlockNumber,
-								TxHash:      e.Raw.TxHash,
-							},
-							Fee: e.Message.FeeTokenAmount,
-						}))
-				} else {
-					lane.Source.CCIPSendRequestedWatcher.Store(e.Raw.TxHash.Hex(), []*contracts.SendReqEventData{
-						{
-							MessageId:      e.Message.MessageId,
-							SequenceNumber: e.Message.SequenceNumber,
-							DataLength:     len(e.Message.Data),
-							NoOfTokens:     len(e.Message.TokenAmounts),
-							LogInfo: contracts.LogInfo{
-								BlockNumber: e.Raw.BlockNumber,
-								TxHash:      e.Raw.TxHash,
-							},
-							Fee: e.Message.FeeTokenAmount,
-						},
-					})
-				}
-
-				lane.Source.CCIPSendRequestedWatcher = testutils.DeleteNilEntriesFromMap(lane.Source.CCIPSendRequestedWatcher)
+				processSendRequestedEvent(lane, e)
 			case <-lane.Context.Done():
 				return
 			}
@@ -3628,19 +3597,7 @@ func (lane *CCIPLane) StartEventWatchers() error {
 		for {
 			select {
 			case e := <-reportAcceptedEvent:
-				lane.Logger.Info().Interface("Interval", e.Report.Interval).Msgf("ReportAccepted event received")
-				for i := e.Report.Interval.Min; i <= e.Report.Interval.Max; i++ {
-					lane.Dest.ReportAcceptedWatcher.Store(i, &contracts.CommitStoreReportAccepted{
-						Min:        e.Report.Interval.Min,
-						Max:        e.Report.Interval.Max,
-						MerkleRoot: e.Report.MerkleRoot,
-						LogInfo: contracts.LogInfo{
-							BlockNumber: e.Raw.BlockNumber,
-							TxHash:      e.Raw.TxHash,
-						},
-					})
-				}
-				lane.Dest.ReportAcceptedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ReportAcceptedWatcher)
+				processReportAcceptedEvent(lane, e)
 			case <-lane.Context.Done():
 				return
 			}
@@ -3693,14 +3650,7 @@ func (lane *CCIPLane) StartEventWatchers() error {
 			for {
 				select {
 				case e := <-reportBlessedEvent:
-					lane.Logger.Info().Msgf("TaggedRootBlessed event received for root %x", e.TaggedRoot.Root)
-					if e.TaggedRoot.CommitStore == lane.Dest.CommitStore.EthAddress {
-						lane.Dest.ReportBlessedWatcher.Store(e.TaggedRoot.Root, &contracts.LogInfo{
-							BlockNumber: e.Raw.BlockNumber,
-							TxHash:      e.Raw.TxHash,
-						})
-					}
-					lane.Dest.ReportBlessedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ReportBlessedWatcher)
+					processTaggedRootBlessedEvent(lane, e)
 				case <-lane.Context.Done():
 					return
 				}
@@ -3724,24 +3674,95 @@ func (lane *CCIPLane) StartEventWatchers() error {
 		for {
 			select {
 			case e := <-execStateChangedEventLatest:
-				lane.Logger.Info().Msgf("Execution state changed event received for seq number %d", e.SequenceNumber)
-				lane.Dest.ExecStateChangedWatcher.Store(e.SequenceNumber, &contracts.EVM2EVMOffRampExecutionStateChanged{
-					SequenceNumber: e.SequenceNumber,
-					MessageId:      e.MessageId,
-					State:          e.State,
-					ReturnData:     e.ReturnData,
-					LogInfo: contracts.LogInfo{
-						BlockNumber: e.Raw.BlockNumber,
-						TxHash:      e.Raw.TxHash,
-					},
-				})
-				lane.Dest.ExecStateChangedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ExecStateChangedWatcher)
+				processExecutionStateChangedEvent(lane, e)
 			case <-lane.Context.Done():
 				return
 			}
 		}
 	}(execSub)
 	return nil
+}
+
+func processSendRequestedEvent(lane *CCIPLane, e *evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested) {
+	lane.Logger.Info().Msgf("CCIPSendRequested event received for seq number %d", e.Message.SequenceNumber)
+	eventsForTx, ok := lane.Source.CCIPSendRequestedWatcher.Load(e.Raw.TxHash.Hex())
+	if ok {
+		lane.Source.CCIPSendRequestedWatcher.Store(e.Raw.TxHash.Hex(), append(eventsForTx.([]*contracts.SendReqEventData),
+			&contracts.SendReqEventData{
+				MessageId:      e.Message.MessageId,
+				SequenceNumber: e.Message.SequenceNumber,
+				DataLength:     len(e.Message.Data),
+				NoOfTokens:     len(e.Message.TokenAmounts),
+				LogInfo: contracts.LogInfo{
+					BlockNumber: e.Raw.BlockNumber,
+					TxHash:      e.Raw.TxHash,
+				},
+				Fee: e.Message.FeeTokenAmount,
+			}))
+	} else {
+		lane.Source.CCIPSendRequestedWatcher.Store(e.Raw.TxHash.Hex(), []*contracts.SendReqEventData{
+			{
+				MessageId:      e.Message.MessageId,
+				SequenceNumber: e.Message.SequenceNumber,
+				DataLength:     len(e.Message.Data),
+				NoOfTokens:     len(e.Message.TokenAmounts),
+				LogInfo: contracts.LogInfo{
+					BlockNumber: e.Raw.BlockNumber,
+					TxHash:      e.Raw.TxHash,
+				},
+				Fee: e.Message.FeeTokenAmount,
+			},
+		})
+	}
+
+	lane.Source.CCIPSendRequestedWatcher = testutils.DeleteNilEntriesFromMap(lane.Source.CCIPSendRequestedWatcher)
+}
+
+func processReportAcceptedEvent(lane *CCIPLane, e *commit_store.CommitStoreReportAccepted) {
+	lane.Logger.Info().Interface("Interval", e.Report.Interval).Msgf("ReportAccepted event received")
+	for i := e.Report.Interval.Min; i <= e.Report.Interval.Max; i++ {
+		lane.Dest.ReportAcceptedWatcher.Store(i, &contracts.CommitStoreReportAccepted{
+			Min:        e.Report.Interval.Min,
+			Max:        e.Report.Interval.Max,
+			MerkleRoot: e.Report.MerkleRoot,
+			LogInfo: contracts.LogInfo{
+				BlockNumber: e.Raw.BlockNumber,
+				TxHash:      e.Raw.TxHash,
+			},
+		})
+	}
+
+	// Clean up nil entries
+	lane.Dest.ReportAcceptedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ReportAcceptedWatcher)
+}
+
+func processTaggedRootBlessedEvent(lane *CCIPLane, e *rmn_contract.RMNContractTaggedRootBlessed) {
+	// Process the event
+	lane.Logger.Info().Msgf("TaggedRootBlessed event received for root %x", e.TaggedRoot.Root)
+	if e.TaggedRoot.CommitStore == lane.Dest.CommitStore.EthAddress {
+		lane.Dest.ReportBlessedWatcher.Store(e.TaggedRoot.Root, &contracts.LogInfo{
+			BlockNumber: e.Raw.BlockNumber,
+			TxHash:      e.Raw.TxHash,
+		})
+	}
+
+	// Clean up nil entries
+	lane.Dest.ReportBlessedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ReportBlessedWatcher)
+}
+
+func processExecutionStateChangedEvent(lane *CCIPLane, e *evm_2_evm_offramp.EVM2EVMOffRampExecutionStateChanged) {
+	lane.Logger.Info().Msgf("Execution state changed event received for seq number %d", e.SequenceNumber)
+	lane.Dest.ExecStateChangedWatcher.Store(e.SequenceNumber, &contracts.EVM2EVMOffRampExecutionStateChanged{
+		SequenceNumber: e.SequenceNumber,
+		MessageId:      e.MessageId,
+		State:          e.State,
+		ReturnData:     e.ReturnData,
+		LogInfo: contracts.LogInfo{
+			BlockNumber: e.Raw.BlockNumber,
+			TxHash:      e.Raw.TxHash,
+		},
+	})
+	lane.Dest.ExecStateChangedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ExecStateChangedWatcher)
 }
 
 func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator) error {
@@ -3775,38 +3796,7 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 				}
 				typesLog, _ := sentinel.ConvertAPILogToTypesLog(event)
 				e, _ := lane.Source.OnRamp.Instance.Latest.EVM2EVMOnRampFilterer.ParseCCIPSendRequested(*typesLog)
-				lane.Logger.Info().Msgf("CCIPSendRequested event received for seq number %d", e.Message.SequenceNumber)
-				eventsForTx, ok := lane.Source.CCIPSendRequestedWatcher.Load(e.Raw.TxHash.Hex())
-				if ok {
-					lane.Source.CCIPSendRequestedWatcher.Store(e.Raw.TxHash.Hex(), append(eventsForTx.([]*contracts.SendReqEventData),
-						&contracts.SendReqEventData{
-							MessageId:      e.Message.MessageId,
-							SequenceNumber: e.Message.SequenceNumber,
-							DataLength:     len(e.Message.Data),
-							NoOfTokens:     len(e.Message.TokenAmounts),
-							LogInfo: contracts.LogInfo{
-								BlockNumber: e.Raw.BlockNumber,
-								TxHash:      e.Raw.TxHash,
-							},
-							Fee: e.Message.FeeTokenAmount,
-						}))
-				} else {
-					lane.Source.CCIPSendRequestedWatcher.Store(e.Raw.TxHash.Hex(), []*contracts.SendReqEventData{
-						{
-							MessageId:      e.Message.MessageId,
-							SequenceNumber: e.Message.SequenceNumber,
-							DataLength:     len(e.Message.Data),
-							NoOfTokens:     len(e.Message.TokenAmounts),
-							LogInfo: contracts.LogInfo{
-								BlockNumber: e.Raw.BlockNumber,
-								TxHash:      e.Raw.TxHash,
-							},
-							Fee: e.Message.FeeTokenAmount,
-						},
-					})
-				}
-
-				lane.Source.CCIPSendRequestedWatcher = testutils.DeleteNilEntriesFromMap(lane.Source.CCIPSendRequestedWatcher)
+				processSendRequestedEvent(lane, e)
 			case <-lane.Context.Done():
 				return
 			}
@@ -3845,23 +3835,7 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 					lane.Logger.Error().Err(err).Msg("error parsing ReportAccepted event")
 					continue
 				}
-
-				// Log and store the event
-				lane.Logger.Info().Interface("Interval", e.Report.Interval).Msgf("ReportAccepted event received")
-				for i := e.Report.Interval.Min; i <= e.Report.Interval.Max; i++ {
-					lane.Dest.ReportAcceptedWatcher.Store(i, &contracts.CommitStoreReportAccepted{
-						Min:        e.Report.Interval.Min,
-						Max:        e.Report.Interval.Max,
-						MerkleRoot: e.Report.MerkleRoot,
-						LogInfo: contracts.LogInfo{
-							BlockNumber: e.Raw.BlockNumber,
-							TxHash:      e.Raw.TxHash,
-						},
-					})
-				}
-
-				// Clean up nil entries
-				lane.Dest.ReportAcceptedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ReportAcceptedWatcher)
+				processReportAcceptedEvent(lane, e)
 			case <-lane.Context.Done():
 				return
 			}
@@ -3903,18 +3877,7 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 						lane.Logger.Error().Err(err).Msg("error parsing TaggedRootBlessed event")
 						continue
 					}
-
-					// Process the event
-					lane.Logger.Info().Msgf("TaggedRootBlessed event received for root %x", e.TaggedRoot.Root)
-					if e.TaggedRoot.CommitStore == lane.Dest.CommitStore.EthAddress {
-						lane.Dest.ReportBlessedWatcher.Store(e.TaggedRoot.Root, &contracts.LogInfo{
-							BlockNumber: e.Raw.BlockNumber,
-							TxHash:      e.Raw.TxHash,
-						})
-					}
-
-					// Clean up nil entries
-					lane.Dest.ReportBlessedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ReportBlessedWatcher)
+					processTaggedRootBlessedEvent(lane, e)
 				case <-lane.Context.Done():
 					return
 				}
@@ -3955,22 +3918,7 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 					lane.Logger.Error().Err(err).Msg("error parsing ExecutionStateChanged event")
 					continue
 				}
-
-				// Process the event
-				lane.Logger.Info().Msgf("Execution state changed event received for seq number %d", e.SequenceNumber)
-				lane.Dest.ExecStateChangedWatcher.Store(e.SequenceNumber, &contracts.EVM2EVMOffRampExecutionStateChanged{
-					SequenceNumber: e.SequenceNumber,
-					MessageId:      e.MessageId,
-					State:          e.State,
-					ReturnData:     e.ReturnData,
-					LogInfo: contracts.LogInfo{
-						BlockNumber: e.Raw.BlockNumber,
-						TxHash:      e.Raw.TxHash,
-					},
-				})
-
-				// Clean up nil entries
-				lane.Dest.ExecStateChangedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ExecStateChangedWatcher)
+				processExecutionStateChangedEvent(lane, e)
 			case <-lane.Context.Done():
 				return
 			}

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -32,7 +32,6 @@ import (
 	"golang.org/x/exp/rand"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
 	"github.com/smartcontractkit/chainlink-testing-framework/sentinel"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -3818,7 +3818,7 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 	go func() {
 		defer func() {
 			if err := sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.CommitStore.EthAddress, commit_store.CommitStoreReportAccepted{}.Topic(), reportAcceptedSub); err != nil {
-				lane.Logger.Error().Err(err).Msg("failed to unsubscribe from CCIPSendRequested event")
+				lane.Logger.Error().Err(err).Msg("failed to unsubscribe from ReportAccepted event")
 			}
 		}()
 		for {
@@ -3863,7 +3863,7 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 		go func() {
 			defer func() {
 				if err := sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.Common.ARM.EthAddress, rmn_contract.RMNContractTaggedRootBlessed{}.Topic(), reportBlessedEventSub); err != nil {
-					lane.Logger.Error().Err(err).Msg("failed to unsubscribe from CCIPSendRequested event")
+					lane.Logger.Error().Err(err).Msg("failed to unsubscribe from TaggedRootBlessed event")
 				}
 			}()
 			for {
@@ -3906,7 +3906,11 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 	}
 
 	go func() {
-		defer sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.OffRamp.EthAddress, evm_2_evm_offramp.EVM2EVMOffRampExecutionStateChanged{}.Topic(), execStateChangedEventSub)
+		defer func() {
+			if err := sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.OffRamp.EthAddress, evm_2_evm_offramp.EVM2EVMOffRampExecutionStateChanged{}.Topic(), execStateChangedEventSub); err != nil {
+				lane.Logger.Error().Err(err).Msg("failed to unsubscribe from ExecutionStateChanged event")
+			}
+		}()
 		for {
 			select {
 			case <-sc.Ctx.Done():

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -3783,7 +3783,11 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 		return err
 	}
 	go func() {
-		defer sc.Sentinel.Unsubscribe(lane.SourceChain.GetChainID().Int64(), lane.Source.OnRamp.EthAddress, evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested{}.Topic(), sendReqEventSub)
+		defer func() {
+			if err := sc.Sentinel.Unsubscribe(lane.SourceChain.GetChainID().Int64(), lane.Source.OnRamp.EthAddress, evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested{}.Topic(), sendReqEventSub); err != nil {
+				lane.Logger.Error().Err(err).Msg("failed to unsubscribe from CCIPSendRequested event")
+			}
+		}()
 		for {
 			select {
 			case <-sc.Ctx.Done():
@@ -3809,10 +3813,14 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 	)
 	if err != nil {
 		log.Error().Err(err).Msg("error in setting up polling to ReportAccepted event")
-		return fmt.Errorf("failed to subscribe to ReportAccepted event")
+		return errors.New("failed to subscribe to ReportAccepted event")
 	}
 	go func() {
-		defer sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.CommitStore.EthAddress, commit_store.CommitStoreReportAccepted{}.Topic(), reportAcceptedSub)
+		defer func() {
+			if err := sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.CommitStore.EthAddress, commit_store.CommitStoreReportAccepted{}.Topic(), reportAcceptedSub); err != nil {
+				lane.Logger.Error().Err(err).Msg("failed to unsubscribe from CCIPSendRequested event")
+			}
+		}()
 		for {
 			select {
 			case <-sc.Ctx.Done():
@@ -3842,7 +3850,6 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 	}()
 
 	if lane.Dest.Common.ARM != nil {
-
 		reportBlessedEventSub, err := sc.Sentinel.Subscribe(
 			lane.DestChain.GetChainID().Int64(),
 			lane.Dest.Common.ARM.EthAddress,
@@ -3850,11 +3857,15 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 		)
 		if err != nil {
 			log.Error().Err(err).Msg("error in setting up polling to TaggedRootBlessed event")
-			return fmt.Errorf("failed to subscribe to TaggedRootBlessed event")
+			return errors.New("failed to subscribe to TaggedRootBlessed event")
 		}
 
 		go func() {
-			defer sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.Common.ARM.EthAddress, rmn_contract.RMNContractTaggedRootBlessed{}.Topic(), reportBlessedEventSub)
+			defer func() {
+				if err := sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.Common.ARM.EthAddress, rmn_contract.RMNContractTaggedRootBlessed{}.Topic(), reportBlessedEventSub); err != nil {
+					lane.Logger.Error().Err(err).Msg("failed to unsubscribe from CCIPSendRequested event")
+				}
+			}()
 			for {
 				select {
 				case <-sc.Ctx.Done():
@@ -3891,7 +3902,7 @@ func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator
 	)
 	if err != nil {
 		log.Error().Err(err).Msg("error in setting up polling to ExecutionStateChanged event")
-		return fmt.Errorf("failed to subscribe to ExecutionStateChanged event")
+		return errors.New("failed to subscribe to ExecutionStateChanged event")
 	}
 
 	go func() {

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -32,6 +32,9 @@ import (
 	"golang.org/x/exp/rand"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
+	"github.com/smartcontractkit/chainlink-testing-framework/sentinel"
+
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
@@ -3738,6 +3741,241 @@ func (lane *CCIPLane) StartEventWatchers() error {
 			}
 		}
 	}(execSub)
+	return nil
+}
+
+func (lane *CCIPLane) StartEventWatchersPolling(sc *sentinel.SentinelCoordinator) error {
+	lane.Logger.Info().Msg("Starting event watchers, Polling")
+	if lane.Source.Common.ChainClient.GetNetworkConfig().FinalityDepth == 0 {
+		err := lane.Source.Common.ChainClient.PollFinality()
+		if err != nil {
+			return err
+		}
+	}
+
+	sendReqEventSub, err := sc.Sentinel.Subscribe(
+		lane.SourceChain.GetChainID().Int64(),
+		lane.Source.OnRamp.EthAddress,
+		evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested{}.Topic(),
+	)
+	if err != nil {
+		log.Error().Err(err).Msg("error in setting up polling to CCIPSendRequested event")
+		return err
+	}
+	go func() {
+		defer sc.Sentinel.Unsubscribe(lane.SourceChain.GetChainID().Int64(), lane.Source.OnRamp.EthAddress, evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested{}.Topic(), sendReqEventSub)
+		for {
+			select {
+			case <-sc.Ctx.Done():
+				return
+			case event, ok := <-sendReqEventSub:
+				if !ok {
+					lane.Logger.Info().Msg("Sentinel log channel closed. Exiting goroutine.")
+					return
+				}
+				typesLog, _ := sentinel.ConvertAPILogToTypesLog(event)
+				e, _ := lane.Source.OnRamp.Instance.Latest.EVM2EVMOnRampFilterer.ParseCCIPSendRequested(*typesLog)
+				lane.Logger.Info().Msgf("CCIPSendRequested event received for seq number %d", e.Message.SequenceNumber)
+				eventsForTx, ok := lane.Source.CCIPSendRequestedWatcher.Load(e.Raw.TxHash.Hex())
+				if ok {
+					lane.Source.CCIPSendRequestedWatcher.Store(e.Raw.TxHash.Hex(), append(eventsForTx.([]*contracts.SendReqEventData),
+						&contracts.SendReqEventData{
+							MessageId:      e.Message.MessageId,
+							SequenceNumber: e.Message.SequenceNumber,
+							DataLength:     len(e.Message.Data),
+							NoOfTokens:     len(e.Message.TokenAmounts),
+							LogInfo: contracts.LogInfo{
+								BlockNumber: e.Raw.BlockNumber,
+								TxHash:      e.Raw.TxHash,
+							},
+							Fee: e.Message.FeeTokenAmount,
+						}))
+				} else {
+					lane.Source.CCIPSendRequestedWatcher.Store(e.Raw.TxHash.Hex(), []*contracts.SendReqEventData{
+						{
+							MessageId:      e.Message.MessageId,
+							SequenceNumber: e.Message.SequenceNumber,
+							DataLength:     len(e.Message.Data),
+							NoOfTokens:     len(e.Message.TokenAmounts),
+							LogInfo: contracts.LogInfo{
+								BlockNumber: e.Raw.BlockNumber,
+								TxHash:      e.Raw.TxHash,
+							},
+							Fee: e.Message.FeeTokenAmount,
+						},
+					})
+				}
+
+				lane.Source.CCIPSendRequestedWatcher = testutils.DeleteNilEntriesFromMap(lane.Source.CCIPSendRequestedWatcher)
+			case <-lane.Context.Done():
+				return
+			}
+		}
+	}()
+
+	reportAcceptedSub, err := sc.Sentinel.Subscribe(
+		lane.DestChain.GetChainID().Int64(),
+		lane.Dest.CommitStore.EthAddress,
+		commit_store.CommitStoreReportAccepted{}.Topic(),
+	)
+	if err != nil {
+		log.Error().Err(err).Msg("error in setting up polling to ReportAccepted event")
+		return fmt.Errorf("failed to subscribe to ReportAccepted event")
+	}
+	go func() {
+		defer sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.CommitStore.EthAddress, commit_store.CommitStoreReportAccepted{}.Topic(), reportAcceptedSub)
+		for {
+			select {
+			case <-sc.Ctx.Done():
+				return
+			case event, ok := <-reportAcceptedSub:
+				if !ok {
+					lane.Logger.Info().Msg("Sentinel log channel closed. Exiting goroutine.")
+					return
+				}
+
+				// Convert the log and parse the ReportAccepted event
+				typesLog, err := sentinel.ConvertAPILogToTypesLog(event)
+				if err != nil {
+					lane.Logger.Error().Err(err).Msg("error converting Sentinel log to types.Log")
+					continue
+				}
+				e, err := lane.Dest.CommitStore.Instance.Latest.CommitStoreFilterer.ParseReportAccepted(*typesLog)
+				if err != nil {
+					lane.Logger.Error().Err(err).Msg("error parsing ReportAccepted event")
+					continue
+				}
+
+				// Log and store the event
+				lane.Logger.Info().Interface("Interval", e.Report.Interval).Msgf("ReportAccepted event received")
+				for i := e.Report.Interval.Min; i <= e.Report.Interval.Max; i++ {
+					lane.Dest.ReportAcceptedWatcher.Store(i, &contracts.CommitStoreReportAccepted{
+						Min:        e.Report.Interval.Min,
+						Max:        e.Report.Interval.Max,
+						MerkleRoot: e.Report.MerkleRoot,
+						LogInfo: contracts.LogInfo{
+							BlockNumber: e.Raw.BlockNumber,
+							TxHash:      e.Raw.TxHash,
+						},
+					})
+				}
+
+				// Clean up nil entries
+				lane.Dest.ReportAcceptedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ReportAcceptedWatcher)
+			case <-lane.Context.Done():
+				return
+			}
+		}
+	}()
+
+	if lane.Dest.Common.ARM != nil {
+
+		reportBlessedEventSub, err := sc.Sentinel.Subscribe(
+			lane.DestChain.GetChainID().Int64(),
+			lane.Dest.Common.ARM.EthAddress,
+			rmn_contract.RMNContractTaggedRootBlessed{}.Topic(),
+		)
+		if err != nil {
+			log.Error().Err(err).Msg("error in setting up polling to TaggedRootBlessed event")
+			return fmt.Errorf("failed to subscribe to TaggedRootBlessed event")
+		}
+
+		go func() {
+			defer sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.Common.ARM.EthAddress, rmn_contract.RMNContractTaggedRootBlessed{}.Topic(), reportBlessedEventSub)
+			for {
+				select {
+				case <-sc.Ctx.Done():
+					return
+				case event, ok := <-reportBlessedEventSub:
+					if !ok {
+						lane.Logger.Info().Msg("Sentinel log channel closed. Exiting goroutine.")
+						return
+					}
+
+					// Convert the log and parse the TaggedRootBlessed event
+					typesLog, err := sentinel.ConvertAPILogToTypesLog(event)
+					if err != nil {
+						lane.Logger.Error().Err(err).Msg("error converting Sentinel log to types.Log")
+						continue
+					}
+					e, err := lane.Dest.Common.ARM.Instance.RMNContractFilterer.ParseTaggedRootBlessed(*typesLog)
+					if err != nil {
+						lane.Logger.Error().Err(err).Msg("error parsing TaggedRootBlessed event")
+						continue
+					}
+
+					// Process the event
+					lane.Logger.Info().Msgf("TaggedRootBlessed event received for root %x", e.TaggedRoot.Root)
+					if e.TaggedRoot.CommitStore == lane.Dest.CommitStore.EthAddress {
+						lane.Dest.ReportBlessedWatcher.Store(e.TaggedRoot.Root, &contracts.LogInfo{
+							BlockNumber: e.Raw.BlockNumber,
+							TxHash:      e.Raw.TxHash,
+						})
+					}
+
+					// Clean up nil entries
+					lane.Dest.ReportBlessedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ReportBlessedWatcher)
+				case <-lane.Context.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	execStateChangedEventSub, err := sc.Sentinel.Subscribe(
+		lane.DestChain.GetChainID().Int64(),
+		lane.Dest.OffRamp.EthAddress,
+		evm_2_evm_offramp.EVM2EVMOffRampExecutionStateChanged{}.Topic(),
+	)
+	if err != nil {
+		log.Error().Err(err).Msg("error in setting up polling to ExecutionStateChanged event")
+		return fmt.Errorf("failed to subscribe to ExecutionStateChanged event")
+	}
+
+	go func() {
+		defer sc.Sentinel.Unsubscribe(lane.DestChain.GetChainID().Int64(), lane.Dest.OffRamp.EthAddress, evm_2_evm_offramp.EVM2EVMOffRampExecutionStateChanged{}.Topic(), execStateChangedEventSub)
+		for {
+			select {
+			case <-sc.Ctx.Done():
+				return
+			case event, ok := <-execStateChangedEventSub:
+				if !ok {
+					lane.Logger.Info().Msg("Sentinel log channel closed. Exiting goroutine.")
+					return
+				}
+
+				// Convert the log and parse the ExecutionStateChanged event
+				typesLog, err := sentinel.ConvertAPILogToTypesLog(event)
+				if err != nil {
+					lane.Logger.Error().Err(err).Msg("error converting Sentinel log to types.Log")
+					continue
+				}
+				e, err := lane.Dest.OffRamp.Instance.Latest.EVM2EVMOffRampFilterer.ParseExecutionStateChanged(*typesLog)
+				if err != nil {
+					lane.Logger.Error().Err(err).Msg("error parsing ExecutionStateChanged event")
+					continue
+				}
+
+				// Process the event
+				lane.Logger.Info().Msgf("Execution state changed event received for seq number %d", e.SequenceNumber)
+				lane.Dest.ExecStateChangedWatcher.Store(e.SequenceNumber, &contracts.EVM2EVMOffRampExecutionStateChanged{
+					SequenceNumber: e.SequenceNumber,
+					MessageId:      e.MessageId,
+					State:          e.State,
+					ReturnData:     e.ReturnData,
+					LogInfo: contracts.LogInfo{
+						BlockNumber: e.Raw.BlockNumber,
+						TxHash:      e.Raw.TxHash,
+					},
+				})
+
+				// Clean up nil entries
+				lane.Dest.ExecStateChangedWatcher = testutils.DeleteNilEntriesFromMap(lane.Dest.ExecStateChangedWatcher)
+			case <-lane.Context.Done():
+				return
+			}
+		}
+	}()
 	return nil
 }
 

--- a/integration-tests/ccip-tests/contracts/contract_deployer.go
+++ b/integration-tests/ccip-tests/contracts/contract_deployer.go
@@ -809,7 +809,7 @@ func (e *CCIPContractsDeployer) DeployReceiverDapp(revert bool) (
 	return &ReceiverDapp{
 		client:     e.evmClient,
 		logger:     e.logger,
-		instance:   instance.(*maybe_revert_message_receiver.MaybeRevertMessageReceiver),
+		Instance:   instance.(*maybe_revert_message_receiver.MaybeRevertMessageReceiver),
 		EthAddress: *address,
 	}, err
 }
@@ -828,7 +828,7 @@ func (e *CCIPContractsDeployer) NewReceiverDapp(addr common.Address) (
 	return &ReceiverDapp{
 		client:     e.evmClient,
 		logger:     e.logger,
-		instance:   ins,
+		Instance:   ins,
 		EthAddress: addr,
 	}, err
 }

--- a/integration-tests/ccip-tests/contracts/contract_models.go
+++ b/integration-tests/ccip-tests/contracts/contract_models.go
@@ -1455,7 +1455,7 @@ func (r *Router) SetOnRamp(chainSelector uint64, onRamp common.Address) error {
 
 func (r *Router) CCIPSend(destChainSelector uint64, msg router.ClientEVM2AnyMessage, valueForNative *big.Int) (*types.Transaction, error) {
 	opts, err := r.client.TransactionOpts(r.client.GetDefaultWallet())
-	//print out opts
+	// print out opts
 	r.logger.Info().
 		Str("from", opts.From.Hex()).
 		Str("nonce", fmt.Sprintf("%v", opts.Nonce)).

--- a/integration-tests/ccip-tests/contracts/contract_models.go
+++ b/integration-tests/ccip-tests/contracts/contract_models.go
@@ -1078,7 +1078,7 @@ func (b *CommitStore) WatchReportAccepted(opts *bind.WatchOpts, acceptedEvent ch
 type ReceiverDapp struct {
 	client     blockchain.EVMClient
 	logger     *zerolog.Logger
-	instance   *maybe_revert_message_receiver.MaybeRevertMessageReceiver
+	Instance   *maybe_revert_message_receiver.MaybeRevertMessageReceiver
 	EthAddress common.Address
 }
 
@@ -1091,7 +1091,7 @@ func (rDapp *ReceiverDapp) ToggleRevert(revert bool) error {
 	if err != nil {
 		return fmt.Errorf("error getting transaction opts: %w", err)
 	}
-	tx, err := rDapp.instance.SetRevert(opts, revert)
+	tx, err := rDapp.Instance.SetRevert(opts, revert)
 	if err != nil {
 		return fmt.Errorf("error setting revert: %w", err)
 	}
@@ -1106,8 +1106,8 @@ func (rDapp *ReceiverDapp) ToggleRevert(revert bool) error {
 
 // WatchMessageReceived watches for `MessageReceived` events from the ReceiverDapp contract.
 func (rDapp *ReceiverDapp) WatchMessageReceived(opts *bind.WatchOpts, messageReceivedEvent chan *maybe_revert_message_receiver.MaybeRevertMessageReceiverMessageReceived) (event.Subscription, error) {
-	if rDapp.instance != nil {
-		return rDapp.instance.WatchMessageReceived(opts, messageReceivedEvent)
+	if rDapp.Instance != nil {
+		return rDapp.Instance.WatchMessageReceived(opts, messageReceivedEvent)
 	}
 
 	newInstance, err := maybe_revert_message_receiver.NewMaybeRevertMessageReceiver(rDapp.EthAddress, wrappers.MustNewWrappedContractBackend(rDapp.client, nil))

--- a/integration-tests/ccip-tests/contracts/contract_models.go
+++ b/integration-tests/ccip-tests/contracts/contract_models.go
@@ -1455,6 +1455,20 @@ func (r *Router) SetOnRamp(chainSelector uint64, onRamp common.Address) error {
 
 func (r *Router) CCIPSend(destChainSelector uint64, msg router.ClientEVM2AnyMessage, valueForNative *big.Int) (*types.Transaction, error) {
 	opts, err := r.client.TransactionOpts(r.client.GetDefaultWallet())
+	//print out opts
+	r.logger.Info().
+		Str("from", opts.From.Hex()).
+		Str("nonce", fmt.Sprintf("%v", opts.Nonce)).
+		Str("value", fmt.Sprintf("%v", opts.Value)).
+		Str("gasPrice", fmt.Sprintf("%v", opts.GasPrice)).
+		Str("gasFeeCap", fmt.Sprintf("%v", opts.GasFeeCap)).
+		Str("gasTipCap", fmt.Sprintf("%v", opts.GasTipCap)).
+		Uint64("gasLimit", opts.GasLimit).
+		Str("accessList", fmt.Sprintf("%v", opts.AccessList)).
+		Str("context", fmt.Sprintf("%v", opts.Context)).
+		Bool("noSend", opts.NoSend).
+		Msg("TransactOpts")
+
 	if err != nil {
 		return nil, fmt.Errorf("error getting transaction opts: %w", err)
 	}

--- a/integration-tests/ccip-tests/testconfig/README.md
+++ b/integration-tests/ccip-tests/testconfig/README.md
@@ -423,6 +423,23 @@ Example usage:
 TTL = "11h"
 ```
 
+### CCIP.Env.Logging
+
+Specifies the logging configuration for the test. Imported from [LoggingConfig](https://github.com/smartcontractkit/chainlink-testing-framework/blob/main/config/logging.go#L11) in chainlink-testing-framework.
+Example usage:
+
+```toml
+[CCIP.Env.Logging]
+
+[CCIP.Env.Logging.Loki]
+tenant_id = "..."
+endpoint = "https://loki...."
+
+[CCIP.Env.Logging.Grafana]
+base_url = "https://grafana..../"
+dashboard_url = "/d/6vjVx-1V8/ccip-long-running-tests"
+```
+
 ### CCIP.Env.Lane.LeaderLaneEnabled
 
 Specifies whether to enable the leader lane feature. This setting is only applicable for new deployments.

--- a/integration-tests/ccip-tests/testconfig/README.md
+++ b/integration-tests/ccip-tests/testconfig/README.md
@@ -430,6 +430,15 @@ Example usage:
 
 ```toml
 [CCIP.Env.Logging]
+test_log_collect = false # if set to true will save logs even if test did not fail
+
+[CCIP.Env.Logging.LogStream]
+# supported targets: file, loki, in-memory. if empty no logs will be persistet
+log_targets = ["file"]
+# context timeout for starting log producer and also time-frame for requesting logs
+log_producer_timeout = "10s"
+# number of retries before log producer gives up and stops listening to logs
+log_producer_retry_limit = 10
 
 [CCIP.Env.Logging.Loki]
 tenant_id = "..."

--- a/integration-tests/ccip-tests/testconfig/global.go
+++ b/integration-tests/ccip-tests/testconfig/global.go
@@ -223,8 +223,8 @@ func (p *Common) ReadFromEnvVar() error {
 		p.Logging.Loki.BearerToken = &lokiBearerToken
 	}
 
-	grafanaBaseUrl := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_GRAFANA_BASE_URL_ENV)
-	if grafanaBaseUrl != "" {
+	grafanaBaseURL := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_GRAFANA_BASE_URL_ENV)
+	if grafanaBaseURL != "" {
 		if p.Logging == nil {
 			p.Logging = &ctfconfig.LoggingConfig{}
 		}
@@ -232,11 +232,11 @@ func (p *Common) ReadFromEnvVar() error {
 			p.Logging.Grafana = &ctfconfig.GrafanaConfig{}
 		}
 		logger.Debug().Msgf("Using %s env var to override Logging.Grafana.BaseUrl", ctfconfig.E2E_TEST_GRAFANA_BASE_URL_ENV)
-		p.Logging.Grafana.BaseUrl = &grafanaBaseUrl
+		p.Logging.Grafana.BaseUrl = &grafanaBaseURL
 	}
 
-	grafanaDashboardUrl := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_GRAFANA_DASHBOARD_URL_ENV)
-	if grafanaDashboardUrl != "" {
+	grafanaDashboardURL := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_GRAFANA_DASHBOARD_URL_ENV)
+	if grafanaDashboardURL != "" {
 		if p.Logging == nil {
 			p.Logging = &ctfconfig.LoggingConfig{}
 		}
@@ -244,7 +244,7 @@ func (p *Common) ReadFromEnvVar() error {
 			p.Logging.Grafana = &ctfconfig.GrafanaConfig{}
 		}
 		logger.Debug().Msgf("Using %s env var to override Logging.Grafana.DashboardUrl", ctfconfig.E2E_TEST_GRAFANA_DASHBOARD_URL_ENV)
-		p.Logging.Grafana.DashboardUrl = &grafanaDashboardUrl
+		p.Logging.Grafana.DashboardUrl = &grafanaDashboardURL
 	}
 
 	grafanaBearerToken := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_GRAFANA_BEARER_TOKEN_ENV)

--- a/integration-tests/ccip-tests/testconfig/global.go
+++ b/integration-tests/ccip-tests/testconfig/global.go
@@ -175,6 +175,90 @@ type Common struct {
 func (p *Common) ReadFromEnvVar() error {
 	logger := logging.GetTestLogger(nil)
 
+	lokiTenantID := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_LOKI_TENANT_ID_ENV)
+	if lokiTenantID != "" {
+		if p.Logging == nil {
+			p.Logging = &ctfconfig.LoggingConfig{}
+		}
+		if p.Logging.Loki == nil {
+			p.Logging.Loki = &ctfconfig.LokiConfig{}
+		}
+		logger.Debug().Msgf("Using %s env var to override Logging.Loki.TenantId", ctfconfig.E2E_TEST_LOKI_TENANT_ID_ENV)
+		p.Logging.Loki.TenantId = &lokiTenantID
+	}
+
+	lokiEndpoint := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_LOKI_ENDPOINT_ENV)
+	if lokiEndpoint != "" {
+		if p.Logging == nil {
+			p.Logging = &ctfconfig.LoggingConfig{}
+		}
+		if p.Logging.Loki == nil {
+			p.Logging.Loki = &ctfconfig.LokiConfig{}
+		}
+		logger.Debug().Msgf("Using %s env var to override Logging.Loki.Endpoint", ctfconfig.E2E_TEST_LOKI_ENDPOINT_ENV)
+		p.Logging.Loki.Endpoint = &lokiEndpoint
+	}
+
+	lokiBasicAuth := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_LOKI_BASIC_AUTH_ENV)
+	if lokiBasicAuth != "" {
+		if p.Logging == nil {
+			p.Logging = &ctfconfig.LoggingConfig{}
+		}
+		if p.Logging.Loki == nil {
+			p.Logging.Loki = &ctfconfig.LokiConfig{}
+		}
+		logger.Debug().Msgf("Using %s env var to override Logging.Loki.BasicAuth", ctfconfig.E2E_TEST_LOKI_BASIC_AUTH_ENV)
+		p.Logging.Loki.BasicAuth = &lokiBasicAuth
+	}
+
+	lokiBearerToken := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_LOKI_BEARER_TOKEN_ENV)
+	if lokiBearerToken != "" {
+		if p.Logging == nil {
+			p.Logging = &ctfconfig.LoggingConfig{}
+		}
+		if p.Logging.Loki == nil {
+			p.Logging.Loki = &ctfconfig.LokiConfig{}
+		}
+		logger.Debug().Msgf("Using %s env var to override Logging.Loki.BearerToken", ctfconfig.E2E_TEST_LOKI_BEARER_TOKEN_ENV)
+		p.Logging.Loki.BearerToken = &lokiBearerToken
+	}
+
+	grafanaBaseUrl := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_GRAFANA_BASE_URL_ENV)
+	if grafanaBaseUrl != "" {
+		if p.Logging == nil {
+			p.Logging = &ctfconfig.LoggingConfig{}
+		}
+		if p.Logging.Grafana == nil {
+			p.Logging.Grafana = &ctfconfig.GrafanaConfig{}
+		}
+		logger.Debug().Msgf("Using %s env var to override Logging.Grafana.BaseUrl", ctfconfig.E2E_TEST_GRAFANA_BASE_URL_ENV)
+		p.Logging.Grafana.BaseUrl = &grafanaBaseUrl
+	}
+
+	grafanaDashboardUrl := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_GRAFANA_DASHBOARD_URL_ENV)
+	if grafanaDashboardUrl != "" {
+		if p.Logging == nil {
+			p.Logging = &ctfconfig.LoggingConfig{}
+		}
+		if p.Logging.Grafana == nil {
+			p.Logging.Grafana = &ctfconfig.GrafanaConfig{}
+		}
+		logger.Debug().Msgf("Using %s env var to override Logging.Grafana.DashboardUrl", ctfconfig.E2E_TEST_GRAFANA_DASHBOARD_URL_ENV)
+		p.Logging.Grafana.DashboardUrl = &grafanaDashboardUrl
+	}
+
+	grafanaBearerToken := ctfconfig.MustReadEnvVar_String(ctfconfig.E2E_TEST_GRAFANA_BEARER_TOKEN_ENV)
+	if grafanaBearerToken != "" {
+		if p.Logging == nil {
+			p.Logging = &ctfconfig.LoggingConfig{}
+		}
+		if p.Logging.Grafana == nil {
+			p.Logging.Grafana = &ctfconfig.GrafanaConfig{}
+		}
+		logger.Debug().Msgf("Using %s env var to override Logging.Grafana.BearerToken", ctfconfig.E2E_TEST_GRAFANA_BEARER_TOKEN_ENV)
+		p.Logging.Grafana.BearerToken = &grafanaBearerToken
+	}
+
 	selectedNetworks := ctfconfig.MustReadEnvVar_Strings(ctfconfig.E2E_TEST_SELECTED_NETWORK_ENV, ",")
 	if len(selectedNetworks) > 0 {
 		if p.Network == nil {

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -1234,7 +1234,8 @@ func CCIPDefaultTestSetUp(
 		setUpArgs.StartEventWatchers()
 	} else {
 		setUpArgs.SC = sentinel.NewSentinelCoordinator(*lggr)
-		setUpArgs.addChains()
+		err := setUpArgs.addChains()
+		require.NoError(t, err, "error adding chain to Sentinel")
 		setUpArgs.StartEventWatchersPolling()
 		t.Cleanup(func() {
 			if setUpArgs.SC != nil {
@@ -1277,16 +1278,23 @@ func useWebSocket(chainClientByChainID map[int64]blockchain.EVMClient) bool {
 	return true
 }
 
-func (o *CCIPTestSetUpOutputs) addChains() {
+func (o *CCIPTestSetUpOutputs) addChains() error {
 	for _, lane := range o.ReadLanes() {
 		// Add both forward and reverse lanes
-		o.addChainToSentinel(lane.ForwardLane.SourceChain)
-		o.addChainToSentinel(lane.ForwardLane.DestChain)
+		err := o.addChainToSentinel(lane.ForwardLane.SourceChain)
+		if err != nil {
+			return err
+		}
+		err = o.addChainToSentinel(lane.ForwardLane.DestChain)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // addChainToSentinel is a helper function to add a chain to Sentinel
-func (o *CCIPTestSetUpOutputs) addChainToSentinel(chain blockchain.EVMClient) {
+func (o *CCIPTestSetUpOutputs) addChainToSentinel(chain blockchain.EVMClient) error {
 	blockchainClient := blockchain_client_wrapper.NewGethClientWrapper(chain.GetEthClient())
 
 	// Define the chain poller service configuration
@@ -1298,8 +1306,9 @@ func (o *CCIPTestSetUpOutputs) addChainToSentinel(chain blockchain.EVMClient) {
 
 	// Add the chain to Sentinel
 	if err := o.SC.Sentinel.AddChain(addChainConfig); err != nil {
-		require.NoErrorf(nil, err, "error adding chain to Sentinel")
+		return err
 	}
+	return nil
 }
 
 // CreateEnvironment creates the environment for the test and registers the test clean-up function to tear down the set-up environment

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -1305,10 +1305,10 @@ func (o *CCIPTestSetUpOutputs) addChainToSentinel(chain blockchain.EVMClient) er
 	}
 
 	// Add the chain to Sentinel
-	if err := o.SC.Sentinel.AddChain(addChainConfig); err != nil {
-		return err
-	}
-	return nil
+	err := o.SC.Sentinel.AddChain(addChainConfig)
+
+	return err
+
 }
 
 // CreateEnvironment creates the environment for the test and registers the test clean-up function to tear down the set-up environment

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -1281,7 +1281,7 @@ func (o *CCIPTestSetUpOutputs) addChains() {
 	for _, lane := range o.ReadLanes() {
 		// Add both forward and reverse lanes
 		o.addChainToSentinel(lane.ForwardLane.SourceChain)
-		o.addChainToSentinel(lane.ReverseLane.SourceChain)
+		o.addChainToSentinel(lane.ForwardLane.DestChain)
 	}
 }
 

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -1308,7 +1308,6 @@ func (o *CCIPTestSetUpOutputs) addChainToSentinel(chain blockchain.EVMClient) er
 	err := o.SC.Sentinel.AddChain(addChainConfig)
 
 	return err
-
 }
 
 // CreateEnvironment creates the environment for the test and registers the test clean-up function to tear down the set-up environment

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -37,6 +37,8 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/k8s/environment"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/networks"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
+	"github.com/smartcontractkit/chainlink-testing-framework/sentinel"
+	"github.com/smartcontractkit/chainlink-testing-framework/sentinel/blockchain_client_wrapper"
 	tc "github.com/smartcontractkit/chainlink/integration-tests/testconfig"
 
 	integrationactions "github.com/smartcontractkit/chainlink/integration-tests/actions"
@@ -47,6 +49,7 @@ import (
 	ccipconfig "github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/testconfig"
 	"github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/testreporters"
 	testutils "github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/utils"
+
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
 )
 
@@ -577,6 +580,7 @@ type CCIPTestSetUpOutputs struct {
 	Balance                *actions.BalanceSheet
 	BootstrapAdded         *atomic.Bool
 	JobAddGrp              *errgroup.Group
+	SC                     *sentinel.SentinelCoordinator
 }
 
 func (o *CCIPTestSetUpOutputs) AddToLanes(lane *BiDirectionalLaneConfig) {
@@ -883,6 +887,17 @@ func (o *CCIPTestSetUpOutputs) StartEventWatchers() {
 		require.NoError(o.Cfg.Test, err)
 		if lane.ReverseLane != nil {
 			err = lane.ReverseLane.StartEventWatchers()
+			require.NoError(o.Cfg.Test, err)
+		}
+	}
+}
+
+func (o *CCIPTestSetUpOutputs) StartEventWatchersPolling() {
+	for _, lane := range o.ReadLanes() {
+		err := lane.ForwardLane.StartEventWatchersPolling(o.SC)
+		require.NoError(o.Cfg.Test, err)
+		if lane.ReverseLane != nil {
+			err = lane.ReverseLane.StartEventWatchersPolling(o.SC)
 			require.NoError(o.Cfg.Test, err)
 		}
 	}
@@ -1215,7 +1230,20 @@ func CCIPDefaultTestSetUp(
 	}
 
 	// start event watchers for all lanes
-	setUpArgs.StartEventWatchers()
+	if useWebSocket(chainClientByChainID) {
+		setUpArgs.StartEventWatchers()
+	} else {
+		setUpArgs.SC = sentinel.NewSentinelCoordinator(*lggr)
+		setUpArgs.addChains()
+		setUpArgs.StartEventWatchersPolling()
+		t.Cleanup(func() {
+			if setUpArgs.SC != nil {
+				lggr.Info().Msg("Closing Sentinel")
+				setUpArgs.SC.Sentinel.Close()
+			}
+		})
+	}
+
 	// now that lane configs are already dumped to file, we can clean up the lane config map
 	setUpArgs.LaneConfig = nil
 	setUpArgs.TearDown = func() error {
@@ -1238,6 +1266,40 @@ func CCIPDefaultTestSetUp(
 	}
 	lggr.Info().Msg("Test setup completed")
 	return setUpArgs
+}
+
+func useWebSocket(chainClientByChainID map[int64]blockchain.EVMClient) bool {
+	for _, c := range chainClientByChainID {
+		if !c.GetEthClient().Client().SupportsSubscriptions() {
+			return false
+		}
+	}
+	return true
+}
+
+func (o *CCIPTestSetUpOutputs) addChains() {
+	for _, lane := range o.ReadLanes() {
+		// Add both forward and reverse lanes
+		o.addChainToSentinel(lane.ForwardLane.SourceChain)
+		o.addChainToSentinel(lane.ReverseLane.SourceChain)
+	}
+}
+
+// addChainToSentinel is a helper function to add a chain to Sentinel
+func (o *CCIPTestSetUpOutputs) addChainToSentinel(chain blockchain.EVMClient) {
+	blockchainClient := blockchain_client_wrapper.NewGethClientWrapper(chain.GetEthClient())
+
+	// Define the chain poller service configuration
+	addChainConfig := sentinel.AddChainConfig{
+		ChainID:          chain.GetChainID().Int64(),
+		PollInterval:     30 * time.Second,
+		BlockchainClient: blockchainClient,
+	}
+
+	// Add the chain to Sentinel
+	if err := o.SC.Sentinel.AddChain(addChainConfig); err != nil {
+		require.NoErrorf(nil, err, "error adding chain to Sentinel")
+	}
 }
 
 // CreateEnvironment creates the environment for the test and registers the test clean-up function to tear down the set-up environment

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -54,8 +54,9 @@ require (
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.51.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0
+	github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.10
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2
 	github.com/smartcontractkit/libocr v0.0.0-20241223215956-e5b78d8e3919

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1465,10 +1465,12 @@ github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7 h1:E7k5
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7/go.mod h1:WYxCxAWpeXEHfhB0GaiV2sj21Ooh9r/Nf7tzmJgAibs=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22 h1:W3doYLVoZN8VwJb/kAZsbDjW+6cgZPgNTcQHJUH9JrA=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22/go.mod h1:70JLBXQncNHyW63ik4PvPQGjQGZ1xK67MKrDanVAk2w=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.51.0 h1:z7t2OhfE32KK4r5Nt3U0hOnbRwOwIbJs8i7kqKvjAA0=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.51.0/go.mod h1:y6pVvAT/R+YGocAqoQIat+AEaZz2Jdmj/0uUBmwvLCU=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
+github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2 h1:ihRlWrii5nr4RUuMu1hStTbwFvVuHUDoQQwXmCU5IdQ=
+github.com/smartcontractkit/chainlink-testing-framework/sentinel v0.1.2/go.mod h1:J1Za5EuI/vWDsQSIh6qbPXlVvuEhmHmnvLQBN0XVxqA=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.10 h1:Yf+n3T/fnUWcYyfe7bsygV4sWAkNo0QhN58APJFIKIc=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.10/go.mod h1:05duR85P8YHuIfIkA7sn2bvrhKo/pDpFKV2rliYHNOo=
 github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2 h1:7bCdbTUWzyczQg+kwHCxlx6y07zE8HNB8+ntTne6qd8=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250205140756-e0f1a86dfdb3
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250130202959-6f1f48342e36
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250206144234-88579df97ecd
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22
+	github.com/smartcontractkit/chainlink-testing-framework/lib v1.51.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.10
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1452,8 +1452,8 @@ github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7 h1:E7k5
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7/go.mod h1:WYxCxAWpeXEHfhB0GaiV2sj21Ooh9r/Nf7tzmJgAibs=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2 h1:GDGrC5OGiV0RyM1znYWehSQXyZQWTOzrEeJRYmysPCE=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2/go.mod h1:DsT43c1oTBmp3iQkMcoZOoKThwZvt8X3Pz6UmznJ4GY=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22 h1:W3doYLVoZN8VwJb/kAZsbDjW+6cgZPgNTcQHJUH9JrA=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22/go.mod h1:70JLBXQncNHyW63ik4PvPQGjQGZ1xK67MKrDanVAk2w=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.51.0 h1:z7t2OhfE32KK4r5Nt3U0hOnbRwOwIbJs8i7kqKvjAA0=
+github.com/smartcontractkit/chainlink-testing-framework/lib v1.51.0/go.mod h1:y6pVvAT/R+YGocAqoQIat+AEaZz2Jdmj/0uUBmwvLCU=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 h1:VIxK8u0Jd0Q/VuhmsNm6Bls6Tb31H/sA3A/rbc5hnhg=
 github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0/go.mod h1:lyAu+oMXdNUzEDScj2DXB2IueY+SDXPPfyl/kb63tMM=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.10 h1:Yf+n3T/fnUWcYyfe7bsygV4sWAkNo0QhN58APJFIKIc=


### PR DESCRIPTION
    - Pulls back in Grafana and Loki configs
    - Adds in missing config
    - Integrates Sentinel to allow for polling for fetching events in CCIP QA tests.

This pull request to `integration-tests/ccip-tests` includes changes to refactor event handling and improve logging configuration. The most important changes include the introduction of helper functions to process events, updates to the logging configuration, and modifications to the `ReceiverDapp` struct.

Refactoring event handling:

* [`integration-tests/ccip-tests/actions/ccip_helpers.go`](diffhunk://#diff-690ee40c4aed6971f9a47af22218de9b36387541a4b65b6a3a275e7e69dcb924L3574-R3576): Introduced new helper functions (`processSendRequestedEvent`, `processReportAcceptedEvent`, `processTaggedRootBlessedEvent`, `processExecutionStateChangedEvent`, `processMessageReceivedEvent`) to handle different events and replaced inline event handling code with calls to these helper functions. [[1]](diffhunk://#diff-690ee40c4aed6971f9a47af22218de9b36387541a4b65b6a3a275e7e69dcb924L3574-R3576) [[2]](diffhunk://#diff-690ee40c4aed6971f9a47af22218de9b36387541a4b65b6a3a275e7e69dcb924L3628-R3599) [[3]](diffhunk://#diff-690ee40c4aed6971f9a47af22218de9b36387541a4b65b6a3a275e7e69dcb924L3663-R3622) [[4]](diffhunk://#diff-690ee40c4aed6971f9a47af22218de9b36387541a4b65b6a3a275e7e69dcb924L3693-R3646) [[5]](diffhunk://#diff-690ee40c4aed6971f9a47af22218de9b36387541a4b65b6a3a275e7e69dcb924R3670-R3746) [[6]](diffhunk://#diff-690ee40c4aed6971f9a47af22218de9b36387541a4b65b6a3a275e7e69dcb924R3759-R3951)

Logging configuration improvements:

* [`integration-tests/ccip-tests/testconfig/global.go`](diffhunk://#diff-9592dd2b4f8e4d5244f5004406fb383efa438b6b0bfea0d0d6ad8fbedd5e8d77R178-R261): Added support for reading logging configuration (Loki and Grafana) from environment variables.
* [`integration-tests/ccip-tests/testconfig/README.md`](diffhunk://#diff-b47769974a5308ee298f4a6fbc7c82cbffba005ecd851660d1927676a05f2504R426-R451): Updated documentation to include logging configuration examples.

Struct modifications:

* `integration-tests/ccip-tests/contracts/contract_deployer.go`, `integration-tests/ccip-tests/contracts/contract_models.go`: Changed the `ReceiverDapp` struct to use `Instance` instead of `instance` for consistency. [[1]](diffhunk://#diff-bb6425014bae7d2701a1f45df427331c89ca8ef52c6091733bd995da7ac20521L812-R812) [[2]](diffhunk://#diff-bb6425014bae7d2701a1f45df427331c89ca8ef52c6091733bd995da7ac20521L831-R831) [[3]](diffhunk://#diff-b1f753ae2b74d5dc79183393af4fd54f2b4bfee89a023b83d1a1937c71618cbbL1081-R1081) [[4]](diffhunk://#diff-b1f753ae2b74d5dc79183393af4fd54f2b4bfee89a023b83d1a1937c71618cbbL1094-R1094) [[5]](diffhunk://#diff-b1f753ae2b74d5dc79183393af4fd54f2b4bfee89a023b83d1a1937c71618cbbL1109-R1110)

Debugging enhancements:

* [`integration-tests/ccip-tests/contracts/contract_models.go`](diffhunk://#diff-b1f753ae2b74d5dc79183393af4fd54f2b4bfee89a023b83d1a1937c71618cbbR1458-R1471): Added logging of transaction options in the `CCIPSend` function for better debugging.    

[SHIP-3971](https://smartcontract-it.atlassian.net/browse/SHIP-3971)

[SHIP-3971]: https://smartcontract-it.atlassian.net/browse/SHIP-3971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ