### PR TITLE
feat(deployment): changesets to deploy and initialize mcms contracts in Solana

### DIFF
--- a/deployment/ccip/changeset/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/cs_deploy_chain_test.go
@@ -29,10 +29,10 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 	nodes, err := deployment.NodeInfo(e.NodeIDs, e.Offchain)
 	require.NoError(t, err)
 	p2pIds := nodes.NonBootstraps().PeerIDs()
-	cfg := make(map[uint64]commontypes.MCMSWithTimelockConfig)
+	cfg := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 	contractParams := make(map[uint64]changeset.ChainContractParams)
 	for _, chain := range e.AllChainSelectors() {
-		cfg[chain] = proposalutils.SingleGroupTimelockConfig(t)
+		cfg[chain] = proposalutils.SingleGroupTimelockConfigV2(t)
 		contractParams[chain] = changeset.ChainContractParams{
 			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
 			OffRampParams:   changeset.DefaultOffRampParams(),
@@ -63,7 +63,7 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 			evmSelectors,
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
 			cfg,
 		),
 		commonchangeset.Configure(

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -32,10 +32,10 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	solChainSelectors := e.AllChainSelectorsSolana()
 	nodes, err := deployment.NodeInfo(e.NodeIDs, e.Offchain)
 	require.NoError(t, err)
-	cfg := make(map[uint64]commontypes.MCMSWithTimelockConfig)
+	cfg := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 	contractParams := make(map[uint64]changeset.ChainContractParams)
 	for _, chain := range e.AllChainSelectors() {
-		cfg[chain] = proposalutils.SingleGroupTimelockConfig(t)
+		cfg[chain] = proposalutils.SingleGroupTimelockConfigV2(t)
 		contractParams[chain] = changeset.ChainContractParams{
 			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
 			OffRampParams:   changeset.DefaultOffRampParams(),
@@ -72,7 +72,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 		),
 
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
 			cfg,
 		),
 		commonchangeset.Configure(

--- a/deployment/ccip/changeset/solana_state.go
+++ b/deployment/ccip/changeset/solana_state.go
@@ -27,8 +27,8 @@ var (
 	TokenPoolLookupTable deployment.ContractType = "TokenPoolLookupTable"
 )
 
-// SolChainState holds a Go binding for all the currently deployed CCIP programs
-// on a chain. If a binding is nil, it means here is no such contract on the chain.
+// SolCCIPChainState holds public keys for all the currently deployed CCIP programs
+// on a chain. If a key has zero value, it means the program does not exist on the chain.
 type SolCCIPChainState struct {
 	LinkToken                 solana.PublicKey
 	Router                    solana.PublicKey

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -419,9 +419,9 @@ func NewEnvironmentWithPrerequisitesContracts(t *testing.T, tEnv TestEnvironment
 	if len(solChains) > 0 {
 		SavePreloadedSolAddresses(t, e.Env, solChains[0])
 	}
-	mcmsCfg := make(map[uint64]commontypes.MCMSWithTimelockConfig)
+	mcmsCfg := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 	for _, c := range e.Env.AllChainSelectors() {
-		mcmsCfg[c] = proposalutils.SingleGroupTimelockConfig(t)
+		mcmsCfg[c] = proposalutils.SingleGroupTimelockConfigV2(t)
 	}
 	prereqCfg := make([]changeset.DeployPrerequisiteConfigPerChain, 0)
 	for _, chain := range evmChains {
@@ -461,7 +461,7 @@ func NewEnvironmentWithPrerequisitesContracts(t *testing.T, tEnv TestEnvironment
 			},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
 			mcmsCfg,
 		),
 	)

--- a/deployment/ccip/changeset/testhelpers/test_token_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_token_helpers.go
@@ -44,9 +44,9 @@ func SetupTwoChainEnvironmentWithTokens(
 		}
 	}
 
-	mcmsCfg := make(map[uint64]commontypes.MCMSWithTimelockConfig)
+	mcmsCfg := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 	for _, selector := range selectors {
-		mcmsCfg[selector] = proposalutils.SingleGroupTimelockConfig(t)
+		mcmsCfg[selector] = proposalutils.SingleGroupTimelockConfigV2(t)
 	}
 
 	// Deploy one burn-mint token per chain to use in the tests
@@ -82,7 +82,7 @@ func SetupTwoChainEnvironmentWithTokens(
 			changeset.DeployPrerequisiteConfig{Configs: prereqCfg},
 		),
 		commoncs.Configure(
-			deployment.CreateLegacyChangeSet(commoncs.DeployMCMSWithTimelock),
+			deployment.CreateLegacyChangeSet(commoncs.DeployMCMSWithTimelockV2),
 			mcmsCfg,
 		),
 	)

--- a/deployment/common/changeset/deploy_mcms_with_timelock.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock.go
@@ -6,16 +6,23 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/gagliardetto/solana-go"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/internal"
+	evminternal "github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/evm"
+	solanainternal "github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/solana"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
-var _ deployment.ChangeSet[map[uint64]types.MCMSWithTimelockConfig] = DeployMCMSWithTimelock
+var (
+	_ deployment.ChangeSet[map[uint64]types.MCMSWithTimelockConfig]   = DeployMCMSWithTimelock
+	_ deployment.ChangeSet[map[uint64]types.MCMSWithTimelockConfigV2] = DeployMCMSWithTimelockV2
+)
 
+// DeployMCMSWithTimelock deploys and initializes the MCM and Timelock contracts
+// Deprecated: use DeployMCMSWithTimelockV2 instead
 func DeployMCMSWithTimelock(e deployment.Environment, cfgByChain map[uint64]types.MCMSWithTimelockConfig) (deployment.ChangesetOutput, error) {
 	newAddresses := deployment.NewMemoryAddressBook()
 	err := internal.DeployMCMSWithTimelockContractsBatch(
@@ -24,6 +31,40 @@ func DeployMCMSWithTimelock(e deployment.Environment, cfgByChain map[uint64]type
 	if err != nil {
 		return deployment.ChangesetOutput{AddressBook: newAddresses}, err
 	}
+	return deployment.ChangesetOutput{AddressBook: newAddresses}, nil
+}
+
+// DeployMCMSWithTimelockV2 deploys and initializes the MCM and Timelock contracts
+func DeployMCMSWithTimelockV2(
+	env deployment.Environment, cfgByChain map[uint64]types.MCMSWithTimelockConfigV2,
+) (deployment.ChangesetOutput, error) {
+	newAddresses := deployment.NewMemoryAddressBook()
+
+	for chainSel, cfg := range cfgByChain {
+		family, err := chain_selectors.GetSelectorFamily(chainSel)
+		if err != nil {
+			return deployment.ChangesetOutput{AddressBook: newAddresses}, err
+		}
+
+		switch family {
+		case chain_selectors.FamilyEVM:
+			_, err := evminternal.DeployMCMSWithTimelockContractsEVM(env.Logger, env.Chains[chainSel], newAddresses, cfg)
+			if err != nil {
+				return deployment.ChangesetOutput{AddressBook: newAddresses}, err
+			}
+
+		case chain_selectors.FamilySolana:
+			_, err := solanainternal.DeployMCMSWithTimelockProgramsSolana(env, env.SolChains[chainSel], newAddresses, cfg)
+			if err != nil {
+				return deployment.ChangesetOutput{AddressBook: newAddresses}, err
+			}
+
+		default:
+			err = fmt.Errorf("unsupported chain family: %s", family)
+			return deployment.ChangesetOutput{AddressBook: newAddresses}, err
+		}
+	}
+
 	return deployment.ChangesetOutput{AddressBook: newAddresses}, nil
 }
 

--- a/deployment/common/changeset/deploy_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock_test.go
@@ -124,16 +124,14 @@ func TestDeployMCMSWithTimelockV2(t *testing.T) {
 			TimelockMinDelay: big.NewInt(2),
 		},
 	}
-	changesetApplication := []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
-			Config:    changesetConfig,
-		},
-	}
+	configuredChangeset := commonchangeset.Configure(
+		deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
+		changesetConfig,
+	)
 	setPreloadedSolanaAddresses(t, env, solanaSelectors[0])
 
 	// --- act ---
-	updatedEnv, err := commonchangeset.ApplyChangesets(t, env, nil, changesetApplication)
+	updatedEnv, err := commonchangeset.Apply(t, env, nil, configuredChangeset)
 	require.NoError(t, err)
 
 	evmState, err := mcmschangesetstate.MaybeLoadMCMSWithTimelockState(updatedEnv, evmSelectors)

--- a/deployment/common/changeset/deploy_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock_test.go
@@ -1,0 +1,280 @@
+//nolint:testifylint // inverting want and got is more succinct
+package changeset_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gagliardetto/solana-go"
+	"github.com/google/go-cmp/cmp"
+	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
+	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	solanainternal "github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/solana"
+	mcmschangesetstate "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestDeployMCMSWithTimelockV2(t *testing.T) {
+	// --- arrange ---
+	log := logger.TestLogger(t)
+	envConfig := memory.MemoryEnvironmentConfig{Chains: 2, SolChains: 1}
+	env := memory.NewMemoryEnvironment(t, log, zapcore.InfoLevel, envConfig)
+	evmSelectors := env.AllChainSelectors()
+	solanaSelectors := env.AllChainSelectorsSolana()
+	changesetConfig := map[uint64]commontypes.MCMSWithTimelockConfigV2{
+		evmSelectors[0]: {
+			Proposer: mcmstypes.Config{
+				Quorum:  1,
+				Signers: []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")},
+				GroupSigners: []mcmstypes.Config{
+					{
+						Quorum:       1,
+						Signers:      []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000002")},
+						GroupSigners: []mcmstypes.Config{},
+					},
+				},
+			},
+			Canceller: mcmstypes.Config{
+				Quorum:       1,
+				Signers:      []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000003")},
+				GroupSigners: []mcmstypes.Config{},
+			},
+			Bypasser: mcmstypes.Config{
+				Quorum:       1,
+				Signers:      []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000004")},
+				GroupSigners: []mcmstypes.Config{},
+			},
+			TimelockMinDelay: big.NewInt(0),
+		},
+		evmSelectors[1]: {
+			Proposer: mcmstypes.Config{
+				Quorum:       1,
+				Signers:      []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000011")},
+				GroupSigners: []mcmstypes.Config{},
+			},
+			Canceller: mcmstypes.Config{
+				Quorum: 2,
+				Signers: []common.Address{
+					common.HexToAddress("0x0000000000000000000000000000000000000012"),
+					common.HexToAddress("0x0000000000000000000000000000000000000013"),
+					common.HexToAddress("0x0000000000000000000000000000000000000014"),
+				},
+				GroupSigners: []mcmstypes.Config{},
+			},
+			Bypasser: mcmstypes.Config{
+				Quorum:       1,
+				Signers:      []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000005")},
+				GroupSigners: []mcmstypes.Config{},
+			},
+			TimelockMinDelay: big.NewInt(1),
+		},
+		solanaSelectors[0]: {
+			Proposer: mcmstypes.Config{
+				Quorum: 1,
+				Signers: []common.Address{
+					common.HexToAddress("0x0000000000000000000000000000000000000021"),
+					common.HexToAddress("0x0000000000000000000000000000000000000022"),
+				},
+				GroupSigners: []mcmstypes.Config{
+					{
+						Quorum: 2,
+						Signers: []common.Address{
+							common.HexToAddress("0x0000000000000000000000000000000000000023"),
+							common.HexToAddress("0x0000000000000000000000000000000000000024"),
+							common.HexToAddress("0x0000000000000000000000000000000000000025"),
+						},
+						GroupSigners: []mcmstypes.Config{
+							{
+								Quorum: 1,
+								Signers: []common.Address{
+									common.HexToAddress("0x0000000000000000000000000000000000000026"),
+								},
+								GroupSigners: []mcmstypes.Config{},
+							},
+						},
+					},
+				},
+			},
+			Canceller: mcmstypes.Config{
+				Quorum: 1,
+				Signers: []common.Address{
+					common.HexToAddress("0x0000000000000000000000000000000000000027"),
+				},
+				GroupSigners: []mcmstypes.Config{},
+			},
+			Bypasser: mcmstypes.Config{
+				Quorum: 1,
+				Signers: []common.Address{
+					common.HexToAddress("0x0000000000000000000000000000000000000028"),
+					common.HexToAddress("0x0000000000000000000000000000000000000029"),
+				},
+				GroupSigners: []mcmstypes.Config{},
+			},
+			TimelockMinDelay: big.NewInt(2),
+		},
+	}
+	changesetApplication := []commonchangeset.ChangesetApplication{
+		{
+			Changeset: commonchangeset.WrapChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
+			Config:    changesetConfig,
+		},
+	}
+	setPreloadedSolanaAddresses(t, env, solanaSelectors[0])
+
+	// --- act ---
+	updatedEnv, err := commonchangeset.ApplyChangesets(t, env, nil, changesetApplication)
+	require.NoError(t, err)
+
+	evmState, err := mcmschangesetstate.MaybeLoadMCMSWithTimelockState(updatedEnv, evmSelectors)
+	require.NoError(t, err)
+	solanaState, err := mcmschangesetstate.MaybeLoadMCMSWithTimelockStateSolana(updatedEnv, solanaSelectors)
+	require.NoError(t, err)
+
+	// --- assert ---
+	require.Len(t, evmState, 2)
+	require.Len(t, solanaState, 1)
+
+	// evm chain 0
+	evmState0 := evmState[evmSelectors[0]]
+	evmInspector := mcmsevmsdk.NewInspector(updatedEnv.Chains[evmSelectors[0]].Client)
+	evmTimelockInspector := mcmsevmsdk.NewTimelockInspector(updatedEnv.Chains[evmSelectors[0]].Client)
+
+	config, err := evmInspector.GetConfig(updatedEnv.GetContext(), evmState0.ProposerMcm.Address().Hex())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[0]].Proposer))
+
+	config, err = evmInspector.GetConfig(updatedEnv.GetContext(), evmState0.CancellerMcm.Address().Hex())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[0]].Canceller))
+
+	config, err = evmInspector.GetConfig(updatedEnv.GetContext(), evmState0.BypasserMcm.Address().Hex())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[0]].Bypasser))
+
+	proposers, err := evmTimelockInspector.GetProposers(updatedEnv.GetContext(), evmState0.Timelock.Address().Hex())
+	require.NoError(t, err)
+	require.Equal(t, proposers, []string{evmState0.ProposerMcm.Address().Hex()})
+
+	executors, err := evmTimelockInspector.GetExecutors(updatedEnv.GetContext(), evmState0.Timelock.Address().Hex())
+	require.NoError(t, err)
+	require.Equal(t, executors, []string{evmState0.CallProxy.Address().Hex()})
+
+	cancellers, err := evmTimelockInspector.GetCancellers(updatedEnv.GetContext(), evmState0.Timelock.Address().Hex())
+	require.NoError(t, err)
+	require.ElementsMatch(t, cancellers, []string{
+		evmState0.CancellerMcm.Address().Hex(),
+		evmState0.ProposerMcm.Address().Hex(),
+		evmState0.BypasserMcm.Address().Hex(),
+	})
+
+	bypassers, err := evmTimelockInspector.GetBypassers(updatedEnv.GetContext(), evmState0.Timelock.Address().Hex())
+	require.NoError(t, err)
+	require.Equal(t, bypassers, []string{evmState0.BypasserMcm.Address().Hex()})
+
+	// evm chain 1
+	evmState1 := evmState[evmSelectors[1]]
+	evmInspector = mcmsevmsdk.NewInspector(updatedEnv.Chains[evmSelectors[1]].Client)
+	evmTimelockInspector = mcmsevmsdk.NewTimelockInspector(updatedEnv.Chains[evmSelectors[1]].Client)
+
+	config, err = evmInspector.GetConfig(updatedEnv.GetContext(), evmState1.ProposerMcm.Address().Hex())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[1]].Proposer))
+
+	config, err = evmInspector.GetConfig(updatedEnv.GetContext(), evmState1.CancellerMcm.Address().Hex())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[1]].Canceller))
+
+	config, err = evmInspector.GetConfig(updatedEnv.GetContext(), evmState1.BypasserMcm.Address().Hex())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[1]].Bypasser))
+
+	proposers, err = evmTimelockInspector.GetProposers(updatedEnv.GetContext(), evmState1.Timelock.Address().Hex())
+	require.NoError(t, err)
+	require.Equal(t, proposers, []string{evmState1.ProposerMcm.Address().Hex()})
+
+	executors, err = evmTimelockInspector.GetExecutors(updatedEnv.GetContext(), evmState1.Timelock.Address().Hex())
+	require.NoError(t, err)
+	require.Equal(t, executors, []string{evmState1.CallProxy.Address().Hex()})
+
+	cancellers, err = evmTimelockInspector.GetCancellers(updatedEnv.GetContext(), evmState1.Timelock.Address().Hex())
+	require.NoError(t, err)
+	require.ElementsMatch(t, cancellers, []string{
+		evmState1.CancellerMcm.Address().Hex(),
+		evmState1.ProposerMcm.Address().Hex(),
+		evmState1.BypasserMcm.Address().Hex(),
+	})
+
+	bypassers, err = evmTimelockInspector.GetBypassers(updatedEnv.GetContext(), evmState1.Timelock.Address().Hex())
+	require.NoError(t, err)
+	require.Equal(t, bypassers, []string{evmState1.BypasserMcm.Address().Hex()})
+
+	// solana chain 0
+	solanaState0 := solanaState[solanaSelectors[0]]
+	solanaInspector := mcmssolanasdk.NewInspector(updatedEnv.SolChains[solanaSelectors[0]].Client)
+	solanaTimelockInspector := mcmssolanasdk.NewTimelockInspector(updatedEnv.SolChains[solanaSelectors[0]].Client)
+
+	addr := mcmssolanasdk.ContractAddress(solanaState0.McmProgram, mcmssolanasdk.PDASeed(solanaState0.ProposerMcmSeed))
+	config, err = solanaInspector.GetConfig(updatedEnv.GetContext(), addr)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(*config, changesetConfig[solanaSelectors[0]].Proposer))
+
+	addr = mcmssolanasdk.ContractAddress(solanaState0.McmProgram, mcmssolanasdk.PDASeed(solanaState0.CancellerMcmSeed))
+	config, err = solanaInspector.GetConfig(updatedEnv.GetContext(), addr)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(*config, changesetConfig[solanaSelectors[0]].Canceller))
+
+	addr = mcmssolanasdk.ContractAddress(solanaState0.McmProgram, mcmssolanasdk.PDASeed(solanaState0.BypasserMcmSeed))
+	config, err = solanaInspector.GetConfig(updatedEnv.GetContext(), addr)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(*config, changesetConfig[solanaSelectors[0]].Bypasser))
+
+	addr = mcmssolanasdk.ContractAddress(solanaState0.TimelockProgram, mcmssolanasdk.PDASeed(solanaState0.TimelockSeed))
+	proposers, err = solanaTimelockInspector.GetProposers(updatedEnv.GetContext(), addr)
+	require.NoError(t, err)
+	require.Equal(t, proposers, []string{signerPDA(solanaState0.McmProgram, solanaState0.ProposerMcmSeed)})
+
+	executors, err = solanaTimelockInspector.GetExecutors(updatedEnv.GetContext(), addr)
+	require.NoError(t, err)
+	require.Equal(t, executors, []string{}) // FIXME: who should be executor?
+
+	cancellers, err = solanaTimelockInspector.GetCancellers(updatedEnv.GetContext(), addr)
+	require.NoError(t, err)
+	require.ElementsMatch(t, cancellers, []string{
+		signerPDA(solanaState0.McmProgram, solanaState0.CancellerMcmSeed),
+		signerPDA(solanaState0.McmProgram, solanaState0.ProposerMcmSeed),
+		signerPDA(solanaState0.McmProgram, solanaState0.BypasserMcmSeed),
+	})
+
+	bypassers, err = solanaTimelockInspector.GetBypassers(updatedEnv.GetContext(), addr)
+	require.NoError(t, err)
+	require.Equal(t, bypassers, []string{signerPDA(solanaState0.McmProgram, solanaState0.BypasserMcmSeed)})
+}
+
+// ----- helpers -----
+
+func signerPDA(programID solana.PublicKey, seed mcmschangesetstate.PDASeed) string {
+	return solanainternal.GetMCMSignerPDA(programID, seed).String()
+}
+
+func setPreloadedSolanaAddresses(t *testing.T, env deployment.Environment, selector uint64) {
+	typeAndVersion := deployment.NewTypeAndVersion(commontypes.ManyChainMultisigProgram, deployment.Version1_0_0)
+	err := env.ExistingAddresses.Save(selector, memory.SolanaProgramIDs["mcm"], typeAndVersion)
+	require.NoError(t, err)
+
+	typeAndVersion = deployment.NewTypeAndVersion(commontypes.AccessControllerProgram, deployment.Version1_0_0)
+	err = env.ExistingAddresses.Save(selector, memory.SolanaProgramIDs["access_controller"], typeAndVersion)
+	require.NoError(t, err)
+
+	typeAndVersion = deployment.NewTypeAndVersion(commontypes.RBACTimelockProgram, deployment.Version1_0_0)
+	err = env.ExistingAddresses.Save(selector, memory.SolanaProgramIDs["timelock"], typeAndVersion)
+	require.NoError(t, err)
+}

--- a/deployment/common/changeset/deploy_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock_test.go
@@ -2,6 +2,7 @@
 package changeset_test
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	solanainternal "github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/solana"
@@ -142,33 +144,34 @@ func TestDeployMCMSWithTimelockV2(t *testing.T) {
 	// --- assert ---
 	require.Len(t, evmState, 2)
 	require.Len(t, solanaState, 1)
+	ctx := updatedEnv.GetContext()
 
 	// evm chain 0
 	evmState0 := evmState[evmSelectors[0]]
 	evmInspector := mcmsevmsdk.NewInspector(updatedEnv.Chains[evmSelectors[0]].Client)
 	evmTimelockInspector := mcmsevmsdk.NewTimelockInspector(updatedEnv.Chains[evmSelectors[0]].Client)
 
-	config, err := evmInspector.GetConfig(updatedEnv.GetContext(), evmState0.ProposerMcm.Address().Hex())
+	config, err := evmInspector.GetConfig(ctx, evmState0.ProposerMcm.Address().Hex())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[0]].Proposer))
 
-	config, err = evmInspector.GetConfig(updatedEnv.GetContext(), evmState0.CancellerMcm.Address().Hex())
+	config, err = evmInspector.GetConfig(ctx, evmState0.CancellerMcm.Address().Hex())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[0]].Canceller))
 
-	config, err = evmInspector.GetConfig(updatedEnv.GetContext(), evmState0.BypasserMcm.Address().Hex())
+	config, err = evmInspector.GetConfig(ctx, evmState0.BypasserMcm.Address().Hex())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[0]].Bypasser))
 
-	proposers, err := evmTimelockInspector.GetProposers(updatedEnv.GetContext(), evmState0.Timelock.Address().Hex())
+	proposers, err := evmTimelockInspector.GetProposers(ctx, evmState0.Timelock.Address().Hex())
 	require.NoError(t, err)
 	require.Equal(t, proposers, []string{evmState0.ProposerMcm.Address().Hex()})
 
-	executors, err := evmTimelockInspector.GetExecutors(updatedEnv.GetContext(), evmState0.Timelock.Address().Hex())
+	executors, err := evmTimelockInspector.GetExecutors(ctx, evmState0.Timelock.Address().Hex())
 	require.NoError(t, err)
 	require.Equal(t, executors, []string{evmState0.CallProxy.Address().Hex()})
 
-	cancellers, err := evmTimelockInspector.GetCancellers(updatedEnv.GetContext(), evmState0.Timelock.Address().Hex())
+	cancellers, err := evmTimelockInspector.GetCancellers(ctx, evmState0.Timelock.Address().Hex())
 	require.NoError(t, err)
 	require.ElementsMatch(t, cancellers, []string{
 		evmState0.CancellerMcm.Address().Hex(),
@@ -176,7 +179,7 @@ func TestDeployMCMSWithTimelockV2(t *testing.T) {
 		evmState0.BypasserMcm.Address().Hex(),
 	})
 
-	bypassers, err := evmTimelockInspector.GetBypassers(updatedEnv.GetContext(), evmState0.Timelock.Address().Hex())
+	bypassers, err := evmTimelockInspector.GetBypassers(ctx, evmState0.Timelock.Address().Hex())
 	require.NoError(t, err)
 	require.Equal(t, bypassers, []string{evmState0.BypasserMcm.Address().Hex()})
 
@@ -185,27 +188,27 @@ func TestDeployMCMSWithTimelockV2(t *testing.T) {
 	evmInspector = mcmsevmsdk.NewInspector(updatedEnv.Chains[evmSelectors[1]].Client)
 	evmTimelockInspector = mcmsevmsdk.NewTimelockInspector(updatedEnv.Chains[evmSelectors[1]].Client)
 
-	config, err = evmInspector.GetConfig(updatedEnv.GetContext(), evmState1.ProposerMcm.Address().Hex())
+	config, err = evmInspector.GetConfig(ctx, evmState1.ProposerMcm.Address().Hex())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[1]].Proposer))
 
-	config, err = evmInspector.GetConfig(updatedEnv.GetContext(), evmState1.CancellerMcm.Address().Hex())
+	config, err = evmInspector.GetConfig(ctx, evmState1.CancellerMcm.Address().Hex())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[1]].Canceller))
 
-	config, err = evmInspector.GetConfig(updatedEnv.GetContext(), evmState1.BypasserMcm.Address().Hex())
+	config, err = evmInspector.GetConfig(ctx, evmState1.BypasserMcm.Address().Hex())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(*config, changesetConfig[evmSelectors[1]].Bypasser))
 
-	proposers, err = evmTimelockInspector.GetProposers(updatedEnv.GetContext(), evmState1.Timelock.Address().Hex())
+	proposers, err = evmTimelockInspector.GetProposers(ctx, evmState1.Timelock.Address().Hex())
 	require.NoError(t, err)
 	require.Equal(t, proposers, []string{evmState1.ProposerMcm.Address().Hex()})
 
-	executors, err = evmTimelockInspector.GetExecutors(updatedEnv.GetContext(), evmState1.Timelock.Address().Hex())
+	executors, err = evmTimelockInspector.GetExecutors(ctx, evmState1.Timelock.Address().Hex())
 	require.NoError(t, err)
 	require.Equal(t, executors, []string{evmState1.CallProxy.Address().Hex()})
 
-	cancellers, err = evmTimelockInspector.GetCancellers(updatedEnv.GetContext(), evmState1.Timelock.Address().Hex())
+	cancellers, err = evmTimelockInspector.GetCancellers(ctx, evmState1.Timelock.Address().Hex())
 	require.NoError(t, err)
 	require.ElementsMatch(t, cancellers, []string{
 		evmState1.CancellerMcm.Address().Hex(),
@@ -213,56 +216,66 @@ func TestDeployMCMSWithTimelockV2(t *testing.T) {
 		evmState1.BypasserMcm.Address().Hex(),
 	})
 
-	bypassers, err = evmTimelockInspector.GetBypassers(updatedEnv.GetContext(), evmState1.Timelock.Address().Hex())
+	bypassers, err = evmTimelockInspector.GetBypassers(ctx, evmState1.Timelock.Address().Hex())
 	require.NoError(t, err)
 	require.Equal(t, bypassers, []string{evmState1.BypasserMcm.Address().Hex()})
 
 	// solana chain 0
 	solanaState0 := solanaState[solanaSelectors[0]]
-	solanaInspector := mcmssolanasdk.NewInspector(updatedEnv.SolChains[solanaSelectors[0]].Client)
-	solanaTimelockInspector := mcmssolanasdk.NewTimelockInspector(updatedEnv.SolChains[solanaSelectors[0]].Client)
+	solanaChain0 := updatedEnv.SolChains[solanaSelectors[0]]
+	solanaInspector := mcmssolanasdk.NewInspector(solanaChain0.Client)
+	solanaTimelockInspector := mcmssolanasdk.NewTimelockInspector(solanaChain0.Client)
 
 	addr := mcmssolanasdk.ContractAddress(solanaState0.McmProgram, mcmssolanasdk.PDASeed(solanaState0.ProposerMcmSeed))
-	config, err = solanaInspector.GetConfig(updatedEnv.GetContext(), addr)
+	config, err = solanaInspector.GetConfig(ctx, addr)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(*config, changesetConfig[solanaSelectors[0]].Proposer))
 
 	addr = mcmssolanasdk.ContractAddress(solanaState0.McmProgram, mcmssolanasdk.PDASeed(solanaState0.CancellerMcmSeed))
-	config, err = solanaInspector.GetConfig(updatedEnv.GetContext(), addr)
+	config, err = solanaInspector.GetConfig(ctx, addr)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(*config, changesetConfig[solanaSelectors[0]].Canceller))
 
 	addr = mcmssolanasdk.ContractAddress(solanaState0.McmProgram, mcmssolanasdk.PDASeed(solanaState0.BypasserMcmSeed))
-	config, err = solanaInspector.GetConfig(updatedEnv.GetContext(), addr)
+	config, err = solanaInspector.GetConfig(ctx, addr)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(*config, changesetConfig[solanaSelectors[0]].Bypasser))
 
 	addr = mcmssolanasdk.ContractAddress(solanaState0.TimelockProgram, mcmssolanasdk.PDASeed(solanaState0.TimelockSeed))
-	proposers, err = solanaTimelockInspector.GetProposers(updatedEnv.GetContext(), addr)
+	proposers, err = solanaTimelockInspector.GetProposers(ctx, addr)
 	require.NoError(t, err)
-	require.Equal(t, proposers, []string{signerPDA(solanaState0.McmProgram, solanaState0.ProposerMcmSeed)})
+	require.Equal(t, proposers, []string{mcmSignerPDA(solanaState0.McmProgram, solanaState0.ProposerMcmSeed)})
 
-	executors, err = solanaTimelockInspector.GetExecutors(updatedEnv.GetContext(), addr)
+	executors, err = solanaTimelockInspector.GetExecutors(ctx, addr)
 	require.NoError(t, err)
-	require.Equal(t, executors, []string{}) // FIXME: who should be executor?
+	require.Equal(t, executors, []string{solanaChain0.DeployerKey.PublicKey().String()})
 
-	cancellers, err = solanaTimelockInspector.GetCancellers(updatedEnv.GetContext(), addr)
+	cancellers, err = solanaTimelockInspector.GetCancellers(ctx, addr)
 	require.NoError(t, err)
 	require.ElementsMatch(t, cancellers, []string{
-		signerPDA(solanaState0.McmProgram, solanaState0.CancellerMcmSeed),
-		signerPDA(solanaState0.McmProgram, solanaState0.ProposerMcmSeed),
-		signerPDA(solanaState0.McmProgram, solanaState0.BypasserMcmSeed),
+		mcmSignerPDA(solanaState0.McmProgram, solanaState0.CancellerMcmSeed),
+		mcmSignerPDA(solanaState0.McmProgram, solanaState0.ProposerMcmSeed),
+		mcmSignerPDA(solanaState0.McmProgram, solanaState0.BypasserMcmSeed),
 	})
 
-	bypassers, err = solanaTimelockInspector.GetBypassers(updatedEnv.GetContext(), addr)
+	bypassers, err = solanaTimelockInspector.GetBypassers(ctx, addr)
 	require.NoError(t, err)
-	require.Equal(t, bypassers, []string{signerPDA(solanaState0.McmProgram, solanaState0.BypasserMcmSeed)})
+	require.Equal(t, bypassers, []string{mcmSignerPDA(solanaState0.McmProgram, solanaState0.BypasserMcmSeed)})
+
+	timelockConfig := solanaTimelockConfig(ctx, t, solanaChain0, solanaState0.TimelockProgram, solanaState0.TimelockSeed)
+	require.NoError(t, err)
+	require.Equal(t, timelockConfig.ProposedOwner.String(),
+		timelockSignerPDA(solanaState0.TimelockProgram, solanaState0.TimelockSeed))
 }
 
 // ----- helpers -----
 
-func signerPDA(programID solana.PublicKey, seed mcmschangesetstate.PDASeed) string {
+func mcmSignerPDA(programID solana.PublicKey, seed mcmschangesetstate.PDASeed) string {
 	return solanainternal.GetMCMSignerPDA(programID, seed).String()
+}
+
+func timelockSignerPDA(programID solana.PublicKey, seed mcmschangesetstate.PDASeed) string {
+	return solanainternal.GetTimelockSignerPDA(programID, seed).String()
 }
 
 func setPreloadedSolanaAddresses(t *testing.T, env deployment.Environment, selector uint64) {
@@ -277,4 +290,16 @@ func setPreloadedSolanaAddresses(t *testing.T, env deployment.Environment, selec
 	typeAndVersion = deployment.NewTypeAndVersion(commontypes.RBACTimelockProgram, deployment.Version1_0_0)
 	err = env.ExistingAddresses.Save(selector, memory.SolanaProgramIDs["timelock"], typeAndVersion)
 	require.NoError(t, err)
+}
+
+func solanaTimelockConfig(
+	ctx context.Context, t *testing.T, chain deployment.SolChain, programID solana.PublicKey, seed mcmschangesetstate.PDASeed,
+) timelockBindings.Config {
+	t.Helper()
+
+	var data timelockBindings.Config
+	err := chain.GetAccountDataBorshInto(ctx, solanainternal.GetTimelockConfigPDA(programID, seed), &data)
+	require.NoError(t, err)
+
+	return data
 }

--- a/deployment/common/changeset/example/link_transfer_test.go
+++ b/deployment/common/changeset/example/link_transfer_test.go
@@ -32,7 +32,7 @@ func setupLinkTransferTestEnv(t *testing.T) deployment.Environment {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 	chainSelector := env.AllChainSelectors()[0]
-	config := proposalutils.SingleGroupMCMS(t)
+	config := proposalutils.SingleGroupMCMSV2(t)
 
 	// Deploy MCMS and Timelock
 	env, err := changeset.Apply(t, env, nil,
@@ -41,8 +41,8 @@ func setupLinkTransferTestEnv(t *testing.T) deployment.Environment {
 			[]uint64{chainSelector},
 		),
 		changeset.Configure(
-			deployment.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelock),
-			map[uint64]types.MCMSWithTimelockConfig{
+			deployment.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
+			map[uint64]types.MCMSWithTimelockConfigV2{
 				chainSelector: {
 					Canceller:        config,
 					Bypasser:         config,

--- a/deployment/common/changeset/internal/evm/mcms.go
+++ b/deployment/common/changeset/internal/evm/mcms.go
@@ -1,0 +1,162 @@
+package mcmsnew
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	bindings "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+	evmMcms "github.com/smartcontractkit/mcms/sdk/evm"
+	mcmsTypes "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/common/view/v1_0"
+)
+
+// MCMSWithTimelockEVMDeploy holds a bundle of MCMS contract deploys.
+type MCMSWithTimelockEVMDeploy struct {
+	Canceller *deployment.ContractDeploy[*bindings.ManyChainMultiSig]
+	Bypasser  *deployment.ContractDeploy[*bindings.ManyChainMultiSig]
+	Proposer  *deployment.ContractDeploy[*bindings.ManyChainMultiSig]
+	Timelock  *deployment.ContractDeploy[*bindings.RBACTimelock]
+	CallProxy *deployment.ContractDeploy[*bindings.CallProxy]
+}
+
+func deployMCMSWithConfigEVM(
+	contractType deployment.ContractType,
+	lggr logger.Logger,
+	chain deployment.Chain,
+	ab deployment.AddressBook,
+	mcmConfig mcmsTypes.Config,
+) (*deployment.ContractDeploy[*bindings.ManyChainMultiSig], error) {
+	groupQuorums, groupParents, signerAddresses, signerGroups, err := evmMcms.ExtractSetConfigInputs(&mcmConfig)
+	if err != nil {
+		lggr.Errorw("Failed to extract set config inputs", "chain", chain.String(), "err", err)
+		return nil, err
+	}
+	mcm, err := deployment.DeployContract(lggr, chain, ab,
+		func(chain deployment.Chain) deployment.ContractDeploy[*bindings.ManyChainMultiSig] {
+			mcmAddr, tx, mcm, err2 := bindings.DeployManyChainMultiSig(
+				chain.DeployerKey,
+				chain.Client,
+			)
+			return deployment.ContractDeploy[*bindings.ManyChainMultiSig]{
+				Address: mcmAddr, Contract: mcm, Tx: tx, Tv: deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0), Err: err2,
+			}
+		})
+	if err != nil {
+		lggr.Errorw("Failed to deploy mcm", "chain", chain.String(), "err", err)
+		return mcm, err
+	}
+	mcmsTx, err := mcm.Contract.SetConfig(chain.DeployerKey,
+		signerAddresses,
+		// Signer 1 is int group 0 (root group) with quorum 1.
+		signerGroups,
+		groupQuorums,
+		groupParents,
+		false,
+	)
+	if _, err := deployment.ConfirmIfNoError(chain, mcmsTx, err); err != nil {
+		lggr.Errorw("Failed to confirm mcm config", "chain", chain.String(), "err", err)
+		return mcm, err
+	}
+	return mcm, nil
+}
+
+// DeployMCMSWithTimelockContractsEVM deploys an MCMS for
+// each of the timelock roles Bypasser, ProposerMcm, Canceller on an EVM chain.
+// MCMS contracts for the given configuration
+// as well as the timelock. It's not necessarily the only way to use
+// the timelock and MCMS, but its reasonable pattern.
+func DeployMCMSWithTimelockContractsEVM(
+	lggr logger.Logger,
+	chain deployment.Chain,
+	ab deployment.AddressBook,
+	config commontypes.MCMSWithTimelockConfigV2,
+) (*MCMSWithTimelockEVMDeploy, error) {
+	bypasser, err := deployMCMSWithConfigEVM(commontypes.BypasserManyChainMultisig, lggr, chain, ab, config.Bypasser)
+	if err != nil {
+		return nil, err
+	}
+	canceller, err := deployMCMSWithConfigEVM(commontypes.CancellerManyChainMultisig, lggr, chain, ab, config.Canceller)
+	if err != nil {
+		return nil, err
+	}
+	proposer, err := deployMCMSWithConfigEVM(commontypes.ProposerManyChainMultisig, lggr, chain, ab, config.Proposer)
+	if err != nil {
+		return nil, err
+	}
+
+	timelock, err := deployment.DeployContract(lggr, chain, ab,
+		func(chain deployment.Chain) deployment.ContractDeploy[*bindings.RBACTimelock] {
+			timelock, tx2, cc, err2 := bindings.DeployRBACTimelock(
+				chain.DeployerKey,
+				chain.Client,
+				config.TimelockMinDelay,
+				// Deployer is the initial admin.
+				// TODO: Could expose this as config?
+				// Or keep this enforced to follow the same pattern?
+				chain.DeployerKey.From,
+				[]common.Address{proposer.Address}, // proposers
+				// Executors field is empty here because we grant the executor role to the call proxy later
+				// and the call proxy cannot be deployed before the timelock.
+				[]common.Address{},
+				[]common.Address{canceller.Address, proposer.Address, bypasser.Address}, // cancellers
+				[]common.Address{bypasser.Address},                                      // bypassers
+			)
+			return deployment.ContractDeploy[*bindings.RBACTimelock]{
+				Address: timelock, Contract: cc, Tx: tx2, Tv: deployment.NewTypeAndVersion(commontypes.RBACTimelock, deployment.Version1_0_0), Err: err2,
+			}
+		})
+	if err != nil {
+		lggr.Errorw("Failed to deploy timelock", "chain", chain.String(), "err", err)
+		return nil, err
+	}
+
+	callProxy, err := deployment.DeployContract(lggr, chain, ab,
+		func(chain deployment.Chain) deployment.ContractDeploy[*bindings.CallProxy] {
+			callProxy, tx2, cc, err2 := bindings.DeployCallProxy(
+				chain.DeployerKey,
+				chain.Client,
+				timelock.Address,
+			)
+			return deployment.ContractDeploy[*bindings.CallProxy]{
+				Address: callProxy, Contract: cc, Tx: tx2, Tv: deployment.NewTypeAndVersion(commontypes.CallProxy, deployment.Version1_0_0), Err: err2,
+			}
+		})
+	if err != nil {
+		lggr.Errorw("Failed to deploy call proxy", "chain", chain.String(), "err", err)
+		return nil, err
+	}
+
+	grantRoleTx, err := timelock.Contract.GrantRole(
+		chain.DeployerKey,
+		v1_0.EXECUTOR_ROLE.ID,
+		callProxy.Address,
+	)
+	if err != nil {
+		lggr.Errorw("Failed to grant timelock executor role", "chain", chain.String(), "err", err)
+		return nil, err
+	}
+
+	if _, err := deployment.ConfirmIfNoError(chain, grantRoleTx, err); err != nil {
+		lggr.Errorw("Failed to grant timelock executor role", "chain", chain.String(), "err", err)
+		return nil, err
+	}
+	// We grant the timelock the admin role on the MCMS contracts.
+	tx, err := timelock.Contract.GrantRole(chain.DeployerKey,
+		v1_0.ADMIN_ROLE.ID, timelock.Address)
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
+		lggr.Errorw("Failed to grant timelock admin role", "chain", chain.String(), "err", err)
+		return nil, err
+	}
+	// After the proposer cycle is validated,
+	// we can remove the deployer as an admin.
+	return &MCMSWithTimelockEVMDeploy{
+		Canceller: canceller,
+		Bypasser:  bypasser,
+		Proposer:  proposer,
+		Timelock:  timelock,
+		CallProxy: callProxy,
+	}, nil
+}

--- a/deployment/common/changeset/internal/evm/ownable.go
+++ b/deployment/common/changeset/internal/evm/ownable.go
@@ -1,0 +1,14 @@
+package mcmsnew
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+type Ownable interface {
+	Owner(opts *bind.CallOpts) (common.Address, error)
+	TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*gethtypes.Transaction, error)
+	AcceptOwnership(opts *bind.TransactOpts) (*gethtypes.Transaction, error)
+	Address() common.Address
+}

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -100,7 +100,6 @@ func initAccessController(
 		return fmt.Errorf("failed to save onchain state: %w", err)
 	}
 
-	// FIXME: review if we need to setup an "AddressLookupTable".
 	return nil
 }
 

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -71,13 +71,6 @@ func initAccessController(
 	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
 	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String(), "programID", programID)
 
-	// FIXME: should we always redeploy or skip?
-	// pid, acc, err := chainState.GetStateFromType(contractType)
-	// if err == nil && !pid.IsZero() && pid == programID && !solana.PublicKey(acc).IsZero() {
-	// 	log.Infow("access controller already initialized", "account", acc)
-	// 	return nil
-	// }
-
 	account, err := solana.NewRandomPrivateKey() // FIXME: what should we do with the account private key?
 	if err != nil {
 		return fmt.Errorf("failed to generate new random private key for access controller account: %w", err)
@@ -103,12 +96,12 @@ func initAccessController(
 	return nil
 }
 
+// discriminator + owner + proposed owner + access_list (64 max addresses + length)
 const accessControllerAccountSize = uint64(8 + 32 + 32 + ((32 * 64) + 8))
 
 func initializeAccessController(
 	e deployment.Environment, chain deployment.SolChain, programID solana.PublicKey, account solana.PrivateKey,
 ) error {
-	// discriminator + owner + proposed owner + access_list (64 max addresses + length)
 	rentExemption, err := chain.Client.GetMinimumBalanceForRentExemption(e.GetContext(),
 		accessControllerAccountSize, rpc.CommitmentConfirmed)
 	if err != nil {
@@ -152,6 +145,11 @@ func setupRoles(chainState *state.MCMSWithTimelockStateSolana, chain deployment.
 	err := addAccess(chain, chainState, timelockBindings.Proposer_Role, proposerPDA)
 	if err != nil {
 		return fmt.Errorf("failed to add access for proposer role: %w", err)
+	}
+
+	err = addAccess(chain, chainState, timelockBindings.Executor_Role, chain.DeployerKey.PublicKey())
+	if err != nil {
+		return fmt.Errorf("failed to add access for executor role: %w", err)
 	}
 
 	err = addAccess(chain, chainState, timelockBindings.Canceller_Role, cancellerPDA, proposerPDA, bypasserPDA)

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -103,17 +103,19 @@ func initAccessController(
 	return nil
 }
 
+const accessControllerAccountSize = uint64(8 + 32 + 32 + ((32 * 64) + 8))
+
 func initializeAccessController(
 	e deployment.Environment, chain deployment.SolChain, programID solana.PublicKey, account solana.PrivateKey,
 ) error {
 	// discriminator + owner + proposed owner + access_list (64 max addresses + length)
-	dataSize := uint64(8 + 32 + 32 + ((32 * 64) + 8))
-	rentExemption, err := chain.Client.GetMinimumBalanceForRentExemption(e.GetContext(), dataSize, rpc.CommitmentConfirmed)
+	rentExemption, err := chain.Client.GetMinimumBalanceForRentExemption(e.GetContext(),
+		accessControllerAccountSize, rpc.CommitmentConfirmed)
 	if err != nil {
 		return fmt.Errorf("failed to get minimum balance for rent exemption: %w", err)
 	}
 
-	createAccountInstruction, err := system.NewCreateAccountInstruction(rentExemption, dataSize,
+	createAccountInstruction, err := system.NewCreateAccountInstruction(rentExemption, accessControllerAccountSize,
 		programID, chain.DeployerKey.PublicKey(), account.PublicKey()).ValidateAndBuild()
 	if err != nil {
 		return fmt.Errorf("failed to create CreateAccount instruction: %w", err)

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -1,0 +1,192 @@
+package mcmsnew
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/gagliardetto/solana-go/rpc"
+
+	accessControllerBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/access_controller"
+	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
+	solanaUtils "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+)
+
+func deployAccessControllerProgram(
+	e deployment.Environment, chainState *state.MCMSWithTimelockStateSolana,
+	chain deployment.SolChain, addressBook deployment.AddressBook,
+) error {
+	typeAndVersion := deployment.NewTypeAndVersion(commontypes.AccessControllerProgram, deployment.Version1_0_0)
+	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
+
+	programID, _, err := chainState.GetStateFromType(commontypes.AccessControllerProgram)
+	if err != nil {
+		return fmt.Errorf("failed to get access controller program state: %w", err)
+	}
+
+	if programID.IsZero() {
+		deployedProgramID, err := chain.DeployProgram(e.Logger, "access_controller")
+		if err != nil {
+			return fmt.Errorf("failed to deploy access controller program: %w", err)
+		}
+
+		programID, err = solana.PublicKeyFromBase58(deployedProgramID)
+		if err != nil {
+			return fmt.Errorf("failed to convert mcm program id to public key: %w", err)
+		}
+
+		err = addressBook.Save(chain.Selector, programID.String(), typeAndVersion)
+		if err != nil {
+			return fmt.Errorf("failed to save address: %w", err)
+		}
+
+		err = chainState.SetState(commontypes.AccessControllerProgram, programID, state.PDASeed{})
+		if err != nil {
+			return fmt.Errorf("failed to save onchain state: %w", err)
+		}
+
+		log.Infow("deployed access controller contract", "programId", programID)
+	} else {
+		log.Infow("using existing AccessController program", "programId", programID)
+	}
+
+	return nil
+}
+
+func initAccessController(
+	e deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, contractType deployment.ContractType,
+	chain deployment.SolChain, addressBook deployment.AddressBook,
+) error {
+	if chainState.AccessControllerProgram.IsZero() {
+		return errors.New("access controller program is not deployed")
+	}
+	programID := chainState.AccessControllerProgram
+	accessControllerBindings.SetProgramID(programID)
+
+	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
+	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String(), "programID", programID)
+
+	// FIXME: should we always redeploy or skip?
+	// pid, acc, err := chainState.GetStateFromType(contractType)
+	// if err == nil && !pid.IsZero() && pid == programID && !solana.PublicKey(acc).IsZero() {
+	// 	log.Infow("access controller already initialized", "account", acc)
+	// 	return nil
+	// }
+
+	account, err := solana.NewRandomPrivateKey() // FIXME: what should we do with the account private key?
+	if err != nil {
+		return fmt.Errorf("failed to generate new random private key for access controller account: %w", err)
+	}
+
+	err = initializeAccessController(e, chain, programID, account)
+	if err != nil {
+		return fmt.Errorf("failed to initialize access controller: %w", err)
+	}
+	log.Infow("initialized access controller", "account", account.PublicKey())
+
+	address := state.EncodeAddressWithAccount(programID, account.PublicKey())
+	err = addressBook.Save(chain.Selector, address, typeAndVersion)
+	if err != nil {
+		return fmt.Errorf("failed to save address: %w", err)
+	}
+
+	err = chainState.SetState(contractType, programID, state.PDASeed(account.PublicKey()))
+	if err != nil {
+		return fmt.Errorf("failed to save onchain state: %w", err)
+	}
+
+	// FIXME: review if we need to setup an "AddressLookupTable".
+	return nil
+}
+
+func initializeAccessController(
+	e deployment.Environment, chain deployment.SolChain, programID solana.PublicKey, account solana.PrivateKey,
+) error {
+	// discriminator + owner + proposed owner + access_list (64 max addresses + length)
+	dataSize := uint64(8 + 32 + 32 + ((32 * 64) + 8))
+	rentExemption, err := chain.Client.GetMinimumBalanceForRentExemption(e.GetContext(), dataSize, rpc.CommitmentConfirmed)
+	if err != nil {
+		return fmt.Errorf("failed to get minimum balance for rent exemption: %w", err)
+	}
+
+	createAccountInstruction, err := system.NewCreateAccountInstruction(rentExemption, dataSize,
+		programID, chain.DeployerKey.PublicKey(), account.PublicKey()).ValidateAndBuild()
+	if err != nil {
+		return fmt.Errorf("failed to create CreateAccount instruction: %w", err)
+	}
+
+	initializeInstruction, err := accessControllerBindings.NewInitializeInstruction(
+		account.PublicKey(),
+		chain.DeployerKey.PublicKey(),
+	).ValidateAndBuild()
+	if err != nil {
+		return fmt.Errorf("failed to build instruction: %w", err)
+	}
+
+	instructions := []solana.Instruction{createAccountInstruction, initializeInstruction}
+	err = chain.Confirm(instructions, solanaUtils.AddSigners(account))
+	if err != nil {
+		return fmt.Errorf("failed to confirm CreateAccount and InitializeAccessController instructions: %w", err)
+	}
+
+	var data accessControllerBindings.AccessController
+	err = solanaUtils.GetAccountDataBorshInto(e.GetContext(), chain.Client, account.PublicKey(), rpc.CommitmentConfirmed, &data)
+	if err != nil {
+		return fmt.Errorf("failed to read access controller account: %w", err)
+	}
+
+	return nil
+}
+
+func setupRoles(chainState *state.MCMSWithTimelockStateSolana, chain deployment.SolChain) error {
+	proposerPDA := GetMCMSignerPDA(chainState.McmProgram, chainState.ProposerMcmSeed)
+	cancellerPDA := GetMCMSignerPDA(chainState.McmProgram, chainState.CancellerMcmSeed)
+	bypasserPDA := GetMCMSignerPDA(chainState.McmProgram, chainState.BypasserMcmSeed)
+
+	err := addAccess(chain, chainState, timelockBindings.Proposer_Role, proposerPDA)
+	if err != nil {
+		return fmt.Errorf("failed to add access for proposer role: %w", err)
+	}
+
+	err = addAccess(chain, chainState, timelockBindings.Canceller_Role, cancellerPDA, proposerPDA, bypasserPDA)
+	if err != nil {
+		return fmt.Errorf("failed to add access for canceller role: %w", err)
+	}
+
+	err = addAccess(chain, chainState, timelockBindings.Bypasser_Role, bypasserPDA)
+	if err != nil {
+		return fmt.Errorf("failed to add access for bypasser role: %w", err)
+	}
+
+	return nil
+}
+
+func addAccess(
+	chain deployment.SolChain, chainState *state.MCMSWithTimelockStateSolana,
+	role timelockBindings.Role, accounts ...solana.PublicKey,
+) error {
+	timelockConfigPDA := GetTimelockConfigPDA(chainState.TimelockProgram, chainState.TimelockSeed)
+
+	instructionBuilder := timelockBindings.NewBatchAddAccessInstruction([32]uint8(chainState.TimelockSeed), role,
+		timelockConfigPDA, chainState.AccessControllerProgram, chainState.RoleAccount(role), chain.DeployerKey.PublicKey())
+	for _, account := range accounts {
+		instructionBuilder.Append(solana.Meta(account))
+	}
+
+	instruction, err := instructionBuilder.ValidateAndBuild()
+	if err != nil {
+		return fmt.Errorf("failed to build BatchAddAccess instruction: %w", err)
+	}
+
+	err = chain.Confirm([]solana.Instruction{instruction})
+	if err != nil {
+		return fmt.Errorf("failed to confirm BatchAddAccess instruction: %w", err)
+	}
+
+	return nil
+}

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -106,7 +106,6 @@ func initMCM(
 		return fmt.Errorf("failed to save onchain state: %w", err)
 	}
 
-	// FIXME: review if we need to setup an "AddressLookupTable".
 	return nil
 }
 

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -1,0 +1,168 @@
+package mcmsnew
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+
+	binary "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	mcmsSolanaSdk "github.com/smartcontractkit/mcms/sdk/solana"
+	mcmsTypes "github.com/smartcontractkit/mcms/types"
+
+	mcmBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+)
+
+func deployMCMProgram(
+	env deployment.Environment, chainState *state.MCMSWithTimelockStateSolana,
+	chain deployment.SolChain, addressBook deployment.AddressBook,
+) error {
+	typeAndVersion := deployment.NewTypeAndVersion(commontypes.ManyChainMultisigProgram, deployment.Version1_0_0)
+	log := logger.With(env.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
+
+	programID, _, err := chainState.GetStateFromType(commontypes.ManyChainMultisigProgram)
+	if err != nil {
+		return fmt.Errorf("failed to get mcm state: %w", err)
+	}
+
+	if programID.IsZero() {
+		deployedProgramID, err := chain.DeployProgram(log, "mcm")
+		if err != nil {
+			return fmt.Errorf("failed to deploy mcm program: %w", err)
+		}
+
+		programID, err = solana.PublicKeyFromBase58(deployedProgramID)
+		if err != nil {
+			return fmt.Errorf("failed to convert mcm program id to public key: %w", err)
+		}
+
+		err = addressBook.Save(chain.Selector, programID.String(), typeAndVersion)
+		if err != nil {
+			return fmt.Errorf("failed to save mcm address: %w", err)
+		}
+
+		err = chainState.SetState(commontypes.ManyChainMultisigProgram, programID, state.PDASeed{})
+		if err != nil {
+			return fmt.Errorf("failed to save onchain state: %w", err)
+		}
+
+		log.Infow("deployed mcm contract", "programId", deployedProgramID)
+	} else {
+		log.Infow("using existing MCM program", "programId", programID.String())
+	}
+
+	return nil
+}
+
+func initMCM(
+	env deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, contractType deployment.ContractType,
+	chain deployment.SolChain, addressBook deployment.AddressBook, mcmConfig *mcmsTypes.Config,
+) error {
+	if chainState.McmProgram.IsZero() {
+		return errors.New("mcm program is not deployed")
+	}
+	programID := chainState.McmProgram
+	mcmBindings.SetProgramID(programID)
+
+	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
+	log := logger.With(env.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
+
+	// FIXME: should we always redeploy or skip?
+	// pid, seed, err := chainState.GetStateFromType(contractType)
+	// if err == nil && !pid.IsZero() && pid == programID && seed == state.PDASeed{} {
+	// 	log.Infow("mcm already initialized", "seed", seed)
+	// 	return nil
+	// }
+
+	seed := randomSeed()
+	log.Infow("generated MCM seed", "seed", string(seed[:]))
+
+	err := initializeMCM(env, chain, programID, seed)
+	if err != nil {
+		return fmt.Errorf("failed to initialize mcm: %w", err)
+	}
+
+	mcmAddress := state.EncodeAddressWithSeed(programID, seed)
+
+	configurer := mcmsSolanaSdk.NewConfigurer(chain.Client, *chain.DeployerKey, mcmsTypes.ChainSelector(chain.Selector))
+	tx, err := configurer.SetConfig(env.GetContext(), mcmAddress, mcmConfig, false)
+	if err != nil {
+		return fmt.Errorf("failed to set config on mcm: %w", err)
+	}
+	log.Infow("called SetConfig on MCM", "transaction", tx.Hash)
+
+	err = addressBook.Save(chain.Selector, mcmAddress, typeAndVersion)
+	if err != nil {
+		return fmt.Errorf("failed to save address: %w", err)
+	}
+
+	err = chainState.SetState(contractType, programID, seed)
+	if err != nil {
+		return fmt.Errorf("failed to save onchain state: %w", err)
+	}
+
+	// FIXME: review if we need to setup an "AddressLookupTable".
+	return nil
+}
+
+func initializeMCM(e deployment.Environment, chain deployment.SolChain, mcmProgram solana.PublicKey, multisigID state.PDASeed) error {
+	var mcmConfig mcmBindings.MultisigConfig
+	err := chain.GetAccountDataBorshInto(e.GetContext(), GetMCMConfigPDA(mcmProgram, multisigID), &mcmConfig)
+	if err == nil {
+		e.Logger.Infow("MCM already initialized, skipping initialization", "chain", chain.String())
+		return nil
+	}
+
+	var programData struct {
+		DataType uint32
+		Address  solana.PublicKey
+	}
+	opts := &rpc.GetAccountInfoOpts{Commitment: rpc.CommitmentConfirmed}
+
+	data, err := chain.Client.GetAccountInfoWithOpts(e.GetContext(), mcmProgram, opts)
+	if err != nil {
+		return fmt.Errorf("failed to get mcm program account info: %w", err)
+	}
+	err = binary.UnmarshalBorsh(&programData, data.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal program data: %w", err)
+	}
+
+	instruction, err := mcmBindings.NewInitializeInstruction(
+		chain.Selector,
+		multisigID,
+		GetMCMConfigPDA(mcmProgram, multisigID),
+		chain.DeployerKey.PublicKey(),
+		solana.SystemProgramID,
+		mcmProgram,
+		programData.Address,
+		GetMCMRootMetadataPDA(mcmProgram, multisigID),
+		GetMCMExpiringRootAndOpCountPDA(mcmProgram, multisigID),
+	).ValidateAndBuild()
+	if err != nil {
+		return fmt.Errorf("failed to build instruction: %w", err)
+	}
+
+	err = chain.Confirm([]solana.Instruction{instruction})
+	if err != nil {
+		return fmt.Errorf("failed to confirm instructions: %w", err)
+	}
+
+	return nil
+}
+
+func randomSeed() state.PDASeed {
+	const alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	seed := state.PDASeed{}
+	for i := range seed {
+		seed[i] = alphabet[rand.Intn(len(alphabet))]
+	}
+
+	return seed
+}

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -72,13 +72,6 @@ func initMCM(
 	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
 	log := logger.With(env.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
 
-	// FIXME: should we always redeploy or skip?
-	// pid, seed, err := chainState.GetStateFromType(contractType)
-	// if err == nil && !pid.IsZero() && pid == programID && seed == state.PDASeed{} {
-	// 	log.Infow("mcm already initialized", "seed", seed)
-	// 	return nil
-	// }
-
 	seed := randomSeed()
 	log.Infow("generated MCM seed", "seed", string(seed[:]))
 

--- a/deployment/common/changeset/internal/solana/mcms.go
+++ b/deployment/common/changeset/internal/solana/mcms.go
@@ -83,8 +83,19 @@ func DeployMCMSWithTimelockProgramsSolana(
 		return nil, fmt.Errorf("failed to setup roles and ownership: %w", err)
 	}
 
-	// TODO: how do we handle the absence of the callProxy? there's no "executor" configured at the moment
-	// TODO: how do we handle the absence of EVM's "grantRole"? the Timelock is not setup as the MCM admin
+	err = transferOwnership(chainState, chain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup roles and ownership: %w", err)
+	}
 
 	return chainState, nil
+}
+
+func transferOwnership(chainState *state.MCMSWithTimelockStateSolana, chain deployment.SolChain) error {
+	err := transferOwnershipTimelock(chain, chainState.TimelockProgram, chainState.TimelockSeed)
+	if err != nil {
+		return fmt.Errorf("failed to transfer ownership of timelock: %w", err)
+	}
+
+	return nil
 }

--- a/deployment/common/changeset/internal/solana/mcms.go
+++ b/deployment/common/changeset/internal/solana/mcms.go
@@ -1,0 +1,90 @@
+package mcmsnew
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+)
+
+// DeployMCMSWithTimelockProgramsSolana deploys an MCMS program f
+// and initializes 3 instances for each of the timelock roles: Bypasser, ProposerMcm, Canceller on an Solana chain.
+// as well as the timelock program. It's not necessarily the only way to use
+// the timelock and MCMS, but its reasonable pattern.
+func DeployMCMSWithTimelockProgramsSolana(
+	e deployment.Environment,
+	chain deployment.SolChain,
+	addressBook deployment.AddressBook,
+	config commontypes.MCMSWithTimelockConfigV2,
+) (*state.MCMSWithTimelockStateSolana, error) {
+	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get addresses for chain %v from environment: %w", chain.Selector, err)
+	}
+
+	chainState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load mcms with timelock solana chain state: %w", err)
+	}
+
+	// access controller
+	err = deployAccessControllerProgram(e, chainState, chain, addressBook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy access controller program: %w", err)
+	}
+	err = initAccessController(e, chainState, commontypes.ProposerAccessControllerAccount, chain, addressBook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy proposer access controller: %w", err)
+	}
+	err = initAccessController(e, chainState, commontypes.ExecutorAccessControllerAccount, chain, addressBook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy access controller: %w", err)
+	}
+	err = initAccessController(e, chainState, commontypes.CancellerAccessControllerAccount, chain, addressBook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy access controller: %w", err)
+	}
+	err = initAccessController(e, chainState, commontypes.BypasserAccessControllerAccount, chain, addressBook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy access controller: %w", err)
+	}
+
+	// mcm
+	err = deployMCMProgram(e, chainState, chain, addressBook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy mcm program: %w", err)
+	}
+	err = initMCM(e, chainState, commontypes.BypasserManyChainMultisig, chain, addressBook, &config.Bypasser)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy bypasser mcm: %w", err)
+	}
+	err = initMCM(e, chainState, commontypes.CancellerManyChainMultisig, chain, addressBook, &config.Canceller)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy canceller mcm: %w", err)
+	}
+	err = initMCM(e, chainState, commontypes.ProposerManyChainMultisig, chain, addressBook, &config.Proposer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy proposer mcm: %w", err)
+	}
+
+	// timelock
+	err = deployTimelockProgram(e, chainState, chain, addressBook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy timelock program: %w", err)
+	}
+	err = initTimelock(e, chainState, chain, addressBook, config.TimelockMinDelay)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy timelock: %w", err)
+	}
+
+	err = setupRoles(chainState, chain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup roles and ownership: %w", err)
+	}
+
+	// TODO: how do we handle the absence of the callProxy? there's no "executor" configured at the moment
+	// TODO: how do we handle the absence of EVM's "grantRole"? the Timelock is not setup as the MCM admin
+
+	return chainState, nil
+}

--- a/deployment/common/changeset/internal/solana/mcms.go
+++ b/deployment/common/changeset/internal/solana/mcms.go
@@ -8,7 +8,7 @@ import (
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
-// DeployMCMSWithTimelockProgramsSolana deploys an MCMS program f
+// DeployMCMSWithTimelockProgramsSolana deploys an MCMS program
 // and initializes 3 instances for each of the timelock roles: Bypasser, ProposerMcm, Canceller on an Solana chain.
 // as well as the timelock program. It's not necessarily the only way to use
 // the timelock and MCMS, but its reasonable pattern.
@@ -35,19 +35,19 @@ func DeployMCMSWithTimelockProgramsSolana(
 	}
 	err = initAccessController(e, chainState, commontypes.ProposerAccessControllerAccount, chain, addressBook)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deploy proposer access controller: %w", err)
+		return nil, fmt.Errorf("failed to init proposer access controller: %w", err)
 	}
 	err = initAccessController(e, chainState, commontypes.ExecutorAccessControllerAccount, chain, addressBook)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deploy access controller: %w", err)
+		return nil, fmt.Errorf("failed to init access controller: %w", err)
 	}
 	err = initAccessController(e, chainState, commontypes.CancellerAccessControllerAccount, chain, addressBook)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deploy access controller: %w", err)
+		return nil, fmt.Errorf("failed to init access controller: %w", err)
 	}
 	err = initAccessController(e, chainState, commontypes.BypasserAccessControllerAccount, chain, addressBook)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deploy access controller: %w", err)
+		return nil, fmt.Errorf("failed to init access controller: %w", err)
 	}
 
 	// mcm
@@ -57,15 +57,15 @@ func DeployMCMSWithTimelockProgramsSolana(
 	}
 	err = initMCM(e, chainState, commontypes.BypasserManyChainMultisig, chain, addressBook, &config.Bypasser)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deploy bypasser mcm: %w", err)
+		return nil, fmt.Errorf("failed to init bypasser mcm: %w", err)
 	}
 	err = initMCM(e, chainState, commontypes.CancellerManyChainMultisig, chain, addressBook, &config.Canceller)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deploy canceller mcm: %w", err)
+		return nil, fmt.Errorf("failed to init canceller mcm: %w", err)
 	}
 	err = initMCM(e, chainState, commontypes.ProposerManyChainMultisig, chain, addressBook, &config.Proposer)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deploy proposer mcm: %w", err)
+		return nil, fmt.Errorf("failed to init proposer mcm: %w", err)
 	}
 
 	// timelock
@@ -75,7 +75,7 @@ func DeployMCMSWithTimelockProgramsSolana(
 	}
 	err = initTimelock(e, chainState, chain, addressBook, config.TimelockMinDelay)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deploy timelock: %w", err)
+		return nil, fmt.Errorf("failed to init timelock: %w", err)
 	}
 
 	err = setupRoles(chainState, chain)
@@ -85,7 +85,7 @@ func DeployMCMSWithTimelockProgramsSolana(
 
 	err = transferOwnership(chainState, chain)
 	if err != nil {
-		return nil, fmt.Errorf("failed to setup roles and ownership: %w", err)
+		return nil, fmt.Errorf("failed to transfer ownership: %w", err)
 	}
 
 	return chainState, nil

--- a/deployment/common/changeset/internal/solana/pda.go
+++ b/deployment/common/changeset/internal/solana/pda.go
@@ -1,0 +1,77 @@
+package mcmsnew
+
+import (
+	"encoding/binary"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gagliardetto/solana-go"
+
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+)
+
+func getPDA(programID solana.PublicKey, seeds [][]byte) solana.PublicKey {
+	pda, _, _ := solana.FindProgramAddress(seeds, programID)
+	return pda
+}
+
+func GetMCMSignerPDA(programID solana.PublicKey, msigID state.PDASeed) solana.PublicKey {
+	seeds := [][]byte{[]byte("multisig_signer"), msigID[:]}
+	return getPDA(programID, seeds)
+}
+
+func GetMCMConfigPDA(programID solana.PublicKey, msigID state.PDASeed) solana.PublicKey {
+	seeds := [][]byte{[]byte("multisig_config"), msigID[:]}
+	return getPDA(programID, seeds)
+}
+
+func GetMCMRootMetadataPDA(programID solana.PublicKey, msigID state.PDASeed) solana.PublicKey {
+	seeds := [][]byte{[]byte("root_metadata"), msigID[:]}
+	return getPDA(programID, seeds)
+}
+
+func GetMCMExpiringRootAndOpCountPDA(programID solana.PublicKey, pdaSeed state.PDASeed) solana.PublicKey {
+	seeds := [][]byte{[]byte("expiring_root_and_op_count"), pdaSeed[:]}
+	return getPDA(programID, seeds)
+}
+
+func GetMCMRootSignaturesPDA(
+	programID solana.PublicKey, msigID state.PDASeed, root common.Hash, validUntil uint32,
+) solana.PublicKey {
+	seeds := [][]byte{[]byte("root_signatures"), msigID[:], root[:], validUntilBytes(validUntil)}
+	return getPDA(programID, seeds)
+}
+
+func GetMCMSeenSignedHashesPDA(
+	programID solana.PublicKey, msigID state.PDASeed, root common.Hash, validUntil uint32,
+) solana.PublicKey {
+	seeds := [][]byte{[]byte("seen_signed_hashes"), msigID[:], root[:], validUntilBytes(validUntil)}
+	return getPDA(programID, seeds)
+}
+
+func GetTimelockConfigPDA(programID solana.PublicKey, timelockID state.PDASeed) solana.PublicKey {
+	seeds := [][]byte{[]byte("timelock_config"), timelockID[:]}
+	return getPDA(programID, seeds)
+}
+
+func GetTimelockOperationPDA(programID solana.PublicKey, timelockID state.PDASeed, opID [32]byte) solana.PublicKey {
+	seeds := [][]byte{[]byte("timelock_operation"), timelockID[:], opID[:]}
+	return getPDA(programID, seeds)
+}
+
+func GetTimelockBypasserOperationPDA(programID solana.PublicKey, timelockID state.PDASeed, opID [32]byte) solana.PublicKey {
+	seeds := [][]byte{[]byte("timelock_bypasser_operation"), timelockID[:], opID[:]}
+	return getPDA(programID, seeds)
+}
+
+func GetTimelockSignerPDA(programID solana.PublicKey, timelockID state.PDASeed) solana.PublicKey {
+	seeds := [][]byte{[]byte("timelock_signer"), timelockID[:]}
+	return getPDA(programID, seeds)
+}
+
+func validUntilBytes(validUntil uint32) []byte {
+	const uint32Size = 4
+	vuBytes := make([]byte, uint32Size)
+	binary.LittleEndian.PutUint32(vuBytes, validUntil)
+
+	return vuBytes
+}

--- a/deployment/common/changeset/internal/solana/timelock.go
+++ b/deployment/common/changeset/internal/solana/timelock.go
@@ -1,0 +1,160 @@
+package mcmsnew
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	binary "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+
+	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+)
+
+func deployTimelockProgram(
+	e deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, chain deployment.SolChain,
+	addressBook deployment.AddressBook,
+) error {
+	typeAndVersion := deployment.NewTypeAndVersion(commontypes.RBACTimelockProgram, deployment.Version1_0_0)
+	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
+
+	programID, _, err := chainState.GetStateFromType(commontypes.RBACTimelock)
+	if err != nil {
+		return fmt.Errorf("failed to get timelock state: %w", err)
+	}
+
+	if programID.IsZero() {
+		deployedProgramID, err := chain.DeployProgram(log, "timelock")
+		if err != nil {
+			return fmt.Errorf("failed to deploy timelock program: %w", err)
+		}
+
+		programID, err = solana.PublicKeyFromBase58(deployedProgramID)
+		if err != nil {
+			return fmt.Errorf("failed to convert timelock program id to public key: %w", err)
+		}
+
+		err = addressBook.Save(chain.Selector, programID.String(), typeAndVersion)
+		if err != nil {
+			return fmt.Errorf("failed to save mcm address: %w", err)
+		}
+
+		err = chainState.SetState(commontypes.RBACTimelockProgram, programID, state.PDASeed{})
+		if err != nil {
+			return fmt.Errorf("failed to save onchain state: %w", err)
+		}
+
+		log.Infow("deployed timelock contract", "programId", programID)
+	} else {
+		log.Infow("using existing Timelock program", "programId", programID.String())
+	}
+
+	// FIXME: review if we need to setup an "AddressLookupTable".
+	return nil
+}
+
+func initTimelock(
+	e deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, chain deployment.SolChain,
+	addressBook deployment.AddressBook, minDelay *big.Int,
+) error {
+	if chainState.TimelockProgram.IsZero() {
+		return errors.New("mcm program is not deployed")
+	}
+	programID := chainState.TimelockProgram
+	timelockBindings.SetProgramID(programID)
+
+	typeAndVersion := deployment.NewTypeAndVersion(commontypes.RBACTimelock, deployment.Version1_0_0)
+	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
+
+	// FIXME: should we always redeploy or skip?
+	// pid, seed, err := chainState.GetStateFromType(commontypes.RBACTimelock)
+	// if err == nil && !pid.IsZero() && pid == programID && seed == state.PDASeed{} {
+	// 	log.Infow("timelock already initialized", "seed", seed)
+	// 	return nil
+	// }
+
+	seed := randomSeed()
+	log.Infow("generated Timelock seed", "seed", string(seed[:]))
+
+	err := initializeTimelock(e, chain, programID, seed, chainState, minDelay)
+	if err != nil {
+		return fmt.Errorf("failed to initialize timelock: %w", err)
+	}
+
+	timelockAddress := state.EncodeAddressWithSeed(programID, seed)
+
+	err = addressBook.Save(chain.Selector, timelockAddress, typeAndVersion)
+	if err != nil {
+		return fmt.Errorf("failed to save address: %w", err)
+	}
+
+	err = chainState.SetState(commontypes.RBACTimelock, programID, seed)
+	if err != nil {
+		return fmt.Errorf("failed to save onchain state: %w", err)
+	}
+
+	// FIXME: review if we need to setup an "AddressLookupTable".
+	return nil
+}
+
+func initializeTimelock(
+	e deployment.Environment, chain deployment.SolChain, timelockProgram solana.PublicKey, timelockID state.PDASeed,
+	chainState *state.MCMSWithTimelockStateSolana, minDelay *big.Int,
+) error {
+	if minDelay == nil {
+		minDelay = big.NewInt(0)
+	}
+
+	var timelockConfig timelockBindings.Config
+	err := chain.GetAccountDataBorshInto(e.GetContext(), GetTimelockConfigPDA(timelockProgram, timelockID),
+		&timelockConfig)
+	if err == nil {
+		e.Logger.Infow("Timelock already initialized, skipping initialization", "chain", chain.String())
+		return nil
+	}
+
+	var programData struct {
+		DataType uint32
+		Address  solana.PublicKey
+	}
+	opts := &rpc.GetAccountInfoOpts{Commitment: rpc.CommitmentConfirmed}
+
+	data, err := chain.Client.GetAccountInfoWithOpts(e.GetContext(), timelockProgram, opts)
+	if err != nil {
+		return fmt.Errorf("failed to get timelock program account info: %w", err)
+	}
+	err = binary.UnmarshalBorsh(&programData, data.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal program data: %w", err)
+	}
+
+	instruction, err := timelockBindings.NewInitializeInstruction(
+		timelockID,
+		minDelay.Uint64(),
+		GetTimelockConfigPDA(timelockProgram, timelockID),
+		chain.DeployerKey.PublicKey(),
+		solana.SystemProgramID,
+		timelockProgram,
+		programData.Address,
+		chainState.AccessControllerProgram,
+		chainState.ProposerAccessControllerAccount,
+		chainState.ExecutorAccessControllerAccount,
+		chainState.CancellerAccessControllerAccount,
+		chainState.BypasserAccessControllerAccount,
+	).ValidateAndBuild()
+	if err != nil {
+		return fmt.Errorf("failed to build instruction: %w", err)
+	}
+
+	err = chain.Confirm([]solana.Instruction{instruction})
+	if err != nil {
+		return fmt.Errorf("failed to confirm instructions: %w", err)
+	}
+
+	return nil
+}

--- a/deployment/common/changeset/internal/solana/timelock.go
+++ b/deployment/common/changeset/internal/solana/timelock.go
@@ -54,7 +54,6 @@ func deployTimelockProgram(
 		log.Infow("using existing Timelock program", "programId", programID.String())
 	}
 
-	// FIXME: review if we need to setup an "AddressLookupTable".
 	return nil
 }
 
@@ -98,7 +97,6 @@ func initTimelock(
 		return fmt.Errorf("failed to save onchain state: %w", err)
 	}
 
-	// FIXME: review if we need to setup an "AddressLookupTable".
 	return nil
 }
 

--- a/deployment/common/changeset/internal/solana/timelock.go
+++ b/deployment/common/changeset/internal/solana/timelock.go
@@ -70,13 +70,6 @@ func initTimelock(
 	typeAndVersion := deployment.NewTypeAndVersion(commontypes.RBACTimelock, deployment.Version1_0_0)
 	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
 
-	// FIXME: should we always redeploy or skip?
-	// pid, seed, err := chainState.GetStateFromType(commontypes.RBACTimelock)
-	// if err == nil && !pid.IsZero() && pid == programID && seed == state.PDASeed{} {
-	// 	log.Infow("timelock already initialized", "seed", seed)
-	// 	return nil
-	// }
-
 	seed := randomSeed()
 	log.Infow("generated Timelock seed", "seed", string(seed[:]))
 
@@ -152,6 +145,26 @@ func initializeTimelock(
 	err = chain.Confirm([]solana.Instruction{instruction})
 	if err != nil {
 		return fmt.Errorf("failed to confirm instructions: %w", err)
+	}
+
+	return nil
+}
+
+func transferOwnershipTimelock(chain deployment.SolChain, programID solana.PublicKey, seed state.PDASeed) error {
+	// transfer timelock ownership to itself
+	timelockConfigPDA := GetTimelockConfigPDA(programID, seed)
+	timelockSignerPDA := GetTimelockSignerPDA(programID, seed)
+
+	instructionBuilder := timelockBindings.NewTransferOwnershipInstruction([32]uint8(seed),
+		timelockSignerPDA, timelockConfigPDA, chain.DeployerKey.PublicKey())
+	instruction, err := instructionBuilder.ValidateAndBuild()
+	if err != nil {
+		return fmt.Errorf("failed to build TransferOwnership instruction: %w", err)
+	}
+
+	err = chain.Confirm([]solana.Instruction{instruction})
+	if err != nil {
+		return fmt.Errorf("failed to confirm TransferOwnership instruction: %w", err)
 	}
 
 	return nil

--- a/deployment/common/changeset/set_config_mcms_test.go
+++ b/deployment/common/changeset/set_config_mcms_test.go
@@ -33,7 +33,7 @@ func setupSetConfigTestEnv(t *testing.T) deployment.Environment {
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 	chainSelector := env.AllChainSelectors()[0]
 
-	config := proposalutils.SingleGroupTimelockConfig(t)
+	config := proposalutils.SingleGroupTimelockConfigV2(t)
 	// Deploy MCMS and Timelock
 	env, err := commonchangeset.Apply(t, env, nil,
 		commonchangeset.Configure(
@@ -41,8 +41,8 @@ func setupSetConfigTestEnv(t *testing.T) deployment.Environment {
 			[]uint64{chainSelector},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
-			map[uint64]types.MCMSWithTimelockConfig{
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
+			map[uint64]types.MCMSWithTimelockConfigV2{
 				chainSelector: config,
 			},
 		),

--- a/deployment/common/changeset/state/evm.go
+++ b/deployment/common/changeset/state/evm.go
@@ -1,0 +1,235 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	bindings "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/common/view/v1_0"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/link_token_interface"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/link_token"
+)
+
+// MCMSWithTimelockState holds the Go bindings
+// for a MCMSWithTimelock contract deployment.
+// It is public for use in product specific packages.
+// Either all fields are nil or all fields are non-nil.
+type MCMSWithTimelockState struct {
+	*proposalutils.MCMSWithTimelockContracts
+}
+
+func (state MCMSWithTimelockState) GenerateMCMSWithTimelockView() (v1_0.MCMSWithTimelockView, error) {
+	if err := state.Validate(); err != nil {
+		return v1_0.MCMSWithTimelockView{}, err
+	}
+	timelockView, err := v1_0.GenerateTimelockView(*state.Timelock)
+	if err != nil {
+		return v1_0.MCMSWithTimelockView{}, nil
+	}
+	callProxyView, err := v1_0.GenerateCallProxyView(*state.CallProxy)
+	if err != nil {
+		return v1_0.MCMSWithTimelockView{}, nil
+	}
+	bypasserView, err := v1_0.GenerateMCMSView(*state.BypasserMcm)
+	if err != nil {
+		return v1_0.MCMSWithTimelockView{}, nil
+	}
+	proposerView, err := v1_0.GenerateMCMSView(*state.ProposerMcm)
+	if err != nil {
+		return v1_0.MCMSWithTimelockView{}, nil
+	}
+	cancellerView, err := v1_0.GenerateMCMSView(*state.CancellerMcm)
+	if err != nil {
+		return v1_0.MCMSWithTimelockView{}, nil
+	}
+	return v1_0.MCMSWithTimelockView{
+		Timelock:  timelockView,
+		Bypasser:  bypasserView,
+		Proposer:  proposerView,
+		Canceller: cancellerView,
+		CallProxy: callProxyView,
+	}, nil
+}
+
+// MaybeLoadMCMSWithTimelockState loads the MCMSWithTimelockState state for each chain in the given environment.
+func MaybeLoadMCMSWithTimelockState(env deployment.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
+	result := map[uint64]*MCMSWithTimelockState{}
+	for _, chainSelector := range chainSelectors {
+		chain, ok := env.Chains[chainSelector]
+		if !ok {
+			return nil, fmt.Errorf("chain %d not found", chainSelector)
+		}
+		addressesChain, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+		if err != nil {
+			return nil, err
+		}
+		state, err := MaybeLoadMCMSWithTimelockChainState(chain, addressesChain)
+		if err != nil {
+			return nil, err
+		}
+		result[chainSelector] = state
+	}
+	return result, nil
+}
+
+// MaybeLoadMCMSWithTimelockChainState looks for the addresses corresponding to
+// contracts deployed with DeployMCMSWithTimelock and loads them into a
+// MCMSWithTimelockState struct. If none of the contracts are found, the state struct will be nil.
+// An error indicates:
+// - Found but was unable to load a contract
+// - It only found part of the bundle of contracts
+// - If found more than one instance of a contract (we expect one bundle in the given addresses)
+func MaybeLoadMCMSWithTimelockChainState(chain deployment.Chain, addresses map[string]deployment.TypeAndVersion) (*MCMSWithTimelockState, error) {
+	state := MCMSWithTimelockState{
+		MCMSWithTimelockContracts: &proposalutils.MCMSWithTimelockContracts{},
+	}
+	// We expect one of each contract on the chain.
+	timelock := deployment.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
+	callProxy := deployment.NewTypeAndVersion(types.CallProxy, deployment.Version1_0_0)
+	proposer := deployment.NewTypeAndVersion(types.ProposerManyChainMultisig, deployment.Version1_0_0)
+	canceller := deployment.NewTypeAndVersion(types.CancellerManyChainMultisig, deployment.Version1_0_0)
+	bypasser := deployment.NewTypeAndVersion(types.BypasserManyChainMultisig, deployment.Version1_0_0)
+
+	// Convert map keys to a slice
+	wantTypes := []deployment.TypeAndVersion{timelock, proposer, canceller, bypasser, callProxy}
+
+	// Ensure we either have the bundle or not.
+	_, err := deployment.AddressesContainBundle(addresses, wantTypes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to check MCMS contracts on chain %s error: %w", chain.Name(), err)
+	}
+
+	for address, tvStr := range addresses {
+		switch {
+		case tvStr.Type == timelock.Type && tvStr.Version.String() == timelock.Version.String():
+			tl, err := bindings.NewRBACTimelock(common.HexToAddress(address), chain.Client)
+			if err != nil {
+				return nil, err
+			}
+			state.Timelock = tl
+		case tvStr.Type == callProxy.Type && tvStr.Version.String() == callProxy.Version.String():
+			cp, err := bindings.NewCallProxy(common.HexToAddress(address), chain.Client)
+			if err != nil {
+				return nil, err
+			}
+			state.CallProxy = cp
+		case tvStr.Type == proposer.Type && tvStr.Version.String() == proposer.Version.String():
+			mcms, err := bindings.NewManyChainMultiSig(common.HexToAddress(address), chain.Client)
+			if err != nil {
+				return nil, err
+			}
+			state.ProposerMcm = mcms
+		case tvStr.Type == bypasser.Type && tvStr.Version.String() == bypasser.Version.String():
+			mcms, err := bindings.NewManyChainMultiSig(common.HexToAddress(address), chain.Client)
+			if err != nil {
+				return nil, err
+			}
+			state.BypasserMcm = mcms
+		case tvStr.Type == canceller.Type && tvStr.Version.String() == canceller.Version.String():
+			mcms, err := bindings.NewManyChainMultiSig(common.HexToAddress(address), chain.Client)
+			if err != nil {
+				return nil, err
+			}
+			state.CancellerMcm = mcms
+		}
+	}
+	return &state, nil
+}
+
+type LinkTokenState struct {
+	LinkToken *link_token.LinkToken
+}
+
+func (s LinkTokenState) GenerateLinkView() (v1_0.LinkTokenView, error) {
+	if s.LinkToken == nil {
+		return v1_0.LinkTokenView{}, errors.New("link token not found")
+	}
+	return v1_0.GenerateLinkTokenView(s.LinkToken)
+}
+
+// MaybeLoadLinkTokenState loads the LinkTokenState state for each chain in the given environment.
+func MaybeLoadLinkTokenState(env deployment.Environment, chainSelectors []uint64) (map[uint64]*LinkTokenState, error) {
+	result := map[uint64]*LinkTokenState{}
+	for _, chainSelector := range chainSelectors {
+		chain, ok := env.Chains[chainSelector]
+		if !ok {
+			return nil, fmt.Errorf("chain %d not found", chainSelector)
+		}
+		addressesChain, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+		if err != nil {
+			return nil, err
+		}
+		state, err := MaybeLoadLinkTokenChainState(chain, addressesChain)
+		if err != nil {
+			return nil, err
+		}
+		result[chainSelector] = state
+	}
+	return result, nil
+}
+
+func MaybeLoadLinkTokenChainState(chain deployment.Chain, addresses map[string]deployment.TypeAndVersion) (*LinkTokenState, error) {
+	state := LinkTokenState{}
+	linkToken := deployment.NewTypeAndVersion(types.LinkToken, deployment.Version1_0_0)
+
+	// Convert map keys to a slice
+	wantTypes := []deployment.TypeAndVersion{linkToken}
+
+	// Ensure we either have the bundle or not.
+	_, err := deployment.AddressesContainBundle(addresses, wantTypes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to check link token on chain %s error: %w", chain.Name(), err)
+	}
+
+	for address, tvStr := range addresses {
+		if tvStr.Type == linkToken.Type && tvStr.Version.String() == linkToken.Version.String() {
+			lt, err := link_token.NewLinkToken(common.HexToAddress(address), chain.Client)
+			if err != nil {
+				return nil, err
+			}
+			state.LinkToken = lt
+		}
+	}
+	return &state, nil
+}
+
+type StaticLinkTokenState struct {
+	StaticLinkToken *link_token_interface.LinkToken
+}
+
+func (s StaticLinkTokenState) GenerateStaticLinkView() (v1_0.StaticLinkTokenView, error) {
+	if s.StaticLinkToken == nil {
+		return v1_0.StaticLinkTokenView{}, errors.New("static link token not found")
+	}
+	return v1_0.GenerateStaticLinkTokenView(s.StaticLinkToken)
+}
+
+func MaybeLoadStaticLinkTokenState(chain deployment.Chain, addresses map[string]deployment.TypeAndVersion) (*StaticLinkTokenState, error) {
+	state := StaticLinkTokenState{}
+	staticLinkToken := deployment.NewTypeAndVersion(types.StaticLinkToken, deployment.Version1_0_0)
+
+	// Convert map keys to a slice
+	wantTypes := []deployment.TypeAndVersion{staticLinkToken}
+
+	// Ensure we either have the bundle or not.
+	_, err := deployment.AddressesContainBundle(addresses, wantTypes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to check static link token on chain %s error: %w", chain.Name(), err)
+	}
+
+	for address, tvStr := range addresses {
+		if tvStr.Type == staticLinkToken.Type && tvStr.Version.String() == staticLinkToken.Version.String() {
+			lt, err := link_token_interface.NewLinkToken(common.HexToAddress(address), chain.Client)
+			if err != nil {
+				return nil, err
+			}
+			state.StaticLinkToken = lt
+		}
+	}
+	return &state, nil
+}

--- a/deployment/common/changeset/state/solana.go
+++ b/deployment/common/changeset/state/solana.go
@@ -276,7 +276,7 @@ func MaybeLoadMCMSWithTimelockChainStateSolana(chain deployment.SolChain, addres
 		case tvStr.Type == proposerMCM.Type && tvStr.Version.String() == proposerMCM.Version.String():
 			programID, seed, err := DecodeAddressWithSeed(address)
 			if err != nil {
-				return nil, fmt.Errorf("unable to decode timelock address (%s): %w", address, err)
+				return nil, fmt.Errorf("unable to decode proposer address (%s): %w", address, err)
 			}
 			state.McmProgram = programID
 			state.ProposerMcmSeed = seed
@@ -284,7 +284,7 @@ func MaybeLoadMCMSWithTimelockChainStateSolana(chain deployment.SolChain, addres
 		case tvStr.Type == bypasserMCM.Type && tvStr.Version.String() == bypasserMCM.Version.String():
 			programID, seed, err := DecodeAddressWithSeed(address)
 			if err != nil {
-				return nil, fmt.Errorf("unable to decode timelock address (%s): %w", address, err)
+				return nil, fmt.Errorf("unable to decode bypasser address (%s): %w", address, err)
 			}
 			state.McmProgram = programID
 			state.BypasserMcmSeed = seed
@@ -292,7 +292,7 @@ func MaybeLoadMCMSWithTimelockChainStateSolana(chain deployment.SolChain, addres
 		case tvStr.Type == cancellerMCM.Type && tvStr.Version.String() == cancellerMCM.Version.String():
 			programID, seed, err := DecodeAddressWithSeed(address)
 			if err != nil {
-				return nil, fmt.Errorf("unable to decode timelock address (%s): %w", address, err)
+				return nil, fmt.Errorf("unable to decode canceller address (%s): %w", address, err)
 			}
 			state.McmProgram = programID
 			state.CancellerMcmSeed = seed

--- a/deployment/common/changeset/state/solana.go
+++ b/deployment/common/changeset/state/solana.go
@@ -1,0 +1,354 @@
+package state
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gagliardetto/solana-go"
+
+	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
+)
+
+type PDASeed [32]byte
+
+// MCMSWithTimelockProgramsSolana holds the solana publick keys
+// and seeds for the MCM, AccessController and Timelock programs.
+// It is public for use in product specific packages.
+type MCMSWithTimelockProgramsSolana struct {
+	McmProgram                       solana.PublicKey
+	ProposerMcmSeed                  PDASeed
+	CancellerMcmSeed                 PDASeed
+	BypasserMcmSeed                  PDASeed
+	TimelockProgram                  solana.PublicKey
+	TimelockSeed                     PDASeed
+	AccessControllerProgram          solana.PublicKey
+	ProposerAccessControllerAccount  solana.PublicKey
+	ExecutorAccessControllerAccount  solana.PublicKey
+	CancellerAccessControllerAccount solana.PublicKey
+	BypasserAccessControllerAccount  solana.PublicKey
+	// CallProxy                     solana.PublicKey // TODO: do we need this?
+}
+
+func (s *MCMSWithTimelockProgramsSolana) GetStateFromType(programType deployment.ContractType) (solana.PublicKey, PDASeed, error) {
+	switch programType {
+	case types.ManyChainMultisigProgram:
+		return s.McmProgram, PDASeed{}, nil
+	case types.RBACTimelock:
+		return s.TimelockProgram, s.TimelockSeed, nil
+	case types.AccessControllerProgram:
+		return s.AccessControllerProgram, PDASeed{}, nil
+	case types.ProposerAccessControllerAccount:
+		return s.AccessControllerProgram, PDASeed(s.ProposerAccessControllerAccount), nil
+	case types.ExecutorAccessControllerAccount:
+		return s.AccessControllerProgram, PDASeed(s.ExecutorAccessControllerAccount), nil
+	case types.CancellerAccessControllerAccount:
+		return s.AccessControllerProgram, PDASeed(s.CancellerAccessControllerAccount), nil
+	case types.BypasserAccessControllerAccount:
+		return s.AccessControllerProgram, PDASeed(s.BypasserAccessControllerAccount), nil
+	case types.ProposerManyChainMultisig:
+		return s.McmProgram, s.ProposerMcmSeed, nil
+	case types.BypasserManyChainMultisig:
+		return s.McmProgram, s.BypasserMcmSeed, nil
+	case types.CancellerManyChainMultisig:
+		return s.McmProgram, s.CancellerMcmSeed, nil
+	// case types.CallProxy:
+	// 	return state.CallProxy, PDASeed{}, nil
+	default:
+		return solana.PublicKey{}, PDASeed{}, fmt.Errorf("unknown program type: %s", programType)
+	}
+}
+
+func (s *MCMSWithTimelockProgramsSolana) SetState(contractType deployment.ContractType, program solana.PublicKey, seed PDASeed) error {
+	switch contractType {
+	case types.ManyChainMultisigProgram:
+		s.McmProgram = program
+	case types.RBACTimelock:
+		s.TimelockProgram = program
+		s.TimelockSeed = seed
+	case types.AccessControllerProgram:
+		s.AccessControllerProgram = program
+	case types.ProposerAccessControllerAccount:
+		s.AccessControllerProgram = program
+		s.ProposerAccessControllerAccount = solana.PublicKey(seed)
+	case types.ExecutorAccessControllerAccount:
+		s.AccessControllerProgram = program
+		s.ExecutorAccessControllerAccount = solana.PublicKey(seed)
+	case types.CancellerAccessControllerAccount:
+		s.AccessControllerProgram = program
+		s.CancellerAccessControllerAccount = solana.PublicKey(seed)
+	case types.BypasserAccessControllerAccount:
+		s.AccessControllerProgram = program
+		s.BypasserAccessControllerAccount = solana.PublicKey(seed)
+	case types.ProposerManyChainMultisig:
+		s.McmProgram = program
+		s.ProposerMcmSeed = seed
+	case types.BypasserManyChainMultisig:
+		s.McmProgram = program
+		s.BypasserMcmSeed = seed
+	case types.CancellerManyChainMultisig:
+		s.McmProgram = program
+		s.CancellerMcmSeed = seed
+	// case types.CallProxy:
+	//	s.CallProxyProgram = program
+	default:
+		return fmt.Errorf("unknown program type: %s", contractType)
+	}
+	return nil
+}
+
+// Validate checks that all fields are non-nil, ensuring it's ready
+// for use generating views or interactions.
+func (s *MCMSWithTimelockProgramsSolana) Validate() error {
+	if s.McmProgram.IsZero() {
+		return errors.New("canceller not found")
+	}
+	if s.TimelockProgram.IsZero() {
+		return errors.New("timelock not found")
+	}
+	if s.AccessControllerProgram.IsZero() {
+		return errors.New("timelock not found")
+	}
+	if s.ProposerAccessControllerAccount.IsZero() {
+		return errors.New("access controller not found")
+	}
+	if s.ExecutorAccessControllerAccount.IsZero() {
+		return errors.New("access controller not found")
+	}
+	if s.CancellerAccessControllerAccount.IsZero() {
+		return errors.New("access controller not found")
+	}
+	if s.BypasserAccessControllerAccount.IsZero() {
+		return errors.New("access controller not found")
+	}
+	// if state.CallProxy.IsZero() {
+	// 	return errors.New("call proxy not found")
+	// }
+	return nil
+}
+
+func (s *MCMSWithTimelockProgramsSolana) RoleAccount(role timelockBindings.Role) solana.PublicKey {
+	switch role {
+	case timelockBindings.Proposer_Role:
+		return s.ProposerAccessControllerAccount
+	case timelockBindings.Executor_Role:
+		return s.ExecutorAccessControllerAccount
+	case timelockBindings.Canceller_Role:
+		return s.CancellerAccessControllerAccount
+	case timelockBindings.Bypasser_Role:
+		return s.BypasserAccessControllerAccount
+	default:
+		return solana.PublicKey{}
+	}
+}
+
+// MCMSWithTimelockStateStateSolana holds the Go bindings
+// for a MCMSWithTimelock contract deployment.
+// It is public for use in product specific packages.
+// Either all fields are nil or all fields are non-nil.
+type MCMSWithTimelockStateSolana struct {
+	*MCMSWithTimelockProgramsSolana
+}
+
+// MaybeLoadMCMSWithTimelockState loads the MCMSWithTimelockState state for each chain in the given environment.
+func MaybeLoadMCMSWithTimelockStateSolana(env deployment.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockStateSolana, error) {
+	result := map[uint64]*MCMSWithTimelockStateSolana{}
+	for _, chainSelector := range chainSelectors {
+		chain, ok := env.SolChains[chainSelector]
+		if !ok {
+			return nil, fmt.Errorf("chain %d not found", chainSelector)
+		}
+		addressesChain, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+		if err != nil {
+			if !errors.Is(err, deployment.ErrChainNotFound) {
+				return nil, fmt.Errorf("unable to get addresses for chain %v: %w", chainSelector, err)
+			}
+			// chain not found in address book, initialize empty
+			addressesChain = make(map[string]deployment.TypeAndVersion)
+		}
+		state, err := MaybeLoadMCMSWithTimelockChainStateSolana(chain, addressesChain)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load mcms and timelock solana chain state: %w", err)
+		}
+		result[chainSelector] = state
+	}
+	return result, nil
+}
+
+// MaybeLoadMCMSWithTimelockChainState looks for the addresses corresponding to
+// contracts deployed with DeployMCMSWithTimelock and loads them into a
+// MCMSWithTimelockState struct. If none of the contracts are found, the state struct will be nil.
+// An error indicates:
+// - Found but was unable to load a contract
+// - It only found part of the bundle of contracts
+// - If found more than one instance of a contract (we expect one bundle in the given addresses)
+func MaybeLoadMCMSWithTimelockChainStateSolana(chain deployment.SolChain, addresses map[string]deployment.TypeAndVersion) (*MCMSWithTimelockStateSolana, error) {
+	state := MCMSWithTimelockStateSolana{MCMSWithTimelockProgramsSolana: &MCMSWithTimelockProgramsSolana{}}
+
+	mcmProgram := deployment.NewTypeAndVersion(types.ManyChainMultisigProgram, deployment.Version1_0_0)
+	timelockProgram := deployment.NewTypeAndVersion(types.RBACTimelockProgram, deployment.Version1_0_0)
+	accessControllerProgram := deployment.NewTypeAndVersion(types.AccessControllerProgram, deployment.Version1_0_0)
+	proposerMCM := deployment.NewTypeAndVersion(types.ProposerManyChainMultisig, deployment.Version1_0_0)
+	cancellerMCM := deployment.NewTypeAndVersion(types.CancellerManyChainMultisig, deployment.Version1_0_0)
+	bypasserMCM := deployment.NewTypeAndVersion(types.BypasserManyChainMultisig, deployment.Version1_0_0)
+	timelock := deployment.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
+	proposerAccessControllerAccount := deployment.NewTypeAndVersion(types.ProposerAccessControllerAccount, deployment.Version1_0_0)
+	executorAccessControllerAccount := deployment.NewTypeAndVersion(types.ExecutorAccessControllerAccount, deployment.Version1_0_0)
+	cancellerAccessControllerAccount := deployment.NewTypeAndVersion(types.CancellerAccessControllerAccount, deployment.Version1_0_0)
+	bypasserAccessControllerAccount := deployment.NewTypeAndVersion(types.BypasserAccessControllerAccount, deployment.Version1_0_0)
+	// callProxy := deployment.NewTypeAndVersion(types.CallProxy, deployment.Version1_0_0)
+
+	// Convert map keys to a slice
+	wantTypes := []deployment.TypeAndVersion{
+		mcmProgram, timelockProgram, accessControllerProgram, proposerMCM, cancellerMCM, bypasserMCM, timelock,
+		proposerAccessControllerAccount, executorAccessControllerAccount, cancellerAccessControllerAccount,
+		bypasserAccessControllerAccount, // callProxy,
+	}
+
+	// Ensure we either have the bundle or not.
+	_, err := deployment.AddressesContainBundle(addresses, wantTypes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to check MCMS contracts on chain %s error: %w", chain.Name(), err)
+	}
+
+	for address, tvStr := range addresses {
+		switch {
+		case tvStr.Type == timelockProgram.Type && tvStr.Version.String() == timelockProgram.Version.String():
+			programID, err := solana.PublicKeyFromBase58(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode timelock program address (%s): %w", address, err)
+			}
+			state.TimelockProgram = programID
+
+		case tvStr.Type == timelock.Type && tvStr.Version.String() == timelock.Version.String():
+			programID, seed, err := DecodeAddressWithSeed(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode timelock address (%s): %w", address, err)
+			}
+			state.TimelockProgram = programID
+			state.TimelockSeed = seed
+
+		case tvStr.Type == accessControllerProgram.Type && tvStr.Version.String() == accessControllerProgram.Version.String():
+			programID, err := solana.PublicKeyFromBase58(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse public key from access controller address: %s", address)
+			}
+			state.AccessControllerProgram = programID
+
+		case tvStr.Type == proposerAccessControllerAccount.Type && tvStr.Version.String() == proposerAccessControllerAccount.Version.String():
+			programID, account, err := DecodeAddressWithAccount(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode proposer access controlle address (%s): %w", address, err)
+			}
+			state.AccessControllerProgram = programID
+			state.ProposerAccessControllerAccount = account
+
+		case tvStr.Type == executorAccessControllerAccount.Type && tvStr.Version.String() == executorAccessControllerAccount.Version.String():
+			programID, account, err := DecodeAddressWithAccount(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode executor access controlle address (%s): %w", address, err)
+			}
+			state.AccessControllerProgram = programID
+			state.ExecutorAccessControllerAccount = account
+
+		case tvStr.Type == cancellerAccessControllerAccount.Type && tvStr.Version.String() == cancellerAccessControllerAccount.Version.String():
+			programID, account, err := DecodeAddressWithAccount(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode canceller access controlle address (%s): %w", address, err)
+			}
+			state.AccessControllerProgram = programID
+			state.CancellerAccessControllerAccount = account
+
+		case tvStr.Type == bypasserAccessControllerAccount.Type && tvStr.Version.String() == bypasserAccessControllerAccount.Version.String():
+			programID, account, err := DecodeAddressWithAccount(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode bypasser access controlle address (%s): %w", address, err)
+			}
+			state.AccessControllerProgram = programID
+			state.BypasserAccessControllerAccount = account
+
+		case tvStr.Type == mcmProgram.Type && tvStr.Version.String() == mcmProgram.Version.String():
+			programID, err := solana.PublicKeyFromBase58(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse public key from mcm address: %s", address)
+			}
+			state.McmProgram = programID
+
+		case tvStr.Type == proposerMCM.Type && tvStr.Version.String() == proposerMCM.Version.String():
+			programID, seed, err := DecodeAddressWithSeed(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode timelock address (%s): %w", address, err)
+			}
+			state.McmProgram = programID
+			state.ProposerMcmSeed = seed
+
+		case tvStr.Type == bypasserMCM.Type && tvStr.Version.String() == bypasserMCM.Version.String():
+			programID, seed, err := DecodeAddressWithSeed(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode timelock address (%s): %w", address, err)
+			}
+			state.McmProgram = programID
+			state.BypasserMcmSeed = seed
+
+		case tvStr.Type == cancellerMCM.Type && tvStr.Version.String() == cancellerMCM.Version.String():
+			programID, seed, err := DecodeAddressWithSeed(address)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode timelock address (%s): %w", address, err)
+			}
+			state.McmProgram = programID
+			state.CancellerMcmSeed = seed
+		}
+	}
+	return &state, nil
+}
+
+func EncodeAddressWithSeed(programID solana.PublicKey, seed PDASeed) string {
+	return fmt.Sprintf("%s.%s", programID.String(), bytes.Trim(seed[:], "\x00"))
+}
+
+func DecodeAddressWithSeed(address string) (solana.PublicKey, PDASeed, error) {
+	parts := strings.Split(address, ".")
+	if len(parts) != 2 {
+		return solana.PublicKey{}, PDASeed{}, fmt.Errorf("invalid address: %s", address)
+	}
+
+	programID, err := solana.PublicKeyFromBase58(parts[0])
+	if err != nil {
+		return solana.PublicKey{}, PDASeed{}, fmt.Errorf("unable to parse public key from program id: %s", parts[0])
+	}
+
+	if len(parts[1]) > len(PDASeed{}) {
+		return solana.PublicKey{}, PDASeed{}, fmt.Errorf("seed must have at most %d bytes", len(PDASeed{}))
+	}
+
+	var seed PDASeed
+	copy(seed[:], []byte(parts[1]))
+
+	return programID, seed, nil
+}
+
+func EncodeAddressWithAccount(programID, account solana.PublicKey) string {
+	return fmt.Sprintf("%s.%s", programID.String(), account.String())
+}
+
+func DecodeAddressWithAccount(address string) (solana.PublicKey, solana.PublicKey, error) {
+	parts := strings.Split(address, ".")
+	if len(parts) != 2 {
+		return solana.PublicKey{}, solana.PublicKey{}, fmt.Errorf("invalid address: %s", address)
+	}
+
+	programID, err := solana.PublicKeyFromBase58(parts[0])
+	if err != nil {
+		return solana.PublicKey{}, solana.PublicKey{}, fmt.Errorf("unable to parse public key from program id: %s", parts[0])
+	}
+
+	account, err := solana.PublicKeyFromBase58(parts[1])
+	if err != nil {
+		return solana.PublicKey{}, solana.PublicKey{}, fmt.Errorf("unable to parse public key from account: %s", parts[1])
+	}
+
+	return programID, account, nil
+}

--- a/deployment/common/changeset/state/solana.go
+++ b/deployment/common/changeset/state/solana.go
@@ -1,12 +1,12 @@
 package state
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/gagliardetto/solana-go"
+	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 
 	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -30,13 +30,20 @@ type MCMSWithTimelockProgramsSolana struct {
 	ExecutorAccessControllerAccount  solana.PublicKey
 	CancellerAccessControllerAccount solana.PublicKey
 	BypasserAccessControllerAccount  solana.PublicKey
-	// CallProxy                     solana.PublicKey // TODO: do we need this?
 }
 
 func (s *MCMSWithTimelockProgramsSolana) GetStateFromType(programType deployment.ContractType) (solana.PublicKey, PDASeed, error) {
 	switch programType {
 	case types.ManyChainMultisigProgram:
 		return s.McmProgram, PDASeed{}, nil
+	case types.ProposerManyChainMultisig:
+		return s.McmProgram, s.ProposerMcmSeed, nil
+	case types.BypasserManyChainMultisig:
+		return s.McmProgram, s.BypasserMcmSeed, nil
+	case types.CancellerManyChainMultisig:
+		return s.McmProgram, s.CancellerMcmSeed, nil
+	case types.RBACTimelockProgram:
+		return s.TimelockProgram, PDASeed{}, nil
 	case types.RBACTimelock:
 		return s.TimelockProgram, s.TimelockSeed, nil
 	case types.AccessControllerProgram:
@@ -49,14 +56,6 @@ func (s *MCMSWithTimelockProgramsSolana) GetStateFromType(programType deployment
 		return s.AccessControllerProgram, PDASeed(s.CancellerAccessControllerAccount), nil
 	case types.BypasserAccessControllerAccount:
 		return s.AccessControllerProgram, PDASeed(s.BypasserAccessControllerAccount), nil
-	case types.ProposerManyChainMultisig:
-		return s.McmProgram, s.ProposerMcmSeed, nil
-	case types.BypasserManyChainMultisig:
-		return s.McmProgram, s.BypasserMcmSeed, nil
-	case types.CancellerManyChainMultisig:
-		return s.McmProgram, s.CancellerMcmSeed, nil
-	// case types.CallProxy:
-	// 	return state.CallProxy, PDASeed{}, nil
 	default:
 		return solana.PublicKey{}, PDASeed{}, fmt.Errorf("unknown program type: %s", programType)
 	}
@@ -66,6 +65,17 @@ func (s *MCMSWithTimelockProgramsSolana) SetState(contractType deployment.Contra
 	switch contractType {
 	case types.ManyChainMultisigProgram:
 		s.McmProgram = program
+	case types.ProposerManyChainMultisig:
+		s.McmProgram = program
+		s.ProposerMcmSeed = seed
+	case types.BypasserManyChainMultisig:
+		s.McmProgram = program
+		s.BypasserMcmSeed = seed
+	case types.CancellerManyChainMultisig:
+		s.McmProgram = program
+		s.CancellerMcmSeed = seed
+	case types.RBACTimelockProgram:
+		s.TimelockProgram = program
 	case types.RBACTimelock:
 		s.TimelockProgram = program
 		s.TimelockSeed = seed
@@ -83,17 +93,6 @@ func (s *MCMSWithTimelockProgramsSolana) SetState(contractType deployment.Contra
 	case types.BypasserAccessControllerAccount:
 		s.AccessControllerProgram = program
 		s.BypasserAccessControllerAccount = solana.PublicKey(seed)
-	case types.ProposerManyChainMultisig:
-		s.McmProgram = program
-		s.ProposerMcmSeed = seed
-	case types.BypasserManyChainMultisig:
-		s.McmProgram = program
-		s.BypasserMcmSeed = seed
-	case types.CancellerManyChainMultisig:
-		s.McmProgram = program
-		s.CancellerMcmSeed = seed
-	// case types.CallProxy:
-	//	s.CallProxyProgram = program
 	default:
 		return fmt.Errorf("unknown program type: %s", contractType)
 	}
@@ -124,9 +123,6 @@ func (s *MCMSWithTimelockProgramsSolana) Validate() error {
 	if s.BypasserAccessControllerAccount.IsZero() {
 		return errors.New("access controller not found")
 	}
-	// if state.CallProxy.IsZero() {
-	// 	return errors.New("call proxy not found")
-	// }
 	return nil
 }
 
@@ -199,13 +195,12 @@ func MaybeLoadMCMSWithTimelockChainStateSolana(chain deployment.SolChain, addres
 	executorAccessControllerAccount := deployment.NewTypeAndVersion(types.ExecutorAccessControllerAccount, deployment.Version1_0_0)
 	cancellerAccessControllerAccount := deployment.NewTypeAndVersion(types.CancellerAccessControllerAccount, deployment.Version1_0_0)
 	bypasserAccessControllerAccount := deployment.NewTypeAndVersion(types.BypasserAccessControllerAccount, deployment.Version1_0_0)
-	// callProxy := deployment.NewTypeAndVersion(types.CallProxy, deployment.Version1_0_0)
 
 	// Convert map keys to a slice
 	wantTypes := []deployment.TypeAndVersion{
 		mcmProgram, timelockProgram, accessControllerProgram, proposerMCM, cancellerMCM, bypasserMCM, timelock,
 		proposerAccessControllerAccount, executorAccessControllerAccount, cancellerAccessControllerAccount,
-		bypasserAccessControllerAccount, // callProxy,
+		bypasserAccessControllerAccount,
 	}
 
 	// Ensure we either have the bundle or not.
@@ -306,28 +301,16 @@ func MaybeLoadMCMSWithTimelockChainStateSolana(chain deployment.SolChain, addres
 }
 
 func EncodeAddressWithSeed(programID solana.PublicKey, seed PDASeed) string {
-	return fmt.Sprintf("%s.%s", programID.String(), bytes.Trim(seed[:], "\x00"))
+	return mcmssolanasdk.ContractAddress(programID, mcmssolanasdk.PDASeed(seed))
 }
 
 func DecodeAddressWithSeed(address string) (solana.PublicKey, PDASeed, error) {
-	parts := strings.Split(address, ".")
-	if len(parts) != 2 {
-		return solana.PublicKey{}, PDASeed{}, fmt.Errorf("invalid address: %s", address)
-	}
-
-	programID, err := solana.PublicKeyFromBase58(parts[0])
+	programID, seed, err := mcmssolanasdk.ParseContractAddress(address)
 	if err != nil {
-		return solana.PublicKey{}, PDASeed{}, fmt.Errorf("unable to parse public key from program id: %s", parts[0])
+		return solana.PublicKey{}, PDASeed{}, fmt.Errorf("unable to parse address: %s", address)
 	}
 
-	if len(parts[1]) > len(PDASeed{}) {
-		return solana.PublicKey{}, PDASeed{}, fmt.Errorf("seed must have at most %d bytes", len(PDASeed{}))
-	}
-
-	var seed PDASeed
-	copy(seed[:], []byte(parts[1]))
-
-	return programID, seed, nil
+	return programID, PDASeed(seed), nil
 }
 
 func EncodeAddressWithAccount(programID, account solana.PublicKey) string {

--- a/deployment/common/changeset/state/solana.go
+++ b/deployment/common/changeset/state/solana.go
@@ -176,7 +176,8 @@ func MaybeLoadMCMSWithTimelockStateSolana(env deployment.Environment, chainSelec
 
 // MaybeLoadMCMSWithTimelockChainState looks for the addresses corresponding to
 // contracts deployed with DeployMCMSWithTimelock and loads them into a
-// MCMSWithTimelockState struct. If none of the contracts are found, the state struct will be nil.
+// MCMSWithTimelockStateSolana struct. If none of the contracts are found, the
+// state struct will be nil.
 // An error indicates:
 // - Found but was unable to load a contract
 // - It only found part of the bundle of contracts

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
@@ -29,9 +29,9 @@ func TestTransferToMCMSWithTimelock(t *testing.T) {
 			[]uint64{chain1},
 		),
 		Configure(
-			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelock),
-			map[uint64]types.MCMSWithTimelockConfig{
-				chain1: proposalutils.SingleGroupTimelockConfig(t),
+			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelockV2),
+			map[uint64]types.MCMSWithTimelockConfigV2{
+				chain1: proposalutils.SingleGroupTimelockConfigV2(t),
 			},
 		),
 	)
@@ -94,9 +94,9 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 			[]uint64{chain1},
 		),
 		Configure(
-			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelock),
-			map[uint64]types.MCMSWithTimelockConfig{
-				chain1: proposalutils.SingleGroupTimelockConfig(t),
+			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelockV2),
+			map[uint64]types.MCMSWithTimelockConfigV2{
+				chain1: proposalutils.SingleGroupTimelockConfigV2(t),
 			},
 		),
 	)
@@ -156,9 +156,9 @@ func TestRenounceTimelockDeployerConfigValidate(t *testing.T) {
 	chain1 := e.AllChainSelectors()[0]
 	e, err := Apply(t, e, nil,
 		Configure(
-			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelock),
-			map[uint64]types.MCMSWithTimelockConfig{
-				chain1: proposalutils.SingleGroupTimelockConfig(t),
+			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelockV2),
+			map[uint64]types.MCMSWithTimelockConfigV2{
+				chain1: proposalutils.SingleGroupTimelockConfigV2(t),
 			},
 		),
 	)
@@ -230,9 +230,9 @@ func TestRenounceTimelockDeployer(t *testing.T) {
 	chain1 := e.AllChainSelectors()[0]
 	e, err := Apply(t, e, nil,
 		Configure(
-			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelock),
-			map[uint64]types.MCMSWithTimelockConfig{
-				chain1: proposalutils.SingleGroupTimelockConfig(t),
+			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelockV2),
+			map[uint64]types.MCMSWithTimelockConfigV2{
+				chain1: proposalutils.SingleGroupTimelockConfigV2(t),
 			},
 		),
 	)

--- a/deployment/common/proposalutils/mcms_test_helpers.go
+++ b/deployment/common/proposalutils/mcms_test_helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/smartcontractkit/mcms/types"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -44,6 +45,15 @@ func SingleGroupMCMS(t *testing.T) config.Config {
 	c, err := config.NewConfig(1, []common.Address{address}, []config.Config{})
 	require.NoError(t, err)
 	return *c
+}
+
+func SingleGroupMCMSV2(t *testing.T) mcmstypes.Config {
+	publicKey := TestXXXMCMSSigner.Public().(*ecdsa.PublicKey)
+	// Convert the public key to an Ethereum address
+	address := crypto.PubkeyToAddress(*publicKey)
+	c, err := mcmstypes.NewConfig(1, []common.Address{address}, []mcmstypes.Config{})
+	require.NoError(t, err)
+	return c
 }
 
 // Deprecated: Use SignMCMSTimelockProposal instead.
@@ -294,6 +304,15 @@ func SingleGroupTimelockConfig(t *testing.T) commontypes.MCMSWithTimelockConfig 
 		Canceller:        SingleGroupMCMS(t),
 		Bypasser:         SingleGroupMCMS(t),
 		Proposer:         SingleGroupMCMS(t),
+		TimelockMinDelay: big.NewInt(0),
+	}
+}
+
+func SingleGroupTimelockConfigV2(t *testing.T) commontypes.MCMSWithTimelockConfigV2 {
+	return commontypes.MCMSWithTimelockConfigV2{
+		Canceller:        SingleGroupMCMSV2(t),
+		Bypasser:         SingleGroupMCMSV2(t),
+		Proposer:         SingleGroupMCMSV2(t),
 		TimelockMinDelay: big.NewInt(0),
 	}
 }

--- a/deployment/common/proposalutils/propose_test.go
+++ b/deployment/common/proposalutils/propose_test.go
@@ -30,12 +30,12 @@ func TestBuildProposalFromBatchesV2(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 	chainSelector := env.AllChainSelectors()[0]
-	config := proposalutils.SingleGroupMCMS(t)
+	config := proposalutils.SingleGroupMCMSV2(t)
 
 	env, err := changeset.Apply(t, env, nil,
 		changeset.Configure(
-			deployment.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelock),
-			map[uint64]types2.MCMSWithTimelockConfig{
+			deployment.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
+			map[uint64]types2.MCMSWithTimelockConfigV2{
 				chainSelector: {
 					Canceller:        config,
 					Bypasser:         config,

--- a/deployment/common/types/types.go
+++ b/deployment/common/types/types.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/config"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 )
@@ -35,6 +36,14 @@ const (
 	// Corresponds to the ABI
 	// https://github.com/smartcontractkit/chainlink/blob/develop/core/gethwrappers/generated/link_token_interface/link_token_interface.go#L34
 	StaticLinkToken deployment.ContractType = "StaticLinkToken"
+	// mcms Solana specific
+	ManyChainMultisigProgram         deployment.ContractType = "ManyChainMultiSigProgram"
+	RBACTimelockProgram              deployment.ContractType = "RBACTimelockProgram"
+	AccessControllerProgram          deployment.ContractType = "AccessControllerProgram"
+	ProposerAccessControllerAccount  deployment.ContractType = "ProposerAccessControllerAccount"
+	ExecutorAccessControllerAccount  deployment.ContractType = "ExecutorAccessControllerAccount"
+	CancellerAccessControllerAccount deployment.ContractType = "CancellerAccessControllerAccount"
+	BypasserAccessControllerAccount  deployment.ContractType = "BypasserAccessControllerAccount"
 )
 
 func (role MCMSRole) String() string {
@@ -47,6 +56,15 @@ type MCMSWithTimelockConfig struct {
 	Proposer         config.Config
 	TimelockMinDelay *big.Int
 	Label            *string
+}
+
+// MCMSWithTimelockConfigV2 holds the configuration for an MCMS with timelock.
+// Note that this type already exists in types.go, but this one is using the new lib version.
+type MCMSWithTimelockConfigV2 struct {
+	Canceller        mcmstypes.Config
+	Bypasser         mcmstypes.Config
+	Proposer         mcmstypes.Config
+	TimelockMinDelay *big.Int
 }
 
 type OCRParameters struct {

--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -14,8 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/config"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 
@@ -46,22 +45,22 @@ func DeployHomeChainContracts(ctx context.Context, lggr logger.Logger, envConfig
 		return deployment.CapabilityRegistryConfig{}, e.ExistingAddresses, fmt.Errorf("failed to get node info from env: %w", err)
 	}
 	p2pIds := nodes.NonBootstraps().PeerIDs()
-	cfg := make(map[uint64]commontypes.MCMSWithTimelockConfig)
+	cfg := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 	for _, chain := range e.AllChainSelectors() {
-		mcmsConfig, err := config.NewConfig(1, []common.Address{e.Chains[chain].DeployerKey.From}, []config.Config{})
+		mcmsConfig, err := mcmstypes.NewConfig(1, []common.Address{e.Chains[chain].DeployerKey.From}, []mcmstypes.Config{})
 		if err != nil {
 			return deployment.CapabilityRegistryConfig{}, e.ExistingAddresses, fmt.Errorf("failed to create mcms config: %w", err)
 		}
-		cfg[chain] = commontypes.MCMSWithTimelockConfig{
-			Canceller:        *mcmsConfig,
-			Bypasser:         *mcmsConfig,
-			Proposer:         *mcmsConfig,
+		cfg[chain] = commontypes.MCMSWithTimelockConfigV2{
+			Canceller:        mcmsConfig,
+			Bypasser:         mcmsConfig,
+			Proposer:         mcmsConfig,
 			TimelockMinDelay: big.NewInt(0),
 		}
 	}
 	*e, err = commonchangeset.Apply(nil, *e, nil,
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
 			cfg,
 		),
 		commonchangeset.Configure(

--- a/deployment/environment/memory/chain.go
+++ b/deployment/environment/memory/chain.go
@@ -181,6 +181,18 @@ func evmChain(t *testing.T, numUsers int) EVMChain {
 	}
 }
 
+var SolanaProgramIDs = map[string]string{
+	"ccip_router":               solTestConfig.CcipRouterProgram.String(),
+	"test_token_pool":           solTestConfig.CcipTokenPoolProgram.String(),
+	"fee_quoter":                solTestConfig.FeeQuoterProgram.String(),
+	"test_ccip_receiver":        solTestConfig.CcipLogicReceiver.String(),
+	"ccip_offramp":              solTestConfig.CcipOfframpProgram.String(),
+	"mcm":                       solTestConfig.McmProgram.String(),
+	"timelock":                  solTestConfig.TimelockProgram.String(),
+	"access_controller":         solTestConfig.AccessControllerProgram.String(),
+	"external_program_cpi_stub": solTestConfig.ExternalCpiStubProgram.String(),
+}
+
 var once = &sync.Once{}
 
 func solChain(t *testing.T, chainID uint64, adminKey *solana.PrivateKey) (string, string, error) {
@@ -195,21 +207,13 @@ func solChain(t *testing.T, chainID uint64, adminKey *solana.PrivateKey) (string
 	for i := 0; i < maxRetries; i++ {
 		port := freeport.GetOne(t)
 
-		programIds := map[string]string{
-			"ccip_router":        solTestConfig.CcipRouterProgram.String(),
-			"test_token_pool":    solTestConfig.CcipTokenPoolProgram.String(),
-			"fee_quoter":         solTestConfig.FeeQuoterProgram.String(),
-			"test_ccip_receiver": solTestConfig.CcipLogicReceiver.String(),
-			"ccip_offramp":       solTestConfig.CcipOfframpProgram.String(),
-		}
-
 		bcInput := &blockchain.Input{
 			Type:           "solana",
 			ChainID:        strconv.FormatUint(chainID, 10),
 			PublicKey:      adminKey.PublicKey().String(),
 			Port:           strconv.Itoa(port),
 			ContractsDir:   ProgramsPath,
-			SolanaPrograms: programIds,
+			SolanaPrograms: SolanaProgramIDs,
 		}
 		output, err := blockchain.NewBlockchainNetwork(bcInput)
 		if err != nil {

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -2,8 +2,6 @@ module github.com/smartcontractkit/chainlink/deployment
 
 go 1.23.3
 
-toolchain go1.23.4
-
 // Make sure we're working with the latest chainlink libs
 replace github.com/smartcontractkit/chainlink/v2 => ../
 
@@ -22,6 +20,7 @@ require (
 	github.com/gagliardetto/binary v0.8.0
 	github.com/gagliardetto/solana-go v1.12.0
 	github.com/go-resty/resty/v2 v2.15.3
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/consul/sdk v0.16.1
 	github.com/mr-tron/base58 v1.2.0
@@ -211,7 +210,6 @@ require (
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/flatbuffers v24.3.25+incompatible // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-github/v41 v41.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/go-tpm v0.9.0 // indirect
@@ -469,4 +467,5 @@ replace (
 	// replicating the replace directive on cosmos SDK
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/sourcegraph/sourcegraph/lib => github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240822153003-c864f15af264
+	github.com/testcontainers/testcontainers-go => github.com/testcontainers/testcontainers-go v0.34.0
 )

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1237,8 +1237,8 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/testcontainers/testcontainers-go v0.35.0 h1:uADsZpTKFAtp8SLK+hMwSaa+X+JiERHtd4sQAFmXeMo=
-github.com/testcontainers/testcontainers-go v0.35.0/go.mod h1:oEVBj5zrfJTrgjwONs1SsRbnBtH9OKl+IGl3UMcr2B4=
+github.com/testcontainers/testcontainers-go v0.34.0 h1:5fbgF0vIN5u+nD3IWabQwRybuB4GY8G2HHgCkbMzMHo=
+github.com/testcontainers/testcontainers-go v0.34.0/go.mod h1:6P/kMkQe8yqPHfPWNulFGdFHTD8HB2vLq/231xY2iPQ=
 github.com/theodesp/go-heaps v0.0.0-20190520121037-88e35354fe0a h1:YuO+afVc3eqrjiCUizNCxI53bl/BnPiVwXqLzqYTqgU=
 github.com/theodesp/go-heaps v0.0.0-20190520121037-88e35354fe0a/go.mod h1:/sfW47zCZp9FrtGcWyo1VjbgDaodxX9ovZvgLb/MxaA=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=

--- a/deployment/keystone/changeset/accept_ownership_test.go
+++ b/deployment/keystone/changeset/accept_ownership_test.go
@@ -43,9 +43,9 @@ func TestAcceptAllOwnership(t *testing.T) {
 			&changeset.DeployFeedsConsumerRequest{ChainSelector: registrySel},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
-			map[uint64]types.MCMSWithTimelockConfig{
-				registrySel: proposalutils.SingleGroupTimelockConfig(t),
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
+			map[uint64]types.MCMSWithTimelockConfigV2{
+				registrySel: proposalutils.SingleGroupTimelockConfigV2(t),
 			},
 		),
 	)

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -298,14 +298,14 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 
 	if c.UseMCMS {
 		// deploy, configure and xfer ownership of MCMS on all chains
-		timelockCfgs := make(map[uint64]commontypes.MCMSWithTimelockConfig)
+		timelockCfgs := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 		for sel := range env.Chains {
 			t.Logf("Enabling MCMS on chain %d", sel)
-			timelockCfgs[sel] = proposalutils.SingleGroupTimelockConfig(t)
+			timelockCfgs[sel] = proposalutils.SingleGroupTimelockConfigV2(t)
 		}
 		env, err = commonchangeset.Apply(t, env, nil,
 			commonchangeset.Configure(
-				deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
+				deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
 				timelockCfgs,
 			),
 		)

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/smartcontractkit/chainlink/v2
 
 go 1.23.3
 
-toolchain go1.23.4
-
 require (
 	github.com/Depado/ginprom v1.8.0
 	github.com/Masterminds/semver/v3 v3.3.0


### PR DESCRIPTION
Adds a new changeset (`DeployMCMSWithTimelockV2`) to deploy the MCM and Timelock contracts using the new mcms library. It supports both EVM and Solana, and the specific logic for each chain family is located in the `internal/evm` and `internal/solana` sub-packages.

The evm logic was directly adapted from the existing logic with minor adjustments so that the new mcms library is used instead of the legacy one.

The solana logic is entirely new and was partially based on the ccip chain deployment changesets developed by the ccip-solana team. One significant feature of this PR is how we handle the seeds and accounts needed for the solana deployments:
* each program id has a dedicated entry stored in the chain state and address book
* when initializing each MCM and Timelock instance, we use a randomly generated seed. The seed are stored in the chain state and address table encoded with the program, using the format `${program_id}.${seed}`
* likewise for the AccessController: when initializing it, we store the accounts created for each role in the chain state and address book using the same format: `${program_id}.${account}`

JIRA: DPA-1534 and DPA-1535