### PR TITLE
[CLD-50]: fix(operations): make report fully serialiazable

### DIFF
--- a/deployment/operations/execute.go
+++ b/deployment/operations/execute.go
@@ -88,7 +88,10 @@ func ExecuteOperation[IN, OUT, DEP any](
 	if err != nil {
 		return Report[IN, OUT]{}, err
 	}
-	return report, report.Err
+	if report.Err != nil {
+		return report, report.Err
+	}
+	return report, nil
 }
 
 // ExecuteSequence executes a Sequence and returns a SequenceReport.
@@ -148,7 +151,10 @@ func ExecuteSequence[IN, OUT, DEP any](
 	if err != nil {
 		return SequenceReport[IN, OUT]{}, err
 	}
-	return SequenceReport[IN, OUT]{report, executionReports}, report.Err
+	if report.Err != nil {
+		return SequenceReport[IN, OUT]{report, executionReports}, report.Err
+	}
+	return SequenceReport[IN, OUT]{report, executionReports}, nil
 }
 
 // NewUnrecoverableError creates an error that indicates an unrecoverable error.

--- a/deployment/operations/execute_test.go
+++ b/deployment/operations/execute_test.go
@@ -84,7 +84,7 @@ func Test_ExecuteOperation(t *testing.T) {
 				require.ErrorContains(t, res.Err, tt.wantErr)
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {
-				require.NoError(t, res.Err)
+				require.Nil(t, res.Err)
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantOutput, res.Output)
 			}
@@ -113,7 +113,7 @@ func Test_ExecuteOperation_ErrorReporter(t *testing.T) {
 	res, err := ExecuteOperation(e, op, nil, 1)
 	require.Error(t, err)
 	require.ErrorContains(t, err, reportErr.Error())
-	require.NoError(t, res.Err)
+	require.Nil(t, res.Err)
 }
 
 func Test_ExecuteOperation_WithPreviousRun(t *testing.T) {
@@ -137,21 +137,21 @@ func Test_ExecuteOperation_WithPreviousRun(t *testing.T) {
 	// first run
 	res, err := ExecuteOperation(bundle, op, nil, 1)
 	require.NoError(t, err)
-	require.NoError(t, res.Err)
+	require.Nil(t, res.Err)
 	assert.Equal(t, 2, res.Output)
 	assert.Equal(t, 1, handlerCalledTimes)
 
 	// rerun should return previous report
 	res, err = ExecuteOperation(bundle, op, nil, 1)
 	require.NoError(t, err)
-	require.NoError(t, res.Err)
+	require.Nil(t, res.Err)
 	assert.Equal(t, 2, res.Output)
 	assert.Equal(t, 1, handlerCalledTimes)
 
 	// new run with different input, should perform execution
 	res, err = ExecuteOperation(bundle, op, nil, 3)
 	require.NoError(t, err)
-	require.NoError(t, res.Err)
+	require.Nil(t, res.Err)
 	assert.Equal(t, 4, res.Output)
 	assert.Equal(t, 2, handlerCalledTimes)
 
@@ -159,7 +159,7 @@ func Test_ExecuteOperation_WithPreviousRun(t *testing.T) {
 	op = NewOperation("plus1-v2", semver.MustParse("2.0.0"), "test operation", handler)
 	res, err = ExecuteOperation(bundle, op, nil, 1)
 	require.NoError(t, err)
-	require.NoError(t, res.Err)
+	require.Nil(t, res.Err)
 	assert.Equal(t, 2, res.Output)
 	assert.Equal(t, 3, handlerCalledTimes)
 
@@ -235,7 +235,7 @@ func Test_ExecuteSequence(t *testing.T) {
 				require.ErrorContains(t, seqReport.Err, tt.wantErr)
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {
-				require.NoError(t, seqReport.Err)
+				require.Nil(t, seqReport.Err)
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantOutput, seqReport.Output)
 			}
@@ -286,7 +286,7 @@ func Test_ExecuteSequence_WithPreviousRun(t *testing.T) {
 	// first run
 	res, err := ExecuteSequence(bundle, sequence, nil, 1)
 	require.NoError(t, err)
-	require.NoError(t, res.Err)
+	require.Nil(t, res.Err)
 	assert.Equal(t, 2, res.Output)
 	assert.Len(t, res.ExecutionReports, 2) // 1 seq report + 1 op report
 	assert.Equal(t, 1, handlerCalledTimes)
@@ -297,7 +297,7 @@ func Test_ExecuteSequence_WithPreviousRun(t *testing.T) {
 	// rerun should return previous report
 	res, err = ExecuteSequence(bundle, sequence, nil, 1)
 	require.NoError(t, err)
-	require.NoError(t, res.Err)
+	require.Nil(t, res.Err)
 	assert.Equal(t, 2, res.Output)
 	assert.Len(t, res.ExecutionReports, 2) // 1 seq report + 1 op report
 	assert.Equal(t, 1, handlerCalledTimes)
@@ -305,7 +305,7 @@ func Test_ExecuteSequence_WithPreviousRun(t *testing.T) {
 	// new run with different input, should perform execution
 	res, err = ExecuteSequence(bundle, sequence, nil, 3)
 	require.NoError(t, err)
-	require.NoError(t, res.Err)
+	require.Nil(t, res.Err)
 	assert.Equal(t, 4, res.Output)
 	assert.Len(t, res.ExecutionReports, 2) // 1 seq report + 1 op report
 	assert.Equal(t, 2, handlerCalledTimes)
@@ -314,7 +314,7 @@ func Test_ExecuteSequence_WithPreviousRun(t *testing.T) {
 	sequence = NewSequence("seq-plus1-v2", semver.MustParse("2.0.0"), "plus 1", handler)
 	res, err = ExecuteSequence(bundle, sequence, nil, 1)
 	require.NoError(t, err)
-	require.NoError(t, res.Err)
+	require.Nil(t, res.Err)
 	assert.Equal(t, 2, res.Output)
 	// only 1 because the op was not executed due to previous execution found
 	assert.Len(t, res.ExecutionReports, 1)

--- a/deployment/operations/report_test.go
+++ b/deployment/operations/report_test.go
@@ -14,12 +14,13 @@ import (
 func Test_MemoryReporter(t *testing.T) {
 	t.Parallel()
 
+	now := time.Now()
 	existingReport := Report[any, any]{
 		ID:                    "1",
 		Def:                   Definition{},
 		Output:                "2",
 		Input:                 1,
-		Timestamp:             time.Now(),
+		Timestamp:             &now,
 		ChildOperationReports: []string{uuid.New().String()},
 	}
 
@@ -39,7 +40,7 @@ func Test_MemoryReporter(t *testing.T) {
 		Def:       Definition{},
 		Output:    "3",
 		Input:     2,
-		Timestamp: time.Now(),
+		Timestamp: &now,
 	}
 	err = reporter.AddReport(newReport)
 	require.NoError(t, err)
@@ -73,7 +74,7 @@ func Test_NewReport(t *testing.T) {
 	assert.Equal(t, 1, report.Input)
 	assert.Equal(t, 2, report.Output)
 	assert.NotEmpty(t, report.Timestamp)
-	assert.Equal(t, testErr, report.Err)
+	require.ErrorContains(t, report.Err, testErr.Error())
 	assert.Len(t, report.ChildOperationReports, 1)
 	assert.Equal(t, childOperationID, report.ChildOperationReports[0])
 }
@@ -81,12 +82,13 @@ func Test_NewReport(t *testing.T) {
 func Test_RecentReporter(t *testing.T) {
 	t.Parallel()
 
+	now := time.Now()
 	existingReport := Report[any, any]{
 		ID:                    "1",
 		Def:                   Definition{},
 		Output:                "2",
 		Input:                 1,
-		Timestamp:             time.Now(),
+		Timestamp:             &now,
 		ChildOperationReports: []string{uuid.New().String()},
 	}
 
@@ -102,7 +104,7 @@ func Test_RecentReporter(t *testing.T) {
 		Def:       Definition{},
 		Output:    "3",
 		Input:     2,
-		Timestamp: time.Now(),
+		Timestamp: &now,
 	}
 	err := recentReporter.AddReport(newReport)
 	require.NoError(t, err)
@@ -114,12 +116,13 @@ func Test_RecentReporter(t *testing.T) {
 func Test_typeReport(t *testing.T) {
 	t.Parallel()
 
+	now := time.Now()
 	report := Report[any, any]{
 		ID:                    "1",
 		Def:                   Definition{},
 		Output:                2,
 		Input:                 1,
-		Timestamp:             time.Now(),
+		Timestamp:             &now,
 		Err:                   nil,
 		ChildOperationReports: []string{uuid.New().String()},
 	}


### PR DESCRIPTION
Currently operations report has 2 fields which are not fully serializable
- Timestamp time.Time
- Err error

`Timestamp` is not serialisable because it has exported fields (potential data lost), however by changing it to pointer, it implements json.marshaler and json.unmarshaler which formats time to RFC 3339.

`Error` is an interface, and error object does not have an exported field so serialising error becomes an empty struct {}. Creating a new error with exported `Message` field allows serialization to write the message to json.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-50

