### PR TITLE
reusable workflow without log spamming

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -183,7 +183,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.keystone_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@244b17ef5c6ddad3cc841ba90117304216d031f5
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@8f9993dc54340a98716e6a9f5fcfbc33681d63dd
     with:
       workflow_name: Run Core Workflow Engine Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -211,8 +211,6 @@ jobs:
       AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN }}
       AWS_API_GW_HOST_GRAFANA: ${{ secrets.AWS_API_GW_HOST_GRAFANA }}
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
-      MAIN_DNS_ZONE_PUBLIC_SDLC: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
-      AWS_K8S_CLUSTER_NAME_SDLC: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
       OPTIONAL_GATI_AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       OPTIONAL_GATI_LAMBDA_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
@@ -226,7 +224,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@244b17ef5c6ddad3cc841ba90117304216d031f5
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@8f9993dc54340a98716e6a9f5fcfbc33681d63dd
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -267,7 +265,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@244b17ef5c6ddad3cc841ba90117304216d031f5
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@8f9993dc54340a98716e6a9f5fcfbc33681d63dd
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -312,7 +310,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@244b17ef5c6ddad3cc841ba90117304216d031f5
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@8f9993dc54340a98716e6a9f5fcfbc33681d63dd
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -354,7 +352,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@244b17ef5c6ddad3cc841ba90117304216d031f5
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@8f9993dc54340a98716e6a9f5fcfbc33681d63dd
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -183,7 +183,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.keystone_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@8f9993dc54340a98716e6a9f5fcfbc33681d63dd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@18ee2276811ff4ad56a2284590c9917bec33b748
     with:
       workflow_name: Run Core Workflow Engine Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -224,7 +224,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@8f9993dc54340a98716e6a9f5fcfbc33681d63dd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@18ee2276811ff4ad56a2284590c9917bec33b748
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -265,7 +265,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@8f9993dc54340a98716e6a9f5fcfbc33681d63dd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@18ee2276811ff4ad56a2284590c9917bec33b748
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -310,7 +310,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@8f9993dc54340a98716e6a9f5fcfbc33681d63dd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@18ee2276811ff4ad56a2284590c9917bec33b748
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -352,7 +352,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@8f9993dc54340a98716e6a9f5fcfbc33681d63dd
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@18ee2276811ff4ad56a2284590c9917bec33b748
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -252,8 +252,6 @@ jobs:
       AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN }}
       AWS_API_GW_HOST_GRAFANA: ${{ secrets.AWS_API_GW_HOST_GRAFANA }}
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
-      MAIN_DNS_ZONE_PUBLIC_SDLC: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
-      AWS_K8S_CLUSTER_NAME_SDLC: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
 
   run-core-e2e-tests-for-merge-queue:
     name: Run Core E2E Tests For Merge Queue
@@ -297,8 +295,6 @@ jobs:
       AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN }}
       AWS_API_GW_HOST_GRAFANA: ${{ secrets.AWS_API_GW_HOST_GRAFANA }}
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
-      MAIN_DNS_ZONE_PUBLIC_SDLC: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
-      AWS_K8S_CLUSTER_NAME_SDLC: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
 
   run-ccip-e2e-tests-for-pr:
     name: Run CCIP E2E Tests For PR

--- a/system-tests/tests/smoke/capabilities/workflow_test.go
+++ b/system-tests/tests/smoke/capabilities/workflow_test.go
@@ -785,9 +785,6 @@ func TestKeystoneWithOCR3Workflow_SingleDon_MockedPrice(t *testing.T) {
 		return !hasNextPrice
 	}, timeout, 10*time.Second, "feed did not update, timeout after: %s", timeout)
 
-	testLogger.Error().Msg("failing on purpose")
-	t.FailNow()
-
 	require.EqualValues(t, priceProvider.ExpectedPrices(), priceProvider.ActualPrices(), "prices do not match")
 	testLogger.Info().Msgf("All %d prices were found in the feed", len(priceProvider.ExpectedPrices()))
 }

--- a/system-tests/tests/smoke/capabilities/workflow_test.go
+++ b/system-tests/tests/smoke/capabilities/workflow_test.go
@@ -785,6 +785,9 @@ func TestKeystoneWithOCR3Workflow_SingleDon_MockedPrice(t *testing.T) {
 		return !hasNextPrice
 	}, timeout, 10*time.Second, "feed did not update, timeout after: %s", timeout)
 
+	testLogger.Error().Msg("failing on purpose")
+	t.FailNow()
+
 	require.EqualValues(t, priceProvider.ExpectedPrices(), priceProvider.ActualPrices(), "prices do not match")
 	testLogger.Info().Msgf("All %d prices were found in the feed", len(priceProvider.ExpectedPrices()))
 }


### PR DESCRIPTION
do not print Docker container logs, when test fails.

What we want to achieve is this:
```
Run jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
Found 11 containers...
Found 0 matching containers...
```

Instead of what we currently have:
```
Run jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e
Found 12 containers...


***.dkr.ecr.***.amazonaws.com/chainlink:10ed0f95f98f03aa058b66cf05fc63aa3c418cc0-plugins (workflow-node1)
***.dkr.ecr.***.amazonaws.com/chainlink:10ed0f95f98f03aa058b66cf05fc63aa3c418cc0-plugins (workflow-node3)
***.dkr.ecr.***.amazonaws.com/chainlink:10ed0f95f98f03aa058b66cf05fc63aa3c418cc0-plugins (workflow-node4)
***.dkr.ecr.***.amazonaws.com/chainlink:10ed0f95f98f03aa058b66cf05fc63aa3c418cc0-plugins (workflow-node2)
***.dkr.ecr.***.amazonaws.com/chainlink:10ed0f95f98f03aa058b66cf05fc63aa3c418cc0-plugins (workflow-node0)
postgres:12.0 (workflow-ns-postgresql)
gaiaadm/pumba (chaos-e1012)
***.dkr.ecr.***.amazonaws.com/job-distributor:0.6.0 (jd-5dc23)
postgres:12 (jd-db)
f4hrenh9it/foundry:latest (blockchain-node-a858b)
testcontainers/ryuk:0.11.0 (reaper_4464d94da0acc500833dcb3bc93062922a0c9fcf4df6d0206f8952c2c56a56ad)
envoyproxy/envoy:v1.33.0 (gap)
```

As that resulted in printing logs of all these tests to the CI.