### PR TITLE
chore: configure runs-on runners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,4 +180,4 @@ flake.lock @smartcontractkit/core
 
 
 # Runs-On
-./github/runs-on.yml @smartcontractkit/prodsec-public
+./.github/runs-on.yml @smartcontractkit/prodsec-public

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,30 +1,47 @@
 runners:
+  # default runners (https://runs-on.com/runners/linux/):
+  # - 1cpu-linux-x64
+  # - 2cpu-linux-x64
+  # - 4cpu-linux-x64
+  # - 8cpu-linux-x64
+  # - 16cpu-linux-x64
+  # - 32cpu-linux-x64
+  # - 48cpu-linux-x64
+  # - 64cpu-linux-x64
+
   # Used for go-mod-cache.yml
-  # 4cpu/8gp offers better EBS performance over 2cpu/4gb
-  4core-8gb-large-ubuntu-s3:
-    cpu: 4
-    ram: 8
-    family: c7
+  standard-x64:
+    cpu: [4, 8]
+    ram: [8, 32]
+    family: ["c7", "m7", "c6", "m6", "c5", "m5"]
     image: ubuntu24-full-x64
     disk: large
-    extras: [ "s3-cache" ]
-
-  # Used for ci-core.yml jobs
-  32core-256gb-large-ubuntu-r7-s3:
-    cpu: 32
-    ram: 256
-    family: r7
-    disk: large
-    image: ubuntu24-full-x64
     extras: [ "s3-cache"]
 
-  # Used for race tests / ccip deployment tests
-  64core-128gb-large-ubuntu-c7-s3:
-    cpu: 64
-    ram: 128
-    family: c7
-    disk: large
-    image: ubuntu24-full-x64
+  # 8-16 core, ssd-backed instances.
+  # For general purpose CI tasks reliant on fast IOPS.
+  medium-ssd-backed-x64:
+    cpu: [8, 16]
+    ram: [16, 128]
+    family: ["c6id", "c5ad", "m6id", "m6idn", "m5d", "m5dn", "m5ad", "r5ad"]
+    image: ubuntu22-full-x64
     extras: [ "s3-cache"]
 
+  # 32-64 core, ssd-backed instances.
+  # Unit tests require fast IOPS, which EBS-backed instances cannot provide.
+  ci-core-unit-tests-x64:
+    cpu: [32, 64]
+    ram: [64, 256]
+    family: ["c6id", "c5ad", "m6id", "m6idn", "m5d", "m5dn", "m5ad", "r5ad"]
+    image: ubuntu22-full-x64
+    extras: [ "s3-cache"]
 
+  # 64-128 core runner for race tests.
+  # large disk = 80GB EBS volume, as these are not SSD backed and the default (40GB) is not enough.
+  ci-core-race-tests-x64:
+    cpu: [64, 128]
+    ram: [128, 256]
+    family: ["c7", "m7"]
+    disk: large
+    image: ubuntu22-full-x64
+    extras: [ "s3-cache"]

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -46,11 +46,11 @@ jobs:
         run:  go mod download
 
   go-cache-self-hosted:
-    name: Go Cache
+    name: Go Cache (Self-Hosted)
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=4core-8gb-large-ubuntu-s3
+      - runner=standard-x64
     steps:
       # enable runs-on magic cache
       - uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1


### PR DESCRIPTION
### Changes

- Update `runs-on.yml` configuration for some standard runners we will use
- Fix CODEOWNERS entry for prodsec on `runs-on.yml`
- Update go-mod-cache workflow for renamed runner.

---

DX-365