### PR TITLE
s/results/report for flakeguard download artifact step

### DIFF
--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -749,7 +749,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: context/results.json
-          pattern: failed-test-results-with-logs-${{ needs.get-tests.outputs.workflow_id }}.json
+          pattern: failed-test-report-with-logs-${{ needs.get-tests.outputs.workflow_id }}.json
       - name: Analyze
         uses: smartcontractkit/.github/actions/flakeguard-ai-analysis@flakeguard-ai-analysis/1.1.0
         with:


### PR DESCRIPTION
### Supports
Flakeguard initiative

the download artifact step was using the old(?) naming convention for the report files.
`s/results/report` 😄 