### PR TITLE
Default configurations for multi-family CCIP utilities.

### DIFF
--- a/core/capabilities/ccip/ccipevm/executecodec_test.go
+++ b/core/capabilities/ccip/ccipevm/executecodec_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/mocks"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/message_hasher"
@@ -244,7 +243,7 @@ func Test_DecodeReport(t *testing.T) {
 
 	rawReport := *abi.ConvertType(executeInputs[1], new([]byte)).(*[]byte)
 
-	codec := NewExecutePluginCodecV1(defaults.DefaultExtraDataCodec)
+	codec := NewExecutePluginCodecV1(extraDataCodec)
 	decoded, err := codec.Decode(t.Context(), rawReport)
 	require.NoError(t, err)
 

--- a/core/capabilities/ccip/ccipevm/executecodec_test.go
+++ b/core/capabilities/ccip/ccipevm/executecodec_test.go
@@ -15,8 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
-	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/mocks"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/message_hasher"
@@ -227,7 +226,6 @@ func TestExecutePluginCodecV1(t *testing.T) {
 }
 
 func Test_DecodeReport(t *testing.T) {
-	ExtraDataCodec := ccipcommon.NewExtraDataCodec(ccipcommon.NewExtraDataCodecParams(ExtraDataDecoder{}, ccipsolana.ExtraDataDecoder{}))
 	offRampABI, err := offramp.OffRampMetaData.GetAbi()
 	require.NoError(t, err)
 
@@ -246,7 +244,7 @@ func Test_DecodeReport(t *testing.T) {
 
 	rawReport := *abi.ConvertType(executeInputs[1], new([]byte)).(*[]byte)
 
-	codec := NewExecutePluginCodecV1(ExtraDataCodec)
+	codec := NewExecutePluginCodecV1(defaults.DefaultExtraDataCodec)
 	decoded, err := codec.Decode(t.Context(), rawReport)
 	require.NoError(t, err)
 

--- a/core/capabilities/ccip/ccipevm/gas_helpers_test.go
+++ b/core/capabilities/ccip/ccipevm/gas_helpers_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
@@ -80,7 +82,7 @@ func Test_calculateMessageMaxGas(t *testing.T) {
 			}
 			// Set the source chain selector to be EVM for now
 			msg.Header.SourceChainSelector = ccipocr3.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector)
-			ep := EstimateProvider{extraDataCodec: ExtraDataCodec}
+			ep := EstimateProvider{extraDataCodec: defaults.DefaultExtraDataCodec}
 			got := ep.CalculateMessageMaxGas(msg)
 			t.Log(got)
 			assert.Equalf(t, tt.want, got, "calculateMessageMaxGas(%v, %v)", tt.args.dataLen, tt.args.numTokens)
@@ -138,7 +140,7 @@ func TestCalculateMaxGas(t *testing.T) {
 			}
 
 			msg.Header.SourceChainSelector = ccipocr3.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector)
-			ep := EstimateProvider{extraDataCodec: ExtraDataCodec}
+			ep := EstimateProvider{extraDataCodec: defaults.DefaultExtraDataCodec}
 			gotTree := ep.CalculateMerkleTreeGas(tt.numRequests)
 			gotMsg := ep.CalculateMessageMaxGas(msg)
 			t.Log("want", tt.want, "got", gotTree+gotMsg)

--- a/core/capabilities/ccip/ccipevm/gas_helpers_test.go
+++ b/core/capabilities/ccip/ccipevm/gas_helpers_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
-
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
@@ -82,7 +80,7 @@ func Test_calculateMessageMaxGas(t *testing.T) {
 			}
 			// Set the source chain selector to be EVM for now
 			msg.Header.SourceChainSelector = ccipocr3.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector)
-			ep := EstimateProvider{extraDataCodec: defaults.DefaultExtraDataCodec}
+			ep := EstimateProvider{extraDataCodec: extraDataCodec}
 			got := ep.CalculateMessageMaxGas(msg)
 			t.Log(got)
 			assert.Equalf(t, tt.want, got, "calculateMessageMaxGas(%v, %v)", tt.args.dataLen, tt.args.numTokens)
@@ -140,7 +138,7 @@ func TestCalculateMaxGas(t *testing.T) {
 			}
 
 			msg.Header.SourceChainSelector = ccipocr3.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector)
-			ep := EstimateProvider{extraDataCodec: defaults.DefaultExtraDataCodec}
+			ep := EstimateProvider{extraDataCodec: extraDataCodec}
 			gotTree := ep.CalculateMerkleTreeGas(tt.numRequests)
 			gotMsg := ep.CalculateMessageMaxGas(msg)
 			t.Log("want", tt.want, "got", gotTree+gotMsg)

--- a/core/capabilities/ccip/ccipevm/msghasher_test.go
+++ b/core/capabilities/ccip/ccipevm/msghasher_test.go
@@ -25,21 +25,19 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
 
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
-	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/message_hasher"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
-var ExtraDataCodec = ccipcommon.NewExtraDataCodec(ccipcommon.NewExtraDataCodecParams(ExtraDataDecoder{}, ccipsolana.ExtraDataDecoder{}))
+var extraDataCodec = defaults.DefaultExtraDataCodec
 
 // NOTE: these test cases are only EVM <-> EVM.
 // Update these cases once we have non-EVM examples.
@@ -93,7 +91,7 @@ func testHasherEVM2EVM(ctx context.Context, t *testing.T, d *testSetupData, evmE
 	expectedHash, err := d.contract.Hash(&bind.CallOpts{Context: ctx}, evmMsg, ccipMsg.Header.OnRamp)
 	require.NoError(t, err)
 
-	evmMsgHasher := NewMessageHasherV1(logger.Test(t), ExtraDataCodec)
+	evmMsgHasher := NewMessageHasherV1(logger.Test(t), extraDataCodec)
 	actualHash, err := evmMsgHasher.Hash(ctx, ccipMsg)
 	require.NoError(t, err)
 
@@ -268,7 +266,7 @@ func TestMessagerHasher_againstRmnSharedVector(t *testing.T) {
 		}, any2EVMMessage, common.LeftPadBytes(msg.Header.OnRamp, 32))
 		require.NoError(t, err)
 
-		h := NewMessageHasherV1(logger.Test(t), ExtraDataCodec)
+		h := NewMessageHasherV1(logger.Test(t), extraDataCodec)
 		msgH, err := h.Hash(t.Context(), msg)
 		require.NoError(t, err)
 		require.Equal(t, expectedMsgHash, msgH.String())
@@ -340,7 +338,7 @@ func TestMessagerHasher_againstRmnSharedVector(t *testing.T) {
 			rmnMsgHash = "0xb6ea678f918293745bfb8db05d79dcf08986c7da3e302ac5f6782618a6f11967"
 		)
 
-		h := NewMessageHasherV1(logger.Test(t), ExtraDataCodec)
+		h := NewMessageHasherV1(logger.Test(t), extraDataCodec)
 		msgH, err := h.Hash(t.Context(), msg)
 		require.NoError(t, err)
 
@@ -434,7 +432,7 @@ func TestMessagerHasher_againstRmnSharedVector(t *testing.T) {
 		//	rmnMsgHash = "0xb6ea678f918293745bfb8db05d79dcf08986c7da3e302ac5f6782618a6f11967"
 		//)
 
-		h := NewMessageHasherV1(logger.Test(t), ExtraDataCodec)
+		h := NewMessageHasherV1(logger.Test(t), extraDataCodec)
 		msgH, err := h.Hash(t.Context(), msg)
 		require.NoError(t, err)
 
@@ -459,7 +457,7 @@ func TestMessagerHasher_againstRmnSharedVector(t *testing.T) {
 		err = json.Unmarshal(data, &msgs)
 		require.NoError(t, err)
 
-		msgHasher := NewMessageHasherV1(logger.Test(t), ExtraDataCodec)
+		msgHasher := NewMessageHasherV1(logger.Test(t), extraDataCodec)
 
 		for _, msg := range msgs {
 			any2EVMMessage := ccipMsgToAny2EVMMessage(t, msg, msg.Header.SourceChainSelector)
@@ -481,7 +479,7 @@ func TestMessagerHasher_againstRmnSharedVector(t *testing.T) {
 func ccipMsgToAny2EVMMessage(t *testing.T, msg cciptypes.Message, sourceSelector cciptypes.ChainSelector) message_hasher.InternalAny2EVMRampMessage {
 	var tokenAmounts []message_hasher.InternalAny2EVMTokenTransfer
 	for _, rta := range msg.TokenAmounts {
-		decodedMap, err := ExtraDataCodec.DecodeTokenAmountDestExecData(rta.DestExecData, sourceSelector)
+		decodedMap, err := extraDataCodec.DecodeTokenAmountDestExecData(rta.DestExecData, sourceSelector)
 		require.NoError(t, err)
 		gasAmount, err := extractDestGasAmountFromMap(decodedMap)
 		require.NoError(t, err)
@@ -495,7 +493,7 @@ func ccipMsgToAny2EVMMessage(t *testing.T, msg cciptypes.Message, sourceSelector
 		})
 	}
 
-	decodedMap, err := ExtraDataCodec.DecodeExtraArgs(msg.ExtraArgs, sourceSelector)
+	decodedMap, err := extraDataCodec.DecodeExtraArgs(msg.ExtraArgs, sourceSelector)
 	require.NoError(t, err)
 	gasLimit, err := parseExtraArgsMap(decodedMap)
 	require.NoError(t, err)

--- a/core/capabilities/ccip/ccipevm/msghasher_test.go
+++ b/core/capabilities/ccip/ccipevm/msghasher_test.go
@@ -24,20 +24,25 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/message_hasher"
-	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
-	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/ccip/generated/v1_6_0/message_hasher"
+	"github.com/smartcontractkit/chainlink-integrations/evm/assets"
+	evmtestutils "github.com/smartcontractkit/chainlink-integrations/evm/testutils"
+	"github.com/smartcontractkit/chainlink-integrations/evm/utils"
+	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
-var extraDataCodec = defaults.DefaultExtraDataCodec
+var extraDataCodec = ccipcommon.NewExtraDataCodec(
+	ccipcommon.ExtraDataCodecParams{
+		EVMExtraDataDecoder:    ExtraDataDecoder{},
+		SolanaExtraDataDecoder: ccipsolana.ExtraDataDecoder{},
+	})
 
 // NOTE: these test cases are only EVM <-> EVM.
 // Update these cases once we have non-EVM examples.
@@ -213,7 +218,7 @@ func testSetup(t *testing.T) *testSetupData {
 	}
 }
 
-func TestMessagerHasher_againstRmnSharedVector(t *testing.T) {
+func TestMessageHasher_againstRmnSharedVector(t *testing.T) {
 	transactor := evmtestutils.MustNewSimTransactor(t)
 	backend := backends.NewSimulatedBackend(types.GenesisAlloc{
 		transactor.From: {Balance: assets.Ether(1000).ToInt()},

--- a/core/capabilities/ccip/ccipsolana/msghasher_test.go
+++ b/core/capabilities/ccip/ccipsolana/msghasher_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/mocks"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
@@ -26,9 +27,15 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
+var extraDataCodec = common.NewExtraDataCodec(
+	common.ExtraDataCodecParams{
+		EVMExtraDataDecoder:    ccipevm.ExtraDataDecoder{},
+		SolanaExtraDataDecoder: ExtraDataDecoder{},
+	})
+
 func TestMessageHasher_EVM2SVM(t *testing.T) {
 	any2AnyMsg, any2SolanaMsg, msgAccounts := createEVM2SolanaMessages(t)
-	msgHasher := NewMessageHasherV1(logger.Test(t), defaults.DefaultExtraDataCodec)
+	msgHasher := NewMessageHasherV1(logger.Test(t), extraDataCodec)
 	actualHash, err := msgHasher.Hash(testutils.Context(t), any2AnyMsg)
 	require.NoError(t, err)
 	expectedHash, err := ccip.HashAnyToSVMMessage(any2SolanaMsg, any2AnyMsg.Header.OnRamp, msgAccounts)

--- a/core/capabilities/ccip/ccipsolana/msghasher_test.go
+++ b/core/capabilities/ccip/ccipsolana/msghasher_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
-	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
-
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/mocks"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
@@ -28,11 +26,9 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
-var ExtraDataCodec = ccipcommon.NewExtraDataCodec(ccipcommon.NewExtraDataCodecParams(ccipevm.ExtraDataDecoder{}, ExtraDataDecoder{}))
-
 func TestMessageHasher_EVM2SVM(t *testing.T) {
 	any2AnyMsg, any2SolanaMsg, msgAccounts := createEVM2SolanaMessages(t)
-	msgHasher := NewMessageHasherV1(logger.Test(t), ExtraDataCodec)
+	msgHasher := NewMessageHasherV1(logger.Test(t), defaults.DefaultExtraDataCodec)
 	actualHash, err := msgHasher.Hash(testutils.Context(t), any2AnyMsg)
 	require.NoError(t, err)
 	expectedHash, err := ccip.HashAnyToSVMMessage(any2SolanaMsg, any2AnyMsg.Header.OnRamp, msgAccounts)

--- a/core/capabilities/ccip/common/addresscodec.go
+++ b/core/capabilities/ccip/common/addresscodec.go
@@ -22,23 +22,15 @@ type AddressCodec struct {
 
 // AddressCodecParams is a struct that holds the parameters for creating a AddressCodec
 type AddressCodecParams struct {
-	evmAddressCodec    ChainSpecificAddressCodec
-	solanaAddressCodec ChainSpecificAddressCodec
-}
-
-// NewAddressCodecParams is a constructor for AddressCodecParams
-func NewAddressCodecParams(evmAddressCodec ChainSpecificAddressCodec, solanaAddressCodec ChainSpecificAddressCodec) AddressCodecParams {
-	return AddressCodecParams{
-		evmAddressCodec:    evmAddressCodec,
-		solanaAddressCodec: solanaAddressCodec,
-	}
+	EVMAddressCodec    ChainSpecificAddressCodec
+	SolanaAddressCodec ChainSpecificAddressCodec
 }
 
 // NewAddressCodec is a constructor for AddressCodec
 func NewAddressCodec(params AddressCodecParams) AddressCodec {
 	return AddressCodec{
-		EVMAddressCodec:    params.evmAddressCodec,
-		SolanaAddressCodec: params.solanaAddressCodec,
+		EVMAddressCodec:    params.EVMAddressCodec,
+		SolanaAddressCodec: params.SolanaAddressCodec,
 	}
 }
 

--- a/core/capabilities/ccip/common/defaults/defaults.go
+++ b/core/capabilities/ccip/common/defaults/defaults.go
@@ -1,0 +1,18 @@
+package defaults
+
+import (
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+)
+
+// DefaultExtraDataCodec is the default ExtraDataCodec for CCIP initialized with all supported chain families.
+var DefaultExtraDataCodec = common.NewExtraDataCodec(
+	common.NewExtraDataCodecParams(ccipevm.ExtraDataDecoder{}, ccipsolana.ExtraDataDecoder{}))
+
+// DefaultAddressCodec is the default AddressCodec for CCIP initialized with all supported chain families.
+var DefaultAddressCodec = common.NewAddressCodec(
+	common.NewAddressCodecParams(
+		ccipevm.AddressCodec{},
+		ccipsolana.AddressCodec{},
+	))

--- a/core/capabilities/ccip/common/defaults/defaults.go
+++ b/core/capabilities/ccip/common/defaults/defaults.go
@@ -8,11 +8,14 @@ import (
 
 // DefaultExtraDataCodec is the default ExtraDataCodec for CCIP initialized with all supported chain families.
 var DefaultExtraDataCodec = common.NewExtraDataCodec(
-	common.NewExtraDataCodecParams(ccipevm.ExtraDataDecoder{}, ccipsolana.ExtraDataDecoder{}))
+	common.ExtraDataCodecParams{
+		EVMExtraDataDecoder:    ccipevm.ExtraDataDecoder{},
+		SolanaExtraDataDecoder: ccipsolana.ExtraDataDecoder{},
+	})
 
 // DefaultAddressCodec is the default AddressCodec for CCIP initialized with all supported chain families.
 var DefaultAddressCodec = common.NewAddressCodec(
-	common.NewAddressCodecParams(
-		ccipevm.AddressCodec{},
-		ccipsolana.AddressCodec{},
-	))
+	common.AddressCodecParams{
+		EVMAddressCodec:    ccipevm.AddressCodec{},
+		SolanaAddressCodec: ccipsolana.AddressCodec{},
+	})

--- a/core/capabilities/ccip/common/extradatacodec.go
+++ b/core/capabilities/ccip/common/extradatacodec.go
@@ -30,23 +30,15 @@ type RealExtraDataCodec struct {
 
 // ExtraDataCodecParams is a struct that holds the parameters for creating a RealExtraDataCodec
 type ExtraDataCodecParams struct {
-	evmExtraDataDecoder    ExtraDataDecoder
-	solanaExtraDataDecoder ExtraDataDecoder
-}
-
-// NewExtraDataCodecParams is a constructor for ExtraDataCodecParams
-func NewExtraDataCodecParams(evmDecoder ExtraDataDecoder, solanaDecoder ExtraDataDecoder) ExtraDataCodecParams {
-	return ExtraDataCodecParams{
-		evmExtraDataDecoder:    evmDecoder,
-		solanaExtraDataDecoder: solanaDecoder,
-	}
+	EVMExtraDataDecoder    ExtraDataDecoder
+	SolanaExtraDataDecoder ExtraDataDecoder
 }
 
 // NewExtraDataCodec is a constructor for RealExtraDataCodec
 func NewExtraDataCodec(params ExtraDataCodecParams) RealExtraDataCodec {
 	return RealExtraDataCodec{
-		EVMExtraDataDecoder:    params.evmExtraDataDecoder,
-		SolanaExtraDataDecoder: params.solanaExtraDataDecoder,
+		EVMExtraDataDecoder:    params.EVMExtraDataDecoder,
+		SolanaExtraDataDecoder: params.SolanaExtraDataDecoder,
 	}
 }
 

--- a/core/capabilities/ccip/delegate.go
+++ b/core/capabilities/ccip/delegate.go
@@ -9,10 +9,8 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
-
 	"github.com/avast/retry-go/v4"
+
 	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
@@ -29,6 +27,7 @@ import (
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
 	configsevm "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/configs/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/launcher"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/oraclecreator"
@@ -206,12 +205,6 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 		return nil, fmt.Errorf("failed to get chain selector from chain ID %d", homeChainChainID)
 	}
 
-	addressCodec := common.NewAddressCodec(
-		common.NewAddressCodecParams(
-			ccipevm.AddressCodec{},
-			ccipsolana.AddressCodec{},
-		))
-
 	// if bootstrappers are provided we assume that the node is a plugin oracle.
 	// the reason for this is that bootstrap oracles do not need to be aware
 	// of other bootstrap oracles. however, plugin oracles, at least initially,
@@ -233,7 +226,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 			bootstrapperLocators,
 			hcr,
 			cciptypes.ChainSelector(homeChainChainSelector),
-			addressCodec,
+			defaults.DefaultAddressCodec,
 		)
 	} else {
 		oracleCreator = oraclecreator.NewBootstrapOracleCreator(
@@ -243,7 +236,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 			d.monitoringEndpointGen,
 			d.lggr,
 			homeChainContractReader,
-			addressCodec,
+			defaults.DefaultAddressCodec,
 		)
 	}
 

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter_test.go
@@ -36,8 +36,7 @@ import (
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ocrimpls"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
@@ -49,8 +48,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 	evmrelaytypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
-
-	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 )
 
 func Test_ContractTransmitter_TransmitWithoutSignatures(t *testing.T) {
@@ -188,12 +185,7 @@ func abiEncodeUint32(data uint32) ([]byte, error) {
 
 // Test EVM -> SVM extra data decoding in contract transmitter
 func TestSVMExecCallDataFuncExtraDataDecoding(t *testing.T) {
-	extraDataCodec := ccipcommon.NewExtraDataCodec(
-		ccipcommon.NewExtraDataCodecParams(
-			ccipevm.ExtraDataDecoder{},
-			ccipsolana.ExtraDataDecoder{},
-		),
-	)
+	extraDataCodec := defaults.DefaultExtraDataCodec
 	t.Run("fails when multiple reports are included", func(t *testing.T) {
 		reports := []ccipocr3.ExecutePluginReportSingleChain{{}, {}}
 		reportWithInfo := ccipocr3.ExecuteReportInfo{

--- a/core/capabilities/ccip/ocrimpls/svm_contract_transmitter_factory.go
+++ b/core/capabilities/ccip/ocrimpls/svm_contract_transmitter_factory.go
@@ -9,10 +9,8 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
-
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
 )
 
 // SVMCommitCallArgs defines the calldata structure for an SVM commit transaction.
@@ -173,8 +171,6 @@ func (f *SVMContractTransmitterFactory) NewExecTransmitter(
 		fromAccount:    fromAccount,
 		offrampAddress: offrampAddress,
 		toCalldataFn:   SVMExecCalldataFunc,
-		extraDataCodec: ccipcommon.NewExtraDataCodec(
-			ccipcommon.NewExtraDataCodecParams(ccipevm.ExtraDataDecoder{}, ccipsolana.ExtraDataDecoder{}),
-		),
+		extraDataCodec: defaults.DefaultExtraDataCodec,
 	}
 }

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
 	solanaconfig "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/configs/solana"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr3/promwrapper"
 
@@ -50,17 +51,10 @@ import (
 	evmrelaytypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/synchronization"
 	"github.com/smartcontractkit/chainlink/v2/core/services/telemetry"
-
-	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 )
 
 var _ cctypes.OracleCreator = &pluginOracleCreator{}
-var extraDataCodec = ccipcommon.NewExtraDataCodec(
-	ccipcommon.NewExtraDataCodecParams(
-		ccipevm.ExtraDataDecoder{},
-		ccipsolana.ExtraDataDecoder{},
-	),
-)
+var extraDataCodec = defaults.DefaultExtraDataCodec
 
 var plugins = map[string]plugin{
 	chainsel.FamilyEVM: {
@@ -358,7 +352,8 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 				ContractReaders:   contractReaders,
 				ContractWriters:   chainWriters,
 				RmnPeerClient:     rmnPeerClient,
-				RmnCrypto:         rmnCrypto})
+				RmnCrypto:         rmnCrypto,
+			})
 		factory = promwrapper.NewReportingPluginFactory[[]byte](factory, i.lggr, chainID, "CCIPCommit")
 		transmitter = plugins[chainFamily].ContractTransmitterFactory.NewCommitTransmitter(destChainWriter,
 			ocrtypes.Account(destFromAccounts[0]),

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	chainsel "github.com/smartcontractkit/chain-selectors"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana"
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/defaults"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
@@ -373,7 +373,6 @@ func ManuallyExecuteAll(
 	lookbackDuration time.Duration,
 	reExecuteIfFailed bool,
 ) error {
-	extraDataCodec := ccipcommon.NewExtraDataCodec(ccipcommon.NewExtraDataCodecParams(ccipevm.ExtraDataDecoder{}, ccipsolana.ExtraDataDecoder{}))
 	for _, seqNr := range msgSeqNrs {
 		err := manuallyExecuteSingle(
 			ctx,
@@ -385,7 +384,7 @@ func ManuallyExecuteAll(
 			uint64(seqNr), //nolint:gosec // seqNr is never <= 0.
 			lookbackDuration,
 			reExecuteIfFailed,
-			extraDataCodec,
+			defaults.DefaultExtraDataCodec,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
Add and use default instantiations of multi-family CCIP utilities to reduce the number of places where all implementations are listed.

This PR simply adds the following, and updates code to use them wherever possible:
```
// DefaultExtraDataCodec is the default ExtraDataCodec for CCIP initialized with all supported chain families.
var DefaultExtraDataCodec = common.NewExtraDataCodec(
	common.NewExtraDataCodecParams(ccipevm.ExtraDataDecoder{}, ccipsolana.ExtraDataDecoder{}))

// DefaultAddressCodec is the default AddressCodec for CCIP initialized with all supported chain families.
var DefaultAddressCodec = common.NewAddressCodec(
	common.NewAddressCodecParams(
		ccipevm.AddressCodec{},
		ccipsolana.AddressCodec{},
	))
```