### PR TITLE
[CAPPL-536] Workflow update not picked up by Syncer

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -183,7 +183,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.keystone_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@70a84a2a8546ea6dd8778217df16558e9a5afba3
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@cc44f7e74a3c356690612955171613d16dceeb9f
     with:
       workflow_name: Run Core Workflow Engine Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/client_golang v1.21.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0
+	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250227012921-08252fd61672
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1093,8 +1093,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0 h1:BTN2nQgFKBxgas6oqY3ym82O+wT++WlpP1+a6KzIfY0=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942 h1:z73HRzp3NmTS+8UQLisIUdqfW/TrFMe8hEgqHxFnpHc=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e h1:QBG+Wn5rHAi4gjnBAq6x6CZj/GjWAahFjj81VhQEu6U=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.1 h1:JzvUOM/OgGQA1sOqTXXl52R6AnNt+Wg64sVG+XSA49c=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.40
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01
-	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0
+	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250211162441-3d6cea220efb
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250227012921-08252fd61672
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1140,8 +1140,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0 h1:BTN2nQgFKBxgas6oqY3ym82O+wT++WlpP1+a6KzIfY0=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942 h1:z73HRzp3NmTS+8UQLisIUdqfW/TrFMe8hEgqHxFnpHc=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e h1:QBG+Wn5rHAi4gjnBAq6x6CZj/GjWAahFjj81VhQEu6U=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.1 h1:JzvUOM/OgGQA1sOqTXXl52R6AnNt+Wg64sVG+XSA49c=

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01
-	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea
+	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e
 	github.com/smartcontractkit/chainlink-feeds v0.1.1
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420ccacab78a

--- a/go.sum
+++ b/go.sum
@@ -1020,8 +1020,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea h1:/1f/pWf7vSV9acTR9UPn2exPAwQG/LHGa4l9OywhS00=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250214231858-f365e2bdecea/go.mod h1:Z2e1ynSJ4pg83b4Qldbmryc5lmnrI3ojOdg1FUloa68=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942 h1:z73HRzp3NmTS+8UQLisIUdqfW/TrFMe8hEgqHxFnpHc=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e h1:QBG+Wn5rHAi4gjnBAq6x6CZj/GjWAahFjj81VhQEu6U=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.1 h1:JzvUOM/OgGQA1sOqTXXl52R6AnNt+Wg64sVG+XSA49c=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.40
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124
-	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0
+	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250227012921-08252fd61672
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1434,8 +1434,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0 h1:BTN2nQgFKBxgas6oqY3ym82O+wT++WlpP1+a6KzIfY0=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942 h1:z73HRzp3NmTS+8UQLisIUdqfW/TrFMe8hEgqHxFnpHc=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e h1:QBG+Wn5rHAi4gjnBAq6x6CZj/GjWAahFjj81VhQEu6U=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.1 h1:JzvUOM/OgGQA1sOqTXXl52R6AnNt+Wg64sVG+XSA49c=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.40
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124
-	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0
+	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250227012921-08252fd61672
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.0

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1419,8 +1419,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0 h1:BTN2nQgFKBxgas6oqY3ym82O+wT++WlpP1+a6KzIfY0=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942 h1:z73HRzp3NmTS+8UQLisIUdqfW/TrFMe8hEgqHxFnpHc=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e h1:QBG+Wn5rHAi4gjnBAq6x6CZj/GjWAahFjj81VhQEu6U=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.1 h1:JzvUOM/OgGQA1sOqTXXl52R6AnNt+Wg64sVG+XSA49c=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
-	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0
+	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.5.8
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.0

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1128,8 +1128,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0 h1:BTN2nQgFKBxgas6oqY3ym82O+wT++WlpP1+a6KzIfY0=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942 h1:z73HRzp3NmTS+8UQLisIUdqfW/TrFMe8hEgqHxFnpHc=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e h1:QBG+Wn5rHAi4gjnBAq6x6CZj/GjWAahFjj81VhQEu6U=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.1 h1:JzvUOM/OgGQA1sOqTXXl52R6AnNt+Wg64sVG+XSA49c=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -343,7 +343,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 // indirect
-	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0 // indirect
+	github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.1 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250207205350-420ccacab78a // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1128,8 +1128,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250227123107-8b14b35f0124/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0 h1:BTN2nQgFKBxgas6oqY3ym82O+wT++WlpP1+a6KzIfY0=
-github.com/smartcontractkit/chainlink-common v0.4.2-0.20250221174903-e1e47fdb11b0/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942 h1:z73HRzp3NmTS+8UQLisIUdqfW/TrFMe8hEgqHxFnpHc=
+github.com/smartcontractkit/chainlink-common v0.4.2-0.20250225100621-f0e1dd7b7942/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e h1:QBG+Wn5rHAi4gjnBAq6x6CZj/GjWAahFjj81VhQEu6U=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250224190032-809e4b8cf29e/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.1 h1:JzvUOM/OgGQA1sOqTXXl52R6AnNt+Wg64sVG+XSA49c=

--- a/system-tests/tests/smoke/capabilities/environment-one-don-ci.toml
+++ b/system-tests/tests/smoke/capabilities/environment-one-don-ci.toml
@@ -17,7 +17,7 @@
   should_compile_new_workflow = false
 
   [workflow_config.dependencies]
-  capabilities_version = "v1.0.0-alpha"
+  capabilities_version = "v1.0.2-alpha"
   cre_cli_version = "v0.0.2"
 
   [workflow_config.compiled_config]

--- a/system-tests/tests/smoke/capabilities/environment-one-don.toml
+++ b/system-tests/tests/smoke/capabilities/environment-one-don.toml
@@ -21,7 +21,7 @@
   workflow_folder_location = "/Users/bartektofel/Downloads/workflow_test"
 
   [workflow_config.dependencies]
-  capabilities_version = "v1.0.0-alpha"
+  capabilities_version = "v1.0.2-alpha"
   cre_cli_version = "v0.0.2"
 
   [workflow_config.compiled_config]

--- a/system-tests/tests/smoke/capabilities/environment-one-don.toml
+++ b/system-tests/tests/smoke/capabilities/environment-one-don.toml
@@ -26,7 +26,7 @@
 
   [workflow_config.compiled_config]
     binary_url = "https://gist.githubusercontent.com/Tofel/73d703157bafe65ab51f7e619c589091/raw/cb7b2a56b37e333fe0bdce07b79538c4ce332f5f/binary.wasm.br"
-    config_url = "https://gist.githubusercontent.com/Tofel/a261990c5b177fe58f304a52d0998e51/raw/2e28ee10feacf4e451a38fdfbdff8a38cf2628d8/config.json2891974493"
+    config_url = "https://gist.githubusercontent.com/Tofel/ca04d5bd02f431ad68a8c13a05da5b39/raw/a1f5b68c523f0795cf3123e266e01736e86580a1/config.json763939347"
 
 [[nodesets]]
   nodes = 5

--- a/system-tests/tests/smoke/capabilities/environment-three-dons-ci.toml
+++ b/system-tests/tests/smoke/capabilities/environment-three-dons-ci.toml
@@ -14,7 +14,7 @@
   should_compile_new_workflow = false
 
   [workflow_config.dependencies]
-  capabilities_version = "v1.0.0-alpha"
+  capabilities_version = "v1.0.2-alpha"
   cre_cli_version = "v0.0.2"
 
   [workflow_config.compiled_config]

--- a/system-tests/tests/smoke/capabilities/environment-three-dons.toml
+++ b/system-tests/tests/smoke/capabilities/environment-three-dons.toml
@@ -17,7 +17,7 @@
   workflow_folder_location = "/Users/bartektofel/Downloads/workflow_test"
 
   [workflow_config.dependencies]
-  capabilities_version = "v1.0.0-alpha"
+  capabilities_version = "v1.0.2-alpha"
   cre_cli_version = "v0.0.2"
 
   [workflow_config.compiled_config]

--- a/system-tests/tests/smoke/capabilities/environment-three-dons.toml
+++ b/system-tests/tests/smoke/capabilities/environment-three-dons.toml
@@ -22,7 +22,7 @@
 
   [workflow_config.compiled_config]
     binary_url = "https://gist.githubusercontent.com/Tofel/73d703157bafe65ab51f7e619c589091/raw/cb7b2a56b37e333fe0bdce07b79538c4ce332f5f/binary.wasm.br"
-    config_url = "https://gist.githubusercontent.com/Tofel/a261990c5b177fe58f304a52d0998e51/raw/2e28ee10feacf4e451a38fdfbdff8a38cf2628d8/config.json2891974493"
+    config_url = "https://gist.githubusercontent.com/Tofel/9af85e8e704f8b8e3946ad265075e18a/raw/2e28ee10feacf4e451a38fdfbdff8a38cf2628d8/config.json702797677"
 
 [[nodesets]]
   nodes = 5

--- a/system-tests/tests/smoke/capabilities/environment-two-dons-ci.toml
+++ b/system-tests/tests/smoke/capabilities/environment-two-dons-ci.toml
@@ -18,7 +18,7 @@
   workflow_folder_location = "not-needed-here"
 
   [workflow_config.dependencies]
-  capabilities_version = "v1.0.0-alpha"
+  capabilities_version = "v1.0.2-alpha"
   cre_cli_version = "v0.0.2"
 
   [workflow_config.compiled_config]

--- a/system-tests/tests/smoke/capabilities/environment-two-dons.toml
+++ b/system-tests/tests/smoke/capabilities/environment-two-dons.toml
@@ -21,7 +21,7 @@
   workflow_folder_location = "/Users/bartektofel/Downloads/workflow_test"
 
   [workflow_config.dependencies]
-  capabilities_version = "v1.0.0-alpha"
+  capabilities_version = "v1.0.2-alpha"
   cre_cli_version = "v0.0.2"
 
   [workflow_config.compiled_config]


### PR DESCRIPTION
### Description

This pr bumps the `chainlink-common` dependency to include the changes implemented on [this pr](https://github.com/smartcontractkit/chainlink-common/pull/1048). It also bumps the `capabilities` dependency on the smoke tests, given this change affects both the workflow don as the capabilities don. So the new `capabilities` tag also contains these same changes.
[CAPPL-536](https://smartcontract-it.atlassian.net/browse/CAPPL-536)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CAPPL-536]: https://smartcontract-it.atlassian.net/browse/CAPPL-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ