### PR TITLE
change pendingStepsRequest default queue size

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -1263,7 +1263,7 @@ type Config struct {
 
 const (
 	defaultWorkerLimit          = 100
-	defaultQueueSize            = 100000
+	defaultQueueSize            = 1000
 	defaultNewWorkerTimeout     = 2 * time.Second
 	defaultMaxExecutionDuration = 10 * time.Minute
 	defaultHeartbeatCadence     = 5 * time.Minute


### PR DESCRIPTION
Part of: https://smartcontract-it.atlassian.net/browse/CAPPL-348

Reducing the pendingStepsRequest default queue size in engine.go accounts for 75% in the reduction in memory shown here, (which shoes a ~10 times reductions in memory usage)

https://docs.google.com/spreadsheets/d/1Hw9du-4K5obVLdrbso1nYKMQHDkbAvp8ulWq3wSkY64/edit?usp=sharing


The above results show that reducing the queue size from 100,000 to 1,000 does not have any impact on the workflow latency when running 200 workflows (in fact its a little better but not meaningfully so)