### PR TITLE
CCIP-5421 Include feed address into token pool view

### DIFF
--- a/deployment/ccip/changeset/state.go
+++ b/deployment/ccip/changeset/state.go
@@ -264,7 +264,7 @@ func (c CCIPChainState) GenerateView() (view.ChainView, error) {
 	for tokenSymbol, versionToPool := range c.BurnMintTokenPools {
 		for _, tokenPool := range versionToPool {
 			tpUpdateGrp.Go(func() error {
-				tokenPoolView, err := viewv1_5_1.GenerateTokenPoolView(tokenPool)
+				tokenPoolView, err := viewv1_5_1.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
 					return errors.Wrapf(err, "failed to generate burn mint token pool view for %s", tokenPool.Address().String())
 				}
@@ -278,7 +278,7 @@ func (c CCIPChainState) GenerateView() (view.ChainView, error) {
 	for tokenSymbol, versionToPool := range c.BurnWithFromMintTokenPools {
 		for _, tokenPool := range versionToPool {
 			tpUpdateGrp.Go(func() error {
-				tokenPoolView, err := viewv1_5_1.GenerateTokenPoolView(tokenPool)
+				tokenPoolView, err := viewv1_5_1.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
 					return errors.Wrapf(err, "failed to generate burn mint token pool view for %s", tokenPool.Address().String())
 				}
@@ -292,7 +292,7 @@ func (c CCIPChainState) GenerateView() (view.ChainView, error) {
 	for tokenSymbol, versionToPool := range c.BurnFromMintTokenPools {
 		for _, tokenPool := range versionToPool {
 			tpUpdateGrp.Go(func() error {
-				tokenPoolView, err := viewv1_5_1.GenerateTokenPoolView(tokenPool)
+				tokenPoolView, err := viewv1_5_1.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
 					return errors.Wrapf(err, "failed to generate burn mint token pool view for %s", tokenPool.Address().String())
 				}
@@ -306,7 +306,7 @@ func (c CCIPChainState) GenerateView() (view.ChainView, error) {
 	for tokenSymbol, versionToPool := range c.LockReleaseTokenPools {
 		for _, tokenPool := range versionToPool {
 			tpUpdateGrp.Go(func() error {
-				tokenPoolView, err := viewv1_5_1.GenerateLockReleaseTokenPoolView(tokenPool)
+				tokenPoolView, err := viewv1_5_1.GenerateLockReleaseTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
 					return errors.Wrapf(err, "failed to generate lock release token pool view for %s", tokenPool.Address().String())
 				}
@@ -353,7 +353,15 @@ func (c CCIPChainState) GenerateView() (view.ChainView, error) {
 	}
 
 	if c.FeeQuoter != nil && c.Router != nil && c.TokenAdminRegistry != nil {
-		fqView, err := viewv1_6.GenerateFeeQuoterView(c.FeeQuoter, c.Router, c.TokenAdminRegistry)
+		tokenDetails, err := c.TokenDetailsBySymbol()
+		if err != nil {
+			return chainView, err
+		}
+		tokens := make([]common.Address, 0, len(tokenDetails))
+		for _, tokenDetail := range tokenDetails {
+			tokens = append(tokens, tokenDetail.Address())
+		}
+		fqView, err := viewv1_6.GenerateFeeQuoterView(c.FeeQuoter, c.Router, tokens)
 		if err != nil {
 			return chainView, errors.Wrapf(err, "failed to generate fee quoter view for fee quoter %s", c.FeeQuoter.Address().String())
 		}
@@ -473,6 +481,13 @@ func (c CCIPChainState) GenerateView() (view.ChainView, error) {
 	}
 
 	return chainView, nil
+}
+
+func (c CCIPChainState) usdFeedOrDefault(symbol TokenSymbol) common.Address {
+	if feed, ok := c.USDFeeds[symbol]; ok {
+		return feed.Address()
+	}
+	return common.Address{}
 }
 
 // CCIPOnChainState state always derivable from an address book.

--- a/deployment/ccip/changeset/state.go
+++ b/deployment/ccip/changeset/state.go
@@ -198,6 +198,7 @@ func (c CCIPChainState) TokenAddressBySymbol() (map[TokenSymbol]common.Address, 
 	return tokenAddresses, nil
 }
 
+// TokenDetailsBySymbol get token mapping from the state. It contains only tokens that we have in address book
 func (c CCIPChainState) TokenDetailsBySymbol() (map[TokenSymbol]TokenDetails, error) {
 	tokenDetails := make(map[TokenSymbol]TokenDetails)
 	for symbol, token := range c.ERC20Tokens {
@@ -353,6 +354,7 @@ func (c CCIPChainState) GenerateView() (view.ChainView, error) {
 	}
 
 	if c.FeeQuoter != nil && c.Router != nil && c.TokenAdminRegistry != nil {
+		// FeeQuoter knows only about tokens that managed by CCIP (i.e. imported from address book)
 		tokenDetails, err := c.TokenDetailsBySymbol()
 		if err != nil {
 			return chainView, err

--- a/deployment/ccip/view/v1_5_1/token_pool.go
+++ b/deployment/ccip/view/v1_5_1/token_pool.go
@@ -7,9 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/exp/maps"
 
-	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_5_1/burn_from_mint_token_pool"
-
 	"github.com/smartcontractkit/chainlink/deployment/common/view/types"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_5_1/burn_from_mint_token_pool"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_5_1/burn_mint_token_pool"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_5_1/burn_with_from_mint_token_pool"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_5_1/lock_release_token_pool"
@@ -93,6 +92,7 @@ type PoolView struct {
 type TokenPoolView struct {
 	types.ContractMetaData
 	Token              common.Address               `json:"token"`
+	TokenPriceFeed     common.Address               `json:"tokenPriceFeed"`
 	RemoteChainConfigs map[uint64]RemoteChainConfig `json:"remoteChainConfigs"`
 	AllowList          []common.Address             `json:"allowList"`
 	AllowListEnabled   bool                         `json:"allowListEnable"`
@@ -111,7 +111,7 @@ type LockReleaseTokenPoolView struct {
 	Rebalancer      common.Address `json:"rebalancer,omitempty"`
 }
 
-func GenerateTokenPoolView(pool TokenPoolContract) (TokenPoolView, error) {
+func GenerateTokenPoolView(pool TokenPoolContract, priceFeed common.Address) (TokenPoolView, error) {
 	owner, err := pool.Owner(nil)
 	if err != nil {
 		return TokenPoolView{}, err
@@ -177,14 +177,15 @@ func GenerateTokenPoolView(pool TokenPoolContract) (TokenPoolView, error) {
 			Owner:          owner,
 		},
 		Token:              token,
+		TokenPriceFeed:     priceFeed,
 		RemoteChainConfigs: remoteChainConfigs,
 		AllowList:          allowList,
 		AllowListEnabled:   allowListEnabled,
 	}, nil
 }
 
-func GenerateLockReleaseTokenPoolView(pool *lock_release_token_pool.LockReleaseTokenPool) (PoolView, error) {
-	basePoolView, err := GenerateTokenPoolView(pool)
+func GenerateLockReleaseTokenPoolView(pool *lock_release_token_pool.LockReleaseTokenPool, priceFeed common.Address) (PoolView, error) {
+	basePoolView, err := GenerateTokenPoolView(pool, priceFeed)
 	if err != nil {
 		return PoolView{}, err
 	}
@@ -208,7 +209,7 @@ func GenerateLockReleaseTokenPoolView(pool *lock_release_token_pool.LockReleaseT
 }
 
 func GenerateUSDCTokenPoolView(pool *usdc_token_pool.USDCTokenPool) (PoolView, error) {
-	basePoolView, err := GenerateTokenPoolView(pool)
+	basePoolView, err := GenerateTokenPoolView(pool, common.Address{})
 	if err != nil {
 		return PoolView{}, err
 	}

--- a/deployment/ccip/view/v1_6/feequoter.go
+++ b/deployment/ccip/view/v1_6/feequoter.go
@@ -3,11 +3,11 @@ package v1_6
 import (
 	"fmt"
 
-	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/v1_2"
 	"github.com/smartcontractkit/chainlink/deployment/common/view/types"
 	router1_2 "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_2_0/router"
-	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_5_0/token_admin_registry"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/v1_6_0/fee_quoter"
 )
 
@@ -52,7 +52,7 @@ type FeeQuoterTokenPriceFeedConfig struct {
 	TokenDecimals   uint8  `json:"tokenDecimals,omitempty"`
 }
 
-func GenerateFeeQuoterView(fqContract *fee_quoter.FeeQuoter, router *router1_2.Router, ta *token_admin_registry.TokenAdminRegistry) (FeeQuoterView, error) {
+func GenerateFeeQuoterView(fqContract *fee_quoter.FeeQuoter, router *router1_2.Router, tokens []common.Address) (FeeQuoterView, error) {
 	fq := FeeQuoterView{}
 	authorizedCallers, err := fqContract.GetAllAuthorizedCallers(nil)
 	if err != nil {
@@ -116,10 +116,6 @@ func GenerateFeeQuoterView(fqContract *fee_quoter.FeeQuoter, router *router1_2.R
 		}
 	}
 	fq.TokenPriceFeedConfig = make(map[string]FeeQuoterTokenPriceFeedConfig)
-	tokens, err := shared.GetSupportedTokens(ta)
-	if err != nil {
-		return FeeQuoterView{}, fmt.Errorf("view error for FeeQuoter: %w", err)
-	}
 	for _, token := range tokens {
 		t, err := fqContract.GetTokenPriceFeedConfig(nil, token)
 		if err != nil {

--- a/deployment/ccip/view/view.go
+++ b/deployment/ccip/view/view.go
@@ -14,6 +14,8 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/helpers"
 )
 
+// ChainView is a json-persistable structure that represents chain state. Store all versions of CCIP contracts
+// CCIP observability relies on ChainView. When making changes that makes final json backward incompatible, warn CCIP observability team
 type ChainView struct {
 	ChainSelector uint64 `json:"chainSelector,omitempty"`
 	ChainID       string `json:"chainID,omitempty"`


### PR DESCRIPTION
Moving from RDD to CLD field `"tokenPriceType": PriceFeeds|TokenPrices` was eliminated. This field is still used by CCIP o11y to determine if we need to track price staleness and its deviation.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
https://smartcontract-it.atlassian.net/browse/CCIP-5421