### PR TITLE
CCIP - disable fee boosting for Hedera destinations

### DIFF
--- a/.changeset/eighty-pianos-invite.md
+++ b/.changeset/eighty-pianos-invite.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#changed Disabled fee boosting when destination is Hedera

--- a/core/services/ocr2/plugins/ccip/ccipexec/batching.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/batching.go
@@ -9,6 +9,7 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/hashutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
@@ -49,6 +50,7 @@ type BatchContext struct {
 	gasPriceEstimator          prices.GasPriceEstimatorExec
 	destWrappedNative          cciptypes.Address
 	offchainConfig             cciptypes.ExecOffchainConfig
+	destChainSelector          uint64
 }
 
 type BatchingStrategy interface {
@@ -260,6 +262,12 @@ func performCommonChecks(
 		return TokenNotInDestTokenPrices, 0, nil, nil, nil
 	}
 
+	// Check if destChainSelector is Hedera, if so, skip fee boosting message for now due to token decimal mismatches.
+	if isHederaSelector(batchCtx.destChainSelector) {
+		msgLggr.Infow("Skipping fee boosting for Hedera destination chain")
+		return SuccesfullyValidated, messageMaxGas, tokenData, msgValue, nil
+	}
+
 	// calculating the source chain fee, dividing by 1e18 for denomination.
 	// For example:
 	// FeeToken=link; FeeTokenAmount=1e17 i.e. 0.1 link, price is 6e18 USD/link (1 USD = 1e18),
@@ -293,6 +301,11 @@ func performCommonChecks(
 	}
 
 	return SuccesfullyValidated, messageMaxGas, tokenData, msgValue, nil
+}
+
+// isHederaSelector returns true if the selector is for Hedera mainnet or testnet.
+func isHederaSelector(selector uint64) bool {
+	return selector == chainsel.HEDERA_MAINNET.Selector || selector == chainsel.HEDERA_TESTNET.Selector
 }
 
 // getTokenDataWithCappedLatency gets the token data for the provided message.

--- a/core/services/ocr2/plugins/ccip/ccipexec/batching.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/batching.go
@@ -263,6 +263,10 @@ func performCommonChecks(
 	}
 
 	// Check if destChainSelector is Hedera, if so, skip fee boosting message for now due to token decimal mismatches.
+	// This is required because Hedera uses 8 decimals for its native token instead of the usual 18 and when we
+	// calculate gasLimit * gasPrice, we assume we're operating with 18 decimals. Since the multiplier in the jobspec
+	// is set to 1e10, calculateUsdPer1e18TokenAmount() will return a value of 1e28 instead of 1e18 which in turn will
+	// trigger the 'insufficient remaining fee' error below.
 	if isHederaSelector(batchCtx.destChainSelector) {
 		msgLggr.Infow("Skipping fee boosting for Hedera destination chain")
 		return SuccesfullyValidated, messageMaxGas, tokenData, msgValue, nil

--- a/core/services/ocr2/plugins/ccip/ccipexec/factory.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/factory.go
@@ -139,6 +139,7 @@ func (rf *ExecutionReportingPluginFactory) NewReportingPluginFn(ctx context.Cont
 			commitStoreReader:           rf.config.commitStoreReader,
 			destPriceRegistry:           rf.destPriceRegReader,
 			destWrappedNative:           destWrappedNative,
+			destChainSelector:           rf.config.destChainSelector,
 			onchainConfig:               onchainConfig,
 			offRampReader:               rf.config.offRampReader,
 			tokenPoolBatchedReader:      rf.config.tokenPoolBatchedReader,

--- a/core/services/ocr2/plugins/ccip/ccipexec/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/ocr2.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/hashutil"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/cache"
@@ -84,6 +85,7 @@ type ExecutionReportingPlugin struct {
 	onRampReader                ccipdata.OnRampReader
 
 	// Dest
+	destChainSelector      uint64
 	commitStoreReader      ccipdata.CommitStoreReader
 	destPriceRegistry      ccipdata.PriceRegistryReader
 	destWrappedNative      cciptypes.Address
@@ -300,6 +302,7 @@ func (r *ExecutionReportingPlugin) buildBatch(
 		r.gasPriceEstimator,
 		r.destWrappedNative,
 		r.offchainConfig,
+		r.destChainSelector,
 	}
 
 	return r.batchingStrategy.BuildBatch(ctx, batchCtx)


### PR DESCRIPTION
- Hedera uses 8 decimals for its native token instead of the usual 18
- To account for that, we need to set the jobspec multiplier to 1e10 so that Hedera --> Eth lanes work as expected since getFee will return 8 digits which we then scale up to 18 before submitting the send
- However, this multiplier then causes the reported prices to be excessively high (28 digits instead of 18), which then triggered `Insufficient remaining fee` errors in batching.go during fee boosting
- In order to keep Hedera --> Eth working correctly, and get Hedera --> Eth working, this PR disables fee boosting temporarily