### PR TITLE
chore: pin actions/* to major versions

### DIFF
--- a/.github/actions/delete-deployments/action.yml
+++ b/.github/actions/delete-deployments/action.yml
@@ -33,7 +33,7 @@ runs:
       with:
         version: ^9.0.0
 
-    - uses: actions/setup-node@v4.0.4
+    - uses: actions/setup-node@v4
       with:
         node-version: "20"
         cache: "pnpm"

--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - name: Checkout repo (full)
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       # Only do a full checkout on merge_groups
       if: github.event_name == 'merge_group'
       with:
@@ -35,7 +35,7 @@ runs:
         fetch-depth: 0
 
     - name: Checkout repo
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       if: github.event_name != 'merge_group'
       with:
         persist-credentials: false
@@ -89,7 +89,7 @@ runs:
       run: |
         go_directory=${{ steps.set-working-directory.outputs.golangci-lint-working-directory }}
         echo "Validating if directory name '$go_directory' is empty or has slashes"
-        
+
         if [[ $go_directory == *\/* ]]; then
             suffix=$(echo "$go_directory" | sed 's:\/$::' | tr '/' '-')
             echo "Directory name with slashes '$go_directory' updated to a valid artifact suffix '$suffix'"

--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -106,7 +106,7 @@ runs:
     - name: Store Golangci-lint report artifact
       if: always()
       id: upload-artifact
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v4
       with:
         # Use a unique suffix for each lint report artifact to avoid duplication errors
         name: golangci-lint-report-${{ steps.suffix.outputs.suffix }}

--- a/.github/actions/goreleaser-build-sign-publish/README.md
+++ b/.github/actions/goreleaser-build-sign-publish/README.md
@@ -23,7 +23,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Configure aws credentials

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -42,7 +42,7 @@ runs:
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
     - name: Set up Go
-      uses: actions/setup-go@v5.0.2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         cache: false

--- a/.github/actions/setup-nodejs/action.yaml
+++ b/.github/actions/setup-nodejs/action.yaml
@@ -15,7 +15,7 @@ runs:
       with:
         version: ^9.0.0
 
-    - uses: actions/setup-node@v4.0.4
+    - uses: actions/setup-node@v4
       with:
         node-version: "20"
         cache: "pnpm"

--- a/.github/actions/setup-solana/build-contracts/action.yml
+++ b/.github/actions/setup-solana/build-contracts/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Checkout chainlink-ccip
-      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      uses: actions/checkout@v4
       with:
         repository: smartcontractkit/chainlink-ccip
         path: chainlink-ccip

--- a/.github/actions/setup-solana/build-contracts/action.yml
+++ b/.github/actions/setup-solana/build-contracts/action.yml
@@ -41,7 +41,7 @@ runs:
           ARTIFACT_NAME=$(echo "$artifact" | jq -r '.name')
           ARTIFACT_EXPIRED=$(echo "$artifact" | jq -r '.expired')
           ARTIFACT_DOWNLOAD_URL=$(echo "$artifact" | jq -r '.archive_download_url')
-          
+
           if [[ "$ARTIFACT_NAME" == "${{ env.ARTIFACT_NAME }}" && "$ARTIFACT_EXPIRED" == false ]]; then
             # First non-expired artifact found, set variables and break loop
             echo "Artifact found"
@@ -81,4 +81,3 @@ runs:
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: chainlink-ccip/chains/solana/contracts/target/deploy/*.so
-       

--- a/.github/workflows/bash-scripts.yml
+++ b/.github/workflows/bash-scripts.yml
@@ -11,7 +11,7 @@ jobs:
       bash-scripts-src: ${{ steps.bash-scripts.outputs.src }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -27,7 +27,7 @@ jobs:
     needs: [changes]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Run ShellCheck

--- a/.github/workflows/build-publish-develop-pr.yml
+++ b/.github/workflows/build-publish-develop-pr.yml
@@ -36,7 +36,7 @@ jobs:
       release-type: ${{ steps.get-image-tag.outputs.release-type }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ env.CHECKOUT_REF }}
@@ -90,7 +90,7 @@ jobs:
             dist_name: linux_arm64
     steps:
       - name: Checkout chainlink repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ env.CHECKOUT_REF }}
@@ -105,7 +105,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Checkout capabilities repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           repository: smartcontractkit/capabilities
           token: ${{ steps.token.outputs.access-token }}
@@ -144,7 +144,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ env.CHECKOUT_REF }}

--- a/.github/workflows/build-publish-goreleaser.yml
+++ b/.github/workflows/build-publish-goreleaser.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Check for VERSION file bump on tags
@@ -38,7 +38,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -97,7 +97,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -19,7 +19,7 @@ jobs:
       is-pre-release: ${{ steps.release-tag-check.outputs.is-pre-release }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Check git tag type
@@ -68,7 +68,7 @@ jobs:
       docker-image-digest: ${{ steps.build-sign-publish.outputs.docker-image-digest }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -103,7 +103,7 @@ jobs:
     environment: build-publish
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Notify Slack
@@ -149,7 +149,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/chain-selectors-check.yml
+++ b/.github/workflows/chain-selectors-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -70,7 +70,7 @@ jobs:
           version: ^9.0.0
 
       - name: Setup node
-        uses: actions/setup-node@v4.0.4
+        uses: actions/setup-node@v4
         if: ${{ steps.files-changed.outputs.core == 'true' || steps.files-changed.outputs.shared == 'true' }}
         with:
           node-version: 20

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -13,7 +13,7 @@ jobs:
         - `#added` For any new functionality added.
         - `#breaking_change` For any functionality that requires manual action for the node to boot.
         - `#bugfix` For bug fixes.
-        - `#changed` For any change to the existing functionality. 
+        - `#changed` For any change to the existing functionality.
         - `#db_update` For any feature that introduces updates to database schema.
         - `#deprecation_notice` For any upcoming deprecation functionality.
         - `#internal` For changesets that need to be excluded from the final changelog.
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -94,7 +94,7 @@ jobs:
         run: echo "top_level_dir=$(pwd)" >> $GITHUB_OUTPUT
 
       - name: Checkout .Github repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/.github
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/changesets-preview-pr.yml
+++ b/.github/workflows/changesets-preview-pr.yml
@@ -36,7 +36,7 @@ jobs:
           version: ^9.0.0
 
       - name: Setup node
-        uses: actions/setup-node@v4.0.4
+        uses: actions/setup-node@v4
         if: steps.change.outputs.core-changeset == 'true'
         with:
           node-version: 20

--- a/.github/workflows/changesets-preview-pr.yml
+++ b/.github/workflows/changesets-preview-pr.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-core-partial.yml
+++ b/.github/workflows/ci-core-partial.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -61,7 +61,7 @@ jobs:
             module-directory: "./deployment"
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           # fetches all history for all tags and branches to provide more metadata for sonar reports
@@ -205,7 +205,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -257,7 +257,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-core-partial.yml
+++ b/.github/workflows/ci-core-partial.yml
@@ -153,7 +153,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4
         with:
           path: coverage
           pattern: coverage-*

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -377,7 +377,7 @@ jobs:
           fetch-depth: 0 # fetches all history for all tags and branches to provide more metadata for sonar reports
 
       - name: Download all workflow artifacts
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4
 
       - name: Check and Set SonarQube Report Paths
         shell: bash

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -308,7 +308,7 @@ jobs:
 
       - name: Store logs artifacts
         if: ${{ always() && needs.filter.outputs.should-run-ci-core == 'true' }}
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.type.cmd }}_logs
           path: |
@@ -356,7 +356,7 @@ jobs:
 
       - name: Store test report artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           name: go_core_scripts_tests_logs
           path: |

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -132,7 +132,7 @@ jobs:
         modules: ${{ fromJson(needs.filter.outputs.affected-modules) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Golang Lint (${{ matrix.modules }})
@@ -200,7 +200,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -341,7 +341,7 @@ jobs:
     if: ${{  needs.filter.outputs.should-run-ci-core == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -371,7 +371,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0 # fetches all history for all tags and branches to provide more metadata for sonar reports
@@ -474,7 +474,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/ci-flakeguard.yml
+++ b/.github/workflows/ci-flakeguard.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -47,7 +47,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FLAKEGUARD_SPLUNK_ENDPOINT: ${{ secrets.FLAKEGUARD_SPLUNK_ENDPOINT }}
         FLAKEGUARD_SPLUNK_HEC: ${{ secrets.FLAKEGUARD_SPLUNK_HEC }}
-    
+
   trigger-flaky-test-detection-for-deployment-project:
     name: Flakeguard Deployment Project
     uses: ./.github/workflows/flakeguard.yml

--- a/.github/workflows/ci-protobuf.yml
+++ b/.github/workflows/ci-protobuf.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -48,7 +48,7 @@ jobs:
       dependency_changed: ${{ steps.changes.outputs.dependency_changed }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -339,7 +339,7 @@ jobs:
     needs: [should-run, select-versions]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ needs.select-versions.outputs.chainlink_version }}
@@ -609,7 +609,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -868,7 +868,7 @@ jobs:
           - runlog
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ needs.select-versions.outputs.chainlink_version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -55,7 +55,7 @@ jobs:
             should-run: ${{ needs.filter.outputs.should-run-js }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/crib-integration-test.yml
+++ b/.github/workflows/crib-integration-test.yml
@@ -21,7 +21,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/delete-caches.yml
+++ b/.github/workflows/delete-caches.yml
@@ -1,6 +1,6 @@
 name: Cleanup Caches
 
-# See: 
+# See:
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
 
 on:
@@ -21,7 +21,7 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -45,7 +45,7 @@ jobs:
         run: |
           set +e
 
-          PR_BRANCH=refs/pull/$PR_NUMBER/merge          
+          PR_BRANCH=refs/pull/$PR_NUMBER/merge
           echo "Fetching list of cache keys for the PR branch ($PR_BRANCH)"
           PR_CACHE_KEYS=$(gh actions-cache list -R $REPO -B $PR_BRANCH | cut -f 1)
 
@@ -57,9 +57,9 @@ jobs:
           if [[ -n "$TRUNK_SHA" ]]; then
             echo "Found corresponding merge commit $TRUNK_SHA"
             QUEUE_BRANCH="gh-readonly-queue/develop/pr-${PR_NUMBER}-${TRUNK_SHA}"
-            echo "Fetching list of cache keys for the merge queue branch ($QUEUE_BRANCH)"            
+            echo "Fetching list of cache keys for the merge queue branch ($QUEUE_BRANCH)"
             QUEUE_CACHE_KEYS=$(gh actions-cache list -R $REPO -B $QUEUE_BRANCH | cut -f 1)
-          
+
             echo "Deleting caches for merge queue branch ($QUEUE_BRANCH)..."
             for CACHE_KEY in $QUEUE_CACHE_KEYS; do
                 gh actions-cache delete $CACHE_KEY -R $REPO -B $QUEUE_BRANCH --confirm

--- a/.github/workflows/delete-deployments.yml
+++ b/.github/workflows/delete-deployments.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -11,7 +11,7 @@ jobs:
       changes: ${{ steps.changes.outputs.src }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         with:
@@ -25,7 +25,7 @@ jobs:
     needs: [changes]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
         description: 'The path to the project to run the flaky test detection.'
-        default: '.'  
+        default: '.'
       baseRef:
         required: false
         type: string
@@ -25,7 +25,7 @@ on:
         required: false
         type: boolean
         description: 'Run all tests in the project.'
-        default: false    
+        default: false
       maxPassRatio:
         required: false
         type: string
@@ -92,7 +92,7 @@ jobs:
       git_base_sha: ${{ steps.get_commit_sha.outputs.git_base_sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -105,11 +105,11 @@ jobs:
           git_head_sha=$(git rev-parse HEAD)
           git_head_short_sha=$(git rev-parse --short HEAD)
           echo "git_head_sha=$git_head_sha" >> $GITHUB_OUTPUT
-          echo "git_head_short_sha=$git_head_short_sha" >> $GITHUB_OUTPUT          
+          echo "git_head_short_sha=$git_head_short_sha" >> $GITHUB_OUTPUT
 
           # Print HEAD SHAs to the console
           echo "HEAD SHA: $git_head_sha"
-          echo "HEAD Short SHA: $git_head_short_sha"          
+          echo "HEAD Short SHA: $git_head_short_sha"
 
           # Conditionally resolve BASE SHA
           if [ -n "${{ env.GIT_BASE_REF }}" ]; then
@@ -117,13 +117,13 @@ jobs:
 
             git_base_sha=$(git rev-parse origin/${{ env.GIT_BASE_REF }})
             echo "git_base_sha=$git_base_sha" >> $GITHUB_OUTPUT
-            
+
             # Print BASE SHA to the console
             echo "BASE SHA: $git_base_sha"
           else
             echo "BASE SHA not provided."
             echo "git_base_sha=" >> $GITHUB_OUTPUT
-          fi  
+          fi
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -153,7 +153,7 @@ jobs:
           echo $PACKAGES
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
-      - name: Find changed test files 
+      - name: Find changed test files
         if: ${{ inputs.runAllTests == false && env.RUN_CUSTOM_TEST_PACKAGES == '' }}
         id: find-changed-test-files
         shell: bash
@@ -168,7 +168,7 @@ jobs:
           TEST_FILES=$(flakeguard find --only-show-changed-test-files=true --base-ref=origin/${{ env.GIT_BASE_REF }} --project-path=${GH_INPUTS_PROJECT_PATH})
           echo $TEST_FILES
           echo "test_files=$TEST_FILES" >> $GITHUB_OUTPUT
-          
+
       - name: Split test packages into groups
         id: split-packages
         shell: bash
@@ -182,11 +182,11 @@ jobs:
           if [[ "$GH_INPUTS_RUN_ALL_TESTS" == "true" ]]; then
             # Use ALL_TESTS_RUNNER for a specified number of groups, each with "./..." to run all tests
             ALL_TESTS_RUNNER_COUNT=${{ env.ALL_TESTS_RUNNER_COUNT }}
-            
+
             # Create the JSON array dynamically based on ALL_TESTS_RUNNER_COUNT
             json_groups=$(jq -nc --argjson count "$ALL_TESTS_RUNNER_COUNT" \
               '[range(0; $count) | { "testPackages": "./...", "runs_on": "'"${{ env.ALL_TESTS_RUNNER }}"'" }]')
-              
+
             echo "$json_groups"
             echo "matrix<<EOF" >> $GITHUB_OUTPUT
             echo "$json_groups" >> $GITHUB_OUTPUT
@@ -236,7 +236,7 @@ jobs:
               if [[ $i -lt $EXTRA ]]; then
                   group_size=$(($group_size + 1))
               fi
-              
+
               # Extract the packages for the current group
               if [[ $group_size -gt 0 ]]; then
                   group=("${PACKAGES[@]:current_index:group_size}")
@@ -255,7 +255,7 @@ jobs:
       - name: Generate random workflow id
         id: gen_id
         shell: bash
-        run: echo "workflow_id=$(uuidgen)" >> "$GITHUB_OUTPUT"          
+        run: echo "workflow_id=$(uuidgen)" >> "$GITHUB_OUTPUT"
 
   run-tests:
     name: Run Tests
@@ -265,7 +265,7 @@ jobs:
     timeout-minutes: 180
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         include: ${{ fromJSON(needs.get-tests.outputs.matrix) }}
     outputs:
       flakeguard_error: ${{ steps.run-tests.outputs.flakeguard_error }}
@@ -273,7 +273,7 @@ jobs:
       DB_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ env.GIT_HEAD_REF }}
@@ -316,7 +316,7 @@ jobs:
       - name: Setup DB
         run: go run ./core/store/cmd/preparetest
         env:
-          CL_DATABASE_URL: ${{ env.DB_URL }}        
+          CL_DATABASE_URL: ${{ env.DB_URL }}
 
       - name: Install LOOP Plugins
         run: make install-plugins
@@ -363,7 +363,7 @@ jobs:
         with:
           name: test-result-${{ needs.get-tests.outputs.workflow_id }}-${{ steps.gen_id.outputs.id }}
           path: test-result.json
-          retention-days: 1   
+          retention-days: 1
 
   report:
     needs: [get-tests, run-tests]
@@ -374,7 +374,7 @@ jobs:
       test_results: ${{ steps.results.outputs.results }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ env.GIT_HEAD_REF }}
@@ -409,11 +409,11 @@ jobs:
           path: ci_test_results
           pattern:
             test-result-${{ needs.get-tests.outputs.workflow_id }}-*
-            
+
       - name: Install flakeguard
         shell: bash
         run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@49bbad97ccd743e7b704e4a17f92c475f2ee044d # flakguard@0.1.0
-                
+
       - name: Aggregate Flakeguard Results
         id: results
         shell: bash
@@ -423,13 +423,13 @@ jobs:
         run: |
           # Create test results folder if it doesn't exist
           mkdir -p ci_test_results
-      
+
           # Fix flakeguard binary path
           PATH=$PATH:$(go env GOPATH)/bin
           export PATH
 
           current_branch_name="${{ github.head_ref || github.ref_name }} "
-      
+
           # Aggregate Flakeguard test results
           flakeguard aggregate-results \
             --results-path ./ci_test_results \
@@ -455,7 +455,7 @@ jobs:
 
           # Print out the summary file
           echo -e "\nFlakeguard Summary:"
-          jq .summary_data ./flakeguard-report/all-test-results.json          
+          jq .summary_data ./flakeguard-report/all-test-results.json
 
           # Read the summary from the generated report
           summary=$(jq -c '.summary_data' ./flakeguard-report/all-test-results.json)
@@ -468,15 +468,15 @@ jobs:
           path: ./flakeguard-report/all-test-results.json
           name: all-test-results.json
           retention-days: 90
-      
+
       - name: Upload Failed Test Results as Artifact
         if: ${{ (success() || failure()) && fromJSON(steps.results.outputs.summary).failed_runs > 0 }}
         uses: actions/upload-artifact@v4.4.3
         with:
           path: ./flakeguard-report/failed-test-results.json
           name: failed-test-results.json
-          retention-days: 90 
-          
+          retention-days: 90
+
       - name: Upload Failed Test Results With Logs as Artifact
         if: ${{ (success() || failure()) && fromJSON(steps.results.outputs.summary).failed_runs > 0 }}
         uses: actions/upload-artifact@v4.4.3
@@ -499,7 +499,7 @@ jobs:
           # Fix flakeguard binary path
           PATH=$PATH:$(go env GOPATH)/bin
           export PATH
-      
+
           # Check if the event is a pull request
           if [ "$GH_EVENT_NAME" = "pull_request" ]; then
             flakeguard generate-report \
@@ -527,7 +527,7 @@ jobs:
               --current-commit-sha "$GH_EVENT_PULL_REQUEST_HEAD_SHA" \
               --repo-url "https://github.com/${{ github.repository }}" \
               --action-run-id "${{ github.run_id }}" \
-              --max-pass-ratio "$GH_INPUTS_MAX_PASS_RATIO"          
+              --max-pass-ratio "$GH_INPUTS_MAX_PASS_RATIO"
           fi
           EXIT_CODE=$?
           if [ $EXIT_CODE -eq 2 ]; then
@@ -535,7 +535,7 @@ jobs:
             echo "ERROR: Flakeguard encountered an error while generating reports" >> $GITHUB_STEP_SUMMARY
             exit $EXIT_CODE
           fi
-        
+
       - name: Add Github Summary
         if: (success() || failure())
         run: |
@@ -618,7 +618,7 @@ jobs:
                   ]
                 }
               ]
-            }            
+            }
 
       - name: Send general Slack message
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
@@ -654,7 +654,7 @@ jobs:
                         "type": "mrkdwn",
                         "text": "${{ inputs.runAllTests == true && format('<{0}/{1}/actions/runs/{2}|View Flaky Detector Details>', github.server_url, github.repository, github.run_id) || format('<{0}/{1}/actions/runs/{2}|View Flaky Detector Details> | <{3}/compare/{4}...{5}#files_bucket|Compare Changes>{6}', github.server_url, github.repository, github.run_id, inputs.repoUrl, inputs.baseRef, needs.get-tests.outputs.git_head_sha, github.event_name == 'pull_request' && format(' | <{0}|View PR>', github.event.pull_request.html_url) || '') }}"
                       }
-                    }                 
+                    }
                   ]
                 }
               ]

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -359,7 +359,7 @@ jobs:
 
       - name: Upload test result as artifact
         if: always()
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           name: test-result-${{ needs.get-tests.outputs.workflow_id }}-${{ steps.gen_id.outputs.id }}
           path: test-result.json
@@ -463,7 +463,7 @@ jobs:
 
       - name: Upload All Test Results as Artifact
         if: ${{ (success() || failure()) && fromJSON(steps.results.outputs.summary).total_tests > 0 }}
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           path: ./flakeguard-report/all-test-results.json
           name: all-test-results.json
@@ -471,7 +471,7 @@ jobs:
 
       - name: Upload Failed Test Results as Artifact
         if: ${{ (success() || failure()) && fromJSON(steps.results.outputs.summary).failed_runs > 0 }}
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           path: ./flakeguard-report/failed-test-results.json
           name: failed-test-results.json
@@ -479,7 +479,7 @@ jobs:
 
       - name: Upload Failed Test Results With Logs as Artifact
         if: ${{ (success() || failure()) && fromJSON(steps.results.outputs.summary).failed_runs > 0 }}
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           path: ./flakeguard-report/failed-test-results-with-logs.json
           name: failed-test-results-with-logs.json

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -404,7 +404,7 @@ jobs:
           fi
 
       - name: Download all test result artifacts
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4
         with:
           path: ci_test_results
           pattern:

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -39,7 +39,7 @@ jobs:
         with:
           only-modules: "true"
           restore-module-cache-only: "false"
-      
+
       - name: Install Dependencies
         shell: bash
         run:  go mod download all

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -137,7 +137,7 @@ jobs:
     steps:
       - name: Checkout repo
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu22.04-8cores-32GB
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu22.04-8cores-32GB
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -479,7 +479,7 @@ jobs:
           repository: smartcontractkit/chainlink
           ref: ${{ inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4
         with:
           path: cl_node_coverage_data
           pattern: cl_node_coverage_data_*
@@ -638,7 +638,7 @@ jobs:
           ref: ${{ needs.get_solana_sha.outputs.sha }}
       - name: Download Artifacts
         if: (needs.changes.outputs.core_changes == 'true' || github.event_name == 'workflow_dispatch') && needs.solana-test-image-exists.outputs.exists == 'false'
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: artifacts
           path: ${{ env.CONTRACT_ARTIFACTS_PATH }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -774,7 +774,7 @@ jobs:
           CHAINLINK_USER_TEAM: "BIX"
 
       - name: Upload Coverage Data
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         timeout-minutes: 2
         continue-on-error: true
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - run: echo "${{github.event_name}}"
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -87,7 +87,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -148,7 +148,7 @@ jobs:
     needs: [changes, enforce-ctf-version]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -452,7 +452,7 @@ jobs:
     steps:
       - name: Checkout repo
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -473,7 +473,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -498,7 +498,7 @@ jobs:
       sha: ${{ steps.getsha.outputs.sha }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
@@ -519,7 +519,7 @@ jobs:
           echo "short sha is: ${short_sha}"
           echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
       - name: Checkout solana
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink-solana
@@ -547,7 +547,7 @@ jobs:
       projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
     steps:
       - name: Checkout the solana repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink-solana
@@ -596,7 +596,7 @@ jobs:
       ]
     steps:
       - name: Checkout the solana repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink-solana
@@ -631,7 +631,7 @@ jobs:
     steps:
       - name: Checkout the repo
         if: (needs.changes.outputs.core_changes == 'true' || github.event_name == 'workflow_dispatch') && needs.solana-test-image-exists.outputs.exists == 'false'
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink-solana
@@ -680,7 +680,7 @@ jobs:
       CONTRACT_ARTIFACTS_PATH: contracts/target/deploy
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink-solana

--- a/.github/workflows/lint-gh-workflows.yml
+++ b/.github/workflows/lint-gh-workflows.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Run actionlint

--- a/.github/workflows/operator-ui-ci.yml
+++ b/.github/workflows/operator-ui-ci.yml
@@ -32,7 +32,7 @@ jobs:
           url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/solidity-foundry-artifacts.yml
+++ b/.github/workflows/solidity-foundry-artifacts.yml
@@ -48,7 +48,7 @@ jobs:
       changeset_files: ${{ steps.changes-dorny.outputs.changeset_files }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ env.head_ref }}
@@ -129,7 +129,7 @@ jobs:
       generate_code_coverage: ${{ steps.skip-code-coverage.outputs.generate_code_coverage }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -345,7 +345,7 @@ jobs:
         uses: ./.github/actions/install-solidity-foundry
 
       - name: Set up Python
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
 

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -48,7 +48,7 @@ jobs:
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -65,7 +65,7 @@ jobs:
       all_changes: ${{ steps.changes.outputs.changes }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Detect changes
@@ -153,7 +153,7 @@ jobs:
           ${{ contains(fromJson(needs.changes.outputs.all_changes), matrix.product.name)
           || contains(fromJson(needs.changes.outputs.all_changes), 'shared')
           || needs.changes.outputs.non_src_changes == 'true' }}
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: recursive
@@ -218,7 +218,7 @@ jobs:
         shell: bash
         working-directory: contracts/src/v0.8
         run: |
-          exact_versions=$(grep -rh "pragma solidity" ${{ matrix.product.name }} | sort | uniq | grep -v '\^' | awk '{print $3}' | tr -d ';')  
+          exact_versions=$(grep -rh "pragma solidity" ${{ matrix.product.name }} | sort | uniq | grep -v '\^' | awk '{print $3}' | tr -d ';')
           for version in $exact_versions; do
             echo "Installing exact version: $version"
             if ! svm install "$version"; then
@@ -326,12 +326,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Checkout .github repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/.github
@@ -414,7 +414,7 @@ jobs:
 
       - name: Checkout earlier version of this repository
         if: needs.changes.outputs.sol_mod_only == 'true'
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ github.base_ref }}
@@ -608,7 +608,7 @@ jobs:
     steps:
       - name: Checkout the repo
         if: ${{ (contains(fromJson(needs.changes.outputs.all_changes), matrix.product.name) || needs.changes.outputs.non_src_changes == 'true') && matrix.product.setup.run-forge-fmt }}
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -382,7 +382,7 @@ jobs:
       # in that case we extract new issues introduced by the changes by using an LLM model
       - name: Upload Slither results for current branch
         if: needs.changes.outputs.sol_mod_only == 'true'
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         timeout-minutes: 2
         continue-on-error: true
         with:
@@ -393,7 +393,7 @@ jobs:
       # we need to upload scripts and configuration in case base_ref doesn't have the scripts, or they are in different version
       - name: Upload Slither scripts
         if: needs.changes.outputs.sol_mod_only == 'true'
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         timeout-minutes: 2
         continue-on-error: true
         with:
@@ -403,7 +403,7 @@ jobs:
 
       - name: Upload configs
         if: needs.changes.outputs.sol_mod_only == 'true'
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         timeout-minutes: 2
         with:
           name: tmp-configs-${{ github.sha }}
@@ -465,7 +465,7 @@ jobs:
 
       - name: Upload Slither report
         if: needs.changes.outputs.sol_mod_only == 'true'
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         timeout-minutes: 10
         continue-on-error: true
         with:
@@ -529,7 +529,7 @@ jobs:
           sol_files: ${{ needs.changes.outputs.not_test_sol_modified_files }}
 
       - name: Upload Slither reports
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         timeout-minutes: 10
         continue-on-error: true
         with:

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -421,14 +421,14 @@ jobs:
 
       - name: Download Slither scripts
         if: needs.changes.outputs.sol_mod_only == 'true'
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: tmp-slither-scripts-${{ github.sha }}
           path: ./dot_github/tools/scripts/solidity
 
       - name: Download configs
         if: needs.changes.outputs.sol_mod_only == 'true'
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: tmp-configs-${{ github.sha }}
           path: contracts/configs
@@ -476,7 +476,7 @@ jobs:
 
       - name: Download Slither results for current branch
         if: needs.changes.outputs.sol_mod_only == 'true'
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: slither-reports-current-${{ github.sha }}
           path: contracts/slither-reports-current

--- a/.github/workflows/solidity-hardhat.yml
+++ b/.github/workflows/solidity-hardhat.yml
@@ -19,7 +19,7 @@ jobs:
       changes: ${{ steps.changes.outputs.src }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Setup NodeJS

--- a/.github/workflows/solidity-traceability.yml
+++ b/.github/workflows/solidity-traceability.yml
@@ -22,7 +22,7 @@ jobs:
       changesets_files: ${{ steps.files-changed.outputs.changesets_files }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
       # Include the pull request ref in the checkout action to prevent merge commit
       # https://github.com/actions/checkout?tab=readme-ov-file#checkout-pull-request-head-commit-instead-of-merge-commit
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
@@ -95,7 +95,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
 
       - name: Checkout .Github repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/.github
@@ -193,11 +193,11 @@ jobs:
           body: |
             ## Solidity Review Jira issue
             Hey! We have taken the liberty to link this PR to a Jira issue for Solidity Review.
-            
+
             This is a new feature, that's currently in the pilot phase, so please make sure that the linkage is correct. In a contrary case, please update it manually in JIRA and replace Solidity Review issue key in the changeset file with the correct one.
             Please reach out to the Test Tooling team and notify them about any issues you encounter.
-            
+
             Any changes to the Solidity Review Jira issue should be reflected in the changeset file. If you need to update the issue key, please do so manually in the following changeset file: `${{ needs.files-changed.outputs.changesets_files }}`
-            
+
             This PR has been linked to Solidity Review Jira issue: [${{ env.SOLIDITY_REVIEW_JIRA_ISSUE_KEY }}](${{ vars.JIRA_HOST }}browse/${{ env.SOLIDITY_REVIEW_JIRA_ISSUE_KEY }})
           edit-mode: replace

--- a/.github/workflows/solidity-wrappers.yml
+++ b/.github/workflows/solidity-wrappers.yml
@@ -23,7 +23,7 @@ jobs:
       changes: ${{ steps.ch.outputs.changes }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Detect changes
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu22.04-8cores-32GB
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -16,7 +16,7 @@ jobs:
       changes: ${{ steps.ch.outputs.changes }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Detect readonly solidity file changes
@@ -30,7 +30,7 @@ jobs:
       changes: ${{ steps.ch.outputs.changes }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Detect changes
@@ -51,7 +51,7 @@ jobs:
       release-version-ccip: ${{ steps.release-tag-check-ccip.outputs.release-version }}
       pre-release-version-ccip: ${{ steps.release-tag-check-ccip.outputs.pre-release-version }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Check release tag (core)
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Setup NodeJS
@@ -113,13 +113,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           path: chainlink
 
       - name: Checkout diff-so-fancy
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: so-fancy/diff-so-fancy
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Setup NodeJS
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Setup NodeJS
@@ -210,7 +210,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -256,7 +256,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v9.0.0
+      - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           exempt-all-pr-assignees: true

--- a/.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml
+++ b/.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml
@@ -10,7 +10,7 @@ jobs:
     name: Sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: develop


### PR DESCRIPTION
### Changes

- Updates all ([except 1](https://github.com/smartcontractkit/chainlink/blob/6b99dad8301efccd1305e89c409f3cefa60b3efe/.github/workflows/build-publish.yml#L92)) usages of Github's reusable actions to point at the major version tag, rather than the hash or specific tag of their actions


### Motivation

When Github rolls out new features and/or breaking changes, it is not feasible for us to update all action references everytime. We trust Github to manage their actions properly, and therefore we should have them tagged to the major version. 

---

RE-3330