### PR TITLE
fix: runs-on tmp mount

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -177,12 +177,12 @@ jobs:
         type:
           - cmd: go_core_tests
             os: ubuntu22.04-32cores-128GB
-            os-self-hosted: runs-on=${{ github.run_id }}/cpu=32+64/ram=64+256/family=c6id+m6id+m6idn+c5ad+r6id/spot=false/extras=s3-cache
+            os-self-hosted: runs-on=${{ github.run_id }}/cpu=32+64/ram=64+256/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
 
           - cmd: go_core_tests_integration
             os: ubuntu22.04-32cores-128GB
-            os-self-hosted: runs-on=${{ github.run_id }}/cpu=32+64/ram=64+256/family=c6id+m6id+m6idn+c5ad+r6id/spot=false/extras=s3-cache
+            os-self-hosted: runs-on=${{ github.run_id }}/cpu=32+64/ram=64+256/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
 
           - cmd: go_core_fuzz
@@ -198,7 +198,7 @@ jobs:
           - cmd: go_core_ccip_deployment_tests
             os: ubuntu22.04-32cores-128GB
             # Use "*d" instances because they have NVME storage which improves performance for this test suite
-            os-self-hosted: runs-on=${{ github.run_id }}/cpu=32+64/ram=64+256/family=c6id+m6id+m6idn+c5ad+r6id/spot=false/extras=s3-cache
+            os-self-hosted: runs-on=${{ github.run_id }}/cpu=32+64/ram=64+256/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
             build-solana-artifacts: 'true'
             should-run: ${{ needs.filter.outputs.should-run-deployment-tests }}
 
@@ -218,23 +218,35 @@ jobs:
         if: ${{ needs.run-frequency.outputs.should-use-self-hosted == 'true' }}
         uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
 
-      - name: Mount /tmp
-        # For self-hosted runners - the volume mounted to / is too small to handle flakeguard
-        # outputs to /tmp. If we are using an SSD backed volume, we can mount /mnt/ephemeral/tmp.
-        # Otherwise, we will need to use `disk=large` label for the runner.
+      - name: Setup self-hosted directory mounts
+        # For self-hosted runners - the volume mounted to / is too small to handle everything stored in
+        # /home/runner. So we mount certain directories to the larger volume.
         if: ${{ needs.run-frequency.outputs.should-use-self-hosted == 'true' }}
         run: |
-          if [ -d "/mnt/ephemeral" ]; then
-            if [ ! -d "/mnt/ephemeral/tmp" ]; then
-              sudo mkdir -p /mnt/ephemeral/tmp
-              sudo chmod 1777 /mnt/ephemeral/tmp
-            fi
-
-            sudo mount --bind /mnt/ephemeral/tmp /tmp
-            echo "Successfully mounted /mnt/ephemeral/tmp to /tmp"
-          else
-            echo "/mnt/ephemeral does not exist, using default /tmp"
+          if [ ! -d "/home/runner/_work" ]; then
+            echo "::warning::/home/runner/_work does not exist, skipping mount."
+            exit 0
           fi
+
+          # Define the directories to mount as tuples of source:destination
+          DIRS=(
+            "/home/runner/_work/runner-go:/home/runner/go"
+            "/home/runner/_work/runner-cache:/home/runner/.cache"
+          )
+
+          # Process each directory pair
+          for DIR_PAIR in "${DIRS[@]}"; do
+            SRC_DIR=$(echo $DIR_PAIR | cut -d':' -f1)
+            DEST_DIR=$(echo $DIR_PAIR | cut -d':' -f2)
+
+            sudo mkdir -m 755 "$SRC_DIR"
+            sudo chown -R $(id -u):$(id -g) "$SRC_DIR"
+
+            mkdir -p "$DEST_DIR"
+            sudo mount --bind "$SRC_DIR" "$DEST_DIR"
+            echo "Successfully mounted $SRC_DIR to $DEST_DIR"
+          done
+
 
       - name: Checkout the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
A mount for `/tmp` was added in #17212. This created issues with `actions/cache` when using self-hosted runners. The cache would never upload. 

Example: https://github.com/smartcontractkit/chainlink/actions/runs/14387743608/job/40347247923?pr=17232#step:50:3

<details>
<summary>Error Output</summary>

```
 /usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/_work/chainlink/chainlink --files-from manifest.txt --use-compress-program zstdmt
Sent 0 of 2111453068 (0.0%), 0.0 MBs/sec
...
Sent 0 of 2111453068 (0.0%), 0.0 MBs/sec
Warning: uploadCacheArchiveSDK: internal error uploading cache archive: failed to create block file

Sent 0 of 2111453068 (0.0%), 0.0 MBs/sec
Warning: Failed to save: failed to create block file
```


</details>


Removing this mount reintroduces disk space issues. It was discovered that most of the issue is from the `/home/runner/.cache` and `/home/runner/go` directories, which fill up during the build/run of the unit tests.

These directories do not exist when the workflow is started, so they're safe to create ourselves and mount to the NVME storage.

### Changes

- Bind mount `/home/runner/_work/runner-go` to `/home/runner/go`
- Bind mount `/home/runner/_work/runner-cache` to `home/runner/.cache`

### Testing

https://github.com/smartcontractkit/chainlink/actions/runs/14391337090/job/40360714285

Caching now works again

---

DX-365

https://docs.google.com/document/d/1rFfZQnpCp0-8BzZlURziZ9j4VPiORsPAMy8_ZUgMfrA/edit?tab=t.0
