### PR TITLE
[CLD-50]: fix(operations): ensure valid hash key and stable ordering

### DIFF
--- a/deployment/operations/execute.go
+++ b/deployment/operations/execute.go
@@ -1,11 +1,7 @@
 package operations
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"sync"
 
 	"github.com/avast/retry-go/v4"
 )
@@ -162,34 +158,6 @@ func ExecuteSequence[IN, OUT, DEP any](
 // This allows the operation to fail fast if it encounters an unrecoverable error.
 func NewUnrecoverableError(err error) error {
 	return retry.Unrecoverable(err)
-}
-
-func constructUniqueHashFrom(hashCache *sync.Map, def Definition, input any) (string, error) {
-	// Create cache key by combining def and input
-	key := struct {
-		Def   Definition
-		Input any
-	}{def, input}
-
-	if cached, ok := hashCache.Load(key); ok {
-		return cached.(string), nil
-	}
-
-	// Calculate hash if not in cache
-	defBytes, err := json.Marshal(def)
-	if err != nil {
-		return "", err
-	}
-	inputBytes, err := json.Marshal(input)
-	if err != nil {
-		return "", err
-	}
-
-	hash := sha256.Sum256(append(defBytes, inputBytes...))
-	result := hex.EncodeToString(hash[:])
-
-	hashCache.Store(key, result)
-	return result, nil
 }
 
 func loadPreviousSuccessfulReport[IN, OUT any](

--- a/deployment/operations/hashing.go
+++ b/deployment/operations/hashing.go
@@ -1,0 +1,84 @@
+package operations
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"sync"
+)
+
+func constructUniqueHashFrom(hashCache *sync.Map, def Definition, input any) (string, error) {
+	// convert def and input into string to be used as cachekey
+	// as input can be any type, some types cannot be used as cache argument for sync.map
+	// converting to string ensure argument is always valid
+
+	key, err := json.Marshal(def)
+	if err != nil {
+		return "", err
+	}
+
+	// convert to a canonical representation that's stable regardless of field order
+	// If the keys are not sorted, the hash generated can be different in maps.
+	inputBytes, err := canonicalizeJSON(input)
+	if err != nil {
+		return "", err
+	}
+
+	key = append(key, inputBytes...)
+	if cached, ok := hashCache.Load(string(key)); ok {
+		return cached.(string), nil
+	}
+
+	hash := sha256.Sum256(key)
+	result := hex.EncodeToString(hash[:])
+
+	hashCache.Store(string(key), result)
+	return result, nil
+}
+
+// canonicalizeJSON converts value to a canonical JSON representation with sorted keys
+func canonicalizeJSON(value any) ([]byte, error) {
+	// First marshal to standard JSON
+	b, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal into a structure that can be canonically marshaled
+	var data any
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.UseNumber()
+	if err := decoder.Decode(&data); err != nil {
+		return nil, err
+	}
+	// Marshal with sorted keys
+	return json.Marshal(canonicalize(data))
+}
+
+// canonicalize recursively processes data structures for stable serialization
+func canonicalize(data any) any {
+	switch v := data.(type) {
+	case map[string]any:
+		// For maps, create a sorted representation
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		m := make(map[string]any, len(v))
+		for _, k := range keys {
+			m[k] = canonicalize(v[k]) // Recursively process values
+		}
+		return m
+
+	case []any:
+		// For arrays, recursively process each element
+		for i, val := range v {
+			v[i] = canonicalize(val)
+		}
+	}
+	return data
+}

--- a/deployment/operations/hashing_test.go
+++ b/deployment/operations/hashing_test.go
@@ -1,0 +1,202 @@
+package operations
+
+import (
+	"encoding/json"
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type argument struct {
+	def   Definition
+	input any
+}
+
+func Test_constructUniqueHashFrom(t *testing.T) {
+	t.Parallel()
+
+	type Input struct {
+		A int
+		B int
+	}
+
+	definition := Definition{
+		ID:          "plus1",
+		Version:     semver.MustParse("1.0.0"),
+		Description: "plus 1",
+	}
+	altDefinition := Definition{
+		ID:          "plus2",
+		Version:     semver.MustParse("1.0.0"),
+		Description: "plus 2",
+	}
+
+	tests := []struct {
+		name           string
+		left           argument
+		right          argument
+		wantSame       bool
+		wantErr        string
+		skipCacheCheck bool
+	}{
+		{
+			name: "Same def and input should have same hash (struct)",
+			left: argument{
+				def:   definition,
+				input: Input{A: 1, B: 2},
+			},
+			right: argument{
+				def:   definition,
+				input: Input{A: 1, B: 2},
+			},
+			wantSame: true,
+		},
+		{
+			name: "Same def but different input should have different hash",
+			left: argument{
+				def:   definition,
+				input: Input{A: 1, B: 2},
+			},
+			right: argument{
+				def:   definition,
+				input: Input{A: 2, B: 1},
+			},
+			wantSame: false,
+		},
+		{
+			name: "Same def but different literal input should have different hash",
+			left: argument{
+				def:   definition,
+				input: 2,
+			},
+			right: argument{
+				def:   definition,
+				input: 1,
+			},
+			wantSame: false,
+		},
+		{
+			name: "Different def same input should have different hash",
+			left: argument{
+				def:   definition,
+				input: Input{A: 1, B: 2},
+			},
+			right: argument{
+				def:   altDefinition,
+				input: Input{A: 1, B: 2},
+			},
+			wantSame: false,
+		},
+		{
+			name: "Invalid input should error",
+			left: argument{
+				def:   definition,
+				input: math.NaN(),
+			},
+			right: argument{
+				def:   definition,
+				input: math.NaN(),
+			},
+			wantErr:        "json: unsupported value: NaN",
+			skipCacheCheck: true,
+		},
+		{
+			name: "different order of map keys should have the same hash",
+			left: argument{
+				def: definition,
+				input: map[string]any{
+					"a": 1,
+					"b": 2,
+					"c": 3,
+				},
+			},
+			right: argument{
+				def: definition,
+				input: map[string]any{
+					"b": 2,
+					"c": 3,
+					"a": 1,
+				},
+			},
+			wantSame: true,
+		},
+		{
+			name: "different order of nested struct in a slice should have the same hash",
+			left: argument{
+				def: definition,
+				input: []map[string]any{
+					{
+						"a": 1,
+						"b": 2,
+					},
+					{
+						"b": 2,
+						"a": 1,
+					},
+				}},
+			right: argument{
+				def: definition,
+				input: []map[string]any{
+					{
+						"b": 2,
+						"a": 1,
+					},
+					{
+						"a": 1,
+						"b": 2,
+					},
+				},
+			},
+			wantSame: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cache := &sync.Map{}
+			hash1, err1 := constructUniqueHashFrom(cache, tt.left.def, tt.left.input)
+			hash2, err2 := constructUniqueHashFrom(&sync.Map{}, tt.right.def, tt.right.input)
+
+			if tt.wantErr != "" {
+				require.Error(t, err1)
+				require.Error(t, err2)
+				require.ErrorContains(t, err1, tt.wantErr)
+				require.ErrorContains(t, err2, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err1)
+			require.NoError(t, err2)
+
+			if tt.wantSame {
+				assert.Equal(t, hash1, hash2)
+			} else {
+				assert.NotEqual(t, hash1, hash2)
+			}
+
+			if !tt.skipCacheCheck {
+				// Verify cache behavior
+				defBytes1, err := json.Marshal(tt.left.def)
+				require.NoError(t, err)
+				inputBytes1, err := json.Marshal(tt.left.input)
+				require.NoError(t, err)
+				cacheKey1 := string(append(defBytes1, inputBytes1...))
+
+				cached1, ok := cache.Load(cacheKey1)
+				require.True(t, ok)
+				assert.Equal(t, hash1, cached1)
+
+				// Second call should use cache
+				cachedHash1, err := constructUniqueHashFrom(cache, tt.left.def, tt.left.input)
+				require.NoError(t, err)
+				assert.Equal(t, hash1, cachedHash1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When constructing hash from the report to check if operation has been executed previously to support the idempotency behaviour. 2 issues were identified:
- a different ordering of data in map changes the hash generated
- not all type can be used as key for sync.map (must be comparable, eg slices and map are not comparable)

This commit introduces fixes for the above 2 scenarios. Data in map are now sorted before converting into hash for comparison. Key for syncmap are serialised into string before being used as cache key, string is always a valid cache key.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-50
