### PR TITLE
Update GoReleaser config to avoid adding duplicate images in manifests

### DIFF
--- a/.goreleaser.develop.yaml
+++ b/.goreleaser.develop.yaml
@@ -1,308 +1,300 @@
 version: 2
 project_name: chainlink
 env:
-    - IMG_PRE={{ if index .Env "IMAGE_PREFIX"  }}{{ .Env.IMAGE_PREFIX }}{{ else }}localhost:5001{{ end }}
-    - IMG_TAG={{ if index .Env "IMAGE_TAG" }}{{ .Env.IMAGE_TAG }}{{ else }}develop{{ end }}
-    - CGO_ENABLED=1
-    - VERSION={{ if index .Env "CHAINLINK_VERSION" }}{{ .Env.CHAINLINK_VERSION }}{{ else }}v0.0.0-local{{ end }}
+  - IMG_PRE={{ if index .Env "IMAGE_PREFIX"  }}{{ .Env.IMAGE_PREFIX }}{{ else }}localhost:5001{{ end }}
+  - IMG_TAG={{ if index .Env "IMAGE_TAG" }}{{ .Env.IMAGE_TAG }}{{ else }}develop{{ end }}
+  - CGO_ENABLED=1
+  - VERSION={{ if index .Env "CHAINLINK_VERSION" }}{{ .Env.CHAINLINK_VERSION }}{{ else }}v0.0.0-local{{ end }}
 release:
-    disable: "true"
+  disable: "true"
 builds:
-    - targets:
-        - go_first_class
-      binary: chainlink
-      hooks:
-        post:
-            - cmd: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }}
-      no_unique_dist_dir: "true"
-      ldflags:
-        - -s -w -r=$ORIGIN/libs
-        - -X github.com/smartcontractkit/chainlink/v2/core/static.Sha={{ .FullCommit }}
-        - |-
-          -extldflags "-Wl,--dynamic-linker={{ if contains .Runtime.Goarch "amd64" -}}
-          /lib64/ld-linux-x86-64.so.2
-          {{- else if contains .Runtime.Goarch "arm64" -}}
-          /lib/ld-linux-aarch64.so.1
-          {{- end }}"
-        - -X github.com/smartcontractkit/chainlink/v2/core/static.Version={{ .Env.VERSION }}
-      flags:
-        - -trimpath
-        - -buildmode=pie
-archives:
-    - format: binary
-snapshot:
-    version_template: '{{ .Env.VERSION }}-{{ .ShortCommit }}'
-checksum:
-    name_template: checksums.txt
-dockers:
-    - id: linux-amd64-chainlink
-      goos: linux
-      goarch: amd64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink:{{ .Env.IMG_TAG }}'
-        - '{{ .Env.IMG_PRE }}/chainlink:{{ .Env.IMG_TAG }}-amd64'
-        - '{{ .Env.IMG_PRE }}/chainlink:sha-{{ .ShortCommit }}-amd64'
-      extra_files:
-        - tmp/libs
-      build_flag_templates:
-        - --platform=linux/amd64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-amd64-chainlink-plugins
-      goos: linux
-      goarch: amd64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink:{{ .Env.IMG_TAG }}-plugins'
-        - '{{ .Env.IMG_PRE }}/chainlink:{{ .Env.IMG_TAG }}-plugins-amd64'
-        - '{{ .Env.IMG_PRE }}/chainlink:sha-{{ .ShortCommit }}-plugins-amd64'
-      extra_files:
-        - tmp/libs
-        - tmp/plugins
-      build_flag_templates:
-        - --platform=linux/amd64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
-        - --build-arg=CL_MERCURY_CMD=chainlink-mercury
-        - --build-arg=CL_SOLANA_CMD=chainlink-solana
-        - --build-arg=CL_STARKNET_CMD=chainlink-starknet
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-arm64-chainlink
-      goos: linux
-      goarch: arm64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink:{{ .Env.IMG_TAG }}-arm64'
-        - '{{ .Env.IMG_PRE }}/chainlink:sha-{{ .ShortCommit }}-arm64'
-      extra_files:
-        - tmp/libs
-      build_flag_templates:
-        - --platform=linux/arm64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-arm64-chainlink-plugins
-      goos: linux
-      goarch: arm64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink:{{ .Env.IMG_TAG }}-plugins-arm64'
-        - '{{ .Env.IMG_PRE }}/chainlink:sha-{{ .ShortCommit }}-plugins-arm64'
-      extra_files:
-        - tmp/libs
-        - tmp/plugins
-      build_flag_templates:
-        - --platform=linux/arm64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
-        - --build-arg=CL_MERCURY_CMD=chainlink-mercury
-        - --build-arg=CL_SOLANA_CMD=chainlink-solana
-        - --build-arg=CL_STARKNET_CMD=chainlink-starknet
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-amd64-ccip
-      goos: linux
-      goarch: amd64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/ccip:{{ .Env.IMG_TAG }}'
-        - '{{ .Env.IMG_PRE }}/ccip:{{ .Env.IMG_TAG }}-amd64'
-        - '{{ .Env.IMG_PRE }}/ccip:sha-{{ .ShortCommit }}-amd64'
-      extra_files:
-        - tmp/libs
-        - ccip/config
-      build_flag_templates:
-        - --platform=linux/amd64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-amd64-ccip-plugins
-      goos: linux
-      goarch: amd64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/ccip:{{ .Env.IMG_TAG }}-plugins'
-        - '{{ .Env.IMG_PRE }}/ccip:{{ .Env.IMG_TAG }}-plugins-amd64'
-        - '{{ .Env.IMG_PRE }}/ccip:sha-{{ .ShortCommit }}-plugins-amd64'
-      extra_files:
-        - tmp/libs
-        - tmp/plugins
-        - ccip/config
-      build_flag_templates:
-        - --platform=linux/amd64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
-        - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
-        - --build-arg=CL_MERCURY_CMD=chainlink-mercury
-        - --build-arg=CL_SOLANA_CMD=chainlink-solana
-        - --build-arg=CL_STARKNET_CMD=chainlink-starknet
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-arm64-ccip
-      goos: linux
-      goarch: arm64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/ccip:{{ .Env.IMG_TAG }}-arm64'
-        - '{{ .Env.IMG_PRE }}/ccip:sha-{{ .ShortCommit }}-arm64'
-      extra_files:
-        - tmp/libs
-        - ccip/config
-      build_flag_templates:
-        - --platform=linux/arm64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-arm64-ccip-plugins
-      goos: linux
-      goarch: arm64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/ccip:{{ .Env.IMG_TAG }}-plugins-arm64'
-        - '{{ .Env.IMG_PRE }}/ccip:sha-{{ .ShortCommit }}-plugins-arm64'
-      extra_files:
-        - tmp/libs
-        - tmp/plugins
-        - ccip/config
-      build_flag_templates:
-        - --platform=linux/arm64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
-        - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
-        - --build-arg=CL_MERCURY_CMD=chainlink-mercury
-        - --build-arg=CL_SOLANA_CMD=chainlink-solana
-        - --build-arg=CL_STARKNET_CMD=chainlink-starknet
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-docker_manifests:
-    - id: tagged-chainlink
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-arm64'
-    - id: sha-chainlink
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}-arm64'
-    - id: tagged-plugins-chainlink
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-plugins'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-plugins'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-plugins-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-plugins-arm64'
-    - id: sha-plugins-chainlink
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}-plugins'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}-plugins-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}-plugins-arm64'
-    - id: tagged-ccip
-      name_template: '{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}'
-        - '{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-arm64'
-    - id: sha-ccip
-      name_template: '{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}-arm64'
-    - id: tagged-plugins-ccip
-      name_template: '{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-plugins'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-plugins'
-        - '{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-plugins-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-plugins-arm64'
-    - id: sha-plugins-ccip
-      name_template: '{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}-plugins'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}-plugins-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}-plugins-arm64'
-changelog:
-    disable: "true"
-before:
+  - targets:
+      - go_first_class
+    binary: chainlink
     hooks:
-        - cmd: go mod tidy
-        - cmd: ./tools/bin/goreleaser_utils before_hook
+      post:
+        - cmd: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }}
+    no_unique_dist_dir: "true"
+    ldflags:
+      - -s -w -r=$ORIGIN/libs
+      - -X github.com/smartcontractkit/chainlink/v2/core/static.Sha={{ .FullCommit }}
+      - |-
+        -extldflags "-Wl,--dynamic-linker={{ if contains .Runtime.Goarch "amd64" -}}
+        /lib64/ld-linux-x86-64.so.2
+        {{- else if contains .Runtime.Goarch "arm64" -}}
+        /lib/ld-linux-aarch64.so.1
+        {{- end }}"
+      - -X github.com/smartcontractkit/chainlink/v2/core/static.Version={{ .Env.VERSION }}
+    flags:
+      - -trimpath
+      - -buildmode=pie
+archives:
+  - format: binary
+snapshot:
+  version_template: "{{ .Env.VERSION }}-{{ .ShortCommit }}"
+checksum:
+  name_template: checksums.txt
+dockers:
+  - id: linux-amd64-chainlink
+    goos: linux
+    goarch: amd64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink:{{ .Env.IMG_TAG }}-amd64"
+      - "{{ .Env.IMG_PRE }}/chainlink:sha-{{ .ShortCommit }}-amd64"
+    extra_files:
+      - tmp/libs
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-amd64-chainlink-plugins
+    goos: linux
+    goarch: amd64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink:{{ .Env.IMG_TAG }}-plugins-amd64"
+      - "{{ .Env.IMG_PRE }}/chainlink:sha-{{ .ShortCommit }}-plugins-amd64"
+    extra_files:
+      - tmp/libs
+      - tmp/plugins
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
+      - --build-arg=CL_MERCURY_CMD=chainlink-mercury
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
+      - --build-arg=CL_STARKNET_CMD=chainlink-starknet
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-arm64-chainlink
+    goos: linux
+    goarch: arm64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink:{{ .Env.IMG_TAG }}-arm64"
+      - "{{ .Env.IMG_PRE }}/chainlink:sha-{{ .ShortCommit }}-arm64"
+    extra_files:
+      - tmp/libs
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-arm64-chainlink-plugins
+    goos: linux
+    goarch: arm64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink:{{ .Env.IMG_TAG }}-plugins-arm64"
+      - "{{ .Env.IMG_PRE }}/chainlink:sha-{{ .ShortCommit }}-plugins-arm64"
+    extra_files:
+      - tmp/libs
+      - tmp/plugins
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
+      - --build-arg=CL_MERCURY_CMD=chainlink-mercury
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
+      - --build-arg=CL_STARKNET_CMD=chainlink-starknet
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-amd64-ccip
+    goos: linux
+    goarch: amd64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/ccip:{{ .Env.IMG_TAG }}-amd64"
+      - "{{ .Env.IMG_PRE }}/ccip:sha-{{ .ShortCommit }}-amd64"
+    extra_files:
+      - tmp/libs
+      - ccip/config
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-amd64-ccip-plugins
+    goos: linux
+    goarch: amd64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/ccip:{{ .Env.IMG_TAG }}-plugins-amd64"
+      - "{{ .Env.IMG_PRE }}/ccip:sha-{{ .ShortCommit }}-plugins-amd64"
+    extra_files:
+      - tmp/libs
+      - tmp/plugins
+      - ccip/config
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
+      - --build-arg=CL_MERCURY_CMD=chainlink-mercury
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
+      - --build-arg=CL_STARKNET_CMD=chainlink-starknet
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-arm64-ccip
+    goos: linux
+    goarch: arm64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/ccip:{{ .Env.IMG_TAG }}-arm64"
+      - "{{ .Env.IMG_PRE }}/ccip:sha-{{ .ShortCommit }}-arm64"
+    extra_files:
+      - tmp/libs
+      - ccip/config
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-arm64-ccip-plugins
+    goos: linux
+    goarch: arm64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/ccip:{{ .Env.IMG_TAG }}-plugins-arm64"
+      - "{{ .Env.IMG_PRE }}/ccip:sha-{{ .ShortCommit }}-plugins-arm64"
+    extra_files:
+      - tmp/libs
+      - tmp/plugins
+      - ccip/config
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
+      - --build-arg=CL_MERCURY_CMD=chainlink-mercury
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
+      - --build-arg=CL_STARKNET_CMD=chainlink-starknet
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+docker_manifests:
+  - id: tagged-chainlink
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}"
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-arm64"
+  - id: sha-chainlink
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}"
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}-arm64"
+  - id: tagged-plugins-chainlink
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-plugins"
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-plugins-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink:{{ .Env.IMG_TAG }}-plugins-arm64"
+  - id: sha-plugins-chainlink
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}-plugins"
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}-plugins-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink:sha-{{ .ShortCommit }}-plugins-arm64"
+  - id: tagged-ccip
+    name_template: "{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}"
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-arm64"
+  - id: sha-ccip
+    name_template: "{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}"
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}-arm64"
+  - id: tagged-plugins-ccip
+    name_template: "{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-plugins"
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-plugins-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/ccip:{{ .Env.IMG_TAG }}-plugins-arm64"
+  - id: sha-plugins-ccip
+    name_template: "{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}-plugins"
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}-plugins-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/ccip:sha-{{ .ShortCommit }}-plugins-arm64"
+changelog:
+  disable: "true"
+before:
+  hooks:
+    - cmd: go mod tidy
+    - cmd: ./tools/bin/goreleaser_utils before_hook
 partial:
-    by: target
+  by: target
 nightly:
-    version_template: '{{ .Env.VERSION }}-{{ .Env.IMG_TAG }}'
+  version_template: "{{ .Env.VERSION }}-{{ .Env.IMG_TAG }}"

--- a/.goreleaser.devspace.yaml
+++ b/.goreleaser.devspace.yaml
@@ -1,102 +1,102 @@
 version: 2
 project_name: chainlink
 env:
-    - IMG_PRE={{ if index .Env "IMAGE_PREFIX"  }}{{ .Env.IMAGE_PREFIX }}{{ else }}localhost:5001{{ end }}
-    - IMG_TAG={{ if index .Env "IMAGE_TAG" }}{{ .Env.IMAGE_TAG }}{{ else }}develop{{ end }}
-    - CGO_ENABLED=1
+  - IMG_PRE={{ if index .Env "IMAGE_PREFIX"  }}{{ .Env.IMAGE_PREFIX }}{{ else }}localhost:5001{{ end }}
+  - IMG_TAG={{ if index .Env "IMAGE_TAG" }}{{ .Env.IMAGE_TAG }}{{ else }}develop{{ end }}
+  - CGO_ENABLED=1
 release:
-    disable: "true"
+  disable: "true"
 builds:
-    - targets:
-        - go_first_class
-      binary: chainlink
-      hooks:
-        post:
-            - cmd: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }}
-      no_unique_dist_dir: "true"
-      ldflags:
-        - -s -w -r=$ORIGIN/libs
-        - -X github.com/smartcontractkit/chainlink/v2/core/static.Sha={{ .FullCommit }}
-        - |-
-          -extldflags "-Wl,--dynamic-linker={{ if contains .Runtime.Goarch "amd64" -}}
-          /lib64/ld-linux-x86-64.so.2
-          {{- else if contains .Runtime.Goarch "arm64" -}}
-          /lib/ld-linux-aarch64.so.1
-          {{- end }}"
-        - -X github.com/smartcontractkit/chainlink/v2/core/static.Version={{ .Version }}
-      flags:
-        - -trimpath
-        - -buildmode=pie
-archives:
-    - format: binary
-snapshot:
-    version_template: v0.0.0-{{ .Runtime.Goarch }}-{{ .Now.Format "2006-01-02-15-04-05Z" }}
-checksum:
-    name_template: checksums.txt
-dockers:
-    - id: linux-amd64
-      goos: linux
-      goarch: amd64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMAGE }}'
-      extra_files:
-        - tmp/libs
-        - tmp/plugins
-      build_flag_templates:
-        - --platform=linux/amd64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
-        - --build-arg=CL_MERCURY_CMD=chainlink-mercury
-        - --build-arg=CL_SOLANA_CMD=chainlink-solana
-        - --build-arg=CL_STARKNET_CMD=chainlink-starknet
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-      use: buildx
-    - id: linux-arm64
-      goos: linux
-      goarch: arm64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMAGE }}'
-      extra_files:
-        - tmp/libs
-        - tmp/plugins
-      build_flag_templates:
-        - --platform=linux/arm64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
-        - --build-arg=CL_MERCURY_CMD=chainlink-mercury
-        - --build-arg=CL_SOLANA_CMD=chainlink-solana
-        - --build-arg=CL_STARKNET_CMD=chainlink-starknet
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-      use: buildx
-docker_manifests:
-    - name_template: '{{ .Env.IMAGE }}'
-      image_templates:
-        - '{{ .Env.IMAGE }}'
-changelog:
-    disable: "true"
-before:
+  - targets:
+      - go_first_class
+    binary: chainlink
     hooks:
-        - cmd: go mod tidy
-        - cmd: ./tools/bin/goreleaser_utils before_hook
+      post:
+        - cmd: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }}
+    no_unique_dist_dir: "true"
+    ldflags:
+      - -s -w -r=$ORIGIN/libs
+      - -X github.com/smartcontractkit/chainlink/v2/core/static.Sha={{ .FullCommit }}
+      - |-
+        -extldflags "-Wl,--dynamic-linker={{ if contains .Runtime.Goarch "amd64" -}}
+        /lib64/ld-linux-x86-64.so.2
+        {{- else if contains .Runtime.Goarch "arm64" -}}
+        /lib/ld-linux-aarch64.so.1
+        {{- end }}"
+      - -X github.com/smartcontractkit/chainlink/v2/core/static.Version={{ .Version }}
+    flags:
+      - -trimpath
+      - -buildmode=pie
+archives:
+  - format: binary
+snapshot:
+  version_template: v0.0.0-{{ .Runtime.Goarch }}-{{ .Now.Format "2006-01-02-15-04-05Z" }}
+checksum:
+  name_template: checksums.txt
+dockers:
+  - id: linux-amd64
+    goos: linux
+    goarch: amd64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMAGE }}"
+    extra_files:
+      - tmp/libs
+      - tmp/plugins
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
+      - --build-arg=CL_MERCURY_CMD=chainlink-mercury
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
+      - --build-arg=CL_STARKNET_CMD=chainlink-starknet
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+    use: buildx
+  - id: linux-arm64
+    goos: linux
+    goarch: arm64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMAGE }}"
+    extra_files:
+      - tmp/libs
+      - tmp/plugins
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
+      - --build-arg=CL_MERCURY_CMD=chainlink-mercury
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
+      - --build-arg=CL_STARKNET_CMD=chainlink-starknet
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+    use: buildx
+docker_manifests:
+  - name_template: "{{ .Env.IMAGE }}"
+    image_templates:
+      - "{{ .Env.IMAGE }}"
+changelog:
+  disable: "true"
+before:
+  hooks:
+    - cmd: go mod tidy
+    - cmd: ./tools/bin/goreleaser_utils before_hook
 partial:
-    by: target
+  by: target
 nightly:
-    version_template: v0.0.0-{{ .Runtime.Goarch }}-{{ .Now.Format "2006-01-02-15-04-05Z" }}
+  version_template: v0.0.0-{{ .Runtime.Goarch }}-{{ .Now.Format "2006-01-02-15-04-05Z" }}

--- a/.goreleaser.production.yaml
+++ b/.goreleaser.production.yaml
@@ -1,330 +1,322 @@
 version: 2
 project_name: chainlink
 env:
-    - IMG_PRE={{ if index .Env "IMAGE_PREFIX"  }}{{ .Env.IMAGE_PREFIX }}{{ else }}localhost:5001{{ end }}
-    - IMG_TAG={{ if index .Env "IMAGE_TAG" }}{{ .Env.IMAGE_TAG }}{{ else }}develop{{ end }}
-    - CGO_ENABLED=1
-    - VERSION={{ if index .Env "CHAINLINK_VERSION" }}{{ .Env.CHAINLINK_VERSION }}{{ else }}v0.0.0-local{{ end }}
+  - IMG_PRE={{ if index .Env "IMAGE_PREFIX"  }}{{ .Env.IMAGE_PREFIX }}{{ else }}localhost:5001{{ end }}
+  - IMG_TAG={{ if index .Env "IMAGE_TAG" }}{{ .Env.IMAGE_TAG }}{{ else }}develop{{ end }}
+  - CGO_ENABLED=1
+  - VERSION={{ if index .Env "CHAINLINK_VERSION" }}{{ .Env.CHAINLINK_VERSION }}{{ else }}v0.0.0-local{{ end }}
 release:
-    disable: "true"
+  disable: "true"
 builds:
-    - targets:
-        - go_first_class
-      binary: chainlink
-      hooks:
-        post:
-            - cmd: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }}
-      no_unique_dist_dir: "true"
-      ldflags:
-        - -s -w -r=$ORIGIN/libs
-        - -X github.com/smartcontractkit/chainlink/v2/core/static.Sha={{ .FullCommit }}
-        - |-
-          -extldflags "-Wl,--dynamic-linker={{ if contains .Runtime.Goarch "amd64" -}}
-          /lib64/ld-linux-x86-64.so.2
-          {{- else if contains .Runtime.Goarch "arm64" -}}
-          /lib/ld-linux-aarch64.so.1
-          {{- end }}"
-        - -X github.com/smartcontractkit/chainlink/v2/core/static.Version={{ .Env.VERSION }}
-      flags:
-        - -trimpath
-        - -buildmode=pie
-archives:
-    - format: tar.gz
-snapshot:
-    version_template: '{{ .Env.VERSION }}-{{ .ShortCommit }}'
-checksum:
-    name_template: checksums.txt
-dockers:
-    - id: linux-amd64-chainlink
-      goos: linux
-      goarch: amd64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-amd64'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-amd64'
-      skip_push: '{{ contains .Tag "-ccip" }}'
-      extra_files:
-        - tmp/libs
-      build_flag_templates:
-        - --platform=linux/amd64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-amd64-chainlink-plugins
-      goos: linux
-      goarch: amd64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-amd64'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-amd64'
-      skip_push: '{{ contains .Tag "-ccip" }}'
-      extra_files:
-        - tmp/libs
-        - tmp/plugins
-      build_flag_templates:
-        - --platform=linux/amd64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
-        - --build-arg=CL_MERCURY_CMD=chainlink-mercury
-        - --build-arg=CL_SOLANA_CMD=chainlink-solana
-        - --build-arg=CL_STARKNET_CMD=chainlink-starknet
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-arm64-chainlink
-      goos: linux
-      goarch: arm64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-arm64'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-arm64'
-      skip_push: '{{ contains .Tag "-ccip" }}'
-      extra_files:
-        - tmp/libs
-      build_flag_templates:
-        - --platform=linux/arm64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-arm64-chainlink-plugins
-      goos: linux
-      goarch: arm64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-arm64'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-arm64'
-      skip_push: '{{ contains .Tag "-ccip" }}'
-      extra_files:
-        - tmp/libs
-        - tmp/plugins
-      build_flag_templates:
-        - --platform=linux/arm64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
-        - --build-arg=CL_MERCURY_CMD=chainlink-mercury
-        - --build-arg=CL_SOLANA_CMD=chainlink-solana
-        - --build-arg=CL_STARKNET_CMD=chainlink-starknet
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-amd64-ccip
-      goos: linux
-      goarch: amd64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-amd64'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-amd64'
-      skip_push: '{{ not (contains .Tag "-ccip") }}'
-      extra_files:
-        - tmp/libs
-        - ccip/config
-      build_flag_templates:
-        - --platform=linux/amd64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-amd64-ccip-plugins
-      goos: linux
-      goarch: amd64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-amd64'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-amd64'
-      skip_push: '{{ not (contains .Tag "-ccip") }}'
-      extra_files:
-        - tmp/libs
-        - tmp/plugins
-        - ccip/config
-      build_flag_templates:
-        - --platform=linux/amd64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
-        - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
-        - --build-arg=CL_MERCURY_CMD=chainlink-mercury
-        - --build-arg=CL_SOLANA_CMD=chainlink-solana
-        - --build-arg=CL_STARKNET_CMD=chainlink-starknet
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-arm64-ccip
-      goos: linux
-      goarch: arm64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-arm64'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-arm64'
-      skip_push: '{{ not (contains .Tag "-ccip") }}'
-      extra_files:
-        - tmp/libs
-        - ccip/config
-      build_flag_templates:
-        - --platform=linux/arm64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-    - id: linux-arm64-ccip-plugins
-      goos: linux
-      goarch: arm64
-      dockerfile: core/chainlink.goreleaser.Dockerfile
-      image_templates:
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-arm64'
-        - '{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-arm64'
-      skip_push: '{{ not (contains .Tag "-ccip") }}'
-      extra_files:
-        - tmp/libs
-        - tmp/plugins
-        - ccip/config
-      build_flag_templates:
-        - --platform=linux/arm64
-        - --pull
-        - --build-arg=CHAINLINK_USER=chainlink
-        - --build-arg=COMMIT_SHA={{ .FullCommit }}
-        - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
-        - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
-        - --build-arg=CL_MERCURY_CMD=chainlink-mercury
-        - --build-arg=CL_SOLANA_CMD=chainlink-solana
-        - --build-arg=CL_STARKNET_CMD=chainlink-starknet
-        - --label=org.opencontainers.image.created={{ .Date }}
-        - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
-        - --label=org.opencontainers.image.licenses=MIT
-        - --label=org.opencontainers.image.revision={{ .FullCommit }}
-        - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.title=chainlink
-        - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
-        - --label=org.opencontainers.image.version={{ .Env.VERSION }}
-      use: buildx
-docker_manifests:
-    - id: tagged-chainlink-chainlink-experimental-goreleaser
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}'
-      skip_push: '{{ contains .Tag "-ccip" }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-arm64'
-    - id: sha-chainlink-chainlink-experimental-goreleaser
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}'
-      skip_push: '{{ contains .Tag "-ccip" }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-arm64'
-    - id: tagged-plugins-chainlink-chainlink-experimental-goreleaser
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins'
-      skip_push: '{{ contains .Tag "-ccip" }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-arm64'
-    - id: sha-plugins-chainlink-chainlink-experimental-goreleaser
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins'
-      skip_push: '{{ contains .Tag "-ccip" }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-arm64'
-    - id: tagged-chainlink-chainlink-ccip-experimental-goreleaser
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}'
-      skip_push: '{{ not (contains .Tag "-ccip") }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-arm64'
-    - id: sha-chainlink-chainlink-ccip-experimental-goreleaser
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}'
-      skip_push: '{{ not (contains .Tag "-ccip") }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-arm64'
-    - id: tagged-plugins-chainlink-chainlink-ccip-experimental-goreleaser
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins'
-      skip_push: '{{ not (contains .Tag "-ccip") }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-arm64'
-    - id: sha-plugins-chainlink-chainlink-ccip-experimental-goreleaser
-      name_template: '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins'
-      skip_push: '{{ not (contains .Tag "-ccip") }}'
-      image_templates:
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-amd64'
-        - '{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-arm64'
-changelog:
-    filters:
-        exclude:
-            - '^docs:'
-            - '^test:'
-    sort: asc
-before:
+  - targets:
+      - go_first_class
+    binary: chainlink
     hooks:
-        - cmd: go mod tidy
-        - cmd: ./tools/bin/goreleaser_utils before_hook
+      post:
+        - cmd: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }}
+    no_unique_dist_dir: "true"
+    ldflags:
+      - -s -w -r=$ORIGIN/libs
+      - -X github.com/smartcontractkit/chainlink/v2/core/static.Sha={{ .FullCommit }}
+      - |-
+        -extldflags "-Wl,--dynamic-linker={{ if contains .Runtime.Goarch "amd64" -}}
+        /lib64/ld-linux-x86-64.so.2
+        {{- else if contains .Runtime.Goarch "arm64" -}}
+        /lib/ld-linux-aarch64.so.1
+        {{- end }}"
+      - -X github.com/smartcontractkit/chainlink/v2/core/static.Version={{ .Env.VERSION }}
+    flags:
+      - -trimpath
+      - -buildmode=pie
+archives:
+  - format: tar.gz
+snapshot:
+  version_template: "{{ .Env.VERSION }}-{{ .ShortCommit }}"
+checksum:
+  name_template: checksums.txt
+dockers:
+  - id: linux-amd64-chainlink
+    goos: linux
+    goarch: amd64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-amd64"
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-amd64"
+    skip_push: '{{ contains .Tag "-ccip" }}'
+    extra_files:
+      - tmp/libs
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-amd64-chainlink-plugins
+    goos: linux
+    goarch: amd64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-amd64"
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-amd64"
+    skip_push: '{{ contains .Tag "-ccip" }}'
+    extra_files:
+      - tmp/libs
+      - tmp/plugins
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
+      - --build-arg=CL_MERCURY_CMD=chainlink-mercury
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
+      - --build-arg=CL_STARKNET_CMD=chainlink-starknet
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-arm64-chainlink
+    goos: linux
+    goarch: arm64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-arm64"
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-arm64"
+    skip_push: '{{ contains .Tag "-ccip" }}'
+    extra_files:
+      - tmp/libs
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-arm64-chainlink-plugins
+    goos: linux
+    goarch: arm64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-arm64"
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-arm64"
+    skip_push: '{{ contains .Tag "-ccip" }}'
+    extra_files:
+      - tmp/libs
+      - tmp/plugins
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
+      - --build-arg=CL_MERCURY_CMD=chainlink-mercury
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
+      - --build-arg=CL_STARKNET_CMD=chainlink-starknet
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-amd64-ccip
+    goos: linux
+    goarch: amd64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-amd64"
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-amd64"
+    skip_push: '{{ not (contains .Tag "-ccip") }}'
+    extra_files:
+      - tmp/libs
+      - ccip/config
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-amd64-ccip-plugins
+    goos: linux
+    goarch: amd64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-amd64"
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-amd64"
+    skip_push: '{{ not (contains .Tag "-ccip") }}'
+    extra_files:
+      - tmp/libs
+      - tmp/plugins
+      - ccip/config
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
+      - --build-arg=CL_MERCURY_CMD=chainlink-mercury
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
+      - --build-arg=CL_STARKNET_CMD=chainlink-starknet
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-arm64-ccip
+    goos: linux
+    goarch: arm64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-arm64"
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-arm64"
+    skip_push: '{{ not (contains .Tag "-ccip") }}'
+    extra_files:
+      - tmp/libs
+      - ccip/config
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+  - id: linux-arm64-ccip-plugins
+    goos: linux
+    goarch: arm64
+    dockerfile: core/chainlink.goreleaser.Dockerfile
+    image_templates:
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-arm64"
+      - "{{ .Env.IMG_PRE }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-arm64"
+    skip_push: '{{ not (contains .Tag "-ccip") }}'
+    extra_files:
+      - tmp/libs
+      - tmp/plugins
+      - ccip/config
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --pull
+      - --build-arg=CHAINLINK_USER=chainlink
+      - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
+      - --build-arg=CL_MERCURY_CMD=chainlink-mercury
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
+      - --build-arg=CL_STARKNET_CMD=chainlink-starknet
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.source=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.title=chainlink
+      - --label=org.opencontainers.image.url=https://github.com/smartcontractkit/chainlink
+      - --label=org.opencontainers.image.version={{ .Env.VERSION }}
+    use: buildx
+docker_manifests:
+  - id: tagged-chainlink-chainlink-experimental-goreleaser
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}"
+    skip_push: '{{ contains .Tag "-ccip" }}'
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-arm64"
+  - id: sha-chainlink-chainlink-experimental-goreleaser
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}"
+    skip_push: '{{ contains .Tag "-ccip" }}'
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-arm64"
+  - id: tagged-plugins-chainlink-chainlink-experimental-goreleaser
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins"
+    skip_push: '{{ contains .Tag "-ccip" }}'
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-arm64"
+  - id: sha-plugins-chainlink-chainlink-experimental-goreleaser
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins"
+    skip_push: '{{ contains .Tag "-ccip" }}'
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-arm64"
+  - id: tagged-chainlink-chainlink-ccip-experimental-goreleaser
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}"
+    skip_push: '{{ not (contains .Tag "-ccip") }}'
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-arm64"
+  - id: sha-chainlink-chainlink-ccip-experimental-goreleaser
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}"
+    skip_push: '{{ not (contains .Tag "-ccip") }}'
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-arm64"
+  - id: tagged-plugins-chainlink-chainlink-ccip-experimental-goreleaser
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins"
+    skip_push: '{{ not (contains .Tag "-ccip") }}'
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:{{ .Env.IMG_TAG }}-plugins-arm64"
+  - id: sha-plugins-chainlink-chainlink-ccip-experimental-goreleaser
+    name_template: "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins"
+    skip_push: '{{ not (contains .Tag "-ccip") }}'
+    image_templates:
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/chainlink/chainlink-ccip-experimental-goreleaser:sha-{{ .ShortCommit }}-plugins-arm64"
+changelog:
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+  sort: asc
+before:
+  hooks:
+    - cmd: go mod tidy
+    - cmd: ./tools/bin/goreleaser_utils before_hook
 sboms:
-    - artifacts: archive
+  - artifacts: archive
 partial:
-    by: target
+  by: target
 nightly:
-    version_template: '{{ .Env.VERSION }}-{{ .Env.IMG_TAG }}'
+  version_template: "{{ .Env.VERSION }}-{{ .Env.IMG_TAG }}"


### PR DESCRIPTION
[Diff ignoring whitespace changes](https://github.com/smartcontractkit/chainlink/pull/16155/files?diff=unified&w=1)

```
❯ docker images|grep pr-16122
chainlink   pr-16122-bbf3e3b-plugins-arm64   e51b00dcfb8b   33 minutes ago   1.35GB
chainlink   pr-16122-bbf3e3b-plugins         236a8970ddea   33 minutes ago   4.11GB
chainlink   pr-16122-bbf3e3b-arm64           68a0e040d33f   33 minutes ago   595MB
chainlink   pr-16122-bbf3e3b                 afb321755057   33 minutes ago   1.76GB
chainlink   pr-16122-bbf3e3b-plugins-amd64   b8a44c5b8153   34 minutes ago   1.38GB
chainlink   pr-16122-bbf3e3b-amd64           675608235ebf   34 minutes ago   584MB
```

The size of the manifest is 4.11 GB. If we inspect the manifest, we can see that we're adding the amd64 image twice to the manifest:

```
❯ docker manifest inspect chainlink:pr-16122-bbf3e3b-plugins

{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2416,
         "digest": "sha256:b8a44c5b8153a67e2ca6a055ad1faba48b6f66daab5a2e84da05393abc394ad0",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2416,
         "digest": "sha256:e51b00dcfb8bb21956a23db9457dea16988e37a6ea6e1839d92e72a8867e725d",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2416,
         "digest": "sha256:b8a44c5b8153a67e2ca6a055ad1faba48b6f66daab5a2e84da05393abc394ad0",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      }
   ]
}
```