### PR TITLE
feat(deployment): changesets to transfer Solana contracts to timelock

### DIFF
--- a/deployment/common/changeset/solana/transfer_ownership.go
+++ b/deployment/common/changeset/solana/transfer_ownership.go
@@ -37,8 +37,17 @@ type OwnableContract struct {
 	Type      deployment.ContractType
 }
 
-func (c TransferToTimelockSolanaConfig) Validate(env deployment.Environment) error {
-	for chainSelector, contracts := range c.ContractsByChain {
+// TransferToTimelockSolana transfers a set of Solana "contracts" to the Timelock
+// signer PDA.
+// The "transfer ownership" instructions are immediatelly sent and
+// confirmed onchain. The "accept ownership" instructions are added to an MCMS
+// timelock proposal that should be executed using the standard MCMS workflows.
+type TransferToTimelockSolana struct{}
+
+func (t *TransferToTimelockSolana) VerifyPreconditions(
+	env deployment.Environment, config TransferToTimelockSolanaConfig,
+) error {
+	for chainSelector, contracts := range config.ContractsByChain {
 		err := addressBookContains(env.ExistingAddresses, chainSelector,
 			commontypes.RBACTimelockProgram,
 			commontypes.RBACTimelock,
@@ -88,16 +97,9 @@ func (c TransferToTimelockSolanaConfig) Validate(env deployment.Environment) err
 	return nil
 }
 
-// TransferToTimelockSolana transfers a set of Solana "contracts" to the Timelock
-// signer PDA
-func TransferToTimelockSolana(
+func (t *TransferToTimelockSolana) Apply(
 	env deployment.Environment, cfg TransferToTimelockSolanaConfig,
 ) (deployment.ChangesetOutput, error) {
-	err := cfg.Validate(env)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("invalid transfer ownership config: %w", err)
-	}
-
 	mcmsState, err := state.MaybeLoadMCMSWithTimelockStateSolana(env, slices.Collect(maps.Keys(env.SolChains)))
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
@@ -180,8 +182,16 @@ type TransferMCMSToTimelockSolanaConfig struct {
 	MinDelay time.Duration
 }
 
-func (c *TransferMCMSToTimelockSolanaConfig) Validate(env deployment.Environment) error {
-	for _, chainSelector := range c.Chains {
+// TransferMCMSToTimelockSolana transfers set MCMS "contracts" to the timelock
+// signer PDA. It relies on the TransferToTimelockSolana changeset and merely
+// adds the MCM, Timelock and AccessController contracts found in the address
+// book to the list of contracts to transfer.
+type TransferMCMSToTimelockSolana struct{}
+
+func (t *TransferMCMSToTimelockSolana) VerifyPreconditions(
+	env deployment.Environment, config TransferMCMSToTimelockSolanaConfig,
+) error {
+	for _, chainSelector := range config.Chains {
 		err := addressBookContains(env.ExistingAddresses, chainSelector,
 			commontypes.RBACTimelockProgram,
 			commontypes.RBACTimelock,
@@ -195,14 +205,9 @@ func (c *TransferMCMSToTimelockSolanaConfig) Validate(env deployment.Environment
 	return nil
 }
 
-func TransferMCMSToTimelockSolana(
+func (t *TransferMCMSToTimelockSolana) Apply(
 	env deployment.Environment, cfg TransferMCMSToTimelockSolanaConfig,
 ) (deployment.ChangesetOutput, error) {
-	err := cfg.Validate(env)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("invalid transfer ownership config: %w", err)
-	}
-
 	mcmsState, err := state.MaybeLoadMCMSWithTimelockStateSolana(env, cfg.Chains)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load mcms state: %w", err)
@@ -254,7 +259,7 @@ func TransferMCMSToTimelockSolana(
 		contracts[chainSelector] = chainContracts
 	}
 
-	return TransferToTimelockSolana(env, TransferToTimelockSolanaConfig{
+	return new(TransferToTimelockSolana).Apply(env, TransferToTimelockSolanaConfig{
 		ContractsByChain: contracts,
 		MinDelay:         cfg.MinDelay,
 	})

--- a/deployment/common/changeset/solana/transfer_ownership.go
+++ b/deployment/common/changeset/solana/transfer_ownership.go
@@ -39,7 +39,7 @@ type OwnableContract struct {
 
 // TransferToTimelockSolana transfers a set of Solana "contracts" to the Timelock
 // signer PDA.
-// The "transfer ownership" instructions are immediatelly sent and
+// The "transfer ownership" instructions are immediately sent and
 // confirmed onchain. The "accept ownership" instructions are added to an MCMS
 // timelock proposal that should be executed using the standard MCMS workflows.
 type TransferToTimelockSolana struct{}
@@ -233,6 +233,12 @@ func (t *TransferMCMSToTimelockSolana) Apply(
 				Seed:      chainState.BypasserMcmSeed,
 				OwnerPDA:  state.GetMCMConfigPDA(chainState.McmProgram, chainState.BypasserMcmSeed),
 				Type:      commontypes.BypasserManyChainMultisig,
+			},
+			{
+				ProgramID: chainState.TimelockProgram,
+				Seed:      chainState.TimelockSeed,
+				OwnerPDA:  state.GetTimelockConfigPDA(chainState.TimelockProgram, chainState.TimelockSeed),
+				Type:      commontypes.RBACTimelock,
 			},
 			{
 				ProgramID: chainState.AccessControllerProgram,

--- a/deployment/common/changeset/solana/transfer_ownership.go
+++ b/deployment/common/changeset/solana/transfer_ownership.go
@@ -1,0 +1,353 @@
+package solana
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/mr-tron/base58"
+	mcms "github.com/smartcontractkit/mcms"
+	mcmssdk "github.com/smartcontractkit/mcms/sdk"
+	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	accessControllerBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/access_controller"
+	mcmBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	state "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+)
+
+const maxAcceptInstructionsPerBatch = 5
+
+// TransferToTimelockSolanaConfig holds the configuration for an ownership transfer changeset
+type TransferToTimelockSolanaConfig struct {
+	ContractsByChain map[uint64][]OwnableContract
+	MinDelay         time.Duration
+}
+
+type OwnableContract struct {
+	ProgramID solana.PublicKey
+	Seed      [32]byte
+	OwnerPDA  solana.PublicKey
+	Type      deployment.ContractType
+}
+
+func (c TransferToTimelockSolanaConfig) Validate(env deployment.Environment) error {
+	for chainSelector, contracts := range c.ContractsByChain {
+		err := addressBookContains(env.ExistingAddresses, chainSelector,
+			commontypes.RBACTimelockProgram,
+			commontypes.RBACTimelock,
+			commontypes.ManyChainMultisigProgram,
+			commontypes.ProposerManyChainMultisig,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, contract := range contracts {
+			exists, err := deployment.AddressBookContains(env.ExistingAddresses, chainSelector, contract.ProgramID.String())
+			if err != nil {
+				return fmt.Errorf("failed to search address book for program id: %w", err)
+			}
+			if !exists {
+				return fmt.Errorf("program id %s not found in address book", contract.ProgramID.String())
+			}
+
+			if (contract.Seed == state.PDASeed{}) {
+				continue
+			}
+
+			exists, err = deployment.AddressBookContains(env.ExistingAddresses, chainSelector, base58.Encode(contract.Seed[:]))
+			if err != nil {
+				return fmt.Errorf("failed to search address book for seed (%s): %w", base58.Encode(contract.Seed[:]), err)
+			}
+			if !exists {
+				address := solanaAddress(contract.ProgramID, contract.Seed)
+				exists, err = deployment.AddressBookContains(env.ExistingAddresses, chainSelector, address)
+				if err != nil {
+					return fmt.Errorf("failed to search address book for seed (%s): %w", address, err)
+				}
+			}
+			if !exists {
+				exists, err = deployment.AddressBookContains(env.ExistingAddresses, chainSelector, string(contract.Seed[:]))
+				if err != nil {
+					return fmt.Errorf("failed to search address book for seed (%s): %w", string(contract.Seed[:]), err)
+				}
+			}
+			if !exists {
+				return fmt.Errorf("seed %s not found in address book", base58.Encode(contract.Seed[:]))
+			}
+		}
+	}
+
+	return nil
+}
+
+// TransferToTimelockSolana transfers a set of Solana "contracts" to the Timelock
+// signer PDA
+func TransferToTimelockSolana(
+	env deployment.Environment, cfg TransferToTimelockSolanaConfig,
+) (deployment.ChangesetOutput, error) {
+	err := cfg.Validate(env)
+	if err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("invalid transfer ownership config: %w", err)
+	}
+
+	mcmsState, err := state.MaybeLoadMCMSWithTimelockStateSolana(env, slices.Collect(maps.Keys(env.SolChains)))
+	if err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	batches := []mcmstypes.BatchOperation{}
+	timelocks := map[uint64]string{}
+	proposers := map[uint64]string{}
+	inspectors := map[uint64]mcmssdk.Inspector{}
+	instructions := map[uint64][]solana.Instruction{}
+
+	for chainSelector, contractsToTransfer := range cfg.ContractsByChain {
+		solChain, ok := env.SolChains[chainSelector]
+		if !ok {
+			return deployment.ChangesetOutput{}, fmt.Errorf("solana chain not found in environment (selector: %v)", chainSelector)
+		}
+		chainState, ok := mcmsState[chainSelector]
+		if !ok {
+			return deployment.ChangesetOutput{}, fmt.Errorf("chain state not found for selector: %v", chainSelector)
+		}
+		timelocks[chainSelector] = solanaAddress(chainState.TimelockProgram, mcmssolanasdk.PDASeed(chainState.TimelockSeed))
+		proposers[chainSelector] = solanaAddress(chainState.McmProgram, mcmssolanasdk.PDASeed(chainState.ProposerMcmSeed))
+		inspectors[chainSelector] = mcmssolanasdk.NewInspector(solChain.Client)
+
+		timelockSignerPDA := state.GetTimelockSignerPDA(chainState.TimelockProgram, chainState.TimelockSeed)
+
+		transactions := []mcmstypes.Transaction{}
+		for _, contract := range contractsToTransfer {
+			transferInstruction, err := transferOwnershipInstruction(contract.ProgramID, contract.Seed, timelockSignerPDA,
+				contract.OwnerPDA, solChain.DeployerKey.PublicKey())
+			if err != nil {
+				return deployment.ChangesetOutput{}, fmt.Errorf("failed to create transfer ownership instruction: %w", err)
+			}
+			instructions[chainSelector] = append(instructions[chainSelector], transferInstruction)
+
+			acceptMCMSTransaction, err := acceptMCMSTransaction(contract, timelockSignerPDA)
+			if err != nil {
+				return deployment.ChangesetOutput{}, fmt.Errorf("failed to create accept ownership mcms transaction: %w", err)
+			}
+			transactions = append(transactions, acceptMCMSTransaction)
+		}
+
+		// FIXME: remove the chunking logic once we have custom CU limit support in MCMS
+		for chunk := range slices.Chunk(transactions, maxAcceptInstructionsPerBatch) {
+			batches = append(batches, mcmstypes.BatchOperation{
+				ChainSelector: mcmstypes.ChainSelector(chainSelector),
+				Transactions:  chunk,
+			})
+			env.Logger.Debugw("added BatchOperation with accept ownwership instructions",
+				"# transactions", len(transactions), "chain", chainSelector)
+		}
+	}
+
+	// send & confim TransferOwnership instructions
+	for chainSelector, chainInstructions := range instructions {
+		solChain := env.SolChains[chainSelector]
+		// REVIEW: are we limited by the 1232 byte limit? or can we confirm all instructions in one go?
+		for _, instruction := range chainInstructions {
+			env.Logger.Debugw("confirming solana transfer ownership instruction", "instruction", instruction.ProgramID())
+			err = solChain.Confirm([]solana.Instruction{instruction})
+			if err != nil {
+				return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm instruction: %w", err)
+			}
+		}
+	}
+
+	// create timelock proposal with accept transactions
+	proposal, err := proposalutils.BuildProposalFromBatchesV2(env, timelocks, proposers, inspectors,
+		batches, "proposal to transfer ownership of contracts to timelock", cfg.MinDelay)
+	if err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
+	}
+	env.Logger.Debugw("created timelock proposal", "# batches", len(batches))
+
+	return deployment.ChangesetOutput{MCMSTimelockProposals: []mcms.TimelockProposal{*proposal}}, nil
+}
+
+type TransferMCMSToTimelockSolanaConfig struct {
+	Chains   []uint64
+	MinDelay time.Duration
+}
+
+func (c *TransferMCMSToTimelockSolanaConfig) Validate(env deployment.Environment) error {
+	for _, chainSelector := range c.Chains {
+		err := addressBookContains(env.ExistingAddresses, chainSelector,
+			commontypes.RBACTimelockProgram,
+			commontypes.RBACTimelock,
+			commontypes.ManyChainMultisigProgram,
+			commontypes.ProposerManyChainMultisig,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TransferMCMSToTimelockSolana(
+	env deployment.Environment, cfg TransferMCMSToTimelockSolanaConfig,
+) (deployment.ChangesetOutput, error) {
+	err := cfg.Validate(env)
+	if err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("invalid transfer ownership config: %w", err)
+	}
+
+	mcmsState, err := state.MaybeLoadMCMSWithTimelockStateSolana(env, cfg.Chains)
+	if err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load mcms state: %w", err)
+	}
+
+	contracts := map[uint64][]OwnableContract{}
+	for chainSelector, chainState := range mcmsState {
+		chainContracts := []OwnableContract{
+			{
+				ProgramID: chainState.McmProgram,
+				Seed:      chainState.ProposerMcmSeed,
+				OwnerPDA:  state.GetMCMConfigPDA(chainState.McmProgram, chainState.ProposerMcmSeed),
+				Type:      commontypes.ProposerManyChainMultisig,
+			},
+			{
+				ProgramID: chainState.McmProgram,
+				Seed:      chainState.CancellerMcmSeed,
+				OwnerPDA:  state.GetMCMConfigPDA(chainState.McmProgram, chainState.CancellerMcmSeed),
+				Type:      commontypes.CancellerManyChainMultisig,
+			},
+			{
+				ProgramID: chainState.McmProgram,
+				Seed:      chainState.BypasserMcmSeed,
+				OwnerPDA:  state.GetMCMConfigPDA(chainState.McmProgram, chainState.BypasserMcmSeed),
+				Type:      commontypes.BypasserManyChainMultisig,
+			},
+			{
+				ProgramID: chainState.AccessControllerProgram,
+				OwnerPDA:  chainState.ProposerAccessControllerAccount,
+				Type:      commontypes.ProposerAccessControllerAccount,
+			},
+			{
+				ProgramID: chainState.AccessControllerProgram,
+				OwnerPDA:  chainState.ExecutorAccessControllerAccount,
+				Type:      commontypes.ExecutorAccessControllerAccount,
+			},
+			{
+				ProgramID: chainState.AccessControllerProgram,
+				OwnerPDA:  chainState.CancellerAccessControllerAccount,
+				Type:      commontypes.CancellerAccessControllerAccount,
+			},
+			{
+				ProgramID: chainState.AccessControllerProgram,
+				OwnerPDA:  chainState.BypasserAccessControllerAccount,
+				Type:      commontypes.BypasserAccessControllerAccount,
+			},
+		}
+
+		contracts[chainSelector] = chainContracts
+	}
+
+	return TransferToTimelockSolana(env, TransferToTimelockSolanaConfig{
+		ContractsByChain: contracts,
+		MinDelay:         cfg.MinDelay,
+	})
+}
+
+func transferOwnershipInstruction(
+	programID solana.PublicKey, seed state.PDASeed, proposedOwner, ownerPDA, auth solana.PublicKey,
+) (solana.Instruction, error) {
+	if (seed == state.PDASeed{}) {
+		return newSeedlessTransferOwnershipInstruction(programID, proposedOwner, ownerPDA, auth)
+	}
+	return newSeededTransferOwnershipInstruction(programID, seed, proposedOwner, ownerPDA, auth)
+}
+
+func acceptMCMSTransaction(
+	contract OwnableContract,
+	authority solana.PublicKey,
+) (mcmstypes.Transaction, error) {
+	acceptInstruction, err := acceptOwnershipInstruction(contract.ProgramID, contract.Seed, contract.OwnerPDA, authority)
+	if err != nil {
+		return mcmstypes.Transaction{}, fmt.Errorf("failed to build accept ownership instruction: %w", err)
+	}
+	acceptMCMSTx, err := mcmssolanasdk.NewTransactionFromInstruction(acceptInstruction, string(contract.Type), []string{})
+	if err != nil {
+		return mcmstypes.Transaction{}, fmt.Errorf("failed to build mcms transaction from accept ownership instruction: %w", err)
+	}
+
+	return acceptMCMSTx, nil
+}
+
+func acceptOwnershipInstruction(
+	programID solana.PublicKey, seed state.PDASeed, ownerPDA, auth solana.PublicKey,
+) (solana.Instruction, error) {
+	if (seed == state.PDASeed{}) {
+		return newSeedlessAcceptOwnershipInstruction(programID, ownerPDA, auth)
+	}
+	return newSeededAcceptOwnershipInstruction(programID, seed, ownerPDA, auth)
+}
+
+func newSeededTransferOwnershipInstruction(
+	programID solana.PublicKey, seed state.PDASeed, proposedOwner, config, authority solana.PublicKey,
+) (solana.Instruction, error) {
+	ix, err := mcmBindings.NewTransferOwnershipInstruction(seed, proposedOwner, config, authority).ValidateAndBuild()
+	return &seededInstruction{ix, programID}, err
+}
+
+func newSeededAcceptOwnershipInstruction(
+	programID solana.PublicKey, seed state.PDASeed, config, authority solana.PublicKey,
+) (solana.Instruction, error) {
+	ix, err := mcmBindings.NewAcceptOwnershipInstruction(seed, config, authority).ValidateAndBuild()
+	return &seededInstruction{ix, programID}, err
+}
+
+func newSeedlessTransferOwnershipInstruction(
+	programID, proposedOwner, config, authority solana.PublicKey,
+) (solana.Instruction, error) {
+	ix, err := accessControllerBindings.NewTransferOwnershipInstruction(proposedOwner, config, authority).ValidateAndBuild()
+	return &seedlessInstruction{ix, programID}, err
+}
+
+func newSeedlessAcceptOwnershipInstruction(
+	programID, config, authority solana.PublicKey,
+) (solana.Instruction, error) {
+	ix, err := accessControllerBindings.NewAcceptOwnershipInstruction(config, authority).ValidateAndBuild()
+	return &seedlessInstruction{ix, programID}, err
+}
+
+type seedlessInstruction struct {
+	*accessControllerBindings.Instruction
+	programID solana.PublicKey
+}
+
+func (s *seedlessInstruction) ProgramID() solana.PublicKey {
+	return s.programID
+}
+
+type seededInstruction struct {
+	*mcmBindings.Instruction
+	programID solana.PublicKey
+}
+
+func (s *seededInstruction) ProgramID() solana.PublicKey {
+	return s.programID
+}
+
+func addressBookContains(addressBook deployment.AddressBook, chainSelector uint64, ctypes ...deployment.ContractType) error {
+	for _, ctype := range ctypes {
+		_, err := deployment.SearchAddressBook(addressBook, chainSelector, ctype)
+		if err != nil {
+			return fmt.Errorf("address book does not contain a %s contract for chain %d", ctype, chainSelector)
+		}
+	}
+	return nil
+}
+
+var solanaAddress = mcmssolanasdk.ContractAddress

--- a/deployment/common/changeset/solana/transfer_ownership_test.go
+++ b/deployment/common/changeset/solana/transfer_ownership_test.go
@@ -1,0 +1,116 @@
+package solana_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	accessControllerBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/access_controller"
+	mcmBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	internalsolana "github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/solana"
+	solanachangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestTransferToMCMSToTimelockSolana(t *testing.T) {
+	// --- arrange ---
+	log := logger.TestLogger(t)
+	envConfig := memory.MemoryEnvironmentConfig{Chains: 0, SolChains: 1}
+	env := memory.NewMemoryEnvironment(t, log, zapcore.InfoLevel, envConfig)
+	solanaSelector := env.AllChainSelectorsSolana()[0]
+
+	commonchangeset.SetPreloadedSolanaAddresses(t, env, solanaSelector)
+	chainState := deployMCMS(t, env, solanaSelector)
+	fundSignerPDAs(t, env, solanaSelector, chainState)
+
+	configuredChangeset := commonchangeset.Configure(
+		deployment.CreateLegacyChangeSet(solanachangesets.TransferMCMSToTimelockSolana),
+		solanachangesets.TransferMCMSToTimelockSolanaConfig{
+			Chains:   []uint64{solanaSelector},
+			MinDelay: 1 * time.Second,
+		},
+	)
+	// validate initial owner
+	assertOwner(t, env, solanaSelector, chainState, env.SolChains[solanaSelector].DeployerKey.PublicKey())
+
+	// --- act ---
+	_, err := commonchangeset.ApplyChangesetsV2(t, env, []commonchangeset.ConfiguredChangeSet{configuredChangeset})
+	require.NoError(t, err)
+
+	// --- assert ---
+	assertOwner(t, env, solanaSelector, chainState, state.GetTimelockSignerPDA(chainState.TimelockProgram, chainState.TimelockSeed))
+}
+
+func deployMCMS(t *testing.T, env deployment.Environment, selector uint64) *state.MCMSWithTimelockStateSolana {
+	t.Helper()
+
+	solanaChain := env.SolChains[selector]
+	addressBook := deployment.NewMemoryAddressBook()
+	mcmsConfig := commontypes.MCMSWithTimelockConfigV2{
+		Canceller:        proposalutils.SingleGroupMCMSV2(t),
+		Bypasser:         proposalutils.SingleGroupMCMSV2(t),
+		Proposer:         proposalutils.SingleGroupMCMSV2(t),
+		TimelockMinDelay: big.NewInt(1),
+	}
+
+	chainState, err := internalsolana.DeployMCMSWithTimelockProgramsSolana(env, solanaChain, addressBook, mcmsConfig)
+	require.NoError(t, err)
+	err = env.ExistingAddresses.Merge(addressBook)
+	require.NoError(t, err)
+
+	return chainState
+}
+
+func assertOwner(
+	t *testing.T, env deployment.Environment, selector uint64, chainState *state.MCMSWithTimelockStateSolana, owner solana.PublicKey,
+) {
+	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.ProposerMcmSeed), env, selector)
+	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.CancellerMcmSeed), env, selector)
+	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.BypasserMcmSeed), env, selector)
+	assertAccessControllerOwner(t, owner, chainState.ProposerAccessControllerAccount, env, selector)
+	assertAccessControllerOwner(t, owner, chainState.ExecutorAccessControllerAccount, env, selector)
+	assertAccessControllerOwner(t, owner, chainState.CancellerAccessControllerAccount, env, selector)
+	assertAccessControllerOwner(t, owner, chainState.BypasserAccessControllerAccount, env, selector)
+}
+
+func assertMCMOwner(
+	t *testing.T, want solana.PublicKey, configPDA solana.PublicKey, env deployment.Environment, selector uint64,
+) {
+	t.Helper()
+	var config mcmBindings.MultisigConfig
+	err := env.SolChains[selector].GetAccountDataBorshInto(env.GetContext(), configPDA, &config)
+	require.NoError(t, err)
+	require.Equal(t, want, config.Owner)
+}
+
+func assertAccessControllerOwner(
+	t *testing.T, want solana.PublicKey, account solana.PublicKey, env deployment.Environment, selector uint64,
+) {
+	t.Helper()
+	var config accessControllerBindings.AccessController
+	err := env.SolChains[selector].GetAccountDataBorshInto(env.GetContext(), account, &config)
+	require.NoError(t, err)
+	require.Equal(t, want, config.Owner)
+}
+
+func fundSignerPDAs(
+	t *testing.T, env deployment.Environment, chainSelector uint64, chainState *state.MCMSWithTimelockStateSolana,
+) {
+	t.Helper()
+	solChain := env.SolChains[chainSelector]
+	timelockSignerPDA := state.GetTimelockSignerPDA(chainState.TimelockProgram, chainState.TimelockSeed)
+	mcmSignerPDA := state.GetMCMSignerPDA(chainState.McmProgram, chainState.ProposerMcmSeed)
+	signerPDAs := []solana.PublicKey{timelockSignerPDA, mcmSignerPDA}
+	memory.FundSolanaAccounts(env.GetContext(), t, signerPDAs, 1, solChain.Client)
+}

--- a/deployment/common/changeset/solana/transfer_ownership_test.go
+++ b/deployment/common/changeset/solana/transfer_ownership_test.go
@@ -35,7 +35,7 @@ func TestTransferToMCMSToTimelockSolana(t *testing.T) {
 	fundSignerPDAs(t, env, solanaSelector, chainState)
 
 	configuredChangeset := commonchangeset.Configure(
-		deployment.CreateLegacyChangeSet(solanachangesets.TransferMCMSToTimelockSolana),
+		&solanachangesets.TransferMCMSToTimelockSolana{},
 		solanachangesets.TransferMCMSToTimelockSolanaConfig{
 			Chains:   []uint64{solanaSelector},
 			MinDelay: 1 * time.Second,

--- a/deployment/common/changeset/solana/transfer_ownership_test.go
+++ b/deployment/common/changeset/solana/transfer_ownership_test.go
@@ -11,6 +11,7 @@ import (
 
 	accessControllerBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/access_controller"
 	mcmBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
+	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -42,14 +43,16 @@ func TestTransferToMCMSToTimelockSolana(t *testing.T) {
 		},
 	)
 	// validate initial owner
-	assertOwner(t, env, solanaSelector, chainState, env.SolChains[solanaSelector].DeployerKey.PublicKey())
+	deployer := env.SolChains[solanaSelector].DeployerKey.PublicKey()
+	assertOwner(t, env, solanaSelector, chainState, deployer)
 
 	// --- act ---
 	_, err := commonchangeset.ApplyChangesetsV2(t, env, []commonchangeset.ConfiguredChangeSet{configuredChangeset})
 	require.NoError(t, err)
 
 	// --- assert ---
-	assertOwner(t, env, solanaSelector, chainState, state.GetTimelockSignerPDA(chainState.TimelockProgram, chainState.TimelockSeed))
+	timelockSignerPDA := state.GetTimelockSignerPDA(chainState.TimelockProgram, chainState.TimelockSeed)
+	assertOwner(t, env, solanaSelector, chainState, timelockSignerPDA)
 }
 
 func deployMCMS(t *testing.T, env deployment.Environment, selector uint64) *state.MCMSWithTimelockStateSolana {
@@ -78,6 +81,7 @@ func assertOwner(
 	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.ProposerMcmSeed), env, selector)
 	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.CancellerMcmSeed), env, selector)
 	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.BypasserMcmSeed), env, selector)
+	assertTimelockOwner(t, owner, state.GetTimelockConfigPDA(chainState.TimelockProgram, chainState.TimelockSeed), env, selector)
 	assertAccessControllerOwner(t, owner, chainState.ProposerAccessControllerAccount, env, selector)
 	assertAccessControllerOwner(t, owner, chainState.ExecutorAccessControllerAccount, env, selector)
 	assertAccessControllerOwner(t, owner, chainState.CancellerAccessControllerAccount, env, selector)
@@ -89,6 +93,16 @@ func assertMCMOwner(
 ) {
 	t.Helper()
 	var config mcmBindings.MultisigConfig
+	err := env.SolChains[selector].GetAccountDataBorshInto(env.GetContext(), configPDA, &config)
+	require.NoError(t, err)
+	require.Equal(t, want, config.Owner)
+}
+
+func assertTimelockOwner(
+	t *testing.T, want solana.PublicKey, configPDA solana.PublicKey, env deployment.Environment, selector uint64,
+) {
+	t.Helper()
+	var config timelockBindings.Config
 	err := env.SolChains[selector].GetAccountDataBorshInto(env.GetContext(), configPDA, &config)
 	require.NoError(t, err)
 	require.Equal(t, want, config.Owner)


### PR DESCRIPTION
This PR adds two changesets:

* `TransferToTimelockSolana`: transfers a set of arbitrary contracts to the MCMS timelock

* `TransferMCMSToTimelockSolana`: builds upon the previous one, and transfers the contracts that compose MCMS itself (the proposer, canceller and bypasser mcms, the timelock and the access controllers)

To transfer arbitrary solana contracts using the same instructions, we assume that all TransferOwnership and AcceptOwnership instructions will conform to either of the following signatures:
```
// (contracts that require a "seed" to identify PDAs)
TransferOwnerhip(seed, newOwner, ownerPDA, authority)
AcceptOwnership(seed, ownerPDA, authority)

// (contracts without a "seed")
TransferOwnerhip(newOwner, ownerPDA, authority)
AcceptOwnership(ownerPDA, authority)
```

[DPA-1583](https://smartcontract-it.atlassian.net/browse/DPA-1583)

[DPA-1583]: https://smartcontract-it.atlassian.net/browse/DPA-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ