### PR TITLE
[CLD-19]: tests(operations): added examples for operations API

### DIFF
--- a/deployment/common/changeset/example/operations/deploy_and_mint_example.go
+++ b/deployment/common/changeset/example/operations/deploy_and_mint_example.go
@@ -1,0 +1,105 @@
+package example
+
+import (
+	"math/big"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/operations"
+)
+
+/**
+DeployAndMintExampleChangeset demonstrates how to use Operations API to deploy and mint LINK token in EVM by using
+a sequence of operations.
+*/
+
+var _ deployment.ChangeSetV2[SqDeployLinkInput] = DeployAndMintExampleChangeset{}
+
+// SqDeployLinkInput must be JSON Serializable with no private fields
+type SqDeployLinkInput struct {
+	MintAmount *big.Int
+	Amount     *big.Int
+	To         common.Address
+	ChainID    uint64
+}
+
+// SqDeployLinkOutput must be JSON Serializable with no private fields
+type SqDeployLinkOutput struct {
+	Address common.Address
+}
+
+type EthereumDeps struct {
+	Auth  *bind.TransactOpts
+	Chain deployment.Chain
+	AB    deployment.AddressBook
+}
+
+type DeployAndMintExampleChangeset struct{}
+
+func (l DeployAndMintExampleChangeset) VerifyPreconditions(e deployment.Environment, config SqDeployLinkInput) error {
+	// perform any preconditions checks here
+	return nil
+}
+
+func (l DeployAndMintExampleChangeset) Apply(e deployment.Environment, config SqDeployLinkInput) (deployment.ChangesetOutput, error) {
+	auth := e.Chains[config.ChainID].DeployerKey
+	ab := deployment.NewMemoryAddressBook()
+
+	// build your custom dependencies needed in the sequence/operation
+	deps := EthereumDeps{
+		Auth:  auth,
+		Chain: e.Chains[config.ChainID],
+		AB:    ab,
+	}
+
+	seqReport, err := operations.ExecuteSequence(e.OperationsBundle, DeployAndMintSequence, deps, config)
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
+	return deployment.ChangesetOutput{
+		AddressBook: ab,
+		Reports:     seqReport.ExecutionReports,
+	}, nil
+}
+
+// DeployAndMintSequence calls 3 operations in sequence:
+// 1. DeployLinkOp: Deploys LINK token contract
+// 2. GrantMintOp: Grants mint role to the same address
+// 3. MintLinkOp: Mints some amount to the same address
+// The output of the sequence is the address of the deployed LINK token contract.
+var DeployAndMintSequence = operations.NewSequence(
+	"deploy-mint-sequence",
+	semver.MustParse("1.0.0"),
+	"Deploy LINK token contract, grants mint and mints some amount to same address",
+	func(b operations.Bundle, deps EthereumDeps, input SqDeployLinkInput) (SqDeployLinkOutput, error) {
+		linkDeployReport, err := operations.ExecuteOperation(b, DeployLinkOp, deps, operations.EmptyInput{})
+		if err != nil {
+			return SqDeployLinkOutput{}, err
+		}
+
+		grantMintConfig := GrantMintRoleConfig{
+			ContractAddress: linkDeployReport.Output,
+			To:              deps.Auth.From,
+		}
+		_, err = operations.ExecuteOperation(b, GrantMintOp, deps, grantMintConfig)
+		if err != nil {
+			return SqDeployLinkOutput{}, err
+		}
+
+		mintConfig := MintLinkConfig{
+			ContractAddress: linkDeployReport.Output,
+			Amount:          input.MintAmount,
+			To:              input.To,
+		}
+		_, err = operations.ExecuteOperation(b, MintLinkOp, deps, mintConfig)
+		if err != nil {
+			return SqDeployLinkOutput{}, err
+		}
+
+		return SqDeployLinkOutput{Address: linkDeployReport.Output}, nil
+	},
+)

--- a/deployment/common/changeset/example/operations/deploy_and_mint_example_test.go
+++ b/deployment/common/changeset/example/operations/deploy_and_mint_example_test.go
@@ -1,0 +1,33 @@
+package example
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestDeployAndMintExampleChangeset(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+		Chains: 1,
+	})
+	chain1 := e.AllChainSelectors()[0]
+
+	changesetInput := SqDeployLinkInput{
+		MintAmount: big.NewInt(1000000000000000000),
+		Amount:     big.NewInt(1000000000000),
+		To:         common.HexToAddress("0x1"),
+		ChainID:    chain1,
+	}
+	result, err := DeployAndMintExampleChangeset{}.Apply(e, changesetInput)
+	require.NoError(t, err)
+
+	require.Len(t, result.Reports, 4) // 3 ops + 1 seq report
+	require.NoError(t, err)
+}

--- a/deployment/common/changeset/example/operations/operation.go
+++ b/deployment/common/changeset/example/operations/operation.go
@@ -1,0 +1,86 @@
+package example
+
+import (
+	"math/big"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/operations"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/link_token"
+)
+
+var DeployLinkOp = operations.NewOperation(
+	"deploy-link-token-op",
+	semver.MustParse("1.0.0"),
+	"Deploy LINK Contract Operation",
+	func(b operations.Bundle, deps EthereumDeps, input operations.EmptyInput) (common.Address, error) {
+		linkToken, err := deployment.DeployContract[*link_token.LinkToken](b.Logger, deps.Chain, deps.AB,
+			func(chain deployment.Chain) deployment.ContractDeploy[*link_token.LinkToken] {
+				linkTokenAddr, tx, linkToken, err2 := link_token.DeployLinkToken(
+					chain.DeployerKey,
+					chain.Client,
+				)
+				return deployment.ContractDeploy[*link_token.LinkToken]{
+					Address:  linkTokenAddr,
+					Contract: linkToken,
+					Tx:       tx,
+					Tv:       deployment.NewTypeAndVersion(types.LinkToken, deployment.Version1_0_0),
+					Err:      err2,
+				}
+			})
+		if err != nil {
+			b.Logger.Errorw("Failed to deploy link token", "chain", deps.Chain.String(), "err", err)
+			return common.Address{}, err
+		}
+		return linkToken.Address, nil
+	})
+
+type GrantMintRoleConfig struct {
+	ContractAddress common.Address
+	To              common.Address
+}
+
+var GrantMintOp = operations.NewOperation(
+	"grant-mint-role-op",
+	semver.MustParse("1.0.0"),
+	"Grant Mint Role Operation",
+	func(b operations.Bundle, deps EthereumDeps, input GrantMintRoleConfig) (any, error) {
+		contract, err := link_token.NewLinkToken(input.ContractAddress, deps.Chain.Client)
+		if err != nil {
+			return nil, err
+		}
+		tx, err := contract.GrantMintRole(deps.Auth, input.To)
+		_, err = deployment.ConfirmIfNoError(deps.Chain, tx, err)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	})
+
+type MintLinkConfig struct {
+	Amount          *big.Int
+	To              common.Address
+	ContractAddress common.Address
+}
+
+var MintLinkOp = operations.NewOperation(
+	"mint-link-token-op",
+	semver.MustParse("1.0.0"),
+	"Mint LINK Operation",
+	func(ctx operations.Bundle, deps EthereumDeps, input MintLinkConfig) (any, error) {
+		contract, err := link_token.NewLinkToken(input.ContractAddress, deps.Chain.Client)
+		if err != nil {
+			return nil, err
+		}
+		tx, err := contract.Mint(deps.Auth, input.To, input.Amount)
+		_, err = deployment.ConfirmIfNoError(deps.Chain, tx, err)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	})

--- a/deployment/common/changeset/example/operations/retry_config_example.go
+++ b/deployment/common/changeset/example/operations/retry_config_example.go
@@ -1,0 +1,95 @@
+package example
+
+import (
+	"errors"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/operations"
+)
+
+/**
+DisableRetryExampleChangeset demonstrates how to use Operations API to disable retry for an operation.
+UpdateInputExampleChangeset demonstrates how to use Operations API to update input for an operation (eg for changing gas limit)
+*/
+
+var _ deployment.ChangeSetV2[operations.EmptyInput] = DisableRetryExampleChangeset{}
+
+type DisableRetryExampleChangeset struct{}
+
+func (l DisableRetryExampleChangeset) VerifyPreconditions(e deployment.Environment, config operations.EmptyInput) error {
+	// perform any preconditions checks here
+	return nil
+}
+
+func (l DisableRetryExampleChangeset) Apply(e deployment.Environment, config operations.EmptyInput) (deployment.ChangesetOutput, error) {
+	ab := deployment.NewMemoryAddressBook()
+
+	operationInput := SuccessFailOperationInput{ShouldFail: true}
+
+	// Disable retry for this operation
+	// If retry was not disable, the operation would be retried for 10 times with exponential backoff.
+	_, err := operations.ExecuteOperation(e.OperationsBundle, SuccessFailOperation, nil, operationInput,
+		operations.WithRetryConfig[SuccessFailOperationInput, any](operations.RetryConfig[SuccessFailOperationInput, any]{
+			DisableRetry: true,
+		}))
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
+	return deployment.ChangesetOutput{
+		AddressBook: ab,
+	}, nil
+}
+
+var _ deployment.ChangeSetV2[operations.EmptyInput] = UpdateInputExampleChangeset{}
+
+type UpdateInputExampleChangeset struct{}
+
+func (l UpdateInputExampleChangeset) VerifyPreconditions(e deployment.Environment, config operations.EmptyInput) error {
+	// perform any preconditions checks here
+	return nil
+}
+
+func (l UpdateInputExampleChangeset) Apply(e deployment.Environment, config operations.EmptyInput) (deployment.ChangesetOutput, error) {
+	ab := deployment.NewMemoryAddressBook()
+
+	operationInput := SuccessFailOperationInput{ShouldFail: true}
+
+	// Retry operation with updated input
+	// This operation will fail once and then succeed because the input was updated
+	_, err := operations.ExecuteOperation(e.OperationsBundle, SuccessFailOperation, nil, operationInput,
+		operations.WithRetryConfig[SuccessFailOperationInput, any](operations.RetryConfig[SuccessFailOperationInput, any]{
+			InputHook: func(input SuccessFailOperationInput, _ any) SuccessFailOperationInput {
+				// Update input to false, so it stops failing
+				input.ShouldFail = false
+				return input
+			},
+		}))
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
+	return deployment.ChangesetOutput{
+		AddressBook: ab,
+	}, nil
+}
+
+type SuccessFailOperationInput struct {
+	ShouldFail bool
+}
+
+// SuccessFailOperation is an operation that always fails if ShouldFail is true.
+// Else it succeeds.
+var SuccessFailOperation = operations.NewOperation(
+	"success-fail-operation",
+	semver.MustParse("1.0.0"),
+	"Operation that always fails",
+	func(b operations.Bundle, _ any, input SuccessFailOperationInput) (any, error) {
+		if input.ShouldFail {
+			return nil, errors.New("operation failed")
+		}
+		return nil, nil
+	},
+)

--- a/deployment/common/changeset/example/operations/retry_config_example_test.go
+++ b/deployment/common/changeset/example/operations/retry_config_example_test.go
@@ -1,0 +1,34 @@
+package example
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/deployment/operations"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestDisableRetryExampleChangeset(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+		Chains: 1,
+	})
+
+	changesetInput := operations.EmptyInput{}
+	_, err := DisableRetryExampleChangeset{}.Apply(e, changesetInput)
+	require.ErrorContains(t, err, "operation failed")
+}
+
+func TestUpdateInputExampleChangeset(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+		Chains: 1,
+	})
+
+	changesetInput := operations.EmptyInput{}
+	_, err := UpdateInputExampleChangeset{}.Apply(e, changesetInput)
+	require.NoError(t, err)
+}

--- a/deployment/common/changeset/example/operations/terminal_error_example.go
+++ b/deployment/common/changeset/example/operations/terminal_error_example.go
@@ -1,0 +1,48 @@
+package example
+
+import (
+	"errors"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/operations"
+)
+
+/**
+TerminalErrorExampleChangeset demonstrates how to use Operations API to return a terminal error from an operation.
+By returning an UnrecoverableError, the operation will not be retried by the framework and is returned immediately.
+This is useful when an operation encounters an error that should not be retried.
+*/
+
+var _ deployment.ChangeSetV2[operations.EmptyInput] = TerminalErrorExampleChangeset{}
+
+type TerminalErrorExampleChangeset struct{}
+
+func (l TerminalErrorExampleChangeset) VerifyPreconditions(e deployment.Environment, config operations.EmptyInput) error {
+	// perform any preconditions checks here
+	return nil
+}
+
+func (l TerminalErrorExampleChangeset) Apply(e deployment.Environment, config operations.EmptyInput) (deployment.ChangesetOutput, error) {
+	ab := deployment.NewMemoryAddressBook()
+
+	_, err := operations.ExecuteOperation(e.OperationsBundle, TerminalErrorOperation, nil, operations.EmptyInput{})
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
+	return deployment.ChangesetOutput{
+		AddressBook: ab,
+	}, nil
+}
+
+var TerminalErrorOperation = operations.NewOperation(
+	"terminal-error-operation",
+	semver.MustParse("1.0.0"),
+	"Operation that returns a terminal error",
+	func(b operations.Bundle, _ any, input operations.EmptyInput) (any, error) {
+		// by returning an UnrecoverableError, the operation will not be retried by the framework
+		return nil, operations.NewUnrecoverableError(errors.New("terminal error"))
+	},
+)

--- a/deployment/common/changeset/example/operations/terminal_error_example_test.go
+++ b/deployment/common/changeset/example/operations/terminal_error_example_test.go
@@ -1,0 +1,23 @@
+package example
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/deployment/operations"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestTerminalErrorExampleChangeset(t *testing.T) {
+	lggr := logger.TestLogger(t)
+	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+		Chains: 1,
+	})
+
+	changesetInput := operations.EmptyInput{}
+	_, err := TerminalErrorExampleChangeset{}.Apply(e, changesetInput)
+	require.ErrorContains(t, err, "terminal error")
+}


### PR DESCRIPTION
Created a few example changesets to demonstrate the Operations API and the available retry configs. This will also be reference in the docs for Operations API.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-19
