### PR TITLE
deployment/ccip/manualexechelpers: performance improvements

### DIFF
--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -23,8 +24,13 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm/manualexeclib"
 )
 
-// 14 days is the default lookback but it can be overridden.
-const DefaultLookback = 14 * 24 * time.Hour
+const (
+	// 14 days is the default lookback but it can be overridden.
+	DefaultLookbackMessages = 14 * 24 * time.Hour
+
+	// DefaultLookbackCommitReport is the default lookback for commit reports.
+	DefaultLookbackCommitReport = 14 * 24 * time.Hour
+)
 
 var (
 	blockTimeSecondsPerChain = map[uint64]uint64{
@@ -84,6 +90,15 @@ func getStartBlock(srcChainSel uint64, currentHead uint64, lookbackDuration time
 	return start
 }
 
+func durationToBlocks(srcChainSel uint64, lookbackDuration time.Duration) uint64 {
+	blockTimeSeconds := blockTimeSecondsPerChain[srcChainSel]
+	if blockTimeSeconds == 0 {
+		blockTimeSeconds = defaultBlockTimeSeconds
+	}
+
+	return uint64(lookbackDuration.Seconds()) / blockTimeSeconds
+}
+
 func getCommitRootAcceptedEvent(
 	ctx context.Context,
 	lggr logger.Logger,
@@ -100,10 +115,12 @@ func getCommitRootAcceptedEvent(
 	}
 
 	start := getStartBlock(srcChainSel, hdr.Number.Uint64(), lookbackDuration)
-	lggr.Debugw("Getting commit root accepted event", "startBlock", start)
+	end := start + durationToBlocks(destChainSel, 48*time.Hour)
+	lggr.Debugw("Getting commit root accepted event", "startBlock", start, "endBlock", end)
 	iter, err := state.Chains[destChainSel].OffRamp.FilterCommitReportAccepted(
 		&bind.FilterOpts{
 			Start: start,
+			End:   &end,
 		},
 	)
 	if err != nil {
@@ -161,6 +178,7 @@ func getCCIPMessageSentEvents(
 	}
 
 	start := getStartBlock(srcChainSel, hdr.Number.Uint64(), lookbackDuration)
+	step := durationToBlocks(srcChainSel, 24*time.Hour)
 
 	var seqNrs []uint64
 	for i := merkleRoot.MinSeqNr; i <= merkleRoot.MaxSeqNr; i++ {
@@ -172,35 +190,54 @@ func getCCIPMessageSentEvents(
 		"minSeqNr", merkleRoot.MinSeqNr,
 		"maxSeqNr", merkleRoot.MaxSeqNr,
 		"startBlock", start,
+		"step", step,
 	)
-
-	iter, err := state.Chains[srcChainSel].OnRamp.FilterCCIPMessageSent(
-		&bind.FilterOpts{
-			Start: start,
-		},
-		[]uint64{destChainSel},
-		seqNrs,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to filter ccip message sent: %w", err)
-	}
 
 	var ret []onramp.OnRampCCIPMessageSent
 	var count int
 	var toDestCount int
-	for iter.Next() {
-		count++
-		if iter.Event.DestChainSelector == destChainSel {
-			toDestCount++
-			lggr.Debugw("checking message",
-				"seqNr", iter.Event.SequenceNumber,
-				"destChain", iter.Event.DestChainSelector,
-				"txHash", iter.Event.Raw.TxHash.String())
-			if iter.Event.SequenceNumber >= merkleRoot.MinSeqNr &&
-				iter.Event.SequenceNumber <= merkleRoot.MaxSeqNr {
-				ret = append(ret, *iter.Event)
+	merkleRootSize := merkleRoot.MaxSeqNr - merkleRoot.MinSeqNr + 1
+	for uint64(len(ret)) < merkleRootSize {
+		if start > hdr.Number.Uint64() {
+			// Probably didn't find everything
+			lggr.Debugw("start block is greater than current head, stopping")
+			break
+		}
+
+		end := start + step
+		if end > hdr.Number.Uint64() {
+			end = hdr.Number.Uint64()
+		}
+
+		lggr.Debugw("Querying with", "startBlock", start, "endBlock", end, "step", step)
+		iter, err := state.Chains[srcChainSel].OnRamp.FilterCCIPMessageSent(
+			&bind.FilterOpts{
+				Start: start,
+				End:   &end,
+			},
+			[]uint64{destChainSel},
+			seqNrs,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to filter ccip message sent: %w", err)
+		}
+
+		for iter.Next() {
+			count++
+			if iter.Event.DestChainSelector == destChainSel {
+				toDestCount++
+				lggr.Debugw("checking message",
+					"seqNr", iter.Event.SequenceNumber,
+					"destChain", iter.Event.DestChainSelector,
+					"txHash", iter.Event.Raw.TxHash.String())
+				if iter.Event.SequenceNumber >= merkleRoot.MinSeqNr &&
+					iter.Event.SequenceNumber <= merkleRoot.MaxSeqNr {
+					ret = append(ret, *iter.Event)
+				}
 			}
 		}
+
+		start = end + 1
 	}
 
 	lggr.Debugw("found messages", "count", count, "toDestCount", toDestCount)
@@ -220,9 +257,12 @@ func manuallyExecuteSingle(
 	srcChainSel uint64,
 	destChainSel uint64,
 	msgSeqNr uint64,
-	lookbackDuration time.Duration,
+	lookbackDuration,
+	lookbackDurationCommitReport time.Duration,
 	reExecuteIfFailed bool,
 	extraDataCodec ccipcommon.ExtraDataCodec,
+	messageSentCache map[uint64]onramp.OnRampCCIPMessageSent,
+	commitRootCache *RootCache,
 ) error {
 	onRampAddress := state.Chains[srcChainSel].OnRamp.Address()
 
@@ -244,18 +284,30 @@ func manuallyExecuteSingle(
 		"onRampAddress", onRampAddress,
 		"execState", execState,
 	)
-	merkleRoot, err := getCommitRootAcceptedEvent(
-		ctx,
-		lggr,
-		env,
-		state,
-		srcChainSel,
-		destChainSel,
-		msgSeqNr,
-		lookbackDuration,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to get merkle root: %w", err)
+
+	merkleRoot, inCache := commitRootCache.Get(msgSeqNr)
+	if !inCache {
+		lggr.Debugw("merkle root not found in cache, fetching from the chain", "msgSeqNr", msgSeqNr)
+		var err error
+		merkleRoot, err = getCommitRootAcceptedEvent(
+			ctx,
+			lggr,
+			env,
+			state,
+			srcChainSel,
+			destChainSel,
+			msgSeqNr,
+			lookbackDurationCommitReport,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to get merkle root: %w", err)
+		}
+
+		// add to the cache for faster fetching.
+		commitRootCache.Add(merkleRoot)
+		commitRootCache.Build()
+	} else {
+		lggr.Debugw("found merkle root in cache", "msgSeqNr", msgSeqNr, "merkleRoot", merkleRoot)
 	}
 
 	lggr.Debugw("merkle root",
@@ -265,18 +317,51 @@ func manuallyExecuteSingle(
 		"sourceChainSel", merkleRoot.SourceChainSelector,
 	)
 
-	ccipMessageSentEvents, err := getCCIPMessageSentEvents(
-		ctx,
-		lggr,
-		env,
-		state,
-		srcChainSel,
-		destChainSel,
-		merkleRoot,
-		lookbackDuration,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to get ccip message sent event: %w", err)
+	var ccipMessageSentEvents []onramp.OnRampCCIPMessageSent
+	if _, ok := messageSentCache[msgSeqNr]; ok {
+		lggr.Debugw("found message in cache, fetching the rest", "msgSeqNr", msgSeqNr)
+		for start := merkleRoot.MinSeqNr; start <= merkleRoot.MaxSeqNr; start++ {
+			ccipMessageSentEvents = append(ccipMessageSentEvents, messageSentCache[start])
+		}
+
+		if len(ccipMessageSentEvents) != int(merkleRoot.MaxSeqNr-merkleRoot.MinSeqNr+1) {
+			lggr.Debugw("not all messages found in cache, fetching from the chain", "msgSeqNr", msgSeqNr)
+			var err error
+			ccipMessageSentEvents, err = getCCIPMessageSentEvents(
+				ctx,
+				lggr,
+				env,
+				state,
+				srcChainSel,
+				destChainSel,
+				merkleRoot,
+				lookbackDuration,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to get ccip message sent event: %w", err)
+			}
+		}
+	} else {
+		lggr.Debugw("not found in cache, fetching from the chain", "msgSeqNr", msgSeqNr)
+		var err error
+		ccipMessageSentEvents, err = getCCIPMessageSentEvents(
+			ctx,
+			lggr,
+			env,
+			state,
+			srcChainSel,
+			destChainSel,
+			merkleRoot,
+			lookbackDuration,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to get ccip message sent event: %w", err)
+		}
+
+		// add to the cache
+		for _, event := range ccipMessageSentEvents {
+			messageSentCache[event.Message.Header.SequenceNumber] = event
+		}
 	}
 
 	messageHashes, err := manualexeclib.GetMessageHashes(
@@ -370,10 +455,13 @@ func ManuallyExecuteAll(
 	srcChainSel uint64,
 	destChainSel uint64,
 	msgSeqNrs []int64,
-	lookbackDuration time.Duration,
+	lookbackDurationMsgs,
+	lookbackDurationCommitReport time.Duration,
 	reExecuteIfFailed bool,
 ) error {
 	extraDataCodec := ccipcommon.NewExtraDataCodec(ccipcommon.NewExtraDataCodecParams(ccipevm.ExtraDataDecoder{}, ccipsolana.ExtraDataDecoder{}))
+	messageSentCache := make(map[uint64]onramp.OnRampCCIPMessageSent)
+	commitRootCache := NewRootCache()
 	for _, seqNr := range msgSeqNrs {
 		err := manuallyExecuteSingle(
 			ctx,
@@ -383,9 +471,12 @@ func ManuallyExecuteAll(
 			srcChainSel,
 			destChainSel,
 			uint64(seqNr), //nolint:gosec // seqNr is never <= 0.
-			lookbackDuration,
+			lookbackDurationMsgs,
+			lookbackDurationCommitReport,
 			reExecuteIfFailed,
 			extraDataCodec,
+			messageSentCache,
+			commitRootCache,
 		)
 		if err != nil {
 			return err
@@ -422,4 +513,48 @@ func CheckAlreadyExecuted(
 	}
 
 	return nil
+}
+
+// RootCache caches merkle roots for fast lookups via a single sequence number.
+// For example, if we have
+// cache = {(1, 10), (20, 30), (40, 50)}
+// Get(5) = (1, 10)
+// Get(25) = (20, 30)
+// Get(35) = nil
+type RootCache struct {
+	roots []offramp.InternalMerkleRoot
+}
+
+// NewRootCache creates a new RootCache
+// with an empty list of ranges.
+func NewRootCache() *RootCache {
+	return &RootCache{
+		roots: []offramp.InternalMerkleRoot{},
+	}
+}
+
+// Add a root to the RootCache
+func (rm *RootCache) Add(root offramp.InternalMerkleRoot) {
+	rm.roots = append(rm.roots, root)
+}
+
+// Build prepares the RootCache for fast lookups (sorts by MinSeqNr)
+func (rm *RootCache) Build() {
+	sort.Slice(rm.roots, func(i, j int) bool {
+		return rm.roots[i].MinSeqNr < rm.roots[j].MinSeqNr
+	})
+}
+
+// Get finds the commit root associated that the given sequence number belongs to
+// returns the root and a boolean indicating if it was found.
+func (rm *RootCache) Get(seqNr uint64) (offramp.InternalMerkleRoot, bool) {
+	// Use binary search to find the range
+	idx := sort.Search(len(rm.roots), func(i int) bool {
+		return rm.roots[i].MinSeqNr > seqNr
+	}) - 1
+
+	if idx >= 0 && idx < len(rm.roots) && seqNr >= rm.roots[idx].MinSeqNr && seqNr <= rm.roots[idx].MaxSeqNr {
+		return rm.roots[idx], true
+	}
+	return offramp.InternalMerkleRoot{}, false
 }

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
@@ -30,6 +31,13 @@ const (
 
 	// DefaultLookbackCommitReport is the default lookback for commit reports.
 	DefaultLookbackCommitReport = 14 * 24 * time.Hour
+
+	// DefaultStepDuration is the default duration for each filter logs query performed.
+	// For lookbacks that are really far back, we need to break it up into smaller chunks.
+	// This is the duration of each chunk.
+	// For example, if the lookback is 14 days and the step duration is 24 hours,
+	// we will make 14 queries, each for 24 hours worth of blocks.
+	DefaultStepDuration = 24 * time.Hour
 )
 
 var (
@@ -99,6 +107,11 @@ func durationToBlocks(srcChainSel uint64, lookbackDuration time.Duration) uint64
 	return uint64(lookbackDuration.Seconds()) / blockTimeSeconds
 }
 
+// getCommitRootAcceptedEvent retrieves the CommitRootAccepted event for the provided
+// (srcChainSel, destChainSel, msgSeqNr) triplet.
+// If the commit root is not found, it returns an error.
+// The lookback duration is used to determine how far back to look for the event.
+// Queries are performed in steps of stepDuration worth of blocks.
 func getCommitRootAcceptedEvent(
 	ctx context.Context,
 	lggr logger.Logger,
@@ -107,30 +120,22 @@ func getCommitRootAcceptedEvent(
 	srcChainSel uint64,
 	destChainSel uint64,
 	msgSeqNr uint64,
-	lookbackDuration time.Duration,
+	lookbackDuration,
+	stepDuration time.Duration,
 ) (offramp.InternalMerkleRoot, error) {
 	hdr, err := env.Chains[destChainSel].Client.HeaderByNumber(ctx, nil)
 	if err != nil {
 		return offramp.InternalMerkleRoot{}, fmt.Errorf("failed to get header: %w", err)
 	}
 
+	// TODO: we might be able to optimize this further by starting from the last block
+	// from the previous batch?
 	start := getStartBlock(srcChainSel, hdr.Number.Uint64(), lookbackDuration)
-	step := durationToBlocks(destChainSel, 24*time.Hour)
+	step := durationToBlocks(destChainSel, stepDuration)
+
 	lggr.Debugw("Getting commit root accepted event", "startBlock", start, "step", step)
-
-	var countMerkleRoots int
-	var countNoRoots int
-	for {
-		if start > hdr.Number.Uint64() {
-			// Probably didn't find everything
-			lggr.Debugw("start block is greater than current head, stopping")
-			break
-		}
-
-		end := start + step
-		if end > hdr.Number.Uint64() {
-			end = hdr.Number.Uint64()
-		}
+	for start <= hdr.Number.Uint64() {
+		end := min(start+step, hdr.Number.Uint64())
 		lggr.Debugw("Querying with", "startBlock", start, "endBlock", end, "step", step)
 
 		iter, err := state.Chains[destChainSel].OffRamp.FilterCommitReportAccepted(
@@ -145,40 +150,76 @@ func getCommitRootAcceptedEvent(
 
 		for iter.Next() {
 			if len(iter.Event.BlessedMerkleRoots) == 0 && len(iter.Event.UnblessedMerkleRoots) == 0 {
-				countNoRoots++
+				// price updates only, can skip this event.
 				continue
 			}
 
-			countMerkleRoots++
-			for _, root := range iter.Event.BlessedMerkleRoots {
-				if root.SourceChainSelector == srcChainSel {
-					lggr.Debugw("checking commit root", "minSeqNr", root.MinSeqNr, "maxSeqNr", root.MaxSeqNr, "txHash", iter.Event.Raw.TxHash.String())
-					if msgSeqNr >= root.MinSeqNr && msgSeqNr <= root.MaxSeqNr {
-						lggr.Debugw("found commit root", "root", root, "txHash", iter.Event.Raw.TxHash.String())
-						return root, nil
-					}
-				}
+			// Check BlessedMerkleRoots
+			if root, found := findCommitRoot(
+				lggr,
+				iter.Event.BlessedMerkleRoots,
+				srcChainSel,
+				msgSeqNr,
+				iter.Event.Raw.TxHash,
+				"blessed",
+			); found {
+				return root, nil
 			}
 
-			for _, root := range iter.Event.UnblessedMerkleRoots {
-				if root.SourceChainSelector == srcChainSel {
-					lggr.Debugw("checking commit root", "minSeqNr", root.MinSeqNr, "maxSeqNr", root.MaxSeqNr, "txHash", iter.Event.Raw.TxHash.String())
-					if msgSeqNr >= root.MinSeqNr && msgSeqNr <= root.MaxSeqNr {
-						lggr.Debugw("found commit root", "root", root, "txHash", iter.Event.Raw.TxHash.String())
-						return root, nil
-					}
-				}
+			// Check UnblessedMerkleRoots
+			if root, found := findCommitRoot(
+				lggr,
+				iter.Event.UnblessedMerkleRoots,
+				srcChainSel,
+				msgSeqNr,
+				iter.Event.Raw.TxHash,
+				"unblessed",
+			); found {
+				return root, nil
 			}
 		}
 
 		start = end + 1
 	}
 
-	lggr.Debugw("didn't find commit root", "countMerkleRoots", countMerkleRoots, "countNoRoots", countNoRoots)
+	lggr.Debugw("didn't find commit root, maybe increase lookback duration")
 
 	return offramp.InternalMerkleRoot{}, errors.New("commit root not found")
 }
 
+// Helper function to find a commit root in a list of merkle roots
+func findCommitRoot(
+	lggr logger.Logger,
+	roots []offramp.InternalMerkleRoot,
+	srcChainSel uint64,
+	msgSeqNr uint64,
+	txHash common.Hash,
+	rootType string,
+) (offramp.InternalMerkleRoot, bool) {
+	for _, root := range roots {
+		if root.SourceChainSelector == srcChainSel {
+			lggr.Debugw("checking commit root",
+				"rootType", rootType,
+				"minSeqNr", root.MinSeqNr,
+				"maxSeqNr", root.MaxSeqNr,
+				"txHash", txHash.Hex(),
+			)
+			if msgSeqNr >= root.MinSeqNr && msgSeqNr <= root.MaxSeqNr {
+				lggr.Debugw("found commit root",
+					"rootType", rootType,
+					"root", root,
+					"txHash", txHash.Hex(),
+				)
+				return root, true
+			}
+		}
+	}
+	return offramp.InternalMerkleRoot{}, false
+}
+
+// getCCIPMessageSentEvents retrieves the CCIPMessageSent events for the provided
+// (srcChainSel, destChainSel, merkleRoot) triplet.
+// It returns a list of CCIPMessageSent events whose sequence numbers match the range in the provided root.
 func getCCIPMessageSentEvents(
 	ctx context.Context,
 	lggr logger.Logger,
@@ -187,15 +228,18 @@ func getCCIPMessageSentEvents(
 	srcChainSel uint64,
 	destChainSel uint64,
 	merkleRoot offramp.InternalMerkleRoot,
-	lookbackDuration time.Duration,
+	lookbackDuration,
+	stepDuration time.Duration,
 ) ([]onramp.OnRampCCIPMessageSent, error) {
 	hdr, err := env.Chains[srcChainSel].Client.HeaderByNumber(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get header: %w", err)
 	}
 
+	// TODO: we might be able to optimize this further by starting from the last block
+	// from the previous batch?
 	start := getStartBlock(srcChainSel, hdr.Number.Uint64(), lookbackDuration)
-	step := durationToBlocks(srcChainSel, 24*time.Hour)
+	step := durationToBlocks(srcChainSel, stepDuration)
 
 	var seqNrs []uint64
 	for i := merkleRoot.MinSeqNr; i <= merkleRoot.MaxSeqNr; i++ {
@@ -207,26 +251,21 @@ func getCCIPMessageSentEvents(
 		"minSeqNr", merkleRoot.MinSeqNr,
 		"maxSeqNr", merkleRoot.MaxSeqNr,
 		"startBlock", start,
-		"step", step,
+		"stepBlocks", step,
 	)
 
-	var ret []onramp.OnRampCCIPMessageSent
-	var count int
-	var toDestCount int
-	merkleRootSize := merkleRoot.MaxSeqNr - merkleRoot.MinSeqNr + 1
-	for uint64(len(ret)) < merkleRootSize {
-		if start > hdr.Number.Uint64() {
-			// Probably didn't find everything
-			lggr.Debugw("start block is greater than current head, stopping")
-			break
-		}
+	var (
+		ret            []onramp.OnRampCCIPMessageSent
+		merkleRootSize = merkleRoot.MaxSeqNr - merkleRoot.MinSeqNr + 1
+	)
 
-		end := start + step
-		if end > hdr.Number.Uint64() {
-			end = hdr.Number.Uint64()
-		}
-
-		lggr.Debugw("Querying with", "startBlock", start, "endBlock", end, "step", step)
+	// scan the chain until either:
+	// 1. we find all the messages in the merkle root.
+	// 2. we reach the current head block.
+	// Usually (1) is completed before (2) but (2) is still needed to terminate the loop.
+	for uint64(len(ret)) < merkleRootSize && start <= hdr.Number.Uint64() {
+		end := min(start+step, hdr.Number.Uint64())
+		lggr.Debugw("Querying for messages with", "startBlock", start, "endBlock", end, "stepBlocks", step)
 		iter, err := state.Chains[srcChainSel].OnRamp.FilterCCIPMessageSent(
 			&bind.FilterOpts{
 				Start: start,
@@ -240,9 +279,7 @@ func getCCIPMessageSentEvents(
 		}
 
 		for iter.Next() {
-			count++
 			if iter.Event.DestChainSelector == destChainSel {
-				toDestCount++
 				lggr.Debugw("checking message",
 					"seqNr", iter.Event.SequenceNumber,
 					"destChain", iter.Event.DestChainSelector,
@@ -257,15 +294,16 @@ func getCCIPMessageSentEvents(
 		start = end + 1
 	}
 
-	lggr.Debugw("found messages", "count", count, "toDestCount", toDestCount)
-
 	if len(ret) != len(seqNrs) {
 		return nil, fmt.Errorf("not all messages found, got: %d, expected: %d", len(ret), len(seqNrs))
 	}
 
+	lggr.Debugw("found all messages for root", "merkleRoot", merkleRoot, "messages", len(ret))
+
 	return ret, nil
 }
 
+// manuallyExecuteSingle manually executes a single message on the destination chain.
 func manuallyExecuteSingle(
 	ctx context.Context,
 	lggr logger.Logger,
@@ -275,7 +313,8 @@ func manuallyExecuteSingle(
 	destChainSel uint64,
 	msgSeqNr uint64,
 	lookbackDuration,
-	lookbackDurationCommitReport time.Duration,
+	lookbackDurationCommitReport,
+	stepDuration time.Duration,
 	reExecuteIfFailed bool,
 	extraDataCodec ccipcommon.ExtraDataCodec,
 	messageSentCache map[uint64]onramp.OnRampCCIPMessageSent,
@@ -296,7 +335,7 @@ func manuallyExecuteSingle(
 		return nil
 	}
 
-	lggr.Debugw("addresses",
+	lggr.Debugw("contract addresses",
 		"offRampAddress", state.Chains[destChainSel].OffRamp.Address(),
 		"onRampAddress", onRampAddress,
 		"execState", execState,
@@ -315,6 +354,7 @@ func manuallyExecuteSingle(
 			destChainSel,
 			msgSeqNr,
 			lookbackDurationCommitReport,
+			stepDuration,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to get merkle root: %w", err)
@@ -353,6 +393,7 @@ func manuallyExecuteSingle(
 				destChainSel,
 				merkleRoot,
 				lookbackDuration,
+				stepDuration,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to get ccip message sent event: %w", err)
@@ -370,6 +411,7 @@ func manuallyExecuteSingle(
 			destChainSel,
 			merkleRoot,
 			lookbackDuration,
+			stepDuration,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to get ccip message sent event: %w", err)
@@ -418,6 +460,8 @@ func manuallyExecuteSingle(
 		return fmt.Errorf("no message found for seqNr %d", msgSeqNr)
 	}
 
+	// TODO: further throughput speedups can be achieved if we batch, but that requires
+	// some rejigging of the current code.
 	execReport, err := manualexeclib.CreateExecutionReport(
 		srcChainSel,
 		onRampAddress,
@@ -463,7 +507,8 @@ func manuallyExecuteSingle(
 }
 
 // ManuallyExecuteAll will manually execute the provided messages if they were not already executed.
-// At the moment offchain token data (i.e USDC/Lombard attestations) is not supported.
+// At the moment offchain token data (i.e USDC/Lombard attestations) is not supported,
+// and only EVM is supported as a source or dest chain.
 func ManuallyExecuteAll(
 	ctx context.Context,
 	lggr logger.Logger,
@@ -473,10 +518,14 @@ func ManuallyExecuteAll(
 	destChainSel uint64,
 	msgSeqNrs []int64,
 	lookbackDurationMsgs,
-	lookbackDurationCommitReport time.Duration,
+	lookbackDurationCommitReport,
+	stepDuration time.Duration,
 	reExecuteIfFailed bool,
 ) error {
 	extraDataCodec := ccipcommon.NewExtraDataCodec(ccipcommon.NewExtraDataCodecParams(ccipevm.ExtraDataDecoder{}, ccipsolana.ExtraDataDecoder{}))
+
+	// for large backfills, these caches can speed things up because we don't need to query
+	// the chain multiple times for the same root/messages.
 	messageSentCache := make(map[uint64]onramp.OnRampCCIPMessageSent)
 	commitRootCache := NewRootCache()
 	for _, seqNr := range msgSeqNrs {
@@ -490,6 +539,7 @@ func ManuallyExecuteAll(
 			uint64(seqNr), //nolint:gosec // seqNr is never <= 0.
 			lookbackDurationMsgs,
 			lookbackDurationCommitReport,
+			stepDuration,
 			reExecuteIfFailed,
 			extraDataCodec,
 			messageSentCache,

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -128,8 +128,7 @@ func getCommitRootAcceptedEvent(
 		return offramp.InternalMerkleRoot{}, fmt.Errorf("failed to get header: %w", err)
 	}
 
-	// TODO: we might be able to optimize this further by starting from the last block
-	// from the previous batch?
+	// TODO: CCIP-5700
 	start := getStartBlock(srcChainSel, hdr.Number.Uint64(), lookbackDuration)
 	step := durationToBlocks(destChainSel, stepDuration)
 
@@ -154,26 +153,12 @@ func getCommitRootAcceptedEvent(
 				continue
 			}
 
-			// Check BlessedMerkleRoots
 			if root, found := findCommitRoot(
 				lggr,
-				iter.Event.BlessedMerkleRoots,
+				append(iter.Event.BlessedMerkleRoots, iter.Event.UnblessedMerkleRoots...),
 				srcChainSel,
 				msgSeqNr,
 				iter.Event.Raw.TxHash,
-				"blessed",
-			); found {
-				return root, nil
-			}
-
-			// Check UnblessedMerkleRoots
-			if root, found := findCommitRoot(
-				lggr,
-				iter.Event.UnblessedMerkleRoots,
-				srcChainSel,
-				msgSeqNr,
-				iter.Event.Raw.TxHash,
-				"unblessed",
 			); found {
 				return root, nil
 			}
@@ -194,19 +179,16 @@ func findCommitRoot(
 	srcChainSel uint64,
 	msgSeqNr uint64,
 	txHash common.Hash,
-	rootType string,
 ) (offramp.InternalMerkleRoot, bool) {
 	for _, root := range roots {
 		if root.SourceChainSelector == srcChainSel {
 			lggr.Debugw("checking commit root",
-				"rootType", rootType,
 				"minSeqNr", root.MinSeqNr,
 				"maxSeqNr", root.MaxSeqNr,
 				"txHash", txHash.Hex(),
 			)
 			if msgSeqNr >= root.MinSeqNr && msgSeqNr <= root.MaxSeqNr {
 				lggr.Debugw("found commit root",
-					"rootType", rootType,
 					"root", root,
 					"txHash", txHash.Hex(),
 				)
@@ -236,8 +218,7 @@ func getCCIPMessageSentEvents(
 		return nil, fmt.Errorf("failed to get header: %w", err)
 	}
 
-	// TODO: we might be able to optimize this further by starting from the last block
-	// from the previous batch?
+	// TODO: CCIP-5700
 	start := getStartBlock(srcChainSel, hdr.Number.Uint64(), lookbackDuration)
 	step := durationToBlocks(srcChainSel, stepDuration)
 
@@ -461,8 +442,7 @@ func manuallyExecuteSingle(
 		return fmt.Errorf("no message found for seqNr %d", msgSeqNr)
 	}
 
-	// TODO: further throughput speedups can be achieved if we batch, but that requires
-	// some rejigging of the current code.
+	// TODO: CCIP-5702
 	execReport, err := manualexeclib.CreateExecutionReport(
 		srcChainSel,
 		onRampAddress,

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -115,46 +115,63 @@ func getCommitRootAcceptedEvent(
 	}
 
 	start := getStartBlock(srcChainSel, hdr.Number.Uint64(), lookbackDuration)
-	end := start + durationToBlocks(destChainSel, 48*time.Hour)
-	lggr.Debugw("Getting commit root accepted event", "startBlock", start, "endBlock", end)
-	iter, err := state.Chains[destChainSel].OffRamp.FilterCommitReportAccepted(
-		&bind.FilterOpts{
-			Start: start,
-			End:   &end,
-		},
-	)
-	if err != nil {
-		return offramp.InternalMerkleRoot{}, fmt.Errorf("failed to filter commit report accepted: %w", err)
-	}
+	step := durationToBlocks(destChainSel, 24*time.Hour)
+	lggr.Debugw("Getting commit root accepted event", "startBlock", start, "step", step)
 
 	var countMerkleRoots int
 	var countNoRoots int
-	for iter.Next() {
-		if len(iter.Event.BlessedMerkleRoots) == 0 && len(iter.Event.UnblessedMerkleRoots) == 0 {
-			countNoRoots++
-			continue
+	for {
+		if start > hdr.Number.Uint64() {
+			// Probably didn't find everything
+			lggr.Debugw("start block is greater than current head, stopping")
+			break
 		}
 
-		countMerkleRoots++
-		for _, root := range iter.Event.BlessedMerkleRoots {
-			if root.SourceChainSelector == srcChainSel {
-				lggr.Debugw("checking commit root", "minSeqNr", root.MinSeqNr, "maxSeqNr", root.MaxSeqNr, "txHash", iter.Event.Raw.TxHash.String())
-				if msgSeqNr >= root.MinSeqNr && msgSeqNr <= root.MaxSeqNr {
-					lggr.Debugw("found commit root", "root", root, "txHash", iter.Event.Raw.TxHash.String())
-					return root, nil
+		end := start + step
+		if end > hdr.Number.Uint64() {
+			end = hdr.Number.Uint64()
+		}
+		lggr.Debugw("Querying with", "startBlock", start, "endBlock", end, "step", step)
+
+		iter, err := state.Chains[destChainSel].OffRamp.FilterCommitReportAccepted(
+			&bind.FilterOpts{
+				Start: start,
+				End:   &end,
+			},
+		)
+		if err != nil {
+			return offramp.InternalMerkleRoot{}, fmt.Errorf("failed to filter commit report accepted: %w", err)
+		}
+
+		for iter.Next() {
+			if len(iter.Event.BlessedMerkleRoots) == 0 && len(iter.Event.UnblessedMerkleRoots) == 0 {
+				countNoRoots++
+				continue
+			}
+
+			countMerkleRoots++
+			for _, root := range iter.Event.BlessedMerkleRoots {
+				if root.SourceChainSelector == srcChainSel {
+					lggr.Debugw("checking commit root", "minSeqNr", root.MinSeqNr, "maxSeqNr", root.MaxSeqNr, "txHash", iter.Event.Raw.TxHash.String())
+					if msgSeqNr >= root.MinSeqNr && msgSeqNr <= root.MaxSeqNr {
+						lggr.Debugw("found commit root", "root", root, "txHash", iter.Event.Raw.TxHash.String())
+						return root, nil
+					}
+				}
+			}
+
+			for _, root := range iter.Event.UnblessedMerkleRoots {
+				if root.SourceChainSelector == srcChainSel {
+					lggr.Debugw("checking commit root", "minSeqNr", root.MinSeqNr, "maxSeqNr", root.MaxSeqNr, "txHash", iter.Event.Raw.TxHash.String())
+					if msgSeqNr >= root.MinSeqNr && msgSeqNr <= root.MaxSeqNr {
+						lggr.Debugw("found commit root", "root", root, "txHash", iter.Event.Raw.TxHash.String())
+						return root, nil
+					}
 				}
 			}
 		}
 
-		for _, root := range iter.Event.UnblessedMerkleRoots {
-			if root.SourceChainSelector == srcChainSel {
-				lggr.Debugw("checking commit root", "minSeqNr", root.MinSeqNr, "maxSeqNr", root.MaxSeqNr, "txHash", iter.Event.Raw.TxHash.String())
-				if msgSeqNr >= root.MinSeqNr && msgSeqNr <= root.MaxSeqNr {
-					lggr.Debugw("found commit root", "root", root, "txHash", iter.Event.Raw.TxHash.String())
-					return root, nil
-				}
-			}
-		}
+		start = end + 1
 	}
 
 	lggr.Debugw("didn't find commit root", "countMerkleRoots", countMerkleRoots, "countNoRoots", countNoRoots)

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -374,6 +374,7 @@ func manuallyExecuteSingle(
 		"sourceChainSel", merkleRoot.SourceChainSelector,
 	)
 
+	merkleRootSize := merkleRoot.MaxSeqNr - merkleRoot.MinSeqNr + 1
 	var ccipMessageSentEvents []onramp.OnRampCCIPMessageSent
 	if _, ok := messageSentCache[msgSeqNr]; ok {
 		lggr.Debugw("found message in cache, fetching the rest", "msgSeqNr", msgSeqNr)
@@ -381,7 +382,7 @@ func manuallyExecuteSingle(
 			ccipMessageSentEvents = append(ccipMessageSentEvents, messageSentCache[start])
 		}
 
-		if len(ccipMessageSentEvents) != int(merkleRoot.MaxSeqNr-merkleRoot.MinSeqNr+1) {
+		if uint64(len(ccipMessageSentEvents)) != merkleRootSize {
 			lggr.Debugw("not all messages found in cache, fetching from the chain", "msgSeqNr", msgSeqNr)
 			var err error
 			ccipMessageSentEvents, err = getCCIPMessageSentEvents(

--- a/deployment/ccip/manualexechelpers/exec_test.go
+++ b/deployment/ccip/manualexechelpers/exec_test.go
@@ -1,0 +1,50 @@
+package manualexechelpers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/manualexechelpers"
+)
+
+func TestRootMap_AddAndGet(t *testing.T) {
+	// Mock data
+	root1 := offramp.InternalMerkleRoot{MinSeqNr: 1, MaxSeqNr: 10}
+	root2 := offramp.InternalMerkleRoot{MinSeqNr: 11, MaxSeqNr: 20}
+	root3 := offramp.InternalMerkleRoot{MinSeqNr: 21, MaxSeqNr: 30}
+
+	// Initialize RootMap
+	rm := manualexechelpers.NewRootCache()
+
+	// Add roots
+	rm.Add(root1)
+	rm.Add(root2)
+	rm.Add(root3)
+
+	// Build the RootMap
+	rm.Build()
+
+	// Test cases
+	tests := []struct {
+		key      uint64
+		expected offramp.InternalMerkleRoot
+		found    bool
+	}{
+		{key: 5, expected: root1, found: true},
+		{key: 15, expected: root2, found: true},
+		{key: 25, expected: root3, found: true},
+		{key: 31, expected: offramp.InternalMerkleRoot{}, found: false},
+		{key: 0, expected: offramp.InternalMerkleRoot{}, found: false},
+	}
+
+	for _, test := range tests {
+		result, found := rm.Get(test.key)
+		require.Equal(t, test.found, found)
+		if found {
+			require.Equal(t, test.expected.MinSeqNr, result.MinSeqNr)
+			require.Equal(t, test.expected.MaxSeqNr, result.MaxSeqNr)
+		}
+	}
+}

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -179,8 +179,10 @@ func Test_CCIPMessaging_EVM2EVM(t *testing.T) {
 			[]int64{
 				int64(out.MsgSentEvent.Message.Header.SequenceNumber), //nolint:gosec // seqNr fits in int64
 			},
-			24*time.Hour,
-			true, // reExecuteIfFailed
+			24*time.Hour, // lookbackDurationMsgs
+			24*time.Hour, // lookbackDurationCommitReport
+			24*time.Hour, // stepDuration
+			true,         // reExecuteIfFailed
 		)
 		require.NoError(t, err)
 


### PR DESCRIPTION
We recently had to do a really large manual execution backfill on staging due to a broken config being set and it being out of commission for 4 days or so. The number of messages were about ~2k per source chain for the OP sepolia DON. In order to manually execute such a large backlog we had to make a few changes to the manual exec helpers package.

The most important change is adding caching mechanisms to optimize the process of retrieving and handling commit root events and CCIP message events.

### Enhancements to manual execution helpers:

* Added new constants for default durations and lookback periods to improve code readability and maintainability. ([deployment/ccip/manualexechelpers/exec.goR28-R41](diffhunk://#diff-df9e2bbceed8c43b09ff3b8d7cf9a189ef2307a4959a38e63fea9b4915641413R28-R41))
* Introduced the `durationToBlocks` function to convert a duration into the number of blocks, which helps in querying blockchain data more efficiently. ([deployment/ccip/manualexechelpers/exec.goR101-R114](diffhunk://#diff-df9e2bbceed8c43b09ff3b8d7cf9a189ef2307a4959a38e63fea9b4915641413R101-R114))
* Modified the `getCommitRootAcceptedEvent` and `getCCIPMessageSentEvents` functions to use step durations for breaking down large lookback periods into smaller, manageable chunks. This change improves the performance of querying events from the blockchain. ([[1]](diffhunk://#diff-df9e2bbceed8c43b09ff3b8d7cf9a189ef2307a4959a38e63fea9b4915641413L95-R222), [[2]](diffhunk://#diff-df9e2bbceed8c43b09ff3b8d7cf9a189ef2307a4959a38e63fea9b4915641413L156-R242))
* Implemented caching mechanisms (`RootCache` and `messageSentCache`) to store and quickly retrieve previously fetched commit roots and CCIP message events, reducing redundant blockchain queries and enhancing execution speed. ([[1]](diffhunk://#diff-df9e2bbceed8c43b09ff3b8d7cf9a189ef2307a4959a38e63fea9b4915641413L223-R321), [[2]](diffhunk://#diff-df9e2bbceed8c43b09ff3b8d7cf9a189ef2307a4959a38e63fea9b4915641413R585-R628))

### Follow ups

* We currently use time and convert that to a block number via a map of block times. This might be more convenient but probably less efficient than specifying a starting block number and a step size in blocks instead of doing the lookback -> starting block translation.
* Batching multiple message executions into a single tx

### Requires
N/A

### Supports
https://github.com/smartcontractkit/chainlink-deployments/pull/1614
