### PR TITLE
system-tests/lib/cre: fix lint issues

### DIFF
--- a/system-tests/lib/cre/capabilities/download.go
+++ b/system-tests/lib/cre/capabilities/download.go
@@ -21,7 +21,7 @@ func DownloadCapabilityFromRelease(ghToken, version, assetFileName string) (stri
 	}
 	defer file.Close()
 
-	if _, err := file.Write(content); err != nil {
+	if _, err = file.Write(content); err != nil {
 		return "", err
 	}
 

--- a/system-tests/lib/cre/don/jobs/jobs.go
+++ b/system-tests/lib/cre/don/jobs/jobs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 
-	types "github.com/smartcontractkit/chainlink/system-tests/lib/cre/types"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/types"
 )
 
 func Create(offChainClient deployment.OffchainClient, don *devenv.DON, flags []string, jobSpecs types.DonJobs) error {
@@ -47,13 +47,4 @@ func Create(offChainClient deployment.OffchainClient, don *devenv.DON, flags []s
 	}
 
 	return nil
-}
-
-func calculateJobCount(jobSpecs types.DonJobs) int {
-	count := 0
-	for _, jobSpec := range jobSpecs {
-		count += len(jobSpec)
-	}
-
-	return count
 }


### PR DESCRIPTION
```xml
<checkstyle version="5.0">
  <file name="system-tests/lib/cre/capabilities/download.go">
    <error column="8" line="24" message="shadow: declaration of &#34;err&#34; shadows declaration at line 12" severity="error" source="govet"></error>
  </file>
  <file name="system-tests/lib/cre/don/jobs/jobs.go">
    <error column="6" line="52" message="func `calculateJobCount` is unused" severity="error" source="unused"></error>
  </file>
</checkstyle>
```