### PR TITLE
chore(deployments/data-streams): adds don related label to node registration 

### DIFF
--- a/deployment/data-streams/changeset/jd_register_nodes.go
+++ b/deployment/data-streams/changeset/jd_register_nodes.go
@@ -66,14 +66,20 @@ func validateNodeSlice(nodes []NodeCfg, nodeType string, donIndex int) error {
 	return nil
 }
 
-func registerNodesForDON(e deployment.Environment, nodes []NodeCfg, baseLabels []*ptypes.Label, nodeType NodeType) {
+func registerNodesForDON(e deployment.Environment, donName string, donID int, nodes []NodeCfg, baseLabels []*ptypes.Label, nodeType NodeType) {
 	ntStr := nodeType.String()
 	for _, node := range nodes {
 		labels := append([]*ptypes.Label(nil), baseLabels...)
+
 		labels = append(labels, &ptypes.Label{
 			Key:   "nodeType",
 			Value: &ntStr,
 		})
+
+		labels = append(labels, &ptypes.Label{
+			Key: fmt.Sprintf("don-%d-%s", donID, donName),
+		})
+
 		nodeID, err := e.Offchain.RegisterNode(e.GetContext(), &nodev1.RegisterNodeRequest{
 			Name:      node.Name,
 			PublicKey: node.CSAKey,
@@ -100,8 +106,8 @@ func RegisterNodesWithJD(e deployment.Environment, cfg RegisterNodesInput) (depl
 	}
 
 	for _, don := range cfg.DONsList {
-		registerNodesForDON(e, don.Nodes, baseLabels, NodeTypeOracle)
-		registerNodesForDON(e, don.BootstrapNodes, baseLabels, NodeTypeBootstrap)
+		registerNodesForDON(e, don.Name, don.ID, don.Nodes, baseLabels, NodeTypeOracle)
+		registerNodesForDON(e, don.Name, don.ID, don.BootstrapNodes, baseLabels, NodeTypeBootstrap)
 	}
 
 	return deployment.ChangesetOutput{}, nil


### PR DESCRIPTION
This PR adds an additional label to indicate the DON a node belongs to, making it easier to retrieve a set of nodes from a specific DON in data-streams changesets.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
