### PR TITLE
fix: update deprecated fields for goreleaser configs

### DIFF
--- a/.goreleaser.develop.yaml
+++ b/.goreleaser.develop.yaml
@@ -29,7 +29,7 @@ builds:
       - -trimpath
       - -buildmode=pie
 archives:
-  - format: binary
+  - formats: binary
 snapshot:
   version_template: "{{ .Env.VERSION }}-{{ .ShortCommit }}"
 checksum:

--- a/.goreleaser.devspace.yaml
+++ b/.goreleaser.devspace.yaml
@@ -28,7 +28,7 @@ builds:
       - -trimpath
       - -buildmode=pie
 archives:
-  - format: binary
+  - formats: binary
 snapshot:
   version_template: v0.0.0-{{ .Runtime.Goarch }}-{{ .Now.Format "2006-01-02-15-04-05Z" }}
 checksum:

--- a/.goreleaser.production.yaml
+++ b/.goreleaser.production.yaml
@@ -29,7 +29,7 @@ builds:
       - -trimpath
       - -buildmode=pie
 archives:
-  - format: tar.gz
+  - formats: tar.gz
 snapshot:
   version_template: "{{ .Env.VERSION }}-{{ .ShortCommit }}"
 checksum:


### PR DESCRIPTION
### Changes

- Updates archive.format to archive.formats.


### Motivation

Fixes goreleaser logs like:
```
    • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```