### PR TITLE
Make StreamValue from int64 values

### DIFF
--- a/core/services/llo/observation_context.go
+++ b/core/services/llo/observation_context.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-data-streams/llo"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/telem"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/streams"
@@ -134,6 +135,8 @@ func resultToStreamValue(val interface{}) (llo.StreamValue, error) {
 		return llo.ToDecimal(v), nil
 	case float64:
 		return llo.ToDecimal(decimal.NewFromFloat(v)), nil
+	case int64:
+		return llo.ToDecimal(decimal.NewFromInt(v)), nil
 	case pipeline.ObjectParam:
 		switch v.Type {
 		case pipeline.DecimalType:

--- a/core/services/llo/observation_context_test.go
+++ b/core/services/llo/observation_context_test.go
@@ -23,6 +23,7 @@ import (
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-data-streams/llo"
+
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	clhttptest "github.com/smartcontractkit/chainlink/v2/core/internal/testutils/httptest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
@@ -71,6 +72,8 @@ func TestObservationContext_Observe(t *testing.T) {
 	streamID4 := streams.StreamID(4)
 	streamID5 := streams.StreamID(5)
 	streamID6 := streams.StreamID(6)
+	streamID7 := streams.StreamID(7)
+	streamID8 := streams.StreamID(8)
 
 	multiPipelineDecimal := makePipelineWithMultipleStreamResults([]streams.StreamID{streamID4, streamID5, streamID6}, []interface{}{decimal.NewFromFloat(12.34), decimal.NewFromFloat(56.78), decimal.NewFromFloat(90.12)})
 
@@ -81,6 +84,8 @@ func TestObservationContext_Observe(t *testing.T) {
 		streamID4: multiPipelineDecimal,
 		streamID5: multiPipelineDecimal,
 		streamID6: multiPipelineDecimal,
+		streamID7: makePipelineWithSingleResult[float64](rand.Int64(), 1.23, nil),
+		streamID8: makePipelineWithSingleResult[int64](rand.Int64(), 5, nil),
 	}
 
 	t.Run("returns error in case of missing pipeline", func(t *testing.T) {
@@ -122,6 +127,18 @@ func TestObservationContext_Observe(t *testing.T) {
 		assert.Equal(t, "90.12", val.(*llo.Decimal).String())
 
 		assert.Equal(t, 1, multiPipelineDecimal.runCount)
+	})
+	t.Run("returns value from float64 value", func(t *testing.T) {
+		val, err := oc.Observe(ctx, streamID7, opts)
+		require.NoError(t, err)
+
+		assert.Equal(t, "1.23", val.(*llo.Decimal).String())
+	})
+	t.Run("returns value from int64 value", func(t *testing.T) {
+		val, err := oc.Observe(ctx, streamID8, opts)
+		require.NoError(t, err)
+
+		assert.Equal(t, "5", val.(*llo.Decimal).String())
 	})
 }
 

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -941,7 +941,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 	"benchmarkPrice": "2976.39",
 	"baseMarketDepth": "1000.1212",
 	"quoteMarketDepth": "998.5431",
-	"marketStatus": "1",
+	"marketStatus": 1,
 	"binanceFundingRate": "1234.5678",
 	"binanceFundingTime": "1630000000",
 	"binanceFundingIntervalHours": "8",
@@ -978,13 +978,13 @@ dp -> base_market_depth_parse -> base_market_depth_decimal;
 dp -> quote_market_depth_parse -> quote_market_depth_decimal;
 `, bridgeName, dexBasedAssetPriceStreamID, baseMarketDepthStreamID, quoteMarketDepthStreamID)
 
+		// Don't use a multiply task so that the task result has int64 type.
 		rwaPipeline := fmt.Sprintf(`
 dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
 
-market_status_parse   [type=jsonparse path="result,marketStatus"];
-market_status_decimal [type=multiply times=1 streamID=%d];
+market_status_parse   [type=jsonparse path="result,marketStatus" streamID=%d];
 
-dp -> market_status_parse -> market_status_decimal;
+dp -> market_status_parse;
 `, bridgeName, marketStatusStreamID)
 
 		benchmarkPricePipeline := fmt.Sprintf(`


### PR DESCRIPTION
RWA and Funding Rate EAs can return integer values (e.g. timestamps, enum values, etc.) which apparently come through the pipeline as `int64` typed. See the following error log:
```
  "msg": "Observation failed for streams",
  ...
  "errs": [
	...
    "StreamID: 1000001305; Reason: failed to observe stream; Err: failed to convert result to StreamValue for streamID 1000001305: don't know how to convert pipeline output result of type int64 to llo.StreamValue (got: 2)"
  ]
```
