### PR TITLE
.github: fix test run

### DIFF
--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -52,7 +52,7 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
-    test_cmd: cd integration-tests/smoke/ccip && go test -run "Test_CCIPBatching_MultiSource" -timeout 25m -test.parallel=2 -count=1 -json
+    test_cmd: cd integration-tests/smoke/ccip && go test -run "^Test_CCIPBatching_MultiSource$" -timeout 25m -test.parallel=2 -count=1 -json
 
   - id: smoke/ccip/ccip_batching_test.go:Test_CCIPBatching_MultiSource_MultiReports
     path: integration-tests/smoke/ccip/ccip_batching_test.go
@@ -60,7 +60,7 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
-    test_cmd: cd integration-tests/smoke/ccip && go test -run "Test_CCIPBatching_MultiSource_MultiReports" -timeout 25m -test.parallel=2 -count=1 -json
+    test_cmd: cd integration-tests/smoke/ccip && go test -run "^Test_CCIPBatching_MultiSource_MultiReports$" -timeout 25m -test.parallel=2 -count=1 -json
 
   - id: smoke/ccip/ccip_batching_test.go:Test_CCIPBatching_SingleSource
     path: integration-tests/smoke/ccip/ccip_batching_test.go
@@ -68,7 +68,7 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
-    test_cmd: cd integration-tests/smoke/ccip && go test -run "Test_CCIPBatching_SingleSource" -timeout 25m -test.parallel=2 -count=1 -json
+    test_cmd: cd integration-tests/smoke/ccip && go test -run "^Test_CCIPBatching_SingleSource$" -timeout 25m -test.parallel=2 -count=1 -json
   
   - id: smoke/ccip/ccip_batching_test.go:Test_CCIPBatching_SingleSource_MultipleReports
     path: integration-tests/smoke/ccip/ccip_batching_test.go
@@ -76,7 +76,7 @@ runner-test-matrix:
     runs_on: ubuntu-latest
     triggers:
       - PR Integration CCIP Tests
-    test_cmd: cd integration-tests/smoke/ccip && go test -run "Test_CCIPBatching_SingleSource_MultipleReports" -timeout 25m -test.parallel=2 -count=1 -json
+    test_cmd: cd integration-tests/smoke/ccip && go test -run "^Test_CCIPBatching_SingleSource_MultipleReports$" -timeout 25m -test.parallel=2 -count=1 -json
 
   - id: smoke/ccip/ccip_add_chain_test.go:*
     path: integration-tests/smoke/ccip/ccip_add_chain_test.go


### PR DESCRIPTION
The multireport and single report tests were running twice, make sure they only run once.