### PR TITLE
feat: Adds MemoryDataStore implementation

### DIFF
--- a/deployment/datastore/memory_datastore.go
+++ b/deployment/datastore/memory_datastore.go
@@ -20,16 +20,14 @@ type BaseDataStore[R AddressRefStore] interface {
 	Addresses() R
 }
 
-// DataStore is an interface that defines the operations for a
+// DataStore is an interface that defines the operations for a read-only data store.
 type DataStore interface {
-	Merger[DataStore]
-
 	BaseDataStore[AddressRefStore]
 }
 
 // MutableDataStore is an interface that defines the operations for a mutable data store.
 type MutableDataStore interface {
-	Merger[MutableDataStore]
+	Merger[DataStore]
 	Sealer[DataStore]
 
 	BaseDataStore[MutableAddressRefStore]
@@ -61,7 +59,7 @@ func (s *MemoryDataStore) Addresses() MutableAddressRefStore {
 }
 
 // Merge merges the given mutable data store into the current MemoryDataStore.
-func (s *MemoryDataStore) Merge(other MutableDataStore) error {
+func (s *MemoryDataStore) Merge(other DataStore) error {
 	addressRefs, err := other.Addresses().Fetch()
 	if err != nil {
 		return err
@@ -88,20 +86,4 @@ type sealedMemoryDataStore struct {
 // It implements the BaseDataStore interface.
 func (s *sealedMemoryDataStore) Addresses() AddressRefStore {
 	return s.AddressRefStore
-}
-
-// Merge merges the given data store into the current sealedMemoryDataStore.
-func (s *sealedMemoryDataStore) Merge(other DataStore) error {
-	addressRefs, err := other.Addresses().Fetch()
-	if err != nil {
-		return err
-	}
-
-	for _, addressRef := range addressRefs {
-		if err := s.AddressRefStore.AddOrUpdate(addressRef); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/deployment/datastore/memory_datastore.go
+++ b/deployment/datastore/memory_datastore.go
@@ -1,0 +1,107 @@
+package datastore
+
+// Merger is an interface that defines a method for merging two data stores.
+type Merger[T any] interface {
+	// Merge merges the given data into the current data store.
+	// It should return an error if the merge fails.
+	Merge(other T) error
+}
+
+// Sealer is an interface that defines a method for sealing a data store.
+// A sealed data store cannot be modified further.
+type Sealer[T any] interface {
+	// Seal seals the data store, preventing further modifications.
+	Seal() T
+}
+
+// BaseDataStore is an interface that defines the basic operations for a data store.
+// It is parameterized by the type of address reference store it uses.
+type BaseDataStore[R AddressRefStore] interface {
+	Addresses() R
+}
+
+// DataStore is an interface that defines the operations for a
+type DataStore interface {
+	Merger[DataStore]
+
+	BaseDataStore[AddressRefStore]
+}
+
+// MutableDataStore is an interface that defines the operations for a mutable data store.
+type MutableDataStore interface {
+	Merger[MutableDataStore]
+	Sealer[DataStore]
+
+	BaseDataStore[MutableAddressRefStore]
+}
+
+// MemoryDataStore is a concrete implementation of the MutableDataStore interface.
+var _ MutableDataStore = &MemoryDataStore{}
+
+type MemoryDataStore struct {
+	AddressRefStore *MemoryAddressRefStore `json:"addressRefStore"`
+}
+
+// NewMemoryDataStore creates a new instance of MemoryDataStore.
+// NOTE: The instance returned is mutable and can be modified.
+func NewMemoryDataStore() *MemoryDataStore {
+	return &MemoryDataStore{
+		AddressRefStore: NewMemoryAddressRefStore(),
+	}
+}
+
+// Seal seals the MemoryDataStore, by returning a new instance of sealedMemoryDataStore.
+func (s *MemoryDataStore) Seal() DataStore {
+	return &sealedMemoryDataStore{AddressRefStore: s.AddressRefStore}
+}
+
+// Addresses returns the AddressRefStore of the MemoryDataStore.
+func (s *MemoryDataStore) Addresses() MutableAddressRefStore {
+	return s.AddressRefStore
+}
+
+// Merge merges the given mutable data store into the current MemoryDataStore.
+func (s *MemoryDataStore) Merge(other MutableDataStore) error {
+	addressRefs, err := other.Addresses().Fetch()
+	if err != nil {
+		return err
+	}
+
+	for _, addressRef := range addressRefs {
+		if err := s.AddressRefStore.AddOrUpdate(addressRef); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SealedMemoryDataStore is a concrete implementation of the DataStore interface.
+// It represents a sealed data store that cannot be modified further.
+var _ DataStore = &sealedMemoryDataStore{}
+
+type sealedMemoryDataStore struct {
+	AddressRefStore *MemoryAddressRefStore `json:"addressRefStore"`
+}
+
+// Addresses returns the AddressRefStore of the sealedMemoryDataStore.
+// It implements the BaseDataStore interface.
+func (s *sealedMemoryDataStore) Addresses() AddressRefStore {
+	return s.AddressRefStore
+}
+
+// Merge merges the given data store into the current sealedMemoryDataStore.
+func (s *sealedMemoryDataStore) Merge(other DataStore) error {
+	addressRefs, err := other.Addresses().Fetch()
+	if err != nil {
+		return err
+	}
+
+	for _, addressRef := range addressRefs {
+		if err := s.AddressRefStore.AddOrUpdate(addressRef); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/deployment/datastore/memory_datastore_test.go
+++ b/deployment/datastore/memory_datastore_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMemoryDataStore_Merge(t *testing.T) {
@@ -19,17 +19,17 @@ func TestMemoryDataStore_Merge(t *testing.T) {
 		Version:   semver.MustParse("1.0.0"),
 		Qualifier: "qualifier1",
 	})
-	assert.NoError(t, err, "Adding data to dataStore2 should not fail")
+	require.NoError(t, err, "Adding data to dataStore2 should not fail")
 
 	// Merge dataStore2 into dataStore1
 	err = dataStore1.Merge(dataStore2)
-	assert.NoError(t, err, "Merging dataStore2 into dataStore1 should not fail")
+	require.NoError(t, err, "Merging dataStore2 into dataStore1 should not fail")
 
 	// Verify that dataStore1 contains the merged data
 	addressRefs, err := dataStore1.Addresses().Fetch()
-	assert.NoError(t, err, "Fetching addresses from dataStore1 should not fail")
-	assert.Len(t, addressRefs, 1, "dataStore1 should contain 1 address after merge")
-	assert.Equal(t, "0x123", addressRefs[0].Address, "Merged address should match")
+	require.NoError(t, err, "Fetching addresses from dataStore1 should not fail")
+	require.Len(t, addressRefs, 1, "dataStore1 should contain 1 address after merge")
+	require.Equal(t, "0x123", addressRefs[0].Address, "Merged address should match")
 }
 
 func TestSealedMemoryDataStore_Merge(t *testing.T) {
@@ -45,15 +45,15 @@ func TestSealedMemoryDataStore_Merge(t *testing.T) {
 		Version:   semver.MustParse("1.0.0"),
 		Qualifier: "qualifier2",
 	})
-	assert.NoError(t, err, "Adding data to otherDataStore should not fail")
+	require.NoError(t, err, "Adding data to otherDataStore should not fail")
 
 	// Merge otherDataStore into the sealed data store
 	err = sealedDataStore.Merge(otherDataStore.Seal())
-	assert.NoError(t, err, "Merging into a sealed data store should not fail")
+	require.NoError(t, err, "Merging into a sealed data store should not fail")
 
 	// Verify that the sealed data store contains the merged data
 	addressRefs, err := sealedDataStore.Addresses().Fetch()
-	assert.NoError(t, err, "Fetching addresses from sealedDataStore should not fail")
-	assert.Len(t, addressRefs, 1, "sealedDataStore should contain 1 address after merge")
-	assert.Equal(t, "0x456", addressRefs[0].Address, "Merged address should match")
+	require.NoError(t, err, "Fetching addresses from sealedDataStore should not fail")
+	require.Len(t, addressRefs, 1, "sealedDataStore should contain 1 address after merge")
+	require.Equal(t, "0x456", addressRefs[0].Address, "Merged address should match")
 }

--- a/deployment/datastore/memory_datastore_test.go
+++ b/deployment/datastore/memory_datastore_test.go
@@ -1,0 +1,59 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemoryDataStore_Merge(t *testing.T) {
+	// Create two mutable MemoryDataStores
+	dataStore1 := NewMemoryDataStore()
+	dataStore2 := NewMemoryDataStore()
+
+	// Add some data to the second data store
+	err := dataStore2.Addresses().AddOrUpdate(AddressRef{
+		Address:   "0x123",
+		Type:      "type1",
+		Version:   semver.MustParse("1.0.0"),
+		Qualifier: "qualifier1",
+	})
+	assert.NoError(t, err, "Adding data to dataStore2 should not fail")
+
+	// Merge dataStore2 into dataStore1
+	err = dataStore1.Merge(dataStore2)
+	assert.NoError(t, err, "Merging dataStore2 into dataStore1 should not fail")
+
+	// Verify that dataStore1 contains the merged data
+	addressRefs, err := dataStore1.Addresses().Fetch()
+	assert.NoError(t, err, "Fetching addresses from dataStore1 should not fail")
+	assert.Len(t, addressRefs, 1, "dataStore1 should contain 1 address after merge")
+	assert.Equal(t, "0x123", addressRefs[0].Address, "Merged address should match")
+}
+
+func TestSealedMemoryDataStore_Merge(t *testing.T) {
+	// Create a mutable MemoryDataStore and seal it
+	mutableDataStore := NewMemoryDataStore()
+	sealedDataStore := mutableDataStore.Seal()
+
+	// Create another mutable MemoryDataStore with some data
+	otherDataStore := NewMemoryDataStore()
+	err := otherDataStore.Addresses().AddOrUpdate(AddressRef{
+		Address:   "0x456",
+		Type:      "type2",
+		Version:   semver.MustParse("1.0.0"),
+		Qualifier: "qualifier2",
+	})
+	assert.NoError(t, err, "Adding data to otherDataStore should not fail")
+
+	// Merge otherDataStore into the sealed data store
+	err = sealedDataStore.Merge(otherDataStore.Seal())
+	assert.NoError(t, err, "Merging into a sealed data store should not fail")
+
+	// Verify that the sealed data store contains the merged data
+	addressRefs, err := sealedDataStore.Addresses().Fetch()
+	assert.NoError(t, err, "Fetching addresses from sealedDataStore should not fail")
+	assert.Len(t, addressRefs, 1, "sealedDataStore should contain 1 address after merge")
+	assert.Equal(t, "0x456", addressRefs[0].Address, "Merged address should match")
+}

--- a/deployment/datastore/memory_datastore_test.go
+++ b/deployment/datastore/memory_datastore_test.go
@@ -8,52 +8,74 @@ import (
 )
 
 func TestMemoryDataStore_Merge(t *testing.T) {
-	// Create two mutable MemoryDataStores
-	dataStore1 := NewMemoryDataStore()
-	dataStore2 := NewMemoryDataStore()
+	tests := []struct {
+		name          string
+		setup         func() (*MemoryDataStore, *MemoryDataStore)
+		expectedCount int
+		expectedLabel string
+	}{
+		{
+			name: "Merge single address",
+			setup: func() (*MemoryDataStore, *MemoryDataStore) {
+				dataStore1 := NewMemoryDataStore()
+				dataStore2 := NewMemoryDataStore()
+				err := dataStore2.Addresses().AddOrUpdate(AddressRef{
+					Address:   "0x123",
+					Type:      "type1",
+					Version:   semver.MustParse("1.0.0"),
+					Qualifier: "qualifier1",
+				})
+				require.NoError(t, err, "Adding data to dataStore2 should not fail")
+				return dataStore1, dataStore2
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "Match existing address with labels",
+			setup: func() (*MemoryDataStore, *MemoryDataStore) {
+				dataStore1 := NewMemoryDataStore()
+				dataStore2 := NewMemoryDataStore()
 
-	// Add some data to the second data store
-	err := dataStore2.Addresses().AddOrUpdate(AddressRef{
-		Address:   "0x123",
-		Type:      "type1",
-		Version:   semver.MustParse("1.0.0"),
-		Qualifier: "qualifier1",
-	})
-	require.NoError(t, err, "Adding data to dataStore2 should not fail")
+				// Add initial data to dataStore1
+				err := dataStore1.Addresses().AddOrUpdate(AddressRef{
+					Address:   "0x123",
+					Type:      "type1",
+					Version:   semver.MustParse("1.0.0"),
+					Qualifier: "qualifier1",
+					Labels:    NewLabelSet("label1"),
+				})
+				require.NoError(t, err, "Adding initial data to dataStore1 should not fail")
 
-	// Merge dataStore2 into dataStore1
-	err = dataStore1.Merge(dataStore2)
-	require.NoError(t, err, "Merging dataStore2 into dataStore1 should not fail")
+				// Add matching data to dataStore2
+				err = dataStore2.Addresses().AddOrUpdate(AddressRef{
+					Address:   "0x123",
+					Type:      "type1",
+					Version:   semver.MustParse("1.0.0"),
+					Qualifier: "qualifier1",
+					Labels:    NewLabelSet("label2"),
+				})
+				require.NoError(t, err, "Adding matching data to dataStore2 should not fail")
 
-	// Verify that dataStore1 contains the merged data
-	addressRefs, err := dataStore1.Addresses().Fetch()
-	require.NoError(t, err, "Fetching addresses from dataStore1 should not fail")
-	require.Len(t, addressRefs, 1, "dataStore1 should contain 1 address after merge")
-	require.Equal(t, "0x123", addressRefs[0].Address, "Merged address should match")
-}
+				return dataStore1, dataStore2
+			},
+			expectedCount: 1,
+			expectedLabel: "label2",
+		},
+	}
 
-func TestSealedMemoryDataStore_Merge(t *testing.T) {
-	// Create a mutable MemoryDataStore and seal it
-	mutableDataStore := NewMemoryDataStore()
-	sealedDataStore := mutableDataStore.Seal()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataStore1, dataStore2 := tt.setup()
 
-	// Create another mutable MemoryDataStore with some data
-	otherDataStore := NewMemoryDataStore()
-	err := otherDataStore.Addresses().AddOrUpdate(AddressRef{
-		Address:   "0x456",
-		Type:      "type2",
-		Version:   semver.MustParse("1.0.0"),
-		Qualifier: "qualifier2",
-	})
-	require.NoError(t, err, "Adding data to otherDataStore should not fail")
+			// Merge dataStore2 into dataStore1
+			err := dataStore1.Merge(dataStore2.Seal())
+			require.NoError(t, err, "Merging dataStore2 into dataStore1 should not fail")
 
-	// Merge otherDataStore into the sealed data store
-	err = sealedDataStore.Merge(otherDataStore.Seal())
-	require.NoError(t, err, "Merging into a sealed data store should not fail")
-
-	// Verify that the sealed data store contains the merged data
-	addressRefs, err := sealedDataStore.Addresses().Fetch()
-	require.NoError(t, err, "Fetching addresses from sealedDataStore should not fail")
-	require.Len(t, addressRefs, 1, "sealedDataStore should contain 1 address after merge")
-	require.Equal(t, "0x456", addressRefs[0].Address, "Merged address should match")
+			// Verify that dataStore1 contains the merged data
+			addressRefs, err := dataStore1.Addresses().Fetch()
+			require.NoError(t, err, "Fetching addresses from dataStore1 should not fail")
+			require.Len(t, addressRefs, tt.expectedCount, "dataStore1 should contain the expected number of addresses after merge")
+			require.Equal(t, tt.expectedLabel, addressRefs[0].Labels.String(), "Labels should be updated correctly after merge")
+		})
+	}
 }


### PR DESCRIPTION
This PR introduces a top-level struct named MemoryDataStore, which serves as the main container for the three types of metadata defined in the DataStore design. The struct is mutable by default to support writing and updating metadata, but it can also be exposed as read-only when needed.

At this stage, MemoryDataStore only includes a reference to a MemoryAddressRefStore. It will be extended in future iterations to include the remaining metadata types as the implementation evolves.

JIRA:
https://smartcontract-it.atlassian.net/browse/CLD-98