### PR TITLE
Implement `ContractSetV2`

### DIFF
--- a/deployment/keystone/changeset/accept_ownership.go
+++ b/deployment/keystone/changeset/accept_ownership.go
@@ -24,7 +24,7 @@ func AcceptAllOwnershipsProposal(e deployment.Environment, req *AcceptAllOwnersh
 	chain := e.Chains[chainSelector]
 	addrBook := e.ExistingAddresses
 
-	r, err := GetContractSets(e.Logger, &GetContractSetsRequest{
+	r, err := GetContractSetsV2(e.Logger, GetContractSetsRequestV2{
 		Chains: map[uint64]deployment.Chain{
 			req.ChainSelector: chain,
 		},

--- a/deployment/keystone/changeset/accept_ownership_test.go
+++ b/deployment/keystone/changeset/accept_ownership_test.go
@@ -24,6 +24,9 @@ func TestAcceptAllOwnership(t *testing.T) {
 		Chains: 2,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+	for chainSel, chain := range env.Chains {
+		require.NoError(t, env.ExistingAddresses.Save(chainSel, chain.DeployerKey.From.Hex(), deployment.NewTypeAndVersion("TestAcceptAllOwnership", deployment.Version1_0_0)))
+	}
 	registrySel := env.AllChainSelectors()[0]
 	env, err := commonchangeset.Apply(t, env, nil,
 		commonchangeset.Configure(

--- a/deployment/keystone/changeset/accept_ownership_test.go
+++ b/deployment/keystone/changeset/accept_ownership_test.go
@@ -24,9 +24,7 @@ func TestAcceptAllOwnership(t *testing.T) {
 		Chains: 2,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-	for chainSel, chain := range env.Chains {
-		require.NoError(t, env.ExistingAddresses.Save(chainSel, chain.DeployerKey.From.Hex(), deployment.NewTypeAndVersion("TestAcceptAllOwnership", deployment.Version1_0_0)))
-	}
+
 	registrySel := env.AllChainSelectors()[0]
 	env, err := commonchangeset.Apply(t, env, nil,
 		commonchangeset.Configure(

--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -37,7 +37,7 @@ func AddCapabilities(env deployment.Environment, req *AddCapabilitiesRequest) (d
 	if !ok {
 		return deployment.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}
-	cs, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	cs, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      map[uint64]deployment.Chain{req.RegistryChainSel: registryChain},
 		AddressBook: env.ExistingAddresses,
 	})
@@ -49,7 +49,7 @@ func AddCapabilities(env deployment.Environment, req *AddCapabilitiesRequest) (d
 		return deployment.ChangesetOutput{}, fmt.Errorf("contract set not found for chain %d", req.RegistryChainSel)
 	}
 	useMCMS := req.MCMSConfig != nil
-	ops, err := internal.AddCapabilities(env.Logger, contractSet.CapabilitiesRegistry, env.Chains[req.RegistryChainSel], req.Capabilities, useMCMS)
+	ops, err := internal.AddCapabilities(env.Logger, contractSet.CapabilitiesRegistry.Contract, env.Chains[req.RegistryChainSel], req.Capabilities, useMCMS)
 	if err != nil {
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to add capabilities: %w", err)
 	}
@@ -59,10 +59,10 @@ func AddCapabilities(env deployment.Environment, req *AddCapabilitiesRequest) (d
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 		timelocksPerChain := map[uint64]string{
-			registryChain.Selector: contractSet.Timelock.Address().Hex(),
+			registryChain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			registryChain.Selector: contractSet.ProposerMcm.Address().Hex(),
+			registryChain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.ProposerMcm.Address().Hex(),
 		}
 		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
 		if err != nil {

--- a/deployment/keystone/changeset/add_nodes.go
+++ b/deployment/keystone/changeset/add_nodes.go
@@ -197,7 +197,7 @@ func AddNodes(env deployment.Environment, req *AddNodesRequest) (deployment.Chan
 		return deployment.ChangesetOutput{}, fmt.Errorf("invalid request: %w", err)
 	}
 
-	contractSetResp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	contractSetResp, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	})
@@ -207,7 +207,7 @@ func AddNodes(env deployment.Environment, req *AddNodesRequest) (deployment.Chan
 
 	nodeParams := make(map[string]kcr.CapabilitiesRegistryNodeParams)
 	for nodeName, cr := range req.CreateNodeRequests {
-		params, err := cr.Resolve(contractSetResp.ContractSets[req.RegistryChainSel].CapabilitiesRegistry)
+		params, err := cr.Resolve(contractSetResp.ContractSets[req.RegistryChainSel].CapabilitiesRegistry.Contract)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to resolve node params for node %s: %w", nodeName, err)
 		}
@@ -219,14 +219,13 @@ func AddNodes(env deployment.Environment, req *AddNodesRequest) (deployment.Chan
 	}
 
 	var (
-		useMCMS                = req.MCMSConfig != nil
-		registryChain          = env.Chains[req.RegistryChainSel]
-		registry               = contractSetResp.ContractSets[req.RegistryChainSel].CapabilitiesRegistry
-		registryChainContracts = contractSetResp.ContractSets[req.RegistryChainSel]
+		useMCMS       = req.MCMSConfig != nil
+		registryChain = env.Chains[req.RegistryChainSel]
+		registry      = contractSetResp.ContractSets[req.RegistryChainSel].CapabilitiesRegistry
 	)
 	resp, err := internal.AddNodes(env.Logger, &internal.AddNodesRequest{
 		RegistryChain:        registryChain,
-		CapabilitiesRegistry: registry,
+		CapabilitiesRegistry: registry.Contract,
 		NodeParams:           nodeParams,
 		UseMCMS:              useMCMS,
 	})
@@ -240,10 +239,10 @@ func AddNodes(env deployment.Environment, req *AddNodesRequest) (deployment.Chan
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 		timelocksPerChain := map[uint64]string{
-			registryChain.Selector: registryChainContracts.Timelock.Address().Hex(),
+			registryChain.Selector: registry.McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			registryChain.Selector: registryChainContracts.ProposerMcm.Address().Hex(),
+			registryChain.Selector: registry.McmsContracts.ProposerMcm.Address().Hex(),
 		}
 		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
 		if err != nil {

--- a/deployment/keystone/changeset/add_nops.go
+++ b/deployment/keystone/changeset/add_nops.go
@@ -31,7 +31,7 @@ func AddNops(env deployment.Environment, req *AddNopsRequest) (deployment.Change
 	if !ok {
 		return deployment.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}
-	cs, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	cs, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      map[uint64]deployment.Chain{req.RegistryChainSel: registryChain},
 		AddressBook: env.ExistingAddresses,
 	})
@@ -62,10 +62,10 @@ func AddNops(env deployment.Environment, req *AddNopsRequest) (deployment.Change
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 		timelocksPerChain := map[uint64]gethcommon.Address{
-			registryChain.Selector: contractSet.Timelock.Address(),
+			registryChain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.Timelock.Address(),
 		}
 		proposerMCMSes := map[uint64]*gethwrappers.ManyChainMultiSig{
-			registryChain.Selector: contractSet.ProposerMcm,
+			registryChain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.ProposerMcm,
 		}
 
 		proposal, err := proposalutils.BuildProposalFromBatches(

--- a/deployment/keystone/changeset/append_node_capabilities.go
+++ b/deployment/keystone/changeset/append_node_capabilities.go
@@ -35,10 +35,10 @@ func AppendNodeCapabilities(env deployment.Environment, req *AppendNodeCapabilit
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 		timelocksPerChain := map[uint64]string{
-			c.Chain.Selector: contractSet.Timelock.Address().Hex(),
+			c.Chain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			c.Chain.Selector: contractSet.ProposerMcm.Address().Hex(),
+			c.Chain.Selector: contractSet.CapabilitiesRegistry.McmsContracts.ProposerMcm.Address().Hex(),
 		}
 		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
 		if err != nil {
@@ -65,12 +65,12 @@ func AppendNodeCapabilities(env deployment.Environment, req *AppendNodeCapabilit
 	return out, nil
 }
 
-func (req *AppendNodeCapabilitiesRequest) convert(e deployment.Environment) (*internal.AppendNodeCapabilitiesRequest, *ContractSet, error) {
+func (req *AppendNodeCapabilitiesRequest) convert(e deployment.Environment) (*internal.AppendNodeCapabilitiesRequest, *ContractSetV2, error) {
 	if err := req.Validate(e); err != nil {
 		return nil, nil, fmt.Errorf("failed to validate UpdateNodeCapabilitiesRequest: %w", err)
 	}
 	registryChain := e.Chains[req.RegistryChainSel] // exists because of the validation above
-	resp, err := GetContractSets(e.Logger, &GetContractSetsRequest{
+	resp, err := GetContractSetsV2(e.Logger, GetContractSetsRequestV2{
 		Chains:      map[uint64]deployment.Chain{req.RegistryChainSel: registryChain},
 		AddressBook: e.ExistingAddresses,
 	})
@@ -81,7 +81,7 @@ func (req *AppendNodeCapabilitiesRequest) convert(e deployment.Environment) (*in
 
 	return &internal.AppendNodeCapabilitiesRequest{
 		Chain:                registryChain,
-		CapabilitiesRegistry: contractSet.CapabilitiesRegistry,
+		CapabilitiesRegistry: contractSet.CapabilitiesRegistry.Contract,
 		P2pToCapabilities:    req.P2pToCapabilities,
 		UseMCMS:              req.UseMCMS(),
 	}, &contractSet, nil

--- a/deployment/keystone/changeset/contract_set.go
+++ b/deployment/keystone/changeset/contract_set.go
@@ -1,0 +1,161 @@
+package changeset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink/deployment"
+
+	capabilities_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+	forwarder "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/forwarder_1_0_0"
+	ocr3_capability "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
+	workflow_registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/workflow/generated/workflow_registry_wrapper"
+)
+
+// ContractSetV2 represents a set of contracts for a specific chain.
+type ContractSetV2 struct {
+	OCR3                 map[common.Address]OwnedContract[*ocr3_capability.OCR3Capability]
+	Forwarder            *OwnedContract[*forwarder.KeystoneForwarder]
+	CapabilitiesRegistry *OwnedContract[*capabilities_registry.CapabilitiesRegistry]
+	WorkflowRegistry     *OwnedContract[*workflow_registry.WorkflowRegistry]
+}
+
+// GetContractSetsRequestV2 is the request structure for getting contract sets.
+type GetContractSetsRequestV2 struct {
+	AddressBook deployment.AddressBook
+	Chains      map[uint64]deployment.Chain
+	Labels      []string
+}
+
+// GetContractSetsResponseV2 is the response structure for getting contract sets.
+type GetContractSetsResponseV2 struct {
+	ContractSets map[uint64]ContractSetV2
+}
+
+func (cs ContractSetV2) toContractSet() ContractSet {
+	ocr3Contracts := make(map[common.Address]*ocr3_capability.OCR3Capability)
+	for addr, ocr := range cs.OCR3 {
+		ocr3Contracts[addr] = ocr.Contract
+	}
+
+	// We don't set the `ContractSet.MCMSWithTimelockState` due to the nature of `ContractSetV2`.
+	// Now each contract has its own MCMS state, and that format is not compatible with `ContractSet`.
+	return ContractSet{
+		OCR3:                 ocr3Contracts,
+		Forwarder:            cs.Forwarder.Contract,
+		CapabilitiesRegistry: cs.CapabilitiesRegistry.Contract,
+		WorkflowRegistry:     cs.WorkflowRegistry.Contract,
+	}
+}
+
+// TransferableContracts returns a list of addresses of contracts that are transferable.
+func (cs ContractSetV2) TransferableContracts() []common.Address {
+	return cs.toContractSet().TransferableContracts()
+}
+
+// View is a view of the keystone chain. Internally, it uses the ContractSet view to get the state of the contracts.
+// This is to preserve the view functionality.
+func (cs ContractSetV2) View(ctx context.Context, prevView KeystoneChainView, lggr logger.Logger) (KeystoneChainView, error) {
+	return cs.toContractSet().View(ctx, prevView, lggr)
+}
+
+// GetContractSetsV2 retrieves the contract sets for the given chains and labels.
+func GetContractSetsV2(lggr logger.Logger, req GetContractSetsRequestV2) (*GetContractSetsResponseV2, error) {
+	out := &GetContractSetsResponseV2{
+		ContractSets: make(map[uint64]ContractSetV2),
+	}
+
+	for id, chain := range req.Chains {
+		addresses, err := req.AddressBook.AddressesForChain(id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get addresses for chain %d: %w", id, err)
+		}
+
+		// Forwarder addresses now have informative labels, but we don't want them to be ignored if no labels are provided for filtering.
+		// If labels are provided, just filter by those.
+		forwarderAddrs := make(map[string]deployment.TypeAndVersion)
+		if len(req.Labels) == 0 {
+			for addr, tv := range addresses {
+				if tv.Type == KeystoneForwarder {
+					forwarderAddrs[addr] = tv
+				}
+			}
+		}
+
+		// TODO: we need to expand/refactor the way labeled addresses are filtered
+		// see: https://smartcontract-it.atlassian.net/browse/CRE-363
+		filtered := deployment.LabeledAddresses(addresses).And(req.Labels...)
+		for addr, tv := range forwarderAddrs {
+			filtered[addr] = tv
+		}
+
+		cs, err := loadContractSetV2(lggr, req.AddressBook, chain, filtered)
+		if err != nil {
+			return nil, fmt.Errorf("error loading contract set for chain %s: %w", chain.Name(), err)
+		}
+
+		out.ContractSets[id] = *cs
+	}
+
+	return out, nil
+}
+
+func loadContractSetV2(lggr logger.Logger, addressBook deployment.AddressBook, chain deployment.Chain, addresses map[string]deployment.TypeAndVersion) (*ContractSetV2, error) {
+	var out ContractSetV2
+
+	handlers := map[deployment.ContractType]func(string) error{
+		OCR3Capability: func(addr string) error {
+			contract, err := GetOwnedContract[*ocr3_capability.OCR3Capability](addressBook, chain, addr)
+			if err != nil {
+				return err
+			}
+			if out.OCR3 == nil {
+				out.OCR3 = make(map[common.Address]OwnedContract[*ocr3_capability.OCR3Capability])
+			}
+			out.OCR3[common.HexToAddress(addr)] = *contract
+			return nil
+		},
+		KeystoneForwarder: func(addr string) error {
+			contract, err := GetOwnedContract[*forwarder.KeystoneForwarder](addressBook, chain, addr)
+			if err != nil {
+				return err
+			}
+			out.Forwarder = contract
+			return nil
+		},
+		CapabilitiesRegistry: func(addr string) error {
+			contract, err := GetOwnedContract[*capabilities_registry.CapabilitiesRegistry](addressBook, chain, addr)
+			if err != nil {
+				return err
+			}
+			out.CapabilitiesRegistry = contract
+			return nil
+		},
+		WorkflowRegistry: func(addr string) error {
+			contract, err := GetOwnedContract[*workflow_registry.WorkflowRegistry](addressBook, chain, addr)
+			if err != nil {
+				return err
+			}
+			out.WorkflowRegistry = contract
+			return nil
+		},
+	}
+
+	for addr, tv := range addresses {
+		handler, exists := handlers[tv.Type]
+		if !exists {
+			// ignore unknown contract types
+			lggr.Warnf("Unknown contract type %s for address %s", tv.Type, addr)
+			continue
+		}
+
+		if err := handler(addr); err != nil {
+			return nil, fmt.Errorf("error trying to load contract type `%s` for address %s: %w", tv.Type, addr, err)
+		}
+	}
+
+	return &out, nil
+}

--- a/deployment/keystone/changeset/contract_set.go
+++ b/deployment/keystone/changeset/contract_set.go
@@ -36,19 +36,27 @@ type GetContractSetsResponseV2 struct {
 }
 
 func (cs ContractSetV2) toContractSet() ContractSet {
+	// We don't set the `ContractSet.MCMSWithTimelockState` due to the nature of `ContractSetV2`.
+	// Now each contract has its own MCMS state, and that format is not compatible with `ContractSet`.
+	out := ContractSet{}
+
 	ocr3Contracts := make(map[common.Address]*ocr3_capability.OCR3Capability)
 	for addr, ocr := range cs.OCR3 {
 		ocr3Contracts[addr] = ocr.Contract
 	}
 
-	// We don't set the `ContractSet.MCMSWithTimelockState` due to the nature of `ContractSetV2`.
-	// Now each contract has its own MCMS state, and that format is not compatible with `ContractSet`.
-	return ContractSet{
-		OCR3:                 ocr3Contracts,
-		Forwarder:            cs.Forwarder.Contract,
-		CapabilitiesRegistry: cs.CapabilitiesRegistry.Contract,
-		WorkflowRegistry:     cs.WorkflowRegistry.Contract,
+	out.OCR3 = ocr3Contracts
+	if cs.Forwarder != nil {
+		out.Forwarder = cs.Forwarder.Contract
 	}
+	if cs.CapabilitiesRegistry != nil {
+		out.CapabilitiesRegistry = cs.CapabilitiesRegistry.Contract
+	}
+	if cs.WorkflowRegistry != nil {
+		out.WorkflowRegistry = cs.WorkflowRegistry.Contract
+	}
+
+	return out
 }
 
 // TransferableContracts returns a list of addresses of contracts that are transferable.

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -186,3 +186,18 @@ func createContractInstance[T Ownable](addr string, chain deployment.Chain) (*T,
 
 	return &instance, nil
 }
+
+// GetOwnedContract is a helper function that gets a contract and wraps it in OwnedContract
+func GetOwnedContract[T Ownable](addressBook deployment.AddressBook, chain deployment.Chain, addr string) (*OwnedContract[T], error) {
+	contract, err := GetOwnableContract[T](addressBook, chain, &addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get contract at %s: %w", addr, err)
+	}
+
+	ownedContract, err := NewOwnable(*contract, addressBook, chain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create owned contract for %s: %w", addr, err)
+	}
+
+	return ownedContract, nil
+}

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -48,7 +48,8 @@ func NewOwnable[T Ownable](contract T, ab deployment.AddressBook, chain deployme
 	}
 
 	// Check if the owner is a timelock contract (owned by MCMS)
-	if ownerTV.Type == timelockTV.Type && ownerTV.Version.String() == timelockTV.Version.String() {
+	// If the owner is not in the address book (ownerTV = nil and err = nil), we assume it's not owned by MCMS
+	if ownerTV != nil && ownerTV.Type == timelockTV.Type && ownerTV.Version.String() == timelockTV.Version.String() {
 		// Load MCMS state
 		stateMCMS, mcmsErr := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 		if mcmsErr != nil {
@@ -95,7 +96,8 @@ func GetOwnerTypeAndVersion[T Ownable](contract T, ab deployment.AddressBook, ch
 		}
 	}
 
-	return nil, fmt.Errorf("owner %s not found in address book", ownerStr)
+	// Owner not found, assume it's non-MCMS so no error is returned
+	return nil, nil
 }
 
 // GetOwnableContract retrieves a contract instance of type T from the address book.

--- a/deployment/keystone/changeset/contracts_test.go
+++ b/deployment/keystone/changeset/contracts_test.go
@@ -154,7 +154,7 @@ func TestGetOwnerTypeAndVersion(t *testing.T) {
 		assert.Equal(t, deployment.Version1_0_0, tv.Version)
 	})
 
-	t.Run("errors when owner not in address book", func(t *testing.T) {
+	t.Run("nil owner when owner not in address book", func(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -173,16 +173,14 @@ func TestGetOwnerTypeAndVersion(t *testing.T) {
 			targetAddrStr = addr
 			break // Just take the first one
 		}
-
 		addrBook := env.ExistingAddresses
-
 		contract, err := changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &targetAddrStr)
 		require.NoError(t, err)
 
-		_, err = changeset.GetOwnerTypeAndVersion(*contract, addrBook, chain)
+		ownerTV, err := changeset.GetOwnerTypeAndVersion(*contract, addrBook, chain)
 
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "not found in address book")
+		require.NoError(t, err)
+		assert.Nil(t, ownerTV)
 	})
 }
 
@@ -282,7 +280,7 @@ func TestNewOwnable(t *testing.T) {
 		assert.NotNil(t, ownedContract.McmsContracts)
 	})
 
-	t.Run("handles error when owner type lookup fails", func(t *testing.T) {
+	t.Run("no error when owner type lookup fails due to missing address on address book (it is non-MCMS owned)", func(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -309,11 +307,13 @@ func TestNewOwnable(t *testing.T) {
 		contract, err := changeset.GetOwnableContract[*capabilities_registry.CapabilitiesRegistry](addrBook, chain, &targetAddrStr)
 		require.NoError(t, err)
 
-		// Don't add owner to address book, so lookup will fail
+		// Don't add owner to address book, so lookup will return nil TV and no error
 
-		// Call NewOwnable, should fail because owner is not in address book
-		_, err = changeset.NewOwnable(*contract, addrBook, chain)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to get owner type and version")
+		// Call NewOwnable, should not fail because owner is not in address book, but should return a non-MCMS contract
+		ownableContract, err := changeset.NewOwnable(*contract, addrBook, chain)
+		require.NoError(t, err)
+		assert.NotNil(t, ownableContract)
+		assert.Nil(t, ownableContract.McmsContracts)
+		assert.Equal(t, (*contract).Address(), ownableContract.Contract.Address())
 	})
 }

--- a/deployment/keystone/changeset/deploy_forwarder.go
+++ b/deployment/keystone/changeset/deploy_forwarder.go
@@ -90,7 +90,7 @@ func ConfigureForwardContracts(env deployment.Environment, req ConfigureForwardC
 		return deployment.ChangesetOutput{}, fmt.Errorf("failed to configure forward contracts: %w", err)
 	}
 
-	cresp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	cresp, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	})
@@ -106,10 +106,10 @@ func ConfigureForwardContracts(env deployment.Environment, req ConfigureForwardC
 		for chainSelector, op := range r.OpsPerChain {
 			contracts := cresp.ContractSets[chainSelector]
 			timelocksPerChain := map[uint64]common.Address{
-				chainSelector: contracts.Timelock.Address(),
+				chainSelector: contracts.CapabilitiesRegistry.McmsContracts.Timelock.Address(),
 			}
 			proposerMCMSes := map[uint64]*gethwrappers.ManyChainMultiSig{
-				chainSelector: contracts.ProposerMcm,
+				chainSelector: contracts.CapabilitiesRegistry.McmsContracts.ProposerMcm,
 			}
 
 			proposal, err := proposalutils.BuildProposalFromBatches(

--- a/deployment/keystone/changeset/deploy_forwarder.go
+++ b/deployment/keystone/changeset/deploy_forwarder.go
@@ -106,10 +106,10 @@ func ConfigureForwardContracts(env deployment.Environment, req ConfigureForwardC
 		for chainSelector, op := range r.OpsPerChain {
 			contracts := cresp.ContractSets[chainSelector]
 			timelocksPerChain := map[uint64]common.Address{
-				chainSelector: contracts.CapabilitiesRegistry.McmsContracts.Timelock.Address(),
+				chainSelector: contracts.Forwarder.McmsContracts.Timelock.Address(),
 			}
 			proposerMCMSes := map[uint64]*gethwrappers.ManyChainMultiSig{
-				chainSelector: contracts.CapabilitiesRegistry.McmsContracts.ProposerMcm,
+				chainSelector: contracts.Forwarder.McmsContracts.ProposerMcm,
 			}
 
 			proposal, err := proposalutils.BuildProposalFromBatches(

--- a/deployment/keystone/changeset/deploy_ocr3.go
+++ b/deployment/keystone/changeset/deploy_ocr3.go
@@ -84,7 +84,7 @@ func ConfigureOCR3Contract(env deployment.Environment, cfg ConfigureOCR3Config) 
 		if resp.Ops == nil {
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
-		r, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+		r, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 			Chains:      env.Chains,
 			AddressBook: env.ExistingAddresses,
 		})
@@ -93,10 +93,10 @@ func ConfigureOCR3Contract(env deployment.Environment, cfg ConfigureOCR3Config) 
 		}
 		contracts := r.ContractSets[cfg.ChainSel]
 		timelocksPerChain := map[uint64]string{
-			cfg.ChainSel: contracts.Timelock.Address().Hex(),
+			cfg.ChainSel: contracts.OCR3[*cfg.Address].McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			cfg.ChainSel: contracts.ProposerMcm.Address().Hex(),
+			cfg.ChainSel: contracts.OCR3[*cfg.Address].McmsContracts.ProposerMcm.Address().Hex(),
 		}
 
 		inspector, err := proposalutils.McmsInspectorForChain(env, cfg.ChainSel)

--- a/deployment/keystone/changeset/deploy_ocr3_test.go
+++ b/deployment/keystone/changeset/deploy_ocr3_test.go
@@ -97,7 +97,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 		existingContracts, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, existingContracts, 4)
+		require.Len(t, existingContracts, 5)
 
 		// Find existing OCR3 contract
 		var existingOCR3Addr string
@@ -117,7 +117,7 @@ func TestConfigureOCR3(t *testing.T) {
 		// Verify after merge there are three original contracts plus one new one
 		addrs, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, addrs, 5)
+		require.Len(t, addrs, 6)
 
 		// Find new OCR3 contract
 		var newOCR3Addr string
@@ -162,7 +162,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 		existingContracts, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, existingContracts, 4)
+		require.Len(t, existingContracts, 5)
 
 		// Deploy a new OCR3 contract
 		resp, err := changeset.DeployOCR3(te.Env, registrySel)
@@ -173,7 +173,7 @@ func TestConfigureOCR3(t *testing.T) {
 		// Verify after merge there are original contracts plus one new one
 		addrs, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, addrs, 5)
+		require.Len(t, addrs, 6)
 
 		wfNodes := te.GetP2PIDs("wfDon").Strings()
 
@@ -202,7 +202,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 		existingContracts, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, existingContracts, 4)
+		require.Len(t, existingContracts, 5)
 
 		// Deploy a new OCR3 contract
 		resp, err := changeset.DeployOCR3(te.Env, registrySel)
@@ -213,7 +213,7 @@ func TestConfigureOCR3(t *testing.T) {
 		// Verify after merge there are original contracts plus one new one
 		addrs, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, addrs, 5)
+		require.Len(t, addrs, 6)
 
 		wfNodes := te.GetP2PIDs("wfDon").Strings()
 
@@ -243,12 +243,28 @@ func TestConfigureOCR3(t *testing.T) {
 
 		wfNodes := te.GetP2PIDs("wfDon").Strings()
 
+		registrySel := te.Env.AllChainSelectors()[0]
+		// Verify after merge there are three original contracts plus one new one
+		addrs, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
+		require.NoError(t, err)
+
+		// Find new OCR3 contract
+		var existingOCR3Addr string
+		for addr, tv := range addrs {
+			if tv.Type == internal.OCR3Capability {
+				existingOCR3Addr = addr
+				break
+			}
+		}
+
 		w := &bytes.Buffer{}
+		addr := common.HexToAddress(existingOCR3Addr)
 		cfg := changeset.ConfigureOCR3Config{
 			ChainSel:             te.RegistrySelector,
 			NodeIDs:              wfNodes,
 			OCR3Config:           &c,
 			WriteGeneratedConfig: w,
+			Address:              &addr,
 			MCMSConfig:           &changeset.MCMSConfig{MinDuration: 0},
 		}
 

--- a/deployment/keystone/changeset/deploy_ocr3_test.go
+++ b/deployment/keystone/changeset/deploy_ocr3_test.go
@@ -97,7 +97,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 		existingContracts, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, existingContracts, 5)
+		require.Len(t, existingContracts, 4)
 
 		// Find existing OCR3 contract
 		var existingOCR3Addr string
@@ -117,7 +117,7 @@ func TestConfigureOCR3(t *testing.T) {
 		// Verify after merge there are three original contracts plus one new one
 		addrs, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, addrs, 6)
+		require.Len(t, addrs, 5)
 
 		// Find new OCR3 contract
 		var newOCR3Addr string
@@ -162,7 +162,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 		existingContracts, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, existingContracts, 5)
+		require.Len(t, existingContracts, 4)
 
 		// Deploy a new OCR3 contract
 		resp, err := changeset.DeployOCR3(te.Env, registrySel)
@@ -173,7 +173,7 @@ func TestConfigureOCR3(t *testing.T) {
 		// Verify after merge there are original contracts plus one new one
 		addrs, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, addrs, 6)
+		require.Len(t, addrs, 5)
 
 		wfNodes := te.GetP2PIDs("wfDon").Strings()
 
@@ -202,7 +202,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 		existingContracts, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, existingContracts, 5)
+		require.Len(t, existingContracts, 4)
 
 		// Deploy a new OCR3 contract
 		resp, err := changeset.DeployOCR3(te.Env, registrySel)
@@ -213,7 +213,7 @@ func TestConfigureOCR3(t *testing.T) {
 		// Verify after merge there are original contracts plus one new one
 		addrs, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
-		require.Len(t, addrs, 6)
+		require.Len(t, addrs, 5)
 
 		wfNodes := te.GetP2PIDs("wfDon").Strings()
 

--- a/deployment/keystone/changeset/remove_dons.go
+++ b/deployment/keystone/changeset/remove_dons.go
@@ -56,7 +56,7 @@ func RemoveDONs(env deployment.Environment, req *RemoveDONsRequest) (deployment.
 	if !ok {
 		return deployment.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}
-	cresp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	cresp, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	})
@@ -70,7 +70,7 @@ func RemoveDONs(env deployment.Environment, req *RemoveDONsRequest) (deployment.
 
 	resp, err := internal.RemoveDONs(env.Logger, &internal.RemoveDONsRequest{
 		Chain:                registryChain,
-		CapabilitiesRegistry: contracts.CapabilitiesRegistry,
+		CapabilitiesRegistry: contracts.CapabilitiesRegistry.Contract,
 		DONs:                 req.DONs,
 		UseMCMS:              req.UseMCMS(),
 	})
@@ -85,10 +85,10 @@ func RemoveDONs(env deployment.Environment, req *RemoveDONsRequest) (deployment.
 		}
 
 		timelocksPerChain := map[uint64]string{
-			req.RegistryChainSel: contracts.Timelock.Address().Hex(),
+			req.RegistryChainSel: contracts.CapabilitiesRegistry.McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			req.RegistryChainSel: contracts.ProposerMcm.Address().Hex(),
+			req.RegistryChainSel: contracts.CapabilitiesRegistry.McmsContracts.ProposerMcm.Address().Hex(),
 		}
 		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
 		if err != nil {

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -317,7 +317,8 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 			),
 		)
 		require.NoError(t, err)
-		// extract the MCMS address
+		// extract the MCMS address using `GetContractSets` instead of `GetContractSetsV2` because the latter
+		// expects contracts to already be owned by MCMS
 		r, err := changeset.GetContractSets(lggr, &changeset.GetContractSetsRequest{
 			Chains:      env.Chains,
 			AddressBook: env.ExistingAddresses,

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -26,8 +26,6 @@ import (
 	kcr "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 )
 
-const DeployerOwner deployment.ContractType = "DeployerOwner"
-
 type DonConfig struct {
 	Name             string // required, must be unique across all dons
 	N                int
@@ -159,11 +157,6 @@ func initEnv(t *testing.T, nChains int) (registryChainSel uint64, env deployment
 		Logger:            logger.Test(t),
 		Chains:            chains,
 		ExistingAddresses: deployment.NewMemoryAddressBook(),
-	}
-
-	for chainSel, chain := range chains {
-		// We add the owners addresses to the address book
-		require.NoError(t, env.ExistingAddresses.Save(chainSel, chain.DeployerKey.From.Hex(), deployment.NewTypeAndVersion(DeployerOwner, deployment.Version1_0_0)))
 	}
 
 	env, err := commonchangeset.Apply(t, env, nil,
@@ -455,15 +448,15 @@ func validateInitialChainState(t *testing.T, env deployment.Environment, registr
 	// all contracts on registry chain
 	registryChainAddrs, err := ad.AddressesForChain(registryChainSel)
 	require.NoError(t, err)
-	require.Len(t, registryChainAddrs, 5) // registry, ocr3, forwarder, workflowRegistry, owner address
+	require.Len(t, registryChainAddrs, 4) // registry, ocr3, forwarder, workflowRegistry
 	// only forwarder on non-home chain
 	for sel := range env.Chains {
 		chainAddrs, err := ad.AddressesForChain(sel)
 		require.NoError(t, err)
 		if sel != registryChainSel {
-			require.Len(t, chainAddrs, 2) // plus owner address
+			require.Len(t, chainAddrs, 1)
 		} else {
-			require.Len(t, chainAddrs, 5) // plus owner address
+			require.Len(t, chainAddrs, 4)
 		}
 		containsForwarder := false
 		for _, tv := range chainAddrs {

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -26,6 +26,8 @@ import (
 	kcr "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 )
 
+const DeployerOwner deployment.ContractType = "DeployerOwner"
+
 type DonConfig struct {
 	Name             string // required, must be unique across all dons
 	N                int
@@ -158,6 +160,12 @@ func initEnv(t *testing.T, nChains int) (registryChainSel uint64, env deployment
 		Chains:            chains,
 		ExistingAddresses: deployment.NewMemoryAddressBook(),
 	}
+
+	for chainSel, chain := range chains {
+		// We add the owners addresses to the address book
+		require.NoError(t, env.ExistingAddresses.Save(chainSel, chain.DeployerKey.From.Hex(), deployment.NewTypeAndVersion(DeployerOwner, deployment.Version1_0_0)))
+	}
+
 	env, err := commonchangeset.Apply(t, env, nil,
 		commonchangeset.Configure(
 			deployment.CreateLegacyChangeSet(changeset.DeployCapabilityRegistry),
@@ -270,16 +278,16 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 	require.NoError(t, err)
 	require.Nil(t, csOut.AddressBook, "no new addresses should be created in configure initial contracts")
 
-	req := &changeset.GetContractSetsRequest{
+	req := changeset.GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	}
 
-	contractSetsResp, err := changeset.GetContractSets(lggr, req)
+	contractSetsResp, err := changeset.GetContractSetsV2(lggr, req)
 	require.NoError(t, err)
 	require.Len(t, contractSetsResp.ContractSets, len(env.Chains))
 	// check the registry
-	gotRegistry := contractSetsResp.ContractSets[registryChainSel].CapabilitiesRegistry
+	gotRegistry := contractSetsResp.ContractSets[registryChainSel].CapabilitiesRegistry.Contract
 	require.NotNil(t, gotRegistry)
 	// validate the registry
 	// check the nodes
@@ -446,15 +454,15 @@ func validateInitialChainState(t *testing.T, env deployment.Environment, registr
 	// all contracts on registry chain
 	registryChainAddrs, err := ad.AddressesForChain(registryChainSel)
 	require.NoError(t, err)
-	require.Len(t, registryChainAddrs, 4) // registry, ocr3, forwarder, workflowRegistry
+	require.Len(t, registryChainAddrs, 5) // registry, ocr3, forwarder, workflowRegistry, owner address
 	// only forwarder on non-home chain
 	for sel := range env.Chains {
 		chainAddrs, err := ad.AddressesForChain(sel)
 		require.NoError(t, err)
 		if sel != registryChainSel {
-			require.Len(t, chainAddrs, 1)
+			require.Len(t, chainAddrs, 2) // plus owner address
 		} else {
-			require.Len(t, chainAddrs, 4)
+			require.Len(t, chainAddrs, 5) // plus owner address
 		}
 		containsForwarder := false
 		for _, tv := range chainAddrs {

--- a/deployment/keystone/changeset/update_don.go
+++ b/deployment/keystone/changeset/update_don.go
@@ -98,7 +98,7 @@ func appendRequest(r *UpdateDonRequest) *AppendNodeCapabilitiesRequest {
 }
 
 func updateDonRequest(env deployment.Environment, r *UpdateDonRequest) (*internal.UpdateDonRequest, error) {
-	resp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	resp, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	})
@@ -109,7 +109,7 @@ func updateDonRequest(env deployment.Environment, r *UpdateDonRequest) (*interna
 
 	return &internal.UpdateDonRequest{
 		Chain:                env.Chains[r.RegistryChainSel],
-		CapabilitiesRegistry: contractSet.CapabilitiesRegistry,
+		CapabilitiesRegistry: contractSet.CapabilitiesRegistry.Contract,
 		P2PIDs:               r.P2PIDs,
 		CapabilityConfigs:    r.CapabilityConfigs,
 		UseMCMS:              r.UseMCMS(),

--- a/deployment/keystone/changeset/update_nodes.go
+++ b/deployment/keystone/changeset/update_nodes.go
@@ -63,7 +63,7 @@ func UpdateNodes(env deployment.Environment, req *UpdateNodesRequest) (deploymen
 	if !ok {
 		return deployment.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}
-	cresp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
+	cresp, err := GetContractSetsV2(env.Logger, GetContractSetsRequestV2{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
 	})
@@ -77,7 +77,7 @@ func UpdateNodes(env deployment.Environment, req *UpdateNodesRequest) (deploymen
 
 	resp, err := internal.UpdateNodes(env.Logger, &internal.UpdateNodesRequest{
 		Chain:                registryChain,
-		CapabilitiesRegistry: contracts.CapabilitiesRegistry,
+		CapabilitiesRegistry: contracts.CapabilitiesRegistry.Contract,
 		P2pToUpdates:         req.P2pToUpdates,
 		UseMCMS:              req.UseMCMS(),
 	})
@@ -91,10 +91,10 @@ func UpdateNodes(env deployment.Environment, req *UpdateNodesRequest) (deploymen
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 		timelocksPerChain := map[uint64]string{
-			req.RegistryChainSel: contracts.Timelock.Address().Hex(),
+			req.RegistryChainSel: contracts.CapabilitiesRegistry.McmsContracts.Timelock.Address().Hex(),
 		}
 		proposerMCMSes := map[uint64]string{
-			req.RegistryChainSel: contracts.ProposerMcm.Address().Hex(),
+			req.RegistryChainSel: contracts.CapabilitiesRegistry.McmsContracts.ProposerMcm.Address().Hex(),
 		}
 		inspector, err := proposalutils.McmsInspectorForChain(env, req.RegistryChainSel)
 		if err != nil {


### PR DESCRIPTION
This helps to address [DEVSVCS-1550](https://smartcontract-it.atlassian.net/browse/DEVSVCS-1550) by implementing a new `ContractSetV2` and using it on Keystone changesets.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->
- <https://github.com/smartcontractkit/chainlink/pull/17055>

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
- <https://github.com/smartcontractkit/chainlink-deployments/pull/1302>


[DEVSVCS-1550]: https://smartcontract-it.atlassian.net/browse/DEVSVCS-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ