### PR TITLE
feat: runs-on 10% allocation

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -651,19 +651,16 @@ jobs:
             exit 0
           fi
 
-          if [ "GITHUB_EVENT_NAME" != 'pull_request' ]; then
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
             echo "Not using self-hosted runners for event ${GITHUB_EVENT_NAME}"
             echo "self-hosted-runners=false" | tee -a $GITHUB_OUTPUT
             exit 0
           fi
 
-          # TODO: Enable below logic once ready for rollout
-          exit 0
-
           # PR Events
           # generate a deterministic random number based on the branch name
           branch_name="${GITHUB_HEAD_REF:-$(echo $GITHUB_REF | sed 's/refs\/heads\///')}"
-          hash=$(echo -n "$branch" | sha256sum | cut -d' ' -f1)
+          hash=$(echo -n "$branch_name" | sha256sum | cut -d' ' -f1)
           deterministic_number=$((16#${hash:0:8} % 100))
 
           echo "Branch name: $branch_name"


### PR DESCRIPTION
### Changes

Automatically opts-in 10% of PRs, randomly based on branch name.
- This adds a `runs-on` label to the PR
- Opt-out mechanism is to add `runs-on-opt-out` label to the PR.

### Testing

I made sure this branch name would trigger the `runs-on` opt-in logic.
- https://github.com/smartcontractkit/chainlink/actions/runs/14321130372?pr=17157

---

DX-365

