### PR TITLE
[CAPPL-505] make sure the trigger is registered before unregistering it

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -470,6 +470,9 @@ func (e *Engine) registerTrigger(ctx context.Context, t *triggerCapability, trig
 			}}
 	}
 
+	// mark the trigger as successfully registered
+	t.registered = true
+
 	e.wg.Add(1)
 	go func() {
 		defer e.wg.Done()
@@ -1037,10 +1040,10 @@ func (e *Engine) deregisterTrigger(ctx context.Context, t *triggerCapability, tr
 		Config:    t.config.Load(),
 	}
 
-	// if t.trigger == nil, then we haven't initialized the workflow
+	// if t.trigger == nil or !t.registered, then we haven't initialized the workflow
 	// yet, and can safely consider the trigger deregistered with
 	// no further action.
-	if t.trigger != nil {
+	if t.trigger != nil && t.registered {
 		return t.trigger.UnregisterTrigger(ctx, deregRequest)
 	}
 

--- a/core/services/workflows/models.go
+++ b/core/services/workflows/models.go
@@ -116,6 +116,9 @@ type triggerCapability struct {
 	sdk.StepDefinition
 	trigger capabilities.TriggerCapability
 
+	// flag to track registration of the trigger and avoid removal of non registered triggers
+	registered bool
+
 	config atomic.Pointer[values.Map]
 }
 


### PR DESCRIPTION
### Description
This pr adds a flag to track the state of registration of a trigger to avoid trying to unregister a trigger that hasn't been registered.

we were failing to initialize the capability (this was a real error given the public key was wrong)
```
{
    "level": "error",
    "ts": "2025-01-30T13:17:51.961Z",
    "logger": "WorkflowRegistrySyncer.WorkflowEngine",
    "caller": "workflows/retry.go:39",
    "msg": "workflowID 0021d385d5b0daa1bbd2310c37a4e57ed9f2c1ebbeffa92df88cf58f6f907abc: failed to resolve workflow capabilities: workflowID 0021d385d5b0daa1bbd2310c37a4e57ed9f2c1ebbeffa92df88cf58f6f907abc: stepID custom-compute@1.0.0: stepRef compute: failed to initialize capability for step: workflowID 0021d385d5b0daa1bbd2310c37a4e57ed9f2c1ebbeffa92df88cf58f6f907abc: stepID custom-compute@1.0.0: failed to get config for step: failed to fetch secrets: cannot find public key 765e7feb0637f0362c5e036794e76a5d6677d351f305ba2d4fb2ef22fa114654 in nodePublicEncryptionKeys list, retrying in 5.00s",
    "version": "2.19.0@beec717",
    "workflowID": "0021d385d5b0daa1bbd2310c37a4e57ed9f2c1ebbeffa92df88cf58f6f907abc",
    "sentryEventID": null,
    "stacktrace": "github.com/smartcontractkit/chainlink/v2/core/services/workflows.retryable\n\tgithub.com/smartcontractkit/chainlink/v2/core/services/workflows/retry.go:39\ngithub.com/smartcontractkit/chainlink/v2/core/services/workflows.(*Engine).init\n\tgithub.com/smartcontractkit/chainlink/v2/core/services/workflows/engine.go:313"
}
```
but then we tried to unregister a trigger that did not exist (because of the previous) and thats why we failed with
```
{
    "level": "error",
    "ts": "2025-01-30T13:15:34.067Z",
    "logger": "WorkflowRegistrySyncer",
    "caller": "syncer/workflow_registry.go:335",
    "msg": "failed to handle event",
    "version": "2.19.0@beec717",
    "err": "failed to close workflow engine: rpc error: code = Unknown desc = error unregistering trigger: triggerId wf_0021d385d5b0daa1bbd2310c37a4e57ed9f2c1ebbeffa92df88cf58f6f907abc_trigger_0 not found",
    "type": "WorkflowUpdatedV1",
    "sentryEventID": null,
    "stacktrace": "github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer.(*workflowRegistry).readRegistryEvents\n\tgithub.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer/workflow_registry.go:335\ngithub.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer.(*workflowRegistry).Start.func1.1\n\tgithub.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer/workflow_registry.go:234"
}
```
[CAPPL-505](https://smartcontract-it.atlassian.net/browse/CAPPL-505)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CAPPL-505]: https://smartcontract-it.atlassian.net/browse/CAPPL-505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ