### PR TITLE
fix: remove CL_SOLANA_CMD for non-plugin images

### DIFF
--- a/.goreleaser.develop.yaml
+++ b/.goreleaser.develop.yaml
@@ -49,7 +49,6 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -101,7 +100,6 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -154,7 +152,6 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
@@ -210,7 +207,6 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"

--- a/.goreleaser.production.yaml
+++ b/.goreleaser.production.yaml
@@ -50,7 +50,6 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -104,7 +103,6 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
       - --label=org.opencontainers.image.licenses=MIT
@@ -159,7 +157,6 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"
@@ -217,7 +214,6 @@ dockers:
       - --pull
       - --build-arg=CHAINLINK_USER=chainlink
       - --build-arg=COMMIT_SHA={{ .FullCommit }}
-      - --build-arg=CL_SOLANA_CMD=chainlink-solana
       - --build-arg=CL_CHAIN_DEFAULTS=/ccip-config
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.description="node of the decentralized oracle network, bridging on and off-chain computation"


### PR DESCRIPTION
### Changes

Removes the `CL_SOLANA_CMD` build-arg (eventually translating to the environment variable) for non-plugin images.

Plugin images are those with:
```
extra_files:
      - tmp/libs
      - tmp/plugins # this line
```
