### PR TITLE
[TT-1991] use github.sha in integration-tests workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -183,7 +183,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.keystone_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f4aa64e4bcb3cc7033a53581857a5fd768bc7e24
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@59ca3330cde92af5974cfb5ca2504e67fcf19db3
     with:
       workflow_name: Run Core Workflow Engine Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -226,7 +226,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f4aa64e4bcb3cc7033a53581857a5fd768bc7e24
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@59ca3330cde92af5974cfb5ca2504e67fcf19db3
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -267,7 +267,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f4aa64e4bcb3cc7033a53581857a5fd768bc7e24
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@59ca3330cde92af5974cfb5ca2504e67fcf19db3
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -312,7 +312,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f4aa64e4bcb3cc7033a53581857a5fd768bc7e24
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@59ca3330cde92af5974cfb5ca2504e67fcf19db3
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -354,7 +354,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f4aa64e4bcb3cc7033a53581857a5fd768bc7e24
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@59ca3330cde92af5974cfb5ca2504e67fcf19db3
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -183,7 +183,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.keystone_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1b7926104331b7c6c6f2700d67968b0c0c005813
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f4aa64e4bcb3cc7033a53581857a5fd768bc7e24
     with:
       workflow_name: Run Core Workflow Engine Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -226,7 +226,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1b7926104331b7c6c6f2700d67968b0c0c005813
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f4aa64e4bcb3cc7033a53581857a5fd768bc7e24
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -267,7 +267,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1b7926104331b7c6c6f2700d67968b0c0c005813
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f4aa64e4bcb3cc7033a53581857a5fd768bc7e24
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -312,7 +312,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1b7926104331b7c6c6f2700d67968b0c0c005813
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f4aa64e4bcb3cc7033a53581857a5fd768bc7e24
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -354,7 +354,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1b7926104331b7c6c6f2700d67968b0c0c005813
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@f4aa64e4bcb3cc7033a53581857a5fd768bc7e24
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,7 +35,7 @@ concurrency:
 
 env:
   # for run-test variables and environment
-  ENV_JOB_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests:${{ inputs.evm-ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+  ENV_JOB_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests:${{ inputs.evm-ref || github.sha }}
   CHAINLINK_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
   TEST_SUITE: smoke
   TEST_ARGS: -test.timeout 12m
@@ -152,7 +152,7 @@ jobs:
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
-          ref: ${{ inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          ref: ${{ inputs.cl_ref || github.sha }}
       - name: Setup Github Token
         if: ${{ inputs.evm-ref }}
         id: get-gh-token
@@ -168,7 +168,7 @@ jobs:
         with:
           tag_suffix: ${{ matrix.image.tag-suffix }}
           dockerfile: ${{ matrix.image.dockerfile }}
-          git_commit_sha: ${{ inputs.evm-ref || inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          git_commit_sha: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           dep_evm_sha: ${{ inputs.evm-ref }}
@@ -183,10 +183,10 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.keystone_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@e600c1954dacd5f4a2c24d49b81ab73cc9d75763
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1b7926104331b7c6c6f2700d67968b0c0c005813
     with:
       workflow_name: Run Core Workflow Engine Tests For PR
-      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: PR Workflow Engine E2E Core Tests
       upload_cl_node_coverage_artifact: true
@@ -226,10 +226,10 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@e600c1954dacd5f4a2c24d49b81ab73cc9d75763
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1b7926104331b7c6c6f2700d67968b0c0c005813
     with:
       workflow_name: Run Core E2E Tests For PR
-      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: PR E2E Core Tests
       upload_cl_node_coverage_artifact: true
@@ -267,10 +267,10 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@e600c1954dacd5f4a2c24d49b81ab73cc9d75763
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1b7926104331b7c6c6f2700d67968b0c0c005813
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
-      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: Merge Queue E2E Core Tests
       upload_cl_node_coverage_artifact: true
@@ -312,10 +312,10 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@e600c1954dacd5f4a2c24d49b81ab73cc9d75763
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1b7926104331b7c6c6f2700d67968b0c0c005813
     with:
       workflow_name: Run CCIP E2E Tests For PR
-      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: PR E2E CCIP Tests
       upload_cl_node_coverage_artifact: true
@@ -354,10 +354,10 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@e600c1954dacd5f4a2c24d49b81ab73cc9d75763
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1b7926104331b7c6c6f2700d67968b0c0c005813
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
-      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: Merge Queue E2E CCIP Tests
       upload_cl_node_coverage_artifact: true
@@ -456,7 +456,7 @@ jobs:
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
-          ref: ${{ inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          ref: ${{ inputs.cl_ref || github.sha }}
 
       - name: 🧼 Clean up Environment
         if: ${{ github.event_name == 'pull_request' }}
@@ -477,7 +477,7 @@ jobs:
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
-          ref: ${{ inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          ref: ${{ inputs.cl_ref || github.sha }}
       - name: Download All Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
@@ -502,7 +502,7 @@ jobs:
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink
-          ref: ${{ inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          ref: ${{ inputs.cl_ref || github.sha }}
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:
@@ -674,7 +674,7 @@ jobs:
         get_solana_sha,
       ]
     env:
-      CHAINLINK_COMMIT_SHA: ${{ inputs.evm-ref || inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+      CHAINLINK_COMMIT_SHA: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       CHAINLINK_ENV_USER: ${{ github.actor }}
       TEST_LOG_LEVEL: debug
       CONTRACT_ARTIFACTS_PATH: contracts/target/deploy
@@ -726,7 +726,7 @@ jobs:
       - name: Generate config overrides
         env:
           GH_INPUTS_EVM_REF: ${{ inputs.evm-ref }}
-          GH_SHA: ${{ inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          GH_SHA: ${{ inputs.cl_ref || github.sha }}
         run: | # https://github.com/smartcontractkit/chainlink-testing-framework/lib/blob/main/config/README.md
           cat << EOF > config.toml
           [ChainlinkImage]
@@ -748,7 +748,7 @@ jobs:
           test_command_to_run: export ENV_JOB_IMAGE=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ needs.get_solana_sha.outputs.sha }} && make test_smoke
           test_config_override_base64: ${{ env.BASE64_CONFIG_OVERRIDE }}
           cl_repo: ${{ env.CHAINLINK_IMAGE }}
-          cl_image_tag: ${{ inputs.evm-ref || inputs.cl_ref || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          cl_image_tag: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
           publish_check_name: Solana Smoke Test Results
           go_mod_path: ./integration-tests/go.mod
           cache_key_id: core-solana-e2e-${{ env.MOD_CACHE_VERSION }}


### PR DESCRIPTION
Let's use `github.sha` everywhere in the `integration-tests` workflow instead of `github.event.pull_request.head.sha || github.event.merge_group.head_sha }}`