### PR TITLE
DF jd refactor

### DIFF
--- a/deployment/data-feeds/changeset/jd_delete_jobs.go
+++ b/deployment/data-feeds/changeset/jd_delete_jobs.go
@@ -2,6 +2,7 @@ package changeset
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -13,17 +14,20 @@ const (
 	deleteJobTimeout = 120 * time.Second
 )
 
-// DeleteJobsJDChangeset is a changeset that deletes jobs from JD
+// DeleteJobsJDChangeset is a changeset that deletes jobs from JD either using job ids or workflow name
 var DeleteJobsJDChangeset = deployment.CreateChangeSet(deleteJobsJDLogic, deleteJobsJDPrecondition)
 
 func deleteJobsJDLogic(env deployment.Environment, c types.DeleteJobsConfig) (deployment.ChangesetOutput, error) {
 	ctx, cancel := context.WithTimeout(env.GetContext(), deleteJobTimeout)
 	defer cancel()
 
-	offchain.DeleteJobs(ctx, env, c.JobIDs)
+	offchain.DeleteJobs(ctx, env, c.JobIDs, c.WorkflowName)
 	return deployment.ChangesetOutput{}, nil
 }
 
 func deleteJobsJDPrecondition(_ deployment.Environment, c types.DeleteJobsConfig) error {
+	if len(c.JobIDs) == 0 && c.WorkflowName == "" {
+		return errors.New("job ids or workflow name are required")
+	}
 	return nil
 }

--- a/deployment/data-feeds/changeset/jd_propose_bt_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_bt_jobs.go
@@ -27,7 +27,7 @@ func proposeBtJobsToJDLogic(env deployment.Environment, c types.ProposeBtJobsCon
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to create job spec from bootstrap: %w", err)
 	}
 
-	return offchain.ProposeJobs(ctx, env, bootstrapJobSpec, c.NodeFilter)
+	return offchain.ProposeJobs(ctx, env, bootstrapJobSpec, "", c.NodeFilter)
 }
 
 func proposeBtJobsToJDPrecondition(env deployment.Environment, c types.ProposeBtJobsConfig) error {

--- a/deployment/data-feeds/changeset/jd_propose_bt_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_bt_jobs.go
@@ -27,7 +27,7 @@ func proposeBtJobsToJDLogic(env deployment.Environment, c types.ProposeBtJobsCon
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to create job spec from bootstrap: %w", err)
 	}
 
-	return offchain.ProposeJobs(ctx, env, bootstrapJobSpec, "", c.NodeFilter)
+	return offchain.ProposeJobs(ctx, env, bootstrapJobSpec, nil, c.NodeFilter)
 }
 
 func proposeBtJobsToJDPrecondition(env deployment.Environment, c types.ProposeBtJobsConfig) error {

--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
@@ -28,7 +28,7 @@ func proposeWfJobsToJDLogic(env deployment.Environment, c types.ProposeWfJobsCon
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to create job spec from workflow: %w", err)
 	}
 
-	return offchain.ProposeJobs(ctx, env, workflowJobSpec, workflowName, c.NodeFilter)
+	return offchain.ProposeJobs(ctx, env, workflowJobSpec, &workflowName, c.NodeFilter)
 }
 
 func proposeWfJobsToJDPrecondition(_ deployment.Environment, c types.ProposeWfJobsConfig) error {

--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
@@ -23,12 +23,12 @@ func proposeWfJobsToJDLogic(env deployment.Environment, c types.ProposeWfJobsCon
 	ctx, cancel := context.WithTimeout(env.GetContext(), timeout)
 	defer cancel()
 
-	workflowJobSpec, err := offchain.JobSpecFromWorkflow(c.InputFS, c.InputFileName, c.WorkflowJobName)
+	workflowJobSpec, workflowName, err := offchain.JobSpecFromWorkflow(c.InputFS, c.InputFileName, c.WorkflowJobName)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to create job spec from workflow: %w", err)
 	}
 
-	return offchain.ProposeJobs(ctx, env, workflowJobSpec, c.NodeFilter)
+	return offchain.ProposeJobs(ctx, env, workflowJobSpec, workflowName, c.NodeFilter)
 }
 
 func proposeWfJobsToJDPrecondition(_ deployment.Environment, c types.ProposeWfJobsConfig) error {

--- a/deployment/data-feeds/changeset/types/types.go
+++ b/deployment/data-feeds/changeset/types/types.go
@@ -154,5 +154,6 @@ type ProposeBtJobsConfig struct {
 }
 
 type DeleteJobsConfig struct {
-	JobIDs []string
+	JobIDs       []string
+	WorkflowName string
 }

--- a/deployment/data-feeds/changeset/utils.go
+++ b/deployment/data-feeds/changeset/utils.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+
+	workflowUtils "github.com/smartcontractkit/chainlink-common/pkg/workflows"
 )
 
 func FeedIDsToBytes16(feedIDs []string) ([][16]byte, error) {
@@ -38,9 +40,11 @@ func ConvertHexToBytes16(hexStr string) ([16]byte, error) {
 	return result, nil
 }
 
+// HashedWorkflowName returns first 10 bytes of the sha256(workflow_name)
 func HashedWorkflowName(name string) [10]byte {
+	nameHash := workflowUtils.HashTruncateName(name)
 	var result [10]byte
-	copy(result[:], name)
+	copy(result[:], nameHash)
 	return result
 }
 

--- a/deployment/data-feeds/offchain/jd.go
+++ b/deployment/data-feeds/offchain/jd.go
@@ -74,7 +74,7 @@ func fetchNodesFromJD(ctx context.Context, env deployment.Environment, nodeFilte
 	return resp.Nodes, nil
 }
 
-func ProposeJobs(ctx context.Context, env deployment.Environment, workflowJobSpec string, workflowName string, nodeFilters *NodesFilter) (deployment.ChangesetOutput, error) {
+func ProposeJobs(ctx context.Context, env deployment.Environment, workflowJobSpec string, workflowName *string, nodeFilters *NodesFilter) (deployment.ChangesetOutput, error) {
 	out := deployment.ChangesetOutput{
 		Jobs: []deployment.ProposedJob{},
 	}
@@ -90,10 +90,10 @@ func ProposeJobs(ctx context.Context, env deployment.Environment, workflowJobSpe
 			Value: pointer.To(strconv.FormatUint(nodeFilters.DONID, 10)),
 		},
 	}
-	if workflowName != "" {
+	if workflowName != nil {
 		jobLabels = append(jobLabels, &ptypes.Label{
 			Key:   "workflow_name",
-			Value: &workflowName,
+			Value: workflowName,
 		})
 	}
 

--- a/deployment/data-feeds/offchain/jd.go
+++ b/deployment/data-feeds/offchain/jd.go
@@ -74,7 +74,7 @@ func fetchNodesFromJD(ctx context.Context, env deployment.Environment, nodeFilte
 	return resp.Nodes, nil
 }
 
-func ProposeJobs(ctx context.Context, env deployment.Environment, workflowJobSpec string, nodeFilters *NodesFilter) (deployment.ChangesetOutput, error) {
+func ProposeJobs(ctx context.Context, env deployment.Environment, workflowJobSpec string, workflowName string, nodeFilters *NodesFilter) (deployment.ChangesetOutput, error) {
 	out := deployment.ChangesetOutput{
 		Jobs: []deployment.ProposedJob{},
 	}
@@ -89,6 +89,12 @@ func ProposeJobs(ctx context.Context, env deployment.Environment, workflowJobSpe
 			Key:   "don_id",
 			Value: pointer.To(strconv.FormatUint(nodeFilters.DONID, 10)),
 		},
+	}
+	if workflowName != "" {
+		jobLabels = append(jobLabels, &ptypes.Label{
+			Key:   "workflow_name",
+			Value: &workflowName,
+		})
 	}
 
 	for _, node := range nodes {
@@ -111,7 +117,31 @@ func ProposeJobs(ctx context.Context, env deployment.Environment, workflowJobSpe
 	return out, nil
 }
 
-func DeleteJobs(ctx context.Context, env deployment.Environment, jobIDs []string) {
+func DeleteJobs(ctx context.Context, env deployment.Environment, jobIDs []string, workflowName string) {
+	if len(jobIDs) == 0 {
+		env.Logger.Debugf("jobIDs not present. Listing jobs to delete via workflow name")
+		jobSelectors := []*jdtypesv1.Selector{
+			{
+				Key:   "workflow_name",
+				Op:    jdtypesv1.SelectorOp_EQ,
+				Value: &workflowName,
+			},
+		}
+
+		listJobResponse, err := env.Offchain.ListJobs(ctx, &jobv1.ListJobsRequest{
+			Filter: &jobv1.ListJobsRequest_Filter{
+				Selectors: jobSelectors,
+			},
+		})
+		if err != nil {
+			env.Logger.Errorf("Failed to list jobs before deleting: %v", err)
+			return
+		}
+		for _, job := range listJobResponse.Jobs {
+			jobIDs = append(jobIDs, job.Id)
+		}
+	}
+
 	for _, jobID := range jobIDs {
 		env.Logger.Debugf("Deleting job %s", jobID)
 		_, err := env.Offchain.DeleteJob(ctx, &jobv1.DeleteJobRequest{

--- a/deployment/data-feeds/offchain/workflow.go
+++ b/deployment/data-feeds/offchain/workflow.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/google/uuid"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
@@ -23,6 +24,12 @@ const (
 
 type WorkflowSpecAlias sdk.WorkflowSpec
 
+type FeedSpec struct {
+	Deviation  string `json:"deviation"`
+	Heartbeat  int    `json:"heartbeat"`
+	RemappedID string `json:"remappedID"`
+}
+
 type WorkflowJobCfg struct {
 	JobName       string
 	SpecFileName  string
@@ -32,26 +39,23 @@ type WorkflowJobCfg struct {
 	WorkflowOwner string
 }
 
-func JobSpecFromWorkflow(inputFs embed.FS, inputFileName string, workflowJobName string) (string, error) {
+func JobSpecFromWorkflow(inputFs embed.FS, inputFileName string, workflowJobName string) (string, string, error) {
 	wfYaml, err := inputFs.ReadFile(inputFileName)
 	if err != nil {
-		return "", fmt.Errorf("failed to read workflow file: %w", err)
+		return "", "", fmt.Errorf("failed to read workflow file: %w", err)
 	}
 	wfStr := string(wfYaml)
 	wf, err := workflows.ParseWorkflowSpecYaml(wfStr)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse workflow spec: %w", err)
+		return "", "", fmt.Errorf("failed to parse workflow spec: %w", err)
 	}
 
 	wfAlias := WorkflowSpecAlias(wf)
 	if err := wfAlias.validate(); err != nil {
-		return "", fmt.Errorf("workflow validation failed: %w", err)
+		return "", "", fmt.Errorf("workflow validation failed: %w", err)
 	}
 
-	externalID, err := createExternalJobID(wf.Name, wf.Owner)
-	if err != nil {
-		return "", fmt.Errorf("failed to get external job id: %w", err)
-	}
+	externalID := uuid.New().String()
 
 	wfCfg := WorkflowJobCfg{
 		JobName:       workflowJobName,
@@ -63,9 +67,9 @@ func JobSpecFromWorkflow(inputFs embed.FS, inputFileName string, workflowJobName
 
 	workflowJobSpec, err := wfCfg.createSpec()
 	if err != nil {
-		return "", fmt.Errorf("failed to create workflow job spec: %w", err)
+		return "", "", fmt.Errorf("failed to create workflow job spec: %w", err)
 	}
-	return workflowJobSpec, nil
+	return workflowJobSpec, wf.Name, nil
 }
 
 func (wf WorkflowSpecAlias) validate() error {
@@ -80,23 +84,21 @@ func (wf WorkflowSpecAlias) validate() error {
 		return fmt.Errorf("feeds not found in aggregation_config for workflow %s", wf.Name)
 	}
 	for streamsID, feed := range feeds.(map[string]interface{}) {
-		feedMap, feedMapExists := feed.(map[string]string)
+		_, feedMapExists := feed.(map[string]interface{})
 		if !feedMapExists {
 			return fmt.Errorf("invalid feed type %s", streamsID)
 		}
-		_, deviation := feedMap["deviation"]
-		if !deviation {
-			return fmt.Errorf("deviation not found in feed %s", streamsID)
+		var f FeedSpec
+		if err := mapstructure.Decode(feed, &f); err != nil {
+			return fmt.Errorf("failed to decode feed %s: %w", streamsID, err)
 		}
-		_, heartbeat := feedMap["heartbeat"]
-		if !heartbeat {
-			return fmt.Errorf("heartbeat not found in feed %s", streamsID)
+		if f.Deviation == "" {
+			return fmt.Errorf("invalid deviation for feed %s", streamsID)
 		}
-		remmapedID, hasRemmapedID := feedMap["remappedID"]
-		if !hasRemmapedID {
-			return fmt.Errorf("remappedID not found in feed %s", streamsID)
+		if f.Heartbeat == 0 {
+			return fmt.Errorf("invalid heartbeat for feed %s", streamsID)
 		}
-		if len(remmapedID) != 66 {
+		if len(f.RemappedID) != 66 {
 			return fmt.Errorf("invalid remappedID for feed %s", streamsID)
 		}
 	}

--- a/deployment/data-feeds/offchain/workflow.go
+++ b/deployment/data-feeds/offchain/workflow.go
@@ -39,7 +39,7 @@ type WorkflowJobCfg struct {
 	WorkflowOwner string
 }
 
-func JobSpecFromWorkflow(inputFs embed.FS, inputFileName string, workflowJobName string) (string, string, error) {
+func JobSpecFromWorkflow(inputFs embed.FS, inputFileName string, workflowJobName string) (wfSpec string, wfName string, err error) {
 	wfYaml, err := inputFs.ReadFile(inputFileName)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to read workflow file: %w", err)

--- a/deployment/data-feeds/offchain/workflow.go
+++ b/deployment/data-feeds/offchain/workflow.go
@@ -10,7 +10,6 @@ import (
 	"text/template"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/go-viper/mapstructure/v2"
 	"github.com/google/uuid"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
@@ -23,12 +22,6 @@ const (
 )
 
 type WorkflowSpecAlias sdk.WorkflowSpec
-
-type FeedSpec struct {
-	Deviation  string `json:"deviation"`
-	Heartbeat  int    `json:"heartbeat"`
-	RemappedID string `json:"remappedID"`
-}
 
 type WorkflowJobCfg struct {
 	JobName       string
@@ -84,21 +77,24 @@ func (wf WorkflowSpecAlias) validate() error {
 		return fmt.Errorf("feeds not found in aggregation_config for workflow %s", wf.Name)
 	}
 	for streamsID, feed := range feeds.(map[string]interface{}) {
-		_, feedMapExists := feed.(map[string]interface{})
-		if !feedMapExists {
+		feedMap, feedExists := feed.(map[string]interface{})
+		if !feedExists {
 			return fmt.Errorf("invalid feed type %s", streamsID)
 		}
-		var f FeedSpec
-		if err := mapstructure.Decode(feed, &f); err != nil {
-			return fmt.Errorf("failed to decode feed %s: %w", streamsID, err)
+		_, hasDeviation := feedMap["deviation"].(string)
+		if !hasDeviation {
+			return fmt.Errorf("deviation not found in feed %s", streamsID)
 		}
-		if f.Deviation == "" {
-			return fmt.Errorf("invalid deviation for feed %s", streamsID)
+
+		_, hasHeartbeat := feedMap["heartbeat"].(int64)
+		if !hasHeartbeat {
+			return fmt.Errorf("heartbeat not found in feed %s", streamsID)
 		}
-		if f.Heartbeat == 0 {
-			return fmt.Errorf("invalid heartbeat for feed %s", streamsID)
+		remmapedID, hasRemmapedID := feedMap["remappedID"].(string)
+		if !hasRemmapedID {
+			return fmt.Errorf("remappedID not found in feed %s", streamsID)
 		}
-		if len(f.RemappedID) != 66 {
+		if len(remmapedID) != 66 {
 			return fmt.Errorf("invalid remappedID for feed %s", streamsID)
 		}
 	}

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/gagliardetto/binary v0.8.0
 	github.com/gagliardetto/solana-go v1.12.0
 	github.com/go-resty/resty/v2 v2.15.3
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/consul/sdk v0.16.1
@@ -200,7 +201,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.25.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/go-webauthn/webauthn v0.9.4 // indirect
 	github.com/go-webauthn/x v0.1.5 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/gagliardetto/binary v0.8.0
 	github.com/gagliardetto/solana-go v1.12.0
 	github.com/go-resty/resty/v2 v2.15.3
-	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/consul/sdk v0.16.1
@@ -201,6 +200,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.25.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/go-webauthn/webauthn v0.9.4 // indirect
 	github.com/go-webauthn/x v0.1.5 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect


### PR DESCRIPTION
Refactored `DeleteJobsJDChangeset` to delete either using specific job ids or workflow name
Refactored workflow job spec generation to use random external job ids. This will enable support for green/blue deployments
Refactored `HashedWorkflowName` function to always hash and truncate the workflow name before converting it to bytes. This allows us to use longer workflow names