### PR TITLE
fix: disable go module index during ci-core tests

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -277,7 +277,10 @@ jobs:
         env:
           OUTPUT_FILE: ./output.txt
           CL_DATABASE_URL: ${{ env.DB_URL }}
-        run: ./tools/bin/${{ matrix.type.cmd }} ./...
+        run: |
+          # See: https://github.com/golang/go/issues/69179
+          GODEBUG=goindex=0
+          ./tools/bin/${{ matrix.type.cmd }} ./...
 
       - name: Print Races
         id: print-races


### PR DESCRIPTION
### Changes

- Disables the go module index before running tests

### Notes

- This was previously added in #16362
- And removed in #16371

From #16362:
> From what I understand the build cache uses a module index to resolve modules during the build step. If that module index doesn't correspond to the go module cache properly  (ie. a `go.mod` was updated after the build cache was populated) then the index may map improperly causing compilation errors.
> 
> The two solutions I see for this is:
> 1. This change - disabling the go module index
> 2. Restricting build cache restores
>    1. The build cache can restore from caches that are keyed with previous hashes of the `go.mod`, we could > restrict it so it cannot do that. I'm *guessing* this would also fix the issue.

It appears that we encountered two related but different issues in which we need both solutions if we want to keep utilizing the build cache.
