### PR TITLE
Fix: Upgrade go-releaser setup action

### DIFF
--- a/.github/actions/goreleaser-build-sign-publish/action.yml
+++ b/.github/actions/goreleaser-build-sign-publish/action.yml
@@ -57,7 +57,7 @@ runs:
         only-modules: 'true'
 
     - name: Setup goreleaser
-      uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
+      uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
       with:
         distribution: goreleaser-pro
         install-only: true


### PR DESCRIPTION
## Fix issues with installing the latest v2 version of goreleaser

The new version of go-releaser drops support for the `-pro` suffix on the release version. In order to setup the correct version, we need to [use the latest setup goreleaser-action](https://github.com/goreleaser/goreleaser-action/releases/tag/v6.2.1) that has that functionality. 

### Supports
https://chainlink-core.slack.com/archives/C038Q8K1HTR/p1739262431421559
