### PR TITLE
fix(deployments): label bootstrap nodes on NewNode

### DIFF
--- a/deployment/environment/devenv/don.go
+++ b/deployment/environment/devenv/don.go
@@ -168,11 +168,19 @@ func NewNode(nodeInfo NodeInfo) (*Node, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create node rest client: %w", err)
 	}
+	labels := []*ptypes.Label{}
+	if nodeInfo.IsBootstrap {
+		labels = append(labels, &ptypes.Label{
+			Key:   NodeLabelKeyType,
+			Value: ptr(NodeLabelValueBootstrap),
+		})
+	}
 	return &Node{
 		gqlClient:  gqlClient,
 		restClient: chainlinkClient,
 		Name:       nodeInfo.Name,
 		adminAddr:  nodeInfo.AdminAddr,
+		labels:     labels,
 	}, nil
 }
 


### PR DESCRIPTION
# Summary
`NodeInfo.IsBootstrap` flag is currently being ignored when instantiating a `NewNode`, so the node instance doesn't receive a bootstrap `label`. This PR fixes this.

# Features
- Fixes `NewNode` adding bootstrap label on nodes that have `NodeInfo.IsBootstrap == true`
