### PR TITLE
LabeSet fixes for address book

### DIFF
--- a/deployment/address_book_labels.go
+++ b/deployment/address_book_labels.go
@@ -18,13 +18,17 @@ func NewLabelSet(labels ...string) LabelSet {
 }
 
 // Add inserts a labels into the set.
-func (ls LabelSet) Add(labels string) {
-	ls[labels] = struct{}{}
+func (ls LabelSet) Add(labels ...string) {
+	for _, label := range labels {
+		ls[label] = struct{}{}
+	}
 }
 
 // Remove deletes a labels from the set, if it exists.
-func (ls LabelSet) Remove(labels string) {
-	delete(ls, labels)
+func (ls LabelSet) Remove(labels ...string) {
+	for _, label := range labels {
+		delete(ls, label)
+	}
 }
 
 // Contains checks if the set contains the given labels.
@@ -64,4 +68,16 @@ func (ls LabelSet) Equal(other LabelSet) bool {
 		}
 	}
 	return true
+}
+
+// DeepClone returns a copy of the LabelSet.
+func (ls LabelSet) DeepClone() LabelSet {
+	if ls == nil {
+		return nil
+	}
+	out := make(LabelSet, len(ls))
+	for label := range ls {
+		out[label] = struct{}{}
+	}
+	return out
 }

--- a/deployment/address_book_labels_test.go
+++ b/deployment/address_book_labels_test.go
@@ -8,51 +8,71 @@ import (
 
 func TestNewLabelSet(t *testing.T) {
 	t.Run("no labels", func(t *testing.T) {
-		ms := NewLabelSet()
-		assert.Empty(t, ms, "expected empty set")
+		ls := NewLabelSet()
+		assert.Empty(t, ls, "expected empty set")
 	})
 
 	t.Run("some labels", func(t *testing.T) {
-		ms := NewLabelSet("foo", "bar")
-		assert.Len(t, ms, 2)
-		assert.True(t, ms.Contains("foo"))
-		assert.True(t, ms.Contains("bar"))
-		assert.False(t, ms.Contains("baz"))
+		ls := NewLabelSet("foo", "bar")
+		assert.Len(t, ls, 2)
+		assert.True(t, ls.Contains("foo"))
+		assert.True(t, ls.Contains("bar"))
+		assert.False(t, ls.Contains("baz"))
 	})
 }
 
 func TestLabelSet_Add(t *testing.T) {
-	ms := NewLabelSet("initial")
-	ms.Add("new")
+	ls := NewLabelSet("initial")
+	ls.Add("new")
 
-	assert.True(t, ms.Contains("initial"), "expected 'initial' in set")
-	assert.True(t, ms.Contains("new"), "expected 'new' in set")
-	assert.Len(t, ms, 2, "expected 2 distinct labels in set")
+	assert.True(t, ls.Contains("initial"), "expected 'initial' in set")
+	assert.True(t, ls.Contains("new"), "expected 'new' in set")
+	assert.Len(t, ls, 2, "expected 2 distinct labels in set")
 
 	// Add duplicate "new" again; size should remain 2
-	ms.Add("new")
-	assert.Len(t, ms, 2, "expected size to remain 2 after adding a duplicate")
+	ls.Add("new")
+	assert.Len(t, ls, 2, "expected size to remain 2 after adding a duplicate")
+
+	// Add multiple labels at once
+	ls.Add("label1", "label2", "label3")
+	assert.Len(t, ls, 5, "expected 5 distinct labels in set") // 2 previous + 3 new
+	assert.True(t, ls.Contains("label1"))
+	assert.True(t, ls.Contains("label2"))
+	assert.True(t, ls.Contains("label3"))
 }
 
 func TestLabelSet_Remove(t *testing.T) {
-	ms := NewLabelSet("remove_me", "keep")
-	ms.Remove("remove_me")
+	ls := NewLabelSet("remove_me", "keep", "label1", "label2", "label3")
+	ls.Remove("remove_me")
 
-	assert.False(t, ms.Contains("remove_me"), "expected 'remove_me' to be removed")
-	assert.True(t, ms.Contains("keep"), "expected 'keep' to remain")
-	assert.Len(t, ms, 1, "expected set size to be 1 after removal")
+	assert.False(t, ls.Contains("remove_me"), "expected 'remove_me' to be removed")
+	assert.True(t, ls.Contains("keep"), "expected 'keep' to remain")
+	assert.True(t, ls.Contains("label1"), "expected 'label1' to remain")
+	assert.True(t, ls.Contains("label2"), "expected 'label2' to remain")
+	assert.True(t, ls.Contains("label3"), "expected 'label3' to remain")
+	assert.Len(t, ls, 4, "expected set size to be 4 after removal")
 
 	// Removing a non-existent item shouldn't change the size
-	ms.Remove("non_existent")
-	assert.Len(t, ms, 1, "expected size to remain 1 after removing a non-existent item")
+	ls.Remove("non_existent")
+	assert.Len(t, ls, 4, "expected size to remain 4 after removing a non-existent item")
+
+	// Remove multiple labels at once
+	ls.Remove("label2", "label4")
+
+	assert.Len(t, ls, 3, "expected 3 distinct labels in set after removal") // keep, label1, label3
+	assert.True(t, ls.Contains("keep"))
+	assert.True(t, ls.Contains("label1"))
+	assert.False(t, ls.Contains("label2"))
+	assert.True(t, ls.Contains("label3"))
+	assert.False(t, ls.Contains("label4"))
 }
 
 func TestLabelSet_Contains(t *testing.T) {
-	ms := NewLabelSet("foo", "bar")
+	ls := NewLabelSet("foo", "bar")
 
-	assert.True(t, ms.Contains("foo"))
-	assert.True(t, ms.Contains("bar"))
-	assert.False(t, ms.Contains("baz"))
+	assert.True(t, ls.Contains("foo"))
+	assert.True(t, ls.Contains("bar"))
+	assert.False(t, ls.Contains("baz"))
 }
 
 // TestLabelSet_String tests the String() method of the LabelSet type.
@@ -178,6 +198,78 @@ func TestLabelSet_Equal(t *testing.T) {
 
 			result := tt.set1.Equal(tt.set2)
 			assert.Equal(t, tt.expected, result, "Equal(%v, %v) should be %v", tt.set1, tt.set2, tt.expected)
+		})
+	}
+}
+
+func TestLabelSet_DeepClone(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     LabelSet
+		mutate    func(ls LabelSet)
+		wantEqual bool
+	}{
+		{
+			name: "Empty label set",
+			// An empty-but-initialized map
+			input: NewLabelSet(),
+			mutate: func(ls LabelSet) {
+				ls.Add("test-label")
+			},
+			wantEqual: false,
+		},
+		{
+			name:  "Non-empty label set",
+			input: NewLabelSet("fast", "secure"),
+			mutate: func(ls LabelSet) {
+				ls.Remove("secure") // remove an existing label
+				ls.Add("extra")     // add a new label
+			},
+			wantEqual: false,
+		},
+		{
+			name:  "Clone but no mutation",
+			input: NewLabelSet("unchanged"),
+			mutate: func(ls LabelSet) {
+				// no change
+			},
+			// If we do no mutation, they should remain equal
+			wantEqual: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := tt.input
+			clone := original.DeepClone()
+
+			// Clones should initially match the original (especially for non-nil).
+			// For nil, clone should also be nil, so they're logically "equal" if you treat nil sets as empty.
+			assert.True(t, original.Equal(clone),
+				"DeepClone result should match input before mutation")
+
+			// Mutate the clone
+			tt.mutate(clone)
+
+			// After mutation, check if they should remain equal or differ.
+			if tt.wantEqual {
+				assert.True(t, original.Equal(clone),
+					"Unexpected difference between original and clone")
+			} else {
+				assert.False(t, original.Equal(clone),
+					"Expected original and clone to differ after mutation, but they are equal")
+			}
+
+			// Optionally, also check that mutating the original won't affect the clone.
+			if original != nil {
+				original.Add("original-mutated")
+				// They should differ if we just mutated original (unless they were already different).
+				// We'll just do a quick check that the new label isn't in the clone.
+				if original.Contains("original-mutated") && clone != nil {
+					assert.False(t, clone.Contains("original-mutated"),
+						"Clone should not contain a label added to the original after deep clone")
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
The original cloneAddress was actually performing a shallow copy and not recursively copying each of the elements in TypeAndVersion