### PR TITLE
fix: full clone on goreleaser 'nightly' releases

### DIFF
--- a/.github/workflows/build-publish-develop-pr.yml
+++ b/.github/workflows/build-publish-develop-pr.yml
@@ -98,7 +98,8 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ env.CHECKOUT_REF }}
-          fetch-depth: 1
+          # nightly builds require a full clone for goreleaser to work
+          fetch-depth: ${{ needs.image-tag.outputs.release-type == 'nightly' && '0' || '1' }}
 
       - name: Setup Github Token
         id: token


### PR DESCRIPTION
### Changes

- Fix goreleaser by performing a full clone during 'nightly' release
  - broken by me in #16592
- PRs by default are a 'snapshot' release which do not need tags
