### PR TITLE
remove github.com/sourcegraph/sourcegraph/lib replaces

### DIFF
--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install Dependencies
         shell: bash
-        run:  go mod download all
+        run:  go mod download
 
   go-cache-self-hosted:
     name: Go Cache
@@ -68,4 +68,4 @@ jobs:
 
       - name: Install Dependencies
         shell: bash
-        run:  go mod download all
+        run:  go mod download

--- a/core/scripts/ccip/manual-execution/go.mod
+++ b/core/scripts/ccip/manual-execution/go.mod
@@ -40,5 +40,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -453,8 +453,5 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace (
-	// replicating the replace directive on cosmos SDK
-	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/sourcegraph/sourcegraph/lib => github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240822153003-c864f15af264
-)
+// replicating the replace directive on cosmos SDK
+replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -463,6 +463,5 @@ require (
 replace (
 	// replicating the replace directive on cosmos SDK
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/sourcegraph/sourcegraph/lib => github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240822153003-c864f15af264
 	github.com/testcontainers/testcontainers-go => github.com/testcontainers/testcontainers-go v0.34.0
 )

--- a/go.mod
+++ b/go.mod
@@ -375,5 +375,4 @@ replace (
 	// replicating the replace directive on cosmos SDK
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/sourcegraph/sourcegraph/lib => github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240822153003-c864f15af264
 )

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -579,5 +579,4 @@ replace (
 	// replicating the replace directive on cosmos SDK
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/sourcegraph/sourcegraph/lib => github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240822153003-c864f15af264
 )

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -463,5 +463,4 @@ replace (
 	// replicating the replace directive on cosmos SDK
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/sourcegraph/sourcegraph/lib => github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240822153003-c864f15af264
 )

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -559,5 +559,4 @@ replace (
 	// replicating the replace directive on cosmos SDK
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-	github.com/sourcegraph/sourcegraph/lib => github.com/sourcegraph/sourcegraph-public-snapshot/lib v0.0.0-20240822153003-c864f15af264
 )


### PR DESCRIPTION
This is an experiment to see if we can remove these `replace github.com/sourcegraph/sourcegraph/lib` lines, which appear to no longer have an effect.