### PR TITLE
make install-plugins: parameterize LOOPP versions

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,6 +6,14 @@ GO_LDFLAGS := $(shell tools/bin/ldflags)
 GOFLAGS = -ldflags "$(GO_LDFLAGS)"
 GCFLAGS = -gcflags "$(GO_GCFLAGS)"
 
+# LOOP Plugin version defaults
+ifndef COSMOS_SHA
+override COSMOS_SHA = "f740e9ae54e79762991bdaf8ad6b50363261c056"
+endif
+ifndef STARKNET_SHA
+override STARKNET_SHA = "9a780650af4708e4bd9b75495feff2c5b4054e46"
+endif
+
 .PHONY: install
 install: install-chainlink-autoinstall ## Install chainlink and all its dependencies.
 
@@ -75,11 +83,11 @@ install-plugins: ## Build & install LOOPP binaries for products and chains.
 	go install $(GOFLAGS) ./cmd/chainlink-feeds
 	cd $(shell go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-data-streams) && \
 	go install $(GOFLAGS) ./mercury/cmd/chainlink-mercury
-	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-cosmos@f740e9ae54e79762991bdaf8ad6b50363261c056 | jq -r .Dir) && \
+	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-cosmos@$(COSMOS_SHA) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./pkg/cosmos/cmd/chainlink-cosmos
 	cd $(shell go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-solana) && \
 	go install $(GOFLAGS) ./pkg/solana/cmd/chainlink-solana
-	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-starknet/relayer@9a780650af4708e4bd9b75495feff2c5b4054e46 | jq -r .Dir) && \
+	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-starknet/relayer@$(STARKNET_SHA) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./pkg/chainlink/cmd/chainlink-starknet
 
 .PHONY: docker ## Build the chainlink docker image
@@ -102,6 +110,8 @@ docker-ccip:
 docker-plugins:
 	docker buildx build \
 	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+	--build-arg COSMOS_SHA=$(COSMOS_SHA) \
+	--build-arg STARKNET_SHA=$(STARKNET_SHA) \
 	-f plugins/chainlink.Dockerfile .
 
 .PHONY: operator-ui

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -11,6 +11,8 @@ RUN go mod download
 
 # Env vars needed for chainlink build
 ARG COMMIT_SHA
+ARG COSMOS_SHA
+ARG STARKNET_SHA
 
 # Flags for Go Delve debugger
 ARG GO_GCFLAGS
@@ -32,7 +34,7 @@ RUN make install-medianpoc
 RUN make install-ocr3-capability
 
 # Install LOOP Plugins
-RUN make install-plugins
+RUN make install-plugins COSMOS_SHA=${COSMOS_SHA} STARKNET_SHA=${STARKNET_SHA}
 
 # Final image: ubuntu with chainlink binary
 FROM ubuntu:24.04


### PR DESCRIPTION
This PR enables setting custom cosmos and starknet shas via env/build args:
```
make install-plugins COSMOS_SHA=abcd
make docker-plugins STARKNET_SHA=1234
docker buildx build --build-arg COSMOS_SHA=abcd1234 -t local_chainlink -f plugins/chainlink.Dockerfile .
```