### PR TITLE
Update LLO Config Validation to allow CRE Transmitter without Mercury Server

### DIFF
--- a/.changeset/silver-starfishes-tie.md
+++ b/.changeset/silver-starfishes-tie.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-Update LLO Config Validation to allow CRE Transmitter without Mercury Server
+#updated LLO Config Validation to allow CRE Transmitter without Mercury Server

--- a/.changeset/silver-starfishes-tie.md
+++ b/.changeset/silver-starfishes-tie.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Update LLO Config Validation to allow CRE Transmitter without Mercury Server

--- a/core/services/llo/transmitter.go
+++ b/core/services/llo/transmitter.go
@@ -62,8 +62,13 @@ type TransmitterOpts struct {
 
 // The transmitter will handle starting and stopping the subtransmitters
 func NewTransmitter(opts TransmitterOpts) (Transmitter, error) {
-	subTransmitters := []Transmitter{
-		mercurytransmitter.New(&(opts.MercuryTransmitterOpts)),
+	subTransmitters := []Transmitter{}
+
+	if opts.MercuryTransmitterOpts != nil {
+		subTransmitters = append(
+			subTransmitters,
+			mercurytransmitter.New(*opts.MercuryTransmitterOpts),
+		)
 	}
 	for _, cfg := range opts.Subtransmitters {
 		switch cfg.Type {

--- a/core/services/llo/transmitter.go
+++ b/core/services/llo/transmitter.go
@@ -55,7 +55,7 @@ type TransmitterOpts struct {
 	DonID                  uint32
 	VerboseLogging         bool
 	FromAccount            string
-	MercuryTransmitterOpts mercurytransmitter.Opts
+	MercuryTransmitterOpts *mercurytransmitter.Opts
 	Subtransmitters        []config.TransmitterConfig
 	RetirementReportCache  TransmitterRetirementReportCacheWriter
 }
@@ -63,7 +63,7 @@ type TransmitterOpts struct {
 // The transmitter will handle starting and stopping the subtransmitters
 func NewTransmitter(opts TransmitterOpts) (Transmitter, error) {
 	subTransmitters := []Transmitter{
-		mercurytransmitter.New(opts.MercuryTransmitterOpts),
+		mercurytransmitter.New(&(opts.MercuryTransmitterOpts)),
 	}
 	for _, cfg := range opts.Subtransmitters {
 		switch cfg.Type {

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -907,7 +907,7 @@ func (d *Delegate) newServicesMercury(
 	if relayConfig.EnableTriggerCapability && len(jb.OCR2OracleSpec.PluginConfig) == 0 {
 		telemetryType = synchronization.OCR3DataFeeds
 		// First use case for TriggerCapability transmission is Data Feeds, so telemetry should be routed accordingly.
-		// This is only true if TriggerCapability is the *only* transmission method (PluginConfig is empty)..
+		// This is only true if TriggerCapability is the *only* transmission method (PluginConfig is empty).
 	} else {
 		telemetryType = synchronization.OCR3Mercury
 	}

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -907,7 +907,7 @@ func (d *Delegate) newServicesMercury(
 	if relayConfig.EnableTriggerCapability && len(jb.OCR2OracleSpec.PluginConfig) == 0 {
 		telemetryType = synchronization.OCR3DataFeeds
 		// First use case for TriggerCapability transmission is Data Feeds, so telemetry should be routed accordingly.
-		// This is only true if TriggerCapability is the *only* transmission method (PluginConfig is empty).
+		// This is only true if TriggerCapability is the *only* transmission method (PluginConfig is empty)..
 	} else {
 		telemetryType = synchronization.OCR3Mercury
 	}

--- a/core/services/ocr2/plugins/llo/config/config.go
+++ b/core/services/ocr2/plugins/llo/config/config.go
@@ -97,8 +97,8 @@ func (p PluginConfig) Validate() (merr error) {
 		merr = errors.Join(merr, errors.New("llo: DonID must be specified and not zero"))
 	}
 
-	if len(p.Servers) == 0 {
-		merr = errors.Join(merr, errors.New("llo: At least one Mercury server must be specified"))
+	if len(p.Servers) == 0 && len(p.Transmitters) == 0 {
+		merr = errors.Join(merr, errors.New("llo: At least one Mercury server or Transmitter must be specified"))
 	} else {
 		for serverName, serverPubKey := range p.Servers {
 			if err := validateURL(serverName); err != nil {

--- a/core/services/ocr2/plugins/llo/config/config_test.go
+++ b/core/services/ocr2/plugins/llo/config/config_test.go
@@ -138,7 +138,7 @@ func Test_Config(t *testing.T) {
 			err = mc.Validate()
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), `DonID must be specified and not zero`)
-			assert.Contains(t, err.Error(), `At least one Mercury server must be specified`)
+			assert.Contains(t, err.Error(), `At least one Mercury server or Transmitter must be specified`)
 			assert.Contains(t, err.Error(), `ChannelDefinitionsContractAddress is required if ChannelDefinitions is not specified`)
 		})
 	})

--- a/core/services/relay/evm/llo_provider.go
+++ b/core/services/relay/evm/llo_provider.go
@@ -122,7 +122,7 @@ func NewLLOProvider(
 	} else {
 		clients := make(map[string]grpc.Client)
 
-		mercuryServers := mercuryCfg.GetServers()
+		mercuryServers := lloCfg.GetServers()
 
 		for _, server := range mercuryServers {
 			var client grpc.Client

--- a/core/services/relay/evm/llo_provider.go
+++ b/core/services/relay/evm/llo_provider.go
@@ -148,10 +148,10 @@ func NewLLOProvider(
 			clients[server.URL] = client
 		}
 
-		mercuryTransmitterOpts := nil
+		var mercuryTransmitterOpts *mercurytransmitter.Opts = nil
 
 		if len(mercuryServers) > 0 {
-			mercuryTransmitterOpts = mercurytransmitter.Opts{
+			mercuryTransmitterOpts = &mercurytransmitter.Opts{
 				Lggr:                 lggr,
 				VerboseLogging:       mercuryCfg.VerboseLogging(),
 				Cfg:                  mercuryCfg.Transmitter(),
@@ -167,13 +167,13 @@ func NewLLOProvider(
 		// the evm relay into llo package
 		// https://smartcontract-it.atlassian.net/browse/MERC-6847
 		transmitter, err = llo.NewTransmitter(llo.TransmitterOpts{
-			Lggr:           lggr,
-			DonID:          lloCfg.DonID,
-			FromAccount:    csaPub, // NOTE: This may need to change if we support e.g. multiple tranmsmitters, to be a composite of all keys
-			VerboseLogging: mercuryCfg.VerboseLogging(),
+			Lggr:                   lggr,
+			DonID:                  lloCfg.DonID,
+			FromAccount:            csaPub, // NOTE: This may need to change if we support e.g. multiple tranmsmitters, to be a composite of all keys
+			VerboseLogging:         mercuryCfg.VerboseLogging(),
 			MercuryTransmitterOpts: mercuryTransmitterOpts,
-			Subtransmitters:       lloCfg.Transmitters,
-			RetirementReportCache: retirementReportCache,
+			Subtransmitters:        lloCfg.Transmitters,
+			RetirementReportCache:  retirementReportCache,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create LLO transmitter: %w", err)

--- a/core/services/relay/evm/llo_provider.go
+++ b/core/services/relay/evm/llo_provider.go
@@ -121,7 +121,10 @@ func NewLLOProvider(
 		transmitter = bm.NewTransmitter(lggr, csaPub)
 	} else {
 		clients := make(map[string]grpc.Client)
-		for _, server := range lloCfg.GetServers() {
+
+		mercuryServers := mercuryCfg.GetServers()
+
+		for _, server := range mercuryServers {
 			var client grpc.Client
 			switch mercuryCfg.Transmitter().Protocol() {
 			case config.MercuryTransmitterProtocolGRPC:
@@ -144,15 +147,11 @@ func NewLLOProvider(
 			}
 			clients[server.URL] = client
 		}
-		// FIXME: The transmitter instantiation really ought to be moved out of
-		// the evm relay into llo package
-		// https://smartcontract-it.atlassian.net/browse/MERC-6847
-		transmitter, err = llo.NewTransmitter(llo.TransmitterOpts{
-			Lggr:           lggr,
-			DonID:          lloCfg.DonID,
-			FromAccount:    csaPub, // NOTE: This may need to change if we support e.g. multiple tranmsmitters, to be a composite of all keys
-			VerboseLogging: mercuryCfg.VerboseLogging(),
-			MercuryTransmitterOpts: mercurytransmitter.Opts{
+
+		mercuryTransmitterOpts := nil
+
+		if len(mercuryServers) > 0 {
+			mercuryTransmitterOpts = mercurytransmitter.Opts{
 				Lggr:                 lggr,
 				VerboseLogging:       mercuryCfg.VerboseLogging(),
 				Cfg:                  mercuryCfg.Transmitter(),
@@ -161,7 +160,18 @@ func NewLLOProvider(
 				DonID:                lloCfg.DonID,
 				ORM:                  mercurytransmitter.NewORM(ds, relayConfig.LLODONID),
 				CapabilitiesRegistry: capabilitiesRegistry,
-			},
+			}
+		}
+
+		// FIXME: The transmitter instantiation really ought to be moved out of
+		// the evm relay into llo package
+		// https://smartcontract-it.atlassian.net/browse/MERC-6847
+		transmitter, err = llo.NewTransmitter(llo.TransmitterOpts{
+			Lggr:           lggr,
+			DonID:          lloCfg.DonID,
+			FromAccount:    csaPub, // NOTE: This may need to change if we support e.g. multiple tranmsmitters, to be a composite of all keys
+			VerboseLogging: mercuryCfg.VerboseLogging(),
+			MercuryTransmitterOpts: mercuryTransmitterOpts,
 			Subtransmitters:       lloCfg.Transmitters,
 			RetirementReportCache: retirementReportCache,
 		})


### PR DESCRIPTION
Updates LLO Config Validation to allow CRE Transmitter without Mercury Server.

Also doesn't initialise the mercury server if it isn't being used. 