### PR TITLE
DX-230 Optimise Flakeguard in ci-core workflow when unit tests not executed

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -278,10 +278,6 @@ jobs:
           echo "COUNT=50" >> $GITHUB_ENV
           echo "FUZZ_TIMEOUT_MINUTES=10">> $GITHUB_ENV
 
-      - name: Install flakeguard
-        shell: bash
-        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@7f6887061b2ea2ac7f0849f539fe36a8f6c7054f # flakguard@0.1.0
-        
       - name: Run tests
         if: ${{ matrix.type.should-run == 'true' }}
         id: run-tests
@@ -295,7 +291,7 @@ jobs:
           ./tools/bin/${{ matrix.type.cmd }} ./...
 
       - name: Generate Flakeguard Test Reports
-        if: ${{ always() && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
+        if: ${{ always() && matrix.type.should-run == 'true' && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
         env:
           MATRIX_TYPE_CMD: ${{ matrix.type.cmd }}
           GITHUB_WORKSPACE: ${{ github.workspace }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -341,7 +341,7 @@ jobs:
           if-no-files-found: ignore          
 
       - name: Send Flakeguard Reports to Splunk
-        if: ${{ always() && matrix.type.should-run == 'true' && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
+        if: ${{ always() && matrix.type.should-run == 'true' && github.event_name == 'merge_group' && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -309,7 +309,7 @@ jobs:
         run: ./.github/scripts/flakeguard-generate-reports.sh   
 
       - name: Upload Flakeguard Main Test Report as Artifact (All Tests)
-        if: ${{ always() && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
+        if: ${{ always() && matrix.type.should-run == 'true' && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.type.cmd }}_flakeguard_report_main_all_tests.json
@@ -318,7 +318,7 @@ jobs:
           if-no-files-found: ignore 
           
       - name: Upload Flakeguard Rerun Test Report as Artifact (All Tests)
-        if: ${{ always() && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
+        if: ${{ always() && matrix.type.should-run == 'true' && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.type.cmd }}_flakeguard_report_rerun_all_tests.json
@@ -327,7 +327,7 @@ jobs:
           if-no-files-found: ignore           
 
       - name: Upload Flakeguard Main Test Report as Artifact (Failed Tests)
-        if: ${{ always() && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
+        if: ${{ always() && matrix.type.should-run == 'true' && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.type.cmd }}_flakeguard_report_main_failed_tests.json
@@ -336,7 +336,7 @@ jobs:
           if-no-files-found: ignore
           
       - name: Upload Flakeguard Rerun Test Report as Artifact (Failed Tests)
-        if: ${{ always() && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
+        if: ${{ always() && matrix.type.should-run == 'true' && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.type.cmd }}_flakeguard_report_rerun_failed_tests.json
@@ -345,7 +345,7 @@ jobs:
           if-no-files-found: ignore          
 
       - name: Send Flakeguard Reports to Splunk
-        if: ${{ always() && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
+        if: ${{ always() && matrix.type.should-run == 'true' && (matrix.type.cmd == 'go_core_tests' || matrix.type.cmd == 'go_core_ccip_deployment_tests') }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -175,7 +175,7 @@ jobs:
         type:
           - cmd: go_core_tests
             os: ubuntu22.04-32cores-128GB
-            should-run: ${{ needs.filter.outputs.should-run-core-tests }}
+            should-run: 'false'
 
           - cmd: go_core_tests_integration
             os: ubuntu22.04-32cores-128GB

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -175,7 +175,7 @@ jobs:
         type:
           - cmd: go_core_tests
             os: ubuntu22.04-32cores-128GB
-            should-run: 'false'
+            should-run: ${{ needs.filter.outputs.should-run-core-tests }}
 
           - cmd: go_core_tests_integration
             os: ubuntu22.04-32cores-128GB

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Install flakeguard
         if: ${{ inputs.runAllTests == false }}
         shell: bash
-        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@7f6887061b2ea2ac7f0849f539fe36a8f6c7054f # flakguard@0.1.0
+        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@63eefaae8f1aab2716f462c7b286f98866018977 # flakguard@0.1.0
 
       - name: Find new or updated test packages
         if: ${{ inputs.runAllTests == false && env.RUN_CUSTOM_TEST_PACKAGES == '' }}
@@ -335,7 +335,7 @@ jobs:
 
       - name: Install flakeguard
         shell: bash
-        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@7f6887061b2ea2ac7f0849f539fe36a8f6c7054f # flakguard@0.1.0
+        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@63eefaae8f1aab2716f462c7b286f98866018977 # flakguard@0.1.0
 
       - name: Run tests with flakeguard
         shell: bash
@@ -429,7 +429,7 @@ jobs:
 
       - name: Install flakeguard
         shell: bash
-        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@7f6887061b2ea2ac7f0849f539fe36a8f6c7054f # flakguard@0.1.0
+        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@63eefaae8f1aab2716f462c7b286f98866018977 # flakguard@0.1.0
 
       - name: Aggregate Flakeguard Results
         id: results

--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -8,7 +8,7 @@ EXTRA_FLAGS=""
 
 if [[ -n "$USE_FLAKEGUARD" ]]; then
   # Install flakeguard
-  go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@df5b0374ca878f1f3f4982b9a00f16844549e176
+  go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@63eefaae8f1aab2716f462c7b286f98866018977
   # Install gotestsum to parse JSON test outputs from flakeguard to console outputs
   go install gotest.tools/gotestsum@latest
 

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -9,7 +9,7 @@ EXTRA_FLAGS="-timeout 20m"
 
 if [[ -n "$USE_FLAKEGUARD" ]]; then
   # Install flakeguard
-  go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@df5b0374ca878f1f3f4982b9a00f16844549e176
+  go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@63eefaae8f1aab2716f462c7b286f98866018977
   # Install gotestsum to parse JSON test outputs from flakeguard to console outputs
   go install gotest.tools/gotestsum@latest
   # Make sure bins are in PATH


### PR DESCRIPTION
1. Optimise Flakeguard in ci-core workflow when unit tests not executed
2. Send Flakeguard data only on MQ
3. Bump Flakeguard to update how test results table look like in console logs

- [x] Requires https://github.com/smartcontractkit/chainlink-testing-framework/pull/1723