### PR TITLE
fix Engine.HealthReport

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -1195,7 +1195,7 @@ func (e *Engine) Close() error {
 }
 
 func (e *Engine) HealthReport() map[string]error {
-	return map[string]error{e.Name(): nil}
+	return map[string]error{e.Name(): e.Healthy()}
 }
 
 func (e *Engine) Name() string {


### PR DESCRIPTION
Return the result of `Engine.Healthy()` instead of `nil`.