### PR TITLE
[DX-495] use static job names equal to capability names

### DIFF
--- a/system-tests/lib/cre/don/jobs/chainreader/chainreader.go
+++ b/system-tests/lib/cre/don/jobs/chainreader/chainreader.go
@@ -17,6 +17,14 @@ var ChainReaderJobSpecFactoryFn = func(chainID int, networkFamily, logEventTrigg
 	}
 }
 
+var LogEventTriggerJobName = func(chainID int) string {
+	return fmt.Sprintf("log-event-trigger-%d", chainID)
+}
+
+var ReadContractJobName = func(chainID int) string {
+	return fmt.Sprintf("read-contract-%d", chainID)
+}
+
 func GenerateJobSpecs(donTopology *types.DonTopology, chainID int, networkFamily, logEventTriggerBinaryPath, readContractBinaryPath string) (types.DonsToJobSpecs, error) {
 	if donTopology == nil {
 		return nil, errors.New("topology is nil")
@@ -40,7 +48,7 @@ func GenerateJobSpecs(donTopology *types.DonTopology, chainID int, networkFamily
 					return nil, errors.New("log event trigger binary path is empty")
 				}
 
-				jobSpec := libjobs.WorkerStandardCapability(nodeID, fmt.Sprintf("log-event-trigger-capability-%d", chainID), logEventTriggerBinaryPath, fmt.Sprintf(`'{"chainId":"%d","network":"%s","lookbackBlocks":1000,"pollPeriod":1000}'`, chainID, networkFamily))
+				jobSpec := libjobs.WorkerStandardCapability(nodeID, LogEventTriggerJobName(chainID), logEventTriggerBinaryPath, fmt.Sprintf(`'{"chainId":"%d","network":"%s","lookbackBlocks":1000,"pollPeriod":1000}'`, chainID, networkFamily))
 
 				if _, ok := donToJobSpecs[donWithMetadata.ID]; !ok {
 					donToJobSpecs[donWithMetadata.ID] = make(types.DonJobs, 0)
@@ -54,7 +62,7 @@ func GenerateJobSpecs(donTopology *types.DonTopology, chainID int, networkFamily
 					return nil, errors.New("read contract binary path is empty")
 				}
 
-				jobSpec := libjobs.WorkerStandardCapability(nodeID, fmt.Sprintf("read-contract-capability-%d", chainID), readContractBinaryPath, fmt.Sprintf(`'{"chainId":%d,"network":"%s"}'`, chainID, networkFamily))
+				jobSpec := libjobs.WorkerStandardCapability(nodeID, ReadContractJobName(chainID), readContractBinaryPath, fmt.Sprintf(`'{"chainId":%d,"network":"%s"}'`, chainID, networkFamily))
 
 				if _, ok := donToJobSpecs[donWithMetadata.ID]; !ok {
 					donToJobSpecs[donWithMetadata.ID] = make(types.DonJobs, 0)

--- a/system-tests/lib/cre/don/jobs/definitions.go
+++ b/system-tests/lib/cre/don/jobs/definitions.go
@@ -25,7 +25,7 @@ func BootstrapOCR3(nodeID string, ocr3CapabilityAddress common.Address, chainID 
 	type = "bootstrap"
 	schemaVersion = 1
 	externalJobID = "%s"
-	name = "Botostrap-%s"
+	name = "%s"
 	contractID = "%s"
 	contractConfigTrackerPollInterval = "1s"
 	contractConfigConfirmations = 1
@@ -35,7 +35,7 @@ func BootstrapOCR3(nodeID string, ocr3CapabilityAddress common.Address, chainID 
 	providerType = "ocr3-capability"
 `,
 			uuid,
-			uuid[0:8],
+			types.OCR3Capability,
 			ocr3CapabilityAddress.Hex(),
 			chainID),
 	}
@@ -79,7 +79,7 @@ func AnyGateway(bootstrapNodeID string, chainID uint64, donID uint32, extraAllow
 	type = "gateway"
 	schemaVersion = 1
 	externalJobID = "%s"
-	name = "Gateway-%s"
+	name = "%s"
 	forwardingAllowed = false
 	[gatewayConfig.ConnectionManagerConfig]
 	AuthChallengeLen = 10
@@ -109,7 +109,7 @@ func AnyGateway(bootstrapNodeID string, chainID uint64, donID uint32, extraAllow
 	MaxResponseBytes = 100_000_000
 `,
 		uuid,
-		uuid[0:8],
+		types.GatewayJobName,
 		gatewayDons,
 		gatewayConnectorData.Path,
 		gatewayConnectorData.Port,
@@ -177,7 +177,7 @@ func WorkerStandardCapability(nodeID, name, command, config string) *jobv1.Propo
 	config = %s
 `,
 			uuid,
-			name+"-"+uuid[0:8],
+			name,
 			command,
 			config),
 	}
@@ -192,7 +192,7 @@ func WorkerOCR3(nodeID string, ocr3CapabilityAddress common.Address, nodeEthAddr
 	type = "offchainreporting2"
 	schemaVersion = 1
 	externalJobID = "%s"
-	name = "ocr3-consensus-%s"
+	name = "%s"
 	contractID = "%s"
 	ocrKeyBundleID = "%s"
 	p2pv2Bootstrappers = [
@@ -215,7 +215,7 @@ func WorkerOCR3(nodeID string, ocr3CapabilityAddress common.Address, nodeEthAddr
 	evm = "%s"
 `,
 			uuid,
-			uuid[0:8],
+			types.OCR3Capability,
 			ocr3CapabilityAddress,
 			ocr2KeyBundleID,
 			ocrPeeringData.OCRBootstraperPeerID,

--- a/system-tests/lib/cre/don/jobs/por/por.go
+++ b/system-tests/lib/cre/don/jobs/por/por.go
@@ -200,7 +200,7 @@ func generateDonJobSpecs(
 		}
 
 		if creflags.HasFlag(donWithMetadata.Flags, types.CronCapability) {
-			jobSpecs = append(jobSpecs, jobs.WorkerStandardCapability(nodeID, "cron-capability", cronCapBinPath, jobs.EmptyStdCapConfig))
+			jobSpecs = append(jobSpecs, jobs.WorkerStandardCapability(nodeID, types.CronCapability, cronCapBinPath, jobs.EmptyStdCapConfig))
 		}
 
 		if creflags.HasFlag(donWithMetadata.Flags, types.CustomComputeCapability) {
@@ -212,7 +212,7 @@ func generateDonJobSpecs(
 				perSenderRPS = 1.0
 				perSenderBurst = 5
 				"""`
-			jobSpecs = append(jobSpecs, jobs.WorkerStandardCapability(nodeID, "custom-compute", "__builtin_custom-compute-action", config))
+			jobSpecs = append(jobSpecs, jobs.WorkerStandardCapability(nodeID, types.CustomComputeCapability, "__builtin_custom-compute-action", config))
 		}
 	}
 

--- a/system-tests/lib/cre/don/jobs/webapi/webapi.go
+++ b/system-tests/lib/cre/don/jobs/webapi/webapi.go
@@ -35,7 +35,7 @@ func GenerateJobSpecs(donTopology *types.DonTopology) (types.DonsToJobSpecs, err
 				if _, ok := donToJobSpecs[donWithMetadata.ID]; !ok {
 					donToJobSpecs[donWithMetadata.ID] = make(types.DonJobs, 0)
 				}
-				donToJobSpecs[donWithMetadata.ID] = append(donToJobSpecs[donWithMetadata.ID], libjobs.WorkerStandardCapability(nodeID, "web-api-trigger-capability", "__builtin_web-api-trigger", libjobs.EmptyStdCapConfig))
+				donToJobSpecs[donWithMetadata.ID] = append(donToJobSpecs[donWithMetadata.ID], libjobs.WorkerStandardCapability(nodeID, types.WebAPITriggerCapability, "__builtin_web-api-trigger", libjobs.EmptyStdCapConfig))
 			}
 
 			if flags.HasFlag(donWithMetadata.Flags, types.WebAPITargetCapability) {
@@ -47,7 +47,7 @@ func GenerateJobSpecs(donTopology *types.DonTopology) (types.DonsToJobSpecs, err
 						PerSenderBurst = 1000
 						"""`
 
-				donToJobSpecs[donWithMetadata.ID] = append(donToJobSpecs[donWithMetadata.ID], libjobs.WorkerStandardCapability(nodeID, "web-api-target-capability", "__builtin_web-api-target", config))
+				donToJobSpecs[donWithMetadata.ID] = append(donToJobSpecs[donWithMetadata.ID], libjobs.WorkerStandardCapability(nodeID, types.WebAPITargetCapability, "__builtin_web-api-target", config))
 			}
 		}
 	}

--- a/system-tests/lib/cre/types/flags.go
+++ b/system-tests/lib/cre/types/flags.go
@@ -21,6 +21,10 @@ const (
 	WebAPITargetCapability  CapabilityFlag = "web-api-target"
 	WebAPITriggerCapability CapabilityFlag = "web-api-trigger"
 	MockCapability          CapabilityFlag = "mock"
-
 	// Add more capabilities as needed
+)
+
+// Job names for which there are no specific capabilities
+const (
+	GatewayJobName = "gateway"
 )


### PR DESCRIPTION
So that we can easily know whether a job for capability already exists and for example skip its creation.