### PR TITLE
chore: disable solana artifact builds for certain tests

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -176,15 +176,15 @@ jobs:
         type:
           - cmd: go_core_tests
             os: ubuntu22.04-32cores-128GB
-            printResults: true
+            build-solana-artifacts: 'false'
           - cmd: go_core_tests_integration
             os: ubuntu22.04-32cores-128GB
-            printResults: true
+            build-solana-artifacts: 'false'
           - cmd: go_core_ccip_deployment_tests
             os: ubuntu22.04-32cores-128GB
-            printResults: true
           - cmd: go_core_fuzz
             os: ubuntu22.04-8cores-32GB
+            build-solana-artifacts: 'false'
           - cmd: go_core_race_tests
             # use 64cores for certain scheduled runs only
             os: ${{ needs.run-frequency.outputs.two-per-day-frequency == 'true' && 'ubuntu-latest-64cores-256GB' || 'ubuntu-latest-32cores-128GB' }}
@@ -230,7 +230,8 @@ jobs:
         uses: ./.github/actions/setup-solana
 
       - name: Build Solana artifacts
-        if: ${{ needs.filter.outputs.should-run-ci-core == 'true' }}
+        # do not build for core tests, core 'integration' tests, or fuzz tests
+        if: ${{ needs.filter.outputs.should-run-ci-core == 'true' && matrix.type.build-solana-artifacts != 'false' }}
         uses: ./.github/actions/setup-solana/build-contracts
 
       - name: Setup wasmd


### PR DESCRIPTION
### Changes

Disables the "Build Solana artifacts" step for:
- core tests
- core 'integration' tests
- core fuzz tests


### Motivation

- This step is not needed for these test suites
- This step is taking 7-9 minutes each time it is run
    - At the current frequency is adding significant costs to our CI.





