### PR TITLE
feat(deployments/data-streams): adds jobs package + bootstrap logic

### DIFF
--- a/deployment/data-streams/jobs/base.go
+++ b/deployment/data-streams/jobs/base.go
@@ -1,0 +1,24 @@
+package jobs
+
+import "github.com/google/uuid"
+
+// JobSpecType is the type of job spec set in the TOML.
+type JobSpecType string
+
+var (
+	JobSpecTypeLLO       JobSpecType = "offchainreporting2" // used for LLO specs
+	JobSpecTypeBootstrap JobSpecType = "bootstrap"          // used for bootstrap specs in LLO dons
+	JobSpecTypeStream    JobSpecType = "stream"             // used for stream specs in LLO dons
+)
+
+type Base struct {
+	Name          string      `toml:"name"`
+	Type          JobSpecType `toml:"type"`
+	SchemaVersion uint        `toml:"schemaVersion"`
+	ExternalJobID uuid.UUID   `toml:"externalJobID"`
+}
+
+// Job interface
+type JobSpec interface {
+	MarshalTOML() ([]byte, error)
+}

--- a/deployment/data-streams/jobs/bootstrap.go
+++ b/deployment/data-streams/jobs/bootstrap.go
@@ -1,0 +1,32 @@
+package jobs
+
+import "github.com/pelletier/go-toml/v2"
+
+var _ JobSpec = &BootstrapSpec{}
+
+type BootstrapSpec struct {
+	Base
+
+	ContractID  string      `toml:"contractID"`
+	DonID       uint64      `toml:"donID,omitempty"`
+	Relay       RelayType   `toml:"relay"`
+	RelayConfig RelayConfig `toml:"relayConfig"`
+}
+
+// RelayType is the type of relay set in the TOML.
+type RelayType string
+
+var (
+	RelayTypeEVM    RelayType = "evm"
+	RelayTypeSolana RelayType = "solana"
+)
+
+// RelayConfig is the configuration for the relay. This could change depending on the relay type.
+type RelayConfig struct {
+	ChainID   string `toml:"chainID"`
+	FromBlock uint64 `toml:"fromBlock,omitempty"`
+}
+
+func (b *BootstrapSpec) MarshalTOML() ([]byte, error) {
+	return toml.Marshal(b)
+}

--- a/deployment/data-streams/jobs/bootstrap_test.go
+++ b/deployment/data-streams/jobs/bootstrap_test.go
@@ -1,0 +1,65 @@
+package jobs
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+const bootstrapSpecTOML = `name = 'bootstrap 1'
+type = 'bootstrap'
+schemaVersion = 1
+externalJobID = 'f1ac5211-ab79-4c31-ba1c-0997b72db466'
+contractID = '0x123'
+donID = 1
+relay = 'evm'
+
+[relayConfig]
+chainID = '42161'
+fromBlock = 283806260
+`
+
+func Test_Bootstrap(t *testing.T) {
+	t.Parallel()
+
+	bootstrapSpec := BootstrapSpec{
+		Base: Base{
+			Name:          "bootstrap 1",
+			Type:          JobSpecTypeBootstrap,
+			SchemaVersion: 1,
+			ExternalJobID: uuid.MustParse("f1ac5211-ab79-4c31-ba1c-0997b72db466"),
+		},
+		ContractID: "0x123",
+		DonID:      1,
+		Relay:      RelayTypeEVM,
+		RelayConfig: RelayConfig{
+			ChainID:   "42161",
+			FromBlock: 283806260,
+		},
+	}
+
+	tests := []struct {
+		name string
+		give BootstrapSpec
+		want string
+	}{
+		{
+			name: "bootstrap 1",
+			give: bootstrapSpec,
+			want: bootstrapSpecTOML,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.give.MarshalTOML()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(got) != test.want {
+				t.Errorf("got %s, want %s", got, test.want)
+			}
+		})
+	}
+}

--- a/deployment/data-streams/jobs/llo.go
+++ b/deployment/data-streams/jobs/llo.go
@@ -1,0 +1,1 @@
+package jobs

--- a/deployment/data-streams/jobs/stream.go
+++ b/deployment/data-streams/jobs/stream.go
@@ -1,0 +1,1 @@
+package jobs


### PR DESCRIPTION
This PR introduces the foundational structure for the data-streams jobs package, including an initial implementation for rendering data streams bootstrap job specs. The functionality was originally developed in the chainlink-deployments repository and is now being migrated to chainlink/deployment.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
