### PR TITLE
Add Solana codec validations

### DIFF
--- a/core/capabilities/ccip/ccipsolana/commitcodec.go
+++ b/core/capabilities/ccip/ccipsolana/commitcodec.go
@@ -111,9 +111,7 @@ func (c *CommitPluginCodecV1) Decode(ctx context.Context, bytes []byte) (cciptyp
 	}
 
 	var merkleRoots []cciptypes.MerkleRootChain
-	if commitReport.MerkleRoot == nil {
-		merkleRoots = nil
-	} else {
+	if commitReport.MerkleRoot != nil {
 		merkleRoots = []cciptypes.MerkleRootChain{
 			{
 				ChainSel:      cciptypes.ChainSelector(commitReport.MerkleRoot.SourceChainSelector),

--- a/core/capabilities/ccip/ccipsolana/commitcodec.go
+++ b/core/capabilities/ccip/ccipsolana/commitcodec.go
@@ -110,16 +110,21 @@ func (c *CommitPluginCodecV1) Decode(ctx context.Context, bytes []byte) (cciptyp
 		return cciptypes.CommitPluginReport{}, err
 	}
 
-	merkleRoots := []cciptypes.MerkleRootChain{
-		{
-			ChainSel:      cciptypes.ChainSelector(commitReport.MerkleRoot.SourceChainSelector),
-			OnRampAddress: commitReport.MerkleRoot.OnRampAddress,
-			SeqNumsRange: cciptypes.NewSeqNumRange(
-				cciptypes.SeqNum(commitReport.MerkleRoot.MinSeqNr),
-				cciptypes.SeqNum(commitReport.MerkleRoot.MaxSeqNr),
-			),
-			MerkleRoot: commitReport.MerkleRoot.MerkleRoot,
-		},
+	var merkleRoots []cciptypes.MerkleRootChain
+	if commitReport.MerkleRoot == nil {
+		merkleRoots = nil
+	} else {
+		merkleRoots = []cciptypes.MerkleRootChain{
+			{
+				ChainSel:      cciptypes.ChainSelector(commitReport.MerkleRoot.SourceChainSelector),
+				OnRampAddress: commitReport.MerkleRoot.OnRampAddress,
+				SeqNumsRange: cciptypes.NewSeqNumRange(
+					cciptypes.SeqNum(commitReport.MerkleRoot.MinSeqNr),
+					cciptypes.SeqNum(commitReport.MerkleRoot.MaxSeqNr),
+				),
+				MerkleRoot: commitReport.MerkleRoot.MerkleRoot,
+			},
+		}
 	}
 
 	tokenPriceUpdates := make([]cciptypes.TokenPrice, 0, len(commitReport.PriceUpdates.TokenPriceUpdates))

--- a/core/capabilities/ccip/ccipsolana/executecodec.go
+++ b/core/capabilities/ccip/ccipsolana/executecodec.go
@@ -10,6 +10,7 @@ import (
 
 	agbinary "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
@@ -64,6 +65,9 @@ func (e *ExecutePluginCodecV1) Encode(ctx context.Context, report cciptypes.Exec
 				return nil, err
 			}
 
+			if solana.PublicKeyLength != len(tokenAmount.DestTokenAddress) {
+				return nil, fmt.Errorf("invalid DestTokenAddress length: %d", len(tokenAmount.DestTokenAddress))
+			}
 			tokenAmounts = append(tokenAmounts, ccip_offramp.Any2SVMTokenTransfer{
 				SourcePoolAddress: tokenAmount.SourcePoolAddress,
 				DestTokenAddress:  solana.PublicKeyFromBytes(tokenAmount.DestTokenAddress),

--- a/core/capabilities/ccip/ccipsolana/executecodec_test.go
+++ b/core/capabilities/ccip/ccipsolana/executecodec_test.go
@@ -17,6 +17,7 @@ import (
 
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-integrations/evm/utils"
+
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 
 	"github.com/stretchr/testify/assert"
@@ -135,6 +136,24 @@ func TestExecutePluginCodecV1(t *testing.T) {
 				return report
 			},
 			expErr:        false,
+			chainSelector: 124615329519749607, // Solana mainnet chain selector
+		},
+		{
+			name: "reports have invalid DestTokenAddress",
+			report: func(report cciptypes.ExecutePluginReport) cciptypes.ExecutePluginReport {
+				report.ChainReports[0].Messages[0].TokenAmounts[0].DestTokenAddress = []byte{0, 0}
+				return report
+			},
+			expErr:        true,
+			chainSelector: 124615329519749607, // Solana mainnet chain selector
+		},
+		{
+			name: "reports have invalid receiver",
+			report: func(report cciptypes.ExecutePluginReport) cciptypes.ExecutePluginReport {
+				report.ChainReports[0].Messages[0].Receiver = []byte{0, 0}
+				return report
+			},
+			expErr:        true,
 			chainSelector: 124615329519749607, // Solana mainnet chain selector
 		},
 	}

--- a/core/capabilities/ccip/ccipsolana/msghasher.go
+++ b/core/capabilities/ccip/ccipsolana/msghasher.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gagliardetto/solana-go"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
@@ -44,6 +45,9 @@ func (h *MessageHasherV1) Hash(_ context.Context, msg cciptypes.Message) (ccipty
 		MessageId:           msg.Header.MessageID,
 		Nonce:               msg.Header.Nonce,
 	}
+	if solana.PublicKeyLength != len(msg.Receiver) {
+		return [32]byte{}, fmt.Errorf("invalid receiver length: %d", len(msg.Receiver))
+	}
 	anyToSolanaMessage.TokenReceiver = solana.PublicKeyFromBytes(msg.Receiver)
 	anyToSolanaMessage.Sender = msg.Sender
 	anyToSolanaMessage.Data = msg.Data
@@ -58,6 +62,9 @@ func (h *MessageHasherV1) Hash(_ context.Context, msg cciptypes.Message) (ccipty
 			return [32]byte{}, err
 		}
 
+		if solana.PublicKeyLength != len(ta.DestTokenAddress) {
+			return [32]byte{}, fmt.Errorf("invalid DestTokenAddress length: %d", len(ta.DestTokenAddress))
+		}
 		anyToSolanaMessage.TokenAmounts = append(anyToSolanaMessage.TokenAmounts, ccip_offramp.Any2SVMTokenTransfer{
 			SourcePoolAddress: ta.SourcePoolAddress,
 			DestTokenAddress:  solana.PublicKeyFromBytes(ta.DestTokenAddress),

--- a/core/capabilities/ccip/ccipsolana/msghasher_test.go
+++ b/core/capabilities/ccip/ccipsolana/msghasher_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-integrations/evm/utils"
+
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
-func TestMessageHasher_Any2Solana(t *testing.T) {
+func TestMessageHasher_Any2SVM(t *testing.T) {
 	any2AnyMsg, any2SolanaMsg, msgAccounts := createAny2SolanaMessages(t)
 	mockExtraDataCodec := &mocks.ExtraDataCodec{}
 	mockExtraDataCodec.On("DecodeTokenAmountDestExecData", mock.Anything, mock.Anything).Return(map[string]any{
@@ -47,6 +48,52 @@ func TestMessageHasher_Any2Solana(t *testing.T) {
 	expectedHash, err := ccip.HashAnyToSVMMessage(any2SolanaMsg, any2AnyMsg.Header.OnRamp, msgAccounts)
 	require.NoError(t, err)
 	require.Equal(t, expectedHash, actualHash[:32])
+}
+
+func TestMessageHasher_InvalidReceiver(t *testing.T) {
+	any2AnyMsg, _, _ := createAny2SolanaMessages(t)
+
+	// Set receiver to a []byte of 2 length
+	any2AnyMsg.Receiver = []byte{0, 0}
+	mockExtraDataCodec := &mocks.ExtraDataCodec{}
+	mockExtraDataCodec.On("DecodeTokenAmountDestExecData", mock.Anything, mock.Anything).Return(map[string]any{
+		"destGasAmount": uint32(10),
+	}, nil)
+	mockExtraDataCodec.On("DecodeExtraArgs", mock.Anything, mock.Anything).Return(map[string]any{
+		"ComputeUnits":            uint32(1000),
+		"AccountIsWritableBitmap": uint64(10),
+		"Accounts": [][32]byte{
+			[32]byte(config.CcipLogicReceiver.Bytes()),
+			[32]byte(config.ReceiverTargetAccountPDA.Bytes()),
+			[32]byte(solana.SystemProgramID.Bytes()),
+		},
+	}, nil)
+	msgHasher := NewMessageHasherV1(logger.Test(t), mockExtraDataCodec)
+	_, err := msgHasher.Hash(testutils.Context(t), any2AnyMsg)
+	require.Error(t, err)
+}
+
+func TestMessageHasher_InvalidDestinationTokenAddress(t *testing.T) {
+	any2AnyMsg, _, _ := createAny2SolanaMessages(t)
+
+	// Set DestTokenAddress to a []byte of 2 length
+	any2AnyMsg.TokenAmounts[0].DestTokenAddress = []byte{0, 0}
+	mockExtraDataCodec := &mocks.ExtraDataCodec{}
+	mockExtraDataCodec.On("DecodeTokenAmountDestExecData", mock.Anything, mock.Anything).Return(map[string]any{
+		"destGasAmount": uint32(10),
+	}, nil)
+	mockExtraDataCodec.On("DecodeExtraArgs", mock.Anything, mock.Anything).Return(map[string]any{
+		"ComputeUnits":            uint32(1000),
+		"AccountIsWritableBitmap": uint64(10),
+		"Accounts": [][32]byte{
+			[32]byte(config.CcipLogicReceiver.Bytes()),
+			[32]byte(config.ReceiverTargetAccountPDA.Bytes()),
+			[32]byte(solana.SystemProgramID.Bytes()),
+		},
+	}, nil)
+	msgHasher := NewMessageHasherV1(logger.Test(t), mockExtraDataCodec)
+	_, err := msgHasher.Hash(testutils.Context(t), any2AnyMsg)
+	require.Error(t, err)
 }
 
 func createAny2SolanaMessages(t *testing.T) (cciptypes.Message, ccip_offramp.Any2SVMRampMessage, []solana.PublicKey) {

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -38,6 +38,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/chainwriter"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
+
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	evmconfig "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/configs/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ocrimpls"
@@ -599,8 +600,11 @@ func createChainWriter(
 	switch chainFamily {
 	case relay.NetworkSolana:
 		var solConfig chainwriter.ChainWriterConfig
+		if solana.PublicKeyLength != len(offrampProgramAddress) {
+			return nil, fmt.Errorf("invalid DestTokenAddress length: %d", len(offrampProgramAddress))
+		}
 		offrampAddress := solana.PublicKeyFromBytes(offrampProgramAddress)
-		if solConfig, err = solanaconfig.GetSolanaChainWriterConfig(offrampAddress.String(), transmitter[0], destChainSelector); err == nil {
+		if solConfig, err = solanaconfig.GetSolanaChainWriterConfig(offrampAddress.String(), transmitter[0], destChainSelector); err != nil {
 			return nil, fmt.Errorf("failed to get Solana chain writer config: %w", err)
 		}
 		if chainWriterConfig, err = json.Marshal(solConfig); err != nil {

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -601,7 +601,7 @@ func createChainWriter(
 	case relay.NetworkSolana:
 		var solConfig chainwriter.ChainWriterConfig
 		if solana.PublicKeyLength != len(offrampProgramAddress) {
-			return nil, fmt.Errorf("invalid DestTokenAddress length: %d", len(offrampProgramAddress))
+			return nil, fmt.Errorf("invalid offrampProgramAddress length: %d", len(offrampProgramAddress))
 		}
 		offrampAddress := solana.PublicKeyFromBytes(offrampProgramAddress)
 		if solConfig, err = solanaconfig.GetSolanaChainWriterConfig(offrampAddress.String(), transmitter[0], destChainSelector); err != nil {


### PR DESCRIPTION
- All instances of solana.PublicKeyFromBytes() should first validate if the bytes are of valid length for Solana
- CommitPlugin codec's decode() should handle the merkleRoot being nil

