### PR TITLE
Ownable contract sets

### DIFF
--- a/deployment/keystone/changeset/accept_ownership.go
+++ b/deployment/keystone/changeset/accept_ownership.go
@@ -24,7 +24,7 @@ func AcceptAllOwnershipsProposal(e deployment.Environment, req *AcceptAllOwnersh
 	chain := e.Chains[chainSelector]
 	addrBook := e.ExistingAddresses
 
-	r, err := GetContractSets(e.Logger, &GetContractSetsRequest{
+	r, err := GetContractSetsV2(e.Logger, GetContractSetsRequestV2{
 		Chains: map[uint64]deployment.Chain{
 			req.ChainSelector: chain,
 		},

--- a/deployment/keystone/changeset/accept_ownership_test.go
+++ b/deployment/keystone/changeset/accept_ownership_test.go
@@ -24,6 +24,7 @@ func TestAcceptAllOwnership(t *testing.T) {
 		Chains: 2,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+
 	registrySel := env.AllChainSelectors()[0]
 	env, err := commonchangeset.Apply(t, env, nil,
 		commonchangeset.Configure(

--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -37,7 +37,7 @@ func AddCapabilities(env deployment.Environment, req *AddCapabilitiesRequest) (d
 	if !ok {
 		return deployment.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}
-	cs, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	cs, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      map[uint64]deployment.Chain{req.RegistryChainSel: registryChain},
 		AddressBook: env.ExistingAddresses,
 	})
@@ -49,7 +49,7 @@ func AddCapabilities(env deployment.Environment, req *AddCapabilitiesRequest) (d
 		return deployment.ChangesetOutput{}, fmt.Errorf("contract set not found for chain %d", req.RegistryChainSel)
 	}
 	useMCMS := req.MCMSConfig != nil
-	ops, err := internal.AddCapabilities(env.Logger, contractSet.CapabilitiesRegistry, env.Chains[req.RegistryChainSel], req.Capabilities, useMCMS)
+	ops, err := internal.AddCapabilities(env.Logger, contractSet.CapabilitiesRegistry.Contract, env.Chains[req.RegistryChainSel], req.Capabilities, useMCMS)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to add capabilities: %w", err)
 	}
@@ -59,10 +59,10 @@ func AddCapabilities(env deployment.Environment, req *AddCapabilitiesRequest) (d
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 		timelocksPerChain := map[uint64]string{
-			registryChain.Selector: contractSet.Timelock.Address().Hex(),
+			registryChain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			registryChain.Selector: contractSet.ProposerMcm.Address().Hex(),
+			registryChain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.ProposerMcm.Address().Hex(),
 		}
 		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
 		if err != nil {

--- a/deployment/keystone/changeset/add_nodes.go
+++ b/deployment/keystone/changeset/add_nodes.go
@@ -197,7 +197,7 @@ func AddNodes(env deployment.Environment, req *AddNodesRequest) (deployment.Chan
 		return deployment.ChangesetOutput{}, fmt.Errorf("invalid request: %w", err)
 	}
 
-	contractSetResp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	contractSetResp, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	})
@@ -207,7 +207,7 @@ func AddNodes(env deployment.Environment, req *AddNodesRequest) (deployment.Chan
 
 	nodeParams := make(map[string]kcr.CapabilitiesRegistryNodeParams)
 	for nodeName, cr := range req.CreateNodeRequests {
-		params, err := cr.Resolve(contractSetResp.ContractSets[req.RegistryChainSel].CapabilitiesRegistry)
+		params, err := cr.Resolve(contractSetResp.ContractSets[req.RegistryChainSel].CapabilitiesRegistry.Contract)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to resolve node params for node %s: %w", nodeName, err)
 		}
@@ -219,14 +219,13 @@ func AddNodes(env deployment.Environment, req *AddNodesRequest) (deployment.Chan
 	}
 
 	var (
-		useMCMS                = req.MCMSConfig != nil
-		registryChain          = env.Chains[req.RegistryChainSel]
-		registry               = contractSetResp.ContractSets[req.RegistryChainSel].CapabilitiesRegistry
-		registryChainContracts = contractSetResp.ContractSets[req.RegistryChainSel]
+		useMCMS       = req.MCMSConfig != nil
+		registryChain = env.Chains[req.RegistryChainSel]
+		registry      = contractSetResp.ContractSets[req.RegistryChainSel].CapabilitiesRegistry
 	)
 	resp, err := internal.AddNodes(env.Logger, &internal.AddNodesRequest{
 		RegistryChain:        registryChain,
-		CapabilitiesRegistry: registry,
+		CapabilitiesRegistry: registry.Contract,
 		NodeParams:           nodeParams,
 		UseMCMS:              useMCMS,
 	})
@@ -240,10 +239,10 @@ func AddNodes(env deployment.Environment, req *AddNodesRequest) (deployment.Chan
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 		timelocksPerChain := map[uint64]string{
-			registryChain.Selector: registryChainContracts.Timelock.Address().Hex(),
+			registryChain.Selector: registry.McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			registryChain.Selector: registryChainContracts.ProposerMcm.Address().Hex(),
+			registryChain.Selector: registry.McmsContracts.ProposerMcm.Address().Hex(),
 		}
 		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
 		if err != nil {

--- a/deployment/keystone/changeset/add_nops.go
+++ b/deployment/keystone/changeset/add_nops.go
@@ -31,7 +31,7 @@ func AddNops(env deployment.Environment, req *AddNopsRequest) (deployment.Change
 	if !ok {
 		return deployment.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}
-	cs, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	cs, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      map[uint64]deployment.Chain{req.RegistryChainSel: registryChain},
 		AddressBook: env.ExistingAddresses,
 	})
@@ -62,10 +62,10 @@ func AddNops(env deployment.Environment, req *AddNopsRequest) (deployment.Change
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 		timelocksPerChain := map[uint64]gethcommon.Address{
-			registryChain.Selector: contractSet.Timelock.Address(),
+			registryChain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.Timelock.Address(),
 		}
 		proposerMCMSes := map[uint64]*gethwrappers.ManyChainMultiSig{
-			registryChain.Selector: contractSet.ProposerMcm,
+			registryChain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.ProposerMcm,
 		}
 
 		proposal, err := proposalutils.BuildProposalFromBatches(

--- a/deployment/keystone/changeset/append_node_capabilities.go
+++ b/deployment/keystone/changeset/append_node_capabilities.go
@@ -35,10 +35,10 @@ func AppendNodeCapabilities(env deployment.Environment, req *AppendNodeCapabilit
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 		timelocksPerChain := map[uint64]string{
-			c.Chain.Selector: contractSet.Timelock.Address().Hex(),
+			c.Chain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			c.Chain.Selector: contractSet.ProposerMcm.Address().Hex(),
+			c.Chain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.ProposerMcm.Address().Hex(),
 		}
 		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
 		if err != nil {
@@ -65,12 +65,12 @@ func AppendNodeCapabilities(env deployment.Environment, req *AppendNodeCapabilit
 	return out, nil
 }
 
-func (req *AppendNodeCapabilitiesRequest) convert(e deployment.Environment) (*internal.AppendNodeCapabilitiesRequest, *ContractSet, error) {
+func (req *AppendNodeCapabilitiesRequest) convert(e deployment.Environment) (*internal.AppendNodeCapabilitiesRequest, *ContractSetV2, error) {
 	if err := req.Validate(e); err != nil {
 		return nil, nil, fmt.Errorf("failed to validate UpdateNodeCapabilitiesRequest: %w", err)
 	}
 	registryChain := e.Chains[req.RegistryChainSel] // exists because of the validation above
-	resp, err := GetContractSets(e.Logger, &GetContractSetsRequest{
+	resp, err := GetContractSetsV2(e.Logger, GetContractSetsRequestV2{
 		Chains:      map[uint64]deployment.Chain{req.RegistryChainSel: registryChain},
 		AddressBook: e.ExistingAddresses,
 	})
@@ -81,7 +81,7 @@ func (req *AppendNodeCapabilitiesRequest) convert(e deployment.Environment) (*in
 
 	return &internal.AppendNodeCapabilitiesRequest{
 		Chain:                registryChain,
-		CapabilitiesRegistry: contractSet.CapabilitiesRegistry,
+		CapabilitiesRegistry: contractSet.CapabilitiesRegistry.Contract,
 		P2pToCapabilities:    req.P2pToCapabilities,
 		UseMCMS:              req.UseMCMS(),
 	}, &contractSet, nil

--- a/deployment/keystone/changeset/contract_set.go
+++ b/deployment/keystone/changeset/contract_set.go
@@ -1,0 +1,169 @@
+package changeset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment"
+
+	capabilities_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+	forwarder "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/forwarder_1_0_0"
+	ocr3_capability "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
+	workflow_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/workflow/generated/workflow_registry_wrapper"
+)
+
+// ContractSetV2 represents a set of contracts for a specific chain.
+type ContractSetV2 struct {
+	OCR3                 map[common.Address]OwnedContract[*ocr3_capability.OCR3Capability]
+	Forwarder            *OwnedContract[*forwarder.KeystoneForwarder]
+	CapabilitiesRegistry *OwnedContract[*capabilities_registry.CapabilitiesRegistry]
+	WorkflowRegistry     *OwnedContract[*workflow_registry.WorkflowRegistry]
+}
+
+// GetContractSetsRequestV2 is the request structure for getting contract sets.
+type GetContractSetsRequestV2 struct {
+	AddressBook deployment.AddressBook
+	Chains      map[uint64]deployment.Chain
+	Labels      []string
+}
+
+// GetContractSetsResponseV2 is the response structure for getting contract sets.
+type GetContractSetsResponseV2 struct {
+	ContractSets map[uint64]ContractSetV2
+}
+
+func (cs ContractSetV2) toContractSet() ContractSet {
+	// We don't set the `ContractSet.MCMSWithTimelockState` due to the nature of `ContractSetV2`.
+	// Now each contract has its own MCMS state, and that format is not compatible with `ContractSet`.
+	out := ContractSet{}
+
+	ocr3Contracts := make(map[common.Address]*ocr3_capability.OCR3Capability)
+	for addr, ocr := range cs.OCR3 {
+		ocr3Contracts[addr] = ocr.Contract
+	}
+
+	out.OCR3 = ocr3Contracts
+	if cs.Forwarder != nil {
+		out.Forwarder = cs.Forwarder.Contract
+	}
+	if cs.CapabilitiesRegistry != nil {
+		out.CapabilitiesRegistry = cs.CapabilitiesRegistry.Contract
+	}
+	if cs.WorkflowRegistry != nil {
+		out.WorkflowRegistry = cs.WorkflowRegistry.Contract
+	}
+
+	return out
+}
+
+// TransferableContracts returns a list of addresses of contracts that are transferable.
+func (cs ContractSetV2) TransferableContracts() []common.Address {
+	return cs.toContractSet().TransferableContracts()
+}
+
+// View is a view of the keystone chain. Internally, it uses the ContractSet view to get the state of the contracts.
+// This is to preserve the view functionality.
+func (cs ContractSetV2) View(ctx context.Context, prevView KeystoneChainView, lggr logger.Logger) (KeystoneChainView, error) {
+	return cs.toContractSet().View(ctx, prevView, lggr)
+}
+
+// GetContractSetsV2 retrieves the contract sets for the given chains and labels.
+func GetContractSetsV2(lggr logger.Logger, req GetContractSetsRequestV2) (*GetContractSetsResponseV2, error) {
+	out := &GetContractSetsResponseV2{
+		ContractSets: make(map[uint64]ContractSetV2),
+	}
+
+	for id, chain := range req.Chains {
+		addresses, err := req.AddressBook.AddressesForChain(id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get addresses for chain %d: %w", id, err)
+		}
+
+		// Forwarder addresses now have informative labels, but we don't want them to be ignored if no labels are provided for filtering.
+		// If labels are provided, just filter by those.
+		forwarderAddrs := make(map[string]deployment.TypeAndVersion)
+		if len(req.Labels) == 0 {
+			for addr, tv := range addresses {
+				if tv.Type == KeystoneForwarder {
+					forwarderAddrs[addr] = tv
+				}
+			}
+		}
+
+		// TODO: we need to expand/refactor the way labeled addresses are filtered
+		// see: https://smartcontract-it.atlassian.net/browse/CRE-363
+		filtered := deployment.LabeledAddresses(addresses).And(req.Labels...)
+		for addr, tv := range forwarderAddrs {
+			filtered[addr] = tv
+		}
+
+		cs, err := loadContractSetV2(lggr, req.AddressBook, chain, filtered)
+		if err != nil {
+			return nil, fmt.Errorf("error loading contract set for chain %s: %w", chain.Name(), err)
+		}
+
+		out.ContractSets[id] = *cs
+	}
+
+	return out, nil
+}
+
+func loadContractSetV2(lggr logger.Logger, addressBook deployment.AddressBook, chain deployment.Chain, addresses map[string]deployment.TypeAndVersion) (*ContractSetV2, error) {
+	var out ContractSetV2
+
+	handlers := map[deployment.ContractType]func(string) error{
+		OCR3Capability: func(addr string) error {
+			contract, err := GetOwnedContract[*ocr3_capability.OCR3Capability](addressBook, chain, addr)
+			if err != nil {
+				return err
+			}
+			if out.OCR3 == nil {
+				out.OCR3 = make(map[common.Address]OwnedContract[*ocr3_capability.OCR3Capability])
+			}
+			out.OCR3[common.HexToAddress(addr)] = *contract
+			return nil
+		},
+		KeystoneForwarder: func(addr string) error {
+			contract, err := GetOwnedContract[*forwarder.KeystoneForwarder](addressBook, chain, addr)
+			if err != nil {
+				return err
+			}
+			out.Forwarder = contract
+			return nil
+		},
+		CapabilitiesRegistry: func(addr string) error {
+			contract, err := GetOwnedContract[*capabilities_registry.CapabilitiesRegistry](addressBook, chain, addr)
+			if err != nil {
+				return err
+			}
+			out.CapabilitiesRegistry = contract
+			return nil
+		},
+		WorkflowRegistry: func(addr string) error {
+			contract, err := GetOwnedContract[*workflow_registry.WorkflowRegistry](addressBook, chain, addr)
+			if err != nil {
+				return err
+			}
+			out.WorkflowRegistry = contract
+			return nil
+		},
+	}
+
+	for addr, tv := range addresses {
+		handler, exists := handlers[tv.Type]
+		if !exists {
+			// ignore unknown contract types
+			lggr.Warnf("Unknown contract type %s for address %s", tv.Type, addr)
+			continue
+		}
+
+		if err := handler(addr); err != nil {
+			return nil, fmt.Errorf("error trying to load contract type `%s` for address %s: %w", tv.Type, addr, err)
+		}
+	}
+
+	return &out, nil
+}

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -6,10 +6,9 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/chainlink/deployment/common/types"
-
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
 
 	capabilities_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	forwarder "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/forwarder_1_0_0"
@@ -17,15 +16,7 @@ import (
 	workflow_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/workflow/generated/workflow_registry_wrapper"
 )
 
-var (
-	// We expect one of each contract on the chain.
-	timelock  = deployment.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
-	callProxy = deployment.NewTypeAndVersion(types.CallProxy, deployment.Version1_0_0)
-	proposer  = deployment.NewTypeAndVersion(types.ProposerManyChainMultisig, deployment.Version1_0_0)
-	canceller = deployment.NewTypeAndVersion(types.CancellerManyChainMultisig, deployment.Version1_0_0)
-	bypasser  = deployment.NewTypeAndVersion(types.BypasserManyChainMultisig, deployment.Version1_0_0)
-)
-
+// Ownable is an interface for contracts that have an owner.
 type Ownable interface {
 	Address() common.Address
 	Owner(opts *bind.CallOpts) (common.Address, error)
@@ -39,41 +30,42 @@ type OwnedContract[T Ownable] struct {
 	Contract T
 }
 
-// NewOwnable creates an OwnedContract instance
+// NewOwnable creates an OwnedContract instance.
+// It checks if the contract is owned by a timelock contract and loads the MCMS state if necessary.
 func NewOwnable[T Ownable](contract T, ab deployment.AddressBook, chain deployment.Chain) (*OwnedContract[T], error) {
+	var timelockTV = deployment.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
+
 	// Look for MCMS contracts that might be owned by the contract
 	addresses, err := ab.AddressesForChain(chain.Selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get addresses: %w", err)
 	}
 
-	// Get the contract owner
-	owner, err := contract.Owner(nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get contract owner: %w", err)
-	}
-
-	ownerTv, err := GetOwnerTypeAndVersion(contract, ab, chain)
+	ownerTV, err := GetOwnerTypeAndVersion[T](contract, ab, chain)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get owner type and version: %w", err)
 	}
-	if ownerTv.Type == timelock.Type && ownerTv.Version.String() == timelock.Version.String() {
-		stateMCMS, mcmsErr := loadMCMSWithTimelockChainState(chain, addresses)
+
+	// Check if the owner is a timelock contract (owned by MCMS)
+	if ownerTV.Type == timelockTV.Type && ownerTV.Version.String() == timelockTV.Version.String() {
+		// Load MCMS state
+		stateMCMS, mcmsErr := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 		if mcmsErr != nil {
 			return nil, fmt.Errorf("failed to load MCMS state: %w", mcmsErr)
 		}
+
 		return &OwnedContract[T]{
 			McmsContracts: *stateMCMS,
 			Contract:      contract,
 		}, nil
 	}
-	fmt.Println("Contract owner:", owner.Hex())
 
 	return &OwnedContract[T]{
 		Contract: contract,
 	}, nil
 }
 
+// GetOwnerTypeAndVersion retrieves the owner type and version of a contract.
 func GetOwnerTypeAndVersion[T Ownable](contract T, ab deployment.AddressBook, chain deployment.Chain) (*deployment.TypeAndVersion, error) {
 	// Get the contract owner
 	owner, err := contract.Owner(nil)
@@ -104,43 +96,11 @@ func GetOwnerTypeAndVersion[T Ownable](contract T, ab deployment.AddressBook, ch
 	return nil, fmt.Errorf("owner %s not found in address book", ownerStr)
 }
 
-func loadMCMSWithTimelockChainState(
-	chain deployment.Chain,
-	addresses map[string]deployment.TypeAndVersion,
-) (*commonchangeset.MCMSWithTimelockState, error) {
-	var (
-		// the same contract can have different roles
-		// multichain    = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
-		proposerMCMS  = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
-		bypasserMCMS  = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
-		cancellerMCMS = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
-	)
-
-	// Convert map keys to a slice
-	proposerMCMS.Labels.Add(types.ProposerRole.String())
-	bypasserMCMS.Labels.Add(types.BypasserRole.String())
-	cancellerMCMS.Labels.Add(types.CancellerRole.String())
-	wantTypes := []deployment.TypeAndVersion{timelock, proposer, canceller, bypasser, callProxy,
-		proposerMCMS, bypasserMCMS, cancellerMCMS,
-	}
-	// Ensure we either have the bundle or not.
-	_, err := deployment.EnsureDeduped(addresses, wantTypes)
-	if err != nil {
-		return nil, fmt.Errorf("unable to check MCMS contracts on chain %s error: %w", chain.Name(), err)
-	}
-
-	// Load MCMS state
-	stateMCMS, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load MCMS state: %w", err)
-	}
-
-	return stateMCMS, nil
-}
-
-func GetContract[T Ownable](ab deployment.AddressBook, chain deployment.Chain, targetAddr string) (*T, error) {
+// GetContract retrieves a contract instance of type T from the address book.
+// If `targetAddr` is provided, it will look for that specific address.
+// If not, it will default to looking one contract of type T, and if it doesn't find exactly one, it will error.
+func GetContract[T Ownable](ab deployment.AddressBook, chain deployment.Chain, targetAddr *string) (*T, error) {
 	var contractType deployment.ContractType
-
 	// Determine contract type based on T
 	switch any(*new(T)).(type) {
 	case *forwarder.KeystoneForwarder:
@@ -161,69 +121,66 @@ func GetContract[T Ownable](ab deployment.AddressBook, chain deployment.Chain, t
 	}
 
 	// If addr is provided, look for that specific address
-	if len(targetAddr) > 0 {
-		tv, exists := addresses[targetAddr]
+	if targetAddr != nil {
+		addr := *targetAddr
+		tv, exists := addresses[addr]
 		if !exists {
-			return nil, fmt.Errorf("address %s not found in address book", targetAddr)
+			return nil, fmt.Errorf("address %s not found in address book", addr)
 		}
 
 		if tv.Type != contractType {
-			return nil, fmt.Errorf("address %s is not a %s, got %s", targetAddr, contractType, tv.Type)
+			return nil, fmt.Errorf("address %s is not a %s, got %s", addr, contractType, tv.Type)
 		}
 
-		// Create and return the contract instance
-		var instance T
-		var err error
-		switch any(*new(T)).(type) {
-		case *forwarder.KeystoneForwarder:
-			c, e := forwarder.NewKeystoneForwarder(common.HexToAddress(targetAddr), chain.Client)
-			instance, err = any(c).(T), e
-		case *capabilities_registry.CapabilitiesRegistry:
-			c, e := capabilities_registry.NewCapabilitiesRegistry(common.HexToAddress(targetAddr), chain.Client)
-			instance, err = any(c).(T), e
-		case *ocr3_capability.OCR3Capability:
-			c, e := ocr3_capability.NewOCR3Capability(common.HexToAddress(targetAddr), chain.Client)
-			instance, err = any(c).(T), e
-		case *workflow_registry.WorkflowRegistry:
-			c, e := workflow_registry.NewWorkflowRegistry(common.HexToAddress(targetAddr), chain.Client)
-			instance, err = any(c).(T), e
-		}
-
-		if err != nil {
-			return nil, fmt.Errorf("failed to create contract instance: %w", err)
-		}
-
-		return &instance, nil
+		return createContractInstance[T](addr, chain)
 	}
 
-	// Find first contract of the required type
+	var foundAddr string
+	var contractCount int
+
 	for addr, tv := range addresses {
 		if tv.Type == contractType {
-			// Create and return the contract instance
-			var instance T
-			var err error
-			switch any(*new(T)).(type) {
-			case *forwarder.KeystoneForwarder:
-				c, e := forwarder.NewKeystoneForwarder(common.HexToAddress(addr), chain.Client)
-				instance, err = any(c).(T), e
-			case *capabilities_registry.CapabilitiesRegistry:
-				c, e := capabilities_registry.NewCapabilitiesRegistry(common.HexToAddress(addr), chain.Client)
-				instance, err = any(c).(T), e
-			case *ocr3_capability.OCR3Capability:
-				c, e := ocr3_capability.NewOCR3Capability(common.HexToAddress(addr), chain.Client)
-				instance, err = any(c).(T), e
-			case *workflow_registry.WorkflowRegistry:
-				c, e := workflow_registry.NewWorkflowRegistry(common.HexToAddress(addr), chain.Client)
-				instance, err = any(c).(T), e
-			}
+			contractCount++
+			foundAddr = addr
 
-			if err != nil {
-				return nil, fmt.Errorf("failed to create contract instance: %w", err)
+			if contractCount > 1 {
+				return nil, fmt.Errorf("multiple contracts of type %s found, must provide a `targetAddr`", contractType)
 			}
-
-			return &instance, nil
 		}
 	}
 
-	return nil, fmt.Errorf("no contract of type %s found", contractType)
+	if contractCount == 0 {
+		return nil, fmt.Errorf("no contract of type %s found", contractType)
+	}
+
+	return createContractInstance[T](foundAddr, chain)
+}
+
+// createContractInstance is a helper function to create contract instances
+func createContractInstance[T Ownable](addr string, chain deployment.Chain) (*T, error) {
+	var instance T
+	var err error
+
+	switch any(*new(T)).(type) {
+	case *forwarder.KeystoneForwarder:
+		c, e := forwarder.NewKeystoneForwarder(common.HexToAddress(addr), chain.Client)
+		instance, err = any(c).(T), e
+	case *capabilities_registry.CapabilitiesRegistry:
+		c, e := capabilities_registry.NewCapabilitiesRegistry(common.HexToAddress(addr), chain.Client)
+		instance, err = any(c).(T), e
+	case *ocr3_capability.OCR3Capability:
+		c, e := ocr3_capability.NewOCR3Capability(common.HexToAddress(addr), chain.Client)
+		instance, err = any(c).(T), e
+	case *workflow_registry.WorkflowRegistry:
+		c, e := workflow_registry.NewWorkflowRegistry(common.HexToAddress(addr), chain.Client)
+		instance, err = any(c).(T), e
+	default:
+		return nil, fmt.Errorf("unsupported contract type for instance creation")
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create contract instance: %w", err)
+	}
+
+	return &instance, nil
 }

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -48,7 +48,8 @@ func NewOwnable[T Ownable](contract T, ab deployment.AddressBook, chain deployme
 	}
 
 	// Check if the owner is a timelock contract (owned by MCMS)
-	if ownerTV.Type == timelockTV.Type && ownerTV.Version.String() == timelockTV.Version.String() {
+	// If the owner is not in the address book (ownerTV = nil and err = nil), we assume it's not owned by MCMS
+	if ownerTV != nil && ownerTV.Type == timelockTV.Type && ownerTV.Version.String() == timelockTV.Version.String() {
 		// Load MCMS state
 		stateMCMS, mcmsErr := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 		if mcmsErr != nil {
@@ -95,7 +96,8 @@ func GetOwnerTypeAndVersion[T Ownable](contract T, ab deployment.AddressBook, ch
 		}
 	}
 
-	return nil, fmt.Errorf("owner %s not found in address book", ownerStr)
+	// Owner not found, assume it's non-MCMS so no error is returned
+	return nil, nil
 }
 
 // GetOwnableContract retrieves a contract instance of type T from the address book.
@@ -185,4 +187,19 @@ func createContractInstance[T Ownable](addr string, chain deployment.Chain) (*T,
 	}
 
 	return &instance, nil
+}
+
+// GetOwnedContract is a helper function that gets a contract and wraps it in OwnedContract
+func GetOwnedContract[T Ownable](addressBook deployment.AddressBook, chain deployment.Chain, addr string) (*OwnedContract[T], error) {
+	contract, err := GetOwnableContract[T](addressBook, chain, &addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get contract at %s: %w", addr, err)
+	}
+
+	ownedContract, err := NewOwnable(*contract, addressBook, chain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create owned contract for %s: %w", addr, err)
+	}
+
+	return ownedContract, nil
 }

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -97,10 +97,10 @@ func GetOwnerTypeAndVersion[T Ownable](contract T, ab deployment.AddressBook, ch
 	return nil, fmt.Errorf("owner %s not found in address book", ownerStr)
 }
 
-// GetContract retrieves a contract instance of type T from the address book.
+// GetOwnableContract retrieves a contract instance of type T from the address book.
 // If `targetAddr` is provided, it will look for that specific address.
 // If not, it will default to looking one contract of type T, and if it doesn't find exactly one, it will error.
-func GetContract[T Ownable](ab deployment.AddressBook, chain deployment.Chain, targetAddr *string) (*T, error) {
+func GetOwnableContract[T Ownable](ab deployment.AddressBook, chain deployment.Chain, targetAddr *string) (*T, error) {
 	var contractType deployment.ContractType
 	// Determine contract type based on T
 	switch any(*new(T)).(type) {

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -1,0 +1,178 @@
+package changeset
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+
+	capabilities_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+	forwarder "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/forwarder_1_0_0"
+	ocr3_capability "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
+	workflow_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/workflow/generated/workflow_registry_wrapper"
+)
+
+type Ownable interface {
+	Address() common.Address
+	Owner(opts *bind.CallOpts) (common.Address, error)
+}
+
+// OwnedContract represents a contract and its owned MCMS contracts.
+type OwnedContract[T Ownable] struct {
+	// The MCMS contracts that the contract might own
+	McmsContracts commonchangeset.MCMSWithTimelockState
+	// The actual contract instance
+	Contract T
+}
+
+// NewOwnable creates an OwnedContract instance
+func NewOwnable[T Ownable](contract T, ab deployment.AddressBook, chain deployment.Chain) (*OwnedContract[T], error) {
+	var (
+		// We expect one of each contract on the chain.
+		timelock  = deployment.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
+		callProxy = deployment.NewTypeAndVersion(types.CallProxy, deployment.Version1_0_0)
+		proposer  = deployment.NewTypeAndVersion(types.ProposerManyChainMultisig, deployment.Version1_0_0)
+		canceller = deployment.NewTypeAndVersion(types.CancellerManyChainMultisig, deployment.Version1_0_0)
+		bypasser  = deployment.NewTypeAndVersion(types.BypasserManyChainMultisig, deployment.Version1_0_0)
+
+		// the same contract can have different roles
+		// multichain    = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
+		proposerMCMS  = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
+		bypasserMCMS  = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
+		cancellerMCMS = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
+	)
+
+	// Look for MCMS contracts that might be owned by the contract
+	addresses, err := ab.AddressesForChain(chain.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get addresses: %w", err)
+	}
+
+	// Convert map keys to a slice
+	proposerMCMS.Labels.Add(types.ProposerRole.String())
+	bypasserMCMS.Labels.Add(types.BypasserRole.String())
+	cancellerMCMS.Labels.Add(types.CancellerRole.String())
+	wantTypes := []deployment.TypeAndVersion{timelock, proposer, canceller, bypasser, callProxy,
+		proposerMCMS, bypasserMCMS, cancellerMCMS,
+	}
+
+	// Ensure we either have the bundle or not.
+	_, err = deployment.EnsureDeduped(addresses, wantTypes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to check MCMS contracts on chain %s error: %w", chain.Name(), err)
+	}
+
+	// Get the contract owner
+	owner, err := contract.Owner(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get contract owner: %w", err)
+	}
+	fmt.Println("Contract owner:", owner.Hex())
+
+	// Filter for potential MCMS contracts
+	// TODO: figure out if the contract is owned by MCMS and only load the state if that's the case.
+	// Load MCMS state
+	mcmsState, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load MCMS state: %w", err)
+	}
+
+	return &OwnedContract[T]{
+		McmsContracts: *mcmsState,
+		Contract:      contract,
+	}, nil
+}
+
+func GetContract[T Ownable](ab deployment.AddressBook, chain deployment.Chain, targetAddr string) (*T, error) {
+	var contractType deployment.ContractType
+
+	// Determine contract type based on T
+	switch any(*new(T)).(type) {
+	case *forwarder.KeystoneForwarder:
+		contractType = KeystoneForwarder
+	case *capabilities_registry.CapabilitiesRegistry:
+		contractType = CapabilitiesRegistry
+	case *ocr3_capability.OCR3Capability:
+		contractType = OCR3Capability
+	case *workflow_registry.WorkflowRegistry:
+		contractType = WorkflowRegistry
+	default:
+		return nil, fmt.Errorf("unsupported contract type %T", *new(T))
+	}
+
+	addresses, err := ab.AddressesForChain(chain.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get addresses for chain %d: %w", chain.Selector, err)
+	}
+
+	// If addr is provided, look for that specific address
+	if len(targetAddr) > 0 {
+		tv, exists := addresses[targetAddr]
+		if !exists {
+			return nil, fmt.Errorf("address %s not found in address book", targetAddr)
+		}
+
+		if tv.Type != contractType {
+			return nil, fmt.Errorf("address %s is not a %s, got %s", targetAddr, contractType, tv.Type)
+		}
+
+		// Create and return the contract instance
+		var instance T
+		var err error
+		switch any(*new(T)).(type) {
+		case *forwarder.KeystoneForwarder:
+			c, e := forwarder.NewKeystoneForwarder(common.HexToAddress(targetAddr), chain.Client)
+			instance, err = any(c).(T), e
+		case *capabilities_registry.CapabilitiesRegistry:
+			c, e := capabilities_registry.NewCapabilitiesRegistry(common.HexToAddress(targetAddr), chain.Client)
+			instance, err = any(c).(T), e
+		case *ocr3_capability.OCR3Capability:
+			c, e := ocr3_capability.NewOCR3Capability(common.HexToAddress(targetAddr), chain.Client)
+			instance, err = any(c).(T), e
+		case *workflow_registry.WorkflowRegistry:
+			c, e := workflow_registry.NewWorkflowRegistry(common.HexToAddress(targetAddr), chain.Client)
+			instance, err = any(c).(T), e
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create contract instance: %w", err)
+		}
+
+		return &instance, nil
+	}
+
+	// Find first contract of the required type
+	for addr, tv := range addresses {
+		if tv.Type == contractType {
+			// Create and return the contract instance
+			var instance T
+			var err error
+			switch any(*new(T)).(type) {
+			case *forwarder.KeystoneForwarder:
+				c, e := forwarder.NewKeystoneForwarder(common.HexToAddress(addr), chain.Client)
+				instance, err = any(c).(T), e
+			case *capabilities_registry.CapabilitiesRegistry:
+				c, e := capabilities_registry.NewCapabilitiesRegistry(common.HexToAddress(addr), chain.Client)
+				instance, err = any(c).(T), e
+			case *ocr3_capability.OCR3Capability:
+				c, e := ocr3_capability.NewOCR3Capability(common.HexToAddress(addr), chain.Client)
+				instance, err = any(c).(T), e
+			case *workflow_registry.WorkflowRegistry:
+				c, e := workflow_registry.NewWorkflowRegistry(common.HexToAddress(addr), chain.Client)
+				instance, err = any(c).(T), e
+			}
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to create contract instance: %w", err)
+			}
+
+			return &instance, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no contract of type %s found", contractType)
+}

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -14,6 +15,15 @@ import (
 	forwarder "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/forwarder_1_0_0"
 	ocr3_capability "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
 	workflow_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/workflow/generated/workflow_registry_wrapper"
+)
+
+var (
+	// We expect one of each contract on the chain.
+	timelock  = deployment.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
+	callProxy = deployment.NewTypeAndVersion(types.CallProxy, deployment.Version1_0_0)
+	proposer  = deployment.NewTypeAndVersion(types.ProposerManyChainMultisig, deployment.Version1_0_0)
+	canceller = deployment.NewTypeAndVersion(types.CancellerManyChainMultisig, deployment.Version1_0_0)
+	bypasser  = deployment.NewTypeAndVersion(types.BypasserManyChainMultisig, deployment.Version1_0_0)
 )
 
 type Ownable interface {
@@ -31,26 +41,80 @@ type OwnedContract[T Ownable] struct {
 
 // NewOwnable creates an OwnedContract instance
 func NewOwnable[T Ownable](contract T, ab deployment.AddressBook, chain deployment.Chain) (*OwnedContract[T], error) {
-	var (
-		// We expect one of each contract on the chain.
-		timelock  = deployment.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
-		callProxy = deployment.NewTypeAndVersion(types.CallProxy, deployment.Version1_0_0)
-		proposer  = deployment.NewTypeAndVersion(types.ProposerManyChainMultisig, deployment.Version1_0_0)
-		canceller = deployment.NewTypeAndVersion(types.CancellerManyChainMultisig, deployment.Version1_0_0)
-		bypasser  = deployment.NewTypeAndVersion(types.BypasserManyChainMultisig, deployment.Version1_0_0)
+	// Look for MCMS contracts that might be owned by the contract
+	addresses, err := ab.AddressesForChain(chain.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get addresses: %w", err)
+	}
 
+	// Get the contract owner
+	owner, err := contract.Owner(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get contract owner: %w", err)
+	}
+
+	ownerTv, err := GetOwnerTypeAndVersion(contract, ab, chain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get owner type and version: %w", err)
+	}
+	if ownerTv.Type == timelock.Type && ownerTv.Version.String() == timelock.Version.String() {
+		stateMCMS, mcmsErr := loadMCMSWithTimelockChainState(chain, addresses)
+		if mcmsErr != nil {
+			return nil, fmt.Errorf("failed to load MCMS state: %w", mcmsErr)
+		}
+		return &OwnedContract[T]{
+			McmsContracts: *stateMCMS,
+			Contract:      contract,
+		}, nil
+	}
+	fmt.Println("Contract owner:", owner.Hex())
+
+	return &OwnedContract[T]{
+		Contract: contract,
+	}, nil
+}
+
+func GetOwnerTypeAndVersion[T Ownable](contract T, ab deployment.AddressBook, chain deployment.Chain) (*deployment.TypeAndVersion, error) {
+	// Get the contract owner
+	owner, err := contract.Owner(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get contract owner: %w", err)
+	}
+
+	// Look for owner in address book
+	addresses, err := ab.AddressesForChain(chain.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get addresses for chain %d: %w", chain.Selector, err)
+	}
+
+	ownerStr := owner.Hex()
+	// Check if owner matches any address in the address book
+	if tv, exists := addresses[ownerStr]; exists {
+		return &tv, nil
+	}
+
+	// Handle case where owner is not in address book
+	// Check for case-insensitive match since some addresses might be stored with different casing
+	for addr, tv := range addresses {
+		if common.HexToAddress(addr) == owner {
+			return &tv, nil
+		}
+	}
+
+	return nil, fmt.Errorf("owner %s not found in address book", ownerStr)
+}
+
+func loadMCMSWithTimelockChainState(
+	chain deployment.Chain,
+	addresses map[string]deployment.TypeAndVersion,
+) (*commonchangeset.MCMSWithTimelockState, error) {
+	var (
 		// the same contract can have different roles
 		// multichain    = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
 		proposerMCMS  = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
 		bypasserMCMS  = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
 		cancellerMCMS = deployment.NewTypeAndVersion(types.ManyChainMultisig, deployment.Version1_0_0)
 	)
-
-	// Look for MCMS contracts that might be owned by the contract
-	addresses, err := ab.AddressesForChain(chain.Selector)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get addresses: %w", err)
-	}
 
 	// Convert map keys to a slice
 	proposerMCMS.Labels.Add(types.ProposerRole.String())
@@ -59,32 +123,19 @@ func NewOwnable[T Ownable](contract T, ab deployment.AddressBook, chain deployme
 	wantTypes := []deployment.TypeAndVersion{timelock, proposer, canceller, bypasser, callProxy,
 		proposerMCMS, bypasserMCMS, cancellerMCMS,
 	}
-
 	// Ensure we either have the bundle or not.
-	_, err = deployment.EnsureDeduped(addresses, wantTypes)
+	_, err := deployment.EnsureDeduped(addresses, wantTypes)
 	if err != nil {
 		return nil, fmt.Errorf("unable to check MCMS contracts on chain %s error: %w", chain.Name(), err)
 	}
 
-	// Get the contract owner
-	owner, err := contract.Owner(nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get contract owner: %w", err)
-	}
-	fmt.Println("Contract owner:", owner.Hex())
-
-	// Filter for potential MCMS contracts
-	// TODO: figure out if the contract is owned by MCMS and only load the state if that's the case.
 	// Load MCMS state
-	mcmsState, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
+	stateMCMS, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load MCMS state: %w", err)
 	}
 
-	return &OwnedContract[T]{
-		McmsContracts: *mcmsState,
-		Contract:      contract,
-	}, nil
+	return stateMCMS, nil
 }
 
 func GetContract[T Ownable](ab deployment.AddressBook, chain deployment.Chain, targetAddr string) (*T, error) {

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -26,7 +26,7 @@ type Ownable interface {
 // OwnedContract represents a contract and its owned MCMS contracts.
 type OwnedContract[T Ownable] struct {
 	// The MCMS contracts that the contract might own
-	McmsContracts commonchangeset.MCMSWithTimelockState
+	McmsContracts *commonchangeset.MCMSWithTimelockState
 	// The actual contract instance
 	Contract T
 }
@@ -56,13 +56,14 @@ func NewOwnable[T Ownable](contract T, ab deployment.AddressBook, chain deployme
 		}
 
 		return &OwnedContract[T]{
-			McmsContracts: *stateMCMS,
+			McmsContracts: stateMCMS,
 			Contract:      contract,
 		}, nil
 	}
 
 	return &OwnedContract[T]{
-		Contract: contract,
+		McmsContracts: nil,
+		Contract:      contract,
 	}, nil
 }
 

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -1,6 +1,7 @@
 package changeset
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -175,7 +176,7 @@ func createContractInstance[T Ownable](addr string, chain deployment.Chain) (*T,
 		c, e := workflow_registry.NewWorkflowRegistry(common.HexToAddress(addr), chain.Client)
 		instance, err = any(c).(T), e
 	default:
-		return nil, fmt.Errorf("unsupported contract type for instance creation")
+		return nil, errors.New("unsupported contract type for instance creation")
 	}
 
 	if err != nil {

--- a/deployment/keystone/changeset/contracts_test.go
+++ b/deployment/keystone/changeset/contracts_test.go
@@ -7,9 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
-	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
 	"github.com/smartcontractkit/chainlink-integrations/evm/testutils"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -17,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	capabilities_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	forwarder "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/forwarder_1_0_0"
 )

--- a/deployment/keystone/changeset/contracts_test.go
+++ b/deployment/keystone/changeset/contracts_test.go
@@ -154,7 +154,7 @@ func TestGetOwnerTypeAndVersion(t *testing.T) {
 		assert.Equal(t, deployment.Version1_0_0, tv.Version)
 	})
 
-	t.Run("errors when owner not in address book", func(t *testing.T) {
+	t.Run("nil owner when owner not in address book", func(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -173,16 +173,14 @@ func TestGetOwnerTypeAndVersion(t *testing.T) {
 			targetAddrStr = addr
 			break // Just take the first one
 		}
-
 		addrBook := env.ExistingAddresses
-
 		contract, err := changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &targetAddrStr)
 		require.NoError(t, err)
 
-		_, err = changeset.GetOwnerTypeAndVersion(*contract, addrBook, chain)
+		ownerTV, err := changeset.GetOwnerTypeAndVersion(*contract, addrBook, chain)
 
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "not found in address book")
+		require.NoError(t, err)
+		assert.Nil(t, ownerTV)
 	})
 }
 
@@ -282,7 +280,7 @@ func TestNewOwnable(t *testing.T) {
 		assert.NotNil(t, ownedContract.McmsContracts)
 	})
 
-	t.Run("handles error when owner type lookup fails", func(t *testing.T) {
+	t.Run("no error when owner type lookup fails due to missing address on address book (it is non-MCMS owned)", func(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -309,11 +307,13 @@ func TestNewOwnable(t *testing.T) {
 		contract, err := changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &targetAddrStr)
 		require.NoError(t, err)
 
-		// Don't add owner to address book, so lookup will fail
+		// Don't add owner to address book, so lookup will return nil TV and no error
 
-		// Call NewOwnable, should fail because owner is not in address book
-		_, err = changeset.NewOwnable(*contract, addrBook, chain)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to get owner type and version")
+		// Call NewOwnable, should not fail because owner is not in address book, but should return a non-MCMS contract
+		ownableContract, err := changeset.NewOwnable(*contract, addrBook, chain)
+		require.NoError(t, err)
+		assert.NotNil(t, ownableContract)
+		assert.Nil(t, ownableContract.McmsContracts)
+		assert.Equal(t, (*contract).Address(), ownableContract.Contract.Address())
 	})
 }

--- a/deployment/keystone/changeset/contracts_test.go
+++ b/deployment/keystone/changeset/contracts_test.go
@@ -3,11 +3,11 @@ package changeset_test
 import (
 	"testing"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
-	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-integrations/evm/testutils"
 

--- a/deployment/keystone/changeset/contracts_test.go
+++ b/deployment/keystone/changeset/contracts_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-integrations/evm/testutils"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 
-	chainsel "github.com/smartcontractkit/chain-selectors"
 	capabilities_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	forwarder "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/forwarder_1_0_0"
 )

--- a/deployment/keystone/changeset/contracts_test.go
+++ b/deployment/keystone/changeset/contracts_test.go
@@ -5,11 +5,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-integrations/evm/testutils"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 
@@ -59,7 +62,7 @@ func TestGetOwnableContract(t *testing.T) {
 		// No target address provided
 		_, err = changeset.GetOwnableContract[*forwarder.KeystoneForwarder](addrBook, chain, nil)
 
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "multiple contracts")
 		assert.Contains(t, err.Error(), "must provide a `targetAddr`")
 	})
@@ -79,7 +82,7 @@ func TestGetOwnableContract(t *testing.T) {
 		// No target address provided
 		_, err = changeset.GetOwnableContract[*forwarder.KeystoneForwarder](addrBook, chain, nil)
 
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no contract of type")
 	})
 
@@ -99,7 +102,86 @@ func TestGetOwnableContract(t *testing.T) {
 
 		_, err = changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &nonExistentAddrStr)
 
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in address book")
+	})
+}
+
+func TestGetOwnerTypeAndVersion(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.Test(t)
+	cfg := memory.MemoryEnvironmentConfig{
+		Nodes:  1, // nodes unused but required in config
+		Chains: 3,
+	}
+
+	t.Run("finds owner in address book", func(t *testing.T) {
+		t.Parallel()
+
+		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+		chain := env.Chains[env.AllChainSelectors()[0]]
+		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		err = env.ExistingAddresses.Merge(resp.AddressBook)
+		require.NoError(t, err)
+		addrs, err := resp.AddressBook.AddressesForChain(chain.Selector)
+		require.NoError(t, err)
+		require.Len(t, addrs, 1)
+		// Get the first address from the map
+		var targetAddrStr string
+		for addr := range addrs {
+			targetAddrStr = addr
+			break // Just take the first one
+		}
+
+		addrBook := env.ExistingAddresses
+
+		contract, err := changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &targetAddrStr)
+		require.NoError(t, err)
+		owner, err := (*contract).Owner(nil)
+		require.NoError(t, err)
+		mockAddresses := map[string]deployment.TypeAndVersion{
+			owner.Hex(): {Type: types.RBACTimelock, Version: deployment.Version1_0_0},
+		}
+		err = addrBook.Save(chain.Selector, owner.Hex(), mockAddresses[owner.Hex()])
+		require.NoError(t, err)
+
+		tv, err := changeset.GetOwnerTypeAndVersion(*contract, addrBook, chain)
+		require.NoError(t, err)
+		assert.Equal(t, types.RBACTimelock, tv.Type)
+		assert.Equal(t, deployment.Version1_0_0, tv.Version)
+	})
+
+	t.Run("errors when owner not in address book", func(t *testing.T) {
+		t.Parallel()
+
+		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+		chain := env.Chains[env.AllChainSelectors()[0]]
+		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		err = env.ExistingAddresses.Merge(resp.AddressBook)
+		require.NoError(t, err)
+		addrs, err := resp.AddressBook.AddressesForChain(chain.Selector)
+		require.NoError(t, err)
+		require.Len(t, addrs, 1)
+		// Get the first address from the map
+		var targetAddrStr string
+		for addr := range addrs {
+			targetAddrStr = addr
+			break // Just take the first one
+		}
+
+		addrBook := env.ExistingAddresses
+
+		contract, err := changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &targetAddrStr)
+		require.NoError(t, err)
+
+		_, err = changeset.GetOwnerTypeAndVersion(*contract, addrBook, chain)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found in address book")
 	})
 }

--- a/deployment/keystone/changeset/contracts_test.go
+++ b/deployment/keystone/changeset/contracts_test.go
@@ -9,6 +9,7 @@ import (
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-integrations/evm/testutils"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -183,5 +184,137 @@ func TestGetOwnerTypeAndVersion(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not found in address book")
+	})
+}
+
+func TestNewOwnable(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.Test(t)
+	cfg := memory.MemoryEnvironmentConfig{
+		Nodes:  1,
+		Chains: 3,
+	}
+
+	t.Run("creates OwnedContract for non-MCMS owner", func(t *testing.T) {
+		t.Parallel()
+
+		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+		chain := env.Chains[env.AllChainSelectors()[0]]
+		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		err = env.ExistingAddresses.Merge(resp.AddressBook)
+		require.NoError(t, err)
+
+		addrs, err := resp.AddressBook.AddressesForChain(chain.Selector)
+		require.NoError(t, err)
+		require.Len(t, addrs, 1)
+
+		// Get the first address from the map
+		var targetAddrStr string
+		for addr := range addrs {
+			targetAddrStr = addr
+			break
+		}
+
+		addrBook := env.ExistingAddresses
+
+		contract, err := changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &targetAddrStr)
+		require.NoError(t, err)
+		owner, err := (*contract).Owner(nil)
+		require.NoError(t, err)
+
+		// Setup owner as non-MCMS contract
+		mockAddresses := map[string]deployment.TypeAndVersion{
+			owner.Hex(): {Type: changeset.CapabilitiesRegistry, Version: deployment.Version1_0_0},
+		}
+		err = addrBook.Save(chain.Selector, owner.Hex(), mockAddresses[owner.Hex()])
+		require.NoError(t, err)
+
+		ownedContract, err := changeset.NewOwnable(*contract, addrBook, chain)
+		require.NoError(t, err)
+
+		// Verify the owned contract contains the contract but no MCMS contracts
+		assert.Equal(t, (*contract).Address(), ownedContract.Contract.Address())
+		assert.Nil(t, ownedContract.McmsContracts)
+	})
+
+	t.Run("creates OwnedContract for MCMS owner", func(t *testing.T) {
+		t.Parallel()
+
+		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+		chain := env.Chains[env.AllChainSelectors()[0]]
+		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		err = env.ExistingAddresses.Merge(resp.AddressBook)
+		require.NoError(t, err)
+
+		addrs, err := resp.AddressBook.AddressesForChain(chain.Selector)
+		require.NoError(t, err)
+		require.Len(t, addrs, 1)
+
+		// Get the first address from the map
+		var targetAddrStr string
+		for addr := range addrs {
+			targetAddrStr = addr
+			break
+		}
+
+		addrBook := env.ExistingAddresses
+
+		contract, err := changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &targetAddrStr)
+		require.NoError(t, err)
+		owner, err := (*contract).Owner(nil)
+		require.NoError(t, err)
+
+		// Setup owner as timelock contract
+		mockAddresses := map[string]deployment.TypeAndVersion{
+			owner.Hex(): {Type: types.RBACTimelock, Version: deployment.Version1_0_0},
+		}
+		err = addrBook.Save(chain.Selector, owner.Hex(), mockAddresses[owner.Hex()])
+		require.NoError(t, err)
+
+		ownedContract, err := changeset.NewOwnable(*contract, addrBook, chain)
+
+		require.NoError(t, err)
+		assert.Equal(t, (*contract).Address(), ownedContract.Contract.Address())
+		assert.NotNil(t, ownedContract.McmsContracts)
+	})
+
+	t.Run("handles error when owner type lookup fails", func(t *testing.T) {
+		t.Parallel()
+
+		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+		chain := env.Chains[env.AllChainSelectors()[0]]
+		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		err = env.ExistingAddresses.Merge(resp.AddressBook)
+		require.NoError(t, err)
+
+		addrs, err := resp.AddressBook.AddressesForChain(chain.Selector)
+		require.NoError(t, err)
+		require.Len(t, addrs, 1)
+
+		// Get the first address from the map
+		var targetAddrStr string
+		for addr := range addrs {
+			targetAddrStr = addr
+			break
+		}
+
+		addrBook := env.ExistingAddresses
+
+		contract, err := changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &targetAddrStr)
+		require.NoError(t, err)
+
+		// Don't add owner to address book, so lookup will fail
+
+		// Call NewOwnable, should fail because owner is not in address book
+		_, err = changeset.NewOwnable(*contract, addrBook, chain)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get owner type and version")
 	})
 }

--- a/deployment/keystone/changeset/contracts_test.go
+++ b/deployment/keystone/changeset/contracts_test.go
@@ -1,0 +1,105 @@
+package changeset_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-integrations/evm/testutils"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
+
+	capabilities_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+	forwarder "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/forwarder_1_0_0"
+)
+
+func TestGetOwnableContract(t *testing.T) {
+	t.Parallel()
+
+	chain := memory.NewMemoryChain(t, chainsel.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector)
+
+	t.Run("finds contract when targetAddr is provided", func(t *testing.T) {
+		t.Parallel()
+
+		addrBook := deployment.NewMemoryAddressBook()
+		targetAddr := testutils.NewAddress()
+		targetAddrStr := targetAddr.String()
+		tv := deployment.TypeAndVersion{Type: changeset.CapabilitiesRegistry, Version: deployment.Version1_1_0}
+		err := addrBook.Save(chainsel.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector, targetAddrStr, tv)
+		require.NoError(t, err)
+
+		c, err := changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &targetAddrStr)
+		require.NoError(t, err)
+		assert.NotNil(t, c)
+		contract := *c
+		assert.Equal(t, targetAddr, contract.Address())
+	})
+
+	t.Run("errors when multiple contracts found without targetAddr", func(t *testing.T) {
+		t.Parallel()
+
+		addrBook := deployment.NewMemoryAddressBook()
+		targetAddr1 := testutils.NewAddress()
+		targetAddrStr1 := targetAddr1.String()
+		targetAddr2 := testutils.NewAddress()
+		targetAddrStr2 := targetAddr2.String()
+		mockAddresses := map[string]deployment.TypeAndVersion{
+			targetAddrStr2: {Type: changeset.KeystoneForwarder, Version: deployment.Version1_1_0},
+			targetAddrStr1: {Type: changeset.KeystoneForwarder, Version: deployment.Version1_1_0},
+		}
+		err := addrBook.Save(chainsel.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector, targetAddrStr1, mockAddresses[targetAddrStr1])
+		require.NoError(t, err)
+		err = addrBook.Save(chainsel.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector, targetAddrStr2, mockAddresses[targetAddrStr2])
+		require.NoError(t, err)
+
+		// No target address provided
+		_, err = changeset.GetOwnableContract[*forwarder.KeystoneForwarder](addrBook, chain, nil)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple contracts")
+		assert.Contains(t, err.Error(), "must provide a `targetAddr`")
+	})
+
+	t.Run("errors when no contracts of the requested type exist", func(t *testing.T) {
+		t.Parallel()
+
+		targetAddr := testutils.NewAddress()
+		targetAddrStr := targetAddr.String()
+		addrBook := deployment.NewMemoryAddressBook()
+		mockAddresses := map[string]deployment.TypeAndVersion{
+			targetAddrStr: {Type: "DifferentType", Version: deployment.Version1_0_0},
+		}
+		err := addrBook.Save(chainsel.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector, targetAddrStr, mockAddresses[targetAddrStr])
+		require.NoError(t, err)
+
+		// No target address provided
+		_, err = changeset.GetOwnableContract[*forwarder.KeystoneForwarder](addrBook, chain, nil)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no contract of type")
+	})
+
+	t.Run("errors when targetAddr not found in address book", func(t *testing.T) {
+		t.Parallel()
+
+		targetAddr := testutils.NewAddress()
+		targetAddrStr := targetAddr.String()
+		nonExistentAddr := testutils.NewAddress()
+		nonExistentAddrStr := nonExistentAddr.String()
+		addrBook := deployment.NewMemoryAddressBook()
+		mockAddresses := map[string]deployment.TypeAndVersion{
+			targetAddrStr: {Type: changeset.CapabilitiesRegistry, Version: deployment.Version1_1_0},
+		}
+		err := addrBook.Save(chainsel.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector, targetAddrStr, mockAddresses[targetAddrStr])
+		require.NoError(t, err)
+
+		_, err = changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &nonExistentAddrStr)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in address book")
+	})
+}

--- a/deployment/keystone/changeset/deploy_forwarder.go
+++ b/deployment/keystone/changeset/deploy_forwarder.go
@@ -90,7 +90,7 @@ func ConfigureForwardContracts(env deployment.Environment, req ConfigureForwardC
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to configure forward contracts: %w", err)
 	}
 
-	cresp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	cresp, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	})
@@ -106,10 +106,10 @@ func ConfigureForwardContracts(env deployment.Environment, req ConfigureForwardC
 		for chainSelector, op := range r.OpsPerChain {
 			contracts := cresp.ContractSets[chainSelector]
 			timelocksPerChain := map[uint64]common.Address{
-				chainSelector: contracts.Timelock.Address(),
+				chainSelector: contracts.Forwarder.McmsContracts.Timelock.Address(),
 			}
 			proposerMCMSes := map[uint64]*gethwrappers.ManyChainMultiSig{
-				chainSelector: contracts.ProposerMcm,
+				chainSelector: contracts.Forwarder.McmsContracts.ProposerMcm,
 			}
 
 			proposal, err := proposalutils.BuildProposalFromBatches(

--- a/deployment/keystone/changeset/deploy_ocr3.go
+++ b/deployment/keystone/changeset/deploy_ocr3.go
@@ -84,7 +84,7 @@ func ConfigureOCR3Contract(env deployment.Environment, cfg ConfigureOCR3Config) 
 		if resp.Ops == nil {
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
-		r, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+		r, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 			Chains:      env.Chains,
 			AddressBook: env.ExistingAddresses,
 		})
@@ -93,10 +93,10 @@ func ConfigureOCR3Contract(env deployment.Environment, cfg ConfigureOCR3Config) 
 		}
 		contracts := r.ContractSets[cfg.ChainSel]
 		timelocksPerChain := map[uint64]string{
-			cfg.ChainSel: contracts.Timelock.Address().Hex(),
+			cfg.ChainSel: contracts.OCR3[*cfg.Address].McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			cfg.ChainSel: contracts.ProposerMcm.Address().Hex(),
+			cfg.ChainSel: contracts.OCR3[*cfg.Address].McmsContracts.ProposerMcm.Address().Hex(),
 		}
 
 		inspector, err := proposalutils.McmsInspectorForChain(env, cfg.ChainSel)

--- a/deployment/keystone/changeset/deploy_ocr3_test.go
+++ b/deployment/keystone/changeset/deploy_ocr3_test.go
@@ -243,12 +243,28 @@ func TestConfigureOCR3(t *testing.T) {
 
 		wfNodes := te.GetP2PIDs("wfDon").Strings()
 
+		registrySel := te.Env.AllChainSelectors()[0]
+		// Verify after merge there are three original contracts plus one new one
+		addrs, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
+		require.NoError(t, err)
+
+		// Find new OCR3 contract
+		var existingOCR3Addr string
+		for addr, tv := range addrs {
+			if tv.Type == internal.OCR3Capability {
+				existingOCR3Addr = addr
+				break
+			}
+		}
+
 		w := &bytes.Buffer{}
+		addr := common.HexToAddress(existingOCR3Addr)
 		cfg := changeset.ConfigureOCR3Config{
 			ChainSel:             te.RegistrySelector,
 			NodeIDs:              wfNodes,
 			OCR3Config:           &c,
 			WriteGeneratedConfig: w,
+			Address:              &addr,
 			MCMSConfig:           &changeset.MCMSConfig{MinDuration: 0},
 		}
 

--- a/deployment/keystone/changeset/remove_dons.go
+++ b/deployment/keystone/changeset/remove_dons.go
@@ -56,7 +56,7 @@ func RemoveDONs(env deployment.Environment, req *RemoveDONsRequest) (deployment.
 	if !ok {
 		return deployment.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}
-	cresp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	cresp, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	})
@@ -70,7 +70,7 @@ func RemoveDONs(env deployment.Environment, req *RemoveDONsRequest) (deployment.
 
 	resp, err := internal.RemoveDONs(env.Logger, &internal.RemoveDONsRequest{
 		Chain:                registryChain,
-		CapabilitiesRegistry: contracts.CapabilitiesRegistry,
+		CapabilitiesRegistry: contracts.CapabilitiesRegistry.Contract,
 		DONs:                 req.DONs,
 		UseMCMS:              req.UseMCMS(),
 	})
@@ -85,10 +85,10 @@ func RemoveDONs(env deployment.Environment, req *RemoveDONsRequest) (deployment.
 		}
 
 		timelocksPerChain := map[uint64]string{
-			req.RegistryChainSel: contracts.Timelock.Address().Hex(),
+			req.RegistryChainSel: contracts.CapabilitiesRegistry.McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			req.RegistryChainSel: contracts.ProposerMcm.Address().Hex(),
+			req.RegistryChainSel: contracts.CapabilitiesRegistry.McmsContracts.ProposerMcm.Address().Hex(),
 		}
 		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
 		if err != nil {

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -158,6 +158,7 @@ func initEnv(t *testing.T, nChains int) (registryChainSel uint64, env deployment
 		Chains:            chains,
 		ExistingAddresses: deployment.NewMemoryAddressBook(),
 	}
+
 	env, err := commonchangeset.Apply(t, env, nil,
 		commonchangeset.Configure(
 			deployment.CreateLegacyChangeSet(changeset.DeployCapabilityRegistry),
@@ -270,16 +271,16 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 	require.NoError(t, err)
 	require.Nil(t, csOut.AddressBook, "no new addresses should be created in configure initial contracts")
 
-	req := &changeset.GetContractSetsRequest{
+	req := changeset.GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	}
 
-	contractSetsResp, err := changeset.GetContractSets(lggr, req)
+	contractSetsResp, err := changeset.GetContractSetsV2(lggr, req)
 	require.NoError(t, err)
 	require.Len(t, contractSetsResp.ContractSets, len(env.Chains))
 	// check the registry
-	gotRegistry := contractSetsResp.ContractSets[registryChainSel].CapabilitiesRegistry
+	gotRegistry := contractSetsResp.ContractSets[registryChainSel].CapabilitiesRegistry.Contract
 	require.NotNil(t, gotRegistry)
 	// validate the registry
 	// check the nodes
@@ -309,7 +310,8 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 			),
 		)
 		require.NoError(t, err)
-		// extract the MCMS address
+		// extract the MCMS address using `GetContractSets` instead of `GetContractSetsV2` because the latter
+		// expects contracts to already be owned by MCMS
 		r, err := changeset.GetContractSets(lggr, &changeset.GetContractSetsRequest{
 			Chains:      env.Chains,
 			AddressBook: env.ExistingAddresses,

--- a/deployment/keystone/changeset/update_don.go
+++ b/deployment/keystone/changeset/update_don.go
@@ -98,7 +98,7 @@ func appendRequest(r *UpdateDonRequest) *AppendNodeCapabilitiesRequest {
 }
 
 func updateDonRequest(env deployment.Environment, r *UpdateDonRequest) (*internal.UpdateDonRequest, error) {
-	resp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	resp, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	})
@@ -109,7 +109,7 @@ func updateDonRequest(env deployment.Environment, r *UpdateDonRequest) (*interna
 
 	return &internal.UpdateDonRequest{
 		Chain:                env.Chains[r.RegistryChainSel],
-		CapabilitiesRegistry: contractSet.CapabilitiesRegistry,
+		CapabilitiesRegistry: contractSet.CapabilitiesRegistry.Contract,
 		P2PIDs:               r.P2PIDs,
 		CapabilityConfigs:    r.CapabilityConfigs,
 		UseMCMS:              r.UseMCMS(),

--- a/deployment/keystone/changeset/update_nodes.go
+++ b/deployment/keystone/changeset/update_nodes.go
@@ -63,7 +63,7 @@ func UpdateNodes(env deployment.Environment, req *UpdateNodesRequest) (deploymen
 	if !ok {
 		return deployment.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}
-	cresp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	cresp, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	})
@@ -77,7 +77,7 @@ func UpdateNodes(env deployment.Environment, req *UpdateNodesRequest) (deploymen
 
 	resp, err := internal.UpdateNodes(env.Logger, &internal.UpdateNodesRequest{
 		Chain:                registryChain,
-		CapabilitiesRegistry: contracts.CapabilitiesRegistry,
+		CapabilitiesRegistry: contracts.CapabilitiesRegistry.Contract,
 		P2pToUpdates:         req.P2pToUpdates,
 		UseMCMS:              req.UseMCMS(),
 	})
@@ -91,10 +91,10 @@ func UpdateNodes(env deployment.Environment, req *UpdateNodesRequest) (deploymen
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 		timelocksPerChain := map[uint64]string{
-			req.RegistryChainSel: contracts.Timelock.Address().Hex(),
+			req.RegistryChainSel: contracts.CapabilitiesRegistry.McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			req.RegistryChainSel: contracts.ProposerMcm.Address().Hex(),
+			req.RegistryChainSel: contracts.CapabilitiesRegistry.McmsContracts.ProposerMcm.Address().Hex(),
 		}
 		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
 		if err != nil {


### PR DESCRIPTION
This addresses [DEVSVCS-1550](https://smartcontract-it.atlassian.net/browse/DEVSVCS-1550).

It implements an Ownable Contract implementation, in order to properly load MCMS state on contracts load by MCMS. This will be used to then create a contract set using this new ownable contracts and will be provided for MCMS operations/changesets.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
- <https://github.com/smartcontractkit/chainlink-deployments/pull/1302>
- <https://github.com/smartcontractkit/chainlink/pull/17089>


[DEVSVCS-1550]: https://smartcontract-it.atlassian.net/browse/DEVSVCS-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ