### PR TITLE
[CCIP-5242] go.mod: bump cl-ccip to version w/out boosting

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -336,7 +336,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/ccip-owner-contracts v0.0.0-salt-fix // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.40 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.1 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420ccacab78a // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1078,8 +1078,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670 h1:7v5FGwt6y0FKeB2aXPUO+vEyNhVE00KT8CjDsEP2IxE=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e h1:S42dUrpYRXaNd88HW94JLqvYTjsmz+Z94mjzJcwhhYw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/smartcontractkit/ccip-owner-contracts v0.0.0-salt-fix
 	github.com/smartcontractkit/chain-selectors v1.0.40
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250211162441-3d6cea220efb

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1126,8 +1126,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670 h1:7v5FGwt6y0FKeB2aXPUO+vEyNhVE00KT8CjDsEP2IxE=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e h1:S42dUrpYRXaNd88HW94JLqvYTjsmz+Z94mjzJcwhhYw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.40
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250128203428-08031923fbe5

--- a/go.sum
+++ b/go.sum
@@ -1010,8 +1010,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670 h1:7v5FGwt6y0FKeB2aXPUO+vEyNhVE00KT8CjDsEP2IxE=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e h1:S42dUrpYRXaNd88HW94JLqvYTjsmz+Z94mjzJcwhhYw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.40
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250213145514-41d874782c02
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.6.0

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1378,8 +1378,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670 h1:7v5FGwt6y0FKeB2aXPUO+vEyNhVE00KT8CjDsEP2IxE=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e h1:S42dUrpYRXaNd88HW94JLqvYTjsmz+Z94mjzJcwhhYw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.40
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250213145514-41d874782c02
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.51.0

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1361,8 +1361,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670 h1:7v5FGwt6y0FKeB2aXPUO+vEyNhVE00KT8CjDsEP2IxE=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218100940-acd7281f1670/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e h1:S42dUrpYRXaNd88HW94JLqvYTjsmz+Z94mjzJcwhhYw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250218132527-dd540e1dd85e/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=


### PR DESCRIPTION
### Requires

https://github.com/smartcontractkit/chainlink-ccip/pull/624

### Supports

https://github.com/smartcontractkit/chainlink-ccip/pull/624
