### PR TITLE
feature(deployment): Add Aptos to test memory env

### DIFF
--- a/deployment/aptos_chain.go
+++ b/deployment/aptos_chain.go
@@ -9,4 +9,5 @@ type AptosChain struct {
 	Selector       uint64
 	Client         aptos.AptosRpcClient
 	DeployerSigner aptos.TransactionSigner
+	URL            string
 }

--- a/deployment/ccip/changeset/aptos/aptos_test.go
+++ b/deployment/ccip/changeset/aptos/aptos_test.go
@@ -1,0 +1,38 @@
+package aptos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+// TODO: This is to test the implementation of Aptos chains in memory environment
+// To be deleted after changesets tests are added
+func TestAptosMemoryEnv(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+		AptosChains: 1,
+	})
+	aptosChainSelectors := env.AllChainSelectorsAptos()
+	require.Len(t, aptosChainSelectors, 1)
+	require.NotEqual(t, 0, env.AptosChains[0].Selector)
+}
+
+// TODO: This is to test the implementation of Aptos chains in memory environment
+// To be deleted after changesets tests are added
+func TestAptosHelperMemoryEnv(t *testing.T) {
+	depEvn, testEnv := testhelpers.NewMemoryEnvironment(
+		t,
+		testhelpers.WithAptosChains(1),
+		testhelpers.WithNoJobsAndContracts(), // currently not supporting jobs and contracts
+	)
+	aptosChainSelectors := depEvn.Env.AllChainSelectorsAptos()
+	require.Len(t, aptosChainSelectors, 1)
+	aptosChainSelectors2 := testEnv.DeployedEnvironment().Env.AllChainSelectorsAptos()
+	require.Len(t, aptosChainSelectors2, 1)
+}

--- a/deployment/ccip/changeset/aptos_state.go
+++ b/deployment/ccip/changeset/aptos_state.go
@@ -1,6 +1,72 @@
 package changeset
 
-// AptosCCIPChainState holds a Go binding for all the currently deployed CCIP contracts
-// on a chain. If a binding is nil, it means here is no such contract on the chain.
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+)
+
+const (
+	AptosMCMSType     deployment.ContractType = "AptosManyChainMultisig"
+	AptosCCIPType     deployment.ContractType = "AptosCCIP"
+	AptosReceiverType deployment.ContractType = "AptosReceiver"
+)
+
 type AptosCCIPChainState struct {
+	MCMSAddress      aptos.AccountAddress
+	CCIPAddress      aptos.AccountAddress
+	LinkTokenAddress aptos.AccountAddress
+
+	// Test contracts
+	TestRouterAddress aptos.AccountAddress
+	ReceiverAddress   aptos.AccountAddress
+}
+
+// LoadOnchainStateAptos loads chain state for Aptos chains from env
+func LoadOnchainStateAptos(env deployment.Environment) (map[uint64]AptosCCIPChainState, error) {
+	aptosChains := make(map[uint64]AptosCCIPChainState)
+	for chainSelector := range env.AptosChains {
+		addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+		if err != nil {
+			// Chain not found in address book, initialize empty
+			if !errors.Is(err, deployment.ErrChainNotFound) {
+				return aptosChains, err
+			}
+			addresses = make(map[string]deployment.TypeAndVersion)
+		}
+		chainState, err := loadAptosChainStateFromAddresses(addresses)
+		if err != nil {
+			return aptosChains, err
+		}
+		aptosChains[chainSelector] = chainState
+	}
+	return aptosChains, nil
+}
+
+func loadAptosChainStateFromAddresses(addresses map[string]deployment.TypeAndVersion) (AptosCCIPChainState, error) {
+	chainState := AptosCCIPChainState{}
+	for addrStr, typeAndVersion := range addresses {
+		// Parse address
+		address := &aptos.AccountAddress{}
+		err := address.ParseStringRelaxed(addrStr)
+		if err != nil {
+			return chainState, fmt.Errorf("failed to parse address %s for %s: %w", addrStr, typeAndVersion.Type, err)
+		}
+		// Set address based on type
+		switch typeAndVersion.Type {
+		case AptosMCMSType:
+			chainState.MCMSAddress = *address
+		case AptosCCIPType:
+			chainState.CCIPAddress = *address
+		case commontypes.LinkToken:
+			chainState.LinkTokenAddress = *address
+		case AptosReceiverType:
+			chainState.ReceiverAddress = *address
+		}
+	}
+	return chainState, nil
 }

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -59,6 +59,7 @@ type TestConfigs struct {
 	V1_5Cfg                    changeset.V1_5DeploymentConfig
 	Chains                     int      // only used in memory mode, for docker mode, this is determined by the integration-test config toml input
 	SolChains                  int      // only used in memory mode, for docker mode, this is determined by the integration-test config toml input
+	AptosChains                int      // only used in memory mode, for docker mode, this is determined by the integration-test config toml input
 	ChainIDs                   []uint64 // only used in memory mode, for docker mode, this is determined by the integration-test config toml input
 	NumOfUsersPerChain         int      // only used in memory mode, for docker mode, this is determined by the integration-test config toml input
 	Nodes                      int      // only used in memory mode, for docker mode, this is determined by the integration-test config toml input
@@ -208,6 +209,12 @@ func WithSolChains(numChains int) TestOps {
 	}
 }
 
+func WithAptosChains(numChains int) TestOps {
+	return func(testCfg *TestConfigs) {
+		testCfg.AptosChains = numChains
+	}
+}
+
 func WithNumOfUsersPerChain(numUsers int) TestOps {
 	return func(testCfg *TestConfigs) {
 		testCfg.NumOfUsersPerChain = numUsers
@@ -268,10 +275,11 @@ func (d *DeployedEnv) SetupJobs(t *testing.T) {
 
 type MemoryEnvironment struct {
 	DeployedEnv
-	nodes      map[string]memory.Node
-	TestConfig *TestConfigs
-	Chains     map[uint64]deployment.Chain
-	SolChains  map[uint64]deployment.SolChain
+	nodes       map[string]memory.Node
+	TestConfig  *TestConfigs
+	Chains      map[uint64]deployment.Chain
+	SolChains   map[uint64]deployment.SolChain
+	AptosChains map[uint64]deployment.AptosChain
 }
 
 func (m *MemoryEnvironment) TestConfigs() *TestConfigs {
@@ -308,9 +316,11 @@ func (m *MemoryEnvironment) StartChains(t *testing.T) {
 
 	m.Chains = chains
 	m.SolChains = memory.NewMemoryChainsSol(t, tc.SolChains)
+	m.AptosChains = memory.NewMemoryChainsAptos(t, tc.AptosChains)
 	env := deployment.Environment{
-		Chains:    m.Chains,
-		SolChains: m.SolChains,
+		Chains:      m.Chains,
+		SolChains:   m.SolChains,
+		AptosChains: m.AptosChains,
 	}
 	homeChainSel, feedSel := allocateCCIPChainSelectors(chains)
 	replayBlocks, err := LatestBlocksByChain(ctx, env)
@@ -328,7 +338,7 @@ func (m *MemoryEnvironment) StartNodes(t *testing.T, crConfig deployment.Capabil
 	require.NotNil(t, m.Chains, "start chains first, chains are empty")
 	require.NotNil(t, m.DeployedEnv, "start chains and initiate deployed env first before starting nodes")
 	tc := m.TestConfig
-	nodes := memory.NewNodes(t, zapcore.InfoLevel, m.Chains, m.SolChains, tc.Nodes, tc.Bootstraps, crConfig, tc.CLNodeConfigOpts...)
+	nodes := memory.NewNodes(t, zapcore.InfoLevel, m.Chains, m.SolChains, m.AptosChains, tc.Nodes, tc.Bootstraps, crConfig, tc.CLNodeConfigOpts...)
 	ctx := testcontext.Get(t)
 	lggr := logger.Test(t)
 	for _, node := range nodes {
@@ -338,7 +348,7 @@ func (m *MemoryEnvironment) StartNodes(t *testing.T, crConfig deployment.Capabil
 		})
 	}
 	m.nodes = nodes
-	m.DeployedEnv.Env = memory.NewMemoryEnvironmentFromChainsNodes(func() context.Context { return ctx }, lggr, m.Chains, m.SolChains, nodes)
+	m.DeployedEnv.Env = memory.NewMemoryEnvironmentFromChainsNodes(func() context.Context { return ctx }, lggr, m.Chains, m.SolChains, m.AptosChains, nodes)
 }
 
 func (m *MemoryEnvironment) DeleteJobs(ctx context.Context, jobIDs map[string][]string) error {
@@ -513,8 +523,10 @@ func NewEnvironmentWithJobsAndContracts(t *testing.T, tEnv TestEnvironment) Depl
 	e := NewEnvironmentWithPrerequisitesContracts(t, tEnv)
 	evmChains := e.Env.AllChainSelectors()
 	solChains := e.Env.AllChainSelectorsSolana()
+	aptosChains := e.Env.AllChainSelectorsAptos()
 	//nolint:gocritic // we need to segregate EVM and Solana chains
 	allChains := append(evmChains, solChains...)
+	allChains = append(allChains, aptosChains...)
 	mcmsCfg := make(map[uint64]commontypes.MCMSWithTimelockConfig)
 
 	for _, c := range e.Env.AllChainSelectors() {
@@ -612,6 +624,13 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 	for _, chain := range allChains {
 		if _, ok := e.Env.SolChains[chain]; ok {
 			solChains = append(solChains, chain)
+		}
+	}
+
+	aptosChains := []uint64{}
+	for _, chain := range allChains {
+		if _, ok := e.Env.AptosChains[chain]; ok {
+			aptosChains = append(aptosChains, chain)
 		}
 	}
 

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -627,13 +627,6 @@ func AddCCIPContractsToEnvironment(t *testing.T, allChains []uint64, tEnv TestEn
 		}
 	}
 
-	aptosChains := []uint64{}
-	for _, chain := range allChains {
-		if _, ok := e.Env.AptosChains[chain]; ok {
-			aptosChains = append(aptosChains, chain)
-		}
-	}
-
 	for _, chain := range evmChains {
 		evmContractParams[chain] = v1_6.ChainContractParams{
 			FeeQuoterParams: v1_6.DefaultFeeQuoterParams(),

--- a/deployment/changeset_test.go
+++ b/deployment/changeset_test.go
@@ -98,6 +98,7 @@ func NewNoopEnvironment(t *testing.T) Environment {
 		NewMemoryAddressBook(),
 		map[uint64]Chain{},
 		map[uint64]SolChain{},
+		map[uint64]AptosChain{},
 		[]string{},
 		nil,
 		t.Context,

--- a/deployment/common/changeset/test_helpers_test.go
+++ b/deployment/common/changeset/test_helpers_test.go
@@ -69,6 +69,7 @@ func NewNoopEnvironment(t *testing.T) deployment.Environment {
 		deployment.NewMemoryAddressBook(),
 		map[uint64]deployment.Chain{},
 		map[uint64]deployment.SolChain{},
+		map[uint64]deployment.AptosChain{},
 		[]string{},
 		nil,
 		func() context.Context { return tests.Context(t) },

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -120,6 +120,7 @@ func NewEnvironment(
 	existingAddrs AddressBook,
 	chains map[uint64]Chain,
 	solChains map[uint64]SolChain,
+	aptosChains map[uint64]AptosChain,
 	nodeIDs []string,
 	offchain OffchainClient,
 	ctx func() context.Context,
@@ -131,6 +132,7 @@ func NewEnvironment(
 		ExistingAddresses: existingAddrs,
 		Chains:            chains,
 		SolChains:         solChains,
+		AptosChains:       aptosChains,
 		NodeIDs:           nodeIDs,
 		Offchain:          offchain,
 		GetContext:        ctx,
@@ -193,6 +195,17 @@ func (e Environment) AllChainSelectorsExcluding(excluding []uint64) []uint64 {
 func (e Environment) AllChainSelectorsSolana() []uint64 {
 	selectors := make([]uint64, 0, len(e.SolChains))
 	for sel := range e.SolChains {
+		selectors = append(selectors, sel)
+	}
+	sort.Slice(selectors, func(i, j int) bool {
+		return selectors[i] < selectors[j]
+	})
+	return selectors
+}
+
+func (e Environment) AllChainSelectorsAptos() []uint64 {
+	selectors := make([]uint64, 0, len(e.AptosChains))
+	for sel := range e.AptosChains {
 		selectors = append(selectors, sel)
 	}
 	sort.Slice(selectors, func(i, j int) bool {

--- a/deployment/environment/crib/types.go
+++ b/deployment/environment/crib/types.go
@@ -34,6 +34,7 @@ func NewDeployEnvironmentFromCribOutput(lggr logger.Logger, output DeployOutput)
 		output.AddressBook,
 		chains,
 		nil, // nil for solana chains, can use memory solana chain example when required
+		nil, // nil for aptos chains, can use memory solana chain example when required
 		output.NodeIDs,
 		nil, // todo: populate the offchain client using output.DON
 		func() context.Context { return context.Background() }, deployment.XXXGenerateTestOCRSecrets(),

--- a/deployment/environment/devenv/environment.go
+++ b/deployment/environment/devenv/environment.go
@@ -56,6 +56,7 @@ func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config Envir
 		deployment.NewMemoryAddressBook(),
 		chains,
 		nil, // sending nil for solana chains right now, we can build this when we need it
+		nil, // sending nil for aptos chains right now, we can build this when we need it
 		nodeIDs,
 		offChain,
 		ctx,

--- a/deployment/environment/memory/aptos_chains.go
+++ b/deployment/environment/memory/aptos_chains.go
@@ -1,0 +1,153 @@
+package memory
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/crypto"
+	"github.com/hashicorp/consul/sdk/freeport"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
+)
+
+func getTestAptosChainSelectors() []uint64 {
+	// TODO: CTF to support different chain ids, need to investigate if it's possible (thru node config.yaml?)
+	return []uint64{chainsel.APTOS_LOCALNET.Selector}
+}
+
+func createAptosAccount(t *testing.T, useDefault bool) *aptos.Account {
+	if useDefault {
+		addressStr := blockchain.DefaultAptosAccount
+		var defaultAddress aptos.AccountAddress
+		err := defaultAddress.ParseStringRelaxed(addressStr)
+		require.NoError(t, err)
+
+		privateKeyStr := blockchain.DefaultAptosPrivateKey
+		privateKeyBytes, err := hex.DecodeString(strings.TrimPrefix(privateKeyStr, "0x"))
+		require.NoError(t, err)
+		privateKey := ed25519.NewKeyFromSeed(privateKeyBytes)
+
+		t.Logf("Using default Aptos account: %s %+v", addressStr, privateKeyBytes)
+
+		account, err := aptos.NewAccountFromSigner(&crypto.Ed25519PrivateKey{Inner: privateKey}, *defaultAddress.AuthKey())
+		require.NoError(t, err)
+		return account
+	} else {
+		account, err := aptos.NewEd25519SingleSenderAccount()
+		require.NoError(t, err)
+		return account
+	}
+}
+
+func GenerateChainsAptos(t *testing.T, numChains int) map[uint64]deployment.AptosChain {
+	testAptosChainSelectors := getTestAptosChainSelectors()
+	if len(testAptosChainSelectors) < numChains {
+		t.Fatalf("not enough test aptos chain selectors available")
+	}
+	chains := make(map[uint64]deployment.AptosChain)
+	for i := 0; i < numChains; i++ {
+		selector := testAptosChainSelectors[i]
+		chainID, err := chainsel.GetChainIDFromSelector(selector)
+		require.NoError(t, err)
+		account := createAptosAccount(t, true)
+
+		url, nodeClient := aptosChain(t, chainID, account.Address)
+		chains[selector] = deployment.AptosChain{
+			Selector:       selector,
+			Client:         nodeClient,
+			DeployerSigner: account,
+			URL:            url,
+		}
+	}
+	t.Logf("Created %d Aptos chains: %+v", len(chains), chains)
+	return chains
+}
+
+func aptosChain(t *testing.T, chainID string, adminAddress aptos.AccountAddress) (string, *aptos.NodeClient) {
+	t.Helper()
+
+	// initialize the docker network used by CTF
+	err := framework.DefaultNetwork(once)
+	require.NoError(t, err)
+
+	maxRetries := 10
+	var url string
+	var containerName string
+	for i := 0; i < maxRetries; i++ {
+		port := freeport.GetOne(t)
+
+		bcInput := &blockchain.Input{
+			Image:       "", // filled out by defaultAptos function
+			Type:        "aptos",
+			ChainID:     chainID,
+			PublicKey:   adminAddress.String(),
+			CustomPorts: []string{fmt.Sprintf("%d:8080", port), fmt.Sprintf("%d:8081", port+1)},
+		}
+		output, err := blockchain.NewBlockchainNetwork(bcInput)
+		if err != nil {
+			t.Logf("Error creating Aptos network: %v", err)
+			time.Sleep(time.Second)
+			maxRetries -= 1
+			continue
+		}
+		require.NoError(t, err)
+		containerName = output.ContainerName
+		testcontainers.CleanupContainer(t, output.Container)
+		url = output.Nodes[0].ExternalHTTPUrl + "/v1"
+		break
+	}
+
+	client, err := aptos.NewNodeClient(url, 0)
+	require.NoError(t, err)
+
+	var ready bool
+	for i := 0; i < 30; i++ {
+		time.Sleep(time.Second)
+		_, err := client.GetChainId()
+		if err != nil {
+			t.Logf("API server not ready yet (attempt %d): %+v\n", i+1, err)
+			continue
+		}
+		ready = true
+		break
+	}
+	require.True(t, ready, "Aptos network not ready")
+	time.Sleep(15 * time.Second) // we have slot errors that force retries if the chain is not given enough time to boot
+
+	// incase we didn't use the default account above
+	_, err = framework.ExecContainer(containerName, []string{"aptos", "account", "fund-with-faucet", "--account", adminAddress.String(), "--amount", "100000000000"})
+	require.NoError(t, err)
+
+	return url, client
+}
+
+func createAptosChainConfig(chainID string, chain deployment.AptosChain) chainlink.RawConfig {
+	chainConfig := chainlink.RawConfig{}
+
+	chainConfig["Enabled"] = true
+	chainConfig["ChainID"] = chainID
+	chainConfig["NetworkName"] = "aptos-local"
+	chainConfig["NetworkNameFull"] = "aptos-local"
+	chainConfig["Nodes"] = []any{
+		map[string]any{
+			"Name": "primary",
+			"URL":  chain.URL,
+		},
+	}
+
+	return chainConfig
+}

--- a/deployment/environment/memory/job_service_client_test.go
+++ b/deployment/environment/memory/job_service_client_test.go
@@ -24,7 +24,7 @@ func TestJobClientProposeJob(t *testing.T) {
 	ctx := testutils.Context(t)
 	chains, _ := memory.NewMemoryChains(t, 1, 1)
 	ports := freeport.GetN(t, 1)
-	testNode := memory.NewNode(t, ports[0], chains, nil, zapcore.DebugLevel, false, deployment.CapabilityRegistryConfig{})
+	testNode := memory.NewNode(t, ports[0], chains, nil, nil, zapcore.DebugLevel, false, deployment.CapabilityRegistryConfig{})
 
 	// Set up the JobClient with a mock node
 	nodeID := "node-1"
@@ -119,7 +119,7 @@ func TestJobClientJobAPI(t *testing.T) {
 	ctx := testutils.Context(t)
 	chains, _ := memory.NewMemoryChains(t, 1, 1)
 	ports := freeport.GetN(t, 1)
-	testNode := memory.NewNode(t, ports[0], chains, nil, zapcore.DebugLevel, false, deployment.CapabilityRegistryConfig{})
+	testNode := memory.NewNode(t, ports[0], chains, nil, nil, zapcore.DebugLevel, false, deployment.CapabilityRegistryConfig{})
 
 	// Set up the JobClient with a mock node
 	nodeID := "node-1"

--- a/deployment/environment/memory/node_test.go
+++ b/deployment/environment/memory/node_test.go
@@ -19,7 +19,7 @@ func TestNode(t *testing.T) {
 	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-102")
 	chains, _ := NewMemoryChains(t, 3, 5)
 	ports := freeport.GetN(t, 1)
-	node := NewNode(t, ports[0], chains, nil, zapcore.DebugLevel, false, deployment.CapabilityRegistryConfig{})
+	node := NewNode(t, ports[0], chains, nil, nil, zapcore.DebugLevel, false, deployment.CapabilityRegistryConfig{})
 	// We expect 3 transmitter keys
 	keys, err := node.App.GetKeyStore().Eth().GetAll(tests.Context(t))
 	require.NoError(t, err)

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -389,6 +389,7 @@ func setupViewOnlyNodeTest(t *testing.T, registryChainSel uint64, chains map[uin
 		deployment.NewMemoryAddressBook(),
 		chains,
 		nil,
+		nil,
 		dons.NodeList().IDs(),
 		envtest.NewJDService(dons.NodeList()),
 		t.Context,
@@ -409,17 +410,17 @@ func setupMemoryNodeTest(t *testing.T, registryChainSel uint64, chains map[uint6
 
 	wfChains := map[uint64]deployment.Chain{}
 	wfChains[registryChainSel] = chains[registryChainSel]
-	wfNodes := memory.NewNodes(t, zapcore.InfoLevel, wfChains, nil, c.WFDonConfig.N, 0, crConfig)
+	wfNodes := memory.NewNodes(t, zapcore.InfoLevel, wfChains, nil, nil, c.WFDonConfig.N, 0, crConfig)
 	require.Len(t, wfNodes, c.WFDonConfig.N)
 
 	writerChains := map[uint64]deployment.Chain{}
 	maps.Copy(writerChains, chains)
-	cwNodes := memory.NewNodes(t, zapcore.InfoLevel, writerChains, nil, c.WriterDonConfig.N, 0, crConfig)
+	cwNodes := memory.NewNodes(t, zapcore.InfoLevel, writerChains, nil, nil, c.WriterDonConfig.N, 0, crConfig)
 	require.Len(t, cwNodes, c.WriterDonConfig.N)
 
 	assetChains := map[uint64]deployment.Chain{}
 	assetChains[registryChainSel] = chains[registryChainSel]
-	assetNodes := memory.NewNodes(t, zapcore.InfoLevel, assetChains, nil, c.AssetDonConfig.N, 0, crConfig)
+	assetNodes := memory.NewNodes(t, zapcore.InfoLevel, assetChains, nil, nil, c.AssetDonConfig.N, 0, crConfig)
 	require.Len(t, assetNodes, c.AssetDonConfig.N)
 
 	dons := newMemoryDons()
@@ -427,7 +428,7 @@ func setupMemoryNodeTest(t *testing.T, registryChainSel uint64, chains map[uint6
 	dons.Put(newMemoryDon(c.AssetDonConfig.Name, assetNodes))
 	dons.Put(newMemoryDon(c.WriterDonConfig.Name, cwNodes))
 
-	env := memory.NewMemoryEnvironmentFromChainsNodes(t.Context, lggr, chains, nil, dons.AllNodes())
+	env := memory.NewMemoryEnvironmentFromChainsNodes(t.Context, lggr, chains, nil, nil, dons.AllNodes())
 	return dons, env
 }
 


### PR DESCRIPTION
# Summary
Adds Aptos chain to test memory environment. This supports both e2e integration tests and changesets unit tests.

# Features
- Implement Aptos state
- Create aptos memory chain nodes
- Add aptos to memory cl node

# Test
1. start Docker
2. in root run `make setup-testdb`
3. `make start-testdb`
4. follow the `export` or `source` cmd
5. if running from VSCode create a `.vscode/settings.json` file with
```
    "go.testEnvVars": {
        "CL_DATABASE_URL": "<database url from make start-testdb>",
    },
```