### PR TITLE
[CLD-50]: fix(operations): improve report type conversion

### DIFF
--- a/deployment/operations/execute_test.go
+++ b/deployment/operations/execute_test.go
@@ -538,9 +538,9 @@ func Test_loadPreviousSuccessfulReport(t *testing.T) {
 	tests := []struct {
 		name          string
 		setupReporter func() Reporter
-		input         any
+		input         float64
 		wantDef       Definition
-		wantInput     int
+		wantInput     float64
 		wantFound     bool
 	}{
 		{
@@ -618,12 +618,12 @@ func Test_loadPreviousSuccessfulReport(t *testing.T) {
 				bundle.reporter = tt.setupReporter()
 			}
 
-			report, found := loadPreviousSuccessfulReport[any, int](bundle, definition, tt.input)
+			report, found := loadPreviousSuccessfulReport[float64, int](bundle, definition, tt.input)
 			assert.Equal(t, tt.wantFound, found)
 
 			if tt.wantFound {
 				assert.Equal(t, tt.wantDef, report.Def)
-				assert.Equal(t, tt.wantInput, report.Input)
+				assert.InDelta(t, tt.wantInput, report.Input, 0)
 			}
 		})
 	}

--- a/deployment/operations/report_test.go
+++ b/deployment/operations/report_test.go
@@ -117,17 +117,26 @@ func Test_typeReport(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
+
+	type Input struct {
+		A int
+	}
+
 	report := Report[any, any]{
 		ID:                    "1",
 		Def:                   Definition{},
-		Output:                2,
-		Input:                 1,
+		Output:                float64(2),
+		Input:                 map[string]interface{}{"a": 1},
 		Timestamp:             &now,
 		Err:                   nil,
 		ChildOperationReports: []string{uuid.New().String()},
 	}
 
-	_, ok := typeReport[int, int](report)
+	_, ok := typeReport[map[string]interface{}, float64](report)
+	assert.True(t, ok)
+
+	// supports unmarshalling into a different type as long it is compatible
+	_, ok = typeReport[Input, int](report)
 	assert.True(t, ok)
 
 	// incorrect input type


### PR DESCRIPTION
Operations reports are read from disk and will be consumed during operation execution during migration. There will be a point where we need to convert the type from Report[any,any] into Report[IN,OUT] due to the type information being known later during the execution.

However, the existing conversion method was incorrect as the type casting is not reliable enough since when json marshalling and unmarshalling, the type information is lost, struct is converted into maps and int becomes float64. Eg when marshaling a struct and unmarhalling back it becomes a map[string]interface{}.

This commit addresses this by using json.unmarshal to perform the type conversion instead which is more reliable.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-50
