### PR TITLE
chore(cre-deployment): validate ocr xmission schedule

### DIFF
--- a/deployment/keystone/changeset/deploy_ocr3_test.go
+++ b/deployment/keystone/changeset/deploy_ocr3_test.go
@@ -48,14 +48,16 @@ func TestDeployOCR3(t *testing.T) {
 func TestConfigureOCR3(t *testing.T) {
 	t.Parallel()
 
+	nWfNodes := 4
 	c := internal.OracleConfig{
-		MaxFaultyOracles:    1,
-		DeltaProgressMillis: 12345,
+		MaxFaultyOracles:     1,
+		DeltaProgressMillis:  12345,
+		TransmissionSchedule: []int{nWfNodes},
 	}
 
 	t.Run("no mcms", func(t *testing.T) {
 		te := test.SetupTestEnv(t, test.TestConfig{
-			WFDonConfig:     test.DonConfig{N: 4},
+			WFDonConfig:     test.DonConfig{N: nWfNodes},
 			AssetDonConfig:  test.DonConfig{N: 4},
 			WriterDonConfig: test.DonConfig{N: 4},
 			NumChains:       1,
@@ -86,7 +88,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 	t.Run("success multiple OCR3 contracts", func(t *testing.T) {
 		te := test.SetupTestEnv(t, test.TestConfig{
-			WFDonConfig:     test.DonConfig{N: 4},
+			WFDonConfig:     test.DonConfig{N: nWfNodes},
 			AssetDonConfig:  test.DonConfig{N: 4},
 			WriterDonConfig: test.DonConfig{N: 4},
 			NumChains:       1,
@@ -154,7 +156,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 	t.Run("fails multiple OCR3 contracts but unspecified address", func(t *testing.T) {
 		te := test.SetupTestEnv(t, test.TestConfig{
-			WFDonConfig:     test.DonConfig{N: 4},
+			WFDonConfig:     test.DonConfig{N: nWfNodes},
 			AssetDonConfig:  test.DonConfig{N: 4},
 			WriterDonConfig: test.DonConfig{N: 4},
 			NumChains:       1,
@@ -197,7 +199,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 	t.Run("fails multiple OCR3 contracts but address not found", func(t *testing.T) {
 		te := test.SetupTestEnv(t, test.TestConfig{
-			WFDonConfig:     test.DonConfig{N: 4},
+			WFDonConfig:     test.DonConfig{N: nWfNodes},
 			AssetDonConfig:  test.DonConfig{N: 4},
 			WriterDonConfig: test.DonConfig{N: 4},
 			NumChains:       1,
@@ -242,7 +244,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 	t.Run("mcms", func(t *testing.T) {
 		te := test.SetupTestEnv(t, test.TestConfig{
-			WFDonConfig:     test.DonConfig{N: 4},
+			WFDonConfig:     test.DonConfig{N: nWfNodes},
 			AssetDonConfig:  test.DonConfig{N: 4},
 			WriterDonConfig: test.DonConfig{N: 4},
 			NumChains:       1,

--- a/deployment/keystone/changeset/internal/ocr3config.go
+++ b/deployment/keystone/changeset/internal/ocr3config.go
@@ -148,6 +148,10 @@ func (c *OCR2OracleConfig) UnmarshalJSON(data []byte) error {
 }
 
 func GenerateOCR3Config(cfg OracleConfig, nca []NodeKeys, secrets deployment.OCRSecrets) (OCR2OracleConfig, error) {
+	// the transmission schedule is very specific; arguably it should be not be a parameter
+	if len(cfg.TransmissionSchedule) != 1 || cfg.TransmissionSchedule[0] != len(nca) {
+		return OCR2OracleConfig{}, fmt.Errorf("transmission schedule must have exactly one entry, matching the len of the number of nodes want [%d], got %v", len(nca), cfg.TransmissionSchedule)
+	}
 	onchainPubKeys := [][]byte{}
 	allPubKeys := map[string]any{}
 	if secrets.IsEmpty() {

--- a/deployment/keystone/changeset/internal/ocr3config_test.go
+++ b/deployment/keystone/changeset/internal/ocr3config_test.go
@@ -97,6 +97,38 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 	b, err := json.MarshalIndent(got, "", "  ")
 	require.NoError(t, err)
 	require.Equal(t, wantOCR3Config, string(b))
+
+	t.Run("no multiple transmitters", func(t *testing.T) {
+		cfg2 := cfg
+		cfg2.TransmissionSchedule = []int{}
+		for i := 1; i <= len(nodes); i++ {
+			cfg2.TransmissionSchedule = append(cfg2.TransmissionSchedule, i)
+		}
+		r := configureOCR3Request{
+			cfg:   &cfg2,
+			nodes: nodes,
+			chain: deployment.Chain{
+				Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
+			},
+			ocrSecrets: deployment.XXXGenerateTestOCRSecrets(),
+		}
+		_, err := r.generateOCR3Config()
+		require.Error(t, err)
+	})
+	t.Run("transmitter schedule eqaul num nodes", func(t *testing.T) {
+		cfg2 := cfg
+		cfg2.TransmissionSchedule = []int{len(nodes) + 1}
+		r := configureOCR3Request{
+			cfg:   &cfg2,
+			nodes: nodes,
+			chain: deployment.Chain{
+				Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
+			},
+			ocrSecrets: deployment.XXXGenerateTestOCRSecrets(),
+		}
+		_, err := r.generateOCR3Config()
+		require.Error(t, err)
+	})
 }
 
 func loadTestData(t *testing.T, path string) []deployment.Node {

--- a/deployment/keystone/changeset/test/helpers.go
+++ b/deployment/keystone/changeset/test/helpers.go
@@ -216,7 +216,8 @@ func SetupTestEnv(t *testing.T, c TestConfig) TestEnv {
 	require.NoError(t, err)
 
 	var ocr3Config = internal.OracleConfig{
-		MaxFaultyOracles: len(wfNodes) / 3,
+		MaxFaultyOracles:     len(wfNodes) / 3,
+		TransmissionSchedule: []int{len(wfNodes)},
 	}
 	var allDons = []internal.DonCapabilities{wfDon, cwDon, assetDon}
 


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
Validate the internal OCR capability transmission schedule.

This is the schedule for capability to 'transmit' from the OCR instance to the engine. 

We need this to happen right way for all nodes, so the schedule is strictly validated against the number of nodes in the OCR capability DON

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
