### PR TITLE
Avoid failing test when context is canceled

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_assertions.go
+++ b/deployment/ccip/changeset/testhelpers/test_assertions.go
@@ -422,7 +422,10 @@ func ConfirmCommitWithExpectedSeqNumRange(
 			iter, err := offRamp.FilterCommitReportAccepted(&bind.FilterOpts{
 				Context: t.Context(),
 			})
-			require.NoError(t, err)
+			// In some test case the test ends while the filter is still running resulting in a context.Canceled error.
+			if err != nil && !errors.Is(err, context.Canceled) {
+				require.NoError(t, err)
+			}
 			for iter.Next() {
 				event := iter.Event
 				verified := verifyCommitReport(event)


### PR DESCRIPTION
Avoid failing test when context is canceled