### PR TITLE
fix(services/feeds): only check for standard cap spec by ext job id

### DIFF
--- a/.changeset/pink-singers-greet.md
+++ b/.changeset/pink-singers-greet.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+fixes inability to approve multiple jobs with same command for standard capabilities

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -894,12 +894,8 @@ func (s *service) ApproveSpec(ctx context.Context, id int64, force bool) error {
 					return fmt.Errorf("failed while checking for existing ccip job: %w", txerr)
 				}
 			case job.StandardCapabilities:
-				existingJobID, txerr = tx.jobORM.FindStandardCapabilityJobID(ctx, *j.StandardCapabilitiesSpec)
-				// Return an error if the repository errors. If there is a not found
-				// error we want to continue with approving the job.
-				if txerr != nil && !errors.Is(txerr, sql.ErrNoRows) {
-					return fmt.Errorf("failed while checking for existing standard capabilities job: %w", txerr)
-				}
+				// Only possible to match standard capabilities by external job id
+				// no-op
 			case job.Gateway:
 				existingJobID, txerr = tx.jobORM.FindGatewayJobID(ctx, *j.GatewaySpec)
 				// Return an error if the repository errors. If there is a not found


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
