### PR TITLE
fix(cre-297): unique id per execution step

### DIFF
--- a/.changeset/fuzzy-pugs-provide.md
+++ b/.changeset/fuzzy-pugs-provide.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal #bugfix correct request id to support parallel step execution

--- a/core/capabilities/remote/executable/request/client_request.go
+++ b/core/capabilities/remote/executable/request/client_request.go
@@ -61,7 +61,9 @@ func NewClientExecuteRequest(ctx context.Context, lggr logger.Logger, req common
 		return nil, fmt.Errorf("workflow execution ID is invalid: %w", err)
 	}
 
-	requestID := types.MethodExecute + ":" + workflowExecutionID
+	// the requestID must be delineated by the workflow execution ID and the reference ID
+	// to ensure that it supports parallel step execution
+	requestID := types.MethodExecute + ":" + workflowExecutionID + ":" + req.Metadata.ReferenceID
 
 	tc, err := transmission.ExtractTransmissionConfig(req.Config)
 	if err != nil {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[CRE-297](https://smartcontract-it.atlassian.net/browse/CRE-297)

Ensure that requests are unique per execution and step so that we correctly support parallel steps
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-297]: https://smartcontract-it.atlassian.net/browse/CRE-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ