### PR TITLE
Fix abigen compilation on Mac.

### DIFF
--- a/.changeset/olive-comics-wave.md
+++ b/.changeset/olive-comics-wave.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#updated Fix abigen compilation on Mac.

--- a/tools/bin/build_abigen
+++ b/tools/bin/build_abigen
@@ -34,7 +34,7 @@ pushd "$TMPDIR"
 
 git clone --depth=1 --single-branch --branch "$GETH_VERSION" "$GETH_REPO_URL"
 cd go-ethereum/cmd/abigen
-go build -ldflags="-s -w"
+go build -ldflags="-s -w" # necessary on MacOS for code signing (see  https://github.com/confluentinc/confluent-kafka-go/issues/1092#issuecomment-2373681430)
 rm -f "$THIS_DIR/abigen" # necessary on MacOS for code signing
 cp ./abigen "$THIS_DIR"
 

--- a/tools/bin/build_abigen
+++ b/tools/bin/build_abigen
@@ -34,7 +34,7 @@ pushd "$TMPDIR"
 
 git clone --depth=1 --single-branch --branch "$GETH_VERSION" "$GETH_REPO_URL"
 cd go-ethereum/cmd/abigen
-go build
+go build -ldflags="-s -w"
 rm -f "$THIS_DIR/abigen" # necessary on MacOS for code signing
 cp ./abigen "$THIS_DIR"
 


### PR DESCRIPTION
The main reason for adding "-s -w" flags is to be coherent with the main build command [make all](https://github.com/ethereum/go-ethereum/blob/master/Makefile).

Currently, go-ethereum is not buildable with the latest go version 1.24.0, so instead of using `make all`,  we will keep building abigen only.