### PR TITLE
fix(vrf-coordinator): support native and token balance in fundSubscription without breaking interface

### DIFF
--- a/contracts/src/v0.8/vrf/mocks/VRFCoordinatorV2_5Mock.sol
+++ b/contracts/src/v0.8/vrf/mocks/VRFCoordinatorV2_5Mock.sol
@@ -17,6 +17,7 @@ contract VRFCoordinatorV2_5Mock is SubscriptionAPI, IVRFCoordinatorV2Plus {
   error InvalidRandomWords();
   error InvalidExtraArgsTag();
   error NotImplemented();
+  error ValueAndAmountMismatch();
 
   event RandomWordsRequested(
     bytes32 indexed keyHash,
@@ -172,14 +173,29 @@ contract VRFCoordinatorV2_5Mock is SubscriptionAPI, IVRFCoordinatorV2Plus {
    * @param _subId the subscription to fund
    * @param _amount the amount to fund
    */
-  function fundSubscription(uint256 _subId, uint256 _amount) public {
+  function fundSubscription(uint256 _subId, uint256 _amount) public payable {
     if (s_subscriptionConfigs[_subId].owner == address(0)) {
       revert InvalidSubscription();
     }
-    uint256 oldBalance = s_subscriptions[_subId].balance;
-    s_subscriptions[_subId].balance += uint96(_amount);
-    s_totalBalance += uint96(_amount);
-    emit SubscriptionFunded(_subId, oldBalance, oldBalance + _amount);
+
+    uint96 amount = uint96(_amount);
+
+    if (msg.value > 0) {
+      if (msg.value != _amount) {
+        revert ValueAndAmountMismatch();
+      }
+
+      uint96 oldNativeBalance = s_subscriptions[_subId].nativeBalance;
+      s_subscriptions[_subId].nativeBalance += amount;
+
+      emit SubscriptionFunded(_subId, oldNativeBalance, oldNativeBalance + amount);
+    } else {
+      uint96 oldBalance = s_subscriptions[_subId].balance;
+      s_subscriptions[_subId].balance += amount;
+      s_totalBalance += amount;
+
+      emit SubscriptionFunded(_subId, oldBalance, oldBalance + amount);
+    }
   }
 
   /// @dev Convert the extra args bytes into a struct


### PR DESCRIPTION
## Support native and token-based funding in `fundSubscription` without breaking changes

This PR enhances the `fundSubscription(uint256, uint256)` method in `VRFCoordinatorV2_5Mock` to correctly handle both native (ETH) and token-based funding without changing the function signature.

The logic now uses `msg.value` to determine whether the subscription should be funded via native tokens or LINK-like balance. This ensures backward compatibility for existing integrations while supporting `nativePayment: true` in VRF v2.5 Plus clients.

### Changes

- Updated `fundSubscription` to detect ETH funding via `msg.value`.
- Preserved the original function interface to avoid breaking existing test setups or mocks.
- Emitted consistent `SubscriptionFunded` events for both funding types.

### Why

This update is necessary for testing and supporting `nativePayment: true` in `VRFConsumerBaseV2Plus` setups using mocks.