### PR TITLE
address decoding big number

### DIFF
--- a/core/capabilities/ccip/ccipsolana/commitcodec.go
+++ b/core/capabilities/ccip/ccipsolana/commitcodec.go
@@ -190,7 +190,7 @@ func decodeLEToBigInt(data []byte) cciptypes.BigInt {
 
 	// Use big.Int.SetBytes to construct the big.Int
 	bi := new(big.Int).SetBytes(data)
-	if bi.Int64() == 0 {
+	if bi.Cmp(big.NewInt(0)) == 0 {
 		return cciptypes.NewBigInt(big.NewInt(0))
 	}
 


### PR DESCRIPTION
Audit feedback. Should not convert [big.Int](http://big.int/) to int64 to avoid intended 0 price value.