### PR TITLE
Added multi chain support for Data Feeds mcms proposal generation

### DIFF
--- a/deployment/data-feeds/changeset/accept_ownership.go
+++ b/deployment/data-feeds/changeset/accept_ownership.go
@@ -29,12 +29,16 @@ func acceptOwnershipLogic(env deployment.Environment, c types.AcceptOwnershipCon
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to create accept transfer ownership tx %w", err)
 	}
 
-	proposal, err := BuildMCMProposals(env, "accept ownership to timelock", c.ChainSelector, []ProposalData{
-		{
-			contract: c.ContractAddress.Hex(),
-			tx:       tx,
+	proposalConfig := MultiChainProposalConfig{
+		c.ChainSelector: []ProposalData{
+			{
+				contract: contract.Address().Hex(),
+				tx:       tx,
+			},
 		},
-	}, c.McmsConfig.MinDelay)
+	}
+
+	proposal, err := BuildMultiChainProposals(env, "accept ownership to timelock", proposalConfig, c.McmsConfig.MinDelay)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 	}

--- a/deployment/data-feeds/changeset/confirm_aggregator.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator.go
@@ -28,9 +28,6 @@ func confirmAggregatorLogic(env deployment.Environment, c types.ProposeConfirmAg
 	}
 
 	tx, err := aggregatorProxy.ConfirmAggregator(txOpt, c.NewAggregatorAddress)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to execute ConfirmAggregator: %w", err)
-	}
 
 	if c.McmsConfig != nil {
 		proposalConfig := MultiChainProposalConfig{
@@ -49,8 +46,7 @@ func confirmAggregatorLogic(env deployment.Environment, c types.ProposeConfirmAg
 		return deployment.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
 
-	_, err = chain.Confirm(tx)
-	if err != nil {
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 

--- a/deployment/data-feeds/changeset/confirm_aggregator.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator.go
@@ -33,12 +33,16 @@ func confirmAggregatorLogic(env deployment.Environment, c types.ProposeConfirmAg
 	}
 
 	if c.McmsConfig != nil {
-		proposal, err := BuildMCMProposals(env, "proposal to confirm a new aggregator", c.ChainSelector, []ProposalData{
-			{
-				contract: aggregatorProxy.Address().Hex(),
-				tx:       tx,
+		proposalConfig := MultiChainProposalConfig{
+			c.ChainSelector: []ProposalData{
+				{
+					contract: aggregatorProxy.Address().Hex(),
+					tx:       tx,
+				},
 			},
-		}, c.McmsConfig.MinDelay)
+		}
+
+		proposal, err := BuildMultiChainProposals(env, "proposal to confirm a new aggregator", proposalConfig, c.McmsConfig.MinDelay)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}

--- a/deployment/data-feeds/changeset/migrate_feeds.go
+++ b/deployment/data-feeds/changeset/migrate_feeds.go
@@ -59,23 +59,13 @@ func migrateFeedsLogic(env deployment.Environment, c types.MigrationConfig) (dep
 
 	// Set the feed config
 	tx, err := contract.SetDecimalFeedConfigs(chain.DeployerKey, dataIDs, descriptions, c.WorkflowMetadata)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to set feed config %w", err)
-	}
-
-	_, err = chain.Confirm(tx)
-	if err != nil {
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 
 	// Set the proxy to dataId mapping
 	tx, err = contract.UpdateDataIdMappingsForProxies(chain.DeployerKey, addresses, dataIDs)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to update feed proxy mapping %w", err)
-	}
-
-	_, err = chain.Confirm(tx)
-	if err != nil {
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 

--- a/deployment/data-feeds/changeset/new_feed_with_proxy.go
+++ b/deployment/data-feeds/changeset/new_feed_with_proxy.go
@@ -85,11 +85,7 @@ func newFeedWithProxyLogic(env deployment.Environment, c types.NewFeedWithProxyC
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to load proxy contract %w", err)
 	}
 	tx, err := proxyContract.TransferOwnership(chain.DeployerKey, common.HexToAddress(timelockAddr))
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to create transfer ownership tx %w", err)
-	}
-	_, err = chain.Confirm(tx)
-	if err != nil {
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 
@@ -140,6 +136,10 @@ func newFeedWithProxyPrecondition(env deployment.Environment, c types.NewFeedWit
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
+	}
+
+	if c.McmsConfig == nil {
+		return errors.New("mcms config is required")
 	}
 
 	return ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector)

--- a/deployment/data-feeds/changeset/new_feed_with_proxy.go
+++ b/deployment/data-feeds/changeset/new_feed_with_proxy.go
@@ -133,13 +133,13 @@ func newFeedWithProxyLogic(env deployment.Environment, c types.NewFeedWithProxyC
 }
 
 func newFeedWithProxyPrecondition(env deployment.Environment, c types.NewFeedWithProxyConfig) error {
+	if c.McmsConfig == nil {
+		return errors.New("mcms config is required")
+	}
+
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
-	}
-
-	if c.McmsConfig == nil {
-		return errors.New("mcms config is required")
 	}
 
 	return ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector)

--- a/deployment/data-feeds/changeset/new_feed_with_proxy.go
+++ b/deployment/data-feeds/changeset/new_feed_with_proxy.go
@@ -111,22 +111,24 @@ func newFeedWithProxyLogic(env deployment.Environment, c types.NewFeedWithProxyC
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to set proxy-dataId mapping %w", err)
 	}
 
-	txs := []ProposalData{
-		{
-			contract: proxyContract.Address().Hex(),
-			tx:       acceptProxyOwnerShipTx,
-		},
-		{
-			contract: dataFeedsCache.Address().Hex(),
-			tx:       setFeedConfigTx,
-		},
-		{
-			contract: dataFeedsCache.Address().Hex(),
-			tx:       setProxyMappingTx,
+	proposalConfig := MultiChainProposalConfig{
+		c.ChainSelector: []ProposalData{
+			{
+				contract: proxyContract.Address().Hex(),
+				tx:       acceptProxyOwnerShipTx,
+			},
+			{
+				contract: dataFeedsCache.Address().Hex(),
+				tx:       setFeedConfigTx,
+			},
+			{
+				contract: dataFeedsCache.Address().Hex(),
+				tx:       setProxyMappingTx,
+			},
 		},
 	}
 
-	proposals, err := BuildMCMProposals(env, "accept AggregatorProxy ownership to timelock. set feed config and proxy mapping on cache", c.ChainSelector, txs, c.McmsConfig.MinDelay)
+	proposals, err := BuildMultiChainProposals(env, "accept AggregatorProxy ownership to timelock. set feed config and proxy mapping on cache", proposalConfig, c.McmsConfig.MinDelay)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 	}

--- a/deployment/data-feeds/changeset/proposal.go
+++ b/deployment/data-feeds/changeset/proposal.go
@@ -19,41 +19,44 @@ type ProposalData struct {
 	tx       *gethTypes.Transaction
 }
 
-func BuildMCMProposals(env deployment.Environment, description string, chainSelector uint64, pd []ProposalData, minDelay time.Duration) (*mcmslib.TimelockProposal, error) {
-	state, _ := LoadOnchainState(env)
-	chain := env.Chains[chainSelector]
-	chainState := state.Chains[chainSelector]
+// MultiChainProposalConfig is a map of chain selector to a list of proposals to be executed on that chain
+type MultiChainProposalConfig map[uint64][]ProposalData
 
-	var transactions []mcmstypes.Transaction
-	for _, proposal := range pd {
-		transactions = append(transactions, mcmstypes.Transaction{
-			To:               proposal.contract,
-			Data:             proposal.tx.Data(),
-			AdditionalFields: json.RawMessage(`{"value": 0}`),
+func BuildMultiChainProposals(env deployment.Environment, description string, proposalConfig MultiChainProposalConfig, minDelay time.Duration) (*mcmslib.TimelockProposal, error) {
+	state, _ := LoadOnchainState(env)
+
+	var timelocksPerChain = map[uint64]string{}
+	var proposerMCMSes = map[uint64]string{}
+	var inspectorPerChain = map[uint64]sdk.Inspector{}
+	var batches []mcmstypes.BatchOperation
+
+	for chainSelector, proposalData := range proposalConfig {
+		chain := env.Chains[chainSelector]
+		chainState := state.Chains[chainSelector]
+
+		inspectorPerChain[chainSelector] = evm.NewInspector(chain.Client)
+		timelocksPerChain[chainSelector] = chainState.Timelock.Address().Hex()
+		proposerMCMSes[chainSelector] = chainState.ProposerMcm.Address().Hex()
+
+		var transactions []mcmstypes.Transaction
+		for _, proposal := range proposalData {
+			transactions = append(transactions, mcmstypes.Transaction{
+				To:               proposal.contract,
+				Data:             proposal.tx.Data(),
+				AdditionalFields: json.RawMessage(`{"value": 0}`),
+			})
+		}
+		batches = append(batches, mcmstypes.BatchOperation{
+			ChainSelector: mcmstypes.ChainSelector(chainSelector),
+			Transactions:  transactions,
 		})
 	}
-
-	ops := &mcmstypes.BatchOperation{
-		ChainSelector: mcmstypes.ChainSelector(chainSelector),
-		Transactions:  transactions,
-	}
-
-	timelocksPerChain := map[uint64]string{
-		chainSelector: chainState.Timelock.Address().Hex(),
-	}
-	proposerMCMSes := map[uint64]string{
-		chainSelector: chainState.ProposerMcm.Address().Hex(),
-	}
-
-	inspectorPerChain := map[uint64]sdk.Inspector{}
-	inspectorPerChain[chainSelector] = evm.NewInspector(chain.Client)
-
 	proposal, err := proposalutils.BuildProposalFromBatchesV2(
 		env,
 		timelocksPerChain,
 		proposerMCMSes,
 		inspectorPerChain,
-		[]mcmstypes.BatchOperation{*ops},
+		batches,
 		description,
 		minDelay,
 	)

--- a/deployment/data-feeds/changeset/propose_aggregator.go
+++ b/deployment/data-feeds/changeset/propose_aggregator.go
@@ -33,12 +33,15 @@ func proposeAggregatorLogic(env deployment.Environment, c types.ProposeConfirmAg
 	}
 
 	if c.McmsConfig != nil {
-		proposal, err := BuildMCMProposals(env, "proposal to propose a new aggregator", c.ChainSelector, []ProposalData{
-			{
-				contract: aggregatorProxy.Address().Hex(),
-				tx:       tx,
+		proposalConfig := MultiChainProposalConfig{
+			c.ChainSelector: []ProposalData{
+				{
+					contract: aggregatorProxy.Address().Hex(),
+					tx:       tx,
+				},
 			},
-		}, c.McmsConfig.MinDelay)
+		}
+		proposal, err := BuildMultiChainProposals(env, "proposal to propose a new aggregator", proposalConfig, c.McmsConfig.MinDelay)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}

--- a/deployment/data-feeds/changeset/propose_aggregator.go
+++ b/deployment/data-feeds/changeset/propose_aggregator.go
@@ -28,9 +28,6 @@ func proposeAggregatorLogic(env deployment.Environment, c types.ProposeConfirmAg
 	}
 
 	tx, err := aggregatorProxy.ProposeAggregator(txOpt, c.NewAggregatorAddress)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to execute ProposeAggregator: %w", err)
-	}
 
 	if c.McmsConfig != nil {
 		proposalConfig := MultiChainProposalConfig{
@@ -47,8 +44,8 @@ func proposeAggregatorLogic(env deployment.Environment, c types.ProposeConfirmAg
 		}
 		return deployment.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
-	_, err = chain.Confirm(tx)
-	if err != nil {
+
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 

--- a/deployment/data-feeds/changeset/remove_dataid_proxy_mapping.go
+++ b/deployment/data-feeds/changeset/remove_dataid_proxy_mapping.go
@@ -31,12 +31,16 @@ func removeFeedProxyMappingLogic(env deployment.Environment, c types.RemoveFeedP
 	}
 
 	if c.McmsConfig != nil {
-		proposal, err := BuildMCMProposals(env, "proposal to remove a feed proxy mapping from cache", c.ChainSelector, []ProposalData{
-			{
-				contract: contract.Address().Hex(),
-				tx:       tx,
+		proposalConfig := MultiChainProposalConfig{
+			c.ChainSelector: []ProposalData{
+				{
+					contract: contract.Address().Hex(),
+					tx:       tx,
+				},
 			},
-		}, c.McmsConfig.MinDelay)
+		}
+
+		proposal, err := BuildMultiChainProposals(env, "proposal to remove a feed proxy mapping from cache", proposalConfig, c.McmsConfig.MinDelay)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}

--- a/deployment/data-feeds/changeset/remove_dataid_proxy_mapping.go
+++ b/deployment/data-feeds/changeset/remove_dataid_proxy_mapping.go
@@ -26,9 +26,6 @@ func removeFeedProxyMappingLogic(env deployment.Environment, c types.RemoveFeedP
 	}
 
 	tx, err := contract.RemoveDataIdMappingsForProxies(txOpt, c.ProxyAddresses)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to remove feed proxy mapping %w", err)
-	}
 
 	if c.McmsConfig != nil {
 		proposalConfig := MultiChainProposalConfig{
@@ -46,8 +43,8 @@ func removeFeedProxyMappingLogic(env deployment.Environment, c types.RemoveFeedP
 		}
 		return deployment.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
-	_, err = chain.Confirm(tx)
-	if err != nil {
+
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 

--- a/deployment/data-feeds/changeset/remove_feed.go
+++ b/deployment/data-feeds/changeset/remove_feed.go
@@ -32,8 +32,7 @@ func removeFeedLogic(env deployment.Environment, c types.RemoveFeedConfig) (depl
 	}
 
 	if c.McmsConfig == nil {
-		_, err = chain.Confirm(removeConfigTx)
-		if err != nil {
+		if _, err := deployment.ConfirmIfNoError(chain, removeConfigTx, err); err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", removeConfigTx.Hash().String(), err)
 		}
 	}
@@ -45,9 +44,8 @@ func removeFeedLogic(env deployment.Environment, c types.RemoveFeedConfig) (depl
 	}
 
 	if c.McmsConfig == nil {
-		_, err = chain.Confirm(removeProxyMappingTx)
-		if err != nil {
-			return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", removeConfigTx.Hash().String(), err)
+		if _, err := deployment.ConfirmIfNoError(chain, removeProxyMappingTx, err); err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", removeProxyMappingTx.Hash().String(), err)
 		}
 		return deployment.ChangesetOutput{}, nil
 	}

--- a/deployment/data-feeds/changeset/remove_feed.go
+++ b/deployment/data-feeds/changeset/remove_feed.go
@@ -52,17 +52,20 @@ func removeFeedLogic(env deployment.Environment, c types.RemoveFeedConfig) (depl
 		return deployment.ChangesetOutput{}, nil
 	}
 
-	txs := []ProposalData{
-		{
-			contract: contract.Address().Hex(),
-			tx:       removeConfigTx,
-		},
-		{
-			contract: contract.Address().Hex(),
-			tx:       removeProxyMappingTx,
+	proposalConfig := MultiChainProposalConfig{
+		c.ChainSelector: []ProposalData{
+			{
+				contract: contract.Address().Hex(),
+				tx:       removeConfigTx,
+			},
+			{
+				contract: contract.Address().Hex(),
+				tx:       removeProxyMappingTx,
+			},
 		},
 	}
-	proposal, err := BuildMCMProposals(env, "proposal to remove a feed from cache", c.ChainSelector, txs, c.McmsConfig.MinDelay)
+
+	proposal, err := BuildMultiChainProposals(env, "proposal to remove a feed from cache", proposalConfig, c.McmsConfig.MinDelay)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 	}

--- a/deployment/data-feeds/changeset/remove_feed_config.go
+++ b/deployment/data-feeds/changeset/remove_feed_config.go
@@ -26,9 +26,6 @@ func removeFeedConfigLogic(env deployment.Environment, c types.RemoveFeedConfigC
 	}
 
 	tx, err := contract.RemoveFeedConfigs(txOpt, c.DataIDs)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to remove feed config %w", err)
-	}
 
 	if c.McmsConfig != nil {
 		proposalConfig := MultiChainProposalConfig{
@@ -46,8 +43,8 @@ func removeFeedConfigLogic(env deployment.Environment, c types.RemoveFeedConfigC
 		}
 		return deployment.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
-	_, err = chain.Confirm(tx)
-	if err != nil {
+
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 

--- a/deployment/data-feeds/changeset/remove_feed_config.go
+++ b/deployment/data-feeds/changeset/remove_feed_config.go
@@ -31,12 +31,16 @@ func removeFeedConfigLogic(env deployment.Environment, c types.RemoveFeedConfigC
 	}
 
 	if c.McmsConfig != nil {
-		proposal, err := BuildMCMProposals(env, "proposal to remove a feed config from cache", c.ChainSelector, []ProposalData{
-			{
-				contract: contract.Address().Hex(),
-				tx:       tx,
+		proposalConfig := MultiChainProposalConfig{
+			c.ChainSelector: []ProposalData{
+				{
+					contract: contract.Address().Hex(),
+					tx:       tx,
+				},
 			},
-		}, c.McmsConfig.MinDelay)
+		}
+
+		proposal, err := BuildMultiChainProposals(env, "proposal to remove a feed config from cache", proposalConfig, c.McmsConfig.MinDelay)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}

--- a/deployment/data-feeds/changeset/set_feed_admin.go
+++ b/deployment/data-feeds/changeset/set_feed_admin.go
@@ -25,9 +25,6 @@ func setFeedAdminLogic(env deployment.Environment, c types.SetFeedAdminConfig) (
 	}
 
 	tx, err := contract.SetFeedAdmin(txOpt, c.AdminAddress, c.IsAdmin)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to set feed admin %w", err)
-	}
 
 	if c.McmsConfig != nil {
 		proposalConfig := MultiChainProposalConfig{
@@ -45,8 +42,8 @@ func setFeedAdminLogic(env deployment.Environment, c types.SetFeedAdminConfig) (
 		}
 		return deployment.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
-	_, err = chain.Confirm(tx)
-	if err != nil {
+
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 

--- a/deployment/data-feeds/changeset/set_feed_admin.go
+++ b/deployment/data-feeds/changeset/set_feed_admin.go
@@ -30,12 +30,16 @@ func setFeedAdminLogic(env deployment.Environment, c types.SetFeedAdminConfig) (
 	}
 
 	if c.McmsConfig != nil {
-		proposal, err := BuildMCMProposals(env, "proposal to set feed admin on a cache", c.ChainSelector, []ProposalData{
-			{
-				contract: contract.Address().Hex(),
-				tx:       tx,
+		proposalConfig := MultiChainProposalConfig{
+			c.ChainSelector: []ProposalData{
+				{
+					contract: contract.Address().Hex(),
+					tx:       tx,
+				},
 			},
-		}, c.McmsConfig.MinDelay)
+		}
+
+		proposal, err := BuildMultiChainProposals(env, "proposal to set feed admin on a cache", proposalConfig, c.McmsConfig.MinDelay)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}

--- a/deployment/data-feeds/changeset/set_feed_config.go
+++ b/deployment/data-feeds/changeset/set_feed_config.go
@@ -31,12 +31,15 @@ func setFeedConfigLogic(env deployment.Environment, c types.SetFeedDecimalConfig
 	}
 
 	if c.McmsConfig != nil {
-		proposal, err := BuildMCMProposals(env, "proposal to set feed config on a cache", c.ChainSelector, []ProposalData{
-			{
-				contract: contract.Address().Hex(),
-				tx:       tx,
+		proposals := MultiChainProposalConfig{
+			c.ChainSelector: []ProposalData{
+				{
+					contract: contract.Address().Hex(),
+					tx:       tx,
+				},
 			},
-		}, c.McmsConfig.MinDelay)
+		}
+		proposal, err := BuildMultiChainProposals(env, "proposal to set feed config on a cache", proposals, c.McmsConfig.MinDelay)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}

--- a/deployment/data-feeds/changeset/set_feed_config.go
+++ b/deployment/data-feeds/changeset/set_feed_config.go
@@ -26,9 +26,6 @@ func setFeedConfigLogic(env deployment.Environment, c types.SetFeedDecimalConfig
 	}
 
 	tx, err := contract.SetDecimalFeedConfigs(txOpt, c.DataIDs, c.Descriptions, c.WorkflowMetadata)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to set feed config %w", err)
-	}
 
 	if c.McmsConfig != nil {
 		proposals := MultiChainProposalConfig{
@@ -45,8 +42,8 @@ func setFeedConfigLogic(env deployment.Environment, c types.SetFeedDecimalConfig
 		}
 		return deployment.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
-	_, err = chain.Confirm(tx)
-	if err != nil {
+
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 

--- a/deployment/data-feeds/changeset/update_data_id_proxy.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy.go
@@ -26,9 +26,6 @@ func updateDataIDProxyLogic(env deployment.Environment, c types.UpdateDataIDProx
 	}
 
 	tx, err := contract.UpdateDataIdMappingsForProxies(txOpt, c.ProxyAddresses, c.DataIDs)
-	if err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to set proxy-dataId mapping %w", err)
-	}
 
 	if c.McmsConfig != nil {
 		proposals := MultiChainProposalConfig{
@@ -46,8 +43,8 @@ func updateDataIDProxyLogic(env deployment.Environment, c types.UpdateDataIDProx
 		}
 		return deployment.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
-	_, err = chain.Confirm(tx)
-	if err != nil {
+
+	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 

--- a/deployment/data-feeds/changeset/update_data_id_proxy.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy.go
@@ -31,12 +31,16 @@ func updateDataIDProxyLogic(env deployment.Environment, c types.UpdateDataIDProx
 	}
 
 	if c.McmsConfig != nil {
-		proposal, err := BuildMCMProposals(env, "proposal to update proxy-dataId mapping on a cache", c.ChainSelector, []ProposalData{
-			{
-				contract: contract.Address().Hex(),
-				tx:       tx,
+		proposals := MultiChainProposalConfig{
+			c.ChainSelector: []ProposalData{
+				{
+					contract: contract.Address().Hex(),
+					tx:       tx,
+				},
 			},
-		}, c.McmsConfig.MinDelay)
+		}
+
+		proposal, err := BuildMultiChainProposals(env, "proposal to update proxy-dataId mapping on a cache", proposals, c.McmsConfig.MinDelay)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
 		}


### PR DESCRIPTION
Refactored MCM proposal generation helper function so that we can build many transactions for many chains at once, in one proposal, instead of many transactions for one chain as previously. 