### PR TITLE
DX-242 Skip flaky TestAddRemoteChain

### DIFF
--- a/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
@@ -49,6 +49,8 @@ func deployToken(t *testing.T, tenv deployment.Environment, solChain uint64) (de
 }
 
 func TestAddRemoteChain(t *testing.T) {
+	t.Skip("Flaky Test: https://smartcontract-it.atlassian.net/browse/DX-242")
+
 	t.Parallel()
 	// Default env just has 2 chains with all contracts
 	// deployed but no lanes.


### PR DESCRIPTION
[Related ticket: https://smartcontract-it.atlassian.net/browse/DX-241](https://smartcontract-it.atlassian.net/browse/DX-242). `TestAddRemoteChain` has 24% flake rate in the last 7 days and it is the main reason of failed tests in the merge queue recently.