### PR TITLE
Missing Metering Report for Resumed Workflows

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -659,6 +659,12 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 		}
 
 		logCustMsg(ctx, cma, "execution status: "+status, l)
+
+		// this case is only for resuming executions and should be updated when metering is added to save execution state
+		if e.meterReport == nil {
+			e.meterReport = NewMeteringReport()
+		}
+
 		e.sendMeteringReport(e.meterReport)
 
 		return e.finishExecution(ctx, cma, state.ExecutionID, status)


### PR DESCRIPTION
metering is not yet saved with capability state so create a new instance in the case that a capability should be resumed

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
