### PR TITLE
Skip flaky tests as of March 17

### DIFF
--- a/deployment/ccip/changeset/v1_5_1/cs_sync_usdc_domains_with_chains_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_sync_usdc_domains_with_chains_test.go
@@ -127,6 +127,9 @@ func TestValidateSyncUSDCDomainsWithChainsConfig(t *testing.T) {
 			if t.Name() == "TestValidateSyncUSDCDomainsWithChainsConfig/Domain_mapping_not_defined" {
 				tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-113")
 			}
+			if t.Name() == "TestValidateSyncUSDCDomainsWithChainsConfig/Chain_selector_is_not_valid" {
+				tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-195")
+			}
 			deployedEnvironment, _ := testhelpers.NewMemoryEnvironment(t, func(testCfg *testhelpers.TestConfigs) {
 				testCfg.Chains = 2
 				testCfg.PrerequisiteDeploymentOnly = true

--- a/deployment/data-streams/changeset/jd_distribute_bootstrap_jobs_test.go
+++ b/deployment/data-streams/changeset/jd_distribute_bootstrap_jobs_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestDistributeBootstrapJobSpecs(t *testing.T) {
+	t.Skip("Flaky Test: https://smartcontract-it.atlassian.net/browse/DX-196")
 	t.Parallel()
 
 	lggr := logger.TestLogger(t)

--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -303,6 +303,7 @@ func TestV1_5_Message_RMNRemote_Curse(t *testing.T) {
 
 // TestV1_5_Message_RMNRemote this test verify that 1.5 lane can be uncuresed when using RMNRemote
 func TestV1_5_Message_RMNRemote_Curse_Uncurse(t *testing.T) {
+	t.Skip("Flaky Test: https://smartcontract-it.atlassian.net/browse/DX-197")
 	// Deploy CCIP 1.5 with 3 chains and 4 nodes + 1 bootstrap
 	// Deploy 1.5 contracts (excluding pools to start, but including MCMS) .
 	e, _, tEnv := testsetups.NewIntegrationEnvironment(

--- a/integration-tests/smoke/ccip/ccip_rmn_test.go
+++ b/integration-tests/smoke/ccip/ccip_rmn_test.go
@@ -60,6 +60,7 @@ func TestRMN_IncorrectSig(t *testing.T) {
 }
 
 func TestRMN_TwoMessagesOnTwoLanesIncludingBatching(t *testing.T) {
+	t.Skip("Flaky Test: https://smartcontract-it.atlassian.net/browse/DX-199")
 	runRmnTestCase(t, rmnTestCase{
 		name:        "messages on two lanes including batching one lane RMN-enabled the other RMN-disabled",
 		waitForExec: true,
@@ -110,6 +111,7 @@ func TestRMN_TwoMessagesOnTwoLanesIncludingBatchingWithTemporaryPause(t *testing
 }
 
 func TestRMN_MultipleMessagesOnOneLaneNoWaitForExec(t *testing.T) {
+	t.Skip("Flaky Test: https://smartcontract-it.atlassian.net/browse/DX-201")
 	runRmnTestCase(t, rmnTestCase{
 		name:        "multiple messages for rmn batching inspection and one rmn node down",
 		waitForExec: false, // do not wait for execution reports
@@ -154,6 +156,7 @@ func TestRMN_NotEnoughObservers(t *testing.T) {
 }
 
 func TestRMN_DifferentSigners(t *testing.T) {
+	t.Skip("Flaky Test: https://smartcontract-it.atlassian.net/browse/DX-200")
 	runRmnTestCase(t, rmnTestCase{
 		name: "different signers and different observers",
 		homeChainConfig: homeChainConfig{
@@ -203,6 +206,7 @@ func TestRMN_NotEnoughSigners(t *testing.T) {
 }
 
 func TestRMN_DifferentRmnNodesForDifferentChains(t *testing.T) {
+	t.Skip("Flaky Test: https://smartcontract-it.atlassian.net/browse/DX-202")
 	runRmnTestCase(t, rmnTestCase{
 		name:        "different rmn nodes support different chains",
 		waitForExec: false,


### PR DESCRIPTION
Marking currently identified flaky tests as skipped to improve test stability. These tests will be revisited once their flakiness is resolved.

Related tickets:
- https://smartcontract-it.atlassian.net/browse/DX-202
- https://smartcontract-it.atlassian.net/browse/DX-201
- https://smartcontract-it.atlassian.net/browse/DX-200
- https://smartcontract-it.atlassian.net/browse/DX-199
- https://smartcontract-it.atlassian.net/browse/DX-197
- https://smartcontract-it.atlassian.net/browse/DX-196
- https://smartcontract-it.atlassian.net/browse/DX-195
