### PR TITLE
[CCIP-5233] CCIP: price-only commit report method override.

### DIFF
--- a/core/capabilities/ccip/ocrimpls/contract_transmitter.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter.go
@@ -123,14 +123,23 @@ type ccipTransmitter struct {
 func XXXNewContractTransmitterTestsOnly(
 	cw commontypes.ContractWriter,
 	fromAccount ocrtypes.Account,
+	contractName string,
+	method string,
 	offrampAddress string,
 	toCalldataFn ToCalldataFunc,
 ) ocr3types.ContractTransmitter[[]byte] {
+	wrappedToCalldataFunc := func(rawReportCtx [2][32]byte,
+		report ocr3types.ReportWithInfo[[]byte],
+		rs, ss [][32]byte,
+		vs [32]byte) (string, string, any, error) {
+		_, _, args, err := toCalldataFn(rawReportCtx, report, rs, ss, vs)
+		return contractName, method, args, err
+	}
 	return &ccipTransmitter{
 		cw:             cw,
 		fromAccount:    fromAccount,
 		offrampAddress: offrampAddress,
-		toCalldataFn:   toCalldataFn,
+		toCalldataFn:   wrappedToCalldataFunc,
 	}
 }
 

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter.go
@@ -18,20 +18,27 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 )
 
+// ToCalldataFunc is a function that takes in the OCR3 report and signature data and processes them.
+// It returns the contract name, method name, and arguments for the on-chain contract call.
+// The ReportWithInfo bytes field is also decoded according to the implementation of this function,
+// the commit and execute plugins have different representations for this data.
 type ToCalldataFunc func(
 	rawReportCtx [2][32]byte,
 	report ocr3types.ReportWithInfo[[]byte],
 	rs, ss [][32]byte,
 	vs [32]byte,
-) (string, string, any, error)
+) (contract string, method string, args any, err error)
 
-func NewToCommitCalldata(defaultMethod, priceOnlyMethod string) ToCalldataFunc {
+// NewToCommitCalldataFunc returns a ToCalldataFunc that is used to generate the calldata for the commit method.
+// Multiple methods are accepted in order to allow for different methods to be called based on the report data.
+// The Solana on-chain contract has two methods, one for the default commit and one for the price-only commit.
+func NewToCommitCalldataFunc(defaultMethod, priceOnlyMethod string) ToCalldataFunc {
 	return func(
 		rawReportCtx [2][32]byte,
 		report ocr3types.ReportWithInfo[[]byte],
 		rs, ss [][32]byte,
 		vs [32]byte,
-	) (string, string, any, error) {
+	) (contract string, method string, args any, err error) {
 		// Note that the name of the struct field is very important, since the encoder used
 		// by the chainwriter uses mapstructure, which will use the struct field name to map
 		// to the argument name in the function call.
@@ -46,8 +53,8 @@ func NewToCommitCalldata(defaultMethod, priceOnlyMethod string) ToCalldataFunc {
 			}
 		}
 
-		method := defaultMethod
-		if len(priceOnlyMethod) > 0 && len(info.MerkleRoots) == 0 && len(info.TokenPrices) > 0 {
+		method = defaultMethod
+		if priceOnlyMethod != "" && len(info.MerkleRoots) == 0 && len(info.TokenPrices) > 0 {
 			method = priceOnlyMethod
 		}
 
@@ -74,6 +81,7 @@ func NewToCommitCalldata(defaultMethod, priceOnlyMethod string) ToCalldataFunc {
 	}
 }
 
+// ToExecCalldata is a ToCalldataFunc that is used to generate the calldata for the execute method.
 func ToExecCalldata(
 	rawReportCtx [2][32]byte,
 	report ocr3types.ReportWithInfo[[]byte],
@@ -153,7 +161,7 @@ func NewCommitContractTransmitter(
 		cw:             cw,
 		fromAccount:    fromAccount,
 		offrampAddress: offrampAddress,
-		toCalldataFn:   NewToCommitCalldata(defaultMethod, priceOnlyMethod),
+		toCalldataFn:   NewToCommitCalldataFunc(defaultMethod, priceOnlyMethod),
 	}
 }
 

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter.go
@@ -23,46 +23,55 @@ type ToCalldataFunc func(
 	report ocr3types.ReportWithInfo[[]byte],
 	rs, ss [][32]byte,
 	vs [32]byte,
-) (any, error)
+) (string, string, any, error)
 
-func ToCommitCalldata(
-	rawReportCtx [2][32]byte,
-	report ocr3types.ReportWithInfo[[]byte],
-	rs, ss [][32]byte,
-	vs [32]byte,
-) (any, error) {
-	// Note that the name of the struct field is very important, since the encoder used
-	// by the chainwriter uses mapstructure, which will use the struct field name to map
-	// to the argument name in the function call.
-	// If, for whatever reason, we want to change the field name, make sure to add a `mapstructure:"<arg_name>"` tag
-	// for that field.
-	var info ccipocr3.CommitReportInfo
-	if len(report.Info) != 0 {
-		var err error
-		info, err = ccipocr3.DecodeCommitReportInfo(report.Info)
-		if err != nil {
-			return nil, err
+func NewToCommitCalldata(defaultMethod, priceOnlyMethod string) ToCalldataFunc {
+	return func(
+		rawReportCtx [2][32]byte,
+		report ocr3types.ReportWithInfo[[]byte],
+		rs, ss [][32]byte,
+		vs [32]byte,
+	) (string, string, any, error) {
+		// Note that the name of the struct field is very important, since the encoder used
+		// by the chainwriter uses mapstructure, which will use the struct field name to map
+		// to the argument name in the function call.
+		// If, for whatever reason, we want to change the field name, make sure to add a `mapstructure:"<arg_name>"` tag
+		// for that field.
+		var info ccipocr3.CommitReportInfo
+		if len(report.Info) != 0 {
+			var err error
+			info, err = ccipocr3.DecodeCommitReportInfo(report.Info)
+			if err != nil {
+				return "", "", nil, err
+			}
 		}
-	}
 
-	// WARNING: Be careful if you change the data types.
-	// Using a different type e.g. `type Foo [32]byte` instead of `[32]byte`
-	// will trigger undefined chainWriter behavior, e.g. transactions submitted with wrong arguments.
-	return struct {
-		ReportContext [2][32]byte
-		Report        []byte
-		Rs            [][32]byte
-		Ss            [][32]byte
-		RawVs         [32]byte
-		Info          ccipocr3.CommitReportInfo
-	}{
-		ReportContext: rawReportCtx,
-		Report:        report.Report,
-		Rs:            rs,
-		Ss:            ss,
-		RawVs:         vs,
-		Info:          info,
-	}, nil
+		method := defaultMethod
+		if len(priceOnlyMethod) > 0 && len(info.MerkleRoots) == 0 && len(info.TokenPrices) > 0 {
+			method = priceOnlyMethod
+		}
+
+		// WARNING: Be careful if you change the data types.
+		// Using a different type e.g. `type Foo [32]byte` instead of `[32]byte`
+		// will trigger undefined chainWriter behavior, e.g. transactions submitted with wrong arguments.
+		return consts.ContractNameOffRamp,
+			method,
+			struct {
+				ReportContext [2][32]byte
+				Report        []byte
+				Rs            [][32]byte
+				Ss            [][32]byte
+				RawVs         [32]byte
+				Info          ccipocr3.CommitReportInfo
+			}{
+				ReportContext: rawReportCtx,
+				Report:        report.Report,
+				Rs:            rs,
+				Ss:            ss,
+				RawVs:         vs,
+				Info:          info,
+			}, nil
+	}
 }
 
 func ToExecCalldata(
@@ -70,7 +79,7 @@ func ToExecCalldata(
 	report ocr3types.ReportWithInfo[[]byte],
 	_, _ [][32]byte,
 	_ [32]byte,
-) (any, error) {
+) (string, string, any, error) {
 	// Note that the name of the struct field is very important, since the encoder used
 	// by the chainwriter uses mapstructure, which will use the struct field name to map
 	// to the argument name in the function call.
@@ -85,19 +94,21 @@ func ToExecCalldata(
 		var err error
 		info, err = ccipocr3.DecodeExecuteReportInfo(report.Info)
 		if err != nil {
-			return nil, err
+			return "", "", nil, err
 		}
 	}
 
-	return struct {
-		ReportContext [2][32]byte
-		Report        []byte
-		Info          ccipocr3.ExecuteReportInfo
-	}{
-		ReportContext: rawReportCtx,
-		Report:        report.Report,
-		Info:          info,
-	}, nil
+	return consts.ContractNameOffRamp,
+		consts.MethodExecute,
+		struct {
+			ReportContext [2][32]byte
+			Report        []byte
+			Info          ccipocr3.ExecuteReportInfo
+		}{
+			ReportContext: rawReportCtx,
+			Report:        report.Report,
+			Info:          info,
+		}, nil
 }
 
 var _ ocr3types.ContractTransmitter[[]byte] = &ccipTransmitter{}
@@ -105,8 +116,6 @@ var _ ocr3types.ContractTransmitter[[]byte] = &ccipTransmitter{}
 type ccipTransmitter struct {
 	cw             commontypes.ContractWriter
 	fromAccount    ocrtypes.Account
-	contractName   string
-	method         string
 	offrampAddress string
 	toCalldataFn   ToCalldataFunc
 }
@@ -114,16 +123,12 @@ type ccipTransmitter struct {
 func XXXNewContractTransmitterTestsOnly(
 	cw commontypes.ContractWriter,
 	fromAccount ocrtypes.Account,
-	contractName string,
-	method string,
 	offrampAddress string,
 	toCalldataFn ToCalldataFunc,
 ) ocr3types.ContractTransmitter[[]byte] {
 	return &ccipTransmitter{
 		cw:             cw,
 		fromAccount:    fromAccount,
-		contractName:   contractName,
-		method:         method,
 		offrampAddress: offrampAddress,
 		toCalldataFn:   toCalldataFn,
 	}
@@ -133,14 +138,13 @@ func NewCommitContractTransmitter(
 	cw commontypes.ContractWriter,
 	fromAccount ocrtypes.Account,
 	offrampAddress string,
+	defaultMethod, priceOnlyMethod string,
 ) ocr3types.ContractTransmitter[[]byte] {
 	return &ccipTransmitter{
 		cw:             cw,
 		fromAccount:    fromAccount,
-		contractName:   consts.ContractNameOffRamp,
-		method:         consts.MethodCommit,
 		offrampAddress: offrampAddress,
-		toCalldataFn:   ToCommitCalldata,
+		toCalldataFn:   NewToCommitCalldata(defaultMethod, priceOnlyMethod),
 	}
 }
 
@@ -152,8 +156,6 @@ func NewExecContractTransmitter(
 	return &ccipTransmitter{
 		cw:             cw,
 		fromAccount:    fromAccount,
-		contractName:   consts.ContractNameOffRamp,
-		method:         consts.MethodExecute,
 		offrampAddress: offrampAddress,
 		toCalldataFn:   ToExecCalldata,
 	}
@@ -198,7 +200,7 @@ func (c *ccipTransmitter) Transmit(
 	}
 
 	// chain writer takes in the raw calldata and packs it on its own.
-	args, err := c.toCalldataFn(rawReportCtx, reportWithInfo, rs, ss, vs)
+	contract, method, args, err := c.toCalldataFn(rawReportCtx, reportWithInfo, rs, ss, vs)
 	if err != nil {
 		return fmt.Errorf("failed to generate call data: %w", err)
 	}
@@ -211,7 +213,7 @@ func (c *ccipTransmitter) Transmit(
 		return fmt.Errorf("failed to generate UUID: %w", err)
 	}
 	zero := big.NewInt(0)
-	if err := c.cw.SubmitTransaction(ctx, c.contractName, c.method, args, fmt.Sprintf("%s-%s-%s", c.contractName, c.offrampAddress, txID.String()), c.offrampAddress, &meta, zero); err != nil {
+	if err := c.cw.SubmitTransaction(ctx, contract, method, args, fmt.Sprintf("%s-%s-%s", contract, c.offrampAddress, txID.String()), c.offrampAddress, &meta, zero); err != nil {
 		return fmt.Errorf("failed to submit transaction thru chainwriter: %w", err)
 	}
 

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter.go
@@ -87,7 +87,7 @@ func ToExecCalldata(
 	report ocr3types.ReportWithInfo[[]byte],
 	_, _ [][32]byte,
 	_ [32]byte,
-) (string, string, any, error) {
+) (contract string, method string, args any, err error) {
 	// Note that the name of the struct field is very important, since the encoder used
 	// by the chainwriter uses mapstructure, which will use the struct field name to map
 	// to the argument name in the function call.

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -316,7 +317,7 @@ func newTestUniverse(t *testing.T, ks *keyringsAndSigners[[]byte]) *testUniverse
 		contractName,
 		methodTransmitWithSignatures,
 		ocr3HelperAddr.Hex(),
-		ocrimpls.ToCommitCalldata,
+		ocrimpls.NewToCommitCalldata(consts.MethodCommit, ""),
 	)
 	transmitterWithoutSigs := ocrimpls.XXXNewContractTransmitterTestsOnly(
 		chainWriter,

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
@@ -317,7 +317,7 @@ func newTestUniverse(t *testing.T, ks *keyringsAndSigners[[]byte]) *testUniverse
 		contractName,
 		methodTransmitWithSignatures,
 		ocr3HelperAddr.Hex(),
-		ocrimpls.NewToCommitCalldata(consts.MethodCommit, ""),
+		ocrimpls.NewToCommitCalldataFunc(consts.MethodCommit, ""),
 	)
 	transmitterWithoutSigs := ocrimpls.XXXNewContractTransmitterTestsOnly(
 		chainWriter,

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
@@ -15,21 +15,21 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-	"github.com/smartcontractkit/chainlink-integrations/evm/heads"
 
+	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-integrations/evm/assets"
 	"github.com/smartcontractkit/chainlink-integrations/evm/client"
 	evmconfig "github.com/smartcontractkit/chainlink-integrations/evm/config"
 	"github.com/smartcontractkit/chainlink-integrations/evm/config/chaintype"
 	"github.com/smartcontractkit/chainlink-integrations/evm/config/toml"
 	"github.com/smartcontractkit/chainlink-integrations/evm/gas"
+	"github.com/smartcontractkit/chainlink-integrations/evm/heads"
 	"github.com/smartcontractkit/chainlink-integrations/evm/keystore"
 	"github.com/smartcontractkit/chainlink-integrations/evm/logpoller"
 	evmtestutils "github.com/smartcontractkit/chainlink-integrations/evm/testutils"

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/gagliardetto/solana-go"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/gagliardetto/solana-go"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -79,6 +78,7 @@ var plugins = map[string]plugin{
 		TokenDataEncoder:    ccipsolana.NewSolanaTokenDataEncoder(),
 		GasEstimateProvider: ccipsolana.NewGasEstimateProvider(),
 		RMNCrypto:           func(lggr logger.Logger) cciptypes.RMNCrypto { return nil },
+		PriceOnlyCommitFn:   consts.MethodCommitPriceOnly,
 	},
 }
 
@@ -94,6 +94,8 @@ type plugin struct {
 	TokenDataEncoder    cciptypes.TokenDataEncoder
 	GasEstimateProvider cciptypes.EstimateProvider
 	RMNCrypto           func(lggr logger.Logger) cciptypes.RMNCrypto
+	// PriceOnlyCommitFn optional method override for price only commit reports.
+	PriceOnlyCommitFn string
 }
 
 // pluginOracleCreator creates oracles that reference plugins running
@@ -354,6 +356,8 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 		transmitter = ocrimpls.NewCommitContractTransmitter(destChainWriter,
 			ocrtypes.Account(destFromAccounts[0]),
 			offrampAddrStr,
+			consts.MethodCommit,
+			plugins[chainFamily].PriceOnlyCommitFn,
 		)
 	} else if config.Config.PluginType == uint8(cctypes.PluginTypeCCIPExec) {
 		factory = execocr3.NewExecutePluginFactory(


### PR DESCRIPTION
Adds option to override the commit method for price-only commit reports.

Implemented by extending the `ToExecCalldata` handler to return the contract/method in addition to the args object.