### PR TITLE
fix linter issues

### DIFF
--- a/core/scripts/ccip/manual-execution/helpers/execReport.go
+++ b/core/scripts/ccip/manual-execution/helpers/execReport.go
@@ -170,7 +170,7 @@ func getMetaDataHash[H Hash](ctx Ctx[H], prefix [32]byte, sourceChainID uint64, 
 	paddedOnRamp := onRampID.Bytes()
 	return ctx.Hash(ConcatBytes(prefix[:],
 		math.U256Bytes(big.NewInt(0).SetUint64(sourceChainID)),
-		math.U256Bytes(big.NewInt(0).SetUint64(destChainID)), paddedOnRamp[:]))
+		math.U256Bytes(big.NewInt(0).SetUint64(destChainID)), paddedOnRamp))
 }
 
 // ConcatBytes appends a bunch of byte arrays into a single byte array

--- a/integration-tests/load/ccip/helpers.go
+++ b/integration-tests/load/ccip/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/big"
 	"slices"
 	"sync"
 	"time"
@@ -26,9 +27,8 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/environment/crib"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	chainselectors "github.com/smartcontractkit/chain-selectors"
 
-	"math/big"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -162,7 +162,6 @@ func subscribeTransmitEvents(
 			}
 			return
 		}
-
 	}
 }
 


### PR DESCRIPTION
```xml
<checkstyle version="5.0">
  <file name="core/scripts/ccip/manual-execution/helpers/execReport.go">
    <error column="57" line="173" message="unslice: could simplify paddedOnRamp[:] to paddedOnRamp" severity="error" source="gocritic"></error>
  </file>
</checkstyle>
```
```xml
<checkstyle version="5.0">
  <file name="integration-tests/load/ccip/helpers.go">
    <error column="2" line="166" message="unnecessary trailing newline" severity="error" source="whitespace"></error>
  </file>
</checkstyle>
```