### PR TITLE
ccip/changeset/solana: run tests in parallel

### DIFF
--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -342,6 +342,7 @@ func verifyProgramSizes(t *testing.T, e deployment.Environment) {
 }
 
 func TestDeployChainContractsChangesetLocal(t *testing.T) {
+	t.Parallel()
 	ci := os.Getenv("CI") == "true"
 	if ci {
 		return

--- a/deployment/ccip/changeset/solana/cs_solana_token_test.go
+++ b/deployment/ccip/changeset/solana/cs_solana_token_test.go
@@ -96,5 +96,6 @@ func TestSolanaTokenOps(t *testing.T) {
 }
 
 func TestDeployLinkToken(t *testing.T) {
+	t.Parallel()
 	testhelpers.DeployLinkTokenTest(t, 1)
 }

--- a/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock_test.go
+++ b/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	solBinary "github.com/gagliardetto/binary"
+
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
 
@@ -105,6 +106,7 @@ func TestValidateContracts(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	t.Parallel()
 	lggr := logger.TestLogger(t)
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Bootstraps: 1,


### PR DESCRIPTION
These package tests can take six minutes.
```diff
-ok  	github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana	350.524s

```