### PR TITLE
fix(cre-300): allow state view missing evm

### DIFF
--- a/deployment/common/view/nops.go
+++ b/deployment/common/view/nops.go
@@ -36,7 +36,9 @@ type OCRKeyView struct {
 func GenerateNopsView(nodeIds []string, oc deployment.OffchainClient) (map[string]NopView, error) {
 	nv := make(map[string]NopView)
 	nodes, err := deployment.NodeInfo(nodeIds, oc)
-	if err != nil {
+	if errors.Is(err, deployment.ErrMissingNodeMetadata) {
+		fmt.Println("WARNING: Missing node metadata:\n%s", err.Error())
+	} else if err != nil {
 		return nv, err
 	}
 	for _, node := range nodes {

--- a/deployment/common/view/nops.go
+++ b/deployment/common/view/nops.go
@@ -33,11 +33,11 @@ type OCRKeyView struct {
 	KeyBundleID               string `json:"keyBundleID"`
 }
 
-func GenerateNopsView(nodeIds []string, oc deployment.OffchainClient) (map[string]NopView, error) {
+func GenerateNopsView(nodeIDs []string, oc deployment.OffchainClient) (map[string]NopView, error) {
 	nv := make(map[string]NopView)
-	nodes, err := deployment.NodeInfo(nodeIds, oc)
+	nodes, err := deployment.NodeInfo(nodeIDs, oc)
 	if errors.Is(err, deployment.ErrMissingNodeMetadata) {
-		fmt.Println("WARNING: Missing node metadata:\n%s", err.Error())
+		fmt.Printf("WARNING: Missing node metadata:\n%s", err.Error())
 	} else if err != nil {
 		return nv, err
 	}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[CRE-300](https://smartcontract-it.atlassian.net/browse/CRE-300)

new validation was too strict for downstream consumers; add explicit errors to for consumers to handle and fix the state view to WARN on missing node metadata


### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-300]: https://smartcontract-it.atlassian.net/browse/CRE-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ