### PR TITLE
fix(operations): camelCase for report serialization

### DIFF
--- a/deployment/operations/operation.go
+++ b/deployment/operations/operation.go
@@ -38,9 +38,9 @@ type OperationHandler[IN, OUT, DEP any] func(e Bundle, deps DEP, input IN) (outp
 // This definition and OperationHandler together form the composite keys for an Operation.
 // 2 Operations are considered the same if they have the Definition and OperationHandler.
 type Definition struct {
-	ID          string
-	Version     *semver.Version
-	Description string
+	ID          string          `json:"id"`
+	Version     *semver.Version `json:"version"`
+	Description string          `json:"description"`
 }
 
 // Operation is the low level building blocks of the Operations API.

--- a/deployment/operations/report.go
+++ b/deployment/operations/report.go
@@ -12,14 +12,14 @@ import (
 // Report is the result of an operation.
 // It contains the inputs and other metadata that was used to execute the operation.
 type Report[IN, OUT any] struct {
-	ID        string       `json:"ID"`
-	Def       Definition   `json:"Definition"`
-	Output    OUT          `json:"Output"`
-	Input     IN           `json:"Input"`
-	Timestamp *time.Time   `json:"Timestamp"`
-	Err       *ReportError `json:"Error"`
+	ID        string       `json:"id"`
+	Def       Definition   `json:"definition"`
+	Output    OUT          `json:"output"`
+	Input     IN           `json:"input"`
+	Timestamp *time.Time   `json:"timestamp"`
+	Err       *ReportError `json:"error"`
 	// stores a list of report ID for an operation that was executed as part of a sequence.
-	ChildOperationReports []string `json:"ChildOperationReports"`
+	ChildOperationReports []string `json:"childOperationReports"`
 }
 
 // SequenceReport is a report for a sequence.
@@ -59,7 +59,7 @@ func NewReport[IN, OUT any](
 // Its purpose is to have an exported field `Message` for marshalling as the
 // native error cant be marshaled to JSON.
 type ReportError struct {
-	Message string
+	Message string `json:"message"`
 }
 
 // Error implements the error interface.


### PR DESCRIPTION
Just to be consistent, changing the report json serialization to use camelcase instead of pascal case

