### PR TITLE
Install foundry in solidity publish jobs

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -217,6 +217,11 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/setup-nodejs
 
+      - name: Install Foundry
+        uses: ./chainlink/.github/actions/install-solidity-foundry
+        with:
+          working-directory: chainlink/contracts
+
       - name: Version package.json
         working-directory: contracts
         shell: bash
@@ -262,6 +267,11 @@ jobs:
 
       - name: Setup NodeJS
         uses: ./.github/actions/setup-nodejs
+
+      - name: Install Foundry
+        uses: ./chainlink/.github/actions/install-solidity-foundry
+        with:
+          working-directory: chainlink/contracts
 
       - name: Validate version
         working-directory: contracts

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -218,9 +218,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
 
       - name: Install Foundry
-        uses: ./chainlink/.github/actions/install-solidity-foundry
-        with:
-          working-directory: chainlink/contracts
+        uses: ./.github/actions/install-solidity-foundry
 
       - name: Version package.json
         working-directory: contracts
@@ -269,9 +267,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
 
       - name: Install Foundry
-        uses: ./chainlink/.github/actions/install-solidity-foundry
-        with:
-          working-directory: chainlink/contracts
+        uses: ./.github/actions/install-solidity-foundry
 
       - name: Validate version
         working-directory: contracts


### PR DESCRIPTION
Fixes:

```
❯ pnpm prepublishOnly

> @chainlink/contracts-ccip@1.6.0 prepublishOnly 
> pnpm compile


> @chainlink/contracts-ccip@1.6.0 compile
> ./scripts/native_solc_compile_all_ccip

 ┌──────────────────────────────────────────────┐
 │          Compiling CCIP contracts...         │
 └──────────────────────────────────────────────┘
Compiling OffRamp
./scripts/native_solc_compile_all_ccip: line 33: forge: command not found
 ELIFECYCLE  Command failed.
 ELIFECYCLE  Command failed with exit code 1.
 ```