### PR TITLE
fix(deployment/ccip): readjust error check for changesets

### DIFF
--- a/deployment/ccip/changeset/cs_ccip_home.go
+++ b/deployment/ccip/changeset/cs_ccip_home.go
@@ -735,17 +735,17 @@ func newDonWithCandidateOp(
 		false, // acceptsWorkflows
 		nodes.DefaultF(),
 	)
-	if err != nil {
-		return mcmstypes.Transaction{}, fmt.Errorf("failed to call AddDON (ptype: %s): %w",
-			types.PluginType(pluginConfig.PluginType).String(), err)
-	}
 
+	// note: error check is handled below
 	if !mcmsEnabled {
 		_, err = deployment.ConfirmIfNoErrorWithABI(
 			homeChain, addDonTx, ccip_home.CCIPHomeABI, err)
 		if err != nil {
 			return mcmstypes.Transaction{}, fmt.Errorf("error confirming addDon call: %w", err)
 		}
+	} else if err != nil {
+		return mcmstypes.Transaction{}, fmt.Errorf("failed to call AddDON (ptype: %s): %w",
+			types.PluginType(pluginConfig.PluginType).String(), err)
 	}
 
 	tx, err := proposalutils.TransactionForChain(homeChain.Selector, capReg.Address().Hex(), addDonTx.Data(),
@@ -928,11 +928,8 @@ func setCandidateOnExistingDon(
 		false,
 		nodes.DefaultF(),
 	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call UpdateDON in set candidate (don: %d; ptype: %s): %w",
-			donID, types.PluginType(pluginConfig.PluginType).String(), err)
-	}
 
+	// note: error check is handled below
 	if !mcmsEnabled {
 		_, err = deployment.ConfirmIfNoErrorWithABI(
 			homeChain, updateDonTx, ccip_home.CCIPHomeABI, err)
@@ -940,6 +937,9 @@ func setCandidateOnExistingDon(
 			return nil, fmt.Errorf("error confirming UpdateDON call in set candidate (don: %d; ptype: %s): %w",
 				donID, types.PluginType(pluginConfig.PluginType).String(), err)
 		}
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to call UpdateDON in set candidate (don: %d; ptype: %s): %w",
+			donID, types.PluginType(pluginConfig.PluginType).String(), err)
 	}
 
 	tx, err := proposalutils.TransactionForChain(homeChain.Selector, capReg.Address().Hex(), updateDonTx.Data(), big.NewInt(0), string(CapabilitiesRegistry), []string{})
@@ -991,11 +991,8 @@ func promoteCandidateOp(
 		false,
 		nodes.DefaultF(),
 	)
-	if err != nil {
-		return mcmstypes.Transaction{}, fmt.Errorf("failed to call UpdateDON in promote candidate (don: %d; ptype: %s): %w",
-			donID, types.PluginType(pluginType).String(), err)
-	}
 
+	// note: error check is handled below
 	if !mcmsEnabled {
 		_, err = deployment.ConfirmIfNoErrorWithABI(
 			homeChain, updateDonTx, ccip_home.CCIPHomeABI, err)
@@ -1003,6 +1000,9 @@ func promoteCandidateOp(
 			return mcmstypes.Transaction{}, fmt.Errorf("error confirming UpdateDON call in promote candidate (don: %d; ptype: %s): %w",
 				donID, types.PluginType(pluginType).String(), err)
 		}
+	} else if err != nil {
+		return mcmstypes.Transaction{}, fmt.Errorf("failed to call UpdateDON in promote candidate (don: %d; ptype: %s): %w",
+			donID, types.PluginType(pluginType).String(), err)
 	}
 
 	tx, err := proposalutils.TransactionForChain(homeChain.Selector, capReg.Address().Hex(), updateDonTx.Data(),
@@ -1218,11 +1218,8 @@ func revokeCandidateOps(
 		false, // isPublic
 		nodes.DefaultF(),
 	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call UpdateDON in revoke candidate (don: %d; ptype: %s): %w",
-			donID, types.PluginType(pluginType).String(), err)
-	}
 
+	// note: error check is handled below
 	if !mcmsEnabled {
 		_, err = deployment.ConfirmIfNoErrorWithABI(
 			homeChain, updateDonTx,
@@ -1231,6 +1228,9 @@ func revokeCandidateOps(
 			return nil, fmt.Errorf("error confirming UpdateDON call in revoke candidate (don: %d; ptype: %s): %w",
 				donID, types.PluginType(pluginType).String(), err)
 		}
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to call UpdateDON in revoke candidate (don: %d; ptype: %s): %w",
+			donID, types.PluginType(pluginType).String(), err)
 	}
 
 	tx, err := proposalutils.TransactionForChain(homeChain.Selector, capReg.Address().Hex(), updateDonTx.Data(),

--- a/deployment/ccip/changeset/cs_update_rmn_config.go
+++ b/deployment/ccip/changeset/cs_update_rmn_config.go
@@ -123,14 +123,15 @@ func setRMNRemoteOnRMNProxyOp(
 	rmnProxy := chainState.RMNProxy
 	rmnRemoteAddr := chainState.RMNRemote.Address()
 	setRMNTx, err := rmnProxy.SetARM(txOpts, rmnRemoteAddr)
-	if err != nil {
-		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to build call data/transaction to set RMNRemote on RMNProxy for chain %s: %w", chain.String(), err)
-	}
+
+	// note: error check is handled below
 	if !mcmsEnabled {
 		_, err = deployment.ConfirmIfNoErrorWithABI(chain, setRMNTx, rmn_proxy_contract.RMNProxyABI, err)
 		if err != nil {
 			return mcmstypes.BatchOperation{}, fmt.Errorf("failed to confirm tx to set RMNRemote on RMNProxy  for chain %s: %w", chain.String(), deployment.MaybeDataErr(err))
 		}
+	} else if err != nil {
+		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to build call data/transaction to set RMNRemote on RMNProxy for chain %s: %w", chain.String(), err)
 	}
 
 	batchOperation, err := proposalutils.BatchOperationForChain(chain.Selector, rmnProxy.Address().Hex(),

--- a/deployment/ccip/changeset/v1_5/cs_rmn.go
+++ b/deployment/ccip/changeset/v1_5/cs_rmn.go
@@ -134,10 +134,8 @@ func PermaBlessCommitStoreChangeset(env deployment.Environment, c PermaBlessComm
 			txOpts = deployment.SimTransactOpts()
 		}
 		tx, err := RMN.OwnerRemoveThenAddPermaBlessedCommitStores(txOpts, removes, adds)
-		if err != nil {
-			return deployment.ChangesetOutput{}, err
-		}
 
+		// note: error check is handled below
 		if c.MCMSConfig == nil {
 			_, err = deployment.ConfirmIfNoErrorWithABI(env.Chains[destChain], tx, rmn_contract.RMNContractABI, err)
 			if err != nil {
@@ -145,6 +143,8 @@ func PermaBlessCommitStoreChangeset(env deployment.Environment, c PermaBlessComm
 			}
 			env.Logger.Infof("PermaBlessed commit stores on chain %d removed %v, added %v", destChain, removes, adds)
 			continue
+		} else if err != nil {
+			return deployment.ChangesetOutput{}, err
 		}
 
 		timelocks[destChain] = destState.Timelock.Address().Hex()


### PR DESCRIPTION
In the previous [PR](https://github.com/smartcontractkit/chainlink/pull/16458/files#diff-f6eeb14804b5d16769abc3f48ad18187965263d5e5d29345e4079e85199de731R127), there was a bug that was introduced that made the code exit early and did not fall in to the `ConfirmIfNoErrorWithABI` so better error message can be decoded when mcms is not enabled. This commit brings back that behaviour.
