### PR TITLE
chore(datastore): add t.Parallel() to all datastore tests

### DIFF
--- a/deployment/datastore/address_ref_key_test.go
+++ b/deployment/datastore/address_ref_key_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAddressRefKey_Equals(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		key1     AddressRefKey
@@ -48,12 +50,16 @@ func TestAddressRefKey_Equals(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, tt.expected, tt.key1.Equals(tt.key2))
 		})
 	}
 }
 
 func TestNewAddressRefKey(t *testing.T) {
+	t.Parallel()
+
 	version := semver.MustParse("1.0.0")
 	key := NewAddressRefKey(1, ContractType("typeA"), version, "qualifier1")
 

--- a/deployment/datastore/address_ref_test.go
+++ b/deployment/datastore/address_ref_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAddressRef_Clone(t *testing.T) {
+	t.Parallel()
+
 	original := AddressRef{
 		Address:       "0x123",
 		ChainSelector: 1,
@@ -24,6 +26,8 @@ func TestAddressRef_Clone(t *testing.T) {
 }
 
 func TestAddressRef_Key(t *testing.T) {
+	t.Parallel()
+
 	ref := AddressRef{
 		Address:       "0x123",
 		ChainSelector: 1,

--- a/deployment/datastore/contract_metadata_key_test.go
+++ b/deployment/datastore/contract_metadata_key_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestContractMetadataKey_Equals(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		key1     ContractMetadataKey
@@ -41,12 +43,16 @@ func TestContractMetadataKey_Equals(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, tt.expected, tt.key1.Equals(tt.key2))
 		})
 	}
 }
 
 func TestContractMetadataKey(t *testing.T) {
+	t.Parallel()
+
 	chainSelector := uint64(1)
 	address := "0x1234567890abcdef"
 

--- a/deployment/datastore/contract_metadata_test.go
+++ b/deployment/datastore/contract_metadata_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestContractMetadata_Clone(t *testing.T) {
+	t.Parallel()
+
 	original := ContractMetadata[DefaultMetadata]{
 		ChainSelector: 1,
 		Address:       "0x123",
@@ -30,6 +32,8 @@ func TestContractMetadata_Clone(t *testing.T) {
 }
 
 func TestContractMetadata_Key(t *testing.T) {
+	t.Parallel()
+
 	metadata := ContractMetadata[DefaultMetadata]{
 		ChainSelector: 1,
 		Address:       "0x123",

--- a/deployment/datastore/env_metadata_key_test.go
+++ b/deployment/datastore/env_metadata_key_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestEnvMetadataKey(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name           string
 		domain         string
@@ -43,6 +45,8 @@ func TestEnvMetadataKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			key := NewEnvMetadataKey(tt.domain, tt.environment)
 			otherKey := NewEnvMetadataKey(tt.otherDomain, tt.otherEnv)
 

--- a/deployment/datastore/env_metadata_test.go
+++ b/deployment/datastore/env_metadata_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestEnvMetadata_Clone(t *testing.T) {
+	t.Parallel()
+
 	original := EnvMetadata[DefaultMetadata]{
 		Domain:      "example.com",
 		Environment: "production",
@@ -22,6 +24,8 @@ func TestEnvMetadata_Clone(t *testing.T) {
 }
 
 func TestEnvMetadata_Key(t *testing.T) {
+	t.Parallel()
+
 	envMetadata := EnvMetadata[DefaultMetadata]{
 		Domain:      "example.com",
 		Environment: "production",

--- a/deployment/datastore/filters_test.go
+++ b/deployment/datastore/filters_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAddressRefByChainSelector(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = AddressRef{
 			Address:       "0x2324224",
@@ -60,6 +62,8 @@ func TestAddressRefByChainSelector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter := AddressRefByChainSelector(tt.giveChain)
 			filteredRecords := filter(tt.givenState)
 			assert.Equal(t, tt.expectedResult, filteredRecords)
@@ -68,6 +72,8 @@ func TestAddressRefByChainSelector(t *testing.T) {
 }
 
 func TestAddressRefByType(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = AddressRef{
 			Address:       "0x2324224",
@@ -122,6 +128,8 @@ func TestAddressRefByType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter := AddressRefByType(tt.giveType)
 			filteredRecords := filter(tt.givenState)
 			assert.Equal(t, tt.expectedResult, filteredRecords)
@@ -130,6 +138,8 @@ func TestAddressRefByType(t *testing.T) {
 }
 
 func TestAddressRefByVersion(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = AddressRef{
 			Address:       "0x2324224",
@@ -185,6 +195,8 @@ func TestAddressRefByVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter := AddressRefByVersion(tt.giveVersion)
 			filteredRecords := filter(tt.givenState)
 			assert.Equal(t, tt.expectedResult, filteredRecords)
@@ -193,6 +205,8 @@ func TestAddressRefByVersion(t *testing.T) {
 }
 
 func TestAddressRefByQualifier(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = AddressRef{
 			Address:       "0x2324224",
@@ -247,6 +261,8 @@ func TestAddressRefByQualifier(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter := AddressRefByQualifier(tt.giveQualifier)
 			filteredRecords := filter(tt.givenState)
 			assert.Equal(t, tt.expectedResult, filteredRecords)
@@ -255,6 +271,8 @@ func TestAddressRefByQualifier(t *testing.T) {
 }
 
 func TestContractMetadataByChainSelector(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = ContractMetadata[DefaultMetadata]{
 			ChainSelector: 1,
@@ -303,6 +321,8 @@ func TestContractMetadataByChainSelector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter := ContractMetadataByChainSelector[DefaultMetadata](tt.giveChain)
 			filteredRecords := filter(tt.givenState)
 			assert.Equal(t, tt.expectedResult, filteredRecords)

--- a/deployment/datastore/label_set_test.go
+++ b/deployment/datastore/label_set_test.go
@@ -9,22 +9,35 @@ import (
 func TestNewLabelSet(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no labels", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "no labels",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "some labels",
+			input:    []string{"foo", "bar"},
+			expected: []string{"foo", "bar"},
+		},
+	}
 
-		ms := NewLabelSet()
-		assert.Empty(t, ms, "expected empty set")
-	})
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("some labels", func(t *testing.T) {
-		t.Parallel()
-
-		ms := NewLabelSet("foo", "bar")
-		assert.Len(t, ms, 2)
-		assert.True(t, ms.Contains("foo"))
-		assert.True(t, ms.Contains("bar"))
-		assert.False(t, ms.Contains("baz"))
-	})
+			ms := NewLabelSet(tt.input...)
+			assert.Len(t, ms, len(tt.expected), "unexpected number of labels in the set")
+			for _, label := range tt.expected {
+				assert.True(t, ms.Contains(label), "expected label '%s' in the set", label)
+			}
+		})
+	}
 }
 
 func TestLabelSet_Add(t *testing.T) {
@@ -70,28 +83,35 @@ func TestLabelSet_Contains(t *testing.T) {
 func TestLabelSet_List(t *testing.T) {
 	t.Parallel()
 
-	t.Run("list with items", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "list with items",
+			input:    []string{"foo", "bar", "baz"},
+			expected: []string{"bar", "baz", "foo"},
+		},
+		{
+			name:     "empty list",
+			input:    []string{},
+			expected: []string{},
+		},
+	}
 
-		ms := NewLabelSet("foo", "bar", "baz")
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		labels := ms.List()
+			ms := NewLabelSet(tt.input...)
+			labels := ms.List()
 
-		assert.Len(t, labels, 3, "expected 3 labels in the list")
-		assert.Equal(t, "bar", labels[0])
-		assert.Equal(t, "baz", labels[1])
-		assert.Equal(t, "foo", labels[2])
-	})
-
-	t.Run("empty list", func(t *testing.T) {
-		t.Parallel()
-
-		ms := NewLabelSet()
-
-		labels := ms.List()
-
-		assert.Empty(t, labels, "expected 0 labels in the list")
-	})
+			assert.Len(t, labels, len(tt.expected), "unexpected number of labels in the list")
+			assert.ElementsMatch(t, tt.expected, labels, "unexpected labels in the list")
+		})
+	}
 }
 
 // TestLabelSet_String tests the String() method of the LabelSet type.

--- a/deployment/datastore/label_set_test.go
+++ b/deployment/datastore/label_set_test.go
@@ -27,7 +27,6 @@ func TestNewLabelSet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -101,7 +100,6 @@ func TestLabelSet_List(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/deployment/datastore/label_set_test.go
+++ b/deployment/datastore/label_set_test.go
@@ -7,12 +7,18 @@ import (
 )
 
 func TestNewLabelSet(t *testing.T) {
+	t.Parallel()
+
 	t.Run("no labels", func(t *testing.T) {
+		t.Parallel()
+
 		ms := NewLabelSet()
 		assert.Empty(t, ms, "expected empty set")
 	})
 
 	t.Run("some labels", func(t *testing.T) {
+		t.Parallel()
+
 		ms := NewLabelSet("foo", "bar")
 		assert.Len(t, ms, 2)
 		assert.True(t, ms.Contains("foo"))
@@ -22,6 +28,8 @@ func TestNewLabelSet(t *testing.T) {
 }
 
 func TestLabelSet_Add(t *testing.T) {
+	t.Parallel()
+
 	ms := NewLabelSet("initial")
 	ms.Add("new")
 
@@ -35,6 +43,8 @@ func TestLabelSet_Add(t *testing.T) {
 }
 
 func TestLabelSet_Remove(t *testing.T) {
+	t.Parallel()
+
 	ms := NewLabelSet("remove_me", "keep")
 	ms.Remove("remove_me")
 
@@ -48,6 +58,8 @@ func TestLabelSet_Remove(t *testing.T) {
 }
 
 func TestLabelSet_Contains(t *testing.T) {
+	t.Parallel()
+
 	ms := NewLabelSet("foo", "bar")
 
 	assert.True(t, ms.Contains("foo"))
@@ -56,7 +68,11 @@ func TestLabelSet_Contains(t *testing.T) {
 }
 
 func TestLabelSet_List(t *testing.T) {
+	t.Parallel()
+
 	t.Run("list with items", func(t *testing.T) {
+		t.Parallel()
+
 		ms := NewLabelSet("foo", "bar", "baz")
 
 		labels := ms.List()
@@ -68,6 +84,8 @@ func TestLabelSet_List(t *testing.T) {
 	})
 
 	t.Run("empty list", func(t *testing.T) {
+		t.Parallel()
+
 		ms := NewLabelSet()
 
 		labels := ms.List()
@@ -78,6 +96,8 @@ func TestLabelSet_List(t *testing.T) {
 
 // TestLabelSet_String tests the String() method of the LabelSet type.
 func TestLabelSet_String(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		labels   LabelSet
@@ -123,6 +143,8 @@ func TestLabelSet_String(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := tt.labels.String()
 			assert.Equal(t, tt.expected, result, "LabelSet.String() should return the expected sorted string")
 		})
@@ -130,6 +152,8 @@ func TestLabelSet_String(t *testing.T) {
 }
 
 func TestLabelSet_Equal(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		set1     LabelSet

--- a/deployment/datastore/memory_address_ref_store_test.go
+++ b/deployment/datastore/memory_address_ref_store_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestMemoryAddressRefStore_indexOf(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = AddressRef{
 			Address:       "0x2324224",
@@ -60,6 +62,8 @@ func TestMemoryAddressRefStore_indexOf(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryAddressRefStore{Records: tt.givenState}
 			idx := store.indexOf(tt.giveKey)
 			assert.Equal(t, tt.expectedIndex, idx)
@@ -68,6 +72,8 @@ func TestMemoryAddressRefStore_indexOf(t *testing.T) {
 }
 
 func TestMemoryAddressRefStore_Add(t *testing.T) {
+	t.Parallel()
+
 	var (
 		record = AddressRef{
 			Address:       "0x2324224",
@@ -108,6 +114,8 @@ func TestMemoryAddressRefStore_Add(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryAddressRefStore{Records: tt.givenState}
 			err := store.Add(tt.giveRecord)
 
@@ -123,6 +131,8 @@ func TestMemoryAddressRefStore_Add(t *testing.T) {
 }
 
 func TestMemoryAddressRefStore_AddOrUpdate(t *testing.T) {
+	t.Parallel()
+
 	var (
 		oldRecord = AddressRef{
 			Address:       "0x2324224",
@@ -174,6 +184,8 @@ func TestMemoryAddressRefStore_AddOrUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryAddressRefStore{Records: tt.givenState}
 			// Check the error, which will always be nil for the
 			// in memory implementation, to satisfy the linter
@@ -185,6 +197,8 @@ func TestMemoryAddressRefStore_AddOrUpdate(t *testing.T) {
 }
 
 func TestMemoryAddressRefStore_Update(t *testing.T) {
+	t.Parallel()
+
 	var (
 		oldRecord = AddressRef{
 			Address:       "0x2324224",
@@ -235,6 +249,8 @@ func TestMemoryAddressRefStore_Update(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryAddressRefStore{Records: tt.givenState}
 			err := store.Update(tt.giveRecord)
 
@@ -250,6 +266,8 @@ func TestMemoryAddressRefStore_Update(t *testing.T) {
 }
 
 func TestMemoryAddressRefStore_Delete(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = AddressRef{
 			Address:       "0x2324224",
@@ -318,6 +336,8 @@ func TestMemoryAddressRefStore_Delete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryAddressRefStore{Records: tt.givenState}
 			err := store.Delete(tt.giveKey)
 
@@ -333,6 +353,8 @@ func TestMemoryAddressRefStore_Delete(t *testing.T) {
 }
 
 func TestMemoryAddressRefStore_Fetch(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = AddressRef{
 			Address:       "0x2324224",
@@ -382,6 +404,8 @@ func TestMemoryAddressRefStore_Fetch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryAddressRefStore{Records: tt.givenState}
 			// Check the error, which will always be nil for the
 			// in memory implementation, to satisfy the linter
@@ -393,6 +417,8 @@ func TestMemoryAddressRefStore_Fetch(t *testing.T) {
 }
 
 func TestMemoryAddressRefStore_Get(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = AddressRef{
 			Address:       "0x2324224",
@@ -445,6 +471,8 @@ func TestMemoryAddressRefStore_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryAddressRefStore{Records: tt.givenState}
 			record, err := store.Get(tt.giveKey)
 
@@ -460,6 +488,8 @@ func TestMemoryAddressRefStore_Get(t *testing.T) {
 }
 
 func TestMemoryAddressRefStore_Filter(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = AddressRef{
 			Address:       "0x2324224",
@@ -541,6 +571,8 @@ func TestMemoryAddressRefStore_Filter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryAddressRefStore{Records: tt.givenState}
 			filteredRecords := store.Filter(tt.giveFilters...)
 			assert.Equal(t, tt.expectedResult, filteredRecords)

--- a/deployment/datastore/memory_contract_metadata_store_test.go
+++ b/deployment/datastore/memory_contract_metadata_store_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestMemoryContractMetadataStore_indexOf(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = ContractMetadata[DefaultMetadata]{
 			ChainSelector: 1,
@@ -49,6 +51,8 @@ func TestMemoryContractMetadataStore_indexOf(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryContractMetadataStore[DefaultMetadata]{Records: tt.givenState}
 			idx := store.indexOf(tt.giveKey)
 			assert.Equal(t, tt.expectedIndex, idx)
@@ -57,6 +61,8 @@ func TestMemoryContractMetadataStore_indexOf(t *testing.T) {
 }
 
 func TestMemoryContractMetadataStore_Add(t *testing.T) {
+	t.Parallel()
+
 	var (
 		record = ContractMetadata[DefaultMetadata]{
 			ChainSelector: 1,
@@ -92,6 +98,8 @@ func TestMemoryContractMetadataStore_Add(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryContractMetadataStore[DefaultMetadata]{Records: tt.givenState}
 			err := store.Add(tt.giveRecord)
 
@@ -107,6 +115,8 @@ func TestMemoryContractMetadataStore_Add(t *testing.T) {
 }
 
 func TestMemoryContractMetadataStore_AddOrUpdate(t *testing.T) {
+	t.Parallel()
+
 	var (
 		oldRecord = ContractMetadata[DefaultMetadata]{
 			ChainSelector: 1,
@@ -149,6 +159,8 @@ func TestMemoryContractMetadataStore_AddOrUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryContractMetadataStore[DefaultMetadata]{Records: tt.givenState}
 			// Check the error for the in-memory store, which will always be nil for the
 			// in memory implementation, to satisfy the linter
@@ -160,6 +172,8 @@ func TestMemoryContractMetadataStore_AddOrUpdate(t *testing.T) {
 }
 
 func TestMemoryContractMetadataStore_Update(t *testing.T) {
+	t.Parallel()
+
 	var (
 		oldRecord = ContractMetadata[DefaultMetadata]{
 			ChainSelector: 1,
@@ -201,6 +215,8 @@ func TestMemoryContractMetadataStore_Update(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryContractMetadataStore[DefaultMetadata]{Records: tt.givenState}
 			err := store.Update(tt.giveRecord)
 
@@ -216,6 +232,8 @@ func TestMemoryContractMetadataStore_Update(t *testing.T) {
 }
 
 func TestMemoryMemoryContractMetadataStore_Delete(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = ContractMetadata[DefaultMetadata]{
 			ChainSelector: 1,
@@ -269,6 +287,8 @@ func TestMemoryMemoryContractMetadataStore_Delete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryContractMetadataStore[DefaultMetadata]{Records: tt.givenState}
 			err := store.Delete(tt.giveKey)
 
@@ -284,6 +304,8 @@ func TestMemoryMemoryContractMetadataStore_Delete(t *testing.T) {
 }
 
 func TestMemoryContractMetadataStore_Fetch(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = ContractMetadata[DefaultMetadata]{
 			ChainSelector: 1,
@@ -326,6 +348,8 @@ func TestMemoryContractMetadataStore_Fetch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryContractMetadataStore[DefaultMetadata]{Records: tt.givenState}
 			records, err := store.Fetch()
 
@@ -341,6 +365,8 @@ func TestMemoryContractMetadataStore_Fetch(t *testing.T) {
 }
 
 func TestMemoryContractMetadataStore_Get(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = ContractMetadata[DefaultMetadata]{
 			ChainSelector: 1,
@@ -382,6 +408,8 @@ func TestMemoryContractMetadataStore_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryContractMetadataStore[DefaultMetadata]{Records: tt.givenState}
 			record, err := store.Get(tt.giveKey)
 
@@ -397,6 +425,8 @@ func TestMemoryContractMetadataStore_Get(t *testing.T) {
 }
 
 func TestMemoryContractMetadataStore_Filter(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = ContractMetadata[DefaultMetadata]{
 			ChainSelector: 1,
@@ -460,6 +490,8 @@ func TestMemoryContractMetadataStore_Filter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryContractMetadataStore[DefaultMetadata]{Records: tt.givenState}
 			filteredRecords := store.Filter(tt.giveFilters...)
 			assert.Equal(t, tt.expectedResult, filteredRecords)

--- a/deployment/datastore/memory_datastore_test.go
+++ b/deployment/datastore/memory_datastore_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestMemoryDataStore_Merge(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		setup         func() (*MemoryDataStore[DefaultMetadata, DefaultMetadata], *MemoryDataStore[DefaultMetadata, DefaultMetadata])
@@ -65,6 +67,8 @@ func TestMemoryDataStore_Merge(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			dataStore1, dataStore2 := tt.setup()
 
 			// Merge dataStore2 into dataStore1

--- a/deployment/datastore/memory_env_metadata_store_test.go
+++ b/deployment/datastore/memory_env_metadata_store_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestMemoryEnvMetadataStore_Get(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = EnvMetadata[DefaultMetadata]{
 			Domain:      "example.com",
@@ -41,6 +43,8 @@ func TestMemoryEnvMetadataStore_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryEnvMetadataStore[DefaultMetadata]{Record: tt.givenState}
 
 			record, err := store.Get()
@@ -56,6 +60,8 @@ func TestMemoryEnvMetadataStore_Get(t *testing.T) {
 }
 
 func TestMemoryEnvMetadataStore_Set(t *testing.T) {
+	t.Parallel()
+
 	var (
 		recordOne = EnvMetadata[DefaultMetadata]{
 			Domain:      "example.com",
@@ -90,6 +96,8 @@ func TestMemoryEnvMetadataStore_Set(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store := MemoryEnvMetadataStore[DefaultMetadata]{Record: tt.initialState}
 
 			err := store.Set(tt.updateRecord)


### PR DESCRIPTION
This PR adds missing `t.Parallel()` calls to tests in the datastore package to enable better concurrency during test execution. It also includes minor refactors to improve clarity and consistency across a few test cases.

