### PR TITLE
fix(multi): removes response logging from gateway

### DIFF
--- a/core/capabilities/compute/compute.go
+++ b/core/capabilities/compute/compute.go
@@ -364,7 +364,7 @@ func (f *outgoingConnectorFetcherFactory) NewFetcher(log logger.Logger, emitter 
 			return nil, err
 		}
 
-		log.Debugw("received gateway response", "resp", resp)
+		log.Debugw("received gateway response", "donID", resp.Body.DonId, "msgID", resp.Body.MessageId, "receiver", resp.Body.Receiver, "sender", resp.Body.Sender)
 		var response wasmpb.FetchResponse
 		err = json.Unmarshal(resp.Body.Payload, &response)
 		if err != nil {

--- a/core/capabilities/webapi/target/target.go
+++ b/core/capabilities/webapi/target/target.go
@@ -150,7 +150,7 @@ func (c *Capability) Execute(ctx context.Context, req capabilities.CapabilityReq
 		if err != nil {
 			return capabilities.CapabilityResponse{}, err
 		}
-		c.lggr.Debugw("received gateway response", "resp", resp)
+		c.lggr.Debugw("received gateway response", "donID", resp.Body.DonId, "msgID", resp.Body.MessageId, "receiver", resp.Body.Receiver, "sender", resp.Body.Sender)
 		var payload ghcapabilities.Response
 		err = json.Unmarshal(resp.Body.Payload, &payload)
 		if err != nil {

--- a/core/services/workflows/syncer/fetcher.go
+++ b/core/services/workflows/syncer/fetcher.go
@@ -106,7 +106,7 @@ func (s *FetcherService) Fetch(ctx context.Context, url string, n uint32) ([]byt
 		return nil, fmt.Errorf("invalid response from gateway: %w", err)
 	}
 
-	s.lggr.Debugw("received gateway response", "donID", resp.Body.DonId, "msgID", resp.Body.MessageId)
+	s.lggr.Debugw("received gateway response", "donID", resp.Body.DonId, "msgID", resp.Body.MessageId, "receiver", resp.Body.Receiver, "sender", resp.Body.Sender)
 
 	var payload ghcapabilities.Response
 	if err = json.Unmarshal(resp.Body.Payload, &payload); err != nil {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

soak of ST3 shows that custom compute is [logging](https://grafana.ops.prod.cldev.sh/goto/D-8rBt2HR?orgId=1) full response from gateway.

this PR stops that and removes full response logging from other locations in the code

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
