### PR TITLE
Partially revert "Remove unused python and solc-select setup step."

### DIFF
--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -346,12 +346,6 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Install solc-select and solc
-        uses: smartcontractkit/.github/actions/setup-solc-select@b6e37806737eef87e8c9137ceeb23ef0bff8b1db # validate-solidity-artifacts@0.1.0
-        with:
-          to_install: "0.8.24"
-          to_use: "0.8.24"
-
       - name: Install Slither
         uses: smartcontractkit/.github/actions/setup-slither@b6e37806737eef87e8c9137ceeb23ef0bff8b1db # validate-solidity-artifacts@0.1.0
 

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -341,6 +341,17 @@ jobs:
       - name: Install Foundry
         uses: ./.github/actions/install-solidity-foundry
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+
+      - name: Install solc-select and solc
+        uses: smartcontractkit/.github/actions/setup-solc-select@b6e37806737eef87e8c9137ceeb23ef0bff8b1db # validate-solidity-artifacts@0.1.0
+        with:
+          to_install: "0.8.24"
+          to_use: "0.8.24"
+
       - name: Install Slither
         uses: smartcontractkit/.github/actions/setup-slither@b6e37806737eef87e8c9137ceeb23ef0bff8b1db # validate-solidity-artifacts@0.1.0
 


### PR DESCRIPTION
Partially reverts smartcontractkit/chainlink#16820

Slither does use python - https://github.com/crytic/slither?tab=readme-ov-file#how-to-install , so we should not remove it.

Generally, we should probably switch to https://github.com/crytic/slither-action