### PR TITLE
[DX-455] universal workflow registration function for CRE CLI

### DIFF
--- a/system-tests/lib/cre/types/keystone.go
+++ b/system-tests/lib/cre/types/keystone.go
@@ -583,3 +583,66 @@ type JobSpecFactoryInput struct {
 	DonTopology             *DonTopology
 	KeystoneContractsOutput *KeystoneContractsOutput
 }
+
+type RegisterWorkflowWithCRECLIInput struct {
+	DoNotUseCRECLI              bool
+	ShouldCompileNewWorkflow    bool
+	ChainSelector               uint64
+	WorkflowName                string
+	WorkflowDonID               uint32
+	WorkflowRegistryAddress     common.Address
+	CapabilitiesRegistryAddress common.Address
+	WorkflowOwnerAddress        common.Address
+	CRECLIPrivateKey            string
+	HTTPRPCURL                  string
+	CRECLIAbsPath               string
+	NewWorkflow                 *NewWorkflow
+	ExistingWorkflow            *ExistingWorkflow
+}
+
+type NewWorkflow struct {
+	FolderLocation  string
+	ConfigFilePath  *string
+	SecretsFilePath *string
+}
+
+type ExistingWorkflow struct {
+	BinaryURL  string
+	ConfigURL  *string
+	SecretsURL *string
+}
+
+func (w *RegisterWorkflowWithCRECLIInput) Validate() error {
+	if w.ChainSelector == 0 {
+		return errors.New("ChainSelector is required")
+	}
+	if w.WorkflowName == "" {
+		return errors.New("WorkflowName is required")
+	}
+	if w.WorkflowDonID == 0 {
+		return errors.New("WorkflowDonID is required")
+	}
+	if w.CRECLIPrivateKey == "" {
+		return errors.New("CRECLIPrivateKey is required")
+	}
+	if w.HTTPRPCURL == "" {
+		return errors.New("HTTPRPCURL is required")
+	}
+	if w.NewWorkflow != nil && w.ExistingWorkflow != nil {
+		return errors.New("only one of NewWorkflow or ExistingWorkflow can be provided")
+	}
+	if w.ShouldCompileNewWorkflow && w.NewWorkflow == nil {
+		return errors.New("NewWorkflow is required when ShouldCompileNewWorkflow is true")
+	}
+	if !w.ShouldCompileNewWorkflow && w.ExistingWorkflow == nil {
+		return errors.New("ExistingWorkflow is required when ShouldCompileNewWorkflow is false")
+	}
+	if w.NewWorkflow != nil && w.NewWorkflow.FolderLocation == "" {
+		return errors.New("WorkflowFolderLocation is required when ShouldCompileNewWorkflow is true")
+	}
+	if w.ExistingWorkflow != nil && w.ExistingWorkflow.BinaryURL == "" {
+		return errors.New("BinaryURL is required when ShouldCompileNewWorkflow is false")
+	}
+
+	return nil
+}

--- a/system-tests/lib/cre/workflow/workflow.go
+++ b/system-tests/lib/cre/workflow/workflow.go
@@ -1,0 +1,69 @@
+package workflow
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+
+	cretypes "github.com/smartcontractkit/chainlink/system-tests/lib/cre/types"
+	libcrecli "github.com/smartcontractkit/chainlink/system-tests/lib/crecli"
+)
+
+func RegisterWithCRECLI(input cretypes.RegisterWorkflowWithCRECLIInput) error {
+	if valErr := input.Validate(); valErr != nil {
+		return errors.Wrap(valErr, "failed to validate RegisterWorkflowInput")
+	}
+
+	// This env var is required by the CRE CLI
+	pkErr := os.Setenv("CRE_ETH_PRIVATE_KEY", input.CRECLIPrivateKey)
+	if pkErr != nil {
+		return errors.Wrap(pkErr, "failed to set CRE_ETH_PRIVATE_KEY")
+	}
+
+	// create CRE CLI settings file
+	settingsFile, settingsErr := libcrecli.PrepareCRECLISettingsFile(
+		input.WorkflowOwnerAddress,
+		input.CapabilitiesRegistryAddress,
+		input.WorkflowRegistryAddress,
+		input.WorkflowDonID,
+		input.ChainSelector,
+		input.HTTPRPCURL,
+	)
+	if settingsErr != nil {
+		return errors.Wrap(settingsErr, "failed to create CRE CLI settings file")
+	}
+
+	var workflowURL string
+	var workflowConfigURL *string
+	var workflowSecretsURL *string
+
+	// compile and upload the workflow, if we are not using an existing one
+	if input.ShouldCompileNewWorkflow {
+		compilationResult, compileErr := libcrecli.CompileWorkflow(input.CRECLIAbsPath, input.NewWorkflow.FolderLocation, input.NewWorkflow.ConfigFilePath, settingsFile)
+		if compileErr != nil {
+			return errors.Wrap(compileErr, "failed to compile workflow")
+		}
+
+		workflowURL = compilationResult.WorkflowURL
+		workflowConfigURL = &compilationResult.ConfigURL
+
+		if input.NewWorkflow.SecretsFilePath != nil {
+			secretsURL, secretsErr := libcrecli.EncryptSecrets(input.CRECLIAbsPath, *input.NewWorkflow.SecretsFilePath, settingsFile)
+			if secretsErr != nil {
+				return errors.Wrap(secretsErr, "failed to encrypt workflow secrets")
+			}
+			workflowSecretsURL = &secretsURL
+		}
+	} else {
+		workflowURL = input.ExistingWorkflow.BinaryURL
+		workflowConfigURL = input.ExistingWorkflow.ConfigURL
+		workflowSecretsURL = input.ExistingWorkflow.SecretsURL
+	}
+
+	registerErr := libcrecli.DeployWorkflow(input.CRECLIAbsPath, input.WorkflowName, workflowURL, workflowConfigURL, workflowSecretsURL, settingsFile)
+	if registerErr != nil {
+		return errors.Wrap(registerErr, "failed to register workflow")
+	}
+
+	return nil
+}

--- a/system-tests/lib/crecli/commands.go
+++ b/system-tests/lib/crecli/commands.go
@@ -13,15 +13,20 @@ import (
 type CompilationResult struct {
 	WorkflowURL string
 	ConfigURL   string
-	SecretsURL  string
 }
 
-func CompileWorkflow(creCLICommandPath, workflowFolder string, configFile, settingsFile *os.File) (CompilationResult, error) {
+func CompileWorkflow(creCLICommandPath, workflowFolder string, configFile *string, settingsFile *os.File) (CompilationResult, error) {
 	var outputBuffer bytes.Buffer
 
 	// the CLI expects the workflow code to be located in the same directory as its `go.mod`` file. That's why we assume that the file, which
 	// contains the entrypoint method is always named `main.go`. This is a limitation of the CLI, which we can't change.
-	compileCmd := exec.Command(creCLICommandPath, "workflow", "compile", "-S", settingsFile.Name(), "-c", configFile.Name(), "main.go") // #nosec G204
+
+	compileArgs := []string{"workflow", "compile", "-S", settingsFile.Name()}
+	if configFile != nil {
+		compileArgs = append(compileArgs, "-c", *configFile)
+	}
+	compileArgs = append(compileArgs, "main.go")
+	compileCmd := exec.Command(creCLICommandPath, compileArgs...) // #nosec G204
 	compileCmd.Stdout = &outputBuffer
 	compileCmd.Stderr = &outputBuffer
 	compileCmd.Dir = workflowFolder
@@ -38,29 +43,45 @@ func CompileWorkflow(creCLICommandPath, workflowFolder string, configFile, setti
 
 	re := regexp.MustCompile(`Gist URL=([^\s]+)`)
 	matches := re.FindAllStringSubmatch(outputBuffer.String(), -1)
-	if len(matches) < 2 {
-		return CompilationResult{}, errors.New("failed to find gist URLs in compile output")
-	}
 
 	ansiEscapePattern := `\x1b\[[0-9;]*m`
 	re = regexp.MustCompile(ansiEscapePattern)
 
-	workflowGistURL := re.ReplaceAllString(matches[0][1], "")
-	workflowConfigURL := re.ReplaceAllString(matches[1][1], "")
+	result := CompilationResult{}
 
-	if workflowGistURL == "" || workflowConfigURL == "" {
-		return CompilationResult{}, errors.New("failed to find gist URLs in compile output")
+	expectedGistURLs := 1
+	if configFile != nil {
+		expectedGistURLs++
 	}
 
-	return CompilationResult{
-		WorkflowURL: workflowGistURL,
-		ConfigURL:   workflowConfigURL,
-	}, nil
+	switch len(matches) {
+	case 1:
+		result.WorkflowURL = re.ReplaceAllString(matches[0][1], "")
+	case 2:
+		result.WorkflowURL = re.ReplaceAllString(matches[0][1], "")
+		result.ConfigURL = re.ReplaceAllString(matches[1][1], "")
+	default:
+		return CompilationResult{}, errors.New("unsupported number of gist URLs in compile output")
+	}
+
+	if len(matches) != expectedGistURLs {
+		return CompilationResult{}, fmt.Errorf("unexpected number of gist URLs in compile output: %d, expected %d", len(matches), expectedGistURLs)
+	}
+
+	return result, nil
 }
 
 // Same command to register a workflow or update an existing one
-func DeployWorkflow(creCLICommandPath, workflowName, workflowURL, configURL string, settingsFile *os.File) error {
-	deployCmd := exec.Command(creCLICommandPath, "workflow", "deploy", workflowName, "-b", workflowURL, "-c", configURL, "-S", settingsFile.Name(), "-v") // #nosec G204
+func DeployWorkflow(creCLICommandPath, workflowName, workflowURL string, configURL, secretsURL *string, settingsFile *os.File) error {
+	commandArgs := []string{"workflow", "deploy", workflowName, "-b", workflowURL, "-S", settingsFile.Name(), "-v"}
+	if configURL != nil {
+		commandArgs = append(commandArgs, "-c", *configURL)
+	}
+	if secretsURL != nil {
+		commandArgs = append(commandArgs, "-s", *secretsURL)
+	}
+
+	deployCmd := exec.Command(creCLICommandPath, commandArgs...) // #nosec G204
 	deployCmd.Stdout = os.Stdout
 	deployCmd.Stderr = os.Stderr
 	if err := deployCmd.Start(); err != nil {
@@ -68,4 +89,19 @@ func DeployWorkflow(creCLICommandPath, workflowName, workflowURL, configURL stri
 	}
 
 	return nil
+}
+
+func EncryptSecrets(creCLICommandPath, secretsFile string, settingsFile *os.File) (string, error) {
+	return "", errors.New("not implemented")
+
+	// TODO finish this in the scope of https://smartcontract-it.atlassian.net/browse/DX-81
+	// commandArgs := []string{"workflow", "secrets", "encrypt", "-S", settingsFile.Name(), "-v", "-s", "secretsFile"}
+	// encryptCmd := exec.Command(creCLICommandPath, commandArgs...) // #nosec G204
+	// encryptCmd.Stdout = os.Stdout
+	// encryptCmd.Stderr = os.Stderr
+	// if err := encryptCmd.Start(); err != nil {
+	// 	return "", errors.Wrap(err, "failed to start encrypt command")
+	// }
+
+	// return "", nil
 }

--- a/system-tests/tests/smoke/cre/por_test.go
+++ b/system-tests/tests/smoke/cre/por_test.go
@@ -238,10 +238,18 @@ func registerPoRWorkflow(input registerPoRWorkflowInput) error {
 		CRECLIAbsPath:               input.creCLIAbsPath,
 		WorkflowName:                input.WorkflowConfig.WorkflowName,
 		ShouldCompileNewWorkflow:    input.WorkflowConfig.ShouldCompileNewWorkflow,
-		NewWorkflow: &keystonetypes.NewWorkflow{
+	}
+
+	if input.WorkflowConfig.ShouldCompileNewWorkflow {
+		registerWorkflowInput.NewWorkflow = &keystonetypes.NewWorkflow{
 			FolderLocation: *input.WorkflowConfig.WorkflowFolderLocation,
 			ConfigFilePath: &workflowConfigFilePath,
-		},
+		}
+	} else {
+		registerWorkflowInput.ExistingWorkflow = &keystonetypes.ExistingWorkflow{
+			BinaryURL: input.WorkflowConfig.CompiledWorkflowConfig.BinaryURL,
+			ConfigURL: &input.WorkflowConfig.CompiledWorkflowConfig.ConfigURL,
+		}
 	}
 
 	registerErr := creworkflow.RegisterWithCRECLI(registerWorkflowInput)

--- a/system-tests/tests/smoke/cre/por_test.go
+++ b/system-tests/tests/smoke/cre/por_test.go
@@ -38,7 +38,7 @@ import (
 	keystonepor "github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/jobs/por"
 	creenv "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment"
 	keystonetypes "github.com/smartcontractkit/chainlink/system-tests/lib/cre/types"
-	libcrecli "github.com/smartcontractkit/chainlink/system-tests/lib/crecli"
+	creworkflow "github.com/smartcontractkit/chainlink/system-tests/lib/cre/workflow"
 	keystoneporcrecli "github.com/smartcontractkit/chainlink/system-tests/lib/crecli/por"
 	libtypes "github.com/smartcontractkit/chainlink/system-tests/lib/types"
 )
@@ -199,11 +199,19 @@ type registerPoRWorkflowInput struct {
 }
 
 func registerPoRWorkflow(input registerPoRWorkflowInput) error {
-	// Register workflow directly using the provided binary and config URLs
+	// Register workflow directly using the provided binary URL and optionally config and secrets URLs
 	// This is a legacy solution, probably we can remove it soon, but there's still quite a lot of people
 	// who have no access to dev-platform repo, so they cannot use the CRE CLI
 	if !input.WorkflowConfig.ShouldCompileNewWorkflow && !input.WorkflowConfig.UseCRECLI {
-		err := libcontracts.RegisterWorkflow(input.sethClient, input.workflowRegistryAddress, input.workflowDonID, input.WorkflowConfig.WorkflowName, input.WorkflowConfig.CompiledWorkflowConfig.BinaryURL, input.WorkflowConfig.CompiledWorkflowConfig.ConfigURL)
+		err := libcontracts.RegisterWorkflow(
+			input.sethClient,
+			input.workflowRegistryAddress,
+			input.workflowDonID,
+			input.WorkflowConfig.WorkflowName,
+			input.WorkflowConfig.CompiledWorkflowConfig.BinaryURL,
+			&input.WorkflowConfig.CompiledWorkflowConfig.ConfigURL,
+			nil, // TODO pass secrets URL once support for them has been added
+		)
 		if err != nil {
 			return errors.Wrap(err, "failed to register workflow")
 		}
@@ -211,43 +219,34 @@ func registerPoRWorkflow(input registerPoRWorkflowInput) error {
 		return nil
 	}
 
-	// These two env vars are required by the CRE CLI
-	err := os.Setenv("CRE_ETH_PRIVATE_KEY", input.deployerPrivateKey)
-	if err != nil {
-		return errors.Wrap(err, "failed to set CRE_ETH_PRIVATE_KEY")
-	}
-
-	// create CRE CLI settings file
-	settingsFile, settingsErr := libcrecli.PrepareCRECLISettingsFile(input.sethClient.MustGetRootKeyAddress(), input.capabilitiesRegistryAddress, input.workflowRegistryAddress, input.workflowDonID, input.chainSelector, input.blockchain.Nodes[0].ExternalHTTPUrl)
-	if settingsErr != nil {
-		return errors.Wrap(settingsErr, "failed to create CRE CLI settings file")
-	}
-
-	var workflowURL string
-	var workflowConfigURL string
-
+	// create workflow-specific config file
 	workflowConfigFile, configErr := keystoneporcrecli.CreateConfigFile(input.feedConsumerAddress, input.feedID, input.priceProvider.URL(), input.writeTargetName)
 	if configErr != nil {
 		return errors.Wrap(configErr, "failed to create workflow config file")
 	}
 
-	// compile and upload the workflow, if we are not using an existing one
-	if input.WorkflowConfig.ShouldCompileNewWorkflow {
-		compilationResult, err := libcrecli.CompileWorkflow(input.creCLIAbsPath, *input.WorkflowConfig.WorkflowFolderLocation, workflowConfigFile, settingsFile)
-		if err != nil {
-			return errors.Wrap(err, "failed to compile workflow")
-		}
+	workflowConfigFilePath := workflowConfigFile.Name()
 
-		workflowURL = compilationResult.WorkflowURL
-		workflowConfigURL = compilationResult.ConfigURL
-	} else {
-		workflowURL = input.WorkflowConfig.CompiledWorkflowConfig.BinaryURL
-		workflowConfigURL = input.WorkflowConfig.CompiledWorkflowConfig.ConfigURL
+	registerWorkflowInput := keystonetypes.RegisterWorkflowWithCRECLIInput{
+		ChainSelector:               input.chainSelector,
+		WorkflowDonID:               input.workflowDonID,
+		WorkflowRegistryAddress:     input.workflowRegistryAddress,
+		CapabilitiesRegistryAddress: input.capabilitiesRegistryAddress,
+		WorkflowOwnerAddress:        input.sethClient.MustGetRootKeyAddress(),
+		HTTPRPCURL:                  input.blockchain.Nodes[0].ExternalHTTPUrl,
+		CRECLIPrivateKey:            input.deployerPrivateKey,
+		CRECLIAbsPath:               input.creCLIAbsPath,
+		WorkflowName:                input.WorkflowConfig.WorkflowName,
+		ShouldCompileNewWorkflow:    input.WorkflowConfig.ShouldCompileNewWorkflow,
+		NewWorkflow: &keystonetypes.NewWorkflow{
+			FolderLocation: *input.WorkflowConfig.WorkflowFolderLocation,
+			ConfigFilePath: &workflowConfigFilePath,
+		},
 	}
 
-	registerErr := libcrecli.DeployWorkflow(input.creCLIAbsPath, input.WorkflowName, workflowURL, workflowConfigURL, settingsFile)
+	registerErr := creworkflow.RegisterWithCRECLI(registerWorkflowInput)
 	if registerErr != nil {
-		return errors.Wrap(registerErr, "failed to register workflow")
+		return errors.Wrap(registerErr, "failed to register workflow with CRE CLI")
 	}
 
 	return nil


### PR DESCRIPTION
move workflow registration via CRE CLI function to `lib` and in por test use only test-specific bits. Prepare the ground for secrets integration.