### PR TITLE
integration-tests/load: fix outstanding linter issues

### DIFF
--- a/integration-tests/load/ccip/ccip_test.go
+++ b/integration-tests/load/ccip/ccip_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common/math"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -123,14 +123,13 @@ func TestCCIPLoad_RPS(t *testing.T) {
 				mu.Lock()
 				messageKeys[src] = transmitKeys[src][ind]
 				mu.Unlock()
-				err := prepareAccountToSendLink(
+				assert.NoError(t, prepareAccountToSendLink(
 					t,
 					state,
 					*env,
 					src,
 					messageKeys[src],
-				)
-				require.NoError(t, err)
+				))
 			}(src)
 		}
 		wg2.Wait()
@@ -239,7 +238,9 @@ func prepareAccountToSendLink(
 	lggr.Infow("Granting mint and burn roles")
 	tx, err := srcLink.GrantMintAndBurnRoles(srcDeployer, srcAccount.From)
 	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
-	require.NoError(t, err)
+	if err != nil {
+		return err
+	}
 
 	lggr.Infow("Minting transfer amounts")
 	//--------------------------------------------------------------------------------------------

--- a/integration-tests/load/ccip/destination_gun.go
+++ b/integration-tests/load/ccip/destination_gun.go
@@ -138,7 +138,7 @@ func (m *DestinationGun) Call(_ *wasp.Generator) *wasp.Response {
 				dst:    m.chainSelector,
 				seqNum: 0,
 			},
-			timestamp: uint64(time.Now().Unix()),
+			timestamp: uint64(time.Now().Unix()), //nolint:gosec // G115
 		}
 		m.metricPipe <- data
 

--- a/integration-tests/load/ccip/helpers.go
+++ b/integration-tests/load/ccip/helpers.go
@@ -4,35 +4,29 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/big"
 	"slices"
 	"sync"
 	"time"
 
-	"go.uber.org/atomic"
-
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
-	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/onramp"
-
-	"github.com/ethereum/go-ethereum/event"
-
-	"golang.org/x/sync/errgroup"
-
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
+	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
 
-	"github.com/smartcontractkit/chainlink-testing-framework/seth"
-	"github.com/smartcontractkit/chainlink/deployment/environment/crib"
-
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	chainselectors "github.com/smartcontractkit/chain-selectors"
-
-	"math/big"
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
+	"github.com/smartcontractkit/chainlink-testing-framework/seth"
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	"github.com/smartcontractkit/chainlink/deployment/environment/crib"
+
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/offramp"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/onramp"
 )
 
 const (
@@ -159,7 +153,6 @@ func subscribeTransmitEvents(
 			}
 			return
 		}
-
 	}
 }
 


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/13777376230/job/38529222822
```xml
<checkstyle version="5.0">
  <file name="integration-tests/load/ccip/ccip_test.go">
    <error column="12" line="126" message="go-require: prepareAccountToSendLink contains assertions that must only be used in the goroutine running the test function" severity="error" source="testifylint"></error>
    <error column="5" line="133" message="go-require: require must only be used in the goroutine running the test function" severity="error" source="testifylint"></error>
  </file>
  <file name="integration-tests/load/ccip/destination_gun.go">
    <error column="21" line="141" message="G115: integer overflow conversion int64 -&gt; uint64" severity="error" source="gosec"></error>
  </file>
  <file name="integration-tests/load/ccip/helpers.go">
    <error column="2" line="163" message="unnecessary trailing newline" severity="error" source="whitespace"></error>
  </file>
</checkstyle>
```