### PR TITLE
add timelock to solana remote chain

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -183,7 +183,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.keystone_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@244b17ef5c6ddad3cc841ba90117304216d031f5
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@18ee2276811ff4ad56a2284590c9917bec33b748
     with:
       workflow_name: Run Core Workflow Engine Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -211,8 +211,6 @@ jobs:
       AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN }}
       AWS_API_GW_HOST_GRAFANA: ${{ secrets.AWS_API_GW_HOST_GRAFANA }}
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
-      MAIN_DNS_ZONE_PUBLIC_SDLC: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
-      AWS_K8S_CLUSTER_NAME_SDLC: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
       OPTIONAL_GATI_AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       OPTIONAL_GATI_LAMBDA_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
@@ -226,7 +224,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@244b17ef5c6ddad3cc841ba90117304216d031f5
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@18ee2276811ff4ad56a2284590c9917bec33b748
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -254,8 +252,6 @@ jobs:
       AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN }}
       AWS_API_GW_HOST_GRAFANA: ${{ secrets.AWS_API_GW_HOST_GRAFANA }}
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
-      MAIN_DNS_ZONE_PUBLIC_SDLC: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
-      AWS_K8S_CLUSTER_NAME_SDLC: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
 
   run-core-e2e-tests-for-merge-queue:
     name: Run Core E2E Tests For Merge Queue
@@ -267,7 +263,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@244b17ef5c6ddad3cc841ba90117304216d031f5
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@18ee2276811ff4ad56a2284590c9917bec33b748
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -299,8 +295,6 @@ jobs:
       AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN }}
       AWS_API_GW_HOST_GRAFANA: ${{ secrets.AWS_API_GW_HOST_GRAFANA }}
       SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
-      MAIN_DNS_ZONE_PUBLIC_SDLC: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
-      AWS_K8S_CLUSTER_NAME_SDLC: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
 
   run-ccip-e2e-tests-for-pr:
     name: Run CCIP E2E Tests For PR
@@ -312,7 +306,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@244b17ef5c6ddad3cc841ba90117304216d031f5
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@18ee2276811ff4ad56a2284590c9917bec33b748
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -354,7 +348,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@244b17ef5c6ddad3cc841ba90117304216d031f5
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@18ee2276811ff4ad56a2284590c9917bec33b748
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -340,7 +340,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.40 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.1 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420ccacab78a // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1086,8 +1086,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4 h1:voKtyPNWsT4o/IilRbkEMsvYEWhYMpkl94mi3fDQz60=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb h1:Z5QRY8DtXnxnPwbo+mR1mxwaL+OClza3ATUqcQ1Ynz8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=

--- a/deployment/ccip/changeset/globals/config.go
+++ b/deployment/ccip/changeset/globals/config.go
@@ -18,14 +18,14 @@ const (
 	InflightCacheExpiry                     = 10 * time.Minute
 	RootSnoozeTime                          = 30 * time.Minute
 	BatchingStrategyID                      = 0
-	DeltaProgress                           = 30 * time.Second
+	DeltaProgress                           = 10 * time.Second
 	DeltaResend                             = 10 * time.Second
 	DeltaInitial                            = 20 * time.Second
 	DeltaRound                              = 2 * time.Second
 	DeltaGrace                              = 2 * time.Second
 	DeltaCertifiedCommitRequest             = 10 * time.Second
 	DeltaStage                              = 10 * time.Second
-	Rmax                                    = 3
+	Rmax                                    = 50
 	MaxDurationQuery                        = 500 * time.Millisecond
 	MaxDurationObservation                  = 5 * time.Second
 	MaxDurationShouldAcceptAttestedReport   = 10 * time.Second

--- a/deployment/ccip/changeset/solana/cs_add_remote_chain.go
+++ b/deployment/ccip/changeset/solana/cs_add_remote_chain.go
@@ -36,7 +36,7 @@ type AddRemoteChainToSolanaConfig struct {
 	// Disallow mixing MCMS/non-MCMS per chain for simplicity.
 	// (can still be achieved by calling this function multiple times)
 	MCMS *cs.MCMSConfig
-	// Public key of program authorites. Depending on when this changeset is called, some may be under
+	// Public key of program authorities. Depending on when this changeset is called, some may be under
 	// the control of the deployer, and some may be under the control of the timelock. (e.g. during new offramp deploy)
 	RouterAuthority    solana.PublicKey
 	FeeQuoterAuthority solana.PublicKey

--- a/deployment/ccip/changeset/solana/cs_add_remote_chain.go
+++ b/deployment/ccip/changeset/solana/cs_add_remote_chain.go
@@ -2,12 +2,17 @@ package solana
 
 import (
 	"context"
-	// "errors"
+
 	"fmt"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+
+	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/sdk"
+	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
+	mcmsTypes "github.com/smartcontractkit/mcms/types"
 
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	solRouter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
@@ -17,8 +22,10 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	cs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
 // ADD REMOTE CHAIN
@@ -29,6 +36,11 @@ type AddRemoteChainToSolanaConfig struct {
 	// Disallow mixing MCMS/non-MCMS per chain for simplicity.
 	// (can still be achieved by calling this function multiple times)
 	MCMS *ccipChangeset.MCMSConfig
+	// Public key of program authorites. Depending on when this changeset is called, some may be under
+	// the control of the deployer, and some may be under the control of the timelock. (e.g. during new offramp deploy)
+	RouterAuthority    solana.PublicKey
+	FeeQuoterAuthority solana.PublicKey
+	OffRampAuthority   solana.PublicKey
 }
 
 type RemoteChainConfigSolana struct {
@@ -55,19 +67,23 @@ func (cfg AddRemoteChainToSolanaConfig) Validate(e deployment.Environment) error
 	if err := validateOffRampConfig(chain, chainState); err != nil {
 		return err
 	}
+	if err := ValidateMCMSConfig(e, cfg.ChainSelector, cfg.MCMS); err != nil {
+		return err
+	}
+	routerUsingMCMS := cfg.MCMS != nil && !cfg.RouterAuthority.IsZero()
+	feeQuoterUsingMCMS := cfg.MCMS != nil && !cfg.FeeQuoterAuthority.IsZero()
+	offRampUsingMCMS := cfg.MCMS != nil && !cfg.OffRampAuthority.IsZero()
 	chain, ok := e.SolChains[cfg.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain %d not found in environment", cfg.ChainSelector)
 	}
-	addresses, err := e.ExistingAddresses.AddressesForChain(cfg.ChainSelector)
-	if err != nil {
-		return err
+	if err := ccipChangeset.ValidateOwnershipSolana(&e, chain, routerUsingMCMS, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), chainState.Router, ccipChangeset.Router); err != nil {
+		return fmt.Errorf("failed to validate ownership: %w", err)
 	}
-	mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
-	if err != nil {
-		return fmt.Errorf("error loading MCMS state for chain %d: %w", cfg.ChainSelector, err)
+	if err := ccipChangeset.ValidateOwnershipSolana(&e, chain, feeQuoterUsingMCMS, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), chainState.FeeQuoter, ccipChangeset.FeeQuoter); err != nil {
+		return fmt.Errorf("failed to validate ownership: %w", err)
 	}
-	if err := commoncs.ValidateOwnershipSolana(e.GetContext(), cfg.MCMS != nil, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), mcmState.TimelockProgram, mcmState.TimelockSeed, chainState.Router); err != nil {
+	if err := ccipChangeset.ValidateOwnershipSolana(&e, chain, offRampUsingMCMS, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), chainState.OffRamp, ccipChangeset.OffRamp); err != nil {
 		return fmt.Errorf("failed to validate ownership: %w", err)
 	}
 	var routerConfigAccount solRouter.Config
@@ -110,9 +126,46 @@ func AddRemoteChainToSolana(e deployment.Environment, cfg AddRemoteChainToSolana
 	}
 
 	ab := deployment.NewMemoryAddressBook()
-	err = doAddRemoteChainToSolana(e, s, cfg.ChainSelector, cfg.UpdatesByChain, ab)
+	txns, err := doAddRemoteChainToSolana(e, s, cfg, ab)
 	if err != nil {
 		return deployment.ChangesetOutput{AddressBook: ab}, err
+	}
+
+	// create proposals for ixns
+	if len(txns) > 0 {
+		timelocks := map[uint64]string{}
+		proposers := map[uint64]string{}
+		inspectors := map[uint64]sdk.Inspector{}
+		batches := make([]mcmsTypes.BatchOperation, 0)
+		chain := e.SolChains[cfg.ChainSelector]
+		addresses, _ := e.ExistingAddresses.AddressesForChain(cfg.ChainSelector)
+		mcmState, _ := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+
+		timelocks[cfg.ChainSelector] = mcmsSolana.ContractAddress(
+			mcmState.TimelockProgram,
+			mcmsSolana.PDASeed(mcmState.TimelockSeed),
+		)
+		proposers[cfg.ChainSelector] = mcmsSolana.ContractAddress(mcmState.McmProgram, mcmsSolana.PDASeed(mcmState.ProposerMcmSeed))
+		inspectors[cfg.ChainSelector] = mcmsSolana.NewInspector(chain.Client)
+		batches = append(batches, mcmsTypes.BatchOperation{
+			ChainSelector: mcmsTypes.ChainSelector(cfg.ChainSelector),
+			Transactions:  txns,
+		})
+		proposal, err := proposalutils.BuildProposalFromBatchesV2(
+			e.GetContext(),
+			timelocks,
+			proposers,
+			inspectors,
+			batches,
+			"proposal to add remote chains to Solana",
+			cfg.MCMS.MinDelay)
+		if err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
+		}
+		return deployment.ChangesetOutput{
+			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
+			AddressBook:           ab,
+		}, nil
 	}
 	return deployment.ChangesetOutput{AddressBook: ab}, nil
 }
@@ -120,13 +173,19 @@ func AddRemoteChainToSolana(e deployment.Environment, cfg AddRemoteChainToSolana
 func doAddRemoteChainToSolana(
 	e deployment.Environment,
 	s ccipChangeset.CCIPOnChainState,
-	chainSel uint64,
-	updates map[uint64]RemoteChainConfigSolana,
-	ab deployment.AddressBook) error {
+	cfg AddRemoteChainToSolanaConfig,
+	ab deployment.AddressBook) ([]mcmsTypes.Transaction, error) {
+	txns := make([]mcmsTypes.Transaction, 0)
+	ixns := make([]solana.Instruction, 0)
+	chainSel := cfg.ChainSelector
+	updates := cfg.UpdatesByChain
 	chain := e.SolChains[chainSel]
 	ccipRouterID := s.SolChains[chainSel].Router
 	feeQuoterID := s.SolChains[chainSel].FeeQuoter
 	offRampID := s.SolChains[chainSel].OffRamp
+	routerUsingMCMS := cfg.MCMS != nil && !cfg.RouterAuthority.IsZero()
+	feeQuoterUsingMCMS := cfg.MCMS != nil && !cfg.FeeQuoterAuthority.IsZero()
+	offRampUsingMCMS := cfg.MCMS != nil && !cfg.OffRampAuthority.IsZero()
 	lookUpTableEntries := make([]solana.PublicKey, 0)
 
 	for remoteChainSel, update := range updates {
@@ -149,6 +208,12 @@ func doAddRemoteChainToSolana(
 		)
 
 		solRouter.SetProgramID(ccipRouterID)
+		var authority solana.PublicKey
+		if routerUsingMCMS {
+			authority = cfg.RouterAuthority
+		} else {
+			authority = chain.DeployerKey.PublicKey()
+		}
 		routerIx, err := solRouter.NewAddChainSelectorInstruction(
 			remoteChainSel,
 			update.RouterDestinationConfig,
@@ -166,24 +231,47 @@ func doAddRemoteChainToSolana(
 			offRampID,
 			allowedOffRampRemotePDA,
 			s.SolChains[chainSel].RouterConfigPDA,
-			chain.DeployerKey.PublicKey(),
+			authority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {
-			return fmt.Errorf("failed to generate instructions: %w", err)
+			return txns, fmt.Errorf("failed to generate instructions: %w", err)
+		}
+		if routerUsingMCMS {
+			tx, err := BuildMCMSTxn(routerIx, ccipRouterID.String(), cs.Router)
+			if err != nil {
+				return txns, fmt.Errorf("failed to create transaction: %w", err)
+			}
+			txns = append(txns, *tx)
+		} else {
+			ixns = append(ixns, routerIx)
 		}
 
 		solFeeQuoter.SetProgramID(feeQuoterID)
+		if feeQuoterUsingMCMS {
+			authority = cfg.RouterAuthority
+		} else {
+			authority = chain.DeployerKey.PublicKey()
+		}
 		feeQuoterIx, err := solFeeQuoter.NewAddDestChainInstruction(
 			remoteChainSel,
 			update.FeeQuoterDestinationConfig,
 			s.SolChains[chainSel].FeeQuoterConfigPDA,
 			fqRemoteChainPDA,
-			chain.DeployerKey.PublicKey(),
+			authority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {
-			return fmt.Errorf("failed to generate instructions: %w", err)
+			return txns, fmt.Errorf("failed to generate instructions: %w", err)
+		}
+		if feeQuoterUsingMCMS {
+			tx, err := BuildMCMSTxn(feeQuoterIx, feeQuoterID.String(), cs.FeeQuoter)
+			if err != nil {
+				return txns, fmt.Errorf("failed to create transaction: %w", err)
+			}
+			txns = append(txns, *tx)
+		} else {
+			ixns = append(ixns, feeQuoterIx)
 		}
 
 		solOffRamp.SetProgramID(offRampID)
@@ -191,22 +279,37 @@ func doAddRemoteChainToSolana(
 			OnRamp:    [2][64]byte{onRampBytes, [64]byte{}},
 			IsEnabled: update.EnabledAsSource,
 		}
+		if offRampUsingMCMS {
+			authority = cfg.RouterAuthority
+		} else {
+			authority = chain.DeployerKey.PublicKey()
+		}
 		offRampIx, err := solOffRamp.NewAddSourceChainInstruction(
 			remoteChainSel,
 			validSourceChainConfig,
 			offRampRemoteStatePDA,
 			s.SolChains[chainSel].OffRampConfigPDA,
-			chain.DeployerKey.PublicKey(),
+			authority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 
 		if err != nil {
-			return fmt.Errorf("failed to generate instructions: %w", err)
+			return txns, fmt.Errorf("failed to generate instructions: %w", err)
 		}
-
-		err = chain.Confirm([]solana.Instruction{routerIx, routerOfframpIx, feeQuoterIx, offRampIx})
-		if err != nil {
-			return fmt.Errorf("failed to confirm instructions: %w", err)
+		if offRampUsingMCMS {
+			tx, err := BuildMCMSTxn(offRampIx, offRampID.String(), ccipChangeset.OffRamp)
+			if err != nil {
+				return txns, fmt.Errorf("failed to create transaction: %w", err)
+			}
+			txns = append(txns, *tx)
+		} else {
+			ixns = append(ixns, offRampIx)
+		}
+		if len(ixns) > 0 {
+			err = chain.Confirm(ixns)
+			if err != nil {
+				return txns, fmt.Errorf("failed to confirm instructions: %w", err)
+			}
 		}
 
 		tv := deployment.NewTypeAndVersion(ccipChangeset.RemoteDest, deployment.Version1_0_0)
@@ -214,20 +317,20 @@ func doAddRemoteChainToSolana(
 		tv.AddLabel(remoteChainSelStr)
 		err = ab.Save(chainSel, routerRemoteStatePDA.String(), tv)
 		if err != nil {
-			return fmt.Errorf("failed to save dest chain state to address book: %w", err)
+			return txns, fmt.Errorf("failed to save dest chain state to address book: %w", err)
 		}
 
 		tv = deployment.NewTypeAndVersion(ccipChangeset.RemoteSource, deployment.Version1_0_0)
 		tv.AddLabel(remoteChainSelStr)
 		err = ab.Save(chainSel, allowedOffRampRemotePDA.String(), tv)
 		if err != nil {
-			return fmt.Errorf("failed to save source chain state to address book: %w", err)
+			return txns, fmt.Errorf("failed to save source chain state to address book: %w", err)
 		}
 	}
 
 	addressLookupTable, err := ccipChangeset.FetchOfframpLookupTable(e.GetContext(), chain, offRampID)
 	if err != nil {
-		return fmt.Errorf("failed to get offramp reference addresses: %w", err)
+		return txns, fmt.Errorf("failed to get offramp reference addresses: %w", err)
 	}
 
 	if err := solCommonUtil.ExtendLookupTable(
@@ -237,8 +340,8 @@ func doAddRemoteChainToSolana(
 		*chain.DeployerKey,
 		lookUpTableEntries,
 	); err != nil {
-		return fmt.Errorf("failed to extend lookup table: %w", err)
+		return txns, fmt.Errorf("failed to extend lookup table: %w", err)
 	}
 
-	return nil
+	return txns, nil
 }

--- a/deployment/ccip/changeset/solana/cs_add_remote_chain.go
+++ b/deployment/ccip/changeset/solana/cs_add_remote_chain.go
@@ -2,12 +2,17 @@ package solana
 
 import (
 	"context"
-	// "errors"
+
 	"fmt"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+
+	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/sdk"
+	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
+	mcmsTypes "github.com/smartcontractkit/mcms/types"
 
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	solRouter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
@@ -19,8 +24,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	cs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
 // ADD REMOTE CHAIN
@@ -31,6 +36,11 @@ type AddRemoteChainToSolanaConfig struct {
 	// Disallow mixing MCMS/non-MCMS per chain for simplicity.
 	// (can still be achieved by calling this function multiple times)
 	MCMS *cs.MCMSConfig
+	// Public key of program authorites. Depending on when this changeset is called, some may be under
+	// the control of the deployer, and some may be under the control of the timelock. (e.g. during new offramp deploy)
+	RouterAuthority    solana.PublicKey
+	FeeQuoterAuthority solana.PublicKey
+	OffRampAuthority   solana.PublicKey
 }
 
 type RemoteChainConfigSolana struct {
@@ -57,19 +67,23 @@ func (cfg AddRemoteChainToSolanaConfig) Validate(e deployment.Environment) error
 	if err := validateOffRampConfig(chain, chainState); err != nil {
 		return err
 	}
+	if err := ValidateMCMSConfig(e, cfg.ChainSelector, cfg.MCMS); err != nil {
+		return err
+	}
+	routerUsingMCMS := cfg.MCMS != nil && !cfg.RouterAuthority.IsZero()
+	feeQuoterUsingMCMS := cfg.MCMS != nil && !cfg.FeeQuoterAuthority.IsZero()
+	offRampUsingMCMS := cfg.MCMS != nil && !cfg.OffRampAuthority.IsZero()
 	chain, ok := e.SolChains[cfg.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain %d not found in environment", cfg.ChainSelector)
 	}
-	addresses, err := e.ExistingAddresses.AddressesForChain(cfg.ChainSelector)
-	if err != nil {
-		return err
+	if err := cs.ValidateOwnershipSolana(&e, chain, routerUsingMCMS, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), chainState.Router, cs.Router); err != nil {
+		return fmt.Errorf("failed to validate ownership: %w", err)
 	}
-	mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
-	if err != nil {
-		return fmt.Errorf("error loading MCMS state for chain %d: %w", cfg.ChainSelector, err)
+	if err := cs.ValidateOwnershipSolana(&e, chain, feeQuoterUsingMCMS, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), chainState.FeeQuoter, cs.FeeQuoter); err != nil {
+		return fmt.Errorf("failed to validate ownership: %w", err)
 	}
-	if err := commoncs.ValidateOwnershipSolana(e.GetContext(), cfg.MCMS != nil, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), mcmState.TimelockProgram, mcmState.TimelockSeed, chainState.Router); err != nil {
+	if err := cs.ValidateOwnershipSolana(&e, chain, offRampUsingMCMS, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), chainState.OffRamp, cs.OffRamp); err != nil {
 		return fmt.Errorf("failed to validate ownership: %w", err)
 	}
 	var routerConfigAccount solRouter.Config
@@ -112,9 +126,46 @@ func AddRemoteChainToSolana(e deployment.Environment, cfg AddRemoteChainToSolana
 	}
 
 	ab := deployment.NewMemoryAddressBook()
-	err = doAddRemoteChainToSolana(e, s, cfg.ChainSelector, cfg.UpdatesByChain, ab)
+	txns, err := doAddRemoteChainToSolana(e, s, cfg, ab)
 	if err != nil {
 		return deployment.ChangesetOutput{AddressBook: ab}, err
+	}
+
+	// create proposals for ixns
+	if len(txns) > 0 {
+		timelocks := map[uint64]string{}
+		proposers := map[uint64]string{}
+		inspectors := map[uint64]sdk.Inspector{}
+		batches := make([]mcmsTypes.BatchOperation, 0)
+		chain := e.SolChains[cfg.ChainSelector]
+		addresses, _ := e.ExistingAddresses.AddressesForChain(cfg.ChainSelector)
+		mcmState, _ := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+
+		timelocks[cfg.ChainSelector] = mcmsSolana.ContractAddress(
+			mcmState.TimelockProgram,
+			mcmsSolana.PDASeed(mcmState.TimelockSeed),
+		)
+		proposers[cfg.ChainSelector] = mcmsSolana.ContractAddress(mcmState.McmProgram, mcmsSolana.PDASeed(mcmState.ProposerMcmSeed))
+		inspectors[cfg.ChainSelector] = mcmsSolana.NewInspector(chain.Client)
+		batches = append(batches, mcmsTypes.BatchOperation{
+			ChainSelector: mcmsTypes.ChainSelector(cfg.ChainSelector),
+			Transactions:  txns,
+		})
+		proposal, err := proposalutils.BuildProposalFromBatchesV2(
+			e.GetContext(),
+			timelocks,
+			proposers,
+			inspectors,
+			batches,
+			"proposal to add remote chains to Solana",
+			cfg.MCMS.MinDelay)
+		if err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
+		}
+		return deployment.ChangesetOutput{
+			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
+			AddressBook:           ab,
+		}, nil
 	}
 	return deployment.ChangesetOutput{AddressBook: ab}, nil
 }
@@ -122,13 +173,19 @@ func AddRemoteChainToSolana(e deployment.Environment, cfg AddRemoteChainToSolana
 func doAddRemoteChainToSolana(
 	e deployment.Environment,
 	s cs.CCIPOnChainState,
-	chainSel uint64,
-	updates map[uint64]RemoteChainConfigSolana,
-	ab deployment.AddressBook) error {
+	cfg AddRemoteChainToSolanaConfig,
+	ab deployment.AddressBook) ([]mcmsTypes.Transaction, error) {
+	txns := make([]mcmsTypes.Transaction, 0)
+	ixns := make([]solana.Instruction, 0)
+	chainSel := cfg.ChainSelector
+	updates := cfg.UpdatesByChain
 	chain := e.SolChains[chainSel]
 	ccipRouterID := s.SolChains[chainSel].Router
 	feeQuoterID := s.SolChains[chainSel].FeeQuoter
 	offRampID := s.SolChains[chainSel].OffRamp
+	routerUsingMCMS := cfg.MCMS != nil && !cfg.RouterAuthority.IsZero()
+	feeQuoterUsingMCMS := cfg.MCMS != nil && !cfg.FeeQuoterAuthority.IsZero()
+	offRampUsingMCMS := cfg.MCMS != nil && !cfg.OffRampAuthority.IsZero()
 	lookUpTableEntries := make([]solana.PublicKey, 0)
 
 	for remoteChainSel, update := range updates {
@@ -157,29 +214,58 @@ func doAddRemoteChainToSolana(
 		)
 
 		solRouter.SetProgramID(ccipRouterID)
+		var authority solana.PublicKey
+		if routerUsingMCMS {
+			authority = cfg.RouterAuthority
+		} else {
+			authority = chain.DeployerKey.PublicKey()
+		}
 		routerIx, err := solRouter.NewAddChainSelectorInstruction(
 			remoteChainSel,
 			update.RouterDestinationConfig,
 			routerDestChainPDA,
 			s.SolChains[chainSel].RouterConfigPDA,
-			chain.DeployerKey.PublicKey(),
+			authority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {
-			return fmt.Errorf("failed to generate instructions: %w", err)
+			return txns, fmt.Errorf("failed to generate instructions: %w", err)
+		}
+		if routerUsingMCMS {
+			tx, err := BuildMCMSTxn(routerIx, ccipRouterID.String(), cs.Router)
+			if err != nil {
+				return txns, fmt.Errorf("failed to create transaction: %w", err)
+			}
+			txns = append(txns, *tx)
+		} else {
+			ixns = append(ixns, routerIx)
 		}
 
 		solFeeQuoter.SetProgramID(feeQuoterID)
+		if feeQuoterUsingMCMS {
+			authority = cfg.RouterAuthority
+		} else {
+			authority = chain.DeployerKey.PublicKey()
+		}
 		feeQuoterIx, err := solFeeQuoter.NewAddDestChainInstruction(
 			remoteChainSel,
 			update.FeeQuoterDestinationConfig,
 			s.SolChains[chainSel].FeeQuoterConfigPDA,
 			fqDestChainPDA,
-			chain.DeployerKey.PublicKey(),
+			authority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {
-			return fmt.Errorf("failed to generate instructions: %w", err)
+			return txns, fmt.Errorf("failed to generate instructions: %w", err)
+		}
+		if feeQuoterUsingMCMS {
+			tx, err := BuildMCMSTxn(feeQuoterIx, feeQuoterID.String(), cs.FeeQuoter)
+			if err != nil {
+				return txns, fmt.Errorf("failed to create transaction: %w", err)
+			}
+			txns = append(txns, *tx)
+		} else {
+			ixns = append(ixns, feeQuoterIx)
 		}
 
 		solOffRamp.SetProgramID(offRampID)
@@ -187,21 +273,36 @@ func doAddRemoteChainToSolana(
 			OnRamp:    [2][64]byte{onRampBytes, [64]byte{}},
 			IsEnabled: update.EnabledAsSource,
 		}
+		if offRampUsingMCMS {
+			authority = cfg.RouterAuthority
+		} else {
+			authority = chain.DeployerKey.PublicKey()
+		}
 		offRampIx, err := solOffRamp.NewAddSourceChainInstruction(
 			remoteChainSel,
 			validSourceChainConfig,
 			offRampSourceChainPDA,
 			s.SolChains[chainSel].OffRampConfigPDA,
-			chain.DeployerKey.PublicKey(),
+			authority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {
-			return fmt.Errorf("failed to generate instructions: %w", err)
+			return txns, fmt.Errorf("failed to generate instructions: %w", err)
 		}
-
-		err = chain.Confirm([]solana.Instruction{routerIx, feeQuoterIx, offRampIx})
-		if err != nil {
-			return fmt.Errorf("failed to confirm instructions: %w", err)
+		if offRampUsingMCMS {
+			tx, err := BuildMCMSTxn(offRampIx, offRampID.String(), cs.OffRamp)
+			if err != nil {
+				return txns, fmt.Errorf("failed to create transaction: %w", err)
+			}
+			txns = append(txns, *tx)
+		} else {
+			ixns = append(ixns, offRampIx)
+		}
+		if len(ixns) > 0 {
+			err = chain.Confirm(ixns)
+			if err != nil {
+				return txns, fmt.Errorf("failed to confirm instructions: %w", err)
+			}
 		}
 
 		tv := deployment.NewTypeAndVersion(cs.RemoteDest, deployment.Version1_0_0)
@@ -209,20 +310,20 @@ func doAddRemoteChainToSolana(
 		tv.AddLabel(remoteChainSelStr)
 		err = ab.Save(chainSel, routerDestChainPDA.String(), tv)
 		if err != nil {
-			return fmt.Errorf("failed to save dest chain state to address book: %w", err)
+			return txns, fmt.Errorf("failed to save dest chain state to address book: %w", err)
 		}
 
 		tv = deployment.NewTypeAndVersion(cs.RemoteSource, deployment.Version1_0_0)
 		tv.AddLabel(remoteChainSelStr)
 		err = ab.Save(chainSel, offRampSourceChainPDA.String(), tv)
 		if err != nil {
-			return fmt.Errorf("failed to save source chain state to address book: %w", err)
+			return txns, fmt.Errorf("failed to save source chain state to address book: %w", err)
 		}
 	}
 
 	addressLookupTable, err := cs.FetchOfframpLookupTable(e.GetContext(), chain, offRampID)
 	if err != nil {
-		return fmt.Errorf("failed to get offramp reference addresses: %w", err)
+		return txns, fmt.Errorf("failed to get offramp reference addresses: %w", err)
 	}
 
 	if err := solCommonUtil.ExtendLookupTable(
@@ -232,8 +333,8 @@ func doAddRemoteChainToSolana(
 		*chain.DeployerKey,
 		lookUpTableEntries,
 	); err != nil {
-		return fmt.Errorf("failed to extend lookup table: %w", err)
+		return txns, fmt.Errorf("failed to extend lookup table: %w", err)
 	}
 
-	return nil
+	return txns, nil
 }

--- a/deployment/ccip/changeset/solana/cs_build_solana.go
+++ b/deployment/ccip/changeset/solana/cs_build_solana.go
@@ -115,7 +115,7 @@ func replaceKeysForUpgrade(e deployment.Environment, keys map[deployment.Contrac
 
 		// Replace declare_id!("..."); with the new key
 		updatedContent := regexp.MustCompile(`declare_id!\(".*?"\);`).ReplaceAllString(string(content), fmt.Sprintf(`declare_id!("%s");`, key))
-		err = os.WriteFile(fullPath, []byte(updatedContent), 0644)
+		err = os.WriteFile(fullPath, []byte(updatedContent), 0600)
 		if err != nil {
 			return fmt.Errorf("failed to write updated keys to file %s: %w", fullPath, err)
 		}

--- a/deployment/ccip/changeset/solana/cs_build_solana.go
+++ b/deployment/ccip/changeset/solana/cs_build_solana.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	cs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 )
 
 var _ deployment.ChangeSet[BuildSolanaConfig] = BuildSolanaChangeset
@@ -21,6 +23,13 @@ const (
 	anchorDir = "chains/solana/contracts" // Path to the Anchor project within the repo
 	deployDir = "chains/solana/contracts/target/deploy"
 )
+
+// Map program names to their Rust file paths (relative to the Anchor project root)
+// Needed for upgrades in place
+var programToFileMap = map[deployment.ContractType]string{
+	cs.Router:    "programs/ccip-router/src/lib.rs",
+	cs.FeeQuoter: "programs/fee-quoter/src/lib.rs",
+}
 
 // Run a command in a specific directory
 func runCommand(command string, args []string, workDir string) (string, error) {
@@ -37,8 +46,14 @@ func runCommand(command string, args []string, workDir string) (string, error) {
 }
 
 // Clone and checkout the specific revision of the repo
-func cloneRepo(e deployment.Environment, revision string) error {
+func cloneRepo(e deployment.Environment, revision string, forceClean bool) error {
 	// Check if the repository already exists
+	if forceClean {
+		e.Logger.Debugw("Cleaning repository", "dir", cloneDir)
+		if err := os.RemoveAll(cloneDir); err != nil {
+			return fmt.Errorf("failed to clean repository: %w", err)
+		}
+	}
 	if _, err := os.Stat(filepath.Join(cloneDir, ".git")); err == nil {
 		e.Logger.Debugw("Repository already exists, discarding local changes and updating", "dir", cloneDir)
 
@@ -83,6 +98,32 @@ func replaceKeys(e deployment.Environment) error {
 	return nil
 }
 
+func replaceKeysForUpgrade(e deployment.Environment, keys map[deployment.ContractType]string) error {
+	e.Logger.Debug("Replacing keys in Rust files...")
+	for program, key := range keys {
+		programStr := string(program)
+		filePath, exists := programToFileMap[program]
+		if !exists {
+			return fmt.Errorf("no file path found for program %s", programStr)
+		}
+
+		fullPath := filepath.Join(cloneDir, anchorDir, filePath)
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", fullPath, err)
+		}
+
+		// Replace declare_id!("..."); with the new key
+		updatedContent := regexp.MustCompile(`declare_id!\(".*?"\);`).ReplaceAllString(string(content), fmt.Sprintf(`declare_id!("%s");`, key))
+		err = os.WriteFile(fullPath, []byte(updatedContent), 0644)
+		if err != nil {
+			return fmt.Errorf("failed to write updated keys to file %s: %w", fullPath, err)
+		}
+		e.Logger.Debugw("Updated key for program %s in file %s\n", programStr, filePath)
+	}
+	return nil
+}
+
 func copyFile(srcFile string, destDir string) error {
 	output, err := runCommand("cp", []string{srcFile, destDir}, ".")
 	if err != nil {
@@ -108,6 +149,9 @@ type BuildSolanaConfig struct {
 	DestinationDir       string
 	CleanDestinationDir  bool
 	CreateDestinationDir bool
+	// Forces re-clone of git directory. Useful for forcing regeneration of keys
+	CleanGitDir bool
+	UpgradeKeys map[deployment.ContractType]string
 }
 
 func BuildSolanaChangeset(e deployment.Environment, config BuildSolanaConfig) (deployment.ChangesetOutput, error) {
@@ -124,12 +168,19 @@ func BuildSolanaChangeset(e deployment.Environment, config BuildSolanaConfig) (d
 	}
 
 	// Clone the repository
-	if err := cloneRepo(e, config.GitCommitSha); err != nil {
+	if err := cloneRepo(e, config.GitCommitSha, config.CleanGitDir); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("error cloning repo: %w", err)
 	}
 
+	// Replace keys in Rust files using anchor keys sync
 	if err := replaceKeys(e); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("error replacing keys: %w", err)
+	}
+
+	// Replace keys in Rust files for upgrade by replacing the declare_id!() macro explicitly
+	// We need to do this so the keys will match the existing deployed program
+	if err := replaceKeysForUpgrade(e, config.UpgradeKeys); err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("error replacing keys for upgrade: %w", err)
 	}
 
 	// Build the project with Anchor

--- a/deployment/ccip/changeset/solana/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts.go
@@ -12,13 +12,13 @@ import (
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 )
 
 var _ deployment.ChangeSet[v1_6.SetOCR3OffRampConfig] = SetOCR3ConfigSolana
 var _ deployment.ChangeSet[AddRemoteChainToSolanaConfig] = AddRemoteChainToSolana
-var _ deployment.ChangeSet[BillingTokenConfig] = AddBillingToken
+var _ deployment.ChangeSet[BillingTokenConfig] = AddBillingTokenChangeset
 var _ deployment.ChangeSet[BillingTokenForRemoteChainConfig] = AddBillingTokenForRemoteChain
 var _ deployment.ChangeSet[RegisterTokenAdminRegistryConfig] = RegisterTokenAdminRegistry
 var _ deployment.ChangeSet[TransferAdminRoleTokenAdminRegistryConfig] = TransferAdminRoleTokenAdminRegistry
@@ -27,15 +27,15 @@ var _ deployment.ChangeSet[SetFeeAggregatorConfig] = SetFeeAggregator
 
 // HELPER FUNCTIONS
 // GetTokenProgramID returns the program ID for the given token program name
-func GetTokenProgramID(programName string) (solana.PublicKey, error) {
-	tokenPrograms := map[string]solana.PublicKey{
-		deployment.SPLTokens:     solana.TokenProgramID, // not used yet
-		deployment.SPL2022Tokens: solana.Token2022ProgramID,
+func GetTokenProgramID(programName deployment.ContractType) (solana.PublicKey, error) {
+	tokenPrograms := map[deployment.ContractType]solana.PublicKey{
+		ccipChangeset.SPLTokens:     solana.TokenProgramID,
+		ccipChangeset.SPL2022Tokens: solana.Token2022ProgramID,
 	}
 
 	programID, ok := tokenPrograms[programName]
 	if !ok {
-		return solana.PublicKey{}, fmt.Errorf("invalid token program: %s. Must be one of: %s, %s", programName, deployment.SPLTokens, deployment.SPL2022Tokens)
+		return solana.PublicKey{}, fmt.Errorf("invalid token program: %s. Must be one of: %s, %s", programName, ccipChangeset.SPLTokens, ccipChangeset.SPL2022Tokens)
 	}
 	return programID, nil
 }
@@ -45,7 +45,7 @@ func commonValidation(e deployment.Environment, selector uint64, tokenPubKey sol
 	if !ok {
 		return fmt.Errorf("chain selector %d not found in environment", selector)
 	}
-	state, err := changeset.LoadOnchainState(e)
+	state, err := ccipChangeset.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
 	}
@@ -57,7 +57,9 @@ func commonValidation(e deployment.Environment, selector uint64, tokenPubKey sol
 		return nil
 	}
 	exists := false
-	for _, token := range chainState.SPL2022Tokens {
+	allTokens := chainState.SPL2022Tokens
+	allTokens = append(allTokens, chainState.SPLTokens...)
+	for _, token := range allTokens {
 		if token.Equals(tokenPubKey) {
 			exists = true
 			break
@@ -69,7 +71,7 @@ func commonValidation(e deployment.Environment, selector uint64, tokenPubKey sol
 	return nil
 }
 
-func validateRouterConfig(chain deployment.SolChain, chainState changeset.SolCCIPChainState) error {
+func validateRouterConfig(chain deployment.SolChain, chainState ccipChangeset.SolCCIPChainState) error {
 	if chainState.Router.IsZero() {
 		return fmt.Errorf("router not found in existing state, deploy the router first for chain %d", chain.Selector)
 	}
@@ -82,7 +84,7 @@ func validateRouterConfig(chain deployment.SolChain, chainState changeset.SolCCI
 	return nil
 }
 
-func validateFeeQuoterConfig(chain deployment.SolChain, chainState changeset.SolCCIPChainState) error {
+func validateFeeQuoterConfig(chain deployment.SolChain, chainState ccipChangeset.SolCCIPChainState) error {
 	if chainState.FeeQuoter.IsZero() {
 		return fmt.Errorf("fee quoter not found in existing state, deploy the fee quoter first for chain %d", chain.Selector)
 	}
@@ -95,7 +97,7 @@ func validateFeeQuoterConfig(chain deployment.SolChain, chainState changeset.Sol
 	return nil
 }
 
-func validateOffRampConfig(chain deployment.SolChain, chainState changeset.SolCCIPChainState) error {
+func validateOffRampConfig(chain deployment.SolChain, chainState ccipChangeset.SolCCIPChainState) error {
 	if chainState.OffRamp.IsZero() {
 		return fmt.Errorf("offramp not found in existing state, deploy the offramp first for chain %d", chain.Selector)
 	}

--- a/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/require"
 
+	solBaseTokenPool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/base_token_pool"
 	solRouter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
 	solFeeQuoter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
 	solTestTokenPool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/test_token_pool"
@@ -17,13 +18,32 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
 	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	changeset_solana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
+	ccipChangesetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 )
+
+func deployToken(t *testing.T, tenv deployment.Environment, solChain uint64) (deployment.Environment, solana.PublicKey, error) {
+	e, err := commonchangeset.Apply(t, tenv, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeploySolanaToken),
+			ccipChangesetSolana.DeploySolanaTokenConfig{
+				ChainSelector:    solChain,
+				TokenProgramName: ccipChangeset.SPL2022Tokens,
+				TokenDecimals:    9,
+				TokenSymbol:      "TEST_TOKEN",
+			},
+		),
+	)
+	require.NoError(t, err)
+	state, err := ccipChangeset.LoadOnchainStateSolana(e)
+	require.NoError(t, err)
+	tokenAddress := state.SolChains[solChain].SPL2022Tokens[0]
+	return e, tokenAddress, err
+}
 
 func TestAddRemoteChain(t *testing.T) {
 	t.Parallel()
@@ -54,10 +74,10 @@ func TestAddRemoteChain(t *testing.T) {
 			},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(changeset_solana.AddRemoteChainToSolana),
-			changeset_solana.AddRemoteChainToSolanaConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.AddRemoteChainToSolana),
+			ccipChangesetSolana.AddRemoteChainToSolanaConfig{
 				ChainSelector: solChain,
-				UpdatesByChain: map[uint64]changeset_solana.RemoteChainConfigSolana{
+				UpdatesByChain: map[uint64]ccipChangesetSolana.RemoteChainConfigSolana{
 					evmChain: {
 						EnabledAsSource:         true,
 						RouterDestinationConfig: solRouter.DestChainConfig{},
@@ -108,87 +128,87 @@ func TestAddTokenPool(t *testing.T) {
 
 	evmChain := tenv.Env.AllChainSelectors()[0]
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
-
-	e, err := commonchangeset.Apply(t, tenv.Env, nil,
-		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(changeset_solana.DeploySolanaToken),
-			changeset_solana.DeploySolanaTokenConfig{
-				ChainSelector:    solChain,
-				TokenProgramName: deployment.SPL2022Tokens,
-				TokenDecimals:    9,
-			},
-		),
-	)
+	e, newTokenAddress, err := deployToken(t, tenv.Env, solChain)
 	require.NoError(t, err)
-
 	state, err := ccipChangeset.LoadOnchainStateSolana(e)
 	require.NoError(t, err)
-	newTokenAddress := state.SolChains[solChain].SPL2022Tokens[0]
-
-	remoteConfig := solTestTokenPool.RemoteConfig{
+	remoteConfig := solBaseTokenPool.RemoteConfig{
 		PoolAddresses: []solTestTokenPool.RemoteAddress{{Address: []byte{1, 2, 3}}},
 		TokenAddress:  solTestTokenPool.RemoteAddress{Address: []byte{4, 5, 6}},
 		Decimals:      9,
 	}
-	inboundConfig := solTestTokenPool.RateLimitConfig{
+	inboundConfig := solBaseTokenPool.RateLimitConfig{
 		Enabled:  true,
 		Capacity: uint64(1000),
 		Rate:     1,
 	}
-	outboundConfig := solTestTokenPool.RateLimitConfig{
+	outboundConfig := solBaseTokenPool.RateLimitConfig{
 		Enabled:  false,
 		Capacity: 0,
 		Rate:     0,
 	}
 
-	tokenMap := map[string]solana.PublicKey{
-		deployment.SPL2022Tokens: newTokenAddress,
-		deployment.SPLTokens:     state.SolChains[solChain].WSOL,
+	tokenMap := map[deployment.ContractType]solana.PublicKey{
+		ccipChangeset.SPL2022Tokens: newTokenAddress,
+		ccipChangeset.SPLTokens:     state.SolChains[solChain].WSOL,
 	}
 
-	for tokenProgramName, tokenAddress := range tokenMap {
-		e, err = commonchangeset.Apply(t, e, nil,
-			commonchangeset.Configure(
-				deployment.CreateLegacyChangeSet(changeset_solana.AddTokenPool),
-				changeset_solana.TokenPoolConfig{
-					ChainSelector:    solChain,
-					TokenPubKey:      tokenAddress.String(),
-					TokenProgramName: tokenProgramName,
-					PoolType:         solTestTokenPool.LockAndRelease_PoolType,
-					// this works for testing, but if we really want some other authority we need to pass in a private key for signing purposes
-					Authority: e.SolChains[solChain].DeployerKey.PublicKey().String(),
-				},
-			),
-			commonchangeset.Configure(
-				deployment.CreateLegacyChangeSet(changeset_solana.SetupTokenPoolForRemoteChain),
-				changeset_solana.RemoteChainTokenPoolConfig{
-					SolChainSelector:    solChain,
-					RemoteChainSelector: evmChain,
-					SolTokenPubKey:      tokenAddress.String(),
-					RemoteConfig:        remoteConfig,
-					InboundRateLimit:    inboundConfig,
-					OutboundRateLimit:   outboundConfig,
-				},
-			),
-		)
-		require.NoError(t, err)
-
-		// test AddTokenPool results
-		poolConfigPDA, err := solTokenUtil.TokenPoolConfigAddress(tokenAddress, state.SolChains[solChain].TokenPool)
-		require.NoError(t, err)
-		var configAccount solTestTokenPool.State
-		err = e.SolChains[solChain].GetAccountDataBorshInto(ctx, poolConfigPDA, &configAccount)
-		require.NoError(t, err)
-		require.Equal(t, solTestTokenPool.LockAndRelease_PoolType, configAccount.PoolType)
-		require.Equal(t, tokenAddress, configAccount.Config.Mint)
-
-		// test SetupTokenPoolForRemoteChain results
-		remoteChainConfigPDA, _, _ := solTokenUtil.TokenPoolChainConfigPDA(evmChain, tokenAddress, state.SolChains[solChain].TokenPool)
-		var remoteChainConfigAccount solTestTokenPool.ChainConfig
-		err = e.SolChains[solChain].GetAccountDataBorshInto(ctx, remoteChainConfigPDA, &remoteChainConfigAccount)
-		require.NoError(t, err)
-		require.Equal(t, uint8(9), remoteChainConfigAccount.Base.Remote.Decimals)
+	type poolTestType struct {
+		poolType    solTestTokenPool.PoolType
+		poolAddress solana.PublicKey
 	}
+	testCases := []poolTestType{
+		{
+			poolType:    solTestTokenPool.BurnAndMint_PoolType,
+			poolAddress: state.SolChains[solChain].BurnMintTokenPool,
+		},
+		{
+			poolType:    solTestTokenPool.LockAndRelease_PoolType,
+			poolAddress: state.SolChains[solChain].LockReleaseTokenPool,
+		},
+	}
+	for _, testCase := range testCases {
+		for _, tokenAddress := range tokenMap {
+			e, err = commonchangeset.Apply(t, e, nil,
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(ccipChangesetSolana.AddTokenPool),
+					ccipChangesetSolana.TokenPoolConfig{
+						ChainSelector: solChain,
+						TokenPubKey:   tokenAddress.String(),
+						PoolType:      testCase.poolType,
+						// this works for testing, but if we really want some other authority we need to pass in a private key for signing purposes
+						Authority: tenv.Env.SolChains[solChain].DeployerKey.PublicKey().String(),
+					},
+				),
+				commonchangeset.Configure(
+					deployment.CreateLegacyChangeSet(ccipChangesetSolana.SetupTokenPoolForRemoteChain),
+					ccipChangesetSolana.RemoteChainTokenPoolConfig{
+						SolChainSelector:    solChain,
+						RemoteChainSelector: evmChain,
+						SolTokenPubKey:      tokenAddress.String(),
+						RemoteConfig:        remoteConfig,
+						InboundRateLimit:    inboundConfig,
+						OutboundRateLimit:   outboundConfig,
+						PoolType:            testCase.poolType,
+					},
+				),
+			)
+			require.NoError(t, err)
+			// test AddTokenPool results
+			configAccount := solTestTokenPool.State{}
+			poolConfigPDA, _ := solTokenUtil.TokenPoolConfigAddress(tokenAddress, testCase.poolAddress)
+			err = e.SolChains[solChain].GetAccountDataBorshInto(ctx, poolConfigPDA, &configAccount)
+			require.NoError(t, err)
+			require.Equal(t, tokenAddress, configAccount.Config.Mint)
+			// test SetupTokenPoolForRemoteChain results
+			remoteChainConfigPDA, _, _ := solTokenUtil.TokenPoolChainConfigPDA(evmChain, tokenAddress, testCase.poolAddress)
+			var remoteChainConfigAccount solTestTokenPool.ChainConfig
+			err = e.SolChains[solChain].GetAccountDataBorshInto(ctx, remoteChainConfigPDA, &remoteChainConfigAccount)
+			require.NoError(t, err)
+			require.Equal(t, uint8(9), remoteChainConfigAccount.Base.Remote.Decimals)
+		}
+	}
+
 }
 
 func TestBilling(t *testing.T) {
@@ -199,21 +219,10 @@ func TestBilling(t *testing.T) {
 	evmChain := tenv.Env.AllChainSelectors()[0]
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
 
-	e, err := commonchangeset.Apply(t, tenv.Env, nil,
-		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(changeset_solana.DeploySolanaToken),
-			changeset_solana.DeploySolanaTokenConfig{
-				ChainSelector:    solChain,
-				TokenProgramName: deployment.SPL2022Tokens,
-				TokenDecimals:    9,
-			},
-		),
-	)
+	e, tokenAddress, err := deployToken(t, tenv.Env, solChain)
 	require.NoError(t, err)
-
 	state, err := ccipChangeset.LoadOnchainStateSolana(e)
 	require.NoError(t, err)
-	tokenAddress := state.SolChains[solChain].SPL2022Tokens[0]
 	validTimestamp := int64(100)
 	value := [28]uint8{}
 	bigNum, ok := new(big.Int).SetString("19816680000000000000", 10)
@@ -221,11 +230,10 @@ func TestBilling(t *testing.T) {
 	bigNum.FillBytes(value[:])
 	e, err = commonchangeset.Apply(t, e, nil,
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(changeset_solana.AddBillingToken),
-			changeset_solana.BillingTokenConfig{
-				ChainSelector:    solChain,
-				TokenPubKey:      tokenAddress.String(),
-				TokenProgramName: deployment.SPL2022Tokens,
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.AddBillingTokenChangeset),
+			ccipChangesetSolana.BillingTokenConfig{
+				ChainSelector: solChain,
+				TokenPubKey:   tokenAddress.String(),
 				Config: solFeeQuoter.BillingTokenConfig{
 					Enabled: true,
 					Mint:    tokenAddress,
@@ -238,8 +246,8 @@ func TestBilling(t *testing.T) {
 			},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(changeset_solana.AddBillingTokenForRemoteChain),
-			changeset_solana.BillingTokenForRemoteChainConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.AddBillingTokenForRemoteChain),
+			ccipChangesetSolana.BillingTokenForRemoteChainConfig{
 				ChainSelector:       solChain,
 				RemoteChainSelector: evmChain,
 				TokenPubKey:         tokenAddress.String(),
@@ -275,48 +283,34 @@ func TestTokenAdminRegistry(t *testing.T) {
 	t.Parallel()
 	ctx := testcontext.Get(t)
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
-
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
-
-	e, err := commonchangeset.Apply(t, tenv.Env, nil,
-		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(changeset_solana.DeploySolanaToken),
-			changeset_solana.DeploySolanaTokenConfig{
-				ChainSelector:    solChain,
-				TokenProgramName: deployment.SPL2022Tokens,
-				TokenDecimals:    9,
-			},
-		),
-	)
+	e, tokenAddress, err := deployToken(t, tenv.Env, solChain)
 	require.NoError(t, err)
-
 	state, err := ccipChangeset.LoadOnchainStateSolana(e)
 	require.NoError(t, err)
-	tokenAddress := state.SolChains[solChain].SPL2022Tokens[0]
-	tokenAdminRegistryAdminPrivKey, _ := solana.NewRandomPrivateKey()
-
-	// We have to do run the ViaOwnerInstruction testcase for linkToken as we already register a PDA for tokenAddress in the previous testcase
 	linkTokenAddress := state.SolChains[solChain].LinkToken
+
+	tokenAdminRegistryAdminPrivKey, _ := solana.NewRandomPrivateKey()
 
 	e, err = commonchangeset.Apply(t, e, nil,
 		commonchangeset.Configure(
 			// register token admin registry for tokenAddress via admin instruction
-			deployment.CreateLegacyChangeSet(changeset_solana.RegisterTokenAdminRegistry),
-			changeset_solana.RegisterTokenAdminRegistryConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.RegisterTokenAdminRegistry),
+			ccipChangesetSolana.RegisterTokenAdminRegistryConfig{
 				ChainSelector:           solChain,
 				TokenPubKey:             tokenAddress.String(),
 				TokenAdminRegistryAdmin: tokenAdminRegistryAdminPrivKey.PublicKey().String(),
-				RegisterType:            changeset_solana.ViaGetCcipAdminInstruction,
+				RegisterType:            ccipChangesetSolana.ViaGetCcipAdminInstruction,
 			},
 		),
 		commonchangeset.Configure(
 			// register token admin registry for linkToken via owner instruction
-			deployment.CreateLegacyChangeSet(changeset_solana.RegisterTokenAdminRegistry),
-			changeset_solana.RegisterTokenAdminRegistryConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.RegisterTokenAdminRegistry),
+			ccipChangesetSolana.RegisterTokenAdminRegistryConfig{
 				ChainSelector:           solChain,
 				TokenPubKey:             linkTokenAddress.String(),
 				TokenAdminRegistryAdmin: tokenAdminRegistryAdminPrivKey.PublicKey().String(),
-				RegisterType:            changeset_solana.ViaOwnerInstruction,
+				RegisterType:            ccipChangesetSolana.ViaOwnerInstruction,
 			},
 		),
 	)
@@ -339,8 +333,8 @@ func TestTokenAdminRegistry(t *testing.T) {
 	e, err = commonchangeset.Apply(t, e, nil,
 		commonchangeset.Configure(
 			// accept admin role for tokenAddress
-			deployment.CreateLegacyChangeSet(changeset_solana.AcceptAdminRoleTokenAdminRegistry),
-			changeset_solana.AcceptAdminRoleTokenAdminRegistryConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.AcceptAdminRoleTokenAdminRegistry),
+			ccipChangesetSolana.AcceptAdminRoleTokenAdminRegistryConfig{
 				ChainSelector:              solChain,
 				TokenPubKey:                tokenAddress.String(),
 				NewRegistryAdminPrivateKey: tokenAdminRegistryAdminPrivKey.String(),
@@ -358,8 +352,8 @@ func TestTokenAdminRegistry(t *testing.T) {
 	e, err = commonchangeset.Apply(t, e, nil,
 		commonchangeset.Configure(
 			// transfer admin role for tokenAddress
-			deployment.CreateLegacyChangeSet(changeset_solana.TransferAdminRoleTokenAdminRegistry),
-			changeset_solana.TransferAdminRoleTokenAdminRegistryConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.TransferAdminRoleTokenAdminRegistry),
+			ccipChangesetSolana.TransferAdminRoleTokenAdminRegistryConfig{
 				ChainSelector:                  solChain,
 				TokenPubKey:                    tokenAddress.String(),
 				NewRegistryAdminPublicKey:      newTokenAdminRegistryAdminPrivKey.PublicKey().String(),
@@ -377,40 +371,22 @@ func TestPoolLookupTable(t *testing.T) {
 	t.Parallel()
 	ctx := testcontext.Get(t)
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
-
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
 
-	e, err := commonchangeset.Apply(t, tenv.Env, nil,
-		commonchangeset.Configure(
-			// deploy token
-			deployment.CreateLegacyChangeSet(changeset_solana.DeploySolanaToken),
-			changeset_solana.DeploySolanaTokenConfig{
-				ChainSelector:    solChain,
-				TokenProgramName: deployment.SPL2022Tokens,
-				TokenDecimals:    9,
-			},
-		),
-	)
+	e, tokenAddress, err := deployToken(t, tenv.Env, solChain)
 	require.NoError(t, err)
-
-	state, err := ccipChangeset.LoadOnchainStateSolana(e)
-	require.NoError(t, err)
-	tokenAddress := state.SolChains[solChain].SPL2022Tokens[0]
-
 	e, err = commonchangeset.Apply(t, e, nil,
 		commonchangeset.Configure(
 			// add token pool lookup table
-			deployment.CreateLegacyChangeSet(changeset_solana.AddTokenPoolLookupTable),
-			changeset_solana.TokenPoolLookupTableConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.AddTokenPoolLookupTable),
+			ccipChangesetSolana.TokenPoolLookupTableConfig{
 				ChainSelector: solChain,
 				TokenPubKey:   tokenAddress.String(),
-				TokenProgram:  deployment.SPL2022Tokens,
 			},
 		),
 	)
 	require.NoError(t, err)
-
-	state, err = ccipChangeset.LoadOnchainStateSolana(e)
+	state, err := ccipChangeset.LoadOnchainStateSolana(e)
 	require.NoError(t, err)
 	lookupTablePubKey := state.SolChains[solChain].TokenPoolLookupTable[tokenAddress]
 
@@ -424,18 +400,18 @@ func TestPoolLookupTable(t *testing.T) {
 	e, err = commonchangeset.Apply(t, e, nil,
 		commonchangeset.Configure(
 			// register token admin registry for linkToken via owner instruction
-			deployment.CreateLegacyChangeSet(changeset_solana.RegisterTokenAdminRegistry),
-			changeset_solana.RegisterTokenAdminRegistryConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.RegisterTokenAdminRegistry),
+			ccipChangesetSolana.RegisterTokenAdminRegistryConfig{
 				ChainSelector:           solChain,
 				TokenPubKey:             tokenAddress.String(),
 				TokenAdminRegistryAdmin: tokenAdminRegistryAdminPrivKey.PublicKey().String(),
-				RegisterType:            changeset_solana.ViaGetCcipAdminInstruction,
+				RegisterType:            ccipChangesetSolana.ViaGetCcipAdminInstruction,
 			},
 		),
 		commonchangeset.Configure(
 			// accept admin role for tokenAddress
-			deployment.CreateLegacyChangeSet(changeset_solana.AcceptAdminRoleTokenAdminRegistry),
-			changeset_solana.AcceptAdminRoleTokenAdminRegistryConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.AcceptAdminRoleTokenAdminRegistry),
+			ccipChangesetSolana.AcceptAdminRoleTokenAdminRegistryConfig{
 				ChainSelector:              solChain,
 				TokenPubKey:                tokenAddress.String(),
 				NewRegistryAdminPrivateKey: tokenAdminRegistryAdminPrivKey.String(),
@@ -443,11 +419,10 @@ func TestPoolLookupTable(t *testing.T) {
 		),
 		commonchangeset.Configure(
 			// set pool -> this updates tokenAdminRegistryPDA, hence above changeset is required
-			deployment.CreateLegacyChangeSet(changeset_solana.SetPool),
-			changeset_solana.SetPoolConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.SetPool),
+			ccipChangesetSolana.SetPoolConfig{
 				ChainSelector:                     solChain,
 				TokenPubKey:                       tokenAddress.String(),
-				PoolLookupTable:                   lookupTablePubKey.String(),
 				TokenAdminRegistryAdminPrivateKey: tokenAdminRegistryAdminPrivKey.String(),
 				WritableIndexes:                   []uint8{3, 4, 7},
 			},

--- a/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
@@ -3,6 +3,7 @@ package solana_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,7 @@ func TestAddRemoteChain(t *testing.T) {
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
 
 	evmChain := tenv.Env.AllChainSelectors()[0]
+	evmChain2 := tenv.Env.AllChainSelectors()[1]
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
 
 	_, err := ccipChangeset.LoadOnchainStateSolana(tenv.Env)
@@ -110,6 +112,72 @@ func TestAddRemoteChain(t *testing.T) {
 
 	var destChainFqAccount solFeeQuoter.DestChain
 	fqEvmDestChainPDA, _, _ := solState.FindFqDestChainPDA(evmChain, state.SolChains[solChain].FeeQuoter)
+	err = tenv.Env.SolChains[solChain].GetAccountDataBorshInto(ctx, fqEvmDestChainPDA, &destChainFqAccount)
+	require.NoError(t, err, "failed to get account info")
+	require.Equal(t, solFeeQuoter.TimestampedPackedU224{}, destChainFqAccount.State.UsdPerUnitGas)
+	require.True(t, destChainFqAccount.Config.IsEnabled)
+
+	timelockSignerPDA, _ := testhelpers.TransferOwnershipSolana(t, &tenv.Env, solChain, true, true, true, true)
+
+	tenv.Env, err = commonchangeset.ApplyChangesetsV2(t, tenv.Env,
+		[]commonchangeset.ConfiguredChangeSet{
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(v1_6.UpdateOnRampsDestsChangeset),
+				v1_6.UpdateOnRampDestsConfig{
+					UpdatesByChain: map[uint64]map[uint64]v1_6.OnRampDestinationUpdate{
+						evmChain2: {
+							solChain: {
+								IsEnabled:        true,
+								TestRouter:       false,
+								AllowListEnabled: false,
+							},
+						},
+					},
+				},
+			),
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(changeset_solana.AddRemoteChainToSolana),
+				changeset_solana.AddRemoteChainToSolanaConfig{
+					ChainSelector: solChain,
+					UpdatesByChain: map[uint64]changeset_solana.RemoteChainConfigSolana{
+						evmChain2: {
+							EnabledAsSource:         true,
+							RouterDestinationConfig: solRouter.DestChainConfig{},
+							FeeQuoterDestinationConfig: solFeeQuoter.DestChainConfig{
+								IsEnabled:                   true,
+								DefaultTxGasLimit:           200000,
+								MaxPerMsgGasLimit:           3000000,
+								MaxDataBytes:                30000,
+								MaxNumberOfTokensPerMsg:     5,
+								DefaultTokenDestGasOverhead: 5000,
+								// bytes4(keccak256("CCIP ChainFamilySelector EVM"))
+								// TODO: do a similar test for other chain families
+								// https://smartcontract-it.atlassian.net/browse/INTAUTO-438
+								ChainFamilySelector: [4]uint8{40, 18, 213, 44},
+							},
+						},
+					},
+					MCMS: &ccipChangeset.MCMSConfig{
+						MinDelay: 1 * time.Second,
+					},
+					RouterAuthority:    timelockSignerPDA,
+					FeeQuoterAuthority: timelockSignerPDA,
+					OffRampAuthority:   timelockSignerPDA,
+				},
+			),
+		},
+	)
+
+	require.NoError(t, err)
+
+	state, err = ccipChangeset.LoadOnchainStateSolana(tenv.Env)
+	require.NoError(t, err)
+
+	evmDestChainStatePDA = state.SolChains[solChain].DestChainStatePDAs[evmChain2]
+	err = tenv.Env.SolChains[solChain].GetAccountDataBorshInto(ctx, evmDestChainStatePDA, &destChainStateAccount)
+	require.NoError(t, err)
+
+	fqEvmDestChainPDA, _, _ = solState.FindFqDestChainPDA(evmChain2, state.SolChains[solChain].FeeQuoter)
 	err = tenv.Env.SolChains[solChain].GetAccountDataBorshInto(ctx, fqEvmDestChainPDA, &destChainFqAccount)
 	require.NoError(t, err, "failed to get account info")
 	require.Equal(t, solFeeQuoter.TimestampedPackedU224{}, destChainFqAccount.State.UsdPerUnitGas)

--- a/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
@@ -3,6 +3,7 @@ package solana_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/require"
@@ -33,6 +34,7 @@ func TestAddRemoteChain(t *testing.T) {
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
 
 	evmChain := tenv.Env.AllChainSelectors()[0]
+	evmChain2 := tenv.Env.AllChainSelectors()[1]
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
 
 	_, err := ccipChangeset.LoadOnchainStateSolana(tenv.Env)
@@ -90,6 +92,72 @@ func TestAddRemoteChain(t *testing.T) {
 
 	var destChainFqAccount solFeeQuoter.DestChain
 	fqEvmDestChainPDA, _, _ := solState.FindFqDestChainPDA(evmChain, state.SolChains[solChain].FeeQuoter)
+	err = tenv.Env.SolChains[solChain].GetAccountDataBorshInto(ctx, fqEvmDestChainPDA, &destChainFqAccount)
+	require.NoError(t, err, "failed to get account info")
+	require.Equal(t, solFeeQuoter.TimestampedPackedU224{}, destChainFqAccount.State.UsdPerUnitGas)
+	require.True(t, destChainFqAccount.Config.IsEnabled)
+
+	timelockSignerPDA, _ := testhelpers.TransferOwnershipSolana(t, &tenv.Env, solChain, true, true, true, true)
+
+	tenv.Env, err = commonchangeset.ApplyChangesetsV2(t, tenv.Env,
+		[]commonchangeset.ConfiguredChangeSet{
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(v1_6.UpdateOnRampsDestsChangeset),
+				v1_6.UpdateOnRampDestsConfig{
+					UpdatesByChain: map[uint64]map[uint64]v1_6.OnRampDestinationUpdate{
+						evmChain2: {
+							solChain: {
+								IsEnabled:        true,
+								TestRouter:       false,
+								AllowListEnabled: false,
+							},
+						},
+					},
+				},
+			),
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(changeset_solana.AddRemoteChainToSolana),
+				changeset_solana.AddRemoteChainToSolanaConfig{
+					ChainSelector: solChain,
+					UpdatesByChain: map[uint64]changeset_solana.RemoteChainConfigSolana{
+						evmChain2: {
+							EnabledAsSource:         true,
+							RouterDestinationConfig: solRouter.DestChainConfig{},
+							FeeQuoterDestinationConfig: solFeeQuoter.DestChainConfig{
+								IsEnabled:                   true,
+								DefaultTxGasLimit:           200000,
+								MaxPerMsgGasLimit:           3000000,
+								MaxDataBytes:                30000,
+								MaxNumberOfTokensPerMsg:     5,
+								DefaultTokenDestGasOverhead: 5000,
+								// bytes4(keccak256("CCIP ChainFamilySelector EVM"))
+								// TODO: do a similar test for other chain families
+								// https://smartcontract-it.atlassian.net/browse/INTAUTO-438
+								ChainFamilySelector: [4]uint8{40, 18, 213, 44},
+							},
+						},
+					},
+					MCMS: &ccipChangeset.MCMSConfig{
+						MinDelay: 1 * time.Second,
+					},
+					RouterAuthority:    timelockSignerPDA,
+					FeeQuoterAuthority: timelockSignerPDA,
+					OffRampAuthority:   timelockSignerPDA,
+				},
+			),
+		},
+	)
+
+	require.NoError(t, err)
+
+	state, err = ccipChangeset.LoadOnchainStateSolana(tenv.Env)
+	require.NoError(t, err)
+
+	evmDestChainStatePDA = state.SolChains[solChain].DestChainStatePDAs[evmChain2]
+	err = tenv.Env.SolChains[solChain].GetAccountDataBorshInto(ctx, evmDestChainStatePDA, &destChainStateAccount)
+	require.NoError(t, err)
+
+	fqEvmDestChainPDA, _, _ = solState.FindFqDestChainPDA(evmChain2, state.SolChains[solChain].FeeQuoter)
 	err = tenv.Env.SolChains[solChain].GetAccountDataBorshInto(ctx, fqEvmDestChainPDA, &destChainFqAccount)
 	require.NoError(t, err, "failed to get account info")
 	require.Equal(t, solFeeQuoter.TimestampedPackedU224{}, destChainFqAccount.State.UsdPerUnitGas)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -445,7 +445,7 @@ func deployChainContractsSolana(
 		if err != nil {
 			return txns, fmt.Errorf("failed to build instruction: %w", err)
 		}
-		priceUpdaterTx, err := BuildMCMSTxn(priceUpdaterix, feeQuoterAddress.String(), cs.OffRamp)
+		priceUpdaterTx, err := BuildMCMSTxn(priceUpdaterix, feeQuoterAddress.String(), cs.FeeQuoter)
 		if err != nil {
 			return txns, fmt.Errorf("failed to create price updater transaction: %w", err)
 		}

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -79,12 +79,16 @@ type UpgradeConfig struct {
 	// SpillAddress and UpgradeAuthority must be set
 	SpillAddress     solana.PublicKey
 	UpgradeAuthority solana.PublicKey
-	MCMS             *ccipChangeset.MCMSConfig
+	// MCMS config must be set for upgrades and offramp redploys (to configure the fee quoter after redeploy)
+	MCMS *ccipChangeset.MCMSConfig
 }
 
 func (cfg UpgradeConfig) Validate(e deployment.Environment, chainSelector uint64) error {
 	if cfg.NewFeeQuoterVersion == nil && cfg.NewRouterVersion == nil && cfg.NewOffRampVersion == nil {
 		return nil
+	}
+	if cfg.MCMS == nil {
+		return errors.New("MCMS config must be set for upgrades")
 	}
 	if cfg.NewFeeQuoterVersion != nil || cfg.NewRouterVersion != nil {
 		if cfg.SpillAddress.IsZero() {

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -90,13 +90,11 @@ func (cfg UpgradeConfig) Validate(e deployment.Environment, chainSelector uint64
 	if cfg.MCMS == nil {
 		return errors.New("MCMS config must be set for upgrades")
 	}
-	if cfg.NewFeeQuoterVersion != nil || cfg.NewRouterVersion != nil {
-		if cfg.SpillAddress.IsZero() {
-			return errors.New("spill address must be set for fee quoter and router upgrades")
-		}
-		if cfg.UpgradeAuthority.IsZero() {
-			return errors.New("upgrade authority must be set for fee quoter and router upgrades")
-		}
+	if cfg.SpillAddress.IsZero() {
+		return errors.New("spill address must be set for fee quoter and router upgrades")
+	}
+	if cfg.UpgradeAuthority.IsZero() {
+		return errors.New("upgrade authority must be set for fee quoter and router upgrades")
 	}
 	return ValidateMCMSConfig(e, chainSelector, cfg.MCMS)
 }
@@ -487,7 +485,7 @@ func deployChainContractsSolana(
 			offRampBillingSignerPDA,
 			fqAllowedPriceUpdaterOfframpPDA,
 			feeQuoterConfigPDA,
-			chain.DeployerKey.PublicKey(),
+			config.UpgradeConfig.UpgradeAuthority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -125,7 +125,7 @@ func DeployChainContractsChangesetSolana(e deployment.Environment, config Deploy
 			e.Logger.Errorw("Failed to deploy CCIP contracts", "err", err, "newAddresses", newAddresses)
 			return deployment.ChangesetOutput{}, err
 		}
-		// create proposals for ixns
+		// create proposals for txns
 		if len(mcmsTxs) > 0 {
 			batches = append(batches, mcmsTypes.BatchOperation{
 				ChainSelector: mcmsTypes.ChainSelector(chainSel),
@@ -134,7 +134,7 @@ func DeployChainContractsChangesetSolana(e deployment.Environment, config Deploy
 		}
 	}
 
-	if config.UpgradeConfig.MCMS != nil {
+	if len(batches) > 0 {
 		proposal, err := proposalutils.BuildProposalFromBatchesV2(
 			e.GetContext(),
 			timelocks,
@@ -344,18 +344,18 @@ func deployChainContractsSolana(
 	config DeployChainContractsConfigSolana,
 ) ([]mcmsTypes.Transaction, error) {
 	// we may need to gather instructions and submit them as part of MCMS
-	ixns := make([]mcmsTypes.Transaction, 0)
+	txns := make([]mcmsTypes.Transaction, 0)
 	state, err := cs.LoadOnchainStateSolana(e)
 	if err != nil {
 		e.Logger.Errorw("Failed to load existing onchain state", "err", err)
-		return ixns, err
+		return txns, err
 	}
 	chainState, chainExists := state.SolChains[chain.Selector]
 	if !chainExists {
-		return ixns, fmt.Errorf("chain %s not found in existing state, deploy the link token first", chain.String())
+		return txns, fmt.Errorf("chain %s not found in existing state, deploy the link token first", chain.String())
 	}
 	if chainState.LinkToken.IsZero() {
-		return ixns, fmt.Errorf("failed to get link token address for chain %s", chain.String())
+		return txns, fmt.Errorf("failed to get link token address for chain %s", chain.String())
 	}
 
 	// FEE QUOTER DEPLOY
@@ -364,96 +364,16 @@ func deployChainContractsSolana(
 	if chainState.FeeQuoter.IsZero() {
 		feeQuoterAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, FeeQuoterProgramName, deployment.Version1_0_0, false)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
+			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewFeeQuoterVersion != nil {
 		// fee quoter updated in place
-		bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, FeeQuoterProgramName, *config.UpgradeConfig.NewFeeQuoterVersion, true)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
-		}
-		if err := setUpgradeAuthority(&e, &chain, bufferProgram, chain.DeployerKey, config.UpgradeConfig.UpgradeAuthority.ToPointer(), true); err != nil {
-			return ixns, fmt.Errorf("failed to set upgrade authority: %w", err)
-		}
-		extendIxn, err := generateExtendIxn(
-			&e,
-			chain,
-			chainState.FeeQuoter,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate extend instruction: %w", err)
-		}
-		upgradeIxn, err := generateUpgradeIxn(
-			&e,
-			chainState.FeeQuoter,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-			config.UpgradeConfig.UpgradeAuthority,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate upgrade instruction: %w", err)
-		}
-		closeIxn, err := generateCloseBufferIxn(
-			&e,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-			config.UpgradeConfig.UpgradeAuthority,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate close buffer instruction: %w", err)
-		}
 		feeQuoterAddress = chainState.FeeQuoter
-		upgradeData, err := upgradeIxn.Data()
+		newTxns, err := generateUpgradeTxns(e, chain, ab, config, *&config.UpgradeConfig.NewFeeQuoterVersion, chainState.FeeQuoter, cs.FeeQuoter)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to extract upgrade data: %w", err)
+			return txns, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
-		upgradeTx, err := mcmsSolana.NewTransaction(
-			solana.BPFLoaderUpgradeableProgramID.String(),
-			upgradeData,
-			big.NewInt(0),         // e.g. value
-			upgradeIxn.Accounts(), // pass along needed accounts
-			string(cs.FeeQuoter),  // some string identifying the target
-			[]string{},            // any relevant metadata
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to create upgrade transaction: %w", err)
-		}
-		closeData, err := closeIxn.Data()
-		if err != nil {
-			return ixns, fmt.Errorf("failed to extract close data: %w", err)
-		}
-		closeTx, err := mcmsSolana.NewTransaction(
-			solana.BPFLoaderUpgradeableProgramID.String(),
-			closeData,
-			big.NewInt(0),        // e.g. value
-			closeIxn.Accounts(),  // pass along needed accounts
-			string(cs.FeeQuoter), // some string identifying the target
-			[]string{},           // any relevant metadata
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to create close transaction: %w", err)
-		}
-		if extendIxn != nil {
-			extendData, err := extendIxn.Data()
-			if err != nil {
-				return ixns, fmt.Errorf("failed to extract extend data: %w", err)
-			}
-			extendTx, err := mcmsSolana.NewTransaction(
-				solana.BPFLoaderUpgradeableProgramID.String(),
-				extendData,
-				big.NewInt(0),        // e.g. value
-				extendIxn.Accounts(), // pass along needed accounts
-				string(cs.FeeQuoter), // some string identifying the target
-				[]string{},           // any relevant metadata
-			)
-			if err != nil {
-				return ixns, fmt.Errorf("failed to create extend transaction: %w", err)
-			}
-			ixns = append(ixns, extendTx)
-		}
-		ixns = append(ixns, upgradeTx, closeTx)
+		txns = append(txns, newTxns...)
 	} else {
 		e.Logger.Infow("Using existing fee quoter", "addr", chainState.FeeQuoter.String())
 		feeQuoterAddress = chainState.FeeQuoter
@@ -467,96 +387,16 @@ func deployChainContractsSolana(
 		// deploy router
 		ccipRouterProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, RouterProgramName, deployment.Version1_0_0, false)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
+			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewRouterVersion != nil {
 		// router updated in place
-		bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, RouterProgramName, *config.UpgradeConfig.NewRouterVersion, true)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
-		}
-		if err := setUpgradeAuthority(&e, &chain, bufferProgram, chain.DeployerKey, config.UpgradeConfig.UpgradeAuthority.ToPointer(), true); err != nil {
-			return ixns, fmt.Errorf("failed to set upgrade authority: %w", err)
-		}
-		upgradeIxn, err := generateUpgradeIxn(
-			&e,
-			chainState.Router,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-			config.UpgradeConfig.UpgradeAuthority,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate upgrade instruction: %w", err)
-		}
-		extendIxn, err := generateExtendIxn(
-			&e,
-			chain,
-			chainState.Router,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate extend instruction: %w", err)
-		}
-		closeIxn, err := generateCloseBufferIxn(
-			&e,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-			config.UpgradeConfig.UpgradeAuthority,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate close buffer instruction: %w", err)
-		}
 		ccipRouterProgram = chainState.Router
-		upgradeData, err := upgradeIxn.Data()
+		newTxns, err := generateUpgradeTxns(e, chain, ab, config, *&config.UpgradeConfig.NewRouterVersion, chainState.Router, cs.Router)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to extract upgrade data: %w", err)
+			return txns, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
-		upgradeTx, err := mcmsSolana.NewTransaction(
-			solana.BPFLoaderUpgradeableProgramID.String(),
-			upgradeData,
-			big.NewInt(0),         // e.g. value
-			upgradeIxn.Accounts(), // pass along needed accounts
-			string(cs.Router),     // some string identifying the target
-			[]string{},            // any relevant metadata
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to create upgrade transaction: %w", err)
-		}
-		closeData, err := closeIxn.Data()
-		if err != nil {
-			return ixns, fmt.Errorf("failed to extract close data: %w", err)
-		}
-		closeTx, err := mcmsSolana.NewTransaction(
-			solana.BPFLoaderUpgradeableProgramID.String(),
-			closeData,
-			big.NewInt(0),       // e.g. value
-			closeIxn.Accounts(), // pass along needed accounts
-			string(cs.Router),   // some string identifying the target
-			[]string{},          // any relevant metadata
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to create close transaction: %w", err)
-		}
-		if extendIxn != nil {
-			extendData, err := extendIxn.Data()
-			if err != nil {
-				return ixns, fmt.Errorf("failed to extract extend data: %w", err)
-			}
-			extendTx, err := mcmsSolana.NewTransaction(
-				solana.BPFLoaderUpgradeableProgramID.String(),
-				extendData,
-				big.NewInt(0),        // e.g. value
-				extendIxn.Accounts(), // pass along needed accounts
-				string(cs.Router),    // some string identifying the target
-				[]string{},           // any relevant metadata
-			)
-			if err != nil {
-				return ixns, fmt.Errorf("failed to create extend transaction: %w", err)
-			}
-			ixns = append(ixns, extendTx)
-		}
-		ixns = append(ixns, upgradeTx, closeTx)
+		txns = append(txns, newTxns...)
 	} else {
 		e.Logger.Infow("Using existing router", "addr", chainState.Router.String())
 		ccipRouterProgram = chainState.Router
@@ -575,20 +415,20 @@ func deployChainContractsSolana(
 		// deploy offramp
 		offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, OffRampProgramName, deployment.Version1_0_0, false)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
+			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewOffRampVersion != nil {
 		tv := deployment.NewTypeAndVersion(cs.OffRamp, *config.UpgradeConfig.NewOffRampVersion)
 		existingAddresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to get existing addresses: %w", err)
+			return txns, fmt.Errorf("failed to get existing addresses: %w", err)
 		}
 		offRampAddress = cs.FindSolanaAddress(tv, existingAddresses)
 		if offRampAddress.IsZero() {
 			// deploy offramp, not upgraded in place so upgrade is false
 			offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, OffRampProgramName, *config.UpgradeConfig.NewOffRampVersion, false)
 			if err != nil {
-				return ixns, fmt.Errorf("failed to deploy program: %w", err)
+				return txns, fmt.Errorf("failed to deploy program: %w", err)
 			}
 		}
 
@@ -604,11 +444,11 @@ func deployChainContractsSolana(
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {
-			return ixns, fmt.Errorf("failed to build instruction: %w", err)
+			return txns, fmt.Errorf("failed to build instruction: %w", err)
 		}
 		priceUpdaterData, err := priceUpdaterix.Data()
 		if err != nil {
-			return ixns, fmt.Errorf("failed to extract price updater data: %w", err)
+			return txns, fmt.Errorf("failed to extract price updater data: %w", err)
 		}
 		priceUpdaterTx, err := mcmsSolana.NewTransaction(
 			feeQuoterAddress.String(),
@@ -619,9 +459,9 @@ func deployChainContractsSolana(
 			[]string{},                // any relevant metadata
 		)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to create price updater transaction: %w", err)
+			return txns, fmt.Errorf("failed to create price updater transaction: %w", err)
 		}
-		ixns = append(ixns, priceUpdaterTx)
+		txns = append(txns, priceUpdaterTx)
 	} else {
 		e.Logger.Infow("Using existing offramp", "addr", chainState.OffRamp.String())
 		offRampAddress = chainState.OffRamp
@@ -634,7 +474,7 @@ func deployChainContractsSolana(
 	err = chain.GetAccountDataBorshInto(e.GetContext(), feeQuoterConfigPDA, &fqConfig)
 	if err != nil {
 		if err2 := initializeFeeQuoter(e, chain, ccipRouterProgram, chainState.LinkToken, feeQuoterAddress, offRampAddress); err2 != nil {
-			return ixns, err2
+			return txns, err2
 		}
 	} else {
 		e.Logger.Infow("Fee quoter already initialized, skipping initialization", "chain", chain.String())
@@ -647,7 +487,7 @@ func deployChainContractsSolana(
 	err = chain.GetAccountDataBorshInto(e.GetContext(), routerConfigPDA, &routerConfigAccount)
 	if err != nil {
 		if err2 := initializeRouter(e, chain, ccipRouterProgram, chainState.LinkToken, feeQuoterAddress); err2 != nil {
-			return ixns, err2
+			return txns, err2
 		}
 	} else {
 		e.Logger.Infow("Router already initialized, skipping initialization", "chain", chain.String())
@@ -673,10 +513,10 @@ func deployChainContractsSolana(
 				solana.SPLAssociatedTokenAccountProgramID,
 			})
 		if err2 != nil {
-			return ixns, fmt.Errorf("failed to create address lookup table: %w", err)
+			return txns, fmt.Errorf("failed to create address lookup table: %w", err)
 		}
 		if err2 := initializeOffRamp(e, chain, ccipRouterProgram, feeQuoterAddress, offRampAddress, table); err2 != nil {
-			return ixns, err2
+			return txns, err2
 		}
 		// Initializing a new offramp means we need a new lookup table and need to fully populate it
 		needFQinLookupTable = true
@@ -703,7 +543,7 @@ func deployChainContractsSolana(
 		// separate token pools are not ready yet
 		tokenPoolProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, TokenPoolProgramName, deployment.Version1_0_0, false)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
+			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
 		needTokenPoolinLookupTable = true
 	} else {
@@ -747,11 +587,11 @@ func deployChainContractsSolana(
 	if len(lookupTableKeys) > 0 {
 		addressLookupTable, err := cs.FetchOfframpLookupTable(e.GetContext(), chain, offRampAddress)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to get offramp reference addresses: %w", err)
+			return txns, fmt.Errorf("failed to get offramp reference addresses: %w", err)
 		}
 		e.Logger.Debugw("Populating lookup table", "lookupTable", addressLookupTable.String(), "keys", lookupTableKeys)
 		if err := solCommonUtil.ExtendLookupTable(e.GetContext(), chain.Client, addressLookupTable, *chain.DeployerKey, lookupTableKeys); err != nil {
-			return ixns, fmt.Errorf("failed to extend lookup table: %w", err)
+			return txns, fmt.Errorf("failed to extend lookup table: %w", err)
 		}
 	}
 
@@ -760,12 +600,77 @@ func deployChainContractsSolana(
 		e.Logger.Infow("Setting upgrade authority", "newUpgradeAuthority", config.NewUpgradeAuthority.String())
 		for _, programID := range []solana.PublicKey{ccipRouterProgram, feeQuoterAddress} {
 			if err := setUpgradeAuthority(&e, &chain, programID, chain.DeployerKey, config.NewUpgradeAuthority, false); err != nil {
-				return ixns, fmt.Errorf("failed to set upgrade authority: %w", err)
+				return txns, fmt.Errorf("failed to set upgrade authority: %w", err)
 			}
 		}
 	}
 
-	return ixns, nil
+	return txns, nil
+}
+
+func generateUpgradeTxns(
+	e deployment.Environment,
+	chain deployment.SolChain,
+	ab deployment.AddressBook,
+	config DeployChainContractsConfigSolana,
+	newVersion *semver.Version,
+	programID solana.PublicKey,
+	contractType deployment.ContractType,
+) ([]mcmsTypes.Transaction, error) {
+	txns := make([]mcmsTypes.Transaction, 0)
+	bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, FeeQuoterProgramName, *newVersion, true)
+	if err != nil {
+		return txns, fmt.Errorf("failed to deploy program: %w", err)
+	}
+	if err := setUpgradeAuthority(&e, &chain, bufferProgram, chain.DeployerKey, config.UpgradeConfig.UpgradeAuthority.ToPointer(), true); err != nil {
+		return txns, fmt.Errorf("failed to set upgrade authority: %w", err)
+	}
+	extendIxn, err := generateExtendIxn(
+		&e,
+		chain,
+		programID,
+		bufferProgram,
+		config.UpgradeConfig.SpillAddress,
+	)
+	if err != nil {
+		return txns, fmt.Errorf("failed to generate extend instruction: %w", err)
+	}
+	upgradeIxn, err := generateUpgradeIxn(
+		&e,
+		programID,
+		bufferProgram,
+		config.UpgradeConfig.SpillAddress,
+		config.UpgradeConfig.UpgradeAuthority,
+	)
+	if err != nil {
+		return txns, fmt.Errorf("failed to generate upgrade instruction: %w", err)
+	}
+	closeIxn, err := generateCloseBufferIxn(
+		&e,
+		bufferProgram,
+		config.UpgradeConfig.SpillAddress,
+		config.UpgradeConfig.UpgradeAuthority,
+	)
+	if err != nil {
+		return txns, fmt.Errorf("failed to generate close buffer instruction: %w", err)
+	}
+	upgradeTx, err := BuildMCMSTxn(upgradeIxn, solana.BPFLoaderUpgradeableProgramID.String(), contractType)
+	if err != nil {
+		return txns, fmt.Errorf("failed to create upgrade transaction: %w", err)
+	}
+	closeTx, err := BuildMCMSTxn(closeIxn, solana.BPFLoaderUpgradeableProgramID.String(), contractType)
+	if err != nil {
+		return txns, fmt.Errorf("failed to create close transaction: %w", err)
+	}
+	if extendIxn != nil {
+		extendTx, err := BuildMCMSTxn(extendIxn, solana.BPFLoaderUpgradeableProgramID.String(), contractType)
+		if err != nil {
+			return txns, fmt.Errorf("failed to create extend transaction: %w", err)
+		}
+		txns = append(txns, *extendTx)
+	}
+	txns = append(txns, *upgradeTx, *closeTx)
+	return txns, nil
 }
 
 // DeployAndMaybeSaveToAddressBook deploys a program to the Solana chain and saves it to the address book
@@ -861,7 +766,7 @@ func generateUpgradeIxn(
 		solana.NewAccountMeta(spillAddress, true, false),              // Spill account (writable)
 		solana.NewAccountMeta(solana.SysVarRentPubkey, false, false),  // System program
 		solana.NewAccountMeta(solana.SysVarClockPubkey, false, false), // System program
-		solana.NewAccountMeta(upgradeAuthority, false, false),         // Current upgrade authority (signer)
+		solana.NewAccountMeta(upgradeAuthority, false, true),          // Current upgrade authority (signer)
 	}
 
 	instruction := solana.NewInstruction(
@@ -912,7 +817,7 @@ func generateExtendIxn(
 		solana.NewAccountMeta(programDataAccount, true, false),      // Program data account (writable)
 		solana.NewAccountMeta(programID, true, false),               // Program account (writable)
 		solana.NewAccountMeta(solana.SystemProgramID, false, false), // System program
-		solana.NewAccountMeta(payer, true, false),                   // Payer for rent
+		solana.NewAccountMeta(payer, true, true),                    // Payer for rent
 	}
 
 	ixn := solana.NewInstruction(
@@ -933,7 +838,7 @@ func generateCloseBufferIxn(
 	keys := solana.AccountMetaSlice{
 		solana.NewAccountMeta(bufferAddress, true, false),
 		solana.NewAccountMeta(recipient, true, false),
-		solana.NewAccountMeta(upgradeAuthority, false, false),
+		solana.NewAccountMeta(upgradeAuthority, false, true),
 	}
 
 	instruction := solana.NewInstruction(

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -38,6 +38,15 @@ const (
 	TokenPoolProgramName = "test_token_pool"
 )
 
+func getTypeToProgramDeployName() map[deployment.ContractType]string {
+	return map[deployment.ContractType]string{
+		cs.Router:    RouterProgramName,
+		cs.OffRamp:   OffRampProgramName,
+		cs.FeeQuoter: FeeQuoterProgramName,
+		cs.TokenPool: TokenPoolProgramName,
+	}
+}
+
 var _ deployment.ChangeSet[DeployChainContractsConfigSolana] = DeployChainContractsChangesetSolana
 
 type DeployChainContractsConfigSolana struct {
@@ -361,7 +370,7 @@ func deployChainContractsSolana(
 	var feeQuoterAddress solana.PublicKey
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.FeeQuoter.IsZero() {
-		feeQuoterAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, FeeQuoterProgramName, deployment.Version1_0_0, false)
+		feeQuoterAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, cs.FeeQuoter, deployment.Version1_0_0, false)
 		if err != nil {
 			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -384,7 +393,7 @@ func deployChainContractsSolana(
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.Router.IsZero() {
 		// deploy router
-		ccipRouterProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, RouterProgramName, deployment.Version1_0_0, false)
+		ccipRouterProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, cs.Router, deployment.Version1_0_0, false)
 		if err != nil {
 			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -412,7 +421,7 @@ func deployChainContractsSolana(
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.OffRamp.IsZero() {
 		// deploy offramp
-		offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, OffRampProgramName, deployment.Version1_0_0, false)
+		offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, cs.OffRamp, deployment.Version1_0_0, false)
 		if err != nil {
 			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -425,7 +434,7 @@ func deployChainContractsSolana(
 		offRampAddress = cs.FindSolanaAddress(tv, existingAddresses)
 		if offRampAddress.IsZero() {
 			// deploy offramp, not upgraded in place so upgrade is false
-			offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, OffRampProgramName, *config.UpgradeConfig.NewOffRampVersion, false)
+			offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, cs.OffRamp, *config.UpgradeConfig.NewOffRampVersion, false)
 			if err != nil {
 				return txns, fmt.Errorf("failed to deploy program: %w", err)
 			}
@@ -529,7 +538,7 @@ func deployChainContractsSolana(
 	if chainState.TokenPool.IsZero() {
 		// TODO: there should be two token pools deployed one of each type (lock/burn)
 		// separate token pools are not ready yet
-		tokenPoolProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, TokenPoolProgramName, deployment.Version1_0_0, false)
+		tokenPoolProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, cs.TokenPool, deployment.Version1_0_0, false)
 		if err != nil {
 			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -606,7 +615,7 @@ func generateUpgradeTxns(
 	contractType deployment.ContractType,
 ) ([]mcmsTypes.Transaction, error) {
 	txns := make([]mcmsTypes.Transaction, 0)
-	bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, FeeQuoterProgramName, *newVersion, true)
+	bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, contractType, *newVersion, true)
 	if err != nil {
 		return txns, fmt.Errorf("failed to deploy program: %w", err)
 	}
@@ -667,29 +676,20 @@ func DeployAndMaybeSaveToAddressBook(
 	e deployment.Environment,
 	chain deployment.SolChain,
 	ab deployment.AddressBook,
-	programName string,
+	contractType deployment.ContractType,
 	version semver.Version,
 	isUpgrade bool) (solana.PublicKey, error) {
+	programName := getTypeToProgramDeployName()[contractType]
 	programID, err := chain.DeployProgram(e.Logger, programName, isUpgrade)
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("failed to deploy program: %w", err)
 	}
 	address := solana.MustPublicKeyFromBase58(programID)
 
-	programNameToType := map[string]deployment.ContractType{
-		RouterProgramName:    cs.Router,
-		OffRampProgramName:   cs.OffRamp,
-		FeeQuoterProgramName: cs.FeeQuoter,
-		TokenPoolProgramName: cs.TokenPool,
-	}
-	programType, ok := programNameToType[programName]
-	if !ok {
-		return solana.PublicKey{}, fmt.Errorf("unknown program name: %s", programName)
-	}
-	e.Logger.Infow("Deployed program", "Program", programType, "addr", programID, "chain", chain.String(), "isUpgrade", isUpgrade)
+	e.Logger.Infow("Deployed program", "Program", contractType, "addr", programID, "chain", chain.String(), "isUpgrade", isUpgrade)
 
 	if !isUpgrade {
-		tv := deployment.NewTypeAndVersion(programType, version)
+		tv := deployment.NewTypeAndVersion(contractType, version)
 		err = ab.Save(chain.Selector, programID, tv)
 		if err != nil {
 			return solana.PublicKey{}, fmt.Errorf("failed to save address: %w", err)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/big"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gagliardetto/solana-go"
@@ -446,22 +445,11 @@ func deployChainContractsSolana(
 		if err != nil {
 			return txns, fmt.Errorf("failed to build instruction: %w", err)
 		}
-		priceUpdaterData, err := priceUpdaterix.Data()
-		if err != nil {
-			return txns, fmt.Errorf("failed to extract price updater data: %w", err)
-		}
-		priceUpdaterTx, err := mcmsSolana.NewTransaction(
-			feeQuoterAddress.String(),
-			priceUpdaterData,
-			big.NewInt(0),             // e.g. value
-			priceUpdaterix.Accounts(), // pass along needed accounts
-			string(cs.OffRamp),        // some string identifying the target
-			[]string{},                // any relevant metadata
-		)
+		priceUpdaterTx, err := BuildMCMSTxn(priceUpdaterix, feeQuoterAddress.String(), cs.OffRamp)
 		if err != nil {
 			return txns, fmt.Errorf("failed to create price updater transaction: %w", err)
 		}
-		txns = append(txns, priceUpdaterTx)
+		txns = append(txns, *priceUpdaterTx)
 	} else {
 		e.Logger.Infow("Using existing offramp", "addr", chainState.OffRamp.String())
 		offRampAddress = chainState.OffRamp

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -63,12 +63,16 @@ type UpgradeConfigSolana struct {
 	// SpillAddress and UpgradeAuthority must be set
 	SpillAddress     solana.PublicKey
 	UpgradeAuthority solana.PublicKey
+	// MCMS config must be set for upgrades and offramp redploys (to configure the fee quoter after redeploy)
 	MCMS             *cs.MCMSConfig
 }
 
 func (cfg UpgradeConfigSolana) Validate(e deployment.Environment, chainSelector uint64) error {
 	if cfg.NewFeeQuoterVersion == nil && cfg.NewRouterVersion == nil && cfg.NewOffRampVersion == nil {
 		return nil
+	}
+	if cfg.MCMS == nil {
+		return errors.New("MCMS config must be set for upgrades")
 	}
 	if cfg.NewFeeQuoterVersion != nil || cfg.NewRouterVersion != nil {
 		if cfg.SpillAddress.IsZero() {

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/big"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gagliardetto/solana-go"
@@ -480,22 +479,11 @@ func deployChainContractsSolana(
 		if err != nil {
 			return txns, fmt.Errorf("failed to build instruction: %w", err)
 		}
-		priceUpdaterData, err := priceUpdaterix.Data()
-		if err != nil {
-			return txns, fmt.Errorf("failed to extract price updater data: %w", err)
-		}
-		priceUpdaterTx, err := mcmsSolana.NewTransaction(
-			feeQuoterAddress.String(),
-			priceUpdaterData,
-			big.NewInt(0),                 // e.g. value
-			priceUpdaterix.Accounts(),     // pass along needed accounts
-			string(ccipChangeset.OffRamp), // some string identifying the target
-			[]string{},                    // any relevant metadata
-		)
+		priceUpdaterTx, err := BuildMCMSTxn(priceUpdaterix, feeQuoterAddress.String(), ccipChangeset.OffRamp)
 		if err != nil {
 			return txns, fmt.Errorf("failed to create price updater transaction: %w", err)
 		}
-		txns = append(txns, priceUpdaterTx)
+		txns = append(txns, *priceUpdaterTx)
 	} else {
 		e.Logger.Infow("Using existing offramp", "addr", chainState.OffRamp.String())
 		offRampAddress = chainState.OffRamp

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -64,7 +64,7 @@ type UpgradeConfigSolana struct {
 	SpillAddress     solana.PublicKey
 	UpgradeAuthority solana.PublicKey
 	// MCMS config must be set for upgrades and offramp redploys (to configure the fee quoter after redeploy)
-	MCMS             *cs.MCMSConfig
+	MCMS *cs.MCMSConfig
 }
 
 func (cfg UpgradeConfigSolana) Validate(e deployment.Environment, chainSelector uint64) error {
@@ -74,13 +74,11 @@ func (cfg UpgradeConfigSolana) Validate(e deployment.Environment, chainSelector 
 	if cfg.MCMS == nil {
 		return errors.New("MCMS config must be set for upgrades")
 	}
-	if cfg.NewFeeQuoterVersion != nil || cfg.NewRouterVersion != nil {
-		if cfg.SpillAddress.IsZero() {
-			return errors.New("spill address must be set for fee quoter and router upgrades")
-		}
-		if cfg.UpgradeAuthority.IsZero() {
-			return errors.New("upgrade authority must be set for fee quoter and router upgrades")
-		}
+	if cfg.SpillAddress.IsZero() {
+		return errors.New("spill address must be set for fee quoter and router upgrades")
+	}
+	if cfg.UpgradeAuthority.IsZero() {
+		return errors.New("upgrade authority must be set for fee quoter and router upgrades")
 	}
 	return ValidateMCMSConfig(e, chainSelector, cfg.MCMS)
 }
@@ -452,7 +450,7 @@ func deployChainContractsSolana(
 			offRampBillingSignerPDA,
 			fqAllowedPriceUpdaterOfframpPDA,
 			feeQuoterConfigPDA,
-			chain.DeployerKey.PublicKey(),
+			config.UpgradeConfig.UpgradeAuthority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -152,7 +152,7 @@ func DeployChainContractsChangeset(e deployment.Environment, c DeployChainContra
 			e.Logger.Errorw("Failed to deploy CCIP contracts", "err", err, "newAddresses", newAddresses)
 			return deployment.ChangesetOutput{}, err
 		}
-		// create proposals for ixns
+		// create proposals for txns
 		if len(mcmsTxs) > 0 {
 			batches = append(batches, mcmsTypes.BatchOperation{
 				ChainSelector: mcmsTypes.ChainSelector(chainSel),
@@ -161,7 +161,7 @@ func DeployChainContractsChangeset(e deployment.Environment, c DeployChainContra
 		}
 	}
 
-	if c.UpgradeConfig.MCMS != nil {
+	if len(batches) > 0 {
 		proposal, err := proposalutils.BuildProposalFromBatchesV2(
 			e.GetContext(),
 			timelocks,
@@ -376,18 +376,18 @@ func deployChainContractsSolana(
 	config DeployChainContractsConfig,
 ) ([]mcmsTypes.Transaction, error) {
 	// we may need to gather instructions and submit them as part of MCMS
-	ixns := make([]mcmsTypes.Transaction, 0)
+	txns := make([]mcmsTypes.Transaction, 0)
 	state, err := ccipChangeset.LoadOnchainStateSolana(e)
 	if err != nil {
 		e.Logger.Errorw("Failed to load existing onchain state", "err", err)
-		return ixns, err
+		return txns, err
 	}
 	chainState, chainExists := state.SolChains[chain.Selector]
 	if !chainExists {
-		return ixns, fmt.Errorf("chain %s not found in existing state, deploy the link token first", chain.String())
+		return txns, fmt.Errorf("chain %s not found in existing state, deploy the link token first", chain.String())
 	}
 	if chainState.LinkToken.IsZero() {
-		return ixns, fmt.Errorf("failed to get link token address for chain %s", chain.String())
+		return txns, fmt.Errorf("failed to get link token address for chain %s", chain.String())
 	}
 
 	params := config.ContractParamsPerChain[chain.Selector]
@@ -398,96 +398,16 @@ func deployChainContractsSolana(
 	if chainState.FeeQuoter.IsZero() {
 		feeQuoterAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, FeeQuoterProgramName, deployment.Version1_0_0, false)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
+			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewFeeQuoterVersion != nil {
 		// fee quoter updated in place
-		bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, FeeQuoterProgramName, *config.UpgradeConfig.NewFeeQuoterVersion, true)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
-		}
-		if err := setUpgradeAuthority(&e, &chain, bufferProgram, chain.DeployerKey, config.UpgradeConfig.UpgradeAuthority.ToPointer(), true); err != nil {
-			return ixns, fmt.Errorf("failed to set upgrade authority: %w", err)
-		}
-		extendIxn, err := generateExtendIxn(
-			&e,
-			chain,
-			chainState.FeeQuoter,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate extend instruction: %w", err)
-		}
-		upgradeIxn, err := generateUpgradeIxn(
-			&e,
-			chainState.FeeQuoter,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-			config.UpgradeConfig.UpgradeAuthority,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate upgrade instruction: %w", err)
-		}
-		closeIxn, err := generateCloseBufferIxn(
-			&e,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-			config.UpgradeConfig.UpgradeAuthority,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate close buffer instruction: %w", err)
-		}
 		feeQuoterAddress = chainState.FeeQuoter
-		upgradeData, err := upgradeIxn.Data()
+		newTxns, err := generateUpgradeTxns(e, chain, ab, config, *&config.UpgradeConfig.NewFeeQuoterVersion, chainState.FeeQuoter, ccipChangeset.FeeQuoter)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to extract upgrade data: %w", err)
+			return txns, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
-		upgradeTx, err := mcmsSolana.NewTransaction(
-			solana.BPFLoaderUpgradeableProgramID.String(),
-			upgradeData,
-			big.NewInt(0),                   // e.g. value
-			upgradeIxn.Accounts(),           // pass along needed accounts
-			string(ccipChangeset.FeeQuoter), // some string identifying the target
-			[]string{},                      // any relevant metadata
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to create upgrade transaction: %w", err)
-		}
-		closeData, err := closeIxn.Data()
-		if err != nil {
-			return ixns, fmt.Errorf("failed to extract close data: %w", err)
-		}
-		closeTx, err := mcmsSolana.NewTransaction(
-			solana.BPFLoaderUpgradeableProgramID.String(),
-			closeData,
-			big.NewInt(0),                   // e.g. value
-			closeIxn.Accounts(),             // pass along needed accounts
-			string(ccipChangeset.FeeQuoter), // some string identifying the target
-			[]string{},                      // any relevant metadata
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to create close transaction: %w", err)
-		}
-		if extendIxn != nil {
-			extendData, err := extendIxn.Data()
-			if err != nil {
-				return ixns, fmt.Errorf("failed to extract extend data: %w", err)
-			}
-			extendTx, err := mcmsSolana.NewTransaction(
-				solana.BPFLoaderUpgradeableProgramID.String(),
-				extendData,
-				big.NewInt(0),                   // e.g. value
-				extendIxn.Accounts(),            // pass along needed accounts
-				string(ccipChangeset.FeeQuoter), // some string identifying the target
-				[]string{},                      // any relevant metadata
-			)
-			if err != nil {
-				return ixns, fmt.Errorf("failed to create extend transaction: %w", err)
-			}
-			ixns = append(ixns, extendTx)
-		}
-		ixns = append(ixns, upgradeTx, closeTx)
+		txns = append(txns, newTxns...)
 	} else {
 		e.Logger.Infow("Using existing fee quoter", "addr", chainState.FeeQuoter.String())
 		feeQuoterAddress = chainState.FeeQuoter
@@ -501,96 +421,16 @@ func deployChainContractsSolana(
 		// deploy router
 		ccipRouterProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, RouterProgramName, deployment.Version1_0_0, false)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
+			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewRouterVersion != nil {
 		// router updated in place
-		bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, RouterProgramName, *config.UpgradeConfig.NewRouterVersion, true)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
-		}
-		if err := setUpgradeAuthority(&e, &chain, bufferProgram, chain.DeployerKey, config.UpgradeConfig.UpgradeAuthority.ToPointer(), true); err != nil {
-			return ixns, fmt.Errorf("failed to set upgrade authority: %w", err)
-		}
-		upgradeIxn, err := generateUpgradeIxn(
-			&e,
-			chainState.Router,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-			config.UpgradeConfig.UpgradeAuthority,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate upgrade instruction: %w", err)
-		}
-		extendIxn, err := generateExtendIxn(
-			&e,
-			chain,
-			chainState.Router,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate extend instruction: %w", err)
-		}
-		closeIxn, err := generateCloseBufferIxn(
-			&e,
-			bufferProgram,
-			config.UpgradeConfig.SpillAddress,
-			config.UpgradeConfig.UpgradeAuthority,
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to generate close buffer instruction: %w", err)
-		}
 		ccipRouterProgram = chainState.Router
-		upgradeData, err := upgradeIxn.Data()
+		newTxns, err := generateUpgradeTxns(e, chain, ab, config, *&config.UpgradeConfig.NewRouterVersion, chainState.Router, ccipChangeset.Router)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to extract upgrade data: %w", err)
+			return txns, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
-		upgradeTx, err := mcmsSolana.NewTransaction(
-			solana.BPFLoaderUpgradeableProgramID.String(),
-			upgradeData,
-			big.NewInt(0),                // e.g. value
-			upgradeIxn.Accounts(),        // pass along needed accounts
-			string(ccipChangeset.Router), // some string identifying the target
-			[]string{},                   // any relevant metadata
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to create upgrade transaction: %w", err)
-		}
-		closeData, err := closeIxn.Data()
-		if err != nil {
-			return ixns, fmt.Errorf("failed to extract close data: %w", err)
-		}
-		closeTx, err := mcmsSolana.NewTransaction(
-			solana.BPFLoaderUpgradeableProgramID.String(),
-			closeData,
-			big.NewInt(0),                // e.g. value
-			closeIxn.Accounts(),          // pass along needed accounts
-			string(ccipChangeset.Router), // some string identifying the target
-			[]string{},                   // any relevant metadata
-		)
-		if err != nil {
-			return ixns, fmt.Errorf("failed to create close transaction: %w", err)
-		}
-		if extendIxn != nil {
-			extendData, err := extendIxn.Data()
-			if err != nil {
-				return ixns, fmt.Errorf("failed to extract extend data: %w", err)
-			}
-			extendTx, err := mcmsSolana.NewTransaction(
-				solana.BPFLoaderUpgradeableProgramID.String(),
-				extendData,
-				big.NewInt(0),                // e.g. value
-				extendIxn.Accounts(),         // pass along needed accounts
-				string(ccipChangeset.Router), // some string identifying the target
-				[]string{},                   // any relevant metadata
-			)
-			if err != nil {
-				return ixns, fmt.Errorf("failed to create extend transaction: %w", err)
-			}
-			ixns = append(ixns, extendTx)
-		}
-		ixns = append(ixns, upgradeTx, closeTx)
+		txns = append(txns, newTxns...)
 	} else {
 		e.Logger.Infow("Using existing router", "addr", chainState.Router.String())
 		ccipRouterProgram = chainState.Router
@@ -609,20 +449,20 @@ func deployChainContractsSolana(
 		// deploy offramp
 		offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, OffRampProgramName, deployment.Version1_0_0, false)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
+			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
 	} else if config.UpgradeConfig.NewOffRampVersion != nil {
 		tv := deployment.NewTypeAndVersion(ccipChangeset.OffRamp, *config.UpgradeConfig.NewOffRampVersion)
 		existingAddresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to get existing addresses: %w", err)
+			return txns, fmt.Errorf("failed to get existing addresses: %w", err)
 		}
 		offRampAddress = ccipChangeset.FindSolanaAddress(tv, existingAddresses)
 		if offRampAddress.IsZero() {
 			// deploy offramp, not upgraded in place so upgrade is false
 			offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, OffRampProgramName, *config.UpgradeConfig.NewOffRampVersion, false)
 			if err != nil {
-				return ixns, fmt.Errorf("failed to deploy program: %w", err)
+				return txns, fmt.Errorf("failed to deploy program: %w", err)
 			}
 		}
 
@@ -638,11 +478,11 @@ func deployChainContractsSolana(
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {
-			return ixns, fmt.Errorf("failed to build instruction: %w", err)
+			return txns, fmt.Errorf("failed to build instruction: %w", err)
 		}
 		priceUpdaterData, err := priceUpdaterix.Data()
 		if err != nil {
-			return ixns, fmt.Errorf("failed to extract price updater data: %w", err)
+			return txns, fmt.Errorf("failed to extract price updater data: %w", err)
 		}
 		priceUpdaterTx, err := mcmsSolana.NewTransaction(
 			feeQuoterAddress.String(),
@@ -653,9 +493,9 @@ func deployChainContractsSolana(
 			[]string{},                    // any relevant metadata
 		)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to create price updater transaction: %w", err)
+			return txns, fmt.Errorf("failed to create price updater transaction: %w", err)
 		}
-		ixns = append(ixns, priceUpdaterTx)
+		txns = append(txns, priceUpdaterTx)
 	} else {
 		e.Logger.Infow("Using existing offramp", "addr", chainState.OffRamp.String())
 		offRampAddress = chainState.OffRamp
@@ -668,7 +508,7 @@ func deployChainContractsSolana(
 	err = chain.GetAccountDataBorshInto(e.GetContext(), feeQuoterConfigPDA, &fqConfig)
 	if err != nil {
 		if err2 := initializeFeeQuoter(e, chain, ccipRouterProgram, chainState.LinkToken, feeQuoterAddress, offRampAddress, params.FeeQuoterParams); err2 != nil {
-			return ixns, err2
+			return txns, err2
 		}
 	} else {
 		e.Logger.Infow("Fee quoter already initialized, skipping initialization", "chain", chain.String())
@@ -681,7 +521,7 @@ func deployChainContractsSolana(
 	err = chain.GetAccountDataBorshInto(e.GetContext(), routerConfigPDA, &routerConfigAccount)
 	if err != nil {
 		if err2 := initializeRouter(e, chain, ccipRouterProgram, chainState.LinkToken, feeQuoterAddress); err2 != nil {
-			return ixns, err2
+			return txns, err2
 		}
 	} else {
 		e.Logger.Infow("Router already initialized, skipping initialization", "chain", chain.String())
@@ -707,10 +547,10 @@ func deployChainContractsSolana(
 				solana.SPLAssociatedTokenAccountProgramID,
 			})
 		if err2 != nil {
-			return ixns, fmt.Errorf("failed to create address lookup table: %w", err)
+			return txns, fmt.Errorf("failed to create address lookup table: %w", err)
 		}
 		if err2 := initializeOffRamp(e, chain, ccipRouterProgram, feeQuoterAddress, offRampAddress, table, params.OffRampParams); err2 != nil {
-			return ixns, err2
+			return txns, err2
 		}
 		// Initializing a new offramp means we need a new lookup table and need to fully populate it
 		needFQinLookupTable = true
@@ -734,7 +574,7 @@ func deployChainContractsSolana(
 	if chainState.BurnMintTokenPool.IsZero() {
 		burnMintTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, BurnMintTokenPool, deployment.Version1_0_0, false)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
+			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
 		needTokenPoolinLookupTable = true
 	} else {
@@ -746,7 +586,7 @@ func deployChainContractsSolana(
 	if chainState.LockReleaseTokenPool.IsZero() {
 		lockReleaseTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, LockReleaseTokenPool, deployment.Version1_0_0, false)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to deploy program: %w", err)
+			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
 		needTokenPoolinLookupTable = true
 	} else {
@@ -758,7 +598,7 @@ func deployChainContractsSolana(
 		if err := AddBillingToken(
 			e, chain, chainState, billingConfig,
 		); err != nil {
-			return ixns, err
+			return txns, err
 		}
 	}
 
@@ -801,11 +641,11 @@ func deployChainContractsSolana(
 	if len(lookupTableKeys) > 0 {
 		addressLookupTable, err := ccipChangeset.FetchOfframpLookupTable(e.GetContext(), chain, offRampAddress)
 		if err != nil {
-			return ixns, fmt.Errorf("failed to get offramp reference addresses: %w", err)
+			return txns, fmt.Errorf("failed to get offramp reference addresses: %w", err)
 		}
 		e.Logger.Debugw("Populating lookup table", "lookupTable", addressLookupTable.String(), "keys", lookupTableKeys)
 		if err := solCommonUtil.ExtendLookupTable(e.GetContext(), chain.Client, addressLookupTable, *chain.DeployerKey, lookupTableKeys); err != nil {
-			return ixns, fmt.Errorf("failed to extend lookup table: %w", err)
+			return txns, fmt.Errorf("failed to extend lookup table: %w", err)
 		}
 	}
 
@@ -814,12 +654,77 @@ func deployChainContractsSolana(
 		e.Logger.Infow("Setting upgrade authority", "newUpgradeAuthority", config.NewUpgradeAuthority.String())
 		for _, programID := range []solana.PublicKey{ccipRouterProgram, feeQuoterAddress} {
 			if err := setUpgradeAuthority(&e, &chain, programID, chain.DeployerKey, config.NewUpgradeAuthority, false); err != nil {
-				return ixns, fmt.Errorf("failed to set upgrade authority: %w", err)
+				return txns, fmt.Errorf("failed to set upgrade authority: %w", err)
 			}
 		}
 	}
 
-	return ixns, nil
+	return txns, nil
+}
+
+func generateUpgradeTxns(
+	e deployment.Environment,
+	chain deployment.SolChain,
+	ab deployment.AddressBook,
+	config DeployChainContractsConfig,
+	newVersion *semver.Version,
+	programID solana.PublicKey,
+	contractType deployment.ContractType,
+) ([]mcmsTypes.Transaction, error) {
+	txns := make([]mcmsTypes.Transaction, 0)
+	bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, FeeQuoterProgramName, *newVersion, true)
+	if err != nil {
+		return txns, fmt.Errorf("failed to deploy program: %w", err)
+	}
+	if err := setUpgradeAuthority(&e, &chain, bufferProgram, chain.DeployerKey, config.UpgradeConfig.UpgradeAuthority.ToPointer(), true); err != nil {
+		return txns, fmt.Errorf("failed to set upgrade authority: %w", err)
+	}
+	extendIxn, err := generateExtendIxn(
+		&e,
+		chain,
+		programID,
+		bufferProgram,
+		config.UpgradeConfig.SpillAddress,
+	)
+	if err != nil {
+		return txns, fmt.Errorf("failed to generate extend instruction: %w", err)
+	}
+	upgradeIxn, err := generateUpgradeIxn(
+		&e,
+		programID,
+		bufferProgram,
+		config.UpgradeConfig.SpillAddress,
+		config.UpgradeConfig.UpgradeAuthority,
+	)
+	if err != nil {
+		return txns, fmt.Errorf("failed to generate upgrade instruction: %w", err)
+	}
+	closeIxn, err := generateCloseBufferIxn(
+		&e,
+		bufferProgram,
+		config.UpgradeConfig.SpillAddress,
+		config.UpgradeConfig.UpgradeAuthority,
+	)
+	if err != nil {
+		return txns, fmt.Errorf("failed to generate close buffer instruction: %w", err)
+	}
+	upgradeTx, err := BuildMCMSTxn(upgradeIxn, solana.BPFLoaderUpgradeableProgramID.String(), contractType)
+	if err != nil {
+		return txns, fmt.Errorf("failed to create upgrade transaction: %w", err)
+	}
+	closeTx, err := BuildMCMSTxn(closeIxn, solana.BPFLoaderUpgradeableProgramID.String(), contractType)
+	if err != nil {
+		return txns, fmt.Errorf("failed to create close transaction: %w", err)
+	}
+	if extendIxn != nil {
+		extendTx, err := BuildMCMSTxn(extendIxn, solana.BPFLoaderUpgradeableProgramID.String(), contractType)
+		if err != nil {
+			return txns, fmt.Errorf("failed to create extend transaction: %w", err)
+		}
+		txns = append(txns, *extendTx)
+	}
+	txns = append(txns, *upgradeTx, *closeTx)
+	return txns, nil
 }
 
 // DeployAndMaybeSaveToAddressBook deploys a program to the Solana chain and saves it to the address book
@@ -916,7 +821,7 @@ func generateUpgradeIxn(
 		solana.NewAccountMeta(spillAddress, true, false),              // Spill account (writable)
 		solana.NewAccountMeta(solana.SysVarRentPubkey, false, false),  // System program
 		solana.NewAccountMeta(solana.SysVarClockPubkey, false, false), // System program
-		solana.NewAccountMeta(upgradeAuthority, false, false),         // Current upgrade authority (signer)
+		solana.NewAccountMeta(upgradeAuthority, false, true),          // Current upgrade authority (signer)
 	}
 
 	instruction := solana.NewInstruction(
@@ -967,7 +872,7 @@ func generateExtendIxn(
 		solana.NewAccountMeta(programDataAccount, true, false),      // Program data account (writable)
 		solana.NewAccountMeta(programID, true, false),               // Program account (writable)
 		solana.NewAccountMeta(solana.SystemProgramID, false, false), // System program
-		solana.NewAccountMeta(payer, true, false),                   // Payer for rent
+		solana.NewAccountMeta(payer, true, true),                    // Payer for rent
 	}
 
 	ixn := solana.NewInstruction(
@@ -988,7 +893,7 @@ func generateCloseBufferIxn(
 	keys := solana.AccountMetaSlice{
 		solana.NewAccountMeta(bufferAddress, true, false),
 		solana.NewAccountMeta(recipient, true, false),
-		solana.NewAccountMeta(upgradeAuthority, false, false),
+		solana.NewAccountMeta(upgradeAuthority, false, true),
 	}
 
 	instruction := solana.NewInstruction(

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -479,7 +479,7 @@ func deployChainContractsSolana(
 		if err != nil {
 			return txns, fmt.Errorf("failed to build instruction: %w", err)
 		}
-		priceUpdaterTx, err := BuildMCMSTxn(priceUpdaterix, feeQuoterAddress.String(), ccipChangeset.OffRamp)
+		priceUpdaterTx, err := BuildMCMSTxn(priceUpdaterix, feeQuoterAddress.String(), ccipChangeset.FeeQuoter)
 		if err != nil {
 			return txns, fmt.Errorf("failed to create price updater transaction: %w", err)
 		}

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -403,7 +403,7 @@ func deployChainContractsSolana(
 	} else if config.UpgradeConfig.NewFeeQuoterVersion != nil {
 		// fee quoter updated in place
 		feeQuoterAddress = chainState.FeeQuoter
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, *&config.UpgradeConfig.NewFeeQuoterVersion, chainState.FeeQuoter, ccipChangeset.FeeQuoter)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewFeeQuoterVersion, chainState.FeeQuoter, ccipChangeset.FeeQuoter)
 		if err != nil {
 			return txns, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -426,7 +426,7 @@ func deployChainContractsSolana(
 	} else if config.UpgradeConfig.NewRouterVersion != nil {
 		// router updated in place
 		ccipRouterProgram = chainState.Router
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, *&config.UpgradeConfig.NewRouterVersion, chainState.Router, ccipChangeset.Router)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewRouterVersion, chainState.Router, ccipChangeset.Router)
 		if err != nil {
 			return txns, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -369,7 +369,7 @@ func deployChainContractsSolana(
 	} else if config.UpgradeConfig.NewFeeQuoterVersion != nil {
 		// fee quoter updated in place
 		feeQuoterAddress = chainState.FeeQuoter
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, *&config.UpgradeConfig.NewFeeQuoterVersion, chainState.FeeQuoter, cs.FeeQuoter)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewFeeQuoterVersion, chainState.FeeQuoter, cs.FeeQuoter)
 		if err != nil {
 			return txns, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}
@@ -392,7 +392,7 @@ func deployChainContractsSolana(
 	} else if config.UpgradeConfig.NewRouterVersion != nil {
 		// router updated in place
 		ccipRouterProgram = chainState.Router
-		newTxns, err := generateUpgradeTxns(e, chain, ab, config, *&config.UpgradeConfig.NewRouterVersion, chainState.Router, cs.Router)
+		newTxns, err := generateUpgradeTxns(e, chain, ab, config, config.UpgradeConfig.NewRouterVersion, chainState.Router, cs.Router)
 		if err != nil {
 			return txns, fmt.Errorf("failed to generate upgrade txns: %w", err)
 		}

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -41,6 +41,16 @@ const (
 
 var _ deployment.ChangeSet[DeployChainContractsConfig] = DeployChainContractsChangeset
 
+func getTypeToProgramDeployName() map[deployment.ContractType]string {
+	return map[deployment.ContractType]string{
+		ccipChangeset.Router:               RouterProgramName,
+		ccipChangeset.OffRamp:              OffRampProgramName,
+		ccipChangeset.FeeQuoter:            FeeQuoterProgramName,
+		ccipChangeset.BurnMintTokenPool:    BurnMintTokenPool,
+		ccipChangeset.LockReleaseTokenPool: LockReleaseTokenPool,
+	}
+}
+
 type DeployChainContractsConfig struct {
 	HomeChainSelector      uint64
 	ContractParamsPerChain map[uint64]ChainContractParams
@@ -395,7 +405,7 @@ func deployChainContractsSolana(
 	var feeQuoterAddress solana.PublicKey
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.FeeQuoter.IsZero() {
-		feeQuoterAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, FeeQuoterProgramName, deployment.Version1_0_0, false)
+		feeQuoterAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ccipChangeset.FeeQuoter, deployment.Version1_0_0, false)
 		if err != nil {
 			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -418,7 +428,7 @@ func deployChainContractsSolana(
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.Router.IsZero() {
 		// deploy router
-		ccipRouterProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, RouterProgramName, deployment.Version1_0_0, false)
+		ccipRouterProgram, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ccipChangeset.Router, deployment.Version1_0_0, false)
 		if err != nil {
 			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -446,7 +456,7 @@ func deployChainContractsSolana(
 	//nolint:gocritic // this is a false positive, we need to check if the address is zero
 	if chainState.OffRamp.IsZero() {
 		// deploy offramp
-		offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, OffRampProgramName, deployment.Version1_0_0, false)
+		offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ccipChangeset.OffRamp, deployment.Version1_0_0, false)
 		if err != nil {
 			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -459,7 +469,7 @@ func deployChainContractsSolana(
 		offRampAddress = ccipChangeset.FindSolanaAddress(tv, existingAddresses)
 		if offRampAddress.IsZero() {
 			// deploy offramp, not upgraded in place so upgrade is false
-			offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, OffRampProgramName, *config.UpgradeConfig.NewOffRampVersion, false)
+			offRampAddress, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ccipChangeset.OffRamp, *config.UpgradeConfig.NewOffRampVersion, false)
 			if err != nil {
 				return txns, fmt.Errorf("failed to deploy program: %w", err)
 			}
@@ -560,7 +570,7 @@ func deployChainContractsSolana(
 
 	var burnMintTokenPool solana.PublicKey
 	if chainState.BurnMintTokenPool.IsZero() {
-		burnMintTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, BurnMintTokenPool, deployment.Version1_0_0, false)
+		burnMintTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ccipChangeset.BurnMintTokenPool, deployment.Version1_0_0, false)
 		if err != nil {
 			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -572,7 +582,7 @@ func deployChainContractsSolana(
 
 	var lockReleaseTokenPool solana.PublicKey
 	if chainState.LockReleaseTokenPool.IsZero() {
-		lockReleaseTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, LockReleaseTokenPool, deployment.Version1_0_0, false)
+		lockReleaseTokenPool, err = DeployAndMaybeSaveToAddressBook(e, chain, ab, ccipChangeset.LockReleaseTokenPool, deployment.Version1_0_0, false)
 		if err != nil {
 			return txns, fmt.Errorf("failed to deploy program: %w", err)
 		}
@@ -660,7 +670,7 @@ func generateUpgradeTxns(
 	contractType deployment.ContractType,
 ) ([]mcmsTypes.Transaction, error) {
 	txns := make([]mcmsTypes.Transaction, 0)
-	bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, FeeQuoterProgramName, *newVersion, true)
+	bufferProgram, err := DeployAndMaybeSaveToAddressBook(e, chain, ab, contractType, *newVersion, true)
 	if err != nil {
 		return txns, fmt.Errorf("failed to deploy program: %w", err)
 	}
@@ -721,30 +731,20 @@ func DeployAndMaybeSaveToAddressBook(
 	e deployment.Environment,
 	chain deployment.SolChain,
 	ab deployment.AddressBook,
-	programName string,
+	contractType deployment.ContractType,
 	version semver.Version,
 	isUpgrade bool) (solana.PublicKey, error) {
+	programName := getTypeToProgramDeployName()[contractType]
 	programID, err := chain.DeployProgram(e.Logger, programName, isUpgrade)
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("failed to deploy program: %w", err)
 	}
 	address := solana.MustPublicKeyFromBase58(programID)
 
-	programNameToType := map[string]deployment.ContractType{
-		RouterProgramName:    ccipChangeset.Router,
-		OffRampProgramName:   ccipChangeset.OffRamp,
-		FeeQuoterProgramName: ccipChangeset.FeeQuoter,
-		BurnMintTokenPool:    ccipChangeset.BurnMintTokenPool,
-		LockReleaseTokenPool: ccipChangeset.LockReleaseTokenPool,
-	}
-	programType, ok := programNameToType[programName]
-	if !ok {
-		return solana.PublicKey{}, fmt.Errorf("unknown program name: %s", programName)
-	}
-	e.Logger.Infow("Deployed program", "Program", programType, "addr", programID, "chain", chain.String(), "isUpgrade", isUpgrade)
+	e.Logger.Infow("Deployed program", "Program", contractType, "addr", programID, "chain", chain.String(), "isUpgrade", isUpgrade)
 
 	if !isUpgrade {
-		tv := deployment.NewTypeAndVersion(programType, version)
+		tv := deployment.NewTypeAndVersion(contractType, version)
 		err = ab.Save(chain.Selector, programID, tv)
 		if err != nil {
 			return solana.PublicKey{}, fmt.Errorf("failed to save address: %w", err)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -1,7 +1,6 @@
 package solana_test
 
 import (
-	"math/big"
 	"os"
 	"testing"
 	"time"
@@ -14,10 +13,10 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	cs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	ccipChangesetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
-	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -118,70 +117,32 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
-			map[uint64]commontypes.MCMSWithTimelockConfigV2{
-				solChainSelectors[0]: {
-					Canceller:        proposalutils.SingleGroupMCMSV2(t),
-					Proposer:         proposalutils.SingleGroupMCMSV2(t),
-					Bypasser:         proposalutils.SingleGroupMCMSV2(t),
-					TimelockMinDelay: big.NewInt(0),
+			deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
+			cs_solana.DeployChainContractsConfigSolana{
+				DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
+					HomeChainSelector: homeChainSel,
+					ContractParamsPerChain: map[uint64]v1_6.ChainContractParams{
+						solChainSelectors[0]: {
+							FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
+							OffRampParams:   v1_6.DefaultOffRampParams(),
+						},
+					},
 				},
+			},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(cs_solana.SetFeeAggregator),
+			cs_solana.SetFeeAggregatorConfig{
+				ChainSelector: solChainSelectors[0],
+				FeeAggregator: feeAggregatorPubKey.String(),
 			},
 		),
 	})
 	require.NoError(t, err)
-	addresses, err := e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
-	require.NoError(t, err)
-	mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(e.SolChains[solChainSelectors[0]], addresses)
-	require.NoError(t, err)
-
-	// Fund signer PDAs for timelock and mcm
-	// If we don't fund, execute() calls will fail with "no funds" errors.
-	timelockSignerPDA := commonState.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
-	mcmSignerPDA := commonState.GetMCMSignerPDA(mcmState.McmProgram, mcmState.ProposerMcmSeed)
-	memory.FundSolanaAccounts(e.GetContext(), t, []solana.PublicKey{timelockSignerPDA, mcmSignerPDA},
-		100, e.SolChains[solChainSelectors[0]].Client)
-	t.Logf("funded timelock signer PDA: %s", timelockSignerPDA.String())
-	t.Logf("funded mcm signer PDA: %s", mcmSignerPDA.String())
+	testhelpers.ValidateSolanaState(t, e, solChainSelectors)
+	timelockSignerPDA, _ := testhelpers.TransferOwnershipSolana(t, &e, solChainSelectors[0], true, true, true, true)
 	upgradeAuthority := timelockSignerPDA
 
-	deployCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
-		ccipChangesetSolana.DeployChainContractsConfig{
-			HomeChainSelector: homeChainSel,
-			ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
-				solChainSelectors[0]: {
-					FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
-						DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
-					},
-					OffRampParams: ccipChangesetSolana.OffRampParams{
-						EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
-					},
-				},
-			},
-		},
-	)
-	// set the fee aggregator address
-	feeAggregatorCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.SetFeeAggregator),
-		ccipChangesetSolana.SetFeeAggregatorConfig{
-			ChainSelector: solChainSelectors[0],
-			FeeAggregator: feeAggregatorPubKey.String(),
-		},
-	)
-	transferOwnershipCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.TransferCCIPToMCMSWithTimelockSolana),
-		cs_solana.TransferCCIPToMCMSWithTimelockSolanaConfig{
-			MinDelay: 1 * time.Second,
-			ContractsByChain: map[uint64]cs_solana.CCIPContractsToTransfer{
-				solChainSelectors[0]: {
-					Router:    true,
-					FeeQuoter: true,
-					OffRamp:   true,
-				},
-			},
-		},
-	)
 	// make sure idempotency works and setting the upgrade authority
 	upgradeAuthorityCs := commonchangeset.Configure(
 		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
@@ -252,10 +213,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	)
 	if ci {
 		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			deployCs,
-			feeAggregatorCs,
 			upgradeAuthorityCs,
-			transferOwnershipCs,
 			buildCs,
 			upgradeCs,
 		})
@@ -276,17 +234,14 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 		require.NotEqual(t, oldOffRampAddress, newOffRampAddress)
 	} else {
 		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			deployCs,
-			feeAggregatorCs,
 			upgradeAuthorityCs,
 			upgradeCs,
-			transferOwnershipCs,
 		})
 		require.NoError(t, err)
 	}
 	// Verify router and fee quoter upgraded in place
 	// and offramp had 2nd address added
-	addresses, err = e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
+	addresses, err := e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
 	require.NoError(t, err)
 	numRouters := 0
 	numFeeQuoters := 0

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -164,19 +164,6 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			FeeAggregator: feeAggregatorPubKey.String(),
 		},
 	)
-	transferOwnershipCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.TransferCCIPToMCMSWithTimelockSolana),
-		ccipChangesetSolana.TransferCCIPToMCMSWithTimelockSolanaConfig{
-			MinDelay: 1 * time.Second,
-			ContractsByChain: map[uint64]ccipChangesetSolana.CCIPContractsToTransfer{
-				solChainSelectors[0]: {
-					Router:    true,
-					FeeQuoter: true,
-					OffRamp:   true,
-				},
-			},
-		},
-	)
 	// make sure idempotency works and setting the upgrade authority
 	upgradeAuthorityCs := commonchangeset.Configure(
 		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
@@ -245,7 +232,6 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			deployCs,
 			feeAggregatorCs,
 			upgradeAuthorityCs,
-			transferOwnershipCs,
 		})
 		require.NoError(t, err)
 		state, err := ccipChangeset.LoadOnchainStateSolana(e)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	cs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	cs_solana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
-	solanachangesets "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -162,19 +161,6 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			FeeAggregator: feeAggregatorPubKey.String(),
 		},
 	)
-	transferOwnershipCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(solanachangesets.TransferCCIPToMCMSWithTimelockSolana),
-		solanachangesets.TransferCCIPToMCMSWithTimelockSolanaConfig{
-			MinDelay: 1 * time.Second,
-			ContractsByChain: map[uint64]solanachangesets.CCIPContractsToTransfer{
-				solChainSelectors[0]: {
-					Router:    true,
-					FeeQuoter: true,
-					OffRamp:   true,
-				},
-			},
-		},
-	)
 	// make sure idempotency works and setting the upgrade authority
 	upgradeAuthorityCs := commonchangeset.Configure(
 		deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
@@ -237,7 +223,6 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			deployCs,
 			feeAggregatorCs,
 			upgradeAuthorityCs,
-			transferOwnershipCs,
 		})
 		require.NoError(t, err)
 		state, err := changeset.LoadOnchainStateSolana(e)
@@ -293,5 +278,4 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	require.NoError(t, err)
 	// solana verification
 	testhelpers.ValidateSolanaState(t, e, solChainSelectors)
-
 }

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -187,6 +187,19 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			NewUpgradeAuthority: &upgradeAuthority,
 		},
 	)
+	transferOwnershipCs := commonchangeset.Configure(
+		deployment.CreateLegacyChangeSet(cs_solana.TransferCCIPToMCMSWithTimelockSolana),
+		cs_solana.TransferCCIPToMCMSWithTimelockSolanaConfig{
+			MinDelay: 1 * time.Second,
+			ContractsByChain: map[uint64]cs_solana.CCIPContractsToTransfer{
+				solChainSelectors[0]: {
+					Router:    true,
+					FeeQuoter: true,
+					OffRamp:   true,
+				},
+			},
+		},
+	)
 	upgradeCs := commonchangeset.Configure(
 		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
 		ccipChangesetSolana.DeployChainContractsConfig{
@@ -237,6 +250,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			deployCs,
 			feeAggregatorCs,
 			upgradeAuthorityCs,
+			transferOwnershipCs,
 		})
 		require.NoError(t, err)
 		state, err := ccipChangeset.LoadOnchainStateSolana(e)
@@ -260,6 +274,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			feeAggregatorCs,
 			upgradeAuthorityCs,
 			upgradeCs,
+			transferOwnershipCs,
 		})
 	}
 	require.NoError(t, err)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -1,7 +1,6 @@
 package solana_test
 
 import (
-	"math/big"
 	"os"
 	"testing"
 	"time"
@@ -22,7 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
@@ -118,68 +116,32 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
-			map[uint64]commontypes.MCMSWithTimelockConfigV2{
-				solChainSelectors[0]: {
-					Canceller:        proposalutils.SingleGroupMCMSV2(t),
-					Proposer:         proposalutils.SingleGroupMCMSV2(t),
-					Bypasser:         proposalutils.SingleGroupMCMSV2(t),
-					TimelockMinDelay: big.NewInt(0),
+			deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
+			cs_solana.DeployChainContractsConfigSolana{
+				DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
+					HomeChainSelector: homeChainSel,
+					ContractParamsPerChain: map[uint64]v1_6.ChainContractParams{
+						solChainSelectors[0]: {
+							FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
+							OffRampParams:   v1_6.DefaultOffRampParams(),
+						},
+					},
 				},
+			},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(cs_solana.SetFeeAggregator),
+			cs_solana.SetFeeAggregatorConfig{
+				ChainSelector: solChainSelectors[0],
+				FeeAggregator: feeAggregatorPubKey.String(),
 			},
 		),
 	})
 	require.NoError(t, err)
-	addresses, err := e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
-	require.NoError(t, err)
-	mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(e.SolChains[solChainSelectors[0]], addresses)
-	require.NoError(t, err)
-
-	// Fund signer PDAs for timelock and mcm
-	// If we don't fund, execute() calls will fail with "no funds" errors.
-	timelockSignerPDA := commonState.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
-	mcmSignerPDA := commonState.GetMCMSignerPDA(mcmState.McmProgram, mcmState.ProposerMcmSeed)
-	memory.FundSolanaAccounts(e.GetContext(), t, []solana.PublicKey{timelockSignerPDA, mcmSignerPDA},
-		100, e.SolChains[solChainSelectors[0]].Client)
-	t.Logf("funded timelock signer PDA: %s", timelockSignerPDA.String())
-	t.Logf("funded mcm signer PDA: %s", mcmSignerPDA.String())
+	testhelpers.ValidateSolanaState(t, e, solChainSelectors)
+	timelockSignerPDA, _ := testhelpers.TransferOwnershipSolana(t, &e, solChainSelectors[0], true, true, true, true)
 	upgradeAuthority := timelockSignerPDA
 
-	deployCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
-		cs_solana.DeployChainContractsConfigSolana{
-			DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
-				HomeChainSelector: homeChainSel,
-				ContractParamsPerChain: map[uint64]v1_6.ChainContractParams{
-					solChainSelectors[0]: {
-						FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
-						OffRampParams:   v1_6.DefaultOffRampParams(),
-					},
-				},
-			},
-		},
-	)
-	// set the fee aggregator address
-	feeAggregatorCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.SetFeeAggregator),
-		cs_solana.SetFeeAggregatorConfig{
-			ChainSelector: solChainSelectors[0],
-			FeeAggregator: feeAggregatorPubKey.String(),
-		},
-	)
-	transferOwnershipCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.TransferCCIPToMCMSWithTimelockSolana),
-		cs_solana.TransferCCIPToMCMSWithTimelockSolanaConfig{
-			MinDelay: 1 * time.Second,
-			ContractsByChain: map[uint64]cs_solana.CCIPContractsToTransfer{
-				solChainSelectors[0]: {
-					Router:    true,
-					FeeQuoter: true,
-					OffRamp:   true,
-				},
-			},
-		},
-	)
 	// make sure idempotency works and setting the upgrade authority
 	upgradeAuthorityCs := commonchangeset.Configure(
 		deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
@@ -244,10 +206,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	)
 	if ci {
 		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			deployCs,
-			feeAggregatorCs,
 			upgradeAuthorityCs,
-			transferOwnershipCs,
 			buildCs,
 			upgradeCs,
 		})
@@ -268,17 +227,14 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 		require.NotEqual(t, oldOffRampAddress, newOffRampAddress)
 	} else {
 		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			deployCs,
-			feeAggregatorCs,
 			upgradeAuthorityCs,
 			upgradeCs,
-			transferOwnershipCs,
 		})
 		require.NoError(t, err)
 	}
 	// Verify router and fee quoter upgraded in place
 	// and offramp had 2nd address added
-	addresses, err = e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
+	addresses, err := e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
 	require.NoError(t, err)
 	numRouters := 0
 	numFeeQuoters := 0

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -57,21 +57,21 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	feeAggregatorPrivKey, _ := solana.NewRandomPrivateKey()
 	feeAggregatorPubKey := feeAggregatorPrivKey.PublicKey()
 	ci := os.Getenv("CI") == "true"
-	// we can't upgrade in place locally so we have to change where we build
-	buildCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.BuildSolanaChangeset),
-		cs_solana.BuildSolanaConfig{
-			ChainSelector:       solChainSelectors[0],
-			GitCommitSha:        "0863d8fed5fbada9f352f33c405e1753cbb7d72c",
-			DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
-			CleanDestinationDir: true,
-		},
-	)
+	// we can't upgrade in place locally if we preload addresses so we have to change where we build
+	// we also don't want to incur two builds in CI, so only do it locally
 	if ci {
 		testhelpers.SavePreloadedSolAddresses(t, e, solChainSelectors[0])
 	} else {
 		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			buildCs,
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(cs_solana.BuildSolanaChangeset),
+				cs_solana.BuildSolanaConfig{
+					ChainSelector:       solChainSelectors[0],
+					GitCommitSha:        "3da552ac9d30b821310718b8b67e6a298335a485",
+					DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
+					CleanDestinationDir: true,
+				},
+			),
 		})
 		require.NoError(t, err)
 	}
@@ -141,97 +141,100 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	testhelpers.ValidateSolanaState(t, e, solChainSelectors)
 	timelockSignerPDA, _ := testhelpers.TransferOwnershipSolana(t, &e, solChainSelectors[0], true, true, true, true)
 	upgradeAuthority := timelockSignerPDA
+	state, err := changeset.LoadOnchainStateSolana(e)
+	require.NoError(t, err)
 
-	// make sure idempotency works and setting the upgrade authority
-	upgradeAuthorityCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
-		cs_solana.DeployChainContractsConfigSolana{
-			DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
-				HomeChainSelector: homeChainSel,
-				ContractParamsPerChain: map[uint64]v1_6.ChainContractParams{
-					solChainSelectors[0]: {
-						FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
-						OffRampParams:   v1_6.DefaultOffRampParams(),
+	e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
+			cs_solana.DeployChainContractsConfigSolana{
+				DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
+					HomeChainSelector: homeChainSel,
+					ContractParamsPerChain: map[uint64]v1_6.ChainContractParams{
+						solChainSelectors[0]: {
+							FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
+							OffRampParams:   v1_6.DefaultOffRampParams(),
+						},
+					},
+				},
+				NewUpgradeAuthority: &upgradeAuthority,
+			},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(cs_solana.BuildSolanaChangeset),
+			cs_solana.BuildSolanaConfig{
+				ChainSelector:       solChainSelectors[0],
+				GitCommitSha:        "0863d8fed5fbada9f352f33c405e1753cbb7d72c",
+				DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
+				CleanDestinationDir: true,
+				CleanGitDir:         true,
+				UpgradeKeys: map[deployment.ContractType]string{
+					cs.Router:    state.SolChains[solChainSelectors[0]].Router.String(),
+					cs.FeeQuoter: state.SolChains[solChainSelectors[0]].FeeQuoter.String(),
+				},
+			},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
+			cs_solana.DeployChainContractsConfigSolana{
+				DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
+					HomeChainSelector: homeChainSel,
+					ContractParamsPerChain: map[uint64]v1_6.ChainContractParams{
+						solChainSelectors[0]: {
+							FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
+							OffRampParams:   v1_6.DefaultOffRampParams(),
+						},
+					},
+				},
+				UpgradeConfig: cs_solana.UpgradeConfigSolana{
+					NewFeeQuoterVersion: &deployment.Version1_1_0,
+					NewRouterVersion:    &deployment.Version1_1_0,
+					UpgradeAuthority:    upgradeAuthority,
+					SpillAddress:        upgradeAuthority,
+					MCMS: &cs.MCMSConfig{
+						MinDelay: 1 * time.Second,
 					},
 				},
 			},
-			NewUpgradeAuthority: &upgradeAuthority,
-		},
-	)
-	upgradeCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
-		cs_solana.DeployChainContractsConfigSolana{
-			DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
-				HomeChainSelector: homeChainSel,
-				ContractParamsPerChain: map[uint64]v1_6.ChainContractParams{
-					solChainSelectors[0]: {
-						FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
-						OffRampParams:   v1_6.DefaultOffRampParams(),
+		),
+	})
+	require.NoError(t, err)
+	testhelpers.ValidateSolanaState(t, e, solChainSelectors)
+	state, err = changeset.LoadOnchainStateSolana(e)
+	require.NoError(t, err)
+	oldOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
+	// add a second offramp address
+	e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
+			cs_solana.DeployChainContractsConfigSolana{
+				DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
+					HomeChainSelector: homeChainSel,
+					ContractParamsPerChain: map[uint64]v1_6.ChainContractParams{
+						solChainSelectors[0]: {
+							FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
+							OffRampParams:   v1_6.DefaultOffRampParams(),
+						},
+					},
+				},
+				UpgradeConfig: cs_solana.UpgradeConfigSolana{
+					NewOffRampVersion: &deployment.Version1_1_0,
+					UpgradeAuthority:  upgradeAuthority,
+					SpillAddress:      upgradeAuthority,
+					MCMS: &cs.MCMSConfig{
+						MinDelay: 1 * time.Second,
 					},
 				},
 			},
-			UpgradeConfig: cs_solana.UpgradeConfigSolana{
-				NewFeeQuoterVersion: &deployment.Version1_1_0,
-				NewRouterVersion:    &deployment.Version1_1_0,
-				UpgradeAuthority:    upgradeAuthority,
-				SpillAddress:        upgradeAuthority,
-				MCMS: &cs.MCMSConfig{
-					MinDelay: 1 * time.Second,
-				},
-			},
-		},
-	)
-	// because we cannot upgrade in place locally, we can't redeploy offramp
-	offRampCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
-		cs_solana.DeployChainContractsConfigSolana{
-			DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
-				HomeChainSelector: homeChainSel,
-				ContractParamsPerChain: map[uint64]v1_6.ChainContractParams{
-					solChainSelectors[0]: {
-						FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
-						OffRampParams:   v1_6.DefaultOffRampParams(),
-					},
-				},
-			},
-			UpgradeConfig: cs_solana.UpgradeConfigSolana{
-				NewOffRampVersion: &deployment.Version1_1_0,
-				UpgradeAuthority:  upgradeAuthority,
-				SpillAddress:      upgradeAuthority,
-				MCMS: &cs.MCMSConfig{
-					MinDelay: 1 * time.Second,
-				},
-			},
-		},
-	)
-	if ci {
-		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			upgradeAuthorityCs,
-			buildCs,
-			upgradeCs,
-		})
-		require.NoError(t, err)
-		state, err := changeset.LoadOnchainStateSolana(e)
-		require.NoError(t, err)
-		testhelpers.ValidateSolanaState(t, e, solChainSelectors)
-		oldOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
-		// add a second offramp address
-		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			offRampCs,
-		})
-		require.NoError(t, err)
-		// verify the offramp address is different
-		state, err = changeset.LoadOnchainStateSolana(e)
-		require.NoError(t, err)
-		newOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
-		require.NotEqual(t, oldOffRampAddress, newOffRampAddress)
-	} else {
-		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			upgradeAuthorityCs,
-			upgradeCs,
-		})
-		require.NoError(t, err)
-	}
+		),
+	})
+	require.NoError(t, err)
+	// verify the offramp address is different
+	state, err = changeset.LoadOnchainStateSolana(e)
+	require.NoError(t, err)
+	newOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
+	require.NotEqual(t, oldOffRampAddress, newOffRampAddress)
+
 	// Verify router and fee quoter upgraded in place
 	// and offramp had 2nd address added
 	addresses, err := e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
@@ -252,11 +255,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	}
 	require.Equal(t, 1, numRouters)
 	require.Equal(t, 1, numFeeQuoters)
-	if ci {
-		require.Equal(t, 2, numOffRamps)
-	} else {
-		require.Equal(t, 1, numOffRamps)
-	}
+	require.Equal(t, 2, numOffRamps)
 	require.NoError(t, err)
 	// solana verification
 	testhelpers.ValidateSolanaState(t, e, solChainSelectors)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -60,11 +60,26 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	feeAggregatorPrivKey, _ := solana.NewRandomPrivateKey()
 	feeAggregatorPubKey := feeAggregatorPrivKey.PublicKey()
 	ci := os.Getenv("CI") == "true"
+	// we can't upgrade in place locally so we have to change where we build
+	buildCs := commonchangeset.Configure(
+		deployment.CreateLegacyChangeSet(ccipChangesetSolana.BuildSolanaChangeset),
+		ccipChangesetSolana.BuildSolanaConfig{
+			ChainSelector:       solChainSelectors[0],
+			GitCommitSha:        "0863d8fed5fbada9f352f33c405e1753cbb7d72c",
+			DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
+			CleanDestinationDir: true,
+		},
+	)
 	if ci {
 		testhelpers.SavePreloadedSolAddresses(t, e, solChainSelectors[0])
+	} else {
+		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+			buildCs,
+		})
+		require.NoError(t, err)
 	}
 
-	e, err = commonchangeset.Apply(t, e, nil,
+	e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			deployment.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
 			v1_6.DeployHomeChainConfig{
@@ -113,7 +128,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 				},
 			},
 		),
-	)
+	})
 	require.NoError(t, err)
 	addresses, err := e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
 	require.NoError(t, err)
@@ -130,16 +145,6 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	t.Logf("funded mcm signer PDA: %s", mcmSignerPDA.String())
 	upgradeAuthority := timelockSignerPDA
 
-	// we can't upgrade in place locally so we have to change where we build
-	buildCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.BuildSolanaChangeset),
-		ccipChangesetSolana.BuildSolanaConfig{
-			ChainSelector:       solChainSelectors[0],
-			GitCommitSha:        "0863d8fed5fbada9f352f33c405e1753cbb7d72c",
-			DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
-			CleanDestinationDir: true,
-		},
-	)
 	deployCs := commonchangeset.Configure(
 		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
 		ccipChangesetSolana.DeployChainContractsConfig{
@@ -251,7 +256,6 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 		require.NotEqual(t, oldOffRampAddress, newOffRampAddress)
 	} else {
 		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			buildCs,
 			deployCs,
 			feeAggregatorCs,
 			upgradeAuthorityCs,

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -183,6 +183,19 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			NewUpgradeAuthority: &upgradeAuthority,
 		},
 	)
+	transferOwnershipCs := commonchangeset.Configure(
+		deployment.CreateLegacyChangeSet(cs_solana.TransferCCIPToMCMSWithTimelockSolana),
+		cs_solana.TransferCCIPToMCMSWithTimelockSolanaConfig{
+			MinDelay: 1 * time.Second,
+			ContractsByChain: map[uint64]cs_solana.CCIPContractsToTransfer{
+				solChainSelectors[0]: {
+					Router:    true,
+					FeeQuoter: true,
+					OffRamp:   true,
+				},
+			},
+		},
+	)
 	upgradeCs := commonchangeset.Configure(
 		deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
 		cs_solana.DeployChainContractsConfigSolana{
@@ -229,6 +242,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			deployCs,
 			feeAggregatorCs,
 			upgradeAuthorityCs,
+			transferOwnershipCs,
 		})
 		require.NoError(t, err)
 		state, err := changeset.LoadOnchainStateSolana(e)
@@ -252,6 +266,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			feeAggregatorCs,
 			upgradeAuthorityCs,
 			upgradeCs,
+			transferOwnershipCs,
 		})
 	}
 	require.NoError(t, err)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -242,6 +242,9 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			},
 			UpgradeConfig: ccipChangesetSolana.UpgradeConfig{
 				NewOffRampVersion: &deployment.Version1_1_0,
+				MCMS: &cs.MCMSConfig{
+					MinDelay: 1 * time.Second,
+				},
 			},
 		},
 	)
@@ -276,8 +279,8 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			upgradeCs,
 			transferOwnershipCs,
 		})
+		require.NoError(t, err)
 	}
-	require.NoError(t, err)
 	// Verify router and fee quoter upgraded in place
 	// and offramp had 2nd address added
 	addresses, err = e.ExistingAddresses.AddressesForChain(solChainSelectors[0])

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -169,6 +169,19 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			FeeAggregator: feeAggregatorPubKey.String(),
 		},
 	)
+	transferOwnershipCs := commonchangeset.Configure(
+		deployment.CreateLegacyChangeSet(cs_solana.TransferCCIPToMCMSWithTimelockSolana),
+		cs_solana.TransferCCIPToMCMSWithTimelockSolanaConfig{
+			MinDelay: 1 * time.Second,
+			ContractsByChain: map[uint64]cs_solana.CCIPContractsToTransfer{
+				solChainSelectors[0]: {
+					Router:    true,
+					FeeQuoter: true,
+					OffRamp:   true,
+				},
+			},
+		},
+	)
 	// make sure idempotency works and setting the upgrade authority
 	upgradeAuthorityCs := commonchangeset.Configure(
 		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
@@ -185,19 +198,6 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 				},
 			},
 			NewUpgradeAuthority: &upgradeAuthority,
-		},
-	)
-	transferOwnershipCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.TransferCCIPToMCMSWithTimelockSolana),
-		cs_solana.TransferCCIPToMCMSWithTimelockSolanaConfig{
-			MinDelay: 1 * time.Second,
-			ContractsByChain: map[uint64]cs_solana.CCIPContractsToTransfer{
-				solChainSelectors[0]: {
-					Router:    true,
-					FeeQuoter: true,
-					OffRamp:   true,
-				},
-			},
 		},
 	)
 	upgradeCs := commonchangeset.Configure(

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -242,6 +242,8 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			},
 			UpgradeConfig: ccipChangesetSolana.UpgradeConfig{
 				NewOffRampVersion: &deployment.Version1_1_0,
+				UpgradeAuthority:  upgradeAuthority,
+				SpillAddress:      upgradeAuthority,
 				MCMS: &cs.MCMSConfig{
 					MinDelay: 1 * time.Second,
 				},
@@ -254,15 +256,16 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			feeAggregatorCs,
 			upgradeAuthorityCs,
 			transferOwnershipCs,
+			buildCs,
+			upgradeCs,
 		})
 		require.NoError(t, err)
 		state, err := ccipChangeset.LoadOnchainStateSolana(e)
 		require.NoError(t, err)
+		testhelpers.ValidateSolanaState(t, e, solChainSelectors)
 		oldOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
 		// add a second offramp address
 		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			buildCs,
-			upgradeCs,
 			offRampCs,
 		})
 		require.NoError(t, err)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -167,6 +167,19 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			FeeAggregator: feeAggregatorPubKey.String(),
 		},
 	)
+	transferOwnershipCs := commonchangeset.Configure(
+		deployment.CreateLegacyChangeSet(cs_solana.TransferCCIPToMCMSWithTimelockSolana),
+		cs_solana.TransferCCIPToMCMSWithTimelockSolanaConfig{
+			MinDelay: 1 * time.Second,
+			ContractsByChain: map[uint64]cs_solana.CCIPContractsToTransfer{
+				solChainSelectors[0]: {
+					Router:    true,
+					FeeQuoter: true,
+					OffRamp:   true,
+				},
+			},
+		},
+	)
 	// make sure idempotency works and setting the upgrade authority
 	upgradeAuthorityCs := commonchangeset.Configure(
 		deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
@@ -181,19 +194,6 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 				},
 			},
 			NewUpgradeAuthority: &upgradeAuthority,
-		},
-	)
-	transferOwnershipCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.TransferCCIPToMCMSWithTimelockSolana),
-		cs_solana.TransferCCIPToMCMSWithTimelockSolanaConfig{
-			MinDelay: 1 * time.Second,
-			ContractsByChain: map[uint64]cs_solana.CCIPContractsToTransfer{
-				solChainSelectors[0]: {
-					Router:    true,
-					FeeQuoter: true,
-					OffRamp:   true,
-				},
-			},
 		},
 	)
 	upgradeCs := commonchangeset.Configure(

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -234,6 +234,9 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			},
 			UpgradeConfig: cs_solana.UpgradeConfigSolana{
 				NewOffRampVersion: &deployment.Version1_1_0,
+				MCMS: &cs.MCMSConfig{
+					MinDelay: 1 * time.Second,
+				},
 			},
 		},
 	)
@@ -268,8 +271,8 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			upgradeCs,
 			transferOwnershipCs,
 		})
+		require.NoError(t, err)
 	}
-	require.NoError(t, err)
 	// Verify router and fee quoter upgraded in place
 	// and offramp had 2nd address added
 	addresses, err = e.ExistingAddresses.AddressesForChain(solChainSelectors[0])

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -12,6 +12,7 @@ import (
 	solBinary "github.com/gagliardetto/binary"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	cs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	ccipChangesetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
@@ -59,21 +60,21 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	feeAggregatorPrivKey, _ := solana.NewRandomPrivateKey()
 	feeAggregatorPubKey := feeAggregatorPrivKey.PublicKey()
 	ci := os.Getenv("CI") == "true"
-	// we can't upgrade in place locally so we have to change where we build
-	buildCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.BuildSolanaChangeset),
-		ccipChangesetSolana.BuildSolanaConfig{
-			ChainSelector:       solChainSelectors[0],
-			GitCommitSha:        "0863d8fed5fbada9f352f33c405e1753cbb7d72c",
-			DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
-			CleanDestinationDir: true,
-		},
-	)
+	// we can't upgrade in place locally if we preload addresses so we have to change where we build
+	// we also don't want to incur two builds in CI, so only do it locally
 	if ci {
 		testhelpers.SavePreloadedSolAddresses(t, e, solChainSelectors[0])
 	} else {
 		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			buildCs,
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(ccipChangesetSolana.BuildSolanaChangeset),
+				ccipChangesetSolana.BuildSolanaConfig{
+					ChainSelector:       solChainSelectors[0],
+					GitCommitSha:        "3da552ac9d30b821310718b8b67e6a298335a485",
+					DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
+					CleanDestinationDir: true,
+				},
+			),
 		})
 		require.NoError(t, err)
 	}
@@ -117,22 +118,24 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
-			cs_solana.DeployChainContractsConfigSolana{
-				DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
-					HomeChainSelector: homeChainSel,
-					ContractParamsPerChain: map[uint64]v1_6.ChainContractParams{
-						solChainSelectors[0]: {
-							FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
-							OffRampParams:   v1_6.DefaultOffRampParams(),
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
+			ccipChangesetSolana.DeployChainContractsConfig{
+				HomeChainSelector: homeChainSel,
+				ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
+					solChainSelectors[0]: {
+						FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
+							DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
+						},
+						OffRampParams: ccipChangesetSolana.OffRampParams{
+							EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
 						},
 					},
 				},
 			},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(cs_solana.SetFeeAggregator),
-			cs_solana.SetFeeAggregatorConfig{
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.SetFeeAggregator),
+			ccipChangesetSolana.SetFeeAggregatorConfig{
 				ChainSelector: solChainSelectors[0],
 				FeeAggregator: feeAggregatorPubKey.String(),
 			},
@@ -142,103 +145,106 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	testhelpers.ValidateSolanaState(t, e, solChainSelectors)
 	timelockSignerPDA, _ := testhelpers.TransferOwnershipSolana(t, &e, solChainSelectors[0], true, true, true, true)
 	upgradeAuthority := timelockSignerPDA
+	state, err := changeset.LoadOnchainStateSolana(e)
+	require.NoError(t, err)
 
-	// make sure idempotency works and setting the upgrade authority
-	upgradeAuthorityCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
-		ccipChangesetSolana.DeployChainContractsConfig{
-			HomeChainSelector: homeChainSel,
-			ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
-				solChainSelectors[0]: {
-					FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
-						DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
+	e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
+			ccipChangesetSolana.DeployChainContractsConfig{
+				HomeChainSelector: homeChainSel,
+				ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
+					solChainSelectors[0]: {
+						FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
+							DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
+						},
+						OffRampParams: ccipChangesetSolana.OffRampParams{
+							EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+						},
 					},
-					OffRampParams: ccipChangesetSolana.OffRampParams{
-						EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+				},
+				NewUpgradeAuthority: &upgradeAuthority,
+			},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.BuildSolanaChangeset),
+			ccipChangesetSolana.BuildSolanaConfig{
+				ChainSelector:       solChainSelectors[0],
+				GitCommitSha:        "0863d8fed5fbada9f352f33c405e1753cbb7d72c",
+				DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
+				CleanDestinationDir: true,
+				CleanGitDir:         true,
+				UpgradeKeys: map[deployment.ContractType]string{
+					cs.Router:    state.SolChains[solChainSelectors[0]].Router.String(),
+					cs.FeeQuoter: state.SolChains[solChainSelectors[0]].FeeQuoter.String(),
+				},
+			},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
+			ccipChangesetSolana.DeployChainContractsConfig{
+				HomeChainSelector: homeChainSel,
+				ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
+					solChainSelectors[0]: {
+						FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
+							DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
+						},
+						OffRampParams: ccipChangesetSolana.OffRampParams{
+							EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+						},
+					},
+				},
+				UpgradeConfig: ccipChangesetSolana.UpgradeConfig{
+					NewFeeQuoterVersion: &deployment.Version1_1_0,
+					NewRouterVersion:    &deployment.Version1_1_0,
+					UpgradeAuthority:    upgradeAuthority,
+					SpillAddress:        upgradeAuthority,
+					MCMS: &ccipChangeset.MCMSConfig{
+						MinDelay: 1 * time.Second,
 					},
 				},
 			},
-			NewUpgradeAuthority: &upgradeAuthority,
-		},
-	)
-	upgradeCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
-		ccipChangesetSolana.DeployChainContractsConfig{
-			HomeChainSelector: homeChainSel,
-			ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
-				solChainSelectors[0]: {
-					FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
-						DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
-					},
-					OffRampParams: ccipChangesetSolana.OffRampParams{
-						EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+		),
+	})
+	require.NoError(t, err)
+	testhelpers.ValidateSolanaState(t, e, solChainSelectors)
+	state, err = changeset.LoadOnchainStateSolana(e)
+	require.NoError(t, err)
+	oldOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
+	// add a second offramp address
+	e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
+			ccipChangesetSolana.DeployChainContractsConfig{
+				HomeChainSelector: homeChainSel,
+				ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
+					solChainSelectors[0]: {
+						FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
+							DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
+						},
+						OffRampParams: ccipChangesetSolana.OffRampParams{
+							EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+						},
 					},
 				},
-			},
-			UpgradeConfig: ccipChangesetSolana.UpgradeConfig{
-				NewFeeQuoterVersion: &deployment.Version1_1_0,
-				NewRouterVersion:    &deployment.Version1_1_0,
-				UpgradeAuthority:    upgradeAuthority,
-				SpillAddress:        upgradeAuthority,
-				MCMS: &ccipChangeset.MCMSConfig{
-					MinDelay: 1 * time.Second,
-				},
-			},
-		},
-	)
-	// because we cannot upgrade in place locally, we can't redeploy offramp
-	offRampCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
-		ccipChangesetSolana.DeployChainContractsConfig{
-			HomeChainSelector: homeChainSel,
-			ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
-				solChainSelectors[0]: {
-					FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
-						DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
-					},
-					OffRampParams: ccipChangesetSolana.OffRampParams{
-						EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+				UpgradeConfig: ccipChangesetSolana.UpgradeConfig{
+					NewOffRampVersion: &deployment.Version1_1_0,
+					UpgradeAuthority:  upgradeAuthority,
+					SpillAddress:      upgradeAuthority,
+					MCMS: &ccipChangeset.MCMSConfig{
+						MinDelay: 1 * time.Second,
 					},
 				},
 			},
-			UpgradeConfig: ccipChangesetSolana.UpgradeConfig{
-				NewOffRampVersion: &deployment.Version1_1_0,
-				UpgradeAuthority:  upgradeAuthority,
-				SpillAddress:      upgradeAuthority,
-				MCMS: &cs.MCMSConfig{
-					MinDelay: 1 * time.Second,
-				},
-			},
-		},
-	)
-	if ci {
-		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			upgradeAuthorityCs,
-			buildCs,
-			upgradeCs,
-		})
-		require.NoError(t, err)
-		state, err := ccipChangeset.LoadOnchainStateSolana(e)
-		require.NoError(t, err)
-		testhelpers.ValidateSolanaState(t, e, solChainSelectors)
-		oldOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
-		// add a second offramp address
-		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			offRampCs,
-		})
-		require.NoError(t, err)
-		// verify the offramp address is different
-		state, err = ccipChangeset.LoadOnchainStateSolana(e)
-		require.NoError(t, err)
-		newOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
-		require.NotEqual(t, oldOffRampAddress, newOffRampAddress)
-	} else {
-		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			upgradeAuthorityCs,
-			upgradeCs,
-		})
-		require.NoError(t, err)
-	}
+		),
+	})
+	require.NoError(t, err)
+	// verify the offramp address is different
+	state, err = changeset.LoadOnchainStateSolana(e)
+	require.NoError(t, err)
+	newOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
+	require.NotEqual(t, oldOffRampAddress, newOffRampAddress)
+
 	// Verify router and fee quoter upgraded in place
 	// and offramp had 2nd address added
 	addresses, err := e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
@@ -259,11 +265,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	}
 	require.Equal(t, 1, numRouters)
 	require.Equal(t, 1, numFeeQuoters)
-	if ci {
-		require.Equal(t, 2, numOffRamps)
-	} else {
-		require.Equal(t, 1, numOffRamps)
-	}
+	require.Equal(t, 2, numOffRamps)
 	require.NoError(t, err)
 	// solana verification
 	testhelpers.ValidateSolanaState(t, e, solChainSelectors)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -59,11 +59,26 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	feeAggregatorPrivKey, _ := solana.NewRandomPrivateKey()
 	feeAggregatorPubKey := feeAggregatorPrivKey.PublicKey()
 	ci := os.Getenv("CI") == "true"
+	// we can't upgrade in place locally so we have to change where we build
+	buildCs := commonchangeset.Configure(
+		deployment.CreateLegacyChangeSet(cs_solana.BuildSolanaChangeset),
+		cs_solana.BuildSolanaConfig{
+			ChainSelector:       solChainSelectors[0],
+			GitCommitSha:        "0863d8fed5fbada9f352f33c405e1753cbb7d72c",
+			DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
+			CleanDestinationDir: true,
+		},
+	)
 	if ci {
 		testhelpers.SavePreloadedSolAddresses(t, e, solChainSelectors[0])
+	} else {
+		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+			buildCs,
+		})
+		require.NoError(t, err)
 	}
 
-	e, err = commonchangeset.Apply(t, e, nil,
+	e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			deployment.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
 			v1_6.DeployHomeChainConfig{
@@ -113,7 +128,8 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 				},
 			},
 		),
-	)
+	})
+	require.NoError(t, err)
 	addresses, err := e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
 	require.NoError(t, err)
 	mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(e.SolChains[solChainSelectors[0]], addresses)
@@ -129,16 +145,6 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	t.Logf("funded mcm signer PDA: %s", mcmSignerPDA.String())
 	upgradeAuthority := timelockSignerPDA
 
-	// we can't upgrade in place locally so we have to change where we build
-	buildCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(cs_solana.BuildSolanaChangeset),
-		cs_solana.BuildSolanaConfig{
-			ChainSelector:       solChainSelectors[0],
-			GitCommitSha:        "0863d8fed5fbada9f352f33c405e1753cbb7d72c",
-			DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
-			CleanDestinationDir: true,
-		},
-	)
 	deployCs := commonchangeset.Configure(
 		deployment.CreateLegacyChangeSet(cs_solana.DeployChainContractsChangesetSolana),
 		cs_solana.DeployChainContractsConfigSolana{
@@ -242,7 +248,6 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 		require.NotEqual(t, oldOffRampAddress, newOffRampAddress)
 	} else {
 		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			buildCs,
 			deployCs,
 			feeAggregatorCs,
 			upgradeAuthorityCs,

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -234,6 +234,8 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			},
 			UpgradeConfig: cs_solana.UpgradeConfigSolana{
 				NewOffRampVersion: &deployment.Version1_1_0,
+				UpgradeAuthority:  upgradeAuthority,
+				SpillAddress:      upgradeAuthority,
 				MCMS: &cs.MCMSConfig{
 					MinDelay: 1 * time.Second,
 				},
@@ -246,15 +248,16 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			feeAggregatorCs,
 			upgradeAuthorityCs,
 			transferOwnershipCs,
+			buildCs,
+			upgradeCs,
 		})
 		require.NoError(t, err)
 		state, err := changeset.LoadOnchainStateSolana(e)
 		require.NoError(t, err)
+		testhelpers.ValidateSolanaState(t, e, solChainSelectors)
 		oldOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
 		// add a second offramp address
 		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			buildCs,
-			upgradeCs,
 			offRampCs,
 		})
 		require.NoError(t, err)

--- a/deployment/ccip/changeset/solana/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana/cs_set_ocr3.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/internal"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 )
@@ -106,7 +107,7 @@ func SetOCR3ConfigSolana(e deployment.Environment, cfg v1_6.SetOCR3OffRampConfig
 func isOCR3ConfigSetOnOffRampSolana(
 	e deployment.Environment,
 	chain deployment.SolChain,
-	chainState changeset.SolCCIPChainState,
+	chainState ccipChangeset.SolCCIPChainState,
 	args []internal.MultiOCR3BaseOCRConfigArgsSolana,
 ) (bool, error) {
 	var configAccount solOffRamp.Config

--- a/deployment/ccip/changeset/solana/cs_solana_token_test.go
+++ b/deployment/ccip/changeset/solana/cs_solana_token_test.go
@@ -33,8 +33,9 @@ func TestSolanaTokenOps(t *testing.T) {
 			deployment.CreateLegacyChangeSet(changeset_solana.DeploySolanaToken),
 			changeset_solana.DeploySolanaTokenConfig{
 				ChainSelector:    solChain1,
-				TokenProgramName: deployment.SPL2022Tokens,
+				TokenProgramName: ccipChangeset.SPL2022Tokens,
 				TokenDecimals:    9,
+				TokenSymbol:      "TEST_TOKEN",
 			},
 		),
 	)
@@ -55,7 +56,7 @@ func TestSolanaTokenOps(t *testing.T) {
 			changeset_solana.CreateSolanaTokenATAConfig{
 				ChainSelector: solChain1,
 				TokenPubkey:   tokenAddress,
-				TokenProgram:  deployment.SPL2022Tokens,
+				TokenProgram:  ccipChangeset.SPL2022Tokens,
 				ATAList:       []string{deployerKey.String(), testUserPubKey.String()},
 			},
 		),
@@ -65,7 +66,6 @@ func TestSolanaTokenOps(t *testing.T) {
 			changeset_solana.MintSolanaTokenConfig{
 				ChainSelector: solChain1,
 				TokenPubkey:   tokenAddress.String(),
-				TokenProgram:  deployment.SPL2022Tokens,
 				AmountToAddress: map[string]uint64{
 					deployerKey.String():    uint64(1000),
 					testUserPubKey.String(): uint64(1000),

--- a/deployment/ccip/changeset/solana/cs_token_admin_registry.go
+++ b/deployment/ccip/changeset/solana/cs_token_admin_registry.go
@@ -12,7 +12,7 @@ import (
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	cs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 )
 
 type RegisterTokenAdminRegistryType int
@@ -42,7 +42,7 @@ func (cfg RegisterTokenAdminRegistryConfig) Validate(e deployment.Environment) e
 	if err := commonValidation(e, cfg.ChainSelector, tokenPubKey); err != nil {
 		return err
 	}
-	state, _ := cs.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
 	chain := e.SolChains[cfg.ChainSelector]
 	if err := validateRouterConfig(chain, chainState); err != nil {
@@ -64,7 +64,7 @@ func RegisterTokenAdminRegistry(e deployment.Environment, cfg RegisterTokenAdmin
 		return deployment.ChangesetOutput{}, err
 	}
 	chain := e.SolChains[cfg.ChainSelector]
-	state, _ := cs.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
 	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.TokenPubKey)
 
@@ -136,7 +136,7 @@ func (cfg TransferAdminRoleTokenAdminRegistryConfig) Validate(e deployment.Envir
 		)
 	}
 
-	state, _ := cs.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
 	chain := e.SolChains[cfg.ChainSelector]
 	if err := validateRouterConfig(chain, chainState); err != nil {
@@ -158,7 +158,7 @@ func TransferAdminRoleTokenAdminRegistry(e deployment.Environment, cfg TransferA
 		return deployment.ChangesetOutput{}, err
 	}
 	chain := e.SolChains[cfg.ChainSelector]
-	state, _ := cs.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
 	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.TokenPubKey)
 
@@ -198,7 +198,7 @@ func (cfg AcceptAdminRoleTokenAdminRegistryConfig) Validate(e deployment.Environ
 	if err := commonValidation(e, cfg.ChainSelector, tokenPubKey); err != nil {
 		return err
 	}
-	state, _ := cs.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
 	chain := e.SolChains[cfg.ChainSelector]
 	if err := validateRouterConfig(chain, chainState); err != nil {
@@ -230,7 +230,7 @@ func AcceptAdminRoleTokenAdminRegistry(e deployment.Environment, cfg AcceptAdmin
 		return deployment.ChangesetOutput{}, err
 	}
 	chain := e.SolChains[cfg.ChainSelector]
-	state, _ := cs.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
 	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.TokenPubKey)
 	newRegistryAdminPrivateKey := solana.MustPrivateKeyFromBase58(cfg.NewRegistryAdminPrivateKey)

--- a/deployment/ccip/changeset/solana/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana/cs_token_pool.go
@@ -6,26 +6,43 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
+	solBaseTokenPool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/base_token_pool"
 	solRouter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
+	solBurnMintTokenPool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/example_burnmint_token_pool"
+	solLockReleaseTokenPool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/example_lockrelease_token_pool"
 	solTestTokenPool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/test_token_pool"
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 	solTokenUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
 	"github.com/smartcontractkit/chainlink/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	state2 "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 )
 
 var _ deployment.ChangeSet[TokenPoolConfig] = AddTokenPool
 var _ deployment.ChangeSet[RemoteChainTokenPoolConfig] = SetupTokenPoolForRemoteChain
 
+func validatePoolDeployment(s ccipChangeset.SolCCIPChainState, poolType solTestTokenPool.PoolType, selector uint64) error {
+	switch poolType {
+	case solTestTokenPool.BurnAndMint_PoolType:
+		if s.BurnMintTokenPool.IsZero() {
+			return fmt.Errorf("token pool of type BurnAndMint not found in existing state, deploy the token pool first for chain %d", selector)
+		}
+	case solTestTokenPool.LockAndRelease_PoolType:
+		if s.LockReleaseTokenPool.IsZero() {
+			return fmt.Errorf("token pool of type LockAndRelease not found in existing state, deploy the token pool first for chain %d", selector)
+		}
+	default:
+		return fmt.Errorf("invalid pool type: %s", poolType)
+	}
+	return nil
+}
+
 type TokenPoolConfig struct {
-	ChainSelector    uint64
-	PoolType         solTestTokenPool.PoolType
-	Authority        string
-	TokenPubKey      string
-	TokenProgramName string
+	ChainSelector uint64
+	PoolType      solTestTokenPool.PoolType
+	Authority     string
+	TokenPubKey   string
 }
 
 func (cfg TokenPoolConfig) Validate(e deployment.Environment) error {
@@ -33,24 +50,38 @@ func (cfg TokenPoolConfig) Validate(e deployment.Environment) error {
 	if err := commonValidation(e, cfg.ChainSelector, tokenPubKey); err != nil {
 		return err
 	}
-	state, _ := state2.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
-	if chainState.TokenPool.IsZero() {
-		return fmt.Errorf("token pool not found in existing state, deploy the token pool first for chain %d", cfg.ChainSelector)
+
+	if _, err := chainState.TokenToTokenProgram(tokenPubKey); err != nil {
+		return fmt.Errorf("failed to get token program for token address %s: %w", tokenPubKey.String(), err)
 	}
-	if _, err := GetTokenProgramID(cfg.TokenProgramName); err != nil {
+
+	if err := validatePoolDeployment(chainState, cfg.PoolType, cfg.ChainSelector); err != nil {
 		return err
 	}
 
-	tokenPool := chainState.TokenPool
+	var tokenPool solana.PublicKey
+	var poolConfigAccount interface{}
+
+	switch cfg.PoolType {
+	case solTestTokenPool.BurnAndMint_PoolType:
+		tokenPool = chainState.BurnMintTokenPool
+		poolConfigAccount = solBurnMintTokenPool.State{}
+	case solTestTokenPool.LockAndRelease_PoolType:
+		tokenPool = chainState.LockReleaseTokenPool
+		poolConfigAccount = solLockReleaseTokenPool.State{}
+	default:
+		return fmt.Errorf("invalid pool type: %s", cfg.PoolType)
+	}
+
 	poolConfigPDA, err := solTokenUtil.TokenPoolConfigAddress(tokenPubKey, tokenPool)
 	if err != nil {
 		return fmt.Errorf("failed to get token pool config address (mint: %s, pool: %s): %w", tokenPubKey.String(), tokenPool.String(), err)
 	}
 	chain := e.SolChains[cfg.ChainSelector]
-	var poolConfigAccount solTestTokenPool.State
 	if err := chain.GetAccountDataBorshInto(context.Background(), poolConfigPDA, &poolConfigAccount); err == nil {
-		return fmt.Errorf("token pool config already exists for (mint: %s, pool: %s)", tokenPubKey.String(), tokenPool.String())
+		return fmt.Errorf("token pool config already exists for (mint: %s, pool: %s, type: %s)", tokenPubKey.String(), tokenPool.String(), cfg.PoolType)
 	}
 	return nil
 }
@@ -60,15 +91,24 @@ func AddTokenPool(e deployment.Environment, cfg TokenPoolConfig) (deployment.Cha
 		return deployment.ChangesetOutput{}, err
 	}
 	chain := e.SolChains[cfg.ChainSelector]
-	state, _ := state2.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
 	authorityPubKey := solana.MustPublicKeyFromBase58(cfg.Authority)
 	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.TokenPubKey)
+	tokenPool := solana.PublicKey{}
+
+	if cfg.PoolType == solTestTokenPool.BurnAndMint_PoolType {
+		tokenPool = chainState.BurnMintTokenPool
+		solBurnMintTokenPool.SetProgramID(tokenPool)
+	} else if cfg.PoolType == solTestTokenPool.LockAndRelease_PoolType {
+		tokenPool = chainState.LockReleaseTokenPool
+		solLockReleaseTokenPool.SetProgramID(tokenPool)
+	}
 
 	// verified
-	tokenprogramID, _ := GetTokenProgramID(cfg.TokenProgramName)
-	poolConfigPDA, _ := solTokenUtil.TokenPoolConfigAddress(tokenPubKey, chainState.TokenPool)
-	poolSigner, _ := solTokenUtil.TokenPoolSignerAddress(tokenPubKey, chainState.TokenPool)
+	tokenprogramID, _ := chainState.TokenToTokenProgram(tokenPubKey)
+	poolConfigPDA, _ := solTokenUtil.TokenPoolConfigAddress(tokenPubKey, tokenPool)
+	poolSigner, _ := solTokenUtil.TokenPoolSignerAddress(tokenPubKey, tokenPool)
 
 	// ata for token pool
 	createI, tokenPoolATA, err := solTokenUtil.CreateAssociatedTokenAccount(
@@ -78,24 +118,38 @@ func AddTokenPool(e deployment.Environment, cfg TokenPoolConfig) (deployment.Cha
 		chain.DeployerKey.PublicKey(),
 	)
 	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to create associated token account for tokenpool (mint: %s, pool: %s): %w", tokenPubKey.String(), chainState.TokenPool.String(), err)
+		return deployment.ChangesetOutput{}, fmt.Errorf("failed to create associated token account for tokenpool (mint: %s, pool: %s): %w", tokenPubKey.String(), tokenPool.String(), err)
 	}
+	instructions := []solana.Instruction{createI}
 
-	solTestTokenPool.SetProgramID(chainState.TokenPool)
-	// initialize token pool for token
-	poolInitI, err := solTestTokenPool.NewInitializeInstruction(
-		cfg.PoolType,
-		chainState.Router,
-		poolConfigPDA,
-		tokenPubKey,
-		authorityPubKey, // this is assumed to be chain.DeployerKey for now (owner of token pool)
-		solana.SystemProgramID,
-	).ValidateAndBuild()
+	var poolInitI solana.Instruction
+	switch cfg.PoolType {
+	case solTestTokenPool.BurnAndMint_PoolType:
+		// initialize token pool for token
+		poolInitI, err = solBurnMintTokenPool.NewInitializeInstruction(
+			chainState.Router,
+			poolConfigPDA,
+			tokenPubKey,
+			authorityPubKey, // this is assumed to be chain.DeployerKey for now (owner of token pool)
+			solana.SystemProgramID,
+		).ValidateAndBuild()
+	case solTestTokenPool.LockAndRelease_PoolType:
+		// initialize token pool for token
+		poolInitI, err = solLockReleaseTokenPool.NewInitializeInstruction(
+			chainState.Router,
+			poolConfigPDA,
+			tokenPubKey,
+			authorityPubKey, // this is assumed to be chain.DeployerKey for now (owner of token pool)
+			solana.SystemProgramID,
+		).ValidateAndBuild()
+	default:
+		return deployment.ChangesetOutput{}, fmt.Errorf("invalid pool type: %s", cfg.PoolType)
+	}
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to generate instructions: %w", err)
 	}
 
-	instructions := []solana.Instruction{createI, poolInitI}
+	instructions = append(instructions, poolInitI)
 
 	if cfg.PoolType == solTestTokenPool.BurnAndMint_PoolType && tokenPubKey != solana.SolMint {
 		// make pool mint_authority for token
@@ -126,10 +180,11 @@ type RemoteChainTokenPoolConfig struct {
 	SolChainSelector    uint64
 	RemoteChainSelector uint64
 	SolTokenPubKey      string
+	PoolType            solTestTokenPool.PoolType
 	// this is actually derivable from on chain given token symbol
-	RemoteConfig      solTestTokenPool.RemoteConfig
-	InboundRateLimit  solTestTokenPool.RateLimitConfig
-	OutboundRateLimit solTestTokenPool.RateLimitConfig
+	RemoteConfig      solBaseTokenPool.RemoteConfig
+	InboundRateLimit  solBaseTokenPool.RateLimitConfig
+	OutboundRateLimit solBaseTokenPool.RateLimitConfig
 }
 
 func (cfg RemoteChainTokenPoolConfig) Validate(e deployment.Environment) error {
@@ -137,23 +192,38 @@ func (cfg RemoteChainTokenPoolConfig) Validate(e deployment.Environment) error {
 	if err := commonValidation(e, cfg.SolChainSelector, tokenPubKey); err != nil {
 		return err
 	}
-	state, _ := state2.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.SolChainSelector]
-	if chainState.TokenPool.IsZero() {
-		return fmt.Errorf("token pool not found in existing state, deploy token pool for chain %d", cfg.SolChainSelector)
+	chain := e.SolChains[cfg.SolChainSelector]
+
+	if err := validatePoolDeployment(chainState, cfg.PoolType, cfg.SolChainSelector); err != nil {
+		return err
 	}
 
-	chain := e.SolChains[cfg.SolChainSelector]
-	tokenPool := chainState.TokenPool
+	var tokenPool solana.PublicKey
+	var poolConfigAccount interface{}
+	var remoteChainConfigAccount interface{}
+
+	switch cfg.PoolType {
+	case solTestTokenPool.BurnAndMint_PoolType:
+		tokenPool = chainState.BurnMintTokenPool
+		poolConfigAccount = solBurnMintTokenPool.State{}
+		remoteChainConfigAccount = solBurnMintTokenPool.ChainConfig{}
+	case solTestTokenPool.LockAndRelease_PoolType:
+		tokenPool = chainState.LockReleaseTokenPool
+		poolConfigAccount = solLockReleaseTokenPool.State{}
+		remoteChainConfigAccount = solLockReleaseTokenPool.ChainConfig{}
+	default:
+		return fmt.Errorf("invalid pool type: %s", cfg.PoolType)
+	}
 
 	// check if pool config exists (cannot do remote setup without it)
 	poolConfigPDA, err := solTokenUtil.TokenPoolConfigAddress(tokenPubKey, tokenPool)
 	if err != nil {
 		return fmt.Errorf("failed to get token pool config address (mint: %s, pool: %s): %w", tokenPubKey.String(), tokenPool.String(), err)
 	}
-	var poolConfigAccount solTestTokenPool.State
 	if err := chain.GetAccountDataBorshInto(context.Background(), poolConfigPDA, &poolConfigAccount); err != nil {
-		return fmt.Errorf("token pool config not found (mint: %s, pool: %s): %w", tokenPubKey.String(), chainState.TokenPool.String(), err)
+		return fmt.Errorf("token pool config not found (mint: %s, pool: %s, type: %s): %w", tokenPubKey.String(), tokenPool.String(), cfg.PoolType, err)
 	}
 
 	// check if this remote chain is already configured for this token
@@ -161,9 +231,8 @@ func (cfg RemoteChainTokenPoolConfig) Validate(e deployment.Environment) error {
 	if err != nil {
 		return fmt.Errorf("failed to get token pool remote chain config pda (remoteSelector: %d, mint: %s, pool: %s): %w", cfg.RemoteChainSelector, tokenPubKey.String(), tokenPool.String(), err)
 	}
-	var remoteChainConfigAccount solTestTokenPool.ChainConfig
 	if err := chain.GetAccountDataBorshInto(context.Background(), remoteChainConfigPDA, &remoteChainConfigAccount); err == nil {
-		return fmt.Errorf("remote chain config already exists for (remoteSelector: %d, mint: %s, pool: %s)", cfg.RemoteChainSelector, tokenPubKey.String(), tokenPool.String())
+		return fmt.Errorf("remote chain config already exists for (remoteSelector: %d, mint: %s, pool: %s, type: %s)", cfg.RemoteChainSelector, tokenPubKey.String(), tokenPool.String(), cfg.PoolType)
 	}
 	return nil
 }
@@ -172,16 +241,44 @@ func SetupTokenPoolForRemoteChain(e deployment.Environment, cfg RemoteChainToken
 	if err := cfg.Validate(e); err != nil {
 		return deployment.ChangesetOutput{}, err
 	}
-	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.SolTokenPubKey)
-	chain := e.SolChains[cfg.SolChainSelector]
-	state, _ := state2.LoadOnchainState(e)
-	chainState := state.SolChains[cfg.SolChainSelector]
-	// verified
-	poolConfigPDA, _ := solTokenUtil.TokenPoolConfigAddress(tokenPubKey, chainState.TokenPool)
-	remoteChainConfigPDA, _, _ := solTokenUtil.TokenPoolChainConfigPDA(cfg.RemoteChainSelector, tokenPubKey, chainState.TokenPool)
 
-	solTestTokenPool.SetProgramID(chainState.TokenPool)
-	ixConfigure, err := solTestTokenPool.NewInitChainRemoteConfigInstruction(
+	chain := e.SolChains[cfg.SolChainSelector]
+	state, _ := ccipChangeset.LoadOnchainState(e)
+	chainState := state.SolChains[cfg.SolChainSelector]
+	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.SolTokenPubKey)
+
+	var instructions []solana.Instruction
+	var err error
+	switch cfg.PoolType {
+	case solTestTokenPool.BurnAndMint_PoolType:
+		instructions, err = getInstructionsForBurnMint(chain, chainState, cfg)
+	case solTestTokenPool.LockAndRelease_PoolType:
+		instructions, err = getInstructionsForLockRelease(chain, chainState, cfg)
+	default:
+		return deployment.ChangesetOutput{}, fmt.Errorf("invalid pool type: %s", cfg.PoolType)
+	}
+	if err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("failed to generate instructions: %w", err)
+	}
+
+	err = chain.Confirm(instructions)
+	if err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm instructions: %w", err)
+	}
+	e.Logger.Infow("Configured token pool for remote chain", "remote_chain_selector", cfg.RemoteChainSelector, "token_pubkey", tokenPubKey.String())
+	return deployment.ChangesetOutput{}, nil
+}
+
+func getInstructionsForBurnMint(
+	chain deployment.SolChain,
+	chainState ccipChangeset.SolCCIPChainState,
+	cfg RemoteChainTokenPoolConfig,
+) ([]solana.Instruction, error) {
+	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.SolTokenPubKey)
+	poolConfigPDA, _ := solTokenUtil.TokenPoolConfigAddress(tokenPubKey, chainState.BurnMintTokenPool)
+	remoteChainConfigPDA, _, _ := solTokenUtil.TokenPoolChainConfigPDA(cfg.RemoteChainSelector, tokenPubKey, chainState.BurnMintTokenPool)
+	solBurnMintTokenPool.SetProgramID(chainState.BurnMintTokenPool)
+	ixConfigure, err := solBurnMintTokenPool.NewInitChainRemoteConfigInstruction(
 		cfg.RemoteChainSelector,
 		tokenPubKey,
 		cfg.RemoteConfig,
@@ -191,9 +288,9 @@ func SetupTokenPoolForRemoteChain(e deployment.Environment, cfg RemoteChainToken
 		solana.SystemProgramID,
 	).ValidateAndBuild()
 	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to generate instructions: %w", err)
+		return nil, fmt.Errorf("failed to generate instructions: %w", err)
 	}
-	ixRates, err := solTestTokenPool.NewSetChainRateLimitInstruction(
+	ixRates, err := solBurnMintTokenPool.NewSetChainRateLimitInstruction(
 		cfg.RemoteChainSelector,
 		tokenPubKey,
 		cfg.InboundRateLimit,
@@ -204,10 +301,9 @@ func SetupTokenPoolForRemoteChain(e deployment.Environment, cfg RemoteChainToken
 		solana.SystemProgramID,
 	).ValidateAndBuild()
 	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to generate instructions: %w", err)
+		return nil, fmt.Errorf("failed to generate instructions: %w", err)
 	}
-
-	ixAppend, err := solTestTokenPool.NewAppendRemotePoolAddressesInstruction(
+	ixAppend, err := solBurnMintTokenPool.NewAppendRemotePoolAddressesInstruction(
 		cfg.RemoteChainSelector,
 		tokenPubKey,
 		cfg.RemoteConfig.PoolAddresses, // i dont know why this is a list (is it for different types of pool of the same token?)
@@ -217,23 +313,65 @@ func SetupTokenPoolForRemoteChain(e deployment.Environment, cfg RemoteChainToken
 		solana.SystemProgramID,
 	).ValidateAndBuild()
 	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to generate instructions: %w", err)
+		return nil, fmt.Errorf("failed to generate instructions: %w", err)
 	}
+	return []solana.Instruction{ixConfigure, ixRates, ixAppend}, nil
+}
 
-	instructions := []solana.Instruction{ixConfigure, ixRates, ixAppend}
-	err = chain.Confirm(instructions)
+func getInstructionsForLockRelease(
+	chain deployment.SolChain,
+	chainState ccipChangeset.SolCCIPChainState,
+	cfg RemoteChainTokenPoolConfig,
+) ([]solana.Instruction, error) {
+	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.SolTokenPubKey)
+	poolConfigPDA, _ := solTokenUtil.TokenPoolConfigAddress(tokenPubKey, chainState.LockReleaseTokenPool)
+	remoteChainConfigPDA, _, _ := solTokenUtil.TokenPoolChainConfigPDA(cfg.RemoteChainSelector, tokenPubKey, chainState.LockReleaseTokenPool)
+	solLockReleaseTokenPool.SetProgramID(chainState.LockReleaseTokenPool)
+	ixConfigure, err := solLockReleaseTokenPool.NewInitChainRemoteConfigInstruction(
+		cfg.RemoteChainSelector,
+		tokenPubKey,
+		cfg.RemoteConfig,
+		poolConfigPDA,
+		remoteChainConfigPDA,
+		chain.DeployerKey.PublicKey(),
+		solana.SystemProgramID,
+	).ValidateAndBuild()
 	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm instructions: %w", err)
+		return nil, fmt.Errorf("failed to generate instructions: %w", err)
 	}
-	e.Logger.Infow("Configured token pool for remote chain", "remote_chain_selector", cfg.RemoteChainSelector, "token_pubkey", tokenPubKey.String())
-	return deployment.ChangesetOutput{}, nil
+	ixRates, err := solLockReleaseTokenPool.NewSetChainRateLimitInstruction(
+		cfg.RemoteChainSelector,
+		tokenPubKey,
+		cfg.InboundRateLimit,
+		cfg.OutboundRateLimit,
+		poolConfigPDA,
+		remoteChainConfigPDA,
+		chain.DeployerKey.PublicKey(),
+		solana.SystemProgramID,
+	).ValidateAndBuild()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate instructions: %w", err)
+	}
+	ixAppend, err := solLockReleaseTokenPool.NewAppendRemotePoolAddressesInstruction(
+		cfg.RemoteChainSelector,
+		tokenPubKey,
+		cfg.RemoteConfig.PoolAddresses, // i dont know why this is a list (is it for different types of pool of the same token?)
+		poolConfigPDA,
+		remoteChainConfigPDA,
+		chain.DeployerKey.PublicKey(),
+		solana.SystemProgramID,
+	).ValidateAndBuild()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate instructions: %w", err)
+	}
+	return []solana.Instruction{ixConfigure, ixRates, ixAppend}, nil
 }
 
 // ADD TOKEN POOL LOOKUP TABLE
 type TokenPoolLookupTableConfig struct {
 	ChainSelector uint64
 	TokenPubKey   string
-	TokenProgram  string // this can go as a address book tag
+	PoolType      solTestTokenPool.PoolType
 }
 
 func (cfg TokenPoolLookupTableConfig) Validate(e deployment.Environment) error {
@@ -241,13 +379,13 @@ func (cfg TokenPoolLookupTableConfig) Validate(e deployment.Environment) error {
 	if err := commonValidation(e, cfg.ChainSelector, tokenPubKey); err != nil {
 		return err
 	}
-	state, _ := state2.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
-	if chainState.TokenPool.IsZero() {
-		return fmt.Errorf("token pool not found in existing state, deploy the token pool first for chain %d", cfg.ChainSelector)
+	_, err := chainState.TokenToTokenProgram(tokenPubKey)
+	if err != nil {
+		return fmt.Errorf("failed to get token program for token address %s: %w", tokenPubKey.String(), err)
 	}
-
-	return nil
+	return validatePoolDeployment(chainState, cfg.PoolType, cfg.ChainSelector)
 }
 
 func AddTokenPoolLookupTable(e deployment.Environment, cfg TokenPoolLookupTableConfig) (deployment.ChangesetOutput, error) {
@@ -257,15 +395,20 @@ func AddTokenPoolLookupTable(e deployment.Environment, cfg TokenPoolLookupTableC
 	chain := e.SolChains[cfg.ChainSelector]
 	ctx := e.GetContext()
 	client := chain.Client
-	state, _ := state2.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
 	authorityPrivKey := chain.DeployerKey // assuming the authority is the deployer key
 	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.TokenPubKey)
-
+	tokenPool := solana.PublicKey{}
+	if cfg.PoolType == solTestTokenPool.BurnAndMint_PoolType {
+		tokenPool = chainState.BurnMintTokenPool
+	} else if cfg.PoolType == solTestTokenPool.LockAndRelease_PoolType {
+		tokenPool = chainState.LockReleaseTokenPool
+	}
 	tokenAdminRegistryPDA, _, _ := solState.FindTokenAdminRegistryPDA(tokenPubKey, chainState.Router)
-	tokenPoolChainConfigPDA, _ := solTokenUtil.TokenPoolConfigAddress(tokenPubKey, chainState.TokenPool)
-	tokenPoolSigner, _ := solTokenUtil.TokenPoolSignerAddress(tokenPubKey, chainState.TokenPool)
-	tokenProgram, _ := GetTokenProgramID(cfg.TokenProgram)
+	tokenPoolChainConfigPDA, _ := solTokenUtil.TokenPoolConfigAddress(tokenPubKey, tokenPool)
+	tokenPoolSigner, _ := solTokenUtil.TokenPoolSignerAddress(tokenPubKey, tokenPool)
+	tokenProgram, _ := chainState.TokenToTokenProgram(tokenPubKey)
 	poolTokenAccount, _, _ := solTokenUtil.FindAssociatedTokenAddress(tokenProgram, tokenPubKey, tokenPoolSigner)
 	feeTokenConfigPDA, _, _ := solState.FindFqBillingTokenConfigPDA(tokenPubKey, chainState.FeeQuoter)
 
@@ -279,7 +422,7 @@ func AddTokenPoolLookupTable(e deployment.Environment, cfg TokenPoolLookupTableC
 	list := solana.PublicKeySlice{
 		table,                   // 0
 		tokenAdminRegistryPDA,   // 1
-		chainState.TokenPool,    // 2
+		tokenPool,               // 2
 		tokenPoolChainConfigPDA, // 3 - writable
 		poolTokenAccount,        // 4 - writable
 		tokenPoolSigner,         // 5
@@ -294,7 +437,7 @@ func AddTokenPoolLookupTable(e deployment.Environment, cfg TokenPoolLookupTableC
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to await slot change while extending lookup table: %w", err)
 	}
 	newAddressBook := deployment.NewMemoryAddressBook()
-	tv := deployment.NewTypeAndVersion(changeset.TokenPoolLookupTable, deployment.Version1_0_0)
+	tv := deployment.NewTypeAndVersion(ccipChangeset.TokenPoolLookupTable, deployment.Version1_0_0)
 	tv.Labels.Add(tokenPubKey.String())
 	if err := newAddressBook.Save(cfg.ChainSelector, table.String(), tv); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to save tokenpool address lookup table: %w", err)
@@ -309,7 +452,6 @@ type SetPoolConfig struct {
 	ChainSelector                     uint64
 	TokenPubKey                       string
 	TokenAdminRegistryAdminPrivateKey string
-	PoolLookupTable                   string
 	WritableIndexes                   []uint8
 }
 
@@ -318,12 +460,9 @@ func (cfg SetPoolConfig) Validate(e deployment.Environment) error {
 	if err := commonValidation(e, cfg.ChainSelector, tokenPubKey); err != nil {
 		return err
 	}
-	state, _ := state2.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
 	chain := e.SolChains[cfg.ChainSelector]
-	if chainState.TokenPool.IsZero() {
-		return fmt.Errorf("token pool not found in existing state, deploy the token pool first for chain %d", cfg.ChainSelector)
-	}
 	if err := validateRouterConfig(chain, chainState); err != nil {
 		return err
 	}
@@ -335,6 +474,9 @@ func (cfg SetPoolConfig) Validate(e deployment.Environment) error {
 	if err := chain.GetAccountDataBorshInto(context.Background(), tokenAdminRegistryPDA, &tokenAdminRegistryAccount); err != nil {
 		return fmt.Errorf("token admin registry not found for (mint: %s, router: %s), cannot set pool", tokenPubKey.String(), chainState.Router.String())
 	}
+	if _, ok := chainState.TokenPoolLookupTable[tokenPubKey]; !ok {
+		return fmt.Errorf("token pool lookup table not found for (mint: %s)", tokenPubKey.String())
+	}
 	return nil
 }
 
@@ -345,13 +487,13 @@ func SetPool(e deployment.Environment, cfg SetPoolConfig) (deployment.ChangesetO
 	}
 
 	chain := e.SolChains[cfg.ChainSelector]
-	state, _ := state2.LoadOnchainState(e)
+	state, _ := ccipChangeset.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
 	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.TokenPubKey)
 	routerConfigPDA, _, _ := solState.FindConfigPDA(chainState.Router)
 	tokenAdminRegistryPDA, _, _ := solState.FindTokenAdminRegistryPDA(tokenPubKey, chainState.Router)
 	tokenAdminRegistryAdminPrivKey := solana.MustPrivateKeyFromBase58(cfg.TokenAdminRegistryAdminPrivateKey)
-	lookupTablePubKey := solana.MustPublicKeyFromBase58(cfg.PoolLookupTable)
+	lookupTablePubKey := chainState.TokenPoolLookupTable[tokenPubKey]
 
 	base := solRouter.NewSetPoolInstruction(
 		cfg.WritableIndexes,

--- a/deployment/ccip/changeset/solana/ownership_transfer_helpers.go
+++ b/deployment/ccip/changeset/solana/ownership_transfer_helpers.go
@@ -2,10 +2,8 @@ package solana
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/gagliardetto/solana-go"
-	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
@@ -60,25 +58,14 @@ func transferAndWrapAcceptOwnership(
 	if err != nil {
 		return mcmsTypes.Transaction{}, fmt.Errorf("%s: failed to create accept ownership instruction: %w", label, err)
 	}
-	acceptData, err := ixAccept.Data()
-	if err != nil {
-		return mcmsTypes.Transaction{}, fmt.Errorf("%s: failed to extract accept data: %w", label, err)
-	}
 
 	// 4. Wrap in MCMS transaction
-	mcmsTx, err := mcmsSolana.NewTransaction(
-		programID.String(),
-		acceptData,
-		big.NewInt(0),       // e.g. value
-		ixAccept.Accounts(), // pass along needed accounts
-		string(label),       // some string identifying the target
-		[]string{},          // any relevant metadata
-	)
+	mcmsTx, err := BuildMCMSTxn(ixAccept, programID.String(), label)
 	if err != nil {
 		return mcmsTypes.Transaction{}, fmt.Errorf("%s: failed to create MCMS transaction: %w", label, err)
 	}
 
-	return mcmsTx, nil
+	return *mcmsTx, nil
 }
 
 // transferOwnershipRouter transfers ownership of the router to the timelock.

--- a/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock_test.go
+++ b/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 
-	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -301,37 +300,7 @@ func TestTransferCCIPToMCMSWithTimelockSolana(t *testing.T) {
 	e, state := prepareEnvironmentForOwnershipTransfer(t)
 	solChain1 := e.AllChainSelectorsSolana()[0]
 	solChain := e.SolChains[solChain1]
-	// tokenAddress := state.SolChains[solChain1].SPL2022Tokens[0]
-	addresses, err := e.ExistingAddresses.AddressesForChain(solChain1)
-	require.NoError(t, err)
-	mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(e.SolChains[solChain1], addresses)
-	require.NoError(t, err)
-
-	// Fund signer PDAs for timelock and mcm
-	// If we don't fund, execute() calls will fail with "no funds" errors.
-	timelockSignerPDA := commonState.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
-	mcmSignerPDA := commonState.GetMCMSignerPDA(mcmState.McmProgram, mcmState.ProposerMcmSeed)
-	memory.FundSolanaAccounts(e.GetContext(), t, []solana.PublicKey{timelockSignerPDA, mcmSignerPDA},
-		100, solChain.Client)
-	t.Logf("funded timelock signer PDA: %s", timelockSignerPDA.String())
-	t.Logf("funded mcm signer PDA: %s", mcmSignerPDA.String())
-	// Apply transfer ownership changeset
-	e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(solanachangesets.TransferCCIPToMCMSWithTimelockSolana),
-			solanachangesets.TransferCCIPToMCMSWithTimelockSolanaConfig{
-				MinDelay: 1 * time.Second,
-				ContractsByChain: map[uint64]solanachangesets.CCIPContractsToTransfer{
-					solChain1: {
-						Router:    true,
-						FeeQuoter: true,
-						OffRamp:   true,
-					},
-				},
-			},
-		),
-	})
-	require.NoError(t, err)
+	timelockSignerPDA, _ := testhelpers.TransferOwnershipSolana(t, &e, solChain1, false, true, true, true)
 
 	// 5. Now verify on-chain that each contract’s “config account” authority is the Timelock PDA.
 	//    Typically, each contract has its own config account: RouterConfigPDA, FeeQuoterConfigPDA,
@@ -343,7 +312,8 @@ func TestTransferCCIPToMCMSWithTimelockSolana(t *testing.T) {
 		routerConfigPDA := state.SolChains[solChain1].RouterConfigPDA
 		t.Logf("Checking Router Config PDA ownership data configPDA: %s", routerConfigPDA.String())
 		programData := ccip_router.Config{}
-		err = solChain.GetAccountDataBorshInto(ctx, routerConfigPDA, &programData)
+		err := solChain.GetAccountDataBorshInto(ctx, routerConfigPDA, &programData)
+		require.NoError(t, err)
 		return timelockSignerPDA.String() == programData.Owner.String()
 	}, 30*time.Second, 5*time.Second, "Router config PDA owner was not changed to timelock signer PDA")
 
@@ -352,7 +322,7 @@ func TestTransferCCIPToMCMSWithTimelockSolana(t *testing.T) {
 		feeQuoterConfigPDA := state.SolChains[solChain1].FeeQuoterConfigPDA
 		t.Logf("Checking Fee Quoter PDA ownership data configPDA: %s", feeQuoterConfigPDA.String())
 		programData := fee_quoter.Config{}
-		err = solChain.GetAccountDataBorshInto(ctx, feeQuoterConfigPDA, &programData)
+		err := solChain.GetAccountDataBorshInto(ctx, feeQuoterConfigPDA, &programData)
 		require.NoError(t, err)
 		return timelockSignerPDA.String() == programData.Owner.String()
 	}, 30*time.Second, 5*time.Second, "Fee Quoter config PDA owner was not changed to timelock signer PDA")
@@ -362,7 +332,7 @@ func TestTransferCCIPToMCMSWithTimelockSolana(t *testing.T) {
 		offRampConfigPDA := state.SolChains[solChain1].OffRampConfigPDA
 		programData := ccip_offramp.Config{}
 		t.Logf("Checking Off Ramp PDA ownership data configPDA: %s", offRampConfigPDA.String())
-		err = solChain.GetAccountDataBorshInto(ctx, offRampConfigPDA, &programData)
+		err := solChain.GetAccountDataBorshInto(ctx, offRampConfigPDA, &programData)
 		require.NoError(t, err)
 		return timelockSignerPDA.String() == programData.Owner.String()
 	}, 30*time.Second, 5*time.Second, "OffRamp config PDA owner was not changed to timelock signer PDA")

--- a/deployment/ccip/changeset/solana_state.go
+++ b/deployment/ccip/changeset/solana_state.go
@@ -12,9 +12,14 @@ import (
 
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
@@ -209,4 +214,59 @@ func (c SolCCIPChainState) OnRampBytes() ([]byte, error) {
 		return c.Router.Bytes(), nil
 	}
 	return nil, errors.New("no onramp found in the state")
+}
+
+func ValidateOwnershipSolana(
+	e *deployment.Environment,
+	chain deployment.SolChain,
+	mcms bool,
+	deployerKey solana.PublicKey,
+	programID solana.PublicKey,
+	contractType deployment.ContractType,
+) error {
+	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
+	if err != nil {
+		return fmt.Errorf("failed to get existing addresses: %w", err)
+	}
+	mcmState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+	if err != nil {
+		return fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
+	}
+	timelockSignerPDA := state.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
+	config, _, err := solState.FindConfigPDA(programID)
+	if err != nil {
+		return fmt.Errorf("failed to find config PDA: %w", err)
+	}
+	switch contractType {
+	case Router:
+		programData := ccip_router.Config{}
+		err = chain.GetAccountDataBorshInto(e.GetContext(), config, &programData)
+		if err != nil {
+			return fmt.Errorf("failed to get account data: %w", err)
+		}
+		if err := commoncs.ValidateOwnershipSolanaCommon(mcms, deployerKey, timelockSignerPDA, programData.Owner); err != nil {
+			return fmt.Errorf("failed to validate ownership for router: %w", err)
+		}
+	case OffRamp:
+		programData := ccip_offramp.Config{}
+		err = chain.GetAccountDataBorshInto(e.GetContext(), config, &programData)
+		if err != nil {
+			return fmt.Errorf("failed to get account data: %w", err)
+		}
+		if err := commoncs.ValidateOwnershipSolanaCommon(mcms, deployerKey, timelockSignerPDA, programData.Owner); err != nil {
+			return fmt.Errorf("failed to validate ownership for offramp: %w", err)
+		}
+	case FeeQuoter:
+		programData := fee_quoter.Config{}
+		err = chain.GetAccountDataBorshInto(e.GetContext(), config, &programData)
+		if err != nil {
+			return fmt.Errorf("failed to get account data: %w", err)
+		}
+		if err := commoncs.ValidateOwnershipSolanaCommon(mcms, deployerKey, timelockSignerPDA, programData.Owner); err != nil {
+			return fmt.Errorf("failed to validate ownership for feequoter: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported contract type: %s", contractType)
+	}
+	return nil
 }

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -21,14 +21,16 @@ import (
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 
+	solBinary "github.com/gagliardetto/binary"
+
 	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
+	solFeeQuoter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
-	changeset_solana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
+	ccipChangeSetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -526,7 +528,7 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 	// no proposals to be made, timelock can be passed as nil here
 	var apps []commonchangeset.ConfiguredChangeSet
 	evmContractParams := make(map[uint64]v1_6.ChainContractParams)
-	solContractParams := make(map[uint64]v1_6.ChainContractParams)
+	solContractParams := make(map[uint64]ccipChangeSetSolana.ChainContractParams)
 	evmChains := []uint64{}
 	for _, chain := range allChains {
 		if _, ok := e.Env.Chains[chain]; ok {
@@ -548,10 +550,40 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 		}
 	}
 
+	value := [28]uint8{}
+	bigNum, ok := new(big.Int).SetString("19816680000000000000", 10)
+	require.True(t, ok)
+	bigNum.FillBytes(value[:])
+	state, err := changeset.LoadOnchainState(e.Env)
+	require.NoError(t, err)
 	for _, chain := range solChains {
-		solContractParams[chain] = v1_6.ChainContractParams{
-			FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),
-			OffRampParams:   v1_6.DefaultOffRampParams(),
+		solContractParams[chain] = ccipChangeSetSolana.ChainContractParams{
+			FeeQuoterParams: ccipChangeSetSolana.FeeQuoterParams{
+				DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
+				BillingConfig: []solFeeQuoter.BillingTokenConfig{
+					{
+						Enabled: true,
+						Mint:    state.SolChains[chain].LinkToken,
+						UsdPerToken: solFeeQuoter.TimestampedPackedU224{
+							Value:     value,
+							Timestamp: int64(100),
+						},
+						PremiumMultiplierWeiPerEth: 100,
+					},
+					{
+						Enabled: true,
+						Mint:    state.SolChains[chain].WSOL,
+						UsdPerToken: solFeeQuoter.TimestampedPackedU224{
+							Value:     value,
+							Timestamp: int64(100),
+						},
+						PremiumMultiplierWeiPerEth: 100,
+					},
+				},
+			},
+			OffRampParams: ccipChangeSetSolana.OffRampParams{
+				EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+			},
 		}
 	}
 
@@ -576,19 +608,17 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 			},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(solana.DeployChainContractsChangesetSolana),
-			solana.DeployChainContractsConfigSolana{
-				DeployChainContractsConfig: v1_6.DeployChainContractsConfig{
-					HomeChainSelector:      e.HomeChainSel,
-					ContractParamsPerChain: solContractParams,
-				},
+			deployment.CreateLegacyChangeSet(ccipChangeSetSolana.DeployChainContractsChangeset),
+			ccipChangeSetSolana.DeployChainContractsConfig{
+				HomeChainSelector:      e.HomeChainSel,
+				ContractParamsPerChain: solContractParams,
 			},
 		),
 	}...)
 	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, nil, apps)
 	require.NoError(t, err)
 
-	state, err := changeset.LoadOnchainState(e.Env)
+	state, err = changeset.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 	// Assert link present
 	if tc.IsStaticLink {
@@ -772,7 +802,7 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 		),
 		commonchangeset.Configure(
 			// Enable the OCR config on the remote chains.
-			deployment.CreateLegacyChangeSet(changeset_solana.SetOCR3ConfigSolana),
+			deployment.CreateLegacyChangeSet(ccipChangeSetSolana.SetOCR3ConfigSolana),
 			v1_6.SetOCR3OffRampConfig{
 				HomeChainSel:       e.HomeChainSel,
 				RemoteChainSels:    solChains,

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	changeset_solana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
+	ccipChangeSetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -455,10 +455,10 @@ func addLaneSolanaChangesets(t *testing.T, solChainSelector, remoteChainSelector
 	}
 	solanaChangesets := []commoncs.ConfiguredChangeSet{
 		commoncs.Configure(
-			deployment.CreateLegacyChangeSet(changeset_solana.AddRemoteChainToSolana),
-			changeset_solana.AddRemoteChainToSolanaConfig{
+			deployment.CreateLegacyChangeSet(ccipChangeSetSolana.AddRemoteChainToSolana),
+			ccipChangeSetSolana.AddRemoteChainToSolanaConfig{
 				ChainSelector: solChainSelector,
-				UpdatesByChain: map[uint64]changeset_solana.RemoteChainConfigSolana{
+				UpdatesByChain: map[uint64]ccipChangeSetSolana.RemoteChainConfigSolana{
 					remoteChainSelector: {
 						EnabledAsSource:         true,
 						RouterDestinationConfig: solRouter.DestChainConfig{},
@@ -864,10 +864,10 @@ func DeployTransferableTokenSolana(
 	e, err = commoncs.Apply(t, e, nil,
 		commoncs.Configure(
 			// this makes the deployer the mint authority by default
-			deployment.CreateLegacyChangeSet(changeset_solana.DeploySolanaToken),
-			changeset_solana.DeploySolanaTokenConfig{
+			deployment.CreateLegacyChangeSet(ccipChangeSetSolana.DeploySolanaToken),
+			ccipChangeSetSolana.DeploySolanaTokenConfig{
 				ChainSelector:    solChainSel,
-				TokenProgramName: deployment.SPL2022Tokens,
+				TokenProgramName: changeset.SPL2022Tokens,
 				TokenDecimals:    9,
 			},
 		),
@@ -881,21 +881,20 @@ func DeployTransferableTokenSolana(
 	e, err = commoncs.Apply(t, e, nil,
 		commoncs.Configure(
 			// create the ata for the deployerKey
-			deployment.CreateLegacyChangeSet(changeset_solana.CreateSolanaTokenATA),
-			changeset_solana.CreateSolanaTokenATAConfig{
+			deployment.CreateLegacyChangeSet(ccipChangeSetSolana.CreateSolanaTokenATA),
+			ccipChangeSetSolana.CreateSolanaTokenATAConfig{
 				ChainSelector: solChainSel,
 				TokenPubkey:   solTokenAddress,
-				TokenProgram:  deployment.SPL2022Tokens,
+				TokenProgram:  changeset.SPL2022Tokens,
 				ATAList:       []string{solDeployerKey.String()},
 			},
 		),
 		commoncs.Configure(
 			// mint the token to the deployerKey
-			deployment.CreateLegacyChangeSet(changeset_solana.MintSolanaToken),
-			changeset_solana.MintSolanaTokenConfig{
+			deployment.CreateLegacyChangeSet(ccipChangeSetSolana.MintSolanaToken),
+			ccipChangeSetSolana.MintSolanaTokenConfig{
 				ChainSelector: solChainSel,
 				TokenPubkey:   solTokenAddress.String(),
-				TokenProgram:  deployment.SPL2022Tokens,
 				AmountToAddress: map[string]uint64{
 					solDeployerKey.String(): uint64(1000),
 				},
@@ -903,20 +902,19 @@ func DeployTransferableTokenSolana(
 		),
 		commoncs.Configure(
 			// deploy token pool and set the burn/mint authority to the tokenPool
-			deployment.CreateLegacyChangeSet(changeset_solana.AddTokenPool),
-			changeset_solana.TokenPoolConfig{
-				ChainSelector:    solChainSel,
-				TokenPubKey:      solTokenAddress.String(),
-				TokenProgramName: deployment.SPL2022Tokens,
-				PoolType:         solTestTokenPool.BurnAndMint_PoolType,
-				Authority:        solDeployerKey.String(),
+			deployment.CreateLegacyChangeSet(ccipChangeSetSolana.AddTokenPool),
+			ccipChangeSetSolana.TokenPoolConfig{
+				ChainSelector: solChainSel,
+				TokenPubKey:   solTokenAddress.String(),
+				PoolType:      solTestTokenPool.BurnAndMint_PoolType,
+				Authority:     solDeployerKey.String(),
 			},
 		),
 	)
 	require.NoError(t, err)
 
 	// configure evm
-	poolConfigPDA, err := solTokenUtil.TokenPoolConfigAddress(solTokenAddress, state.SolChains[solChainSel].TokenPool)
+	poolConfigPDA, err := solTokenUtil.TokenPoolConfigAddress(solTokenAddress, state.SolChains[solChainSel].BurnMintTokenPool)
 	require.NoError(t, err)
 	err = setTokenPoolCounterPart(e.Chains[evmChainSel], evmPool, evmDeployer, solChainSel, solTokenAddress.Bytes(), poolConfigPDA.Bytes())
 	require.NoError(t, err)
@@ -927,8 +925,8 @@ func DeployTransferableTokenSolana(
 	// configure solana
 	e, err = commoncs.Apply(t, e, nil,
 		commoncs.Configure(
-			deployment.CreateLegacyChangeSet(changeset_solana.SetupTokenPoolForRemoteChain),
-			changeset_solana.RemoteChainTokenPoolConfig{
+			deployment.CreateLegacyChangeSet(ccipChangeSetSolana.SetupTokenPoolForRemoteChain),
+			ccipChangeSetSolana.RemoteChainTokenPoolConfig{
 				SolChainSelector:    solChainSel,
 				RemoteChainSelector: evmChainSel,
 				SolTokenPubKey:      solTokenAddress.String(),
@@ -953,6 +951,22 @@ func DeployTransferableTokenSolana(
 					Enabled:  true,
 					Capacity: uint64(1000),
 					Rate:     1,
+				},
+			},
+		),
+		commoncs.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangeSetSolana.AddBillingTokenForRemoteChain),
+			ccipChangeSetSolana.BillingTokenForRemoteChainConfig{
+				ChainSelector:       solChainSel,
+				RemoteChainSelector: evmChainSel,
+				TokenPubKey:         solTokenAddress.String(),
+				Config: solFeeQuoter.TokenTransferFeeConfig{
+					MinFeeUsdcents:    800,
+					MaxFeeUsdcents:    1600,
+					DeciBps:           0,
+					DestGasOverhead:   100,
+					DestBytesOverhead: 100,
+					IsEnabled:         true,
 				},
 			},
 		),
@@ -1541,6 +1555,12 @@ func SavePreloadedSolAddresses(t *testing.T, e deployment.Environment, solChainS
 	require.NoError(t, err)
 	tv = deployment.NewTypeAndVersion(changeset.OffRamp, deployment.Version1_0_0)
 	err = e.ExistingAddresses.Save(solChainSelector, solTestConfig.CcipOfframpProgram.String(), tv)
+	require.NoError(t, err)
+	tv = deployment.NewTypeAndVersion(changeset.BurnMintTokenPool, deployment.Version1_0_0)
+	err = e.ExistingAddresses.Save(solChainSelector, "TokenPooL11111111111111111111111111BurnMint", tv)
+	require.NoError(t, err)
+	tv = deployment.NewTypeAndVersion(changeset.LockReleaseTokenPool, deployment.Version1_0_0)
+	err = e.ExistingAddresses.Save(solChainSelector, "TokenPooL11111111111111111111111LockReLease", tv)
 	require.NoError(t, err)
 	tv = deployment.NewTypeAndVersion(commontypes.ManyChainMultisigProgram, deployment.Version1_0_0)
 	err = e.ExistingAddresses.Save(solChainSelector, memory.SolanaProgramIDs["mcm"], tv)

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -23,6 +23,8 @@ import (
 	changeset_solana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/fee_quoter"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry"
@@ -1608,6 +1610,64 @@ func DeploySolanaCcipReceiver(t *testing.T, e deployment.Environment) {
 func FindReceiverTargetAccount(receiverID solana.PublicKey) solana.PublicKey {
 	receiverTargetAccount, _, _ := solana.FindProgramAddress([][]byte{[]byte("counter")}, receiverID)
 	return receiverTargetAccount
+}
+
+func TransferOwnershipSolana(
+	t *testing.T,
+	e *deployment.Environment,
+	solChain uint64,
+	needTimelockDeployed bool,
+	transferRouter, transferFeeQuoter, transferOffRamp bool) (solana.PublicKey, solana.PublicKey) {
+
+	var err error
+	if needTimelockDeployed {
+		*e, err = commoncs.ApplyChangesetsV2(t, *e, []commoncs.ConfiguredChangeSet{
+			commoncs.Configure(
+				deployment.CreateLegacyChangeSet(commoncs.DeployMCMSWithTimelockV2),
+				map[uint64]commontypes.MCMSWithTimelockConfigV2{
+					solChain: {
+						Canceller:        proposalutils.SingleGroupMCMSV2(t),
+						Proposer:         proposalutils.SingleGroupMCMSV2(t),
+						Bypasser:         proposalutils.SingleGroupMCMSV2(t),
+						TimelockMinDelay: big.NewInt(0),
+					},
+				},
+			),
+		})
+		require.NoError(t, err)
+	}
+
+	addresses, err := e.ExistingAddresses.AddressesForChain(solChain)
+	require.NoError(t, err)
+	mcmState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(e.SolChains[solChain], addresses)
+	require.NoError(t, err)
+
+	// Fund signer PDAs for timelock and mcm
+	// If we don't fund, execute() calls will fail with "no funds" errors.
+	timelockSignerPDA := state.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
+	mcmSignerPDA := state.GetMCMSignerPDA(mcmState.McmProgram, mcmState.ProposerMcmSeed)
+	memory.FundSolanaAccounts(e.GetContext(), t, []solana.PublicKey{timelockSignerPDA, mcmSignerPDA},
+		100, e.SolChains[solChain].Client)
+	t.Logf("funded timelock signer PDA: %s", timelockSignerPDA.String())
+	t.Logf("funded mcm signer PDA: %s", mcmSignerPDA.String())
+	// Apply transfer ownership changeset
+	*e, err = commoncs.ApplyChangesetsV2(t, *e, []commoncs.ConfiguredChangeSet{
+		commoncs.Configure(
+			deployment.CreateLegacyChangeSet(changeset_solana.TransferCCIPToMCMSWithTimelockSolana),
+			changeset_solana.TransferCCIPToMCMSWithTimelockSolanaConfig{
+				MinDelay: 1 * time.Second,
+				ContractsByChain: map[uint64]changeset_solana.CCIPContractsToTransfer{
+					solChain: {
+						Router:    transferRouter,
+						FeeQuoter: transferFeeQuoter,
+						OffRamp:   transferOffRamp,
+					},
+				},
+			},
+		),
+	})
+	require.NoError(t, err)
+	return timelockSignerPDA, mcmSignerPDA
 }
 
 func GenTestTransferOwnershipConfig(

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1618,7 +1618,6 @@ func TransferOwnershipSolana(
 	solChain uint64,
 	needTimelockDeployed bool,
 	transferRouter, transferFeeQuoter, transferOffRamp bool) (solana.PublicKey, solana.PublicKey) {
-
 	var err error
 	if needTimelockDeployed {
 		*e, err = commoncs.ApplyChangesetsV2(t, *e, []commoncs.ConfiguredChangeSet{

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1638,7 +1638,6 @@ func TransferOwnershipSolana(
 	solChain uint64,
 	needTimelockDeployed bool,
 	transferRouter, transferFeeQuoter, transferOffRamp bool) (solana.PublicKey, solana.PublicKey) {
-
 	var err error
 	if needTimelockDeployed {
 		*e, err = commoncs.ApplyChangesetsV2(t, *e, []commoncs.ConfiguredChangeSet{

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -23,6 +23,8 @@ import (
 	ccipChangeSetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/fee_quoter"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry"
@@ -1628,6 +1630,64 @@ func DeploySolanaCcipReceiver(t *testing.T, e deployment.Environment) {
 func FindReceiverTargetAccount(receiverID solana.PublicKey) solana.PublicKey {
 	receiverTargetAccount, _, _ := solana.FindProgramAddress([][]byte{[]byte("counter")}, receiverID)
 	return receiverTargetAccount
+}
+
+func TransferOwnershipSolana(
+	t *testing.T,
+	e *deployment.Environment,
+	solChain uint64,
+	needTimelockDeployed bool,
+	transferRouter, transferFeeQuoter, transferOffRamp bool) (solana.PublicKey, solana.PublicKey) {
+
+	var err error
+	if needTimelockDeployed {
+		*e, err = commoncs.ApplyChangesetsV2(t, *e, []commoncs.ConfiguredChangeSet{
+			commoncs.Configure(
+				deployment.CreateLegacyChangeSet(commoncs.DeployMCMSWithTimelockV2),
+				map[uint64]commontypes.MCMSWithTimelockConfigV2{
+					solChain: {
+						Canceller:        proposalutils.SingleGroupMCMSV2(t),
+						Proposer:         proposalutils.SingleGroupMCMSV2(t),
+						Bypasser:         proposalutils.SingleGroupMCMSV2(t),
+						TimelockMinDelay: big.NewInt(0),
+					},
+				},
+			),
+		})
+		require.NoError(t, err)
+	}
+
+	addresses, err := e.ExistingAddresses.AddressesForChain(solChain)
+	require.NoError(t, err)
+	mcmState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(e.SolChains[solChain], addresses)
+	require.NoError(t, err)
+
+	// Fund signer PDAs for timelock and mcm
+	// If we don't fund, execute() calls will fail with "no funds" errors.
+	timelockSignerPDA := state.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
+	mcmSignerPDA := state.GetMCMSignerPDA(mcmState.McmProgram, mcmState.ProposerMcmSeed)
+	memory.FundSolanaAccounts(e.GetContext(), t, []solana.PublicKey{timelockSignerPDA, mcmSignerPDA},
+		100, e.SolChains[solChain].Client)
+	t.Logf("funded timelock signer PDA: %s", timelockSignerPDA.String())
+	t.Logf("funded mcm signer PDA: %s", mcmSignerPDA.String())
+	// Apply transfer ownership changeset
+	*e, err = commoncs.ApplyChangesetsV2(t, *e, []commoncs.ConfiguredChangeSet{
+		commoncs.Configure(
+			deployment.CreateLegacyChangeSet(changeset_solana.TransferCCIPToMCMSWithTimelockSolana),
+			changeset_solana.TransferCCIPToMCMSWithTimelockSolanaConfig{
+				MinDelay: 1 * time.Second,
+				ContractsByChain: map[uint64]changeset_solana.CCIPContractsToTransfer{
+					solChain: {
+						Router:    transferRouter,
+						FeeQuoter: transferFeeQuoter,
+						OffRamp:   transferOffRamp,
+					},
+				},
+			},
+		),
+	})
+	require.NoError(t, err)
+	return timelockSignerPDA, mcmSignerPDA
 }
 
 func GenTestTransferOwnershipConfig(

--- a/deployment/ccip/changeset/v1_6/cs_ccip_home.go
+++ b/deployment/ccip/changeset/v1_6/cs_ccip_home.go
@@ -222,6 +222,8 @@ func WithDefaultCommitOffChainConfig(feedChainSel uint64, tokenInfo map[ccipocr3
 				MerkleRootAsyncObserverDisabled:    false,
 				MerkleRootAsyncObserverSyncFreq:    4 * time.Second,
 				MerkleRootAsyncObserverSyncTimeout: 12 * time.Second,
+				ChainFeeAsyncObserverSyncFreq:      10 * time.Second,
+				ChainFeeAsyncObserverSyncTimeout:   12 * time.Second,
 			}
 		} else {
 			if params.CommitOffChainConfig.TokenInfo == nil {

--- a/deployment/ccip/changeset/v1_6/cs_ccip_home.go
+++ b/deployment/ccip/changeset/v1_6/cs_ccip_home.go
@@ -632,7 +632,7 @@ func AddDonAndSetCandidateChangeset(
 	}
 	var donMcmsTxs []mcmstypes.Transaction
 	for chainSelector, params := range cfg.PluginInfo.OCRConfigPerRemoteChainSelector {
-		offRampAddress, err := state.GetOffRampAddress(chainSelector)
+		offRampAddress, err := state.GetOffRampAddressBytes(chainSelector)
 		if err != nil {
 			return deployment.ChangesetOutput{}, err
 		}
@@ -827,7 +827,7 @@ func SetCandidateChangeset(
 	for _, plugin := range cfg.PluginInfo {
 		pluginInfos = append(pluginInfos, plugin.String())
 		for chainSelector, params := range plugin.OCRConfigPerRemoteChainSelector {
-			offRampAddress, err := state.GetOffRampAddress(chainSelector)
+			offRampAddress, err := state.GetOffRampAddressBytes(chainSelector)
 			if err != nil {
 				return deployment.ChangesetOutput{}, err
 			}

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -1154,15 +1154,8 @@ func UpdateOffRampSourcesChangeset(e deployment.Environment, cfg UpdateOffRampSo
 			} else {
 				router = state.Chains[chainSel].Router.Address()
 			}
-			sourceChainFamily, _ := chain_selectors.GetSelectorFamily(source)
-
-			onRampBytes := []byte{}
 			// can ignore err as validation checks for nil addresses
-			if sourceChainFamily == chain_selectors.FamilyEVM {
-				onRampBytes, _ = state.Chains[source].OnRampBytes()
-			} else if sourceChainFamily == chain_selectors.FamilySolana {
-				onRampBytes, _ = state.SolChains[source].OnRampBytes()
-			}
+			onRampBytes, _ := state.GetOnRampAddressBytes(source)
 
 			args = append(args, offramp.OffRampSourceChainConfigArgs{
 				SourceChainSelector: source,

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -20,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/fee_quoter"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -1422,24 +1421,12 @@ func (c SetOCR3OffRampConfig) validateRemoteChain(e *deployment.Environment, sta
 	}
 	switch family {
 	case chain_selectors.FamilySolana:
-		chain, ok := e.SolChains[chainSelector]
-		if !ok {
-			return fmt.Errorf("chain %d not found in environment", chainSelector)
-		}
 		chainState, ok := state.SolChains[chainSelector]
 		if !ok {
 			return fmt.Errorf("remote chain %d not found in onchain state", chainSelector)
 		}
-		addresses, err := e.ExistingAddresses.AddressesForChain(chainSelector)
-		if err != nil {
-			return err
-		}
-		mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
-		if err != nil {
-			return fmt.Errorf("error loading MCMS state for chain %d: %w", chainSelector, err)
-		}
-		if err := commoncs.ValidateOwnershipSolana(e.GetContext(), c.MCMS != nil, e.SolChains[chainSelector].DeployerKey.PublicKey(), mcmState.TimelockProgram, mcmState.TimelockSeed, chainState.Router); err != nil {
-			return err
+		if chainState.OffRamp.IsZero() {
+			return fmt.Errorf("missing OffRamp for chain %d", chainSelector)
 		}
 	case chain_selectors.FamilyEVM:
 		chainState, ok := state.Chains[chainSelector]

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -20,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/fee_quoter"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -1429,24 +1428,12 @@ func (c SetOCR3OffRampConfig) validateRemoteChain(e *deployment.Environment, sta
 	}
 	switch family {
 	case chain_selectors.FamilySolana:
-		chain, ok := e.SolChains[chainSelector]
-		if !ok {
-			return fmt.Errorf("chain %d not found in environment", chainSelector)
-		}
 		chainState, ok := state.SolChains[chainSelector]
 		if !ok {
 			return fmt.Errorf("remote chain %d not found in onchain state", chainSelector)
 		}
-		addresses, err := e.ExistingAddresses.AddressesForChain(chainSelector)
-		if err != nil {
-			return err
-		}
-		mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
-		if err != nil {
-			return fmt.Errorf("error loading MCMS state for chain %d: %w", chainSelector, err)
-		}
-		if err := commoncs.ValidateOwnershipSolana(e.GetContext(), c.MCMS != nil, e.SolChains[chainSelector].DeployerKey.PublicKey(), mcmState.TimelockProgram, mcmState.TimelockSeed, chainState.Router); err != nil {
-			return err
+		if chainState.OffRamp.IsZero() {
+			return fmt.Errorf("missing OffRamp for chain %d", chainSelector)
 		}
 	case chain_selectors.FamilyEVM:
 		chainState, ok := state.Chains[chainSelector]

--- a/deployment/common/changeset/deploy_mcms_with_timelock.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/internal"
 	evminternal "github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/evm"
 	solanainternal "github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/solana"
-	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
@@ -82,11 +81,15 @@ func ValidateOwnership(ctx context.Context, mcms bool, deployerKey, timelock com
 	return nil
 }
 
-// TODO: SOLANA_CCIP
-func ValidateOwnershipSolana(
-	ctx context.Context, mcms bool, deployerKey, timelock solana.PublicKey, timelockSeed state.PDASeed,
-	ccipRouter solana.PublicKey,
-) error {
-	// TODO: implement
+func ValidateOwnershipSolanaCommon(mcms bool, deployerKey solana.PublicKey, timelockSignerPDA solana.PublicKey, programOwner solana.PublicKey) error {
+	if !mcms {
+		if deployerKey.String() != programOwner.String() {
+			return fmt.Errorf("deployer key does not match owner")
+		}
+	} else {
+		if timelockSignerPDA.String() != programOwner.String() {
+			return fmt.Errorf("timelock signer PDA does not match owner")
+		}
+	}
 	return nil
 }

--- a/deployment/common/changeset/deploy_mcms_with_timelock.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock.go
@@ -84,11 +84,11 @@ func ValidateOwnership(ctx context.Context, mcms bool, deployerKey, timelock com
 func ValidateOwnershipSolanaCommon(mcms bool, deployerKey solana.PublicKey, timelockSignerPDA solana.PublicKey, programOwner solana.PublicKey) error {
 	if !mcms {
 		if deployerKey.String() != programOwner.String() {
-			return fmt.Errorf("deployer key does not match owner")
+			return fmt.Errorf("deployer key %s does not match owner %s", deployerKey.String(), programOwner.String())
 		}
 	} else {
 		if timelockSignerPDA.String() != programOwner.String() {
-			return fmt.Errorf("timelock signer PDA does not match owner")
+			return fmt.Errorf("timelock signer PDA %s does not match owner %s", timelockSignerPDA.String(), programOwner.String())
 		}
 	}
 	return nil

--- a/deployment/common/types/types.go
+++ b/deployment/common/types/types.go
@@ -102,8 +102,8 @@ func (params OCRParameters) Validate() error {
 	if params.DeltaCertifiedCommitRequest <= 0 {
 		return errors.New("deltaCertifiedCommitRequest must be positive")
 	}
-	if params.DeltaStage <= 0 {
-		return errors.New("deltaStage must be positive")
+	if params.DeltaStage < 0 {
+		return errors.New("deltaStage must be positive or 0 for disabled")
 	}
 	if params.Rmax <= 0 {
 		return errors.New("rmax must be positive")

--- a/deployment/data-streams/changeset/jd_register_nodes.go
+++ b/deployment/data-streams/changeset/jd_register_nodes.go
@@ -66,14 +66,20 @@ func validateNodeSlice(nodes []NodeCfg, nodeType string, donIndex int) error {
 	return nil
 }
 
-func registerNodesForDON(e deployment.Environment, nodes []NodeCfg, baseLabels []*ptypes.Label, nodeType NodeType) {
+func registerNodesForDON(e deployment.Environment, donName string, donID int, nodes []NodeCfg, baseLabels []*ptypes.Label, nodeType NodeType) {
 	ntStr := nodeType.String()
 	for _, node := range nodes {
 		labels := append([]*ptypes.Label(nil), baseLabels...)
+
 		labels = append(labels, &ptypes.Label{
 			Key:   "nodeType",
 			Value: &ntStr,
 		})
+
+		labels = append(labels, &ptypes.Label{
+			Key: fmt.Sprintf("don-%d-%s", donID, donName),
+		})
+
 		nodeID, err := e.Offchain.RegisterNode(e.GetContext(), &nodev1.RegisterNodeRequest{
 			Name:      node.Name,
 			PublicKey: node.CSAKey,
@@ -100,8 +106,8 @@ func RegisterNodesWithJD(e deployment.Environment, cfg RegisterNodesInput) (depl
 	}
 
 	for _, don := range cfg.DONsList {
-		registerNodesForDON(e, don.Nodes, baseLabels, NodeTypeOracle)
-		registerNodesForDON(e, don.BootstrapNodes, baseLabels, NodeTypeBootstrap)
+		registerNodesForDON(e, don.Name, don.ID, don.Nodes, baseLabels, NodeTypeOracle)
+		registerNodesForDON(e, don.Name, don.ID, don.BootstrapNodes, baseLabels, NodeTypeBootstrap)
 	}
 
 	return deployment.ChangesetOutput{}, nil

--- a/deployment/environment/memory/chain.go
+++ b/deployment/environment/memory/chain.go
@@ -226,15 +226,17 @@ func evmChain(t *testing.T, numUsers int) EVMChain {
 }
 
 var SolanaProgramIDs = map[string]string{
-	"ccip_router":               solTestConfig.CcipRouterProgram.String(),
-	"test_token_pool":           solTestConfig.CcipTokenPoolProgram.String(),
-	"fee_quoter":                solTestConfig.FeeQuoterProgram.String(),
-	"test_ccip_receiver":        solTestConfig.CcipLogicReceiver.String(),
-	"ccip_offramp":              solTestConfig.CcipOfframpProgram.String(),
-	"mcm":                       solTestConfig.McmProgram.String(),
-	"timelock":                  solTestConfig.TimelockProgram.String(),
-	"access_controller":         solTestConfig.AccessControllerProgram.String(),
-	"external_program_cpi_stub": solTestConfig.ExternalCpiStubProgram.String(),
+	"ccip_router":                    solTestConfig.CcipRouterProgram.String(),
+	"test_token_pool":                solTestConfig.CcipTokenPoolProgram.String(),
+	"example_burnmint_token_pool":    "TokenPooL11111111111111111111111111BurnMint",
+	"example_lockrelease_token_pool": "TokenPooL11111111111111111111111LockReLease",
+	"fee_quoter":                     solTestConfig.FeeQuoterProgram.String(),
+	"test_ccip_receiver":             solTestConfig.CcipLogicReceiver.String(),
+	"ccip_offramp":                   solTestConfig.CcipOfframpProgram.String(),
+	"mcm":                            solTestConfig.McmProgram.String(),
+	"timelock":                       solTestConfig.TimelockProgram.String(),
+	"access_controller":              solTestConfig.AccessControllerProgram.String(),
+	"external_program_cpi_stub":      solTestConfig.ExternalCpiStubProgram.String(),
 }
 
 var once = &sync.Once{}

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.40
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250211162441-3d6cea220efb

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1134,8 +1134,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4 h1:voKtyPNWsT4o/IilRbkEMsvYEWhYMpkl94mi3fDQz60=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb h1:Z5QRY8DtXnxnPwbo+mR1mxwaL+OClza3ATUqcQ1Ynz8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=

--- a/deployment/solana_chain.go
+++ b/deployment/solana_chain.go
@@ -15,27 +15,16 @@ import (
 	solRpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/pkg/errors"
 
-	solBinary "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go/rpc"
 
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
-)
-
-var (
-	SolDefaultGasLimit          = solBinary.Uint128{Lo: 3000, Hi: 0, Endianness: nil}
-	SolDefaultMaxFeeJuelsPerMsg = solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil}
-	EnableExecutionAfter        = int64(globals.PermissionLessExecutionThreshold.Seconds())
 )
 
 const (
 	ProgramIDPrefix      = "Program Id: "
 	BufferIDPrefix       = "Buffer: "
 	SolDefaultCommitment = rpc.CommitmentConfirmed
-	SPL2022Tokens        = "SPL2022Tokens"
-	SPLTokens            = "SPLTokens"
 )
 
 // SolChain represents a Solana chain.

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.40
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250128203428-08031923fbe5

--- a/go.sum
+++ b/go.sum
@@ -1018,8 +1018,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4 h1:voKtyPNWsT4o/IilRbkEMsvYEWhYMpkl94mi3fDQz60=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb h1:Z5QRY8DtXnxnPwbo+mR1mxwaL+OClza3ATUqcQ1Ynz8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.40
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250213145514-41d874782c02
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1384,8 +1384,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4 h1:voKtyPNWsT4o/IilRbkEMsvYEWhYMpkl94mi3fDQz60=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb h1:Z5QRY8DtXnxnPwbo+mR1mxwaL+OClza3ATUqcQ1Ynz8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=

--- a/integration-tests/load/ccip/ccip_test.go
+++ b/integration-tests/load/ccip/ccip_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment"
 	ccipchangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 
-	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-testing-framework/wasp"
@@ -37,13 +36,13 @@ var (
 const simChainTestKey = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
 // step 1: setup
-// Parse the test config, initialize CRIB with configurations defined
+// Parse the test config
 // step 2: subscribe
-// Create event subscribers on the offramp
+// Create event subscribers in src and dest
 // step 3: load
 // Use wasp to initiate load
 // step 4: teardown
-// Stop the chains, cleanup the environment
+// wait for ccip to finish, push remaining data
 func TestCCIPLoad_RPS(t *testing.T) {
 	// comment out when executing the test
 	// t.Skip("Skipping test as this test should not be auto triggered")
@@ -75,25 +74,43 @@ func TestCCIPLoad_RPS(t *testing.T) {
 	state, err := ccipchangeset.LoadOnchainState(*env)
 	require.NoError(t, err)
 
-	errChan := make(chan error)
-	defer close(errChan)
 	finalSeqNrCommitChannels := make(map[uint64]chan finalSeqNrReport)
 	finalSeqNrExecChannels := make(map[uint64]chan finalSeqNrReport)
+	loadFinished := make(chan struct{})
 
-	mm := NewMetricsManager(t, env.Logger)
+	mm := NewMetricsManager(t, env.Logger, userOverrides)
 	go mm.Start(ctx)
-	defer mm.Stop()
 
 	// gunMap holds a destinationGun for every enabled destination chain
 	gunMap := make(map[uint64]*DestinationGun)
 	p := wasp.NewProfile()
-	// Only create a destination gun if we have decided to send traffic to this chain
-	for ind := range *userOverrides.NumDestinationChains {
-		cs := env.AllChainSelectors()[ind]
+
+	// potential source chains need a subscription
+	for _, cs := range env.AllChainSelectors() {
 		latesthdr, err := env.Chains[cs].Client.HeaderByNumber(ctx, nil)
 		require.NoError(t, err)
 		block := latesthdr.Number.Uint64()
 		startBlocks[cs] = &block
+		other := env.AllChainSelectorsExcluding([]uint64{cs})
+		wg.Add(1)
+		go subscribeTransmitEvents(
+			ctx,
+			lggr,
+			state.Chains[cs].OnRamp,
+			other,
+			startBlocks[cs],
+			cs,
+			loadFinished,
+			env.Chains[cs].Client,
+			&wg,
+			mm.InputChan,
+			finalSeqNrCommitChannels,
+			finalSeqNrExecChannels)
+	}
+
+	// confirmed dest chains need a subscription
+	for ind := range *userOverrides.NumDestinationChains {
+		cs := env.AllChainSelectors()[ind]
 
 		messageKeys := make(map[uint64]*bind.TransactOpts)
 		other := env.AllChainSelectorsExcluding([]uint64{cs})
@@ -134,7 +151,6 @@ func TestCCIPLoad_RPS(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		otherChains := env.AllChainSelectorsExcluding([]uint64{cs})
 		finalSeqNrCommitChannels[cs] = make(chan finalSeqNrReport)
 		finalSeqNrExecChannels[cs] = make(chan finalSeqNrReport)
 
@@ -143,24 +159,22 @@ func TestCCIPLoad_RPS(t *testing.T) {
 			ctx,
 			lggr,
 			state.Chains[cs].OffRamp,
-			otherChains,
-			&block,
+			other,
+			startBlocks[cs],
 			cs,
 			env.Chains[cs].Client,
 			finalSeqNrCommitChannels[cs],
-			errChan,
 			&wg,
 			mm.InputChan)
 		go subscribeExecutionEvents(
 			ctx,
 			lggr,
 			state.Chains[cs].OffRamp,
-			otherChains,
-			&block,
+			other,
+			startBlocks[cs],
 			cs,
 			env.Chains[cs].Client,
 			finalSeqNrExecChannels[cs],
-			errChan,
 			&wg,
 			mm.InputChan)
 	}
@@ -191,28 +205,11 @@ func TestCCIPLoad_RPS(t *testing.T) {
 
 	_, err = p.Run(true)
 	require.NoError(t, err)
-
-	for _, gun := range gunMap {
-		for csPair, seqNums := range gun.seqNums {
-			lggr.Debugw("pushing finalized sequence numbers for ",
-				"chainSelector", gun.chainSelector,
-				"sourceChainSelector", csPair.SourceChainSelector,
-				"seqNums", seqNums)
-			finalSeqNrCommitChannels[csPair.DestChainSelector] <- finalSeqNrReport{
-				sourceChainSelector: csPair.SourceChainSelector,
-				expectedSeqNrRange: ccipocr3.SeqNumRange{
-					ccipocr3.SeqNum(seqNums.Start.Load()), ccipocr3.SeqNum(seqNums.End.Load()),
-				},
-			}
-
-			finalSeqNrExecChannels[csPair.DestChainSelector] <- finalSeqNrReport{
-				sourceChainSelector: csPair.SourceChainSelector,
-				expectedSeqNrRange: ccipocr3.SeqNumRange{
-					ccipocr3.SeqNum(seqNums.Start.Load()), ccipocr3.SeqNum(seqNums.End.Load()),
-				},
-			}
-		}
-	}
+	// wait some duration so that transmits can happen
+	go func() {
+		time.Sleep(tickerDuration)
+		close(loadFinished)
+	}()
 
 	// after load is finished, wait for a "timeout duration" before considering that messages are timed out
 	timeout := userOverrides.GetTimeoutDuration()
@@ -220,7 +217,6 @@ func TestCCIPLoad_RPS(t *testing.T) {
 		testTimer := time.NewTimer(timeout)
 		go func() {
 			<-testTimer.C
-			mm.Stop()
 			cancel()
 		}()
 	}

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.40
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250213145514-41d874782c02
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.51.0

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1369,8 +1369,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4 h1:voKtyPNWsT4o/IilRbkEMsvYEWhYMpkl94mi3fDQz60=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb h1:Z5QRY8DtXnxnPwbo+mR1mxwaL+OClza3ATUqcQ1Ynz8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=

--- a/integration-tests/testconfig/ccip/ccip.toml
+++ b/integration-tests/testconfig/ccip/ccip.toml
@@ -246,9 +246,9 @@ ephemeral_addresses_number = 0
 MessageTypeWeights = [100,0,0]
 # each destination chain will receive 1 incoming request per RequestFrequency for the duration of LoadDuration
 RequestFrequency = "5s"
-LoadDuration = "10m"
+LoadDuration = "5h"
 # destination chain selectors to send messages to
 NumDestinationChains = 8
 # Directory where we receive environment configuration from crib
 CribEnvDirectory = "../../../../crib/deployments/ccip-v2/.tmp"
-TimeoutDuration = "20m"
+TimeoutDuration = "30m"

--- a/integration-tests/testconfig/ccip/load.go
+++ b/integration-tests/testconfig/ccip/load.go
@@ -16,6 +16,7 @@ type LoadConfig struct {
 	CribEnvDirectory     *string
 	NumDestinationChains *int
 	TimeoutDuration      *string
+	TestLabel            *string
 }
 
 func (l *LoadConfig) Validate(t *testing.T, e *deployment.Environment) {

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -338,7 +338,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.40 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250128203428-08031923fbe5 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.1 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1122,8 +1122,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4 h1:voKtyPNWsT4o/IilRbkEMsvYEWhYMpkl94mi3fDQz60=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb h1:Z5QRY8DtXnxnPwbo+mR1mxwaL+OClza3ATUqcQ1Ynz8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -341,7 +341,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 // indirect
 	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250128203428-08031923fbe5 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1122,8 +1122,8 @@ github.com/smartcontractkit/chain-selectors v1.0.40 h1:iLvvoZeehVq6/7F+zzolQLF0D
 github.com/smartcontractkit/chain-selectors v1.0.40/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4 h1:voKtyPNWsT4o/IilRbkEMsvYEWhYMpkl94mi3fDQz60=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250221121938-dd0db587bff4/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb h1:Z5QRY8DtXnxnPwbo+mR1mxwaL+OClza3ATUqcQ1Ynz8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250224132459-c57ae4a97dcb/go.mod h1:Hht/OJq/PxC+gnBCIPyzHt4Otsw6mYwUVsmtOqIvlxo=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=


### PR DESCRIPTION
- Adds MCMS txn builder
- Adds transfer ownership helper
- Prepares for upgrade changeset by moving all upgrade logic to reusable function
- Implements ValidateOwnership for Solana
- Supports timelock ownership on adding remote chain configs (with any or all programs owned by timelock)
- Fixes bugs on upgrade
