### PR TITLE
Patch cre encode nil error + add telemetry logging

### DIFF
--- a/core/services/llo/cre/report_codec.go
+++ b/core/services/llo/cre/report_codec.go
@@ -41,8 +41,7 @@ func (r ReportCodecCapabilityTrigger) Encode(report datastreamsllo.Report, cd ll
 		var d []byte
 		switch stream.(type) {
 		case nil:
-			// Missing observations are ignored
-			continue
+			// Missing observations are nil
 		case *datastreamsllo.Decimal:
 			var err error
 			d, err = stream.MarshalBinary()

--- a/core/services/llo/telem/telemetry.go
+++ b/core/services/llo/telem/telemetry.go
@@ -254,6 +254,7 @@ func (t *telemeter) collectObservationTelemetry(p interface{}, opts llo.DSOpts) 
 		telemType = synchronization.LLOObservation
 		v.DonId = t.donID
 		msg = v
+		t.eng.Infow("Sending LLOObservationTelemetry telemetry")
 	default:
 		t.eng.Warnw("Unknown telemetry type", "type", fmt.Sprintf("%T", p))
 		return

--- a/core/services/llo/telem/telemetry.go
+++ b/core/services/llo/telem/telemetry.go
@@ -254,7 +254,7 @@ func (t *telemeter) collectObservationTelemetry(p interface{}, opts llo.DSOpts) 
 		telemType = synchronization.LLOObservation
 		v.DonId = t.donID
 		msg = v
-		t.eng.Infow("Sending LLOObservationTelemetry telemetry")
+		t.eng.Infow("Sending LLOObservationTelemetry telemetry", "StreamId", v.StreamId, "ObservationTimestamp", v.ObservationTimestamp)
 	default:
 		t.eng.Warnw("Unknown telemetry type", "type", fmt.Sprintf("%T", p))
 		return

--- a/core/services/llo/telem/telemetry.go
+++ b/core/services/llo/telem/telemetry.go
@@ -254,6 +254,7 @@ func (t *telemeter) collectObservationTelemetry(p interface{}, opts llo.DSOpts) 
 		telemType = synchronization.LLOObservation
 		v.DonId = t.donID
 		msg = v
+		// .
 		t.eng.Infow("Sending LLOObservationTelemetry telemetry", "StreamId", v.StreamId, "ObservationTimestamp", v.ObservationTimestamp)
 	default:
 		t.eng.Warnw("Unknown telemetry type", "type", fmt.Sprintf("%T", p))

--- a/core/services/llo/telem/telemetry.go
+++ b/core/services/llo/telem/telemetry.go
@@ -250,12 +250,16 @@ func (t *telemeter) collectObservationTelemetry(p interface{}, opts llo.DSOpts) 
 			ConfigDigest:             cd[:],
 			ObservationTimestamp:     opts.ObservationTimestamp().UnixNano(),
 		}
+		if opts.VerboseLogging() {
+			t.eng.Infow("Sending LLOBridgeTelemetry telemetry", "StreamId", v.StreamID, "BridgeAdapterName", v.Name, "BridgeResponseError", v.ResponseError)
+		}
 	case *LLOObservationTelemetry:
 		telemType = synchronization.LLOObservation
 		v.DonId = t.donID
 		msg = v
-		// .
-		t.eng.Infow("Sending LLOObservationTelemetry telemetry", "StreamId", v.StreamId, "ObservationTimestamp", v.ObservationTimestamp)
+		if opts.VerboseLogging() {
+			t.eng.Infow("Sending LLOObservationTelemetry telemetry", "StreamId", v.StreamId, "ObservationTimestamp", v.ObservationTimestamp)
+		}
 	default:
 		t.eng.Warnw("Unknown telemetry type", "type", fmt.Sprintf("%T", p))
 		return

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.22.1",
+  "version": "2.22.0",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Based off of this PR which has the new cre trigger capability functionality:
https://github.com/smartcontractkit/chainlink/pull/17061

And has a small change to `core/services/llo/cre/report_codec.go` in an attempt to hot fix a nil bug in the cre trigger codec, while another fix for the same issue s progressing to be merged in `chainlink-common`:
https://github.com/smartcontractkit/chainlink-common/pull/1104

The removal of the continue line in `core/services/llo/cre/report_codec.go`, causes streams to be reported with a nil decimal value, rather than the whole `LLOStreamDecimal` ptr being nil. Will assess if this an appropriate change or not after testing, but it is the most obvious work around  until the `chainlink-common` is merged in.

Edit:
-Removing the  continue line works. But the `chainlink-common` fix still seems worthwhile to merge.