### PR TITLE
refactor extradata codec type

### DIFF
--- a/.changeset/silent-maps-visit.md
+++ b/.changeset/silent-maps-visit.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+remove extradata codec reference on CCIP #added

--- a/core/capabilities/ccip/ccipsolana/msghasher.go
+++ b/core/capabilities/ccip/ccipsolana/msghasher.go
@@ -25,7 +25,7 @@ type MessageHasherV1 struct {
 	extraDataCodec common.ExtraDataCodec
 }
 
-func NewMessageHasherV1(lggr logger.Logger, extraDataCodec cciptypes.ExtraDataCodec) *MessageHasherV1 {
+func NewMessageHasherV1(lggr logger.Logger, extraDataCodec common.ExtraDataCodec) *MessageHasherV1 {
 	return &MessageHasherV1{
 		lggr:           lggr,
 		extraDataCodec: extraDataCodec,


### PR DESCRIPTION
change extradata codec type, so we can remove cciptypte.extradataCodec from chainlink-ccip repo completely.