### PR TITLE
[DEVEL] setup-testdb invalid function syntax, mktemp: too few X's in …

### DIFF
--- a/core/scripts/setup_testdb.sh
+++ b/core/scripts/setup_testdb.sh
@@ -1,12 +1,12 @@
-#/bin/sh
+#/bin/bash
 
-function exit_error {
+exit_error() {
     echo "Error: $1"
     exit 1
 }
 # Create a new user and database for development
 # This script is intended to be run on a local development machine
-tdir=$(mktemp -d -t db-dev-user)
+tdir=$(mktemp -d -t db-dev-user.XXX-XXX)
 
 username="chainlink_dev"
 password="insecurepassword"


### PR DESCRIPTION
…template

Address the 3 problems with the setup_testdb.sh script on Linux
1. Invalid function declaration syntax
2. Invalid template syntax for mktemp (missing X characters)
3. Usage of `bash`-only commands in a script that wants to run in `sh` (pushd)

Fixes #16179

### Requires

No dependencies on other pull requests AFAIK.

### Supports

Not that I know of.