### PR TITLE
wasm module serialization

### DIFF
--- a/core/capabilities/compute/cache_test.go
+++ b/core/capabilities/compute/cache_test.go
@@ -26,6 +26,7 @@ func TestCache(t *testing.T) {
 	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-558")
 
 	t.Parallel()
+	ctx := tests.Context(t)
 	clock := clockwork.NewFakeClock()
 	tick := 1 * time.Second
 	timeout := 1 * time.Second
@@ -38,10 +39,11 @@ func TestCache(t *testing.T) {
 	defer cache.close()
 
 	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
-	hmod, err := host.NewModule(&host.ModuleConfig{
+	hmod, err := host.NewModule(ctx, &host.ModuleConfig{
 		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
-	}, binary)
+	},
+		host.NewSingleBinaryWasmBinaryStore(binary), "")
 	require.NoError(t, err)
 
 	id := uuid.New().String()
@@ -77,10 +79,10 @@ func TestCache_EvictAfterSize(t *testing.T) {
 	defer cache.close()
 
 	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
-	hmod, err := host.NewModule(&host.ModuleConfig{
+	hmod, err := host.NewModule(t.Context(), &host.ModuleConfig{
 		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
-	}, binary)
+	}, host.NewSingleBinaryWasmBinaryStore(binary), "")
 	require.NoError(t, err)
 
 	id := uuid.New().String()
@@ -110,6 +112,7 @@ func TestCache_AddDuplicatedModule(t *testing.T) {
 	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-574")
 
 	t.Parallel()
+	ctx := tests.Context(t)
 	clock := clockwork.NewFakeClock()
 	tick := 1 * time.Second
 	timeout := 1 * time.Second
@@ -122,10 +125,10 @@ func TestCache_AddDuplicatedModule(t *testing.T) {
 	defer cache.close()
 
 	simpleBinary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
-	shmod, err := host.NewModule(&host.ModuleConfig{
+	shmod, err := host.NewModule(ctx, &host.ModuleConfig{
 		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
-	}, simpleBinary)
+	}, host.NewSingleBinaryWasmBinaryStore(simpleBinary), "")
 	require.NoError(t, err)
 
 	// we will use the same id for both modules, but should only be associated to the simple module
@@ -142,10 +145,10 @@ func TestCache_AddDuplicatedModule(t *testing.T) {
 
 	// Adding a different module but with the same id should not overwrite the existing module
 	fetchBinary := wasmtest.CreateTestBinary(fetchBinaryCmd, fetchBinaryLocation, false, t)
-	fhmod, err := host.NewModule(&host.ModuleConfig{
+	fhmod, err := host.NewModule(ctx, &host.ModuleConfig{
 		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
-	}, fetchBinary)
+	}, host.NewSingleBinaryWasmBinaryStore(fetchBinary), "")
 	require.NoError(t, err)
 
 	fmod := &module{

--- a/core/capabilities/compute/transformer.go
+++ b/core/capabilities/compute/transformer.go
@@ -14,7 +14,6 @@ import (
 
 // ParsedConfig is a struct that contains the binary and config for a wasm module, as well as the module config.
 type ParsedConfig struct {
-	Binary []byte
 	Config []byte
 
 	// ModuleConfig is the configuration and dependencies to inject into the wasm module.
@@ -49,11 +48,6 @@ func (t *transformer) Transform(req capabilities.CapabilityRequest, opts ...func
 		Inputs:   req.Inputs,
 		Metadata: req.Metadata,
 		Config:   shallowCopy(req.Config),
-	}
-
-	binary, err := popValue[[]byte](copiedReq.Config, binaryKey)
-	if err != nil {
-		return capabilities.CapabilityRequest{}, nil, NewInvalidRequestError(err)
 	}
 
 	config, err := popValue[[]byte](copiedReq.Config, configKey)
@@ -116,7 +110,6 @@ func (t *transformer) Transform(req capabilities.CapabilityRequest, opts ...func
 	}
 
 	pc := &ParsedConfig{
-		Binary:       binary,
 		Config:       config,
 		ModuleConfig: mc,
 	}

--- a/core/capabilities/compute/transformer_test.go
+++ b/core/capabilities/compute/transformer_test.go
@@ -92,7 +92,6 @@ func Test_transformer(t *testing.T) {
 			"maxMemoryMBs": 1024,
 			"timeout":      "4s",
 			"tickInterval": "8s",
-			"binary":       []byte{0x01, 0x02, 0x03},
 			"config":       []byte{0x04, 0x05, 0x06},
 		})
 		giveReq := capabilities.CapabilityRequest{
@@ -102,7 +101,6 @@ func Test_transformer(t *testing.T) {
 
 		wantTO := 4 * time.Second
 		wantConfig := &ParsedConfig{
-			Binary: []byte{0x01, 0x02, 0x03},
 			Config: []byte{0x04, 0x05, 0x06},
 			ModuleConfig: &host.ModuleConfig{
 				MaxMemoryMBs: 1024,
@@ -127,7 +125,6 @@ func Test_transformer(t *testing.T) {
 
 	t.Run("success missing optional fields", func(t *testing.T) {
 		giveMap, err := values.NewMap(map[string]any{
-			"binary": []byte{0x01, 0x02, 0x03},
 			"config": []byte{0x04, 0x05, 0x06},
 		})
 		giveReq := capabilities.CapabilityRequest{
@@ -137,7 +134,6 @@ func Test_transformer(t *testing.T) {
 
 		timeout := defaultMaxTimeout
 		wantConfig := &ParsedConfig{
-			Binary: []byte{0x01, 0x02, 0x03},
 			Config: []byte{0x04, 0x05, 0x06},
 			ModuleConfig: &host.ModuleConfig{
 				Logger:       lgger,

--- a/core/capabilities/integration_tests/framework/serialised_module_store.go
+++ b/core/capabilities/integration_tests/framework/serialised_module_store.go
@@ -1,0 +1,75 @@
+package framework
+
+import (
+	"path/filepath"
+	"sync"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/artifacts"
+)
+
+type SerialisedModuleStoreFactory interface {
+	GetModuleStoreForPeer(peerID string) (artifacts.SerialisedModuleStore, error)
+}
+
+type FileBasedSerialisedModuleStoreFactory struct {
+	storagePath string
+}
+
+func NewFileBasedSerialisedModuleStoreFactory(storagePath string) *FileBasedSerialisedModuleStoreFactory {
+	return &FileBasedSerialisedModuleStoreFactory{
+		storagePath: storagePath,
+	}
+}
+
+func (f *FileBasedSerialisedModuleStoreFactory) GetModuleStoreForPeer(peerID string) (artifacts.SerialisedModuleStore, error) {
+	return artifacts.NewFileBasedModuleStore(filepath.Join(f.storagePath, peerID))
+}
+
+type NoStoreModuleStoreFactory struct {
+}
+
+func NewNoStoreModuleStoreFactory() *NoStoreModuleStoreFactory {
+	return &NoStoreModuleStoreFactory{}
+}
+
+func (n *NoStoreModuleStoreFactory) GetModuleStoreForPeer(peerID string) (artifacts.SerialisedModuleStore, error) {
+	return NewNoStoreModuleStore()
+}
+
+type NoStoreModuleStore struct {
+	mux                  sync.Mutex
+	workflowIDToBinaryID map[string]string
+}
+
+func NewNoStoreModuleStore() (*NoStoreModuleStore, error) {
+	return &NoStoreModuleStore{workflowIDToBinaryID: map[string]string{}}, nil
+}
+
+func (s *NoStoreModuleStore) StoreModule(workflowID string, binaryID string, module []byte) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	s.workflowIDToBinaryID[workflowID] = binaryID
+	return nil
+}
+
+func (s *NoStoreModuleStore) GetModulePath(workflowID string) (string, bool, error) {
+	return "", false, nil
+}
+
+// GetBinaryID retrieves the wasm binary ID for the given workflow ID. Returns the binary ID, a boolean indicating
+// whether the binary ID for the module was found, and an error if one occurred.
+func (s *NoStoreModuleStore) GetBinaryID(workflowID string) (string, bool, error) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	binaryID, ok := s.workflowIDToBinaryID[workflowID]
+	return binaryID, ok, nil
+}
+
+func (s *NoStoreModuleStore) DeleteModule(workflowID string) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	delete(s.workflowIDToBinaryID, workflowID)
+	return nil
+}

--- a/core/config/app_config.go
+++ b/core/config/app_config.go
@@ -58,6 +58,7 @@ type AppConfig interface {
 	WebServer() WebServer
 	Tracing() Tracing
 	Telemetry() Telemetry
+	Wasm() Wasm
 }
 
 type DatabaseBackupMode string

--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -772,3 +772,8 @@ ChipIngressEndpoint = '' # Default
 [Telemetry.ResourceAttributes]
 # foo is an example resource attribute
 foo = "bar" # Example
+
+# Wasm holds settings for the WebAssembly runtime.
+[Wasm]
+# SerialisedModulesDir is the directory where the serialised Wasm modules are stored
+SerialisedModulesDir = '/path/to/serialised/modules' # Example

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -61,6 +61,7 @@ type Core struct {
 	Capabilities     Capabilities     `toml:",omitempty"`
 	Telemetry        Telemetry        `toml:",omitempty"`
 	Workflows        Workflows        `toml:",omitempty"`
+	Wasm             Wasm             `toml:",omitempty"`
 }
 
 // SetFrom updates c with any non-nil values from f. (currently TOML field only!)
@@ -102,6 +103,7 @@ func (c *Core) SetFrom(f *Core) {
 	c.Insecure.setFrom(&f.Insecure)
 	c.Tracing.setFrom(&f.Tracing)
 	c.Telemetry.setFrom(&f.Telemetry)
+	c.Wasm.setFrom(&f.Wasm)
 }
 
 func (c *Core) ValidateConfig() (err error) {
@@ -1902,6 +1904,22 @@ func (t *Tracing) ValidateConfig() (err error) {
 	}
 
 	return err
+}
+
+type Wasm struct {
+	SerialisedModulesDir *string
+}
+
+func (w *Wasm) setFrom(f *Wasm) {
+	if v := f.SerialisedModulesDir; v != nil {
+		w.SerialisedModulesDir = v
+	}
+}
+
+func (w *Wasm) SetDefaults(rootDir *string) {
+	if w.SerialisedModulesDir == nil {
+		w.SerialisedModulesDir = rootDir
+	}
 }
 
 type Telemetry struct {

--- a/core/config/wasm_config.go
+++ b/core/config/wasm_config.go
@@ -1,0 +1,5 @@
+package config
+
+type Wasm interface {
+	SerialisedModulesDir() string
+}

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -347,6 +347,14 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 		}
 	}
 
+	var moduleStore artifacts.SerialisedModuleStore
+	for _, dep := range flagsAndDeps {
+		moduleStore, _ = dep.(artifacts.SerialisedModuleStore)
+		if moduleStore != nil {
+			break
+		}
+	}
+
 	var computeFetcherFactory compute.FetcherFactory
 	for _, dep := range flagsAndDeps {
 		computeFetcherFactory, _ = dep.(compute.FetcherFactory)
@@ -433,6 +441,7 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 			CapabilitiesPeerWrapper: peerWrapper,
 			FetcherFunc:             syncerFetcherFunc,
 			FetcherFactoryFn:        computeFetcherFactory,
+			ModuleStore:             moduleStore,
 		},
 		Config:   cfg,
 		DS:       ds,

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1170,8 +1170,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1 h1:qYv7f++PMP3mEAd1QYLmBmyqKr0036Z1XqIrr19QpC8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1170,8 +1170,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19 h1:cmDDnYCtyXqUotTJvDLD0cGMoAYOyMSWSa3GNyJUjrA=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/core/services/chainlink/config.go
+++ b/core/services/chainlink/config.go
@@ -341,6 +341,8 @@ func (c *Config) setDefaults() {
 	c.Starknet.SetDefaults()
 
 	c.Tron.SetDefaults()
+
+	c.Wasm.SetDefaults(core.RootDir)
 }
 
 func (c *Config) SetFrom(f *Config) (err error) {

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -541,4 +541,8 @@ func (g *generalConfig) Telemetry() coreconfig.Telemetry {
 	return &telemetryConfig{s: g.c.Telemetry}
 }
 
+func (g *generalConfig) Wasm() coreconfig.Wasm {
+	return &wasmConfig{w: g.c.Wasm}
+}
+
 var zeroSha256Hash = models.Sha256Hash{}

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -104,6 +104,7 @@ var (
 					PerOwner: ptr(int32(200)),
 				},
 			},
+			Wasm: toml.Wasm{SerialisedModulesDir: ptr("test/root/dir")},
 		},
 		EVM: []*evmcfg.EVMConfig{
 			{
@@ -568,6 +569,7 @@ func TestConfig_Marshal(t *testing.T) {
 		EmitterExportTimeout:  commoncfg.MustNewDuration(1 * time.Second),
 		ChipIngressEndpoint:   ptr("example.com/chip-ingress"),
 	}
+	full.Wasm = toml.Wasm{SerialisedModulesDir: ptr("test/root/dir")}
 	full.EVM = []*evmcfg.EVMConfig{
 		{
 			ChainID: ubig.NewI(1),

--- a/core/services/chainlink/config_wsm.go
+++ b/core/services/chainlink/config_wsm.go
@@ -1,0 +1,11 @@
+package chainlink
+
+import "github.com/smartcontractkit/chainlink/v2/core/config/toml"
+
+type wasmConfig struct {
+	w toml.Wasm
+}
+
+func (t *wasmConfig) SerialisedModulesDir() string {
+	return *t.w.SerialisedModulesDir
+}

--- a/core/services/chainlink/config_wsm_test.go
+++ b/core/services/chainlink/config_wsm_test.go
@@ -1,0 +1,20 @@
+package chainlink
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWasmConfigTest(t *testing.T) {
+	opts := GeneralConfigOpts{
+		ConfigStrings:  []string{fullTOML},
+		SecretsStrings: []string{secretsFullTOML},
+	}
+	cfg, err := opts.New()
+	require.NoError(t, err)
+
+	wcfg := cfg.Wasm()
+
+	require.Equal(t, "test/root/dir", wcfg.SerialisedModulesDir())
+}

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -315,3 +315,6 @@ ChipIngressEndpoint = ''
 [Workflows.Limits]
 Global = 200
 PerOwner = 200
+
+[Wasm]
+SerialisedModulesDir = ''

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -330,6 +330,9 @@ Foo = 'bar'
 Global = 200
 PerOwner = 200
 
+[Wasm]
+SerialisedModulesDir = 'test/root/dir'
+
 [[EVM]]
 ChainID = '1'
 Enabled = false

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -316,6 +316,9 @@ ChipIngressEndpoint = ''
 Global = 200
 PerOwner = 200
 
+[Wasm]
+SerialisedModulesDir = 'test/root/dir'
+
 [[EVM]]
 ChainID = '1'
 AutoCreateKey = true

--- a/core/services/chainlink/testdata/config-multi-chain.toml
+++ b/core/services/chainlink/testdata/config-multi-chain.toml
@@ -40,6 +40,9 @@ CPUProfileRate = 7
 Global = 200
 PerOwner = 200
 
+[Wasm]
+SerialisedModulesDir = 'test/root/dir'
+
 [[EVM]]
 ChainID = '1'
 FinalityDepth = 26

--- a/core/services/job/wasm_file_spec_factory.go
+++ b/core/services/job/wasm_file_spec_factory.go
@@ -33,8 +33,9 @@ func (w WasmFileSpecFactory) Spec(ctx context.Context, workflow, configLocation 
 		return sdk.WorkflowSpec{}, nil, "", err
 	}
 
-	moduleConfig := &host.ModuleConfig{Logger: logger.NullLogger}
-	spec, err := host.GetWorkflowSpec(ctx, moduleConfig, compressedBinary, config)
+	lggr := logger.NullLogger
+	moduleConfig := &host.ModuleConfig{Logger: lggr}
+	spec, err := host.GetWorkflowSpec(ctx, moduleConfig, host.NewSingleBinaryWasmBinaryStore(compressedBinary), "", config)
 	if err != nil {
 		return sdk.WorkflowSpec{}, nil, "", err
 	} else if spec == nil {

--- a/core/services/job/wasm_file_spec_factory_test.go
+++ b/core/services/job/wasm_file_spec_factory_test.go
@@ -42,7 +42,8 @@ func TestWasmFileSpecFactory(t *testing.T) {
 		actual, rawSpec, actualSha, err2 := factory.Spec(testutils.Context(t), binaryLocation, configLocation)
 		require.NoError(t, err2)
 
-		expected, err2 := host.GetWorkflowSpec(ctx, &host.ModuleConfig{Logger: logger.NullLogger, IsUncompressed: true}, rawBinary, config)
+		expected, err2 := host.GetWorkflowSpec(ctx, logger.TestLogger(t), &host.ModuleConfig{Logger: logger.NullLogger, IsUncompressed: true},
+			"", host.NewSingleBinaryWasmBinaryStore(rawBinary), config)
 		require.NoError(t, err2)
 
 		expectedSha := sha256.New()
@@ -65,7 +66,8 @@ func TestWasmFileSpecFactory(t *testing.T) {
 		actual, rawSpec, actualSha, err2 := factory.Spec(testutils.Context(t), brLoc, configLocation)
 		require.NoError(t, err2)
 
-		expected, err2 := host.GetWorkflowSpec(ctx, &host.ModuleConfig{Logger: logger.NullLogger, IsUncompressed: true}, rawBinary, config)
+		expected, err2 := host.GetWorkflowSpec(ctx, logger.TestLogger(t), &host.ModuleConfig{Logger: logger.NullLogger, IsUncompressed: true},
+			"", host.NewSingleBinaryWasmBinaryStore(rawBinary), config)
 		require.NoError(t, err2)
 
 		expectedSha := sha256.New()

--- a/core/services/relay/evm/capabilities/workflows/syncer/workflow_syncer_test.go
+++ b/core/services/relay/evm/capabilities/workflows/syncer/workflow_syncer_test.go
@@ -390,7 +390,7 @@ func Test_SecretsWorker(t *testing.T) {
 			wl, err := syncerlimiter.NewWorkflowLimits(lggr, wlConfig)
 			require.NoError(t, err)
 
-			store := artifacts.NewStore(lggr, orm, fetcherFn, clockwork.NewFakeClock(), encryptionKey, emitter)
+			store := artifacts.NewStore(lggr, orm, nil, fetcherFn, clockwork.NewFakeClock(), encryptionKey, emitter)
 
 			engineRegistry := syncer.NewEngineRegistry()
 
@@ -573,7 +573,7 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyPaused(t *testing.T) {
 	wl, err := syncerlimiter.NewWorkflowLimits(lggr, wlConfig)
 	require.NoError(t, err)
 
-	store := artifacts.NewStore(lggr, orm, fetcherFn, clockwork.NewFakeClock(), workflowkey.Key{}, emitter)
+	store := artifacts.NewStore(lggr, orm, nil, fetcherFn, clockwork.NewFakeClock(), workflowkey.Key{}, emitter)
 
 	handler, err := syncer.NewEventHandler(lggr, nil, nil, er, emitter, rl, wl, store)
 	require.NoError(t, err)
@@ -676,7 +676,7 @@ func Test_RegistrySyncer_WorkflowRegistered_InitiallyActivated(t *testing.T) {
 	wl, err := syncerlimiter.NewWorkflowLimits(lggr, wlConfig)
 	require.NoError(t, err)
 
-	store := artifacts.NewStore(lggr, orm, fetcherFn, clockwork.NewFakeClock(), workflowkey.Key{}, emitter)
+	store := artifacts.NewStore(lggr, orm, nil, fetcherFn, clockwork.NewFakeClock(), workflowkey.Key{}, emitter)
 
 	handler, err := syncer.NewEventHandler(lggr, nil, nil, er,
 		emitter, rl, wl, store, syncer.WithStaticEngine(&mockService{}))

--- a/core/services/standardcapabilities/delegate.go
+++ b/core/services/standardcapabilities/delegate.go
@@ -50,6 +50,7 @@ type Delegate struct {
 	peerWrapper             *ocrcommon.SingletonPeerWrapper
 	newOracleFactoryFn      NewOracleFactoryFn
 	computeFetcherFactoryFn compute.FetcherFactory
+	wasmBinaryStore         compute.WasmBinaryStore
 	selectorOpts            []func(*webapi.RoundRobinSelector)
 
 	isNewlyCreatedJob bool
@@ -77,6 +78,7 @@ func NewDelegate(
 	peerWrapper *ocrcommon.SingletonPeerWrapper,
 	newOracleFactoryFn NewOracleFactoryFn,
 	fetcherFactoryFn compute.FetcherFactory,
+	wasmBinaryStore compute.WasmBinaryStore,
 	opts ...func(*webapi.RoundRobinSelector),
 ) *Delegate {
 	return &Delegate{
@@ -94,6 +96,7 @@ func NewDelegate(
 		peerWrapper:             peerWrapper,
 		newOracleFactoryFn:      newOracleFactoryFn,
 		computeFetcherFactoryFn: fetcherFactoryFn,
+		wasmBinaryStore:         wasmBinaryStore,
 		selectorOpts:            opts,
 	}
 }
@@ -273,7 +276,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 			return nil, errors.New("config is empty")
 		}
 
-		computeSrvc, err := compute.NewAction(cfg, log, d.registry, fetcherFactoryFn)
+		computeSrvc, err := compute.NewAction(cfg, log, d.registry, fetcherFactoryFn, d.wasmBinaryStore)
 		if err != nil {
 			return nil, err
 		}

--- a/core/services/workflows/artifacts/file_based_module_store.go
+++ b/core/services/workflows/artifacts/file_based_module_store.go
@@ -1,0 +1,106 @@
+package artifacts
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type FileBasedModuleStore struct {
+	storeDir string
+	mux      sync.Mutex
+}
+
+func NewFileBasedModuleStore(storeDir string) (*FileBasedModuleStore, error) {
+	storeDir = filepath.Join(storeDir, "serialised_modules")
+	err := os.MkdirAll(storeDir, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create store directory: %w", err)
+	}
+	return &FileBasedModuleStore{storeDir: storeDir}, nil
+}
+
+func (s *FileBasedModuleStore) StoreModule(workflowID string, binaryID string, module []byte) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	workflowDir := filepath.Join(s.storeDir, workflowID)
+	err := os.MkdirAll(workflowDir, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create workflow directory: %w", err)
+	}
+
+	serialisedModuleFile := filepath.Join(workflowDir, binaryID)
+	err = os.WriteFile(serialisedModuleFile, module, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to store module: %w", err)
+	}
+	return nil
+}
+
+// GetModulePath retrieves the path to the serialised module for the given workflow ID. Returns the path, a boolean indicating
+// whether the module was found, and an error if one occurred.
+func (s *FileBasedModuleStore) GetModulePath(workflowID string) (string, bool, error) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	workflowDir := filepath.Join(s.storeDir, workflowID)
+	if _, err := os.Stat(workflowDir); os.IsNotExist(err) {
+		return "", false, nil
+	}
+
+	// Get the first file in the directory
+	files, err := os.ReadDir(workflowDir)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to read the workflow directory: %w", err)
+	}
+	// Should only be one file in the directory
+	if len(files) == 0 {
+		return "", false, errors.New("no serialised binary found")
+	}
+
+	if len(files) > 1 {
+		return "", false, fmt.Errorf("unexpected number of files (%d) in the workflow directory", len(files))
+	}
+
+	binaryDir := filepath.Join(workflowDir, files[0].Name())
+	return binaryDir, true, nil
+}
+
+// GetBinaryID retrieves the wasm binary ID for the given workflow ID. Returns the binary ID, a boolean indicating
+// whether the binary ID for the module was found, and an error if one occurred.
+func (s *FileBasedModuleStore) GetBinaryID(workflowID string) (string, bool, error) {
+	modulePath, exists, err := s.GetModulePath(workflowID)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get module path: %w", err)
+	}
+
+	if !exists {
+		return "", false, nil
+	}
+
+	// get the last part of the path, this is the binary ID
+	_, binaryID := filepath.Split(modulePath)
+
+	return binaryID, true, nil
+}
+
+// DeleteModule deletes the serialised module for the given workflow ID. Returns a boolean indicating whether the module was
+// deleted and an error if one occurred.
+func (s *FileBasedModuleStore) DeleteModule(workflowID string) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	workflowDir := filepath.Join(s.storeDir, workflowID)
+
+	if _, err := os.Stat(workflowDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	if err := os.RemoveAll(workflowDir); err != nil {
+		return fmt.Errorf("failed to delete workflow dir: %w", err)
+	}
+	return nil
+}

--- a/core/services/workflows/artifacts/file_based_module_store_test.go
+++ b/core/services/workflows/artifacts/file_based_module_store_test.go
@@ -1,0 +1,68 @@
+package artifacts
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerialisedModuleStore(t *testing.T) {
+	storeDir := t.TempDir()
+	store, err := NewFileBasedModuleStore(storeDir)
+	storeDir = filepath.Join(storeDir, "serialised_modules")
+
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	workflowID := "test-workflow"
+	dataString := "test module data"
+
+	moduleData := []byte(dataString)
+
+	// Test StoreModule
+	binaryID := "binaryID"
+	err = store.StoreModule(workflowID, binaryID, moduleData)
+	require.NoError(t, err)
+
+	// Verify the file was created
+	filePath := filepath.Join(storeDir, workflowID, binaryID)
+	_, err = os.Stat(filePath)
+	require.NoError(t, err)
+
+	// Test GetModule
+	path, exists, err := store.GetModulePath(workflowID)
+	require.NoError(t, err)
+	assert.True(t, exists, "expected module to exist")
+
+	// read in the file at path and check it matches original data
+	bytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, moduleData, bytes, "expected module data to match")
+
+	// Test getting the binary ID for a given workflow ID
+	binaryID, exists, err = store.GetBinaryID(workflowID)
+	require.NoError(t, err)
+	assert.True(t, exists, "expected binary ID to exist")
+	assert.Equal(t, "binaryID", binaryID, "expected binary ID to match")
+
+	// Test DeleteModule
+	err = store.DeleteModule(workflowID)
+	if err != nil {
+		t.Fatalf("failed to delete module: %v", err)
+	}
+
+	// Verify the file was deleted
+	if _, err = os.Stat(filePath); !os.IsNotExist(err) {
+		t.Fatalf("expected file %s to be deleted", filePath)
+	}
+
+	// Test GetModule for non-existent module
+	_, exists, err = store.GetModulePath(workflowID)
+	require.NoError(t, err)
+	assert.False(t, exists, "expected module to not exist")
+}

--- a/core/services/workflows/artifacts/store_test.go
+++ b/core/services/workflows/artifacts/store_test.go
@@ -69,6 +69,7 @@ func Test_Handler_SecretsFor(t *testing.T) {
 	h := NewStore(
 		lggr,
 		orm,
+		nil,
 		fetcher.Fetch,
 		clockwork.NewFakeClock(),
 		encryptionKey,
@@ -132,6 +133,7 @@ func Test_Handler_SecretsFor_RefreshesSecrets(t *testing.T) {
 	h := NewStore(
 		lggr,
 		orm,
+		nil,
 		fetcher.Fetch,
 		clockwork.NewFakeClock(),
 		encryptionKey,
@@ -198,6 +200,7 @@ func Test_Handler_SecretsFor_RefreshLogic(t *testing.T) {
 	h := NewStore(
 		lggr,
 		orm,
+		nil,
 		fetcher.Fetch,
 		clock,
 		encryptionKey,

--- a/core/services/workflows/delegate.go
+++ b/core/services/workflows/delegate.go
@@ -51,12 +51,6 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 		return nil, err
 	}
 
-	binary, err := spec.WorkflowSpec.RawSpec(ctx)
-	if err != nil {
-		logCustMsg(ctx, cma, fmt.Sprintf("failed to start workflow engine: failed to fetch workflow spec binary: %v", err), d.logger)
-		return nil, err
-	}
-
 	config, err := spec.WorkflowSpec.GetConfig(ctx)
 	if err != nil {
 		logCustMsg(ctx, cma, fmt.Sprintf("failed to start workflow engine: failed to get workflow spec config: %v", err), d.logger)
@@ -72,7 +66,6 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 		Registry:       d.registry,
 		Store:          d.store,
 		Config:         config,
-		Binary:         binary,
 		SecretsFetcher: d.secretsFetcher,
 		RateLimiter:    d.ratelimiter,
 		WorkflowLimits: d.workflowLimits,

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -1322,7 +1322,6 @@ type Config struct {
 	MaxExecutionDuration time.Duration
 	Store                store.Store
 	Config               []byte
-	Binary               []byte
 	SecretsFetcher       SecretsFor
 	HeartbeatCadence     time.Duration
 	StepTimeout          time.Duration
@@ -1481,7 +1480,6 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 		secretsFetcher: cfg.SecretsFetcher,
 		env: exec.Env{
 			Config: cfg.Config,
-			Binary: cfg.Binary,
 		},
 		executionsStore:      cfg.Store,
 		pendingStepRequests:  make(chan stepRequest, cfg.QueueSize),

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.52
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19
 	github.com/smartcontractkit/chainlink-deployments-framework v0.0.4
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250402142713-6529d36f91f3

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.52
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
 	github.com/smartcontractkit/chainlink-deployments-framework v0.0.4
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250402142713-6529d36f91f3

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1219,8 +1219,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19 h1:cmDDnYCtyXqUotTJvDLD0cGMoAYOyMSWSa3GNyJUjrA=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1219,8 +1219,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1 h1:qYv7f++PMP3mEAd1QYLmBmyqKr0036Z1XqIrr19QpC8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2143,6 +2143,19 @@ foo = "bar" # Example
 ```
 foo is an example resource attribute
 
+## Wasm
+```toml
+[Wasm]
+SerialisedModulesDir = '/path/to/serialised/modules' # Example
+```
+Wasm holds settings for the WebAssembly runtime.
+
+### SerialisedModulesDir
+```toml
+SerialisedModulesDir = '/path/to/serialised/modules' # Example
+```
+SerialisedModulesDir is the directory where the serialised Wasm modules are stored
+
 ## EVM
 EVM defaults depend on ChainID:
 

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135

--- a/go.sum
+++ b/go.sum
@@ -1054,8 +1054,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1 h1:qYv7f++PMP3mEAd1QYLmBmyqKr0036Z1XqIrr19QpC8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/go.sum
+++ b/go.sum
@@ -1054,8 +1054,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19 h1:cmDDnYCtyXqUotTJvDLD0cGMoAYOyMSWSa3GNyJUjrA=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1455,8 +1455,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1 h1:qYv7f++PMP3mEAd1QYLmBmyqKr0036Z1XqIrr19QpC8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1455,8 +1455,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19 h1:cmDDnYCtyXqUotTJvDLD0cGMoAYOyMSWSa3GNyJUjrA=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.52
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.4
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.52
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.4
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1436,8 +1436,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1 h1:qYv7f++PMP3mEAd1QYLmBmyqKr0036Z1XqIrr19QpC8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1436,8 +1436,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19 h1:cmDDnYCtyXqUotTJvDLD0cGMoAYOyMSWSa3GNyJUjrA=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/smartcontractkit/chain-selectors v1.0.52
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.4

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/smartcontractkit/chain-selectors v1.0.52
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.4

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1207,8 +1207,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19 h1:cmDDnYCtyXqUotTJvDLD0cGMoAYOyMSWSa3GNyJUjrA=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1207,8 +1207,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1 h1:qYv7f++PMP3mEAd1QYLmBmyqKr0036Z1XqIrr19QpC8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/shopspring/decimal v1.4.0
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/shopspring/decimal v1.4.0
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1411,8 +1411,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1 h1:qYv7f++PMP3mEAd1QYLmBmyqKr0036Z1XqIrr19QpC8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250423184741-8b59e5dd60e1/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1411,8 +1411,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6/go.mod h1:Jb05WL6lj5H89XGcaaOinxTf4Gdj+vXO4TcUhqTgqIM=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4 h1:ujhHdxB3+K6lOnhku7lqpj3WsoOhyvOAAkdsGtwon/o=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250411163110-21a13ceb3ac4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3 h1:gw2UySIExN4Y40ZK8qgDPj/MJ4mEyOS9/zdaV6Jo7e8=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424155951-46e594cfdef3/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19 h1:cmDDnYCtyXqUotTJvDLD0cGMoAYOyMSWSa3GNyJUjrA=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425090226-f07315c88a19/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=


### PR DESCRIPTION
Part of https://smartcontract-it.atlassian.net/browse/CAPPL-401


### Requires
https://github.com/smartcontractkit/chainlink-common/pull/1027
https://github.com/smartcontractkit/chainlink/pull/16381. - PR is to simplify the review of this PR

**Results from load testing with and without the changes in this PR are summarised in the spreadsheet below.**   

Sheet A:  Shows the mem (21GB at peak), cpu usage taken to run **50 workflows** without the changes in this PR.  The time taken to start all 50 workflows can be inferred from the data and in this case is 3 minutes and 39 seconds.

Sheet B: Shows the mem (2.3GB at peak), cpu usage taken to run **200 workflows** with the changes in this PR.  The time taken to start all 200 workflows is 2 minutes and 6 seconds.

Sheet C: Shows the mem (4GB at. peak), cpu usage taken to run **200 workflows** using an alternative implementation that does not use wasmtime memory mapping to load modules on demand.  The time taken to start all 200 workflows is 2 minutes and 1 second.  This sheet is included here for completeness as an alternative to using wasmtime memory mapping should that be required (no reason we know of at the moment why this would be so).

https://docs.google.com/spreadsheets/d/18Y3xeVmkW6xnEq6mMqdkhPXzTvz-4beuhEFl5K-GwV4/edit?usp=sharing

**Summary of the load test method:**

The load test used a workflow similar to POR (see the wasm file in dir templateworkflowwasmfile) with the only difference being that it is writing to a write target that captures the output and statistics on when the workflow started and finished.  Each workflow used in the test is an instance of a unique workflow wasm, i.e. its not using 200 instances of the same workflow. The load test is setup to split the workflow triggering times over 1 minute, so in the case of 200 workflows 3 to 4 workflows will run every second.  

