### PR TITLE
parallelize changesets on a chain basis

### DIFF
--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -734,8 +734,6 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/consul/sdk v0.16.1 h1:V8TxTnImoPD5cj0U9Spl0TUxcytjcbbJeADFF07KdHg=
 github.com/hashicorp/consul/sdk v0.16.1/go.mod h1:fSXvwxB2hmh1FMZCNl6PwX0Q/1wdWtHJcZ7Ea5tns0s=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -753,8 +751,6 @@ github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJ
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.6.2 h1:zdGAEd0V1lCaU0u+MxWQhtSDQmahpkwOun8U8EiRVog=
 github.com/hashicorp/go-plugin v1.6.2/go.mod h1:CkgLQ5CZqNmdL9U9JzM532t8ZiYQ35+pj3b1FD37R0Q=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=

--- a/deployment/ccip/changeset/cs_ccip_home.go
+++ b/deployment/ccip/changeset/cs_ccip_home.go
@@ -363,6 +363,8 @@ func PromoteCandidateChangeset(
 	e deployment.Environment,
 	cfg PromoteCandidateChangesetConfig,
 ) (deployment.ChangesetOutput, error) {
+	e.Logger.Infow("initiating PromoteCandidateChangeset")
+
 	donIDs, err := cfg.Validate(e)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("%w: %w", deployment.ErrInvalidConfig, err)
@@ -592,6 +594,7 @@ func AddDonAndSetCandidateChangeset(
 	e deployment.Environment,
 	cfg AddDonAndSetCandidateChangesetConfig,
 ) (deployment.ChangesetOutput, error) {
+	e.Logger.Infow("initiating AddDonAndSetCandidateChangeset")
 	state, err := LoadOnchainState(e)
 	if err != nil {
 		return deployment.ChangesetOutput{}, err
@@ -780,6 +783,8 @@ func SetCandidateChangeset(
 	e deployment.Environment,
 	cfg SetCandidateChangesetConfig,
 ) (deployment.ChangesetOutput, error) {
+	e.Logger.Infow("initiating SetCandidateChangeset")
+
 	state, err := LoadOnchainState(e)
 	if err != nil {
 		return deployment.ChangesetOutput{}, err

--- a/deployment/ccip/changeset/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/cs_chain_contracts.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -283,6 +285,7 @@ func (cfg UpdateOnRampDestsConfig) Validate(e deployment.Environment) error {
 // in the chains specified. Multichain support is important - consider when we add a new chain
 // and need to update the onramp destinations for all chains to support the new chain.
 func UpdateOnRampsDestsChangeset(e deployment.Environment, cfg UpdateOnRampDestsConfig) (deployment.ChangesetOutput, error) {
+	e.Logger.Infow("initiating UpdateOnRampsDestsChangeset")
 	if err := cfg.Validate(e); err != nil {
 		return deployment.ChangesetOutput{}, err
 	}
@@ -293,55 +296,73 @@ func UpdateOnRampsDestsChangeset(e deployment.Environment, cfg UpdateOnRampDests
 	var batches []timelock.BatchChainOperation
 	timelocks := make(map[uint64]common.Address)
 	proposers := make(map[uint64]*gethwrappers.ManyChainMultiSig)
+
+	g := new(errgroup.Group)
+	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, updates := range cfg.UpdatesByChain {
-		txOpts := e.Chains[chainSel].DeployerKey
-		txOpts.Context = e.GetContext()
-		if cfg.MCMS != nil {
-			txOpts = deployment.SimTransactOpts()
-		}
-		onRamp := s.Chains[chainSel].OnRamp
-		var args []onramp.OnRampDestChainConfigArgs
-		for destination, update := range updates {
-			router := common.HexToAddress("0x0")
-			// If not enabled, set router to 0x0.
-			if update.IsEnabled {
-				if update.TestRouter {
-					router = s.Chains[chainSel].TestRouter.Address()
-				} else {
-					router = s.Chains[chainSel].Router.Address()
+		chainSel, updates := chainSel, updates
+		g.Go(func() error {
+			txOpts := e.Chains[chainSel].DeployerKey
+			ctx := e.GetContext()
+			txOpts.Context = ctx
+			if cfg.MCMS != nil {
+				txOpts = deployment.SimTransactOpts()
+			}
+			onRamp := s.Chains[chainSel].OnRamp
+			var args []onramp.OnRampDestChainConfigArgs
+			for destination, update := range updates {
+				router := common.HexToAddress("0x0")
+				// If not enabled, set router to 0x0.
+				if update.IsEnabled {
+					if update.TestRouter {
+						router = s.Chains[chainSel].TestRouter.Address()
+					} else {
+						router = s.Chains[chainSel].Router.Address()
+					}
 				}
+				args = append(args, onramp.OnRampDestChainConfigArgs{
+					DestChainSelector: destination,
+					Router:            router,
+					AllowlistEnabled:  update.AllowListEnabled,
+				})
 			}
-			args = append(args, onramp.OnRampDestChainConfigArgs{
-				DestChainSelector: destination,
-				Router:            router,
-				AllowlistEnabled:  update.AllowListEnabled,
-			})
-		}
-		tx, err := onRamp.ApplyDestChainConfigUpdates(txOpts, args)
-		if err != nil {
-			return deployment.ChangesetOutput{}, err
-		}
-		if cfg.MCMS == nil {
-			if _, err := deployment.ConfirmIfNoError(e.Chains[chainSel], tx, err); err != nil {
-				return deployment.ChangesetOutput{}, deployment.DecodedErrFromABIIfDataErr(err, onramp.OnRampABI)
+			tx, err := onRamp.ApplyDestChainConfigUpdates(txOpts, args)
+			if err != nil {
+				return err
 			}
-		} else {
-			batches = append(batches, timelock.BatchChainOperation{
-				ChainIdentifier: mcms.ChainIdentifier(chainSel),
-				Batch: []mcms.Operation{
-					{
-						To:    onRamp.Address(),
-						Data:  tx.Data(),
-						Value: big.NewInt(0),
+			if cfg.MCMS == nil {
+				if _, err := deployment.ConfirmIfNoError(e.Chains[chainSel], tx, err); err != nil {
+					return deployment.DecodedErrFromABIIfDataErr(err, onramp.OnRampABI)
+				}
+			} else {
+				tlOps <- timelock.BatchChainOperation{
+					ChainIdentifier: mcms.ChainIdentifier(chainSel),
+					Batch: []mcms.Operation{
+						{
+							To:    onRamp.Address(),
+							Data:  tx.Data(),
+							Value: big.NewInt(0),
+						},
 					},
-				},
-			})
-			timelocks[chainSel] = s.Chains[chainSel].Timelock.Address()
-			proposers[chainSel] = s.Chains[chainSel].ProposerMcm
-		}
+				}
+				timelocks[chainSel] = s.Chains[chainSel].Timelock.Address()
+				proposers[chainSel] = s.Chains[chainSel].ProposerMcm
+			}
+			return nil
+		})
 	}
+
+	close(tlOps)
+	if err := g.Wait(); err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
 	if cfg.MCMS == nil {
 		return deployment.ChangesetOutput{}, nil
+	}
+
+	for op := range tlOps {
+		batches = append(batches, op)
 	}
 	p, err := proposalutils.BuildProposalFromBatches(
 		timelocks,
@@ -799,6 +820,8 @@ func (cfg UpdateFeeQuoterPricesConfig) Validate(e deployment.Environment) error 
 }
 
 func UpdateFeeQuoterPricesChangeset(e deployment.Environment, cfg UpdateFeeQuoterPricesConfig) (deployment.ChangesetOutput, error) {
+	e.Logger.Infow("initiating UpdateFeeQuoterPricesChangeset")
+
 	if err := cfg.Validate(e); err != nil {
 		return deployment.ChangesetOutput{}, err
 	}
@@ -809,53 +832,70 @@ func UpdateFeeQuoterPricesChangeset(e deployment.Environment, cfg UpdateFeeQuote
 	var batches []timelock.BatchChainOperation
 	timelocks := make(map[uint64]common.Address)
 	proposers := make(map[uint64]*gethwrappers.ManyChainMultiSig)
+
+	g := new(errgroup.Group)
+	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, initialPrice := range cfg.PricesByChain {
-		txOpts := e.Chains[chainSel].DeployerKey
-		if cfg.MCMS != nil {
-			txOpts = deployment.SimTransactOpts()
-		}
-		fq := s.Chains[chainSel].FeeQuoter
-		var tokenPricesArgs []fee_quoter.InternalTokenPriceUpdate
-		for token, price := range initialPrice.TokenPrices {
-			tokenPricesArgs = append(tokenPricesArgs, fee_quoter.InternalTokenPriceUpdate{
-				SourceToken: token,
-				UsdPerToken: price,
-			})
-		}
-		var gasPricesArgs []fee_quoter.InternalGasPriceUpdate
-		for dest, price := range initialPrice.GasPrices {
-			gasPricesArgs = append(gasPricesArgs, fee_quoter.InternalGasPriceUpdate{
-				DestChainSelector: dest,
-				UsdPerUnitGas:     price,
-			})
-		}
-		tx, err := fq.UpdatePrices(txOpts, fee_quoter.InternalPriceUpdates{
-			TokenPriceUpdates: tokenPricesArgs,
-			GasPriceUpdates:   gasPricesArgs,
-		})
-		if err != nil {
-			return deployment.ChangesetOutput{}, fmt.Errorf("error updating prices for chain %s: %w", e.Chains[chainSel].String(), err)
-		}
-		if cfg.MCMS == nil {
-			if _, err := deployment.ConfirmIfNoError(e.Chains[chainSel], tx, err); err != nil {
-				decodedErr := deployment.DecodedErrFromABIIfDataErr(err, fee_quoter.FeeQuoterABI)
-				return deployment.ChangesetOutput{}, fmt.Errorf("error confirming transaction for chain %s: %w", e.Chains[chainSel].String(), decodedErr)
+		chainSel, initialPrice := chainSel, initialPrice
+		g.Go(func() error {
+			txOpts := e.Chains[chainSel].DeployerKey
+			if cfg.MCMS != nil {
+				txOpts = deployment.SimTransactOpts()
 			}
-		} else {
-			batches = append(batches, timelock.BatchChainOperation{
-				ChainIdentifier: mcms.ChainIdentifier(chainSel),
-				Batch: []mcms.Operation{
-					{
-						To:    fq.Address(),
-						Data:  tx.Data(),
-						Value: big.NewInt(0),
-					},
-				},
+			fq := s.Chains[chainSel].FeeQuoter
+			var tokenPricesArgs []fee_quoter.InternalTokenPriceUpdate
+			for token, price := range initialPrice.TokenPrices {
+				tokenPricesArgs = append(tokenPricesArgs, fee_quoter.InternalTokenPriceUpdate{
+					SourceToken: token,
+					UsdPerToken: price,
+				})
+			}
+			var gasPricesArgs []fee_quoter.InternalGasPriceUpdate
+			for dest, price := range initialPrice.GasPrices {
+				gasPricesArgs = append(gasPricesArgs, fee_quoter.InternalGasPriceUpdate{
+					DestChainSelector: dest,
+					UsdPerUnitGas:     price,
+				})
+			}
+			tx, err := fq.UpdatePrices(txOpts, fee_quoter.InternalPriceUpdates{
+				TokenPriceUpdates: tokenPricesArgs,
+				GasPriceUpdates:   gasPricesArgs,
 			})
-			timelocks[chainSel] = s.Chains[chainSel].Timelock.Address()
-			proposers[chainSel] = s.Chains[chainSel].ProposerMcm
-		}
+			if err != nil {
+				return fmt.Errorf("error updating prices for chain %s: %w", e.Chains[chainSel].String(), err)
+			}
+			if cfg.MCMS == nil {
+				if _, err := deployment.ConfirmIfNoError(e.Chains[chainSel], tx, err); err != nil {
+					decodedErr := deployment.DecodedErrFromABIIfDataErr(err, fee_quoter.FeeQuoterABI)
+					return fmt.Errorf("error confirming transaction for chain %s: %w", e.Chains[chainSel].String(), decodedErr)
+				}
+			} else {
+				tlOps <- timelock.BatchChainOperation{
+					ChainIdentifier: mcms.ChainIdentifier(chainSel),
+					Batch: []mcms.Operation{
+						{
+							To:    fq.Address(),
+							Data:  tx.Data(),
+							Value: big.NewInt(0),
+						},
+					},
+				}
+				timelocks[chainSel] = s.Chains[chainSel].Timelock.Address()
+				proposers[chainSel] = s.Chains[chainSel].ProposerMcm
+			}
+			return nil
+		})
 	}
+
+	close(tlOps)
+	if err = g.Wait(); err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
+	for op := range tlOps {
+		batches = append(batches, op)
+	}
+
 	if cfg.MCMS == nil {
 		return deployment.ChangesetOutput{}, nil
 	}
@@ -925,6 +965,8 @@ func (cfg UpdateFeeQuoterDestsConfig) Validate(e deployment.Environment) error {
 }
 
 func UpdateFeeQuoterDestsChangeset(e deployment.Environment, cfg UpdateFeeQuoterDestsConfig) (deployment.ChangesetOutput, error) {
+	e.Logger.Infow("initiating UpdateFeeQuoterDestsChangeset")
+
 	if err := cfg.Validate(e); err != nil {
 		return deployment.ChangesetOutput{}, err
 	}
@@ -935,45 +977,62 @@ func UpdateFeeQuoterDestsChangeset(e deployment.Environment, cfg UpdateFeeQuoter
 	var batches []timelock.BatchChainOperation
 	timelocks := make(map[uint64]common.Address)
 	proposers := make(map[uint64]*gethwrappers.ManyChainMultiSig)
+
+	g := new(errgroup.Group)
+	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, updates := range cfg.UpdatesByChain {
-		txOpts := e.Chains[chainSel].DeployerKey
-		txOpts.Context = e.GetContext()
-		if cfg.MCMS != nil {
-			txOpts = deployment.SimTransactOpts()
-		}
-		fq := s.Chains[chainSel].FeeQuoter
-		var args []fee_quoter.FeeQuoterDestChainConfigArgs
-		for destination, dc := range updates {
-			args = append(args, fee_quoter.FeeQuoterDestChainConfigArgs{
-				DestChainSelector: destination,
-				DestChainConfig:   dc,
-			})
-		}
-		tx, err := fq.ApplyDestChainConfigUpdates(txOpts, args)
-		if err != nil {
-			return deployment.ChangesetOutput{}, err
-		}
-		if cfg.MCMS == nil {
-			if _, err := deployment.ConfirmIfNoError(e.Chains[chainSel], tx, err); err != nil {
-				return deployment.ChangesetOutput{}, deployment.DecodedErrFromABIIfDataErr(err, fee_quoter.FeeQuoterABI)
+		chainSel, updates := chainSel, updates
+		g.Go(func() error {
+			txOpts := e.Chains[chainSel].DeployerKey
+			ctx := e.GetContext()
+			txOpts.Context = ctx
+			if cfg.MCMS != nil {
+				txOpts = deployment.SimTransactOpts()
 			}
-		} else {
-			batches = append(batches, timelock.BatchChainOperation{
-				ChainIdentifier: mcms.ChainIdentifier(chainSel),
-				Batch: []mcms.Operation{
-					{
-						To:    fq.Address(),
-						Data:  tx.Data(),
-						Value: big.NewInt(0),
+			fq := s.Chains[chainSel].FeeQuoter
+			var args []fee_quoter.FeeQuoterDestChainConfigArgs
+			for destination, dc := range updates {
+				args = append(args, fee_quoter.FeeQuoterDestChainConfigArgs{
+					DestChainSelector: destination,
+					DestChainConfig:   dc,
+				})
+			}
+			tx, err := fq.ApplyDestChainConfigUpdates(txOpts, args)
+			if err != nil {
+				return err
+			}
+			if cfg.MCMS == nil {
+				if _, err := deployment.ConfirmIfNoError(e.Chains[chainSel], tx, err); err != nil {
+					return deployment.DecodedErrFromABIIfDataErr(err, fee_quoter.FeeQuoterABI)
+				}
+			} else {
+				tlOps <- timelock.BatchChainOperation{
+					ChainIdentifier: mcms.ChainIdentifier(chainSel),
+					Batch: []mcms.Operation{
+						{
+							To:    fq.Address(),
+							Data:  tx.Data(),
+							Value: big.NewInt(0),
+						},
 					},
-				},
-			})
-			timelocks[chainSel] = s.Chains[chainSel].Timelock.Address()
-			proposers[chainSel] = s.Chains[chainSel].ProposerMcm
-		}
+				}
+				timelocks[chainSel] = s.Chains[chainSel].Timelock.Address()
+				proposers[chainSel] = s.Chains[chainSel].ProposerMcm
+			}
+			return nil
+		})
+	}
+	close(tlOps)
+
+	if err = g.Wait(); err != nil {
+		return deployment.ChangesetOutput{}, err
 	}
 	if cfg.MCMS == nil {
 		return deployment.ChangesetOutput{}, nil
+	}
+
+	for op := range tlOps {
+		batches = append(batches, op)
 	}
 
 	p, err := proposalutils.BuildProposalFromBatches(
@@ -1045,6 +1104,7 @@ func (cfg UpdateOffRampSourcesConfig) Validate(e deployment.Environment, state C
 
 // UpdateOffRampSourcesChangeset updates the offramp sources for each offramp.
 func UpdateOffRampSourcesChangeset(e deployment.Environment, cfg UpdateOffRampSourcesConfig) (deployment.ChangesetOutput, error) {
+	e.Logger.Infow("initiating UpdateOffRampSourcesChangeset")
 	state, err := LoadOnchainState(e)
 	if err != nil {
 		return deployment.ChangesetOutput{}, err
@@ -1055,56 +1115,72 @@ func UpdateOffRampSourcesChangeset(e deployment.Environment, cfg UpdateOffRampSo
 	var batches []timelock.BatchChainOperation
 	timelocks := make(map[uint64]common.Address)
 	proposers := make(map[uint64]*gethwrappers.ManyChainMultiSig)
+
+	g := new(errgroup.Group)
+	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, updates := range cfg.UpdatesByChain {
-		txOpts := e.Chains[chainSel].DeployerKey
-		txOpts.Context = e.GetContext()
-		if cfg.MCMS != nil {
-			txOpts = deployment.SimTransactOpts()
-		}
-		offRamp := state.Chains[chainSel].OffRamp
-		var args []offramp.OffRampSourceChainConfigArgs
-		for source, update := range updates {
-			router := common.HexToAddress("0x0")
-			if update.TestRouter {
-				router = state.Chains[chainSel].TestRouter.Address()
+		chainSel, updates := chainSel, updates
+		g.Go(func() error {
+			txOpts := e.Chains[chainSel].DeployerKey
+			ctx := e.GetContext()
+			txOpts.Context = ctx
+			if cfg.MCMS != nil {
+				txOpts = deployment.SimTransactOpts()
+			}
+			offRamp := state.Chains[chainSel].OffRamp
+			var args []offramp.OffRampSourceChainConfigArgs
+			for source, update := range updates {
+				var r common.Address
+				if update.TestRouter {
+					r = state.Chains[chainSel].TestRouter.Address()
+				} else {
+					r = state.Chains[chainSel].Router.Address()
+				}
+				onRamp := state.Chains[source].OnRamp
+				args = append(args, offramp.OffRampSourceChainConfigArgs{
+					SourceChainSelector: source,
+					Router:              r,
+					IsEnabled:           update.IsEnabled,
+					OnRamp:              common.LeftPadBytes(onRamp.Address().Bytes(), 32),
+				})
+			}
+			tx, err := offRamp.ApplySourceChainConfigUpdates(txOpts, args)
+			if err != nil {
+				return err
+			}
+			if cfg.MCMS == nil {
+				if _, err := deployment.ConfirmIfNoError(e.Chains[chainSel], tx, err); err != nil {
+					return deployment.DecodedErrFromABIIfDataErr(err, offramp.OffRampABI)
+				}
 			} else {
-				router = state.Chains[chainSel].Router.Address()
-			}
-			onRamp := state.Chains[source].OnRamp
-			args = append(args, offramp.OffRampSourceChainConfigArgs{
-				SourceChainSelector: source,
-				Router:              router,
-				IsEnabled:           update.IsEnabled,
-				OnRamp:              common.LeftPadBytes(onRamp.Address().Bytes(), 32),
-			})
-		}
-		tx, err := offRamp.ApplySourceChainConfigUpdates(txOpts, args)
-		if err != nil {
-			return deployment.ChangesetOutput{}, err
-		}
-		if cfg.MCMS == nil {
-			if _, err := deployment.ConfirmIfNoError(e.Chains[chainSel], tx, err); err != nil {
-				return deployment.ChangesetOutput{}, deployment.DecodedErrFromABIIfDataErr(err, offramp.OffRampABI)
-			}
-		} else {
-			batches = append(batches, timelock.BatchChainOperation{
-				ChainIdentifier: mcms.ChainIdentifier(chainSel),
-				Batch: []mcms.Operation{
-					{
-						To:    offRamp.Address(),
-						Data:  tx.Data(),
-						Value: big.NewInt(0),
+				tlOps <- timelock.BatchChainOperation{
+					ChainIdentifier: mcms.ChainIdentifier(chainSel),
+					Batch: []mcms.Operation{
+						{
+							To:    offRamp.Address(),
+							Data:  tx.Data(),
+							Value: big.NewInt(0),
+						},
 					},
-				},
-			})
-			timelocks[chainSel] = state.Chains[chainSel].Timelock.Address()
-			proposers[chainSel] = state.Chains[chainSel].ProposerMcm
-		}
+				}
+				timelocks[chainSel] = state.Chains[chainSel].Timelock.Address()
+				proposers[chainSel] = state.Chains[chainSel].ProposerMcm
+			}
+			return nil
+		})
+	}
+	close(tlOps)
+
+	if err = g.Wait(); err != nil {
+		return deployment.ChangesetOutput{}, err
 	}
 	if cfg.MCMS == nil {
 		return deployment.ChangesetOutput{}, nil
 	}
 
+	for op := range tlOps {
+		batches = append(batches, op)
+	}
 	p, err := proposalutils.BuildProposalFromBatches(
 		timelocks,
 		proposers,
@@ -1201,6 +1277,7 @@ func (cfg UpdateRouterRampsConfig) Validate(e deployment.Environment, state CCIP
 // on all chains to support the new chain through the test router first. Once tested,
 // Enable the new destination on the real router.
 func UpdateRouterRampsChangeset(e deployment.Environment, cfg UpdateRouterRampsConfig) (deployment.ChangesetOutput, error) {
+	e.Logger.Infow("initiating UpdateRouterRampsChangeset")
 	state, err := LoadOnchainState(e)
 	if err != nil {
 		return deployment.ChangesetOutput{}, err
@@ -1211,77 +1288,92 @@ func UpdateRouterRampsChangeset(e deployment.Environment, cfg UpdateRouterRampsC
 	var batches []timelock.BatchChainOperation
 	timelocks := make(map[uint64]common.Address)
 	proposers := make(map[uint64]*gethwrappers.ManyChainMultiSig)
+
+	g := new(errgroup.Group)
+	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, update := range cfg.UpdatesByChain {
-		txOpts := e.Chains[chainSel].DeployerKey
-		txOpts.Context = e.GetContext()
-		if cfg.MCMS != nil {
-			txOpts = deployment.SimTransactOpts()
-		}
-		routerC := state.Chains[chainSel].Router
-		if cfg.TestRouter {
-			routerC = state.Chains[chainSel].TestRouter
-		}
-		// Note if we add distinct offramps per source to the state,
-		// we'll need to add support here for looking them up.
-		// For now its simple, all sources use the same offramp.
-		offRamp := state.Chains[chainSel].OffRamp
-		var removes, adds []router.RouterOffRamp
-		for source, enabled := range update.OffRampUpdates {
-			if enabled {
-				adds = append(adds, router.RouterOffRamp{
-					SourceChainSelector: source,
-					OffRamp:             offRamp.Address(),
-				})
+		chainSel, update := chainSel, update
+		g.Go(func() error {
+			txOpts := e.Chains[chainSel].DeployerKey
+			txOpts.Context = e.GetContext()
+			if cfg.MCMS != nil {
+				txOpts = deployment.SimTransactOpts()
+			}
+			routerC := state.Chains[chainSel].Router
+			if cfg.TestRouter {
+				routerC = state.Chains[chainSel].TestRouter
+			}
+			// Note if we add distinct offramps per source to the state,
+			// we'll need to add support here for looking them up.
+			// For now its simple, all sources use the same offramp.
+			offRamp := state.Chains[chainSel].OffRamp
+			var removes, adds []router.RouterOffRamp
+			for source, enabled := range update.OffRampUpdates {
+				if enabled {
+					adds = append(adds, router.RouterOffRamp{
+						SourceChainSelector: source,
+						OffRamp:             offRamp.Address(),
+					})
+				} else {
+					removes = append(removes, router.RouterOffRamp{
+						SourceChainSelector: source,
+						OffRamp:             offRamp.Address(),
+					})
+				}
+			}
+			// Ditto here, only one onramp expected until 1.7.
+			onRamp := state.Chains[chainSel].OnRamp
+			var onRampUpdates []router.RouterOnRamp
+			for dest, enabled := range update.OnRampUpdates {
+				if enabled {
+					onRampUpdates = append(onRampUpdates, router.RouterOnRamp{
+						DestChainSelector: dest,
+						OnRamp:            onRamp.Address(),
+					})
+				} else {
+					onRampUpdates = append(onRampUpdates, router.RouterOnRamp{
+						DestChainSelector: dest,
+						OnRamp:            common.HexToAddress("0x0"),
+					})
+				}
+			}
+			tx, err := routerC.ApplyRampUpdates(txOpts, onRampUpdates, removes, adds)
+			if err != nil {
+				return err
+			}
+			if cfg.MCMS == nil {
+				if _, err := deployment.ConfirmIfNoError(e.Chains[chainSel], tx, err); err != nil {
+					return deployment.DecodedErrFromABIIfDataErr(err, router.RouterABI)
+				}
 			} else {
-				removes = append(removes, router.RouterOffRamp{
-					SourceChainSelector: source,
-					OffRamp:             offRamp.Address(),
-				})
-			}
-		}
-		// Ditto here, only one onramp expected until 1.7.
-		onRamp := state.Chains[chainSel].OnRamp
-		var onRampUpdates []router.RouterOnRamp
-		for dest, enabled := range update.OnRampUpdates {
-			if enabled {
-				onRampUpdates = append(onRampUpdates, router.RouterOnRamp{
-					DestChainSelector: dest,
-					OnRamp:            onRamp.Address(),
-				})
-			} else {
-				onRampUpdates = append(onRampUpdates, router.RouterOnRamp{
-					DestChainSelector: dest,
-					OnRamp:            common.HexToAddress("0x0"),
-				})
-			}
-		}
-		tx, err := routerC.ApplyRampUpdates(txOpts, onRampUpdates, removes, adds)
-		if err != nil {
-			return deployment.ChangesetOutput{}, err
-		}
-		if cfg.MCMS == nil {
-			if _, err := deployment.ConfirmIfNoError(e.Chains[chainSel], tx, err); err != nil {
-				return deployment.ChangesetOutput{}, deployment.DecodedErrFromABIIfDataErr(err, router.RouterABI)
-			}
-		} else {
-			batches = append(batches, timelock.BatchChainOperation{
-				ChainIdentifier: mcms.ChainIdentifier(chainSel),
-				Batch: []mcms.Operation{
-					{
-						To:    routerC.Address(),
-						Data:  tx.Data(),
-						Value: big.NewInt(0),
+				tlOps <- timelock.BatchChainOperation{
+					ChainIdentifier: mcms.ChainIdentifier(chainSel),
+					Batch: []mcms.Operation{
+						{
+							To:    routerC.Address(),
+							Data:  tx.Data(),
+							Value: big.NewInt(0),
+						},
 					},
-				},
-			})
-			timelocks[chainSel] = state.Chains[chainSel].Timelock.Address()
-			proposers[chainSel] = state.Chains[chainSel].ProposerMcm
-		}
+				}
+				timelocks[chainSel] = state.Chains[chainSel].Timelock.Address()
+				proposers[chainSel] = state.Chains[chainSel].ProposerMcm
+			}
+			return nil
+		})
+	}
+	close(tlOps)
+	err = g.Wait()
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
 	}
 	if cfg.MCMS == nil {
 		return deployment.ChangesetOutput{}, nil
 	}
 
+	for op := range tlOps {
+		batches = append(batches, op)
+	}
 	p, err := proposalutils.BuildProposalFromBatches(
 		timelocks,
 		proposers,
@@ -1360,6 +1452,7 @@ func (c SetOCR3OffRampConfig) validateRemoteChain(e *deployment.Environment, sta
 // Multichain is especially helpful for NOP rotations where we have
 // to touch all the chain to change signers.
 func SetOCR3OffRampChangeset(e deployment.Environment, cfg SetOCR3OffRampConfig) (deployment.ChangesetOutput, error) {
+	e.Logger.Infow("initiating SetOCR3OffRampChangeset")
 	state, err := LoadOnchainState(e)
 	if err != nil {
 		return deployment.ChangesetOutput{}, err
@@ -1370,58 +1463,75 @@ func SetOCR3OffRampChangeset(e deployment.Environment, cfg SetOCR3OffRampConfig)
 	var batches []timelock.BatchChainOperation
 	timelocks := make(map[uint64]common.Address)
 	proposers := make(map[uint64]*gethwrappers.ManyChainMultiSig)
+
+	tlOps := make(chan timelock.BatchChainOperation)
+	g := new(errgroup.Group)
 	for _, remote := range cfg.RemoteChainSels {
-		donID, err := internal.DonIDForChain(
-			state.Chains[cfg.HomeChainSel].CapabilityRegistry,
-			state.Chains[cfg.HomeChainSel].CCIPHome,
-			remote)
-		if err != nil {
-			return deployment.ChangesetOutput{}, err
-		}
-		args, err := internal.BuildSetOCR3ConfigArgs(
-			donID, state.Chains[cfg.HomeChainSel].CCIPHome, remote, cfg.CCIPHomeConfigType)
-		if err != nil {
-			return deployment.ChangesetOutput{}, err
-		}
-		set, err := isOCR3ConfigSetOnOffRamp(e.Logger, e.Chains[remote], state.Chains[remote].OffRamp, args)
-		if err != nil {
-			return deployment.ChangesetOutput{}, err
-		}
-		if set {
-			e.Logger.Infof("OCR3 config already set on offramp for chain %d", remote)
-			continue
-		}
-		txOpts := e.Chains[remote].DeployerKey
-		if cfg.MCMS != nil {
-			txOpts = deployment.SimTransactOpts()
-		}
-		offRamp := state.Chains[remote].OffRamp
-		tx, err := offRamp.SetOCR3Configs(txOpts, args)
-		if err != nil {
-			return deployment.ChangesetOutput{}, err
-		}
-		if cfg.MCMS == nil {
-			if _, err := deployment.ConfirmIfNoError(e.Chains[remote], tx, err); err != nil {
-				return deployment.ChangesetOutput{}, deployment.DecodedErrFromABIIfDataErr(err, offramp.OffRampABI)
+		remote := remote
+		g.Go(func() error {
+			donID, err := internal.DonIDForChain(
+				state.Chains[cfg.HomeChainSel].CapabilityRegistry,
+				state.Chains[cfg.HomeChainSel].CCIPHome,
+				remote)
+			if err != nil {
+				return err
 			}
-		} else {
-			batches = append(batches, timelock.BatchChainOperation{
-				ChainIdentifier: mcms.ChainIdentifier(remote),
-				Batch: []mcms.Operation{
-					{
-						To:    offRamp.Address(),
-						Data:  tx.Data(),
-						Value: big.NewInt(0),
+			args, err := internal.BuildSetOCR3ConfigArgs(
+				donID, state.Chains[cfg.HomeChainSel].CCIPHome, remote, cfg.CCIPHomeConfigType)
+			if err != nil {
+				return err
+			}
+			set, err := isOCR3ConfigSetOnOffRamp(e.Logger, e.Chains[remote], state.Chains[remote].OffRamp, args)
+			if err != nil {
+				return err
+			}
+			if set {
+				e.Logger.Infof("OCR3 config already set on offramp for chain %d", remote)
+				return nil
+			}
+			txOpts := e.Chains[remote].DeployerKey
+			if cfg.MCMS != nil {
+				txOpts = deployment.SimTransactOpts()
+			}
+			offRamp := state.Chains[remote].OffRamp
+			tx, err := offRamp.SetOCR3Configs(txOpts, args)
+			if err != nil {
+				return err
+			}
+			if cfg.MCMS == nil {
+				if _, err := deployment.ConfirmIfNoError(e.Chains[remote], tx, err); err != nil {
+					return deployment.DecodedErrFromABIIfDataErr(err, offramp.OffRampABI)
+				}
+			} else {
+				tlOps <- timelock.BatchChainOperation{
+					ChainIdentifier: mcms.ChainIdentifier(remote),
+					Batch: []mcms.Operation{
+						{
+							To:    offRamp.Address(),
+							Data:  tx.Data(),
+							Value: big.NewInt(0),
+						},
 					},
-				},
-			})
-			timelocks[remote] = state.Chains[remote].Timelock.Address()
-			proposers[remote] = state.Chains[remote].ProposerMcm
-		}
+				}
+				timelocks[remote] = state.Chains[remote].Timelock.Address()
+				proposers[remote] = state.Chains[remote].ProposerMcm
+			}
+			return nil
+		})
+	}
+	close(tlOps)
+	err = g.Wait()
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
 	}
 	if cfg.MCMS == nil {
 		return deployment.ChangesetOutput{}, nil
 	}
+
+	for op := range tlOps {
+		batches = append(batches, op)
+	}
+
 	p, err := proposalutils.BuildProposalFromBatches(
 		timelocks,
 		proposers,

--- a/deployment/ccip/changeset/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/cs_chain_contracts.go
@@ -301,9 +301,9 @@ func UpdateOnRampsDestsChangeset(e deployment.Environment, cfg UpdateOnRampDests
 	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, updates := range cfg.UpdatesByChain {
 		chainSel, updates := chainSel, updates
-		ctx := e.GetContext()
 		g.Go(func() error {
 			txOpts := e.Chains[chainSel].DeployerKey
+			ctx := context.Background()
 			txOpts.Context = ctx
 			if cfg.MCMS != nil {
 				txOpts = deployment.SimTransactOpts()
@@ -982,9 +982,9 @@ func UpdateFeeQuoterDestsChangeset(e deployment.Environment, cfg UpdateFeeQuoter
 	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, updates := range cfg.UpdatesByChain {
 		chainSel, updates := chainSel, updates
-		ctx := e.GetContext()
 		g.Go(func() error {
 			txOpts := e.Chains[chainSel].DeployerKey
+			ctx := context.Background()
 			txOpts.Context = ctx
 			if cfg.MCMS != nil {
 				txOpts = deployment.SimTransactOpts()
@@ -1119,9 +1119,9 @@ func UpdateOffRampSourcesChangeset(e deployment.Environment, cfg UpdateOffRampSo
 	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, updates := range cfg.UpdatesByChain {
 		chainSel, updates := chainSel, updates
-		ctx := e.GetContext()
 		g.Go(func() error {
 			txOpts := e.Chains[chainSel].DeployerKey
+			ctx := context.Background()
 			txOpts.Context = ctx
 			if cfg.MCMS != nil {
 				txOpts = deployment.SimTransactOpts()

--- a/deployment/ccip/changeset/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/cs_chain_contracts.go
@@ -301,9 +301,9 @@ func UpdateOnRampsDestsChangeset(e deployment.Environment, cfg UpdateOnRampDests
 	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, updates := range cfg.UpdatesByChain {
 		chainSel, updates := chainSel, updates
+		ctx := e.GetContext()
 		g.Go(func() error {
 			txOpts := e.Chains[chainSel].DeployerKey
-			ctx := e.GetContext()
 			txOpts.Context = ctx
 			if cfg.MCMS != nil {
 				txOpts = deployment.SimTransactOpts()
@@ -982,9 +982,9 @@ func UpdateFeeQuoterDestsChangeset(e deployment.Environment, cfg UpdateFeeQuoter
 	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, updates := range cfg.UpdatesByChain {
 		chainSel, updates := chainSel, updates
+		ctx := e.GetContext()
 		g.Go(func() error {
 			txOpts := e.Chains[chainSel].DeployerKey
-			ctx := e.GetContext()
 			txOpts.Context = ctx
 			if cfg.MCMS != nil {
 				txOpts = deployment.SimTransactOpts()
@@ -1023,7 +1023,6 @@ func UpdateFeeQuoterDestsChangeset(e deployment.Environment, cfg UpdateFeeQuoter
 		})
 	}
 	close(tlOps)
-
 	if err = g.Wait(); err != nil {
 		return deployment.ChangesetOutput{}, err
 	}
@@ -1120,9 +1119,9 @@ func UpdateOffRampSourcesChangeset(e deployment.Environment, cfg UpdateOffRampSo
 	tlOps := make(chan timelock.BatchChainOperation)
 	for chainSel, updates := range cfg.UpdatesByChain {
 		chainSel, updates := chainSel, updates
+		ctx := e.GetContext()
 		g.Go(func() error {
 			txOpts := e.Chains[chainSel].DeployerKey
-			ctx := e.GetContext()
 			txOpts.Context = ctx
 			if cfg.MCMS != nil {
 				txOpts = deployment.SimTransactOpts()
@@ -1170,7 +1169,6 @@ func UpdateOffRampSourcesChangeset(e deployment.Environment, cfg UpdateOffRampSo
 		})
 	}
 	close(tlOps)
-
 	if err = g.Wait(); err != nil {
 		return deployment.ChangesetOutput{}, err
 	}
@@ -1363,8 +1361,7 @@ func UpdateRouterRampsChangeset(e deployment.Environment, cfg UpdateRouterRampsC
 		})
 	}
 	close(tlOps)
-	err = g.Wait()
-	if err != nil {
+	if err := g.Wait(); err != nil {
 		return deployment.ChangesetOutput{}, err
 	}
 	if cfg.MCMS == nil {
@@ -1520,8 +1517,7 @@ func SetOCR3OffRampChangeset(e deployment.Environment, cfg SetOCR3OffRampConfig)
 		})
 	}
 	close(tlOps)
-	err = g.Wait()
-	if err != nil {
+	if err := g.Wait(); err != nil {
 		return deployment.ChangesetOutput{}, err
 	}
 	if cfg.MCMS == nil {

--- a/deployment/ccip/changeset/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/cs_deploy_chain.go
@@ -48,6 +48,7 @@ var (
 // if there is no existing RMN address found, RMNRemote will be deployed with 0x0 address for previous RMN address
 // which will set RMN to 0x0 address immutably in RMNRemote.
 func DeployChainContractsChangeset(env deployment.Environment, c DeployChainContractsConfig) (deployment.ChangesetOutput, error) {
+	env.Logger.Infow("initiating DeployChainContractsChangeset")
 	if err := c.Validate(); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("invalid DeployChainContractsConfig: %w", err)
 	}
@@ -60,6 +61,8 @@ func DeployChainContractsChangeset(env deployment.Environment, c DeployChainCont
 	return deployment.ChangesetOutput{
 		Proposals:   []timelock.MCMSWithTimelockProposal{},
 		AddressBook: newAddresses,
+		Jobs:        nil,
+		JobSpecs:    nil,
 	}, nil
 }
 

--- a/deployment/ccip/changeset/cs_jobspec.go
+++ b/deployment/ccip/changeset/cs_jobspec.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
-	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
-	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
+	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
@@ -23,18 +22,35 @@ var _ deployment.ChangeSet[any] = CCIPCapabilityJobspecChangeset
 // CCIPCapabilityJobspecChangeset returns the job specs for the CCIP capability.
 // The caller needs to propose these job specs to the offchain system.
 func CCIPCapabilityJobspecChangeset(env deployment.Environment, _ any) (deployment.ChangesetOutput, error) {
+	env.Logger.Infow("initiating CCIPCapabilityJobspecChangeset")
 	nodes, err := deployment.NodeInfo(env.NodeIDs, env.Offchain)
 	if err != nil {
 		return deployment.ChangesetOutput{}, err
 	}
 	// find existing jobs
-	existingSpecs, err := acceptedJobSpecs(env, nodes)
-	if err != nil {
-		return deployment.ChangesetOutput{}, err
+	existingSpecs := make(map[string][]string)
+	for _, node := range nodes {
+		jobs, err := env.Offchain.ListJobs(env.GetContext(), &job.ListJobsRequest{
+			Filter: &job.ListJobsRequest_Filter{
+				NodeIds: []string{node.NodeID},
+			},
+		})
+		if err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to list jobs for node %s: %w", node.NodeID, err)
+		}
+		for _, j := range jobs.Jobs {
+			for _, propID := range j.ProposalIds {
+				jbProposal, err := env.Offchain.GetProposal(env.GetContext(), &job.GetProposalRequest{
+					Id: propID,
+				})
+				if err != nil {
+					return deployment.ChangesetOutput{}, fmt.Errorf("failed to get job proposal %s on node %s: %w", propID, node.NodeID, err)
+				}
+				existingSpecs[node.NodeID] = append(existingSpecs[node.NodeID], jbProposal.Proposal.Spec)
+			}
+		}
 	}
-	// We first generate the job specs for the CCIP capability. so that if
-	// there are any errors in the job specs, we can fail early.
-	// Generate a set of new job specs for CCIP for a specific environment
+	// Generate a set of brand new job specs for CCIP for a specific environment
 	// (including NOPs) and new addresses.
 	// We want to assign one CCIP capability job to each node. And node with
 	// an addr we'll list as bootstrapper.
@@ -99,40 +115,11 @@ func CCIPCapabilityJobspecChangeset(env deployment.Environment, _ any) (deployme
 			nodesToJobSpecs[node.NodeID] = append(nodesToJobSpecs[node.NodeID], spec)
 		}
 	}
-	// Now we propose the job specs to the offchain system.
-	var Jobs []deployment.ProposedJob
-	for nodeID, jobs := range nodesToJobSpecs {
-		nodeID := nodeID
-		for _, job := range jobs {
-			Jobs = append(Jobs, deployment.ProposedJob{
-				Node: nodeID,
-				Spec: job,
-			})
-			if !isJobProposed(env, nodeID, job) {
-				// we add a label to the job spec so that we can identify it later
-				labels := []*ptypes.Label{
-					{
-						Key:   "node_id",
-						Value: &nodeID,
-					},
-				}
-				res, err := env.Offchain.ProposeJob(env.GetContext(),
-					&jobv1.ProposeJobRequest{
-						NodeId: nodeID,
-						Spec:   job,
-						Labels: labels,
-					})
-				if err != nil {
-					return deployment.ChangesetOutput{}, fmt.Errorf("failed to propose job: %w", err)
-				}
-				Jobs[len(Jobs)-1].JobID = res.Proposal.JobId
-			}
-		}
-	}
 	return deployment.ChangesetOutput{
 		Proposals:   []timelock.MCMSWithTimelockProposal{},
 		AddressBook: nil,
-		Jobs:        Jobs,
+		JobSpecs:    nodesToJobSpecs,
+		Jobs:        nil,
 	}, nil
 }
 
@@ -187,40 +174,4 @@ func areCCIPSpecsEqual(existingSpecStr, newSpecStr string) (bool, error) {
 		p2pBootstrapperValue == p2pBootstrapperValueNew &&
 		bytes.Equal(pluginConfigValue.([]byte), pluginConfigValueNew.([]byte)) &&
 		bytes.Equal(relayConfigValue.([]byte), relayConfigValueNew.([]byte)), nil
-}
-
-func acceptedJobSpecs(env deployment.Environment, nodes deployment.Nodes) (map[string][]string, error) {
-	existingSpecs := make(map[string][]string)
-	for _, node := range nodes {
-		jobs, err := env.Offchain.ListJobs(env.GetContext(), &jobv1.ListJobsRequest{
-			Filter: &jobv1.ListJobsRequest_Filter{
-				NodeIds: []string{node.NodeID},
-			},
-		})
-		if err != nil {
-			return make(map[string][]string), fmt.Errorf("failed to list jobs for node %s: %w", node.NodeID, err)
-		}
-		for _, j := range jobs.Jobs {
-			for _, propID := range j.ProposalIds {
-				jbProposal, err := env.Offchain.GetProposal(env.GetContext(), &jobv1.GetProposalRequest{
-					Id: propID,
-				})
-				if err != nil {
-					return nil, fmt.Errorf("failed to get job proposal %s on node %s: %w", propID, node.NodeID, err)
-				}
-				existingSpecs[node.NodeID] = append(existingSpecs[node.NodeID], jbProposal.Proposal.Spec)
-			}
-		}
-	}
-	return existingSpecs, nil
-}
-
-// isJobProposed returns true if the job spec is already proposed to a node
-// currently there is no way to check if a job spec is already proposed to a specific node
-// so we return false TODO implement this check when it is available
-// there is no downside to proposing the same job spec to a node multiple times
-// It will only be accepted once by node
-func isJobProposed(env deployment.Environment, nodeID string, spec string) bool {
-	// implement this when it is available
-	return false
 }

--- a/deployment/ccip/changeset/cs_prerequisites.go
+++ b/deployment/ccip/changeset/cs_prerequisites.go
@@ -38,6 +38,7 @@ var (
 // Or the contracts which are already deployed on the chain ( for example, tokens, feeds, etc)
 // Caller should update the environment's address book with the returned addresses.
 func DeployPrerequisitesChangeset(env deployment.Environment, cfg DeployPrerequisiteConfig) (deployment.ChangesetOutput, error) {
+	env.Logger.Infow("initiating DeployPrerequisitesChangeset")
 	err := cfg.Validate()
 	if err != nil {
 		return deployment.ChangesetOutput{}, errors.Wrapf(deployment.ErrInvalidConfig, "%v", err)
@@ -53,6 +54,8 @@ func DeployPrerequisitesChangeset(env deployment.Environment, cfg DeployPrerequi
 	return deployment.ChangesetOutput{
 		Proposals:   []timelock.MCMSWithTimelockProposal{},
 		AddressBook: ab,
+		JobSpecs:    nil,
+		Jobs:        nil,
 	}, nil
 }
 

--- a/deployment/ccip/changeset/cs_update_rmn_config.go
+++ b/deployment/ccip/changeset/cs_update_rmn_config.go
@@ -7,6 +7,8 @@ import (
 	"math/big"
 	"reflect"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/mcms"
@@ -54,6 +56,7 @@ func (c SetRMNRemoteOnRMNProxyConfig) Validate(state CCIPOnChainState) error {
 }
 
 func SetRMNRemoteOnRMNProxyChangeset(e deployment.Environment, cfg SetRMNRemoteOnRMNProxyConfig) (deployment.ChangesetOutput, error) {
+	e.Logger.Infow("initiating SetRMNRemoteOnRMNProxyChangeset")
 	state, err := LoadOnchainState(e)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
@@ -70,25 +73,38 @@ func SetRMNRemoteOnRMNProxyChangeset(e deployment.Environment, cfg SetRMNRemoteO
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to get proposer MCMS for chains %v: %w", cfg.ChainSelectors, err)
 	}
 	var timelockBatch []timelock.BatchChainOperation
+	g := new(errgroup.Group)
+	tlOps := make(chan timelock.BatchChainOperation)
 	for _, sel := range cfg.ChainSelectors {
-		chain, exists := e.Chains[sel]
-		if !exists {
-			return deployment.ChangesetOutput{}, fmt.Errorf("chain %d not found", sel)
-		}
-		txOpts := chain.DeployerKey
-		if cfg.MCMSConfig != nil {
-			txOpts = deployment.SimTransactOpts()
-		}
-		mcmsOps, err := setRMNRemoteOnRMNProxyOp(txOpts, chain, state.Chains[sel], cfg.MCMSConfig != nil)
-		if err != nil {
-			return deployment.ChangesetOutput{}, fmt.Errorf("failed to set RMNRemote on RMNProxy for chain %s: %w", chain.String(), err)
-		}
-		if cfg.MCMSConfig != nil {
-			timelockBatch = append(timelockBatch, timelock.BatchChainOperation{
-				ChainIdentifier: mcms.ChainIdentifier(sel),
-				Batch:           []mcms.Operation{mcmsOps},
-			})
-		}
+		sel := sel
+		g.Go(func() error {
+			chain, exists := e.Chains[sel]
+			if !exists {
+				return fmt.Errorf("chain %d not found", sel)
+			}
+			txOpts := chain.DeployerKey
+			if cfg.MCMSConfig != nil {
+				txOpts = deployment.SimTransactOpts()
+			}
+			mcmsOps, err := setRMNRemoteOnRMNProxyOp(txOpts, chain, state.Chains[sel], cfg.MCMSConfig != nil)
+			if err != nil {
+				return fmt.Errorf("failed to set RMNRemote on RMNProxy for chain %s: %w", chain.String(), err)
+			}
+			if cfg.MCMSConfig != nil {
+				tlOps <- timelock.BatchChainOperation{
+					ChainIdentifier: mcms.ChainIdentifier(sel),
+					Batch:           []mcms.Operation{mcmsOps},
+				}
+			}
+			return nil
+		})
+	}
+	close(tlOps)
+	if err := g.Wait(); err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+	for op := range tlOps {
+		timelockBatch = append(timelockBatch, op)
 	}
 	// If we're not using MCMS, we can just return now as we've already confirmed the transactions
 	if len(timelockBatch) == 0 {

--- a/deployment/common/changeset/deploy_link_token.go
+++ b/deployment/common/changeset/deploy_link_token.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/gagliardetto/solana-go"
@@ -31,31 +33,37 @@ func DeployLinkToken(e deployment.Environment, chains []uint64) (deployment.Chan
 		return deployment.ChangesetOutput{}, err
 	}
 	newAddresses := deployment.NewMemoryAddressBook()
+
+	g := new(errgroup.Group)
 	for _, chain := range chains {
-		family, err := chainsel.GetSelectorFamily(chain)
-		if err != nil {
-			return deployment.ChangesetOutput{AddressBook: newAddresses}, err
-		}
-		switch family {
-		case chainsel.FamilyEVM:
-			// Deploy EVM LINK token
-			_, err := deployLinkTokenContractEVM(
-				e.Logger, e.Chains[chain], newAddresses,
-			)
+		chain := chain
+		g.Go(func() error {
+			family, err := chainsel.GetSelectorFamily(chain)
 			if err != nil {
-				return deployment.ChangesetOutput{AddressBook: newAddresses}, err
+				return err
 			}
-		case chainsel.FamilySolana:
-			// Deploy Solana LINK token
-			err := deployLinkTokenContractSolana(
-				e.Logger, e.SolChains[chain], newAddresses,
-			)
-			if err != nil {
-				return deployment.ChangesetOutput{AddressBook: newAddresses}, err
+			switch family {
+			case chainsel.FamilyEVM:
+				// Deploy EVM LINK token
+				_, err := deployLinkTokenContractEVM(
+					e.Logger, e.Chains[chain], newAddresses,
+				)
+				if err != nil {
+					return err
+				}
+			case chainsel.FamilySolana:
+				// Deploy Solana LINK token
+				err := deployLinkTokenContractSolana(
+					e.Logger, e.SolChains[chain], newAddresses,
+				)
+				if err != nil {
+					return err
+				}
 			}
-		}
+			return nil
+		})
 	}
-	return deployment.ChangesetOutput{AddressBook: newAddresses}, nil
+	return deployment.ChangesetOutput{AddressBook: newAddresses}, g.Wait()
 }
 
 // DeployStaticLinkToken deploys a static link token contract to the chain identified by the ChainSelector.

--- a/deployment/common/changeset/internal/mcms.go
+++ b/deployment/common/changeset/internal/mcms.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/config"
 	owner_helpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -81,13 +82,18 @@ func DeployMCMSWithTimelockContractsBatch(
 	ab deployment.AddressBook,
 	cfgByChain map[uint64]types.MCMSWithTimelockConfig,
 ) error {
+	deployGrp := errgroup.Group{}
 	for chainSel, cfg := range cfgByChain {
-		_, err := DeployMCMSWithTimelockContracts(lggr, chains[chainSel], ab, cfg)
-		if err != nil {
-			return err
-		}
+		deployGrp.Go(func() error {
+			_, err := DeployMCMSWithTimelockContracts(lggr, chains[chainSel], ab, cfg)
+			if err != nil {
+				lggr.Errorw("Failed to deploy MCMS contracts", "chain", chainSel)
+				return err
+			}
+			return nil
+		})
 	}
-	return nil
+	return deployGrp.Wait()
 }
 
 // DeployMCMSWithTimelockContracts deploys an MCMS for

--- a/deployment/environment/devenv/chain.go
+++ b/deployment/environment/devenv/chain.go
@@ -7,6 +7,8 @@ import (
 	"math/big"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -94,58 +96,63 @@ func (c *ChainConfig) SetDeployerKey(pvtKeyStr *string) error {
 
 func NewChains(logger logger.Logger, configs []ChainConfig) (map[uint64]deployment.Chain, error) {
 	chains := make(map[uint64]deployment.Chain)
+	g := new(errgroup.Group)
 	for _, chainCfg := range configs {
-		selector, err := chainselectors.SelectorFromChainId(chainCfg.ChainID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get selector from chain id %d: %w", chainCfg.ChainID, err)
-		}
-		// TODO : better client handling
-		var ec *ethclient.Client
-		for _, rpc := range chainCfg.WSRPCs {
-			ec, err = ethclient.Dial(rpc.External)
+		g.Go(func() error {
+			selector, err := chainselectors.SelectorFromChainId(chainCfg.ChainID)
 			if err != nil {
-				logger.Warnf("failed to dial ws rpc %s", rpc)
-				continue
+				return fmt.Errorf("failed to get selector from chain id %d: %w", chainCfg.ChainID, err)
 			}
-			logger.Infof("connected to ws rpc %s", rpc)
-			break
-		}
-		if ec == nil {
-			return nil, fmt.Errorf("failed to connect to chain %s", chainCfg.ChainName)
-		}
-		chainInfo, err := deployment.ChainInfo(selector)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get chain info for chain %s: %w", chainCfg.ChainName, err)
-		}
-		chains[selector] = deployment.Chain{
-			Selector:    selector,
-			Client:      ec,
-			DeployerKey: chainCfg.DeployerKey,
-			Confirm: func(tx *types.Transaction) (uint64, error) {
-				var blockNumber uint64
-				if tx == nil {
-					return 0, fmt.Errorf("tx was nil, nothing to confirm chain %s", chainInfo.ChainName)
-				}
-				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-				defer cancel()
-				receipt, err := bind.WaitMined(ctx, ec, tx)
+			// TODO : better client handling
+			var ec *ethclient.Client
+			for _, rpc := range chainCfg.WSRPCs {
+				ec, err = ethclient.Dial(rpc.External)
 				if err != nil {
-					return blockNumber, fmt.Errorf("failed to get confirmed receipt for chain %s: %w", chainInfo.ChainName, err)
+					logger.Warnf("failed to dial ws rpc %s: %s", rpc, err)
+					continue
 				}
-				if receipt == nil {
-					return blockNumber, fmt.Errorf("receipt was nil for tx %s chain %s", tx.Hash().Hex(), chainInfo.ChainName)
-				}
-				blockNumber = receipt.BlockNumber.Uint64()
-				if receipt.Status == 0 {
-					errReason, err := deployment.GetErrorReasonFromTx(ec, chainCfg.DeployerKey.From, tx, receipt)
-					if err == nil && errReason != "" {
-						return blockNumber, fmt.Errorf("tx %s reverted,error reason: %s chain %s", tx.Hash().Hex(), errReason, chainInfo.ChainName)
+				logger.Infof("connected to ws rpc %s", rpc)
+				break
+			}
+			if ec == nil {
+				return fmt.Errorf("failed to connect to chain %s", chainCfg.ChainName)
+			}
+			chainInfo, err := deployment.ChainInfo(selector)
+			if err != nil {
+				return fmt.Errorf("failed to get chain info for chain %s: %w", chainCfg.ChainName, err)
+			}
+			chains[selector] = deployment.Chain{
+				Selector:    selector,
+				Client:      ec,
+				DeployerKey: chainCfg.DeployerKey,
+				Confirm: func(tx *types.Transaction) (uint64, error) {
+					var blockNumber uint64
+					if tx == nil {
+						return 0, fmt.Errorf("tx was nil, nothing to confirm chain %s", chainInfo.ChainName)
 					}
-					return blockNumber, fmt.Errorf("tx %s reverted, could not decode error reason chain %s", tx.Hash().Hex(), chainInfo.ChainName)
-				}
-				return blockNumber, nil
-			},
-		}
+					ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+					defer cancel()
+					receipt, err := bind.WaitMined(ctx, ec, tx)
+					if err != nil {
+						return blockNumber, fmt.Errorf("failed to get confirmed receipt for chain %s: %w", chainInfo.ChainName, err)
+					}
+					if receipt == nil {
+						return blockNumber, fmt.Errorf("receipt was nil for tx %s chain %s", tx.Hash().Hex(), chainInfo.ChainName)
+					}
+					blockNumber = receipt.BlockNumber.Uint64()
+					if receipt.Status == 0 {
+						errReason, err := deployment.GetErrorReasonFromTx(ec, chainCfg.DeployerKey.From, tx, receipt)
+						if err == nil && errReason != "" {
+							return blockNumber, fmt.Errorf("tx %s reverted,error reason: %s chain %s", tx.Hash().Hex(), errReason, chainInfo.ChainName)
+						}
+						return blockNumber, fmt.Errorf("tx %s reverted, could not decode error reason chain %s", tx.Hash().Hex(), chainInfo.ChainName)
+					}
+					return blockNumber, nil
+				},
+			}
+			return nil
+		})
 	}
-	return chains, nil
+	err := g.Wait()
+	return chains, err
 }

--- a/deployment/environment/devenv/don.go
+++ b/deployment/environment/devenv/don.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog"
 	"github.com/sethvargo/go-retry"
 
@@ -75,22 +76,25 @@ func (don *DON) NodeIds() []string {
 }
 
 func (don *DON) CreateSupportedChains(ctx context.Context, chains []ChainConfig, jd JobDistributor) error {
-	var err error
+	g := new(errgroup.Group)
 	for i := range don.Nodes {
-		node := &don.Nodes[i]
-		var jdChains []JDChainConfigInput
-		for _, chain := range chains {
-			jdChains = append(jdChains, JDChainConfigInput{
-				ChainID:   chain.ChainID,
-				ChainType: chain.ChainType,
-			})
-		}
-		if err1 := node.CreateCCIPOCRSupportedChains(ctx, jdChains, jd); err1 != nil {
-			err = multierror.Append(err, err1)
-		}
-		don.Nodes[i] = *node
+		g.Go(func() error {
+			node := &don.Nodes[i]
+			var jdChains []JDChainConfigInput
+			for _, chain := range chains {
+				jdChains = append(jdChains, JDChainConfigInput{
+					ChainID:   chain.ChainID,
+					ChainType: chain.ChainType,
+				})
+			}
+			if err1 := node.CreateCCIPOCRSupportedChains(ctx, jdChains, jd); err1 != nil {
+				return err1
+			}
+			don.Nodes[i] = *node
+			return nil
+		})
 	}
-	return err
+	return g.Wait()
 }
 
 // NewRegisteredDON creates a DON with the given node info, registers the nodes with the job distributor
@@ -106,6 +110,13 @@ func NewRegisteredDON(ctx context.Context, nodeInfo []NodeInfo, jd JobDistributo
 		node, err := NewNode(info)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create node %d: %w", i, err)
+		}
+		// node Labels so that it's easier to query them
+		for key, value := range info.Labels {
+			node.labels = append(node.labels, &ptypes.Label{
+				Key:   key,
+				Value: &value,
+			})
 		}
 		if info.IsBootstrap {
 			// create multi address for OCR2, applicable only for bootstrap nodes
@@ -161,21 +172,11 @@ func NewNode(nodeInfo NodeInfo) (*Node, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create node rest client: %w", err)
 	}
-	// node Labels so that it's easier to query them
-	labels := make([]*ptypes.Label, 0)
-	for key, value := range nodeInfo.Labels {
-		labels = append(labels, &ptypes.Label{
-			Key:   key,
-			Value: &value,
-		})
-	}
 	return &Node{
 		gqlClient:  gqlClient,
 		restClient: chainlinkClient,
 		Name:       nodeInfo.Name,
 		adminAddr:  nodeInfo.AdminAddr,
-		multiAddr:  nodeInfo.MultiAddr,
-		labels:     labels,
 	}, nil
 }
 
@@ -254,8 +255,7 @@ func (n *Node) CreateCCIPOCRSupportedChains(ctx context.Context, chains []JDChai
 		}
 		n.Ocr2KeyBundleID = ocr2BundleId
 		// fetch node labels to know if the node is bootstrap or plugin
-		// if multi address is set, then it's a bootstrap node
-		isBootstrap := n.multiAddr != ""
+		isBootstrap := false
 		for _, label := range n.labels {
 			if label.Key == NodeLabelKeyType && value(label.Value) == NodeLabelValueBootstrap {
 				isBootstrap = true
@@ -375,7 +375,6 @@ func (n *Node) RegisterNodeToJobDistributor(ctx context.Context, jd JobDistribut
 		Name:      n.Name,
 	})
 	// node already registered, fetch it's id
-	// TODO: check for rpc code = "AlreadyExists" instead
 	if err != nil && strings.Contains(err.Error(), "AlreadyExists") {
 		nodesResponse, err := jd.ListNodes(ctx, &nodev1.ListNodesRequest{
 			Filter: &nodev1.ListNodesRequest_Filter{

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/go-resty/resty/v2 v2.15.3
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/consul/sdk v0.16.1
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mr-tron/base58 v1.2.0
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/pkg/errors v0.9.1
@@ -245,7 +244,6 @@ require (
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-envparse v0.1.0 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -738,8 +738,6 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/consul/sdk v0.16.1 h1:V8TxTnImoPD5cj0U9Spl0TUxcytjcbbJeADFF07KdHg=
 github.com/hashicorp/consul/sdk v0.16.1/go.mod h1:fSXvwxB2hmh1FMZCNl6PwX0Q/1wdWtHJcZ7Ea5tns0s=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -757,8 +755,6 @@ github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJ
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.6.2 h1:zdGAEd0V1lCaU0u+MxWQhtSDQmahpkwOun8U8EiRVog=
 github.com/hashicorp/go-plugin v1.6.2/go.mod h1:CkgLQ5CZqNmdL9U9JzM532t8ZiYQ35+pj3b1FD37R0Q=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=


### PR DESCRIPTION
This change should ONLY affect tests!! In production environments, contracts will be behind MCMS where on-chain execution happens outside of the changeset code. 

The changes to context are to avoid `fatcontext` issues as [described here](https://github.com/Crocmagnon/fatcontext)


Parallelize changesets to execute simultaneously on all chains. Leverages an errorgroup rather than a wait group so that if any chain fails, the whole changeset exits early rather than waiting. 

To support production systems, we push timelock operations into a channel so they can be accumulated into the expected batch later on. 