### PR TITLE
don't skip linter validation

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -165,6 +165,7 @@ jobs:
   # Inclusive check: all (new) modules are analyzed, but no need to enable "required" checks for each one
   golangci-matrix-results-validation:
     name: lint
+    if: ${{ always() && needs.golangci.result != 'skipped' }}
     needs: [golangci]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When part of the lint matrix fails, the validation job is skipped:
![Screenshot from 2025-02-05 05-22-08](https://github.com/user-attachments/assets/45e31c39-5398-4ec0-9279-db50224a361e)

Which still counts as passing for the required check:
![image](https://github.com/user-attachments/assets/f09f0dd5-f50f-4cb8-a4e2-a25524e4a3a8)

IIUC we just need to run `always()`