### PR TITLE
Add ccip test suites in testing image

### DIFF
--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -34,6 +34,7 @@ jobs:
         uses: smartcontractkit/.github/actions/ctf-build-test-image@6781e048ecc1aadf7d605722c32e8068a5f829ce # ctf-build-test-image@0.2.0
         with:
           other_tags: ${{ steps.tags.outputs.other_tags }}
+          suites: 'chaos migration reorg smoke soak benchmark load ccip-tests/load ccip-tests/smoke'
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -34,7 +34,7 @@ jobs:
         uses: smartcontractkit/.github/actions/ctf-build-test-image@6781e048ecc1aadf7d605722c32e8068a5f829ce # ctf-build-test-image@0.2.0
         with:
           other_tags: ${{ steps.tags.outputs.other_tags }}
-          suites: 'chaos migration reorg smoke soak benchmark load ccip-tests/load ccip-tests/smoke'
+          suites: 'chaos migration reorg smoke soak benchmark load ccip-tests/load ccip-tests/smoke ccip-tests/chaos'
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}


### PR DESCRIPTION
Include CCIP load, smoke and chaos test suites when building the chainlink testing image