### PR TITLE
core/chains/evm/txm: fix TestLifecycle goroutine leak

### DIFF
--- a/core/chains/evm/txm/txm_test.go
+++ b/core/chains/evm/txm/txm_test.go
@@ -42,7 +42,7 @@ func TestLifecycle(t *testing.T) {
 		txm := NewTxm(lggr, testutils.FixtureChainID, client, nil, txStore, nil, config, keystore)
 		client.On("PendingNonceAt", mock.Anything, address1).Return(uint64(0), errors.New("error")).Once()
 		client.On("PendingNonceAt", mock.Anything, address1).Return(uint64(100), nil).Once()
-		require.NoError(t, txm.Start(tests.Context(t)))
+		servicetest.Run(t, txm)
 		tests.AssertLogEventually(t, observedLogs, "Error when fetching initial nonce")
 		tests.AssertLogEventually(t, observedLogs, fmt.Sprintf("Set initial nonce for address: %v to %d", address1, 100))
 	})


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/14066904344/job/39391626500
```
==================
WARNING: DATA RACE
Read at 0x00c000ae2ac3 by goroutine 966:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1053 +0xca
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1046 +0x9e
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1097 +0x66
  go.uber.org/zap/zaptest.TestingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.[27](https://github.com/smartcontractkit/chainlink/actions/runs/14066904344/job/39391626500#step:22:28).0/zaptest/logger.go:146 +0x11c
  go.uber.org/zap/zaptest.(*TestingWriter).Write()
      <autogenerated>:1 +0x74
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/core.go:99 +0x18d
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:253 +0x1ec
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:355 +0x12c
  go.uber.org/zap.(*SugaredLogger).Debug()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:149 +0x77
  github.com/smartcontractkit/chainlink-common/pkg/logger.(*logger).Debug()
      <autogenerated>:1 +0x1b
  github.com/smartcontractkit/chainlink-common/pkg/logger.(*sugared).Debug()
      <autogenerated>:1 +0x68
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txm.(*Txm).broadcastLoop()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txm/txm.go:234 +0x427
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txm.(*Txm).startAddress.gowrap1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txm/txm.go:136 +0x70

Previous write at 0x00c000ae2ac3 by goroutine 965:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1779 +0x8b9
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.24.0/x64/src/runtime/panic.go:605 +0x5d
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1851 +0x44

Goroutine 966 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txm.(*Txm).startAddress()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txm/txm.go:136 +0x1a6
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txm.TestLifecycle.func1.(*Txm).Start.1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txm/txm.go:125 +0x1d7
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StartOnce()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.5.1-0.20250320205517-3c9893acc471/pkg/services/state.go:93 +0x10a
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txm.(*Txm).Start()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txm/txm.go:112 +0x7e7
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txm.TestLifecycle.func1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txm/txm_test.go:45 +0x7[28](https://github.com/smartcontractkit/chainlink/actions/runs/14066904344/job/39391626500#step:22:29)
  testing.tRunner()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1851 +0x44

Goroutine 965 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1851 +0x8f2
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txm.TestLifecycle()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txm/txm_test.go:[36](https://github.com/smartcontractkit/chainlink/actions/runs/14066904344/job/39391626500#step:22:37) +0x244
  testing.tRunner()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1851 +0x44
==================
```