### PR TITLE
Fix Mercury CapabilitiesRegistry Null Ptr error when no Mercury Servers

### DIFF
--- a/core/services/llo/transmitter.go
+++ b/core/services/llo/transmitter.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	coretypes "github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 )
 
@@ -58,6 +59,7 @@ type TransmitterOpts struct {
 	MercuryTransmitterOpts *mercurytransmitter.Opts
 	Subtransmitters        []config.TransmitterConfig
 	RetirementReportCache  TransmitterRetirementReportCacheWriter
+	CapabilitiesRegistry   coretypes.CapabilitiesRegistry
 }
 
 // The transmitter will handle starting and stopping the subtransmitters
@@ -79,7 +81,7 @@ func NewTransmitter(opts TransmitterOpts) (Transmitter, error) {
 				return nil, fmt.Errorf("failed to unmarshal CRE transmitter config: %w", err)
 			}
 			creTransmitterCfg.Logger = opts.Lggr
-			creTransmitterCfg.CapabilitiesRegistry = opts.MercuryTransmitterOpts.CapabilitiesRegistry
+			creTransmitterCfg.CapabilitiesRegistry = opts.CapabilitiesRegistry
 			creTransmitterCfg.DonID = opts.DonID
 			creTransmitter, err := creTransmitterCfg.NewTransmitter()
 			if err != nil {

--- a/core/services/relay/evm/llo_provider.go
+++ b/core/services/relay/evm/llo_provider.go
@@ -174,6 +174,7 @@ func NewLLOProvider(
 			MercuryTransmitterOpts: mercuryTransmitterOpts,
 			Subtransmitters:        lloCfg.Transmitters,
 			RetirementReportCache:  retirementReportCache,
+			CapabilitiesRegistry:   capabilitiesRegistry,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create LLO transmitter: %w", err)


### PR DESCRIPTION
It's now possible to not run LLO with a Mercury Server, so now we must ensure no MercuryOpts are used when there is no Mercury Sever config available