### PR TITLE
CCIP-3410 : add validations for ocr3 config

### DIFF
--- a/deployment/ccip/changeset/cs_ccip_home.go
+++ b/deployment/ccip/changeset/cs_ccip_home.go
@@ -622,6 +622,7 @@ func AddDonAndSetCandidateChangeset(
 			return deployment.ChangesetOutput{}, err
 		}
 		newDONArgs, err := internal.BuildOCR3ConfigForCCIPHome(
+			state.Chains[cfg.HomeChainSelector].CCIPHome,
 			e.OCRSecrets,
 			offRampAddress,
 			chainSelector,
@@ -726,7 +727,7 @@ func newDonWithCandidateOp(
 	)
 	if !mcmsEnabled {
 		_, err = deployment.ConfirmIfNoErrorWithABI(
-			homeChain, addDonTx, capabilities_registry.CapabilitiesRegistryABI, err)
+			homeChain, addDonTx, ccip_home.CCIPHomeABI, err)
 		if err != nil {
 			return mcms.Operation{}, fmt.Errorf("error confirming addDon call: %w", err)
 		}
@@ -813,6 +814,7 @@ func SetCandidateChangeset(
 				return deployment.ChangesetOutput{}, err
 			}
 			newDONArgs, err := internal.BuildOCR3ConfigForCCIPHome(
+				state.Chains[cfg.HomeChainSelector].CCIPHome,
 				e.OCRSecrets,
 				offRampAddress,
 				chainSelector,
@@ -916,7 +918,7 @@ func setCandidateOnExistingDon(
 	)
 	if !mcmsEnabled {
 		_, err = deployment.ConfirmIfNoErrorWithABI(
-			homeChain, updateDonTx, capabilities_registry.CapabilitiesRegistryABI, err)
+			homeChain, updateDonTx, ccip_home.CCIPHomeABI, err)
 		if err != nil {
 			return nil, fmt.Errorf("error confirming updateDon call: %w", err)
 		}
@@ -973,7 +975,7 @@ func promoteCandidateOp(
 	)
 	if !mcmsEnabled {
 		_, err = deployment.ConfirmIfNoErrorWithABI(
-			homeChain, updateDonTx, capabilities_registry.CapabilitiesRegistryABI, err)
+			homeChain, updateDonTx, ccip_home.CCIPHomeABI, err)
 		if err != nil {
 			return mcms.Operation{},
 				fmt.Errorf("error confirming updateDon call for donID(%d) and plugin type (%d): %w", donID, pluginType, err)

--- a/deployment/ccip/changeset/cs_ccip_home_test.go
+++ b/deployment/ccip/changeset/cs_ccip_home_test.go
@@ -76,6 +76,7 @@ func TestInvalidOCR3Params(t *testing.T) {
 	// make DeltaRound greater than DeltaProgress
 	params.OCRParameters.DeltaRound = params.OCRParameters.DeltaProgress + time.Duration(1)
 	_, err = internal.BuildOCR3ConfigForCCIPHome(
+		state.Chains[e.HomeChainSel].CCIPHome,
 		e.Env.OCRSecrets,
 		state.Chains[chain1].OffRamp.Address().Bytes(),
 		chain1,

--- a/deployment/ccip/changeset/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/cs_chain_contracts_test.go
@@ -867,7 +867,7 @@ func TestSetOCR3ConfigValidations(t *testing.T) {
 		// set wrong chain config with incorrect value of FChain
 		wrongChainConfigs[chain] = changeset.ChainConfig{
 			Readers: envNodes.NonBootstraps().PeerIDs(),
-			//nolint:gosec it can never cause integer overflow conversion`
+			//nolint:gosec // disable G115
 			FChain: uint8(len(envNodes.NonBootstraps().PeerIDs())),
 			EncodableChainConfig: chainconfig.ChainConfig{
 				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(globals.GasPriceDeviationPPB)},

--- a/deployment/ccip/changeset/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/cs_chain_contracts_test.go
@@ -6,12 +6,20 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
+
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/v1_5"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_5_0/rmn_contract"
 
 	"github.com/smartcontractkit/chainlink-integrations/evm/utils"
 
@@ -422,9 +430,13 @@ func TestUpdateOffRampsSources(t *testing.T) {
 			sourceCfg, err := state.Chains[source].OffRamp.GetSourceChainConfig(&bind.CallOpts{Context: ctx}, dest)
 			require.NoError(t, err)
 			require.Equal(t, state.Chains[source].TestRouter.Address(), sourceCfg.Router)
+			require.True(t, sourceCfg.IsRMNVerificationDisabled)
+			require.True(t, sourceCfg.IsEnabled)
 			destCfg, err := state.Chains[dest].OffRamp.GetSourceChainConfig(&bind.CallOpts{Context: ctx}, source)
 			require.NoError(t, err)
 			require.Equal(t, state.Chains[dest].Router.Address(), destCfg.Router)
+			require.True(t, destCfg.IsRMNVerificationDisabled)
+			require.True(t, destCfg.IsEnabled)
 		})
 	}
 }
@@ -690,4 +702,214 @@ func TestUpdateNonceManagersCS(t *testing.T) {
 			require.Contains(t, callers, state.Chains[source].OffRamp.Address())
 		})
 	}
+}
+
+func TestUpdateNonceManagersCSApplyPreviousRampsUpdates(t *testing.T) {
+	e, tenv := testhelpers.NewMemoryEnvironment(
+		t,
+		testhelpers.WithPrerequisiteDeploymentOnly(&changeset.V1_5DeploymentConfig{
+			PriceRegStalenessThreshold: 60 * 60 * 24 * 14, // two weeks
+			RMNConfig: &rmn_contract.RMNConfig{
+				BlessWeightThreshold: 2,
+				CurseWeightThreshold: 2,
+				// setting dummy voters, we will permabless this later
+				Voters: []rmn_contract.RMNVoter{
+					{
+						BlessWeight:   2,
+						CurseWeight:   2,
+						BlessVoteAddr: utils.RandomAddress(),
+						CurseVoteAddr: utils.RandomAddress(),
+					},
+				},
+			},
+		}),
+		testhelpers.WithNumOfChains(3),
+		testhelpers.WithChainIDs([]uint64{chainselectors.GETH_TESTNET.EvmChainID}))
+	state, err := changeset.LoadOnchainState(e.Env)
+	require.NoError(t, err)
+	allChains := e.Env.AllChainSelectorsExcluding([]uint64{chainselectors.GETH_TESTNET.Selector})
+	require.Contains(t, e.Env.AllChainSelectors(), chainselectors.GETH_TESTNET.Selector)
+	require.Len(t, allChains, 2)
+	src, dest := allChains[1], chainselectors.GETH_TESTNET.Selector
+	srcChain := e.Env.Chains[src]
+	destChain := e.Env.Chains[dest]
+	pairs := []testhelpers.SourceDestPair{
+		{SourceChainSelector: src, DestChainSelector: dest},
+	}
+	e = testhelpers.AddCCIPContractsToEnvironment(t, e.Env.AllChainSelectors(), tenv, false)
+	// try to apply previous ramps updates without having any previous ramps
+	// it should fail
+	_, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.UpdateNonceManagersChangeset),
+			changeset.UpdateNonceManagerConfig{
+				UpdatesByChain: map[uint64]changeset.NonceManagerUpdate{
+					srcChain.Selector: {
+						PreviousRampsArgs: []changeset.PreviousRampCfg{
+							{
+								RemoteChainSelector: destChain.Selector,
+							},
+						},
+					},
+				},
+			},
+		),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no previous onramp for source chain")
+	e.Env = v1_5.AddLanes(t, e.Env, state, pairs)
+	// Now apply the nonce manager update
+	// it should fail again as there is no offramp for the source chain
+	_, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.UpdateNonceManagersChangeset),
+			changeset.UpdateNonceManagerConfig{
+				UpdatesByChain: map[uint64]changeset.NonceManagerUpdate{
+					srcChain.Selector: {
+						PreviousRampsArgs: []changeset.PreviousRampCfg{
+							{
+								RemoteChainSelector: destChain.Selector,
+							},
+						},
+					},
+				},
+			},
+		),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no previous offramp for source chain")
+	// Now apply the update with AllowEmptyOffRamp and it should pass
+	_, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.UpdateNonceManagersChangeset),
+			changeset.UpdateNonceManagerConfig{
+				UpdatesByChain: map[uint64]changeset.NonceManagerUpdate{
+					srcChain.Selector: {
+						PreviousRampsArgs: []changeset.PreviousRampCfg{
+							{
+								RemoteChainSelector: destChain.Selector,
+								AllowEmptyOffRamp:   true,
+							},
+						},
+					},
+				},
+			},
+		),
+	)
+	require.NoError(t, err)
+}
+
+func TestSetOCR3ConfigValidations(t *testing.T) {
+	e, _ := testhelpers.NewMemoryEnvironment(
+		t,
+		testhelpers.WithPrerequisiteDeploymentOnly(nil))
+	envNodes, err := deployment.NodeInfo(e.Env.NodeIDs, e.Env.Offchain)
+	require.NoError(t, err)
+	allChains := e.Env.AllChainSelectors()
+	evmContractParams := make(map[uint64]changeset.ChainContractParams)
+	for _, chain := range allChains {
+		evmContractParams[chain] = changeset.ChainContractParams{
+			FeeQuoterParams: changeset.DefaultFeeQuoterParams(),
+			OffRampParams:   changeset.DefaultOffRampParams(),
+		}
+	}
+	var apps []commonchangeset.ConfiguredChangeSet
+	// now deploy contracts
+	apps = append(apps, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployHomeChainChangeset),
+			changeset.DeployHomeChainConfig{
+				HomeChainSel:     e.HomeChainSel,
+				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
+				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
+				NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.Chains[e.HomeChainSel].DeployerKey.From),
+				NodeP2PIDsPerNodeOpAdmin: map[string][][32]byte{
+					testhelpers.TestNodeOperator: envNodes.NonBootstraps().PeerIDs(),
+				},
+			},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployChainContractsChangeset),
+			changeset.DeployChainContractsConfig{
+				HomeChainSelector:      e.HomeChainSel,
+				ContractParamsPerChain: evmContractParams,
+			},
+		),
+	}...)
+	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, nil, apps)
+	require.NoError(t, err)
+	// try to apply ocr3config on offRamp without setting the active config on home chain
+	_, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+		commonchangeset.Configure(
+			// Enable the OCR config on the remote chains.
+			deployment.CreateLegacyChangeSet(changeset.SetOCR3OffRampChangeset),
+			changeset.SetOCR3OffRampConfig{
+				HomeChainSel:       e.HomeChainSel,
+				RemoteChainSels:    allChains,
+				CCIPHomeConfigType: globals.ConfigTypeActive,
+			},
+		),
+	)
+	// it should fail as we need to update the chainconfig on CCIPHome first
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid OCR3 config state, expected active config")
+
+	// Build the per chain config.
+	wrongChainConfigs := make(map[uint64]changeset.ChainConfig)
+	chainConfigs := make(map[uint64]changeset.ChainConfig)
+	ocrConfigs := make(map[uint64]changeset.CCIPOCRParams)
+	for _, chain := range allChains {
+		ocrParams := changeset.DeriveCCIPOCRParams(
+			changeset.WithDefaultCommitOffChainConfig(e.FeedChainSel, nil),
+			changeset.WithDefaultExecuteOffChainConfig(nil),
+		)
+		ocrConfigs[chain] = ocrParams
+		chainConfigs[chain] = changeset.ChainConfig{
+			Readers: envNodes.NonBootstraps().PeerIDs(),
+			FChain:  uint8(len(envNodes.NonBootstraps().PeerIDs()) / 3),
+			EncodableChainConfig: chainconfig.ChainConfig{
+				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(globals.GasPriceDeviationPPB)},
+				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(globals.DAGasPriceDeviationPPB)},
+				OptimisticConfirmations: globals.OptimisticConfirmations,
+			},
+		}
+		// set wrong chain config with incorrect value of FChain
+		wrongChainConfigs[chain] = changeset.ChainConfig{
+			Readers: envNodes.NonBootstraps().PeerIDs(),
+			FChain:  uint8(len(envNodes.NonBootstraps().PeerIDs())),
+			EncodableChainConfig: chainconfig.ChainConfig{
+				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(globals.GasPriceDeviationPPB)},
+				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(globals.DAGasPriceDeviationPPB)},
+				OptimisticConfirmations: globals.OptimisticConfirmations,
+			},
+		}
+	}
+	// now set the chain config with wrong values of FChain
+	// it should fail on addDonAndSetCandidateChangeset
+	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, nil, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			// Add the chain configs for the new chains.
+			deployment.CreateLegacyChangeSet(changeset.UpdateChainConfigChangeset),
+			changeset.UpdateChainConfigConfig{
+				HomeChainSelector: e.HomeChainSel,
+				RemoteChainAdds:   wrongChainConfigs,
+			},
+		),
+		commonchangeset.Configure(
+			// Add the DONs and candidate commit OCR instances for the chain.
+			deployment.CreateLegacyChangeSet(changeset.AddDonAndSetCandidateChangeset),
+			changeset.AddDonAndSetCandidateChangesetConfig{
+				SetCandidateConfigBase: changeset.SetCandidateConfigBase{
+					HomeChainSelector: e.HomeChainSel,
+					FeedChainSelector: e.FeedChainSel,
+				},
+				PluginInfo: changeset.SetCandidatePluginInfo{
+					OCRConfigPerRemoteChainSelector: ocrConfigs,
+					PluginType:                      types.PluginTypeCCIPCommit,
+				},
+			},
+		),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "OCR3 config FRoleDON is lower than chainConfig FChain")
 }

--- a/deployment/ccip/changeset/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/cs_chain_contracts_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	chainselectors "github.com/smartcontractkit/chain-selectors"
-	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
-	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
+
+	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
@@ -856,7 +857,6 @@ func TestSetOCR3ConfigValidations(t *testing.T) {
 
 	// Build the per chain config.
 	wrongChainConfigs := make(map[uint64]changeset.ChainConfig)
-	chainConfigs := make(map[uint64]changeset.ChainConfig)
 	ocrConfigs := make(map[uint64]changeset.CCIPOCRParams)
 	for _, chain := range allChains {
 		ocrParams := changeset.DeriveCCIPOCRParams(
@@ -864,19 +864,11 @@ func TestSetOCR3ConfigValidations(t *testing.T) {
 			changeset.WithDefaultExecuteOffChainConfig(nil),
 		)
 		ocrConfigs[chain] = ocrParams
-		chainConfigs[chain] = changeset.ChainConfig{
-			Readers: envNodes.NonBootstraps().PeerIDs(),
-			FChain:  uint8(len(envNodes.NonBootstraps().PeerIDs()) / 3),
-			EncodableChainConfig: chainconfig.ChainConfig{
-				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(globals.GasPriceDeviationPPB)},
-				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(globals.DAGasPriceDeviationPPB)},
-				OptimisticConfirmations: globals.OptimisticConfirmations,
-			},
-		}
 		// set wrong chain config with incorrect value of FChain
 		wrongChainConfigs[chain] = changeset.ChainConfig{
 			Readers: envNodes.NonBootstraps().PeerIDs(),
-			FChain:  uint8(len(envNodes.NonBootstraps().PeerIDs())),
+			// nolint:gosec it can never cause integer overflow conversion
+			FChain: uint8(len(envNodes.NonBootstraps().PeerIDs())),
 			EncodableChainConfig: chainconfig.ChainConfig{
 				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(globals.GasPriceDeviationPPB)},
 				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(globals.DAGasPriceDeviationPPB)},

--- a/deployment/ccip/changeset/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/cs_chain_contracts_test.go
@@ -867,7 +867,7 @@ func TestSetOCR3ConfigValidations(t *testing.T) {
 		// set wrong chain config with incorrect value of FChain
 		wrongChainConfigs[chain] = changeset.ChainConfig{
 			Readers: envNodes.NonBootstraps().PeerIDs(),
-			// nolint:gosec it can never cause integer overflow conversion
+			//nolint:gosec it can never cause integer overflow conversion`
 			FChain: uint8(len(envNodes.NonBootstraps().PeerIDs())),
 			EncodableChainConfig: chainconfig.ChainConfig{
 				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(globals.GasPriceDeviationPPB)},

--- a/deployment/ccip/changeset/internal/deploy_home_chain.go
+++ b/deployment/ccip/changeset/internal/deploy_home_chain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gagliardetto/solana-go"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -17,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 
 	"github.com/smartcontractkit/chainlink-integrations/evm/utils"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -139,6 +141,10 @@ func BuildSetOCR3ConfigArgs(
 	destSelector uint64,
 	configType globals.ConfigType,
 ) ([]offramp.MultiOCR3BaseOCRConfigArgs, error) {
+	chainCfg, err := ccipHome.GetChainConfig(nil, destSelector)
+	if err != nil {
+		return nil, fmt.Errorf("error getting chain config for chain selector %d it must be set before OCR3Config set up: %w", destSelector, err)
+	}
 	var offrampOCR3Configs []offramp.MultiOCR3BaseOCRConfigArgs
 	for _, pluginType := range []types.PluginType{types.PluginTypeCCIPCommit, types.PluginTypeCCIPExec} {
 		ocrConfig, err2 := ccipHome.GetAllConfigs(&bind.CallOpts{
@@ -165,6 +171,9 @@ func BuildSetOCR3ConfigArgs(
 			}
 			configForOCR3 = ocrConfig.CandidateConfig
 		}
+		if err := validateOCR3Config(destSelector, configForOCR3.Config, chainCfg); err != nil {
+			return nil, err
+		}
 
 		var signerAddresses []common.Address
 		var transmitterAddresses []common.Address
@@ -183,6 +192,63 @@ func BuildSetOCR3ConfigArgs(
 		})
 	}
 	return offrampOCR3Configs, nil
+}
+
+func validateOCR3Config(chainSel uint64, configForOCR3 ccip_home.CCIPHomeOCR3Config, chainConfig ccip_home.CCIPHomeChainConfig) error {
+	// chainConfigs must be set before OCR3 configs due to the added fChain == F validation
+	if chainConfig.FChain == 0 || bytes.IsEmpty(chainConfig.Config) || len(chainConfig.Readers) == 0 {
+		return fmt.Errorf("chain config is not set for chain selector %d", chainSel)
+	}
+	for _, reader := range chainConfig.Readers {
+		if bytes.IsEmpty(reader[:]) {
+			return fmt.Errorf("reader is empty, chain selector %d", chainSel)
+		}
+	}
+	// FRoleDON >= fChain is a requirement
+	if configForOCR3.FRoleDON < chainConfig.FChain {
+		return fmt.Errorf("OCR3 config FRoleDON is lower than chainConfig FChain, chain %d", chainSel)
+	}
+
+	if len(configForOCR3.Nodes) < 3*int(chainConfig.FChain)+1 {
+		return fmt.Errorf("number of nodes %d is less than 3 * fChain + 1 %d", len(configForOCR3.Nodes), 3*int(chainConfig.FChain)+1)
+	}
+	// check if there is any zero byte address
+	// The reason for this is that the MultiOCR3Base disallows zero addresses and duplicates
+	if bytes.IsEmpty(configForOCR3.OfframpAddress) {
+		return fmt.Errorf("zero address found in offramp address,  chain %d", chainSel)
+	}
+	if bytes.IsEmpty(configForOCR3.RmnHomeAddress) {
+		return fmt.Errorf("zero address found in rmn home address,  chain %d", chainSel)
+	}
+	mapSignerKey := make(map[string]struct{})
+	mapTransmitterKey := make(map[string]struct{})
+	for _, node := range configForOCR3.Nodes {
+		if bytes.IsEmpty(node.SignerKey) {
+			return fmt.Errorf("zero address found in signer key, chain %d", chainSel)
+		}
+		if bytes.IsEmpty(node.TransmitterKey) {
+			return fmt.Errorf("zero address found in transmitter key, donID: %d, chain %d", chainSel)
+		}
+		if bytes.IsEmpty(node.P2pId[:]) {
+			return fmt.Errorf("empty p2p id, chain %d", chainSel)
+		}
+		// Signer and transmitter duplication must be checked
+		if _, ok := mapSignerKey[hexutil.Encode(node.SignerKey)]; ok {
+			return fmt.Errorf("duplicate signer key found, chain %d", chainSel)
+		}
+		if _, ok := mapTransmitterKey[hexutil.Encode(node.TransmitterKey)]; ok {
+			return fmt.Errorf("duplicate transmitter key found, chain %d", chainSel)
+		}
+		mapSignerKey[hexutil.Encode(node.SignerKey)] = struct{}{}
+		mapTransmitterKey[hexutil.Encode(node.TransmitterKey)] = struct{}{}
+	}
+	//  transmitters.length should be validated such that it meets the 3 * fChain + 1 requirement
+	minTransmitterReq := 3*int(chainConfig.FChain) + 1
+	if len(configForOCR3.Nodes) < minTransmitterReq {
+		return fmt.Errorf("no of transmitters %d is less than 3 * fChain + 1 %d, chain %d",
+			len(configForOCR3.Nodes), minTransmitterReq, chainSel)
+	}
+	return nil
 }
 
 // https://github.com/smartcontractkit/chainlink-ccip/blob/bdbfcc588847d70817333487a9883e94c39a332e/chains/solana/gobindings/ccip_router/SetOcrConfig.go#L23
@@ -246,6 +312,7 @@ func BuildSetOCR3ConfigArgsSolana(
 }
 
 func BuildOCR3ConfigForCCIPHome(
+	ccipHome *ccip_home.CCIPHome,
 	ocrSecrets deployment.OCRSecrets,
 	offRampAddress []byte,
 	destSelector uint64,
@@ -255,6 +322,10 @@ func BuildOCR3ConfigForCCIPHome(
 	commitOffchainCfg *pluginconfig.CommitOffchainConfig,
 	execOffchainCfg *pluginconfig.ExecuteOffchainConfig,
 ) (map[types.PluginType]ccip_home.CCIPHomeOCR3Config, error) {
+	chainConfig, err := ccipHome.GetChainConfig(nil, destSelector)
+	if err != nil {
+		return nil, fmt.Errorf("can't get chain config for %d: %w", destSelector, err)
+	}
 	p2pIDs := nodes.PeerIDs()
 	// Get OCR3 Config from helper
 	var schedule []int
@@ -291,36 +362,12 @@ func BuildOCR3ConfigForCCIPHome(
 			if commitOffchainCfg == nil {
 				return nil, errors.New("commitOffchainCfg is nil")
 			}
-			encodedOffchainConfig, err2 = pluginconfig.EncodeCommitOffchainConfig(pluginconfig.CommitOffchainConfig{
-				RemoteGasPriceBatchWriteFrequency:  commitOffchainCfg.RemoteGasPriceBatchWriteFrequency,
-				TokenPriceBatchWriteFrequency:      commitOffchainCfg.TokenPriceBatchWriteFrequency,
-				PriceFeedChainSelector:             commitOffchainCfg.PriceFeedChainSelector,
-				TokenInfo:                          commitOffchainCfg.TokenInfo,
-				NewMsgScanBatchSize:                commitOffchainCfg.NewMsgScanBatchSize,
-				MaxReportTransmissionCheckAttempts: commitOffchainCfg.MaxReportTransmissionCheckAttempts,
-				MaxMerkleTreeSize:                  commitOffchainCfg.MaxMerkleTreeSize,
-				SignObservationPrefix:              commitOffchainCfg.SignObservationPrefix,
-				RMNEnabled:                         commitOffchainCfg.RMNEnabled,
-				RMNSignaturesTimeout:               commitOffchainCfg.RMNSignaturesTimeout,
-				MerkleRootAsyncObserverSyncFreq:    commitOffchainCfg.MerkleRootAsyncObserverSyncFreq,
-				MerkleRootAsyncObserverSyncTimeout: commitOffchainCfg.MerkleRootAsyncObserverSyncTimeout,
-				InflightPriceCheckRetries:          commitOffchainCfg.InflightPriceCheckRetries,
-				TransmissionDelayMultiplier:        commitOffchainCfg.TransmissionDelayMultiplier,
-				FeeInfo:                            commitOffchainCfg.FeeInfo,
-			})
+			encodedOffchainConfig, err2 = pluginconfig.EncodeCommitOffchainConfig(*commitOffchainCfg)
 		} else {
 			if execOffchainCfg == nil {
 				return nil, errors.New("execOffchainCfg is nil")
 			}
-			encodedOffchainConfig, err2 = pluginconfig.EncodeExecuteOffchainConfig(pluginconfig.ExecuteOffchainConfig{
-				BatchGasLimit:             execOffchainCfg.BatchGasLimit,
-				RelativeBoostPerWaitHour:  execOffchainCfg.RelativeBoostPerWaitHour,
-				MessageVisibilityInterval: execOffchainCfg.MessageVisibilityInterval,
-				InflightCacheExpiry:       execOffchainCfg.InflightCacheExpiry,
-				RootSnoozeTime:            execOffchainCfg.RootSnoozeTime,
-				BatchingStrategyID:        execOffchainCfg.BatchingStrategyID,
-				TokenDataObservers:        execOffchainCfg.TokenDataObservers,
-			})
+			encodedOffchainConfig, err2 = pluginconfig.EncodeExecuteOffchainConfig(*execOffchainCfg)
 		}
 		if err2 != nil {
 			return nil, err2
@@ -399,6 +446,9 @@ func BuildOCR3ConfigForCCIPHome(
 			Nodes:                 ocrNodes,
 			OffchainConfig:        offchainConfig,
 			RmnHomeAddress:        rmnHomeAddress.Bytes(),
+		}
+		if err := validateOCR3Config(destSelector, ocr3Configs[pluginType], chainConfig); err != nil {
+			return nil, fmt.Errorf("failed to validate ocr3 config: %w", err)
 		}
 	}
 

--- a/deployment/ccip/changeset/internal/deploy_home_chain.go
+++ b/deployment/ccip/changeset/internal/deploy_home_chain.go
@@ -10,10 +10,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gagliardetto/solana-go"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/bytes"
 
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 
@@ -227,7 +228,7 @@ func validateOCR3Config(chainSel uint64, configForOCR3 ccip_home.CCIPHomeOCR3Con
 			return fmt.Errorf("zero address found in signer key, chain %d", chainSel)
 		}
 		if bytes.IsEmpty(node.TransmitterKey) {
-			return fmt.Errorf("zero address found in transmitter key, donID: %d, chain %d", chainSel)
+			return fmt.Errorf("zero address found in transmitter key,  chain %d", chainSel)
 		}
 		if bytes.IsEmpty(node.P2pId[:]) {
 			return fmt.Errorf("empty p2p id, chain %d", chainSel)

--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -206,6 +206,7 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 						PreviousRampsArgs: []changeset.PreviousRampCfg{
 							{
 								RemoteChainSelector: dest,
+								AllowEmptyOffRamp:   true,
 							},
 						},
 					},
@@ -213,6 +214,7 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 						PreviousRampsArgs: []changeset.PreviousRampCfg{
 							{
 								RemoteChainSelector: dest,
+								AllowEmptyOffRamp:   true,
 							},
 						},
 					},
@@ -220,9 +222,11 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 						PreviousRampsArgs: []changeset.PreviousRampCfg{
 							{
 								RemoteChainSelector: src1,
+								AllowEmptyOnRamp:    true,
 							},
 							{
 								RemoteChainSelector: src2,
+								AllowEmptyOnRamp:    true,
 							},
 						},
 					},


### PR DESCRIPTION
1. Allows empty address for prevOnRamp and prevOffRamp only if user input explicitly mentions to allow it.
2. Adds validation for the following -

- When setting OCR configs on OffRamp contracts, the list from CCIPConfig must be filtered to exclude 0-bytes addresses. The reason for this is that the MultiOCR3Base disallows zero addresses and duplicates

- Signer and transmitter duplication must be checked in tooling scripts off-chain prior to setting CCIPConfig (otherwise it will result in OffRamp breakage)

- chainConfigs must be set before OCR3 configs due to the added fChain == F validation

- If fChain becomes higher than F after updates, existing OCR3 configs get invalidated without an on-chain check (since it is difficult to do). There should be an off-chain validation script that prevents this (first, F should be increased for all configs, only after which fChain can be increased)

- OffRamp transmitters.length should be validated such that it meets the 3 * fChain + 1 criteria off-chain, since fChain is not tracked in the OffRamp


