### PR TITLE
CAPPL-527 Add retry loop when initializing workflow registry

### DIFF
--- a/core/services/workflows/syncer/workflow_registry.go
+++ b/core/services/workflows/syncer/workflow_registry.go
@@ -206,28 +206,51 @@ func (w *workflowRegistry) Start(_ context.Context) error {
 			w.lggr.Debugw("Waiting for DON...")
 			don, err := w.workflowDonNotifier.WaitForDon(ctx)
 			if err != nil {
-				w.lggr.Errorw("failed to wait for don", "err", err)
+				w.lggr.Criticalw("failed to wait for don", "err", err)
 				return
 			}
 
-			reader, err := w.newWorkflowRegistryContractReader(ctx)
-			if err != nil {
-				w.lggr.Criticalf("contract reader unavailable : %s", err)
-				return
-			}
-
-			w.lggr.Debugw("Loading initial workflows for DON", "DON", don.ID)
-			loadWorkflowsHead, err := w.loadWorkflows(ctx, don, reader)
-			if err != nil {
-				// TODO - this is a temporary fix to handle the case where the chainreader errors because the contract
-				// contains no workflows.  To track: https://smartcontract-it.atlassian.net/browse/CAPPL-393
-				if !strings.Contains(err.Error(), "attempting to unmarshal an empty string while arguments are expected") {
-					w.lggr.Errorw("failed to load workflows", "err", err)
+			ticker := w.getTicker()
+			var reader ContractReader
+			var loadWorkflowsHead *types.Head
+			shouldRetry := true
+			for shouldRetry {
+				select {
+				case <-ctx.Done():
+					w.lggr.Criticalw("error initializing workflow registry chain reader: %s", ctx.Err())
 					return
-				}
+				case <-ticker:
+					if reader == nil {
+						r, err := w.newWorkflowRegistryContractReader(ctx)
+						if err != nil {
+							w.lggr.Errorf("contract reader unavailable : %s", err)
+							continue
+						}
 
-				loadWorkflowsHead = &types.Head{
-					Height: "0",
+						reader = r
+					}
+
+					w.lggr.Debugw("Loading initial workflows for DON", "DON", don.ID)
+					// Note: we can safely retry this because it will only return
+					// an error if it couldn't fetch any data; not if it failed
+					// to process the events part-way through.
+					lwh, err := w.loadWorkflows(ctx, don, reader)
+					if err != nil {
+						// TODO - this is a temporary fix to handle the case where the chainreader errors because the contract
+						// contains no workflows.  To track: https://smartcontract-it.atlassian.net/browse/CAPPL-393
+						if !strings.Contains(err.Error(), "attempting to unmarshal an empty string while arguments are expected") {
+							w.lggr.Errorw("failed to load workflows", "err", err)
+							continue
+						}
+
+						loadWorkflowsHead = &types.Head{
+							Height: "0",
+						}
+					} else {
+						loadWorkflowsHead = lwh
+					}
+
+					shouldRetry = false
 				}
 			}
 

--- a/core/services/workflows/syncer/workflow_registry_test.go
+++ b/core/services/workflows/syncer/workflow_registry_test.go
@@ -1,0 +1,208 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	"github.com/smartcontractkit/chainlink-common/pkg/values"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+type mockContractReader struct {
+	event     types.Sequence
+	eventType string
+
+	glvError func() error
+}
+
+func (mcr *mockContractReader) Start(ctx context.Context) error {
+	return nil
+}
+
+func (mcr *mockContractReader) Close() error {
+	return nil
+}
+
+func (mcr *mockContractReader) Bind(ctx context.Context, bc []types.BoundContract) error {
+	return nil
+}
+
+func (mcr *mockContractReader) QueryKeys(ctx context.Context, keyQueries []types.ContractKeyFilter, limitAndSort query.LimitAndSort) (iter.Seq2[string, types.Sequence], error) {
+	return func(yield func(string, types.Sequence) bool) {
+		yield(mcr.eventType, mcr.event)
+	}, nil
+}
+
+func (mcr *mockContractReader) GetLatestValueWithHeadData(ctx context.Context, readName string, confidenceLevel primitives.ConfidenceLevel, params any, returnVal any) (head *types.Head, err error) {
+	err = mcr.glvError()
+	return &types.Head{Height: "0"}, err
+
+}
+
+type crMock struct {
+	cnt        int
+	mockReader ContractReader
+}
+
+func (c *crMock) newContractReaderFn(ctx context.Context, b []byte) (ContractReader, error) {
+	c.cnt++
+	if c.cnt > 1 {
+		return c.mockReader, nil
+	}
+
+	return nil, errors.New("not initialized")
+}
+
+type handler struct {
+	onHandler chan struct{}
+	event     Event
+}
+
+func (h *handler) Handle(ctx context.Context, event Event) error {
+	h.onHandler <- struct{}{}
+	h.event = event
+	return nil
+}
+
+type mockDonNotifier struct {
+}
+
+func (d *mockDonNotifier) WaitForDon(ctx context.Context) (capabilities.DON, error) {
+	return capabilities.DON{
+		ID: 1,
+	}, nil
+}
+
+func TestWorkflowRegistry_Start_ContinuesTryingToFetchContractReader(t *testing.T) {
+	event, err := values.NewMap(map[string]any{
+		"WorkflowName": "aworkflow",
+		"WorkflowID":   [32]byte{0: 1},
+		"BinaryURL":    "http://a-url.com",
+	})
+	require.NoError(t, err)
+
+	eventSeq := types.Sequence{
+		Cursor: "1_abc",
+		Head: types.Head{
+			Height: "1",
+		},
+		Data: event,
+	}
+
+	expectedEvent := &WorkflowRegistryEvent{
+		Cursor: "1_abc",
+		Data: WorkflowRegistryWorkflowRegisteredV1{
+			WorkflowID:   [32]byte{0: 1},
+			WorkflowName: "aworkflow",
+			BinaryURL:    "http://a-url.com",
+		},
+		EventType: "WorkflowRegisteredV1",
+		Head: Head{
+			Height: "1",
+		},
+	}
+
+	m := crMock{
+		mockReader: &mockContractReader{
+			event:     eventSeq,
+			eventType: string(WorkflowRegisteredEvent),
+			glvError:  func() error { return nil },
+		},
+	}
+	onHandler := make(chan struct{}, 10)
+	h := &handler{onHandler: onHandler}
+	wr := NewWorkflowRegistry(
+		logger.TestLogger(t),
+		m.newContractReaderFn,
+		"0x0",
+		WorkflowEventPollerConfig{QueryCount: 10},
+		h,
+		&mockDonNotifier{},
+	)
+
+	wr.ticker = time.NewTicker(10 * time.Millisecond).C
+
+	err = wr.Start(tests.Context(t))
+	require.NoError(t, err)
+	defer wr.Close()
+
+	<-h.onHandler
+
+	assert.Equal(t, expectedEvent, h.event)
+}
+
+func TestWorkflowRegistry_Start_ContinuesTryingToLoadWorkflows(t *testing.T) {
+	event, err := values.NewMap(map[string]any{
+		"WorkflowName": "aworkflow",
+		"WorkflowID":   [32]byte{0: 1},
+		"BinaryURL":    "http://a-url.com",
+	})
+	require.NoError(t, err)
+
+	eventSeq := types.Sequence{
+		Cursor: "1_abc",
+		Head: types.Head{
+			Height: "1",
+		},
+		Data: event,
+	}
+
+	expectedEvent := &WorkflowRegistryEvent{
+		Cursor: "1_abc",
+		Data: WorkflowRegistryWorkflowRegisteredV1{
+			WorkflowID:   [32]byte{0: 1},
+			WorkflowName: "aworkflow",
+			BinaryURL:    "http://a-url.com",
+		},
+		EventType: "WorkflowRegisteredV1",
+		Head: Head{
+			Height: "1",
+		},
+	}
+
+	loadWorkflowsErrorCount := 0
+	m := crMock{
+		mockReader: &mockContractReader{
+			event:     eventSeq,
+			eventType: string(WorkflowRegisteredEvent),
+			glvError: func() error {
+				loadWorkflowsErrorCount++
+				if loadWorkflowsErrorCount < 1 {
+					return errors.New("could not call get latest value")
+				}
+				return nil
+			},
+		},
+	}
+	onHandler := make(chan struct{}, 10)
+	h := &handler{onHandler: onHandler}
+	wr := NewWorkflowRegistry(
+		logger.TestLogger(t),
+		m.newContractReaderFn,
+		"0x0",
+		WorkflowEventPollerConfig{QueryCount: 10},
+		h,
+		&mockDonNotifier{},
+	)
+
+	wr.ticker = time.NewTicker(10 * time.Millisecond).C
+
+	err = wr.Start(tests.Context(t))
+	require.NoError(t, err)
+	defer wr.Close()
+
+	<-h.onHandler
+
+	assert.Equal(t, expectedEvent, h.event)
+}


### PR DESCRIPTION
If the workflow registry + capabilities registry are on different chains, WaitForDON() isn't enough to ensure we can connect to the relevant RPCs.

This loops over the chain reader + load workflow initialization so that we retry in the event of RPC connectivity issues.