### PR TITLE
Ensure we execute the full schedule

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -1171,6 +1171,7 @@ func (e *Engine) heartbeat(ctx context.Context) {
 			e.logger.Info("shutting down heartbeat")
 			return
 		case <-ticker.C:
+			e.metrics.engineHeartbeatGauge(ctx)
 			e.metrics.incrementEngineHeartbeatCounter(ctx)
 			e.metrics.updateTotalWorkflowsGauge(ctx, e.stepUpdatesChMap.len())
 			logCustMsg(ctx, e.cma, "engine heartbeat at: "+e.clock.Now().Format(time.RFC3339), e.logger)


### PR DESCRIPTION
Around 10% of requests are mainnet are failing due to a context deadline exceeded error. This is because the capability DON isn't receiving a quorum of requests to execute the underlying request. As a result, the request times out.

Going back to the workflow DON, I can see that one possible reason for this is that we stop executing the schedule on a workflow DON node as soon as it received a successful response back. This prevents members of the DON that are lagging or who are suffering from connectivity issues to some peers from being able to complete successfully.

Instead I propose we execute the full schedule always -- this should allow those members of the DON to execute completely. I'm curious for feedback on this approach and whether there are any obvious downsides (I don't see any).