### PR TITLE
chore: bump ref for solidity-review-artifacts reusable workflow

### DIFF
--- a/.github/workflows/solidity-foundry-artifacts.yml
+++ b/.github/workflows/solidity-foundry-artifacts.yml
@@ -149,7 +149,7 @@ jobs:
   generate-artifacts:
     name: Generate Solidity Review Artifacts
     needs: [changes, prepare-workflow-inputs]
-    uses: smartcontractkit/.github/.github/workflows/solidity-review-artifacts.yml@b6e37806737eef87e8c9137ceeb23ef0bff8b1db # validate-solidity-artifacts@0.1.0
+    uses: smartcontractkit/.github/.github/workflows/solidity-review-artifacts.yml@c88bf65bf8522ea538b9b6df8156d58a0ec80eb4 # validate-solidity-artifacts@0.1.0
     with:
       product: ${{ inputs.product }}
       commit_to_use: ${{ inputs.commit_to_use }}


### PR DESCRIPTION
Bump ref to https://github.com/smartcontractkit/.github/commit/c88bf65bf8522ea538b9b6df8156d58a0ec80eb4 for the `solidity-review-artifacts` reusable workflow.

This is to upgrade to `pnpm` v10. Related #16887.

This workflow hasn't been run in ~6 months, so not sure if this is actually necessary or not (https://github.com/smartcontractkit/chainlink/actions/workflows/solidity-foundry-artifacts.yml).

---

RE-3481.