### PR TITLE
enable solana LOOPP mode by default

### DIFF
--- a/.changeset/serious-scissors-live.md
+++ b/.changeset/serious-scissors-live.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+enable Solana LOOPP mode by default

--- a/.goreleaser.develop.yaml
+++ b/.goreleaser.develop.yaml
@@ -49,6 +49,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -100,6 +101,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -152,6 +154,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
@@ -207,6 +210,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"

--- a/.goreleaser.production.yaml
+++ b/.goreleaser.production.yaml
@@ -50,6 +50,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -103,6 +104,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -157,6 +159,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
@@ -214,6 +217,7 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
+      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -58,9 +58,11 @@ RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
 
 COPY --from=buildgo /go/bin/chainlink /usr/local/bin/
 
-# Install (but don't enable) LOOP Plugins
+# Install (but don't enabled) feeds LOOP Plugin
 COPY --from=buildplugins /go/bin/chainlink-feeds /usr/local/bin/
+# Install and enable Solana LOOP Plugin
 COPY --from=buildplugins /go/bin/chainlink-solana /usr/local/bin/
+ENV CL_SOLANA_CMD=chainlink-solana
 
 # CCIP specific
 COPY ./cci[p]/confi[g] /ccip-config

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -58,7 +58,7 @@ RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
 
 COPY --from=buildgo /go/bin/chainlink /usr/local/bin/
 
-# Install (but don't enabled) feeds LOOP Plugin
+# Install (but don't enable) feeds LOOP Plugin
 COPY --from=buildplugins /go/bin/chainlink-feeds /usr/local/bin/
 # Install and enable Solana LOOP Plugin
 COPY --from=buildplugins /go/bin/chainlink-solana /usr/local/bin/


### PR DESCRIPTION
This PR enables the Solana LOOP plugin by default. It can still be disabled by unsetting the env var. In a future release, embedded mode will be removed, leaving LOOP mode as the only option.

TODO:
- [x] Do other dockerfiles/goreleaser files need to be updated?