### PR TITLE
Update syntax of Dockerfiles to avoid CI warnings

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -1,5 +1,5 @@
 # Build image: Chainlink binary
-FROM golang:1.24-bullseye as buildgo
+FROM golang:1.24-bullseye AS buildgo
 RUN go version
 WORKDIR /chainlink
 
@@ -31,7 +31,7 @@ RUN go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-feeds | xargs
 RUN go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-solana | xargs -I % ln -s % /chainlink-solana
 
 # Build image: Plugins
-FROM golang:1.24-bullseye as buildplugins
+FROM golang:1.24-bullseye AS buildplugins
 RUN go version
 
 WORKDIR /chainlink-feeds
@@ -46,7 +46,7 @@ RUN go install ./pkg/solana/cmd/chainlink-solana
 FROM ubuntu:24.04
 
 ARG CHAINLINK_USER=root
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y ca-certificates gnupg lsb-release curl
 
 # Install Postgres for CLI tools, needed specifically for DB backups
@@ -75,7 +75,7 @@ RUN if [ ${CHAINLINK_USER} != root ]; then \
 USER ${CHAINLINK_USER}
 WORKDIR /home/${CHAINLINK_USER}
 # explicit set the cache dir. needed so both root and non-root user has an explicit location
-ENV XDG_CACHE_HOME /home/${CHAINLINK_USER}/.cache
+ENV XDG_CACHE_HOME=/home/${CHAINLINK_USER}/.cache
 RUN mkdir -p ${XDG_CACHE_HOME}
 
 # Set up env and dir for go coverage profiling https://go.dev/doc/build-cover#FAQ

--- a/core/chainlink.goreleaser.Dockerfile
+++ b/core/chainlink.goreleaser.Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:24.04
 
 ARG CHAINLINK_USER=root
 ARG TARGETARCH
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y ca-certificates gnupg lsb-release curl
 
 # Install Postgres for CLI tools, needed specifically for DB backups
@@ -45,7 +45,7 @@ RUN if [ ${CHAINLINK_USER} != root ]; then \
 USER ${CHAINLINK_USER}
 WORKDIR /home/${CHAINLINK_USER}
 # explicit set the cache dir. needed so both root and non-root user has an explicit location
-ENV XDG_CACHE_HOME /home/${CHAINLINK_USER}/.cache
+ENV XDG_CACHE_HOME=/home/${CHAINLINK_USER}/.cache
 RUN mkdir -p ${XDG_CACHE_HOME}
 
 EXPOSE 6688


### PR DESCRIPTION
1. Wherever we have FROM (uppercase) with an `as` the AS should also be uppercased.
2. Use `ENV key=val` instead of legacy `ENV key val`