### PR TITLE
An example PR demonstrating the new Operations API (throwaway)

### DIFF
--- a/deployment/common/changeset/example/operations/link_example.go
+++ b/deployment/common/changeset/example/operations/link_example.go
@@ -1,0 +1,56 @@
+package example
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/operations"
+)
+
+var _ deployment.ChangeSetV2[SqDeployLinkInput] = LinkExampleChangeset{}
+
+type SqDeployLinkInput struct {
+	MintAmount *big.Int
+	Amount     *big.Int
+	To         common.Address
+	chainID    uint64
+}
+
+type SqDeployLinkOutput struct {
+	Address common.Address
+}
+
+type EthereumDeps struct {
+	Auth  *bind.TransactOpts
+	Chain deployment.Chain
+	AB    deployment.AddressBook
+}
+
+type LinkExampleChangeset struct{}
+
+func (l LinkExampleChangeset) VerifyPreconditions(e deployment.Environment, config SqDeployLinkInput) error {
+	return nil
+}
+
+func (l LinkExampleChangeset) Apply(e deployment.Environment, config SqDeployLinkInput) (deployment.ChangesetOutput, error) {
+	auth := e.Chains[config.chainID].DeployerKey
+	ab := deployment.NewMemoryAddressBook()
+	deps := EthereumDeps{
+		Auth:  auth,
+		Chain: e.Chains[config.chainID],
+		AB:    ab,
+	}
+
+	seqReport, err := operations.ExecuteSequence(e.OperationsBundle, LinkExampleSequence, deps, config)
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
+	return deployment.ChangesetOutput{
+		AddressBook: ab,
+		Reports:     seqReport.ExecutionReports,
+	}, nil
+}

--- a/deployment/common/changeset/example/operations/link_example_test.go
+++ b/deployment/common/changeset/example/operations/link_example_test.go
@@ -1,0 +1,33 @@
+package example
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestLinkChangeset(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+		Chains: 1,
+	})
+	chain1 := e.AllChainSelectors()[0]
+
+	changesetInput := SqDeployLinkInput{
+		MintAmount: big.NewInt(1000000000000000000),
+		Amount:     big.NewInt(1000000000000),
+		To:         common.HexToAddress("0x1"),
+		chainID:    chain1,
+	}
+	result, err := LinkExampleChangeset{}.Apply(e, changesetInput)
+	require.NoError(t, err)
+
+	require.Len(t, result.Reports, 4) // 3 ops + 1 seq report
+	require.NoError(t, err)
+}

--- a/deployment/common/changeset/example/operations/op.go
+++ b/deployment/common/changeset/example/operations/op.go
@@ -1,0 +1,78 @@
+package example
+
+import (
+	"math/big"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/operations"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/link_token"
+)
+
+var DeployLinkOp = operations.NewOperation(
+	"deploy-link-token",
+	semver.MustParse("1.0.0"),
+	"Deploy Contract Operation",
+	func(b operations.Bundle, deps EthereumDeps, input operations.EmptyInput) (*deployment.ContractDeploy[*link_token.LinkToken], error) {
+		linkToken, err := deployment.DeployContract[*link_token.LinkToken](b.Logger, deps.Chain, deps.AB,
+			func(chain deployment.Chain) deployment.ContractDeploy[*link_token.LinkToken] {
+				linkTokenAddr, tx, linkToken, err2 := link_token.DeployLinkToken(
+					chain.DeployerKey,
+					chain.Client,
+				)
+				return deployment.ContractDeploy[*link_token.LinkToken]{
+					Address:  linkTokenAddr,
+					Contract: linkToken,
+					Tx:       tx,
+					Tv:       deployment.NewTypeAndVersion(types.LinkToken, deployment.Version1_0_0),
+					Err:      err2,
+				}
+			})
+		if err != nil {
+			b.Logger.Errorw("Failed to deploy link token", "chain", deps.Chain.String(), "err", err)
+			return linkToken, err
+		}
+		return linkToken, nil
+	})
+
+type GrantMintRoleConfig struct {
+	Contract *link_token.LinkToken
+	To       common.Address
+}
+
+var GrantMintOp = operations.NewOperation(
+	"grant-mint-role",
+	semver.MustParse("1.0.0"),
+	"Grant Mint Role Operation",
+	func(b operations.Bundle, deps EthereumDeps, input GrantMintRoleConfig) (any, error) {
+		tx, err := input.Contract.GrantMintRole(deps.Auth, input.To)
+		_, err = deployment.ConfirmIfNoError(deps.Chain, tx, err)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	})
+
+type MintLinkConfig struct {
+	Amount   *big.Int
+	To       common.Address
+	Contract *link_token.LinkToken
+}
+
+var MintLinkOp = operations.NewOperation(
+	"mint-link-token",
+	semver.MustParse("1.0.0"),
+	"Mint LINK Operation",
+	func(ctx operations.Bundle, deps EthereumDeps, input MintLinkConfig) (any, error) {
+		tx, err := input.Contract.Mint(deps.Auth, input.To, input.Amount)
+		_, err = deployment.ConfirmIfNoError(deps.Chain, tx, err)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	})

--- a/deployment/common/changeset/example/operations/seq.go
+++ b/deployment/common/changeset/example/operations/seq.go
@@ -1,0 +1,59 @@
+package example
+
+import (
+	"math/big"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/smartcontractkit/chainlink/deployment/operations"
+)
+
+var LinkExampleSequence = operations.NewSequence(
+	"link-example-sequence",
+	semver.MustParse("1.0.0"),
+	"Deploy LINK token contract, grants mint and mints some amount to same address",
+	func(b operations.Bundle, deps EthereumDeps, input SqDeployLinkInput) (SqDeployLinkOutput, error) {
+		linkDeployReport, err := operations.ExecuteOperation(b, DeployLinkOp, deps, operations.EmptyInput{},
+			// showcasing how to disable retry, by default operations will retry up to 10 times with exponential backoff
+			operations.WithRetryConfig[operations.EmptyInput, EthereumDeps](
+				operations.RetryConfig[operations.EmptyInput, EthereumDeps]{
+					DisableRetry: true,
+				}),
+		)
+		if err != nil {
+			return SqDeployLinkOutput{}, err
+		}
+
+		grantMintConfig := GrantMintRoleConfig{
+			Contract: linkDeployReport.Output.Contract,
+			To:       deps.Auth.From,
+		}
+		_, err = operations.ExecuteOperation(b, GrantMintOp, deps, grantMintConfig)
+		if err != nil {
+			return SqDeployLinkOutput{}, err
+		}
+
+		mintConfig := MintLinkConfig{
+			Contract: linkDeployReport.Output.Contract,
+			Amount:   input.MintAmount,
+			To:       input.To,
+		}
+		_, err = operations.ExecuteOperation(b, MintLinkOp, deps, mintConfig,
+			// showcasing how to update input before retrying the operation
+			// with a nonsense example of updating the amount to 500.
+			// this is useful for scenarios like updating the gas limit
+			operations.WithRetryConfig[MintLinkConfig, EthereumDeps](
+				operations.RetryConfig[MintLinkConfig, EthereumDeps]{
+					InputHook: func(input MintLinkConfig, deps EthereumDeps) MintLinkConfig {
+						input.Amount = big.NewInt(500)
+						return input
+					},
+				}),
+		)
+		if err != nil {
+			return SqDeployLinkOutput{}, err
+		}
+
+		return SqDeployLinkOutput{Address: linkDeployReport.Output.Address}, nil
+	},
+)


### PR DESCRIPTION
Showcasing a sequence performing 3 operations
 - deploy link token (with no retry policy)
 - grant mint role
 - mint token  (with modified input on retry)

Logs: 
```
=== RUN   TestLinkChangeset
    logger.go:146: 2025-03-19T16:37:52.210+1100	INFO	operations/execute.go:75	Executing sequence	{"version": "unset@unset", "id": "link-example-sequence", "version": "1.0.0", "description": "Deploy LINK token contract, grants mint and mints some amount to same address"}
    logger.go:146: 2025-03-19T16:37:52.210+1100	INFO	operations/operation.go:68	Executing operation	{"version": "unset@unset", "id": "deploy-link-token", "version": "1.0.0", "description": "Deploy Contract Operation"}
    logger.go:146: 2025-03-19T16:37:52.213+1100	INFO	deployment/helpers.go:173	Deployed contract	{"version": "unset@unset", "Contract": "LinkToken 1.0.0", "addr": "0x4Aa6Af0356cBCCFD16E5dD0b6a88e2A2845F032B", "chain": " (909606746561742123)"}
    logger.go:146: 2025-03-19T16:37:52.213+1100	INFO	operations/operation.go:68	Executing operation	{"version": "unset@unset", "id": "grant-mint-role", "version": "1.0.0", "description": "Grant Mint Role Operation"}
    logger.go:146: 2025-03-19T16:37:52.215+1100	INFO	operations/operation.go:68	Executing operation	{"version": "unset@unset", "id": "mint-link-token", "version": "1.0.0", "description": "Mint LINK Operation"}
--- PASS: TestLinkChangeset (0.01s)
````

Build upon the PRs below
- https://github.com/smartcontractkit/chainlink/pull/16756
- https://github.com/smartcontractkit/chainlink/pull/16801
- https://github.com/smartcontractkit/chainlink/pull/16833

Future enhancements
- Caching and Idempotency behaviour for repeat runs + CI retries
- Saving of reports to json file ? 
