### PR TITLE
(fix): Default CapabilityRequest RequestHashExcludedAttributes StepDependency

### DIFF
--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -203,6 +203,11 @@ func (r *server) getMessageHash(msg *types.MessageBody) ([32]byte, error) {
 		return [32]byte{}, fmt.Errorf("failed to unmarshal capability request: %w", err)
 	}
 
+	// default to excluding StepDependency
+	if len(r.config.RequestHashExcludedAttributes) == 0 {
+		r.config.RequestHashExcludedAttributes = []string{"StepDependency"}
+	}
+
 	for _, path := range r.config.RequestHashExcludedAttributes {
 		if req.Inputs != nil {
 			req.Inputs.DeleteAtPath(path)

--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -203,7 +203,8 @@ func (r *server) getMessageHash(msg *types.MessageBody) ([32]byte, error) {
 		return [32]byte{}, fmt.Errorf("failed to unmarshal capability request: %w", err)
 	}
 
-	// default to excluding StepDependency
+	// An attribute called StepDependency is used to define a data dependency between steps,
+	// and not to provide input values; we should therefore disregard it when hashing the request
 	if len(r.config.RequestHashExcludedAttributes) == 0 {
 		r.config.RequestHashExcludedAttributes = []string{"StepDependency"}
 	}


### PR DESCRIPTION
### Description
Prevents non-deterministic trigger events used as references from blocking don2don confirmation