### PR TITLE
fix: compilation errors due to build cache

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -279,7 +279,10 @@ jobs:
         env:
           OUTPUT_FILE: ./output.txt
           CL_DATABASE_URL: ${{ env.DB_URL }}
-        run: ./tools/bin/${{ matrix.type.cmd }} ./...
+        run: |
+          # See: https://github.com/golang/go/issues/69179
+          GODEBUG=goindex=0
+          ./tools/bin/${{ matrix.type.cmd }} ./...
 
       - name: Print Races
         id: print-races


### PR DESCRIPTION
We have seen compilation errors multiple times. This is seemingly due to a weird edge case with build caches.

Examples:
- Restore build cache from develop: https://github.com/smartcontractkit/chainlink/actions/runs/13294343412/job/37122743862?pr=16360
   - With debug info showing that the module exists in the module cache
- Full cache bust (no compilation errors): https://github.com/smartcontractkit/chainlink/actions/runs/13293709210/job/37120428599?pr=16360

### Solution

After coming across https://github.com/golang/go/issues/69179. Seems like its the module index that is not being handled properly in certain cases when restoring the build cache.

- "I don't think disabling the module index should cause any correctness problems."
	```
	export GODEBUG=goindex=0
	```

### Further Notes

From what I understand the build cache uses a module index to resolve modules during the build step. If that module index doesn't correspond to the go module cache properly  (ie. a `go.mod` was updated after the build cache was populated) then the index may map improperly causing compilation errors.

The two solutions I see for this is:
1. This change - disabling the go module index
2. Restricting build cache restores
    1. The build cache can restore from caches that are keyed with previous hashes of the `go.mod`, we could restrict it so it cannot do that. I'm *guessing* this would also fix the issue.

