### PR TITLE
[chore] Fix heartbeat metric

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -1110,13 +1110,17 @@ func (e *Engine) heartbeat(ctx context.Context) {
 	ticker := time.NewTicker(e.heartbeatCadence)
 	defer ticker.Stop()
 
+	// Gauge values are "persisted" by the backend
+	// and will be continually reported until the value changes.
+	e.metrics.engineHeartbeatGauge(ctx, 1)
+
 	for {
 		select {
 		case <-ctx.Done():
+			e.metrics.engineHeartbeatGauge(ctx, 0)
 			e.logger.Info("shutting down heartbeat")
 			return
 		case <-ticker.C:
-			e.metrics.engineHeartbeatGauge(ctx)
 			e.metrics.incrementEngineHeartbeatCounter(ctx)
 			e.metrics.updateTotalWorkflowsGauge(ctx, e.stepUpdatesChMap.len())
 			logCustMsg(ctx, e.cma, "engine heartbeat at: "+e.clock.Now().Format(time.RFC3339), e.logger)

--- a/core/services/workflows/monitoring.go
+++ b/core/services/workflows/monitoring.go
@@ -269,9 +269,9 @@ func (c workflowsMetricLabeler) incrementEngineHeartbeatCounter(ctx context.Cont
 	c.em.engineHeartbeatCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
-func (c workflowsMetricLabeler) engineHeartbeatGauge(ctx context.Context) {
+func (c workflowsMetricLabeler) engineHeartbeatGauge(ctx context.Context, val int64) {
 	otelLabels := monutils.KvMapToOtelAttributes(c.Labels)
-	c.em.engineHeartbeatGauge.Record(ctx, 1, metric.WithAttributes(otelLabels...))
+	c.em.engineHeartbeatGauge.Record(ctx, val, metric.WithAttributes(otelLabels...))
 }
 
 func (c workflowsMetricLabeler) incrementCapabilityFailureCounter(ctx context.Context) {


### PR DESCRIPTION
The last gauge value is continually reported by the backend (assuming the process hasn't crashed) so it needs to be manually reset when the workflow shuts down.