### PR TITLE
[CLD-16]: feat(operation): introduce operation component

### DIFF
--- a/deployment/operations/operation.go
+++ b/deployment/operations/operation.go
@@ -1,0 +1,88 @@
+package operations
+
+import (
+	"context"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+// Bundle contains the dependencies required by Operations API and is passed to the OperationHandler and SequenceHandler.
+// It contains the Logger, Reporter and the context.
+// Use NewBundle to create a new Bundle.
+type Bundle struct {
+	Logger     logger.Logger
+	GetContext func() context.Context
+}
+
+// NewBundle creates and returns a new Bundle.
+func NewBundle(getContext func() context.Context, logger logger.Logger) Bundle {
+	return Bundle{
+		Logger:     logger,
+		GetContext: getContext,
+	}
+}
+
+// OperationHandler is the function signature of an operation handler.
+type OperationHandler[IN, OUT, DEP any] func(e Bundle, deps DEP, input IN) (output OUT, err error)
+
+// Definition is the metadata for a sequence or an operation.
+// It contains the ID, version and description.
+// This definition and OperationHandler together form the composite keys for an Operation.
+// 2 Operations are considered the same if they have the Definition and OperationHandler.
+type Definition struct {
+	ID          string
+	Version     *semver.Version
+	Description string
+}
+
+// Operation is the low level building blocks of the Operations API.
+// Developers define their own operation with custom input and output types.
+// Each operation should only perform max 1 side effect (e.g. send a transaction, post a job spec...)
+// Use NewOperation to create a new operation.
+type Operation[IN, OUT, DEP any] struct {
+	def     Definition
+	handler OperationHandler[IN, OUT, DEP]
+}
+
+// ID returns the operation ID.
+func (o *Operation[IN, OUT, DEP]) ID() string {
+	return o.def.ID
+}
+
+// Version returns the operation semver version in string.
+func (o *Operation[IN, OUT, DEP]) Version() string {
+	return o.def.Version.String()
+}
+
+// Description returns the operation description.
+func (o *Operation[IN, OUT, DEP]) Description() string {
+	return o.def.Description
+}
+
+// execute runs the operation by calling the OperationHandler.
+func (o *Operation[IN, OUT, DEP]) execute(b Bundle, deps DEP, input IN) (output OUT, err error) {
+	b.Logger.Infow("Executing operation",
+		"id", o.def.ID, "version", o.def.Version, "description", o.def.Description)
+	return o.handler(b, deps, input)
+}
+
+// NewOperation creates a new operation.
+// Version can be created using semver.MustParse("1.0.0") or semver.New("1.0.0").
+// Note: The handler should only perform maximum 1 side effect.
+func NewOperation[IN, OUT, DEP any](
+	id string, version *semver.Version, description string, handler OperationHandler[IN, OUT, DEP],
+) *Operation[IN, OUT, DEP] {
+	return &Operation[IN, OUT, DEP]{
+		def: Definition{
+			ID:          id,
+			Version:     version,
+			Description: description,
+		},
+		handler: handler,
+	}
+}
+
+// EmptyInput is a placeholder for operations that do not require input.
+type EmptyInput struct{}

--- a/deployment/operations/operation_test.go
+++ b/deployment/operations/operation_test.go
@@ -1,0 +1,71 @@
+package operations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+type OpDeps struct{}
+
+type OpInput struct {
+	A int
+	B int
+}
+
+func Test_NewOperation(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+	description := "test operation"
+	handler := func(b Bundle, deps OpDeps, input OpInput) (output int, err error) {
+		return input.A + input.B, nil
+	}
+
+	op := NewOperation("sum", version, description, handler)
+
+	assert.Equal(t, "sum", op.ID())
+	assert.Equal(t, version.String(), op.Version())
+	assert.Equal(t, description, op.Description())
+	res, err := op.handler(Bundle{}, OpDeps{}, OpInput{1, 2})
+	require.NoError(t, err)
+	assert.Equal(t, 3, res)
+}
+
+func Test_Operation_Execute(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+	description := "test operation"
+	log, observedLog := logger.TestObserved(t, zapcore.InfoLevel)
+
+	// simulate an addition operation
+	handler := func(b Bundle, deps OpDeps, input OpInput) (output int, err error) {
+		return input.A + input.B, nil
+	}
+
+	op := NewOperation("sum", version, description, handler)
+	e := NewBundle(context.Background, log)
+	input := OpInput{
+		A: 1,
+		B: 2,
+	}
+
+	output, err := op.execute(e, OpDeps{}, input)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, output)
+
+	require.Equal(t, 1, observedLog.Len())
+	entry := observedLog.All()[0]
+	assert.Equal(t, "Executing operation", entry.Message)
+	assert.Equal(t, "sum", entry.ContextMap()["id"])
+	assert.Equal(t, version.String(), entry.ContextMap()["version"])
+	assert.Equal(t, description, entry.ContextMap()["description"])
+}


### PR DESCRIPTION
Introducing the first building block for the operations API, this commit introduces the Operation component.

Ported from Rodrigo [spike PR](https://github.com/smartcontractkit/chainlink/pull/16065), but updated with small changes like factory methods and naming changes.

Currently, it does not include Report, retry policy , those will be in future PRs. One small PR at a time for feedback to incorporate any improvements.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-16

