### PR TITLE
Make install_protoc script work in non-trivial cases.

### DIFF
--- a/core/scripts/install-protoc.sh
+++ b/core/scripts/install-protoc.sh
@@ -24,7 +24,7 @@ fi
 
 if [ "$os" == "Linux" ] ; then
 	os="linux"
-    if [$arch != "x86_64"]; then
+    if [ "$arch" != "x86_64" ]; then
         echo "unsupported os $os-$arch update $0"
         exit 1
     fi
@@ -45,7 +45,7 @@ curl -LO $pb_url/download/v${VERSION}/$artifact
 if [[ ! -d $install_dir ]]; then
     mkdir $install_dir
 fi
-unzip -uo $artifact -d $install_dir
+unzip -o $artifact -d $install_dir
 rm $artifact
 
 echo "protoc $VERSION installed in $install_dir"


### PR DESCRIPTION
There were two problems with this script:
 1. (Minor) the condition at line 27 was written incorrectly, so bash could not parse it. One *must* add spaces inside the [] condition. (I have also added the quotes around "$arch" just to be consistent). But this was not a big problem - the condition never triggered, so we never exited the script without installing protoc.
 2. (Major) the unzip command did not overwrite the existing protoc binary. The -o command *must* be first in order to take the effect - https://superuser.com/a/100659. So, for example, if you have an older protoc binary installed it would never be overwritten.

P.s. such subtleties are one more reason to use something like nix for the tool management.