### PR TITLE
don't enforce ccip tag format in package.json

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -43,16 +43,6 @@ jobs:
       - name: Check release tag
         id: release-tag-check
         uses: smartcontractkit/.github/actions/release-tag-check@c5c4a8186da4218cff6cac8184e47dd3dec69ba3 # release-tag-check@0.1.0
-      - name: Fail if CCIP release has wrong version
-        if: ${{ steps.check-git-tag-type.outputs.git-tag-type == 'ccip' }}
-        run: |
-          version=$(jq -r '.version' ./package.json)
-          echo "Package version: $version"
-          echo "Git tag type: ${{ steps.check-git-tag-type.outputs.git-tag-type }}"
-          if [[ $version != *"-ccip"* ]]; then
-            echo "Error: Version '$version' does not match required CCIP format."
-            exit 1
-          fi
       - name: Check for VERSION file bump on tags
         # Avoids checking VERSION file bump on forks or from CCIP releases.
         if: ${{ github.repository == 'smartcontractkit/chainlink' && steps.check-git-tag-type.outputs.git-tag-type == 'core' }}


### PR DESCRIPTION
CCIP releases are going to reuse Core's package.json instead of coming up with our file. 
It simplifies the process, because CCIP release branches are mergeable and there is no drift between the Core and CCIP. 