### PR TITLE
Edit Treasure Mainnet CCIP Config

### DIFF
--- a/ccip/config/evm/Treasure_Mainnet.toml
+++ b/ccip/config/evm/Treasure_Mainnet.toml
@@ -1,12 +1,25 @@
 ChainID = '61166'
+ChainType = 'zksync'
+LogPollInterval = '10s'
+NoNewHeadsThreshold = '5m' #blocks production can sometimes be delayed by ~5min
+FinalityTagEnabled = true  #based on finality committee decision
+FinalityDepth = 40
 
 [GasEstimator]
+EIP1559DynamicFees = false
 # high LimitDefault for worst case pubdata bytes with BatchGasLimit reduced to 4M in OCR2Config  
 LimitDefault = 600_000_000
 FeeCapDefault = '2000 gwei'
 PriceDefault = '25 mwei'
 PriceMax = '2000 gwei'
+PriceMin = '25 mwei'
 
 [GasEstimator.BlockHistory]
 # increasing this to smooth out gas estimation
 BlockHistorySize = 200
+
+[GasEstimator.DAOracle]
+OracleType = 'zksync'
+
+[HeadTracker]
+HistoryDepth = 250


### PR DESCRIPTION
### What
- Changes Treasure Mainnet config to match the one found in `internal-wiki` ([link](https://github.com/smartcontractkit/internal-wiki/pull/83))
- Enables Finality Tag on Treasure Mainnet
 
 ### Why
 - This config should be the same as the one sent out to NOPs
 - Finality Tag is enabled based on a finality committee decision ([context](https://chainlink-core.slack.com/archives/C07ADV1K97U/p1738608122505109?thread_ts=1738125115.413079&cid=C07ADV1K97U))