### PR TITLE
Enable concurrent start/stop of jobs

### DIFF
--- a/.changeset/ninety-ways-try.md
+++ b/.changeset/ninety-ways-try.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Start/stop jobs in parallel to improve performance #internal #updated


### PR DESCRIPTION
- This should result in a significant decrease in time-to-ready when
  starting nodes with a lot of jobs.
- It should also speed up shutdown making forced exits less common.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
