### PR TITLE
[CLD-21]: feat(operations): introduce idempotency behaviour

### DIFF
--- a/deployment/operations/execute.go
+++ b/deployment/operations/execute.go
@@ -1,6 +1,11 @@
 package operations
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
 	"github.com/avast/retry-go/v4"
 )
 
@@ -29,6 +34,14 @@ func WithRetryConfig[IN, DEP any](config RetryConfig[IN, DEP]) ExecuteOption[IN,
 }
 
 // ExecuteOperation executes an operation with the given input and dependencies.
+// Execution will return the previous successful execution result and skip execution if there was a
+// previous successful run found in the Reports.
+// If previous unsuccessful execution was found, the execution will not be skipped.
+//
+// Note:
+// Operations that were skipped will not be added to the reporter.
+//
+// Retry:
 // By default, it retries the operation up to 10 times with exponential backoff if it fails.
 // Use WithRetryConfig to customize the retry behavior.
 // To cancel the retry early, return an error with NewUnrecoverableError.
@@ -39,6 +52,12 @@ func ExecuteOperation[IN, OUT, DEP any](
 	input IN,
 	opts ...ExecuteOption[IN, DEP],
 ) (Report[IN, OUT], error) {
+	if previousReport, found := loadPreviousSuccessfulReport[IN, OUT](b, operation.def, input); found {
+		b.Logger.Infow("Operation already executed. Returning previous result", "id", operation.def.ID,
+			"version", operation.def.Version, "description", operation.def.Description)
+		return previousReport, nil
+	}
+
 	executeConfig := &ExecuteConfig[IN, DEP]{retryConfig: RetryConfig[IN, DEP]{}}
 	for _, opt := range opts {
 		opt(executeConfig)
@@ -71,10 +90,30 @@ func ExecuteOperation[IN, OUT, DEP any](
 	return report, report.Err
 }
 
-// ExecuteSequence executes a sequence and returns a SequenceReport.
+// ExecuteSequence executes a Sequence and returns a SequenceReport.
+// The SequenceReport contains a report for the Sequence and also the execution reports which are all
+// the operations that were executed as part of this sequence.
+// The latter is useful when we want to return all the executed reports to the changeset output.
+// Execution will return the previous successful execution result and skip execution if there was a
+// previous successful run found in the Reports.
+// If previous unsuccessful execution was found, the execution will not be skipped.
+//
+// Note:
+// Sequences or Operations that were skipped will not be added to the reporter.
+// THe ExecutionReports do not include Sequences or Operations that were skipped.
 func ExecuteSequence[IN, OUT, DEP any](
 	b Bundle, sequence *Sequence[IN, OUT, DEP], deps DEP, input IN,
 ) (SequenceReport[IN, OUT], error) {
+	if previousReport, found := loadPreviousSuccessfulReport[IN, OUT](b, sequence.def, input); found {
+		executionReports, err := b.reporter.GetExecutionReports(previousReport.ID)
+		if err != nil {
+			return SequenceReport[IN, OUT]{}, err
+		}
+		b.Logger.Infow("Sequence already executed. Returning previous result", "id", sequence.def.ID,
+			"version", sequence.def.Version, "description", sequence.def.Description)
+		return SequenceReport[IN, OUT]{previousReport, executionReports}, nil
+	}
+
 	b.Logger.Infow("Executing sequence", "id", sequence.def.ID,
 		"version", sequence.def.Version, "description", sequence.def.Description)
 	recentReporter := NewRecentMemoryReporter(b.reporter)
@@ -110,25 +149,59 @@ func ExecuteSequence[IN, OUT, DEP any](
 	return SequenceReport[IN, OUT]{report, executionReports}, report.Err
 }
 
-func genericReport[IN, OUT any](r Report[IN, OUT]) Report[any, any] {
-	return Report[any, any]{
-		ID: r.ID,
-		Def: Definition{
-			ID:          r.Def.ID,
-			Version:     r.Def.Version,
-			Description: r.Def.Description,
-		},
-		Output:                r.Output,
-		Input:                 r.Input,
-		Timestamp:             r.Timestamp,
-		Err:                   r.Err,
-		ChildOperationReports: r.ChildOperationReports,
-	}
-}
-
 // NewUnrecoverableError creates an error that indicates an unrecoverable error.
 // If this error is returned inside an operation, the operation will no longer retry.
 // This allows the operation to fail fast if it encounters an unrecoverable error.
 func NewUnrecoverableError(err error) error {
 	return retry.Unrecoverable(err)
+}
+
+func constructUniqueHashFrom(def Definition, input any) (string, error) {
+	defBytes, err := json.Marshal(def)
+	if err != nil {
+		return "", err
+	}
+	inputBytes, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha256.Sum256(append(defBytes, inputBytes...))
+
+	return hex.EncodeToString(hash[:]), nil
+}
+
+func loadPreviousSuccessfulReport[IN, OUT any](
+	b Bundle, def Definition, input IN,
+) (Report[IN, OUT], bool) {
+	prevReports, err := b.reporter.GetReports()
+	if err != nil {
+		b.Logger.Errorw("Failed to get reports", "error", err)
+		return Report[IN, OUT]{}, false
+	}
+	currentHash, err := constructUniqueHashFrom(def, input)
+	if err != nil {
+		b.Logger.Errorw("Failed to construct unique hash", "error", err)
+		return Report[IN, OUT]{}, false
+	}
+
+	for _, report := range prevReports {
+		// Check if operation/sequence was run previously and return the report if successful
+		reportHash, err := constructUniqueHashFrom(report.Def, report.Input)
+		if err != nil {
+			b.Logger.Errorw("Failed to construct unique hash for previous report", "error", err)
+			continue
+		}
+		if reportHash == currentHash && report.Err == nil {
+			typedReport, ok := typeReport[IN, OUT](report)
+			if !ok {
+				b.Logger.Debugw(fmt.Sprintf("Previous %s execution found but couldn't find its matching Report", def.ID), "report_id", report.ID)
+				continue
+			}
+			b.Logger.Debugw(fmt.Sprintf("Previous %s execution found. Returning its result from Report storage", def.ID), "report_id", report.ID)
+			return typedReport, true
+		}
+	}
+	// No previous execution was found
+	return Report[IN, OUT]{}, false
 }

--- a/deployment/operations/execute.go
+++ b/deployment/operations/execute.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/avast/retry-go/v4"
 )
@@ -118,9 +119,10 @@ func ExecuteSequence[IN, OUT, DEP any](
 		"version", sequence.def.Version, "description", sequence.def.Description)
 	recentReporter := NewRecentMemoryReporter(b.reporter)
 	newBundle := Bundle{
-		Logger:     b.Logger,
-		GetContext: b.GetContext,
-		reporter:   recentReporter,
+		Logger:          b.Logger,
+		GetContext:      b.GetContext,
+		reporter:        recentReporter,
+		reportHashCache: b.reportHashCache,
 	}
 	ret, err := sequence.handler(newBundle, deps, input)
 
@@ -156,7 +158,18 @@ func NewUnrecoverableError(err error) error {
 	return retry.Unrecoverable(err)
 }
 
-func constructUniqueHashFrom(def Definition, input any) (string, error) {
+func constructUniqueHashFrom(hashCache *sync.Map, def Definition, input any) (string, error) {
+	// Create cache key by combining def and input
+	key := struct {
+		Def   Definition
+		Input any
+	}{def, input}
+
+	if cached, ok := hashCache.Load(key); ok {
+		return cached.(string), nil
+	}
+
+	// Calculate hash if not in cache
 	defBytes, err := json.Marshal(def)
 	if err != nil {
 		return "", err
@@ -167,8 +180,10 @@ func constructUniqueHashFrom(def Definition, input any) (string, error) {
 	}
 
 	hash := sha256.Sum256(append(defBytes, inputBytes...))
+	result := hex.EncodeToString(hash[:])
 
-	return hex.EncodeToString(hash[:]), nil
+	hashCache.Store(key, result)
+	return result, nil
 }
 
 func loadPreviousSuccessfulReport[IN, OUT any](
@@ -179,7 +194,7 @@ func loadPreviousSuccessfulReport[IN, OUT any](
 		b.Logger.Errorw("Failed to get reports", "error", err)
 		return Report[IN, OUT]{}, false
 	}
-	currentHash, err := constructUniqueHashFrom(def, input)
+	currentHash, err := constructUniqueHashFrom(b.reportHashCache, def, input)
 	if err != nil {
 		b.Logger.Errorw("Failed to construct unique hash", "error", err)
 		return Report[IN, OUT]{}, false
@@ -187,7 +202,7 @@ func loadPreviousSuccessfulReport[IN, OUT any](
 
 	for _, report := range prevReports {
 		// Check if operation/sequence was run previously and return the report if successful
-		reportHash, err := constructUniqueHashFrom(report.Def, report.Input)
+		reportHash, err := constructUniqueHashFrom(b.reportHashCache, report.Def, report.Input)
 		if err != nil {
 			b.Logger.Errorw("Failed to construct unique hash for previous report", "error", err)
 			continue

--- a/deployment/operations/execute_test.go
+++ b/deployment/operations/execute_test.go
@@ -2,7 +2,9 @@ package operations
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -102,6 +104,7 @@ func Test_ExecuteOperation_ErrorReporter(t *testing.T) {
 
 	reportErr := errors.New("add report error")
 	errReporter := errorReporter{
+		Reporter:       NewMemoryReporter(),
 		AddReportError: reportErr,
 	}
 	e := NewBundle(context.Background, logger.Test(t), errReporter)
@@ -110,6 +113,68 @@ func Test_ExecuteOperation_ErrorReporter(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, reportErr.Error())
 	require.NoError(t, res.Err)
+}
+
+func Test_ExecuteOperation_WithPreviousRun(t *testing.T) {
+	t.Parallel()
+
+	handlerCalledTimes := 0
+	handler := func(b Bundle, deps any, input int) (output int, err error) {
+		handlerCalledTimes++
+		return input + 1, nil
+	}
+	handlerWithErrorCalledTimes := 0
+	handlerWithError := func(b Bundle, deps any, input int) (output int, err error) {
+		handlerWithErrorCalledTimes++
+		return 0, NewUnrecoverableError(errors.New("test error"))
+	}
+
+	op := NewOperation("plus1", semver.MustParse("1.0.0"), "test operation", handler)
+	opWithError := NewOperation("plus1-error", semver.MustParse("1.0.0"), "test operation error", handlerWithError)
+	bundle := NewBundle(t.Context, logger.Test(t), NewMemoryReporter())
+
+	// first run
+	res, err := ExecuteOperation(bundle, op, nil, 1)
+	require.NoError(t, err)
+	require.NoError(t, res.Err)
+	assert.Equal(t, 2, res.Output)
+	assert.Equal(t, 1, handlerCalledTimes)
+
+	// rerun should return previous report
+	res, err = ExecuteOperation(bundle, op, nil, 1)
+	require.NoError(t, err)
+	require.NoError(t, res.Err)
+	assert.Equal(t, 2, res.Output)
+	assert.Equal(t, 1, handlerCalledTimes)
+
+	// new run with different input, should perform execution
+	res, err = ExecuteOperation(bundle, op, nil, 3)
+	require.NoError(t, err)
+	require.NoError(t, res.Err)
+	assert.Equal(t, 4, res.Output)
+	assert.Equal(t, 2, handlerCalledTimes)
+
+	// new run with different op, should perform execution
+	op = NewOperation("plus1-v2", semver.MustParse("2.0.0"), "test operation", handler)
+	res, err = ExecuteOperation(bundle, op, nil, 1)
+	require.NoError(t, err)
+	require.NoError(t, res.Err)
+	assert.Equal(t, 2, res.Output)
+	assert.Equal(t, 3, handlerCalledTimes)
+
+	// new run with op that returns error
+	res, err = ExecuteOperation(bundle, opWithError, nil, 1)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "test error")
+	require.ErrorContains(t, res.Err, "test error")
+	assert.Equal(t, 1, handlerWithErrorCalledTimes)
+
+	// rerun with op that returns error, should attempt execution again
+	res, err = ExecuteOperation(bundle, opWithError, nil, 1)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "test error")
+	require.ErrorContains(t, res.Err, "test error")
+	assert.Equal(t, 2, handlerWithErrorCalledTimes)
 }
 
 func Test_ExecuteSequence(t *testing.T) {
@@ -189,6 +254,86 @@ func Test_ExecuteSequence(t *testing.T) {
 	}
 }
 
+func Test_ExecuteSequence_WithPreviousRun(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+	op := NewOperation("plus1", version, "plus 1",
+		func(b Bundle, deps OpDeps, input int) (output int, err error) {
+			return input + 1, nil
+		})
+
+	handlerCalledTimes := 0
+	handler := func(b Bundle, deps any, input int) (int, error) {
+		handlerCalledTimes++
+		res, err := ExecuteOperation(b, op, OpDeps{}, input)
+		if err != nil {
+			return 0, err
+		}
+		return res.Output, nil
+	}
+	handlerWithErrorCalledTimes := 0
+	handlerWithError := func(b Bundle, deps any, input int) (int, error) {
+		handlerWithErrorCalledTimes++
+		return 0, NewUnrecoverableError(errors.New("test error"))
+	}
+	sequence := NewSequence("seq-plus1", version, "plus 1", handler)
+	sequenceWithError := NewSequence("seq-plus1-error", version, "plus 1 error", handlerWithError)
+
+	bundle := NewBundle(context.Background, logger.Test(t), NewMemoryReporter())
+
+	// first run
+	res, err := ExecuteSequence(bundle, sequence, nil, 1)
+	require.NoError(t, err)
+	require.NoError(t, res.Err)
+	assert.Equal(t, 2, res.Output)
+	assert.Len(t, res.ExecutionReports, 2) // 1 seq report + 1 op report
+	assert.Equal(t, 1, handlerCalledTimes)
+
+	marshal, err := json.MarshalIndent(res.ExecutionReports, "", "  ")
+	require.NoError(t, err)
+	t.Log(string(marshal))
+	// rerun should return previous report
+	res, err = ExecuteSequence(bundle, sequence, nil, 1)
+	require.NoError(t, err)
+	require.NoError(t, res.Err)
+	assert.Equal(t, 2, res.Output)
+	assert.Len(t, res.ExecutionReports, 2) // 1 seq report + 1 op report
+	assert.Equal(t, 1, handlerCalledTimes)
+
+	// new run with different input, should perform execution
+	res, err = ExecuteSequence(bundle, sequence, nil, 3)
+	require.NoError(t, err)
+	require.NoError(t, res.Err)
+	assert.Equal(t, 4, res.Output)
+	assert.Len(t, res.ExecutionReports, 2) // 1 seq report + 1 op report
+	assert.Equal(t, 2, handlerCalledTimes)
+
+	// new run with different sequence but same operation, should perform execution
+	sequence = NewSequence("seq-plus1-v2", semver.MustParse("2.0.0"), "plus 1", handler)
+	res, err = ExecuteSequence(bundle, sequence, nil, 1)
+	require.NoError(t, err)
+	require.NoError(t, res.Err)
+	assert.Equal(t, 2, res.Output)
+	// only 1 because the op was not executed due to previous execution found
+	assert.Len(t, res.ExecutionReports, 1)
+	assert.Equal(t, 3, handlerCalledTimes)
+
+	// new run with sequence that returns error
+	res, err = ExecuteSequence(bundle, sequenceWithError, nil, 1)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "test error")
+	require.ErrorContains(t, res.Err, "test error")
+	assert.Equal(t, 1, handlerWithErrorCalledTimes)
+
+	// rerun with sequence that returns error, should attempt execution again
+	res, err = ExecuteSequence(bundle, sequenceWithError, nil, 1)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "test error")
+	require.ErrorContains(t, res.Err, "test error")
+	assert.Equal(t, 2, handlerWithErrorCalledTimes)
+}
+
 func Test_ExecuteSequence_ErrorReporter(t *testing.T) {
 	t.Parallel()
 
@@ -209,14 +354,15 @@ func Test_ExecuteSequence_ErrorReporter(t *testing.T) {
 		})
 
 	tests := []struct {
-		name           string
-		setupErrorFunc func() errorReporter
-		wantErr        string
+		name          string
+		setupReporter func() Reporter
+		wantErr       string
 	}{
 		{
 			name: "AddReport returns an error",
-			setupErrorFunc: func() errorReporter {
+			setupReporter: func() Reporter {
 				return errorReporter{
+					Reporter:       NewMemoryReporter(),
 					AddReportError: errors.New("add report error"),
 				}
 			},
@@ -224,10 +370,27 @@ func Test_ExecuteSequence_ErrorReporter(t *testing.T) {
 		},
 		{
 			name: "GetExecutionReports returns an error",
-			setupErrorFunc: func() errorReporter {
+			setupReporter: func() Reporter {
 				return errorReporter{
+					Reporter:                 NewMemoryReporter(),
 					GetExecutionReportsError: errors.New("get execution reports error"),
 				}
+			},
+			wantErr: "get execution reports error",
+		},
+		{
+			name: "Loaded previous report but GetExecutionReports returns an error",
+			setupReporter: func() Reporter {
+				r := errorReporter{
+					Reporter:                 NewMemoryReporter(),
+					GetExecutionReportsError: errors.New("get execution reports error"),
+				}
+				err := r.AddReport(genericReport(
+					NewReport(sequence.def, 1, 2, nil),
+				))
+				require.NoError(t, err)
+
+				return r
 			},
 			wantErr: "get execution reports error",
 		},
@@ -237,7 +400,7 @@ func Test_ExecuteSequence_ErrorReporter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			e := NewBundle(context.Background, logger.Test(t), tt.setupErrorFunc())
+			e := NewBundle(context.Background, logger.Test(t), tt.setupReporter())
 			_, err := ExecuteSequence(e, sequence, OpDeps{}, 1)
 			require.Error(t, err)
 			require.ErrorContains(t, err, tt.wantErr)
@@ -245,7 +408,205 @@ func Test_ExecuteSequence_ErrorReporter(t *testing.T) {
 	}
 }
 
+func Test_constructUniqueHashFrom(t *testing.T) {
+	t.Parallel()
+
+	type Input struct {
+		A int
+		B int
+	}
+
+	definition := Definition{
+		ID:          "plus1",
+		Version:     semver.MustParse("1.0.0"),
+		Description: "plus 1",
+	}
+	tests := []struct {
+		name    string
+		def     Definition
+		input   any
+		want    string
+		wantErr string
+	}{
+		{
+			name: "Same def and input should always have the same hash (struct input)",
+			def:  definition,
+			input: Input{
+				A: 1,
+				B: 2,
+			},
+			want: "e6148d004b97353d8361d8cbcfbefe77da97dec220bd04449667f6ba6180d46c",
+		},
+		{
+			name: "Same def and same input (different map order) should always have the same hash (struct input)",
+			def:  definition,
+			input: Input{
+				B: 2,
+				A: 1,
+			},
+			want: "e6148d004b97353d8361d8cbcfbefe77da97dec220bd04449667f6ba6180d46c",
+		},
+		{
+			name:  "Same def and input should always have the same hash (literal input)",
+			def:   definition,
+			input: 1,
+			want:  "3f409a93e9fe5507c0d4a902ba5cb6e80a3740c74dc6a4a9bca13e71f2d46ca5",
+		},
+		{
+			name: "Different def, same input should have different hash",
+			def: Definition{
+				ID:          "plus2",
+				Version:     semver.MustParse("1.0.0"),
+				Description: "plus 2",
+			},
+			input: 1,
+			want:  "9f9d42fb8ced1129a0071a30a301cc03e94f12f225f7649ab34df16e6891d37c",
+		},
+		{
+			name: "Different input, same def should have different hash (struct input)",
+			def:  definition,
+			input: Input{
+				B: 1,
+				A: 2,
+			},
+			want: "6c8b5986bd08e115df5cbbd77c23fcd28ea31055d0cf6de8ec29ddd7fd056bca",
+		},
+		{
+			name:  "Different input, same def should have different hash (literal input)",
+			def:   definition,
+			input: 2,
+			want:  "468cd7f2b432fa59559c69a2db32fc0d44d829328a6db5c7d745889c53f4fff0",
+		},
+		{
+			name:    "invalid input",
+			def:     definition,
+			input:   math.NaN(),
+			wantErr: "json: unsupported value: NaN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hash, err := constructUniqueHashFrom(tt.def, tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, hash)
+			}
+		})
+	}
+}
+
+func Test_loadPreviousSuccessfulReport(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+	definition := Definition{
+		ID:          "plus1",
+		Version:     version,
+		Description: "plus 1",
+	}
+
+	tests := []struct {
+		name          string
+		setupReporter func() Reporter
+		input         any
+		wantDef       Definition
+		wantInput     int
+		wantFound     bool
+	}{
+		{
+			name: "Failed to GetReports",
+			setupReporter: func() Reporter {
+				return errorReporter{
+					GetReportsError: errors.New("failed to get reports"),
+				}
+			},
+			input:     1,
+			wantFound: false,
+		},
+		{
+			name: "Successful Report found - return report",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				err := r.AddReport(genericReport(
+					NewReport(definition, 1, 2, nil),
+				))
+				require.NoError(t, err)
+
+				return r
+			},
+			input:     1,
+			wantDef:   definition,
+			wantInput: 1,
+			wantFound: true,
+		},
+		{
+			name: "Report with error found - ignore report",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				err := r.AddReport(genericReport(
+					NewReport(definition, 1, 2, errors.New("failed")),
+				))
+				require.NoError(t, err)
+
+				return r
+			},
+			input:     1,
+			wantFound: false,
+		},
+		{
+			name:      "Report not found",
+			input:     1,
+			wantFound: false,
+		},
+		{
+			name:      "Current report with bad hash",
+			input:     math.NaN(),
+			wantFound: false,
+		},
+		{
+			name: "Previous report with bad hash",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				err := r.AddReport(genericReport(
+					NewReport(definition, math.NaN(), 2, nil),
+				))
+				require.NoError(t, err)
+
+				return r
+			},
+			input:     1,
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			bundle := NewBundle(context.Background, logger.Test(t), NewMemoryReporter())
+			if tt.setupReporter != nil {
+				bundle.reporter = tt.setupReporter()
+			}
+
+			report, found := loadPreviousSuccessfulReport[any, int](bundle, definition, tt.input)
+			assert.Equal(t, tt.wantFound, found)
+
+			if tt.wantFound {
+				assert.Equal(t, tt.wantDef, report.Def)
+				assert.Equal(t, tt.wantInput, report.Input)
+			}
+		})
+	}
+}
+
 type errorReporter struct {
+	Reporter
 	GetReportError           error
 	GetReportsError          error
 	AddReportError           error
@@ -253,17 +614,29 @@ type errorReporter struct {
 }
 
 func (e errorReporter) GetReport(id string) (Report[any, any], error) {
-	return Report[any, any]{}, e.GetReportError
+	if e.GetReportError != nil {
+		return Report[any, any]{}, e.GetReportError
+	}
+	return e.Reporter.GetReport(id)
 }
 
 func (e errorReporter) GetReports() ([]Report[any, any], error) {
-	return nil, e.GetReportsError
+	if e.GetReportsError != nil {
+		return nil, e.GetReportsError
+	}
+	return e.Reporter.GetReports()
 }
 
 func (e errorReporter) AddReport(report Report[any, any]) error {
-	return e.AddReportError
+	if e.AddReportError != nil {
+		return e.AddReportError
+	}
+	return e.Reporter.AddReport(report)
 }
 
 func (e errorReporter) GetExecutionReports(id string) ([]Report[any, any], error) {
-	return nil, e.GetExecutionReportsError
+	if e.GetExecutionReportsError != nil {
+		return nil, e.GetExecutionReportsError
+	}
+	return e.Reporter.GetExecutionReports(id)
 }

--- a/deployment/operations/execute_test.go
+++ b/deployment/operations/execute_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math"
+	"sync"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -489,13 +490,36 @@ func Test_constructUniqueHashFrom(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			hash, err := constructUniqueHashFrom(tt.def, tt.input)
+			cache := &sync.Map{}
+			hash, err := constructUniqueHashFrom(cache, tt.def, tt.input)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tt.wantErr)
+
+				// should not store anything in cache on failure
+				key := struct {
+					Def   Definition
+					Input any
+				}{tt.def, tt.input}
+				_, ok := cache.Load(key)
+				require.False(t, ok)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, hash)
+
+				// check cache
+				key := struct {
+					Def   Definition
+					Input any
+				}{tt.def, tt.input}
+				cached, ok := cache.Load(key)
+				require.True(t, ok)
+				assert.Equal(t, tt.want, cached)
+
+				// this call should use the cache
+				hash2, err := constructUniqueHashFrom(cache, tt.def, tt.input)
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, hash2)
 			}
 		})
 	}

--- a/deployment/operations/operation.go
+++ b/deployment/operations/operation.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"context"
+	"sync"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -15,14 +16,17 @@ type Bundle struct {
 	Logger     logger.Logger
 	GetContext func() context.Context
 	reporter   Reporter
+	// internal use only, for storing the hash of the report to avoid repeat sha256 computation.
+	reportHashCache *sync.Map
 }
 
 // NewBundle creates and returns a new Bundle.
 func NewBundle(getContext func() context.Context, logger logger.Logger, reporter Reporter) Bundle {
 	return Bundle{
-		Logger:     logger,
-		GetContext: getContext,
-		reporter:   reporter,
+		Logger:          logger,
+		GetContext:      getContext,
+		reporter:        reporter,
+		reportHashCache: &sync.Map{},
 	}
 }
 

--- a/deployment/operations/report.go
+++ b/deployment/operations/report.go
@@ -164,3 +164,40 @@ func NewRecentMemoryReporter(reporter Reporter) *RecentReporter {
 	}
 	return r
 }
+
+func genericReport[IN, OUT any](r Report[IN, OUT]) Report[any, any] {
+	return Report[any, any]{
+		ID: r.ID,
+		Def: Definition{
+			ID:          r.Def.ID,
+			Version:     r.Def.Version,
+			Description: r.Def.Description,
+		},
+		Output:                r.Output,
+		Input:                 r.Input,
+		Timestamp:             r.Timestamp,
+		Err:                   r.Err,
+		ChildOperationReports: r.ChildOperationReports,
+	}
+}
+
+func typeReport[Input, Output any](r Report[any, any]) (Report[Input, Output], bool) {
+	input, ok := r.Input.(Input)
+	if !ok {
+		return Report[Input, Output]{}, false
+	}
+
+	output, ok := r.Output.(Output)
+	if !ok {
+		return Report[Input, Output]{}, false
+	}
+
+	return Report[Input, Output]{
+		ID:        r.ID,
+		Def:       r.Def,
+		Output:    output,
+		Input:     input,
+		Timestamp: r.Timestamp,
+		Err:       r.Err,
+	}, true
+}

--- a/deployment/operations/report_test.go
+++ b/deployment/operations/report_test.go
@@ -110,3 +110,28 @@ func Test_RecentReporter(t *testing.T) {
 	assert.Len(t, reports, 1)
 	assert.Equal(t, newReport, reports[0])
 }
+
+func Test_typeReport(t *testing.T) {
+	t.Parallel()
+
+	report := Report[any, any]{
+		ID:                    "1",
+		Def:                   Definition{},
+		Output:                2,
+		Input:                 1,
+		Timestamp:             time.Now(),
+		Err:                   nil,
+		ChildOperationReports: []string{uuid.New().String()},
+	}
+
+	_, ok := typeReport[int, int](report)
+	assert.True(t, ok)
+
+	// incorrect input type
+	_, ok = typeReport[string, int](report)
+	assert.False(t, ok)
+
+	// incorrect output type
+	_, ok = typeReport[int, string](report)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
When a sequence or an operation is executed, it nows checks for previous execution in the reporter and if a successful execution was found in the past, it will skip the current execution and return the previous successful result.

Execution will not be skipped if the previous execution was a failure.

An operation or sequence uniqueness is determine by its definition (id + version +description) and its input

The current execution report will not include any reports for operations/sequences that were skipped.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-21

