### PR TITLE
Add an interface to replace the ChangeSet function type.

### DIFF
--- a/deployment/ccip/changeset/accept_ownership_test.go
+++ b/deployment/ccip/changeset/accept_ownership_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -39,13 +40,13 @@ func Test_NewAcceptOwnershipChangeset(t *testing.T) {
 	require.NoError(t, err)
 
 	// compose the transfer ownership and accept ownership changesets
-	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelockContracts, []commonchangeset.ChangesetApplication{
+	_, err = commonchangeset.Apply(t, e.Env, timelockContracts,
 		// note this doesn't have proposals.
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.TransferToMCMSWithTimelock),
-			Config:    testhelpers.GenTestTransferOwnershipConfig(e, allChains, state),
-		},
-	})
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelock),
+			testhelpers.GenTestTransferOwnershipConfig(e, allChains, state),
+		),
+	)
 	require.NoError(t, err)
 
 	testhelpers.AssertTimelockOwnership(t, e, allChains, state)

--- a/deployment/ccip/changeset/cs_accept_admin_role_test.go
+++ b/deployment/ccip/changeset/cs_accept_admin_role_test.go
@@ -102,12 +102,12 @@ func TestAcceptAdminRoleChangeset_Validations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Msg, func(t *testing.T) {
-			_, err := commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.AcceptAdminRoleChangeset),
-					Config:    test.Config,
-				},
-			})
+			_, err := commonchangeset.Apply(t, e, timelockContracts,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.AcceptAdminRoleChangeset),
+					test.Config,
+				),
+			)
 			require.Error(t, err)
 			require.ErrorContains(t, err, test.ErrStr)
 		})
@@ -143,10 +143,10 @@ func TestAcceptAdminRoleChangeset_Execution(t *testing.T) {
 			registryOnA := state.Chains[selectorA].TokenAdminRegistry
 			registryOnB := state.Chains[selectorB].TokenAdminRegistry
 
-			e, err = commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.ProposeAdminRoleChangeset),
-					Config: changeset.TokenAdminRegistryChangesetConfig{
+			e, err = commonchangeset.Apply(t, e, timelockContracts,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.ProposeAdminRoleChangeset),
+					changeset.TokenAdminRegistryChangesetConfig{
 						MCMS: mcmsConfig,
 						Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 							selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -163,10 +163,10 @@ func TestAcceptAdminRoleChangeset_Execution(t *testing.T) {
 							},
 						},
 					},
-				},
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.AcceptAdminRoleChangeset),
-					Config: changeset.TokenAdminRegistryChangesetConfig{
+				),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.AcceptAdminRoleChangeset),
+					changeset.TokenAdminRegistryChangesetConfig{
 						MCMS: mcmsConfig,
 						Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 							selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -183,8 +183,8 @@ func TestAcceptAdminRoleChangeset_Execution(t *testing.T) {
 							},
 						},
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			configOnA, err := registryOnA.GetTokenConfig(nil, tokens[selectorA].Address)

--- a/deployment/ccip/changeset/cs_ccip_home_test.go
+++ b/deployment/ccip/changeset/cs_ccip_home_test.go
@@ -36,10 +36,10 @@ func TestInvalidOCR3Params(t *testing.T) {
 	require.NoError(t, err)
 	// Need to deploy prerequisites first so that we can form the USDC config
 	// no proposals to be made, timelock can be passed as nil here
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployHomeChainChangeset),
-			Config: changeset.DeployHomeChainConfig{
+	e.Env, err = commonchangeset.Apply(t, e.Env, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployHomeChainChangeset),
+			changeset.DeployHomeChainConfig{
 				HomeChainSel:     e.HomeChainSel,
 				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
 				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
@@ -48,10 +48,10 @@ func TestInvalidOCR3Params(t *testing.T) {
 					testhelpers.TestNodeOperator: envNodes.NonBootstraps().PeerIDs(),
 				},
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployChainContractsChangeset),
-			Config: changeset.DeployChainContractsConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployChainContractsChangeset),
+			changeset.DeployChainContractsConfig{
 				HomeChainSelector: e.HomeChainSel,
 				ContractParamsPerChain: map[uint64]changeset.ChainContractParams{
 					chain1: {
@@ -60,8 +60,8 @@ func TestInvalidOCR3Params(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	state, err := changeset.LoadOnchainState(e.Env)
@@ -150,15 +150,16 @@ func Test_PromoteCandidate(t *testing.T) {
 				}
 			}
 			// promotes zero digest on commit and ensure exec is not affected
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, map[uint64]*proposalutils.TimelockExecutionContracts{
-				tenv.HomeChainSel: {
-					Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
-					CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+			_, err = commonchangeset.Apply(t, tenv.Env,
+				map[uint64]*proposalutils.TimelockExecutionContracts{
+					tenv.HomeChainSel: {
+						Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
+						CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+					},
 				},
-			}, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.PromoteCandidateChangeset),
-					Config: changeset.PromoteCandidateChangesetConfig{
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.PromoteCandidateChangeset),
+					changeset.PromoteCandidateChangesetConfig{
 						HomeChainSelector: tenv.HomeChainSel,
 						PluginInfo: []changeset.PromoteCandidatePluginInfo{
 							{
@@ -169,8 +170,8 @@ func Test_PromoteCandidate(t *testing.T) {
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// after promoting the zero digest, active digest should also be zero
@@ -246,15 +247,16 @@ func Test_SetCandidate(t *testing.T) {
 				}
 			}
 			tokenConfig := changeset.NewTestTokenConfig(state.Chains[tenv.FeedChainSel].USDFeeds)
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, map[uint64]*proposalutils.TimelockExecutionContracts{
-				tenv.HomeChainSel: {
-					Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
-					CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+			_, err = commonchangeset.Apply(t, tenv.Env,
+				map[uint64]*proposalutils.TimelockExecutionContracts{
+					tenv.HomeChainSel: {
+						Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
+						CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+					},
 				},
-			}, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.SetCandidateChangeset),
-					Config: changeset.SetCandidateChangesetConfig{
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.SetCandidateChangeset),
+					changeset.SetCandidateChangesetConfig{
 						SetCandidateConfigBase: changeset.SetCandidateConfigBase{
 							HomeChainSelector: tenv.HomeChainSel,
 							FeedChainSelector: tenv.FeedChainSel,
@@ -283,8 +285,8 @@ func Test_SetCandidate(t *testing.T) {
 							},
 						},
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// after setting a new candidate on both plugins, the candidate config digest
@@ -363,15 +365,16 @@ func Test_RevokeCandidate(t *testing.T) {
 				}
 			}
 			tokenConfig := changeset.NewTestTokenConfig(state.Chains[tenv.FeedChainSel].USDFeeds)
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, map[uint64]*proposalutils.TimelockExecutionContracts{
-				tenv.HomeChainSel: {
-					Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
-					CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+			_, err = commonchangeset.Apply(t, tenv.Env,
+				map[uint64]*proposalutils.TimelockExecutionContracts{
+					tenv.HomeChainSel: {
+						Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
+						CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+					},
 				},
-			}, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.SetCandidateChangeset),
-					Config: changeset.SetCandidateChangesetConfig{
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.SetCandidateChangeset),
+					changeset.SetCandidateChangesetConfig{
 						SetCandidateConfigBase: changeset.SetCandidateConfigBase{
 							HomeChainSelector: tenv.HomeChainSel,
 							FeedChainSelector: tenv.FeedChainSel,
@@ -400,8 +403,8 @@ func Test_RevokeCandidate(t *testing.T) {
 							},
 						},
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// after setting a new candidate on both plugins, the candidate config digest
@@ -421,31 +424,32 @@ func Test_RevokeCandidate(t *testing.T) {
 			require.NotEqual(t, candidateDigestExecBefore, candidateDigestExecAfter)
 
 			// next we can revoke candidate - this should set the candidate digest back to zero
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, map[uint64]*proposalutils.TimelockExecutionContracts{
-				tenv.HomeChainSel: {
-					Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
-					CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+			_, err = commonchangeset.Apply(t, tenv.Env,
+				map[uint64]*proposalutils.TimelockExecutionContracts{
+					tenv.HomeChainSel: {
+						Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
+						CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+					},
 				},
-			}, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.RevokeCandidateChangeset),
-					Config: changeset.RevokeCandidateChangesetConfig{
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.RevokeCandidateChangeset),
+					changeset.RevokeCandidateChangesetConfig{
 						HomeChainSelector:   tenv.HomeChainSel,
 						RemoteChainSelector: dest,
 						PluginType:          types.PluginTypeCCIPCommit,
 						MCMS:                mcmsConfig,
 					},
-				},
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.RevokeCandidateChangeset),
-					Config: changeset.RevokeCandidateChangesetConfig{
+				),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.RevokeCandidateChangeset),
+					changeset.RevokeCandidateChangesetConfig{
 						HomeChainSelector:   tenv.HomeChainSel,
 						RemoteChainSelector: dest,
 						PluginType:          types.PluginTypeCCIPExec,
 						MCMS:                mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// after revoking the candidate, the candidate digest should be zero
@@ -471,25 +475,26 @@ func transferToTimelock(
 	source,
 	dest uint64) {
 	// Transfer ownership to timelock so that we can promote the zero digest later down the line.
-	_, err := commonchangeset.ApplyChangesets(t, tenv.Env, map[uint64]*proposalutils.TimelockExecutionContracts{
-		source: {
-			Timelock:  state.Chains[source].Timelock,
-			CallProxy: state.Chains[source].CallProxy,
+	_, err := commonchangeset.Apply(t, tenv.Env,
+		map[uint64]*proposalutils.TimelockExecutionContracts{
+			source: {
+				Timelock:  state.Chains[source].Timelock,
+				CallProxy: state.Chains[source].CallProxy,
+			},
+			dest: {
+				Timelock:  state.Chains[dest].Timelock,
+				CallProxy: state.Chains[dest].CallProxy,
+			},
+			tenv.HomeChainSel: {
+				Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
+				CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+			},
 		},
-		dest: {
-			Timelock:  state.Chains[dest].Timelock,
-			CallProxy: state.Chains[dest].CallProxy,
-		},
-		tenv.HomeChainSel: {
-			Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
-			CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
-		},
-	}, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.TransferToMCMSWithTimelock),
-			Config:    testhelpers.GenTestTransferOwnershipConfig(tenv, []uint64{source, dest}, state),
-		},
-	})
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelock),
+			testhelpers.GenTestTransferOwnershipConfig(tenv, []uint64{source, dest}, state),
+		),
+	)
 	require.NoError(t, err)
 	testhelpers.AssertTimelockOwnership(t, tenv, []uint64{source, dest}, state)
 }
@@ -534,22 +539,23 @@ func Test_UpdateChainConfigs(t *testing.T) {
 					MinDelay: 0,
 				}
 			}
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, map[uint64]*proposalutils.TimelockExecutionContracts{
-				tenv.HomeChainSel: {
-					Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
-					CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+			_, err = commonchangeset.Apply(t, tenv.Env,
+				map[uint64]*proposalutils.TimelockExecutionContracts{
+					tenv.HomeChainSel: {
+						Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
+						CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+					},
 				},
-			}, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.UpdateChainConfigChangeset),
-					Config: changeset.UpdateChainConfigConfig{
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.UpdateChainConfigChangeset),
+					changeset.UpdateChainConfigConfig{
 						HomeChainSelector:  tenv.HomeChainSel,
 						RemoteChainRemoves: []uint64{otherChain},
 						RemoteChainAdds:    make(map[uint64]changeset.ChainConfig),
 						MCMS:               mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// other chain should be gone
@@ -558,15 +564,16 @@ func Test_UpdateChainConfigs(t *testing.T) {
 			assert.Zero(t, chainConfigAfter.FChain)
 
 			// Lets add it back now.
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, map[uint64]*proposalutils.TimelockExecutionContracts{
-				tenv.HomeChainSel: {
-					Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
-					CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+			_, err = commonchangeset.Apply(t, tenv.Env,
+				map[uint64]*proposalutils.TimelockExecutionContracts{
+					tenv.HomeChainSel: {
+						Timelock:  state.Chains[tenv.HomeChainSel].Timelock,
+						CallProxy: state.Chains[tenv.HomeChainSel].CallProxy,
+					},
 				},
-			}, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.UpdateChainConfigChangeset),
-					Config: changeset.UpdateChainConfigConfig{
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.UpdateChainConfigChangeset),
+					changeset.UpdateChainConfigConfig{
 						HomeChainSelector:  tenv.HomeChainSel,
 						RemoteChainRemoves: []uint64{},
 						RemoteChainAdds: map[uint64]changeset.ChainConfig{
@@ -582,8 +589,8 @@ func Test_UpdateChainConfigs(t *testing.T) {
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			chainConfigAfter2, err := ccipHome.GetChainConfig(nil, otherChain)

--- a/deployment/ccip/changeset/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/cs_chain_contracts_test.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
+	"github.com/smartcontractkit/chainlink/deployment"
 
 	"github.com/smartcontractkit/chainlink-integrations/evm/utils"
 
@@ -57,10 +58,10 @@ func TestUpdateOnRampsDests(t *testing.T) {
 					MinDelay: 0,
 				}
 			}
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, tenv.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.UpdateOnRampsDestsChangeset),
-					Config: changeset.UpdateOnRampDestsConfig{
+			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.UpdateOnRampsDestsChangeset),
+					changeset.UpdateOnRampDestsConfig{
 						UpdatesByChain: map[uint64]map[uint64]changeset.OnRampDestinationUpdate{
 							source: {
 								dest: {
@@ -79,8 +80,8 @@ func TestUpdateOnRampsDests(t *testing.T) {
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// Assert the onramp configuration is as we expect.
@@ -133,10 +134,10 @@ func TestUpdateOnRampDynamicConfig(t *testing.T) {
 					MinDelay: 0,
 				}
 			}
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, tenv.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.UpdateOnRampDynamicConfigChangeset),
-					Config: changeset.UpdateOnRampDynamicConfig{
+			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.UpdateOnRampDynamicConfigChangeset),
+					changeset.UpdateOnRampDynamicConfig{
 						UpdatesByChain: map[uint64]changeset.OnRampDynamicConfigUpdate{
 							source: {
 								FeeAggregator: common.HexToAddress("0x1002"),
@@ -147,8 +148,8 @@ func TestUpdateOnRampDynamicConfig(t *testing.T) {
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// Assert the onramp configuration is as we expect.
@@ -201,10 +202,10 @@ func TestUpdateOnRampAllowList(t *testing.T) {
 					MinDelay: 0,
 				}
 			}
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, tenv.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.UpdateOnRampAllowListChangeset),
-					Config: changeset.UpdateOnRampAllowListConfig{
+			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.UpdateOnRampAllowListChangeset),
+					changeset.UpdateOnRampAllowListConfig{
 						UpdatesByChain: map[uint64]map[uint64]changeset.OnRampAllowListUpdate{
 							source: {
 								dest: {
@@ -223,8 +224,8 @@ func TestUpdateOnRampAllowList(t *testing.T) {
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// Assert the onramp configuration is as we expect.
@@ -331,18 +332,18 @@ func TestWithdrawOnRampFeeTokens(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tokenAmount, onRampInitWeth)
 
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, tenv.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.WithdrawOnRampFeeTokensChangeset),
-					Config: changeset.WithdrawOnRampFeeTokensConfig{
+			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.WithdrawOnRampFeeTokensChangeset),
+					changeset.WithdrawOnRampFeeTokensConfig{
 						FeeTokensByChain: map[uint64][]common.Address{
 							source: {linkToken.Address(), weth9.Address()},
 							dest:   {state.Chains[dest].LinkToken.Address(), state.Chains[dest].Weth9.Address()},
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// Assert that feeAggregator receives all fee tokens from OnRamp
@@ -391,10 +392,10 @@ func TestUpdateOffRampsSources(t *testing.T) {
 					MinDelay: 0,
 				}
 			}
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, tenv.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.UpdateOffRampSourcesChangeset),
-					Config: changeset.UpdateOffRampSourcesConfig{
+			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.UpdateOffRampSourcesChangeset),
+					changeset.UpdateOffRampSourcesConfig{
 						UpdatesByChain: map[uint64]map[uint64]changeset.OffRampSourceUpdate{
 							source: {
 								dest: {
@@ -413,8 +414,8 @@ func TestUpdateOffRampsSources(t *testing.T) {
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// Assert the offramp configuration is as we expect.
@@ -467,10 +468,10 @@ func TestUpdateFQDests(t *testing.T) {
 			fqCfg1 := changeset.DefaultFeeQuoterDestChainConfig(true)
 			fqCfg2 := changeset.DefaultFeeQuoterDestChainConfig(true)
 			fqCfg2.DestGasOverhead = 1000
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, tenv.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.UpdateFeeQuoterDestsChangeset),
-					Config: changeset.UpdateFeeQuoterDestsConfig{
+			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.UpdateFeeQuoterDestsChangeset),
+					changeset.UpdateFeeQuoterDestsConfig{
 						UpdatesByChain: map[uint64]map[uint64]fee_quoter.FeeQuoterDestChainConfig{
 							source: {
 								dest: fqCfg1,
@@ -481,8 +482,8 @@ func TestUpdateFQDests(t *testing.T) {
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// Assert the fq configuration is as we expect.
@@ -533,10 +534,10 @@ func TestUpdateRouterRamps(t *testing.T) {
 			}
 
 			// Updates test router.
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, tenv.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.UpdateRouterRampsChangeset),
-					Config: changeset.UpdateRouterRampsConfig{
+			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.UpdateRouterRampsChangeset),
+					changeset.UpdateRouterRampsConfig{
 						TestRouter: true,
 						UpdatesByChain: map[uint64]changeset.RouterUpdates{
 							source: {
@@ -558,8 +559,8 @@ func TestUpdateRouterRamps(t *testing.T) {
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			// Assert the router configuration is as we expect.
@@ -608,10 +609,10 @@ func TestUpdateDynamicConfigOffRampChangeset(t *testing.T) {
 				}
 			}
 			msgInterceptor := utils.RandomAddress()
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, tenv.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.UpdateDynamicConfigOffRampChangeset),
-					Config: changeset.UpdateDynamicConfigOffRampConfig{
+			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.UpdateDynamicConfigOffRampChangeset),
+					changeset.UpdateDynamicConfigOffRampConfig{
 						Updates: map[uint64]changeset.OffRampParams{
 							source: {
 								PermissionLessExecutionThresholdSeconds: uint32(2 * 60 * 60),
@@ -620,8 +621,8 @@ func TestUpdateDynamicConfigOffRampChangeset(t *testing.T) {
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 			// Assert the nonce manager configuration is as we expect.
 			actualConfig, err := state.Chains[source].OffRamp.GetDynamicConfig(nil)
@@ -668,10 +669,10 @@ func TestUpdateNonceManagersCS(t *testing.T) {
 				}
 			}
 
-			_, err = commonchangeset.ApplyChangesets(t, tenv.Env, tenv.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.UpdateNonceManagersChangeset),
-					Config: changeset.UpdateNonceManagerConfig{
+			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.UpdateNonceManagersChangeset),
+					changeset.UpdateNonceManagerConfig{
 						UpdatesByChain: map[uint64]changeset.NonceManagerUpdate{
 							source: {
 								RemovedAuthCallers: []common.Address{state.Chains[source].OnRamp.Address()},
@@ -679,8 +680,8 @@ func TestUpdateNonceManagersCS(t *testing.T) {
 						},
 						MCMS: mcmsConfig,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 			// Assert the nonce manager configuration is as we expect.
 			callers, err := state.Chains[source].NonceManager.GetAllAuthorizedCallers(nil)

--- a/deployment/ccip/changeset/cs_configure_token_pools_test.go
+++ b/deployment/ccip/changeset/cs_configure_token_pools_test.go
@@ -440,10 +440,10 @@ func TestValidateConfigureTokenPoolContracts(t *testing.T) {
 
 				if test.RegistrationPass != nil {
 					// Configure & set the active pools on the registry
-					e, err = commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-						{
-							Changeset: commonchangeset.WrapChangeSet(changeset.ConfigureTokenPoolContractsChangeset),
-							Config: changeset.ConfigureTokenPoolContractsConfig{
+					e, err = commonchangeset.Apply(t, e, timelockContracts,
+						commonchangeset.Configure(
+							deployment.CreateLegacyChangeSet(changeset.ConfigureTokenPoolContractsChangeset),
+							changeset.ConfigureTokenPoolContractsConfig{
 								TokenSymbol: testhelpers.TestTokenSymbol,
 								MCMS:        mcmsConfig,
 								PoolUpdates: map[uint64]changeset.TokenPoolConfig{
@@ -463,10 +463,10 @@ func TestValidateConfigureTokenPoolContracts(t *testing.T) {
 									},
 								},
 							},
-						},
-						{
-							Changeset: commonchangeset.WrapChangeSet(changeset.ProposeAdminRoleChangeset),
-							Config: changeset.TokenAdminRegistryChangesetConfig{
+						),
+						commonchangeset.Configure(
+							deployment.CreateLegacyChangeSet(changeset.ProposeAdminRoleChangeset),
+							changeset.TokenAdminRegistryChangesetConfig{
 								MCMS: mcmsConfig,
 								Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 									selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -483,10 +483,10 @@ func TestValidateConfigureTokenPoolContracts(t *testing.T) {
 									},
 								},
 							},
-						},
-						{
-							Changeset: commonchangeset.WrapChangeSet(changeset.AcceptAdminRoleChangeset),
-							Config: changeset.TokenAdminRegistryChangesetConfig{
+						),
+						commonchangeset.Configure(
+							deployment.CreateLegacyChangeSet(changeset.AcceptAdminRoleChangeset),
+							changeset.TokenAdminRegistryChangesetConfig{
 								MCMS: mcmsConfig,
 								Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 									selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -503,10 +503,10 @@ func TestValidateConfigureTokenPoolContracts(t *testing.T) {
 									},
 								},
 							},
-						},
-						{
-							Changeset: commonchangeset.WrapChangeSet(changeset.SetPoolChangeset),
-							Config: changeset.TokenAdminRegistryChangesetConfig{
+						),
+						commonchangeset.Configure(
+							deployment.CreateLegacyChangeSet(changeset.SetPoolChangeset),
+							changeset.TokenAdminRegistryChangesetConfig{
 								MCMS: mcmsConfig,
 								Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 									selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -523,8 +523,8 @@ func TestValidateConfigureTokenPoolContracts(t *testing.T) {
 									},
 								},
 							},
-						},
-					})
+						),
+					)
 					require.NoError(t, err)
 
 					for _, selector := range e.AllChainSelectors() {
@@ -563,10 +563,10 @@ func TestValidateConfigureTokenPoolContracts(t *testing.T) {
 					if test.UpdatePass.UpdatePoolOnB {
 						bType = changeset.BurnMintTokenPool
 					}
-					e, err = commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-						{
-							Changeset: commonchangeset.WrapChangeSet(changeset.ConfigureTokenPoolContractsChangeset),
-							Config: changeset.ConfigureTokenPoolContractsConfig{
+					e, err = commonchangeset.Apply(t, e, timelockContracts,
+						commonchangeset.Configure(
+							deployment.CreateLegacyChangeSet(changeset.ConfigureTokenPoolContractsChangeset),
+							changeset.ConfigureTokenPoolContractsConfig{
 								TokenSymbol: testhelpers.TestTokenSymbol,
 								MCMS:        mcmsConfig,
 								PoolUpdates: map[uint64]changeset.TokenPoolConfig{
@@ -586,8 +586,8 @@ func TestValidateConfigureTokenPoolContracts(t *testing.T) {
 									},
 								},
 							},
-						},
-					})
+						),
+					)
 					require.NoError(t, err)
 
 					for _, selector := range e.AllChainSelectors() {

--- a/deployment/ccip/changeset/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/cs_deploy_chain_test.go
@@ -45,10 +45,10 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 		})
 	}
 
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployHomeChainChangeset),
-			Config: changeset.DeployHomeChainConfig{
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployHomeChainChangeset),
+			changeset.DeployHomeChainConfig{
 				HomeChainSel:     homeChainSel,
 				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
 				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
@@ -57,29 +57,29 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 					"NodeOperator": p2pIds,
 				},
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.DeployLinkToken),
-			Config:    evmSelectors,
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.DeployMCMSWithTimelock),
-			Config:    cfg,
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployPrerequisitesChangeset),
-			Config: changeset.DeployPrerequisiteConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployLinkToken),
+			evmSelectors,
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
+			cfg,
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
+			changeset.DeployPrerequisiteConfig{
 				Configs: prereqCfg,
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployChainContractsChangeset),
-			Config: changeset.DeployChainContractsConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployChainContractsChangeset),
+			changeset.DeployChainContractsConfig{
 				HomeChainSelector:      homeChainSel,
 				ContractParamsPerChain: contractParams,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	// load onchain state

--- a/deployment/ccip/changeset/cs_deploy_token_pools_test.go
+++ b/deployment/ccip/changeset/cs_deploy_token_pools_test.go
@@ -280,17 +280,17 @@ func TestDeployTokenPoolContracts(t *testing.T) {
 
 			test.Input.TokenAddress = tokens[selectorA].Address
 
-			e, err := commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-				commonchangeset.ChangesetApplication{
-					Changeset: commonchangeset.WrapChangeSet(changeset.DeployTokenPoolContractsChangeset),
-					Config: changeset.DeployTokenPoolContractsConfig{
+			e, err := commonchangeset.Apply(t, e, timelockContracts,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.DeployTokenPoolContractsChangeset),
+					changeset.DeployTokenPoolContractsConfig{
 						TokenSymbol: testhelpers.TestTokenSymbol,
 						NewPools: map[uint64]changeset.DeployTokenPoolInput{
 							selectorA: test.Input,
 						},
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			state, err := changeset.LoadOnchainState(e)

--- a/deployment/ccip/changeset/cs_jobspec_test.go
+++ b/deployment/ccip/changeset/cs_jobspec_test.go
@@ -19,10 +19,10 @@ func TestJobSpecChangeset(t *testing.T) {
 	e := tenv.Env
 	nodes, err := deployment.NodeInfo(e.NodeIDs, e.Offchain)
 	require.NoError(t, err)
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployHomeChainChangeset),
-			Config: changeset.DeployHomeChainConfig{
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployHomeChainChangeset),
+			changeset.DeployHomeChainConfig{
 				HomeChainSel:     tenv.HomeChainSel,
 				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
 				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
@@ -31,8 +31,8 @@ func TestJobSpecChangeset(t *testing.T) {
 					testhelpers.TestNodeOperator: nodes.NonBootstraps().PeerIDs(),
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	output, err := changeset.CCIPCapabilityJobspecChangeset(e, nil)
 	require.NoError(t, err)

--- a/deployment/ccip/changeset/cs_propose_admin_role_test.go
+++ b/deployment/ccip/changeset/cs_propose_admin_role_test.go
@@ -32,10 +32,10 @@ func TestProposeAdminRoleChangeset_Validations(t *testing.T) {
 	}
 
 	// We want an administrator to exist to force failure in the last test
-	e, err := commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.ProposeAdminRoleChangeset),
-			Config: changeset.TokenAdminRegistryChangesetConfig{
+	e, err := commonchangeset.Apply(t, e, timelockContracts,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.ProposeAdminRoleChangeset),
+			changeset.TokenAdminRegistryChangesetConfig{
 				MCMS: mcmsConfig,
 				Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 					selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -46,10 +46,10 @@ func TestProposeAdminRoleChangeset_Validations(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.AcceptAdminRoleChangeset),
-			Config: changeset.TokenAdminRegistryChangesetConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.AcceptAdminRoleChangeset),
+			changeset.TokenAdminRegistryChangesetConfig{
 				MCMS: mcmsConfig,
 				Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 					selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -60,8 +60,8 @@ func TestProposeAdminRoleChangeset_Validations(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -145,12 +145,12 @@ func TestProposeAdminRoleChangeset_Validations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Msg, func(t *testing.T) {
-			_, err = commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.ProposeAdminRoleChangeset),
-					Config:    test.Config,
-				},
-			})
+			_, err = commonchangeset.Apply(t, e, timelockContracts,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.ProposeAdminRoleChangeset),
+					test.Config,
+				),
+			)
 			require.Error(t, err)
 			require.ErrorContains(t, err, test.ErrStr)
 		})
@@ -186,10 +186,10 @@ func TestProposeAdminRoleChangeset_ExecutionWithoutExternalAdmin(t *testing.T) {
 			registryOnA := state.Chains[selectorA].TokenAdminRegistry
 			registryOnB := state.Chains[selectorB].TokenAdminRegistry
 
-			e, err = commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.ProposeAdminRoleChangeset),
-					Config: changeset.TokenAdminRegistryChangesetConfig{
+			e, err = commonchangeset.Apply(t, e, timelockContracts,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.ProposeAdminRoleChangeset),
+					changeset.TokenAdminRegistryChangesetConfig{
 						MCMS: mcmsConfig,
 						Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 							selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -206,8 +206,8 @@ func TestProposeAdminRoleChangeset_ExecutionWithoutExternalAdmin(t *testing.T) {
 							},
 						},
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			configOnA, err := registryOnA.GetTokenConfig(nil, tokens[selectorA].Address)
@@ -260,10 +260,10 @@ func TestProposeAdminRoleChangeset_ExecutionWithExternalAdmin(t *testing.T) {
 			registryOnA := state.Chains[selectorA].TokenAdminRegistry
 			registryOnB := state.Chains[selectorB].TokenAdminRegistry
 
-			_, err = commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.ProposeAdminRoleChangeset),
-					Config: changeset.TokenAdminRegistryChangesetConfig{
+			_, err = commonchangeset.Apply(t, e, timelockContracts,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.ProposeAdminRoleChangeset),
+					changeset.TokenAdminRegistryChangesetConfig{
 						MCMS: mcmsConfig,
 						Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 							selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -282,8 +282,8 @@ func TestProposeAdminRoleChangeset_ExecutionWithExternalAdmin(t *testing.T) {
 							},
 						},
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			configOnA, err := registryOnA.GetTokenConfig(nil, tokens[selectorA].Address)

--- a/deployment/ccip/changeset/cs_set_pool_test.go
+++ b/deployment/ccip/changeset/cs_set_pool_test.go
@@ -102,12 +102,12 @@ func TestSetPoolChangeset_Validations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Msg, func(t *testing.T) {
-			_, err := commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.SetPoolChangeset),
-					Config:    test.Config,
-				},
-			})
+			_, err := commonchangeset.Apply(t, e, timelockContracts,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.SetPoolChangeset),
+					test.Config,
+				),
+			)
 			require.Error(t, err)
 			require.ErrorContains(t, err, test.ErrStr)
 		})
@@ -143,10 +143,10 @@ func TestSetPoolChangeset_Execution(t *testing.T) {
 			registryOnA := state.Chains[selectorA].TokenAdminRegistry
 			registryOnB := state.Chains[selectorB].TokenAdminRegistry
 
-			_, err = commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.ProposeAdminRoleChangeset),
-					Config: changeset.TokenAdminRegistryChangesetConfig{
+			_, err = commonchangeset.Apply(t, e, timelockContracts,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.ProposeAdminRoleChangeset),
+					changeset.TokenAdminRegistryChangesetConfig{
 						MCMS: mcmsConfig,
 						Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 							selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -163,10 +163,10 @@ func TestSetPoolChangeset_Execution(t *testing.T) {
 							},
 						},
 					},
-				},
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.AcceptAdminRoleChangeset),
-					Config: changeset.TokenAdminRegistryChangesetConfig{
+				),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.AcceptAdminRoleChangeset),
+					changeset.TokenAdminRegistryChangesetConfig{
 						MCMS: mcmsConfig,
 						Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 							selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -183,10 +183,10 @@ func TestSetPoolChangeset_Execution(t *testing.T) {
 							},
 						},
 					},
-				},
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.SetPoolChangeset),
-					Config: changeset.TokenAdminRegistryChangesetConfig{
+				),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.SetPoolChangeset),
+					changeset.TokenAdminRegistryChangesetConfig{
 						MCMS: mcmsConfig,
 						Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 							selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -203,8 +203,8 @@ func TestSetPoolChangeset_Execution(t *testing.T) {
 							},
 						},
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			configOnA, err := registryOnA.GetTokenConfig(nil, tokens[selectorA].Address)

--- a/deployment/ccip/changeset/cs_transfer_admin_role_test.go
+++ b/deployment/ccip/changeset/cs_transfer_admin_role_test.go
@@ -119,12 +119,12 @@ func TestTransferAdminRoleChangeset_Validations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Msg, func(t *testing.T) {
-			_, err := commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.TransferAdminRoleChangeset),
-					Config:    test.Config,
-				},
-			})
+			_, err := commonchangeset.Apply(t, e, timelockContracts,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.TransferAdminRoleChangeset),
+					test.Config,
+				),
+			)
 			require.Error(t, err)
 			require.ErrorContains(t, err, test.ErrStr)
 		})
@@ -162,10 +162,10 @@ func TestTransferAdminRoleChangeset_Execution(t *testing.T) {
 			registryOnA := state.Chains[selectorA].TokenAdminRegistry
 			registryOnB := state.Chains[selectorB].TokenAdminRegistry
 
-			_, err = commonchangeset.ApplyChangesets(t, e, timelockContracts, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.ProposeAdminRoleChangeset),
-					Config: changeset.TokenAdminRegistryChangesetConfig{
+			_, err = commonchangeset.Apply(t, e, timelockContracts,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.ProposeAdminRoleChangeset),
+					changeset.TokenAdminRegistryChangesetConfig{
 						MCMS: mcmsConfig,
 						Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 							selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -182,10 +182,10 @@ func TestTransferAdminRoleChangeset_Execution(t *testing.T) {
 							},
 						},
 					},
-				},
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.AcceptAdminRoleChangeset),
-					Config: changeset.TokenAdminRegistryChangesetConfig{
+				),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.AcceptAdminRoleChangeset),
+					changeset.TokenAdminRegistryChangesetConfig{
 						MCMS: mcmsConfig,
 						Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 							selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -202,10 +202,10 @@ func TestTransferAdminRoleChangeset_Execution(t *testing.T) {
 							},
 						},
 					},
-				},
-				{
-					Changeset: commonchangeset.WrapChangeSet(changeset.TransferAdminRoleChangeset),
-					Config: changeset.TokenAdminRegistryChangesetConfig{
+				),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(changeset.TransferAdminRoleChangeset),
+					changeset.TokenAdminRegistryChangesetConfig{
 						MCMS: mcmsConfig,
 						Pools: map[uint64]map[changeset.TokenSymbol]changeset.TokenPoolInfo{
 							selectorA: map[changeset.TokenSymbol]changeset.TokenPoolInfo{
@@ -224,8 +224,8 @@ func TestTransferAdminRoleChangeset_Execution(t *testing.T) {
 							},
 						},
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
 			configOnA, err := registryOnA.GetTokenConfig(nil, tokens[selectorA].Address)

--- a/deployment/ccip/changeset/deployer_group_test.go
+++ b/deployment/ccip/changeset/deployer_group_test.go
@@ -233,31 +233,31 @@ func TestDeployerGroupMCMS(t *testing.T) {
 			contractsByChain := make(map[uint64][]common.Address)
 			contractsByChain[e.HomeChainSel] = []common.Address{state.Chains[e.HomeChainSel].LinkToken.Address()}
 
-			_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(commonchangeset.TransferToMCMSWithTimelock),
-					Config: commonchangeset.TransferToMCMSWithTimelockConfig{
+			_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelock),
+					commonchangeset.TransferToMCMSWithTimelockConfig{
 						ContractsByChain: contractsByChain,
 						MinDelay:         0,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 
-			_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(dummyDeployerGroupGrantMintChangeset),
-					Config:    tc.cfg,
-				},
-			})
+			_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(dummyDeployerGroupGrantMintChangeset),
+					tc.cfg,
+				),
+			)
 			require.NoError(t, err)
 
-			_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(dummyDeployerGroupMintChangeset),
-					Config:    tc.cfg,
-				},
-			})
+			_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(dummyDeployerGroupMintChangeset),
+					tc.cfg,
+				),
+			)
 			require.NoError(t, err)
 
 			state, err = changeset.LoadOnchainState(e.Env)
@@ -310,23 +310,23 @@ func TestDeployerGroupGenerateMultipleProposals(t *testing.T) {
 		contractsByChain[chain] = []common.Address{state.Chains[chain].LinkToken.Address()}
 	}
 
-	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.TransferToMCMSWithTimelock),
-			Config: commonchangeset.TransferToMCMSWithTimelockConfig{
+	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelock),
+			commonchangeset.TransferToMCMSWithTimelockConfig{
 				ContractsByChain: contractsByChain,
 				MinDelay:         0,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
-	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(dummyDeployerGroupGrantMintMultiChainChangeset),
-			Config:    tc,
-		},
-	})
+	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(dummyDeployerGroupGrantMintMultiChainChangeset),
+			tc,
+		),
+	)
 	require.NoError(t, err)
 
 	cs, err := dummyDeployerGroupMintMultiDeploymentContextChangeset(e.Env, tc)
@@ -370,31 +370,31 @@ func TestDeployerGroupMultipleProposalsMCMS(t *testing.T) {
 		contractsByChain[chain] = []common.Address{state.Chains[chain].LinkToken.Address()}
 	}
 
-	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.TransferToMCMSWithTimelock),
-			Config: commonchangeset.TransferToMCMSWithTimelockConfig{
+	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelock),
+			commonchangeset.TransferToMCMSWithTimelockConfig{
 				ContractsByChain: contractsByChain,
 				MinDelay:         0,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
-	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(dummyDeployerGroupGrantMintMultiChainChangeset),
-			Config:    cfg,
-		},
-	})
+	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(dummyDeployerGroupGrantMintMultiChainChangeset),
+			cfg,
+		),
+	)
 	require.NoError(t, err)
 
-	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(dummyDeployerGroupMintMultiDeploymentContextChangeset),
-			Config:    cfg,
-		},
-	})
+	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(dummyDeployerGroupMintMultiDeploymentContextChangeset),
+			cfg,
+		),
+	)
 	require.NoError(t, err)
 
 	state, err = changeset.LoadOnchainState(e.Env)

--- a/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
@@ -36,10 +36,10 @@ func TestAddRemoteChain(t *testing.T) {
 	_, err := ccipChangeset.LoadOnchainStateSolana(tenv.Env)
 	require.NoError(t, err)
 
-	tenv.Env, err = commonchangeset.ApplyChangesets(t, tenv.Env, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(ccipChangeset.UpdateOnRampsDestsChangeset),
-			Config: ccipChangeset.UpdateOnRampDestsConfig{
+	tenv.Env, err = commonchangeset.Apply(t, tenv.Env, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangeset.UpdateOnRampsDestsChangeset),
+			ccipChangeset.UpdateOnRampDestsConfig{
 				UpdatesByChain: map[uint64]map[uint64]ccipChangeset.OnRampDestinationUpdate{
 					evmChain: {
 						solChain: {
@@ -50,10 +50,10 @@ func TestAddRemoteChain(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.AddRemoteChainToSolana),
-			Config: changeset_solana.AddRemoteChainToSolanaConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset_solana.AddRemoteChainToSolana),
+			changeset_solana.AddRemoteChainToSolanaConfig{
 				ChainSelector: solChain,
 				UpdatesByChain: map[uint64]changeset_solana.RemoteChainConfigSolana{
 					evmChain: {
@@ -74,8 +74,8 @@ func TestAddRemoteChain(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	state, err := ccipChangeset.LoadOnchainStateSolana(tenv.Env)
@@ -107,16 +107,16 @@ func TestAddTokenPool(t *testing.T) {
 	evmChain := tenv.Env.AllChainSelectors()[0]
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
 
-	e, err := commonchangeset.ApplyChangesets(t, tenv.Env, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.DeploySolanaToken),
-			Config: changeset_solana.DeploySolanaTokenConfig{
+	e, err := commonchangeset.Apply(t, tenv.Env, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset_solana.DeploySolanaToken),
+			changeset_solana.DeploySolanaTokenConfig{
 				ChainSelector:    solChain,
 				TokenProgramName: deployment.SPL2022Tokens,
 				TokenDecimals:    9,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	state, err := ccipChangeset.LoadOnchainStateSolana(e)
@@ -125,10 +125,10 @@ func TestAddTokenPool(t *testing.T) {
 
 	// TODO: can test this with solana.SolMint as well (WSOL)
 	// https://smartcontract-it.atlassian.net/browse/INTAUTO-440
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.AddTokenPool),
-			Config: changeset_solana.TokenPoolConfig{
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset_solana.AddTokenPool),
+			changeset_solana.TokenPoolConfig{
 				ChainSelector:    solChain,
 				TokenPubKey:      tokenAddress.String(),
 				TokenProgramName: deployment.SPL2022Tokens,
@@ -136,10 +136,10 @@ func TestAddTokenPool(t *testing.T) {
 				// this works for testing, but if we really want some other authority we need to pass in a private key for signing purposes
 				Authority: e.SolChains[solChain].DeployerKey.PublicKey().String(),
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.SetupTokenPoolForRemoteChain),
-			Config: changeset_solana.RemoteChainTokenPoolConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset_solana.SetupTokenPoolForRemoteChain),
+			changeset_solana.RemoteChainTokenPoolConfig{
 				SolChainSelector:    solChain,
 				RemoteChainSelector: evmChain,
 				SolTokenPubKey:      tokenAddress.String(),
@@ -160,8 +160,8 @@ func TestAddTokenPool(t *testing.T) {
 					Rate:     0,
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	// test AddTokenPool results
@@ -190,16 +190,16 @@ func TestBilling(t *testing.T) {
 	evmChain := tenv.Env.AllChainSelectors()[0]
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
 
-	e, err := commonchangeset.ApplyChangesets(t, tenv.Env, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.DeploySolanaToken),
-			Config: changeset_solana.DeploySolanaTokenConfig{
+	e, err := commonchangeset.Apply(t, tenv.Env, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset_solana.DeploySolanaToken),
+			changeset_solana.DeploySolanaTokenConfig{
 				ChainSelector:    solChain,
 				TokenProgramName: deployment.SPL2022Tokens,
 				TokenDecimals:    9,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	state, err := ccipChangeset.LoadOnchainStateSolana(e)
@@ -210,10 +210,10 @@ func TestBilling(t *testing.T) {
 	bigNum, ok := new(big.Int).SetString("19816680000000000000", 10)
 	require.True(t, ok)
 	bigNum.FillBytes(value[:])
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.AddBillingToken),
-			Config: changeset_solana.BillingTokenConfig{
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset_solana.AddBillingToken),
+			changeset_solana.BillingTokenConfig{
 				ChainSelector:    solChain,
 				TokenPubKey:      tokenAddress.String(),
 				TokenProgramName: deployment.SPL2022Tokens,
@@ -227,10 +227,10 @@ func TestBilling(t *testing.T) {
 					PremiumMultiplierWeiPerEth: 100,
 				},
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.AddBillingTokenForRemoteChain),
-			Config: changeset_solana.BillingTokenForRemoteChainConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset_solana.AddBillingTokenForRemoteChain),
+			changeset_solana.BillingTokenForRemoteChainConfig{
 				ChainSelector:       solChain,
 				RemoteChainSelector: evmChain,
 				TokenPubKey:         tokenAddress.String(),
@@ -243,8 +243,8 @@ func TestBilling(t *testing.T) {
 					IsEnabled:         true,
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	billingConfigPDA, _, _ := solState.FindFqBillingTokenConfigPDA(tokenAddress, state.SolChains[solChain].FeeQuoter)
@@ -269,16 +269,16 @@ func TestTokenAdminRegistry(t *testing.T) {
 
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
 
-	e, err := commonchangeset.ApplyChangesets(t, tenv.Env, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.DeploySolanaToken),
-			Config: changeset_solana.DeploySolanaTokenConfig{
+	e, err := commonchangeset.Apply(t, tenv.Env, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset_solana.DeploySolanaToken),
+			changeset_solana.DeploySolanaTokenConfig{
 				ChainSelector:    solChain,
 				TokenProgramName: deployment.SPL2022Tokens,
 				TokenDecimals:    9,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	state, err := ccipChangeset.LoadOnchainStateSolana(e)
@@ -289,26 +289,28 @@ func TestTokenAdminRegistry(t *testing.T) {
 	// We have to do run the ViaOwnerInstruction testcase for linkToken as we already register a PDA for tokenAddress in the previous testcase
 	linkTokenAddress := state.SolChains[solChain].LinkToken
 
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{ // register token admin registry for tokenAddress via admin instruction
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.RegisterTokenAdminRegistry),
-			Config: changeset_solana.RegisterTokenAdminRegistryConfig{
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			// register token admin registry for tokenAddress via admin instruction
+			deployment.CreateLegacyChangeSet(changeset_solana.RegisterTokenAdminRegistry),
+			changeset_solana.RegisterTokenAdminRegistryConfig{
 				ChainSelector:           solChain,
 				TokenPubKey:             tokenAddress.String(),
 				TokenAdminRegistryAdmin: tokenAdminRegistryAdminPrivKey.PublicKey().String(),
 				RegisterType:            changeset_solana.ViaGetCcipAdminInstruction,
 			},
-		},
-		{ // register token admin registry for linkToken via owner instruction
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.RegisterTokenAdminRegistry),
-			Config: changeset_solana.RegisterTokenAdminRegistryConfig{
+		),
+		commonchangeset.Configure(
+			// register token admin registry for linkToken via owner instruction
+			deployment.CreateLegacyChangeSet(changeset_solana.RegisterTokenAdminRegistry),
+			changeset_solana.RegisterTokenAdminRegistryConfig{
 				ChainSelector:           solChain,
 				TokenPubKey:             linkTokenAddress.String(),
 				TokenAdminRegistryAdmin: tokenAdminRegistryAdminPrivKey.PublicKey().String(),
 				RegisterType:            changeset_solana.ViaOwnerInstruction,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	tokenAdminRegistryPDA, _, _ := solState.FindTokenAdminRegistryPDA(tokenAddress, state.SolChains[solChain].Router)
@@ -325,16 +327,17 @@ func TestTokenAdminRegistry(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tokenAdminRegistryAdminPrivKey.PublicKey(), linkTokenAdminRegistryAccount.PendingAdministrator)
 
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{ // accept admin role for tokenAddress
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.AcceptAdminRoleTokenAdminRegistry),
-			Config: changeset_solana.AcceptAdminRoleTokenAdminRegistryConfig{
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			// accept admin role for tokenAddress
+			deployment.CreateLegacyChangeSet(changeset_solana.AcceptAdminRoleTokenAdminRegistry),
+			changeset_solana.AcceptAdminRoleTokenAdminRegistryConfig{
 				ChainSelector:              solChain,
 				TokenPubKey:                tokenAddress.String(),
 				NewRegistryAdminPrivateKey: tokenAdminRegistryAdminPrivKey.String(),
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	err = e.SolChains[solChain].GetAccountDataBorshInto(ctx, tokenAdminRegistryPDA, &tokenAdminRegistryAccount)
 	require.NoError(t, err)
@@ -344,17 +347,18 @@ func TestTokenAdminRegistry(t *testing.T) {
 
 	// TODO: transfer and accept is breaking
 	newTokenAdminRegistryAdminPrivKey, _ := solana.NewRandomPrivateKey()
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{ // transfer admin role for tokenAddress
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.TransferAdminRoleTokenAdminRegistry),
-			Config: changeset_solana.TransferAdminRoleTokenAdminRegistryConfig{
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			// transfer admin role for tokenAddress
+			deployment.CreateLegacyChangeSet(changeset_solana.TransferAdminRoleTokenAdminRegistry),
+			changeset_solana.TransferAdminRoleTokenAdminRegistryConfig{
 				ChainSelector:                  solChain,
 				TokenPubKey:                    tokenAddress.String(),
 				NewRegistryAdminPublicKey:      newTokenAdminRegistryAdminPrivKey.PublicKey().String(),
 				CurrentRegistryAdminPrivateKey: tokenAdminRegistryAdminPrivKey.String(),
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	err = e.SolChains[solChain].GetAccountDataBorshInto(ctx, tokenAdminRegistryPDA, &tokenAdminRegistryAccount)
 	require.NoError(t, err)
@@ -368,32 +372,34 @@ func TestPoolLookupTable(t *testing.T) {
 
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
 
-	e, err := commonchangeset.ApplyChangesets(t, tenv.Env, nil, []commonchangeset.ChangesetApplication{
-		{ // deploy token
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.DeploySolanaToken),
-			Config: changeset_solana.DeploySolanaTokenConfig{
+	e, err := commonchangeset.Apply(t, tenv.Env, nil,
+		commonchangeset.Configure(
+			// deploy token
+			deployment.CreateLegacyChangeSet(changeset_solana.DeploySolanaToken),
+			changeset_solana.DeploySolanaTokenConfig{
 				ChainSelector:    solChain,
 				TokenProgramName: deployment.SPL2022Tokens,
 				TokenDecimals:    9,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	state, err := ccipChangeset.LoadOnchainStateSolana(e)
 	require.NoError(t, err)
 	tokenAddress := state.SolChains[solChain].SPL2022Tokens[0]
 
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{ // add token pool lookup table
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.AddTokenPoolLookupTable),
-			Config: changeset_solana.TokenPoolLookupTableConfig{
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			// add token pool lookup table
+			deployment.CreateLegacyChangeSet(changeset_solana.AddTokenPoolLookupTable),
+			changeset_solana.TokenPoolLookupTableConfig{
 				ChainSelector: solChain,
 				TokenPubKey:   tokenAddress.String(),
 				TokenProgram:  deployment.SPL2022Tokens,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	state, err = ccipChangeset.LoadOnchainStateSolana(e)
@@ -407,35 +413,38 @@ func TestPoolLookupTable(t *testing.T) {
 
 	tokenAdminRegistryAdminPrivKey, _ := solana.NewRandomPrivateKey()
 
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{ // register token admin registry for linkToken via owner instruction
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.RegisterTokenAdminRegistry),
-			Config: changeset_solana.RegisterTokenAdminRegistryConfig{
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			// register token admin registry for linkToken via owner instruction
+			deployment.CreateLegacyChangeSet(changeset_solana.RegisterTokenAdminRegistry),
+			changeset_solana.RegisterTokenAdminRegistryConfig{
 				ChainSelector:           solChain,
 				TokenPubKey:             tokenAddress.String(),
 				TokenAdminRegistryAdmin: tokenAdminRegistryAdminPrivKey.PublicKey().String(),
 				RegisterType:            changeset_solana.ViaGetCcipAdminInstruction,
 			},
-		},
-		{ // accept admin role for tokenAddress
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.AcceptAdminRoleTokenAdminRegistry),
-			Config: changeset_solana.AcceptAdminRoleTokenAdminRegistryConfig{
+		),
+		commonchangeset.Configure(
+			// accept admin role for tokenAddress
+			deployment.CreateLegacyChangeSet(changeset_solana.AcceptAdminRoleTokenAdminRegistry),
+			changeset_solana.AcceptAdminRoleTokenAdminRegistryConfig{
 				ChainSelector:              solChain,
 				TokenPubKey:                tokenAddress.String(),
 				NewRegistryAdminPrivateKey: tokenAdminRegistryAdminPrivKey.String(),
 			},
-		},
-		{ // set pool -> this updates tokenAdminRegistryPDA, hence above changeset is required
-			Changeset: commonchangeset.WrapChangeSet(changeset_solana.SetPool),
-			Config: changeset_solana.SetPoolConfig{
+		),
+		commonchangeset.Configure(
+			// set pool -> this updates tokenAdminRegistryPDA, hence above changeset is required
+			deployment.CreateLegacyChangeSet(changeset_solana.SetPool),
+			changeset_solana.SetPoolConfig{
 				ChainSelector:                     solChain,
 				TokenPubKey:                       tokenAddress.String(),
 				PoolLookupTable:                   lookupTablePubKey.String(),
 				TokenAdminRegistryAdminPrivateKey: tokenAdminRegistryAdminPrivKey.String(),
 				WritableIndexes:                   []uint8{3, 4, 7},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	tokenAdminRegistry := solRouter.TokenAdminRegistry{}
 	tokenAdminRegistryPDA, _, _ := solState.FindTokenAdminRegistryPDA(tokenAddress, state.SolChains[solChain].Router)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -49,10 +49,10 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	}
 
 	testhelpers.SavePreloadedSolAddresses(t, e, solChainSelectors[0])
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployHomeChainChangeset),
-			Config: changeset.DeployHomeChainConfig{
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployHomeChainChangeset),
+			changeset.DeployHomeChainConfig{
 				HomeChainSel:     homeChainSel,
 				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
 				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
@@ -61,35 +61,36 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 					testhelpers.TestNodeOperator: nodes.NonBootstraps().PeerIDs(),
 				},
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.DeployLinkToken),
-			Config:    e.AllChainSelectors(),
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.DeployLinkToken),
-			Config:    e.AllChainSelectorsSolana(),
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.DeployMCMSWithTimelock),
-			Config:    cfg,
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployPrerequisitesChangeset),
-			Config: changeset.DeployPrerequisiteConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployLinkToken),
+			e.AllChainSelectors(),
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployLinkToken),
+			e.AllChainSelectorsSolana(),
+		),
+
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
+			cfg,
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
+			changeset.DeployPrerequisiteConfig{
 				Configs: prereqCfg,
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployChainContractsChangeset),
-			Config: changeset.DeployChainContractsConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployChainContractsChangeset),
+			changeset.DeployChainContractsConfig{
 				HomeChainSelector:      homeChainSel,
 				ContractParamsPerChain: contractParams,
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(solana.DeployChainContractsChangesetSolana),
-			Config: changeset.DeployChainContractsConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(solana.DeployChainContractsChangesetSolana),
+			changeset.DeployChainContractsConfig{
 				HomeChainSelector: homeChainSel,
 				ContractParamsPerChain: map[uint64]changeset.ChainContractParams{
 					solChainSelectors[0]: {
@@ -98,8 +99,8 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	// solana verification
 	testhelpers.ValidateSolanaState(t, e, solChainSelectors)

--- a/deployment/ccip/changeset/testhelpers/test_token_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_token_helpers.go
@@ -76,18 +76,16 @@ func SetupTwoChainEnvironmentWithTokens(
 	}
 
 	// Deploy MCMS setup & prerequisite contracts
-	e, err := commoncs.ApplyChangesets(t, e, nil, []commoncs.ChangesetApplication{
-		{
-			Changeset: commoncs.WrapChangeSet(changeset.DeployPrerequisitesChangeset),
-			Config: changeset.DeployPrerequisiteConfig{
-				Configs: prereqCfg,
-			},
-		},
-		{
-			Changeset: commoncs.WrapChangeSet(commoncs.DeployMCMSWithTimelock),
-			Config:    mcmsCfg,
-		},
-	})
+	e, err := commoncs.Apply(t, e, nil,
+		commoncs.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
+			changeset.DeployPrerequisiteConfig{Configs: prereqCfg},
+		),
+		commoncs.Configure(
+			deployment.CreateLegacyChangeSet(commoncs.DeployMCMSWithTimelock),
+			mcmsCfg,
+		),
+	)
 	require.NoError(t, err)
 
 	state, err := changeset.LoadOnchainState(e)
@@ -110,15 +108,15 @@ func SetupTwoChainEnvironmentWithTokens(
 
 	if transferToTimelock {
 		// Transfer ownership of token admin registry to the Timelock
-		e, err = commoncs.ApplyChangesets(t, e, timelockContracts, []commoncs.ChangesetApplication{
-			{
-				Changeset: commoncs.WrapChangeSet(commoncs.TransferToMCMSWithTimelock),
-				Config: commoncs.TransferToMCMSWithTimelockConfig{
+		e, err = commoncs.Apply(t, e, timelockContracts,
+			commoncs.Configure(
+				deployment.CreateLegacyChangeSet(commoncs.TransferToMCMSWithTimelock),
+				commoncs.TransferToMCMSWithTimelockConfig{
 					ContractsByChain: timelockOwnedContractsByChain,
 					MinDelay:         0,
 				},
-			},
-		})
+			),
+		)
 		require.NoError(t, err)
 	}
 
@@ -147,15 +145,15 @@ func DeployTestTokenPools(
 ) deployment.Environment {
 	selectors := e.AllChainSelectors()
 
-	e, err := commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployTokenPoolContractsChangeset),
-			Config: changeset.DeployTokenPoolContractsConfig{
+	e, err := commonchangeset.Apply(t, e, nil,
+		commoncs.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployTokenPoolContractsChangeset),
+			changeset.DeployTokenPoolContractsConfig{
 				TokenSymbol: TestTokenSymbol,
 				NewPools:    newPools,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	state, err := changeset.LoadOnchainState(e)
@@ -188,15 +186,15 @@ func DeployTestTokenPools(
 		}
 
 		// Transfer ownership of token admin registry to the Timelock
-		e, err = commoncs.ApplyChangesets(t, e, timelockContracts, []commoncs.ChangesetApplication{
-			{
-				Changeset: commoncs.WrapChangeSet(commoncs.TransferToMCMSWithTimelock),
-				Config: commoncs.TransferToMCMSWithTimelockConfig{
+		e, err = commoncs.Apply(t, e, timelockContracts,
+			commoncs.Configure(
+				deployment.CreateLegacyChangeSet(commoncs.TransferToMCMSWithTimelock),
+				commoncs.TransferToMCMSWithTimelockConfig{
 					ContractsByChain: timelockOwnedContractsByChain,
 					MinDelay:         0,
 				},
-			},
-		})
+			),
+		)
 		require.NoError(t, err)
 	}
 

--- a/deployment/ccip/changeset/testhelpers/v1_5/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/v1_5/test_helpers.go
@@ -34,27 +34,20 @@ import (
 func AddLanes(t *testing.T, e deployment.Environment, state changeset.CCIPOnChainState, pairs []testhelpers.SourceDestPair) deployment.Environment {
 	addLanesCfg, commitOCR2Configs, execOCR2Configs, jobspecs := LaneConfigsForChains(t, e, state, pairs)
 	var err error
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(v1_5changeset.DeployLanesChangeset),
-			Config: v1_5changeset.DeployLanesConfig{
-				Configs: addLanesCfg,
-			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(v1_5changeset.SetOCR2ConfigForTestChangeset),
-			Config: v1_5changeset.OCR2Config{
-				CommitConfigs: commitOCR2Configs,
-				ExecConfigs:   execOCR2Configs,
-			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(v1_5changeset.JobSpecsForLanesChangeset),
-			Config: v1_5changeset.JobSpecsForLanesConfig{
-				Configs: jobspecs,
-			},
-		},
-	})
+	e, err = commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(v1_5changeset.DeployLanesChangeset),
+			v1_5changeset.DeployLanesConfig{Configs: addLanesCfg},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(v1_5changeset.SetOCR2ConfigForTestChangeset),
+			v1_5changeset.OCR2Config{CommitConfigs: commitOCR2Configs, ExecConfigs: execOCR2Configs},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(v1_5changeset.JobSpecsForLanesChangeset),
+			v1_5changeset.JobSpecsForLanesConfig{Configs: jobspecs},
+		),
+	)
 	require.NoError(t, err)
 	return e
 }

--- a/deployment/ccip/changeset/v1_5/e2e_test.go
+++ b/deployment/ccip/changeset/v1_5/e2e_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-integrations/evm/utils"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/v1_5"
@@ -56,10 +57,10 @@ func TestE2ELegacy(t *testing.T) {
 	}
 	e.Env = v1_5.AddLanes(t, e.Env, state, pairs)
 	// permabless the commit stores
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(v1_5changeset.PermaBlessCommitStoreChangeset),
-			Config: v1_5changeset.PermaBlessCommitStoreConfig{
+	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(v1_5changeset.PermaBlessCommitStoreChangeset),
+			v1_5changeset.PermaBlessCommitStoreConfig{
 				Configs: map[uint64]v1_5changeset.PermaBlessCommitStoreConfigPerDest{
 					dest: {
 						Sources: []v1_5changeset.PermaBlessConfigPerSourceChain{
@@ -71,8 +72,8 @@ func TestE2ELegacy(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	// reload state after adding lanes
 	state, err = changeset.LoadOnchainState(e.Env)

--- a/deployment/changeset.go
+++ b/deployment/changeset.go
@@ -9,17 +9,83 @@ import (
 )
 
 var (
-	ErrInvalidConfig = errors.New("invalid changeset config")
+	ErrInvalidConfig      = errors.New("invalid changeset config")
+	ErrInvalidEnvironment = errors.New("invalid environment")
 )
 
-// ChangeSet represents a set of changes to be made to an environment.
-// The configuration contains environment specific inputs for a specific changeset.
-// The configuration might contain for example the chainSelectors to apply the change to
-// or existing environment specific contract addresses.
-// Its recommended that changesets operate on a small number of chains (e.g. 1-3)
-// to reduce the risk of partial failures.
-// If the configuration is unexpected type or format, the changeset should return ErrInvalidConfig.
+// ChangeSet is equivalent to ChangeLogic
+// Deprecated: use the ChangeLogic type, or an instance of a ChangeSetV2 in infrastructure or validation code.
 type ChangeSet[C any] func(e Environment, config C) (ChangesetOutput, error)
+
+// ChangeLogic encapsulates the active behavior of a ChangeSetV2.
+// The config struct contains environment-specific inputs for this logical change. For example, it might contain
+// the chainSelectors against which this change logic should be applied, or certain contract addresses or configuration
+// values to be used in this change.
+// The function should perform any deployment or configuration tasks, compose and propose job-specs, and generate any
+// MCMS proposals necessary.
+// This is the standalone version of ChangeSetV2.Apply for use with CreateChangeSet
+//
+// ChangeLogic functions should operate on a modest number of chains to reduce the risk of partial failures.
+type ChangeLogic[C any] func(e Environment, config C) (ChangesetOutput, error)
+
+// PreconditionVerifier functions should evaluate the supplied config, in the context of an environment, to ensure that
+// the config struct is correct, and that the environmental preconditions are as expected. This is the standalone
+// version of ChangeSetV2.VerifyPreconditions for use with CreateChangeSet
+//
+// If the configuration is unexpected type or format, the changeset should return ErrInvalidConfig. If there are
+// surprising aspects in the environment (a contract expected to be present cannot be located, etc.), then
+// ErrInvalidEnvironment should be returned.
+type PreconditionVerifier[C any] func(e Environment, config C) error
+
+// ChangeSetV2 is a type which encapsulates the logic to perform a set of changes to be made to an environment, in the
+// context of deploying Chainlink's product operations - namely deploying and configuring contracts, generating and
+// proposing TOML job-specs and interacting with the Job Distributor, and creating MCMS proposals.
+//
+// ChangeSetV2 has a pre-validation function which is optional (can be implemented as a no-op), which execution
+// environments (such as the migrations infrastructure in chainlink-deployments) should execute before invoking the
+// Apply method.
+//
+// > Note: ChangeSetV2 replaces ChangeSet, though its Apply method is identical in signature to a ChangeSet function.
+type ChangeSetV2[C any] interface {
+	// Apply performs the logic of the changeset, including any side effects, such as on-chain (non-MCMS) writes or
+	// contract deployments,  job-spec creation and Job-Distributor interaction, MCMS proposal creation, etc. It should
+	// return the ingredients of the side effects in a ChangesetOutput.
+	Apply(e Environment, config C) (ChangesetOutput, error)
+
+	// VerifyPreconditions function verifies the preconditions of the config. It should have no side effects, instead
+	// returning an error if the ChangeSetV2 should not be applied, or nil if the ChangeSetV2 is safe to apply.
+	VerifyPreconditions(e Environment, config C) error
+}
+
+type simpleChangeSet[C any] struct {
+	apply  ChangeLogic[C]
+	verify PreconditionVerifier[C]
+}
+
+func (scs simpleChangeSet[C]) Apply(e Environment, config C) (ChangesetOutput, error) {
+	return scs.apply(e, config)
+}
+
+func (scs simpleChangeSet[C]) VerifyPreconditions(e Environment, config C) error {
+	return scs.verify(e, config)
+}
+
+// CreateChangeSet creates a ChangeSetV2 from an existing execution function (or an older ChangeSet) and a
+// precondition verification function.
+func CreateChangeSet[C any](applyFunc ChangeLogic[C], verifyFunc func(e Environment, config C) error) ChangeSetV2[C] {
+	return simpleChangeSet[C]{
+		apply:  applyFunc,
+		verify: verifyFunc,
+	}
+}
+
+func CreateLegacyChangeSet[C any](changeset ChangeSet[C]) ChangeSetV2[C] {
+	var cs ChangeLogic[C] = func(e Environment, config C) (ChangesetOutput, error) { return changeset(e, config) }
+	return simpleChangeSet[C]{
+		apply:  cs,
+		verify: func(e Environment, config C) error { return nil },
+	}
+}
 
 // ProposedJob represents a job spec which has been proposed to a node, with the JobID returned by the
 // Job Distributor.

--- a/deployment/changeset_test.go
+++ b/deployment/changeset_test.go
@@ -1,0 +1,108 @@
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+type MyChangeSet struct{}
+
+func (m MyChangeSet) Apply(e Environment, config uint64) (ChangesetOutput, error) {
+	return ChangesetOutput{AddressBook: NewMemoryAddressBook()}, nil
+}
+func (m MyChangeSet) VerifyPreconditions(e Environment, config uint64) error {
+	return nil
+}
+
+func TestChangeSetNormalType(t *testing.T) {
+	t.Parallel()
+	e := NewNoopEnvironment(t)
+
+	var cs ChangeSetV2[uint64] = MyChangeSet{}
+	verify := cs.VerifyPreconditions(e, 5)
+	require.NoError(t, verify)
+	out, _ := cs.Apply(e, 5)
+	require.Equal(t, NewMemoryAddressBook(), out.AddressBook)
+}
+
+func TestChangeSetConstructionComposedFromLambdas(t *testing.T) {
+	t.Parallel()
+	e := NewNoopEnvironment(t)
+
+	var cs = CreateChangeSet(
+		// Don't do this in real life, this is for a test. Make nice tested functions.
+		func(e Environment, config string) (ChangesetOutput, error) {
+			return ChangesetOutput{AddressBook: NewMemoryAddressBook()}, nil
+		},
+		func(e Environment, config string) error {
+			return nil
+		},
+	)
+	verify := cs.VerifyPreconditions(e, "foo")
+	require.NoError(t, verify)
+	out, _ := cs.Apply(e, "foo")
+	require.Equal(t, NewMemoryAddressBook(), out.AddressBook)
+}
+
+var fakeChangeSet = CreateChangeSet(oldSchool, oldSchoolVerify)
+
+func oldSchool(e Environment, config uint32) (ChangesetOutput, error) {
+	return ChangesetOutput{AddressBook: NewMemoryAddressBook()}, nil
+}
+func oldSchoolVerify(e Environment, _ uint32) error {
+	return nil
+}
+
+// This is likely the best example of how to use this API.
+func TestChangeSetComposedType(t *testing.T) {
+	t.Parallel()
+	e := NewNoopEnvironment(t)
+
+	verify := fakeChangeSet.VerifyPreconditions(e, 5)
+	require.NoError(t, verify)
+	out, _ := fakeChangeSet.Apply(e, 5)
+	require.Equal(t, NewMemoryAddressBook(), out.AddressBook)
+}
+
+// TestChangeSetLegacyFunction tests using legacy ChangeSet functions (but just naturally conforming to the type,
+// via duck-typing, in the new wrapper.
+func TestChangeSetLegacyFunctionWithStandardChangeSetFunction(t *testing.T) {
+	t.Parallel()
+	e := NewNoopEnvironment(t)
+	var cs = CreateLegacyChangeSet(oldSchool)
+	verify := cs.VerifyPreconditions(e, 5)
+	require.NoError(t, verify)
+	out, _ := cs.Apply(e, 5)
+	require.Equal(t, NewMemoryAddressBook(), out.AddressBook)
+}
+
+// TestChangeSetLegacyFunction tests using legacy ChangeSet (strongly declared as a ChangeSet[C]) in the wrapper.
+func TestChangeSetLegacyFunction(t *testing.T) {
+	t.Parallel()
+	e := NewNoopEnvironment(t)
+	var csFunc ChangeSet[uint32] = oldSchool // Cast to a ChangeSet and use in CreateLegacyChangeSet
+	var cs = CreateLegacyChangeSet(csFunc)
+	verify := cs.VerifyPreconditions(e, 5)
+	require.NoError(t, verify)
+	out, _ := cs.Apply(e, 5)
+	require.Equal(t, NewMemoryAddressBook(), out.AddressBook)
+}
+
+func NewNoopEnvironment(t *testing.T) Environment {
+	return *NewEnvironment(
+		"noop",
+		logger.TestLogger(t),
+		NewMemoryAddressBook(),
+		map[uint64]Chain{},
+		map[uint64]SolChain{},
+		[]string{},
+		nil,
+		func() context.Context { return tests.Context(t) },
+		XXXGenerateTestOCRSecrets(),
+	)
+}

--- a/deployment/common/changeset/example/link_transfer_test.go
+++ b/deployment/common/changeset/example/link_transfer_test.go
@@ -35,14 +35,14 @@ func setupLinkTransferTestEnv(t *testing.T) deployment.Environment {
 	config := proposalutils.SingleGroupMCMS(t)
 
 	// Deploy MCMS and Timelock
-	env, err := changeset.ApplyChangesets(t, env, nil, []changeset.ChangesetApplication{
-		{
-			Changeset: changeset.WrapChangeSet(changeset.DeployLinkToken),
-			Config:    []uint64{chainSelector},
-		},
-		{
-			Changeset: changeset.WrapChangeSet(changeset.DeployMCMSWithTimelock),
-			Config: map[uint64]types.MCMSWithTimelockConfig{
+	env, err := changeset.Apply(t, env, nil,
+		changeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployLinkToken),
+			[]uint64{chainSelector},
+		),
+		changeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelock),
+			map[uint64]types.MCMSWithTimelockConfig{
 				chainSelector: {
 					Canceller:        config,
 					Bypasser:         config,
@@ -50,8 +50,8 @@ func setupLinkTransferTestEnv(t *testing.T) deployment.Environment {
 					TimelockMinDelay: big.NewInt(0),
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	return env
 }
@@ -94,12 +94,12 @@ func TestLinkTransferMCMS(t *testing.T) {
 		},
 	}
 	// Apply the changeset
-	_, err = changeset.ApplyChangesets(t, env, timelocks, []changeset.ChangesetApplication{
+	_, err = changeset.Apply(t, env, timelocks,
 		// the changeset produces proposals, ApplyChangesets will sign & execute them.
 		// in practice, signing and executing are separated processes.
-		{
-			Changeset: changeset.WrapChangeSet(example.LinkTransfer),
-			Config: &example.LinkTransferConfig{
+		changeset.Configure(
+			deployment.CreateLegacyChangeSet(example.LinkTransfer),
+			&example.LinkTransferConfig{
 				From: timelockAddress,
 				Transfers: map[uint64][]example.TransferConfig{
 					chainSelector: {
@@ -114,8 +114,8 @@ func TestLinkTransferMCMS(t *testing.T) {
 					OverrideRoot: true,
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	// Check new balances
@@ -169,12 +169,12 @@ func TestLinkTransfer(t *testing.T) {
 	}
 
 	// Apply the changeset
-	_, err = changeset.ApplyChangesets(t, env, timelocks, []changeset.ChangesetApplication{
+	_, err = changeset.Apply(t, env, timelocks,
 		// the changeset produces proposals, ApplyChangesets will sign & execute them.
 		// in practice, signing and executing are separated processes.
-		{
-			Changeset: changeset.WrapChangeSet(example.LinkTransfer),
-			Config: &example.LinkTransferConfig{
+		changeset.Configure(
+			deployment.CreateLegacyChangeSet(example.LinkTransfer),
+			&example.LinkTransferConfig{
 				From: chain.DeployerKey.From,
 				Transfers: map[uint64][]example.TransferConfig{
 					chainSelector: {
@@ -186,8 +186,8 @@ func TestLinkTransfer(t *testing.T) {
 				},
 				// No MCMSConfig here means we'll execute the txs directly.
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	// Check new balances
@@ -407,12 +407,12 @@ func TestLinkTransferMCMSV2(t *testing.T) {
 		},
 	}
 	// Apply the changeset
-	_, err = changeset.ApplyChangesets(t, env, timelocks, []changeset.ChangesetApplication{
+	_, err = changeset.Apply(t, env, timelocks,
 		// the changeset produces proposals, ApplyChangesets will sign & execute them.
 		// in practice, signing and executing are separated processes.
-		{
-			Changeset: changeset.WrapChangeSet(example.LinkTransferV2),
-			Config: &example.LinkTransferConfig{
+		changeset.Configure(
+			deployment.CreateLegacyChangeSet(example.LinkTransferV2),
+			&example.LinkTransferConfig{
 				From: timelockAddress,
 				Transfers: map[uint64][]example.TransferConfig{
 					chainSelector: {
@@ -427,8 +427,8 @@ func TestLinkTransferMCMSV2(t *testing.T) {
 					OverrideRoot: true,
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	// Check new balances

--- a/deployment/common/changeset/example/mint_link_test.go
+++ b/deployment/common/changeset/example/mint_link_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/example"
 )
@@ -29,15 +30,15 @@ func TestMintLink(t *testing.T) {
 	linkState, err := changeset.MaybeLoadLinkTokenChainState(chain, addrs)
 	require.NoError(t, err)
 
-	_, err = changeset.ApplyChangesets(t, env, nil, []changeset.ChangesetApplication{
-		{
-			Changeset: changeset.WrapChangeSet(example.AddMintersBurnersLink),
-			Config: &example.AddMintersBurnersLinkConfig{
+	_, err = changeset.Apply(t, env, nil,
+		changeset.Configure(
+			deployment.CreateLegacyChangeSet(example.AddMintersBurnersLink),
+			&example.AddMintersBurnersLinkConfig{
 				ChainSelector: chainSelector,
 				Minters:       []common.Address{chain.DeployerKey.From},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	timelockAddress := mcmsState.Timelock.Address()

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -10,31 +10,46 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
-type ChangesetApplication struct {
-	Changeset deployment.ChangeSet[any]
-	Config    any
+type ConfiguredChangeSet interface {
+	Apply(e deployment.Environment) (deployment.ChangesetOutput, error)
 }
 
-func WrapChangeSet[C any](fn deployment.ChangeSet[C]) func(e deployment.Environment, config any) (deployment.ChangesetOutput, error) {
-	return func(e deployment.Environment, config any) (deployment.ChangesetOutput, error) {
-		var zeroC C
-		if config != nil {
-			c, ok := config.(C)
-			if !ok {
-				return deployment.ChangesetOutput{}, fmt.Errorf("invalid config type, expected %T", c)
-			}
-			return fn(e, config.(C))
-		}
-
-		return fn(e, zeroC)
+func Configure[C any](
+	changeset deployment.ChangeSetV2[C],
+	config C,
+) ConfiguredChangeSet {
+	return configuredChangeSetImpl[C]{
+		changeset: changeset,
+		config:    config,
 	}
 }
 
+type configuredChangeSetImpl[C any] struct {
+	changeset deployment.ChangeSetV2[C]
+	config    C
+}
+
+func (ca configuredChangeSetImpl[C]) Apply(e deployment.Environment) (deployment.ChangesetOutput, error) {
+	err := ca.changeset.VerifyPreconditions(e, ca.config)
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+	return ca.changeset.Apply(e, ca.config)
+}
+
+// Apply applies the changeset applications to the environment and returns the updated environment. This is the
+// variadic function equivalent of ApplyChangesets, but allowing you to simply pass in one or more changesets as
+// parameters at the end of the function. e.g. `changeset.Apply(t, e, nil, configuredCS1, configuredCS2)` etc.
+func Apply(t *testing.T, e deployment.Environment, timelockContractsPerChain map[uint64]*proposalutils.TimelockExecutionContracts, first ConfiguredChangeSet, rest ...ConfiguredChangeSet) (deployment.Environment, error) {
+	return ApplyChangesets(t, e, timelockContractsPerChain, append([]ConfiguredChangeSet{first}, rest...))
+}
+
 // ApplyChangesets applies the changeset applications to the environment and returns the updated environment.
-func ApplyChangesets(t *testing.T, e deployment.Environment, timelockContractsPerChain map[uint64]*proposalutils.TimelockExecutionContracts, changesetApplications []ChangesetApplication) (deployment.Environment, error) {
+func ApplyChangesets(t *testing.T, e deployment.Environment, timelockContractsPerChain map[uint64]*proposalutils.TimelockExecutionContracts, changesetApplications []ConfiguredChangeSet) (deployment.Environment, error) {
 	currentEnv := e
 	for i, csa := range changesetApplications {
-		out, err := csa.Changeset(currentEnv, csa.Config)
+
+		out, err := csa.Apply(currentEnv)
 		if err != nil {
 			return e, fmt.Errorf("failed to apply changeset at index %d: %w", i, err)
 		}

--- a/deployment/common/changeset/test_helpers_test.go
+++ b/deployment/common/changeset/test_helpers_test.go
@@ -1,0 +1,77 @@
+package changeset
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestChangeSetLegacyFunction_PassingCase(t *testing.T) {
+	t.Parallel()
+	e := NewNoopEnvironment(t)
+
+	executedCs := false
+	executedValidator := false
+
+	csv2 := deployment.CreateChangeSet(
+		func(e deployment.Environment, config uint32) (deployment.ChangesetOutput, error) {
+			executedCs = true
+			return deployment.ChangesetOutput{AddressBook: deployment.NewMemoryAddressBook()}, nil
+		},
+		func(e deployment.Environment, config uint32) error {
+			executedValidator = true
+			return nil
+		},
+	)
+	assert.False(t, executedCs, "Not expected to have executed the changeset yet")
+	assert.False(t, executedValidator, "Not expected to have executed the validator yet")
+	_, err := Apply(t, e, nil, Configure(csv2, 1))
+	assert.True(t, executedCs, "Validator should have returned nil, allowing changeset execution")
+	assert.True(t, executedValidator, "Not expected to have executed the validator yet")
+	assert.NoError(t, err)
+}
+
+func TestChangeSetLegacyFunction_ErrorCase(t *testing.T) {
+	t.Parallel()
+	e := NewNoopEnvironment(t)
+
+	executedCs := false
+	executedValidator := false
+
+	csv2 := deployment.CreateChangeSet(
+		func(e deployment.Environment, config uint32) (deployment.ChangesetOutput, error) {
+			executedCs = true
+			return deployment.ChangesetOutput{AddressBook: deployment.NewMemoryAddressBook()}, nil
+		},
+		func(e deployment.Environment, config uint32) error {
+			executedValidator = true
+			return errors.New("you shall not pass")
+		},
+	)
+	assert.False(t, executedCs, "Not expected to have executed the changeset yet")
+	assert.False(t, executedValidator, "Not expected to have executed the validator yet")
+	_, err := Apply(t, e, nil, Configure(csv2, 1))
+	assert.False(t, executedCs, "Validator should have fired, preventing changeset execution")
+	assert.True(t, executedValidator, "Not expected to have executed the validator yet")
+	assert.Equal(t, "failed to apply changeset at index 0: you shall not pass", err.Error())
+}
+
+func NewNoopEnvironment(t *testing.T) deployment.Environment {
+	return *deployment.NewEnvironment(
+		"noop",
+		logger.TestLogger(t),
+		deployment.NewMemoryAddressBook(),
+		map[uint64]deployment.Chain{},
+		map[uint64]deployment.SolChain{},
+		[]string{},
+		nil,
+		func() context.Context { return tests.Context(t) },
+		deployment.XXXGenerateTestOCRSecrets(),
+	)
+}

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
@@ -23,18 +23,18 @@ func TestTransferToMCMSWithTimelock(t *testing.T) {
 		Nodes:  1,
 	})
 	chain1 := e.AllChainSelectors()[0]
-	e, err := ApplyChangesets(t, e, nil, []ChangesetApplication{
-		{
-			Changeset: WrapChangeSet(DeployLinkToken),
-			Config:    []uint64{chain1},
-		},
-		{
-			Changeset: WrapChangeSet(DeployMCMSWithTimelock),
-			Config: map[uint64]types.MCMSWithTimelockConfig{
+	e, err := Apply(t, e, nil,
+		Configure(
+			deployment.CreateLegacyChangeSet(DeployLinkToken),
+			[]uint64{chain1},
+		),
+		Configure(
+			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelock),
+			map[uint64]types.MCMSWithTimelockConfig{
 				chain1: proposalutils.SingleGroupTimelockConfig(t),
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	addrs, err := e.ExistingAddresses.AddressesForChain(chain1)
 	require.NoError(t, err)
@@ -42,22 +42,20 @@ func TestTransferToMCMSWithTimelock(t *testing.T) {
 	require.NoError(t, err)
 	link, err := MaybeLoadLinkTokenChainState(e.Chains[chain1], addrs)
 	require.NoError(t, err)
-	e, err = ApplyChangesets(t, e, map[uint64]*proposalutils.TimelockExecutionContracts{
-		chain1: {
-			Timelock:  state.Timelock,
-			CallProxy: state.CallProxy,
+	e, err = Apply(t, e,
+		map[uint64]*proposalutils.TimelockExecutionContracts{
+			chain1: {Timelock: state.Timelock, CallProxy: state.CallProxy},
 		},
-	}, []ChangesetApplication{
-		{
-			Changeset: WrapChangeSet(TransferToMCMSWithTimelock),
-			Config: TransferToMCMSWithTimelockConfig{
+		Configure(
+			deployment.CreateLegacyChangeSet(TransferToMCMSWithTimelock),
+			TransferToMCMSWithTimelockConfig{
 				ContractsByChain: map[uint64][]common.Address{
 					chain1: {link.LinkToken.Address()},
 				},
 				MinDelay: 0,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	// We expect now that the link token is owned by the MCMS timelock.
 	link, err = MaybeLoadLinkTokenChainState(e.Chains[chain1], addrs)
@@ -67,15 +65,15 @@ func TestTransferToMCMSWithTimelock(t *testing.T) {
 	require.Equal(t, state.Timelock.Address(), o)
 
 	// Try a rollback to the deployer.
-	e, err = ApplyChangesets(t, e, nil, []ChangesetApplication{
-		{
-			Changeset: WrapChangeSet(TransferToDeployer),
-			Config: TransferToDeployerConfig{
+	e, err = Apply(t, e, nil,
+		Configure(
+			deployment.CreateLegacyChangeSet(TransferToDeployer),
+			TransferToDeployerConfig{
 				ContractAddress: link.LinkToken.Address(),
 				ChainSel:        chain1,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	o, err = link.LinkToken.Owner(nil)
@@ -90,18 +88,18 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 		Nodes:  1,
 	})
 	chain1 := e.AllChainSelectors()[0]
-	e, err := ApplyChangesets(t, e, nil, []ChangesetApplication{
-		{
-			Changeset: WrapChangeSet(DeployLinkToken),
-			Config:    []uint64{chain1},
-		},
-		{
-			Changeset: WrapChangeSet(DeployMCMSWithTimelock),
-			Config: map[uint64]types.MCMSWithTimelockConfig{
+	e, err := Apply(t, e, nil,
+		Configure(
+			deployment.CreateLegacyChangeSet(DeployLinkToken),
+			[]uint64{chain1},
+		),
+		Configure(
+			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelock),
+			map[uint64]types.MCMSWithTimelockConfig{
 				chain1: proposalutils.SingleGroupTimelockConfig(t),
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	addrs, err := e.ExistingAddresses.AddressesForChain(chain1)
 	require.NoError(t, err)
@@ -109,22 +107,20 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 	require.NoError(t, err)
 	link, err := MaybeLoadLinkTokenChainState(e.Chains[chain1], addrs)
 	require.NoError(t, err)
-	e, err = ApplyChangesets(t, e, map[uint64]*proposalutils.TimelockExecutionContracts{
-		chain1: {
-			Timelock:  state.Timelock,
-			CallProxy: state.CallProxy,
+	e, err = Apply(t, e,
+		map[uint64]*proposalutils.TimelockExecutionContracts{
+			chain1: {Timelock: state.Timelock, CallProxy: state.CallProxy},
 		},
-	}, []ChangesetApplication{
-		{
-			Changeset: WrapChangeSet(TransferToMCMSWithTimelockV2),
-			Config: TransferToMCMSWithTimelockConfig{
+		Configure(
+			deployment.CreateLegacyChangeSet(TransferToMCMSWithTimelockV2),
+			TransferToMCMSWithTimelockConfig{
 				ContractsByChain: map[uint64][]common.Address{
 					chain1: {link.LinkToken.Address()},
 				},
 				MinDelay: 0,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	// We expect now that the link token is owned by the MCMS timelock.
 	link, err = MaybeLoadLinkTokenChainState(e.Chains[chain1], addrs)
@@ -134,15 +130,15 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 	require.Equal(t, state.Timelock.Address(), o)
 
 	// Try a rollback to the deployer.
-	e, err = ApplyChangesets(t, e, nil, []ChangesetApplication{
-		{
-			Changeset: WrapChangeSet(TransferToDeployer),
-			Config: TransferToDeployerConfig{
+	e, err = Apply(t, e, nil,
+		Configure(
+			deployment.CreateLegacyChangeSet(TransferToDeployer),
+			TransferToDeployerConfig{
 				ContractAddress: link.LinkToken.Address(),
 				ChainSel:        chain1,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	o, err = link.LinkToken.Owner(nil)
@@ -158,14 +154,14 @@ func TestRenounceTimelockDeployerConfigValidate(t *testing.T) {
 		Nodes:  1,
 	})
 	chain1 := e.AllChainSelectors()[0]
-	e, err := ApplyChangesets(t, e, nil, []ChangesetApplication{
-		{
-			Changeset: WrapChangeSet(DeployMCMSWithTimelock),
-			Config: map[uint64]types.MCMSWithTimelockConfig{
+	e, err := Apply(t, e, nil,
+		Configure(
+			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelock),
+			map[uint64]types.MCMSWithTimelockConfig{
 				chain1: proposalutils.SingleGroupTimelockConfig(t),
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	envWithNoMCMS := memory.NewMemoryEnvironment(t, lggr, 0, memory.MemoryEnvironmentConfig{
@@ -232,14 +228,14 @@ func TestRenounceTimelockDeployer(t *testing.T) {
 		Nodes:  1,
 	})
 	chain1 := e.AllChainSelectors()[0]
-	e, err := ApplyChangesets(t, e, nil, []ChangesetApplication{
-		{
-			Changeset: WrapChangeSet(DeployMCMSWithTimelock),
-			Config: map[uint64]types.MCMSWithTimelockConfig{
+	e, err := Apply(t, e, nil,
+		Configure(
+			deployment.CreateLegacyChangeSet(DeployMCMSWithTimelock),
+			map[uint64]types.MCMSWithTimelockConfig{
 				chain1: proposalutils.SingleGroupTimelockConfig(t),
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	addrs, err := e.ExistingAddresses.AddressesForChain(chain1)
 	require.NoError(t, err)
@@ -258,14 +254,14 @@ func TestRenounceTimelockDeployer(t *testing.T) {
 	require.Equal(t, int64(2), r.Int64())
 
 	// Revoke Deployer
-	e, err = ApplyChangesets(t, e, nil, []ChangesetApplication{
-		{
-			Changeset: WrapChangeSet(RenounceTimelockDeployer),
-			Config: RenounceTimelockDeployerConfig{
+	e, err = Apply(t, e, nil,
+		Configure(
+			deployment.CreateLegacyChangeSet(RenounceTimelockDeployer),
+			RenounceTimelockDeployerConfig{
 				ChainSel: chain1,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	// Check that the deployer is no longer an admin

--- a/deployment/common/proposalutils/propose_test.go
+++ b/deployment/common/proposalutils/propose_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	types2 "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -31,10 +32,10 @@ func TestBuildProposalFromBatchesV2(t *testing.T) {
 	chainSelector := env.AllChainSelectors()[0]
 	config := proposalutils.SingleGroupMCMS(t)
 
-	env, err := changeset.ApplyChangesets(t, env, nil, []changeset.ChangesetApplication{
-		{
-			Changeset: changeset.WrapChangeSet(changeset.DeployMCMSWithTimelock),
-			Config: map[uint64]types2.MCMSWithTimelockConfig{
+	env, err := changeset.Apply(t, env, nil,
+		changeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelock),
+			map[uint64]types2.MCMSWithTimelockConfig{
 				chainSelector: {
 					Canceller:        config,
 					Bypasser:         config,
@@ -42,8 +43,8 @@ func TestBuildProposalFromBatchesV2(t *testing.T) {
 					TimelockMinDelay: big.NewInt(0),
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	chain := env.Chains[chainSelector]

--- a/deployment/data-streams/changeset/jd_register_nodes_test.go
+++ b/deployment/data-streams/changeset/jd_register_nodes_test.go
@@ -7,6 +7,7 @@ import (
 
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -27,10 +28,10 @@ func TestRegisterNodesWithJD(t *testing.T) {
 
 	csaKey := jobClient.Nodes[nodeP2pKey].Keys.CSA.PublicKeyString()
 
-	e, err := changeset.ApplyChangesets(t, e, nil, []changeset.ChangesetApplication{
-		{
-			Changeset: changeset.WrapChangeSet(RegisterNodesWithJD),
-			Config: RegisterNodesInput{
+	e, err := changeset.Apply(t, e, nil,
+		changeset.Configure(
+			deployment.CreateLegacyChangeSet(RegisterNodesWithJD),
+			RegisterNodesInput{
 				EnvLabel:    "test-env",
 				ProductName: "test-product",
 				DONs: DONConfigMap{
@@ -42,8 +43,8 @@ func TestRegisterNodesWithJD(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	require.Lenf(t, jobClient.RegisteredNodes, 1, "1 registered node expected")
 	require.NotNilf(t, jobClient.RegisteredNodes[csaKey], "expected node with csa key %s to be registered", csaKey)

--- a/deployment/keystone/changeset/accept_ownership_test.go
+++ b/deployment/keystone/changeset/accept_ownership_test.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -24,49 +25,47 @@ func TestAcceptAllOwnership(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 	registrySel := env.AllChainSelectors()[0]
-	env, err := commonchangeset.ApplyChangesets(t, env, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployCapabilityRegistry),
-			Config:    registrySel,
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployOCR3),
-			Config:    registrySel,
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployForwarder),
-			Config:    changeset.DeployForwarderRequest{},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.DeployFeedsConsumer),
-			Config:    &changeset.DeployFeedsConsumerRequest{ChainSelector: registrySel},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.DeployMCMSWithTimelock),
-			Config: map[uint64]types.MCMSWithTimelockConfig{
+	env, err := commonchangeset.Apply(t, env, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployCapabilityRegistry),
+			registrySel,
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployOCR3),
+			registrySel,
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployForwarder),
+			changeset.DeployForwarderRequest{},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployFeedsConsumer),
+			&changeset.DeployFeedsConsumerRequest{ChainSelector: registrySel},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
+			map[uint64]types.MCMSWithTimelockConfig{
 				registrySel: proposalutils.SingleGroupTimelockConfig(t),
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	addrs, err := env.ExistingAddresses.AddressesForChain(registrySel)
 	require.NoError(t, err)
 	timelock, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(env.Chains[registrySel], addrs)
 	require.NoError(t, err)
 
-	_, err = commonchangeset.ApplyChangesets(t, env, map[uint64]*proposalutils.TimelockExecutionContracts{
-		registrySel: &proposalutils.TimelockExecutionContracts{
-			Timelock:  timelock.Timelock,
-			CallProxy: timelock.CallProxy,
+	_, err = commonchangeset.Apply(t, env,
+		map[uint64]*proposalutils.TimelockExecutionContracts{
+			registrySel: {Timelock: timelock.Timelock, CallProxy: timelock.CallProxy},
 		},
-	}, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.AcceptAllOwnershipsProposal),
-			Config: &changeset.AcceptAllOwnershipRequest{
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.AcceptAllOwnershipsProposal),
+			&changeset.AcceptAllOwnershipRequest{
 				ChainSelector: registrySel,
 				MinDelay:      0,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 }

--- a/deployment/keystone/changeset/add_capabilities_test.go
+++ b/deployment/keystone/changeset/add_capabilities_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -73,12 +74,9 @@ func TestAddCapabilities(t *testing.T) {
 				CallProxy: contracts.CallProxy,
 			},
 		}
-		_, err = commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, []commonchangeset.ChangesetApplication{
-			{
-				Changeset: commonchangeset.WrapChangeSet(changeset.AddCapabilities),
-				Config:    req,
-			},
-		})
+		_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+			commonchangeset.Configure(deployment.CreateLegacyChangeSet(changeset.AddCapabilities), req),
+		)
 		require.NoError(t, err)
 
 		assertCapabilitiesExist(t, te.CapabilitiesRegistry(), capabilitiesToAdd...)

--- a/deployment/keystone/changeset/add_nodes_test.go
+++ b/deployment/keystone/changeset/add_nodes_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -258,12 +259,14 @@ func TestAddNodes(t *testing.T) {
 						}
 						require.NotNil(t, r.Proposals) //nolint:staticcheck //SA1019 ignoring deprecated field for compatibility; we don't have tools to generate the new field
 						require.Len(t, r.Proposals, 1) //nolint:staticcheck //SA1019 ignoring deprecated field for compatibility; we don't have tools to generate the new field
-						applyErr := applyProposal(t, tc.input.te, []commonchangeset.ChangesetApplication{
-							{
-								Changeset: commonchangeset.WrapChangeSet(changeset.AddNodes),
-								Config:    req,
-							},
-						})
+						applyErr := applyProposal(
+							t,
+							tc.input.te,
+							commonchangeset.Configure(
+								deployment.CreateLegacyChangeSet(changeset.AddNodes),
+								req,
+							),
+						)
 						if tc.checkErr != nil {
 							tc.checkErr(t, useMCMS, applyErr)
 							return
@@ -299,7 +302,7 @@ func assertNodesExist(t *testing.T, registry *kcr.CapabilitiesRegistry, nodes ..
 	}
 }
 
-func applyProposal(t *testing.T, te test.TestEnv, applicable []commonchangeset.ChangesetApplication) error {
+func applyProposal(t *testing.T, te test.TestEnv, applicable ...commonchangeset.ConfiguredChangeSet) error {
 	// now apply the changeset such that the proposal is signed and execed
 	contracts := te.ContractSets()[te.RegistrySelector]
 	timelockContracts := map[uint64]*proposalutils.TimelockExecutionContracts{

--- a/deployment/keystone/changeset/add_nops_test.go
+++ b/deployment/keystone/changeset/add_nops_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -84,12 +85,9 @@ func TestAddNops(t *testing.T) {
 				CallProxy: contracts.CallProxy,
 			},
 		}
-		_, err = commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, []commonchangeset.ChangesetApplication{
-			{
-				Changeset: commonchangeset.WrapChangeSet(changeset.AddNops),
-				Config:    req,
-			},
-		})
+		_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+			commonchangeset.Configure(deployment.CreateLegacyChangeSet(changeset.AddNops), req),
+		)
 		require.NoError(t, err)
 
 		assertNopsExist(t, te.CapabilitiesRegistry(), nops...)

--- a/deployment/keystone/changeset/append_node_capabilities_test.go
+++ b/deployment/keystone/changeset/append_node_capabilities_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -96,12 +97,12 @@ func TestAppendNodeCapabilities(t *testing.T) {
 			},
 		}
 
-		_, err = commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, []commonchangeset.ChangesetApplication{
-			{
-				Changeset: commonchangeset.WrapChangeSet(changeset.AppendNodeCapabilities),
-				Config:    &cfg,
-			},
-		})
+		_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(changeset.AppendNodeCapabilities),
+				&cfg,
+			),
+		)
 		require.NoError(t, err)
 		validateCapabilityAppends(t, te, newCapabilities)
 	})

--- a/deployment/keystone/changeset/deploy_forwarder_test.go
+++ b/deployment/keystone/changeset/deploy_forwarder_test.go
@@ -126,12 +126,12 @@ func TestConfigureForwarders(t *testing.T) {
 						CallProxy: contractSet.CallProxy,
 					}
 				}
-				_, err = commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, []commonchangeset.ChangesetApplication{
-					{
-						Changeset: commonchangeset.WrapChangeSet(changeset.ConfigureForwardContracts),
-						Config:    cfg,
-					},
-				})
+				_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+					commonchangeset.Configure(
+						deployment.CreateLegacyChangeSet(changeset.ConfigureForwardContracts),
+						cfg,
+					),
+				)
 				require.NoError(t, err)
 			})
 		}

--- a/deployment/keystone/changeset/deploy_ocr3_test.go
+++ b/deployment/keystone/changeset/deploy_ocr3_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -287,12 +288,12 @@ func TestConfigureOCR3(t *testing.T) {
 		// now apply the changeset such that the proposal is signed and execed
 		w2 := &bytes.Buffer{}
 		cfg.WriteGeneratedConfig = w2
-		_, err = commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, []commonchangeset.ChangesetApplication{
-			{
-				Changeset: commonchangeset.WrapChangeSet(changeset.ConfigureOCR3Contract),
-				Config:    cfg,
-			},
-		})
+		_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(changeset.ConfigureOCR3Contract),
+				cfg,
+			),
+		)
 		require.NoError(t, err)
 	})
 }

--- a/deployment/keystone/changeset/test/helpers.go
+++ b/deployment/keystone/changeset/test/helpers.go
@@ -139,24 +139,24 @@ func SetupTestEnv(t *testing.T, c TestConfig) TestEnv {
 		Chains:            chains,
 		ExistingAddresses: deployment.NewMemoryAddressBook(),
 	}
-	e, err := commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(kschangeset.DeployCapabilityRegistry),
-			Config:    registryChainSel,
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(kschangeset.DeployOCR3),
-			Config:    registryChainSel,
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(kschangeset.DeployForwarder),
-			Config:    kschangeset.DeployForwarderRequest{},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(workflowregistry.Deploy),
-			Config:    registryChainSel,
-		},
-	})
+	e, err := commonchangeset.Apply(t, e, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(kschangeset.DeployCapabilityRegistry),
+			registryChainSel,
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(kschangeset.DeployOCR3),
+			registryChainSel,
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(kschangeset.DeployForwarder),
+			kschangeset.DeployForwarderRequest{},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(workflowregistry.Deploy),
+			registryChainSel,
+		),
+	)
 	require.NoError(t, err)
 	require.NotNil(t, e)
 	require.Len(t, e.Chains, c.NumChains)
@@ -284,12 +284,12 @@ func SetupTestEnv(t *testing.T, c TestConfig) TestEnv {
 			t.Logf("Enabling MCMS on chain %d", sel)
 			timelockCfgs[sel] = proposalutils.SingleGroupTimelockConfig(t)
 		}
-		env, err = commonchangeset.ApplyChangesets(t, env, nil, []commonchangeset.ChangesetApplication{
-			{
-				Changeset: commonchangeset.WrapChangeSet(commonchangeset.DeployMCMSWithTimelock),
-				Config:    timelockCfgs,
-			},
-		})
+		env, err = commonchangeset.Apply(t, env, nil,
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelock),
+				timelockCfgs,
+			),
+		)
 		require.NoError(t, err)
 		// extract the MCMS address
 		r, err := internal.GetContractSets(lggr, &internal.GetContractSetsRequest{
@@ -303,15 +303,18 @@ func SetupTestEnv(t *testing.T, c TestConfig) TestEnv {
 			require.NoError(t, mcms.Validate())
 
 			// transfer ownership of all contracts to the MCMS
-			env, err = commonchangeset.ApplyChangesets(t, env, map[uint64]*proposalutils.TimelockExecutionContracts{sel: {Timelock: mcms.Timelock, CallProxy: mcms.CallProxy}}, []commonchangeset.ChangesetApplication{
-				{
-					Changeset: commonchangeset.WrapChangeSet(kschangeset.AcceptAllOwnershipsProposal),
-					Config: &kschangeset.AcceptAllOwnershipRequest{
+			env, err = commonchangeset.Apply(t, env,
+				map[uint64]*proposalutils.TimelockExecutionContracts{
+					sel: {Timelock: mcms.Timelock, CallProxy: mcms.CallProxy},
+				},
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(kschangeset.AcceptAllOwnershipsProposal),
+					&kschangeset.AcceptAllOwnershipRequest{
 						ChainSelector: sel,
 						MinDelay:      0,
 					},
-				},
-			})
+				),
+			)
 			require.NoError(t, err)
 		}
 	}

--- a/deployment/keystone/changeset/update_don_test.go
+++ b/deployment/keystone/changeset/update_don_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -129,12 +130,12 @@ func TestUpdateDon(t *testing.T) {
 				CallProxy: contracts.CallProxy,
 			},
 		}
-		_, err = commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, []commonchangeset.ChangesetApplication{
-			{
-				Changeset: commonchangeset.WrapChangeSet(changeset.UpdateDon),
-				Config:    &cfg,
-			},
-		})
+		_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(changeset.UpdateDon),
+				&cfg,
+			),
+		)
 		require.NoError(t, err)
 		assertDonContainsCapabilities(t, te.ContractSets()[te.RegistrySelector].CapabilitiesRegistry, caps, p2pIDs)
 	})

--- a/deployment/keystone/changeset/update_node_capabilities_test.go
+++ b/deployment/keystone/changeset/update_node_capabilities_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -126,12 +127,12 @@ func TestUpdateNodeCapabilities(t *testing.T) {
 			},
 		}
 
-		_, err = commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, []commonchangeset.ChangesetApplication{
-			{
-				Changeset: commonchangeset.WrapChangeSet(changeset.UpdateNodeCapabilities),
-				Config:    &cfg,
-			},
-		})
+		_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(changeset.UpdateNodeCapabilities),
+				&cfg,
+			),
+		)
 		require.NoError(t, err)
 		validateCapabilityUpdates(t, te, capabiltiesToSet)
 	})

--- a/deployment/keystone/changeset/update_nodes_test.go
+++ b/deployment/keystone/changeset/update_nodes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -97,16 +98,16 @@ func TestUpdateNodes(t *testing.T) {
 				CallProxy: contracts.CallProxy,
 			},
 		}
-		_, err = commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, []commonchangeset.ChangesetApplication{
-			{
-				Changeset: commonchangeset.WrapChangeSet(changeset.UpdateNodes),
-				Config: &changeset.UpdateNodesRequest{
+		_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(changeset.UpdateNodes),
+				&changeset.UpdateNodesRequest{
 					RegistryChainSel: te.RegistrySelector,
 					P2pToUpdates:     updates,
 					MCMSConfig:       &changeset.MCMSConfig{MinDuration: 0},
 				},
-			},
-		})
+			),
+		)
 		require.NoError(t, err)
 
 		validateUpdate(t, te, updates)

--- a/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
@@ -100,11 +100,11 @@ func Test_UpdateAllowedDons_WithMCMS(t *testing.T) {
 		},
 	}
 
-	_, err = commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(workflowregistry.UpdateAllowedDons),
-			Config:    req,
-		},
-	})
+	_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(workflowregistry.UpdateAllowedDons),
+			req,
+		),
+	)
 	require.NoError(t, err)
 }

--- a/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
@@ -103,11 +103,11 @@ func Test_UpdateAuthorizedAddresses_WithMCMS(t *testing.T) {
 		},
 	}
 
-	_, err = commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(workflowregistry.UpdateAuthorizedAddresses),
-			Config:    req,
-		},
-	})
+	_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(workflowregistry.UpdateAuthorizedAddresses),
+			req,
+		),
+	)
 	require.NoError(t, err)
 }

--- a/integration-tests/smoke/ccip/ccip_add_chain_test.go
+++ b/integration-tests/smoke/ccip/ccip_add_chain_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
+	"github.com/smartcontractkit/chainlink/deployment"
 
 	ccipcs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
@@ -432,23 +433,23 @@ func setupInboundWiring(
 	}
 
 	var err error
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(ccipcs.UpdateOffRampSourcesChangeset),
-			Config: ccipcs.UpdateOffRampSourcesConfig{
+	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipcs.UpdateOffRampSourcesChangeset),
+			ccipcs.UpdateOffRampSourcesConfig{
 				UpdatesByChain: offRampSourceUpdates(t, newChains, sources, testRouterEnabled),
 				MCMS:           mcmsConfig,
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(ccipcs.UpdateRouterRampsChangeset),
-			Config: ccipcs.UpdateRouterRampsConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipcs.UpdateRouterRampsChangeset),
+			ccipcs.UpdateRouterRampsConfig{
 				TestRouter:     testRouterEnabled,
 				UpdatesByChain: routerOffRampUpdates(t, newChains, sources),
 				MCMS:           mcmsConfig,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	return e
@@ -473,37 +474,37 @@ func setupOutboundWiring(
 	}
 
 	var err error
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(ccipcs.UpdateOnRampsDestsChangeset),
-			Config: ccipcs.UpdateOnRampDestsConfig{
+	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipcs.UpdateOnRampsDestsChangeset),
+			ccipcs.UpdateOnRampDestsConfig{
 				UpdatesByChain: onRampDestUpdates(t, newChains, sources, testRouterEnabled),
 				MCMS:           mcmsConfig,
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(ccipcs.UpdateFeeQuoterPricesChangeset),
-			Config: ccipcs.UpdateFeeQuoterPricesConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipcs.UpdateFeeQuoterPricesChangeset),
+			ccipcs.UpdateFeeQuoterPricesConfig{
 				PricesByChain: feeQuoterPricesByChain(t, newChains, sources),
 				MCMS:          mcmsConfig,
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(ccipcs.UpdateFeeQuoterDestsChangeset),
-			Config: ccipcs.UpdateFeeQuoterDestsConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipcs.UpdateFeeQuoterDestsChangeset),
+			ccipcs.UpdateFeeQuoterDestsConfig{
 				UpdatesByChain: feeQuoterDestUpdates(t, newChains, sources),
 				MCMS:           mcmsConfig,
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(ccipcs.UpdateRouterRampsChangeset),
-			Config: ccipcs.UpdateRouterRampsConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipcs.UpdateRouterRampsChangeset),
+			ccipcs.UpdateRouterRampsConfig{
 				TestRouter:     testRouterEnabled,
 				UpdatesByChain: routerOnRampUpdates(t, newChains, sources),
 				MCMS:           mcmsConfig,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	return e
@@ -517,14 +518,14 @@ func setupChain(t *testing.T, e testhelpers.DeployedEnv, tEnv testhelpers.TestEn
 
 	// Need to update what the RMNProxy is pointing to, otherwise plugin will not work.
 	var err error
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(ccipcs.SetRMNRemoteOnRMNProxyChangeset),
-			Config: ccipcs.SetRMNRemoteOnRMNProxyConfig{
+	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipcs.SetRMNRemoteOnRMNProxyChangeset),
+			ccipcs.SetRMNRemoteOnRMNProxyConfig{
 				ChainSelectors: chains,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	return e
@@ -758,7 +759,7 @@ func transferToMCMSAndRenounceTimelockDeployer(
 	state ccipcs.CCIPOnChainState,
 	onlyChainContracts bool,
 ) {
-	apps := make([]commonchangeset.ChangesetApplication, 0, len(chains)+1)
+	apps := make([]commonchangeset.ConfiguredChangeSet, 0, len(chains)+1)
 	cfg := testhelpers.GenTestTransferOwnershipConfig(e, chains, state)
 	if onlyChainContracts {
 		// filter out the home chain contracts from e.HomeChainSel
@@ -775,17 +776,17 @@ func transferToMCMSAndRenounceTimelockDeployer(
 		}
 		cfg.ContractsByChain[e.HomeChainSel] = chainContracts
 	}
-	apps = append(apps, commonchangeset.ChangesetApplication{
-		Changeset: commonchangeset.WrapChangeSet(commonchangeset.TransferToMCMSWithTimelock),
-		Config:    cfg,
-	})
+	apps = append(apps, commonchangeset.Configure(
+		deployment.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelock),
+		cfg,
+	))
 	for _, chain := range chains {
-		apps = append(apps, commonchangeset.ChangesetApplication{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.RenounceTimelockDeployer),
-			Config: commonchangeset.RenounceTimelockDeployerConfig{
+		apps = append(apps, commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.RenounceTimelockDeployer),
+			commonchangeset.RenounceTimelockDeployerConfig{
 				ChainSel: chain,
 			},
-		})
+		))
 	}
 	var err error
 	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), apps)

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -187,15 +188,15 @@ func transferRMNContractToMCMS(t *testing.T, e *testhelpers.DeployedEnv, state c
 	contractsByChain[e.HomeChainSel] = append(contractsByChain[e.HomeChainSel], state.Chains[e.HomeChainSel].RMNHome.Address())
 
 	// This is required because RMN Contracts is initially owned by the deployer
-	_, err := commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.TransferToMCMSWithTimelock),
-			Config: commonchangeset.TransferToMCMSWithTimelockConfig{
+	_, err := commonchangeset.Apply(t, e.Env, timelocksPerChain,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelock),
+			commonchangeset.TransferToMCMSWithTimelockConfig{
 				ContractsByChain: contractsByChain,
 				MinDelay:         0,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 }
 
@@ -221,22 +222,22 @@ func runRmnUncurseMCMSTest(t *testing.T, tc CurseTestCase) {
 
 	transferRMNContractToMCMS(t, &e, state, timelocksPerChain)
 
-	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.RMNCurseChangeset),
-			Config:    config,
-		},
-	})
+	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.RMNCurseChangeset),
+			config,
+		),
+	)
 	require.NoError(t, err)
 
 	verifyTestCaseAssertions(t, &e, tc, mapIDToSelector)
 
-	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.RMNUncurseChangeset),
-			Config:    config,
-		},
-	})
+	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.RMNUncurseChangeset),
+			config,
+		),
+	)
 	require.NoError(t, err)
 
 	verifyNoActiveCurseOnAllChains(t, &e)
@@ -351,12 +352,12 @@ func runRmnCurseMCMSTest(t *testing.T, tc CurseTestCase) {
 
 	transferRMNContractToMCMS(t, &e, state, timelocksPerChain)
 
-	_, err = commonchangeset.ApplyChangesets(t, e.Env, timelocksPerChain, []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.RMNCurseChangeset),
-			Config:    config,
-		},
-	})
+	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.RMNCurseChangeset),
+			config,
+		),
+	)
 	require.NoError(t, err)
 
 	verifyTestCaseAssertions(t, &e, tc, mapIDToSelector)

--- a/integration-tests/smoke/ccip/ccip_fee_boosting_test.go
+++ b/integration-tests/smoke/ccip/ccip_fee_boosting_test.go
@@ -96,10 +96,10 @@ func Test_CCIPFeeBoosting(t *testing.T) {
 		feeQuoterCfg)
 
 	// Update token prices in destination chain FeeQuoter
-	e.Env, err = commoncs.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commoncs.ChangesetApplication{
-		{
-			Changeset: commoncs.WrapChangeSet(changeset.UpdateFeeQuoterPricesChangeset),
-			Config: changeset.UpdateFeeQuoterPricesConfig{
+	e.Env, err = commoncs.Apply(t, e.Env, e.TimelockContracts(t),
+		commoncs.Configure(
+			deployment.CreateLegacyChangeSet(changeset.UpdateFeeQuoterPricesChangeset),
+			changeset.UpdateFeeQuoterPricesConfig{
 				PricesByChain: map[uint64]changeset.FeeQuoterPriceUpdatePerSource{
 					destChain: {
 						TokenPrices: map[common.Address]*big.Int{
@@ -109,8 +109,8 @@ func Test_CCIPFeeBoosting(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	startBlocks := make(map[uint64]*uint64)
@@ -137,10 +137,10 @@ func Test_CCIPFeeBoosting(t *testing.T) {
 		DestChainSelector:   destChain,
 	}] = []uint64{msgSentEvent.SequenceNumber}
 
-	e.Env, err = commoncs.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commoncs.ChangesetApplication{
-		{
-			Changeset: commoncs.WrapChangeSet(changeset.UpdateFeeQuoterPricesChangeset),
-			Config: changeset.UpdateFeeQuoterPricesConfig{
+	e.Env, err = commoncs.Apply(t, e.Env, e.TimelockContracts(t),
+		commoncs.Configure(
+			deployment.CreateLegacyChangeSet(changeset.UpdateFeeQuoterPricesChangeset),
+			changeset.UpdateFeeQuoterPricesConfig{
 				PricesByChain: map[uint64]changeset.FeeQuoterPriceUpdatePerSource{
 					sourceChain: {
 						GasPrices: map[uint64]*big.Int{
@@ -149,8 +149,8 @@ func Test_CCIPFeeBoosting(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 
 	// Confirm gas prices are updated

--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_5_0/evm_2_evm_onramp"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	v1_5testhelpers "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/v1_5"
@@ -83,10 +84,10 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	e.Env = v1_5testhelpers.AddLanes(t, e.Env, state, pairs)
 
 	// permabless the commit stores
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(v1_5.PermaBlessCommitStoreChangeset),
-			Config: v1_5.PermaBlessCommitStoreConfig{
+	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(v1_5.PermaBlessCommitStoreChangeset),
+			v1_5.PermaBlessCommitStoreConfig{
 				Configs: map[uint64]v1_5.PermaBlessCommitStoreConfigPerDest{
 					dest: {
 						Sources: []v1_5.PermaBlessConfigPerSourceChain{
@@ -102,8 +103,8 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	// reload state after adding lanes
 	state, err = changeset.LoadOnchainState(e.Env)
@@ -169,15 +170,15 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 		}
 	}
 
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(commonchangeset.TransferToMCMSWithTimelock),
-			Config: commonchangeset.TransferToMCMSWithTimelockConfig{
+	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelock),
+			commonchangeset.TransferToMCMSWithTimelockConfig{
 				ContractsByChain: contractsByChain,
 				MinDelay:         0,
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	// add 1.6 contracts to the environment and send 1.6 jobs
 	// First we need to deploy Homechain contracts and restart the nodes with updated cap registry
@@ -185,20 +186,20 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	e = testhelpers.AddCCIPContractsToEnvironment(t, e.Env.AllChainSelectors(), tEnv, false)
 	// Set RMNProxy to point to RMNRemote.
 	// nonce manager should point to 1.5 ramps
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-		{
+	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
 			// as we have already transferred ownership for RMNProxy to MCMS, it needs to be done via MCMS proposal
-			Changeset: commonchangeset.WrapChangeSet(changeset.SetRMNRemoteOnRMNProxyChangeset),
-			Config: changeset.SetRMNRemoteOnRMNProxyConfig{
+			deployment.CreateLegacyChangeSet(changeset.SetRMNRemoteOnRMNProxyChangeset),
+			changeset.SetRMNRemoteOnRMNProxyConfig{
 				ChainSelectors: e.Env.AllChainSelectors(),
 				MCMSConfig: &changeset.MCMSConfig{
 					MinDelay: 0,
 				},
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.UpdateNonceManagersChangeset),
-			Config: changeset.UpdateNonceManagerConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.UpdateNonceManagersChangeset),
+			changeset.UpdateNonceManagerConfig{
 				// we only have lanes between src1 --> dest
 				UpdatesByChain: map[uint64]changeset.NonceManagerUpdate{
 					src1: {
@@ -231,8 +232,8 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	state, err = changeset.LoadOnchainState(e.Env)
 	require.NoError(t, err)
@@ -284,10 +285,10 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	testhelpers.ConfirmExecWithSeqNrsForAll(t, e.Env, state, expectedSeqNumExec, startBlocks)
 
 	// now that the 1.6 lane is working, we can enable the real router
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), []commonchangeset.ChangesetApplication{
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.UpdateOnRampsDestsChangeset),
-			Config: changeset.UpdateOnRampDestsConfig{
+	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.UpdateOnRampsDestsChangeset),
+			changeset.UpdateOnRampDestsConfig{
 				UpdatesByChain: map[uint64]map[uint64]changeset.OnRampDestinationUpdate{
 					src1: {
 						dest: {
@@ -298,10 +299,10 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			Changeset: commonchangeset.WrapChangeSet(changeset.UpdateOffRampSourcesChangeset),
-			Config: changeset.UpdateOffRampSourcesConfig{
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.UpdateOffRampSourcesChangeset),
+			changeset.UpdateOffRampSourcesConfig{
 				UpdatesByChain: map[uint64]map[uint64]changeset.OffRampSourceUpdate{
 					dest: {
 						src1: {
@@ -312,11 +313,11 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
+		),
+		commonchangeset.Configure(
 			// this needs to be MCMS proposal as the router contract is owned by MCMS
-			Changeset: commonchangeset.WrapChangeSet(changeset.UpdateRouterRampsChangeset),
-			Config: changeset.UpdateRouterRampsConfig{
+			deployment.CreateLegacyChangeSet(changeset.UpdateRouterRampsChangeset),
+			changeset.UpdateRouterRampsConfig{
 				TestRouter: false,
 				MCMS: &changeset.MCMSConfig{
 					MinDelay: 0,
@@ -336,8 +337,8 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 					},
 				},
 			},
-		},
-	})
+		),
+	)
 	require.NoError(t, err)
 	// confirm that the other lane src2->dest is still working with v1.5
 	sentEventOnOtherLane, err := v1_5testhelpers.SendRequest(t, e.Env, state,


### PR DESCRIPTION
This preserves the existing function type (as an alias to a new function type, ChangeLogic).  It adds also two function types ChangeLogic and PreconditionVerifier, to encapsulate the logic of these two functions. The interface exposes an Apply and a VerifyPreconditions method. The aforementioned function types can be used with a convenience function to generate an implementation of ChangeSetV2. Alternatively, a full implementation of the interface can be built using a struct that implements those methods.

[DPA-1527](https://smartcontract-it.atlassian.net/browse/DPA-1527)


[DPA-1527]: https://smartcontract-it.atlassian.net/browse/DPA-1527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ