### PR TITLE
Add more granularity (boundaries) to workflow completed histogram

### DIFF
--- a/.changeset/stale-birds-tan.md
+++ b/.changeset/stale-birds-tan.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#changed: Add more granularity for workflow completed histogram metric around expected values

--- a/core/services/workflows/monitoring.go
+++ b/core/services/workflows/monitoring.go
@@ -162,7 +162,8 @@ func MetricViews() []sdkmetric.View {
 		sdkmetric.NewView(
 			sdkmetric.Instrument{Name: "platform_engine_workflow_completed_time_seconds"},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: []float64{0, 10, 30, 60, 120, 300, 600, 900, 1200},
+				// increased granularity for the workflow execution latencies near expected values
+				Boundaries: []float64{0, 10, 20, 40, 50, 70, 90, 120, 150, 180, 210, 300, 600, 900, 1200},
 			}},
 		),
 		sdkmetric.NewView(


### PR DESCRIPTION
[CRE-320](https://smartcontract-it.atlassian.net/browse/CRE-320)

This update reduces the bucket sizing around the observed values for successfully finished workflows to provide more granular metrics. 

[CRE-320]: https://smartcontract-it.atlassian.net/browse/CRE-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ