### PR TITLE
CCIP - Implement token pricing interface for PipelinePriceGetter

### DIFF
--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -6,9 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -53,7 +51,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/retirement"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/ccipcommit"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/ccipexec"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/config"
@@ -1673,100 +1670,23 @@ func (d *Delegate) newServicesCCIPCommit(ctx context.Context, lggr logger.Sugare
 		MetricsRegisterer:      prometheus.WrapRegistererWith(map[string]string{"job_name": jb.Name.ValueOrZero()}, prometheus.DefaultRegisterer),
 	}
 
-	priceGetter, err := d.ccipCommitPriceGetter(ctx, lggr, pluginJobSpecConfig, jb)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create price getter: %w", err)
-	}
 	//nolint:gosec // safe to cast
-	return ccipcommit.NewCommitServices(ctx, d.ds, srcProvider, dstProvider, priceGetter, jb, lggr, d.pipelineRunner, oracleArgsNoPlugin, d.isNewlyCreatedJob, int64(srcChainID), dstChainID, logError)
-}
-
-func (d *Delegate) ccipCommitPriceGetter(ctx context.Context, lggr logger.SugaredLogger, pluginJobSpecConfig ccipconfig.CommitPluginJobSpecConfig, jb job.Job) (priceGetter ccip.AllTokensPriceGetter, err error) {
-	spec := jb.OCR2OracleSpec
-	withPipeline := strings.Trim(pluginJobSpecConfig.TokenPricesUSDPipeline, "\n\t ") != ""
-	if withPipeline {
-		priceGetter, err = ccip.NewPipelineGetter(pluginJobSpecConfig.TokenPricesUSDPipeline, d.pipelineRunner, jb.ID, jb.ExternalJobID, jb.Name.ValueOrZero(), lggr)
-		if err != nil {
-			return nil, fmt.Errorf("creating pipeline price getter: %w", err)
-		}
-	} else {
-		// Use dynamic price getter.
-		if pluginJobSpecConfig.PriceGetterConfig == nil {
-			return nil, errors.New("priceGetterConfig is nil")
-		}
-
-		// Configure contract readers for all chains specified in the aggregator configurations.
-		// Some lanes (e.g. Wemix/Kroma) requires other clients than source and destination, since they use feeds from other chains.
-		aggregatorChainsToContracts := make(map[uint64][]common.Address)
-		for _, aggCfg := range pluginJobSpecConfig.PriceGetterConfig.AggregatorPrices {
-			if _, ok := aggregatorChainsToContracts[aggCfg.ChainID]; !ok {
-				aggregatorChainsToContracts[aggCfg.ChainID] = make([]common.Address, 0)
-			}
-
-			aggregatorChainsToContracts[aggCfg.ChainID] = append(aggregatorChainsToContracts[aggCfg.ChainID], aggCfg.AggregatorContractAddress)
-		}
-
-		for _, priceCfg := range pluginJobSpecConfig.PriceGetterConfig.TokenPrices {
-			if priceCfg.AggregatorConfig == nil {
-				continue
-			}
-			aggCfg := *priceCfg.AggregatorConfig
-			contractAddrs, ok := aggregatorChainsToContracts[aggCfg.ChainID]
-			if !ok {
-				aggregatorChainsToContracts[aggCfg.ChainID] = make([]common.Address, 0)
-			}
-			if !slices.Contains(contractAddrs, aggCfg.AggregatorContractAddress) {
-				aggregatorChainsToContracts[aggCfg.ChainID] = append(aggregatorChainsToContracts[aggCfg.ChainID],
-					aggCfg.AggregatorContractAddress)
-			}
-		}
-
-		contractReaders := map[uint64]types.ContractReader{}
-
-		for chainID, aggregatorContracts := range aggregatorChainsToContracts {
-			relayID := types.RelayID{Network: spec.Relay, ChainID: strconv.FormatUint(chainID, 10)}
-			relay, rerr := d.RelayGetter.Get(relayID)
-			if rerr != nil {
-				return nil, fmt.Errorf("get relay by id=%v: %w", relayID, err)
-			}
-
-			contractsConfig := make(map[string]evmrelaytypes.ChainContractReader, len(aggregatorContracts))
-			for i := range aggregatorContracts {
-				contractsConfig[fmt.Sprintf("%v_%v", ccip.OffchainAggregator, i)] = evmrelaytypes.ChainContractReader{
-					ContractABI: ccip.OffChainAggregatorABI,
-					Configs: map[string]*evmrelaytypes.ChainReaderDefinition{
-						"decimals": { // CR consumers choose an alias
-							ChainSpecificName: "decimals",
-						},
-						"latestRoundData": {
-							ChainSpecificName: "latestRoundData",
-						},
-					},
-				}
-			}
-			contractReaderConfig := evmrelaytypes.ChainReaderConfig{
-				Contracts: contractsConfig,
-			}
-
-			contractReaderConfigJSONBytes, jerr := json.Marshal(contractReaderConfig)
-			if jerr != nil {
-				return nil, fmt.Errorf("marshal contract reader config: %w", jerr)
-			}
-
-			contractReader, cerr := relay.NewContractReader(ctx, contractReaderConfigJSONBytes)
-			if cerr != nil {
-				return nil, fmt.Errorf("new ccip commit contract reader %w", cerr)
-			}
-
-			contractReaders[chainID] = contractReader
-		}
-
-		priceGetter, err = ccip.NewDynamicPriceGetter(*pluginJobSpecConfig.PriceGetterConfig, contractReaders)
-		if err != nil {
-			return nil, fmt.Errorf("creating dynamic price getter: %w", err)
-		}
-	}
-	return priceGetter, nil
+	return ccipcommit.NewCommitServices(
+		ctx,
+		d.ds,
+		srcProvider,
+		dstProvider,
+		jb,
+		lggr,
+		d.pipelineRunner,
+		oracleArgsNoPlugin,
+		d.isNewlyCreatedJob,
+		int64(srcChainID),
+		dstChainID,
+		logError,
+		pluginJobSpecConfig,
+		d.RelayGetter,
+	)
 }
 
 func newCCIPCommitPluginBytes(isSourceProvider bool, sourceStartBlock uint64, destStartBlock uint64) config.CommitPluginConfig {

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -14,7 +17,10 @@ import (
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 	"go.uber.org/multierr"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/pricegetter"
+	evmrelaytypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
@@ -52,7 +58,6 @@ func NewCommitServices(
 	ds sqlutil.DataSource,
 	srcProvider commontypes.CCIPCommitProvider,
 	dstProvider commontypes.CCIPCommitProvider,
-	priceGetter ccip.AllTokensPriceGetter,
 	jb job.Job,
 	lggr logger.Logger,
 	pr pipeline.Runner,
@@ -61,6 +66,8 @@ func NewCommitServices(
 	sourceChainID int64,
 	destChainID int64,
 	logError func(string),
+	pluginJobSpecConfig ccipconfig.CommitPluginJobSpecConfig,
+	relayGetter RelayGetter,
 ) ([]job.ServiceCtx, error) {
 	spec := jb.OCR2OracleSpec
 
@@ -112,6 +119,25 @@ func NewCommitServices(
 	if err != nil {
 		return nil, err
 	}
+
+	if sourceChainID < 0 || destChainID < 0 {
+		return nil, errors.New("source and dest chain IDs must be positive")
+	}
+	srcChain, ok := chainselectors.ChainByEvmChainID(uint64(sourceChainID))
+	if !ok {
+		return nil, fmt.Errorf("failed to get source chain by evm ID %d", destChainID)
+	}
+	dstChain, ok2 := chainselectors.ChainByEvmChainID(uint64(destChainID))
+	if !ok2 {
+		return nil, fmt.Errorf("failed to get dest chain by evm ID %d", destChainID)
+	}
+
+	priceGetter, err := initCommitPriceGetter(ctx, lggr, pluginJobSpecConfig, jb, sourceNative,
+		pr, relayGetter, srcChain.Selector, dstChain.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create price getter: %w", err)
+	}
+
 	// Prom wrappers
 	onRampReader = observability.NewObservedOnRampReader(onRampReader, sourceChainID, ccip.CommitPluginLabel)
 	commitStoreReader = observability.NewObservedCommitStoreReader(commitStoreReader, destChainID, ccip.CommitPluginLabel)
@@ -144,17 +170,6 @@ func NewCommitServices(
 	// --------------------------------------------------------------------------------
 	// Backwards compatibility for old job spec price getter dynamic config.
 	// Should be removed after all jobSpecs migrate to the new format.
-	if sourceChainID < 0 || destChainID < 0 {
-		return nil, errors.New("source and dest chain IDs must be positive")
-	}
-	srcChain, ok := chainselectors.ChainByEvmChainID(uint64(sourceChainID))
-	if !ok {
-		return nil, fmt.Errorf("failed to get source chain by evm ID %d", destChainID)
-	}
-	dstChain, ok2 := chainselectors.ChainByEvmChainID(uint64(destChainID))
-	if !ok2 {
-		return nil, fmt.Errorf("failed to get dest chain by evm ID %d", destChainID)
-	}
 	dynamicPriceGetter, is := priceGetter.(*pricegetter.DynamicPriceGetter)
 	if is {
 		sourceNativeEvmAddr, err2 := ccipcalc.GenericAddrToEvm(sourceNative)
@@ -219,6 +234,114 @@ func NewCommitServices(
 	}, nil
 }
 
+func initCommitPriceGetter(
+	ctx context.Context,
+	lggr logger.Logger,
+	pluginJobSpecConfig ccipconfig.CommitPluginJobSpecConfig,
+	jb job.Job,
+	sourceNativeTokenAddr cciptypes.Address,
+	pipelineRunner pipeline.Runner,
+	relayGetter RelayGetter,
+	sourceChainSelector uint64,
+	destChainSelector uint64,
+) (priceGetter ccip.AllTokensPriceGetter, err error) {
+	spec := jb.OCR2OracleSpec
+	withPipeline := strings.Trim(pluginJobSpecConfig.TokenPricesUSDPipeline, "\n\t ") != ""
+	if withPipeline {
+		priceGetter, err = ccip.NewPipelineGetter(
+			pluginJobSpecConfig.TokenPricesUSDPipeline,
+			pipelineRunner,
+			jb.ID,
+			jb.ExternalJobID,
+			jb.Name.ValueOrZero(),
+			lggr,
+			sourceNativeTokenAddr,
+			sourceChainSelector,
+			destChainSelector,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("creating pipeline price getter: %w", err)
+		}
+	} else {
+		// Use dynamic price getter.
+		if pluginJobSpecConfig.PriceGetterConfig == nil {
+			return nil, errors.New("priceGetterConfig is nil")
+		}
+
+		// Configure contract readers for all chains specified in the aggregator configurations.
+		// Some lanes (e.g. Wemix/Kroma) requires other clients than source and destination, since they use feeds from other chains.
+		aggregatorChainsToContracts := make(map[uint64][]common.Address)
+		for _, aggCfg := range pluginJobSpecConfig.PriceGetterConfig.AggregatorPrices {
+			if _, ok := aggregatorChainsToContracts[aggCfg.ChainID]; !ok {
+				aggregatorChainsToContracts[aggCfg.ChainID] = make([]common.Address, 0)
+			}
+
+			aggregatorChainsToContracts[aggCfg.ChainID] = append(aggregatorChainsToContracts[aggCfg.ChainID], aggCfg.AggregatorContractAddress)
+		}
+
+		for _, priceCfg := range pluginJobSpecConfig.PriceGetterConfig.TokenPrices {
+			if priceCfg.AggregatorConfig == nil {
+				continue
+			}
+			aggCfg := *priceCfg.AggregatorConfig
+			contractAddrs, ok := aggregatorChainsToContracts[aggCfg.ChainID]
+			if !ok {
+				aggregatorChainsToContracts[aggCfg.ChainID] = make([]common.Address, 0)
+			}
+			if !slices.Contains(contractAddrs, aggCfg.AggregatorContractAddress) {
+				aggregatorChainsToContracts[aggCfg.ChainID] = append(aggregatorChainsToContracts[aggCfg.ChainID],
+					aggCfg.AggregatorContractAddress)
+			}
+		}
+
+		contractReaders := map[uint64]commontypes.ContractReader{}
+
+		for chainID, aggregatorContracts := range aggregatorChainsToContracts {
+			relayID := commontypes.RelayID{Network: spec.Relay, ChainID: strconv.FormatUint(chainID, 10)}
+			relay, rerr := relayGetter.Get(relayID)
+			if rerr != nil {
+				return nil, fmt.Errorf("get relay by id=%v: %w", relayID, err)
+			}
+
+			contractsConfig := make(map[string]evmrelaytypes.ChainContractReader, len(aggregatorContracts))
+			for i := range aggregatorContracts {
+				contractsConfig[fmt.Sprintf("%v_%v", ccip.OffchainAggregator, i)] = evmrelaytypes.ChainContractReader{
+					ContractABI: ccip.OffChainAggregatorABI,
+					Configs: map[string]*evmrelaytypes.ChainReaderDefinition{
+						"decimals": { // CR consumers choose an alias
+							ChainSpecificName: "decimals",
+						},
+						"latestRoundData": {
+							ChainSpecificName: "latestRoundData",
+						},
+					},
+				}
+			}
+			contractReaderConfig := evmrelaytypes.ChainReaderConfig{
+				Contracts: contractsConfig,
+			}
+
+			contractReaderConfigJSONBytes, jerr := json.Marshal(contractReaderConfig)
+			if jerr != nil {
+				return nil, fmt.Errorf("marshal contract reader config: %w", jerr)
+			}
+
+			contractReader, cerr := relay.NewContractReader(ctx, contractReaderConfigJSONBytes)
+			if cerr != nil {
+				return nil, fmt.Errorf("new ccip commit contract reader %w", cerr)
+			}
+
+			contractReaders[chainID] = contractReader
+		}
+
+		priceGetter, err = ccip.NewDynamicPriceGetter(*pluginJobSpecConfig.PriceGetterConfig, contractReaders)
+		if err != nil {
+			return nil, fmt.Errorf("creating dynamic price getter: %w", err)
+		}
+	}
+	return priceGetter, nil
+}
+
 func CommitReportToEthTxMeta(typ ccipconfig.ContractType, ver semver.Version) (func(report []byte) (*txmgr.TxMeta, error), error) {
 	return factory.CommitReportToEthTxMeta(typ, ver)
 }
@@ -245,4 +368,9 @@ func UnregisterCommitPluginLpFilters(srcProvider commontypes.CCIPCommitProvider,
 		}
 	}
 	return multiErr
+}
+
+type RelayGetter interface {
+	Get(id commontypes.RelayID) (loop.Relayer, error)
+	GetIDToRelayerMap() (map[commontypes.RelayID]loop.Relayer, error)
 }

--- a/core/services/ocr2/plugins/ccip/clo_ccip_integration_test.go
+++ b/core/services/ocr2/plugins/ccip/clo_ccip_integration_test.go
@@ -21,6 +21,25 @@ import (
 	integrationtesthelpers "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/testhelpers/integration"
 )
 
+func Test_CLOSpecApprovalFlow_pipeline(t *testing.T) {
+	t.Parallel()
+
+	ccipTH := integrationtesthelpers.SetupCCIPIntegrationTH(
+		t,
+		testhelpers.SourceChainID,
+		testhelpers.SourceChainSelector,
+		testhelpers.DestChainID,
+		testhelpers.DestChainSelector,
+		ccip.DefaultSourceFinalityDepth,
+		ccip.DefaultDestFinalityDepth,
+	)
+
+	tokenPricesUSDPipeline, linkUSD, ethUSD := ccipTH.CreatePricesPipeline(t)
+	defer linkUSD.Close()
+	defer ethUSD.Close()
+	test_CLOSpecApprovalFlow(t, ccipTH, tokenPricesUSDPipeline, "")
+}
+
 func Test_CLOSpecApprovalFlow_dynamicPriceGetter(t *testing.T) {
 	t.Parallel()
 	ccipTH := integrationtesthelpers.SetupCCIPIntegrationTH(

--- a/core/services/ocr2/plugins/ccip/config/config.go
+++ b/core/services/ocr2/plugins/ccip/config/config.go
@@ -43,9 +43,9 @@ func (c CommitPluginConfig) Encode() ([]byte, error) {
 
 // DynamicPriceGetterConfig specifies which configuration to use for getting the price of tokens (map keys).
 type DynamicPriceGetterConfig struct {
-	// Deprecated: use TokenPrices instead.
+	// use TokenPrices instead this is Deprecated
 	AggregatorPrices map[common.Address]AggregatorPriceConfig `json:"aggregatorPrices"`
-	// Deprecated: use TokenPrices instead.
+	// use TokenPrices instead this is Deprecated
 	StaticPrices map[common.Address]StaticPriceConfig `json:"staticPrices"`
 
 	TokenPrices []TokenPriceConfig `json:"tokenPrices"`

--- a/core/services/ocr2/plugins/ccip/exportinternal.go
+++ b/core/services/ocr2/plugins/ccip/exportinternal.go
@@ -82,8 +82,19 @@ type DynamicPriceGetter = pricegetter.DynamicPriceGetter
 
 type AllTokensPriceGetter = pricegetter.AllTokensPriceGetter
 
-func NewPipelineGetter(source string, runner pipeline.Runner, jobID int32, externalJobID uuid.UUID, name string, lggr logger.Logger) (*pricegetter.PipelineGetter, error) {
-	return pricegetter.NewPipelineGetter(source, runner, jobID, externalJobID, name, lggr)
+func NewPipelineGetter(
+	source string,
+	runner pipeline.Runner,
+	jobID int32,
+	externalJobID uuid.UUID,
+	name string,
+	lggr logger.Logger,
+	sourceNativeTokenAddr ccip.Address,
+	sourceChainSelector uint64,
+	destChainSelector uint64,
+) (*pricegetter.PipelineGetter, error) {
+	return pricegetter.NewPipelineGetter(source, runner, jobID, externalJobID, name, lggr,
+		sourceNativeTokenAddr, sourceChainSelector, destChainSelector)
 }
 
 func NewDynamicPriceGetterClient(batchCaller rpclib.EvmBatchCaller) DynamicPriceGetterClient {

--- a/core/services/ocr2/plugins/ccip/integration_test.go
+++ b/core/services/ocr2/plugins/ccip/integration_test.go
@@ -42,6 +42,11 @@ func TestIntegration_CCIP(t *testing.T) {
 			withPipeline:             false,
 			allowOutOfOrderExecution: false,
 		},
+		{
+			name:                     "with pipeline allowOutOfOrderExecution true",
+			withPipeline:             true,
+			allowOutOfOrderExecution: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
@@ -2,6 +2,7 @@ package pricegetter
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcommon"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -20,29 +22,46 @@ import (
 
 var _ PriceGetter = &PipelineGetter{}
 
-// Deprecated: not used
+// Deprecated: not supposed to be used but it seems that some JobSpecs are still using it.
+// Should be removed after all JobSpecs migrate to the dynamic price getter.
 type PipelineGetter struct {
-	source        string
-	runner        pipeline.Runner
-	jobID         int32
-	externalJobID uuid.UUID
-	name          string
-	lggr          logger.Logger
+	source                string
+	runner                pipeline.Runner
+	jobID                 int32
+	externalJobID         uuid.UUID
+	name                  string
+	lggr                  logger.Logger
+	sourceNativeTokenAddr cciptypes.Address
+	sourceChainSelector   uint64
+	destChainSelector     uint64
 }
 
-func NewPipelineGetter(source string, runner pipeline.Runner, jobID int32, externalJobID uuid.UUID, name string, lggr logger.Logger) (*PipelineGetter, error) {
+func NewPipelineGetter(
+	source string,
+	runner pipeline.Runner,
+	jobID int32,
+	externalJobID uuid.UUID,
+	name string,
+	lggr logger.Logger,
+	sourceNativeTokenAddr cciptypes.Address,
+	sourceChainSelector uint64,
+	destChainSelector uint64,
+) (*PipelineGetter, error) {
 	_, err := pipeline.Parse(source)
 	if err != nil {
 		return nil, err
 	}
 
 	return &PipelineGetter{
-		source:        source,
-		runner:        runner,
-		jobID:         jobID,
-		externalJobID: externalJobID,
-		name:          name,
-		lggr:          lggr,
+		source:                source,
+		runner:                runner,
+		jobID:                 jobID,
+		externalJobID:         externalJobID,
+		name:                  name,
+		lggr:                  lggr,
+		sourceNativeTokenAddr: sourceNativeTokenAddr,
+		sourceChainSelector:   sourceChainSelector,
+		destChainSelector:     destChainSelector,
 	}, nil
 }
 
@@ -62,7 +81,30 @@ func (d *PipelineGetter) FilterConfiguredTokens(ctx context.Context, tokens []cc
 }
 
 func (d *PipelineGetter) GetJobSpecTokenPricesUSD(ctx context.Context) (map[ccipcommon.TokenID]*big.Int, error) {
-	panic("GetJobSpecTokenPricesUSD not supported by pipeline price getter migrate to dynamic price getter via jobSpec config")
+	prices, err := d.getPricesFromRunner(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// if the token address equals source native token then chain selector is source else it is dest
+
+	tokenPrices := make(map[ccipcommon.TokenID]*big.Int)
+	for tokenAddressStr, rawPrice := range prices {
+		tokenAddr := ccipcalc.HexToAddress(tokenAddressStr)
+		castedPrice, err1 := parseutil.ParseBigIntFromAny(rawPrice)
+		if err1 != nil {
+			return nil, fmt.Errorf("failed to parse price %s for token %s: %w", rawPrice, tokenAddr, err1)
+		}
+
+		tokenID := ccipcommon.TokenID{TokenAddress: tokenAddr, ChainSelector: d.destChainSelector}
+		if tokenAddr == d.sourceNativeTokenAddr {
+			tokenID.ChainSelector = d.sourceChainSelector
+		}
+
+		tokenPrices[tokenID] = castedPrice
+	}
+
+	return tokenPrices, nil
 }
 
 func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.Address) (map[cciptypes.Address]*big.Int, error) {
@@ -97,7 +139,26 @@ func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.
 }
 
 func (d *PipelineGetter) GetTokenPricesUSD(ctx context.Context, tokens []ccipcommon.TokenID) (map[ccipcommon.TokenID]*big.Int, error) {
-	panic("GetTokenPricesUSD not supported by pipeline price getter migrate to dynamic price getter via jobSpec config")
+	tokenAddresses := make([]cciptypes.Address, len(tokens))
+	for i, token := range tokens {
+		tokenAddresses[i] = token.TokenAddress
+	}
+
+	tokenPrices, err := d.TokenPricesUSD(ctx, tokenAddresses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token prices %v: %w", tokenAddresses, err)
+	}
+
+	tokenPricesMap := make(map[ccipcommon.TokenID]*big.Int)
+	for tokenAddr, price := range tokenPrices {
+		tokenID := ccipcommon.TokenID{TokenAddress: tokenAddr, ChainSelector: d.destChainSelector}
+		if tokenAddr == d.sourceNativeTokenAddr {
+			tokenID.ChainSelector = d.sourceChainSelector
+		}
+		tokenPricesMap[tokenID] = price
+	}
+
+	return tokenPricesMap, nil
 }
 
 func (d *PipelineGetter) getPricesFromRunner(ctx context.Context) (map[string]interface{}, error) {

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
@@ -22,8 +22,9 @@ import (
 
 var _ PriceGetter = &PipelineGetter{}
 
-// Deprecated: not supposed to be used but it seems that some JobSpecs are still using it.
-// Should be removed after all JobSpecs migrate to the dynamic price getter.
+// PipelineGetter is not supposed to be used but it seems that some JobSpecs are still using it.
+// Should be removed after all JobSpecs migrate to the dynamic price getter. It uses a legacy pipeline component of
+// chainlink core.
 type PipelineGetter struct {
 	source                string
 	runner                pipeline.Runner

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/uuid"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
 	config2 "github.com/smartcontractkit/chainlink-common/pkg/config"
@@ -114,7 +115,11 @@ func newTestPipelineGetter(t *testing.T, source string) *pricegetter.PipelineGet
 	bridgeORM := bridges.NewORM(db)
 	runner := pipeline.NewRunner(pipeline.NewORM(db, lggr, config.NewTestGeneralConfig(t).JobPipeline().MaxSuccessfulRuns()),
 		bridgeORM, cfg, nil, nil, nil, nil, lggr, &http.Client{}, &http.Client{})
-	ds, err := pricegetter.NewPipelineGetter(source, runner, 1, uuid.New(), "test", lggr)
+	sourceNative := ccipcalc.EvmAddrToGeneric(common.HexToAddress("0x"))
+	sourceChain := chainsel.TEST_1000
+	destChain := chainsel.TEST_1338
+	ds, err := pricegetter.NewPipelineGetter(source, runner, 1, uuid.New(), "test",
+		lggr, sourceNative, sourceChain.Selector, destChain.Selector)
 	require.NoError(t, err)
 	return ds
 }


### PR DESCRIPTION
# About

⚠️⚠️⚠️ The PipelinePriceGetter is a component that was deprecated around one year ago.
There was a migration process to move all the JobSpecs to the dynamic price getter.
Recently we introduced some changes to fix an issue with token addresses collision: https://github.com/smartcontractkit/chainlink/pull/17133 this changes required interfaces to be updated. The pipeline price getter was not migrated to the new interface after getting a confirmation that it's not in use. That did not seem to be the case though, the token prices pipeline is still in use, even on mainnet. ⚠️⚠️⚠️

# Changes

This PR adds support for token pricing pipeline. How it works:
```
0. Lot's of plumbing changes to provide chain selectors and the source native address to the priceGetter initializer.

1. GetJobSpecTokenPricesUSD(ctx context.Context) (map[ccipcommon.TokenID]*big.Int, error)

Keeps the existing functionality to get the prices.
- If the token address is equal to source native then the chain selector is of source chain
- Else it is the dest chain selector

The price service (caller of price getter) is responsible for finding the missing dest native token and reporting that price.
 
2. GetTokenPricesUSD(ctx context.Context, tokens []ccipcommon.TokenID) (map[ccipcommon.TokenID]*big.Int, error)

Flattens all the provided TokenIDs into a slice of addresses.
Fetches prices for this addresses using existing functionality.
And then similar to 1. maps chain selectors to generate TokenIDs
```

