### PR TITLE
fix(deployment): add labels to the MCMSWithTimelockConfigV2 type

### DIFF
--- a/deployment/common/changeset/internal/evm/mcms_test.go
+++ b/deployment/common/changeset/internal/evm/mcms_test.go
@@ -1,0 +1,73 @@
+package mcmsnew_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/internal"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestDeployMCMSWithConfig(t *testing.T) {
+	lggr := logger.TestLogger(t)
+
+	chains, _ := memory.NewMemoryChainsWithChainIDs(t, []uint64{
+		chainsel.TEST_90000001.EvmChainID,
+	}, 1)
+	ab := deployment.NewMemoryAddressBook()
+
+	// 1) Test WITHOUT a label
+	mcmNoLabel, err := internal.DeployMCMSWithConfig(
+		types.ProposerManyChainMultisig,
+		lggr,
+		chains[chainsel.TEST_90000001.Selector],
+		ab,
+		proposalutils.SingleGroupMCMS(t),
+	)
+	require.NoError(t, err)
+	require.Empty(t, mcmNoLabel.Tv.Labels, "expected no label to be set")
+
+	// 2) Test WITH a label
+	label := "SA"
+	mcmWithLabel, err := internal.DeployMCMSWithConfig(
+		types.ProposerManyChainMultisig,
+		lggr,
+		chains[chainsel.TEST_90000001.Selector],
+		ab,
+		proposalutils.SingleGroupMCMS(t),
+		internal.WithLabel(label),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, mcmWithLabel.Tv.Labels, "expected labels to be set")
+	require.Contains(t, mcmWithLabel.Tv.Labels, label, "label mismatch")
+}
+
+func TestDeployMCMSWithTimelockContracts(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	chains, _ := memory.NewMemoryChainsWithChainIDs(t, []uint64{
+		chainsel.TEST_90000001.EvmChainID,
+	}, 1)
+	ab := deployment.NewMemoryAddressBook()
+	_, err := internal.DeployMCMSWithTimelockContracts(lggr,
+		chains[chainsel.TEST_90000001.Selector],
+		ab, proposalutils.SingleGroupTimelockConfig(t))
+	require.NoError(t, err)
+	addresses, err := ab.AddressesForChain(chainsel.TEST_90000001.Selector)
+	require.NoError(t, err)
+	require.Len(t, addresses, 5)
+	mcmsState, err := state.MaybeLoadMCMSWithTimelockChainState(chains[chainsel.TEST_90000001.Selector], addresses)
+	require.NoError(t, err)
+	v, err := mcmsState.GenerateMCMSWithTimelockView()
+	require.NoError(t, err)
+	b, err := json.MarshalIndent(v, "", "  ")
+	require.NoError(t, err)
+	t.Log(string(b))
+}

--- a/deployment/common/types/types.go
+++ b/deployment/common/types/types.go
@@ -65,6 +65,7 @@ type MCMSWithTimelockConfigV2 struct {
 	Bypasser         mcmstypes.Config
 	Proposer         mcmstypes.Config
 	TimelockMinDelay *big.Int
+	Label            *string
 }
 
 type OCRParameters struct {


### PR DESCRIPTION
We missed the addition of the "Label" field to the MCMSWithTimelockConfig type while working on the mcms migration. This PR adds the field to the new V2 type.