### PR TITLE
[CCIP-5118] integration-tests/smoke/ccip: extract setupTokens helper

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_token_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_token_helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -18,6 +19,7 @@ import (
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/burn_mint_erc677"
+	testlogger "github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 const (
@@ -201,4 +203,81 @@ func DeployTestTokenPools(
 	}
 
 	return e
+}
+
+// SetupTokens deploys transferable tokens on the source and dest, mints tokens for the source and dest, and
+// approves the router to spend the tokens
+func SetupTransferableTokens(
+	t *testing.T,
+	state changeset.CCIPOnChainState,
+	tenv DeployedEnv,
+	src, dest uint64,
+	transferTokenMintAmount,
+	feeTokenMintAmount *big.Int,
+) (
+	srcToken *burn_mint_erc677.BurnMintERC677,
+	dstToken *burn_mint_erc677.BurnMintERC677,
+) {
+	lggr := testlogger.TestLogger(t)
+	e := tenv.Env
+
+	// Deploy the token to test transferring
+	srcToken, _, dstToken, _, err := DeployTransferableToken(
+		lggr,
+		tenv.Env.Chains,
+		src,
+		dest,
+		tenv.Env.Chains[src].DeployerKey,
+		tenv.Env.Chains[dest].DeployerKey,
+		state,
+		tenv.Env.ExistingAddresses,
+		"MY_TOKEN",
+	)
+	require.NoError(t, err)
+
+	linkToken := state.Chains[src].LinkToken
+
+	tx, err := srcToken.Mint(
+		e.Chains[src].DeployerKey,
+		e.Chains[src].DeployerKey.From,
+		transferTokenMintAmount,
+	)
+	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	require.NoError(t, err)
+
+	// Mint a destination token
+	tx, err = dstToken.Mint(
+		e.Chains[dest].DeployerKey,
+		e.Chains[dest].DeployerKey.From,
+		transferTokenMintAmount,
+	)
+	_, err = deployment.ConfirmIfNoError(e.Chains[dest], tx, err)
+	require.NoError(t, err)
+
+	// Approve the router to spend the tokens and confirm the tx's
+	// To prevent having to approve the router for every transfer, we approve a sufficiently large amount
+	tx, err = srcToken.Approve(e.Chains[src].DeployerKey, state.Chains[src].Router.Address(), math.MaxBig256)
+	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	require.NoError(t, err)
+
+	tx, err = dstToken.Approve(e.Chains[dest].DeployerKey, state.Chains[dest].Router.Address(), math.MaxBig256)
+	_, err = deployment.ConfirmIfNoError(e.Chains[dest], tx, err)
+	require.NoError(t, err)
+
+	// Grant mint and burn roles to the deployer key for the newly deployed linkToken
+	// Since those roles are not granted automatically
+	tx, err = linkToken.GrantMintAndBurnRoles(e.Chains[src].DeployerKey, e.Chains[src].DeployerKey.From)
+	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	require.NoError(t, err)
+
+	// Mint link token and confirm the tx
+	tx, err = linkToken.Mint(
+		e.Chains[src].DeployerKey,
+		e.Chains[src].DeployerKey.From,
+		feeTokenMintAmount,
+	)
+	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	require.NoError(t, err)
+
+	return srcToken, dstToken
 }

--- a/integration-tests/smoke/ccip/ccip_fees_test.go
+++ b/integration-tests/smoke/ccip/ccip_fees_test.go
@@ -20,86 +20,8 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/router"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/burn_mint_erc677"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/weth9"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/evm/assets"
 )
-
-// setupTokens deploys transferable tokens on the source and dest, mints tokens for the source and dest, and
-// approves the router to spend the tokens
-func setupTokens(
-	t *testing.T,
-	state changeset.CCIPOnChainState,
-	tenv testhelpers.DeployedEnv,
-	src, dest uint64,
-	transferTokenMintAmount,
-	feeTokenMintAmount *big.Int,
-) (
-	srcToken *burn_mint_erc677.BurnMintERC677,
-	dstToken *burn_mint_erc677.BurnMintERC677,
-) {
-	lggr := logger.TestLogger(t)
-	e := tenv.Env
-
-	// Deploy the token to test transferring
-	srcToken, _, dstToken, _, err := testhelpers.DeployTransferableToken(
-		lggr,
-		tenv.Env.Chains,
-		src,
-		dest,
-		tenv.Env.Chains[src].DeployerKey,
-		tenv.Env.Chains[dest].DeployerKey,
-		state,
-		tenv.Env.ExistingAddresses,
-		"MY_TOKEN",
-	)
-	require.NoError(t, err)
-
-	linkToken := state.Chains[src].LinkToken
-
-	tx, err := srcToken.Mint(
-		e.Chains[src].DeployerKey,
-		e.Chains[src].DeployerKey.From,
-		transferTokenMintAmount,
-	)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
-	require.NoError(t, err)
-
-	// Mint a destination token
-	tx, err = dstToken.Mint(
-		e.Chains[dest].DeployerKey,
-		e.Chains[dest].DeployerKey.From,
-		transferTokenMintAmount,
-	)
-	_, err = deployment.ConfirmIfNoError(e.Chains[dest], tx, err)
-	require.NoError(t, err)
-
-	// Approve the router to spend the tokens and confirm the tx's
-	// To prevent having to approve the router for every transfer, we approve a sufficiently large amount
-	tx, err = srcToken.Approve(e.Chains[src].DeployerKey, state.Chains[src].Router.Address(), math.MaxBig256)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
-	require.NoError(t, err)
-
-	tx, err = dstToken.Approve(e.Chains[dest].DeployerKey, state.Chains[dest].Router.Address(), math.MaxBig256)
-	_, err = deployment.ConfirmIfNoError(e.Chains[dest], tx, err)
-	require.NoError(t, err)
-
-	// Grant mint and burn roles to the deployer key for the newly deployed linkToken
-	// Since those roles are not granted automatically
-	tx, err = linkToken.GrantMintAndBurnRoles(e.Chains[src].DeployerKey, e.Chains[src].DeployerKey.From)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
-	require.NoError(t, err)
-
-	// Mint link token and confirm the tx
-	tx, err = linkToken.Mint(
-		e.Chains[src].DeployerKey,
-		e.Chains[src].DeployerKey.From,
-		feeTokenMintAmount,
-	)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
-	require.NoError(t, err)
-
-	return srcToken, dstToken
-}
 
 func Test_CCIPFees(t *testing.T) {
 	t.Parallel()
@@ -118,7 +40,7 @@ func Test_CCIPFees(t *testing.T) {
 	state, err := changeset.LoadOnchainState(e)
 	require.NoError(t, err)
 
-	srcToken, dstToken := setupTokens(
+	srcToken, dstToken := testhelpers.SetupTransferableTokens(
 		t,
 		state,
 		tenv,

--- a/integration-tests/smoke/ccip/ccip_message_limitations_test.go
+++ b/integration-tests/smoke/ccip/ccip_message_limitations_test.go
@@ -32,7 +32,7 @@ func Test_CCIPMessageLimitations(t *testing.T) {
 
 	testhelpers.AddLanesForAll(t, &testEnv, onChainState)
 
-	srcToken, _ := setupTokens(
+	srcToken, _ := testhelpers.SetupTransferableTokens(
 		t,
 		onChainState,
 		testEnv,


### PR DESCRIPTION

[CCIP-5118](https://smartcontract-it.atlassian.net/browse/CCIP-5118)

### Supports
- https://github.com/smartcontractkit/chainlink-deployments/pull/571


[CCIP-5118]: https://smartcontract-it.atlassian.net/browse/CCIP-5118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ