### PR TITLE
Increased DeltaProgress for CCIP simulated chain tests

### DIFF
--- a/deployment/ccip/changeset/v1_6/config.go
+++ b/deployment/ccip/changeset/v1_6/config.go
@@ -39,7 +39,7 @@ var (
 	// Used for only testing with simulated chains
 	OcrParamsForTest = CCIPOCRParams{
 		OCRParameters: types.OCRParameters{
-			DeltaProgress:                           10 * time.Second,
+			DeltaProgress:                           30 * time.Second,
 			DeltaResend:                             10 * time.Second,
 			DeltaInitial:                            20 * time.Second,
 			DeltaRound:                              2 * time.Second,

--- a/deployment/ccip/changeset/v1_6/config.go
+++ b/deployment/ccip/changeset/v1_6/config.go
@@ -39,7 +39,7 @@ var (
 	// Used for only testing with simulated chains
 	OcrParamsForTest = CCIPOCRParams{
 		OCRParameters: types.OCRParameters{
-			DeltaProgress:                           30 * time.Second,
+			DeltaProgress:                           30 * time.Second, // Lower DeltaProgress can lead to timeouts when running tests locally
 			DeltaResend:                             10 * time.Second,
 			DeltaInitial:                            20 * time.Second,
 			DeltaRound:                              2 * time.Second,


### PR DESCRIPTION
The lower `DeltaProgress` led to tests failing with timeout when run locally