### PR TITLE
Fix/send on closed ch engine

### DIFF
--- a/.changeset/sixty-bobcats-rest.md
+++ b/.changeset/sixty-bobcats-rest.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+fix: resovles panic send: on closed channel in workflow engine #bugfix

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -56,15 +56,9 @@ type stepUpdateManager struct {
 }
 
 func (sucm *stepUpdateManager) add(executionID string, ch stepUpdateChannel) (added bool) {
-	sucm.mu.RLock()
-	_, ok := sucm.m[executionID]
-	sucm.mu.RUnlock()
-	if ok {
-		return false
-	}
 	sucm.mu.Lock()
 	defer sucm.mu.Unlock()
-	if _, ok = sucm.m[executionID]; ok {
+	if _, ok := sucm.m[executionID]; ok {
 		return false
 	}
 	sucm.m[executionID] = ch
@@ -74,29 +68,25 @@ func (sucm *stepUpdateManager) add(executionID string, ch stepUpdateChannel) (ad
 func (sucm *stepUpdateManager) remove(executionID string) {
 	sucm.mu.Lock()
 	defer sucm.mu.Unlock()
-	fmt.Printf("removing %s\n", executionID)
 	if _, ok := sucm.m[executionID]; ok {
 		close(sucm.m[executionID].ch)
 		delete(sucm.m, executionID)
-		fmt.Printf("closed and removed %s\n", executionID)
 	}
 }
 
 func (sucm *stepUpdateManager) send(ctx context.Context, executionID string, stepUpdate store.WorkflowExecutionStep) error {
-	sucm.mu.RLock()
+	sucm.mu.Lock()
+	defer sucm.mu.Unlock()
 	stepUpdateCh, ok := sucm.m[executionID]
-	sucm.mu.RUnlock()
 
 	if !ok {
 		return fmt.Errorf("step update channel not found for execution %s, dropping step update", executionID)
 	}
 
-	fmt.Printf("waiting to write for %s\n", executionID)
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("context canceled before step update could be issued: %w", context.Cause(ctx))
 	case stepUpdateCh.ch <- stepUpdate:
-		fmt.Printf("sent on %s\n", executionID)
 		return nil
 	}
 }

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -74,9 +74,11 @@ func (sucm *stepUpdateManager) add(executionID string, ch stepUpdateChannel) (ad
 func (sucm *stepUpdateManager) remove(executionID string) {
 	sucm.mu.Lock()
 	defer sucm.mu.Unlock()
+	fmt.Printf("removing %s\n", executionID)
 	if _, ok := sucm.m[executionID]; ok {
 		close(sucm.m[executionID].ch)
 		delete(sucm.m, executionID)
+		fmt.Printf("closed and removed %s\n", executionID)
 	}
 }
 
@@ -84,14 +86,17 @@ func (sucm *stepUpdateManager) send(ctx context.Context, executionID string, ste
 	sucm.mu.RLock()
 	stepUpdateCh, ok := sucm.m[executionID]
 	sucm.mu.RUnlock()
+
 	if !ok {
 		return fmt.Errorf("step update channel not found for execution %s, dropping step update", executionID)
 	}
 
+	fmt.Printf("waiting to write for %s\n", executionID)
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("context canceled before step update could be issued: %w", context.Cause(ctx))
 	case stepUpdateCh.ch <- stepUpdate:
+		fmt.Printf("sent on %s\n", executionID)
 		return nil
 	}
 }


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

The workflow engine encountered `panic: send on closed channel`.  This PR resolves the issue by holding the `stepUpdateManager`'s lock for the duration of the `send` call.  Previously, the call only used an `RLock`, which it released after getting the channel pointer.  This could fail in cases where a call to remove the given execution ID from the manager occurs before the write to the channel.  Added a test case that ensures there is no panic on concurrent `send` and `remove` calls.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
