### PR TITLE
keystore safety

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -358,7 +358,7 @@ require (
 	github.com/smartcontractkit/mcms v0.14.0 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1160,8 +1160,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 h1:yfukbG7KzP3FGe3WOV4GHowHqnRW1Pg7fDz2vBucS10=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/core/scripts/vrfv2plus/testnet/v2plusscripts/super_scripts.go
+++ b/core/scripts/vrfv2plus/testnet/v2plusscripts/super_scripts.go
@@ -87,7 +87,6 @@ func SmokeTestVRF(e helpers.Environment) {
 	// generate VRF key
 	key, err := vrfkey.NewV2()
 	helpers.PanicErr(err)
-	fmt.Println("vrf private key:", hexutil.Encode(key.Raw()))
 	fmt.Println("vrf public key:", key.PublicKey.String())
 	fmt.Println("vrf key hash:", key.PublicKey.MustHash())
 

--- a/core/services/keystore/beholder.go
+++ b/core/services/keystore/beholder.go
@@ -12,8 +12,11 @@ func BuildBeholderAuth(ctx context.Context, keyStore CSA) (authHeaders map[strin
 	if err != nil {
 		return nil, "", err
 	}
-	csaPrivKey := csaKey.Raw().Bytes()
-	authHeaders = beholder.BuildAuthHeaders(csaPrivKey)
+
+	authHeaders, err = beholder.NewAuthHeaders(csaKey.Signer())
+	if err != nil {
+		return
+	}
 	pubKeyHex = hex.EncodeToString(csaKey.PublicKey)
 	return
 }

--- a/core/services/keystore/csa.go
+++ b/core/services/keystore/csa.go
@@ -52,7 +52,7 @@ func (c CSASigner) Sign(ctx context.Context, account string, data []byte) (signe
 	if data == nil {
 		return nil, nil
 	}
-	return k.PrivateKey().Sign(rand.Reader, data, crypto.Hash(0))
+	return k.Signer().Sign(rand.Reader, data, crypto.Hash(0))
 }
 
 type csa struct {

--- a/core/services/keystore/internal/exportutils.go
+++ b/core/services/keystore/internal/exportutils.go
@@ -1,10 +1,10 @@
-package keys
+package internal
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
-	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -30,7 +30,7 @@ func FromEncryptedJSON[E Encrypted, K any](
 	keyJSON []byte,
 	password string,
 	passwordFunc func(string) string,
-	privKeyToKey func(export E, rawPrivKey []byte) (K, error),
+	privKeyToKey func(export E, rawPrivKey Raw) (K, error),
 ) (K, error) {
 	// unmarshal byte data to [E] Encrypted key export
 	var export E
@@ -41,22 +41,25 @@ func FromEncryptedJSON[E Encrypted, K any](
 	// decrypt data using prefixed password
 	privKey, err := keystore.DecryptDataV3(export.GetCrypto(), passwordFunc(password))
 	if err != nil {
-		return *new(K), errors.Wrapf(err, "failed to decrypt %s key", identifier)
+		return *new(K), fmt.Errorf("failed to decrypt %s key: %w", identifier, err)
 	}
 
 	// convert unmarshalled data and decrypted key to [K] key format
-	key, err := privKeyToKey(export, privKey)
+	key, err := privKeyToKey(export, NewRaw(privKey))
 	if err != nil {
-		return *new(K), errors.Wrapf(err, "failed to convert %s key to key bundle", identifier)
+		return *new(K), fmt.Errorf("failed to convert %s key to key bundle: %w", identifier, err)
 	}
 
 	return key, nil
 }
 
+type Key interface {
+	Raw() Raw
+}
+
 // ToEncryptedJSON returns encrypted JSON [E] representing key [K]
-func ToEncryptedJSON[E Encrypted, K any](
+func ToEncryptedJSON[E Encrypted, K Key](
 	identifier string,
-	raw []byte,
 	key K,
 	password string,
 	scryptParams utils.ScryptParams,
@@ -65,13 +68,13 @@ func ToEncryptedJSON[E Encrypted, K any](
 ) (export []byte, err error) {
 	// encrypt data using prefixed password
 	cryptoJSON, err := keystore.EncryptDataV3(
-		raw,
+		key.Raw().bytes,
 		[]byte(passwordFunc(password)),
 		scryptParams.N,
 		scryptParams.P,
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not encrypt %s key", identifier)
+		return nil, fmt.Errorf("could not encrypt %s key: %w", identifier, err)
 	}
 
 	// build [E] export struct using encrypted key, identifier, and original key [K]

--- a/core/services/keystore/internal/raw.go
+++ b/core/services/keystore/internal/raw.go
@@ -1,0 +1,25 @@
+// Package internal declares a Raw private key type,
+// only available for use in the keystore sub-tree.
+package internal
+
+// Raw is a wrapper type that holds private key bytes
+// and is designed to prevent accidental logging.
+type Raw struct {
+	bytes []byte
+}
+
+func NewRaw(b []byte) Raw {
+	return Raw{bytes: b}
+}
+
+func (raw Raw) String() string {
+	return "<Raw Private Key>"
+}
+
+func (raw Raw) GoString() string {
+	return raw.String()
+}
+
+func (raw Raw) Bytes() []byte {
+	return raw.bytes
+}

--- a/core/services/keystore/internal/raw_test.go
+++ b/core/services/keystore/internal/raw_test.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRaw_nonprintable(t *testing.T) {
+	bytes, err := hex.DecodeString("f0d07ab448018b2754475f9a3b580218b0675a1456aad96ad607c7bbd7d9237b")
+	require.NoError(t, err)
+	r := NewRaw(bytes)
+
+	exp := "<Raw Private Key>"
+
+	assert.Equal(t, exp, fmt.Sprint(r))
+
+	assert.Equal(t, exp, fmt.Sprintf("%v", r))
+
+	assert.Equal(t, exp, fmt.Sprintf("%#v", r))
+
+	assert.Equal(t, exp, fmt.Sprintf("%s", r)) //nolint:gosimple // S1025 deliberately testing formatting verbs
+
+	got, err := json.Marshal(r) //nolint:staticcheck // SA9005 deliberately testing marshalling
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, `{}`, string(got))
+	}
+}

--- a/core/services/keystore/keys/aptoskey/export.go
+++ b/core/services/keystore/keys/aptoskey/export.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
@@ -13,28 +13,27 @@ const keyTypeIdentifier = "Aptos"
 
 // FromEncryptedJSON gets key from json and password
 func FromEncryptedJSON(keyJSON []byte, password string) (Key, error) {
-	return keys.FromEncryptedJSON(
+	return internal.FromEncryptedJSON(
 		keyTypeIdentifier,
 		keyJSON,
 		password,
 		adulteratedPassword,
-		func(_ keys.EncryptedKeyExport, rawPrivKey []byte) (Key, error) {
-			return Raw(rawPrivKey).Key(), nil
+		func(_ internal.EncryptedKeyExport, rawPrivKey internal.Raw) (Key, error) {
+			return KeyFor(rawPrivKey), nil
 		},
 	)
 }
 
 // ToEncryptedJSON returns encrypted JSON representing key
 func (key Key) ToEncryptedJSON(password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	return keys.ToEncryptedJSON(
+	return internal.ToEncryptedJSON(
 		keyTypeIdentifier,
-		key.Raw(),
 		key,
 		password,
 		scryptParams,
 		adulteratedPassword,
-		func(id string, key Key, cryptoJSON keystore.CryptoJSON) keys.EncryptedKeyExport {
-			return keys.EncryptedKeyExport{
+		func(id string, key Key, cryptoJSON keystore.CryptoJSON) internal.EncryptedKeyExport {
+			return internal.EncryptedKeyExport{
 				KeyType:   id,
 				PublicKey: hex.EncodeToString(key.pubKey),
 				Crypto:    cryptoJSON,

--- a/core/services/keystore/keys/aptoskey/key.go
+++ b/core/services/keystore/keys/aptoskey/key.go
@@ -8,30 +8,9 @@ import (
 	"io"
 
 	"golang.org/x/crypto/sha3"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
-
-// Raw represents the Aptos private key
-type Raw []byte
-
-// Key gets the Key
-func (raw Raw) Key() Key {
-	privKey := ed25519.NewKeyFromSeed(raw)
-	pubKey := privKey.Public().(ed25519.PublicKey)
-	return Key{
-		privkey: privKey,
-		pubKey:  pubKey,
-	}
-}
-
-// String returns description
-func (raw Raw) String() string {
-	return "<Aptos Raw Private Key>"
-}
-
-// GoString wraps String()
-func (raw Raw) GoString() string {
-	return raw.String()
-}
 
 var _ fmt.GoStringer = &Key{}
 
@@ -40,6 +19,15 @@ type Key struct {
 	// TODO: store initial Account() derivation to support key rotation
 	privkey ed25519.PrivateKey
 	pubKey  ed25519.PublicKey
+}
+
+func KeyFor(raw internal.Raw) Key {
+	privKey := ed25519.NewKeyFromSeed(raw.Bytes())
+	pubKey := privKey.Public().(ed25519.PublicKey)
+	return Key{
+		privkey: privKey,
+		pubKey:  pubKey,
+	}
 }
 
 // New creates new Key
@@ -90,8 +78,8 @@ func (key Key) PublicKeyStr() string {
 }
 
 // Raw returns the seed from private key
-func (key Key) Raw() Raw {
-	return key.privkey.Seed()
+func (key Key) Raw() internal.Raw {
+	return internal.NewRaw(key.privkey.Seed())
 }
 
 // String is the print-friendly format of the Key

--- a/core/services/keystore/keys/aptoskey/key_test.go
+++ b/core/services/keystore/keys/aptoskey/key_test.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
 func TestAptosKey(t *testing.T) {
 	bytes, err := hex.DecodeString("f0d07ab448018b2754475f9a3b580218b0675a1456aad96ad607c7bbd7d9237b")
 	require.NoError(t, err)
-	k := Raw(bytes).Key()
+	k := KeyFor(internal.NewRaw(bytes))
 	assert.Equal(t, "2acd605efc181e2af8a0b8c0686a5e12578efa1253d15a235fa5e5ad970c4b29", k.PublicKeyStr())
 	assert.Equal(t, "69d8b07f5945185873c622ea66873b0e1fb921de7b94d904d3ef9be80770682e", k.Account())
 }

--- a/core/services/keystore/keys/cosmoskey/export.go
+++ b/core/services/keystore/keys/cosmoskey/export.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
@@ -13,28 +13,27 @@ const keyTypeIdentifier = "Cosmos"
 
 // FromEncryptedJSON gets key from json and password
 func FromEncryptedJSON(keyJSON []byte, password string) (Key, error) {
-	return keys.FromEncryptedJSON(
+	return internal.FromEncryptedJSON(
 		keyTypeIdentifier,
 		keyJSON,
 		password,
 		adulteratedPassword,
-		func(_ keys.EncryptedKeyExport, rawPrivKey []byte) (Key, error) {
-			return Raw(rawPrivKey).Key(), nil
+		func(_ internal.EncryptedKeyExport, rawPrivKey internal.Raw) (Key, error) {
+			return KeyFor(rawPrivKey), nil
 		},
 	)
 }
 
 // ToEncryptedJSON returns encrypted JSON representing key
 func (key Key) ToEncryptedJSON(password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	return keys.ToEncryptedJSON(
+	return internal.ToEncryptedJSON(
 		keyTypeIdentifier,
-		key.Raw(),
 		key,
 		password,
 		scryptParams,
 		adulteratedPassword,
-		func(id string, key Key, cryptoJSON keystore.CryptoJSON) keys.EncryptedKeyExport {
-			return keys.EncryptedKeyExport{
+		func(id string, key Key, cryptoJSON keystore.CryptoJSON) internal.EncryptedKeyExport {
+			return internal.EncryptedKeyExport{
 				KeyType:   id,
 				PublicKey: hex.EncodeToString(key.PublicKey().Bytes()),
 				Crypto:    cryptoJSON,

--- a/core/services/keystore/keys/cosmoskey/key.go
+++ b/core/services/keystore/keys/cosmoskey/key.go
@@ -12,27 +12,19 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
 var secpSigningAlgo, _ = keyring.NewSigningAlgoFromString(string(hd.Secp256k1Type), []keyring.SignatureAlgo{hd.Secp256k1})
 
-type Raw []byte
-
-func (raw Raw) Key() Key {
-	d := big.NewInt(0).SetBytes(raw)
+func KeyFor(raw internal.Raw) Key {
+	d := big.NewInt(0).SetBytes(raw.Bytes())
 	privKey := secpSigningAlgo.Generate()(d.Bytes())
 	return Key{
 		d: d,
 		k: privKey,
 	}
-}
-
-func (raw Raw) String() string {
-	return "<Cosmos Raw Private Key>"
-}
-
-func (raw Raw) GoString() string {
-	return raw.String()
 }
 
 var _ fmt.GoStringer = &Key{}
@@ -78,8 +70,8 @@ func (key Key) PublicKeyStr() string {
 	return fmt.Sprintf("%X", key.k.PubKey().Bytes())
 }
 
-func (key Key) Raw() Raw {
-	return key.d.Bytes()
+func (key Key) Raw() internal.Raw {
+	return internal.NewRaw(key.d.Bytes())
 }
 
 // ToPrivKey returns the key usable for signing.

--- a/core/services/keystore/keys/csakey/export.go
+++ b/core/services/keystore/keys/csakey/export.go
@@ -3,34 +3,33 @@ package csakey
 import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 const keyTypeIdentifier = "CSA"
 
 func FromEncryptedJSON(keyJSON []byte, password string) (KeyV2, error) {
-	return keys.FromEncryptedJSON(
+	return internal.FromEncryptedJSON(
 		keyTypeIdentifier,
 		keyJSON,
 		password,
 		adulteratedPassword,
-		func(_ keys.EncryptedKeyExport, rawPrivKey []byte) (KeyV2, error) {
-			return Raw(rawPrivKey).Key(), nil
+		func(_ internal.EncryptedKeyExport, rawPrivKey internal.Raw) (KeyV2, error) {
+			return KeyFor(rawPrivKey), nil
 		},
 	)
 }
 
 func (k KeyV2) ToEncryptedJSON(password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	return keys.ToEncryptedJSON(
+	return internal.ToEncryptedJSON(
 		keyTypeIdentifier,
-		k.Raw(),
 		k,
 		password,
 		scryptParams,
 		adulteratedPassword,
-		func(id string, key KeyV2, cryptoJSON keystore.CryptoJSON) keys.EncryptedKeyExport {
-			return keys.EncryptedKeyExport{
+		func(id string, key KeyV2, cryptoJSON keystore.CryptoJSON) internal.EncryptedKeyExport {
+			return internal.EncryptedKeyExport{
 				KeyType:   id,
 				PublicKey: key.PublicKeyString(),
 				Crypto:    cryptoJSON,

--- a/core/services/keystore/keys/csakey/key_v2.go
+++ b/core/services/keystore/keys/csakey/key_v2.go
@@ -1,6 +1,7 @@
 package csakey
 
 import (
+	"crypto"
 	"crypto/ed25519"
 	cryptorand "crypto/rand"
 	"encoding/hex"
@@ -8,28 +9,16 @@ import (
 	"math/big"
 
 	"github.com/smartcontractkit/wsrpc/credentials"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
-type Raw []byte
-
-func (raw Raw) Key() KeyV2 {
-	privKey := ed25519.PrivateKey(raw)
+func KeyFor(raw internal.Raw) KeyV2 {
+	privKey := ed25519.PrivateKey(raw.Bytes())
 	return KeyV2{
 		privateKey: &privKey,
 		PublicKey:  privKey.Public().(ed25519.PublicKey),
 	}
-}
-
-func (raw Raw) String() string {
-	return "<CSA Raw Private Key>"
-}
-
-func (raw Raw) GoString() string {
-	return raw.String()
-}
-
-func (raw Raw) Bytes() []byte {
-	return ([]byte)(raw)
 }
 
 var _ fmt.GoStringer = &KeyV2{}
@@ -79,11 +68,11 @@ func (k KeyV2) PublicKeyString() string {
 	return hex.EncodeToString(k.PublicKey)
 }
 
-func (k KeyV2) Raw() Raw {
-	return Raw(*k.privateKey)
+func (k KeyV2) Raw() internal.Raw {
+	return internal.NewRaw(*k.privateKey)
 }
 
-func (k KeyV2) PrivateKey() ed25519.PrivateKey {
+func (k KeyV2) Signer() crypto.Signer {
 	return *k.privateKey
 }
 

--- a/core/services/keystore/keys/csakey/key_v2_test.go
+++ b/core/services/keystore/keys/csakey/key_v2_test.go
@@ -8,23 +8,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
-
-func TestCSAKeyV2_RawPrivateKey(t *testing.T) {
-	_, privKey, err := ed25519.GenerateKey(nil)
-	require.NoError(t, err)
-
-	privateKey := Raw(privKey)
-
-	assert.Equal(t, "<CSA Raw Private Key>", privateKey.String())
-	assert.Equal(t, privateKey.String(), privateKey.GoString())
-}
 
 func TestCSAKeyV2_FromRawPrivateKey(t *testing.T) {
 	pubKey, privKey, err := ed25519.GenerateKey(nil)
 	require.NoError(t, err)
 
-	keyV2 := Raw(privKey).Key()
+	keyV2 := KeyFor(internal.NewRaw(privKey))
 
 	assert.Equal(t, pubKey, keyV2.PublicKey)
 	assert.Equal(t, privKey, *keyV2.privateKey)

--- a/core/services/keystore/keys/ethkey/key_v2.go
+++ b/core/services/keystore/keys/ethkey/key_v2.go
@@ -11,15 +11,15 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/smartcontractkit/chainlink-integrations/evm/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
 var curve = crypto.S256()
 
-type Raw []byte
-
-func (raw Raw) Key() KeyV2 {
+func KeyFor(raw internal.Raw) KeyV2 {
 	var privateKey ecdsa.PrivateKey
-	d := big.NewInt(0).SetBytes(raw)
+	d := big.NewInt(0).SetBytes(raw.Bytes())
 	privateKey.PublicKey.Curve = curve
 	privateKey.D = d
 	privateKey.PublicKey.X, privateKey.PublicKey.Y = curve.ScalarBaseMult(d.Bytes())
@@ -30,14 +30,6 @@ func (raw Raw) Key() KeyV2 {
 		EIP55Address: eip55,
 		privateKey:   &privateKey,
 	}
-}
-
-func (raw Raw) String() string {
-	return "<Eth Raw Private Key>"
-}
-
-func (raw Raw) GoString() string {
-	return raw.String()
 }
 
 var _ fmt.GoStringer = &KeyV2{}
@@ -70,8 +62,8 @@ func (key KeyV2) ID() string {
 	return key.Address.Hex()
 }
 
-func (key KeyV2) Raw() Raw {
-	return key.privateKey.D.Bytes()
+func (key KeyV2) Raw() internal.Raw {
+	return internal.NewRaw(key.privateKey.D.Bytes())
 }
 
 func (key KeyV2) ToEcdsaPrivKey() *ecdsa.PrivateKey {

--- a/core/services/keystore/keys/ethkey/key_v2_test.go
+++ b/core/services/keystore/keys/ethkey/key_v2_test.go
@@ -10,29 +10,21 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-integrations/evm/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
 func TestEthKeyV2_ToKey(t *testing.T) {
 	privateKeyECDSA, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	require.NoError(t, err)
 
-	k := Raw(privateKeyECDSA.D.Bytes()).Key()
+	k := KeyFor(internal.NewRaw(privateKeyECDSA.D.Bytes()))
 
 	assert.Equal(t, k.String(), k.GoString())
 	assert.Equal(t, k.privateKey, privateKeyECDSA)
 	assert.Equal(t, k.privateKey.PublicKey.X, privateKeyECDSA.PublicKey.X)
 	assert.Equal(t, k.privateKey.PublicKey.Y, privateKeyECDSA.PublicKey.Y)
 	assert.Equal(t, types.EIP55AddressFromAddress(crypto.PubkeyToAddress(privateKeyECDSA.PublicKey)).Hex(), k.ID())
-}
-
-func TestEthKeyV2_RawPrivateKey(t *testing.T) {
-	privateKeyECDSA, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
-	require.NoError(t, err)
-
-	k := Raw(privateKeyECDSA.D.Bytes())
-
-	assert.Equal(t, "<Eth Raw Private Key>", k.String())
-	assert.Equal(t, k.String(), k.GoString())
 }
 
 func TestEthKeyV2_NewV2(t *testing.T) {

--- a/core/services/keystore/keys/ocr2key/export.go
+++ b/core/services/keystore/keys/ocr2key/export.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/starkkey"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -30,12 +30,12 @@ func (x EncryptedOCRKeyExport) GetCrypto() keystore.CryptoJSON {
 
 // FromEncryptedJSON returns key from encrypted json
 func FromEncryptedJSON(keyJSON []byte, password string) (KeyBundle, error) {
-	return keys.FromEncryptedJSON(
+	return internal.FromEncryptedJSON(
 		keyTypeIdentifier,
 		keyJSON,
 		password,
 		adulteratedPassword,
-		func(export EncryptedOCRKeyExport, rawPrivKey []byte) (KeyBundle, error) {
+		func(export EncryptedOCRKeyExport, rawPrivKey internal.Raw) (KeyBundle, error) {
 			var kb KeyBundle
 			switch export.ChainType {
 			case chaintype.EVM:
@@ -53,7 +53,7 @@ func FromEncryptedJSON(keyJSON []byte, password string) (KeyBundle, error) {
 			default:
 				return nil, chaintype.NewErrInvalidChainType(export.ChainType)
 			}
-			if err := kb.Unmarshal(rawPrivKey); err != nil {
+			if err := kb.Unmarshal(rawPrivKey.Bytes()); err != nil {
 				return nil, err
 			}
 			return kb, nil
@@ -63,9 +63,8 @@ func FromEncryptedJSON(keyJSON []byte, password string) (KeyBundle, error) {
 
 // ToEncryptedJSON returns encrypted JSON representing key
 func ToEncryptedJSON(key KeyBundle, password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	return keys.ToEncryptedJSON(
+	return internal.ToEncryptedJSON(
 		keyTypeIdentifier,
-		key.Raw(),
 		key,
 		password,
 		scryptParams,

--- a/core/services/keystore/keys/ocr2key/generic_key_bundle.go
+++ b/core/services/keystore/keys/ocr2key/generic_key_bundle.go
@@ -12,6 +12,7 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 )
 
@@ -159,12 +160,12 @@ func (kb *keyBundle[K]) Unmarshal(b []byte) (err error) {
 	return nil
 }
 
-func (kb *keyBundle[K]) Raw() Raw {
+func (kb *keyBundle[K]) Raw() internal.Raw {
 	b, err := kb.Marshal()
 	if err != nil {
 		panic(err)
 	}
-	return b
+	return internal.NewRaw(b)
 }
 
 // migration code

--- a/core/services/keystore/keys/ocr2key/key_bundle.go
+++ b/core/services/keystore/keys/ocr2key/key_bundle.go
@@ -10,6 +10,7 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/starkkey"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 )
@@ -33,7 +34,7 @@ type KeyBundle interface {
 	ChainType() chaintype.ChainType
 	Marshal() ([]byte, error)
 	Unmarshal(b []byte) (err error)
-	Raw() Raw
+	Raw() internal.Raw
 	OnChainPublicKey() string
 	// Decrypts ciphertext using the encryptionKey from an OCR2 OffchainKeyring
 	NaclBoxOpenAnonymous(ciphertext []byte) (plaintext []byte, err error)
@@ -113,11 +114,9 @@ func (kb keyBundleBase) GoString() string {
 	return kb.String()
 }
 
-type Raw []byte
-
-func (raw Raw) Key() (kb KeyBundle) {
+func KeyFor(raw internal.Raw) (kb KeyBundle) {
 	var temp struct{ ChainType chaintype.ChainType }
-	err := json.Unmarshal(raw, &temp)
+	err := json.Unmarshal(raw.Bytes(), &temp)
 	if err != nil {
 		panic(err)
 	}
@@ -137,7 +136,7 @@ func (raw Raw) Key() (kb KeyBundle) {
 	default:
 		return nil
 	}
-	if err := kb.Unmarshal(raw); err != nil {
+	if err := kb.Unmarshal(raw.Bytes()); err != nil {
 		panic(err)
 	}
 	return

--- a/core/services/keystore/keys/ocr2key/key_bundle_test.go
+++ b/core/services/keystore/keys/ocr2key/key_bundle_test.go
@@ -51,18 +51,6 @@ func TestOCR2Keys_New(t *testing.T) {
 	}
 }
 
-func TestOCR2KeyBundle_RawToKey(t *testing.T) {
-	t.Parallel()
-
-	for _, chain := range chaintype.SupportedChainTypes {
-		pk, err := ocr2key.New(chain)
-		require.NoError(t, err)
-
-		pkFromRaw := pk.Raw().Key()
-		assert.NotNil(t, pkFromRaw)
-	}
-}
-
 func TestOCR2KeyBundle_BundleBase(t *testing.T) {
 	t.Parallel()
 

--- a/core/services/keystore/keys/ocrkey/export.go
+++ b/core/services/keystore/keys/ocrkey/export.go
@@ -3,20 +3,20 @@ package ocrkey
 import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 const keyTypeIdentifier = "OCR"
 
 func FromEncryptedJSON(keyJSON []byte, password string) (KeyV2, error) {
-	return keys.FromEncryptedJSON(
+	return internal.FromEncryptedJSON(
 		keyTypeIdentifier,
 		keyJSON,
 		password,
 		adulteratedPassword,
-		func(_ EncryptedOCRKeyExport, rawPrivKey []byte) (KeyV2, error) {
-			return Raw(rawPrivKey).Key(), nil
+		func(_ EncryptedOCRKeyExport, rawPrivKey internal.Raw) (KeyV2, error) {
+			return KeyFor(rawPrivKey), nil
 		},
 	)
 }
@@ -35,9 +35,8 @@ func (x EncryptedOCRKeyExport) GetCrypto() keystore.CryptoJSON {
 }
 
 func (key KeyV2) ToEncryptedJSON(password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	return keys.ToEncryptedJSON(
+	return internal.ToEncryptedJSON(
 		keyTypeIdentifier,
-		key.Raw(),
 		key,
 		password,
 		scryptParams,

--- a/core/services/keystore/keys/ocrkey/key_v2_test.go
+++ b/core/services/keystore/keys/ocrkey/key_v2_test.go
@@ -34,5 +34,5 @@ func TestOCRKeys_New(t *testing.T) {
 func TestOCRKeys_Raw_Key(t *testing.T) {
 	t.Parallel()
 	key := ocrkey.MustNewV2XXXTestingOnly(big.NewInt(1))
-	require.Equal(t, key.ID(), key.Raw().Key().ID())
+	require.Equal(t, key.ID(), ocrkey.KeyFor(key.Raw()).ID())
 }

--- a/core/services/keystore/keys/p2pkey/export.go
+++ b/core/services/keystore/keys/p2pkey/export.go
@@ -3,20 +3,20 @@ package p2pkey
 import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 const keyTypeIdentifier = "P2P"
 
 func FromEncryptedJSON(keyJSON []byte, password string) (KeyV2, error) {
-	return keys.FromEncryptedJSON(
+	return internal.FromEncryptedJSON(
 		keyTypeIdentifier,
 		keyJSON,
 		password,
 		adulteratedPassword,
-		func(_ EncryptedP2PKeyExport, rawPrivKey []byte) (KeyV2, error) {
-			return Raw(rawPrivKey).Key(), nil
+		func(_ EncryptedP2PKeyExport, rawPrivKey internal.Raw) (KeyV2, error) {
+			return KeyFor(rawPrivKey), nil
 		},
 	)
 }
@@ -33,9 +33,8 @@ func (x EncryptedP2PKeyExport) GetCrypto() keystore.CryptoJSON {
 }
 
 func (key KeyV2) ToEncryptedJSON(password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	return keys.ToEncryptedJSON(
+	return internal.ToEncryptedJSON(
 		keyTypeIdentifier,
-		key.Raw(),
 		key,
 		password,
 		scryptParams,

--- a/core/services/keystore/keys/p2pkey/key_v2_test.go
+++ b/core/services/keystore/keys/p2pkey/key_v2_test.go
@@ -2,7 +2,6 @@ package p2pkey
 
 import (
 	"crypto/ed25519"
-	"crypto/rand"
 	"encoding/hex"
 	"testing"
 
@@ -11,16 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestP2PKeys_Raw(t *testing.T) {
-	_, pk, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
-
-	r := Raw(pk)
-
-	assert.Equal(t, r.String(), r.GoString())
-	assert.Equal(t, "<P2P Raw Private Key>", r.String())
-}
 
 func TestP2PKeys_KeyV2(t *testing.T) {
 	kv2, err := NewV2()

--- a/core/services/keystore/keys/solkey/export.go
+++ b/core/services/keystore/keys/solkey/export.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
@@ -13,28 +13,27 @@ const keyTypeIdentifier = "Solana"
 
 // FromEncryptedJSON gets key from json and password
 func FromEncryptedJSON(keyJSON []byte, password string) (Key, error) {
-	return keys.FromEncryptedJSON(
+	return internal.FromEncryptedJSON(
 		keyTypeIdentifier,
 		keyJSON,
 		password,
 		adulteratedPassword,
-		func(_ keys.EncryptedKeyExport, rawPrivKey []byte) (Key, error) {
-			return Raw(rawPrivKey).Key(), nil
+		func(_ internal.EncryptedKeyExport, rawPrivKey internal.Raw) (Key, error) {
+			return KeyFor(rawPrivKey), nil
 		},
 	)
 }
 
 // ToEncryptedJSON returns encrypted JSON representing key
 func (key Key) ToEncryptedJSON(password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	return keys.ToEncryptedJSON(
+	return internal.ToEncryptedJSON(
 		keyTypeIdentifier,
-		key.Raw(),
 		key,
 		password,
 		scryptParams,
 		adulteratedPassword,
-		func(id string, key Key, cryptoJSON keystore.CryptoJSON) keys.EncryptedKeyExport {
-			return keys.EncryptedKeyExport{
+		func(id string, key Key, cryptoJSON keystore.CryptoJSON) internal.EncryptedKeyExport {
+			return internal.EncryptedKeyExport{
 				KeyType:   id,
 				PublicKey: hex.EncodeToString(key.pubKey),
 				Crypto:    cryptoJSON,

--- a/core/services/keystore/keys/solkey/key.go
+++ b/core/services/keystore/keys/solkey/key.go
@@ -9,28 +9,16 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/mr-tron/base58"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
-// Raw represents the Solana private key
-type Raw []byte
-
-// Key gets the Key
-func (raw Raw) Key() Key {
-	privKey := ed25519.NewKeyFromSeed(raw)
+func KeyFor(raw internal.Raw) Key {
+	privKey := ed25519.NewKeyFromSeed(raw.Bytes())
 	return Key{
 		privkey: privKey,
 		pubKey:  privKey.Public().(ed25519.PublicKey),
 	}
-}
-
-// String returns description
-func (raw Raw) String() string {
-	return "<Solana Raw Private Key>"
-}
-
-// GoString wraps String()
-func (raw Raw) GoString() string {
-	return raw.String()
 }
 
 var _ fmt.GoStringer = &Key{}
@@ -82,8 +70,8 @@ func (key Key) PublicKeyStr() string {
 }
 
 // Raw from private key
-func (key Key) Raw() Raw {
-	return key.privkey.Seed()
+func (key Key) Raw() internal.Raw {
+	return internal.NewRaw(key.privkey.Seed())
 }
 
 // String is the print-friendly format of the Key

--- a/core/services/keystore/keys/starkkey/export.go
+++ b/core/services/keystore/keys/starkkey/export.go
@@ -3,7 +3,7 @@ package starkkey
 import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
@@ -11,28 +11,27 @@ const keyTypeIdentifier = "StarkNet"
 
 // FromEncryptedJSON gets key from json and password
 func FromEncryptedJSON(keyJSON []byte, password string) (Key, error) {
-	return keys.FromEncryptedJSON(
+	return internal.FromEncryptedJSON(
 		keyTypeIdentifier,
 		keyJSON,
 		password,
 		adulteratedPassword,
-		func(_ keys.EncryptedKeyExport, rawPrivKey []byte) (Key, error) {
-			return Raw(rawPrivKey).Key(), nil
+		func(_ internal.EncryptedKeyExport, rawPrivKey internal.Raw) (Key, error) {
+			return KeyFor(rawPrivKey), nil
 		},
 	)
 }
 
 // ToEncryptedJSON returns encrypted JSON representing key
 func ToEncryptedJSON(key Key, password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	return keys.ToEncryptedJSON(
+	return internal.ToEncryptedJSON(
 		keyTypeIdentifier,
-		key.Raw(),
 		key,
 		password,
 		scryptParams,
 		adulteratedPassword,
-		func(id string, key Key, cryptoJSON keystore.CryptoJSON) keys.EncryptedKeyExport {
-			return keys.EncryptedKeyExport{
+		func(id string, key Key, cryptoJSON keystore.CryptoJSON) internal.EncryptedKeyExport {
+			return internal.EncryptedKeyExport{
 				KeyType:   id,
 				PublicKey: key.StarkKeyStr(),
 				Crypto:    cryptoJSON,

--- a/core/services/keystore/keys/starkkey/key.go
+++ b/core/services/keystore/keys/starkkey/key.go
@@ -8,32 +8,20 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/curve"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
-// Raw represents the Stark private key
-type Raw []byte
-
-// Key gets the Key
-func (raw Raw) Key() Key {
+func KeyFor(raw internal.Raw) Key {
 	k := Key{}
 	var err error
 
-	k.priv = new(big.Int).SetBytes(raw)
+	k.priv = new(big.Int).SetBytes(raw.Bytes())
 	k.pub.X, k.pub.Y, err = curve.Curve.PrivateToPoint(k.priv)
 	if err != nil {
 		panic(err) // key not generated
 	}
 	return k
-}
-
-// String returns description
-func (raw Raw) String() string {
-	return "<Starknet Raw Private Key>"
-}
-
-// GoString wraps String()
-func (raw Raw) GoString() string {
-	return raw.String()
 }
 
 var _ fmt.GoStringer = &Key{}
@@ -79,8 +67,8 @@ func (key Key) StarkKeyStr() string {
 }
 
 // Raw from private key
-func (key Key) Raw() Raw {
-	return key.priv.Bytes()
+func (key Key) Raw() internal.Raw {
+	return internal.NewRaw(key.priv.Bytes())
 }
 
 // String is the print-friendly format of the Key

--- a/core/services/keystore/keys/starkkey/ocr2key.go
+++ b/core/services/keystore/keys/starkkey/ocr2key.go
@@ -11,6 +11,8 @@ import (
 	"github.com/NethermindEth/starknet.go/curve"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
 var _ types.OnchainKeyring = &OCR2Key{}
@@ -155,7 +157,7 @@ func (sk *OCR2Key) Unmarshal(in []byte) error {
 		return errors.Errorf("unexpected seed size, got %d want %d", len(in), sk.privateKeyLen())
 	}
 
-	sk.Key = Raw(in).Key()
+	sk.Key = KeyFor(internal.NewRaw(in))
 	return nil
 }
 

--- a/core/services/keystore/keys/tronkey/export.go
+++ b/core/services/keystore/keys/tronkey/export.go
@@ -3,7 +3,7 @@ package tronkey
 import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
@@ -11,28 +11,27 @@ const keyTypeIdentifier = "Tron"
 
 // FromEncryptedJSON gets key from json and password
 func FromEncryptedJSON(keyJSON []byte, password string) (Key, error) {
-	return keys.FromEncryptedJSON(
+	return internal.FromEncryptedJSON(
 		keyTypeIdentifier,
 		keyJSON,
 		password,
 		adulteratedPassword,
-		func(_ keys.EncryptedKeyExport, rawPrivKey []byte) (Key, error) {
-			return Raw(rawPrivKey).Key(), nil
+		func(_ internal.EncryptedKeyExport, rawPrivKey internal.Raw) (Key, error) {
+			return KeyFor(rawPrivKey), nil
 		},
 	)
 }
 
 // ToEncryptedJSON returns encrypted JSON representing key
 func (key Key) ToEncryptedJSON(password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	return keys.ToEncryptedJSON(
+	return internal.ToEncryptedJSON(
 		keyTypeIdentifier,
-		key.Raw(),
 		key,
 		password,
 		scryptParams,
 		adulteratedPassword,
-		func(id string, key Key, cryptoJSON keystore.CryptoJSON) keys.EncryptedKeyExport {
-			return keys.EncryptedKeyExport{
+		func(id string, key Key, cryptoJSON keystore.CryptoJSON) internal.EncryptedKeyExport {
+			return internal.EncryptedKeyExport{
 				KeyType:   id,
 				PublicKey: key.PublicKeyStr(),
 				Crypto:    cryptoJSON,

--- a/core/services/keystore/keys/tronkey/key.go
+++ b/core/services/keystore/keys/tronkey/key.go
@@ -9,18 +9,17 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
 // Tron uses the same elliptic curve cryptography as Ethereum (ECDSA with secp256k1)
 var curve = crypto.S256()
 
-// Raw represents the Tron private key
-type Raw []byte
-
 // Key generates a public-private key pair from the raw private key
-func (raw Raw) Key() Key {
+func KeyFor(raw internal.Raw) Key {
 	var privKey ecdsa.PrivateKey
-	d := big.NewInt(0).SetBytes(raw)
+	d := big.NewInt(0).SetBytes(raw.Bytes())
 	privKey.PublicKey.Curve = curve
 	privKey.D = d
 	privKey.PublicKey.X, privKey.PublicKey.Y = curve.ScalarBaseMult(d.Bytes())
@@ -28,14 +27,6 @@ func (raw Raw) Key() Key {
 		pubKey:  &privKey.PublicKey,
 		privKey: &privKey,
 	}
-}
-
-func (raw Raw) String() string {
-	return "<Tron Raw Private Key>"
-}
-
-func (raw Raw) GoString() string {
-	return raw.String()
 }
 
 var _ fmt.GoStringer = &Key{}
@@ -74,8 +65,8 @@ func (key Key) ID() string {
 	return key.Base58Address()
 }
 
-func (key Key) Raw() Raw {
-	return key.privKey.D.Bytes()
+func (key Key) Raw() internal.Raw {
+	return internal.NewRaw(key.privKey.D.Bytes())
 }
 
 func (key Key) ToEcdsaPrivKey() *ecdsa.PrivateKey {

--- a/core/services/keystore/keys/tronkey/key_test.go
+++ b/core/services/keystore/keys/tronkey/key_test.go
@@ -1,8 +1,6 @@
 package tronkey
 
 import (
-	"crypto/ecdsa"
-	"crypto/rand"
 	"encoding/hex"
 	"testing"
 
@@ -10,22 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestTronKeyRawPrivateKey(t *testing.T) {
-	t.Run("Create from raw bytes and check string representation", func(t *testing.T) {
-		// Generate a private key
-		privateKeyECDSA, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
-		require.NoError(t, err, "Failed to generate ECDSA key")
-
-		// Create TronKey from raw bytes
-		tronKey := Raw(privateKeyECDSA.D.Bytes())
-
-		// Check string representation
-		expectedStr := "<Tron Raw Private Key>"
-		assert.Equal(t, expectedStr, tronKey.String(), "Unexpected string representation")
-		assert.Equal(t, expectedStr, tronKey.GoString(), "String() and GoString() should return the same value")
-	})
-}
 
 func TestTronKeyNewKeyGeneration(t *testing.T) {
 	t.Run("Generate new key and verify its components", func(t *testing.T) {

--- a/core/services/keystore/keys/vrfkey/export.go
+++ b/core/services/keystore/keys/vrfkey/export.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/signatures/secp256k1"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -42,7 +43,7 @@ func FromEncryptedJSON(keyJSON []byte, password string) (KeyV2, error) {
 		return KeyV2{}, errors.Wrapf(err, "could not decrypt VRF key %s", export.PublicKey.String())
 	}
 
-	key := Raw(gethKey.PrivateKey.D.Bytes()).Key()
+	key := KeyFor(internal.NewRaw(gethKey.PrivateKey.D.Bytes()))
 	return key, nil
 }
 

--- a/core/services/keystore/keys/vrfkey/key_v2.go
+++ b/core/services/keystore/keys/vrfkey/key_v2.go
@@ -10,30 +10,22 @@ import (
 	"go.dedis.ch/kyber/v3"
 
 	"github.com/smartcontractkit/chainlink-integrations/evm/utils"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/signatures/secp256k1"
 	bm "github.com/smartcontractkit/chainlink/v2/core/utils/big_math"
 )
 
 var suite = secp256k1.NewBlakeKeccackSecp256k1()
 
-type Raw []byte
-
-func (raw Raw) Key() KeyV2 {
-	rawKeyInt := new(big.Int).SetBytes(raw)
+func KeyFor(raw internal.Raw) KeyV2 {
+	rawKeyInt := new(big.Int).SetBytes(raw.Bytes())
 	k := secp256k1.IntToScalar(rawKeyInt)
 	key, err := keyFromScalar(k)
 	if err != nil {
 		panic(err)
 	}
 	return key
-}
-
-func (raw Raw) String() string {
-	return "<VRF Raw Private Key>"
-}
-
-func (raw Raw) GoString() string {
-	return raw.String()
 }
 
 var _ fmt.GoStringer = &KeyV2{}
@@ -60,8 +52,8 @@ func (key KeyV2) ID() string {
 	return hexutil.Encode(key.PublicKey[:])
 }
 
-func (key KeyV2) Raw() Raw {
-	return secp256k1.ToInt(*key.k).Bytes()
+func (key KeyV2) Raw() internal.Raw {
+	return internal.NewRaw(secp256k1.ToInt(*key.k).Bytes())
 }
 
 // GenerateProofWithNonce allows external nonce generation for testing purposes

--- a/core/services/keystore/keys/vrfkey/key_v2_test.go
+++ b/core/services/keystore/keys/vrfkey/key_v2_test.go
@@ -1,35 +1,23 @@
 package vrfkey
 
 import (
-	"crypto/ecdsa"
-	"crypto/rand"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/signatures/secp256k1"
 )
-
-func TestVRFKeys_KeyV2_Raw(t *testing.T) {
-	privK, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
-	require.NoError(t, err)
-
-	r := Raw(privK.D.Bytes())
-
-	assert.Equal(t, r.String(), r.GoString())
-	assert.Equal(t, "<VRF Raw Private Key>", r.String())
-}
 
 func TestVRFKeys_KeyV2(t *testing.T) {
 	k, err := NewV2()
 	require.NoError(t, err)
 
 	assert.Equal(t, hexutil.Encode(k.PublicKey[:]), k.ID())
-	assert.Equal(t, Raw(secp256k1.ToInt(*k.k).Bytes()), k.Raw())
+	assert.Equal(t, internal.NewRaw(secp256k1.ToInt(*k.k).Bytes()), k.Raw())
 
 	t.Run("generates proof", func(t *testing.T) {
 		p, err := k.GenerateProof(big.NewInt(1))

--- a/core/services/keystore/keys/workflowkey/export.go
+++ b/core/services/keystore/keys/workflowkey/export.go
@@ -3,34 +3,33 @@ package workflowkey
 import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 const keyTypeIdentifier = "Workflow"
 
 func FromEncryptedJSON(keyJSON []byte, password string) (Key, error) {
-	return keys.FromEncryptedJSON(
+	return internal.FromEncryptedJSON(
 		keyTypeIdentifier,
 		keyJSON,
 		password,
 		adulteratedPassword,
-		func(_ keys.EncryptedKeyExport, rawPrivKey []byte) (Key, error) {
-			return Raw(rawPrivKey).Key(), nil
+		func(_ internal.EncryptedKeyExport, rawPrivKey internal.Raw) (Key, error) {
+			return KeyFor(rawPrivKey), nil
 		},
 	)
 }
 
 func (k Key) ToEncryptedJSON(password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	return keys.ToEncryptedJSON(
+	return internal.ToEncryptedJSON(
 		keyTypeIdentifier,
-		k.Raw(),
 		k,
 		password,
 		scryptParams,
 		adulteratedPassword,
-		func(id string, key Key, cryptoJSON keystore.CryptoJSON) keys.EncryptedKeyExport {
-			return keys.EncryptedKeyExport{
+		func(id string, key Key, cryptoJSON keystore.CryptoJSON) internal.EncryptedKeyExport {
+			return internal.EncryptedKeyExport{
 				KeyType:   id,
 				PublicKey: key.PublicKeyString(),
 				Crypto:    cryptoJSON,

--- a/core/services/keystore/keys/workflowkey/key.go
+++ b/core/services/keystore/keys/workflowkey/key.go
@@ -10,28 +10,16 @@ import (
 
 	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/nacl/box"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
-type Raw []byte
-
-func (raw Raw) Key() Key {
-	privateKey := [32]byte(raw)
+func KeyFor(raw internal.Raw) Key {
+	privateKey := [32]byte(raw.Bytes())
 	return Key{
 		privateKey: &privateKey,
 		publicKey:  curve25519PubKeyFromPrivateKey(privateKey),
 	}
-}
-
-func (raw Raw) String() string {
-	return fmt.Sprintf("<%s Raw Private Key>", keyTypeIdentifier)
-}
-
-func (raw Raw) GoString() string {
-	return raw.String()
-}
-
-func (raw Raw) Bytes() []byte {
-	return ([]byte)(raw)
 }
 
 type Key struct {
@@ -71,10 +59,10 @@ func (k Key) ID() string {
 	return k.PublicKeyString()
 }
 
-func (k Key) Raw() Raw {
+func (k Key) Raw() internal.Raw {
 	raw := make([]byte, curve25519.PointSize)
 	copy(raw, k.privateKey[:])
-	return Raw(raw)
+	return internal.NewRaw(raw)
 }
 
 func (k Key) String() string {

--- a/core/services/keystore/keys/workflowkey/key_test.go
+++ b/core/services/keystore/keys/workflowkey/key_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/nacl/box"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
 func TestNew(t *testing.T) {
@@ -27,23 +29,13 @@ func TestPublicKey(t *testing.T) {
 	assert.Equal(t, *key.publicKey, key.PublicKey())
 }
 
-func TestEncryptKeyRawPrivateKey(t *testing.T) {
-	privKey, err := New()
-	require.NoError(t, err)
-
-	privateKey := privKey.Raw()
-
-	assert.Equal(t, "<Workflow Raw Private Key>", privateKey.String())
-	assert.Equal(t, privateKey.String(), privateKey.GoString())
-}
-
 func TestEncryptKeyFromRawPrivateKey(t *testing.T) {
 	boxPubKey, boxPrivKey, err := box.GenerateKey(cryptorand.Reader)
 	require.NoError(t, err)
 
 	privKey := make([]byte, 32)
 	copy(privKey, boxPrivKey[:])
-	key := Raw(privKey).Key()
+	key := KeyFor(internal.NewRaw(privKey))
 
 	assert.Equal(t, boxPubKey, key.publicKey)
 	assert.Equal(t, boxPrivKey, key.privateKey)

--- a/core/services/keystore/models.go
+++ b/core/services/keystore/models.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/aptoskey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/cosmoskey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/csakey"
@@ -213,40 +214,40 @@ func (kr *keyRing) Encrypt(password string, scryptParams utils.ScryptParams) (ek
 
 func (kr *keyRing) raw() (rawKeys rawKeyRing) {
 	for _, csaKey := range kr.CSA {
-		rawKeys.CSA = append(rawKeys.CSA, csaKey.Raw())
+		rawKeys.CSA = append(rawKeys.CSA, csaKey.Raw().Bytes())
 	}
 	for _, ethKey := range kr.Eth {
-		rawKeys.Eth = append(rawKeys.Eth, ethKey.Raw())
+		rawKeys.Eth = append(rawKeys.Eth, ethKey.Raw().Bytes())
 	}
 	for _, ocrKey := range kr.OCR {
-		rawKeys.OCR = append(rawKeys.OCR, ocrKey.Raw())
+		rawKeys.OCR = append(rawKeys.OCR, ocrKey.Raw().Bytes())
 	}
 	for _, ocr2key := range kr.OCR2 {
-		rawKeys.OCR2 = append(rawKeys.OCR2, ocr2key.Raw())
+		rawKeys.OCR2 = append(rawKeys.OCR2, ocr2key.Raw().Bytes())
 	}
 	for _, p2pKey := range kr.P2P {
-		rawKeys.P2P = append(rawKeys.P2P, p2pKey.Raw())
+		rawKeys.P2P = append(rawKeys.P2P, p2pKey.Raw().Bytes())
 	}
 	for _, cosmoskey := range kr.Cosmos {
-		rawKeys.Cosmos = append(rawKeys.Cosmos, cosmoskey.Raw())
+		rawKeys.Cosmos = append(rawKeys.Cosmos, cosmoskey.Raw().Bytes())
 	}
 	for _, solkey := range kr.Solana {
-		rawKeys.Solana = append(rawKeys.Solana, solkey.Raw())
+		rawKeys.Solana = append(rawKeys.Solana, solkey.Raw().Bytes())
 	}
 	for _, starkkey := range kr.StarkNet {
-		rawKeys.StarkNet = append(rawKeys.StarkNet, starkkey.Raw())
+		rawKeys.StarkNet = append(rawKeys.StarkNet, starkkey.Raw().Bytes())
 	}
 	for _, aptoskey := range kr.Aptos {
-		rawKeys.Aptos = append(rawKeys.Aptos, aptoskey.Raw())
+		rawKeys.Aptos = append(rawKeys.Aptos, aptoskey.Raw().Bytes())
 	}
 	for _, tronkey := range kr.Tron {
-		rawKeys.Tron = append(rawKeys.Tron, tronkey.Raw())
+		rawKeys.Tron = append(rawKeys.Tron, tronkey.Raw().Bytes())
 	}
 	for _, vrfKey := range kr.VRF {
-		rawKeys.VRF = append(rawKeys.VRF, vrfKey.Raw())
+		rawKeys.VRF = append(rawKeys.VRF, vrfKey.Raw().Bytes())
 	}
 	for _, workflowKey := range kr.Workflow {
-		rawKeys.Workflow = append(rawKeys.Workflow, workflowKey.Raw())
+		rawKeys.Workflow = append(rawKeys.Workflow, workflowKey.Raw().Bytes())
 	}
 	return rawKeys
 }
@@ -348,70 +349,70 @@ func (kr *keyRing) logPubKeys(lggr logger.Logger) {
 // it holds only the essential key information to avoid adding unnecessary data
 // (like public keys) to the database
 type rawKeyRing struct {
-	Eth        []ethkey.Raw
-	CSA        []csakey.Raw
-	OCR        []ocrkey.Raw
-	OCR2       []ocr2key.Raw
-	P2P        []p2pkey.Raw
-	Cosmos     []cosmoskey.Raw
-	Solana     []solkey.Raw
-	StarkNet   []starkkey.Raw
-	Aptos      []aptoskey.Raw
-	Tron       []tronkey.Raw
-	VRF        []vrfkey.Raw
-	Workflow   []workflowkey.Raw
+	Eth        [][]byte
+	CSA        [][]byte
+	OCR        [][]byte
+	OCR2       [][]byte
+	P2P        [][]byte
+	Cosmos     [][]byte
+	Solana     [][]byte
+	StarkNet   [][]byte
+	Aptos      [][]byte
+	Tron       [][]byte
+	VRF        [][]byte
+	Workflow   [][]byte
 	LegacyKeys LegacyKeyStorage `json:"-"`
 }
 
 func (rawKeys rawKeyRing) keys() (*keyRing, error) {
 	keyRing := newKeyRing()
 	for _, rawCSAKey := range rawKeys.CSA {
-		csaKey := rawCSAKey.Key()
+		csaKey := csakey.KeyFor(internal.NewRaw(rawCSAKey))
 		keyRing.CSA[csaKey.ID()] = csaKey
 	}
 	for _, rawETHKey := range rawKeys.Eth {
-		ethKey := rawETHKey.Key()
+		ethKey := ethkey.KeyFor(internal.NewRaw(rawETHKey))
 		keyRing.Eth[ethKey.ID()] = ethKey
 	}
 	for _, rawOCRKey := range rawKeys.OCR {
-		ocrKey := rawOCRKey.Key()
+		ocrKey := ocrkey.KeyFor(internal.NewRaw(rawOCRKey))
 		keyRing.OCR[ocrKey.ID()] = ocrKey
 	}
 	for _, rawOCR2Key := range rawKeys.OCR2 {
-		if ocr2Key := rawOCR2Key.Key(); ocr2Key != nil {
+		if ocr2Key := ocr2key.KeyFor(internal.NewRaw(rawOCR2Key)); ocr2Key != nil {
 			keyRing.OCR2[ocr2Key.ID()] = ocr2Key
 		}
 	}
 	for _, rawP2PKey := range rawKeys.P2P {
-		p2pKey := rawP2PKey.Key()
+		p2pKey := p2pkey.KeyFor(internal.NewRaw(rawP2PKey))
 		keyRing.P2P[p2pKey.ID()] = p2pKey
 	}
 	for _, rawCosmosKey := range rawKeys.Cosmos {
-		cosmosKey := rawCosmosKey.Key()
+		cosmosKey := cosmoskey.KeyFor(internal.NewRaw(rawCosmosKey))
 		keyRing.Cosmos[cosmosKey.ID()] = cosmosKey
 	}
 	for _, rawSolKey := range rawKeys.Solana {
-		solKey := rawSolKey.Key()
+		solKey := solkey.KeyFor(internal.NewRaw(rawSolKey))
 		keyRing.Solana[solKey.ID()] = solKey
 	}
 	for _, rawStarkNetKey := range rawKeys.StarkNet {
-		starkKey := rawStarkNetKey.Key()
+		starkKey := starkkey.KeyFor(internal.NewRaw(rawStarkNetKey))
 		keyRing.StarkNet[starkKey.ID()] = starkKey
 	}
 	for _, rawAptosKey := range rawKeys.Aptos {
-		aptosKey := rawAptosKey.Key()
+		aptosKey := aptoskey.KeyFor(internal.NewRaw(rawAptosKey))
 		keyRing.Aptos[aptosKey.ID()] = aptosKey
 	}
 	for _, rawTronKey := range rawKeys.Tron {
-		tronKey := rawTronKey.Key()
+		tronKey := tronkey.KeyFor(internal.NewRaw(rawTronKey))
 		keyRing.Tron[tronKey.ID()] = tronKey
 	}
 	for _, rawVRFKey := range rawKeys.VRF {
-		vrfKey := rawVRFKey.Key()
+		vrfKey := vrfkey.KeyFor(internal.NewRaw(rawVRFKey))
 		keyRing.VRF[vrfKey.ID()] = vrfKey
 	}
 	for _, rawWorkflowKey := range rawKeys.Workflow {
-		workflowKey := rawWorkflowKey.Key()
+		workflowKey := workflowkey.KeyFor(internal.NewRaw(rawWorkflowKey))
 		keyRing.Workflow[workflowKey.ID()] = workflowKey
 	}
 

--- a/core/services/keystore/models_test.go
+++ b/core/services/keystore/models_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/cosmoskey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/csakey"
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocrkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -31,11 +30,11 @@ func TestKeyRing_Encrypt_Decrypt(t *testing.T) {
 		ocrkey.MustNewV2XXXTestingOnly(big.NewInt(2)),
 	}
 	var ocr2 []ocr2key.KeyBundle
-	var ocr2_raw []ocr2key.Raw
+	ocr2Raw := make([][]byte, 0, len(chaintype.SupportedChainTypes))
 	for _, chain := range chaintype.SupportedChainTypes {
 		key := ocr2key.MustNewInsecure(rand.Reader, chain)
 		ocr2 = append(ocr2, key)
-		ocr2_raw = append(ocr2_raw, key.Raw())
+		ocr2Raw = append(ocr2Raw, key.Raw().Bytes())
 	}
 	p2p1, p2p2 := p2pkey.MustNewV2XXXTestingOnly(big.NewInt(1)), p2pkey.MustNewV2XXXTestingOnly(big.NewInt(2))
 	sol1, sol2 := solkey.MustNewInsecure(rand.Reader), solkey.MustNewInsecure(rand.Reader)
@@ -43,15 +42,15 @@ func TestKeyRing_Encrypt_Decrypt(t *testing.T) {
 	tk1, tk2 := cosmoskey.MustNewInsecure(rand.Reader), cosmoskey.MustNewInsecure(rand.Reader)
 	uk1, uk2 := tronkey.MustNewInsecure(rand.Reader), tronkey.MustNewInsecure(rand.Reader)
 	originalKeyRingRaw := rawKeyRing{
-		CSA:    []csakey.Raw{csa1.Raw(), csa2.Raw()},
-		Eth:    []ethkey.Raw{eth1.Raw(), eth2.Raw()},
-		OCR:    []ocrkey.Raw{ocr[0].Raw(), ocr[1].Raw()},
-		OCR2:   ocr2_raw,
-		P2P:    []p2pkey.Raw{p2p1.Raw(), p2p2.Raw()},
-		Solana: []solkey.Raw{sol1.Raw(), sol2.Raw()},
-		VRF:    []vrfkey.Raw{vrf1.Raw(), vrf2.Raw()},
-		Cosmos: []cosmoskey.Raw{tk1.Raw(), tk2.Raw()},
-		Tron:   []tronkey.Raw{uk1.Raw(), uk2.Raw()},
+		CSA:    [][]byte{csa1.Raw().Bytes(), csa2.Raw().Bytes()},
+		Eth:    [][]byte{eth1.Raw().Bytes(), eth2.Raw().Bytes()},
+		OCR:    [][]byte{ocr[0].Raw().Bytes(), ocr[1].Raw().Bytes()},
+		OCR2:   ocr2Raw,
+		P2P:    [][]byte{p2p1.Raw().Bytes(), p2p2.Raw().Bytes()},
+		Solana: [][]byte{sol1.Raw().Bytes(), sol2.Raw().Bytes()},
+		VRF:    [][]byte{vrf1.Raw().Bytes(), vrf2.Raw().Bytes()},
+		Cosmos: [][]byte{tk1.Raw().Bytes(), tk2.Raw().Bytes()},
+		Tron:   [][]byte{uk1.Raw().Bytes(), uk2.Raw().Bytes()},
 	}
 	originalKeyRing, kerr := originalKeyRingRaw.keys()
 	require.NoError(t, kerr)

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -460,7 +460,7 @@ func testIntegrationLLOEVMPremiumLegacy(t *testing.T, offchainConfig datastreams
 		reqs := make(chan wsrpcRequest, 100000)
 		serverKey := csakey.MustNewV2XXXTestingOnly(big.NewInt(salt - 2))
 		serverPubKey := serverKey.PublicKey
-		srv := NewWSRPCMercuryServer(t, ed25519.PrivateKey(serverKey.Raw()), reqs)
+		srv := NewWSRPCMercuryServer(t, serverKey.Signer(), reqs)
 
 		serverURL := startWSRPCMercuryServer(t, srv, clientPubKeys)
 
@@ -698,7 +698,7 @@ func testIntegrationLLOMultiFormats(t *testing.T, offchainConfig datastreamsllo.
 		packetCh := make(chan *packet, 100000)
 		serverKey := csakey.MustNewV2XXXTestingOnly(big.NewInt(salt - 2))
 		serverPubKey := serverKey.PublicKey
-		srv := NewMercuryServer(t, ed25519.PrivateKey(serverKey.Raw()), packetCh)
+		srv := NewMercuryServer(t, serverKey.Signer(), packetCh)
 
 		serverURL := startMercuryServer(t, srv, clientPubKeys)
 
@@ -1345,7 +1345,7 @@ func TestIntegration_LLO_stress_test_V1(t *testing.T) {
 		packets := make(chan *packet, nReports*nNodes)
 		serverKey := csakey.MustNewV2XXXTestingOnly(big.NewInt(salt - 2))
 		serverPubKey := serverKey.PublicKey
-		srv := NewMercuryServer(t, ed25519.PrivateKey(serverKey.Raw()), packets)
+		srv := NewMercuryServer(t, serverKey.Signer(), packets)
 
 		serverURL := startMercuryServer(t, srv, clientPubKeys)
 
@@ -1574,7 +1574,7 @@ func TestIntegration_LLO_transmit_errors(t *testing.T) {
 		packets := make(chan *packet, 100000)
 		serverKey := csakey.MustNewV2XXXTestingOnly(big.NewInt(salt - 2))
 		serverPubKey := serverKey.PublicKey
-		srv := NewMercuryServer(t, ed25519.PrivateKey(serverKey.Raw()), packets)
+		srv := NewMercuryServer(t, serverKey.Signer(), packets)
 
 		serverURL := startMercuryServer(t, srv, clientPubKeys)
 
@@ -1736,7 +1736,7 @@ func testIntegrationLLOBlueGreenLifecycle(t *testing.T, offchainConfig datastrea
 		packetCh := make(chan *packet, 100000)
 		serverKey := csakey.MustNewV2XXXTestingOnly(big.NewInt(salt - 2))
 		serverPubKey := serverKey.PublicKey
-		srv := NewMercuryServer(t, ed25519.PrivateKey(serverKey.Raw()), packetCh)
+		srv := NewMercuryServer(t, serverKey.Signer(), packetCh)
 
 		serverURL := startMercuryServer(t, srv, clientPubKeys)
 

--- a/core/services/ocr2/plugins/mercury/helpers_test.go
+++ b/core/services/ocr2/plugins/mercury/helpers_test.go
@@ -2,6 +2,7 @@ package mercury_test
 
 import (
 	"context"
+	"crypto"
 	"crypto/ed25519"
 	"encoding/binary"
 	"errors"
@@ -53,14 +54,14 @@ type request struct {
 }
 
 type mercuryServer struct {
-	privKey     ed25519.PrivateKey
+	csaSigner   crypto.Signer
 	reqsCh      chan request
 	t           *testing.T
 	buildReport func() []byte
 }
 
-func NewMercuryServer(t *testing.T, privKey ed25519.PrivateKey, reqsCh chan request, buildReport func() []byte) *mercuryServer {
-	return &mercuryServer{privKey, reqsCh, t, buildReport}
+func NewMercuryServer(t *testing.T, csaSigner crypto.Signer, reqsCh chan request, buildReport func() []byte) *mercuryServer {
+	return &mercuryServer{csaSigner, reqsCh, t, buildReport}
 }
 
 func (s *mercuryServer) Transmit(ctx context.Context, req *pb.TransmitRequest) (*pb.TransmitResponse, error) {
@@ -104,7 +105,7 @@ func startMercuryServer(t *testing.T, srv *mercuryServer, pubKeys []ed25519.Publ
 		t.Fatalf("[MAIN] failed to listen: %v", err)
 	}
 	serverURL = lis.Addr().String()
-	s := wsrpc.NewServer(wsrpc.WithCreds(srv.privKey, pubKeys))
+	s := wsrpc.NewServer(wsrpc.WithSigner(srv.csaSigner, pubKeys))
 
 	// Register mercury implementation with the wsrpc server
 	pb.RegisterMercuryServer(s, srv)

--- a/core/services/ocr2/plugins/mercury/integration_test.go
+++ b/core/services/ocr2/plugins/mercury/integration_test.go
@@ -24,14 +24,15 @@ import (
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/shopspring/decimal"
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
-	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-	"github.com/smartcontractkit/wsrpc/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
+	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/smartcontractkit/wsrpc/credentials"
 
 	mercurytypes "github.com/smartcontractkit/chainlink-common/pkg/types/mercury"
 	v1 "github.com/smartcontractkit/chainlink-common/pkg/types/mercury/v1"
@@ -172,7 +173,7 @@ func integration_MercuryV1(t *testing.T) {
 	reqs := make(chan request)
 	serverKey := csakey.MustNewV2XXXTestingOnly(big.NewInt(-1))
 	serverPubKey := serverKey.PublicKey
-	srv := NewMercuryServer(t, ed25519.PrivateKey(serverKey.Raw()), reqs, func() []byte {
+	srv := NewMercuryServer(t, serverKey.Signer(), reqs, func() []byte {
 		report, err := (&reportcodecv1.ReportCodec{}).BuildReport(ctx, v1.ReportFields{BenchmarkPrice: big.NewInt(234567), Bid: big.NewInt(1), Ask: big.NewInt(1), CurrentBlockHash: make([]byte, 32)})
 		if err != nil {
 			panic(err)
@@ -532,7 +533,7 @@ func integration_MercuryV2(t *testing.T) {
 	reqs := make(chan request)
 	serverKey := csakey.MustNewV2XXXTestingOnly(big.NewInt(-1))
 	serverPubKey := serverKey.PublicKey
-	srv := NewMercuryServer(t, ed25519.PrivateKey(serverKey.Raw()), reqs, func() []byte {
+	srv := NewMercuryServer(t, serverKey.Signer(), reqs, func() []byte {
 		report, err := (&reportcodecv2.ReportCodec{}).BuildReport(ctx, v2.ReportFields{BenchmarkPrice: big.NewInt(234567), LinkFee: big.NewInt(1), NativeFee: big.NewInt(1)})
 		if err != nil {
 			panic(err)
@@ -827,7 +828,7 @@ func integration_MercuryV3(t *testing.T) {
 	for i := 0; i < nSrvs; i++ {
 		k := csakey.MustNewV2XXXTestingOnly(big.NewInt(int64(-(i + 1))))
 		reqs := make(chan request, 100)
-		srv := NewMercuryServer(t, ed25519.PrivateKey(k.Raw()), reqs, func() []byte {
+		srv := NewMercuryServer(t, k.Signer(), reqs, func() []byte {
 			report, err := (&reportcodecv3.ReportCodec{}).BuildReport(ctx, v3.ReportFields{BenchmarkPrice: big.NewInt(234567), Bid: big.NewInt(1), Ask: big.NewInt(1), LinkFee: big.NewInt(1), NativeFee: big.NewInt(1)})
 			if err != nil {
 				panic(err)
@@ -1123,7 +1124,7 @@ func integration_MercuryV4(t *testing.T) {
 	for i := 0; i < nSrvs; i++ {
 		k := csakey.MustNewV2XXXTestingOnly(big.NewInt(int64(-(i + 1))))
 		reqs := make(chan request, 100)
-		srv := NewMercuryServer(t, ed25519.PrivateKey(k.Raw()), reqs, func() []byte {
+		srv := NewMercuryServer(t, k.Signer(), reqs, func() []byte {
 			report, err := (&reportcodecv4.ReportCodec{}).BuildReport(ctx, v4.ReportFields{BenchmarkPrice: big.NewInt(234567), LinkFee: big.NewInt(1), NativeFee: big.NewInt(1), MarketStatus: 1})
 			if err != nil {
 				panic(err)

--- a/core/services/relay/evm/mercury/wsrpc/client_test.go
+++ b/core/services/relay/evm/mercury/wsrpc/client_test.go
@@ -78,7 +78,7 @@ func Test_Client_Transmit(t *testing.T) {
 		}
 		opts := ClientOpts{
 			logger.Sugared(lggr),
-			csakey.MustNewV2XXXTestingOnly(new(big.Int).SetInt64(rand.Int64())).PrivateKey(),
+			csakey.MustNewV2XXXTestingOnly(new(big.Int).SetInt64(rand.Int64())).Signer(),
 			nil,
 			"",
 			noopCacheSet,
@@ -169,7 +169,7 @@ func Test_Client_LatestReport(t *testing.T) {
 			conn := &mocks.MockConn{
 				Ready: true,
 			}
-			c := newClient(ClientOpts{logger.Sugared(lggr), csakey.MustNewV2XXXTestingOnly(big.NewInt(rand.Int64())).PrivateKey(), nil, "", cacheSet, nil})
+			c := newClient(ClientOpts{logger.Sugared(lggr), csakey.MustNewV2XXXTestingOnly(big.NewInt(rand.Int64())).Signer(), nil, "", cacheSet, nil})
 			c.conn = conn
 			c.rawClient = wsrpcClient
 

--- a/core/services/relay/evm/mercury/wsrpc/pool_test.go
+++ b/core/services/relay/evm/mercury/wsrpc/pool_test.go
@@ -70,7 +70,7 @@ func Test_Pool(t *testing.T) {
 				return client
 			}
 
-			c, err := p.Checkout(ctx, clientPrivKey.PublicKeyString(), clientPrivKey.PrivateKey(), serverPubKey, serverURL)
+			c, err := p.Checkout(ctx, clientPrivKey.PublicKeyString(), clientPrivKey.Signer(), serverPubKey, serverURL)
 			require.NoError(t, err)
 
 			assert.True(t, client.started)
@@ -258,8 +258,8 @@ func Test_Pool(t *testing.T) {
 	})
 }
 
-func mustCheckout(t *testing.T, p *pool, clientPrivKey csakey.KeyV2, serverPubKey []byte, serverURL string) Client {
-	c, err := p.Checkout(testutils.Context(t), clientPrivKey.PublicKeyString(), clientPrivKey.PrivateKey(), serverPubKey, serverURL)
+func mustCheckout(t *testing.T, p *pool, csaKey csakey.KeyV2, serverPubKey []byte, serverURL string) Client {
+	c, err := p.Checkout(testutils.Context(t), csaKey.PublicKeyString(), csaKey.Signer(), serverPubKey, serverURL)
 	require.NoError(t, err)
 	return c
 }

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -364,7 +364,7 @@ require (
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1208,8 +1208,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 h1:yfukbG7KzP3FGe3WOV4GHowHqnRW1Pg7fDz2vBucS10=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/smartcontractkit/libocr v0.0.0-20250220133800-f3b940c4f298
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0
 	github.com/theodesp/go-heaps v0.0.0-20190520121037-88e35354fe0a

--- a/go.sum
+++ b/go.sum
@@ -1039,8 +1039,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 h1:yfukbG7KzP3FGe3WOV4GHowHqnRW1Pg7fDz2vBucS10=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -453,7 +453,7 @@ require (
 	github.com/smartcontractkit/mcms v0.14.0 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
 	github.com/sony/gobreaker/v2 v2.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1474,8 +1474,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 h1:yfukbG7KzP3FGe3WOV4GHowHqnRW1Pg7fDz2vBucS10=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -446,7 +446,7 @@ require (
 	github.com/smartcontractkit/libocr v0.0.0-20250220133800-f3b940c4f298 // indirect
 	github.com/smartcontractkit/mcms v0.14.0 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
 	github.com/sony/gobreaker/v2 v2.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1457,8 +1457,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 h1:yfukbG7KzP3FGe3WOV4GHowHqnRW1Pg7fDz2vBucS10=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/system-tests/lib/crypto/p2p.go
+++ b/system-tests/lib/crypto/p2p.go
@@ -1,8 +1,6 @@
 package crypto
 
 import (
-	"encoding/hex"
-
 	"github.com/smartcontractkit/chainlink/system-tests/lib/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -25,7 +23,6 @@ func GenerateP2PKeys(password string, n int) (*types.P2PKeys, error) {
 		result.EncryptedJSONs = append(result.EncryptedJSONs, d)
 		result.PeerIDs = append(result.PeerIDs, key.PeerID().String())
 		result.PublicHexKeys = append(result.PublicHexKeys, key.PublicKeyHex())
-		result.PrivateKeys = append(result.PrivateKeys, hex.EncodeToString(key.Raw()))
 	}
 	return result, nil
 }

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -355,7 +355,7 @@ require (
 	github.com/smartcontractkit/mcms v0.14.0 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1196,8 +1196,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 h1:yfukbG7KzP3FGe3WOV4GHowHqnRW1Pg7fDz2vBucS10=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/system-tests/lib/types/crypto.go
+++ b/system-tests/lib/types/crypto.go
@@ -13,6 +13,5 @@ type P2PKeys struct {
 	EncryptedJSONs [][]byte
 	PeerIDs        []string
 	PublicHexKeys  []string
-	PrivateKeys    []string
 	Password       string
 }

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -361,7 +361,7 @@ require (
 	github.com/smartcontractkit/mcms v0.14.0 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1196,8 +1196,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1 h1:yfukbG7KzP3FGe3WOV4GHowHqnRW1Pg7fDz2vBucS10=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250310183704-ea183816e1d1/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=


### PR DESCRIPTION
Towards https://smartcontract-it.atlassian.net/browse/CRE-339

This PR consolidates and tightens use of `Raw []byte` keys to a restricted internal package and converts to a less-printable type, as well as reduces direct use of private keys in general.

Blocked by:
- https://github.com/smartcontractkit/chainlink/pull/16577

Requires:
- https://github.com/smartcontractkit/chainlink-common/pull/1067
- https://github.com/smartcontractkit/wsrpc/pull/76