### PR TITLE
Create initial nightly build/publish workflow

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,0 +1,82 @@
+name: Nightlies
+description: Build and publish nightly releases from trunk.
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # daily at 03:00 UTC
+
+concurrency:
+  group: nightlies
+  cancel-in-progress: true
+
+jobs:
+  docker-core:
+    permissions:
+      contents: read
+      id-token: write
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@cdd6cd208e7d778ce97b57aa459d8c2242aa8e11 # 2025-03-10
+    with:
+      aws-ecr-name: chainlink
+      dockerfile: core/chainlink.Dockerfile
+      docker-build-context: .
+      docker-build-args: |
+        CHAINLINK_USER=chainlink
+        COMMIT_SHA=${{ github.sha }}
+      docker-image-type: nightly
+      docker-manifest-sign: true
+      git-sha: ${{ github.sha }}
+      github-event-name: ${{ github.event_name }}
+      github-ref-name: ${{ github.ref_name }}
+      github-workflow-repository: ${{ github.repository }}
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
+
+  docker-core-plugins:
+    permissions:
+      contents: read
+      id-token: write
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@cdd6cd208e7d778ce97b57aa459d8c2242aa8e11 # 2025-03-10
+    with:
+      aws-ecr-name: chainlink
+      dockerfile: plugins/chainlink.Dockerfile
+      docker-build-context: .
+      docker-build-args: |
+        CHAINLINK_USER=chainlink
+        COMMIT_SHA=${{ github.sha }}
+      docker-image-type: nightly
+      docker-manifest-sign: true
+      docker-tag-custom-suffix: "-plugins"
+      git-sha: ${{ github.sha }}
+      github-event-name: ${{ github.event_name }}
+      github-ref-name: ${{ github.ref_name }}
+      github-workflow-repository: ${{ github.repository }}
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
+
+  docker-ccip:
+    permissions:
+      contents: read
+      id-token: write
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@cdd6cd208e7d778ce97b57aa459d8c2242aa8e11 # 2025-03-10
+    with:
+      aws-ecr-name: ccip
+      dockerfile: core/chainlink.Dockerfile
+      docker-build-context: .
+      docker-build-args: |
+        CHAINLINK_USER=chainlink
+        CL_CHAIN_DEFAULTS=/ccip-config
+        COMMIT_SHA=${{ github.sha }}
+      docker-image-type: nightly
+      docker-manifest-sign: true
+      git-sha: ${{ github.sha }}
+      github-event-name: ${{ github.event_name }}
+      github-ref-name: ${{ github.ref_name }}
+      github-workflow-repository: ${{ github.repository }}
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}


### PR DESCRIPTION
This creates and publishes a "nightly" build (in the form of a Docker image) from trunk for:

1. core
2. core + plugins
3. ccip

In the future, we'll create the builds only if certain pre-requisites such as `ci-core.yml` and `integration-tests.yml` workflows on the same commit are passing.

This uses a new [reusable workflow](https://github.com/smartcontractkit/.github/blob/main/.github/workflows/reusable-docker-build-publish.yml) which itself uses new actions:

1. [build-push-docker](https://github.com/smartcontractkit/.github/tree/main/actions/build-push-docker)
2. [build-push-docker-manifest](https://github.com/smartcontractkit/.github/tree/main/actions/build-push-docker-manifest)

These new actions give us the following features:

1. SBOM / provenance
2. Manifest signing
3. Multiple arch support (amd64/arm64) with a manifest creation (just refer to one tag and it will pull the right platform)
4. Each arch build runs on a respective runner of that type (e.g. arm64 builds on arm64 runners)
5. [Complete GitHub Summary](https://github.com/smartcontractkit/chainlink/actions/runs/13769031739?pr=16701) with image details
6. Consistent docker image tags. Specify type: `pr`, `nightly`, `branch`, `tag` and get a standardized/tagged image.

Once we get comfortable with this new workflow and its underlying actions, the goal would be to use this pattern for all builds on this (and other!) repos such as builds for PR's, tagged releases, and pushes to trunk.