### PR TITLE
Update solana ref to pull in 3 changes needed for 2.23 (#17237)

### DIFF
--- a/.changeset/spotty-donkeys-punch.md
+++ b/.changeset/spotty-donkeys-punch.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#added Solana LogPoller lookback feature, and LogPollerStartingLookback and BlockTime to Solana config

--- a/core/cmd/shell_test.go
+++ b/core/cmd/shell_test.go
@@ -20,6 +20,7 @@ import (
 	commoncfg "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/sqltest"
 	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
+
 	"github.com/smartcontractkit/chainlink/v2/core/cmd"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -358,24 +359,26 @@ func TestSetupSolanaRelayer(t *testing.T) {
 
 	// config 3 chains but only enable 2 => should only be 2 relayer
 	nEnabledChains := 2
+	chainCfg := solcfg.Chain{}
+	chainCfg.SetDefaults()
 	tConfig := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.Solana = solcfg.TOMLConfigs{
 			&solcfg.TOMLConfig{
 				ChainID: ptr[string]("solana-id-1"),
 				Enabled: ptr(true),
-				Chain:   solcfg.Chain{},
+				Chain:   chainCfg,
 				Nodes:   []*solcfg.Node{},
 			},
 			&solcfg.TOMLConfig{
 				ChainID: ptr[string]("solana-id-2"),
 				Enabled: ptr(true),
-				Chain:   solcfg.Chain{},
+				Chain:   chainCfg,
 				Nodes:   []*solcfg.Node{},
 			},
 			&solcfg.TOMLConfig{
 				ChainID: ptr[string]("disabled-solana-id-1"),
 				Enabled: ptr(false),
-				Chain:   solcfg.Chain{},
+				Chain:   chainCfg,
 				Nodes:   []*solcfg.Node{},
 			},
 		}
@@ -428,13 +431,13 @@ func TestSetupSolanaRelayer(t *testing.T) {
 			&solcfg.TOMLConfig{
 				ChainID: ptr[string]("dupe"),
 				Enabled: ptr(true),
-				Chain:   solcfg.Chain{},
+				Chain:   chainCfg,
 				Nodes:   []*solcfg.Node{},
 			},
 			&solcfg.TOMLConfig{
 				ChainID: ptr[string]("dupe"),
 				Enabled: ptr(true),
-				Chain:   solcfg.Chain{},
+				Chain:   chainCfg,
 				Nodes:   []*solcfg.Node{},
 			},
 		}

--- a/core/config/docs/chains-solana.toml
+++ b/core/config/docs/chains-solana.toml
@@ -3,6 +3,8 @@
 ChainID = 'mainnet' # Example
 # Enabled enables this chain.
 Enabled = false # Default
+# BlockTime specifies the average time between blocks on this chain
+BlockTime = '500ms' # Default
 # BalancePollPeriod is the rate to poll for SOL balance and update Prometheus metrics.
 BalancePollPeriod = '5s' # Default
 # ConfirmPollPeriod is the rate to poll for signature confirmation.
@@ -44,12 +46,18 @@ BlockHistoryPollPeriod = '5s' # Default
 # BlockHistorySize is the number of blocks to take into consideration when using FeeEstimatorMode = 'blockhistory' to determine compute unit price.
 # If set to 1, the compute unit price will be determined by the median of the last block's compute unit prices. 
 # If set N > 1, the compute unit price will be determined by the average of the medians of the last N blocks' compute unit prices.
-# DISCLAIMER: 1:1 ratio between n and RPC calls. It executes once every 'BlockHistoryPollPeriod' value.
+# DISCLAIMER: If set to a value greater than BlockHistoryBatchLoadSize, initial estimations during startup would be over smaller block ranges until the cache is filled.
 BlockHistorySize = 1 # Default
+# BlockHistoryBatchLoadSize is the number of latest blocks to fetch from the chain to store in the cache every BlockHistoryPollPeriod.
+# This config is only relevant if BlockHistorySize > 1 and if BlockHistorySize is greater than BlockHistoryBatchLoadSize.
+# Ensure the value is greater than the number of blocks that would be produced between each BlockHistoryPollPeriod to avoid gaps in block history.
+BlockHistoryBatchLoadSize = 20 # Default
 # ComputeUnitLimitDefault is the compute units limit applied to transactions unless overriden during the txm enqueue
 ComputeUnitLimitDefault = 200_000 # Default
 # EstimateComputeUnitLimit enables or disables compute unit limit estimations per transaction. If estimations return 0 used compute, the ComputeUnitLimitDefault value is used, if set.
 EstimateComputeUnitLimit = false # Default
+# LogPollerStartingLookback
+LogPollerStartingLookback = '24h0m0s' # Default
 
 [Solana.MultiNode]
 # Enabled enables the multinode feature.

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -355,7 +355,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.5.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2 // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/mcms v0.14.0 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1148,8 +1148,8 @@ github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-1
 github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6/go.mod h1:FRwzI3hGj4CJclNS733gfcffmqQ62ONCkbGi49s658w=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+vOwbM+Hnx8tIN2xCPG8H4o=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 h1:o89qSnZaaTTASn43CiNbT99tBOBxc3RQqmhYtUsxFuY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 h1:pEB2q503YLejHDzlBn3tLl1tY7svdUaq5LuSYcngWis=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2 h1:NkaqepHish3/WXY+cFTs/GqJ506AyWDASjqLmvexB3g=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2/go.mod h1:zw3QH/GTvPl/7Cjyw+y4cJYnP16QHTEh7wWLJQd9lM8=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22 h1:W3doYLVoZN8VwJb/kAZsbDjW+6cgZPgNTcQHJUH9JrA=

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -29,6 +29,7 @@ import (
 	evmcfg "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -743,27 +744,30 @@ func TestConfig_Marshal(t *testing.T) {
 			ChainID: ptr("mainnet"),
 			Enabled: ptr(false),
 			Chain: solcfg.Chain{
-				BalancePollPeriod:        commoncfg.MustNewDuration(time.Minute),
-				ConfirmPollPeriod:        commoncfg.MustNewDuration(time.Second),
-				OCR2CachePollPeriod:      commoncfg.MustNewDuration(time.Minute),
-				OCR2CacheTTL:             commoncfg.MustNewDuration(time.Hour),
-				TxTimeout:                commoncfg.MustNewDuration(time.Hour),
-				TxRetryTimeout:           commoncfg.MustNewDuration(time.Minute),
-				TxConfirmTimeout:         commoncfg.MustNewDuration(time.Second),
-				TxExpirationRebroadcast:  ptr(false),
-				TxRetentionTimeout:       commoncfg.MustNewDuration(0 * time.Second),
-				SkipPreflight:            ptr(true),
-				Commitment:               ptr("banana"),
-				MaxRetries:               ptr[int64](7),
-				FeeEstimatorMode:         ptr("fixed"),
-				ComputeUnitPriceMax:      ptr[uint64](1000),
-				ComputeUnitPriceMin:      ptr[uint64](10),
-				ComputeUnitPriceDefault:  ptr[uint64](100),
-				FeeBumpPeriod:            commoncfg.MustNewDuration(time.Minute),
-				BlockHistoryPollPeriod:   commoncfg.MustNewDuration(time.Minute),
-				BlockHistorySize:         ptr[uint64](1),
-				ComputeUnitLimitDefault:  ptr[uint32](100_000),
-				EstimateComputeUnitLimit: ptr(false),
+				BlockTime:                 commoncfg.MustNewDuration(500 * time.Millisecond),
+				BalancePollPeriod:         commoncfg.MustNewDuration(time.Minute),
+				ConfirmPollPeriod:         commoncfg.MustNewDuration(time.Second),
+				OCR2CachePollPeriod:       commoncfg.MustNewDuration(time.Minute),
+				OCR2CacheTTL:              commoncfg.MustNewDuration(time.Hour),
+				TxTimeout:                 commoncfg.MustNewDuration(time.Hour),
+				TxRetryTimeout:            commoncfg.MustNewDuration(time.Minute),
+				TxConfirmTimeout:          commoncfg.MustNewDuration(time.Second),
+				TxExpirationRebroadcast:   ptr(false),
+				TxRetentionTimeout:        commoncfg.MustNewDuration(0 * time.Second),
+				SkipPreflight:             ptr(true),
+				Commitment:                ptr("banana"),
+				MaxRetries:                ptr[int64](7),
+				FeeEstimatorMode:          ptr("fixed"),
+				ComputeUnitPriceMax:       ptr[uint64](1000),
+				ComputeUnitPriceMin:       ptr[uint64](10),
+				ComputeUnitPriceDefault:   ptr[uint64](100),
+				FeeBumpPeriod:             commoncfg.MustNewDuration(time.Minute),
+				BlockHistoryPollPeriod:    commoncfg.MustNewDuration(time.Minute),
+				BlockHistorySize:          ptr[uint64](1),
+				BlockHistoryBatchLoadSize: ptr[uint64](20),
+				ComputeUnitLimitDefault:   ptr[uint32](100_000),
+				EstimateComputeUnitLimit:  ptr(false),
+				LogPollerStartingLookback: commoncfg.MustNewDuration(24 * time.Hour),
 			},
 			MultiNode: mnCfg.MultiNodeConfig{
 				MultiNode: mnCfg.MultiNode{
@@ -1217,6 +1221,7 @@ SendOnly = true
 		{"Solana", Config{Solana: full.Solana}, `[[Solana]]
 ChainID = 'mainnet'
 Enabled = false
+BlockTime = '500ms'
 BalancePollPeriod = '1m0s'
 ConfirmPollPeriod = '1s'
 OCR2CachePollPeriod = '1m0s'
@@ -1236,8 +1241,10 @@ ComputeUnitPriceDefault = 100
 FeeBumpPeriod = '1m0s'
 BlockHistoryPollPeriod = '1m0s'
 BlockHistorySize = 1
+BlockHistoryBatchLoadSize = 20
 ComputeUnitLimitDefault = 100000
 EstimateComputeUnitLimit = false
+LogPollerStartingLookback = '24h0m0s'
 
 [Solana.MultiNode]
 Enabled = false

--- a/core/services/chainlink/relayer_chain_interoperators_test.go
+++ b/core/services/chainlink/relayer_chain_interoperators_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 
 	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
@@ -72,11 +73,14 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 			Nodes:   toml.EVMNodes{&node2_1},
 		})
 
+		solChainCfg := solcfg.Chain{}
+		solChainCfg.SetDefaults()
+
 		c.Solana = solcfg.TOMLConfigs{
 			&solcfg.TOMLConfig{
 				ChainID: &solanaChainID1,
 				Enabled: ptr(true),
-				Chain:   solcfg.Chain{},
+				Chain:   solChainCfg,
 				Nodes: []*solcfg.Node{{
 					Name: ptr("solana chain 1 node 1"),
 					URL:  ((*commonconfig.URL)(commonconfig.MustParseURL("http://localhost:8547").URL())),
@@ -85,7 +89,7 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 			&solcfg.TOMLConfig{
 				ChainID: &solanaChainID2,
 				Enabled: ptr(true),
-				Chain:   solcfg.Chain{},
+				Chain:   solChainCfg,
 				Nodes: []*solcfg.Node{{
 					Name: ptr("solana chain 2 node 1"),
 					URL:  ((*commonconfig.URL)(commonconfig.MustParseURL("http://localhost:8527").URL())),

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -488,6 +488,7 @@ SendOnly = true
 [[Solana]]
 ChainID = 'mainnet'
 Enabled = false
+BlockTime = '500ms'
 BalancePollPeriod = '1m0s'
 ConfirmPollPeriod = '1s'
 OCR2CachePollPeriod = '1m0s'
@@ -507,8 +508,10 @@ ComputeUnitPriceDefault = 100
 FeeBumpPeriod = '1m0s'
 BlockHistoryPollPeriod = '1m0s'
 BlockHistorySize = 1
+BlockHistoryBatchLoadSize = 20
 ComputeUnitLimitDefault = 100000
 EstimateComputeUnitLimit = false
+LogPollerStartingLookback = '24h0m0s'
 
 [Solana.MultiNode]
 Enabled = false

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -650,6 +650,7 @@ WSURL = 'wss://web.socket/test/bar'
 
 [[Solana]]
 ChainID = 'mainnet'
+BlockTime = '500ms'
 BalancePollPeriod = '5s'
 ConfirmPollPeriod = '500ms'
 OCR2CachePollPeriod = '1s'
@@ -669,8 +670,10 @@ ComputeUnitPriceDefault = 0
 FeeBumpPeriod = '3s'
 BlockHistoryPollPeriod = '5s'
 BlockHistorySize = 1
+BlockHistoryBatchLoadSize = 20
 ComputeUnitLimitDefault = 200000
 EstimateComputeUnitLimit = false
+LogPollerStartingLookback = '24h0m0s'
 
 [Solana.MultiNode]
 Enabled = false
@@ -698,6 +701,7 @@ SendOnly = false
 
 [[Solana]]
 ChainID = 'testnet'
+BlockTime = '500ms'
 BalancePollPeriod = '5s'
 ConfirmPollPeriod = '500ms'
 OCR2CachePollPeriod = '1m0s'
@@ -717,8 +721,10 @@ ComputeUnitPriceDefault = 0
 FeeBumpPeriod = '3s'
 BlockHistoryPollPeriod = '5s'
 BlockHistorySize = 1
+BlockHistoryBatchLoadSize = 20
 ComputeUnitLimitDefault = 200000
 EstimateComputeUnitLimit = false
+LogPollerStartingLookback = '24h0m0s'
 
 [Solana.MultiNode]
 Enabled = false

--- a/core/web/chains_controller_test.go
+++ b/core/web/chains_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
@@ -237,6 +238,7 @@ func Test_SolanaChainsController_Show(t *testing.T) {
 					ID:      validID,
 					Enabled: true,
 					Config: `ChainID = 'Chainlink-12'
+BlockTime = '500ms'
 BalancePollPeriod = '5s'
 ConfirmPollPeriod = '500ms'
 OCR2CachePollPeriod = '1s'
@@ -256,8 +258,10 @@ ComputeUnitPriceDefault = 0
 FeeBumpPeriod = '3s'
 BlockHistoryPollPeriod = '5s'
 BlockHistorySize = 1
+BlockHistoryBatchLoadSize = 20
 ComputeUnitLimitDefault = 200000
 EstimateComputeUnitLimit = false
+LogPollerStartingLookback = '24h0m0s'
 Nodes = []
 
 [MultiNode]

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -487,6 +487,7 @@ SendOnly = true
 [[Solana]]
 ChainID = 'mainnet'
 Enabled = false
+BlockTime = '500ms'
 BalancePollPeriod = '1m0s'
 ConfirmPollPeriod = '1s'
 OCR2CachePollPeriod = '1m0s'
@@ -506,8 +507,10 @@ ComputeUnitPriceDefault = 0
 FeeBumpPeriod = '3s'
 BlockHistoryPollPeriod = '5s'
 BlockHistorySize = 1
+BlockHistoryBatchLoadSize = 20
 ComputeUnitLimitDefault = 200000
 EstimateComputeUnitLimit = false
+LogPollerStartingLookback = '24h0m0s'
 
 [Solana.MultiNode]
 Enabled = false

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -650,6 +650,7 @@ WSURL = 'wss://web.socket/test/bar'
 
 [[Solana]]
 ChainID = 'mainnet'
+BlockTime = '500ms'
 BalancePollPeriod = '5s'
 ConfirmPollPeriod = '500ms'
 OCR2CachePollPeriod = '1s'
@@ -669,8 +670,10 @@ ComputeUnitPriceDefault = 0
 FeeBumpPeriod = '3s'
 BlockHistoryPollPeriod = '5s'
 BlockHistorySize = 1
+BlockHistoryBatchLoadSize = 20
 ComputeUnitLimitDefault = 200000
 EstimateComputeUnitLimit = false
+LogPollerStartingLookback = '24h0m0s'
 
 [Solana.MultiNode]
 Enabled = false
@@ -697,6 +700,7 @@ SendOnly = false
 
 [[Solana]]
 ChainID = 'testnet'
+BlockTime = '500ms'
 BalancePollPeriod = '5s'
 ConfirmPollPeriod = '500ms'
 OCR2CachePollPeriod = '1m0s'
@@ -716,8 +720,10 @@ ComputeUnitPriceDefault = 0
 FeeBumpPeriod = '3s'
 BlockHistoryPollPeriod = '5s'
 BlockHistorySize = 1
+BlockHistoryBatchLoadSize = 20
 ComputeUnitLimitDefault = 200000
 EstimateComputeUnitLimit = false
+LogPollerStartingLookback = '24h0m0s'
 
 [Solana.MultiNode]
 Enabled = false

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250402142713-6529d36f91f3
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.9.0
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.5.0
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22
 	github.com/smartcontractkit/libocr v0.0.0-20250408131511-c90716988ee0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1193,8 +1193,8 @@ github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-1
 github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6/go.mod h1:FRwzI3hGj4CJclNS733gfcffmqQ62ONCkbGi49s658w=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+vOwbM+Hnx8tIN2xCPG8H4o=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 h1:o89qSnZaaTTASn43CiNbT99tBOBxc3RQqmhYtUsxFuY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 h1:pEB2q503YLejHDzlBn3tLl1tY7svdUaq5LuSYcngWis=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2 h1:NkaqepHish3/WXY+cFTs/GqJ506AyWDASjqLmvexB3g=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2/go.mod h1:zw3QH/GTvPl/7Cjyw+y4cJYnP16QHTEh7wWLJQd9lM8=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.50.22 h1:W3doYLVoZN8VwJb/kAZsbDjW+6cgZPgNTcQHJUH9JrA=

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -16214,6 +16214,7 @@ TendermintURL is the HTTP(S) tendermint endpoint for this node.
 [[Solana]]
 ChainID = 'mainnet' # Example
 Enabled = false # Default
+BlockTime = '500ms' # Default
 BalancePollPeriod = '5s' # Default
 ConfirmPollPeriod = '500ms' # Default
 OCR2CachePollPeriod = '1s' # Default
@@ -16233,8 +16234,10 @@ ComputeUnitPriceDefault = 0 # Default
 FeeBumpPeriod = '3s' # Default
 BlockHistoryPollPeriod = '5s' # Default
 BlockHistorySize = 1 # Default
+BlockHistoryBatchLoadSize = 20 # Default
 ComputeUnitLimitDefault = 200_000 # Default
 EstimateComputeUnitLimit = false # Default
+LogPollerStartingLookback = '24h0m0s' # Default
 ```
 
 
@@ -16249,6 +16252,12 @@ ChainID is the Solana chain ID. Must be one of: mainnet, testnet, devnet, localn
 Enabled = false # Default
 ```
 Enabled enables this chain.
+
+### BlockTime
+```toml
+BlockTime = '500ms' # Default
+```
+BlockTime specifies the average time between blocks on this chain
 
 ### BalancePollPeriod
 ```toml
@@ -16367,7 +16376,15 @@ BlockHistorySize = 1 # Default
 BlockHistorySize is the number of blocks to take into consideration when using FeeEstimatorMode = 'blockhistory' to determine compute unit price.
 If set to 1, the compute unit price will be determined by the median of the last block's compute unit prices.
 If set N > 1, the compute unit price will be determined by the average of the medians of the last N blocks' compute unit prices.
-DISCLAIMER: 1:1 ratio between n and RPC calls. It executes once every 'BlockHistoryPollPeriod' value.
+DISCLAIMER: If set to a value greater than BlockHistoryBatchLoadSize, initial estimations during startup would be over smaller block ranges until the cache is filled.
+
+### BlockHistoryBatchLoadSize
+```toml
+BlockHistoryBatchLoadSize = 20 # Default
+```
+BlockHistoryBatchLoadSize is the number of latest blocks to fetch from the chain to store in the cache every BlockHistoryPollPeriod.
+This config is only relevant if BlockHistorySize > 1 and if BlockHistorySize is greater than BlockHistoryBatchLoadSize.
+Ensure the value is greater than the number of blocks that would be produced between each BlockHistoryPollPeriod to avoid gaps in block history.
 
 ### ComputeUnitLimitDefault
 ```toml
@@ -16380,6 +16397,12 @@ ComputeUnitLimitDefault is the compute units limit applied to transactions unles
 EstimateComputeUnitLimit = false # Default
 ```
 EstimateComputeUnitLimit enables or disables compute unit limit estimations per transaction. If estimations return 0 used compute, the ComputeUnitLimitDefault value is used, if set.
+
+### LogPollerStartingLookback
+```toml
+LogPollerStartingLookback = '24h0m0s' # Default
+```
+LogPollerStartingLookback
 
 ## Solana.MultiNode
 ```toml

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250402142713-6529d36f91f3
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.5.0
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295
 	github.com/smartcontractkit/libocr v0.0.0-20250408131511-c90716988ee0
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de

--- a/go.sum
+++ b/go.sum
@@ -1033,8 +1033,8 @@ github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-1
 github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6/go.mod h1:FRwzI3hGj4CJclNS733gfcffmqQ62ONCkbGi49s658w=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+vOwbM+Hnx8tIN2xCPG8H4o=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 h1:o89qSnZaaTTASn43CiNbT99tBOBxc3RQqmhYtUsxFuY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 h1:pEB2q503YLejHDzlBn3tLl1tY7svdUaq5LuSYcngWis=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 h1:12ijqMM9tvYVEm+nR826WsrNi6zCKpwBhuApq127wHs=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7/go.mod h1:FX7/bVdoep147QQhsOPkYsPEXhGZjeYx6lBSaSXtZOA=
 github.com/smartcontractkit/libocr v0.0.0-20250408131511-c90716988ee0 h1:yGD0bRNoIQ9vOILzlYg4AiGKMKpJNqi7eIMpW7QIO9Y=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -452,7 +452,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.5.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2 // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/mcms v0.14.0 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1461,8 +1461,8 @@ github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-1
 github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6/go.mod h1:FRwzI3hGj4CJclNS733gfcffmqQ62ONCkbGi49s658w=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+vOwbM+Hnx8tIN2xCPG8H4o=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 h1:o89qSnZaaTTASn43CiNbT99tBOBxc3RQqmhYtUsxFuY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 h1:pEB2q503YLejHDzlBn3tLl1tY7svdUaq5LuSYcngWis=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2 h1:NkaqepHish3/WXY+cFTs/GqJ506AyWDASjqLmvexB3g=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2/go.mod h1:zw3QH/GTvPl/7Cjyw+y4cJYnP16QHTEh7wWLJQd9lM8=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5 h1:S5HND0EDtlA+xp2E+mD11DlUTp2wD6uojwixye8ZB/k=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -444,7 +444,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.5.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.51.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1443,8 +1443,8 @@ github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-1
 github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6/go.mod h1:FRwzI3hGj4CJclNS733gfcffmqQ62ONCkbGi49s658w=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+vOwbM+Hnx8tIN2xCPG8H4o=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 h1:o89qSnZaaTTASn43CiNbT99tBOBxc3RQqmhYtUsxFuY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 h1:pEB2q503YLejHDzlBn3tLl1tY7svdUaq5LuSYcngWis=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2 h1:NkaqepHish3/WXY+cFTs/GqJ506AyWDASjqLmvexB3g=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2/go.mod h1:zw3QH/GTvPl/7Cjyw+y4cJYnP16QHTEh7wWLJQd9lM8=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5 h1:S5HND0EDtlA+xp2E+mD11DlUTp2wD6uojwixye8ZB/k=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -354,7 +354,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.5.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/libocr v0.0.0-20250408131511-c90716988ee0 // indirect
 	github.com/smartcontractkit/mcms v0.14.0 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1181,8 +1181,8 @@ github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-1
 github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6/go.mod h1:FRwzI3hGj4CJclNS733gfcffmqQ62ONCkbGi49s658w=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+vOwbM+Hnx8tIN2xCPG8H4o=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 h1:o89qSnZaaTTASn43CiNbT99tBOBxc3RQqmhYtUsxFuY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 h1:pEB2q503YLejHDzlBn3tLl1tY7svdUaq5LuSYcngWis=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2 h1:NkaqepHish3/WXY+cFTs/GqJ506AyWDASjqLmvexB3g=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2/go.mod h1:zw3QH/GTvPl/7Cjyw+y4cJYnP16QHTEh7wWLJQd9lM8=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.0 h1:rNjLZrwY3TcrANHVz/JUm55vufzoeRogSlgjAH7plvU=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -428,7 +428,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.5.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/mcms v0.14.0 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1412,8 +1412,8 @@ github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-1
 github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6/go.mod h1:FRwzI3hGj4CJclNS733gfcffmqQ62ONCkbGi49s658w=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+vOwbM+Hnx8tIN2xCPG8H4o=
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51 h1:o89qSnZaaTTASn43CiNbT99tBOBxc3RQqmhYtUsxFuY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250408163915-4e13e0299b51/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295 h1:pEB2q503YLejHDzlBn3tLl1tY7svdUaq5LuSYcngWis=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250411233132-251acf7da295/go.mod h1:yEF+XSuGQkZpGyfA38ykPt7vITkmNktwfR2CuFxDfpI=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.3 h1:ksW2gDHNTRrGggOaDmLB5udaqLKsamszmZrheNNDXag=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.3/go.mod h1:zw3QH/GTvPl/7Cjyw+y4cJYnP16QHTEh7wWLJQd9lM8=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.0 h1:rNjLZrwY3TcrANHVz/JUm55vufzoeRogSlgjAH7plvU=


### PR DESCRIPTION
Cherry pick of https://github.com/smartcontractkit/chainlink/pull/17237 for 2.23.0 release

## Description 

Bumps Solana ref by 3 commits:

ChainReader Bind/Unbind race conditions fix:
https://github.com/smartcontractkit/chainlink-solana/commit/f0880d91a84ab969447d8bbb06ba4aea96300f00

Lookback window feature:
https://github.com/smartcontractkit/chainlink-solana/commit/9d9cafa171dfb35c6f8acb76d9cb06de5edcfa72

Add cache to Solana BlockHistory estimator:
https://github.com/smartcontractkit/chainlink-solana/pull/1182