### PR TITLE
core/services: fix race in Test_workflowRegisteredHandler

### DIFF
--- a/core/services/relay/evm/capabilities/workflows/syncer/workflow_syncer_test.go
+++ b/core/services/relay/evm/capabilities/workflows/syncer/workflow_syncer_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	rand2 "math/rand/v2"
 	"strings"
@@ -830,6 +831,7 @@ func updateWorkflow(
 }
 
 type evtHandler interface {
+	io.Closer
 	Handle(ctx context.Context, event syncer.Event) error
 }
 
@@ -838,7 +840,7 @@ type testSecretsWorkEventHandler struct {
 	registeredCh   chan syncer.Event
 }
 
-func (m *testSecretsWorkEventHandler) Close() error { return nil }
+func (m *testSecretsWorkEventHandler) Close() error { return m.wrappedHandler.Close() }
 
 func (m *testSecretsWorkEventHandler) Handle(ctx context.Context, event syncer.Event) error {
 	switch {

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -588,6 +588,7 @@ func testRunningWorkflow(t *testing.T, tc testCase) {
 		artifactStore := artifacts.NewStoreWithDecryptSecretsFn(lggr, orm, fetcher, clockwork.NewFakeClock(), workflowkey.Key{}, custmsg.NewLabeler(), decrypter.decryptSecrets)
 
 		h := NewEventHandler(lggr, store, registry, emitter, rl, workflowLimits, artifactStore, opts...)
+		t.Cleanup(func() { assert.NoError(t, h.Close()) })
 
 		tc.validationFn(t, ctx, event, h, artifactStore, wfOwner, "workflow-name", wfID)
 	})


### PR DESCRIPTION
Test Race: https://github.com/smartcontractkit/chainlink/actions/runs/14090351839/job/39465245088
```
==================
WARNING: DATA RACE
Read at 0x00c001519543 by goroutine 608:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1059 +0x4e4
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1046 +0x9e
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1097 +0x66
  go.uber.org/zap/zaptest.TestingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zaptest/logger.go:146 +0x11c
  go.uber.org/zap/zaptest.(*TestingWriter).Write()
      <autogenerated>:1 +0x74
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/core.go:99 +0x18d
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:253 +0x1ec
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:355 +0x12c
  go.uber.org/zap.(*SugaredLogger).Debugw()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:251 +0xa4
  github.com/smartcontractkit/chainlink/v2/core/logger.(*zapLogger).Debugw()
      <autogenerated>:1 +0x1f
  github.com/smartcontractkit/chainlink/v2/core/capabilities.(*Registry).Get()
      /home/runner/work/chainlink/chainlink/core/capabilities/registry.go:69 +0x1ce
  github.com/smartcontractkit/chainlink/v2/core/capabilities.(*Registry).GetTrigger()
      /home/runner/work/chainlink/chainlink/core/capabilities/registry.go:80 +0x6e
  github.com/smartcontractkit/chainlink/v2/core/services/workflows.(*Engine).resolveWorkflowCapabilities()
      /home/runner/work/chainlink/chainlink/core/services/workflows/engine.go:198 +0x172
  github.com/smartcontractkit/chainlink/v2/core/services/workflows.(*Engine).init.func1()
      /home/runner/work/chainlink/chainlink/core/services/workflows/engine.go:348 +0x2a9
  github.com/smartcontractkit/chainlink/v2/core/services/workflows.retryable()
      /home/runner/work/chainlink/chainlink/core/services/workflows/retry.go:45 +0x401
  github.com/smartcontractkit/chainlink/v2/core/services/workflows.(*Engine).init()
      /home/runner/work/chainlink/chainlink/core/services/workflows/engine.go:339 +0x224
  github.com/smartcontractkit/chainlink/v2/core/services/workflows.(*Engine).Start.func1.gowrap2()
      /home/runner/work/chainlink/chainlink/core/services/workflows/engine.go:179 +0x4f

Previous write at 0x00c001519543 by goroutine 336:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1779 +0x8b9
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.24.0/x64/src/runtime/panic.go:605 +0x5d
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1851 +0x44

Goroutine 608 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/services/workflows.(*Engine).Start.func1()
      /home/runner/work/chainlink/chainlink/core/services/workflows/engine.go:179 +0xf36
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).StartOnce()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.5.1-0.20250320205517-3c9893acc471/pkg/services/state.go:93 +0x10a
  github.com/smartcontractkit/chainlink/v2/core/services/workflows.(*Engine).Start()
      /home/runner/work/chainlink/chainlink/core/services/workflows/engine.go:153 +0x6c
  github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer.(*eventHandler).workflowRegisteredEvent()
      /home/runner/work/chainlink/chainlink/core/services/workflows/syncer/handler.go:579 +0x155d
  github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer.(*orm).UpsertWorkflowSpecWithSecrets()
      /home/runner/work/chainlink/chainlink/core/services/workflows/syncer/orm.go:289 +0x1e4
  github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer.(*eventHandler).workflowRegisteredEvent()
      /home/runner/work/chainlink/chainlink/core/services/workflows/syncer/handler.go:555 +0x1170
  github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer.Test_workflowRegisteredHandler.func1()
      /home/runner/work/chainlink/chainlink/core/services/workflows/syncer/handler_test.go:283 +0xb7
  github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer.testRunningWorkflow.func1()
      /home/runner/work/chainlink/chainlink/core/services/workflows/syncer/handler_test.go:584 +0x16c2
  testing.tRunner()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1851 +0x44

Goroutine 336 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1851 +0x8f2
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:2279 +0x85
  testing.tRunner()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1792 +0x225
  testing.runTests()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:2277 +0x96c
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:2142 +0xeea
  main.main()
      _testmain.go:75 +0x164
  runtime.main()
      /opt/hostedtoolcache/go/1.24.0/x64/src/runtime/proc.go:283 +0x28a
  github.com/godbus/dbus.(*Conn).Auth()
      /home/runner/go/pkg/mod/github.com/godbus/dbus@v0.0.0-20190726142602-4481cbc300e2/auth.go:97 +0xa31
  github.com/godbus/dbus.(*Conn).Auth()
      /home/runner/go/pkg/mod/github.com/godbus/dbus@v0.0.0-20190726142602-4481cbc300e2/auth.go:86 +0x979
  github.com/godbus/dbus.(*Conn).Auth()
      /home/runner/go/pkg/mod/github.com/godbus/dbus@v0.0.0-20190726142602-4481cbc300e2/auth.go:80 +0x90d
  github.com/godbus/dbus.(*Conn).Auth()
      /home/runner/go/pkg/mod/github.com/godbus/dbus@v0.0.0-20190726142602-4481cbc300e2/auth.go:68 +0x47c
  github.com/godbus/dbus.(*Conn).Auth()
      /home/runner/go/pkg/mod/github.com/godbus/dbus@v0.0.0-20190726142602-4481cbc300e2/auth.go:64 +0x466
  github.com/godbus/dbus.SessionBus()
      /home/runner/go/pkg/mod/github.com/godbus/dbus@v0.0.0-20190726142602-4481cbc300e2/conn.go:67 +0x16d
  github.com/99designs/keyring.init.2()
      /home/runner/go/pkg/mod/github.com/99designs/keyring@v1.2.1/kwallet.go:24 +0x47
==================
```