### PR TITLE
remove duplicated fetch opts

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -207,8 +207,6 @@ type ApplicationOpts struct {
 	LLOTransmissionReaper    services.ServiceCtx
 	NewOracleFactoryFn       standardcapabilities.NewOracleFactoryFn
 	EVMFactoryConfigFn       func(*EVMFactoryConfig)
-	FetcherFunc              artifacts.FetcherFunc
-	FetcherFactoryFn         compute.FetcherFactory
 }
 
 type Heartbeat struct {


### PR DESCRIPTION
Fetcher opts were moved to the embedded CRE opts struct but not removed from the containing struct.
