### PR TITLE
feat: check for access controller initialization to make mcms deploym…

### DIFF
--- a/deployment/common/changeset/deploy_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock_test.go
@@ -268,6 +268,95 @@ func TestDeployMCMSWithTimelockV2(t *testing.T) {
 		timelockSignerPDA(solanaState0.TimelockProgram, solanaState0.TimelockSeed))
 }
 
+// TestDeployMCMSWithTimelockV2SkipInit tests calling the deploy changeset when accounts have already been initialized
+func TestDeployMCMSWithTimelockV2SkipInitSolana(t *testing.T) {
+	t.Parallel()
+	// --- arrange ---
+	log := logger.TestLogger(t)
+	envConfig := memory.MemoryEnvironmentConfig{Chains: 0, SolChains: 1}
+	env := memory.NewMemoryEnvironment(t, log, zapcore.InfoLevel, envConfig)
+	solanaSelectors := env.AllChainSelectorsSolana()
+	changesetConfig := map[uint64]commontypes.MCMSWithTimelockConfigV2{
+		solanaSelectors[0]: {
+			Proposer: mcmstypes.Config{
+				Quorum: 1,
+				Signers: []common.Address{
+					common.HexToAddress("0x0000000000000000000000000000000000000021"),
+					common.HexToAddress("0x0000000000000000000000000000000000000022"),
+				},
+				GroupSigners: []mcmstypes.Config{
+					{
+						Quorum: 2,
+						Signers: []common.Address{
+							common.HexToAddress("0x0000000000000000000000000000000000000023"),
+							common.HexToAddress("0x0000000000000000000000000000000000000024"),
+							common.HexToAddress("0x0000000000000000000000000000000000000025"),
+						},
+						GroupSigners: []mcmstypes.Config{
+							{
+								Quorum: 1,
+								Signers: []common.Address{
+									common.HexToAddress("0x0000000000000000000000000000000000000026"),
+								},
+								GroupSigners: []mcmstypes.Config{},
+							},
+						},
+					},
+				},
+			},
+			Canceller: mcmstypes.Config{
+				Quorum: 1,
+				Signers: []common.Address{
+					common.HexToAddress("0x0000000000000000000000000000000000000027"),
+				},
+				GroupSigners: []mcmstypes.Config{},
+			},
+			Bypasser: mcmstypes.Config{
+				Quorum: 1,
+				Signers: []common.Address{
+					common.HexToAddress("0x0000000000000000000000000000000000000028"),
+					common.HexToAddress("0x0000000000000000000000000000000000000029"),
+				},
+				GroupSigners: []mcmstypes.Config{},
+			},
+			TimelockMinDelay: big.NewInt(2),
+		},
+	}
+	configuredChangeset := commonchangeset.Configure(
+		deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
+		changesetConfig,
+	)
+	commonchangeset.SetPreloadedSolanaAddresses(t, env, solanaSelectors[0])
+	// --- act ---
+	updatedEnv, err := commonchangeset.Apply(t, env, nil, configuredChangeset)
+	require.NoError(t, err)
+
+	solanaState, err := mcmschangesetstate.MaybeLoadMCMSWithTimelockStateSolana(updatedEnv, solanaSelectors)
+	require.NoError(t, err)
+
+	// Call deploy again, seeds and addresses from original state should not change
+	updatedEnvReTriggered, err := commonchangeset.Apply(t, updatedEnv, nil, configuredChangeset)
+	require.NoError(t, err)
+	solanaStateNew, err := mcmschangesetstate.MaybeLoadMCMSWithTimelockStateSolana(updatedEnvReTriggered, solanaSelectors)
+	require.NoError(t, err)
+
+	// --- assert ---
+	require.Len(t, solanaState, 1)
+	stateOld := solanaState[solanaSelectors[0]]
+	stateNew := solanaStateNew[solanaSelectors[0]]
+	require.Equal(t, stateOld.TimelockSeed, stateNew.TimelockSeed)
+	require.Equal(t, stateOld.TimelockProgram, stateNew.TimelockProgram)
+	require.Equal(t, stateOld.BypasserAccessControllerAccount, stateNew.BypasserAccessControllerAccount)
+	require.Equal(t, stateOld.CancellerAccessControllerAccount, stateNew.CancellerAccessControllerAccount)
+	require.Equal(t, stateOld.ExecutorAccessControllerAccount, stateNew.ExecutorAccessControllerAccount)
+	require.Equal(t, stateOld.ProposerAccessControllerAccount, stateNew.ProposerAccessControllerAccount)
+	require.Equal(t, stateOld.McmProgram, stateNew.McmProgram)
+	require.Equal(t, stateOld.BypasserMcmSeed, stateNew.BypasserMcmSeed)
+	require.Equal(t, stateOld.CancellerMcmSeed, stateNew.CancellerMcmSeed)
+	require.Equal(t, stateOld.ProposerMcmSeed, stateNew.ProposerMcmSeed)
+	require.Equal(t, stateOld.AccessControllerProgram, stateNew.AccessControllerProgram)
+}
+
 // ----- helpers -----
 
 func mcmSignerPDA(programID solana.PublicKey, seed mcmschangesetstate.PDASeed) string {

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -88,11 +88,10 @@ func initAccessController(
 			return fmt.Errorf("failed to convert access controller account to public key: %w", err)
 		}
 		err = solanaUtils.GetAccountDataBorshInto(e.GetContext(), chain.Client, accessControllerPubKey, rpc.CommitmentConfirmed, &data)
-		if err != nil {
-			return fmt.Errorf("failed to read access controller roleAccount: %w", err)
+		if err == nil {
+			e.Logger.Infow("access controller already initialized, skipping initialization", "chain", chain.String())
+			return nil
 		}
-		e.Logger.Infow("access controller already initialized, skipping initialization", "chain", chain.String())
-		return nil
 	}
 
 	programID := chainState.AccessControllerProgram

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -58,13 +58,19 @@ func deployAccessControllerProgram(
 
 	return nil
 }
-func findExistingAccessController(addresses map[string]deployment.TypeAndVersion, accessControllerType deployment.TypeAndVersion) (string, error) {
-	for addr, typeAndV := range addresses {
-		if typeAndV.Type == accessControllerType.Type && typeAndV.Version == accessControllerType.Version {
-			return addr, nil
-		}
+func accessControllerAccountExists(chainState *state.MCMSWithTimelockStateSolana, typeAndVersion deployment.TypeAndVersion) (solana.PublicKey, error) {
+	switch typeAndVersion {
+	case deployment.NewTypeAndVersion(commontypes.ProposerAccessControllerAccount, deployment.Version1_0_0):
+		return chainState.ProposerAccessControllerAccount, nil
+	case deployment.NewTypeAndVersion(commontypes.ExecutorAccessControllerAccount, deployment.Version1_0_0):
+		return chainState.ExecutorAccessControllerAccount, nil
+	case deployment.NewTypeAndVersion(commontypes.CancellerAccessControllerAccount, deployment.Version1_0_0):
+		return chainState.CancellerAccessControllerAccount, nil
+	case deployment.NewTypeAndVersion(commontypes.BypasserAccessControllerAccount, deployment.Version1_0_0):
+		return chainState.BypasserAccessControllerAccount, nil
+	default:
+		return solana.PublicKey{}, errors.New("unknown access controller account type")
 	}
-	return "", errors.New("access controller account address not found")
 }
 
 func initAccessController(
@@ -75,19 +81,10 @@ func initAccessController(
 		return errors.New("access controller program is not deployed")
 	}
 	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
-	// Check if access controller has already been initialized
-	addresses, err := addressBook.AddressesForChain(chain.Selector)
-	if err != nil {
-		return fmt.Errorf("failed to get addresses for chain %v from environment: %w", chain.Selector, err)
-	}
-	addr, err := findExistingAccessController(addresses, typeAndVersion)
-	if err == nil && addr != "" {
+	pubKeyRole, err := accessControllerAccountExists(chainState, typeAndVersion)
+	if err == nil && !pubKeyRole.IsZero() {
 		var data accessControllerBindings.AccessController
-		accessControllerPubKey, err := solana.PublicKeyFromBase58(addr)
-		if err != nil {
-			return fmt.Errorf("failed to convert access controller account to public key: %w", err)
-		}
-		err = solanaUtils.GetAccountDataBorshInto(e.GetContext(), chain.Client, accessControllerPubKey, rpc.CommitmentConfirmed, &data)
+		err = solanaUtils.GetAccountDataBorshInto(e.GetContext(), chain.Client, pubKeyRole, rpc.CommitmentConfirmed, &data)
 		if err == nil {
 			e.Logger.Infow("access controller already initialized, skipping initialization", "chain", chain.String())
 			return nil

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -81,8 +81,7 @@ func initAccessController(
 			return nil
 		}
 
-		e.Logger.Warnw("unable to read access controller account; discarding it", "account",
-			accessControllerAccount, "chain", chain.String())
+		return fmt.Errorf("unable to read access controller account config %s", accessControllerAccount.String())
 	}
 
 	e.Logger.Infow("access controller not initialized, initializing", "chain", chain.String())

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -58,6 +58,7 @@ func deployAccessControllerProgram(
 
 	return nil
 }
+
 func accessControllerAccountExists(chainState *state.MCMSWithTimelockStateSolana, typeAndVersion deployment.TypeAndVersion) (solana.PublicKey, error) {
 	switch typeAndVersion {
 	case deployment.NewTypeAndVersion(commontypes.ProposerAccessControllerAccount, deployment.Version1_0_0):

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -58,6 +58,14 @@ func deployAccessControllerProgram(
 
 	return nil
 }
+func findExistingAccessController(addresses map[string]deployment.TypeAndVersion, accessControllerType deployment.TypeAndVersion) (string, error) {
+	for addr, typeAndV := range addresses {
+		if typeAndV.Type == accessControllerType.Type && typeAndV.Version == accessControllerType.Version {
+			return addr, nil
+		}
+	}
+	return "", errors.New("access controller program not found")
+}
 
 func initAccessController(
 	e deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, contractType deployment.ContractType,
@@ -66,10 +74,30 @@ func initAccessController(
 	if chainState.AccessControllerProgram.IsZero() {
 		return errors.New("access controller program is not deployed")
 	}
+	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
+	// Check if access controller has already been initialized
+	addresses, err := addressBook.AddressesForChain(chain.Selector)
+	if err != nil {
+		return fmt.Errorf("failed to get addresses for chain %v from environment: %w", chain.Selector, err)
+	}
+	addr, err := findExistingAccessController(addresses, typeAndVersion)
+	if err == nil && addr != "" {
+		var data accessControllerBindings.AccessController
+		accessControllerPubKey, err := solana.PublicKeyFromBase58(addr)
+		if err != nil {
+			return fmt.Errorf("failed to convert access controller account to public key: %w", err)
+		}
+		err = solanaUtils.GetAccountDataBorshInto(e.GetContext(), chain.Client, accessControllerPubKey, rpc.CommitmentConfirmed, &data)
+		if err != nil {
+			return fmt.Errorf("failed to read access controller roleAccount: %w", err)
+		}
+		e.Logger.Infow("access controller already initialized, skipping initialization", "chain", chain.String())
+		return nil
+	}
+
 	programID := chainState.AccessControllerProgram
 	accessControllerBindings.SetProgramID(programID)
 
-	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
 	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String(), "programID", programID)
 
 	account, err := solana.NewRandomPrivateKey() // FIXME: what should we do with the account private key?

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -80,6 +80,7 @@ func initAccessController(
 			return nil
 		}
 	}
+	e.Logger.Infow("access controller not initialized, initializing", "chain", chain.String())
 
 	programID := chainState.AccessControllerProgram
 	accessControllerBindings.SetProgramID(programID)

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -59,20 +59,6 @@ func deployAccessControllerProgram(
 	return nil
 }
 
-func findAccessControllerAccount(chainState *state.MCMSWithTimelockStateSolana, typeAndVersion deployment.TypeAndVersion) (solana.PublicKey, error) {
-	if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.ProposerAccessControllerAccount, deployment.Version1_0_0)) {
-		return chainState.ProposerAccessControllerAccount, nil
-	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.ExecutorAccessControllerAccount, deployment.Version1_0_0)) {
-		return chainState.ExecutorAccessControllerAccount, nil
-	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.CancellerAccessControllerAccount, deployment.Version1_0_0)) {
-		return chainState.CancellerAccessControllerAccount, nil
-	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.BypasserAccessControllerAccount, deployment.Version1_0_0)) {
-		return chainState.BypasserAccessControllerAccount, nil
-	} else {
-		return solana.PublicKey{}, errors.New("unknown access controller account type")
-	}
-}
-
 func initAccessController(
 	e deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, contractType deployment.ContractType,
 	chain deployment.SolChain, addressBook deployment.AddressBook,
@@ -81,10 +67,14 @@ func initAccessController(
 		return errors.New("access controller program is not deployed")
 	}
 	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
-	pubKeyRole, err := findAccessControllerAccount(chainState, typeAndVersion)
-	if err == nil && !pubKeyRole.IsZero() {
+	_, accessControllerAccountSeed, err := chainState.GetStateFromType(contractType)
+	if err != nil {
+		return fmt.Errorf("failed to get account controller state: %w", err)
+	}
+	accessControllerAccount := solana.PublicKeyFromBytes(accessControllerAccountSeed[:])
+	if !accessControllerAccount.IsZero() {
 		var data accessControllerBindings.AccessController
-		err = solanaUtils.GetAccountDataBorshInto(e.GetContext(), chain.Client, pubKeyRole, rpc.CommitmentConfirmed, &data)
+		err = solanaUtils.GetAccountDataBorshInto(e.GetContext(), chain.Client, accessControllerAccount, rpc.CommitmentConfirmed, &data)
 		if err == nil {
 			e.Logger.Infow("access controller already initialized, skipping initialization", "chain", chain.String())
 			return nil

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -59,7 +59,7 @@ func deployAccessControllerProgram(
 	return nil
 }
 
-func accessControllerAccountExists(chainState *state.MCMSWithTimelockStateSolana, typeAndVersion deployment.TypeAndVersion) (solana.PublicKey, error) {
+func findAccessControllerAccount(chainState *state.MCMSWithTimelockStateSolana, typeAndVersion deployment.TypeAndVersion) (solana.PublicKey, error) {
 	switch typeAndVersion {
 	case deployment.NewTypeAndVersion(commontypes.ProposerAccessControllerAccount, deployment.Version1_0_0):
 		return chainState.ProposerAccessControllerAccount, nil
@@ -82,7 +82,7 @@ func initAccessController(
 		return errors.New("access controller program is not deployed")
 	}
 	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
-	pubKeyRole, err := accessControllerAccountExists(chainState, typeAndVersion)
+	pubKeyRole, err := findAccessControllerAccount(chainState, typeAndVersion)
 	if err == nil && !pubKeyRole.IsZero() {
 		var data accessControllerBindings.AccessController
 		err = solanaUtils.GetAccountDataBorshInto(e.GetContext(), chain.Client, pubKeyRole, rpc.CommitmentConfirmed, &data)

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -64,7 +64,7 @@ func findExistingAccessController(addresses map[string]deployment.TypeAndVersion
 			return addr, nil
 		}
 	}
-	return "", errors.New("access controller program not found")
+	return "", errors.New("access controller account address not found")
 }
 
 func initAccessController(

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -71,6 +71,7 @@ func initAccessController(
 	if err != nil {
 		return fmt.Errorf("failed to get account controller state: %w", err)
 	}
+
 	accessControllerAccount := solana.PublicKeyFromBytes(accessControllerAccountSeed[:])
 	if !accessControllerAccount.IsZero() {
 		var data accessControllerBindings.AccessController
@@ -79,7 +80,11 @@ func initAccessController(
 			e.Logger.Infow("access controller already initialized, skipping initialization", "chain", chain.String())
 			return nil
 		}
+
+		e.Logger.Warnw("unable to read access controller account; discarding it", "account",
+			accessControllerAccount, "chain", chain.String())
 	}
+
 	e.Logger.Infow("access controller not initialized, initializing", "chain", chain.String())
 
 	programID := chainState.AccessControllerProgram

--- a/deployment/common/changeset/internal/solana/access_controller.go
+++ b/deployment/common/changeset/internal/solana/access_controller.go
@@ -60,16 +60,15 @@ func deployAccessControllerProgram(
 }
 
 func findAccessControllerAccount(chainState *state.MCMSWithTimelockStateSolana, typeAndVersion deployment.TypeAndVersion) (solana.PublicKey, error) {
-	switch typeAndVersion {
-	case deployment.NewTypeAndVersion(commontypes.ProposerAccessControllerAccount, deployment.Version1_0_0):
+	if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.ProposerAccessControllerAccount, deployment.Version1_0_0)) {
 		return chainState.ProposerAccessControllerAccount, nil
-	case deployment.NewTypeAndVersion(commontypes.ExecutorAccessControllerAccount, deployment.Version1_0_0):
+	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.ExecutorAccessControllerAccount, deployment.Version1_0_0)) {
 		return chainState.ExecutorAccessControllerAccount, nil
-	case deployment.NewTypeAndVersion(commontypes.CancellerAccessControllerAccount, deployment.Version1_0_0):
+	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.CancellerAccessControllerAccount, deployment.Version1_0_0)) {
 		return chainState.CancellerAccessControllerAccount, nil
-	case deployment.NewTypeAndVersion(commontypes.BypasserAccessControllerAccount, deployment.Version1_0_0):
+	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.BypasserAccessControllerAccount, deployment.Version1_0_0)) {
 		return chainState.BypasserAccessControllerAccount, nil
-	default:
+	} else {
 		return solana.PublicKey{}, errors.New("unknown access controller account type")
 	}
 }

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -69,7 +69,7 @@ func findMcmAccount(chainState *state.MCMSWithTimelockStateSolana, typeAndVersio
 	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.BypasserManyChainMultisig, deployment.Version1_0_0)) {
 		return state.GetMCMConfigPDA(chainState.McmProgram, chainState.BypasserMcmSeed), nil
 	} else {
-		return solana.PublicKey{}, errors.New("unknown access controller account type")
+		return solana.PublicKey{}, errors.New("unknown mcm config account type")
 	}
 }
 

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -8,13 +8,13 @@ import (
 	binary "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
-	solanaUtils "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	mcmsSolanaSdk "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
 
 	mcmBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	solanaUtils "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -72,19 +72,24 @@ func initMCM(
 	mcmBindings.SetProgramID(programID)
 
 	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
-	mcmProgram, seedMcm, err := chainState.GetStateFromType(contractType)
+	mcmProgram, mcmSeed, err := chainState.GetStateFromType(contractType)
 	if err != nil {
 		return fmt.Errorf("failed to get mcm state: %w", err)
 	}
-	mcmPubKey := state.GetMCMConfigPDA(mcmProgram, seedMcm)
-	if !mcmPubKey.IsZero() && seedMcm != state.PDASeed([]byte{}) {
+
+	if mcmSeed != (state.PDASeed{}) {
+		mcmConfigPDA := state.GetMCMConfigPDA(mcmProgram, mcmSeed)
 		var data mcmBindings.MultisigConfig
-		err = solanaUtils.GetAccountDataBorshInto(env.GetContext(), chain.Client, mcmPubKey, rpc.CommitmentConfirmed, &data)
+		err = solanaUtils.GetAccountDataBorshInto(env.GetContext(), chain.Client, mcmConfigPDA, rpc.CommitmentConfirmed, &data)
 		if err == nil {
 			env.Logger.Infow("mcm config already initialized, skipping initialization", "chain", chain.String())
 			return nil
 		}
+
+		env.Logger.Warnw("unable to read mcm ConfigPDA; discarding seed", "seed",
+			string(mcmSeed[:]), "chain", chain.String())
 	}
+
 	env.Logger.Infow("mcm config not initialized, initializing", "chain", chain.String())
 	log := logger.With(env.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
 

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -77,7 +77,7 @@ func initMCM(
 		return fmt.Errorf("failed to get mcm state: %w", err)
 	}
 	mcmPubKey := state.GetMCMConfigPDA(mcmProgram, seedMcm)
-	if !mcmPubKey.IsZero() {
+	if !mcmPubKey.IsZero() && seedMcm != state.PDASeed([]byte{}) {
 		var data mcmBindings.MultisigConfig
 		err = solanaUtils.GetAccountDataBorshInto(env.GetContext(), chain.Client, mcmPubKey, rpc.CommitmentConfirmed, &data)
 		if err == nil {

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	solanaUtils "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -85,9 +86,7 @@ func initMCM(
 			env.Logger.Infow("mcm config already initialized, skipping initialization", "chain", chain.String())
 			return nil
 		}
-
-		env.Logger.Warnw("unable to read mcm ConfigPDA; discarding seed", "seed",
-			string(mcmSeed[:]), "chain", chain.String())
+		return fmt.Errorf("unable to read mcm ConfigPDA account config %s", mcmConfigPDA.String())
 	}
 
 	env.Logger.Infow("mcm config not initialized, initializing", "chain", chain.String())

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -89,7 +89,7 @@ func initMCM(
 		var data mcmBindings.MultisigConfig
 		err = solanaUtils.GetAccountDataBorshInto(env.GetContext(), chain.Client, mcmPubKey, rpc.CommitmentConfirmed, &data)
 		if err == nil {
-			env.Logger.Infow("access controller already initialized, skipping initialization", "chain", chain.String())
+			env.Logger.Infow("mcm config already initialized, skipping initialization", "chain", chain.String())
 			return nil
 		}
 	}

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -61,18 +61,6 @@ func deployMCMProgram(
 	return nil
 }
 
-func findMcmAccount(chainState *state.MCMSWithTimelockStateSolana, typeAndVersion deployment.TypeAndVersion) (solana.PublicKey, error) {
-	if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.ProposerManyChainMultisig, deployment.Version1_0_0)) {
-		return state.GetMCMConfigPDA(chainState.McmProgram, chainState.ProposerMcmSeed), nil
-	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.CancellerManyChainMultisig, deployment.Version1_0_0)) {
-		return state.GetMCMConfigPDA(chainState.McmProgram, chainState.CancellerMcmSeed), nil
-	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.BypasserManyChainMultisig, deployment.Version1_0_0)) {
-		return state.GetMCMConfigPDA(chainState.McmProgram, chainState.BypasserMcmSeed), nil
-	} else {
-		return solana.PublicKey{}, errors.New("unknown mcm config account type")
-	}
-}
-
 func initMCM(
 	env deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, contractType deployment.ContractType,
 	chain deployment.SolChain, addressBook deployment.AddressBook, mcmConfig *mcmsTypes.Config,
@@ -84,8 +72,12 @@ func initMCM(
 	mcmBindings.SetProgramID(programID)
 
 	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
-	mcmPubKey, err := findMcmAccount(chainState, typeAndVersion)
-	if err == nil && !mcmPubKey.IsZero() {
+	mcmProgram, seedMcm, err := chainState.GetStateFromType(contractType)
+	if err != nil {
+		return fmt.Errorf("failed to get mcm state: %w", err)
+	}
+	mcmPubKey := state.GetMCMConfigPDA(mcmProgram, seedMcm)
+	if !mcmPubKey.IsZero() {
 		var data mcmBindings.MultisigConfig
 		err = solanaUtils.GetAccountDataBorshInto(env.GetContext(), chain.Client, mcmPubKey, rpc.CommitmentConfirmed, &data)
 		if err == nil {

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -8,11 +8,13 @@ import (
 	binary "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
+	solanaUtils "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	mcmsSolanaSdk "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
 
 	mcmBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -59,6 +61,18 @@ func deployMCMProgram(
 	return nil
 }
 
+func findMcmAccount(chainState *state.MCMSWithTimelockStateSolana, typeAndVersion deployment.TypeAndVersion) (solana.PublicKey, error) {
+	if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.ProposerManyChainMultisig, deployment.Version1_0_0)) {
+		return state.GetMCMConfigPDA(chainState.McmProgram, chainState.ProposerMcmSeed), nil
+	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.CancellerManyChainMultisig, deployment.Version1_0_0)) {
+		return state.GetMCMConfigPDA(chainState.McmProgram, chainState.CancellerMcmSeed), nil
+	} else if typeAndVersion.Equal(deployment.NewTypeAndVersion(commontypes.BypasserManyChainMultisig, deployment.Version1_0_0)) {
+		return state.GetMCMConfigPDA(chainState.McmProgram, chainState.BypasserMcmSeed), nil
+	} else {
+		return solana.PublicKey{}, errors.New("unknown access controller account type")
+	}
+}
+
 func initMCM(
 	env deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, contractType deployment.ContractType,
 	chain deployment.SolChain, addressBook deployment.AddressBook, mcmConfig *mcmsTypes.Config,
@@ -70,12 +84,21 @@ func initMCM(
 	mcmBindings.SetProgramID(programID)
 
 	typeAndVersion := deployment.NewTypeAndVersion(contractType, deployment.Version1_0_0)
+	mcmPubKey, err := findMcmAccount(chainState, typeAndVersion)
+	if err == nil && !mcmPubKey.IsZero() {
+		var data mcmBindings.MultisigConfig
+		err = solanaUtils.GetAccountDataBorshInto(env.GetContext(), chain.Client, mcmPubKey, rpc.CommitmentConfirmed, &data)
+		if err == nil {
+			env.Logger.Infow("access controller already initialized, skipping initialization", "chain", chain.String())
+			return nil
+		}
+	}
 	log := logger.With(env.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
 
 	seed := randomSeed()
 	log.Infow("generated MCM seed", "seed", string(seed[:]))
 
-	err := initializeMCM(env, chain, programID, seed)
+	err = initializeMCM(env, chain, programID, seed)
 	if err != nil {
 		return fmt.Errorf("failed to initialize mcm: %w", err)
 	}

--- a/deployment/common/changeset/internal/solana/mcm.go
+++ b/deployment/common/changeset/internal/solana/mcm.go
@@ -85,6 +85,7 @@ func initMCM(
 			return nil
 		}
 	}
+	env.Logger.Infow("mcm config not initialized, initializing", "chain", chain.String())
 	log := logger.With(env.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
 
 	seed := randomSeed()

--- a/deployment/common/changeset/internal/solana/timelock.go
+++ b/deployment/common/changeset/internal/solana/timelock.go
@@ -69,9 +69,13 @@ func initTimelock(
 	timelockBindings.SetProgramID(programID)
 
 	typeAndVersion := deployment.NewTypeAndVersion(commontypes.RBACTimelock, deployment.Version1_0_0)
-	timelockConfigPDA := state.GetTimelockConfigPDA(chainState.TimelockProgram, chainState.TimelockSeed)
+	timelockProgram, timelockSeed, err := chainState.GetStateFromType(commontypes.RBACTimelock)
+	if err != nil {
+		return fmt.Errorf("failed to get timelock state: %w", err)
+	}
+	timelockConfigPDA := state.GetTimelockConfigPDA(timelockProgram, timelockSeed)
 	var timelockConfig timelockBindings.Config
-	err := chain.GetAccountDataBorshInto(e.GetContext(), timelockConfigPDA, &timelockConfig)
+	err = chain.GetAccountDataBorshInto(e.GetContext(), timelockConfigPDA, &timelockConfig)
 	if err == nil {
 		e.Logger.Infow("timelock config already initialized, skipping initialization", "chain", chain.String())
 		return nil

--- a/deployment/common/changeset/internal/solana/timelock.go
+++ b/deployment/common/changeset/internal/solana/timelock.go
@@ -76,7 +76,7 @@ func initTimelock(
 	timelockConfigPDA := state.GetTimelockConfigPDA(timelockProgram, timelockSeed)
 	var timelockConfig timelockBindings.Config
 	err = chain.GetAccountDataBorshInto(e.GetContext(), timelockConfigPDA, &timelockConfig)
-	if err == nil {
+	if err == nil && timelockSeed != state.PDASeed([]byte{}) {
 		e.Logger.Infow("timelock config already initialized, skipping initialization", "chain", chain.String())
 		return nil
 	}

--- a/deployment/common/changeset/internal/solana/timelock.go
+++ b/deployment/common/changeset/internal/solana/timelock.go
@@ -73,7 +73,7 @@ func initTimelock(
 	var timelockConfig timelockBindings.Config
 	err := chain.GetAccountDataBorshInto(e.GetContext(), timelockConfigPDA, &timelockConfig)
 	if err == nil {
-		e.Logger.Infow("Timelock already initialized, skipping initialization", "chain", chain.String())
+		e.Logger.Infow("timelock config already initialized, skipping initialization", "chain", chain.String())
 		return nil
 	}
 	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String())

--- a/deployment/common/changeset/internal/solana/timelock.go
+++ b/deployment/common/changeset/internal/solana/timelock.go
@@ -82,9 +82,7 @@ func initTimelock(
 			e.Logger.Infow("timelock config already initialized, skipping initialization", "chain", chain.String())
 			return nil
 		}
-
-		e.Logger.Warnw("unable to read timelock ConfigPDA; discarding seed", "seed",
-			string(timelockSeed[:]), "chain", chain.String())
+		return fmt.Errorf("unable to read timelock ConfigPDA account config %s", timelockConfigPDA.String())
 	}
 
 	e.Logger.Infow("timelock config not initialized, initializing", "chain", chain.String())

--- a/deployment/common/changeset/internal/solana/timelock.go
+++ b/deployment/common/changeset/internal/solana/timelock.go
@@ -80,8 +80,8 @@ func initTimelock(
 		e.Logger.Infow("timelock config already initialized, skipping initialization", "chain", chain.String())
 		return nil
 	}
+	e.Logger.Infow("timelock config not initialized, initializing", "chain", chain.String())
 	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
-
 	seed := randomSeed()
 	log.Infow("generated Timelock seed", "seed", string(seed[:]))
 

--- a/deployment/common/changeset/internal/solana/timelock.go
+++ b/deployment/common/changeset/internal/solana/timelock.go
@@ -11,6 +11,7 @@ import (
 
 	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -68,12 +69,19 @@ func initTimelock(
 	timelockBindings.SetProgramID(programID)
 
 	typeAndVersion := deployment.NewTypeAndVersion(commontypes.RBACTimelock, deployment.Version1_0_0)
+	timelockConfigPDA := state.GetTimelockConfigPDA(chainState.TimelockProgram, chainState.TimelockSeed)
+	var timelockConfig timelockBindings.Config
+	err := chain.GetAccountDataBorshInto(e.GetContext(), timelockConfigPDA, &timelockConfig)
+	if err == nil {
+		e.Logger.Infow("Timelock already initialized, skipping initialization", "chain", chain.String())
+		return nil
+	}
 	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
 
 	seed := randomSeed()
 	log.Infow("generated Timelock seed", "seed", string(seed[:]))
 
-	err := initializeTimelock(e, chain, programID, seed, chainState, minDelay)
+	err = initializeTimelock(e, chain, programID, seed, chainState, minDelay)
 	if err != nil {
 		return fmt.Errorf("failed to initialize timelock: %w", err)
 	}

--- a/deployment/common/changeset/internal/solana/timelock.go
+++ b/deployment/common/changeset/internal/solana/timelock.go
@@ -73,15 +73,23 @@ func initTimelock(
 	if err != nil {
 		return fmt.Errorf("failed to get timelock state: %w", err)
 	}
-	timelockConfigPDA := state.GetTimelockConfigPDA(timelockProgram, timelockSeed)
-	var timelockConfig timelockBindings.Config
-	err = chain.GetAccountDataBorshInto(e.GetContext(), timelockConfigPDA, &timelockConfig)
-	if err == nil && timelockSeed != state.PDASeed([]byte{}) {
-		e.Logger.Infow("timelock config already initialized, skipping initialization", "chain", chain.String())
-		return nil
+
+	if (timelockSeed != state.PDASeed{}) {
+		timelockConfigPDA := state.GetTimelockConfigPDA(timelockProgram, timelockSeed)
+		var timelockConfig timelockBindings.Config
+		err = chain.GetAccountDataBorshInto(e.GetContext(), timelockConfigPDA, &timelockConfig)
+		if err == nil {
+			e.Logger.Infow("timelock config already initialized, skipping initialization", "chain", chain.String())
+			return nil
+		}
+
+		e.Logger.Warnw("unable to read timelock ConfigPDA; discarding seed", "seed",
+			string(timelockSeed[:]), "chain", chain.String())
 	}
+
 	e.Logger.Infow("timelock config not initialized, initializing", "chain", chain.String())
 	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
+
 	seed := randomSeed()
 	log.Infow("generated Timelock seed", "seed", string(seed[:]))
 


### PR DESCRIPTION
This PR makes the mcms changeset consistent with all CCIP changesets where they are idempotent in the sense that if an account has already been initialized, the initialization is skipped. This was not the case with the access controllers as they were being created each time the function was called without checking if an address already existed in the address book for this contract type and version