### PR TITLE
[CLD-17]: feat(operations): introduce sequence component

### DIFF
--- a/deployment/.golangci.yml
+++ b/deployment/.golangci.yml
@@ -177,3 +177,12 @@ issues:
     - linters:
         - govet
       text: "declaration of \"err\" shadows"
+    # ignore false positive by revive on the function names (ID, Version, Description) clash between sequence and operation
+    - path: operations/operation.go
+      text: "^confusing-naming:"
+      linters:
+        - revive
+    - path: operations/sequence.go
+      text: "^confusing-naming:"
+      linters:
+        - revive

--- a/deployment/operations/execute_test.go
+++ b/deployment/operations/execute_test.go
@@ -112,10 +112,144 @@ func Test_ExecuteOperation_ErrorReporter(t *testing.T) {
 	require.NoError(t, res.Err)
 }
 
+func Test_ExecuteSequence(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+
+	tests := []struct {
+		name            string
+		simulateOpError bool
+		wantOutput      int
+		wantErr         string
+	}{
+		{
+			name:       "Success Execution",
+			wantOutput: 3,
+		},
+		{
+			name:            "Error Execution",
+			simulateOpError: true,
+			wantErr:         "fatal error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			op := NewOperation("plus1", version, "plus 1",
+				func(e Bundle, deps OpDeps, input int) (output int, err error) {
+					if tt.simulateOpError {
+						return 0, NewUnrecoverableError(errors.New("fatal error"))
+					}
+					return input + 1, nil
+				})
+
+			var opID string
+			sequence := NewSequence("seq-plus1", version, "plus 1",
+				func(env Bundle, deps any, input int) (int, error) {
+					res, err := ExecuteOperation(env, op, OpDeps{}, input)
+					// capture for verification later
+					opID = res.ID
+					if err != nil {
+						return 0, err
+					}
+
+					return res.Output + 1, nil
+				})
+
+			e := NewBundle(context.Background, logger.Test(t), NewMemoryReporter())
+
+			seqReport, err := ExecuteSequence(e, sequence, nil, 1)
+
+			if tt.simulateOpError {
+				require.Error(t, seqReport.Err)
+				require.Error(t, err)
+				require.ErrorContains(t, seqReport.Err, tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, seqReport.Err)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantOutput, seqReport.Output)
+			}
+			assert.Equal(t, []string{opID}, seqReport.ChildOperationReports)
+			// check report is added to reporter
+			report, err := e.reporter.GetReport(seqReport.ID)
+			require.NoError(t, err)
+			assert.NotNil(t, report)
+			assert.Len(t, seqReport.ExecutionReports, 2) // 1 seq report + 1 op report
+
+			// check allReports contain the parent and child reports
+			childReport, err := e.reporter.GetReport(opID)
+			require.NoError(t, err)
+			assert.Equal(t, seqReport.ExecutionReports[0], childReport)
+			assert.Equal(t, seqReport.ExecutionReports[1], report)
+		})
+	}
+}
+
+func Test_ExecuteSequence_ErrorReporter(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+	op := NewOperation("plus1", version, "plus 1",
+		func(e Bundle, deps OpDeps, input int) (output int, err error) {
+			return input + 1, nil
+		})
+
+	sequence := NewSequence("seq-plus1", version, "plus 1",
+		func(env Bundle, deps OpDeps, input int) (int, error) {
+			res, err := ExecuteOperation(env, op, OpDeps{}, input)
+			if err != nil {
+				return 0, err
+			}
+
+			return res.Output + 1, nil
+		})
+
+	tests := []struct {
+		name           string
+		setupErrorFunc func() errorReporter
+		wantErr        string
+	}{
+		{
+			name: "AddReport returns an error",
+			setupErrorFunc: func() errorReporter {
+				return errorReporter{
+					AddReportError: errors.New("add report error"),
+				}
+			},
+			wantErr: "add report error",
+		},
+		{
+			name: "GetExecutionReports returns an error",
+			setupErrorFunc: func() errorReporter {
+				return errorReporter{
+					GetExecutionReportsError: errors.New("get execution reports error"),
+				}
+			},
+			wantErr: "get execution reports error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := NewBundle(context.Background, logger.Test(t), tt.setupErrorFunc())
+			_, err := ExecuteSequence(e, sequence, OpDeps{}, 1)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 type errorReporter struct {
-	GetReportError  error
-	GetReportsError error
-	AddReportError  error
+	GetReportError           error
+	GetReportsError          error
+	AddReportError           error
+	GetExecutionReportsError error
 }
 
 func (e errorReporter) GetReport(id string) (Report[any, any], error) {
@@ -128,4 +262,8 @@ func (e errorReporter) GetReports() ([]Report[any, any], error) {
 
 func (e errorReporter) AddReport(report Report[any, any]) error {
 	return e.AddReportError
+}
+
+func (e errorReporter) GetExecutionReports(id string) ([]Report[any, any], error) {
+	return nil, e.GetExecutionReportsError
 }

--- a/deployment/operations/report_test.go
+++ b/deployment/operations/report_test.go
@@ -77,3 +77,36 @@ func Test_NewReport(t *testing.T) {
 	assert.Len(t, report.ChildOperationReports, 1)
 	assert.Equal(t, childOperationID, report.ChildOperationReports[0])
 }
+
+func Test_RecentReporter(t *testing.T) {
+	t.Parallel()
+
+	existingReport := Report[any, any]{
+		ID:                    "1",
+		Def:                   Definition{},
+		Output:                "2",
+		Input:                 1,
+		Timestamp:             time.Now(),
+		ChildOperationReports: []string{uuid.New().String()},
+	}
+
+	reporter := NewMemoryReporter(WithReports([]Report[any, any]{existingReport}))
+	recentReporter := NewRecentMemoryReporter(reporter)
+
+	// no new reports added since creation of recentReporter
+	reports := recentReporter.GetRecentReports()
+	assert.Empty(t, reports)
+
+	newReport := Report[any, any]{
+		ID:        "2",
+		Def:       Definition{},
+		Output:    "3",
+		Input:     2,
+		Timestamp: time.Now(),
+	}
+	err := recentReporter.AddReport(newReport)
+	require.NoError(t, err)
+	reports = recentReporter.GetRecentReports()
+	assert.Len(t, reports, 1)
+	assert.Equal(t, newReport, reports[0])
+}

--- a/deployment/operations/sequence.go
+++ b/deployment/operations/sequence.go
@@ -1,0 +1,44 @@
+package operations
+
+import (
+	"github.com/Masterminds/semver/v3"
+)
+
+// SequenceHandler is the function signature of a sequence handler.
+// A sequence handler is a function that calls 1 or more operations or child sequence.
+type SequenceHandler[IN, OUT, DEP any] func(b Bundle, deps DEP, input IN) (output OUT, err error)
+
+type Sequence[IN, OUT, DEP any] struct {
+	def     Definition
+	handler SequenceHandler[IN, OUT, DEP]
+}
+
+// NewSequence creates a new sequence.
+// Useful for logically grouping a list of operations and also child sequence together.
+func NewSequence[IN, OUT, DEP any](
+	id string, version *semver.Version, description string, handler SequenceHandler[IN, OUT, DEP],
+) *Sequence[IN, OUT, DEP] {
+	return &Sequence[IN, OUT, DEP]{
+		def: Definition{
+			ID:          id,
+			Version:     version,
+			Description: description,
+		},
+		handler: handler,
+	}
+}
+
+// ID returns the sequence ID.
+func (o *Sequence[IN, OUT, DEP]) ID() string {
+	return o.def.ID
+}
+
+// Version returns the sequence semver version in string.
+func (o *Sequence[IN, OUT, DEP]) Version() string {
+	return o.def.Version.String()
+}
+
+// Description returns the sequence description.
+func (o *Sequence[IN, OUT, DEP]) Description() string {
+	return o.def.Description
+}

--- a/deployment/operations/sequence_test.go
+++ b/deployment/operations/sequence_test.go
@@ -1,0 +1,41 @@
+package operations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+func Test_NewSequence(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+
+	description := "test operation"
+	handler := func(e Bundle, deps OpDeps, input OpInput) (output int, err error) {
+		return input.A + input.B, nil
+	}
+	op := NewOperation("sum", version, description, handler)
+
+	seqDescription := "test sequence"
+	sequence := NewSequence("seq-sum", version, seqDescription, func(env Bundle, deps any, input OpInput) (int, error) {
+		operationRes, err := ExecuteOperation(env, op, OpDeps{}, input)
+		if err != nil {
+			return 0, err
+		}
+		return operationRes.Output, nil
+	})
+
+	assert.Equal(t, "seq-sum", sequence.ID())
+	assert.Equal(t, version.String(), sequence.Version())
+	assert.Equal(t, seqDescription, sequence.Description())
+	e := NewBundle(context.Background, logger.Test(t), NewMemoryReporter())
+	res, err := sequence.handler(e, OpDeps{}, OpInput{1, 2})
+	require.NoError(t, err)
+	assert.Equal(t, 3, res)
+}


### PR DESCRIPTION
Introducing the sequence component for the operations API. Sequence allows user to compose a list of operations in a sequence for execution.

Note: Idempotency behaviour will be added in [this PR](https://github.com/smartcontractkit/chainlink/pull/16901)

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-17
