### PR TITLE
chore: goreleaser workflow maintanence

### DIFF
--- a/.github/actions/goreleaser-build-sign-publish/action.yml
+++ b/.github/actions/goreleaser-build-sign-publish/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   # goreleaser inputs
   goreleaser-release-type:
-    description: The goreleaser release type, it can be either "nightly", "merge", "snapshot", "release" 
+    description: The goreleaser release type, it can be either "nightly", "merge", "snapshot", "release"
     default: "snapshot"
     required: false
   goreleaser-config:
@@ -33,22 +33,18 @@ inputs:
       buildkit debug information, and goreleaser debug, etc.
     required: false
     default: "${{ runner.debug == '1' }}"
- 
+
 runs:
   using: composite
   steps:
-    - # We need QEMU to test the cross architecture builds after they're built. 
-      name: Set up QEMU 
-      uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+    - # We need QEMU to test the cross architecture builds after they're built.
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
 
     - name: Setup docker buildx
-      uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.0
+      uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
       with:
         buildkitd-flags: ${{ inputs.enable-debug == 'true' && '--debug' || '' }}
-        # v0.16.0 until grpc fix is released
-        # see: https://github.com/docker/buildx/issues/2789#issuecomment-2487981922
-        driver-opts: |
-          image=moby/buildkit:v0.16.0
 
     - name: Set up Go
       uses: ./.github/actions/setup-go

--- a/.github/workflows/build-publish-develop-pr.yml
+++ b/.github/workflows/build-publish-develop-pr.yml
@@ -23,6 +23,10 @@ on:
         required: false
         default: "false"
 
+concurrency:
+  group: "build-publish-${{ github.ref_name }}-${{ github.sha }}"
+  cancel-in-progress: true
+
 env:
   # Use github.sha here otherwise a race condition exists if
   # a commit is pushed to develop before merge is run.


### PR DESCRIPTION
### Changes

- Update `docker/setup-qemu-action`,  `docker/setup-buildx-action`
- Unpin buildkit version from `setup-buildx-action` as problem is resolved
- Add concurrency to workflow
	- This is to help if a label is added while the workflow is already running, it will cancel the in-progress one and start the publish one.
	- The concurrency key is formatted so it will not affect image builds/publishes on subsequent pushes to develop

### Testing

Did some testing in #16547.

Also on this PR:
- Started on initial open (cancelled because below): https://github.com/smartcontractkit/chainlink/actions/runs/13506269241
- Started on build-publish tag:  https://github.com/smartcontractkit/chainlink/actions/runs/13506291587

---

RE-3516