### PR TITLE
fix(operations): introduce util function to convert to generic type

### DIFF
--- a/deployment/operations/report.go
+++ b/deployment/operations/report.go
@@ -22,6 +22,12 @@ type Report[IN, OUT any] struct {
 	ChildOperationReports []string `json:"childOperationReports"`
 }
 
+// ToGenericReport converts the Report to a generic Report.
+// This is useful when we want to return the report as a generic type in the changeset.output.
+func (r Report[IN, OUT]) ToGenericReport() Report[any, any] {
+	return genericReport(r)
+}
+
 // SequenceReport is a report for a sequence.
 // It contains a report for the sequence itself and also a list of reports
 // for all the operations executed as part of the sequence.
@@ -32,6 +38,15 @@ type SequenceReport[IN, OUT any] struct {
 
 	// ExecutionReports is a list of report all the operations & sequence that was executed as part of this sequence.
 	ExecutionReports []Report[any, any]
+}
+
+// ToGenericSequenceReport converts the SequenceReport to a generic SequenceReport.
+// This is useful when we want to return the report as a generic type in the changeset.output.
+func (r SequenceReport[IN, OUT]) ToGenericSequenceReport() SequenceReport[any, any] {
+	return SequenceReport[any, any]{
+		Report:           genericReport[IN, OUT](r.Report),
+		ExecutionReports: r.ExecutionReports,
+	}
 }
 
 // NewReport creates a new report.

--- a/deployment/operations/report_test.go
+++ b/deployment/operations/report_test.go
@@ -212,3 +212,60 @@ func Test_Report_Unmarshal(t *testing.T) {
 	assert.Equal(t, "157b4a77-bdcb-497d-899d-1e8bb44ced58", report.ChildOperationReports[0])
 	assert.NotNil(t, report.Timestamp)
 }
+
+func Test_Report_ToGenericReport(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	report := Report[int, string]{
+		ID:                    "1",
+		Def:                   Definition{},
+		Output:                "2",
+		Input:                 1,
+		Timestamp:             &now,
+		Err:                   nil,
+		ChildOperationReports: []string{uuid.New().String()},
+	}
+
+	r := report.ToGenericReport()
+	assert.Equal(t, report.ID, r.ID)
+	assert.Equal(t, report.Def, r.Def)
+	assert.Equal(t, report.Output, r.Output)
+	assert.Equal(t, report.Input, r.Input)
+	assert.Equal(t, report.Timestamp, r.Timestamp)
+	assert.Equal(t, report.Err, r.Err)
+	assert.Equal(t, report.ChildOperationReports, r.ChildOperationReports)
+}
+
+func Test_SequenceReport_ToGenericReport(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	report := SequenceReport[int, string]{
+		Report: Report[int, string]{
+			ID:                    "1",
+			Def:                   Definition{},
+			Output:                "2",
+			Input:                 1,
+			Timestamp:             &now,
+			Err:                   nil,
+			ChildOperationReports: []string{uuid.New().String()},
+		},
+		ExecutionReports: []Report[any, any]{
+			{
+				ID: "2",
+			},
+		},
+	}
+
+	r := report.ToGenericSequenceReport()
+	assert.Equal(t, report.ID, r.ID)
+	assert.Equal(t, report.Def, r.Def)
+	assert.Equal(t, report.Output, r.Output)
+	assert.Equal(t, report.Input, r.Input)
+	assert.Equal(t, report.Timestamp, r.Timestamp)
+	assert.Equal(t, report.Err, r.Err)
+	assert.Equal(t, report.ChildOperationReports, r.ChildOperationReports)
+	assert.Len(t, r.ExecutionReports, 1)
+	assert.Equal(t, report.ExecutionReports[0].ID, r.ExecutionReports[0].ID)
+}


### PR DESCRIPTION
In some cases, we want to return the report created by the operations or sequence to the changeset level, however those level deals with Report[any,any], this commit introduce function to help with the conversion without the user having to convert themselves. We are required to perform an explicit conversion because golang does not support Covariance concept.

