### PR TITLE
An initial cut of a GetState mechanism for the changeset/migrations system of deployment.

### DIFF
--- a/deployment/ccip/changeset/view.go
+++ b/deployment/ccip/changeset/view.go
@@ -9,8 +9,17 @@ import (
 )
 
 var _ deployment.ViewState = ViewCCIP
+var _ deployment.StateRenderer[ccipview.CCIPView] = RenderCCIPState
 
+// ViewCCIP is a legacy renderer
+//
+// deprecated: use RenderCCIPState instead.
 func ViewCCIP(e deployment.Environment) (json.Marshaler, error) {
+	return RenderCCIPState(e)
+}
+
+// RenderCCIPState returns a
+func RenderCCIPState(e deployment.Environment) (*ccipview.CCIPView, error) {
 	state, err := LoadOnchainState(e)
 	if err != nil {
 		return nil, err
@@ -23,7 +32,7 @@ func ViewCCIP(e deployment.Environment) (json.Marshaler, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ccipview.CCIPView{
+	return &ccipview.CCIPView{
 		Chains: chainView,
 		Nops:   nopsView,
 	}, nil

--- a/deployment/changeset.go
+++ b/deployment/changeset.go
@@ -44,6 +44,25 @@ type ChangesetOutput struct {
 	AddressBook           AddressBook
 }
 
+// StateRepresentation is a type which represents a given piece of business domain state, e.g. CCIPView. A
+// A StateRepresentation can render into Json (conforms to `json.Marshaler`), and may have other representations in
+// the future, such as a protobuf representation.
+//
+// StateRepresentation is used in storing and transmitting domain state through artifacts (local or transmitted).
+// In the chainlink/deployment module, it is only used in tests. ChangeSet execution functions have access to state
+// representations via GetState(env, StateKey[SomeStateStruct]{}) calls.
+type StateRepresentation interface {
+	json.Marshaler
+}
+
 // ViewState produces a product specific JSON representation of
 // the on and offchain state of the environment.
+//
+// deprecated: use StateRenderer
 type ViewState func(e Environment) (json.Marshaler, error)
+
+// StateRenderer is a function which transforms elements of the environment into a StateRepresentation, so that the
+// business domain state may be transmitted or persisted. Every domain should have a state representation, and a
+// function to transform environmental elements (such as the address book, and any other artifacts) into a coherent
+
+type StateRenderer[S StateRepresentation] func(e Environment) (*S, error)

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -105,6 +105,7 @@ type Environment struct {
 	Offchain          OffchainClient
 	GetContext        func() context.Context
 	OCRSecrets        OCRSecrets
+	state             StateManager
 }
 
 func NewEnvironment(

--- a/deployment/keystone/changeset/view.go
+++ b/deployment/keystone/changeset/view.go
@@ -14,7 +14,12 @@ import (
 
 var _ deployment.ViewState = ViewKeystone
 
+var _ deployment.StateRenderer[view.KeystoneView] = RenderKeystoneState
+
 func ViewKeystone(e deployment.Environment) (json.Marshaler, error) {
+	return RenderKeystoneState(e)
+}
+func RenderKeystoneState(e deployment.Environment) (*view.KeystoneView, error) {
 	state, err := internal.GetContractSets(e.Logger, &internal.GetContractSetsRequest{
 		Chains:      e.Chains,
 		AddressBook: e.ExistingAddresses,

--- a/deployment/state.go
+++ b/deployment/state.go
@@ -1,0 +1,97 @@
+package deployment
+
+import (
+	"errors"
+	"reflect"
+)
+
+var (
+	ErrInvalidStateType = errors.New("invalid state type")
+	ErrStateNotFound    = errors.New("no state with this type can be found")
+
+	ErrStateManagerNotFound = errors.New("the environment did not include a state manager")
+)
+
+// StateKey is a carrier of type information, to allow a static type to be used as a key, conveniently, without
+// having to mess with the reflection package in client code. Its basic usage is:
+//
+//	key := StateKey[MyStruct]{}
+//
+// The type parameter information is carried on the inner field, and infrastructure code can obtain that type for use
+// in underlying code.
+type StateKey[T StateRepresentation] struct {
+	_ T // Expose the type to generics.
+}
+
+// StateManager is responsible for looking up and supplying state to the typesafe GetState wrapper function. Different
+// implementations will obtain the state (and populate the given struct) from different sources, whether in-memory,
+// from json files, via RPCs or any other mechanism. The simple InMemoryStateManager can be used for in-memory
+// Environments. More complex StateManager implementations can be found where those Environment variations are
+// implemented.
+type StateManager interface {
+	// getState returns a struct of the type given in the "key" parameter, populated with any state data obtained
+	// using that same key. If no such state exists, it returns ErrStateNotFound. If it finds any errors in finding
+	// and marshalling the data in question, it returns those errors.
+	getState(key reflect.Type) (StateRepresentation, error)
+}
+
+// InMemoryStateManager is a non-thread-safe StateManager implementation, which simply maintains an internal
+// map keyed by reflect.Type. The struct value of the map is required to be of the type represented by the key.
+//
+// This can be used in a test quite simply to setup state for use by the GetState function, outside the ChangeSet
+// under test, injected into the environment, and then the ChangeSet can access that state via the GetState function.
+type InMemoryStateManager struct {
+	// Maintains the map of type to state struct. Public for testing. This map is unavailable within a ChangeSet
+	State map[reflect.Type]StateRepresentation
+}
+
+func (m InMemoryStateManager) getState(key reflect.Type) (StateRepresentation, error) {
+	state, ok := m.State[key]
+	if !ok {
+		return nil, ErrStateNotFound
+	}
+	return state, nil
+}
+
+func NewInMemoryStateManager(state ...StateRepresentation) InMemoryStateManager {
+	mgr := InMemoryStateManager{map[reflect.Type]StateRepresentation{}}
+	for _, s := range state {
+		stateType := reflect.TypeOf(s)
+		mgr.State[stateType] = s
+	}
+	return mgr
+}
+
+// GetState obtains a domain-specific state struct (as defined by the product/domain team) from the environment.
+// It relies on a StateManager inside the Environment to manage the actual fetching and marshalling of such state. The
+// basic usage pattern is as follows:
+//
+// state, err := GetState(env, StateKey[MyCustomStruct]{})
+//
+// If no such state can be found with that key (e.g., with that struct), then the method will return ErrStateNotFound.
+// If there are underlying errors in fetching, marshalling, parsing, or any other preparation, these will be surfaced.
+// In tests, state is obtained from an in-memory state store, which simply maintains a map of such state. In other
+// contexts, state may derive from json files or from a back-end data store.
+//
+// This function is intended to be used from within a ChangeSet function, and has undefined behavior outside of that
+// context.
+func GetState[T StateRepresentation](env Environment, key StateKey[T]) (*T, error) {
+	mgr := env.state
+	if mgr == nil {
+		return nil, ErrStateManagerNotFound
+	}
+	keyType := reflect.TypeOf(key)
+	typeField := keyType.Field(0)
+	stateType := typeField.Type
+	rawState, err := mgr.getState(stateType)
+	if err != nil {
+		return nil, err
+	}
+	stronglyTypeState, ok := rawState.(T)
+	if !ok {
+		// Given the guarantees of StateManager.getState, this represents a bug in state manager, which should not
+		// return an instance of anything except the provided struct type.
+		return nil, ErrInvalidStateType
+	}
+	return &stronglyTypeState, nil
+}

--- a/deployment/state_test.go
+++ b/deployment/state_test.go
@@ -1,0 +1,60 @@
+package deployment
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNode_GetState_UsageExample(t *testing.T) {
+	mgr := NewInMemoryStateManager(FooState{"blah"})
+	env := Environment{state: mgr}
+
+	_, err := GetState(env, StateKey[BarState]{})
+	require.ErrorIs(t, err, ErrStateNotFound)
+}
+
+func TestNode_GetState(t *testing.T) {
+	env := Environment{state: NewInMemoryStateManager(FooState{"foo"}, BarState{"bar"})}
+
+	fooState, err := GetState(env, StateKey[FooState]{})
+	require.NoError(t, err)
+	require.Equal(t, "foo", fooState.foo)
+	barState, err := GetState(env, StateKey[BarState]{})
+	require.NoError(t, err)
+	require.Equal(t, "bar", barState.bar)
+}
+
+func TestNode_GetState_NotFound(t *testing.T) {
+	env := Environment{state: NewInMemoryStateManager(FooState{"blah"})}
+
+	_, err := GetState(env, StateKey[BarState]{})
+	require.ErrorIs(t, err, ErrStateNotFound)
+}
+
+// Set up state structs.
+
+var _ StateRepresentation = FooState{}
+
+type FooState struct {
+	foo string
+}
+
+func (f FooState) MarshalJSON() ([]byte, error) {
+	// Alias to avoid recursive calls
+	type Alias FooState
+	return json.MarshalIndent(&struct{ Alias }{Alias: Alias(f)}, "", " ")
+}
+
+var _ StateRepresentation = BarState{}
+
+type BarState struct {
+	bar string
+}
+
+func (b BarState) MarshalJSON() ([]byte, error) {
+	// Alias to avoid recursive calls
+	type Alias BarState
+	return json.MarshalIndent(&struct{ Alias }{Alias: Alias(b)}, "", " ")
+}


### PR DESCRIPTION
An initial cut of a GetState mechanism for the changeset/migrations system of deployment.

The basic API is GetState(env, StateKey[MyStateStruct]{}) which returns MyStateStruct. Under the hood, there is a stateManager on the Environment, which handles the backend. In chainlink/deployment (and integration-tests) this will use an in-memory state store, which will be primed with data for the test. In real deployments, a different backend will pull from json or backend information platform protos (depending on the evolution of that system). From the point of view of the ChangeSet execution function, this will be invisible. The ChangeSet should just be able to call the GetState function and the appropriate system will return the struct, or an error.

A separate function is used, rather than a method on Environment or on the state manager, because methods cannot have type paramters other than those of their owned type, and this function needs to handle any type coercion internally. Otherwise we'd do env.state.GetState(key). Sadly, this limitation of go generics means we have to use a detached outer function.

[DPA-1526](https://smartcontract-it.atlassian.net/browse/DPA-1526)


[DPA-1526]: https://smartcontract-it.atlassian.net/browse/DPA-1526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ