### PR TITLE
[CRE-244] Revert back to use ubuntu-latest in CI.

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -42,12 +42,8 @@ jobs:
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch'
         }}
-    # running on macos allows longer list of files than linux
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
-      # one need to install newest version of bash to support declarative -A used in map-affected-files-to-modules.sh
-      - name: Install bash
-        run: brew install bash
       - name: Checkout the repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This PR reverts https://github.com/smartcontractkit/chainlink/pull/16952/commits/b411f0c6f97edd0a44205d867aa09bd94b5e1290

Reverting back to use ubuntu-latest. (macos was the only system that could handle huge PR https://github.com/smartcontractkit/chainlink/pull/16952)