### PR TITLE
chore: upgrade to pnpm v10

### DIFF
--- a/.github/actions/delete-deployments/action.yml
+++ b/.github/actions/delete-deployments/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       with:
-        version: ^9.0.0
+        version: ^10.0.0
 
     - uses: actions/setup-node@v4
       with:

--- a/.github/actions/delete-deployments/package.json
+++ b/.github/actions/delete-deployments/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "engines": {
     "node": ">=18",
-    "pnpm": ">=9"
+    "pnpm": ">=10"
   },
   "dependencies": {
     "@actions/core": "^1.10.1",

--- a/.github/actions/setup-nodejs/action.yaml
+++ b/.github/actions/setup-nodejs/action.yaml
@@ -13,7 +13,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       with:
-        version: ^9.0.0
+        version: ^10.0.0
 
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -67,7 +67,7 @@ jobs:
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
         if: ${{ steps.files-changed.outputs.core == 'true' || steps.files-changed.outputs.shared == 'true' }}
         with:
-          version: ^9.0.0
+          version: ^10.0.0
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/changesets-preview-pr.yml
+++ b/.github/workflows/changesets-preview-pr.yml
@@ -33,7 +33,7 @@ jobs:
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
         if: steps.change.outputs.core-changeset == 'true'
         with:
-          version: ^9.0.0
+          version: ^10.0.0
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 golang 1.23.3
 mockery 2.53.0
 nodejs 20.13.1
-pnpm 9.4.0
+pnpm 10.6.5
 postgres 15.1
 helm 3.10.3
 golangci-lint 1.64.7

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ regarding Chainlink social accounts, news, and networking.
 
 1. [Install Go 1.23](https://golang.org/doc/install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
    - Example Path for macOS `export PATH=$GOPATH/bin:$PATH` & `export GOPATH=/Users/$USER/go`
-2. Install [NodeJS v20](https://nodejs.org/en/download/package-manager/) & [pnpm v9 via npm](https://pnpm.io/installation#using-npm).
+2. Install [NodeJS v20](https://nodejs.org/en/download/package-manager/) & [pnpm v10 via npm](https://pnpm.io/installation#using-npm).
    - It might be easier long term to use [nvm](https://nodejs.org/en/download/package-manager/#nvm) to switch between node versions for different projects. For example, assuming $NODE_VERSION was set to a valid version of NodeJS, you could run: `nvm install $NODE_VERSION && nvm use $NODE_VERSION`
 3. Install [Postgres (>= 12.x)](https://wiki.postgresql.org/wiki/Detailed_installation_guides). It is recommended to run the latest major version of postgres.
    - Note if you are running the official Chainlink docker image, the highest supported Postgres version is 16.x due to the bundled client.
@@ -151,7 +151,7 @@ cosign verify index.docker.io/smartcontract/chainlink:${tag} \
 
 ### Running tests
 
-1. [Install pnpm 9 via npm](https://pnpm.io/installation#using-npm)
+1. [Install pnpm 10 via npm](https://pnpm.io/installation#using-npm)
 
 2. Install [gencodec](https://github.com/fjl/gencodec) and [jq](https://stedolan.github.io/jq/download/) to be able to run `go generate ./...` and `make abigen`
 
@@ -185,7 +185,7 @@ the given `_test` database.
 Note: Other environment variables should not be set for all tests to pass
 
 There helper script for initial setup to create an appropriate test user. It requires postgres to be running on localhost at port 5432. You will be prompted for
-the `postgres` user password 
+the `postgres` user password
 
 ```bash
 make setup-testdb
@@ -291,7 +291,7 @@ Go generate is used to generate mocks in this project. Mocks are generated with 
 
 ### Nix
 
-A [shell.nix](https://nixos.wiki/wiki/Development_environment_with_nix-shell) is provided for use with the [Nix package manager](https://nixos.org/). By default,we utilize the shell through [Nix Flakes](https://nixos.wiki/wiki/Flakes). 
+A [shell.nix](https://nixos.wiki/wiki/Development_environment_with_nix-shell) is provided for use with the [Nix package manager](https://nixos.org/). By default,we utilize the shell through [Nix Flakes](https://nixos.wiki/wiki/Flakes).
 
 Nix defines a declarative, reproducible development environment. Flakes version use deterministic, frozen (`flake.lock`) dependencies to
 gain more consistency/reproducibility on the built artifacts.

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -33,11 +33,20 @@
     "_comment2_logger": "See https://github.com/ethers-io/ethers.js/issues/379 we pin this version since that's what was used in the old yarn lockfile",
     "overrides": {
       "@ethersproject/logger": "5.0.6"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "// keccak@3.0.4, secp256k1@4.0.4 run node-gyp-build during install",
+      "// core-js@3.4.0 has a postinstall script to print a banner",
+      "// @arbitrum/nitro-contracts@1.1.1 has a postinstall script that runs patch-package. But has no patches.",
+      "secp256k1",
+      "keccak",
+      "core-js",
+      "@arbitrum/nitro-contracts"
+    ]
   },
   "engines": {
     "node": ">=18",
-    "pnpm": ">=9"
+    "pnpm": ">=10"
   },
   "devDependencies": {
     "@ethereum-waffle/mock-contract": "^3.4.4",

--- a/contracts/release/ccip/package.json
+++ b/contracts/release/ccip/package.json
@@ -47,7 +47,7 @@
   ],
   "engines": {
     "node": ">=18",
-    "pnpm": ">=9"
+    "pnpm": ">=10"
   },
   "dependencies": {
     "@changesets/cli": "~2.27.8",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/smartcontractkit/chainlink#readme",
   "engines": {
     "node": ">=18",
-    "pnpm": ">=9"
+    "pnpm": ">=10"
   },
   "devDependencies": {
     "@changesets/cli": "~2.26.2",

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ with pkgs; let
   postgresql = postgresql_15;
   nodejs = nodejs-18_x;
   nodePackages = pkgs.nodePackages.override {inherit nodejs;};
-  pnpm = pnpm_9;
+  pnpm = pnpm_10;
 
   version = "v2.0.18";
   getBinDerivation =


### PR DESCRIPTION
### Changes 

Upgrade to pnpm v10 - https://github.com/pnpm/pnpm/releases/tag/v10.0.0

This is major version bump is because it now doesn't automatically run `install` or `postinstall` scripts from dependencies, and they must be approved.

I've audited the 4 dependencies with (post)install scripts and granted their approval.

---

RE-3481
