### PR TITLE
fix: don't reuse protobuf messages in tests running with t.Parallel

### DIFF
--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -1868,25 +1868,29 @@ func Test_Service_syncNodeInfoWithRetry(t *testing.T) {
 	workflowKey, err := workflowkey.New()
 	require.NoError(t, err)
 
-	request := &proto.UpdateNodeRequest{
-		Version: nodeVersion.Version,
-		ChainConfigs: []*proto.ChainConfig{
-			{
-				Chain: &proto.Chain{
-					Id:   cfg.ChainID,
-					Type: proto.ChainType_CHAIN_TYPE_EVM,
+	request := func() *proto.UpdateNodeRequest {
+		return &proto.UpdateNodeRequest{
+			Version: nodeVersion.Version,
+			ChainConfigs: []*proto.ChainConfig{
+				{
+					Chain: &proto.Chain{
+						Id:   cfg.ChainID,
+						Type: proto.ChainType_CHAIN_TYPE_EVM,
+					},
+					AccountAddress:          cfg.AccountAddress,
+					AccountAddressPublicKey: &cfg.AccountAddressPublicKey.String,
+					AdminAddress:            cfg.AdminAddress,
+					FluxMonitorConfig:       &proto.FluxMonitorConfig{Enabled: true},
+					Ocr1Config:              &proto.OCR1Config{Enabled: false},
+					Ocr2Config:              &proto.OCR2Config{Enabled: false},
 				},
-				AccountAddress:          cfg.AccountAddress,
-				AccountAddressPublicKey: &cfg.AccountAddressPublicKey.String,
-				AdminAddress:            cfg.AdminAddress,
-				FluxMonitorConfig:       &proto.FluxMonitorConfig{Enabled: true},
-				Ocr1Config:              &proto.OCR1Config{Enabled: false},
-				Ocr2Config:              &proto.OCR2Config{Enabled: false},
 			},
-		},
-		WorkflowKey: func(s string) *string { return &s }(workflowKey.ID()),
+			WorkflowKey: func(s string) *string { return &s }(workflowKey.ID()),
+		}
 	}
-	successResponse := &proto.UpdateNodeResponse{ChainConfigErrors: map[string]*proto.ChainConfigError{}}
+	successResponse := func() *proto.UpdateNodeResponse {
+		return &proto.UpdateNodeResponse{ChainConfigErrors: map[string]*proto.ChainConfigError{}}
+	}
 	failureResponse := func(chainID string) *proto.UpdateNodeResponse {
 		return &proto.UpdateNodeResponse{
 			ChainConfigErrors: map[string]*proto.ChainConfigError{chainID: {Message: "error chain " + chainID}},
@@ -1908,10 +1912,10 @@ func Test_Service_syncNodeInfoWithRetry(t *testing.T) {
 				svc.orm.EXPECT().GetManager(mock.Anything, mgr.ID).Return(&mgr, nil)
 				svc.orm.EXPECT().ListChainConfigsByManagerIDs(mock.Anything, []int64{mgr.ID}).Return([]feeds.ChainConfig{cfg}, nil)
 				svc.connMgr.EXPECT().GetClient(mgr.ID).Return(svc.fmsClient, nil)
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(nil, errors.New("error-0")).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(failureResponse("1"), nil).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(failureResponse("2"), nil).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(successResponse, nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(nil, errors.New("error-0")).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(failureResponse("1"), nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(failureResponse("2"), nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(successResponse(), nil).Once()
 			},
 			run: func(svc *TestService) (any, error) {
 				return svc.CreateChainConfig(testutils.Context(t), cfg)
@@ -1932,10 +1936,10 @@ func Test_Service_syncNodeInfoWithRetry(t *testing.T) {
 				svc.orm.EXPECT().GetChainConfig(mock.Anything, cfg.ID).Return(&cfg, nil)
 				svc.orm.EXPECT().ListChainConfigsByManagerIDs(mock.Anything, []int64{mgr.ID}).Return([]feeds.ChainConfig{cfg}, nil)
 				svc.connMgr.EXPECT().GetClient(mgr.ID).Return(svc.fmsClient, nil)
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(failureResponse("3"), nil).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(nil, errors.New("error-4")).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(failureResponse("5"), nil).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(successResponse, nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(failureResponse("3"), nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(nil, errors.New("error-4")).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(failureResponse("5"), nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(successResponse(), nil).Once()
 			},
 			run: func(svc *TestService) (any, error) {
 				return svc.UpdateChainConfig(testutils.Context(t), cfg)
@@ -1957,10 +1961,10 @@ func Test_Service_syncNodeInfoWithRetry(t *testing.T) {
 				svc.orm.EXPECT().GetManager(mock.Anything, mgr.ID).Return(&mgr, nil)
 				svc.orm.EXPECT().ListChainConfigsByManagerIDs(mock.Anything, []int64{mgr.ID}).Return([]feeds.ChainConfig{cfg}, nil)
 				svc.connMgr.EXPECT().GetClient(mgr.ID).Return(svc.fmsClient, nil)
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(failureResponse("6"), nil).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(failureResponse("7"), nil).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(nil, errors.New("error-8")).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(successResponse, nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(failureResponse("6"), nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(failureResponse("7"), nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(nil, errors.New("error-8")).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(successResponse(), nil).Once()
 			},
 			run: func(svc *TestService) (any, error) {
 				return svc.DeleteChainConfig(testutils.Context(t), cfg.ID)
@@ -1981,10 +1985,10 @@ func Test_Service_syncNodeInfoWithRetry(t *testing.T) {
 				svc.orm.EXPECT().GetManager(mock.Anything, mgr.ID).Return(&mgr, nil)
 				svc.orm.EXPECT().ListChainConfigsByManagerIDs(mock.Anything, []int64{mgr.ID}).Return([]feeds.ChainConfig{cfg}, nil)
 				svc.connMgr.EXPECT().GetClient(mgr.ID).Return(svc.fmsClient, nil)
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(failureResponse("9"), nil).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(failureResponse("10"), nil).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(nil, errors.New("error-11")).Once()
-				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request).Return(failureResponse("12"), nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(failureResponse("9"), nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(failureResponse("10"), nil).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(nil, errors.New("error-11")).Once()
+				svc.fmsClient.EXPECT().UpdateNode(mock.Anything, request()).Return(failureResponse("12"), nil).Once()
 			},
 			run: func(svc *TestService) (any, error) {
 				return svc.CreateChainConfig(testutils.Context(t), cfg)


### PR DESCRIPTION
Create a new instance of the protobuf message for each test case in `feeds.Test_Service_syncNodeInfoWithRetry`. This avoids a rar race condition that may occur when two threads try to access the shared object simultaneously.

```
Read at 0x00c03692c0c0 by goroutine 123899:
reflect.Value.IsNil()
    /opt/hostedtoolcache/go/1.24.0/x64/src/reflect/value.go:1550 +0x3d6
github.com/stretchr/testify/assert.ObjectsAreEqual(protobuf1, protobuf2)
...


Previous write at 0x00c03692c0c0 by goroutine 123900:
sync/atomic.StoreInt64()
  /opt/hostedtoolcache/go/1.24.0/x64/src/runtime/race_amd64.s:237 +0xb
github.com/smartcontractkit/chainlink-protos/orchestrator/feedsmanager.(*OCR2Config).ProtoReflect()
  /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-protos/orchestrator@v0.5.0/feedsmanager/feedsmanager.pb.go:416 +0x93
...
```

[DX-374](https://smartcontract-it.atlassian.net/browse/DX-374)

[DX-374]: https://smartcontract-it.atlassian.net/browse/DX-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ