### PR TITLE
fix: execute all operations from proposals when using new mcms lib

### DIFF
--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -79,16 +79,10 @@ func ApplyChangesets(t *testing.T, e deployment.Environment, timelockContractsPe
 					chains.Add(uint64(op.ChainSelector))
 				}
 
-				p := proposalutils.SignMCMSTimelockProposal(t, e, &prop)
-				for _, sel := range chains.ToSlice() {
-					timelockContracts, ok := timelockContractsPerChain[sel]
-					if !ok || timelockContracts == nil {
-						return deployment.Environment{}, fmt.Errorf("timelock contracts not found for chain %d", sel)
-					}
+				mcmProp := proposalutils.SignMCMSTimelockProposal(t, e, &prop)
+				proposalutils.ExecuteMCMSProposalV2(t, e, mcmProp)
 
-					proposalutils.ExecuteMCMSProposalV2(t, e, p, sel)
-					proposalutils.ExecuteMCMSTimelockProposalV2(t, e, &prop, sel)
-				}
+				proposalutils.ExecuteMCMSTimelockProposalV2(t, e, &prop)
 			}
 		}
 		if out.MCMSProposals != nil {
@@ -99,9 +93,7 @@ func ApplyChangesets(t *testing.T, e deployment.Environment, timelockContractsPe
 				}
 
 				p := proposalutils.SignMCMSProposal(t, e, &prop)
-				for _, sel := range chains.ToSlice() {
-					proposalutils.ExecuteMCMSProposalV2(t, e, p, sel)
-				}
+				proposalutils.ExecuteMCMSProposalV2(t, e, p)
 			}
 		}
 		currentEnv = deployment.Environment{

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -74,24 +74,13 @@ func ApplyChangesets(t *testing.T, e deployment.Environment, timelockContractsPe
 		}
 		if out.MCMSTimelockProposals != nil {
 			for _, prop := range out.MCMSTimelockProposals {
-				chains := mapset.NewSet[uint64]()
-				for _, op := range prop.Operations {
-					chains.Add(uint64(op.ChainSelector))
-				}
-
 				mcmProp := proposalutils.SignMCMSTimelockProposal(t, e, &prop)
 				proposalutils.ExecuteMCMSProposalV2(t, e, mcmProp)
-
 				proposalutils.ExecuteMCMSTimelockProposalV2(t, e, &prop)
 			}
 		}
 		if out.MCMSProposals != nil {
 			for _, prop := range out.MCMSProposals {
-				chains := mapset.NewSet[uint64]()
-				for _, op := range prop.Operations {
-					chains.Add(uint64(op.ChainSelector))
-				}
-
 				p := proposalutils.SignMCMSProposal(t, e, &prop)
 				proposalutils.ExecuteMCMSProposalV2(t, e, p)
 			}

--- a/deployment/common/proposalutils/mcms_test_helpers.go
+++ b/deployment/common/proposalutils/mcms_test_helpers.go
@@ -172,51 +172,66 @@ func SignMCMSProposal(t *testing.T, env deployment.Environment, proposal *mcmsli
 }
 
 // ExecuteMCMSProposalV2 - Executes an MCMS proposal on a chain. For timelock proposal, use ExecuteMCMSTimelockProposalV2 instead.
-func ExecuteMCMSProposalV2(t *testing.T, env deployment.Environment, proposal *mcmslib.Proposal, sel uint64) {
-	t.Log("Executing proposal on chain", sel)
+func ExecuteMCMSProposalV2(t *testing.T, env deployment.Environment, proposal *mcmslib.Proposal) {
+	t.Log("Executing proposal")
 
-	executorsMap := map[types.ChainSelector]sdk.Executor{}
 	encoders, err := proposal.GetEncoders()
 	require.NoError(t, err)
 
-	family, err := chainsel.GetSelectorFamily(sel)
-	require.NoError(t, err)
+	executorsMap := map[types.ChainSelector]sdk.Executor{}
+	chainSelectors := map[types.ChainSelector]struct{}{}
+	for _, op := range proposal.Operations {
+		family, err := chainsel.GetSelectorFamily(uint64(op.ChainSelector))
+		require.NoError(t, err)
 
-	chainSel := types.ChainSelector(sel)
+		chainSelectors[op.ChainSelector] = struct{}{}
 
-	switch family {
-	case chainsel.FamilyEVM:
-		encoder := encoders[chainSel].(*evm.Encoder)
-		chain := env.Chains[sel]
-		executorsMap[chainSel] = evm.NewExecutor(encoder, chain.Client, chain.DeployerKey)
-	case chainsel.FamilySolana:
-		encoder := encoders[chainSel].(*solana.Encoder)
-		chain := env.SolChains[sel]
-		executorsMap[chainSel] = solana.NewExecutor(encoder, chain.Client, *chain.DeployerKey)
-	default:
-		require.FailNow(t, "unsupported chain family")
+		switch family {
+		case chainsel.FamilyEVM:
+			encoder := encoders[op.ChainSelector].(*evm.Encoder)
+			executorsMap[op.ChainSelector] = evm.NewExecutor(
+				encoder,
+				env.Chains[uint64(op.ChainSelector)].Client,
+				env.Chains[uint64(op.ChainSelector)].DeployerKey)
+		case chainsel.FamilySolana:
+			encoder := encoders[op.ChainSelector].(*solana.Encoder)
+			executorsMap[op.ChainSelector] = solana.NewExecutor(
+				encoder,
+				env.SolChains[uint64(op.ChainSelector)].Client,
+				*env.SolChains[uint64(op.ChainSelector)].DeployerKey)
+		default:
+			require.FailNow(t, "unsupported chain family")
+		}
 	}
 
 	executable, err := mcmslib.NewExecutable(proposal, executorsMap)
 	require.NoError(t, err)
 
-	root, err := executable.SetRoot(env.GetContext(), chainSel)
-	require.NoError(t, deployment.MaybeDataErr(err))
+	for chainSelector := range chainSelectors {
+		root, err := executable.SetRoot(env.GetContext(), chainSelector)
+		require.NoError(t, deployment.MaybeDataErr(err))
 
-	// no need to confirm transaction on solana as the MCMS sdk confirms it internally
-	if family == chainsel.FamilyEVM {
-		chain := env.Chains[sel]
-		evmTransaction := root.RawTransaction.(*gethtypes.Transaction)
-		_, err = chain.Confirm(evmTransaction)
+		family, err := chainsel.GetSelectorFamily(uint64(chainSelector))
 		require.NoError(t, err)
+
+		// no need to confirm transaction on solana as the MCMS sdk confirms it internally
+		if family == chainsel.FamilyEVM {
+			chain := env.Chains[uint64(chainSelector)]
+			evmTransaction := root.RawTransaction.(*gethtypes.Transaction)
+			_, err = chain.Confirm(evmTransaction)
+			require.NoError(t, err)
+		}
 	}
 
-	for i := range proposal.Operations {
+	for i, op := range proposal.Operations {
 		result, err := executable.Execute(env.GetContext(), i)
 		require.NoError(t, err)
 
+		family, err := chainsel.GetSelectorFamily(uint64(op.ChainSelector))
+		require.NoError(t, err)
+
 		if family == chainsel.FamilyEVM {
-			chain := env.Chains[sel]
+			chain := env.Chains[uint64(op.ChainSelector)]
 			evmTransaction := result.RawTransaction.(*gethtypes.Transaction)
 			_, err = chain.Confirm(evmTransaction)
 			require.NoError(t, err)
@@ -226,24 +241,26 @@ func ExecuteMCMSProposalV2(t *testing.T, env deployment.Environment, proposal *m
 
 // ExecuteMCMSTimelockProposalV2 - Includes an option to set callProxy to execute the calls through a proxy.
 // If the callProxy is not set, the calls will be executed directly to the timelock.
-func ExecuteMCMSTimelockProposalV2(t *testing.T, env deployment.Environment, timelockProposal *mcmslib.TimelockProposal, sel uint64, opts ...mcmslib.Option) {
-	t.Log("Executing timelock proposal on chain", sel)
+func ExecuteMCMSTimelockProposalV2(t *testing.T, env deployment.Environment, timelockProposal *mcmslib.TimelockProposal, opts ...mcmslib.Option) {
+	t.Log("Executing timelock proposal")
 
 	tExecutors := map[types.ChainSelector]sdk.TimelockExecutor{}
-	family, err := chainsel.GetSelectorFamily(sel)
-	require.NoError(t, err)
+	for _, op := range timelockProposal.Operations {
+		family, err := chainsel.GetSelectorFamily(uint64(op.ChainSelector))
+		require.NoError(t, err)
 
-	switch family {
-	case chainsel.FamilyEVM:
-		tExecutors[types.ChainSelector(sel)] = evm.NewTimelockExecutor(
-			env.Chains[sel].Client,
-			env.Chains[sel].DeployerKey)
-	case chainsel.FamilySolana:
-		tExecutors[types.ChainSelector(sel)] = solana.NewTimelockExecutor(
-			env.SolChains[sel].Client,
-			*env.SolChains[sel].DeployerKey)
-	default:
-		require.FailNow(t, "unsupported chain family")
+		switch family {
+		case chainsel.FamilyEVM:
+			tExecutors[op.ChainSelector] = evm.NewTimelockExecutor(
+				env.Chains[uint64(op.ChainSelector)].Client,
+				env.Chains[uint64(op.ChainSelector)].DeployerKey)
+		case chainsel.FamilySolana:
+			tExecutors[op.ChainSelector] = solana.NewTimelockExecutor(
+				env.SolChains[uint64(op.ChainSelector)].Client,
+				*env.SolChains[uint64(op.ChainSelector)].DeployerKey)
+		default:
+			require.FailNow(t, "unsupported chain family")
+		}
 	}
 
 	timelockExecutable, err := mcmslib.NewTimelockExecutable(timelockProposal, tExecutors)
@@ -253,13 +270,16 @@ func ExecuteMCMSTimelockProposalV2(t *testing.T, env deployment.Environment, tim
 	require.NoError(t, err)
 
 	var tx = types.TransactionResult{}
-	for i := range timelockProposal.Operations {
+	for i, op := range timelockProposal.Operations {
 		tx, err = timelockExecutable.Execute(env.GetContext(), i, opts...)
+		require.NoError(t, err)
+
+		family, err := chainsel.GetSelectorFamily(uint64(op.ChainSelector))
 		require.NoError(t, err)
 
 		// no need to confirm transaction on solana as the MCMS sdk confirms it internally
 		if family == chainsel.FamilyEVM {
-			chain := env.Chains[sel]
+			chain := env.Chains[uint64(op.ChainSelector)]
 			evmTransaction := tx.RawTransaction.(*gethtypes.Transaction)
 			_, err = chain.Confirm(evmTransaction)
 			require.NoError(t, err)

--- a/deployment/common/proposalutils/mcms_test_helpers.go
+++ b/deployment/common/proposalutils/mcms_test_helpers.go
@@ -178,13 +178,11 @@ func ExecuteMCMSProposalV2(t *testing.T, env deployment.Environment, proposal *m
 	encoders, err := proposal.GetEncoders()
 	require.NoError(t, err)
 
+	// build a map with chainSelector => executor
 	executorsMap := map[types.ChainSelector]sdk.Executor{}
-	chainSelectors := map[types.ChainSelector]struct{}{}
 	for _, op := range proposal.Operations {
 		family, err := chainsel.GetSelectorFamily(uint64(op.ChainSelector))
 		require.NoError(t, err)
-
-		chainSelectors[op.ChainSelector] = struct{}{}
 
 		switch family {
 		case chainsel.FamilyEVM:
@@ -207,7 +205,8 @@ func ExecuteMCMSProposalV2(t *testing.T, env deployment.Environment, proposal *m
 	executable, err := mcmslib.NewExecutable(proposal, executorsMap)
 	require.NoError(t, err)
 
-	for chainSelector := range chainSelectors {
+	// call SetRoot for each chain
+	for chainSelector := range executorsMap {
 		root, err := executable.SetRoot(env.GetContext(), chainSelector)
 		require.NoError(t, deployment.MaybeDataErr(err))
 
@@ -223,6 +222,7 @@ func ExecuteMCMSProposalV2(t *testing.T, env deployment.Environment, proposal *m
 		}
 	}
 
+	// execute each operation sequentially
 	for i, op := range proposal.Operations {
 		result, err := executable.Execute(env.GetContext(), i)
 		require.NoError(t, err)
@@ -244,18 +244,19 @@ func ExecuteMCMSProposalV2(t *testing.T, env deployment.Environment, proposal *m
 func ExecuteMCMSTimelockProposalV2(t *testing.T, env deployment.Environment, timelockProposal *mcmslib.TimelockProposal, opts ...mcmslib.Option) {
 	t.Log("Executing timelock proposal")
 
-	tExecutors := map[types.ChainSelector]sdk.TimelockExecutor{}
+	// build a "chainSelector => executor" map
+	executorsMap := map[types.ChainSelector]sdk.TimelockExecutor{}
 	for _, op := range timelockProposal.Operations {
 		family, err := chainsel.GetSelectorFamily(uint64(op.ChainSelector))
 		require.NoError(t, err)
 
 		switch family {
 		case chainsel.FamilyEVM:
-			tExecutors[op.ChainSelector] = evm.NewTimelockExecutor(
+			executorsMap[op.ChainSelector] = evm.NewTimelockExecutor(
 				env.Chains[uint64(op.ChainSelector)].Client,
 				env.Chains[uint64(op.ChainSelector)].DeployerKey)
 		case chainsel.FamilySolana:
-			tExecutors[op.ChainSelector] = solana.NewTimelockExecutor(
+			executorsMap[op.ChainSelector] = solana.NewTimelockExecutor(
 				env.SolChains[uint64(op.ChainSelector)].Client,
 				*env.SolChains[uint64(op.ChainSelector)].DeployerKey)
 		default:
@@ -263,12 +264,13 @@ func ExecuteMCMSTimelockProposalV2(t *testing.T, env deployment.Environment, tim
 		}
 	}
 
-	timelockExecutable, err := mcmslib.NewTimelockExecutable(timelockProposal, tExecutors)
+	timelockExecutable, err := mcmslib.NewTimelockExecutable(timelockProposal, executorsMap)
 	require.NoError(t, err)
 
 	err = timelockExecutable.IsReady(env.GetContext())
 	require.NoError(t, err)
 
+	// execute each operation sequentially
 	var tx = types.TransactionResult{}
 	for i, op := range timelockProposal.Operations {
 		tx, err = timelockExecutable.Execute(env.GetContext(), i, opts...)


### PR DESCRIPTION
As opposed to executing "per chain". The existing code that executed per chain was broken as it (1) did not build the executors map properly, (2) did not skip execution of operations from different chains in the inner for loop, and (3) uses the `IsReady` call, which checks the readiness of *all* operations, regardless of chain.

The new implementations simply executes all the proposal operations, in order, regardless of chain. It seems to suit the requirements of the existing changeset tests.