### PR TITLE
[CLD-50]: fix(operations): guard against invalid input and output

### DIFF
--- a/deployment/operations/validation.go
+++ b/deployment/operations/validation.go
@@ -1,0 +1,101 @@
+package operations
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+// IsSerializable returns true if the value can be marshaled and unmarshaled without losing information, false otherwise.
+// For idempotency and reporting purposes, we need to ensure that the value can be marshaled and unmarshaled
+// without losing information.
+// If the value implements json.Marshaler and json.Unmarshaler, it is assumed to be serializable.
+func IsSerializable(lggr logger.Logger, v any) bool {
+	if !isValueSerializable(lggr, reflect.ValueOf(v)) {
+		return false
+	}
+
+	_, err := json.Marshal(v)
+	if err != nil {
+		lggr.Errorw("Failed to marshal value", "err", err)
+		return false
+	}
+
+	return true
+}
+
+func isValueSerializable(lggr logger.Logger, v reflect.Value) bool {
+	// Handle nil values
+	if !v.IsValid() {
+		return true
+	}
+
+	// Check if type implements json.Marshaler and json.Unmarshaler
+	t := v.Type()
+	marshalType := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	unmarshalType := reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
+
+	// If it implements both interfaces, assume it's serializable
+	if t.Implements(marshalType) && t.Implements(unmarshalType) {
+		return true
+	}
+
+	// Dereference pointers to get to the underlying value
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return true
+		}
+		return isValueSerializable(lggr, v.Elem())
+	}
+
+	// Rest of implementation for other types...
+	switch v.Kind() {
+	case reflect.Struct:
+		// Check if each field is serializable
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			fieldType := v.Type().Field(i)
+
+			// Check for json:"-" tag and skip those fields
+			jsonTag := fieldType.Tag.Get("json")
+			if jsonTag == "-" {
+				continue
+			}
+
+			// Check if the field is exported (public)
+			if !v.Type().Field(i).IsExported() {
+				lggr.Errorw("Struct contains unexported field",
+					"struct", v.Type().Name(),
+					"field", v.Type().Field(i).Name)
+				return false
+			}
+			if !isValueSerializable(lggr, field) {
+				return false
+			}
+		}
+		return true
+
+	case reflect.Map:
+		// Check all values in the map
+		for _, key := range v.MapKeys() {
+			if !isValueSerializable(lggr, v.MapIndex(key)) {
+				return false
+			}
+		}
+		return true
+
+	case reflect.Slice, reflect.Array:
+		// Check each element
+		for i := 0; i < v.Len(); i++ {
+			if !isValueSerializable(lggr, v.Index(i)) {
+				return false
+			}
+		}
+		return true
+
+	default:
+		// Basic types (string, int, float, etc.) are serializable
+		return true
+	}
+}

--- a/deployment/operations/validation_test.go
+++ b/deployment/operations/validation_test.go
@@ -1,0 +1,234 @@
+package operations
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	mcmslib "github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func Test_IsSerializable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		v    any
+		want bool
+	}{
+		{
+			name: "should serialise nil",
+			v:    nil,
+			want: true,
+		},
+		{
+			name: "should serialise pointer to nil",
+			v:    (*int)(nil),
+			want: true,
+		},
+		{
+			name: "should serialise string",
+			v:    "test",
+			want: true,
+		},
+		{
+			name: "should serialise int",
+			v:    42,
+			want: true,
+		},
+		{
+			name: "should serialise slice",
+			v:    []string{"a", "b", "c"},
+			want: true,
+		},
+		{
+			name: "should serialise map with string keys",
+			v:    map[string]int{"a": 1, "b": 2},
+			want: true,
+		},
+		{
+			name: "should serialise map with non-string keys",
+			v:    map[int]string{1: "a", 2: "b"},
+			want: true,
+		},
+		{
+			name: "should serialise serializableStruct",
+			v:    serializableStruct{Name: "test", Age: 30, Numbers: []int{1, 2, 3}},
+			want: true,
+		},
+		{
+			name: "should serialise pointer to serializableStruct",
+			v:    &serializableStruct{Name: "test", Age: 30},
+			want: true,
+		},
+		{
+			name: "should serialise nil pointer",
+			v:    (*serializableStruct)(nil),
+			want: true,
+		},
+		{
+			name: "should serialise pointer customMarshaler - implements MarshalJSON & UnmarshalJSON",
+			v:    &customMarshaler{data: "test"},
+			want: true,
+		},
+		{
+			name: "should fail to serialise value customMarshaler - does not implements MarshalJSON & UnmarshalJSON",
+			v:    customMarshaler{data: "test"},
+			want: false,
+		},
+		{
+			name: "should serialise nested struct",
+			v: struct {
+				Inner serializableStruct
+				Data  string
+			}{
+				Inner: serializableStruct{Name: "inner", Age: 25},
+				Data:  "outer",
+			},
+			want: true,
+		},
+		{
+			name: "should fail to serialise nested private field",
+			v: struct {
+				Inner customPrivateStruct
+				Data  string
+			}{
+				Inner: customPrivateStruct{
+					Public:  "public",
+					private: "private",
+				},
+				Data: "outer",
+			},
+			want: false,
+		},
+		{
+			name: "should fail to serialise function",
+			v: customFunctionStruct{Action: func() bool {
+				return true
+			}},
+			want: false,
+		},
+		{
+			name: "should serialise function with json tag '-'",
+			v: customFunctionStructWithTag{Action: func() bool {
+				return true
+			}},
+			want: true,
+		},
+		{
+			name: "should serialise success report",
+			v: NewReport(Definition{
+				ID:          "test",
+				Version:     semver.MustParse("1.0.0"),
+				Description: "test description",
+			}, "test", "test", nil, "child-id"),
+			want: true,
+		},
+		{
+			name: "should serialise error report",
+			v: NewReport(Definition{
+				ID:          "test",
+				Version:     semver.MustParse("1.0.0"),
+				Description: "test description",
+			}, "test", "test", errors.New("error report"), "child-id"),
+			want: true,
+		},
+		{
+			name: "should serialise TimelockProposal",
+			v:    createMCMSTimelockProposal(t),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			lggr := logger.TestLogger(t)
+			if got := IsSerializable(lggr, tt.v); got != tt.want {
+				t.Errorf("IsSerializable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func createMCMSTimelockProposal(t *testing.T) *mcmslib.TimelockProposal {
+	futureTime := time.Now().Add(time.Hour * 72).Unix()
+	builder := mcmslib.NewTimelockProposalBuilder()
+	builder.
+		SetVersion("v1").
+		SetAction(types.TimelockActionSchedule).
+		// #nosec G115
+		SetValidUntil(uint32(futureTime)).
+		SetDescription("mcms description").
+		SetDelay(types.NewDuration(1 * time.Hour)).
+		SetOverridePreviousRoot(true).
+		SetChainMetadata(map[types.ChainSelector]types.ChainMetadata{
+			types.ChainSelector(chainsel.ETHEREUM_MAINNET.Selector): {
+				StartingOpCount:  1,
+				MCMAddress:       "abc",
+				AdditionalFields: nil,
+			},
+		}).
+		SetTimelockAddresses(map[types.ChainSelector]string{
+			types.ChainSelector(chainsel.ETHEREUM_MAINNET.Selector): "0x123",
+		}).
+		SetOperations([]types.BatchOperation{
+			{
+				ChainSelector: types.ChainSelector(chainsel.ETHEREUM_MAINNET.Selector),
+				Transactions: []types.Transaction{
+					{
+						OperationMetadata: types.OperationMetadata{
+							ContractType: "test",
+						},
+						To:               "0x123",
+						Data:             []byte{1, 2, 3},
+						AdditionalFields: json.RawMessage(`{"test": "test"}`),
+					},
+				},
+			},
+		})
+
+	proposal, err := builder.Build()
+	require.NoError(t, err)
+	return proposal
+}
+
+type customFunctionStruct struct {
+	Action func() bool
+}
+
+type customFunctionStructWithTag struct {
+	Action func() bool `json:"-"`
+}
+
+type customPrivateStruct struct {
+	Public  string
+	private string
+}
+
+type serializableStruct struct {
+	Name    string
+	Age     int
+	Numbers []int
+}
+
+// Implement json.Marshaler and json.Unmarshaler via pointer receiver
+type customMarshaler struct {
+	data string
+}
+
+func (c *customMarshaler) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.data)
+}
+
+func (c *customMarshaler) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &c.data)
+}


### PR DESCRIPTION
For operations, since input and output are "any" type, and not all types can be safely written into JSON without data lost. eg struct with unexported fields.

This commit introduces runtime check on the input and output using reflection for unexported fields including nested fields.

To get around this check, devs can either change to use plain native golang type, or struct with only exported members or implement the json.marshaler and json.unmarshaler interface.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-50

