### PR TITLE
CAPPL-607

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -407,7 +407,8 @@ func (w *launcher) addToRegistryAndSetDispatcher(ctx context.Context, capability
 
 var (
 	// TODO: make this configurable
-	defaultTargetRequestTimeout = 8 * time.Minute
+	defaultTargetRequestTimeout                 = 8 * time.Minute
+	defaultMaxParallelCapabilityExecuteRequests = 1000
 )
 
 func (w *launcher) exposeCapabilities(ctx context.Context, myPeerID p2ptypes.PeerID, don registrysyncer.DON, state *registrysyncer.LocalRegistry, remoteWorkflowDONs []registrysyncer.DON) error {
@@ -473,6 +474,7 @@ func (w *launcher) exposeCapabilities(ctx context.Context, myPeerID p2ptypes.Pee
 					idsToDONs,
 					w.dispatcher,
 					defaultTargetRequestTimeout,
+					defaultMaxParallelCapabilityExecuteRequests,
 					w.lggr,
 				), nil
 			}
@@ -505,6 +507,7 @@ func (w *launcher) exposeCapabilities(ctx context.Context, myPeerID p2ptypes.Pee
 					idsToDONs,
 					w.dispatcher,
 					defaultTargetRequestTimeout,
+					defaultMaxParallelCapabilityExecuteRequests,
 					w.lggr,
 				), nil
 			}

--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -25,7 +25,9 @@ import (
 const (
 	stepReferenceID1     = "step1"
 	workflowID1          = "15c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0"
+	workflowID2          = "25c631d295ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce1"
 	workflowExecutionID1 = "95ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0abbadeed"
+	workflowExecutionID2 = "85ef5e32deb99a10ee6804bc4af13855687559d7ff6552ac6dbb2ce0abbadeee"
 	workflowOwnerID      = "0xAA"
 )
 

--- a/core/capabilities/remote/executable/endtoend_test.go
+++ b/core/capabilities/remote/executable/endtoend_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,6 +26,132 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
+
+func Test_RemoteExecutableCapability_ExecutionNotBlockedBySlowCapabilityExecution_AllAtOnce(t *testing.T) {
+	ctx := testutils.Context(t)
+
+	workflowIDToPause := map[string]time.Duration{}
+	workflowIDToPause[workflowID1] = 1 * time.Minute
+	workflowIDToPause[workflowID2] = 1 * time.Second
+	capability := &TestSlowExecutionCapability{
+		workflowIDToPause: workflowIDToPause,
+	}
+
+	var callCount int64
+
+	numWorkflowPeers := int64(10)
+	var testShuttingDown int32
+
+	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
+		shuttingDown := atomic.LoadInt32(&testShuttingDown)
+		if shuttingDown != 0 {
+			return
+		}
+
+		if assert.NoError(t, responseError) {
+			mp, err := response.Value.Unwrap()
+			if assert.NoError(t, err) {
+				assert.Equal(t, "1s", mp.(map[string]any)["response"].(string))
+			}
+
+			atomic.AddInt64(&callCount, 1)
+		}
+	}
+
+	transmissionSchedule, err := values.NewMap(map[string]any{
+		"schedule":   transmission.Schedule_AllAtOnce,
+		"deltaStage": "10ms",
+	})
+	require.NoError(t, err)
+
+	timeOut := 10 * time.Minute
+
+	method := func(ctx context.Context, caller commoncap.ExecutableCapability) {
+		executeCapability(ctx, t, caller, transmissionSchedule, responseTest, workflowID1)
+	}
+	testRemoteExecutableCapability(ctx, t, capability, int(numWorkflowPeers), 9, timeOut, 10,
+		9, timeOut, method, false)
+
+	method = func(ctx context.Context, caller commoncap.ExecutableCapability) {
+		executeCapability(ctx, t, caller, transmissionSchedule, responseTest, workflowID2)
+	}
+	testRemoteExecutableCapability(ctx, t, capability, int(numWorkflowPeers), 9, timeOut, 10,
+		9, timeOut, method, false)
+
+	require.Eventually(t, func() bool {
+		count := atomic.LoadInt64(&callCount)
+
+		if count == numWorkflowPeers {
+			atomic.AddInt32(&testShuttingDown, 1)
+			return true
+		}
+
+		return false
+	}, 1*time.Minute, 10*time.Millisecond, "require 10 callbacks from 1s delay capability")
+}
+
+func Test_RemoteExecutableCapability_ExecutionNotBlockedBySlowCapabilityExecution_OneAtATime(t *testing.T) {
+	ctx := testutils.Context(t)
+
+	workflowIDToPause := map[string]time.Duration{}
+	workflowIDToPause[workflowID1] = 1 * time.Minute
+	workflowIDToPause[workflowID2] = 1 * time.Second
+	capability := &TestSlowExecutionCapability{
+		workflowIDToPause: workflowIDToPause,
+	}
+
+	var callCount int64
+
+	numWorkflowPeers := int64(10)
+	var testShuttingDown int32
+
+	responseTest := func(t *testing.T, response commoncap.CapabilityResponse, responseError error) {
+		shuttingDown := atomic.LoadInt32(&testShuttingDown)
+		if shuttingDown != 0 {
+			return
+		}
+
+		if assert.NoError(t, responseError) {
+			mp, err := response.Value.Unwrap()
+			if assert.NoError(t, err) {
+				assert.Equal(t, "1s", mp.(map[string]any)["response"].(string))
+			}
+
+			atomic.AddInt64(&callCount, 1)
+		}
+	}
+
+	transmissionSchedule, err := values.NewMap(map[string]any{
+		"schedule":   transmission.Schedule_OneAtATime,
+		"deltaStage": "10ms",
+	})
+	require.NoError(t, err)
+
+	timeOut := 10 * time.Minute
+
+	method := func(ctx context.Context, caller commoncap.ExecutableCapability) {
+		executeCapability(ctx, t, caller, transmissionSchedule, responseTest, workflowID1)
+	}
+	testRemoteExecutableCapability(ctx, t, capability, int(numWorkflowPeers), 9, timeOut, 10,
+		9, timeOut, method, false)
+
+	method = func(ctx context.Context, caller commoncap.ExecutableCapability) {
+		executeCapability(ctx, t, caller, transmissionSchedule, responseTest, workflowID2)
+	}
+	testRemoteExecutableCapability(ctx, t, capability, int(numWorkflowPeers), 9, timeOut, 10,
+		9, timeOut, method, false)
+
+	require.Eventually(t, func() bool {
+		count := atomic.LoadInt64(&callCount)
+
+		if count == numWorkflowPeers {
+			atomic.AddInt32(&testShuttingDown, 1)
+			return true
+		}
+
+		return false
+	}, 1*time.Minute, 10*time.Millisecond, "require 10 callbacks from 1s delay capability")
+}
 
 func Test_RemoteExecutableCapability_TransmissionSchedules(t *testing.T) {
 	ctx := testutils.Context(t)
@@ -49,9 +176,9 @@ func Test_RemoteExecutableCapability_TransmissionSchedules(t *testing.T) {
 	capability := &TestCapability{}
 
 	method := func(ctx context.Context, caller commoncap.ExecutableCapability) {
-		executeCapability(ctx, t, caller, transmissionSchedule, responseTest)
+		executeCapability(ctx, t, caller, transmissionSchedule, responseTest, workflowID1)
 	}
-	testRemoteExecutableCapability(ctx, t, capability, 10, 9, timeOut, 10, 9, timeOut, method)
+	testRemoteExecutableCapability(ctx, t, capability, 10, 9, timeOut, 10, 9, timeOut, method, true)
 
 	transmissionSchedule, err = values.NewMap(map[string]any{
 		"schedule":   transmission.Schedule_AllAtOnce,
@@ -59,10 +186,10 @@ func Test_RemoteExecutableCapability_TransmissionSchedules(t *testing.T) {
 	})
 	require.NoError(t, err)
 	method = func(ctx context.Context, caller commoncap.ExecutableCapability) {
-		executeCapability(ctx, t, caller, transmissionSchedule, responseTest)
+		executeCapability(ctx, t, caller, transmissionSchedule, responseTest, workflowID1)
 	}
 
-	testRemoteExecutableCapability(ctx, t, capability, 10, 9, timeOut, 10, 9, timeOut, method)
+	testRemoteExecutableCapability(ctx, t, capability, 10, 9, timeOut, 10, 9, timeOut, method, true)
 }
 
 func Test_RemoteExecutionCapability_CapabilityError(t *testing.T) {
@@ -81,11 +208,11 @@ func Test_RemoteExecutionCapability_CapabilityError(t *testing.T) {
 	methods = append(methods, func(ctx context.Context, caller commoncap.ExecutableCapability) {
 		executeCapability(ctx, t, caller, transmissionSchedule, func(t *testing.T, responseCh commoncap.CapabilityResponse, responseError error) {
 			assert.Equal(t, "error executing request: failed to execute capability", responseError.Error())
-		})
+		}, workflowID1)
 	})
 
 	for _, method := range methods {
-		testRemoteExecutableCapability(ctx, t, capability, 10, 9, 10*time.Minute, 10, 9, 10*time.Minute, method)
+		testRemoteExecutableCapability(ctx, t, capability, 10, 9, 10*time.Minute, 10, 9, 10*time.Minute, method, true)
 	}
 }
 
@@ -105,18 +232,18 @@ func Test_RemoteExecutableCapability_RandomCapabilityError(t *testing.T) {
 	methods = append(methods, func(ctx context.Context, caller commoncap.ExecutableCapability) {
 		executeCapability(ctx, t, caller, transmissionSchedule, func(t *testing.T, responseCh commoncap.CapabilityResponse, responseError error) {
 			assert.Equal(t, "error executing request: failed to execute capability", responseError.Error())
-		})
+		}, workflowID1)
 	})
 
 	for _, method := range methods {
 		testRemoteExecutableCapability(ctx, t, capability, 10, 9, 1*time.Second, 10, 9, 10*time.Minute,
-			method)
+			method, true)
 	}
 }
 
 func testRemoteExecutableCapability(ctx context.Context, t *testing.T, underlying commoncap.ExecutableCapability, numWorkflowPeers int, workflowDonF uint8, workflowNodeTimeout time.Duration,
 	numCapabilityPeers int, capabilityDonF uint8, capabilityNodeResponseTimeout time.Duration,
-	method func(ctx context.Context, caller commoncap.ExecutableCapability)) {
+	method func(ctx context.Context, caller commoncap.ExecutableCapability), waitForExecuteCalls bool) {
 	lggr := logger.TestLogger(t)
 
 	capabilityPeers := make([]p2ptypes.PeerID, numCapabilityPeers)
@@ -166,7 +293,7 @@ func testRemoteExecutableCapability(ctx context.Context, t *testing.T, underlyin
 		capabilityPeer := capabilityPeers[i]
 		capabilityDispatcher := broker.NewDispatcherForNode(capabilityPeer)
 		capabilityNode := executable.NewServer(&commoncap.RemoteExecutableConfig{RequestHashExcludedAttributes: []string{}}, capabilityPeer, underlying, capInfo, capDonInfo, workflowDONs, capabilityDispatcher,
-			capabilityNodeResponseTimeout, lggr)
+			capabilityNodeResponseTimeout, 10, lggr)
 		servicetest.Run(t, capabilityNode)
 		broker.RegisterReceiverNode(capabilityPeer, capabilityNode)
 		capabilityNodes[i] = capabilityNode
@@ -192,8 +319,9 @@ func testRemoteExecutableCapability(ctx context.Context, t *testing.T, underlyin
 			method(ctx, caller)
 		}(caller)
 	}
-
-	wg.Wait()
+	if waitForExecuteCalls {
+		wg.Wait()
+	}
 }
 
 type testAsyncMessageBroker struct {
@@ -336,6 +464,35 @@ func (t TestCapability) Execute(ctx context.Context, request commoncap.Capabilit
 	}, nil
 }
 
+type TestSlowExecutionCapability struct {
+	abstractTestCapability
+	workflowIDToPause map[string]time.Duration
+}
+
+func (t *TestSlowExecutionCapability) Execute(ctx context.Context, request commoncap.CapabilityRequest) (commoncap.CapabilityResponse, error) {
+	var delay time.Duration
+
+	delay, ok := t.workflowIDToPause[request.Metadata.WorkflowID]
+	if !ok {
+		panic("workflowID not found")
+	}
+
+	select {
+	case <-time.After(delay):
+		break
+	case <-ctx.Done():
+		return commoncap.CapabilityResponse{}, nil
+	}
+
+	response, err := values.NewMap(map[string]any{"response": delay.String()})
+	if err != nil {
+		return commoncap.CapabilityResponse{}, err
+	}
+	return commoncap.CapabilityResponse{
+		Value: response,
+	}, nil
+}
+
 type TestErrorCapability struct {
 	abstractTestCapability
 }
@@ -390,7 +547,8 @@ func libp2pMagic() []byte {
 	return []byte{0x00, 0x24, 0x08, 0x01, 0x12, 0x20}
 }
 
-func executeCapability(ctx context.Context, t *testing.T, caller commoncap.ExecutableCapability, transmissionSchedule *values.Map, responseTest func(t *testing.T, response commoncap.CapabilityResponse, responseError error)) {
+func executeCapability(ctx context.Context, t *testing.T, caller commoncap.ExecutableCapability, transmissionSchedule *values.Map, responseTest func(t *testing.T, response commoncap.CapabilityResponse, responseError error),
+	workflowID string) {
 	executeInputs, err := values.NewMap(
 		map[string]any{
 			"executeValue1": "aValue1",
@@ -400,7 +558,7 @@ func executeCapability(ctx context.Context, t *testing.T, caller commoncap.Execu
 	response, err := caller.Execute(ctx,
 		commoncap.CapabilityRequest{
 			Metadata: commoncap.RequestMetadata{
-				WorkflowID:          workflowID1,
+				WorkflowID:          workflowID,
 				WorkflowExecutionID: workflowExecutionID1,
 			},
 			Config: transmissionSchedule,

--- a/core/capabilities/remote/executable/parallel_executor.go
+++ b/core/capabilities/remote/executable/parallel_executor.go
@@ -1,0 +1,58 @@
+package executable
+
+import (
+	"context"
+	"sync"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+)
+
+type task struct {
+	fnCtx *context.Context
+	fn    func(ctx context.Context)
+}
+
+type parallelExecutor struct {
+	tasksCh  chan task
+	wg       sync.WaitGroup
+	stopChan services.StopChan
+}
+
+func newParallelExecutor(maxParallelTasks int) *parallelExecutor {
+	executor := &parallelExecutor{
+		tasksCh:  make(chan task),
+		stopChan: make(services.StopChan),
+		wg:       sync.WaitGroup{},
+	}
+
+	for i := 0; i < maxParallelTasks; i++ {
+		executor.wg.Add(1)
+		go func() {
+			for t := range executor.tasksCh {
+				ctxWithStop, cancel := executor.stopChan.Ctx(*t.fnCtx)
+				t.fn(ctxWithStop)
+				cancel()
+			}
+			executor.wg.Done()
+		}()
+	}
+
+	return executor
+}
+
+// ExecuteTask executes a task in parallel up to the maximum allowed parallel executions.  If the maximum execute limit
+// is reached, the function will block until a slot is available or the context is cancelled.
+func (t *parallelExecutor) ExecuteTask(ctx context.Context, fn func(ctx context.Context)) error {
+	select {
+	case t.tasksCh <- task{fnCtx: &ctx, fn: fn}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (t *parallelExecutor) Close() {
+	close(t.tasksCh)
+	close(t.stopChan)
+	t.wg.Wait()
+}

--- a/core/capabilities/remote/executable/parallel_executor.go
+++ b/core/capabilities/remote/executable/parallel_executor.go
@@ -7,34 +7,18 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
-type task struct {
-	fnCtx *context.Context
-	fn    func(ctx context.Context)
-}
-
 type parallelExecutor struct {
-	tasksCh  chan task
 	wg       sync.WaitGroup
 	stopChan services.StopChan
+
+	taskSemaphore chan struct{}
 }
 
 func newParallelExecutor(maxParallelTasks int) *parallelExecutor {
 	executor := &parallelExecutor{
-		tasksCh:  make(chan task),
-		stopChan: make(services.StopChan),
-		wg:       sync.WaitGroup{},
-	}
-
-	for i := 0; i < maxParallelTasks; i++ {
-		executor.wg.Add(1)
-		go func() {
-			for t := range executor.tasksCh {
-				ctxWithStop, cancel := executor.stopChan.Ctx(*t.fnCtx)
-				t.fn(ctxWithStop)
-				cancel()
-			}
-			executor.wg.Done()
-		}()
+		stopChan:      make(services.StopChan),
+		wg:            sync.WaitGroup{},
+		taskSemaphore: make(chan struct{}, maxParallelTasks),
 	}
 
 	return executor
@@ -44,15 +28,25 @@ func newParallelExecutor(maxParallelTasks int) *parallelExecutor {
 // is reached, the function will block until a slot is available or the context is cancelled.
 func (t *parallelExecutor) ExecuteTask(ctx context.Context, fn func(ctx context.Context)) error {
 	select {
-	case t.tasksCh <- task{fnCtx: &ctx, fn: fn}:
+	case t.taskSemaphore <- struct{}{}:
+		t.wg.Add(1)
+		go func() {
+			ctxWithStop, cancel := t.stopChan.Ctx(ctx)
+			fn(ctxWithStop)
+			cancel()
+			<-t.taskSemaphore
+			t.wg.Done()
+		}()
+	case <-t.stopChan:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+
+	return nil
 }
 
 func (t *parallelExecutor) Close() {
-	close(t.tasksCh)
 	close(t.stopChan)
 	t.wg.Wait()
 }

--- a/core/capabilities/remote/executable/parallel_executor_test.go
+++ b/core/capabilities/remote/executable/parallel_executor_test.go
@@ -1,0 +1,105 @@
+package executable
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CancellingContext_StopsTask(t *testing.T) {
+	tp := newParallelExecutor(10)
+	defer tp.Close()
+
+	var cancelFns []context.CancelFunc
+
+	var counter int32
+	for i := 0; i < 10; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancelFns = append(cancelFns, cancel)
+		err := tp.ExecuteTask(ctx, func(ctx context.Context) {
+			atomic.AddInt32(&counter, 1)
+			<-ctx.Done()
+			atomic.AddInt32(&counter, -1)
+		})
+
+		require.NoError(t, err)
+	}
+
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(&counter) == 10
+	}, 10*time.Second, 10*time.Millisecond)
+
+	for _, cancel := range cancelFns {
+		cancel()
+	}
+
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(&counter) == 0
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+func Test_ExecuteRequestTimesOutWhenParallelExecutionLimitReached(t *testing.T) {
+	tp := newParallelExecutor(3)
+	defer tp.Close()
+
+	for i := 0; i < 3; i++ {
+		err := tp.ExecuteTask(context.Background(), func(ctx context.Context) {
+			<-ctx.Done()
+		})
+		require.NoError(t, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	err := tp.ExecuteTask(ctx, func(ctx context.Context) {
+	})
+	cancel()
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func Test_ExecutingMultipleTasksInParallel(t *testing.T) {
+	tp := newParallelExecutor(10)
+	defer tp.Close()
+
+	var counter int32
+	for i := 0; i < 10; i++ {
+		err := tp.ExecuteTask(context.Background(), func(ctx context.Context) {
+			atomic.AddInt32(&counter, 1)
+			<-ctx.Done()
+			atomic.AddInt32(&counter, -1)
+		})
+		require.NoError(t, err)
+	}
+
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(&counter) == 10
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+func Test_StopsExecutingMultipleParallelTasksWhenClosed(t *testing.T) {
+	tp := newParallelExecutor(10)
+
+	var counter int32
+	for i := 0; i < 10; i++ {
+		err := tp.ExecuteTask(context.Background(), func(ctx context.Context) {
+			atomic.AddInt32(&counter, 1)
+			<-ctx.Done()
+			atomic.AddInt32(&counter, -1)
+		})
+		require.NoError(t, err)
+	}
+
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(&counter) == 10
+	}, 10*time.Second, 10*time.Millisecond)
+
+	tp.Close()
+
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(&counter) == 0
+	}, 10*time.Second, 10*time.Millisecond)
+}

--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -48,6 +48,8 @@ type server struct {
 	receiveLock sync.Mutex
 	stopCh      services.StopChan
 	wg          sync.WaitGroup
+
+	parallelExecutor *parallelExecutor
 }
 
 var _ types.Receiver = &server{}
@@ -60,7 +62,9 @@ type requestAndMsgID struct {
 
 func NewServer(remoteExecutableConfig *commoncap.RemoteExecutableConfig, peerID p2ptypes.PeerID, underlying commoncap.ExecutableCapability,
 	capInfo commoncap.CapabilityInfo, localDonInfo commoncap.DON,
-	workflowDONs map[uint32]commoncap.DON, dispatcher types.Dispatcher, requestTimeout time.Duration, lggr logger.Logger) *server {
+	workflowDONs map[uint32]commoncap.DON, dispatcher types.Dispatcher, requestTimeout time.Duration,
+	maxParallelRequests int,
+	lggr logger.Logger) *server {
 	if remoteExecutableConfig == nil {
 		lggr.Info("no remote config provided, using default values")
 		remoteExecutableConfig = &commoncap.RemoteExecutableConfig{}
@@ -80,6 +84,8 @@ func NewServer(remoteExecutableConfig *commoncap.RemoteExecutableConfig, peerID 
 
 		lggr:   lggr.Named("ExecutableCapabilityServer"),
 		stopCh: make(services.StopChan),
+
+		parallelExecutor: newParallelExecutor(maxParallelRequests),
 	}
 }
 
@@ -94,6 +100,7 @@ func (r *server) Start(ctx context.Context) error {
 			}
 			ticker := time.NewTicker(tickerInterval)
 			defer ticker.Stop()
+
 			r.lggr.Info("executable capability server started")
 			for {
 				select {
@@ -110,6 +117,8 @@ func (r *server) Start(ctx context.Context) error {
 
 func (r *server) Close() error {
 	return r.StopOnce(r.Name(), func() error {
+		r.parallelExecutor.Close()
+
 		close(r.stopCh)
 		r.wg.Wait()
 		r.lggr.Info("executable capability server closed")
@@ -190,10 +199,14 @@ func (r *server) Receive(ctx context.Context, msg *types.MessageBody) {
 	}
 
 	reqAndMsgID := r.requestIDToRequest[requestID]
-
-	err = reqAndMsgID.request.OnMessage(ctx, msg)
-	if err != nil {
-		r.lggr.Errorw("request failed to OnMessage new message", "messageID", reqAndMsgID.messageID, "err", err)
+	if executeTaskErr := r.parallelExecutor.ExecuteTask(ctx,
+		func(ctx context.Context) {
+			err = reqAndMsgID.request.OnMessage(ctx, msg)
+			if err != nil {
+				r.lggr.Errorw("failed to execute on message", "messageID", reqAndMsgID.messageID, "err", err)
+			}
+		}); executeTaskErr != nil {
+		r.lggr.Errorw("failed to execute on message task", "messageID", messageID, "err", executeTaskErr)
 	}
 }
 


### PR DESCRIPTION
fix for https://smartcontract-it.atlassian.net/browse/CAPPL-607, executes the capabilities in parallel.   Limits the number of capability executions that can run in parallel, if no slots are free execution of subsequent will wait pending ctx cancel.


