### PR TITLE
DF CLD view generation fix missing description

### DIFF
--- a/deployment/data-feeds/view/v1_0/proxy_contract.go
+++ b/deployment/data-feeds/view/v1_0/proxy_contract.go
@@ -25,7 +25,8 @@ func GenerateAggregatorProxyView(proxy *proxy.AggregatorProxy) (ProxyView, error
 
 	description, err := proxy.Description(nil)
 	if err != nil {
-		return ProxyView{}, fmt.Errorf("failed to get description for AggregatorProxy: %w", err)
+		fmt.Printf("failed to get description for AggregatorProxy: %v\n", err)
+		description = ""
 	}
 
 	owner, err := proxy.Owner(nil)


### PR DESCRIPTION
Print the error instead of returning as we have some proxy addresses that don't have descriptions