### PR TITLE
introduce a flag to turn off SSRF protection for local development

### DIFF
--- a/.changeset/gentle-lies-sit.md
+++ b/.changeset/gentle-lies-sit.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#added Introduce DisableSSRFProtection flag for local development

--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -656,6 +656,8 @@ OCRDevelopmentMode = false # Default
 InfiniteDepthQueries = false # Default
 # DisableRateLimiting skips ratelimiting on asset requests.
 DisableRateLimiting = false # Default
+# Disable validation of IPs and URLs of outgoing requests.
+DisableSSRFProtection = false # Default
 
 [Tracing]
 # Enabled turns trace collection on or off. On requires an OTEL Tracing Collector.

--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -656,7 +656,7 @@ OCRDevelopmentMode = false # Default
 InfiniteDepthQueries = false # Default
 # DisableRateLimiting skips ratelimiting on asset requests.
 DisableRateLimiting = false # Default
-# Disable validation of IPs and URLs of outgoing requests.
+# DisableSSRFProtection disables validation of IPs and URLs of outgoing requests.
 DisableSSRFProtection = false # Default
 
 [Tracing]

--- a/core/config/insecure_config.go
+++ b/core/config/insecure_config.go
@@ -4,5 +4,6 @@ type Insecure interface {
 	DevWebServer() bool
 	OCRDevelopmentMode() bool
 	DisableRateLimiting() bool
+	DisableSSRFProtection() bool
 	InfiniteDepthQueries() bool
 }

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -1377,10 +1377,11 @@ func (s *Sentry) setFrom(f *Sentry) {
 }
 
 type Insecure struct {
-	DevWebServer         *bool
-	OCRDevelopmentMode   *bool
-	InfiniteDepthQueries *bool
-	DisableRateLimiting  *bool
+	DevWebServer          *bool
+	OCRDevelopmentMode    *bool
+	InfiniteDepthQueries  *bool
+	DisableRateLimiting   *bool
+	DisableSSRFProtection *bool
 }
 
 func (ins *Insecure) ValidateConfig() (err error) {
@@ -1416,6 +1417,9 @@ func (ins *Insecure) setFrom(f *Insecure) {
 	}
 	if v := f.DisableRateLimiting; v != nil {
 		ins.DisableRateLimiting = f.DisableRateLimiting
+	}
+	if v := f.DisableSSRFProtection; v != nil {
+		ins.DisableSSRFProtection = f.DisableSSRFProtection
 	}
 	if v := f.OCRDevelopmentMode; v != nil {
 		ins.OCRDevelopmentMode = f.OCRDevelopmentMode

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -471,6 +471,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 				legacyEVMChains,
 				keyStore.Eth()),
 			job.Gateway: gateway.NewDelegate(
+				cfg,
 				legacyEVMChains,
 				keyStore.Eth(),
 				opts.DS,

--- a/core/services/chainlink/config_general_dev_test.go
+++ b/core/services/chainlink/config_general_dev_test.go
@@ -23,6 +23,7 @@ func TestTOMLGeneralConfig_DevModeInsecureConfig(t *testing.T) {
 
 		assert.False(t, config.Insecure().DevWebServer())
 		assert.False(t, config.Insecure().DisableRateLimiting())
+		assert.False(t, config.Insecure().DisableSSRFProtection())
 		assert.False(t, config.Insecure().InfiniteDepthQueries())
 		assert.False(t, config.Insecure().OCRDevelopmentMode())
 	})
@@ -32,6 +33,7 @@ func TestTOMLGeneralConfig_DevModeInsecureConfig(t *testing.T) {
 			OverrideFn: func(c *Config, s *Secrets) {
 				*c.Insecure.DevWebServer = true
 				*c.Insecure.DisableRateLimiting = true
+				*c.Insecure.DisableSSRFProtection = true
 				*c.Insecure.InfiniteDepthQueries = true
 				*c.Insecure.OCRDevelopmentMode = true
 			}}.New(logger.TestLogger(t))
@@ -39,6 +41,7 @@ func TestTOMLGeneralConfig_DevModeInsecureConfig(t *testing.T) {
 
 		assert.True(t, config.Insecure().DevWebServer())
 		assert.True(t, config.Insecure().DisableRateLimiting())
+		assert.True(t, config.Insecure().DisableSSRFProtection())
 		assert.True(t, config.Insecure().InfiniteDepthQueries())
 		assert.True(t, config.OCRDevelopmentMode())
 	})

--- a/core/services/chainlink/config_general_test.go
+++ b/core/services/chainlink/config_general_test.go
@@ -42,6 +42,7 @@ func TestTOMLGeneralConfig_InsecureConfig(t *testing.T) {
 
 		assert.False(t, config.Insecure().DevWebServer())
 		assert.False(t, config.Insecure().DisableRateLimiting())
+		assert.False(t, config.Insecure().DisableSSRFProtection())
 		assert.False(t, config.Insecure().InfiniteDepthQueries())
 		assert.False(t, config.Insecure().OCRDevelopmentMode())
 	})
@@ -51,6 +52,7 @@ func TestTOMLGeneralConfig_InsecureConfig(t *testing.T) {
 			OverrideFn: func(c *Config, s *Secrets) {
 				*c.Insecure.DevWebServer = true
 				*c.Insecure.DisableRateLimiting = true
+				*c.Insecure.DisableSSRFProtection = true
 				*c.Insecure.InfiniteDepthQueries = true
 				*c.AuditLogger.Enabled = true
 			}}.New()
@@ -61,6 +63,8 @@ func TestTOMLGeneralConfig_InsecureConfig(t *testing.T) {
 
 		assert.False(t, config.Insecure().DevWebServer())
 		assert.False(t, config.Insecure().DisableRateLimiting())
+		assert.False(t, config.Insecure().DisableSSRFProtection())
+		assert.False(t, config.Insecure().DisableSSRFProtection())
 		assert.False(t, config.Insecure().InfiniteDepthQueries())
 	})
 
@@ -69,6 +73,7 @@ func TestTOMLGeneralConfig_InsecureConfig(t *testing.T) {
 		  [insecure]
 		  DevWebServer = true
 		  DisableRateLimiting = false
+		  DisableSSRFProtection = false
 		  InfiniteDepthQueries = false
 		  OCRDevelopmentMode = false
 		`

--- a/core/services/chainlink/config_insecure.go
+++ b/core/services/chainlink/config_insecure.go
@@ -19,6 +19,11 @@ func (i *insecureConfig) DisableRateLimiting() bool {
 		*i.c.DisableRateLimiting
 }
 
+func (i *insecureConfig) DisableSSRFProtection() bool {
+	return build.IsDev() && i.c.DisableSSRFProtection != nil &&
+		*i.c.DisableSSRFProtection
+}
+
 func (i *insecureConfig) OCRDevelopmentMode() bool {
 	// OCRDevelopmentMode is allowed in TestBuilds as well
 	return (build.IsDev() || build.IsTest()) && i.c.OCRDevelopmentMode != nil &&

--- a/core/services/chainlink/config_insecure_test.go
+++ b/core/services/chainlink/config_insecure_test.go
@@ -17,6 +17,7 @@ func TestInsecureConfig(t *testing.T) {
 	ins := cfg.Insecure()
 	assert.False(t, ins.DevWebServer())
 	assert.False(t, ins.DisableRateLimiting())
+	assert.False(t, ins.DisableSSRFProtection())
 	assert.False(t, ins.OCRDevelopmentMode())
 	assert.False(t, ins.InfiniteDepthQueries())
 }

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -241,10 +241,11 @@ func TestConfig_Marshal(t *testing.T) {
 			RootDir:             ptr("test/root/dir"),
 			ShutdownGracePeriod: commoncfg.MustNewDuration(10 * time.Second),
 			Insecure: toml.Insecure{
-				DevWebServer:         ptr(false),
-				OCRDevelopmentMode:   ptr(false),
-				InfiniteDepthQueries: ptr(false),
-				DisableRateLimiting:  ptr(false),
+				DevWebServer:          ptr(false),
+				OCRDevelopmentMode:    ptr(false),
+				InfiniteDepthQueries:  ptr(false),
+				DisableRateLimiting:   ptr(false),
+				DisableSSRFProtection: ptr(false),
 			},
 			Tracing: toml.Tracing{
 				Enabled:         ptr(true),
@@ -823,6 +824,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = true

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -215,6 +215,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -221,6 +221,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = true

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -215,6 +215,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/core/services/gateway/delegate.go
+++ b/core/services/gateway/delegate.go
@@ -10,24 +10,31 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
+	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
+	gatewayconfig "github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/network"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 )
 
 type Delegate struct {
+	cfg          Config
 	legacyChains legacyevm.LegacyChainContainer
 	ks           keystore.Eth
 	ds           sqlutil.DataSource
 	lggr         logger.Logger
 }
 
+type Config interface {
+	Insecure() config.Insecure
+}
+
 var _ job.Delegate = (*Delegate)(nil)
 
-func NewDelegate(legacyChains legacyevm.LegacyChainContainer, ks keystore.Eth, ds sqlutil.DataSource, lggr logger.Logger) *Delegate {
+func NewDelegate(config Config, legacyChains legacyevm.LegacyChainContainer, ks keystore.Eth, ds sqlutil.DataSource, lggr logger.Logger) *Delegate {
 	return &Delegate{
+		cfg:          config,
 		legacyChains: legacyChains,
 		ks:           ks,
 		ds:           ds,
@@ -50,12 +57,12 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 		return nil, errors.Errorf("services.Delegate expects a *jobSpec.GatewaySpec to be present, got %v", spec)
 	}
 
-	var gatewayConfig config.GatewayConfig
+	var gatewayConfig gatewayconfig.GatewayConfig
 	err2 := json.Unmarshal(spec.GatewaySpec.GatewayConfig.Bytes(), &gatewayConfig)
 	if err2 != nil {
 		return nil, errors.Wrap(err2, "unmarshal gateway config")
 	}
-	httpClient, err := network.NewHTTPClient(gatewayConfig.HTTPClientConfig, d.lggr)
+	httpClient, err := network.NewHTTPClient(gatewayConfig.HTTPClientConfig, d.lggr, d.cfg.Insecure().DisableSSRFProtection())
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/gateway/integration_tests/gateway_integration_test.go
+++ b/core/services/gateway/integration_tests/gateway_integration_test.go
@@ -148,7 +148,7 @@ func TestIntegration_Gateway_NoFullNodes_BasicConnectionAndMessage(t *testing.T)
 	c, err := network.NewHTTPClient(network.HTTPClientConfig{
 		DefaultTimeout:   5 * time.Second,
 		MaxResponseBytes: 1000,
-	}, lggr)
+	}, lggr, false)
 	require.NoError(t, err)
 	gateway, err := gateway.NewGatewayFromConfig(parseGatewayConfig(t, gatewayConfig), gateway.NewHandlerFactory(nil, nil, c, lggr), lggr)
 	require.NoError(t, err)

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -77,29 +77,44 @@ type HTTPResponse struct {
 }
 
 type httpClient struct {
-	client *safeurl.WrappedClient
+	client client
 	config HTTPClientConfig
 	lggr   logger.Logger
 }
 
+type client interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // NewHTTPClient creates a new NewHTTPClient
 // As of now, the client does not support TLS configuration but may be extended in the future
-func NewHTTPClient(config HTTPClientConfig, lggr logger.Logger) (HTTPClient, error) {
+// disableSSRFProtection is a flag to disable SSRF protection for testing purposes and should be set to FALSE for production
+func NewHTTPClient(config HTTPClientConfig, lggr logger.Logger, disableSSRFProtection bool) (HTTPClient, error) {
 	config.ApplyDefaults()
-	safeConfig := safeurl.
-		GetConfigBuilder().
-		SetTimeout(config.DefaultTimeout).
-		SetAllowedIPs(config.AllowedIPs...).
-		SetAllowedPorts(config.AllowedPorts...).
-		SetAllowedSchemes(config.AllowedSchemes...).
-		SetBlockedIPs(config.BlockedIPs...).
-		SetBlockedIPsCIDR(config.BlockedIPsCIDR...).
-		SetCheckRedirect(disableRedirects).
-		Build()
+	var client client
+	if disableSSRFProtection {
+		lggr.Warn("SSRF protection is disabled. Please enable it in production.")
+		client = &http.Client{
+			Timeout:   config.DefaultTimeout,
+			Transport: http.DefaultTransport,
+		}
+	} else {
+		safeConfig := safeurl.
+			GetConfigBuilder().
+			SetTimeout(config.DefaultTimeout).
+			SetAllowedIPs(config.AllowedIPs...).
+			SetAllowedPorts(config.AllowedPorts...).
+			SetAllowedSchemes(config.AllowedSchemes...).
+			SetBlockedIPs(config.BlockedIPs...).
+			SetBlockedIPsCIDR(config.BlockedIPsCIDR...).
+			SetCheckRedirect(disableRedirects).
+			Build()
+		client = safeurl.Client(safeConfig)
+	}
 
 	return &httpClient{
 		config: config,
-		client: safeurl.Client(safeConfig),
+		client: client,
 		lggr:   lggr,
 	}, nil
 }

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -184,7 +184,7 @@ func TestHTTPClient_Send(t *testing.T) {
 				AllowedPorts:     []int{int(portInt)},
 			}
 
-			client, err := NewHTTPClient(config, lggr)
+			client, err := NewHTTPClient(config, lggr, false)
 			require.NoError(t, err)
 
 			tt.request.URL = server.URL + tt.request.URL
@@ -399,7 +399,7 @@ func TestHTTPClient_BlocksUnallowed(t *testing.T) {
 				AllowedPorts:     allowedPorts,
 			}
 
-			client, err := NewHTTPClient(config, lggr)
+			client, err := NewHTTPClient(config, lggr, false)
 			require.NoError(t, err)
 
 			require.NoError(t, err)

--- a/core/web/resolver/testdata/config-empty-effective.toml
+++ b/core/web/resolver/testdata/config-empty-effective.toml
@@ -215,6 +215,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -221,6 +221,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -215,6 +215,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1829,6 +1829,7 @@ DevWebServer = false # Default
 OCRDevelopmentMode = false # Default
 InfiniteDepthQueries = false # Default
 DisableRateLimiting = false # Default
+DisableSSRFProtection = false # Default
 ```
 Insecure config family is only allowed in development builds.
 
@@ -1856,6 +1857,13 @@ InfiniteDepthQueries skips graphql query depth limit checks.
 DisableRateLimiting = false # Default
 ```
 DisableRateLimiting skips ratelimiting on asset requests.
+
+### DisableRateLimiting
+```toml
+DisableSSRFProtection = false # Default
+```
+Disable validation of IPs and URLs of outgoing requests.
+
 
 ## Tracing
 ```toml

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1858,12 +1858,11 @@ DisableRateLimiting = false # Default
 ```
 DisableRateLimiting skips ratelimiting on asset requests.
 
-### DisableRateLimiting
+### DisableSSRFProtection
 ```toml
 DisableSSRFProtection = false # Default
 ```
-Disable validation of IPs and URLs of outgoing requests.
-
+DisableSSRFProtection disables validation of IPs and URLs of outgoing requests.
 
 ## Tracing
 ```toml

--- a/testdata/scripts/config/merge_raw_configs.txtar
+++ b/testdata/scripts/config/merge_raw_configs.txtar
@@ -362,6 +362,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/testdata/scripts/node/validate/default.txtar
+++ b/testdata/scripts/node/validate/default.txtar
@@ -227,6 +227,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -288,6 +288,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -271,6 +271,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -271,6 +271,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -271,6 +271,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/testdata/scripts/node/validate/fallback-override.txtar
+++ b/testdata/scripts/node/validate/fallback-override.txtar
@@ -365,6 +365,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
+++ b/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
@@ -256,6 +256,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -261,6 +261,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -268,6 +268,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = false

--- a/testdata/scripts/node/validate/warnings.txtar
+++ b/testdata/scripts/node/validate/warnings.txtar
@@ -250,6 +250,7 @@ DevWebServer = false
 OCRDevelopmentMode = false
 InfiniteDepthQueries = false
 DisableRateLimiting = false
+DisableSSRFProtection = false
 
 [Tracing]
 Enabled = true


### PR DESCRIPTION
- Introduce a flag to turn off SSRF protection. This helps with local development when the gateway needs to make outgoing calls to localhost servers or docker containers. 
- SSRF protection is enabled by default.