### PR TITLE
feat(capabilities/webapi): use a round robin selector in handler

### DIFF
--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -59,6 +59,7 @@ func setup(t *testing.T, config Config) testHarness {
 	registry := capabilities.NewRegistry(log)
 	connector := gcmocks.NewGatewayConnector(t)
 	idGeneratorFn := func() string { return validRequestUUID }
+	connector.EXPECT().GatewayIDs().Return([]string{"gateway1"})
 	connectorHandler, err := webapi.NewOutgoingConnectorHandler(connector, config.ServiceConfig, ghcapabilities.MethodComputeAction, log)
 	require.NoError(t, err)
 

--- a/core/capabilities/webapi/round_robin_selector.go
+++ b/core/capabilities/webapi/round_robin_selector.go
@@ -1,0 +1,35 @@
+package webapi
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+var ErrNoGateways = errors.New("no gateways available")
+
+type RoundRobinSelector struct {
+	items []string
+	index int
+	mu    sync.Mutex
+}
+
+func NewRoundRobinSelector(items []string) *RoundRobinSelector {
+	return &RoundRobinSelector{
+		items: items,
+		index: 0,
+	}
+}
+
+func (r *RoundRobinSelector) NextGateway() (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.items) == 0 {
+		return "", ErrNoGateways
+	}
+
+	item := r.items[r.index]
+	r.index = (r.index + 1) % len(r.items)
+	return item, nil
+}

--- a/core/capabilities/webapi/round_robin_selector_test.go
+++ b/core/capabilities/webapi/round_robin_selector_test.go
@@ -1,0 +1,64 @@
+package webapi
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundRobinSelector(t *testing.T) {
+	gateways := []string{"gateway1", "gateway2", "gateway3"}
+	rr := NewRoundRobinSelector(gateways)
+
+	expectedOrder := []string{"gateway1", "gateway2", "gateway3", "gateway1", "gateway2", "gateway3"}
+
+	for i, expected := range expectedOrder {
+		got, err := rr.NextGateway()
+		require.NoError(t, err, "unexpected error on iteration %d", i)
+		assert.Equal(t, expected, got, "unexpected gateway at iteration %d", i)
+	}
+}
+
+func TestRoundRobinSelector_Empty(t *testing.T) {
+	rr := NewRoundRobinSelector([]string{})
+
+	_, err := rr.NextGateway()
+	assert.ErrorIs(t, err, ErrNoGateways, "expected ErrNoGateways when no gateways are available")
+}
+
+func TestRoundRobinSelector_Concurrency(t *testing.T) {
+	gateways := []string{"gateway1", "gateway2", "gateway3"}
+	rr := NewRoundRobinSelector(gateways)
+
+	var wg sync.WaitGroup
+	numRequests := 100
+	results := make(chan string, numRequests)
+
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			gw, err := rr.NextGateway()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			results <- gw
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	counts := make(map[string]int)
+	for result := range results {
+		counts[result]++
+	}
+
+	expectedCount := numRequests / len(gateways)
+	for _, gateway := range gateways {
+		assert.InDelta(t, expectedCount, counts[gateway], 1, "unexpected request distribution for %s", gateway)
+	}
+}

--- a/core/capabilities/webapi/target/target_test.go
+++ b/core/capabilities/webapi/target/target_test.go
@@ -51,6 +51,7 @@ func setup(t *testing.T, config webapi.ServiceConfig) testHarness {
 	registry := registrymock.NewCapabilitiesRegistry(t)
 	connector := gcmocks.NewGatewayConnector(t)
 	lggr := logger.Test(t)
+	connector.EXPECT().GatewayIDs().Return([]string{"gateway1"})
 	connectorHandler, err := webapi.NewOutgoingConnectorHandler(connector, config, ghcapabilities.MethodWebAPITarget, lggr)
 	require.NoError(t, err)
 

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -1579,6 +1579,7 @@ func TestEngine_WithCustomComputeStep(t *testing.T) {
 	}
 
 	connector := gcmocks.NewGatewayConnector(t)
+	connector.EXPECT().GatewayIDs().Return([]string{"gateway1"})
 	handler, err := webapi.NewOutgoingConnectorHandler(
 		connector,
 		cfg.ServiceConfig,
@@ -1647,6 +1648,7 @@ func TestEngine_CustomComputePropagatesBreaks(t *testing.T) {
 		},
 	}
 	connector := gcmocks.NewGatewayConnector(t)
+	connector.EXPECT().GatewayIDs().Return([]string{"gateway1"})
 	handler, err := webapi.NewOutgoingConnectorHandler(
 		connector,
 		cfg.ServiceConfig,

--- a/core/services/workflows/syncer/fetcher_test.go
+++ b/core/services/workflows/syncer/fetcher_test.go
@@ -45,6 +45,7 @@ func TestNewFetcherService(t *testing.T) {
 
 	t.Run("OK-valid_request", func(t *testing.T) {
 		connector.EXPECT().AddHandler([]string{capabilities.MethodWorkflowSyncer}, mock.Anything).Return(nil)
+		connector.EXPECT().GatewayIDs().Return([]string{"gateway1", "gateway2"})
 
 		fetcher := NewFetcherService(lggr, wrapper)
 		require.NoError(t, fetcher.Start(ctx))
@@ -56,7 +57,6 @@ func TestNewFetcherService(t *testing.T) {
 		}).Return(nil).Times(1)
 		connector.EXPECT().DonID().Return(donID)
 		connector.EXPECT().AwaitConnection(matches.AnyContext, "gateway1").Return(nil)
-		connector.EXPECT().GatewayIDs().Return([]string{"gateway1", "gateway2"})
 
 		payload, err := fetcher.Fetch(ctx, url, 0)
 		require.NoError(t, err)

--- a/deployment/keystone/changeset/internal/update_nodes_test.go
+++ b/deployment/keystone/changeset/internal/update_nodes_test.go
@@ -217,7 +217,8 @@ func TestUpdateNodes(t *testing.T) {
 				lggr: lggr,
 				req: &internal.UpdateNodesRequest{
 					P2pToUpdates: map[p2pkey.PeerID]internal.NodeUpdate{
-						testPeerID(t, "peerID_1"): internal.NodeUpdate{
+						testPeerID(t, "peerID_1"): {
+							NodeOperatorID: 1,
 							Capabilities: []kcr.CapabilitiesRegistryCapability{
 								{
 									LabelledName:   "cap1",
@@ -226,7 +227,8 @@ func TestUpdateNodes(t *testing.T) {
 								},
 							},
 						},
-						testPeerID(t, "peerID_2"): internal.NodeUpdate{
+						testPeerID(t, "peerID_2"): {
+							NodeOperatorID: 2,
 							Capabilities: []kcr.CapabilitiesRegistryCapability{
 								{
 									LabelledName:   "cap1",
@@ -239,14 +241,14 @@ func TestUpdateNodes(t *testing.T) {
 					Chain: chain,
 				},
 				nopsToNodes: map[kcr.CapabilitiesRegistryNodeOperator][]*internal.P2PSignerEnc{
-					testNop(t, "nopA"): []*internal.P2PSignerEnc{
+					testNop(t, "nopA"): {
 						{
 							P2PKey:              testPeerID(t, "peerID_1"),
 							Signer:              [32]byte{0: 1, 31: 1},
 							EncryptionPublicKey: [32]byte{0: 7, 1: 7},
 						},
 					},
-					testNop(t, "nopB"): []*internal.P2PSignerEnc{
+					testNop(t, "nopB"): {
 						{
 							P2PKey:              testPeerID(t, "peerID_2"),
 							Signer:              [32]byte{0: 2, 31: 2},


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

This PR:
* adds a round robin selector that cycles through a slice of gateway IDs
* replaces the gateway selection in the outgoing connector handler to use the round robin selector

Logs below show subsequent requests for the same message ID using gateways iteratively.

```
2025-01-31T12:18:23.727-0500    debug   WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:82 sending request to gateway      {"version": "0.0.1@unset", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
2025-01-31T12:18:23.727-0500    info    WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:96 selected gateway, awaiting connection   {"version": "0.0.1@unset", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0", "gatewayID": "por_gateway"}
2025-01-31T12:18:24.339-0500    debug   WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:124        handling gateway request        {"version": "0.0.1@unset", "gatewayID": "por_gateway", "method": "workflow_syncer", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
2025-01-31T12:18:24.339-0500    debug   WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:108        received response from gateway  {"version": "0.0.1@unset", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
2025-01-31T12:18:24.339-0500    debug   WorkflowRegistrySyncer.FetcherService   syncer/fetcher.go:103   received gateway response       {"version": "0.0.1@unset", "donID": "1", "msgID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
2025-01-31T12:25:15.147-0500    debug   WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:82 sending request to gateway      {"version": "0.0.1@unset", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
2025-01-31T12:25:15.147-0500    info    WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:96 selected gateway, awaiting connection   {"version": "0.0.1@unset", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0", "gatewayID": "por_gateway_2"}
2025-01-31T12:25:15.743-0500    debug   WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:124        handling gateway request        {"version": "0.0.1@unset", "gatewayID": "por_gateway_2", "method": "workflow_syncer", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
2025-01-31T12:25:15.743-0500    debug   WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:108        received response from gateway  {"version": "0.0.1@unset", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
2025-01-31T12:25:15.744-0500    debug   WorkflowRegistrySyncer.FetcherService   syncer/fetcher.go:103   received gateway response       {"version": "0.0.1@unset", "donID": "1", "msgID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
2025-01-31T12:38:43.718-0500    debug   WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:82 sending request to gateway      {"version": "0.0.1@unset", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
2025-01-31T12:38:43.719-0500    info    WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:96 selected gateway, awaiting connection   {"version": "0.0.1@unset", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0", "gatewayID": "por_gateway_2"}
2025-01-31T12:38:44.314-0500    debug   WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:124        handling gateway request        {"version": "0.0.1@unset", "gatewayID": "por_gateway_2", "method": "workflow_syncer", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
2025-01-31T12:38:44.314-0500    debug   WorkflowRegistrySyncer.FetcherService.OutgoingConnectorHandler  webapi/outgoing_connector_handler.go:108        received response from gateway  {"version": "0.0.1@unset", "messageID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0", "gatewayID": "por_gateway_2"}
2025-01-31T12:38:44.314-0500    debug   WorkflowRegistrySyncer.FetcherService   syncer/fetcher.go:103   received gateway response       {"version": "0.0.1@unset", "donID": "1", "msgID": "workflow_syncer/c494b627c6e7c35b55b10b3904e91885c29f13fade8f2739cb8be3e2d53ab3b0"}
```

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
