### PR TITLE
Fix breaking change for e2e test waiting for no commit

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -984,6 +984,7 @@ runner-test-matrix:
     test_env_type: docker
     runs_on: ubuntu24.04-8cores-32GB
     triggers:
+      - PR E2E Core Tests
       - Nightly E2E Tests
     test_cmd: cd integration-tests/smoke/ccip && go test -test.run ^TestRMN_TwoMessagesOnTwoLanesIncludingBatching$ -timeout 30m -test.parallel=1 -count=1 -json
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
@@ -1089,6 +1090,7 @@ runner-test-matrix:
     test_env_type: docker
     runs_on: ubuntu24.04-8cores-32GB
     triggers:
+      - PR E2E Core Tests
       - Nightly E2E Tests
     test_cmd: cd integration-tests/smoke/ccip && go test -test.run ^TestRMN_GlobalCurseTwoMessagesOnTwoLanes$ -timeout 30m -test.parallel=1 -count=1 -json
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated

--- a/deployment/ccip/changeset/testhelpers/test_assertions.go
+++ b/deployment/ccip/changeset/testhelpers/test_assertions.go
@@ -359,13 +359,15 @@ func ConfirmCommitWithExpectedSeqNumRange(
 	defer ticker.Stop()
 	for {
 		select {
+		case <-t.Context().Done():
+			return nil, nil
 		case <-ticker.C:
 			t.Logf("Waiting for commit report on chain selector %d from source selector %d expected seq nr range %s",
 				dest.Selector, srcSelector, expectedSeqNumRange.String())
 
 			// Need to do this because the subscription sometimes fails to get the event.
 			iter, err := offRamp.FilterCommitReportAccepted(&bind.FilterOpts{
-				Context: tests.Context(t),
+				Context: t.Context(),
 			})
 			require.NoError(t, err)
 			for iter.Next() {


### PR DESCRIPTION
Fix breaking change for e2e test waiting for no commit

Full RMN run: https://github.com/smartcontractkit/chainlink/actions/runs/14179897596/job/39723411968