### PR TITLE
Add removed methods to dummy keystore

### DIFF
--- a/core/chains/evm/txm/txm.go
+++ b/core/chains/evm/txm/txm.go
@@ -352,9 +352,9 @@ func (t *Txm) sendTransactionWithError(ctx context.Context, tx *types.Transactio
 			return
 		}
 	} else if txErr != nil {
-		pendingNonce, err := t.client.PendingNonceAt(ctx, fromAddress)
-		if err != nil {
-			return err
+		pendingNonce, pErr := t.client.PendingNonceAt(ctx, fromAddress)
+		if pErr != nil {
+			return pErr
 		}
 		if pendingNonce <= *tx.Nonce {
 			return fmt.Errorf("pending nonce for txID: %v didn't increase. PendingNonce: %d, TxNonce: %d. TxErr: %w", tx.ID, pendingNonce, *tx.Nonce, txErr)


### PR DESCRIPTION
`DummyKeystore` is used for local testing. Keystore changes didn't update the methods correctly. This PR makes DummyKeystore compatible with the generic Keystore interface.