### PR TITLE
CRE-283 Send Metering Report to Beholder

### DIFF
--- a/core/capabilities/integration_tests/framework/don.go
+++ b/core/capabilities/integration_tests/framework/don.go
@@ -24,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	coretypes "github.com/smartcontractkit/chainlink-common/pkg/types/core"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 
 	"github.com/smartcontractkit/chainlink-integrations/evm/assets"
@@ -415,6 +416,7 @@ func startNewNode(ctx context.Context,
 	fetcherFunc syncer.FetcherFunc,
 	fetcherFactoryFunc compute.FetcherFactory,
 ) *cltest.TestApplication {
+	beholderTester := tests.Beholder(t)
 	config, _ := heavyweight.FullTestDBV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.Capabilities.ExternalRegistry.ChainID = ptr(fmt.Sprintf("%d", testutils.SimulatedChainID))
 		c.Capabilities.ExternalRegistry.Address = ptr(capRegistryAddr.String())
@@ -442,8 +444,9 @@ func startNewNode(ctx context.Context,
 	require.NoError(t, err)
 	ethBlockchain.Commit()
 
-	return cltest.NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(t, config, ethBlockchain.Backend, nodeInfo,
-		dispatcher, peerWrapper, newOracleFactoryFn, localCapabilities, keyV2, lggr, fetcherFunc, fetcherFactoryFunc)
+	return cltest.NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(t, config, ethBlockchain.Backend,
+		nodeInfo, dispatcher, peerWrapper, newOracleFactoryFn, localCapabilities, keyV2, lggr, fetcherFunc,
+		fetcherFactoryFunc, beholderTester)
 }
 
 // Functions below this point are for adding non-standard capabilities to a DON, deliberately verbose. Eventually these

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -204,6 +204,7 @@ type TestApplication struct {
 	t testing.TB
 	*chainlink.ChainlinkApplication
 	Logger             logger.Logger
+	Emitter            *tests.BeholderTester
 	Server             *httptest.Server
 	Started            bool
 	Backend            *simulated.Backend
@@ -462,6 +463,12 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 	for _, dep := range flagsAndDeps {
 		if k, ok := dep.(ethkey.KeyV2); ok {
 			ta.Keys = append(ta.Keys, k)
+		}
+	}
+
+	for _, dep := range flagsAndDeps {
+		if k, ok := dep.(*tests.BeholderTester); ok {
+			ta.Emitter = k
 		}
 	}
 

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/client_golang v1.21.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7
+	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250317165050-f8c18e1f415e
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/client_golang v1.21.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6
+	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250317165050-f8c18e1f415e
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1122,8 +1122,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef h1:d3ML7zTiR72d0XFDMKXEYz7SQ0iWu1RBXKthSNPKmzE=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef/go.mod h1:vr6A75MZcooq3tIco+rLt2onDOvoc5Pu9ejcNYPEFmk=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6 h1:d00OJXZlA0Po6u9UmYpJqJIV53YvLhaZOQpFdTUy6oQ=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471 h1:q4TBjKwzRlDnewgMx3DaP8q0nIVEweBClx3nkB1kws0=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf h1:xEwuP8M0TdV8SBwjR5ShG3kj/G8vGo+2L9S8xzNm1sU=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1122,8 +1122,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef h1:d3ML7zTiR72d0XFDMKXEYz7SQ0iWu1RBXKthSNPKmzE=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef/go.mod h1:vr6A75MZcooq3tIco+rLt2onDOvoc5Pu9ejcNYPEFmk=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7 h1:aS94MvYKzkIh+FgiavKh5cHHKeA5NEAzWvSFi3Q6TM4=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6 h1:d00OJXZlA0Po6u9UmYpJqJIV53YvLhaZOQpFdTUy6oQ=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf h1:xEwuP8M0TdV8SBwjR5ShG3kj/G8vGo+2L9S8xzNm1sU=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -1433,6 +1433,7 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 		maxWorkerLimit:       cfg.MaxWorkerLimit,
 		clock:                cfg.clock,
 		ratelimiter:          cfg.RateLimiter,
+		workflowLimits:       cfg.WorkflowLimits,
 		sendMeteringReport:   cfg.sendMeteringReport,
 	}
 

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -144,6 +144,9 @@ type Engine struct {
 	ratelimiter    *ratelimiter.RateLimiter
 	workflowLimits *syncerlimiter.Limits
 	meterReport    *MeteringReport
+
+	// sendMeteringReport is a hook for now to prevent this being sent in production
+	sendMeteringReport func(*MeteringReport)
 }
 
 func (e *Engine) Start(_ context.Context) error {
@@ -656,7 +659,7 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 		}
 
 		logCustMsg(ctx, cma, "execution status: "+status, l)
-		logCustMsg(ctx, cma.With("metering", "report"), fmt.Sprintf("%s; %s", e.meterReport.Message(l), e.meterReport.Description()), l)
+		e.sendMeteringReport(e.meterReport)
 
 		return e.finishExecution(ctx, cma, state.ExecutionID, status)
 	}
@@ -1292,6 +1295,7 @@ type Config struct {
 	onExecutionFinished func(weid string)
 	onRateLimit         func(weid string)
 	clock               clockwork.Clock
+	sendMeteringReport  func(*MeteringReport)
 }
 
 const (
@@ -1354,6 +1358,10 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 
 	if cfg.clock == nil {
 		cfg.clock = clockwork.NewRealClock()
+	}
+
+	if cfg.sendMeteringReport == nil {
+		cfg.sendMeteringReport = func(*MeteringReport) {}
 	}
 
 	if cfg.RateLimiter == nil {
@@ -1425,7 +1433,7 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 		maxWorkerLimit:       cfg.MaxWorkerLimit,
 		clock:                cfg.clock,
 		ratelimiter:          cfg.RateLimiter,
-		workflowLimits:       cfg.WorkflowLimits,
+		sendMeteringReport:   cfg.sendMeteringReport,
 	}
 
 	return engine, nil

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -654,7 +654,10 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 			// This is to ensure that any side effects are executed consistently, since otherwise
 			// the async nature of the workflow engine would provide no guarantees.
 		}
+
 		logCustMsg(ctx, cma, "execution status: "+status, l)
+		logCustMsg(ctx, cma.With("metering", "report"), fmt.Sprintf("%s; %s", e.meterReport.Message(l), e.meterReport.Description()), l)
+
 		return e.finishExecution(ctx, cma, state.ExecutionID, status)
 	}
 

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
@@ -221,6 +222,16 @@ func newTestEngine(t *testing.T, reg *coreCap.Registry, sdkSpec sdk.WorkflowSpec
 		clock:          clock,
 		RateLimiter:    rl,
 		WorkflowLimits: sl,
+		sendMeteringReport: func(report *MeteringReport) {
+			detail := report.Description()
+			bClient := beholder.GetClient()
+			kvAttrs := []any{"beholder_data_schema", detail.Schema, "beholder_domain", detail.Domain, "beholder_entity", detail.Entity}
+
+			data, err := proto.Marshal(report.Message())
+			require.NoError(t, err)
+
+			bClient.Emitter.Emit(t.Context(), data, kvAttrs...)
+		},
 	}
 	for _, o := range opts {
 		o(&cfg)
@@ -352,7 +363,7 @@ func TestEngineWithHardcodedWorkflow(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, store.StatusCompleted, state.Status)
-	assert.Equal(t, 1, beholderTester.Len(t, "metering", "report"))
+	assert.Equal(t, 1, beholderTester.Len(t, "beholder_entity", MeteringReportEntity))
 }
 
 const (

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -227,10 +227,10 @@ func newTestEngine(t *testing.T, reg *coreCap.Registry, sdkSpec sdk.WorkflowSpec
 			bClient := beholder.GetClient()
 			kvAttrs := []any{"beholder_data_schema", detail.Schema, "beholder_domain", detail.Domain, "beholder_entity", detail.Entity}
 
-			data, err := proto.Marshal(report.Message())
-			require.NoError(t, err)
+			data, mErr := proto.Marshal(report.Message())
+			require.NoError(t, mErr)
 
-			bClient.Emitter.Emit(t.Context(), data, kvAttrs...)
+			require.NoError(t, bClient.Emitter.Emit(t.Context(), data, kvAttrs...))
 		},
 	}
 	for _, o := range opts {

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
@@ -237,7 +238,7 @@ func newTestEngine(t *testing.T, reg *coreCap.Registry, sdkSpec sdk.WorkflowSpec
 //
 // If the engine fails to initialize, the test will fail rather
 // than blocking indefinitely.
-func getExecutionID(t *testing.T, eng *Engine, hooks *testHooks) string {
+func getExecutionID(t *testing.T, _ *Engine, hooks *testHooks) string {
 	var eid string
 	select {
 	case <-hooks.initFailed:
@@ -308,6 +309,7 @@ func (m *mockTriggerCapability) UnregisterTrigger(ctx context.Context, req capab
 func TestEngineWithHardcodedWorkflow(t *testing.T) {
 	ctx := testutils.Context(t)
 	reg := coreCap.NewRegistry(logger.TestLogger(t))
+	beholderTester := tests.Beholder(t)
 
 	trigger, cr := mockTrigger(t)
 
@@ -350,6 +352,7 @@ func TestEngineWithHardcodedWorkflow(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, store.StatusCompleted, state.Status)
+	assert.Equal(t, 1, beholderTester.Len(t, "metering", "report"))
 }
 
 const (
@@ -423,6 +426,8 @@ func mockTrigger(t *testing.T) (capabilities.TriggerCapability, capabilities.Tri
 }
 
 func mockNoopTrigger(t *testing.T) capabilities.TriggerCapability {
+	t.Helper()
+
 	mt := &mockTriggerCapability{
 		CapabilityInfo: capabilities.MustNewCapabilityInfo(
 			"mercury-trigger@1.0.0",

--- a/core/services/workflows/metering.go
+++ b/core/services/workflows/metering.go
@@ -130,11 +130,11 @@ func (r *MeteringReport) MedianSpend() map[MeteringSpendUnit]MeteringSpendValue 
 	return medians
 }
 
-func (r *MeteringReport) SetStep(ref MeteringReportStepRef, step []MeteringReportStep) error {
+func (r *MeteringReport) SetStep(ref MeteringReportStepRef, steps []MeteringReportStep) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.steps[ref] = step
+	r.steps[ref] = steps
 
 	return nil
 }

--- a/core/services/workflows/metering.go
+++ b/core/services/workflows/metering.go
@@ -1,13 +1,29 @@
 package workflows
 
 import (
+	"encoding/hex"
+	"fmt"
 	"sort"
 	"sync"
 
 	"github.com/shopspring/decimal"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+const (
+	MeteringReportSchema string = "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb/capabilities.proto"
+	MeteringReportDomain string = "platform"
+	MeteringReportEntity string = "MeteringReport"
 )
 
 type MeteringReportStepRef string
+
+func (s MeteringReportStepRef) String() string {
+	return string(s)
+}
 
 type MeteringSpendUnit string
 
@@ -21,6 +37,15 @@ func (s MeteringSpendUnit) DecimalToSpendValue(value decimal.Decimal) MeteringSp
 
 func (s MeteringSpendUnit) IntToSpendValue(value int64) MeteringSpendValue {
 	return MeteringSpendValue{value: decimal.NewFromInt(value), roundingPlace: 18}
+}
+
+func (s MeteringSpendUnit) StringToSpendValue(value string) (MeteringSpendValue, error) {
+	dec, err := decimal.NewFromString(value)
+	if err != nil {
+		return MeteringSpendValue{}, err
+	}
+
+	return MeteringSpendValue{value: dec, roundingPlace: 18}, nil
 }
 
 type MeteringSpendValue struct {
@@ -50,6 +75,12 @@ func (v MeteringSpendValue) String() string {
 	return v.value.StringFixedBank(int32(v.roundingPlace))
 }
 
+type ProtoDetail struct {
+	Schema string
+	Domain string
+	Entity string
+}
+
 type MeteringReportStep struct {
 	Peer2PeerID string
 	SpendUnit   MeteringSpendUnit
@@ -58,12 +89,12 @@ type MeteringReportStep struct {
 
 type MeteringReport struct {
 	mu    sync.RWMutex
-	steps map[MeteringReportStepRef]MeteringReportStep
+	steps map[MeteringReportStepRef][]MeteringReportStep
 }
 
 func NewMeteringReport() *MeteringReport {
 	return &MeteringReport{
-		steps: make(map[MeteringReportStepRef]MeteringReportStep),
+		steps: make(map[MeteringReportStepRef][]MeteringReportStep),
 	}
 }
 
@@ -74,13 +105,15 @@ func (r *MeteringReport) MedianSpend() map[MeteringSpendUnit]MeteringSpendValue 
 	values := map[MeteringSpendUnit][]MeteringSpendValue{}
 	medians := map[MeteringSpendUnit]MeteringSpendValue{}
 
-	for _, step := range r.steps {
-		vals, ok := values[step.SpendUnit]
-		if !ok {
-			vals = []MeteringSpendValue{}
-		}
+	for _, nodeVals := range r.steps {
+		for _, step := range nodeVals {
+			vals, ok := values[step.SpendUnit]
+			if !ok {
+				vals = []MeteringSpendValue{}
+			}
 
-		values[step.SpendUnit] = append(vals, step.SpendValue)
+			values[step.SpendUnit] = append(vals, step.SpendValue)
+		}
 	}
 
 	for unit, set := range values {
@@ -100,11 +133,46 @@ func (r *MeteringReport) MedianSpend() map[MeteringSpendUnit]MeteringSpendValue 
 	return medians
 }
 
-func (r *MeteringReport) AddStep(ref MeteringReportStepRef, step MeteringReportStep) error {
+func (r *MeteringReport) SetStep(ref MeteringReportStepRef, step []MeteringReportStep) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	r.steps[ref] = step
 
 	return nil
+}
+
+func (r *MeteringReport) Message(lggr logger.Logger) string {
+	protoReport := &pb.MeteringReport{
+		Steps: map[string]*pb.MeteringReportStep{},
+	}
+
+	for key, step := range r.steps {
+		nodeDetail := make([]*pb.MeteringReportNodeDetail, len(step))
+
+		for idx, nodeVal := range step {
+			nodeDetail[idx] = &pb.MeteringReportNodeDetail{
+				Peer_2PeerId: nodeVal.Peer2PeerID,
+				SpendUnit:    nodeVal.SpendUnit.String(),
+				SpendValue:   nodeVal.SpendValue.String(),
+			}
+		}
+		protoReport.Steps[key.String()] = &pb.MeteringReportStep{
+			Nodes: nodeDetail,
+		}
+	}
+
+	encoded, err := proto.Marshal(protoReport)
+	if err != nil {
+		lggr.Error("failed to marshal metering report")
+
+		return ""
+	}
+
+	// using hex encoding here to normalize the data sent over otel
+	return hex.EncodeToString(encoded)
+}
+
+func (r *MeteringReport) Description() string {
+	return fmt.Sprintf("schema: %s; domain: %s; entity: %s", MeteringReportSchema, MeteringReportDomain, MeteringReportEntity)
 }

--- a/core/services/workflows/metering.go
+++ b/core/services/workflows/metering.go
@@ -1,8 +1,6 @@
 package workflows
 
 import (
-	"encoding/hex"
-	"fmt"
 	"sort"
 	"sync"
 
@@ -10,7 +8,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 const (
@@ -142,7 +139,7 @@ func (r *MeteringReport) SetStep(ref MeteringReportStepRef, step []MeteringRepor
 	return nil
 }
 
-func (r *MeteringReport) Message(lggr logger.Logger) string {
+func (r *MeteringReport) Message() proto.Message {
 	protoReport := &pb.MeteringReport{
 		Steps: map[string]*pb.MeteringReportStep{},
 	}
@@ -162,17 +159,19 @@ func (r *MeteringReport) Message(lggr logger.Logger) string {
 		}
 	}
 
-	encoded, err := proto.Marshal(protoReport)
-	if err != nil {
-		lggr.Error("failed to marshal metering report")
-
-		return ""
-	}
-
-	// using hex encoding here to normalize the data sent over otel
-	return hex.EncodeToString(encoded)
+	return protoReport
 }
 
-func (r *MeteringReport) Description() string {
-	return fmt.Sprintf("schema: %s; domain: %s; entity: %s", MeteringReportSchema, MeteringReportDomain, MeteringReportEntity)
+type MessageDescription struct {
+	Schema string
+	Domain string
+	Entity string
+}
+
+func (r *MeteringReport) Description() MessageDescription {
+	return MessageDescription{
+		Schema: MeteringReportSchema,
+		Domain: MeteringReportDomain,
+		Entity: MeteringReportEntity,
+	}
 }

--- a/core/services/workflows/metering_test.go
+++ b/core/services/workflows/metering_test.go
@@ -32,7 +32,7 @@ func TestMeteringReport(t *testing.T) {
 		}
 
 		for idx, step := range steps {
-			require.NoError(t, report.AddStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
+			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
 		}
 
 		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{
@@ -59,7 +59,7 @@ func TestMeteringReport(t *testing.T) {
 		}
 
 		for idx, step := range steps {
-			require.NoError(t, report.AddStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
+			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
 		}
 
 		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{
@@ -85,7 +85,7 @@ func TestMeteringReport(t *testing.T) {
 		}
 
 		for idx, step := range steps {
-			require.NoError(t, report.AddStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
+			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
 		}
 
 		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{
@@ -112,7 +112,7 @@ func TestMeteringReport(t *testing.T) {
 		}
 
 		for idx, step := range steps {
-			require.NoError(t, report.AddStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
+			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
 		}
 
 		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{

--- a/core/services/workflows/metering_test.go
+++ b/core/services/workflows/metering_test.go
@@ -31,8 +31,8 @@ func TestMeteringReport(t *testing.T) {
 			{"abc", testUnitB, testUnitB.DecimalToSpendValue(decimal.NewFromFloat(0.3))},
 		}
 
-		for idx, step := range steps {
-			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
+		for idx := range steps {
+			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), steps))
 		}
 
 		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{
@@ -58,8 +58,8 @@ func TestMeteringReport(t *testing.T) {
 			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
 		}
 
-		for idx, step := range steps {
-			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
+		for idx := range steps {
+			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), steps))
 		}
 
 		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{
@@ -84,8 +84,8 @@ func TestMeteringReport(t *testing.T) {
 			{"xyz", testUnitA, testUnitA.IntToSpendValue(2)},
 		}
 
-		for idx, step := range steps {
-			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
+		for idx := range steps {
+			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), steps))
 		}
 
 		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{
@@ -111,8 +111,8 @@ func TestMeteringReport(t *testing.T) {
 			{"xyz", testUnitA, testUnitA.IntToSpendValue(2)},
 		}
 
-		for idx, step := range steps {
-			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), step))
+		for idx := range steps {
+			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), steps))
 		}
 
 		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.46
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef
-	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7
+	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250211162441-3d6cea220efb
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250317165050-f8c18e1f415e
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1168,8 +1168,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef h1:d3ML7zTiR72d0XFDMKXEYz7SQ0iWu1RBXKthSNPKmzE=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef/go.mod h1:vr6A75MZcooq3tIco+rLt2onDOvoc5Pu9ejcNYPEFmk=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7 h1:aS94MvYKzkIh+FgiavKh5cHHKeA5NEAzWvSFi3Q6TM4=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471 h1:q4TBjKwzRlDnewgMx3DaP8q0nIVEweBClx3nkB1kws0=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf h1:xEwuP8M0TdV8SBwjR5ShG3kj/G8vGo+2L9S8xzNm1sU=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef
-	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7
+	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250317154237-afa0f9b81806

--- a/go.sum
+++ b/go.sum
@@ -1009,8 +1009,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef h1:d3ML7zTiR72d0XFDMKXEYz7SQ0iWu1RBXKthSNPKmzE=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef/go.mod h1:vr6A75MZcooq3tIco+rLt2onDOvoc5Pu9ejcNYPEFmk=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7 h1:aS94MvYKzkIh+FgiavKh5cHHKeA5NEAzWvSFi3Q6TM4=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471 h1:q4TBjKwzRlDnewgMx3DaP8q0nIVEweBClx3nkB1kws0=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf h1:xEwuP8M0TdV8SBwjR5ShG3kj/G8vGo+2L9S8xzNm1sU=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.46
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef
-	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7
+	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250317165050-f8c18e1f415e
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1430,8 +1430,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef h1:d3ML7zTiR72d0XFDMKXEYz7SQ0iWu1RBXKthSNPKmzE=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef/go.mod h1:vr6A75MZcooq3tIco+rLt2onDOvoc5Pu9ejcNYPEFmk=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7 h1:aS94MvYKzkIh+FgiavKh5cHHKeA5NEAzWvSFi3Q6TM4=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471 h1:q4TBjKwzRlDnewgMx3DaP8q0nIVEweBClx3nkB1kws0=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf h1:xEwuP8M0TdV8SBwjR5ShG3kj/G8vGo+2L9S8xzNm1sU=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.46
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef
-	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7
+	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471
 	github.com/smartcontractkit/chainlink-integrations/evm v0.0.0-20250317165050-f8c18e1f415e
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.5.8-0.20250225210020-fc215b29321e
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1411,8 +1411,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef h1:d3ML7zTiR72d0XFDMKXEYz7SQ0iWu1RBXKthSNPKmzE=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef/go.mod h1:vr6A75MZcooq3tIco+rLt2onDOvoc5Pu9ejcNYPEFmk=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7 h1:aS94MvYKzkIh+FgiavKh5cHHKeA5NEAzWvSFi3Q6TM4=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471 h1:q4TBjKwzRlDnewgMx3DaP8q0nIVEweBClx3nkB1kws0=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf h1:xEwuP8M0TdV8SBwjR5ShG3kj/G8vGo+2L9S8xzNm1sU=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
-	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7
+	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.5.8
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.0

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
-	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6
+	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.5.8
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.0

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1156,8 +1156,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef h1:d3ML7zTiR72d0XFDMKXEYz7SQ0iWu1RBXKthSNPKmzE=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef/go.mod h1:vr6A75MZcooq3tIco+rLt2onDOvoc5Pu9ejcNYPEFmk=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7 h1:aS94MvYKzkIh+FgiavKh5cHHKeA5NEAzWvSFi3Q6TM4=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6 h1:d00OJXZlA0Po6u9UmYpJqJIV53YvLhaZOQpFdTUy6oQ=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf h1:xEwuP8M0TdV8SBwjR5ShG3kj/G8vGo+2L9S8xzNm1sU=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1156,8 +1156,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef h1:d3ML7zTiR72d0XFDMKXEYz7SQ0iWu1RBXKthSNPKmzE=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef/go.mod h1:vr6A75MZcooq3tIco+rLt2onDOvoc5Pu9ejcNYPEFmk=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6 h1:d00OJXZlA0Po6u9UmYpJqJIV53YvLhaZOQpFdTUy6oQ=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471 h1:q4TBjKwzRlDnewgMx3DaP8q0nIVEweBClx3nkB1kws0=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf h1:xEwuP8M0TdV8SBwjR5ShG3kj/G8vGo+2L9S8xzNm1sU=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -344,7 +344,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef // indirect
-	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7 // indirect
+	github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250317154237-afa0f9b81806 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1156,8 +1156,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef h1:d3ML7zTiR72d0XFDMKXEYz7SQ0iWu1RBXKthSNPKmzE=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef/go.mod h1:vr6A75MZcooq3tIco+rLt2onDOvoc5Pu9ejcNYPEFmk=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7 h1:aS94MvYKzkIh+FgiavKh5cHHKeA5NEAzWvSFi3Q6TM4=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250319144518-218b4debc6c7/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6 h1:d00OJXZlA0Po6u9UmYpJqJIV53YvLhaZOQpFdTUy6oQ=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf h1:xEwuP8M0TdV8SBwjR5ShG3kj/G8vGo+2L9S8xzNm1sU=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1156,8 +1156,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320162139-28994272f7ef/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef h1:d3ML7zTiR72d0XFDMKXEYz7SQ0iWu1RBXKthSNPKmzE=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250320162139-28994272f7ef/go.mod h1:vr6A75MZcooq3tIco+rLt2onDOvoc5Pu9ejcNYPEFmk=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6 h1:d00OJXZlA0Po6u9UmYpJqJIV53YvLhaZOQpFdTUy6oQ=
-github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320175016-63dac18b22e6/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471 h1:q4TBjKwzRlDnewgMx3DaP8q0nIVEweBClx3nkB1kws0=
+github.com/smartcontractkit/chainlink-common v0.5.1-0.20250320205517-3c9893acc471/go.mod h1:YQuXIqQpmpAqstWV0LHaDTJ5nsSWuip5ivEM+Fisb+4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf h1:xEwuP8M0TdV8SBwjR5ShG3kj/G8vGo+2L9S8xzNm1sU=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250319152737-3be36043bbaf/go.mod h1:2yUpKW1/jFxpozO/Zkh3fKDzI0jthXoEcU2xuDq+vlo=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=


### PR DESCRIPTION
This PR collects metering information from workflow steps, builds a report and sends it as a custom message to beholder. Metering values are persisted along with the workflow.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
-->
[CRE-283](https://smartcontract-it.atlassian.net/browse/CRE-283)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->
- https://github.com/smartcontractkit/chainlink-common/pull/1062


[CRE-283]: https://smartcontract-it.atlassian.net/browse/CRE-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ