### PR TITLE
Adding map of exec IDs to MeteringReports

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -143,10 +143,10 @@ type Engine struct {
 	clock          clockwork.Clock
 	ratelimiter    *ratelimiter.RateLimiter
 	workflowLimits *syncerlimiter.Limits
-	meterReport    *MeteringReport
+	meterReports   map[string]*MeteringReport
 
-	// sendMeteringReport is a hook for now to prevent this being sent in production
-	sendMeteringReport func(*MeteringReport)
+	// sendMeteringReport is a test hook to send a metering report
+	sendMeteringReport func(report *MeteringReport, name string, ID string, execID string)
 }
 
 func (e *Engine) Start(_ context.Context) error {
@@ -568,7 +568,7 @@ func generateExecutionID(workflowID, eventID string) (string, error) {
 
 // startExecution kicks off a new workflow execution when a trigger event is received.
 func (e *Engine) startExecution(ctx context.Context, executionID string, event *values.Map) error {
-	e.meterReport = NewMeteringReport()
+	e.meterReports[executionID] = NewMeteringReport()
 
 	lggr := e.logger.With("event", event, platform.KeyWorkflowExecutionID, executionID)
 	lggr.Debug("executing on a trigger event")
@@ -661,11 +661,11 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 		logCustMsg(ctx, cma, "execution status: "+status, l)
 
 		// this case is only for resuming executions and should be updated when metering is added to save execution state
-		if e.meterReport == nil {
-			e.meterReport = NewMeteringReport()
+		if _, ok := e.meterReports[stepUpdate.ExecutionID]; !ok {
+			e.meterReports[stepUpdate.ExecutionID] = NewMeteringReport()
 		}
 
-		e.sendMeteringReport(e.meterReport)
+		e.sendMeteringReport(e.meterReports[stepUpdate.ExecutionID], e.workflow.name.String(), e.workflow.id, stepUpdate.ExecutionID)
 
 		return e.finishExecution(ctx, cma, state.ExecutionID, status)
 	}
@@ -729,7 +729,9 @@ func (e *Engine) finishExecution(ctx context.Context, cma custmsg.MessageEmitter
 		return err
 	}
 
+	// clean all per execution state trackers
 	e.stepUpdatesChMap.remove(executionID)
+	e.meterReports[executionID] = nil
 
 	executionDuration := int64(execState.FinishedAt.Sub(*execState.CreatedAt).Seconds())
 	switch status {
@@ -1302,7 +1304,7 @@ type Config struct {
 	onExecutionFinished func(weid string)
 	onRateLimit         func(weid string)
 	clock               clockwork.Clock
-	sendMeteringReport  func(*MeteringReport)
+	sendMeteringReport  func(report *MeteringReport, name string, ID string, execID string)
 }
 
 const (
@@ -1368,7 +1370,7 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 	}
 
 	if cfg.sendMeteringReport == nil {
-		cfg.sendMeteringReport = func(*MeteringReport) {}
+		cfg.sendMeteringReport = func(*MeteringReport, string, string, string) {}
 	}
 
 	if cfg.RateLimiter == nil {
@@ -1441,6 +1443,7 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 		clock:                cfg.clock,
 		ratelimiter:          cfg.RateLimiter,
 		workflowLimits:       cfg.WorkflowLimits,
+		meterReports:         map[string]*MeteringReport{},
 		sendMeteringReport:   cfg.sendMeteringReport,
 	}
 

--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -143,7 +143,7 @@ type Engine struct {
 	clock          clockwork.Clock
 	ratelimiter    *ratelimiter.RateLimiter
 	workflowLimits *syncerlimiter.Limits
-	meterReports   map[string]*MeteringReport
+	meterReports   *MeterReports
 
 	// sendMeteringReport is a test hook to send a metering report
 	sendMeteringReport func(report *MeteringReport, name string, ID string, execID string)
@@ -568,7 +568,7 @@ func generateExecutionID(workflowID, eventID string) (string, error) {
 
 // startExecution kicks off a new workflow execution when a trigger event is received.
 func (e *Engine) startExecution(ctx context.Context, executionID string, event *values.Map) error {
-	e.meterReports[executionID] = NewMeteringReport()
+	e.meterReports.Add(executionID, NewMeteringReport())
 
 	lggr := e.logger.With("event", event, platform.KeyWorkflowExecutionID, executionID)
 	lggr.Debug("executing on a trigger event")
@@ -661,11 +661,12 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 		logCustMsg(ctx, cma, "execution status: "+status, l)
 
 		// this case is only for resuming executions and should be updated when metering is added to save execution state
-		if _, ok := e.meterReports[stepUpdate.ExecutionID]; !ok {
-			e.meterReports[stepUpdate.ExecutionID] = NewMeteringReport()
+		if _, ok := e.meterReports.Get(stepUpdate.ExecutionID); !ok {
+			e.meterReports.Add(stepUpdate.ExecutionID, NewMeteringReport())
 		}
 
-		e.sendMeteringReport(e.meterReports[stepUpdate.ExecutionID], e.workflow.name.String(), e.workflow.id, stepUpdate.ExecutionID)
+		report, _ := e.meterReports.Get(stepUpdate.ExecutionID)
+		e.sendMeteringReport(report, e.workflow.name.String(), e.workflow.id, stepUpdate.ExecutionID)
 
 		return e.finishExecution(ctx, cma, state.ExecutionID, status)
 	}
@@ -731,7 +732,7 @@ func (e *Engine) finishExecution(ctx context.Context, cma custmsg.MessageEmitter
 
 	// clean all per execution state trackers
 	e.stepUpdatesChMap.remove(executionID)
-	e.meterReports[executionID] = nil
+	e.meterReports.Delete(executionID)
 
 	executionDuration := int64(execState.FinishedAt.Sub(*execState.CreatedAt).Seconds())
 	switch status {
@@ -1443,7 +1444,7 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 		clock:                cfg.clock,
 		ratelimiter:          cfg.RateLimiter,
 		workflowLimits:       cfg.WorkflowLimits,
-		meterReports:         map[string]*MeteringReport{},
+		meterReports:         NewMeterReports(),
 		sendMeteringReport:   cfg.sendMeteringReport,
 	}
 

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -2302,10 +2302,10 @@ func TestEngine_ConcurrentExecutions(t *testing.T) {
 	reg := coreCap.NewRegistry(logger.TestLogger(t))
 	beholderTester := tests.Beholder(t)
 
-	trigger1, cr := mockTrigger(t)
+	trigger1, cr1 := mockTrigger(t)
 	require.NoError(t, reg.Add(ctx, trigger1))
 
-	trigger2, cr := mockTriggerWithName(t, "other-trigger@1.0.0")
+	trigger2, cr2 := mockTriggerWithName(t, "other-trigger@1.0.0")
 	require.NoError(t, reg.Add(ctx, trigger2))
 
 	require.NoError(t, reg.Add(ctx, mockConsensus("")))
@@ -2338,10 +2338,10 @@ func TestEngine_ConcurrentExecutions(t *testing.T) {
 	// gets the execution ID of the first execution
 	eid := getExecutionID(t, eng, testHooks)
 	resp1 := <-target1.response
-	assert.Equal(t, cr.Event.Outputs, resp1.Value)
+	assert.Equal(t, cr1.Event.Outputs, resp1.Value)
 
 	resp2 := <-target2.response
-	assert.Equal(t, cr.Event.Outputs, resp2.Value)
+	assert.Equal(t, cr2.Event.Outputs, resp2.Value)
 
 	state, err := eng.executionStates.Get(ctx, eid)
 	require.NoError(t, err)

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -100,6 +100,61 @@ targets:
       cre_step_timeout: 610
 `
 
+const multipleTriggersWorkflow = `
+triggers:
+  - id: "mercury-trigger@1.0.0"
+    config:
+      feedIds:
+        - "0x1111111111111111111100000000000000000000000000000000000000000000"
+        - "0x2222222222222222222200000000000000000000000000000000000000000000"
+        - "0x3333333333333333333300000000000000000000000000000000000000000000"
+  - id: "other-trigger@1.0.0"
+    config:
+      feedIds:
+        - "0x1111111111111111111100000000000000000000000000000000000000000000"
+        - "0x2222222222222222222200000000000000000000000000000000000000000000"
+        - "0x3333333333333333333300000000000000000000000000000000000000000000"
+
+consensus:
+  - id: "offchain_reporting@1.0.0"
+    ref: "evm_median"
+    inputs:
+      observations:
+        - "$(trigger.outputs)"
+    config:
+      aggregation_method: "data_feeds_2_0"
+      aggregation_config:
+        "0x1111111111111111111100000000000000000000000000000000000000000000":
+          deviation: "0.001"
+          heartbeat: 3600
+        "0x2222222222222222222200000000000000000000000000000000000000000000":
+          deviation: "0.001"
+          heartbeat: 3600
+        "0x3333333333333333333300000000000000000000000000000000000000000000":
+          deviation: "0.001"
+          heartbeat: 3600
+      encoder: "EVM"
+      encoder_config:
+        abi: "mercury_reports bytes[]"
+
+targets:
+  - id: "write_polygon-testnet-mumbai@1.0.0"
+    inputs:
+      report: "$(evm_median.outputs.report)"
+    config:
+      address: "0x3F3554832c636721F1fD1822Ccca0354576741Ef"
+      params: ["$(report)"]
+      abi: "receive(report bytes)"
+  - id: "write_ethereum-testnet-sepolia@1.0.0"
+    inputs:
+      report: "$(evm_median.outputs.report)"
+    config:
+      address: "0x54e220867af6683aE6DcBF535B4f952cB5116510"
+      params: ["$(report)"]
+      abi: "receive(report bytes)"
+      cre_step_timeout: 610
+`
+
 type testHooks struct {
 	initFailed        chan struct{}
 	initSuccessful    chan struct{}
@@ -222,10 +277,12 @@ func newTestEngine(t *testing.T, reg *coreCap.Registry, sdkSpec sdk.WorkflowSpec
 		clock:          clock,
 		RateLimiter:    rl,
 		WorkflowLimits: sl,
-		sendMeteringReport: func(report *MeteringReport) {
+		sendMeteringReport: func(report *MeteringReport, name string, ID string, execID string) {
 			detail := report.Description()
 			bClient := beholder.GetClient()
-			kvAttrs := []any{"beholder_data_schema", detail.Schema, "beholder_domain", detail.Domain, "beholder_entity", detail.Entity}
+			// kvAttrs is what the test client matches on, view pkg/utils/test in common for more detail
+			kvAttrs := []any{"beholder_data_schema", detail.Schema, "beholder_domain", detail.Domain, "beholder_entity", detail.Entity,
+				platform.KeyWorkflowName, name, platform.KeyWorkflowID, ID, platform.KeyWorkflowExecutionID, execID}
 
 			data, mErr := proto.Marshal(report.Message())
 			require.NoError(t, mErr)
@@ -409,10 +466,10 @@ targets:
 `
 )
 
-func mockTrigger(t *testing.T) (capabilities.TriggerCapability, capabilities.TriggerResponse) {
+func mockTriggerWithName(t *testing.T, name string) (capabilities.TriggerCapability, capabilities.TriggerResponse) {
 	mt := &mockTriggerCapability{
 		CapabilityInfo: capabilities.MustNewCapabilityInfo(
-			"mercury-trigger@1.0.0",
+			name,
 			capabilities.CapabilityTypeTrigger,
 			"issues a trigger when a mercury report is received.",
 		),
@@ -428,12 +485,16 @@ func mockTrigger(t *testing.T) (capabilities.TriggerCapability, capabilities.Tri
 	tr := capabilities.TriggerResponse{
 		Event: capabilities.TriggerEvent{
 			TriggerType: mt.ID,
-			ID:          time.Now().UTC().Format(time.RFC3339),
+			ID:          fmt.Sprintf("%v:%v", name, time.Now().UTC().Format(time.RFC3339)),
 			Outputs:     resp,
 		},
 	}
 	mt.triggerEvent = &tr
 	return mt, tr
+}
+
+func mockTrigger(t *testing.T) (capabilities.TriggerCapability, capabilities.TriggerResponse) {
+	return mockTriggerWithName(t, "mercury-trigger@1.0.0")
 }
 
 func mockNoopTrigger(t *testing.T) capabilities.TriggerCapability {
@@ -2234,4 +2295,62 @@ func Test_stepUpdateManager(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestEngine_ConcurrentExecutions(t *testing.T) {
+	ctx := testutils.Context(t)
+	reg := coreCap.NewRegistry(logger.TestLogger(t))
+	beholderTester := tests.Beholder(t)
+
+	trigger1, cr := mockTrigger(t)
+	require.NoError(t, reg.Add(ctx, trigger1))
+
+	trigger2, cr := mockTriggerWithName(t, "other-trigger@1.0.0")
+	require.NoError(t, reg.Add(ctx, trigger2))
+
+	require.NoError(t, reg.Add(ctx, mockConsensus("")))
+	target1 := mockTarget("")
+	require.NoError(t, reg.Add(ctx, target1))
+
+	target2 := newMockCapability(
+		capabilities.MustNewCapabilityInfo(
+			"write_ethereum-testnet-sepolia@1.0.0",
+			capabilities.CapabilityTypeTarget,
+			"a write capability targeting ethereum sepolia testnet",
+		),
+		func(req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+			m := req.Inputs.Underlying["report"].(*values.Map)
+			return capabilities.CapabilityResponse{
+				Value: m,
+			}, nil
+		},
+	)
+	require.NoError(t, reg.Add(ctx, target2))
+
+	eng, testHooks := newTestEngineWithYAMLSpec(
+		t,
+		reg,
+		multipleTriggersWorkflow,
+	)
+
+	servicetest.Run(t, eng)
+
+	// gets the execution ID of the first execution
+	eid := getExecutionID(t, eng, testHooks)
+	resp1 := <-target1.response
+	assert.Equal(t, cr.Event.Outputs, resp1.Value)
+
+	resp2 := <-target2.response
+	assert.Equal(t, cr.Event.Outputs, resp2.Value)
+
+	state, err := eng.executionStates.Get(ctx, eid)
+	require.NoError(t, err)
+
+	// gets the execution ID of the second execution
+	eid2 := getExecutionID(t, eng, testHooks)
+
+	assert.Equal(t, store.StatusCompleted, state.Status)
+	assert.Equal(t, 2, beholderTester.Len(t, "beholder_entity", MeteringReportEntity))
+	assert.Equal(t, 1, beholderTester.Len(t, platform.KeyWorkflowExecutionID, eid))
+	assert.Equal(t, 1, beholderTester.Len(t, platform.KeyWorkflowExecutionID, eid2))
 }

--- a/core/services/workflows/metering_test.go
+++ b/core/services/workflows/metering_test.go
@@ -1,28 +1,27 @@
-package workflows_test
+package workflows
 
 import (
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
-
-	"github.com/smartcontractkit/chainlink/v2/core/services/workflows"
 )
 
 func TestMeteringReport(t *testing.T) {
 	t.Parallel()
 
-	testUnitA := workflows.MeteringSpendUnit("a")
-	testUnitB := workflows.MeteringSpendUnit("b")
+	testUnitA := MeteringSpendUnit("a")
+	testUnitB := MeteringSpendUnit("b")
 
 	t.Run("MedianSpend returns median for multiple spend units", func(t *testing.T) {
 		t.Parallel()
 
-		report := workflows.NewMeteringReport()
-		steps := []workflows.MeteringReportStep{
+		report := NewMeteringReport()
+		steps := []MeteringReportStep{
 			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
 			{"xyz", testUnitA, testUnitA.IntToSpendValue(2)},
 			{"abc", testUnitA, testUnitA.IntToSpendValue(3)},
@@ -32,10 +31,10 @@ func TestMeteringReport(t *testing.T) {
 		}
 
 		for idx := range steps {
-			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), steps))
+			require.NoError(t, report.SetStep(MeteringReportStepRef(strconv.Itoa(idx)), steps))
 		}
 
-		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{
+		expected := map[MeteringSpendUnit]MeteringSpendValue{
 			testUnitA: testUnitB.IntToSpendValue(2),
 			testUnitB: testUnitB.DecimalToSpendValue(decimal.NewFromFloat(0.2)),
 		}
@@ -53,16 +52,16 @@ func TestMeteringReport(t *testing.T) {
 	t.Run("MedianSpend returns median single spend value", func(t *testing.T) {
 		t.Parallel()
 
-		report := workflows.NewMeteringReport()
-		steps := []workflows.MeteringReportStep{
+		report := NewMeteringReport()
+		steps := []MeteringReportStep{
 			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
 		}
 
 		for idx := range steps {
-			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), steps))
+			require.NoError(t, report.SetStep(MeteringReportStepRef(strconv.Itoa(idx)), steps))
 		}
 
-		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{
+		expected := map[MeteringSpendUnit]MeteringSpendValue{
 			testUnitA: testUnitA.IntToSpendValue(1),
 		}
 
@@ -77,18 +76,18 @@ func TestMeteringReport(t *testing.T) {
 	t.Run("MedianSpend returns median odd number of spend values", func(t *testing.T) {
 		t.Parallel()
 
-		report := workflows.NewMeteringReport()
-		steps := []workflows.MeteringReportStep{
+		report := NewMeteringReport()
+		steps := []MeteringReportStep{
 			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
 			{"abc", testUnitA, testUnitA.IntToSpendValue(3)},
 			{"xyz", testUnitA, testUnitA.IntToSpendValue(2)},
 		}
 
 		for idx := range steps {
-			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), steps))
+			require.NoError(t, report.SetStep(MeteringReportStepRef(strconv.Itoa(idx)), steps))
 		}
 
-		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{
+		expected := map[MeteringSpendUnit]MeteringSpendValue{
 			testUnitA: testUnitA.IntToSpendValue(2),
 		}
 
@@ -103,8 +102,8 @@ func TestMeteringReport(t *testing.T) {
 	t.Run("MedianSpend returns median as average for even number of spend values", func(t *testing.T) {
 		t.Parallel()
 
-		report := workflows.NewMeteringReport()
-		steps := []workflows.MeteringReportStep{
+		report := NewMeteringReport()
+		steps := []MeteringReportStep{
 			{"xyz", testUnitA, testUnitA.IntToSpendValue(42)},
 			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
 			{"abc", testUnitA, testUnitA.IntToSpendValue(3)},
@@ -112,10 +111,10 @@ func TestMeteringReport(t *testing.T) {
 		}
 
 		for idx := range steps {
-			require.NoError(t, report.SetStep(workflows.MeteringReportStepRef(strconv.Itoa(idx)), steps))
+			require.NoError(t, report.SetStep(MeteringReportStepRef(strconv.Itoa(idx)), steps))
 		}
 
-		expected := map[workflows.MeteringSpendUnit]workflows.MeteringSpendValue{
+		expected := map[MeteringSpendUnit]MeteringSpendValue{
 			testUnitA: testUnitA.DecimalToSpendValue(decimal.NewFromFloat(2.5)),
 		}
 
@@ -126,4 +125,65 @@ func TestMeteringReport(t *testing.T) {
 
 		assert.Equal(t, expected[testUnitA].String(), median[testUnitA].String())
 	})
+
+	t.Run("SetStep returns error if step already exists", func(t *testing.T) {
+		t.Parallel()
+		report := NewMeteringReport()
+		steps := []MeteringReportStep{
+			{"xyz", testUnitA, testUnitA.IntToSpendValue(42)},
+			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
+		}
+
+		require.NoError(t, report.SetStep("ref1", steps))
+		require.Error(t, report.SetStep("ref1", steps))
+	})
+}
+
+// Test_MeterReports tests the Add, Get, Delete, and Len methods of a MeterReports.
+// It also tests concurrent safe access.
+func Test_MeterReports(t *testing.T) {
+	mr := NewMeterReports()
+	assert.Equal(t, 0, mr.Len())
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		mr.Add("exec1", NewMeteringReport())
+		r, ok := mr.Get("exec1")
+		assert.True(t, ok)
+		r.SetStep("ref1", []MeteringReportStep{})
+		mr.Delete("exec1")
+	}()
+	go func() {
+		defer wg.Done()
+		mr.Add("exec2", NewMeteringReport())
+		r, ok := mr.Get("exec2")
+		assert.True(t, ok)
+		err := r.SetStep("ref1", []MeteringReportStep{})
+		assert.NoError(t, err)
+		mr.Delete("exec2")
+	}()
+	go func() {
+		defer wg.Done()
+		mr.Add("exec1", NewMeteringReport())
+		r, ok := mr.Get("exec1")
+		assert.True(t, ok)
+		r.SetStep("ref1", []MeteringReportStep{})
+		mr.Delete("exec1")
+	}()
+
+	wg.Wait()
+	assert.Equal(t, 0, mr.Len())
+}
+
+func Test_MeterReportsLength(t *testing.T) {
+	mr := NewMeterReports()
+
+	mr.Add("exec1", NewMeteringReport())
+	mr.Add("exec2", NewMeteringReport())
+	mr.Add("exec3", NewMeteringReport())
+	assert.Equal(t, 3, mr.Len())
+
+	mr.Delete("exec2")
+	assert.Equal(t, 2, mr.Len())
 }

--- a/core/services/workflows/metering_test.go
+++ b/core/services/workflows/metering_test.go
@@ -151,6 +151,7 @@ func Test_MeterReports(t *testing.T) {
 		mr.Add("exec1", NewMeteringReport())
 		r, ok := mr.Get("exec1")
 		assert.True(t, ok)
+		//nolint:errcheck
 		r.SetStep("ref1", []MeteringReportStep{})
 		mr.Delete("exec1")
 	}()
@@ -168,6 +169,7 @@ func Test_MeterReports(t *testing.T) {
 		mr.Add("exec1", NewMeteringReport())
 		r, ok := mr.Get("exec1")
 		assert.True(t, ok)
+		//nolint:errcheck
 		r.SetStep("ref1", []MeteringReportStep{})
 		mr.Delete("exec1")
 	}()

--- a/core/services/workflows/metering_test.go
+++ b/core/services/workflows/metering_test.go
@@ -151,7 +151,7 @@ func Test_MeterReports(t *testing.T) {
 		mr.Add("exec1", NewMeteringReport())
 		r, ok := mr.Get("exec1")
 		assert.True(t, ok)
-		//nolint:errcheck
+		//nolint:errcheck // depending on the concurrent timing, this may or may not err
 		r.SetStep("ref1", []MeteringReportStep{})
 		mr.Delete("exec1")
 	}()
@@ -169,7 +169,7 @@ func Test_MeterReports(t *testing.T) {
 		mr.Add("exec1", NewMeteringReport())
 		r, ok := mr.Get("exec1")
 		assert.True(t, ok)
-		//nolint:errcheck
+		//nolint:errcheck // depending on the concurrent timing, this may or may not err
 		r.SetStep("ref1", []MeteringReportStep{})
 		mr.Delete("exec1")
 	}()


### PR DESCRIPTION
Global MeterReport store in the engine struct needs to be indexed on the execution ID
