### PR TITLE
Jh/fix evmccip gas helper for svm2evm

### DIFF
--- a/core/capabilities/ccip/ccipevm/executecodec.go
+++ b/core/capabilities/ccip/ccipevm/executecodec.go
@@ -104,7 +104,7 @@ func (e *ExecutePluginCodecV1) Encode(ctx context.Context, report cciptypes.Exec
 				return nil, err
 			}
 
-			gasLimit, err := parseExtraDataMap(decodedExtraArgsMap)
+			gasLimit, err := parseExtraArgsMap(decodedExtraArgsMap)
 			if err != nil {
 				return nil, fmt.Errorf("decode extra args to get gas limit: %w", err)
 			}

--- a/core/capabilities/ccip/ccipevm/gas_helpers_test.go
+++ b/core/capabilities/ccip/ccipevm/gas_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -78,7 +79,7 @@ func Test_calculateMessageMaxGas(t *testing.T) {
 				ExtraArgs:    tt.args.extraArgs,
 			}
 			// Set the source chain selector to be EVM for now
-			msg.Header.SourceChainSelector = 5009297550715157269
+			msg.Header.SourceChainSelector = ccipocr3.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector)
 			ep := EstimateProvider{extraDataCodec: ExtraDataCodec}
 			got := ep.CalculateMessageMaxGas(msg)
 			t.Log(got)

--- a/core/capabilities/ccip/ccipevm/gas_helpers_test.go
+++ b/core/capabilities/ccip/ccipevm/gas_helpers_test.go
@@ -77,7 +77,9 @@ func Test_calculateMessageMaxGas(t *testing.T) {
 				TokenAmounts: getTokenAmounts(t, tt.args.numTokens, tt.args.tokenGasOverhead),
 				ExtraArgs:    tt.args.extraArgs,
 			}
-			ep := EstimateProvider{}
+			// Set the source chain selector to be EVM for now
+			msg.Header.SourceChainSelector = 5009297550715157269
+			ep := EstimateProvider{extraDataCodec: ExtraDataCodec}
 			got := ep.CalculateMessageMaxGas(msg)
 			t.Log(got)
 			assert.Equalf(t, tt.want, got, "calculateMessageMaxGas(%v, %v)", tt.args.dataLen, tt.args.numTokens)
@@ -178,7 +180,7 @@ func makeExtraArgsV2(gasLimit uint64, allowOOO bool) []byte {
 }
 
 func getTokenAmounts(t *testing.T, numTokens int, tokenGasOverhead uint32) []ccipocr3.RampTokenAmount {
-	tokenDestGasOverhead, err := TokenDestGasOverheadABI.Pack(tokenGasOverhead)
+	tokenDestGasOverhead, err := abiEncodeUint32(tokenGasOverhead)
 	require.NoError(t, err)
 
 	tokenAmounts := make([]ccipocr3.RampTokenAmount, numTokens)

--- a/core/capabilities/ccip/ccipevm/gas_helpers_test.go
+++ b/core/capabilities/ccip/ccipevm/gas_helpers_test.go
@@ -136,8 +136,9 @@ func TestCalculateMaxGas(t *testing.T) {
 				TokenAmounts: getTokenAmounts(t, tt.numberOfTokens, tt.tokenGasOverhead),
 				ExtraArgs:    tt.extraArgs,
 			}
-			ep := EstimateProvider{}
 
+			msg.Header.SourceChainSelector = ccipocr3.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector)
+			ep := EstimateProvider{extraDataCodec: ExtraDataCodec}
 			gotTree := ep.CalculateMerkleTreeGas(tt.numRequests)
 			gotMsg := ep.CalculateMessageMaxGas(msg)
 			t.Log("want", tt.want, "got", gotTree+gotMsg)

--- a/core/capabilities/ccip/ccipevm/helpers.go
+++ b/core/capabilities/ccip/ccipevm/helpers.go
@@ -71,11 +71,11 @@ func ABITypeOrPanic(t string) abi.Type {
 func CCIPMsgToAny2EVMMessage(msg ccipocr3.Message, codec ccipcommon.ExtraDataCodec) (offramp.InternalAny2EVMRampMessage, error) {
 	var tokenAmounts []offramp.InternalAny2EVMTokenTransfer
 	for _, rta := range msg.TokenAmounts {
-		decodecMap, err := codec.DecodeTokenAmountDestExecData(rta.DestExecData, msg.Header.SourceChainSelector)
+		decodedMap, err := codec.DecodeTokenAmountDestExecData(rta.DestExecData, msg.Header.SourceChainSelector)
 		if err != nil {
 			return offramp.InternalAny2EVMRampMessage{}, fmt.Errorf("failed to decode dest gas amount: %w", err)
 		}
-		destGasAmount, err := extractDestGasAmountFromMap(decodecMap)
+		destGasAmount, err := extractDestGasAmountFromMap(decodedMap)
 		if err != nil {
 			return offramp.InternalAny2EVMRampMessage{}, fmt.Errorf("failed to extract dest gas amount from decodec map: %w", err)
 		}

--- a/core/capabilities/ccip/ccipevm/helpers.go
+++ b/core/capabilities/ccip/ccipevm/helpers.go
@@ -1,7 +1,6 @@
 package ccipevm
 
 import (
-	"bytes"
 	"fmt"
 	"math/big"
 
@@ -19,34 +18,6 @@ const (
 	evmV2DecodeName    = "decodeEVMExtraArgsV2"
 	evmDestExecDataKey = "destGasAmount"
 )
-
-// decodeExtraArgsV1V2 decodes the given EVM Extra Args and extracts the gas limit
-// that was specified.
-func decodeExtraArgsV1V2(extraArgs []byte) (gasLimit *big.Int, err error) {
-	if len(extraArgs) < 4 {
-		return nil, fmt.Errorf("extra args too short: %d, should be at least 4 bytes long (i.e the extraArgs tag)", len(extraArgs))
-	}
-
-	var method string
-	if bytes.Equal(extraArgs[:4], evmExtraArgsV1Tag) {
-		method = evmV1DecodeName
-	} else if bytes.Equal(extraArgs[:4], evmExtraArgsV2Tag) {
-		method = evmV2DecodeName
-	} else {
-		return nil, fmt.Errorf("unknown extra args tag: %x", extraArgs)
-	}
-	ifaces, err := messageHasherABI.Methods[method].Inputs.UnpackValues(extraArgs[4:])
-	if err != nil {
-		return nil, fmt.Errorf("abi decode extra args v1: %w", err)
-	}
-	// gas limit is always the first argument, and allow OOO isn't set explicitly
-	// on the message.
-	_, ok := ifaces[0].(*big.Int)
-	if !ok {
-		return nil, fmt.Errorf("expected *big.Int, got %T", ifaces[0])
-	}
-	return ifaces[0].(*big.Int), nil
-}
 
 // abiEncodeMethodInputs encodes the inputs for a method call.
 // example abi: `[{ "name" : "method", "type": "function", "inputs": [{"name": "a", "type": "uint256"}]}]`

--- a/core/capabilities/ccip/ccipevm/helpers.go
+++ b/core/capabilities/ccip/ccipevm/helpers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/offramp"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/onramp"
 )
@@ -17,15 +18,6 @@ const (
 	evmV1DecodeName    = "decodeEVMExtraArgsV1"
 	evmV2DecodeName    = "decodeEVMExtraArgsV2"
 	evmDestExecDataKey = "destGasAmount"
-)
-
-var (
-	abiUint32               = ABITypeOrPanic("uint32")
-	TokenDestGasOverheadABI = abi.Arguments{
-		{
-			Type: abiUint32,
-		},
-	}
 )
 
 // decodeExtraArgsV1V2 decodes the given EVM Extra Args and extracts the gas limit
@@ -74,27 +66,18 @@ func ABITypeOrPanic(t string) abi.Type {
 	return abiType
 }
 
-// Decodes the given bytes into a uint32, based on the encoding of destGasAmount in FeeQuoter.sol
-func decodeTokenDestGasOverhead(destExecData []byte) (uint32, error) {
-	ifaces, err := TokenDestGasOverheadABI.UnpackValues(destExecData)
-	if err != nil {
-		return 0, fmt.Errorf("abi decode TokenDestGasOverheadABI: %w", err)
-	}
-	_, ok := ifaces[0].(uint32)
-	if !ok {
-		return 0, fmt.Errorf("expected uint32, got %T", ifaces[0])
-	}
-	return ifaces[0].(uint32), nil
-}
-
 // CCIPMsgToAny2EVMMessage converts a ccipocr3.Message object to an offramp.InternalAny2EVMRampMessage object.
 // These are typically used to create the execution report for EVM.
-func CCIPMsgToAny2EVMMessage(msg ccipocr3.Message) (offramp.InternalAny2EVMRampMessage, error) {
+func CCIPMsgToAny2EVMMessage(msg ccipocr3.Message, codec ccipcommon.ExtraDataCodec) (offramp.InternalAny2EVMRampMessage, error) {
 	var tokenAmounts []offramp.InternalAny2EVMTokenTransfer
 	for _, rta := range msg.TokenAmounts {
-		destGasAmount, err := abiDecodeUint32(rta.DestExecData)
+		decodecMap, err := codec.DecodeTokenAmountDestExecData(rta.DestExecData, msg.Header.SourceChainSelector)
 		if err != nil {
 			return offramp.InternalAny2EVMRampMessage{}, fmt.Errorf("failed to decode dest gas amount: %w", err)
+		}
+		destGasAmount, err := extractDestGasAmountFromMap(decodecMap)
+		if err != nil {
+			return offramp.InternalAny2EVMRampMessage{}, fmt.Errorf("failed to extract dest gas amount from decodec map: %w", err)
 		}
 
 		tokenAmounts = append(tokenAmounts, offramp.InternalAny2EVMTokenTransfer{
@@ -106,9 +89,14 @@ func CCIPMsgToAny2EVMMessage(msg ccipocr3.Message) (offramp.InternalAny2EVMRampM
 		})
 	}
 
-	gasLimit, err := decodeExtraArgsV1V2(msg.ExtraArgs)
+	decodeMap, err := codec.DecodeExtraArgs(msg.ExtraArgs, msg.Header.SourceChainSelector)
 	if err != nil {
 		return offramp.InternalAny2EVMRampMessage{}, fmt.Errorf("failed to decode extra args: %w", err)
+	}
+
+	gasLimit, err := parseExtraArgsMap(decodeMap)
+	if err != nil {
+		return offramp.InternalAny2EVMRampMessage{}, fmt.Errorf("failed to get gasLimit by parsing extra args map: %w", err)
 	}
 
 	return offramp.InternalAny2EVMRampMessage{

--- a/core/capabilities/ccip/ccipevm/helpers_test.go
+++ b/core/capabilities/ccip/ccipevm/helpers_test.go
@@ -15,31 +15,6 @@ func Test_decodeExtraArgs(t *testing.T) {
 	gasLimit := big.NewInt(rand.Int63())
 	extraDataDecoder := &ExtraDataDecoder{}
 
-	t.Run("v1", func(t *testing.T) {
-		encoded, err := d.contract.EncodeEVMExtraArgsV1(nil, message_hasher.ClientEVMExtraArgsV1{
-			GasLimit: gasLimit,
-		})
-		require.NoError(t, err)
-
-		decodedGasLimit, err := decodeExtraArgsV1V2(encoded)
-		require.NoError(t, err)
-
-		require.Equal(t, gasLimit, decodedGasLimit)
-	})
-
-	t.Run("v2", func(t *testing.T) {
-		encoded, err := d.contract.EncodeEVMExtraArgsV2(nil, message_hasher.ClientGenericExtraArgsV2{
-			GasLimit:                 gasLimit,
-			AllowOutOfOrderExecution: true,
-		})
-		require.NoError(t, err)
-
-		decodedGasLimit, err := decodeExtraArgsV1V2(encoded)
-		require.NoError(t, err)
-
-		require.Equal(t, gasLimit, decodedGasLimit)
-	})
-
 	t.Run("decode extra args into map evm v1", func(t *testing.T) {
 		encoded, err := d.contract.EncodeEVMExtraArgsV1(nil, message_hasher.ClientEVMExtraArgsV1{
 			GasLimit: gasLimit,

--- a/core/capabilities/ccip/ccipevm/manualexeclib/exec.go
+++ b/core/capabilities/ccip/ccipevm/manualexeclib/exec.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/offramp"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/onramp"
@@ -22,13 +21,11 @@ func GetMessageHashes(
 	lggr logger.Logger,
 	onrampAddress common.Address,
 	ccipMessageSentEvents []onramp.OnRampCCIPMessageSent,
+	extraDataCodec ccipcommon.ExtraDataCodec,
 ) ([][32]byte, error) {
 	msgHasher := ccipevm.NewMessageHasherV1(
 		lggr,
-		ccipcommon.NewExtraDataCodec(ccipcommon.NewExtraDataCodecParams(
-			ccipevm.ExtraDataDecoder{},
-			ccipsolana.ExtraDataDecoder{},
-		)),
+		extraDataCodec,
 	)
 	var ret [][32]byte
 	for _, event := range ccipMessageSentEvents {
@@ -109,11 +106,12 @@ func CreateExecutionReport(
 	ccipMessageSentEvents []onramp.OnRampCCIPMessageSent,
 	hashes [][32]byte,
 	flags *big.Int,
+	extraDataCodec ccipcommon.ExtraDataCodec,
 ) (offramp.InternalExecutionReport, error) {
 	var any2EVMs []offramp.InternalAny2EVMRampMessage
 	for _, event := range ccipMessageSentEvents {
 		ccipMsg := ccipevm.EVM2AnyToCCIPMsg(onrampAddress, event.Message)
-		any2EVM, err := ccipevm.CCIPMsgToAny2EVMMessage(ccipMsg)
+		any2EVM, err := ccipevm.CCIPMsgToAny2EVMMessage(ccipMsg, extraDataCodec)
 		if err != nil {
 			return offramp.InternalExecutionReport{}, fmt.Errorf("failed to convert ccip message to any2evm message: %w", err)
 		}

--- a/core/capabilities/ccip/ccipevm/msghasher.go
+++ b/core/capabilities/ccip/ccipevm/msghasher.go
@@ -180,7 +180,7 @@ func (h *MessageHasherV1) Hash(ctx context.Context, msg cciptypes.Message) (ccip
 		return [32]byte{}, err
 	}
 
-	gasLimit, err := parseExtraDataMap(decodedExtraArgsMap)
+	gasLimit, err := parseExtraArgsMap(decodedExtraArgsMap)
 	if err != nil {
 		return [32]byte{}, fmt.Errorf("decode extra args to get gas limit: %w", err)
 	}
@@ -268,7 +268,7 @@ func abiDecodeAddress(data []byte) (common.Address, error) {
 	return val, nil
 }
 
-func parseExtraDataMap(input map[string]any) (*big.Int, error) {
+func parseExtraArgsMap(input map[string]any) (*big.Int, error) {
 	var outputGas *big.Int
 	for fieldName, fieldValue := range input {
 		lowercase := strings.ToLower(fieldName)

--- a/core/capabilities/ccip/ccipevm/msghasher_test.go
+++ b/core/capabilities/ccip/ccipevm/msghasher_test.go
@@ -497,7 +497,7 @@ func ccipMsgToAny2EVMMessage(t *testing.T, msg cciptypes.Message, sourceSelector
 
 	decodedMap, err := ExtraDataCodec.DecodeExtraArgs(msg.ExtraArgs, sourceSelector)
 	require.NoError(t, err)
-	gasLimit, err := parseExtraDataMap(decodedMap)
+	gasLimit, err := parseExtraArgsMap(decodedMap)
 	require.NoError(t, err)
 
 	return message_hasher.InternalAny2EVMRampMessage{

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -68,7 +68,7 @@ var plugins = map[string]plugin{
 			return ccipevm.NewMessageHasherV1(lggr, extraDataCodec)
 		},
 		TokenDataEncoder:    ccipevm.NewEVMTokenDataEncoder(),
-		GasEstimateProvider: ccipevm.NewGasEstimateProvider(),
+		GasEstimateProvider: ccipevm.NewGasEstimateProvider(extraDataCodec),
 		RMNCrypto:           func(lggr logger.Logger) cciptypes.RMNCrypto { return ccipevm.NewEVMRMNCrypto(lggr) },
 	},
 	chainsel.FamilySolana: {

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -10,6 +10,9 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
+	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -219,6 +222,7 @@ func manuallyExecuteSingle(
 	msgSeqNr uint64,
 	lookbackDuration time.Duration,
 	reExecuteIfFailed bool,
+	extraDataCodec ccipcommon.ExtraDataCodec,
 ) error {
 	onRampAddress := state.Chains[srcChainSel].OnRamp.Address()
 
@@ -280,6 +284,7 @@ func manuallyExecuteSingle(
 		lggr,
 		onRampAddress,
 		ccipMessageSentEvents,
+		extraDataCodec,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to get message hashes: %w", err)
@@ -317,6 +322,7 @@ func manuallyExecuteSingle(
 		filteredMsgSentEvents,
 		hashes,
 		flags,
+		extraDataCodec,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create execution report: %w", err)
@@ -367,6 +373,7 @@ func ManuallyExecuteAll(
 	lookbackDuration time.Duration,
 	reExecuteIfFailed bool,
 ) error {
+	extraDataCodec := ccipcommon.NewExtraDataCodec(ccipcommon.NewExtraDataCodecParams(ccipevm.ExtraDataDecoder{}, ccipsolana.ExtraDataDecoder{}))
 	for _, seqNr := range msgSeqNrs {
 		err := manuallyExecuteSingle(
 			ctx,
@@ -378,6 +385,7 @@ func ManuallyExecuteAll(
 			uint64(seqNr), //nolint:gosec // seqNr is never <= 0.
 			lookbackDuration,
 			reExecuteIfFailed,
+			extraDataCodec
 		)
 		if err != nil {
 			return err

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -385,7 +385,7 @@ func ManuallyExecuteAll(
 			uint64(seqNr), //nolint:gosec // seqNr is never <= 0.
 			lookbackDuration,
 			reExecuteIfFailed,
-			extraDataCodec
+			extraDataCodec,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
EVM gas_helpers.go has evm specific decode logic that blocks SVM->EVM. Injecting extraDataCodec to remove the dependency.

https://chainlink-core.slack.com/archives/C0779R3AH8R/p1741876859315199