### PR TITLE
refactor: use the built-in min to simplify the code

### DIFF
--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -164,12 +164,5 @@ func maxReadBytes(sizes readSize) uint32 {
 	if sizes.requestSize == 0 {
 		return sizes.defaultSize
 	}
-	return minUint32(sizes.defaultSize, sizes.requestSize)
-}
-
-func minUint32(a, b uint32) uint32 {
-	if a < b {
-		return a
-	}
-	return b
+	return min(sizes.defaultSize, sizes.requestSize)
 }


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.





<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->



### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->



