### PR TITLE
Build plugins images on version tag pushes (w/ Aptos) and create general docker build workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -20,7 +20,6 @@ jobs:
       ecr-image-name: ${{ steps.check-git-tag-type.outputs.ecr-image-name }}
       is-release: ${{ steps.release-tag-check.outputs.is-release }}
       is-pre-release: ${{ steps.release-tag-check.outputs.is-pre-release }}
-      github-token: ${{ steps.token.outputs.access-token }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,14 +57,6 @@ jobs:
         with:
           tag: ${{ github.ref_name }}
           assert: true
-      - name: Setup GitHub token using GATI
-        id: token
-        uses: smartcontractkit/.github/actions/setup-github-token@9fc306ac63d8997c9ca0da283e56caaf71589f83 # setup-github-token/1.0.0
-        with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
-          aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          aws-role-duration-seconds: "1800"
 
   build-sign-publish-chainlink:
     needs: [checks]
@@ -114,7 +105,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86b566e52d9e1799d6fc729bb7c45465e1a09154 # 2025-03-26
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@eed8e86304bf7a93e70faacb37de81afc5beb8b2 # TODO
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile
@@ -122,19 +113,22 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+        CL_INSTALL_PRIVATE_PLUGINS=true
       docker-image-type: tag
       docker-manifest-sign: true
       docker-registry-url-override: public.ecr.aws/chainlink
       docker-tag-custom-suffix: "-plugins"
+      docker-target: final-private-plugins
       git-sha: ${{ github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
-      github-token: ${{ needs.checks.outputs.github-token }}
       github-workflow-repository: ${{ github.repository }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
-      AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_SDLC_BUILD_PUBLISH_ARN }}
+      AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
+      AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+      AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
   # Notify Slack channel for new git tags.
   slack-notify:

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -13,7 +13,6 @@ jobs:
     name: "Checks"
     runs-on: ubuntu-24.04
     permissions:
-      id-token: write
       contents: read
     outputs:
       git-tag-type: ${{ steps.check-git-tag-type.outputs.git-tag-type }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -105,7 +105,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@eed8e86304bf7a93e70faacb37de81afc5beb8b2 # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86250a243934401117c92a137579d4cd7a253572 # 2025-03-28
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -12,6 +12,9 @@ jobs:
   checks:
     name: "Checks"
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       git-tag-type: ${{ steps.check-git-tag-type.outputs.git-tag-type }}
       ecr-image-name: ${{ steps.check-git-tag-type.outputs.ecr-image-name }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -95,6 +95,34 @@ jobs:
           subject-name: ${{ env.ECR_HOSTNAME }}/${{ needs.checks.outputs.ecr-image-name }}
           push-to-registry: true
 
+  # XXX: This is using a new way to build images. Other jobs should be updated to use this in the future.
+  build-sign-publish-chainlink-plugins:
+    needs: [checks]
+    if: needs.checks.outputs.git-tag-type == 'core'
+    permissions:
+      contents: read
+      id-token: write
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-reusable-workflow-public-ecr # TODO
+    with:
+      aws-ecr-name: chainlink
+      dockerfile: plugins/chainlink.Dockerfile
+      docker-build-context: .
+      docker-build-args: |
+        CHAINLINK_USER=chainlink
+        COMMIT_SHA=${{ github.sha }}
+      docker-image-type: tag
+      docker-manifest-sign: true
+      docker-registry-url-override: public.ecr.aws/chainlink
+      docker-tag-custom-suffix: "-plugins"
+      git-sha: ${{ github.sha }}
+      github-event-name: ${{ github.event_name }}
+      github-ref-name: ${{ github.ref_name }}
+      github-workflow-repository: ${{ github.repository }}
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_SDLC_BUILD_PUBLISH_ARN }}
+
   # Notify Slack channel for new git tags.
   slack-notify:
     if: github.ref_type == 'tag'

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -17,6 +17,7 @@ jobs:
       ecr-image-name: ${{ steps.check-git-tag-type.outputs.ecr-image-name }}
       is-release: ${{ steps.release-tag-check.outputs.is-release }}
       is-pre-release: ${{ steps.release-tag-check.outputs.is-pre-release }}
+      github-token: ${{ steps.token.outputs.access-token }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -54,6 +55,14 @@ jobs:
         with:
           tag: ${{ github.ref_name }}
           assert: true
+      - name: Setup GitHub token using GATI
+        id: token
+        uses: smartcontractkit/.github/actions/setup-github-token@9fc306ac63d8997c9ca0da283e56caaf71589f83 # setup-github-token/1.0.0
+        with:
+          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-duration-seconds: "1800"
 
   build-sign-publish-chainlink:
     needs: [checks]
@@ -102,7 +111,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-reusable-workflow-public-ecr # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86b566e52d9e1799d6fc729bb7c45465e1a09154 # 2025-03-26
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile
@@ -117,6 +126,7 @@ jobs:
       git-sha: ${{ github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
+      github-token: ${{ needs.checks.outputs.github-token }}
       github-workflow-repository: ${{ github.repository }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-reusable-workflow-github-token-secret # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c1e5964d51b19bfbb59f10cffb631f25e7a62b2d # TODO
     with:
       aws-ecr-name: chainlink
       dockerfile: core/chainlink.Dockerfile
@@ -75,7 +75,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@4a0b21b3d07d1cc31c11de7c76f491b02cfac4e2 # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c1e5964d51b19bfbb59f10cffb631f25e7a62b2d # TODO
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile
@@ -102,7 +102,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-reusable-workflow-github-token-secret # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c1e5964d51b19bfbb59f10cffb631f25e7a62b2d # TODO
     with:
       aws-ecr-name: ccip
       dockerfile: core/chainlink.Dockerfile
@@ -121,3 +121,31 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
+
+  docker-ccip-plugins:
+    needs: [init]
+    permissions:
+      contents: read
+      id-token: write
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c1e5964d51b19bfbb59f10cffb631f25e7a62b2d # TODO
+    with:
+      aws-ecr-name: ccip
+      dockerfile: plugins/chainlink.Dockerfile
+      docker-build-context: .
+      docker-build-args: |
+        CHAINLINK_USER=chainlink
+        CL_CHAIN_DEFAULTS=/ccip-config
+        COMMIT_SHA=${{ github.sha }}
+      docker-image-type: ${{ needs.init.outputs.build-type }}
+      docker-manifest-sign: true
+      docker-tag-custom-suffix: "-plugins"
+      git-sha: ${{ inputs.git-ref || github.sha }}
+      github-event-name: ${{ github.event_name }}
+      github-ref-name: ${{ github.ref_name }}
+      github-workflow-repository: ${{ github.repository }}
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
+      AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+      AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c1e5964d51b19bfbb59f10cffb631f25e7a62b2d # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@eed8e86304bf7a93e70faacb37de81afc5beb8b2 # 2025-03-28
     with:
       aws-ecr-name: chainlink
       dockerfile: core/chainlink.Dockerfile
@@ -75,7 +75,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c1e5964d51b19bfbb59f10cffb631f25e7a62b2d # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@eed8e86304bf7a93e70faacb37de81afc5beb8b2 # 2025-03-28
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile
@@ -102,7 +102,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c1e5964d51b19bfbb59f10cffb631f25e7a62b2d # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@eed8e86304bf7a93e70faacb37de81afc5beb8b2 # 2025-03-28
     with:
       aws-ecr-name: ccip
       dockerfile: core/chainlink.Dockerfile
@@ -127,7 +127,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c1e5964d51b19bfbb59f10cffb631f25e7a62b2d # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@eed8e86304bf7a93e70faacb37de81afc5beb8b2 # 2025-03-28
     with:
       aws-ecr-name: ccip
       dockerfile: plugins/chainlink.Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -59,7 +59,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-tag-sha # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@1c1e3aa4f1a02ed28d98b7fe1bd4d9d34f5bc57c # 2025-03-26
     with:
       aws-ecr-name: chainlink
       dockerfile: core/chainlink.Dockerfile
@@ -83,7 +83,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-tag-sha # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@1c1e3aa4f1a02ed28d98b7fe1bd4d9d34f5bc57c # 2025-03-26
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile
@@ -109,7 +109,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-tag-sha # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@1c1e3aa4f1a02ed28d98b7fe1bd4d9d34f5bc57c # 2025-03-26
     with:
       aws-ecr-name: ccip
       dockerfile: core/chainlink.Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -84,7 +84,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@78235751bcff8f3a7bc298de8ba4706ef9423d80 # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@5a29cf4d53316eaf3e25aee3d74c768c4e8a01cd # TODO
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,7 +10,7 @@ on:
       - develop
   workflow_dispatch:
     inputs:
-      git_ref:
+      git-ref:
         description: "The git ref to check out"
         required: true
 
@@ -69,7 +69,7 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
-      git-sha: ${{ inputs.git_ref || github.sha }}
+      git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-workflow-repository: ${{ github.repository }}
@@ -94,7 +94,7 @@ jobs:
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"
-      git-sha: ${{ inputs.git_ref || github.sha }}
+      git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-token: ${{ needs.init.outputs.github-token }}
@@ -120,7 +120,7 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
-      git-sha: ${{ inputs.git_ref || github.sha }}
+      git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-workflow-repository: ${{ github.repository }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,16 +26,7 @@ jobs:
       contents: read
     outputs:
       build-type: ${{ steps.build-type.outputs.build-type }}
-      github-token: ${{ steps.token.outputs.access-token }}
     steps:
-      - name: Setup GitHub token using GATI
-        id: token
-        uses: smartcontractkit/.github/actions/setup-github-token@9fc306ac63d8997c9ca0da283e56caaf71589f83 # setup-github-token/1.0.0
-        with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
-          aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          aws-role-duration-seconds: "1800"
       - name: Set Build Type
         id: build-type
         shell: bash
@@ -77,14 +68,14 @@ jobs:
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
-      AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
+      AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
 
   docker-core-plugins:
     needs: [init]
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@5a29cf4d53316eaf3e25aee3d74c768c4e8a01cd # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@4a0b21b3d07d1cc31c11de7c76f491b02cfac4e2 # TODO
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile
@@ -102,8 +93,9 @@ jobs:
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
-      AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
-      GITHUB_TOKEN_GATI: ${{ needs.init.outputs.github-token }}
+      AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
+      AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+      AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
   docker-ccip:
     needs: [init]
@@ -128,4 +120,4 @@ jobs:
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
-      AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
+      AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,7 +60,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@1c1e3aa4f1a02ed28d98b7fe1bd4d9d34f5bc57c # 2025-03-26
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-reusable-workflow-github-token-secret # TODO
     with:
       aws-ecr-name: chainlink
       dockerfile: core/chainlink.Dockerfile
@@ -84,7 +84,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@1c1e3aa4f1a02ed28d98b7fe1bd4d9d34f5bc57c # 2025-03-26
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-reusable-workflow-github-token-secret # TODO
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile
@@ -98,19 +98,19 @@ jobs:
       git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
-      github-token: ${{ needs.init.outputs.github-token }}
       github-workflow-repository: ${{ github.repository }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
+      GITHUB_TOKEN: ${{ needs.init.outputs.github-token }}
 
   docker-ccip:
     needs: [init]
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@1c1e3aa4f1a02ed28d98b7fe1bd4d9d34f5bc57c # 2025-03-26
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-reusable-workflow-github-token-secret # TODO
     with:
       aws-ecr-name: ccip
       dockerfile: core/chainlink.Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,6 +36,10 @@ jobs:
           aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-role-duration-seconds: "1800"
+      - name: Debug token output
+        if: always()
+        run: |
+          echo "Token exists: ${{ steps.token.outputs.access-token != '' }}"
       - name: Set Build Type
         id: build-type
         shell: bash

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -103,7 +103,7 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
-      GITHUB_TOKEN: ${{ needs.init.outputs.github-token }}
+      GITHUB_TOKEN_GATI: ${{ needs.init.outputs.github-token }}
 
   docker-ccip:
     needs: [init]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,7 +15,7 @@ on:
         required: true
 
 concurrency:
-  group: "docker-build-${{ github.ref_name }}-${{ github.sha }}"
+  group: "docker-build-${{ github.ref_name }}"
   cancel-in-progress: true
 
 jobs:
@@ -84,7 +84,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-reusable-workflow-github-token-secret # TODO
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@78235751bcff8f3a7bc298de8ba4706ef9423d80 # TODO
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,6 +52,7 @@ jobs:
             echo "build-type=sha" | tee -a "$GITHUB_OUTPUT"
           else
             echo "::error::Unsupported build trigger: ${BUILD_TRIGGER}"
+            exit 1
           fi
 
   docker-core:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,12 +1,21 @@
-name: Nightlies
-description: Build and publish nightly releases from trunk.
+name: Docker Build
+description: Docker build and publish non-releases to AWS ECR.
 
 on:
   schedule:
     - cron: "0 3 * * *" # daily at 03:00 UTC
+  pull_request:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "The git ref to check out"
+        required: true
 
 concurrency:
-  group: nightlies
+  group: "docker-build-${{ github.ref_name }}-${{ github.sha }}"
   cancel-in-progress: true
 
 jobs:
@@ -16,6 +25,7 @@ jobs:
       id-token: write
       contents: read
     outputs:
+      build-type: ${{ steps.build-type.outputs.build-type }}
       github-token: ${{ steps.token.outputs.access-token }}
     steps:
       - name: Setup GitHub token using GATI
@@ -26,12 +36,30 @@ jobs:
           aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-role-duration-seconds: "1800"
+      - name: Set Build Type
+        id: build-type
+        shell: bash
+        env:
+          BUILD_TRIGGER: ${{ github.event_name }}
+        run: |
+          if [[ "${BUILD_TRIGGER}" == "schedule" ]]; then
+            echo "build-type=nightly" | tee -a "$GITHUB_OUTPUT"
+          elif [[ "${BUILD_TRIGGER}" == 'push' ]]; then
+            echo "build-type=branch" | tee -a "$GITHUB_OUTPUT"
+          elif [[ "${BUILD_TRIGGER}" == 'pull_request' ]]; then
+            echo "build-type=pr" | tee -a "$GITHUB_OUTPUT"
+          elif [[ "${BUILD_TRIGGER}" == 'workflow_dispatch' ]]; then
+            echo "build-type=sha" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "::error::Unsupported build trigger: ${BUILD_TRIGGER}"
+          fi
 
   docker-core:
+    needs: [init]
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86b566e52d9e1799d6fc729bb7c45465e1a09154 # 2025-03-26
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-tag-sha # TODO
     with:
       aws-ecr-name: chainlink
       dockerfile: core/chainlink.Dockerfile
@@ -39,9 +67,9 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
-      docker-image-type: nightly
+      docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
-      git-sha: ${{ github.sha }}
+      git-sha: ${{ inputs.git_ref || github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-workflow-repository: ${{ github.repository }}
@@ -55,7 +83,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86b566e52d9e1799d6fc729bb7c45465e1a09154 # 2025-03-26
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-tag-sha # TODO
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile
@@ -63,10 +91,10 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
-      docker-image-type: nightly
+      docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"
-      git-sha: ${{ github.sha }}
+      git-sha: ${{ inputs.git_ref || github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-token: ${{ needs.init.outputs.github-token }}
@@ -77,10 +105,11 @@ jobs:
       AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
 
   docker-ccip:
+    needs: [init]
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86b566e52d9e1799d6fc729bb7c45465e1a09154 # 2025-03-26
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@re-3577/docker-tag-sha # TODO
     with:
       aws-ecr-name: ccip
       dockerfile: core/chainlink.Dockerfile
@@ -89,9 +118,9 @@ jobs:
         CHAINLINK_USER=chainlink
         CL_CHAIN_DEFAULTS=/ccip-config
         COMMIT_SHA=${{ github.sha }}
-      docker-image-type: nightly
+      docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
-      git-sha: ${{ github.sha }}
+      git-sha: ${{ inputs.git_ref || github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-workflow-repository: ${{ github.repository }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,10 +36,6 @@ jobs:
           aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-role-duration-seconds: "1800"
-      - name: Debug token output
-        if: always()
-        run: |
-          echo "Token exists: ${{ steps.token.outputs.access-token != '' }}"
       - name: Set Build Type
         id: build-type
         shell: bash

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@eed8e86304bf7a93e70faacb37de81afc5beb8b2 # 2025-03-28
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86250a243934401117c92a137579d4cd7a253572 # 2025-03-28
     with:
       aws-ecr-name: chainlink
       dockerfile: core/chainlink.Dockerfile
@@ -75,7 +75,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@eed8e86304bf7a93e70faacb37de81afc5beb8b2 # 2025-03-28
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86250a243934401117c92a137579d4cd7a253572 # 2025-03-28
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile
@@ -83,9 +83,11 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+        CL_INSTALL_PRIVATE_PLUGINS=true
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"
+      docker-target: final-private-plugins
       git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
@@ -102,7 +104,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@eed8e86304bf7a93e70faacb37de81afc5beb8b2 # 2025-03-28
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86250a243934401117c92a137579d4cd7a253572 # 2025-03-28
     with:
       aws-ecr-name: ccip
       dockerfile: core/chainlink.Dockerfile
@@ -127,7 +129,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@eed8e86304bf7a93e70faacb37de81afc5beb8b2 # 2025-03-28
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86250a243934401117c92a137579d4cd7a253572 # 2025-03-28
     with:
       aws-ecr-name: ccip
       dockerfile: plugins/chainlink.Dockerfile
@@ -136,9 +138,11 @@ jobs:
         CHAINLINK_USER=chainlink
         CL_CHAIN_DEFAULTS=/ccip-config
         COMMIT_SHA=${{ github.sha }}
+        CL_INSTALL_PRIVATE_PLUGINS=true
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"
+      docker-target: final-private-plugins
       git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,9 +21,6 @@ concurrency:
 jobs:
   init:
     runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-      contents: read
     outputs:
       build-type: ${{ steps.build-type.outputs.build-type }}
     steps:

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -10,11 +10,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      github-token: ${{ steps.token.outputs.access-token }}
+    steps:
+      - name: Setup GitHub token using GATI
+        id: token
+        uses: smartcontractkit/.github/actions/setup-github-token@9fc306ac63d8997c9ca0da283e56caaf71589f83 # setup-github-token/1.0.0
+        with:
+          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-duration-seconds: "1800"
+
   docker-core:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@cdd6cd208e7d778ce97b57aa459d8c2242aa8e11 # 2025-03-10
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86b566e52d9e1799d6fc729bb7c45465e1a09154 # 2025-03-26
     with:
       aws-ecr-name: chainlink
       dockerfile: core/chainlink.Dockerfile
@@ -34,10 +51,11 @@ jobs:
       AWS_ROLE_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
 
   docker-core-plugins:
+    needs: [init]
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@cdd6cd208e7d778ce97b57aa459d8c2242aa8e11 # 2025-03-10
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86b566e52d9e1799d6fc729bb7c45465e1a09154 # 2025-03-26
     with:
       aws-ecr-name: chainlink
       dockerfile: plugins/chainlink.Dockerfile
@@ -51,6 +69,7 @@ jobs:
       git-sha: ${{ github.sha }}
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
+      github-token: ${{ needs.init.outputs.github-token }}
       github-workflow-repository: ${{ github.repository }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
@@ -61,7 +80,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@cdd6cd208e7d778ce97b57aa459d8c2242aa8e11 # 2025-03-10
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@86b566e52d9e1799d6fc729bb7c45465e1a09154 # 2025-03-26
     with:
       aws-ecr-name: ccip
       dockerfile: core/chainlink.Dockerfile

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -93,8 +93,8 @@ install-plugins: ## Build & install LOOPP binaries for products and chains.
 	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-starknet/relayer@$(STARKNET_SHA) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./pkg/chainlink/cmd/chainlink-starknet
 	# Set GOPRIVATE to ensure go installs from our repository instead of the public proxy since we're using lightweight git tags.
-	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-internal-integrations go mod download -json github.com/smartcontractkit/chainlink-internal-integrations/aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
-	go install $(GOFLAGS) ./cmd/chainlink-internal-integrations
+	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-internal-integrations go mod download -json github.com/smartcontractkit/chainlink-internal-integrations@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
+	go install $(GOFLAGS) ./aptos/relayer/cmd/chainlink-aptos
 
 .PHONY: docker ## Build the chainlink docker image
 docker:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,8 @@ VERSION = $(shell jq -r '.version' package.json)
 GO_LDFLAGS := $(shell tools/bin/ldflags)
 GOFLAGS = -ldflags "$(GO_LDFLAGS)"
 GCFLAGS = -gcflags "$(GO_GCFLAGS)"
+# Set to true to install private plugins (will require GitHub auth).
+CL_INSTALL_PRIVATE_PLUGINS ?= false
 
 # LOOP Plugin version defaults
 ifndef COSMOS_SHA
@@ -92,9 +94,14 @@ install-plugins: ## Build & install LOOPP binaries for products and chains.
 	go install $(GOFLAGS) ./pkg/solana/cmd/chainlink-solana
 	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-starknet/relayer@$(STARKNET_SHA) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./pkg/chainlink/cmd/chainlink-starknet
-	# Set GOPRIVATE to ensure go installs from our repository instead of the public proxy since we're using lightweight git tags.
-	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-internal-integrations go mod download -json github.com/smartcontractkit/chainlink-internal-integrations/aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
-	go install $(GOFLAGS) ./cmd/chainlink-aptos
+	@if [ "$(CL_INSTALL_PRIVATE_PLUGINS)" = "true" ]; then \
+		echo "Installing private plugins..."; \
+		cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-internal-integrations go mod download -json github.com/smartcontractkit/chainlink-internal-integrations/aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
+		go install $(GOFLAGS) ./cmd/chainlink-aptos; \
+		echo "Installed private plugins"; \
+	else \
+		echo "Skipping private plugin installation (set CL_INSTALL_PRIVATE_PLUGINS=true to install)"; \
+	fi
 
 .PHONY: docker ## Build the chainlink docker image
 docker:
@@ -114,18 +121,22 @@ docker-ccip:
 
 .PHONY: docker-plugins ## Build the chainlink-plugins docker image
 docker-plugins:
-	@if [ -z "$(GITHUB_TOKEN)" ]; then \
-		echo "Error: GITHUB_TOKEN environment variable is required for fetching plugins from private repositories."; \
-		echo "Usage: GITHUB_TOKEN=$(gh auth token) make docker-plugins"; \
+	@if [ "$(CL_INSTALL_PRIVATE_PLUGINS)" = "true" ] && [ -z "$(GITHUB_TOKEN)" ]; then \
+		echo "Error: GITHUB_TOKEN environment variable is required when CL_INSTALL_PRIVATE_PLUGINS=true"; \
 		exit 1; \
 	fi
+	$(eval PRIVATE_PLUGIN_ARGS := $(if $(and $(filter true,$(CL_INSTALL_PRIVATE_PLUGINS)),$(GITHUB_TOKEN)),--secret id=GIT_AUTH_TOKEN$(comma)env=GITHUB_TOKEN --target final-private-plugins,))
 	docker buildx build \
 	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
 	--build-arg APTOS_RELAYER_GIT_REF=$(APTOS_RELAYER_GIT_REF) \
 	--build-arg COSMOS_SHA=$(COSMOS_SHA) \
 	--build-arg STARKNET_SHA=$(STARKNET_SHA) \
-	--secret id=GIT_AUTH_TOKEN,env=GITHUB_TOKEN \
+	--build-arg CL_INSTALL_PRIVATE_PLUGINS=$(CL_INSTALL_PRIVATE_PLUGINS) \
+	$(PRIVATE_PLUGIN_ARGS) \
 	-f plugins/chainlink.Dockerfile .
+
+# Define a comma variable for use in $(eval) (needed for the PRIVATE_PLUGIN_ARGS)
+comma := ,
 
 .PHONY: operator-ui
 operator-ui: ## Fetch the frontend

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -93,7 +93,7 @@ install-plugins: ## Build & install LOOPP binaries for products and chains.
 	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-starknet/relayer@$(STARKNET_SHA) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./pkg/chainlink/cmd/chainlink-starknet
 	# Set GOPRIVATE to ensure go installs from our repository instead of the public proxy since we're using lightweight git tags.
-	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-aptos go mod download -json github.com/smartcontractkit/chainlink-internal-integrations/aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
+	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-internal-integrations go mod download -json github.com/smartcontractkit/chainlink-internal-integrations/aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./cmd/chainlink-aptos
 
 .PHONY: docker ## Build the chainlink docker image

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ ifndef STARKNET_SHA
 override STARKNET_SHA = "9a780650af4708e4bd9b75495feff2c5b4054e46"
 endif
 ifndef APTOS_RELAYER_GIT_REF
-override APTOS_RELAYER_GIT_REF = "2.21.0-beta16-aptos"
+override APTOS_RELAYER_GIT_REF = "f2277472c607e607e06f295cd74ec2f1cc16a310"
 endif
 
 .PHONY: install
@@ -93,7 +93,7 @@ install-plugins: ## Build & install LOOPP binaries for products and chains.
 	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-starknet/relayer@$(STARKNET_SHA) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./pkg/chainlink/cmd/chainlink-starknet
 	# Set GOPRIVATE to ensure go installs from our repository instead of the public proxy since we're using lightweight git tags.
-	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-internal-integrations go mod download -json github.com/smartcontractkit/chainlink-internal-integrations/aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
+	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-aptos go mod download -json github.com/smartcontractkit/chainlink-aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./cmd/chainlink-aptos
 
 .PHONY: docker ## Build the chainlink docker image

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ ifndef STARKNET_SHA
 override STARKNET_SHA = "9a780650af4708e4bd9b75495feff2c5b4054e46"
 endif
 ifndef APTOS_RELAYER_GIT_REF
-override APTOS_RELAYER_GIT_REF = "f2277472c607e607e06f295cd74ec2f1cc16a310"
+override APTOS_RELAYER_GIT_REF = "2.21.0-beta16-aptos"
 endif
 
 .PHONY: install
@@ -93,8 +93,8 @@ install-plugins: ## Build & install LOOPP binaries for products and chains.
 	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-starknet/relayer@$(STARKNET_SHA) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./pkg/chainlink/cmd/chainlink-starknet
 	# Set GOPRIVATE to ensure go installs from our repository instead of the public proxy since we're using lightweight git tags.
-	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-aptos go mod download -json github.com/smartcontractkit/chainlink-aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
-	go install $(GOFLAGS) ./cmd/chainlink-aptos
+	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-internal-integrations go mod download -json github.com/smartcontractkit/chainlink-internal-integrations/aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
+	go install $(GOFLAGS) ./cmd/chainlink-internal-integrations
 
 .PHONY: docker ## Build the chainlink docker image
 docker:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -93,8 +93,8 @@ install-plugins: ## Build & install LOOPP binaries for products and chains.
 	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-starknet/relayer@$(STARKNET_SHA) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./pkg/chainlink/cmd/chainlink-starknet
 	# Set GOPRIVATE to ensure go installs from our repository instead of the public proxy since we're using lightweight git tags.
-	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-internal-integrations go mod download -json github.com/smartcontractkit/chainlink-internal-integrations@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
-	go install $(GOFLAGS) ./aptos/relayer/cmd/chainlink-aptos
+	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-internal-integrations go mod download -json github.com/smartcontractkit/chainlink-internal-integrations/aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
+	go install $(GOFLAGS) ./cmd/chainlink-aptos
 
 .PHONY: docker ## Build the chainlink docker image
 docker:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ ifndef STARKNET_SHA
 override STARKNET_SHA = "9a780650af4708e4bd9b75495feff2c5b4054e46"
 endif
 ifndef APTOS_RELAYER_GIT_REF
-override APTOS_RELAYER_GIT_REF = "213b9555e7ece0e7988d2aea844ad8d1d736201a"
+override APTOS_RELAYER_GIT_REF = "2.21.0-beta16-aptos"
 endif
 
 .PHONY: install
@@ -93,7 +93,7 @@ install-plugins: ## Build & install LOOPP binaries for products and chains.
 	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-starknet/relayer@$(STARKNET_SHA) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./pkg/chainlink/cmd/chainlink-starknet
 	# Set GOPRIVATE to ensure go installs from our repository instead of the public proxy since we're using lightweight git tags.
-	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-aptos go mod download -json github.com/smartcontractkit/chainlink-aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
+	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-aptos go mod download -json github.com/smartcontractkit/chainlink-internal-integrations/aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./cmd/chainlink-aptos
 
 .PHONY: docker ## Build the chainlink docker image

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,6 +13,9 @@ endif
 ifndef STARKNET_SHA
 override STARKNET_SHA = "9a780650af4708e4bd9b75495feff2c5b4054e46"
 endif
+ifndef APTOS_RELAYER_GIT_REF
+override APTOS_RELAYER_GIT_REF = "213b9555e7ece0e7988d2aea844ad8d1d736201a"
+endif
 
 .PHONY: install
 install: install-chainlink-autoinstall ## Install chainlink and all its dependencies.
@@ -89,6 +92,9 @@ install-plugins: ## Build & install LOOPP binaries for products and chains.
 	go install $(GOFLAGS) ./pkg/solana/cmd/chainlink-solana
 	cd $(shell go mod download -json github.com/smartcontractkit/chainlink-starknet/relayer@$(STARKNET_SHA) | jq -r .Dir) && \
 	go install $(GOFLAGS) ./pkg/chainlink/cmd/chainlink-starknet
+	# Set GOPRIVATE to ensure go installs from our repository instead of the public proxy since we're using lightweight git tags.
+	cd $(shell GOPRIVATE=github.com/smartcontractkit/chainlink-aptos go mod download -json github.com/smartcontractkit/chainlink-aptos/relayer@$(APTOS_RELAYER_GIT_REF) | jq -r .Dir) && \
+	go install $(GOFLAGS) ./cmd/chainlink-aptos
 
 .PHONY: docker ## Build the chainlink docker image
 docker:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -114,10 +114,17 @@ docker-ccip:
 
 .PHONY: docker-plugins ## Build the chainlink-plugins docker image
 docker-plugins:
+	@if [ -z "$(GITHUB_TOKEN)" ]; then \
+		echo "Error: GITHUB_TOKEN environment variable is required for fetching plugins from private repositories."; \
+		echo "Usage: GITHUB_TOKEN=$(gh auth token) make docker-plugins"; \
+		exit 1; \
+	fi
 	docker buildx build \
 	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+	--build-arg APTOS_RELAYER_GIT_REF=$(APTOS_RELAYER_GIT_REF) \
 	--build-arg COSMOS_SHA=$(COSMOS_SHA) \
 	--build-arg STARKNET_SHA=$(STARKNET_SHA) \
+	--secret id=GIT_AUTH_TOKEN,env=GITHUB_TOKEN \
 	-f plugins/chainlink.Dockerfile .
 
 .PHONY: operator-ui

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -11,6 +11,7 @@ RUN go mod download
 
 # Env vars needed for chainlink build
 ARG COMMIT_SHA
+ARG APTOS_RELAYER_GIT_REF
 ARG COSMOS_SHA
 ARG STARKNET_SHA
 
@@ -34,7 +35,10 @@ RUN make install-medianpoc
 RUN make install-ocr3-capability
 
 # Install LOOP Plugins
-RUN make install-plugins COSMOS_SHA=${COSMOS_SHA} STARKNET_SHA=${STARKNET_SHA}
+RUN make install-plugins \
+  APTOS_RELAYER_GIT_REF=${APTOS_RELAYER_GIT_REF} \
+  COSMOS_SHA=${COSMOS_SHA} \
+  STARKNET_SHA=${STARKNET_SHA}
 
 # Final image: ubuntu with chainlink binary
 FROM ubuntu:24.04

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -20,6 +20,9 @@ ARG GO_GCFLAGS
 
 COPY . .
 
+# Used to authenticate with GitHub to fetch private dependencies.
+RUN --mount=type=secret,id=GIT_AUTH_TOKEN ./plugins/scripts/setup_git_auth.sh
+
 RUN apt-get update && apt-get install -y jq
 
 # Install Delve for debugging

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -14,6 +14,8 @@ ARG COMMIT_SHA
 ARG APTOS_RELAYER_GIT_REF
 ARG COSMOS_SHA
 ARG STARKNET_SHA
+# Flag to control installation of private plugins (default: false)
+ARG CL_INSTALL_PRIVATE_PLUGINS=false
 
 # Flags for Go Delve debugger
 ARG GO_GCFLAGS
@@ -41,10 +43,12 @@ RUN make install-ocr3-capability
 RUN make install-plugins \
   APTOS_RELAYER_GIT_REF=${APTOS_RELAYER_GIT_REF} \
   COSMOS_SHA=${COSMOS_SHA} \
-  STARKNET_SHA=${STARKNET_SHA}
+  STARKNET_SHA=${STARKNET_SHA} \
+  CL_INSTALL_PRIVATE_PLUGINS=${CL_INSTALL_PRIVATE_PLUGINS}
 
-# Final image: ubuntu with chainlink binary
-FROM ubuntu:24.04
+# -----------------------------------------------------------------------------
+# Final image: common base stage for the final images
+FROM ubuntu:24.04 as final-base
 
 ARG CHAINLINK_USER=root
 ENV DEBIAN_FRONTEND noninteractive
@@ -70,8 +74,6 @@ COPY --from=buildgo /go/bin/chainlink-cosmos /usr/local/bin/
 COPY --from=buildgo /go/bin/chainlink-solana /usr/local/bin/
 ENV CL_SOLANA_CMD chainlink-solana
 COPY --from=buildgo /go/bin/chainlink-starknet /usr/local/bin/
-COPY --from=buildgo /go/bin/chainlink-aptos /usr/local/bin/
-ENV CL_APTOS_CMD chainlink-aptos
 
 # Dependency of CosmWasm/wasmd
 COPY --from=buildgo /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/internal/api/libwasmvm.*.so /usr/lib/
@@ -88,8 +90,19 @@ ENV XDG_CACHE_HOME /home/${CHAINLINK_USER}/.cache
 RUN mkdir -p ${XDG_CACHE_HOME}
 
 EXPOSE 6688
+
+# -----------------------------------------------------------------------------
+# Final image with private plugins (placed earlier so it's not the default target/stage)
+FROM final-base as final-private-plugins
+COPY --from=buildgo /go/bin/chainlink-aptos /usr/local/bin/
+ENV CL_APTOS_CMD=chainlink-aptos
 ENTRYPOINT ["chainlink"]
-
 HEALTHCHECK CMD curl -f http://localhost:6688/health || exit 1
+CMD ["local", "node"]
 
+# -----------------------------------------------------------------------------
+# Final image without private plugins (this is the last stage, so it will be built by default)
+FROM final-base as final
+ENTRYPOINT ["chainlink"]
+HEALTHCHECK CMD curl -f http://localhost:6688/health || exit 1
 CMD ["local", "node"]

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -79,6 +79,11 @@ COPY --from=buildgo /go/bin/chainlink-starknet /usr/local/bin/
 COPY --from=buildgo /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/internal/api/libwasmvm.*.so /usr/lib/
 RUN chmod 755 /usr/lib/libwasmvm.*.so
 
+# CCIP specific
+COPY ./cci[p]/confi[g] /ccip-config
+ARG CL_CHAIN_DEFAULTS
+ENV CL_CHAIN_DEFAULTS=${CL_CHAIN_DEFAULTS}
+
 RUN if [ ${CHAINLINK_USER} != root ]; then \
   useradd --uid 14933 --create-home ${CHAINLINK_USER}; \
   fi

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -63,6 +63,8 @@ COPY --from=buildgo /go/bin/chainlink-cosmos /usr/local/bin/
 COPY --from=buildgo /go/bin/chainlink-solana /usr/local/bin/
 ENV CL_SOLANA_CMD chainlink-solana
 COPY --from=buildgo /go/bin/chainlink-starknet /usr/local/bin/
+COPY --from=buildgo /go/bin/chainlink-aptos /usr/local/bin/
+ENV CL_APTOS_CMD chainlink-aptos
 
 # Dependency of CosmWasm/wasmd
 COPY --from=buildgo /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/internal/api/libwasmvm.*.so /usr/lib/

--- a/plugins/scripts/setup_git_auth.sh
+++ b/plugins/scripts/setup_git_auth.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e  # Exit on error
+set -u  # Exit on unset variable
+
+# This script configures git to use a GitHub token for authentication
+# with private repositories during Docker build.
+# Usage in Dockerfile: 
+#   COPY ./scripts/setup_git_auth.sh /tmp/
+#   RUN --mount=type=secret,id=GIT_AUTH_TOKEN /tmp/setup_git_auth.sh
+
+# Check if the token is provided
+if [ -f "/run/secrets/GIT_AUTH_TOKEN" ]; then
+  TOKEN=$(cat /run/secrets/GIT_AUTH_TOKEN)
+  
+  if [ -n "$TOKEN" ]; then
+    # Set git config to use the token for github.com
+    git config --global url."https://oauth2:${TOKEN}@github.com/".insteadOf "https://github.com/"
+    echo "Git configured to use authentication token for GitHub repositories"
+  else
+    echo "No GitHub token content found, continuing without authentication"
+  fi
+else
+  echo "No GitHub token file found, continuing without authentication"
+fi


### PR DESCRIPTION
1. On tag pushes like for `v2.23.0`, we will now build and publish Docker images containing plugins to the public ECR.
2. Adds Aptos support (from a private GH repo for now) to the plugins image.
3. The `nightlies` workflow was made generic so we'll use the new docker build reusable workflow for nightlies as well as PR's and trunk pushes.
    - Once we feel comfortable with this, the following two workflows will be decommissioned: `.github/workflows/build-publish-develop-pr.yml` and `.github/workflows/build-publish-goreleaser.yml`


Installing private plugins was made conditional. The following CI jobs will build with private plugins (Aptos):

- build-docker.yml (nightly, PR, trunk pushes)
- build-publish.yml (on tagged releases)

To build with private plugins locally, you'll run:

```shell
CL_INSTALL_PRIVATE_PLUGINS=true make install-plugins
```

To do the same but with Docker:

```shell
CL_INSTALL_PRIVATE_PLUGINS=true make docker-plugins
```

By default `make install-plugins` and `make docker-plugins` won't install the private plugins.