### PR TITLE
Marked mocks as optional for TXM lifecycle test

### DIFF
--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -537,8 +537,8 @@ func TestTxm_Lifecycle(t *testing.T) {
 	head := cltest.Head(42)
 	finalizedHead := cltest.Head(0)
 
-	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(head, nil)
-	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(finalizedHead, nil)
+	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(head, nil).Maybe()
+	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(finalizedHead, nil).Maybe()
 
 	keyChangeCh := make(chan struct{})
 	unsub := cltest.NewAwaiter()


### PR DESCRIPTION
Certain mocks in the TXM lifecycle needed to be marked as optional since they were not always called depending on how far in the process the TXM made it before shutdown.