### PR TITLE
CCIP-5424 Simplify CCIP releases by dropping CCIP-specific version

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -30,9 +30,9 @@ jobs:
         run: |
           # Check if git tag is related to CCIP
           # Should match:
-          #   v1.0.0-ccip1.0.0-beta.1
-          #   v1.0.0-ccip1.0.0-rc.0
-          #   v1.0.0-ccip1.0.0
+          #   v1.0.0-ccip-beta.1
+          #   v1.0.0-ccip-rc.0
+          #   v1.0.0-ccip
           if [[ $GIT_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+-ccip(-((beta|rc)\.[0-9]+))?$ ]]; then
             echo "git-tag-type=ccip" | tee -a "$GITHUB_OUTPUT"
             echo "ecr-image-name=chainlink/ccip" | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -33,7 +33,7 @@ jobs:
           #   v1.0.0-ccip1.0.0-beta.1
           #   v1.0.0-ccip1.0.0-rc.0
           #   v1.0.0-ccip1.0.0
-          if [[ $GIT_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+-ccip[0-9]+\.[0-9]+\.[0-9]+(-((beta|rc)\.[0-9]+))?$ ]]; then
+          if [[ $GIT_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+-ccip(-((beta|rc)\.[0-9]+))?$ ]]; then
             echo "git-tag-type=ccip" | tee -a "$GITHUB_OUTPUT"
             echo "ecr-image-name=chainlink/ccip" | tee -a "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Description

`SEMVER_CCIP` version doesn't bring much value to the CCIP releases and makes the docker image version unnecessarily complicated and confusing, for instance:
* CCIP releases contain both 1.5 and 1.6 versions packed into a single docker image. Therefore, deploying `v2.22.0-ccip1.5.20` will contain both 1.5 and 1.6 codebases. However, runtime decides which version to execute based on the jobspec definition
* Chainlink node has releases every 2-3 weeks, making the CCIP release schedule fully aligned with the Chainlink release lifecycle instead of relying on our release cadence. Thus, we can fully rely on Chainlink versioning.
* CCIP Offchain code always has to be backward compatible, and we don't need to maintain multiple tags per release
* Additional CCIP version in the docker image makes it complicated to understand, especially if you consider that the only change between two releases is incrementing `patch` part of `SEMVER_CCIP`
* `SEMVER_CCIP` is not reflected in the `package.json` and we always rely on the Chainlink version there 


### Solution:
Simplify the versioning for CCIP-specific images and drop the CCIP version to have releases formatted like this
```
v2.22.0-ccip
```
(ccip suffix in the version is required to add CCIP-specific chain configuration during the docker build. It's a mandatory step to differentiate CCIP builds from the Chainlink ones)

Hotfixes or on-demand releases (if needed) will only bump the patch version of the Core node to `v2.22.1-ccip`. Please see "files changes" in this PR for more context.