### PR TITLE
Remove DestGasOverhead from CalculateMessageMaxGasWithError

### DIFF
--- a/core/capabilities/ccip/ccipevm/gas_helpers.go
+++ b/core/capabilities/ccip/ccipevm/gas_helpers.go
@@ -23,8 +23,7 @@ const (
 		30_000*3 // supportsInterface of ERC165Checker library performs 3 static-calls of 30k gas each
 	PerTokenOverheadGas = TokenAdminRegistryPoolLookupGas +
 		SupportsInterfaceCheck +
-		200_000 + // releaseOrMint using callWithExactGas
-		50_000 // transfer using callWithExactGas
+		200_000 // releaseOrMint using callWithExactGas
 	RateLimiterOverheadGas = 2_100 + // COLD_SLOAD_COST for accessing token bucket
 		5_000 // SSTORE_RESET_GAS for updating & decreasing token bucket
 	ConstantMessagePartBytes            = 10 * 32 // A message consists of 10 abi encoded fields 32B each (after encoding)
@@ -106,8 +105,7 @@ func (gp EstimateProvider) CalculateMessageMaxGasWithError(msg cciptypes.Message
 		adminRegistryOverhead = TokenAdminRegistryWarmupCost
 	}
 
-	return DestGasOverhead +
-		messageGasLimit.Uint64() +
+	return messageGasLimit.Uint64() +
 		messageCallDataGas +
 		ExecutionStateProcessingOverheadGas +
 		SupportsInterfaceCheck +

--- a/core/capabilities/ccip/ccipevm/gas_helpers.go
+++ b/core/capabilities/ccip/ccipevm/gas_helpers.go
@@ -30,7 +30,6 @@ const (
 	ExecutionStateProcessingOverheadGas = 2_100 + // COLD_SLOAD_COST for first reading the state
 		20_000 + // SSTORE_SET_GAS for writing from 0 (untouched) to non-zero (in-progress)
 		100 //# SLOAD_GAS = WARM_STORAGE_READ_COST for rewriting from non-zero (in-progress) to non-zero (success/failure)
-	// TODO: investigate the write overhead for v1.6
 	DestGasOverhead = 300_000 // Commit and Exec costs
 )
 

--- a/core/capabilities/ccip/ccipevm/gas_helpers.go
+++ b/core/capabilities/ccip/ccipevm/gas_helpers.go
@@ -31,7 +31,7 @@ const (
 		20_000 + // SSTORE_SET_GAS for writing from 0 (untouched) to non-zero (in-progress)
 		100 //# SLOAD_GAS = WARM_STORAGE_READ_COST for rewriting from non-zero (in-progress) to non-zero (success/failure)
 	// TODO: investigate the write overhead for v1.6
-	DestGasOverhead = 110_000 + 110_000 + 130_000 // 110K for commit, 110K for RMN, 130K for Exec
+	DestGasOverhead = 300_000 // Commit and Exec costs
 )
 
 func NewGasEstimateProvider() EstimateProvider {

--- a/core/capabilities/ccip/ccipevm/gas_helpers_test.go
+++ b/core/capabilities/ccip/ccipevm/gas_helpers_test.go
@@ -104,7 +104,7 @@ func TestCalculateMaxGas(t *testing.T) {
 			numberOfTokens:   0,
 			extraArgs:        makeExtraArgsV1(200_000),
 			tokenGasOverhead: 10,
-			want:             672_992,
+			want:             322_992,
 		},
 		{
 			name:             "maxGasOverheadGas 2",
@@ -113,7 +113,7 @@ func TestCalculateMaxGas(t *testing.T) {
 			numberOfTokens:   1,
 			extraArgs:        makeExtraArgsV1(200_000),
 			tokenGasOverhead: 10,
-			want:             1_028_518,
+			want:             628_518,
 		},
 		{
 			name:             "v2 extra args",
@@ -122,7 +122,7 @@ func TestCalculateMaxGas(t *testing.T) {
 			numberOfTokens:   1,
 			extraArgs:        makeExtraArgsV2(200_000, true),
 			tokenGasOverhead: 10,
-			want:             1_028_518,
+			want:             628_518,
 		},
 	}
 

--- a/core/capabilities/ccip/ccipevm/gas_helpers_test.go
+++ b/core/capabilities/ccip/ccipevm/gas_helpers_test.go
@@ -26,17 +26,17 @@ func Test_calculateMessageMaxGas(t *testing.T) {
 		{
 			name: "base",
 			args: args{dataLen: 5, numTokens: 2, extraArgs: makeExtraArgsV1(200_000), tokenGasOverhead: 10},
-			want: 1_372_284,
+			want: 922_284,
 		},
 		{
 			name: "large",
 			args: args{dataLen: 1000, numTokens: 1000, extraArgs: makeExtraArgsV1(200_000), tokenGasOverhead: 1},
-			want: 347_028_520,
+			want: 296_678_520,
 		},
 		{
 			name: "overheadGas test 1",
 			args: args{dataLen: 0, numTokens: 0, extraArgs: makeExtraArgsV1(200_000), tokenGasOverhead: 100},
-			want: 669_920,
+			want: 319_920,
 		},
 		{
 			name: "overheadGas test 2",
@@ -46,7 +46,7 @@ func Test_calculateMessageMaxGas(t *testing.T) {
 				extraArgs:        makeExtraArgsV1(200_000),
 				tokenGasOverhead: 2,
 			},
-			want: 1_025_950,
+			want: 625_950,
 		},
 		{
 			name: "allowOOO set to true makes no difference to final gas estimate",
@@ -56,7 +56,7 @@ func Test_calculateMessageMaxGas(t *testing.T) {
 				extraArgs:        makeExtraArgsV2(200_000, true),
 				tokenGasOverhead: 100,
 			},
-			want: 1_372_464,
+			want: 922_464,
 		},
 		{
 			name: "allowOOO set to false makes no difference to final gas estimate",
@@ -66,7 +66,7 @@ func Test_calculateMessageMaxGas(t *testing.T) {
 				extraArgs:        makeExtraArgsV2(200_000, false),
 				tokenGasOverhead: 100,
 			},
-			want: 1_372_464,
+			want: 922_464,
 		},
 	}
 


### PR DESCRIPTION
This was wrongly added as we already have enough overhead added from other fields which made the estimation very high

