### PR TITLE
Add multi report tests.

### DIFF
--- a/integration-tests/smoke/ccip/ccip_batching_test.go
+++ b/integration-tests/smoke/ccip/ccip_batching_test.go
@@ -282,7 +282,7 @@ func Test_CCIPBatching_SingleSource(t *testing.T) {
 	ccipBatchingSingleSource(t)
 }
 
-func Test_CCIPBatching_SingleSource_MultiplReports(t *testing.T) {
+func Test_CCIPBatching_SingleSource_MultipleReports(t *testing.T) {
 	opt := testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
 		params.CommitOffChainConfig.MultipleReportsEnabled = true
 		params.CommitOffChainConfig.MaxMerkleRootsPerReport = 1

--- a/integration-tests/smoke/ccip/ccip_batching_test.go
+++ b/integration-tests/smoke/ccip/ccip_batching_test.go
@@ -141,7 +141,7 @@ func Test_CCIPBatching_MaxBatchSizeEVM(t *testing.T) {
 }
 
 func Test_CCIPBatching_MultiSource(t *testing.T) {
-	ccipBatching_MultiSource(t)
+	ccipBatchingMultiSource(t)
 }
 
 func Test_CCIPBatching_MultiSource_MultiReports(t *testing.T) {
@@ -150,10 +150,10 @@ func Test_CCIPBatching_MultiSource_MultiReports(t *testing.T) {
 		params.CommitOffChainConfig.MaxMerkleRootsPerReport = 1
 		return params
 	})
-	ccipBatching_MultiSource(t, opt)
+	ccipBatchingMultiSource(t, opt)
 }
 
-func ccipBatching_MultiSource(t *testing.T, opts ...testhelpers.TestOps) {
+func ccipBatchingMultiSource(t *testing.T, opts ...testhelpers.TestOps) {
 	// Setup 3 chains, with 2 lanes going to the dest.
 	ctx := testhelpers.Context(t)
 	setup := newBatchTestSetup(t, opts...)
@@ -279,7 +279,7 @@ func ccipBatching_MultiSource(t *testing.T, opts ...testhelpers.TestOps) {
 }
 
 func Test_CCIPBatching_SingleSource(t *testing.T) {
-	ccipBatching_SingleSource(t)
+	ccipBatchingSingleSource(t)
 }
 
 func Test_CCIPBatching_SingleSource_MultiplReports(t *testing.T) {
@@ -288,10 +288,10 @@ func Test_CCIPBatching_SingleSource_MultiplReports(t *testing.T) {
 		params.CommitOffChainConfig.MaxMerkleRootsPerReport = 1
 		return params
 	})
-	ccipBatching_SingleSource(t, opt)
+	ccipBatchingSingleSource(t, opt)
 }
 
-func ccipBatching_SingleSource(t *testing.T, opts ...testhelpers.TestOps) {
+func ccipBatchingSingleSource(t *testing.T, opts ...testhelpers.TestOps) {
 	// Setup 3 chains, with 2 lanes going to the dest.
 	ctx := testhelpers.Context(t)
 	setup := newBatchTestSetup(t, opts...)

--- a/integration-tests/smoke/ccip/ccip_batching_test.go
+++ b/integration-tests/smoke/ccip/ccip_batching_test.go
@@ -20,6 +20,7 @@ import (
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/offramp"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/onramp"
@@ -38,13 +39,18 @@ type batchTestSetup struct {
 	destChain    uint64
 }
 
-func newBatchTestSetup(t *testing.T) batchTestSetup {
+func newBatchTestSetup(t *testing.T, opts ...testhelpers.TestOps) batchTestSetup {
 	// Setup 3 chains, with 2 lanes going to the dest.
-	e, _, _ := testsetups.NewIntegrationEnvironment(
-		t,
+	options := []testhelpers.TestOps{
 		testhelpers.WithMultiCall3(),
 		testhelpers.WithNumOfChains(3),
 		testhelpers.WithNumOfUsersPerChain(2),
+	}
+	options = append(options, opts...)
+
+	e, _, _ := testsetups.NewIntegrationEnvironment(
+		t,
+		options...,
 	)
 
 	state, err := changeset.LoadOnchainState(e.Env)
@@ -135,9 +141,22 @@ func Test_CCIPBatching_MaxBatchSizeEVM(t *testing.T) {
 }
 
 func Test_CCIPBatching_MultiSource(t *testing.T) {
+	ccipBatching_MultiSource(t)
+}
+
+func Test_CCIPBatching_MultiSource_MultiReports(t *testing.T) {
+	opt := testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
+		params.CommitOffChainConfig.MultipleReportsEnabled = true
+		params.CommitOffChainConfig.MaxMerkleRootsPerReport = 1
+		return params
+	})
+	ccipBatching_MultiSource(t, opt)
+}
+
+func ccipBatching_MultiSource(t *testing.T, opts ...testhelpers.TestOps) {
 	// Setup 3 chains, with 2 lanes going to the dest.
 	ctx := testhelpers.Context(t)
-	setup := newBatchTestSetup(t)
+	setup := newBatchTestSetup(t, opts...)
 	sourceChain1, sourceChain2, destChain, e, state := setup.sourceChain1, setup.sourceChain2, setup.destChain, setup.e, setup.state
 
 	var (
@@ -260,9 +279,22 @@ func Test_CCIPBatching_MultiSource(t *testing.T) {
 }
 
 func Test_CCIPBatching_SingleSource(t *testing.T) {
+	ccipBatching_SingleSource(t)
+}
+
+func Test_CCIPBatching_SingleSource_MultiplReports(t *testing.T) {
+	opt := testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
+		params.CommitOffChainConfig.MultipleReportsEnabled = true
+		params.CommitOffChainConfig.MaxMerkleRootsPerReport = 1
+		return params
+	})
+	ccipBatching_SingleSource(t, opt)
+}
+
+func ccipBatching_SingleSource(t *testing.T, opts ...testhelpers.TestOps) {
 	// Setup 3 chains, with 2 lanes going to the dest.
 	ctx := testhelpers.Context(t)
-	setup := newBatchTestSetup(t)
+	setup := newBatchTestSetup(t, opts...)
 	sourceChain1, sourceChain2, destChain, e, state := setup.sourceChain1, setup.sourceChain2, setup.destChain, setup.e, setup.state
 
 	var (


### PR DESCRIPTION
Add ccip 1.6 multi commit reports e2e testcases. Extends the batch tests so that they can be run with different configurations.