### PR TITLE
(feat): Add decryptSecrets method to workflow syncer

### DIFF
--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -115,5 +115,9 @@ func (s *FetcherService) Fetch(ctx context.Context, url string, n uint32) ([]byt
 		return nil, fmt.Errorf("execution error from gateway: %s", payload.ErrorMessage)
 	}
 
+	if payload.StatusCode <= 200 && payload.StatusCode >= 300 {
+		return payload.Body, fmt.Errorf("request failed with status code: %d", payload.StatusCode)
+	}
+
 	return payload.Body, nil
 }

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -115,7 +115,8 @@ func (s *FetcherService) Fetch(ctx context.Context, url string, n uint32) ([]byt
 		return nil, fmt.Errorf("execution error from gateway: %s", payload.ErrorMessage)
 	}
 
-	if payload.StatusCode <= 200 && payload.StatusCode >= 300 {
+	if payload.StatusCode < 200 || payload.StatusCode >= 300 {
+		// NOTE: redirects are currently not supported
 		return payload.Body, fmt.Errorf("request failed with status code: %d", payload.StatusCode)
 	}
 

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -475,16 +475,17 @@ func (h *eventHandler) workflowRegisteredEvent(
 	// Always fetch secrets from the SecretsURL
 	var secrets []byte
 	if payload.SecretsURL != "" {
-		secrets, err = h.fetchFn(ctx, payload.SecretsURL, safeUint32(h.limits.MaxSecretsSize))
-		if err != nil {
+		fetchedSecrets, fetchErr := h.fetchFn(ctx, payload.SecretsURL, safeUint32(h.limits.MaxSecretsSize))
+		if fetchErr != nil {
 			return fmt.Errorf("failed to fetch secrets from %s : %w", payload.SecretsURL, err)
 		}
 
 		// sanity check by decoding the secrets
-		_, err := h.decryptSecrets(secrets, string(payload.WorkflowOwner))
-		if err != nil {
+		_, decryptErr := h.decryptSecrets(secrets, string(payload.WorkflowOwner))
+		if decryptErr != nil {
 			return fmt.Errorf("failed to decrypt secrets %s: %w", payload.SecretsURL, err)
 		}
+		secrets = fetchedSecrets
 	}
 
 	// Calculate the hash of the binary and config files

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -178,6 +178,7 @@ type eventHandler struct {
 	engineFactory            engineFactoryFn
 	ratelimiter              *ratelimiter.RateLimiter
 	workflowLimits           *syncerlimiter.Limits
+	decryptSecrets           func(data []byte, owner string) (map[string]string, error)
 }
 
 type Event interface {
@@ -234,6 +235,15 @@ func NewEventHandler(
 		encryptionKey:            encryptionKey,
 		ratelimiter:              ratelimiter,
 		workflowLimits:           workflowLimits,
+		decryptSecrets: func(data []byte, owner string) (map[string]string, error) {
+			secretsPayload := secrets.EncryptedSecretsResult{}
+			err := json.Unmarshal(data, &secretsPayload)
+			if err != nil {
+				return nil, fmt.Errorf("could not unmarshal secrets: %w", err)
+			}
+
+			return secrets.DecryptSecretsForNode(secretsPayload, encryptionKey, owner)
+		},
 	}
 	eh.engineFactory = eh.engineFactoryFn
 	eh.limits.ApplyDefaults()
@@ -305,17 +315,7 @@ func (h *eventHandler) SecretsFor(ctx context.Context, workflowOwner, hexWorkflo
 		}
 	}
 
-	res := secrets.EncryptedSecretsResult{}
-	err = json.Unmarshal([]byte(secretsPayload), &res)
-	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal secrets: %w", err)
-	}
-
-	return secrets.DecryptSecretsForNode(
-		res,
-		h.encryptionKey,
-		workflowOwner,
-	)
+	return h.decryptSecrets([]byte(secretsPayload), workflowOwner)
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event Event) error {
@@ -478,6 +478,12 @@ func (h *eventHandler) workflowRegisteredEvent(
 		secrets, err = h.fetchFn(ctx, payload.SecretsURL, safeUint32(h.limits.MaxSecretsSize))
 		if err != nil {
 			return fmt.Errorf("failed to fetch secrets from %s : %w", payload.SecretsURL, err)
+		}
+
+		// sanity check by decoding the secrets
+		_, err := h.decryptSecrets(secrets, string(payload.WorkflowOwner))
+		if err != nil {
+			return fmt.Errorf("failed to decrypt secrets %s: %w", payload.SecretsURL, err)
 		}
 	}
 
@@ -747,6 +753,13 @@ func (h *eventHandler) forceUpdateSecretsEvent(
 	secrets, err := h.fetchFn(ctx, url, safeUint32(h.limits.MaxSecretsSize))
 	if err != nil {
 		return "", err
+	}
+
+	// Sanity check the payload and ensure we can decrypt it.
+	// If we can't, let's return an error and we won't store the result in the DB.
+	_, err = h.decryptSecrets(secrets, hex.EncodeToString(payload.Owner))
+	if err != nil {
+		return "", fmt.Errorf("failed to validate secrets: could not decrypt: %w", err)
 	}
 
 	h.lastFetchedAtMap.Set(hash, h.clock.Now())

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -165,17 +165,15 @@ func RunTimelockExecutor(env deployment.Environment, cfg RunTimelockExecutorConf
 				if err != nil {
 					return fmt.Errorf("error creating timelock executor proxy: %w", err)
 				}
-
-				ch := env.Chains[cfg.ChainSelector].DeployerKey
-				ch.NoSend = true
-
 				tx, err := timelockExecutorProxy.ExecuteBatch(
-					ch, calls, pred, salt)
+					env.Chains[cfg.ChainSelector].DeployerKey, calls, pred, salt)
 				if err != nil {
-					fmt.Printf("err: %+v", err)
 					return fmt.Errorf("error executing batch: %w", err)
 				}
-				fmt.Printf("%x", tx.Data())
+				_, err = env.Chains[cfg.ChainSelector].Confirm(tx)
+				if err != nil {
+					return fmt.Errorf("error confirming batch: %w", err)
+				}
 			}
 		}
 	}

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -165,15 +165,17 @@ func RunTimelockExecutor(env deployment.Environment, cfg RunTimelockExecutorConf
 				if err != nil {
 					return fmt.Errorf("error creating timelock executor proxy: %w", err)
 				}
+
+				ch := env.Chains[cfg.ChainSelector].DeployerKey
+				ch.NoSend = true
+
 				tx, err := timelockExecutorProxy.ExecuteBatch(
-					env.Chains[cfg.ChainSelector].DeployerKey, calls, pred, salt)
+					ch, calls, pred, salt)
 				if err != nil {
+					fmt.Printf("err: %+v", err)
 					return fmt.Errorf("error executing batch: %w", err)
 				}
-				_, err = env.Chains[cfg.ChainSelector].Confirm(tx)
-				if err != nil {
-					return fmt.Errorf("error confirming batch: %w", err)
-				}
+				fmt.Printf("%x", tx.Data())
 			}
 		}
 	}


### PR DESCRIPTION
### Description

Ensures that secrets from a URL persist through the following:
1. Implements a check for the HTTP response status before processing the response body.
2. Ensures that the secrets are only updated if a valid secrets file is retrieved and validated. This is done through a new method `decryptSecrets` that is called after every refresh.

