### PR TITLE
Remove unused python and solc-select setup step.

### DIFF
--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -346,12 +346,6 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Install solc-select and solc
-        uses: smartcontractkit/.github/actions/setup-solc-select@b6e37806737eef87e8c9137ceeb23ef0bff8b1db # validate-solidity-artifacts@0.1.0
-        with:
-          to_install: "0.8.24"
-          to_use: "0.8.24"
-
       - name: Install Slither
         uses: smartcontractkit/.github/actions/setup-slither@b6e37806737eef87e8c9137ceeb23ef0bff8b1db # validate-solidity-artifacts@0.1.0
 

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -341,11 +341,6 @@ jobs:
       - name: Install Foundry
         uses: ./.github/actions/install-solidity-foundry
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-
       - name: Install Slither
         uses: smartcontractkit/.github/actions/setup-slither@b6e37806737eef87e8c9137ceeb23ef0bff8b1db # validate-solidity-artifacts@0.1.0
 


### PR DESCRIPTION
We don't use solc-select anymore. Solidity itself is installed with foundry in one of the earlier steps.