### PR TITLE
Upgrade chainlink-integrations/evm

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250205141137-8f50d72601bb
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250128203428-08031923fbe5
-	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab
+	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22
 	github.com/smartcontractkit/libocr v0.0.0-20241223215956-e5b78d8e3919
 	github.com/spf13/cobra v1.8.1

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1127,8 +1127,8 @@ github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420ccacab78a/go.mod h1:tHem58EihQh63kR2LlAOKDAs9Vbghf1dJKZRGy6LG8g=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678 h1:3CWUXtDkNppMkXIsKZdDp1ZP2ELkZ3e33h3InZB7TRA=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678/go.mod h1:4JqpgFy01LaqG1yM2iFTzwX3ZgcAvW9WdstBZQgPHzU=
-github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab h1:b39YW3jxiOzUD/zHEWnQhAMhwuxogoW74WsLobyv0so=
-github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab/go.mod h1:sCZR6tZ7O72RmDNC44VsfFToHr/JA/Td99S//wsDHn4=
+github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406 h1:aOEqsgoTmdpTW7i1uIxtXNvVCpUDOEViTxpcPNaAe98=
+github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406/go.mod h1:sCZR6tZ7O72RmDNC44VsfFToHr/JA/Td99S//wsDHn4=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0 h1:0ewLMbAz3rZrovdRUCgd028yOXX8KigB4FndAUdI2kM=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.4.0 h1:ZBat8EBvE2LpSQR9U1gEbRV6PfAkiFdINmQ8nVnXIAQ=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250206215114-fb6c3c35e8e3
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250205141137-8f50d72601bb
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678
-	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab
+	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250207060333-005a15b407b0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1124,8 +1124,8 @@ github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420ccacab78a/go.mod h1:tHem58EihQh63kR2LlAOKDAs9Vbghf1dJKZRGy6LG8g=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678 h1:3CWUXtDkNppMkXIsKZdDp1ZP2ELkZ3e33h3InZB7TRA=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678/go.mod h1:4JqpgFy01LaqG1yM2iFTzwX3ZgcAvW9WdstBZQgPHzU=
-github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab h1:b39YW3jxiOzUD/zHEWnQhAMhwuxogoW74WsLobyv0so=
-github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab/go.mod h1:sCZR6tZ7O72RmDNC44VsfFToHr/JA/Td99S//wsDHn4=
+github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406 h1:aOEqsgoTmdpTW7i1uIxtXNvVCpUDOEViTxpcPNaAe98=
+github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406/go.mod h1:sCZR6tZ7O72RmDNC44VsfFToHr/JA/Td99S//wsDHn4=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0 h1:0ewLMbAz3rZrovdRUCgd028yOXX8KigB4FndAUdI2kM=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.4.0 h1:ZBat8EBvE2LpSQR9U1gEbRV6PfAkiFdINmQ8nVnXIAQ=

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/smartcontractkit/chainlink-feeds v0.1.1
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420ccacab78a
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678
-	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab
+	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.4.0
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250207060333-005a15b407b0
 	github.com/smartcontractkit/libocr v0.0.0-20241223215956-e5b78d8e3919

--- a/go.sum
+++ b/go.sum
@@ -1024,8 +1024,8 @@ github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420ccacab78a/go.mod h1:tHem58EihQh63kR2LlAOKDAs9Vbghf1dJKZRGy6LG8g=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678 h1:3CWUXtDkNppMkXIsKZdDp1ZP2ELkZ3e33h3InZB7TRA=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678/go.mod h1:4JqpgFy01LaqG1yM2iFTzwX3ZgcAvW9WdstBZQgPHzU=
-github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab h1:b39YW3jxiOzUD/zHEWnQhAMhwuxogoW74WsLobyv0so=
-github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab/go.mod h1:sCZR6tZ7O72RmDNC44VsfFToHr/JA/Td99S//wsDHn4=
+github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406 h1:aOEqsgoTmdpTW7i1uIxtXNvVCpUDOEViTxpcPNaAe98=
+github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406/go.mod h1:sCZR6tZ7O72RmDNC44VsfFToHr/JA/Td99S//wsDHn4=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.4.0 h1:ZBat8EBvE2LpSQR9U1gEbRV6PfAkiFdINmQ8nVnXIAQ=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.4.0/go.mod h1:m/A3lqD7ms/RsQ9BT5P2uceYY0QX5mIt4KQxT2G6qEo=
 github.com/smartcontractkit/chainlink-protos/svr v0.0.0-20250123084029-58cce9b32112 h1:c77Gi/APraqwbBO8fbd/5JY2wW+MSIpYg8Uma9MEZFE=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250207140936-540f8266d0c7
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250205141137-8f50d72601bb
-	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab
+	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1374,8 +1374,8 @@ github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420ccacab78a/go.mod h1:tHem58EihQh63kR2LlAOKDAs9Vbghf1dJKZRGy6LG8g=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678 h1:3CWUXtDkNppMkXIsKZdDp1ZP2ELkZ3e33h3InZB7TRA=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678/go.mod h1:4JqpgFy01LaqG1yM2iFTzwX3ZgcAvW9WdstBZQgPHzU=
-github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab h1:b39YW3jxiOzUD/zHEWnQhAMhwuxogoW74WsLobyv0so=
-github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab/go.mod h1:sCZR6tZ7O72RmDNC44VsfFToHr/JA/Td99S//wsDHn4=
+github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406 h1:aOEqsgoTmdpTW7i1uIxtXNvVCpUDOEViTxpcPNaAe98=
+github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406/go.mod h1:sCZR6tZ7O72RmDNC44VsfFToHr/JA/Td99S//wsDHn4=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0 h1:0ewLMbAz3rZrovdRUCgd028yOXX8KigB4FndAUdI2kM=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.4.0 h1:ZBat8EBvE2LpSQR9U1gEbRV6PfAkiFdINmQ8nVnXIAQ=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.40
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250207140936-540f8266d0c7
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250205141137-8f50d72601bb
-	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab
+	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.51.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.10
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1357,8 +1357,8 @@ github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420ccacab78a/go.mod h1:tHem58EihQh63kR2LlAOKDAs9Vbghf1dJKZRGy6LG8g=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678 h1:3CWUXtDkNppMkXIsKZdDp1ZP2ELkZ3e33h3InZB7TRA=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250205171936-649f95193678/go.mod h1:4JqpgFy01LaqG1yM2iFTzwX3ZgcAvW9WdstBZQgPHzU=
-github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab h1:b39YW3jxiOzUD/zHEWnQhAMhwuxogoW74WsLobyv0so=
-github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250207224751-03d585da84ab/go.mod h1:sCZR6tZ7O72RmDNC44VsfFToHr/JA/Td99S//wsDHn4=
+github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406 h1:aOEqsgoTmdpTW7i1uIxtXNvVCpUDOEViTxpcPNaAe98=
+github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250211093128-285968896406/go.mod h1:sCZR6tZ7O72RmDNC44VsfFToHr/JA/Td99S//wsDHn4=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0 h1:0ewLMbAz3rZrovdRUCgd028yOXX8KigB4FndAUdI2kM=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-protos/orchestrator v0.4.0 h1:ZBat8EBvE2LpSQR9U1gEbRV6PfAkiFdINmQ8nVnXIAQ=


### PR DESCRIPTION
Upgrades chainlink-integrations/evm to support `0x4` transactions in Block History Estimator.
Relevant PR:
- https://github.com/smartcontractkit/chainlink-integrations/pull/6