### PR TITLE
[CLD-22]: feat(operation): introduce retry mechanism on operation

### DIFF
--- a/deployment/changeset.go
+++ b/deployment/changeset.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
 	"github.com/smartcontractkit/mcms"
+
+	"github.com/smartcontractkit/chainlink/deployment/operations"
 )
 
 var (
@@ -109,6 +111,9 @@ type ChangesetOutput struct {
 	DescribedTimelockProposals []string
 	MCMSProposals              []mcms.Proposal
 	AddressBook                AddressBook
+	// Reports are populated by the Operations API with the
+	// results of the operations executed in the changeset.
+	Reports []operations.Report[any, any]
 }
 
 // ViewState produces a product specific JSON representation of

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -27,6 +27,8 @@ import (
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
+	"github.com/smartcontractkit/chainlink/deployment/operations"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 )
 
@@ -107,6 +109,8 @@ type Environment struct {
 	Offchain          OffchainClient
 	GetContext        func() context.Context
 	OCRSecrets        OCRSecrets
+	// OperationsBundle contains dependencies required by the operations API.
+	OperationsBundle operations.Bundle
 }
 
 func NewEnvironment(
@@ -130,6 +134,8 @@ func NewEnvironment(
 		Offchain:          offchain,
 		GetContext:        ctx,
 		OCRSecrets:        secrets,
+		// default to memory reporter as that is the only reporter available for now
+		OperationsBundle: operations.NewBundle(ctx, logger, operations.NewMemoryReporter()),
 	}
 }
 

--- a/deployment/operations/execute.go
+++ b/deployment/operations/execute.go
@@ -1,0 +1,95 @@
+package operations
+
+import (
+	"github.com/avast/retry-go/v4"
+)
+
+// ExecuteConfig is the configuration for the ExecuteOperation function.
+type ExecuteConfig[IN, DEP any] struct {
+	retryConfig RetryConfig[IN, DEP]
+}
+
+type ExecuteOption[IN, DEP any] func(*ExecuteConfig[IN, DEP])
+
+type RetryConfig[IN, DEP any] struct {
+	// DisableRetry disables the retry mechanism if set to true.
+	DisableRetry bool
+	// InputHook is a function that returns an updated input before retrying the operation.
+	// The operation when retried will use the input returned by this function.
+	// This is useful for scenarios like updating the gas limit.
+	// This will be ignored if DisableRetry is set to true.
+	InputHook func(input IN, deps DEP) IN
+}
+
+// WithRetryConfig is an ExecuteOption that sets the retry configuration.
+func WithRetryConfig[IN, DEP any](config RetryConfig[IN, DEP]) ExecuteOption[IN, DEP] {
+	return func(c *ExecuteConfig[IN, DEP]) {
+		c.retryConfig = config
+	}
+}
+
+// ExecuteOperation executes an operation with the given input and dependencies.
+// By default, it retries the operation up to 10 times with exponential backoff if it fails.
+// Use WithRetryConfig to customize the retry behavior.
+// To cancel the retry early, return an error with NewUnrecoverableError.
+func ExecuteOperation[IN, OUT, DEP any](
+	b Bundle,
+	operation *Operation[IN, OUT, DEP],
+	deps DEP,
+	input IN,
+	opts ...ExecuteOption[IN, DEP],
+) (Report[IN, OUT], error) {
+	executeConfig := &ExecuteConfig[IN, DEP]{retryConfig: RetryConfig[IN, DEP]{}}
+	for _, opt := range opts {
+		opt(executeConfig)
+	}
+
+	var output OUT
+	var err error
+
+	if executeConfig.retryConfig.DisableRetry {
+		output, err = operation.execute(b, deps, input)
+	} else {
+		var inputTemp = input
+		output, err = retry.DoWithData(func() (OUT, error) {
+			return operation.execute(b, deps, inputTemp)
+		}, retry.OnRetry(func(attempt uint, err error) {
+			b.Logger.Infow("Operation failed. Retrying...",
+				"operation", operation.def.ID, "attempt", attempt, "error", err)
+
+			if executeConfig.retryConfig.InputHook != nil {
+				inputTemp = executeConfig.retryConfig.InputHook(inputTemp, deps)
+			}
+		}))
+	}
+
+	report := NewReport(operation.def, input, output, err)
+	err = b.reporter.AddReport(genericReport(report))
+	if err != nil {
+		return Report[IN, OUT]{}, err
+	}
+	return report, report.Err
+}
+
+func genericReport[IN, OUT any](r Report[IN, OUT]) Report[any, any] {
+	return Report[any, any]{
+		ID: r.ID,
+		Def: Definition{
+			ID:          r.Def.ID,
+			Version:     r.Def.Version,
+			Description: r.Def.Description,
+		},
+		Output:                r.Output,
+		Input:                 r.Input,
+		Timestamp:             r.Timestamp,
+		Err:                   r.Err,
+		ChildOperationReports: r.ChildOperationReports,
+	}
+}
+
+// NewUnrecoverableError creates an error that indicates an unrecoverable error.
+// If this error is returned inside an operation, the operation will no longer retry.
+// This allows the operation to fail fast if it encounters an unrecoverable error.
+func NewUnrecoverableError(err error) error {
+	return retry.Unrecoverable(err)
+}

--- a/deployment/operations/execute_test.go
+++ b/deployment/operations/execute_test.go
@@ -1,0 +1,95 @@
+package operations
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+func Test_ExecuteOperation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		options           []ExecuteOption[int, any]
+		IsUnrecoverable   bool
+		wantOpCalledTimes int
+		wantOutput        int
+		wantErr           string
+	}{
+		{
+			name:              "DefaultRetry",
+			wantOpCalledTimes: 3,
+			wantOutput:        2,
+		},
+		{
+			name:              "NoRetry",
+			options:           []ExecuteOption[int, any]{WithRetryConfig[int, any](RetryConfig[int, any]{DisableRetry: true})},
+			wantOpCalledTimes: 1,
+			wantErr:           "test error",
+		},
+		{
+			name: "NewInputHook",
+			options: []ExecuteOption[int, any]{WithRetryConfig[int, any](RetryConfig[int, any]{InputHook: func(input int, deps any) int {
+				// update input to 5 after first failed attempt
+				return 5
+			}})},
+			wantOpCalledTimes: 3,
+			wantOutput:        6,
+		},
+		{
+			name:              "UnrecoverableError",
+			IsUnrecoverable:   true,
+			wantOpCalledTimes: 1,
+			wantErr:           "fatal error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			failTimes := 2
+			handlerCalledTimes := 0
+			handler := func(b Bundle, deps any, input int) (output int, err error) {
+				handlerCalledTimes++
+				if tt.IsUnrecoverable {
+					return 0, NewUnrecoverableError(errors.New("fatal error"))
+				}
+
+				if failTimes > 0 {
+					failTimes--
+					return 0, errors.New("test error")
+				}
+
+				return input + 1, nil
+			}
+			op := NewOperation("plus1", semver.MustParse("1.0.0"), "test operation", handler)
+			e := NewBundle(context.Background, logger.Test(t), NewMemoryReporter())
+
+			res, err := ExecuteOperation(e, op, nil, 1, tt.options...)
+
+			if tt.wantErr != "" {
+				require.Error(t, res.Err)
+				require.Error(t, err)
+				require.ErrorContains(t, res.Err, tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, res.Err)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantOutput, res.Output)
+			}
+			assert.Equal(t, tt.wantOpCalledTimes, handlerCalledTimes)
+			// check report is added to reporter
+			report, err := e.reporter.GetReport(res.ID)
+			require.NoError(t, err)
+			assert.NotNil(t, report)
+		})
+	}
+}

--- a/deployment/operations/execute_test.go
+++ b/deployment/operations/execute_test.go
@@ -93,3 +93,39 @@ func Test_ExecuteOperation(t *testing.T) {
 		})
 	}
 }
+
+func Test_ExecuteOperation_ErrorReporter(t *testing.T) {
+	op := NewOperation("plus1", semver.MustParse("1.0.0"), "test operation",
+		func(e Bundle, deps any, input int) (output int, err error) {
+			return input + 1, nil
+		})
+
+	reportErr := errors.New("add report error")
+	errReporter := errorReporter{
+		AddReportError: reportErr,
+	}
+	e := NewBundle(context.Background, logger.Test(t), errReporter)
+
+	res, err := ExecuteOperation(e, op, nil, 1)
+	require.Error(t, err)
+	require.ErrorContains(t, err, reportErr.Error())
+	require.NoError(t, res.Err)
+}
+
+type errorReporter struct {
+	GetReportError  error
+	GetReportsError error
+	AddReportError  error
+}
+
+func (e errorReporter) GetReport(id string) (Report[any, any], error) {
+	return Report[any, any]{}, e.GetReportError
+}
+
+func (e errorReporter) GetReports() ([]Report[any, any], error) {
+	return nil, e.GetReportsError
+}
+
+func (e errorReporter) AddReport(report Report[any, any]) error {
+	return e.AddReportError
+}

--- a/deployment/operations/operation.go
+++ b/deployment/operations/operation.go
@@ -14,13 +14,15 @@ import (
 type Bundle struct {
 	Logger     logger.Logger
 	GetContext func() context.Context
+	reporter   Reporter
 }
 
 // NewBundle creates and returns a new Bundle.
-func NewBundle(getContext func() context.Context, logger logger.Logger) Bundle {
+func NewBundle(getContext func() context.Context, logger logger.Logger, reporter Reporter) Bundle {
 	return Bundle{
 		Logger:     logger,
 		GetContext: getContext,
+		reporter:   reporter,
 	}
 }
 

--- a/deployment/operations/operation_test.go
+++ b/deployment/operations/operation_test.go
@@ -51,7 +51,7 @@ func Test_Operation_Execute(t *testing.T) {
 	}
 
 	op := NewOperation("sum", version, description, handler)
-	e := NewBundle(context.Background, log)
+	e := NewBundle(context.Background, log, nil)
 	input := OpInput{
 		A: 1,
 		B: 2,

--- a/deployment/operations/operation_test.go
+++ b/deployment/operations/operation_test.go
@@ -69,3 +69,17 @@ func Test_Operation_Execute(t *testing.T) {
 	assert.Equal(t, version.String(), entry.ContextMap()["version"])
 	assert.Equal(t, description, entry.ContextMap()["description"])
 }
+
+func Test_Operation_WithEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	handler := func(b Bundle, deps OpDeps, _ EmptyInput) (int, error) {
+		return 1, nil
+	}
+	op := NewOperation("return-1", semver.MustParse("1.0.0"), "return 1", handler)
+
+	out, err := op.execute(NewBundle(context.Background, logger.Test(t), nil), OpDeps{}, EmptyInput{})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, out)
+}

--- a/deployment/operations/report.go
+++ b/deployment/operations/report.go
@@ -1,0 +1,93 @@
+package operations
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Report is the result of an operation.
+// It contains the inputs and other metadata that was used to execute the operation.
+type Report[IN, OUT any] struct {
+	ID        string     `json:"ID"`
+	Def       Definition `json:"Definition"`
+	Output    OUT        `json:"Output"`
+	Input     IN         `json:"Input"`
+	Timestamp time.Time  `json:"Timestamp"`
+	Err       error      `json:"Error"`
+	// stores a list of report ID for an operation that was executed as part of a sequence.
+	ChildOperationReports []string `json:"ChildOperationReports"`
+}
+
+// NewReport creates a new report.
+// ChildOperationReports is applicable only for Sequence.
+func NewReport[IN, OUT any](
+	def Definition, input IN, output OUT, err error, childReportsID ...string,
+) Report[IN, OUT] {
+	return Report[IN, OUT]{
+		ID:                    uuid.New().String(),
+		Def:                   def,
+		Output:                output,
+		Input:                 input,
+		Timestamp:             time.Now(),
+		Err:                   err,
+		ChildOperationReports: childReportsID,
+	}
+}
+
+var ErrReportNotFound = errors.New("report not found")
+
+// Reporter manages reports. It can store them in memory, in the FS, etc.
+type Reporter interface {
+	GetReport(id string) (Report[any, any], error)
+	GetReports() ([]Report[any, any], error)
+	AddReport(report Report[any, any]) error
+}
+
+// MemoryReporter stores reports in memory.
+type MemoryReporter struct {
+	reports []Report[any, any]
+}
+
+type MemoryReporterOption func(*MemoryReporter)
+
+// WithReports is an option to initialize the MemoryReporter with a list of reports.
+func WithReports(reports []Report[any, any]) MemoryReporterOption {
+	return func(mr *MemoryReporter) {
+		mr.reports = reports
+	}
+}
+
+// NewMemoryReporter creates a new MemoryReporter.
+// It can be initialized with a list of reports using the WithReports option.
+func NewMemoryReporter(options ...MemoryReporterOption) *MemoryReporter {
+	reporter := &MemoryReporter{}
+	for _, opt := range options {
+		opt(reporter)
+	}
+	return reporter
+}
+
+// AddReport adds a report to the memory reporter.
+func (e *MemoryReporter) AddReport(report Report[any, any]) error {
+	e.reports = append(e.reports, report)
+	return nil
+}
+
+// GetReports returns all reports.
+func (e *MemoryReporter) GetReports() ([]Report[any, any], error) {
+	return e.reports, nil
+}
+
+// GetReport returns a report by ID.
+// Returns ErrReportNotFound if the report is not found.
+func (e *MemoryReporter) GetReport(id string) (Report[any, any], error) {
+	for _, report := range e.reports {
+		if report.ID == id {
+			return report, nil
+		}
+	}
+	return Report[any, any]{}, fmt.Errorf("report_id %s: %w", id, ErrReportNotFound)
+}

--- a/deployment/operations/report_test.go
+++ b/deployment/operations/report_test.go
@@ -1,0 +1,79 @@
+package operations
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_MemoryReporter(t *testing.T) {
+	t.Parallel()
+
+	existingReport := Report[any, any]{
+		ID:                    "1",
+		Def:                   Definition{},
+		Output:                "2",
+		Input:                 1,
+		Timestamp:             time.Now(),
+		ChildOperationReports: []string{uuid.New().String()},
+	}
+
+	reporter := NewMemoryReporter(WithReports([]Report[any, any]{existingReport}))
+
+	reports, err := reporter.GetReports()
+	require.NoError(t, err)
+	assert.Len(t, reports, 1)
+	assert.Equal(t, existingReport, reports[0])
+
+	report, err := reporter.GetReport("1")
+	require.NoError(t, err)
+	assert.Equal(t, report, reports[0])
+
+	newReport := Report[any, any]{
+		ID:        "2",
+		Def:       Definition{},
+		Output:    "3",
+		Input:     2,
+		Timestamp: time.Now(),
+	}
+	err = reporter.AddReport(newReport)
+	require.NoError(t, err)
+	reports, err = reporter.GetReports()
+	require.NoError(t, err)
+	assert.Len(t, reports, 2)
+	assert.Equal(t, newReport, reports[1])
+
+	// get non-existing report
+	_, err = reporter.GetReport("100")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrReportNotFound)
+	assert.ErrorContains(t, err, "report_id 100: report not found")
+}
+
+func Test_NewReport(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+	description := "test operation"
+	handler := func(b Bundle, deps any, input int) (output int, err error) {
+		return input + 1, nil
+	}
+	op := NewOperation("plus1", version, description, handler)
+
+	testErr := errors.New("test error")
+	childOperationID := uuid.New().String()
+	report := NewReport[int, int](op.def, 1, 2, testErr, childOperationID)
+	assert.NotEmpty(t, report.ID)
+	assert.Equal(t, op.def, report.Def)
+	assert.Equal(t, 1, report.Input)
+	assert.Equal(t, 2, report.Output)
+	assert.NotEmpty(t, report.Timestamp)
+	assert.Equal(t, testErr, report.Err)
+	assert.Len(t, report.ChildOperationReports, 1)
+	assert.Equal(t, childOperationID, report.ChildOperationReports[0])
+}


### PR DESCRIPTION
Introducing default retry policy, `no retry` option and `custom input hook` option which allows user to customize the input before retrying eg for customizing gas limit.

Note: Report idempotency behaviour will be introduced in future PR

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-22

