### PR TITLE
add remote chain

### DIFF
--- a/deployment/ccip/changeset/solana/cs_add_remote_chain.go
+++ b/deployment/ccip/changeset/solana/cs_add_remote_chain.go
@@ -234,26 +234,26 @@ func doAddRemoteChainToSolana(
 			ixns = append(ixns, routerIx)
 		}
 
-		// routerOfframpIx, err := solRouter.NewAddOfframpInstruction(
-		// 	remoteChainSel,
-		// 	offRampID,
-		// 	allowedOffRampRemotePDA,
-		// 	s.SolChains[chainSel].RouterConfigPDA,
-		// 	authority,
-		// 	solana.SystemProgramID,
-		// ).ValidateAndBuild()
-		// if err != nil {
-		// 	return txns, fmt.Errorf("failed to generate instructions: %w", err)
-		// }
-		// if routerUsingMCMS {
-		// 	tx, err := BuildMCMSTxn(routerIx, ccipRouterID.String(), cs.Router)
-		// 	if err != nil {
-		// 		return txns, fmt.Errorf("failed to create transaction: %w", err)
-		// 	}
-		// 	txns = append(txns, *tx)
-		// } else {
-		// 	ixns = append(ixns, routerIx)
-		// }
+		routerOfframpIx, err := solRouter.NewAddOfframpInstruction(
+			remoteChainSel,
+			offRampID,
+			allowedOffRampRemotePDA,
+			s.SolChains[chainSel].RouterConfigPDA,
+			authority,
+			solana.SystemProgramID,
+		).ValidateAndBuild()
+		if err != nil {
+			return txns, fmt.Errorf("failed to generate instructions: %w", err)
+		}
+		if routerUsingMCMS {
+			tx, err := BuildMCMSTxn(routerOfframpIx, ccipRouterID.String(), ccipChangeset.Router)
+			if err != nil {
+				return txns, fmt.Errorf("failed to create transaction: %w", err)
+			}
+			txns = append(txns, *tx)
+		} else {
+			ixns = append(ixns, routerOfframpIx)
+		}
 
 		solFeeQuoter.SetProgramID(feeQuoterID)
 		if feeQuoterUsingMCMS {

--- a/deployment/ccip/changeset/solana/cs_add_remote_chain.go
+++ b/deployment/ccip/changeset/solana/cs_add_remote_chain.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	cs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -226,7 +225,7 @@ func doAddRemoteChainToSolana(
 			return txns, fmt.Errorf("failed to generate instructions: %w", err)
 		}
 		if routerUsingMCMS {
-			tx, err := BuildMCMSTxn(routerIx, ccipRouterID.String(), cs.Router)
+			tx, err := BuildMCMSTxn(routerIx, ccipRouterID.String(), ccipChangeset.Router)
 			if err != nil {
 				return txns, fmt.Errorf("failed to create transaction: %w", err)
 			}
@@ -274,7 +273,7 @@ func doAddRemoteChainToSolana(
 			return txns, fmt.Errorf("failed to generate instructions: %w", err)
 		}
 		if feeQuoterUsingMCMS {
-			tx, err := BuildMCMSTxn(feeQuoterIx, feeQuoterID.String(), cs.FeeQuoter)
+			tx, err := BuildMCMSTxn(feeQuoterIx, feeQuoterID.String(), ccipChangeset.FeeQuoter)
 			if err != nil {
 				return txns, fmt.Errorf("failed to create transaction: %w", err)
 			}

--- a/deployment/ccip/changeset/solana/cs_add_remote_chain.go
+++ b/deployment/ccip/changeset/solana/cs_add_remote_chain.go
@@ -2,12 +2,17 @@ package solana
 
 import (
 	"context"
-	// "errors"
+
 	"fmt"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+
+	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/sdk"
+	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
+	mcmsTypes "github.com/smartcontractkit/mcms/types"
 
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	solRouter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
@@ -17,8 +22,10 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	cs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
 // ADD REMOTE CHAIN
@@ -29,6 +36,11 @@ type AddRemoteChainToSolanaConfig struct {
 	// Disallow mixing MCMS/non-MCMS per chain for simplicity.
 	// (can still be achieved by calling this function multiple times)
 	MCMS *ccipChangeset.MCMSConfig
+	// Public key of program authorites. Depending on when this changeset is called, some may be under
+	// the control of the deployer, and some may be under the control of the timelock. (e.g. during new offramp deploy)
+	RouterAuthority    solana.PublicKey
+	FeeQuoterAuthority solana.PublicKey
+	OffRampAuthority   solana.PublicKey
 }
 
 type RemoteChainConfigSolana struct {
@@ -55,19 +67,23 @@ func (cfg AddRemoteChainToSolanaConfig) Validate(e deployment.Environment) error
 	if err := validateOffRampConfig(chain, chainState); err != nil {
 		return err
 	}
+	if err := ValidateMCMSConfig(e, cfg.ChainSelector, cfg.MCMS); err != nil {
+		return err
+	}
+	routerUsingMCMS := cfg.MCMS != nil && !cfg.RouterAuthority.IsZero()
+	feeQuoterUsingMCMS := cfg.MCMS != nil && !cfg.FeeQuoterAuthority.IsZero()
+	offRampUsingMCMS := cfg.MCMS != nil && !cfg.OffRampAuthority.IsZero()
 	chain, ok := e.SolChains[cfg.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain %d not found in environment", cfg.ChainSelector)
 	}
-	addresses, err := e.ExistingAddresses.AddressesForChain(cfg.ChainSelector)
-	if err != nil {
-		return err
+	if err := ccipChangeset.ValidateOwnershipSolana(&e, chain, routerUsingMCMS, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), chainState.Router, ccipChangeset.Router); err != nil {
+		return fmt.Errorf("failed to validate ownership: %w", err)
 	}
-	mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
-	if err != nil {
-		return fmt.Errorf("error loading MCMS state for chain %d: %w", cfg.ChainSelector, err)
+	if err := ccipChangeset.ValidateOwnershipSolana(&e, chain, feeQuoterUsingMCMS, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), chainState.FeeQuoter, ccipChangeset.FeeQuoter); err != nil {
+		return fmt.Errorf("failed to validate ownership: %w", err)
 	}
-	if err := commoncs.ValidateOwnershipSolana(e.GetContext(), cfg.MCMS != nil, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), mcmState.TimelockProgram, mcmState.TimelockSeed, chainState.Router); err != nil {
+	if err := ccipChangeset.ValidateOwnershipSolana(&e, chain, offRampUsingMCMS, e.SolChains[cfg.ChainSelector].DeployerKey.PublicKey(), chainState.OffRamp, ccipChangeset.OffRamp); err != nil {
 		return fmt.Errorf("failed to validate ownership: %w", err)
 	}
 	var routerConfigAccount solRouter.Config
@@ -110,9 +126,46 @@ func AddRemoteChainToSolana(e deployment.Environment, cfg AddRemoteChainToSolana
 	}
 
 	ab := deployment.NewMemoryAddressBook()
-	err = doAddRemoteChainToSolana(e, s, cfg.ChainSelector, cfg.UpdatesByChain, ab)
+	txns, err := doAddRemoteChainToSolana(e, s, cfg, ab)
 	if err != nil {
 		return deployment.ChangesetOutput{AddressBook: ab}, err
+	}
+
+	// create proposals for ixns
+	if len(txns) > 0 {
+		timelocks := map[uint64]string{}
+		proposers := map[uint64]string{}
+		inspectors := map[uint64]sdk.Inspector{}
+		batches := make([]mcmsTypes.BatchOperation, 0)
+		chain := e.SolChains[cfg.ChainSelector]
+		addresses, _ := e.ExistingAddresses.AddressesForChain(cfg.ChainSelector)
+		mcmState, _ := state.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+
+		timelocks[cfg.ChainSelector] = mcmsSolana.ContractAddress(
+			mcmState.TimelockProgram,
+			mcmsSolana.PDASeed(mcmState.TimelockSeed),
+		)
+		proposers[cfg.ChainSelector] = mcmsSolana.ContractAddress(mcmState.McmProgram, mcmsSolana.PDASeed(mcmState.ProposerMcmSeed))
+		inspectors[cfg.ChainSelector] = mcmsSolana.NewInspector(chain.Client)
+		batches = append(batches, mcmsTypes.BatchOperation{
+			ChainSelector: mcmsTypes.ChainSelector(cfg.ChainSelector),
+			Transactions:  txns,
+		})
+		proposal, err := proposalutils.BuildProposalFromBatchesV2(
+			e.GetContext(),
+			timelocks,
+			proposers,
+			inspectors,
+			batches,
+			"proposal to add remote chains to Solana",
+			cfg.MCMS.MinDelay)
+		if err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
+		}
+		return deployment.ChangesetOutput{
+			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
+			AddressBook:           ab,
+		}, nil
 	}
 	return deployment.ChangesetOutput{AddressBook: ab}, nil
 }
@@ -120,13 +173,19 @@ func AddRemoteChainToSolana(e deployment.Environment, cfg AddRemoteChainToSolana
 func doAddRemoteChainToSolana(
 	e deployment.Environment,
 	s ccipChangeset.CCIPOnChainState,
-	chainSel uint64,
-	updates map[uint64]RemoteChainConfigSolana,
-	ab deployment.AddressBook) error {
+	cfg AddRemoteChainToSolanaConfig,
+	ab deployment.AddressBook) ([]mcmsTypes.Transaction, error) {
+	txns := make([]mcmsTypes.Transaction, 0)
+	ixns := make([]solana.Instruction, 0)
+	chainSel := cfg.ChainSelector
+	updates := cfg.UpdatesByChain
 	chain := e.SolChains[chainSel]
 	ccipRouterID := s.SolChains[chainSel].Router
 	feeQuoterID := s.SolChains[chainSel].FeeQuoter
 	offRampID := s.SolChains[chainSel].OffRamp
+	routerUsingMCMS := cfg.MCMS != nil && !cfg.RouterAuthority.IsZero()
+	feeQuoterUsingMCMS := cfg.MCMS != nil && !cfg.FeeQuoterAuthority.IsZero()
+	offRampUsingMCMS := cfg.MCMS != nil && !cfg.OffRampAuthority.IsZero()
 	lookUpTableEntries := make([]solana.PublicKey, 0)
 
 	for remoteChainSel, update := range updates {
@@ -149,41 +208,79 @@ func doAddRemoteChainToSolana(
 		)
 
 		solRouter.SetProgramID(ccipRouterID)
+		var authority solana.PublicKey
+		if routerUsingMCMS {
+			authority = cfg.RouterAuthority
+		} else {
+			authority = chain.DeployerKey.PublicKey()
+		}
 		routerIx, err := solRouter.NewAddChainSelectorInstruction(
 			remoteChainSel,
 			update.RouterDestinationConfig,
 			routerRemoteStatePDA,
 			s.SolChains[chainSel].RouterConfigPDA,
-			chain.DeployerKey.PublicKey(),
+			authority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {
-			return fmt.Errorf("failed to generate instructions: %w", err)
+			return txns, fmt.Errorf("failed to generate instructions: %w", err)
+		}
+		if routerUsingMCMS {
+			tx, err := BuildMCMSTxn(routerIx, ccipRouterID.String(), cs.Router)
+			if err != nil {
+				return txns, fmt.Errorf("failed to create transaction: %w", err)
+			}
+			txns = append(txns, *tx)
+		} else {
+			ixns = append(ixns, routerIx)
 		}
 
-		routerOfframpIx, err := solRouter.NewAddOfframpInstruction(
-			remoteChainSel,
-			offRampID,
-			allowedOffRampRemotePDA,
-			s.SolChains[chainSel].RouterConfigPDA,
-			chain.DeployerKey.PublicKey(),
-			solana.SystemProgramID,
-		).ValidateAndBuild()
-		if err != nil {
-			return fmt.Errorf("failed to generate instructions: %w", err)
-		}
+		// routerOfframpIx, err := solRouter.NewAddOfframpInstruction(
+		// 	remoteChainSel,
+		// 	offRampID,
+		// 	allowedOffRampRemotePDA,
+		// 	s.SolChains[chainSel].RouterConfigPDA,
+		// 	authority,
+		// 	solana.SystemProgramID,
+		// ).ValidateAndBuild()
+		// if err != nil {
+		// 	return txns, fmt.Errorf("failed to generate instructions: %w", err)
+		// }
+		// if routerUsingMCMS {
+		// 	tx, err := BuildMCMSTxn(routerIx, ccipRouterID.String(), cs.Router)
+		// 	if err != nil {
+		// 		return txns, fmt.Errorf("failed to create transaction: %w", err)
+		// 	}
+		// 	txns = append(txns, *tx)
+		// } else {
+		// 	ixns = append(ixns, routerIx)
+		// }
 
 		solFeeQuoter.SetProgramID(feeQuoterID)
+		if feeQuoterUsingMCMS {
+			authority = cfg.RouterAuthority
+		} else {
+			authority = chain.DeployerKey.PublicKey()
+		}
 		feeQuoterIx, err := solFeeQuoter.NewAddDestChainInstruction(
 			remoteChainSel,
 			update.FeeQuoterDestinationConfig,
 			s.SolChains[chainSel].FeeQuoterConfigPDA,
 			fqRemoteChainPDA,
-			chain.DeployerKey.PublicKey(),
+			authority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 		if err != nil {
-			return fmt.Errorf("failed to generate instructions: %w", err)
+			return txns, fmt.Errorf("failed to generate instructions: %w", err)
+		}
+		if feeQuoterUsingMCMS {
+			tx, err := BuildMCMSTxn(feeQuoterIx, feeQuoterID.String(), cs.FeeQuoter)
+			if err != nil {
+				return txns, fmt.Errorf("failed to create transaction: %w", err)
+			}
+			txns = append(txns, *tx)
+		} else {
+			ixns = append(ixns, feeQuoterIx)
 		}
 
 		solOffRamp.SetProgramID(offRampID)
@@ -191,22 +288,37 @@ func doAddRemoteChainToSolana(
 			OnRamp:    [2][64]byte{onRampBytes, [64]byte{}},
 			IsEnabled: update.EnabledAsSource,
 		}
+		if offRampUsingMCMS {
+			authority = cfg.RouterAuthority
+		} else {
+			authority = chain.DeployerKey.PublicKey()
+		}
 		offRampIx, err := solOffRamp.NewAddSourceChainInstruction(
 			remoteChainSel,
 			validSourceChainConfig,
 			offRampRemoteStatePDA,
 			s.SolChains[chainSel].OffRampConfigPDA,
-			chain.DeployerKey.PublicKey(),
+			authority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
 
 		if err != nil {
-			return fmt.Errorf("failed to generate instructions: %w", err)
+			return txns, fmt.Errorf("failed to generate instructions: %w", err)
 		}
-
-		err = chain.Confirm([]solana.Instruction{routerIx, routerOfframpIx, feeQuoterIx, offRampIx})
-		if err != nil {
-			return fmt.Errorf("failed to confirm instructions: %w", err)
+		if offRampUsingMCMS {
+			tx, err := BuildMCMSTxn(offRampIx, offRampID.String(), ccipChangeset.OffRamp)
+			if err != nil {
+				return txns, fmt.Errorf("failed to create transaction: %w", err)
+			}
+			txns = append(txns, *tx)
+		} else {
+			ixns = append(ixns, offRampIx)
+		}
+		if len(ixns) > 0 {
+			err = chain.Confirm(ixns)
+			if err != nil {
+				return txns, fmt.Errorf("failed to confirm instructions: %w", err)
+			}
 		}
 
 		tv := deployment.NewTypeAndVersion(ccipChangeset.RemoteDest, deployment.Version1_0_0)
@@ -214,20 +326,20 @@ func doAddRemoteChainToSolana(
 		tv.AddLabel(remoteChainSelStr)
 		err = ab.Save(chainSel, routerRemoteStatePDA.String(), tv)
 		if err != nil {
-			return fmt.Errorf("failed to save dest chain state to address book: %w", err)
+			return txns, fmt.Errorf("failed to save dest chain state to address book: %w", err)
 		}
 
 		tv = deployment.NewTypeAndVersion(ccipChangeset.RemoteSource, deployment.Version1_0_0)
 		tv.AddLabel(remoteChainSelStr)
 		err = ab.Save(chainSel, allowedOffRampRemotePDA.String(), tv)
 		if err != nil {
-			return fmt.Errorf("failed to save source chain state to address book: %w", err)
+			return txns, fmt.Errorf("failed to save source chain state to address book: %w", err)
 		}
 	}
 
 	addressLookupTable, err := ccipChangeset.FetchOfframpLookupTable(e.GetContext(), chain, offRampID)
 	if err != nil {
-		return fmt.Errorf("failed to get offramp reference addresses: %w", err)
+		return txns, fmt.Errorf("failed to get offramp reference addresses: %w", err)
 	}
 
 	if err := solCommonUtil.ExtendLookupTable(
@@ -237,8 +349,8 @@ func doAddRemoteChainToSolana(
 		*chain.DeployerKey,
 		lookUpTableEntries,
 	); err != nil {
-		return fmt.Errorf("failed to extend lookup table: %w", err)
+		return txns, fmt.Errorf("failed to extend lookup table: %w", err)
 	}
 
-	return nil
+	return txns, nil
 }

--- a/deployment/ccip/changeset/solana/cs_add_remote_chain.go
+++ b/deployment/ccip/changeset/solana/cs_add_remote_chain.go
@@ -35,7 +35,7 @@ type AddRemoteChainToSolanaConfig struct {
 	// Disallow mixing MCMS/non-MCMS per chain for simplicity.
 	// (can still be achieved by calling this function multiple times)
 	MCMS *ccipChangeset.MCMSConfig
-	// Public key of program authorites. Depending on when this changeset is called, some may be under
+	// Public key of program authorities. Depending on when this changeset is called, some may be under
 	// the control of the deployer, and some may be under the control of the timelock. (e.g. during new offramp deploy)
 	RouterAuthority    solana.PublicKey
 	FeeQuoterAuthority solana.PublicKey

--- a/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
@@ -136,10 +136,10 @@ func TestAddRemoteChain(t *testing.T) {
 				},
 			),
 			commonchangeset.Configure(
-				deployment.CreateLegacyChangeSet(changeset_solana.AddRemoteChainToSolana),
-				changeset_solana.AddRemoteChainToSolanaConfig{
+				deployment.CreateLegacyChangeSet(ccipChangesetSolana.AddRemoteChainToSolana),
+				ccipChangesetSolana.AddRemoteChainToSolanaConfig{
 					ChainSelector: solChain,
-					UpdatesByChain: map[uint64]changeset_solana.RemoteChainConfigSolana{
+					UpdatesByChain: map[uint64]ccipChangesetSolana.RemoteChainConfigSolana{
 						evmChain2: {
 							EnabledAsSource:         true,
 							RouterDestinationConfig: solRouter.DestChainConfig{},

--- a/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
@@ -3,6 +3,7 @@ package solana_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,7 @@ func TestAddRemoteChain(t *testing.T) {
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
 
 	evmChain := tenv.Env.AllChainSelectors()[0]
+	evmChain2 := tenv.Env.AllChainSelectors()[1]
 	solChain := tenv.Env.AllChainSelectorsSolana()[0]
 
 	_, err := ccipChangeset.LoadOnchainStateSolana(tenv.Env)
@@ -110,6 +112,72 @@ func TestAddRemoteChain(t *testing.T) {
 
 	var destChainFqAccount solFeeQuoter.DestChain
 	fqEvmDestChainPDA, _, _ := solState.FindFqDestChainPDA(evmChain, state.SolChains[solChain].FeeQuoter)
+	err = tenv.Env.SolChains[solChain].GetAccountDataBorshInto(ctx, fqEvmDestChainPDA, &destChainFqAccount)
+	require.NoError(t, err, "failed to get account info")
+	require.Equal(t, solFeeQuoter.TimestampedPackedU224{}, destChainFqAccount.State.UsdPerUnitGas)
+	require.True(t, destChainFqAccount.Config.IsEnabled)
+
+	timelockSignerPDA, _ := testhelpers.TransferOwnershipSolana(t, &tenv.Env, solChain, true, true, true, true)
+
+	tenv.Env, err = commonchangeset.ApplyChangesetsV2(t, tenv.Env,
+		[]commonchangeset.ConfiguredChangeSet{
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(v1_6.UpdateOnRampsDestsChangeset),
+				v1_6.UpdateOnRampDestsConfig{
+					UpdatesByChain: map[uint64]map[uint64]v1_6.OnRampDestinationUpdate{
+						evmChain2: {
+							solChain: {
+								IsEnabled:        true,
+								TestRouter:       false,
+								AllowListEnabled: false,
+							},
+						},
+					},
+				},
+			),
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(changeset_solana.AddRemoteChainToSolana),
+				changeset_solana.AddRemoteChainToSolanaConfig{
+					ChainSelector: solChain,
+					UpdatesByChain: map[uint64]changeset_solana.RemoteChainConfigSolana{
+						evmChain2: {
+							EnabledAsSource:         true,
+							RouterDestinationConfig: solRouter.DestChainConfig{},
+							FeeQuoterDestinationConfig: solFeeQuoter.DestChainConfig{
+								IsEnabled:                   true,
+								DefaultTxGasLimit:           200000,
+								MaxPerMsgGasLimit:           3000000,
+								MaxDataBytes:                30000,
+								MaxNumberOfTokensPerMsg:     5,
+								DefaultTokenDestGasOverhead: 5000,
+								// bytes4(keccak256("CCIP ChainFamilySelector EVM"))
+								// TODO: do a similar test for other chain families
+								// https://smartcontract-it.atlassian.net/browse/INTAUTO-438
+								ChainFamilySelector: [4]uint8{40, 18, 213, 44},
+							},
+						},
+					},
+					MCMS: &ccipChangeset.MCMSConfig{
+						MinDelay: 1 * time.Second,
+					},
+					RouterAuthority:    timelockSignerPDA,
+					FeeQuoterAuthority: timelockSignerPDA,
+					OffRampAuthority:   timelockSignerPDA,
+				},
+			),
+		},
+	)
+
+	require.NoError(t, err)
+
+	state, err = ccipChangeset.LoadOnchainStateSolana(tenv.Env)
+	require.NoError(t, err)
+
+	evmDestChainStatePDA = state.SolChains[solChain].DestChainStatePDAs[evmChain2]
+	err = tenv.Env.SolChains[solChain].GetAccountDataBorshInto(ctx, evmDestChainStatePDA, &destChainStateAccount)
+	require.NoError(t, err)
+
+	fqEvmDestChainPDA, _, _ = solState.FindFqDestChainPDA(evmChain2, state.SolChains[solChain].FeeQuoter)
 	err = tenv.Env.SolChains[solChain].GetAccountDataBorshInto(ctx, fqEvmDestChainPDA, &destChainFqAccount)
 	require.NoError(t, err, "failed to get account info")
 	require.Equal(t, solFeeQuoter.TimestampedPackedU224{}, destChainFqAccount.State.UsdPerUnitGas)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -1,7 +1,6 @@
 package solana_test
 
 import (
-	"math/big"
 	"os"
 	"testing"
 	"time"
@@ -13,11 +12,12 @@ import (
 	solBinary "github.com/gagliardetto/binary"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	ccipChangeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	cs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	ccipChangesetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
-	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -60,11 +60,26 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	feeAggregatorPrivKey, _ := solana.NewRandomPrivateKey()
 	feeAggregatorPubKey := feeAggregatorPrivKey.PublicKey()
 	ci := os.Getenv("CI") == "true"
+	// we can't upgrade in place locally if we preload addresses so we have to change where we build
+	// we also don't want to incur two builds in CI, so only do it locally
 	if ci {
 		testhelpers.SavePreloadedSolAddresses(t, e, solChainSelectors[0])
+	} else {
+		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+			commonchangeset.Configure(
+				deployment.CreateLegacyChangeSet(ccipChangesetSolana.BuildSolanaChangeset),
+				ccipChangesetSolana.BuildSolanaConfig{
+					ChainSelector:       solChainSelectors[0],
+					GitCommitSha:        "3da552ac9d30b821310718b8b67e6a298335a485",
+					DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
+					CleanDestinationDir: true,
+				},
+			),
+		})
+		require.NoError(t, err)
 	}
 
-	e, err = commonchangeset.Apply(t, e, nil,
+	e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			deployment.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
 			v1_6.DeployHomeChainConfig{
@@ -103,179 +118,136 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 			},
 		),
 		commonchangeset.Configure(
-			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
-			map[uint64]commontypes.MCMSWithTimelockConfigV2{
-				solChainSelectors[0]: {
-					Canceller:        proposalutils.SingleGroupMCMSV2(t),
-					Proposer:         proposalutils.SingleGroupMCMSV2(t),
-					Bypasser:         proposalutils.SingleGroupMCMSV2(t),
-					TimelockMinDelay: big.NewInt(0),
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
+			ccipChangesetSolana.DeployChainContractsConfig{
+				HomeChainSelector: homeChainSel,
+				ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
+					solChainSelectors[0]: {
+						FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
+							DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
+						},
+						OffRampParams: ccipChangesetSolana.OffRampParams{
+							EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+						},
+					},
 				},
 			},
 		),
-	)
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.SetFeeAggregator),
+			ccipChangesetSolana.SetFeeAggregatorConfig{
+				ChainSelector: solChainSelectors[0],
+				FeeAggregator: feeAggregatorPubKey.String(),
+			},
+		),
+	})
 	require.NoError(t, err)
-	addresses, err := e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
-	require.NoError(t, err)
-	mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(e.SolChains[solChainSelectors[0]], addresses)
-	require.NoError(t, err)
-
-	// Fund signer PDAs for timelock and mcm
-	// If we don't fund, execute() calls will fail with "no funds" errors.
-	timelockSignerPDA := commonState.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
-	mcmSignerPDA := commonState.GetMCMSignerPDA(mcmState.McmProgram, mcmState.ProposerMcmSeed)
-	memory.FundSolanaAccounts(e.GetContext(), t, []solana.PublicKey{timelockSignerPDA, mcmSignerPDA},
-		100, e.SolChains[solChainSelectors[0]].Client)
-	t.Logf("funded timelock signer PDA: %s", timelockSignerPDA.String())
-	t.Logf("funded mcm signer PDA: %s", mcmSignerPDA.String())
+	testhelpers.ValidateSolanaState(t, e, solChainSelectors)
+	timelockSignerPDA, _ := testhelpers.TransferOwnershipSolana(t, &e, solChainSelectors[0], true, true, true, true)
 	upgradeAuthority := timelockSignerPDA
-
-	// we can't upgrade in place locally so we have to change where we build
-	buildCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.BuildSolanaChangeset),
-		ccipChangesetSolana.BuildSolanaConfig{
-			ChainSelector:       solChainSelectors[0],
-			GitCommitSha:        "0863d8fed5fbada9f352f33c405e1753cbb7d72c",
-			DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
-			CleanDestinationDir: true,
-		},
-	)
-	deployCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
-		ccipChangesetSolana.DeployChainContractsConfig{
-			HomeChainSelector: homeChainSel,
-			ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
-				solChainSelectors[0]: {
-					FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
-						DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
-					},
-					OffRampParams: ccipChangesetSolana.OffRampParams{
-						EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
-					},
-				},
-			},
-		},
-	)
-	// set the fee aggregator address
-	feeAggregatorCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.SetFeeAggregator),
-		ccipChangesetSolana.SetFeeAggregatorConfig{
-			ChainSelector: solChainSelectors[0],
-			FeeAggregator: feeAggregatorPubKey.String(),
-		},
-	)
-	transferOwnershipCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.TransferCCIPToMCMSWithTimelockSolana),
-		ccipChangesetSolana.TransferCCIPToMCMSWithTimelockSolanaConfig{
-			MinDelay: 1 * time.Second,
-			ContractsByChain: map[uint64]ccipChangesetSolana.CCIPContractsToTransfer{
-				solChainSelectors[0]: {
-					Router:    true,
-					FeeQuoter: true,
-					OffRamp:   true,
-				},
-			},
-		},
-	)
-	// make sure idempotency works and setting the upgrade authority
-	upgradeAuthorityCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
-		ccipChangesetSolana.DeployChainContractsConfig{
-			HomeChainSelector: homeChainSel,
-			ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
-				solChainSelectors[0]: {
-					FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
-						DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
-					},
-					OffRampParams: ccipChangesetSolana.OffRampParams{
-						EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
-					},
-				},
-			},
-			NewUpgradeAuthority: &upgradeAuthority,
-		},
-	)
-	upgradeCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
-		ccipChangesetSolana.DeployChainContractsConfig{
-			HomeChainSelector: homeChainSel,
-			ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
-				solChainSelectors[0]: {
-					FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
-						DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
-					},
-					OffRampParams: ccipChangesetSolana.OffRampParams{
-						EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
-					},
-				},
-			},
-			UpgradeConfig: ccipChangesetSolana.UpgradeConfig{
-				NewFeeQuoterVersion: &deployment.Version1_1_0,
-				NewRouterVersion:    &deployment.Version1_1_0,
-				UpgradeAuthority:    upgradeAuthority,
-				SpillAddress:        upgradeAuthority,
-				MCMS: &ccipChangeset.MCMSConfig{
-					MinDelay: 1 * time.Second,
-				},
-			},
-		},
-	)
-	// because we cannot upgrade in place locally, we can't redeploy offramp
-	offRampCs := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
-		ccipChangesetSolana.DeployChainContractsConfig{
-			HomeChainSelector: homeChainSel,
-			ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
-				solChainSelectors[0]: {
-					FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
-						DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
-					},
-					OffRampParams: ccipChangesetSolana.OffRampParams{
-						EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
-					},
-				},
-			},
-			UpgradeConfig: ccipChangesetSolana.UpgradeConfig{
-				NewOffRampVersion: &deployment.Version1_1_0,
-			},
-		},
-	)
-	if ci {
-		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			deployCs,
-			feeAggregatorCs,
-			upgradeAuthorityCs,
-			transferOwnershipCs,
-		})
-		require.NoError(t, err)
-		state, err := ccipChangeset.LoadOnchainStateSolana(e)
-		require.NoError(t, err)
-		oldOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
-		// add a second offramp address
-		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			buildCs,
-			upgradeCs,
-			offRampCs,
-		})
-		require.NoError(t, err)
-		// verify the offramp address is different
-		state, err = ccipChangeset.LoadOnchainStateSolana(e)
-		require.NoError(t, err)
-		newOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
-		require.NotEqual(t, oldOffRampAddress, newOffRampAddress)
-	} else {
-		e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
-			buildCs,
-			deployCs,
-			feeAggregatorCs,
-			upgradeAuthorityCs,
-			upgradeCs,
-		})
-	}
+	state, err := changeset.LoadOnchainStateSolana(e)
 	require.NoError(t, err)
+
+	e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
+			ccipChangesetSolana.DeployChainContractsConfig{
+				HomeChainSelector: homeChainSel,
+				ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
+					solChainSelectors[0]: {
+						FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
+							DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
+						},
+						OffRampParams: ccipChangesetSolana.OffRampParams{
+							EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+						},
+					},
+				},
+				NewUpgradeAuthority: &upgradeAuthority,
+			},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.BuildSolanaChangeset),
+			ccipChangesetSolana.BuildSolanaConfig{
+				ChainSelector:       solChainSelectors[0],
+				GitCommitSha:        "0863d8fed5fbada9f352f33c405e1753cbb7d72c",
+				DestinationDir:      e.SolChains[solChainSelectors[0]].ProgramsPath,
+				CleanDestinationDir: true,
+				CleanGitDir:         true,
+				UpgradeKeys: map[deployment.ContractType]string{
+					cs.Router:    state.SolChains[solChainSelectors[0]].Router.String(),
+					cs.FeeQuoter: state.SolChains[solChainSelectors[0]].FeeQuoter.String(),
+				},
+			},
+		),
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
+			ccipChangesetSolana.DeployChainContractsConfig{
+				HomeChainSelector: homeChainSel,
+				ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
+					solChainSelectors[0]: {
+						FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
+							DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
+						},
+						OffRampParams: ccipChangesetSolana.OffRampParams{
+							EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+						},
+					},
+				},
+				UpgradeConfig: ccipChangesetSolana.UpgradeConfig{
+					NewFeeQuoterVersion: &deployment.Version1_1_0,
+					NewRouterVersion:    &deployment.Version1_1_0,
+					UpgradeAuthority:    upgradeAuthority,
+					SpillAddress:        upgradeAuthority,
+					MCMS: &ccipChangeset.MCMSConfig{
+						MinDelay: 1 * time.Second,
+					},
+				},
+			},
+		),
+	})
+	require.NoError(t, err)
+	testhelpers.ValidateSolanaState(t, e, solChainSelectors)
+	state, err = changeset.LoadOnchainStateSolana(e)
+	require.NoError(t, err)
+	oldOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
+	// add a second offramp address
+	e, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
+			ccipChangesetSolana.DeployChainContractsConfig{
+				HomeChainSelector: homeChainSel,
+				ContractParamsPerChain: map[uint64]ccipChangesetSolana.ChainContractParams{
+					solChainSelectors[0]: {
+						FeeQuoterParams: ccipChangesetSolana.FeeQuoterParams{
+							DefaultMaxFeeJuelsPerMsg: solBinary.Uint128{Lo: 300000000, Hi: 0, Endianness: nil},
+						},
+						OffRampParams: ccipChangesetSolana.OffRampParams{
+							EnableExecutionAfter: int64(globals.PermissionLessExecutionThreshold.Seconds()),
+						},
+					},
+				},
+				UpgradeConfig: ccipChangesetSolana.UpgradeConfig{
+					NewOffRampVersion: &deployment.Version1_1_0,
+					UpgradeAuthority:  upgradeAuthority,
+					SpillAddress:      upgradeAuthority,
+					MCMS: &ccipChangeset.MCMSConfig{
+						MinDelay: 1 * time.Second,
+					},
+				},
+			},
+		),
+	})
+	require.NoError(t, err)
+	// verify the offramp address is different
+	state, err = changeset.LoadOnchainStateSolana(e)
+	require.NoError(t, err)
+	newOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
+	require.NotEqual(t, oldOffRampAddress, newOffRampAddress)
+
 	// Verify router and fee quoter upgraded in place
 	// and offramp had 2nd address added
-	addresses, err = e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
+	addresses, err := e.ExistingAddresses.AddressesForChain(solChainSelectors[0])
 	require.NoError(t, err)
 	numRouters := 0
 	numFeeQuoters := 0
@@ -293,11 +265,7 @@ func TestDeployChainContractsChangesetSolana(t *testing.T) {
 	}
 	require.Equal(t, 1, numRouters)
 	require.Equal(t, 1, numFeeQuoters)
-	if ci {
-		require.Equal(t, 2, numOffRamps)
-	} else {
-		require.Equal(t, 1, numOffRamps)
-	}
+	require.Equal(t, 2, numOffRamps)
 	require.NoError(t, err)
 	// solana verification
 	testhelpers.ValidateSolanaState(t, e, solChainSelectors)

--- a/deployment/ccip/changeset/solana/ownership_transfer_helpers.go
+++ b/deployment/ccip/changeset/solana/ownership_transfer_helpers.go
@@ -2,10 +2,8 @@ package solana
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/gagliardetto/solana-go"
-	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
@@ -60,25 +58,14 @@ func transferAndWrapAcceptOwnership(
 	if err != nil {
 		return mcmsTypes.Transaction{}, fmt.Errorf("%s: failed to create accept ownership instruction: %w", label, err)
 	}
-	acceptData, err := ixAccept.Data()
-	if err != nil {
-		return mcmsTypes.Transaction{}, fmt.Errorf("%s: failed to extract accept data: %w", label, err)
-	}
 
 	// 4. Wrap in MCMS transaction
-	mcmsTx, err := mcmsSolana.NewTransaction(
-		programID.String(),
-		acceptData,
-		big.NewInt(0),       // e.g. value
-		ixAccept.Accounts(), // pass along needed accounts
-		string(label),       // some string identifying the target
-		[]string{},          // any relevant metadata
-	)
+	mcmsTx, err := BuildMCMSTxn(ixAccept, programID.String(), label)
 	if err != nil {
 		return mcmsTypes.Transaction{}, fmt.Errorf("%s: failed to create MCMS transaction: %w", label, err)
 	}
 
-	return mcmsTx, nil
+	return *mcmsTx, nil
 }
 
 // transferOwnershipRouter transfers ownership of the router to the timelock.

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -20,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
-	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/fee_quoter"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -1422,25 +1421,12 @@ func (c SetOCR3OffRampConfig) validateRemoteChain(e *deployment.Environment, sta
 	}
 	switch family {
 	case chain_selectors.FamilySolana:
-		chain, ok := e.SolChains[chainSelector]
-		if !ok {
-			return fmt.Errorf("chain %d not found in environment", chainSelector)
-		}
 		chainState, ok := state.SolChains[chainSelector]
 		if !ok {
 			return fmt.Errorf("remote chain %d not found in onchain state", chainSelector)
 		}
-		addresses, err := e.ExistingAddresses.AddressesForChain(chainSelector)
-		if err != nil {
-			return err
-		}
-		mcmState, err := commonState.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
-		if err != nil {
-			return fmt.Errorf("error loading MCMS state for chain %d: %w", chainSelector, err)
-		}
-		timelockSignerPDA := commonState.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
-		if err := commoncs.ValidateOwnershipSolanaCommon(c.MCMS != nil, e.SolChains[chainSelector].DeployerKey.PublicKey(), timelockSignerPDA, chainState.Router); err != nil {
-			return err
+		if chainState.OffRamp.IsZero() {
+			return fmt.Errorf("missing OffRamp for chain %d", chainSelector)
 		}
 	case chain_selectors.FamilyEVM:
 		chainState, ok := state.Chains[chainSelector]

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -1438,7 +1438,8 @@ func (c SetOCR3OffRampConfig) validateRemoteChain(e *deployment.Environment, sta
 		if err != nil {
 			return fmt.Errorf("error loading MCMS state for chain %d: %w", chainSelector, err)
 		}
-		if err := commoncs.ValidateOwnershipSolana(e.GetContext(), c.MCMS != nil, e.SolChains[chainSelector].DeployerKey.PublicKey(), mcmState.TimelockProgram, mcmState.TimelockSeed, chainState.Router); err != nil {
+		timelockSignerPDA := commonState.GetTimelockSignerPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
+		if err := commoncs.ValidateOwnershipSolanaCommon(c.MCMS != nil, e.SolChains[chainSelector].DeployerKey.PublicKey(), timelockSignerPDA, chainState.Router); err != nil {
 			return err
 		}
 	case chain_selectors.FamilyEVM:

--- a/deployment/common/changeset/deploy_mcms_with_timelock.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/internal"
 	evminternal "github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/evm"
 	solanainternal "github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/solana"
-	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
@@ -82,11 +81,15 @@ func ValidateOwnership(ctx context.Context, mcms bool, deployerKey, timelock com
 	return nil
 }
 
-// TODO: SOLANA_CCIP
-func ValidateOwnershipSolana(
-	ctx context.Context, mcms bool, deployerKey, timelock solana.PublicKey, timelockSeed state.PDASeed,
-	ccipRouter solana.PublicKey,
-) error {
-	// TODO: implement
+func ValidateOwnershipSolanaCommon(mcms bool, deployerKey solana.PublicKey, timelockSignerPDA solana.PublicKey, programOwner solana.PublicKey) error {
+	if !mcms {
+		if deployerKey.String() != programOwner.String() {
+			return fmt.Errorf("deployer key %s does not match owner %s", deployerKey.String(), programOwner.String())
+		}
+	} else {
+		if timelockSignerPDA.String() != programOwner.String() {
+			return fmt.Errorf("timelock signer PDA %s does not match owner %s", timelockSignerPDA.String(), programOwner.String())
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Adds MCMS txn builder
Adds transfer ownership helper
Prepares for upgrade changeset by moving all upgrade logic to reusable function
Implements ValidateOwnership for Solana
Supports timelock ownership on adding remote chain configs (with any or all programs owned by timelock)
Fixes bugs on upgrade