### PR TITLE
Add block times to ccip metrics in load tests

### DIFF
--- a/deployment/ccip/changeset/globals/ocr3.go
+++ b/deployment/ccip/changeset/globals/ocr3.go
@@ -69,8 +69,8 @@ var (
 		DeltaProgress:               120 * time.Second,
 		DeltaResend:                 30 * time.Second,
 		DeltaInitial:                20 * time.Second,
-		DeltaRound:                  700 * time.Millisecond,
-		DeltaGrace:                  2 * time.Second,
+		DeltaRound:                  2 * time.Second,
+		DeltaGrace:                  5 * time.Second,
 		DeltaCertifiedCommitRequest: 10 * time.Second,
 		// TransmissionDelayMultiplier overrides DeltaStage
 		DeltaStage: 25 * time.Second,

--- a/deployment/ccip/changeset/globals/ocr3.go
+++ b/deployment/ccip/changeset/globals/ocr3.go
@@ -69,8 +69,8 @@ var (
 		DeltaProgress:               120 * time.Second,
 		DeltaResend:                 30 * time.Second,
 		DeltaInitial:                20 * time.Second,
-		DeltaRound:                  2 * time.Second,
-		DeltaGrace:                  5 * time.Second,
+		DeltaRound:                  700 * time.Millisecond,
+		DeltaGrace:                  2 * time.Second,
 		DeltaCertifiedCommitRequest: 10 * time.Second,
 		// TransmissionDelayMultiplier overrides DeltaStage
 		DeltaStage: 25 * time.Second,

--- a/integration-tests/load/ccip/ccip_test.go
+++ b/integration-tests/load/ccip/ccip_test.go
@@ -71,17 +71,17 @@ func TestCCIPLoad_RPS(t *testing.T) {
 		// Get the first block
 		block1, err := env.Chains[cs].Client.HeaderByNumber(context.Background(), big.NewInt(1))
 		require.NoError(t, err)
-		time1 := time.Unix(int64(block1.Time), 0)
+		time1 := time.Unix(int64(block1.Time), 0) //nolint:gosec // G115
 
 		// Get the second block
 		block2, err := env.Chains[cs].Client.HeaderByNumber(context.Background(), big.NewInt(2))
 		require.NoError(t, err)
-		time2 := time.Unix(int64(block2.Time), 0)
+		time2 := time.Unix(int64(block2.Time), 0) //nolint:gosec // G115
 
 		blockTimeDiff := int64(time2.Sub(time1))
 		blockNumberDiff := new(big.Int).Sub(block2.Number, block1.Number).Int64()
 		blockTime := blockTimeDiff / blockNumberDiff / int64(time.Second)
-		blockTimes[cs] = uint64(blockTime)
+		blockTimes[cs] = uint64(blockTime) //nolint:gosec // G115
 		lggr.Infow("Chain block time", "chainSelector", cs, "blockTime", blockTime)
 	}
 

--- a/integration-tests/load/ccip/ccip_test.go
+++ b/integration-tests/load/ccip/ccip_test.go
@@ -65,6 +65,26 @@ func TestCCIPLoad_RPS(t *testing.T) {
 	require.NotNil(t, env)
 	userOverrides.Validate(t, env)
 
+	// initialize the block time for each chain
+	blockTimes := make(map[uint64]uint64)
+	for _, cs := range env.AllChainSelectors() {
+		// Get the first block
+		block1, err := env.Chains[cs].Client.HeaderByNumber(context.Background(), big.NewInt(1))
+		require.NoError(t, err)
+		time1 := time.Unix(int64(block1.Time), 0)
+
+		// Get the second block
+		block2, err := env.Chains[cs].Client.HeaderByNumber(context.Background(), big.NewInt(2))
+		require.NoError(t, err)
+		time2 := time.Unix(int64(block2.Time), 0)
+
+		blockTimeDiff := int64(time2.Sub(time1))
+		blockNumberDiff := new(big.Int).Sub(block2.Number, block1.Number).Int64()
+		blockTime := blockTimeDiff / blockNumberDiff / int64(time.Second)
+		blockTimes[cs] = uint64(blockTime)
+		lggr.Infow("Chain block time", "chainSelector", cs, "blockTime", blockTime)
+	}
+
 	// initialize additional accounts on other chains
 	transmitKeys, err := fundAdditionalKeys(lggr, *env, env.AllChainSelectors()[:*userOverrides.NumDestinationChains])
 	// todo: fund keys on solana
@@ -80,7 +100,7 @@ func TestCCIPLoad_RPS(t *testing.T) {
 	finalSeqNrExecChannels := make(map[uint64]chan finalSeqNrReport)
 	loadFinished := make(chan struct{})
 
-	mm := NewMetricsManager(t, env.Logger, userOverrides)
+	mm := NewMetricsManager(t, env.Logger, userOverrides, blockTimes)
 	go mm.Start(ctx)
 
 	// gunMap holds a destinationGun for every enabled destination chain

--- a/integration-tests/load/ccip/metrics.go
+++ b/integration-tests/load/ccip/metrics.go
@@ -89,8 +89,8 @@ func (mm *MetricManager) Start(ctx context.Context) {
 				commitDuration, execDuration := uint64(0), uint64(0)
 				timestamps := metricState.timestamps
 				if timestamps[committed] != 0 && timestamps[transmitted] != 0 {
-					commitDuration = timestamps[committed] - timestamps[transmitted] -
-						mm.blockTimes[srcDstSeqNum.src]*FinalityDepth
+					commitDuration =
+						timestamps[committed] - timestamps[transmitted] - mm.getChainFinalityTime(srcDstSeqNum.src)
 				}
 				if timestamps[executed] != 0 && timestamps[committed] != 0 {
 					execDuration = timestamps[executed] - timestamps[committed]
@@ -147,8 +147,8 @@ func (mm *MetricManager) Start(ctx context.Context) {
 			// only add commit and exec durations if we have correct timestamps to calculate them
 			commitDuration := uint64(0)
 			if state.timestamps[committed] != 0 && state.timestamps[transmitted] != 0 {
-				commitDuration = state.timestamps[committed] - state.timestamps[transmitted] -
-					mm.blockTimes[data.src]*FinalityDepth
+				commitDuration =
+					state.timestamps[committed] - state.timestamps[transmitted] - mm.getChainFinalityTime(data.src)
 			}
 			execDuration := uint64(0)
 			if state.timestamps[executed] != 0 && state.timestamps[committed] != 0 {
@@ -176,6 +176,13 @@ func SendMetricsToLoki(l logger.Logger, lc *wasp.LokiClient, updatedLabels map[s
 	}
 }
 
+func (mm MetricManager) getChainFinalityTime(chainSelector uint64) uint64 {
+	if blockTime, ok := mm.blockTimes[chainSelector]; ok {
+		return blockTime * FinalityDepth
+	}
+	mm.lggr.Error("block time not found for chainSelector", "chainSelector", chainSelector)
+	return 0
+}
 func setLokiLabels(src, dst uint64, testLabel string) (map[string]string, error) {
 	srcChainID, err := chainselectors.GetChainIDFromSelector(src)
 	if err != nil {

--- a/integration-tests/load/ccip/metrics.go
+++ b/integration-tests/load/ccip/metrics.go
@@ -90,7 +90,7 @@ func (mm *MetricManager) Start(ctx context.Context) {
 				timestamps := metricState.timestamps
 				if timestamps[committed] != 0 && timestamps[transmitted] != 0 {
 					commitDuration = timestamps[committed] - timestamps[transmitted] -
-						mm.blockTimes[srcDstSeqNum.dst]*FinalityDepth
+						mm.blockTimes[srcDstSeqNum.src]*FinalityDepth
 				}
 				if timestamps[executed] != 0 && timestamps[committed] != 0 {
 					execDuration = timestamps[executed] - timestamps[committed]
@@ -148,7 +148,7 @@ func (mm *MetricManager) Start(ctx context.Context) {
 			commitDuration := uint64(0)
 			if state.timestamps[committed] != 0 && state.timestamps[transmitted] != 0 {
 				commitDuration = state.timestamps[committed] - state.timestamps[transmitted] -
-					mm.blockTimes[data.dst]*FinalityDepth
+					mm.blockTimes[data.src]*FinalityDepth
 			}
 			execDuration := uint64(0)
 			if state.timestamps[executed] != 0 && state.timestamps[committed] != 0 {

--- a/integration-tests/load/ccip/metrics.go
+++ b/integration-tests/load/ccip/metrics.go
@@ -18,6 +18,7 @@ import (
 const (
 	LokiLoadLabel = "ccipv2_load_test"
 	ErrLokiPush   = "failed to push metrics to Loki"
+	FinalityDepth = 200
 )
 
 type LokiMetric struct {
@@ -32,12 +33,13 @@ type LokiMetric struct {
 // MetricsManager is used for maintaining state of different sequence numbers
 // Once we've received all expected timestamps, it pushes the metrics to Loki
 type MetricManager struct {
-	lggr      logger.Logger
-	loki      *wasp.LokiClient
-	InputChan chan messageData
-	state     map[srcDstSeqNum]metricState
-	testLabel string
-	ErrorChan chan error
+	lggr       logger.Logger
+	loki       *wasp.LokiClient
+	InputChan  chan messageData
+	state      map[srcDstSeqNum]metricState
+	blockTimes map[uint64]uint64
+	testLabel  string
+	ErrorChan  chan error
 }
 
 type metricState struct {
@@ -56,7 +58,7 @@ type messageData struct {
 	timestamp uint64
 }
 
-func NewMetricsManager(t *testing.T, l logger.Logger, overrides *ccip.LoadConfig) *MetricManager {
+func NewMetricsManager(t *testing.T, l logger.Logger, overrides *ccip.LoadConfig, blockTimes map[uint64]uint64) *MetricManager {
 	// initialize loki using endpoint from user defined env vars
 	loki, err := wasp.NewLokiClient(wasp.NewEnvLokiConfig())
 	require.NoError(t, err)
@@ -66,12 +68,13 @@ func NewMetricsManager(t *testing.T, l logger.Logger, overrides *ccip.LoadConfig
 	}
 
 	return &MetricManager{
-		lggr:      l,
-		loki:      loki,
-		InputChan: make(chan messageData),
-		state:     make(map[srcDstSeqNum]metricState),
-		testLabel: testLabel,
-		ErrorChan: make(chan error),
+		lggr:       l,
+		loki:       loki,
+		InputChan:  make(chan messageData),
+		state:      make(map[srcDstSeqNum]metricState),
+		blockTimes: blockTimes,
+		testLabel:  testLabel,
+		ErrorChan:  make(chan error),
 	}
 }
 
@@ -143,7 +146,8 @@ func (mm *MetricManager) Start(ctx context.Context) {
 			// only add commit and exec durations if we have correct timestamps to calculate them
 			commitDuration := uint64(0)
 			if state.timestamps[committed] != 0 && state.timestamps[transmitted] != 0 {
-				commitDuration = state.timestamps[committed] - state.timestamps[transmitted]
+				commitDuration = state.timestamps[committed] - state.timestamps[transmitted] -
+					mm.blockTimes[data.dst]*FinalityDepth
 			}
 			execDuration := uint64(0)
 			if state.timestamps[executed] != 0 && state.timestamps[committed] != 0 {

--- a/integration-tests/load/ccip/metrics.go
+++ b/integration-tests/load/ccip/metrics.go
@@ -89,7 +89,8 @@ func (mm *MetricManager) Start(ctx context.Context) {
 				commitDuration, execDuration := uint64(0), uint64(0)
 				timestamps := metricState.timestamps
 				if timestamps[committed] != 0 && timestamps[transmitted] != 0 {
-					commitDuration = timestamps[committed] - timestamps[transmitted]
+					commitDuration = timestamps[committed] - timestamps[transmitted] -
+						mm.blockTimes[srcDstSeqNum.dst]*FinalityDepth
 				}
 				if timestamps[executed] != 0 && timestamps[committed] != 0 {
 					execDuration = timestamps[executed] - timestamps[committed]


### PR DESCRIPTION
Computing commit duration by subtracting blockTime * finalityDepth. In a subsequent PR we'll read the finalityDepth from CRIB.