### PR TITLE
deployment/common/changeset: run tests in parallel

### DIFF
--- a/deployment/common/changeset/deploy_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
 	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
 
@@ -26,6 +27,7 @@ import (
 )
 
 func TestDeployMCMSWithTimelockV2(t *testing.T) {
+	t.Parallel()
 	// --- arrange ---
 	log := logger.TestLogger(t)
 	envConfig := memory.MemoryEnvironmentConfig{Chains: 2, SolChains: 1}

--- a/deployment/common/changeset/example/solana_transfer_mcm_test.go
+++ b/deployment/common/changeset/example/solana_transfer_mcm_test.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
-	chainselectors "github.com/smartcontractkit/chain-selectors"
-	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
@@ -53,6 +54,7 @@ func setupFundingTestEnv(t *testing.T) deployment.Environment {
 }
 
 func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
+	t.Parallel()
 	lggr := logger.TestLogger(t)
 	validEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{SolChains: 1})
 	validEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
@@ -204,6 +206,7 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 }
 
 func TestTransferFromTimelockConfig_Apply(t *testing.T) {
+	t.Parallel()
 	env := setupFundingTestEnv(t)
 	cfgAmounts := example.TransferData{
 		Amount: 100 * solana.LAMPORTS_PER_SOL,

--- a/deployment/common/changeset/set_config_mcms_test.go
+++ b/deployment/common/changeset/set_config_mcms_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	solanasdk "github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/config"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
@@ -62,6 +63,7 @@ func setupSetConfigTestEnv(t *testing.T) deployment.Environment {
 
 // TestSetConfigMCMSVariants tests the SetConfigMCMS changeset variants.
 func TestSetConfigMCMSVariants(t *testing.T) {
+	t.Parallel()
 	// Add the timelock as a signer to check state changes
 	for _, tc := range []struct {
 		name       string
@@ -171,6 +173,7 @@ func TestSetConfigMCMSVariants(t *testing.T) {
 }
 
 func TestSetConfigMCMSV2EVM(t *testing.T) {
+	t.Parallel()
 	// Add the timelock as a signer to check state changes
 	for _, tc := range []struct {
 		name       string
@@ -280,6 +283,7 @@ func TestSetConfigMCMSV2EVM(t *testing.T) {
 }
 
 func TestSetConfigMCMSV2Solana(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name       string
 		changeSets func(chainSel uint64, cfgs map[uint64]commonchangeset.ConfigPerRoleV2) []commonchangeset.ConfiguredChangeSet
@@ -380,6 +384,7 @@ func TestSetConfigMCMSV2Solana(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	t.Parallel()
 	env := setupSetConfigTestEnv(t)
 
 	chainSelector := env.AllChainSelectors()[0]
@@ -529,6 +534,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestValidateV2(t *testing.T) {
+	t.Parallel()
 	env := setupSetConfigTestEnv(t)
 
 	chainSelector := env.AllChainSelectors()[0]

--- a/deployment/common/changeset/solana/fund_mcm_pdas_test.go
+++ b/deployment/common/changeset/solana/fund_mcm_pdas_test.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
-	chainselectors "github.com/smartcontractkit/chain-selectors"
-	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
@@ -53,6 +54,7 @@ func setupFundingTestEnv(t *testing.T) deployment.Environment {
 }
 
 func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
+	t.Parallel()
 	lggr := logger.TestLogger(t)
 	validEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{SolChains: 1})
 	validEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
@@ -230,6 +232,7 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 }
 
 func TestFundMCMSignersChangeset_Apply(t *testing.T) {
+	t.Parallel()
 	env := setupFundingTestEnv(t)
 	cfgAmounts := commonSolana.AmountsToTransfer{
 		ProposeMCM:   100 * solana.LAMPORTS_PER_SOL,

--- a/deployment/common/changeset/solana/transfer_ownership_test.go
+++ b/deployment/common/changeset/solana/transfer_ownership_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestTransferToMCMSToTimelockSolana(t *testing.T) {
+	t.Parallel()
 	// --- arrange ---
 	log := logger.TestLogger(t)
 	envConfig := memory.MemoryEnvironmentConfig{Chains: 0, SolChains: 1}

--- a/deployment/common/changeset/state/solana_test.go
+++ b/deployment/common/changeset/state/solana_test.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
-	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -23,6 +24,7 @@ import (
 )
 
 func TestMCMSWithTimelockState_GenerateMCMSWithTimelockViewSolana(t *testing.T) {
+	t.Parallel()
 	envConfig := memory.MemoryEnvironmentConfig{SolChains: 1}
 	env := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, envConfig)
 	chainSelector := env.AllChainSelectorsSolana()[0]


### PR DESCRIPTION
This package can take over seven minutes to test. Trivial parallelization reduces it to just two minutes.
```diff
-ok  	github.com/smartcontractkit/chainlink/deployment/common/changeset	428.955s
+ok  	github.com/smartcontractkit/chainlink/deployment/common/changeset	127.892s
```