### PR TITLE
Print OCR3 settings upon plugin init 

### DIFF
--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -180,6 +180,8 @@ func (i *pluginOracleCreator) Create(ctx context.Context, donID uint32, config c
 
 	i.lggr.Infow("Creating plugin using OCR3 settings",
 		"plugin", pluginType.String(),
+		"chainSelector", chainSelector,
+		"chainID", destChainID,
 		"deltaProgress", publicConfig.DeltaProgress,
 		"deltaResend", publicConfig.DeltaResend,
 		"deltaInitial", publicConfig.DeltaInitial,

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -178,6 +178,24 @@ func (i *pluginOracleCreator) Create(ctx context.Context, donID uint32, config c
 		return nil, fmt.Errorf("failed to get public config from OCR config: %w", err)
 	}
 
+	i.lggr.Infow("Creating plugin using OCR3 settings",
+		"plugin", config.Config.PluginType,
+		"deltaProgress", publicConfig.DeltaProgress,
+		"deltaResend", publicConfig.DeltaResend,
+		"deltaInitial", publicConfig.DeltaInitial,
+		"deltaRound", publicConfig.DeltaRound,
+		"deltaGrace", publicConfig.DeltaGrace,
+		"deltaCertifiedCommitRequest", publicConfig.DeltaCertifiedCommitRequest,
+		"deltaStage", publicConfig.DeltaStage,
+		"rMax", publicConfig.RMax,
+		"s", publicConfig.S,
+		"maxDurationInitialization", publicConfig.MaxDurationInitialization,
+		"maxDurationQuery", publicConfig.MaxDurationQuery,
+		"maxDurationObservation", publicConfig.MaxDurationObservation,
+		"maxDurationShouldAcceptAttestedReport", publicConfig.MaxDurationShouldAcceptAttestedReport,
+		"maxDurationShouldTransmitAcceptedReport", publicConfig.MaxDurationShouldTransmitAcceptedReport,
+	)
+
 	offrampAddrStr, err := i.addressCodec.AddressBytesToString(config.Config.OfframpAddress, cciptypes.ChainSelector(chainSelector))
 	if err != nil {
 		return nil, err

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -179,7 +179,7 @@ func (i *pluginOracleCreator) Create(ctx context.Context, donID uint32, config c
 	}
 
 	i.lggr.Infow("Creating plugin using OCR3 settings",
-		"plugin", config.Config.PluginType,
+		"plugin", pluginType.String(),
 		"deltaProgress", publicConfig.DeltaProgress,
 		"deltaResend", publicConfig.DeltaResend,
 		"deltaInitial", publicConfig.DeltaInitial,


### PR DESCRIPTION
Outcome

```json
{
  "L": "INFO",
  "T": "11:29:16.415550000",
  "C": "oraclecreator/plugin.go:181",
  "M": "Creating plugin using OCR3 settings",
  "plugin": "CCIPCommit",
  "chainSelector": 5548718428018410741,
  "chainID": "90000002",
  "deltaProgress": "10s",
  "deltaResend": "10s",
  "deltaInitial": "20s",
  "deltaRound": "2s",
  "deltaGrace": "2s",
  "deltaCertifiedCommitRequest": "10s",
  "deltaStage": "10s",
  "rMax": 50,
  "s": [
    1,
    1,
    1,
    1
  ],
  "maxDurationInitialization": null,
  "maxDurationQuery": "500ms",
  "maxDurationObservation": "5s",
  "maxDurationShouldAcceptAttestedReport": "10s",
  "maxDurationShouldTransmitAcceptedReport": "10s"
}
```