### PR TITLE
fixing engine deletion bug

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -1174,8 +1173,8 @@ func (e *Engine) Close() error {
 		// engine instance is Closed by the syncer.
 		for idx, t := range e.workflow.triggers {
 			err := e.deregisterTrigger(ctx, t, idx)
-			if err != nil && !strings.Contains(err.Error(), "not found") {
-				return err
+			if err != nil {
+				e.logger.Errorf("failed to deregister trigger: %v", err)
 			}
 		}
 

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -1168,9 +1168,6 @@ func (e *Engine) Close() error {
 		// then we'll close down any background goroutines,
 		// and finally, we'll deregister any workflow steps.
 
-		// deregistering a trigger is done via don2don.
-		// the trigger may be already deregistered by the time this
-		// engine instance is Closed by the syncer.
 		for idx, t := range e.workflow.triggers {
 			err := e.deregisterTrigger(ctx, t, idx)
 			if err != nil {

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -1167,9 +1168,13 @@ func (e *Engine) Close() error {
 		// any triggers to ensure no new executions are triggered,
 		// then we'll close down any background goroutines,
 		// and finally, we'll deregister any workflow steps.
+
+		// deregistering a trigger is done via don2don.
+		// the trigger may be already deregistered by the time this
+		// engine instance is Closed by the syncer.
 		for idx, t := range e.workflow.triggers {
 			err := e.deregisterTrigger(ctx, t, idx)
-			if err != nil {
+			if err != nil && !strings.Contains(err.Error(), "not found") {
 				return err
 			}
 		}

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -1927,7 +1927,7 @@ func TestEngine_CloseUnregisterFails_NotFound(t *testing.T) {
 	// update trigger to mock
 	// triggerCapability wraps a capabilities.TriggerCapability
 	mockedInternalTrigger := newMockRuntimeTrigger(eng.workflow.triggers[0].trigger)
-	mockedInternalTrigger.On("UnregisterTrigger").Return(fmt.Errorf("trigger mock not found"))
+	mockedInternalTrigger.On("UnregisterTrigger").Return(errors.New("trigger mock not found"))
 	eng.workflow.triggers[0].trigger = mockedInternalTrigger
 	eng.workflow.triggers[0].registered = true
 
@@ -1936,7 +1936,7 @@ func TestEngine_CloseUnregisterFails_NotFound(t *testing.T) {
 }
 
 type mockRuntimeTrigger struct {
-	capabilities.TriggerCapability
+	c capabilities.TriggerCapability
 	*mock.Mock
 }
 
@@ -1945,11 +1945,11 @@ func newMockRuntimeTrigger(t capabilities.TriggerCapability) *mockRuntimeTrigger
 }
 
 func (t mockRuntimeTrigger) Info(ctx context.Context) (capabilities.CapabilityInfo, error) {
-	return t.Info(ctx)
+	return t.c.Info(ctx)
 }
 
 func (t mockRuntimeTrigger) RegisterTrigger(ctx context.Context, request capabilities.TriggerRegistrationRequest) (<-chan capabilities.TriggerResponse, error) {
-	return t.RegisterTrigger(ctx, request)
+	return t.c.RegisterTrigger(ctx, request)
 }
 
 func (t mockRuntimeTrigger) UnregisterTrigger(ctx context.Context, request capabilities.TriggerRegistrationRequest) error {

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -1874,6 +1875,143 @@ func TestEngine_CloseHappensOnlyIfWorkflowHasBeenRegistered(t *testing.T) {
 	<-testHooks.initFailed
 	err = eng.Close()
 	require.NoError(t, err)
+}
+
+func TestEngine_CloseUnregisterFails_NotFound(t *testing.T) {
+	ctx := testutils.Context(t)
+	reg := coreCap.NewRegistry(logger.TestLogger(t))
+
+	trigger, _ := mockTrigger(t)
+
+	require.NoError(t, reg.Add(ctx, trigger))
+
+	require.NoError(t, reg.Add(ctx, mockConsensus("")))
+
+	target := mockTarget("write_ethereum-testnet-sepolia@1.0.0")
+	require.NoError(t, reg.Add(ctx, target))
+
+	action := newMockCapability(
+		// Create a remote capability so we don't use the local transmission protocol.
+		capabilities.MustNewRemoteCapabilityInfo(
+			"custom-compute@1.0.0",
+			capabilities.CapabilityTypeAction,
+			"a custom compute action with custom config",
+			&capabilities.DON{ID: 1},
+		),
+		func(req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+			return capabilities.CapabilityResponse{
+				Value: req.Inputs,
+			}, nil
+		},
+	)
+	require.NoError(t, reg.Add(ctx, action))
+
+	eng, testHooks := newTestEngineWithYAMLSpec(
+		t,
+		reg,
+		secretsWorkflow,
+		func(c *Config) {
+			c.SecretsFetcher = &mockFetcher{
+				retval: map[string]string{},
+				retErr: errors.New("failed to fetch secrets XXX"),
+			}
+		},
+	)
+
+	err := eng.Start(ctx)
+	require.NoError(t, err)
+
+	// simulate WorkflowUpdatedEvent that calls tryEngineCleanup
+	<-testHooks.initFailed
+
+	// update trigger to mock
+	// triggerCapability wraps a capabilities.TriggerCapability
+	mockedInternalTrigger := newMockRuntimeTrigger(eng.workflow.triggers[0].trigger)
+	mockedInternalTrigger.On("UnregisterTrigger").Return(fmt.Errorf("trigger mock not found"))
+	eng.workflow.triggers[0].trigger = mockedInternalTrigger
+	eng.workflow.triggers[0].registered = true
+
+	err = eng.Close()
+	require.NoError(t, err)
+}
+
+func TestEngine_CloseUnregisterFails_Other(t *testing.T) {
+	ctx := testutils.Context(t)
+	reg := coreCap.NewRegistry(logger.TestLogger(t))
+
+	trigger, _ := mockTrigger(t)
+
+	require.NoError(t, reg.Add(ctx, trigger))
+
+	require.NoError(t, reg.Add(ctx, mockConsensus("")))
+
+	target := mockTarget("write_ethereum-testnet-sepolia@1.0.0")
+	require.NoError(t, reg.Add(ctx, target))
+
+	action := newMockCapability(
+		// Create a remote capability so we don't use the local transmission protocol.
+		capabilities.MustNewRemoteCapabilityInfo(
+			"custom-compute@1.0.0",
+			capabilities.CapabilityTypeAction,
+			"a custom compute action with custom config",
+			&capabilities.DON{ID: 1},
+		),
+		func(req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+			return capabilities.CapabilityResponse{
+				Value: req.Inputs,
+			}, nil
+		},
+	)
+	require.NoError(t, reg.Add(ctx, action))
+
+	eng, testHooks := newTestEngineWithYAMLSpec(
+		t,
+		reg,
+		secretsWorkflow,
+		func(c *Config) {
+			c.SecretsFetcher = &mockFetcher{
+				retval: map[string]string{},
+				retErr: errors.New("failed to fetch secrets XXX"),
+			}
+		},
+	)
+
+	err := eng.Start(ctx)
+	require.NoError(t, err)
+
+	// simulate WorkflowUpdatedEvent that calls tryEngineCleanup
+	<-testHooks.initFailed
+
+	// update trigger to mock
+	// triggerCapability wraps a capabilities.TriggerCapability
+	mockedInternalTrigger := newMockRuntimeTrigger(eng.workflow.triggers[0].trigger)
+	mockedInternalTrigger.On("UnregisterTrigger").Return(fmt.Errorf("random error message"))
+	eng.workflow.triggers[0].trigger = mockedInternalTrigger
+	eng.workflow.triggers[0].registered = true
+	err = eng.Close()
+	require.Error(t, err)
+}
+
+type mockRuntimeTrigger struct {
+	capabilities.TriggerCapability
+	*mock.Mock
+}
+
+func newMockRuntimeTrigger(t capabilities.TriggerCapability) *mockRuntimeTrigger {
+	return &mockRuntimeTrigger{t, new(mock.Mock)}
+}
+
+func (t mockRuntimeTrigger) Info(ctx context.Context) (capabilities.CapabilityInfo, error) {
+	return t.Info(ctx)
+}
+
+func (t mockRuntimeTrigger) RegisterTrigger(ctx context.Context, request capabilities.TriggerRegistrationRequest) (<-chan capabilities.TriggerResponse, error) {
+	return t.RegisterTrigger(ctx, request)
+}
+
+func (t mockRuntimeTrigger) UnregisterTrigger(ctx context.Context, request capabilities.TriggerRegistrationRequest) error {
+	args := t.Called()
+	return args.Error(0)
 }
 
 func TestMerge(t *testing.T) {

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -1935,63 +1935,6 @@ func TestEngine_CloseUnregisterFails_NotFound(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestEngine_CloseUnregisterFails_Other(t *testing.T) {
-	ctx := testutils.Context(t)
-	reg := coreCap.NewRegistry(logger.TestLogger(t))
-
-	trigger, _ := mockTrigger(t)
-
-	require.NoError(t, reg.Add(ctx, trigger))
-
-	require.NoError(t, reg.Add(ctx, mockConsensus("")))
-
-	target := mockTarget("write_ethereum-testnet-sepolia@1.0.0")
-	require.NoError(t, reg.Add(ctx, target))
-
-	action := newMockCapability(
-		// Create a remote capability so we don't use the local transmission protocol.
-		capabilities.MustNewRemoteCapabilityInfo(
-			"custom-compute@1.0.0",
-			capabilities.CapabilityTypeAction,
-			"a custom compute action with custom config",
-			&capabilities.DON{ID: 1},
-		),
-		func(req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
-			return capabilities.CapabilityResponse{
-				Value: req.Inputs,
-			}, nil
-		},
-	)
-	require.NoError(t, reg.Add(ctx, action))
-
-	eng, testHooks := newTestEngineWithYAMLSpec(
-		t,
-		reg,
-		secretsWorkflow,
-		func(c *Config) {
-			c.SecretsFetcher = &mockFetcher{
-				retval: map[string]string{},
-				retErr: errors.New("failed to fetch secrets XXX"),
-			}
-		},
-	)
-
-	err := eng.Start(ctx)
-	require.NoError(t, err)
-
-	// simulate WorkflowUpdatedEvent that calls tryEngineCleanup
-	<-testHooks.initFailed
-
-	// update trigger to mock
-	// triggerCapability wraps a capabilities.TriggerCapability
-	mockedInternalTrigger := newMockRuntimeTrigger(eng.workflow.triggers[0].trigger)
-	mockedInternalTrigger.On("UnregisterTrigger").Return(fmt.Errorf("random error message"))
-	eng.workflow.triggers[0].trigger = mockedInternalTrigger
-	eng.workflow.triggers[0].registered = true
-	err = eng.Close()
-	require.Error(t, err)
-}
-
 type mockRuntimeTrigger struct {
 	capabilities.TriggerCapability
 	*mock.Mock


### PR DESCRIPTION
We were exiting the close flow [here](https://github.com/smartcontractkit/chainlink/blob/develop/core/services/workflows/engine.go#L1171) when enough triggers had already been Unregistered by other engine nodes.
