### PR TITLE
chore(datastore): rename AddOrUpdate -> Upsert

### DIFF
--- a/deployment/datastore/abstract.go
+++ b/deployment/datastore/abstract.go
@@ -63,9 +63,9 @@ type MutableStore[K Comparable[K], R Record[K, R]] interface {
 	// Add inserts a new record into the MutableStore.
 	Add(record R) error
 
-	// AddOrUpdate behaves like Add where there is not already a record with the same composite primary key as the
+	// Upsert behaves like Add where there is not already a record with the same composite primary key as the
 	// supplied record, otherwise it behaves like an update.
-	AddOrUpdate(record R) error
+	Upsert(record R) error
 
 	// Update edits an existing record whose fields match the primary key elements of the supplied AddressRecord, with
 	// the non-primary-key values of the supplied AddressRecord.

--- a/deployment/datastore/memory_address_ref_store.go
+++ b/deployment/datastore/memory_address_ref_store.go
@@ -97,9 +97,9 @@ func (s *MemoryAddressRefStore) Add(record AddressRef) error {
 	return nil
 }
 
-// AddOrUpdate inserts a new record into the store if no record with the same key already exists.
+// Upsert inserts a new record into the store if no record with the same key already exists.
 // If a record with the same key already exists, it is updated.
-func (s *MemoryAddressRefStore) AddOrUpdate(record AddressRef) error {
+func (s *MemoryAddressRefStore) Upsert(record AddressRef) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/deployment/datastore/memory_address_ref_store_test.go
+++ b/deployment/datastore/memory_address_ref_store_test.go
@@ -130,7 +130,7 @@ func TestMemoryAddressRefStore_Add(t *testing.T) {
 	}
 }
 
-func TestMemoryAddressRefStore_AddOrUpdate(t *testing.T) {
+func TestMemoryAddressRefStore_Upsert(t *testing.T) {
 	t.Parallel()
 
 	var (
@@ -189,7 +189,7 @@ func TestMemoryAddressRefStore_AddOrUpdate(t *testing.T) {
 			store := MemoryAddressRefStore{Records: tt.givenState}
 			// Check the error, which will always be nil for the
 			// in memory implementation, to satisfy the linter
-			err := store.AddOrUpdate(tt.giveRecord)
+			err := store.Upsert(tt.giveRecord)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedState, store.Records)
 		})

--- a/deployment/datastore/memory_contract_metadata_store.go
+++ b/deployment/datastore/memory_contract_metadata_store.go
@@ -97,9 +97,9 @@ func (s *MemoryContractMetadataStore[M]) Add(record ContractMetadata[M]) error {
 	return nil
 }
 
-// AddOrUpdate inserts a new record into the store if no record with the same key already exists.
+// Upsert inserts a new record into the store if no record with the same key already exists.
 // If a record with the same key already exists, it is updated.
-func (s *MemoryContractMetadataStore[M]) AddOrUpdate(record ContractMetadata[M]) error {
+func (s *MemoryContractMetadataStore[M]) Upsert(record ContractMetadata[M]) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/deployment/datastore/memory_contract_metadata_store_test.go
+++ b/deployment/datastore/memory_contract_metadata_store_test.go
@@ -114,7 +114,7 @@ func TestMemoryContractMetadataStore_Add(t *testing.T) {
 	}
 }
 
-func TestMemoryContractMetadataStore_AddOrUpdate(t *testing.T) {
+func TestMemoryContractMetadataStore_Upsert(t *testing.T) {
 	t.Parallel()
 
 	var (
@@ -164,7 +164,7 @@ func TestMemoryContractMetadataStore_AddOrUpdate(t *testing.T) {
 			store := MemoryContractMetadataStore[DefaultMetadata]{Records: tt.givenState}
 			// Check the error for the in-memory store, which will always be nil for the
 			// in memory implementation, to satisfy the linter
-			err := store.AddOrUpdate(tt.giveRecord)
+			err := store.Upsert(tt.giveRecord)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedState, store.Records)
 		})

--- a/deployment/datastore/memory_datastore.go
+++ b/deployment/datastore/memory_datastore.go
@@ -92,7 +92,7 @@ func (s *MemoryDataStore[CM, EM]) Merge(other DataStore[CM, EM]) error {
 	}
 
 	for _, addressRef := range addressRefs {
-		if err := s.AddressRefStore.AddOrUpdate(addressRef); err != nil {
+		if err := s.AddressRefStore.Upsert(addressRef); err != nil {
 			return err
 		}
 	}
@@ -103,7 +103,7 @@ func (s *MemoryDataStore[CM, EM]) Merge(other DataStore[CM, EM]) error {
 	}
 
 	for _, record := range contractMetadataRecords {
-		if err := s.ContractMetadataStore.AddOrUpdate(record); err != nil {
+		if err := s.ContractMetadataStore.Upsert(record); err != nil {
 			return err
 		}
 	}

--- a/deployment/datastore/memory_datastore_test.go
+++ b/deployment/datastore/memory_datastore_test.go
@@ -21,7 +21,7 @@ func TestMemoryDataStore_Merge(t *testing.T) {
 			setup: func() (*MemoryDataStore[DefaultMetadata, DefaultMetadata], *MemoryDataStore[DefaultMetadata, DefaultMetadata]) {
 				dataStore1 := NewMemoryDataStore[DefaultMetadata, DefaultMetadata]()
 				dataStore2 := NewMemoryDataStore[DefaultMetadata, DefaultMetadata]()
-				err := dataStore2.Addresses().AddOrUpdate(AddressRef{
+				err := dataStore2.Addresses().Upsert(AddressRef{
 					Address:   "0x123",
 					Type:      "type1",
 					Version:   semver.MustParse("1.0.0"),
@@ -39,7 +39,7 @@ func TestMemoryDataStore_Merge(t *testing.T) {
 				dataStore2 := NewMemoryDataStore[DefaultMetadata, DefaultMetadata]()
 
 				// Add initial data to dataStore1
-				err := dataStore1.Addresses().AddOrUpdate(AddressRef{
+				err := dataStore1.Addresses().Upsert(AddressRef{
 					Address:   "0x123",
 					Type:      "type1",
 					Version:   semver.MustParse("1.0.0"),
@@ -49,7 +49,7 @@ func TestMemoryDataStore_Merge(t *testing.T) {
 				require.NoError(t, err, "Adding initial data to dataStore1 should not fail")
 
 				// Add matching data to dataStore2
-				err = dataStore2.Addresses().AddOrUpdate(AddressRef{
+				err = dataStore2.Addresses().Upsert(AddressRef{
 					Address:   "0x123",
 					Type:      "type1",
 					Version:   semver.MustParse("1.0.0"),


### PR DESCRIPTION
This PR renames `MutableStore::AddOrUpdate()` and all its implementations to `Upsert` to improve clarity. Since the API is not currently used we can afford the breaking change