### PR TITLE
Adjust path to ccip-config

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -92,7 +92,7 @@ runs:
         if [[ "${GIT_TAG_TYPE}" = "ccip" ]]; then
           SHARED_BUILD_ARGS=$(cat << EOF
         COMMIT_SHA=${GIT_COMMIT_SHA}
-        CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+        CL_CHAIN_DEFAULTS=/ccip-config
         EOF
         )
         else

--- a/.goreleaser.develop.yaml
+++ b/.goreleaser.develop.yaml
@@ -152,7 +152,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -178,7 +178,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
       - --build-arg=CL_MERCURY_CMD=chainlink-mercury
       - --build-arg=CL_SOLANA_CMD=chainlink-solana
@@ -207,7 +207,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -233,7 +233,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
       - --build-arg=CL_MERCURY_CMD=chainlink-mercury
       - --build-arg=CL_SOLANA_CMD=chainlink-solana

--- a/.goreleaser.production.yaml
+++ b/.goreleaser.production.yaml
@@ -157,7 +157,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -184,7 +184,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
       - --build-arg=CL_MERCURY_CMD=chainlink-mercury
       - --build-arg=CL_SOLANA_CMD=chainlink-solana
@@ -214,7 +214,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -241,7 +241,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config
+      - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --build-arg=CL_MEDIAN_CMD=chainlink-feeds
       - --build-arg=CL_MERCURY_CMD=chainlink-mercury
       - --build-arg=CL_SOLANA_CMD=chainlink-solana

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -67,7 +67,7 @@ COPY --from=buildgo /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/internal/api/l
 RUN chmod 755 /usr/lib/libwasmvm.*.so
 
 # CCIP specific
-COPY ./cci[p]/confi[g] /chainlink/ccip-config
+COPY ./cci[p]/confi[g] /ccip-config
 ARG CL_CHAIN_DEFAULTS
 ENV CL_CHAIN_DEFAULTS=${CL_CHAIN_DEFAULTS}
 

--- a/core/chainlink.goreleaser.Dockerfile
+++ b/core/chainlink.goreleaser.Dockerfile
@@ -35,7 +35,7 @@ ENV CL_MEDIAN_CMD=${CL_MEDIAN_CMD} \
   CL_STARKNET_CMD=${CL_STARKNET_CMD}
 
 # CCIP specific
-COPY ./cci[p]/confi[g] /chainlink/ccip-config
+COPY ./cci[p]/confi[g] /ccip-config
 ARG CL_CHAIN_DEFAULTS
 ENV CL_CHAIN_DEFAULTS=${CL_CHAIN_DEFAULTS}
 

--- a/tools/goreleaser-config/gen_config.go
+++ b/tools/goreleaser-config/gen_config.go
@@ -215,7 +215,7 @@ func docker(id, goos, goarch, environment string, isDevspace bool) config.Docker
 
 	if strings.Contains(id, "ccip") {
 		buildFlagTemplates = append(buildFlagTemplates,
-			"--build-arg=CL_CHAIN_DEFAULTS=/chainlink/ccip-config")
+			"--build-arg=CL_CHAIN_DEFAULTS=/ccip-config")
 	}
 
 	if strings.Contains(id, "plugins") || isDevspace {


### PR DESCRIPTION
The docker image typically gets ran with a mounted volume of /chainlink which will remove our local /chainlink/ccip-config path.
