### PR TITLE
feat: runs-on rollout part 1 (DX-365)

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -95,6 +95,32 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
 
+    - name: Build Cache Key
+      id: build-cache-keys
+      shell: bash
+      env:
+        CACHE_VERSION: ${{ inputs.build-cache-version || inputs.cache-version }}
+        CURRENT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
+        RUNNER_OS: ${{ runner.os }}
+      # Build the cache keys here so that we can guarantee that the cache keys are the same
+      # across the conditional steps below.
+      # --
+      # We use a SHA and the branch name in the cache key, so that build caches can be "upserted".
+      # As a PR progresses, it will continue to use a cache that is relevant to a recent commit.
+      #
+      # If the cache is only created once and reused over the life of a PR, then it will become stale over time.
+      # As the cache would be populated on the first run, and then never updated again.
+      run: |
+        SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
+
+        DEVELOP_KEY_PREFIX="${RUNNER_OS}-gobuild-${CACHE_VERSION}-develop-"
+        KEY_PREFIX="${RUNNER_OS}-gobuild-${CACHE_VERSION}-${CURRENT_BRANCH}-"
+        PRIMARY_KEY="${KEY_PREFIX}${SHORT_SHA}"
+
+        echo "primary-key=${PRIMARY_KEY}" >> $GITHUB_OUTPUT
+        echo "key-prefix=${KEY_PREFIX}" >> $GITHUB_OUTPUT
+        echo "develop-key-prefix=${DEVELOP_KEY_PREFIX}" >> $GITHUB_OUTPUT
+
     - uses: actions/cache/restore@v4
       name: Cache Go Build Outputs (restore)
       # For certain events, we don't necessarily want to create a build cache, but we will benefit from restoring from one.
@@ -102,20 +128,20 @@ runs:
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
-        key: ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-${{ steps.branch-name.outputs.current_branch }}
+        key: ${{ steps.build-cache-keys.outputs.primary-key }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-develop
-          ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-
+          ${{ steps.build-cache-keys.outputs.key-prefix }}
+          ${{ steps.build-cache-keys.outputs.develop-key-prefix }}
 
     - uses: actions/cache@v4
       # don't save cache on merge queue events
       if: ${{ inputs.only-modules == 'false' && (github.event_name != 'merge_group' && inputs.restore-build-cache-only == 'false') }}
+      id: build-cache
       name: Cache Go Build Outputs
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
-        # The lifetime of go build outputs is pretty short, so we make our primary cache key be the branch name
-        key: ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-${{ steps.branch-name.outputs.current_branch }}
+        key: ${{ steps.build-cache-keys.outputs.primary-key }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-develop
-          ${{ runner.os }}-gobuild-${{ inputs.build-cache-version || inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}-
+          ${{ steps.build-cache-keys.outputs.key-prefix }}
+          ${{ steps.build-cache-keys.outputs.develop-key-prefix }}

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -4,25 +4,25 @@ runners:
   4core-8gb-large-ubuntu-s3:
     cpu: 4
     ram: 8
-    family: c7i
+    family: c7
     image: ubuntu24-full-x64
     disk: large
     extras: [ "s3-cache" ]
 
   # Used for ci-core.yml jobs
-  32core-256gb-large-ubuntu-r7iz-s3:
+  32core-256gb-large-ubuntu-r7-s3:
     cpu: 32
     ram: 256
-    family: r7iz
+    family: r7
     disk: large
     image: ubuntu24-full-x64
     extras: [ "s3-cache"]
 
-  # Used for race tests
-  64core-128gb-large-ubuntu-c7i-flex-s3:
+  # Used for race tests / ccip deployment tests
+  64core-128gb-large-ubuntu-c7-s3:
     cpu: 64
     ram: 128
-    family: c7i-flex
+    family: c7
     disk: large
     image: ubuntu24-full-x64
     extras: [ "s3-cache"]

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -205,7 +205,7 @@ jobs:
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: ${{ github.actor != 'dependabot[bot]' }}
     needs: [filter, run-frequency]
-    timeout-minutes: 20
+    timeout-minutes: ${{ github.event_name == 'schedule' && 40 || 20 }} # 40 minute timeout for scheduled events (race tests)
     # runs-on rollout - use self-hosted runners 10% of the time
     runs-on: ${{ needs.run-frequency.outputs.should-use-self-hosted == 'true' && matrix.type.os-self-hosted || matrix.type.os }}
     permissions:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -2,7 +2,7 @@ name: CI Core
 run-name: CI Core ${{ inputs.distinct_run_name && inputs.distinct_run_name || '' }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.distinct_run_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 # Run on key branches to make sure integration is good, otherwise run on all PR's
@@ -107,7 +107,7 @@ jobs:
           GH_EVENT_NAME: ${{ github.event_name }}
         run: |
           # if scheduled, run for all modules. Otherwise, run for only affected modules.
-          if [[ "$GH_EVENT_NAME" == "schedule" ]]; then
+          if [[ "$GH_EVENT_NAME" == "schedule" || "$GH_EVENT_NAME" == "workflow_dispatch" ]]; then
             json_array=$(find . -name 'go.mod' -exec dirname {} \; | sed 's|^./||' | uniq |  jq -R -s -c 'split("\n") | map(select(length > 0))')
             echo "module_names=$json_array" >> "$GITHUB_OUTPUT"
           else
@@ -177,16 +177,12 @@ jobs:
         type:
           - cmd: go_core_tests
             os: ubuntu22.04-32cores-128GB
-            os-self-hosted:
-              - runs-on=${{ github.run_id }}
-              - runner=32core-256gb-large-ubuntu-r7iz-s3
+            os-self-hosted: runs-on=${{ github.run_id }}/cpu=32/ram=256/family=r7/disk=large/extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
 
           - cmd: go_core_tests_integration
             os: ubuntu22.04-32cores-128GB
-            os-self-hosted:
-              - runs-on=${{ github.run_id }}
-              - runner=32core-256gb-large-ubuntu-r7iz-s3
+            os-self-hosted: runs-on=${{ github.run_id }}/cpu=32/ram=256/family=r7/disk=large/extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
 
           - cmd: go_core_fuzz
@@ -196,16 +192,12 @@ jobs:
 
           - cmd: go_core_race_tests
             os: 'ubuntu-latest-32cores-128GB'
-            os-self-hosted:
-              - runs-on=${{ github.run_id }}
-              - runner=64core-128gb-large-ubuntu-c7i-flex-s3
+            os-self-hosted: runs-on=${{ github.run_id }}/cpu=64/ram=128/family=c7/disk=large/extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
 
           - cmd: go_core_ccip_deployment_tests
             os: ubuntu22.04-32cores-128GB
-            os-self-hosted:
-              - runs-on=${{ github.run_id }}
-              - runner=32core-256gb-large-ubuntu-r7iz-s3
+            os-self-hosted: runs-on=${{ github.run_id }}/cpu=32/ram=256/family=r7/disk=large/extras=s3-cache
             build-solana-artifacts: 'true'
             should-run: ${{ needs.filter.outputs.should-run-deployment-tests }}
 
@@ -213,8 +205,9 @@ jobs:
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: ${{ github.actor != 'dependabot[bot]' }}
     needs: [filter, run-frequency]
+    timeout-minutes: 20
     # runs-on rollout - use self-hosted runners 10% of the time
-    runs-on: ${{needs.run-frequency.outputs.should-use-self-hosted == 'true' && matrix.type.os-self-hosted || matrix.type.os }}
+    runs-on: ${{ needs.run-frequency.outputs.should-use-self-hosted == 'true' && matrix.type.os-self-hosted || matrix.type.os }}
     permissions:
       id-token: write
       contents: read
@@ -454,7 +447,8 @@ jobs:
   scan:
     name: SonarQube Scan
     needs: [golangci, core, core-scripts-tests]
-    if: ${{ always() && github.actor != 'dependabot[bot]' }}
+    # If core is cancelled, skip this to not delay the cancellation of the workflow.
+    if: ${{ always() && github.actor != 'dependabot[bot]' && needs.core.result != 'cancelled' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
@@ -635,16 +629,31 @@ jobs:
 
       - name: Self-hosted Runner Frequencies
         id: check-branch
+        env:
+          RUNS_ON_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'runs-on') }}
+          RUNS_ON_OPT_OUT: ${{ contains(github.event.pull_request.labels.*.name, 'runs-on-opt-out') }}
         run: |
-          if ["$GITHUB_EVENT_NAME" == "workflow_dispatch" ]; then
+          if [ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]; then
+            echo "Using self-hosted runners for workflow dispatch events"
             echo "self-hosted-runners=true" | tee -a $GITHUB_OUTPUT
             exit 0
           fi
 
-          exit 0
-          # Only enable for workflow dispatch events for now
-          # Following logic will be used once we've validated the reliability
+          if [ "$RUNS_ON_OPT_OUT" == "true" ]; then
+            echo "Not using self-hosted runners for PR with 'runs-on-opt-out' label"
+            echo "self-hosted-runners=false" | tee -a $GITHUB_OUTPUT
+            exit 0
+          fi
 
+          if [ "$RUNS_ON_LABEL" == "true" ]; then
+            echo "Using self-hosted runners for PR with 'runs-on' label"
+            echo "self-hosted-runners=true" | tee -a $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Not using self-hosted runners for this event"
+
+          exit 0
           if [ "$GITHUB_EVENT_NAME" == "merge_group" ]; then
             echo "self-hosted-runners=false" | tee -a $GITHUB_OUTPUT
             exit 0


### PR DESCRIPTION
Initial rollout for runs-on self hosted runners. 

After this PR is merged, only PRs with `runs-on` label will use self-hosted runners. Incremental rollout will start happening after this PR is merged.

This does change the build cache key but should have minimal to no effect for existing PRs once the proper caches on develop are populated.

### Changes

1. Update runner labels to use inline notation for runners (for now)
2. Update the build cache to use a short `sha` in the key
    - The idea behind this is that our build caches can grow stale but we will never upsert/overwrite them in their current key format. With the ability to have unlimited cache with s3 self-hosted runners, we can effectively `upsert` / `overwrite` our caches everytime a new ref is pushed.
    - Currently, PRs which make multiple changes over time, the build cache is still synced to the first time the workflow was run.
 3. Add a 20 minute timeout to our unit tests. Anything longer than 20 minutes, means something is likely hanging and should fail.
     - This is increased for scheduled runs because race tests are extended during these.
 5. Add opt-in / opt-out labels for self-hosted runners
	 - If a PR now adds `runs-on` it will use self-hosted runners
	 - When we start rolling this out across PRs, if the PR has `runs-on-opt-out` label it will use Github runners
6. Do not run sonarqube scan if the workflow was cancelled.
	- This job was configured with an `always()` which means it would still run even if the workflow was cancelled, and it was annoying.

### Notes

There are some problems with the self-hosted runners. Although they are rare its possible:
1. We do use spot instances when possible and spot instances can be interrupted, so sometimes a job will fail.
	- We do have automatic retries on, so if a job is interrupted by a spot instance termination, it will be automatically retried (this creates problem - see point 2)
	- I have seen it a few times in testing. If this is happening too often, then there are also ways to reduce the occurrence.
	- ie. Only use on-demand instances for merge queue so it won't interrupt crucial workflows.
2. Automatic retries will interrupt new workflow runs:
   - If a job is cancelled due to a spot instance termination, and another commit is pushed, then runs-on will retry the already failed job, which will cause the newer workflow to fail. 
   - This is a very rare edge case that shouldn't pop up too much, if it does there are ways to disable automatic retries.

### Testing

I have [run a ton of tests](https://github.com/smartcontractkit/chainlink/actions/workflows/ci-core.yml?query=branch%3Afeat%2Fruns-on-rollout-1) using this PR / branch:

- https://github.com/smartcontractkit/chainlink/actions/runs/14227410891/job/39870270989?pr=17026
- https://github.com/smartcontractkit/chainlink/actions/runs/14227773342/job/39871366996?pr=17026
- https://github.com/smartcontractkit/chainlink/actions/runs/14228065115/job/39872249724?pr=17026
- https://github.com/smartcontractkit/chainlink/actions/runs/14228352375/job/39873206071?pr=17026
- https://github.com/smartcontractkit/chainlink/actions/runs/14228563782/job/39874763941?pr=17026
- https://github.com/smartcontractkit/chainlink/actions/runs/14229343564/job/39876406784?pr=17026
- https://github.com/smartcontractkit/chainlink/actions/runs/14229528429/job/39877094165?pr=17026
- https://github.com/smartcontractkit/chainlink/actions/runs/14229918030/job/39878180631?pr=17026
- https://github.com/smartcontractkit/chainlink/actions/runs/14230168886/job/39878949951?pr=17026
- https://github.com/smartcontractkit/chainlink/actions/runs/14230478702/job/39879954354?pr=17026


---

DX-365
