### PR TITLE
BCFR-1207 remove UnregisterAll on Close for CR

### DIFF
--- a/.changeset/tall-dingos-rhyme.md
+++ b/.changeset/tall-dingos-rhyme.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#changed filters persist after ChainReader Clean being called

--- a/core/services/relay/evm/chain_reader.go
+++ b/core/services/relay/evm/chain_reader.go
@@ -8,7 +8,6 @@ import (
 	"maps"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -172,12 +171,9 @@ func (cr *chainReader) Start(ctx context.Context) error {
 	})
 }
 
-// Close unregisters polling filters for bound contracts.
 func (cr *chainReader) Close() error {
 	return cr.StopOnce("ChainReader", func() error {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		return cr.bindings.UnregisterAll(ctx, cr.lp)
+		return nil
 	})
 }
 


### PR DESCRIPTION
This PR partially fixes [this ticket](https://smartcontract-it.atlassian.net/browse/BCFR-1207)

Filters persist after CR Close() being called.
