### PR TITLE
[DPA-1476]: fix(mcms): update keystones changesets to new MCMS

### DIFF
--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -96,14 +96,25 @@ func ApplyChangesets(t *testing.T, e deployment.Environment, timelockContractsPe
 		if out.MCMSTimelockProposals != nil {
 			for _, prop := range out.MCMSTimelockProposals {
 				mcmProp := proposalutils.SignMCMSTimelockProposal(t, e, &prop)
-				proposalutils.ExecuteMCMSProposalV2(t, e, mcmProp)
-				proposalutils.ExecuteMCMSTimelockProposalV2(t, e, &prop)
+				// return the error so devs can ensure expected reversions
+				err = proposalutils.ExecuteMCMSProposalV2(t, e, mcmProp)
+				if err != nil {
+					return deployment.Environment{}, err
+				}
+				err = proposalutils.ExecuteMCMSTimelockProposalV2(t, e, &prop)
+				if err != nil {
+					return deployment.Environment{}, err
+				}
 			}
 		}
 		if out.MCMSProposals != nil {
 			for _, prop := range out.MCMSProposals {
 				p := proposalutils.SignMCMSProposal(t, e, &prop)
-				proposalutils.ExecuteMCMSProposalV2(t, e, p)
+				// return the error so devs can ensure expected reversions
+				err = proposalutils.ExecuteMCMSProposalV2(t, e, p)
+				if err != nil {
+					return deployment.Environment{}, err
+				}
 			}
 		}
 		currentEnv = deployment.Environment{

--- a/deployment/keystone/changeset/add_capabilities_test.go
+++ b/deployment/keystone/changeset/add_capabilities_test.go
@@ -63,7 +63,7 @@ func TestAddCapabilities(t *testing.T) {
 		}
 		csOut, err := changeset.AddCapabilities(te.Env, req)
 		require.NoError(t, err)
-		require.Len(t, csOut.Proposals, 1)
+		require.Len(t, csOut.MCMSTimelockProposals, 1)
 		require.Nil(t, csOut.AddressBook)
 
 		// now apply the changeset such that the proposal is signed and execed

--- a/deployment/keystone/changeset/add_nodes_test.go
+++ b/deployment/keystone/changeset/add_nodes_test.go
@@ -266,8 +266,8 @@ func TestAddNodes(t *testing.T) {
 							tc.checkErr(t, useMCMS, err)
 							return
 						}
-						require.NotNil(t, r.Proposals) //nolint:staticcheck //SA1019 ignoring deprecated field for compatibility; we don't have tools to generate the new field
-						require.Len(t, r.Proposals, 1) //nolint:staticcheck //SA1019 ignoring deprecated field for compatibility; we don't have tools to generate the new field
+						require.NotNil(t, r.MCMSTimelockProposals)
+						require.Len(t, r.MCMSTimelockProposals, 1)
 						applyErr := applyProposal(
 							t,
 							tc.input.te,

--- a/deployment/keystone/changeset/append_node_capabilities.go
+++ b/deployment/keystone/changeset/append_node_capabilities.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
+	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -34,24 +34,33 @@ func AppendNodeCapabilities(env deployment.Environment, req *AppendNodeCapabilit
 		if r.Ops == nil {
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
-		timelocksPerChain := map[uint64]common.Address{
-			c.Chain.Selector: contractSet.Timelock.Address(),
+		timelocksPerChain := map[uint64]string{
+			c.Chain.Selector: contractSet.Timelock.Address().Hex(),
 		}
-		proposerMCMSes := map[uint64]*gethwrappers.ManyChainMultiSig{
-			c.Chain.Selector: contractSet.ProposerMcm,
+		proposerMCMSes := map[uint64]string{
+			c.Chain.Selector: contractSet.ProposerMcm.Address().Hex(),
+		}
+		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
+		if err != nil {
+			return deployment.ChangesetOutput{}, err
+		}
+		inspectorPerChain := map[uint64]sdk.Inspector{
+			req.RegistryChainSel: inspector,
 		}
 
-		proposal, err := proposalutils.BuildProposalFromBatches(
+		proposal, err := proposalutils.BuildProposalFromBatchesV2(
+			env.GetContext(),
 			timelocksPerChain,
 			proposerMCMSes,
-			[]timelock.BatchChainOperation{*r.Ops},
+			inspectorPerChain,
+			[]types.BatchOperation{*r.Ops},
 			"proposal to set update node capabilities",
 			req.MCMSConfig.MinDuration,
 		)
 		if err != nil {
 			return out, fmt.Errorf("failed to build proposal: %w", err)
 		}
-		out.Proposals = []timelock.MCMSWithTimelockProposal{*proposal}
+		out.MCMSTimelockProposals = []mcms.TimelockProposal{*proposal}
 	}
 	return out, nil
 }

--- a/deployment/keystone/changeset/append_node_capabilities_test.go
+++ b/deployment/keystone/changeset/append_node_capabilities_test.go
@@ -50,7 +50,7 @@ func TestAppendNodeCapabilities(t *testing.T) {
 
 			csOut, err := changeset.AppendNodeCapabilities(te.Env, &cfg)
 			require.NoError(t, err)
-			require.Empty(t, csOut.Proposals)
+			require.Empty(t, csOut.MCMSTimelockProposals)
 			require.Nil(t, csOut.AddressBook)
 
 			validateCapabilityAppends(t, te, newCapabilities)
@@ -78,9 +78,9 @@ func TestAppendNodeCapabilities(t *testing.T) {
 
 		csOut, err := changeset.AppendNodeCapabilities(te.Env, &cfg)
 		require.NoError(t, err)
-		require.Len(t, csOut.Proposals, 1)
-		require.Len(t, csOut.Proposals[0].Transactions, 1)
-		require.Len(t, csOut.Proposals[0].Transactions[0].Batch, 2) // add capabilities, update nodes
+		require.Len(t, csOut.MCMSTimelockProposals, 1)
+		require.Len(t, csOut.MCMSTimelockProposals[0].Operations, 1)
+		require.Len(t, csOut.MCMSTimelockProposals[0].Operations[0].Transactions, 2) // add capabilities, update nodes
 		require.Nil(t, csOut.AddressBook)
 
 		// now apply the changeset such that the proposal is signed and execed

--- a/deployment/keystone/changeset/deploy_ocr3.go
+++ b/deployment/keystone/changeset/deploy_ocr3.go
@@ -7,9 +7,9 @@ import (
 	"io"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
+	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/sdk"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -92,24 +92,33 @@ func ConfigureOCR3Contract(env deployment.Environment, cfg ConfigureOCR3Config) 
 			return out, fmt.Errorf("failed to get contract sets: %w", err)
 		}
 		contracts := r.ContractSets[cfg.ChainSel]
-		timelocksPerChain := map[uint64]common.Address{
-			cfg.ChainSel: contracts.Timelock.Address(),
+		timelocksPerChain := map[uint64]string{
+			cfg.ChainSel: contracts.Timelock.Address().Hex(),
 		}
-		proposerMCMSes := map[uint64]*gethwrappers.ManyChainMultiSig{
-			cfg.ChainSel: contracts.ProposerMcm,
+		proposerMCMSes := map[uint64]string{
+			cfg.ChainSel: contracts.ProposerMcm.Address().Hex(),
 		}
 
-		proposal, err := proposalutils.BuildProposalFromBatches(
+		inspector, err := proposalutils.McmsInspectorForChain(env, cfg.ChainSel)
+		if err != nil {
+			return deployment.ChangesetOutput{}, err
+		}
+		inspectorPerChain := map[uint64]sdk.Inspector{
+			cfg.ChainSel: inspector,
+		}
+		proposal, err := proposalutils.BuildProposalFromBatchesV2(
+			env.GetContext(),
 			timelocksPerChain,
 			proposerMCMSes,
-			[]timelock.BatchChainOperation{*resp.Ops},
+			inspectorPerChain,
+			[]mcmstypes.BatchOperation{*resp.Ops},
 			"proposal to set OCR3 config",
 			cfg.MCMSConfig.MinDuration,
 		)
 		if err != nil {
 			return out, fmt.Errorf("failed to build proposal: %w", err)
 		}
-		out.Proposals = []timelock.MCMSWithTimelockProposal{*proposal}
+		out.MCMSTimelockProposals = []mcms.TimelockProposal{*proposal}
 	}
 	return out, nil
 }

--- a/deployment/keystone/changeset/deploy_ocr3_test.go
+++ b/deployment/keystone/changeset/deploy_ocr3_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -81,7 +82,7 @@ func TestConfigureOCR3(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, got.Signers, 4)
 		assert.Len(t, got.Transmitters, 4)
-		assert.Nil(t, csOut.Proposals)
+		assert.Nil(t, csOut.MCMSTimelockProposals)
 	})
 
 	t.Run("success multiple OCR3 contracts", func(t *testing.T) {
@@ -146,7 +147,7 @@ func TestConfigureOCR3(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, got.Signers, 4)
 		assert.Len(t, got.Transmitters, 4)
-		assert.Nil(t, csOut.Proposals)
+		assert.Nil(t, csOut.MCMSTimelockProposals)
 	})
 
 	t.Run("fails multiple OCR3 contracts but unspecified address", func(t *testing.T) {
@@ -258,8 +259,8 @@ func TestConfigureOCR3(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, got.Signers, 4)
 		assert.Len(t, got.Transmitters, 4)
-		assert.NotNil(t, csOut.Proposals)
-		t.Logf("got: %v", csOut.Proposals[0])
+		assert.NotNil(t, csOut.MCMSTimelockProposals)
+		t.Logf("got: %v", csOut.MCMSTimelockProposals[0])
 
 		contracts := te.ContractSets()[te.RegistrySelector]
 		require.NoError(t, err)

--- a/deployment/keystone/changeset/internal/deploy_test.go
+++ b/deployment/keystone/changeset/internal/deploy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 	kstest "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/test"
@@ -88,7 +89,7 @@ func Test_AddCapabilities(t *testing.T) {
 		ops, err := internal.AddCapabilities(lggr, registry, chain, capabilities, useMCMS)
 		require.NoError(t, err)
 		require.NotNil(t, ops)
-		require.Len(t, ops.Batch, 1)
+		require.Len(t, ops.Transactions, 1)
 	})
 
 	t.Run("does nothing if no capabilities", func(t *testing.T) {
@@ -284,7 +285,7 @@ func Test_RegisterNodes(t *testing.T) {
 				require.NoError(t, err)
 				if tc.useMCMS {
 					require.NotNil(t, resp.Ops)
-					require.Len(t, resp.Ops.Batch, tc.want.nOps)
+					require.Len(t, resp.Ops.Transactions, tc.want.nOps)
 				} else {
 					assertNodesExist(t, registry, tc.want.nodes...)
 				}
@@ -419,7 +420,7 @@ func Test_RegisterDons(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp.Ops)
-		require.Len(t, resp.Ops.Batch, 1)
+		require.Len(t, resp.Ops.Transactions, 1)
 	})
 
 	t.Run("no new dons to add results in no mcms ops", func(t *testing.T) {
@@ -551,7 +552,7 @@ func Test_RegisterDons(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp.Ops)
-		require.Len(t, resp.Ops.Batch, 2)
+		require.Len(t, resp.Ops.Transactions, 2)
 	})
 }
 

--- a/deployment/keystone/changeset/update_don.go
+++ b/deployment/keystone/changeset/update_don.go
@@ -66,16 +66,16 @@ func UpdateDon(env deployment.Environment, req *UpdateDonRequest) (deployment.Ch
 		if updateResult.Ops == nil {
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
-		if len(appendResult.Proposals) == 0 {
+		if len(appendResult.MCMSTimelockProposals) == 0 {
 			return out, errors.New("expected append node capabilities to return proposals")
 		}
 
-		out.Proposals = appendResult.Proposals
+		out.MCMSTimelockProposals = appendResult.MCMSTimelockProposals
 
 		// add the update don to the existing batch
 		// this makes the proposal all-or-nothing because all the operations are in the same batch, there is only one tr
 		// transaction and only one proposal
-		out.Proposals[0].Transactions[0].Batch = append(out.Proposals[0].Transactions[0].Batch, updateResult.Ops.Batch...)
+		out.MCMSTimelockProposals[0].Operations[0].Transactions = append(out.MCMSTimelockProposals[0].Operations[0].Transactions, updateResult.Ops.Transactions...)
 	}
 	return out, nil
 }

--- a/deployment/keystone/changeset/update_don_test.go
+++ b/deployment/keystone/changeset/update_don_test.go
@@ -129,8 +129,8 @@ func TestUpdateDon(t *testing.T) {
 							tc.checkErr(t, useMCMS, err)
 							return
 						}
-						require.NotNil(t, csOut.Proposals) //nolint:staticcheck //SA1019 ignoring deprecated field for compatibility; we don't have tools to generate the new field
-						require.Len(t, csOut.Proposals, 1) //nolint:staticcheck //SA1019 ignoring deprecated field for compatibility; we don't have tools to generate the new field
+						require.NotNil(t, csOut.MCMSTimelockProposals)
+						require.Len(t, csOut.MCMSTimelockProposals, 1)
 						applyErr := applyProposal(t, te, commonchangeset.Configure(
 							deployment.CreateLegacyChangeSet(changeset.UpdateDon),
 							&cfg,

--- a/deployment/keystone/changeset/update_node_capabilities_test.go
+++ b/deployment/keystone/changeset/update_node_capabilities_test.go
@@ -69,7 +69,7 @@ func TestUpdateNodeCapabilities(t *testing.T) {
 
 			csOut, err := changeset.UpdateNodeCapabilities(te.Env, &cfg)
 			require.NoError(t, err)
-			require.Empty(t, csOut.Proposals)
+			require.Empty(t, csOut.MCMSTimelockProposals)
 			require.Nil(t, csOut.AddressBook)
 
 			validateCapabilityUpdates(t, te, capabiltiesToSet)
@@ -106,9 +106,9 @@ func TestUpdateNodeCapabilities(t *testing.T) {
 
 		csOut, err := changeset.UpdateNodeCapabilities(te.Env, &cfg)
 		require.NoError(t, err)
-		require.Len(t, csOut.Proposals, 1)
-		require.Len(t, csOut.Proposals[0].Transactions, 1)
-		require.Len(t, csOut.Proposals[0].Transactions[0].Batch, 2) // add capabilities, update nodes
+		require.Len(t, csOut.MCMSTimelockProposals, 1)
+		require.Len(t, csOut.MCMSTimelockProposals[0].Operations, 1)
+		require.Len(t, csOut.MCMSTimelockProposals[0].Operations[0].Transactions, 2) // add capabilities, update nodes
 		require.Nil(t, csOut.AddressBook)
 
 		// now apply the changeset such that the proposal is signed and execed

--- a/deployment/keystone/changeset/update_nodes_test.go
+++ b/deployment/keystone/changeset/update_nodes_test.go
@@ -82,7 +82,7 @@ func TestUpdateNodes(t *testing.T) {
 
 		csOut, err := changeset.UpdateNodes(te.Env, &cfg)
 		require.NoError(t, err)
-		require.Len(t, csOut.Proposals, 1)
+		require.Len(t, csOut.MCMSTimelockProposals, 1)
 		require.Nil(t, csOut.AddressBook)
 
 		// now apply the changeset such that the proposal is signed and execed

--- a/deployment/keystone/changeset/workflowregistry/update_allowed_dons.go
+++ b/deployment/keystone/changeset/workflowregistry/update_allowed_dons.go
@@ -63,6 +63,7 @@ func UpdateAllowedDons(env deployment.Environment, req *UpdateAllowedDonsRequest
 			Address:     registry.Address(),
 			ChainSel:    req.RegistryChainSel,
 			ContractSet: &cs,
+			Env:         env,
 		}
 	} else {
 		s = &simpleTransaction{

--- a/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
@@ -89,7 +89,7 @@ func Test_UpdateAllowedDons_WithMCMS(t *testing.T) {
 
 	out, err := workflowregistry.UpdateAllowedDons(te.Env, req)
 	require.NoError(t, err)
-	require.Len(t, out.Proposals, 1)
+	require.Len(t, out.MCMSTimelockProposals, 1)
 	require.Nil(t, out.AddressBook)
 
 	contracts := te.ContractSets()[te.RegistrySelector]

--- a/deployment/keystone/changeset/workflowregistry/update_authorized_addresses.go
+++ b/deployment/keystone/changeset/workflowregistry/update_authorized_addresses.go
@@ -88,6 +88,7 @@ func UpdateAuthorizedAddresses(env deployment.Environment, req *UpdateAuthorized
 			Address:     registry.Address(),
 			ChainSel:    chain.Selector,
 			ContractSet: &cs,
+			Env:         env,
 		}
 	} else {
 		s = &simpleTransaction{

--- a/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
@@ -92,7 +92,7 @@ func Test_UpdateAuthorizedAddresses_WithMCMS(t *testing.T) {
 
 	out, err := workflowregistry.UpdateAuthorizedAddresses(te.Env, req)
 	require.NoError(t, err)
-	require.Len(t, out.Proposals, 1)
+	require.Len(t, out.MCMSTimelockProposals, 1)
 	require.Nil(t, out.AddressBook)
 
 	contracts := te.ContractSets()[te.RegistrySelector]


### PR DESCRIPTION
Update the existing keystone changesets to use the [new MCMS library](https://github.com/smartcontractkit/mcms) types. We want to eventually remove the legacy MCMS type. 

**Do not be alarm by the amount of file changes, all the changes are kind of the same**
- Update type `timelock.BatchChainOperation` -> `mcmstypes.BatchOperation`
- use `out.MCMSTimelockProposals` instead of `out.Proposals`
- Update type `Batch` -> `Transactions`

There will be breaking changes on the CLD side due to the types being change, i have an [accompany PR](https://github.com/smartcontractkit/chainlink-deployments/pull/774) for that so it goes in together.


JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1476

