### PR TITLE
fix(deployments): label bootstrap nodes on NewNode

### DIFF
--- a/deployment/environment/devenv/don.go
+++ b/deployment/environment/devenv/don.go
@@ -180,6 +180,7 @@ func NewNode(nodeInfo NodeInfo) (*Node, error) {
 		restClient: chainlinkClient,
 		Name:       nodeInfo.Name,
 		adminAddr:  nodeInfo.AdminAddr,
+		multiAddr:  nodeInfo.MultiAddr,
 		labels:     labels,
 	}, nil
 }

--- a/deployment/environment/devenv/don.go
+++ b/deployment/environment/devenv/don.go
@@ -169,12 +169,17 @@ func NewNode(nodeInfo NodeInfo) (*Node, error) {
 			Value: &value,
 		})
 	}
+	if nodeInfo.IsBootstrap {
+		labels = append(labels, &ptypes.Label{
+			Key:   NodeLabelKeyType,
+			Value: ptr(NodeLabelValueBootstrap),
+		})
+	}
 	return &Node{
 		gqlClient:  gqlClient,
 		restClient: chainlinkClient,
 		Name:       nodeInfo.Name,
 		adminAddr:  nodeInfo.AdminAddr,
-		multiAddr:  nodeInfo.MultiAddr,
 		labels:     labels,
 	}, nil
 }


### PR DESCRIPTION
# Summary
`NewNode` is currently not using `NodeInfo.IsBootstrap` flag. These changes labels nodes as bootstrap if `NodeInfo` contains the `IsBootstrap` flag

# Features
- Fixes Node instantiation
