### PR TITLE
Fix `subId` initialization in `SubscriptionAPI.sol` to prevent underflow from `block.number - 1` when testing locally

### DIFF
--- a/contracts/src/v0.8/vrf/dev/SubscriptionAPI.sol
+++ b/contracts/src/v0.8/vrf/dev/SubscriptionAPI.sol
@@ -346,7 +346,14 @@ abstract contract SubscriptionAPI is ConfirmedOwner, IERC677Receiver, IVRFSubscr
     // Generate a subscription id that is globally unique.
     uint64 currentSubNonce = s_currentSubNonce;
     subId = uint256(
-      keccak256(abi.encodePacked(msg.sender, blockhash(block.number - 1), address(this), currentSubNonce))
+        keccak256(
+            abi.encodePacked(
+                msg.sender,
+                (block.number == 0 ? bytes32(0) : blockhash(block.number - 1)),
+                address(this),
+                currentSubNonce
+            )
+        )
     );
     // Increment the subscription nonce counter.
     s_currentSubNonce = currentSubNonce + 1;


### PR DESCRIPTION
When executing a script to create a VRF subscription locally using `VRFCoordinatorV2_5Mock` on a Foundry Anvil node, it reverts with `panic: arithmetic underflow or overflow (0x11)`, as shown in the screenshot:

![Screenshot 2025-03-12 at 6 37 42 AM](https://github.com/user-attachments/assets/f9e2bdd2-4c80-470d-9862-32a8b13caafe)

Here's the script that I'm using:

```js
//SPDX-License-Identifier: MIT
pragma solidity 0.8.26;

import {Script, console} from "forge-std/Script.sol";
import {VRFCoordinatorV2_5Mock} from
    "lib/chainlink-brownie-contracts/contracts/src/v0.8/vrf/mocks/VRFCoordinatorV2_5Mock.sol";

contract CreateSubscription is Script {
    /**
     * vrf mock values
     */
    uint96 constant MOCK_BASE_FEE = 0.25 ether;
    uint96 constant MOCK_GAS_PRICE_LINK = 1e9;
    //link eth price
    int256 constant MOCK_WEI_PER_UINT_LINK = 4e15;

    address constant DEFAULT_ANVIL_ACCOUNT = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;

    function createSubscription() public {
        console.log("Creating subscription on chainID:", block.chainid);
        vm.startBroadcast(DEFAULT_ANVIL_ACCOUNT);
        uint256 subId =
            new VRFCoordinatorV2_5Mock(MOCK_BASE_FEE, MOCK_GAS_PRICE_LINK, MOCK_WEI_PER_UINT_LINK).createSubscription();
        vm.stopBroadcast();
        console.log("Your Subscription ID is:", subId);
    }

    function run() public {
        createSubscription();
    }
}
```

Upon further inspection, I realized that it is reverting at this [line](https://github.com/smartcontractkit/chainlink-brownie-contracts/blob/5cb41fbc9b525338b6098da5ea7dd0b7e92f89e4/contracts/src/v0.8/vrf/dev/SubscriptionAPI.sol#L349) in `SubscriptionAPI.sol`:

```js
subId = uint256(
    keccak256(abi.encodePacked(msg.sender, blockhash(block.number - 1), address(this), currentSubNonce))
);
```

Since this is the very first transaction when running locally, the value of `block.number` is `0`, making `block.number - 1` negative, which causes an **arithmetic underflow**.

A possible solution is to add a condition to check the value of `block.number`. If it is `0`, then instead of calculating `blockhash`, simply use the empty 32-byte value (`bytes32(0)`). Otherwise, use `blockhash(block.number - 1)` as usual. The revised line would be:

```js
subId = uint256(
    keccak256(
        abi.encodePacked(
            msg.sender,
            (block.number == 0 ? bytes32(0) : blockhash(block.number - 1)),
            address(this),
            currentSubNonce
        )
    )
);
```
