### PR TITLE
Reduce commit's caches sync freq

### DIFF
--- a/deployment/ccip/changeset/globals/config.go
+++ b/deployment/ccip/changeset/globals/config.go
@@ -105,8 +105,26 @@ var (
 // withCommitOffchainOverrides applies the overrides to the base CommitOffchainConfig
 func withCommitOffchainOverrides(base pluginconfig.CommitOffchainConfig, overrides pluginconfig.CommitOffchainConfig) pluginconfig.CommitOffchainConfig {
 	outcome := base
+
+	baseDurationFields := struct {
+		TokenPriceAsyncObserverSyncFreq    config.Duration
+		TokenPriceAsyncObserverSyncTimeout config.Duration
+	}{
+		TokenPriceAsyncObserverSyncFreq:    base.TokenPriceAsyncObserverSyncFreq,
+		TokenPriceAsyncObserverSyncTimeout: base.TokenPriceAsyncObserverSyncTimeout,
+	}
+
 	if err := mergo.Merge(&outcome, overrides, mergo.WithOverride); err != nil {
 		panic(fmt.Sprintf("error while building a CommitOffchainConfig %v", err))
 	}
+
+	if overrides.TokenPriceAsyncObserverSyncFreq.Duration() == 0 {
+		outcome.TokenPriceAsyncObserverSyncFreq = baseDurationFields.TokenPriceAsyncObserverSyncFreq
+	}
+
+	if overrides.TokenPriceAsyncObserverSyncTimeout.Duration() == 0 {
+		outcome.TokenPriceAsyncObserverSyncTimeout = baseDurationFields.TokenPriceAsyncObserverSyncTimeout
+	}
+
 	return outcome
 }

--- a/deployment/ccip/changeset/globals/config.go
+++ b/deployment/ccip/changeset/globals/config.go
@@ -81,9 +81,6 @@ var (
 			ChainFeeAsyncObserverSyncTimeout:   3 * time.Second,
 			TokenPriceAsyncObserverSyncFreq:    *config.MustNewDuration(4 * time.Second),
 			TokenPriceAsyncObserverSyncTimeout: *config.MustNewDuration(3 * time.Second),
-			// Since Ethereum blocks are slower, we can afford to set a higher transmission delay
-			// to match the Ethereum-specific OCR parameters
-			TransmissionDelayMultiplier: 45 * time.Second,
 		},
 	)
 

--- a/deployment/ccip/changeset/globals/config.go
+++ b/deployment/ccip/changeset/globals/config.go
@@ -1,7 +1,10 @@
 package globals
 
 import (
+	"fmt"
 	"time"
+
+	"dario.cat/mergo"
 
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
@@ -67,6 +70,23 @@ var (
 		// TokenInfo: , // Must be configured in CLD
 	}
 
+	// CommitOffChainCfgForEthereum represents a dedicated CommitOffchainConfig for Ethereum.
+	// It's driven by the fact that Ethereum block time is slower (12 seconds) and chain is considered
+	// more expensive compared to other EVM compatible chains
+	CommitOffChainCfgForEthereum = withCommitOffchainOverrides(
+		DefaultCommitOffChainCfg,
+		pluginconfig.CommitOffchainConfig{
+			// Adjusted for longer block times on Ethereum
+			ChainFeeAsyncObserverSyncFreq:      4 * time.Second,
+			ChainFeeAsyncObserverSyncTimeout:   3 * time.Second,
+			TokenPriceAsyncObserverSyncFreq:    *config.MustNewDuration(4 * time.Second),
+			TokenPriceAsyncObserverSyncTimeout: *config.MustNewDuration(3 * time.Second),
+			// Since Ethereum blocks are slower, we can afford to set a higher transmission delay
+			// to match the Ethereum-specific OCR parameters
+			TransmissionDelayMultiplier: 45 * time.Second,
+		},
+	)
+
 	// DefaultExecuteOffChainCfg represents the default offchain configuration for the Execute plugin
 	// on _most_ chains. This should be used as a base for all chains, with overrides only where necessary.
 	// Notable overrides are for Ethereum, which has a slower block time.
@@ -84,3 +104,12 @@ var (
 		// TokenDataObservers: , // Must be configured in CLD
 	}
 )
+
+// withCommitOffchainOverrides applies the overrides to the base CommitOffchainConfig
+func withCommitOffchainOverrides(base pluginconfig.CommitOffchainConfig, overrides pluginconfig.CommitOffchainConfig) pluginconfig.CommitOffchainConfig {
+	outcome := base
+	if err := mergo.Merge(&outcome, overrides, mergo.WithOverride); err != nil {
+		panic(fmt.Sprintf("error while building a CommitOffchainConfig %v", err))
+	}
+	return outcome
+}

--- a/deployment/ccip/changeset/globals/config.go
+++ b/deployment/ccip/changeset/globals/config.go
@@ -56,11 +56,11 @@ var (
 		MerkleRootAsyncObserverSyncFreq:    4 * time.Second,
 		MerkleRootAsyncObserverSyncTimeout: 12 * time.Second,
 		ChainFeeAsyncObserverDisabled:      false,
-		ChainFeeAsyncObserverSyncFreq:      10 * time.Second,
-		ChainFeeAsyncObserverSyncTimeout:   12 * time.Second,
+		ChainFeeAsyncObserverSyncFreq:      1*time.Second + 500*time.Millisecond,
+		ChainFeeAsyncObserverSyncTimeout:   1 * time.Second,
 		TokenPriceAsyncObserverDisabled:    false,
-		TokenPriceAsyncObserverSyncFreq:    *config.MustNewDuration(10 * time.Second),
-		TokenPriceAsyncObserverSyncTimeout: *config.MustNewDuration(12 * time.Second),
+		TokenPriceAsyncObserverSyncFreq:    *config.MustNewDuration(1*time.Second + 500*time.Millisecond),
+		TokenPriceAsyncObserverSyncTimeout: *config.MustNewDuration(1 * time.Second),
 
 		// Remaining fields cannot be statically set:
 		// PriceFeedChainSelector: , // Must be configured in CLD

--- a/deployment/ccip/changeset/globals/config_test.go
+++ b/deployment/ccip/changeset/globals/config_test.go
@@ -1,0 +1,96 @@
+package globals
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
+	"github.com/smartcontractkit/chainlink-common/pkg/config"
+)
+
+func TestWithCommitOffchainOverrides(t *testing.T) {
+	baseConfig := pluginconfig.CommitOffchainConfig{
+		ChainFeeAsyncObserverSyncFreq:      1 * time.Second,
+		ChainFeeAsyncObserverSyncTimeout:   2 * time.Second,
+		TokenPriceAsyncObserverSyncFreq:    *config.MustNewDuration(3 * time.Second),
+		TokenPriceAsyncObserverSyncTimeout: *config.MustNewDuration(4 * time.Second),
+		TransmissionDelayMultiplier:        5 * time.Second,
+		RMNEnabled:                         false,
+		MaxReportTransmissionCheckAttempts: 5,
+	}
+
+	overrideConfig := pluginconfig.CommitOffchainConfig{
+		// Only override specific fields
+		ChainFeeAsyncObserverSyncFreq:      10 * time.Second,
+		ChainFeeAsyncObserverSyncTimeout:   20 * time.Second,
+		TokenPriceAsyncObserverSyncFreq:    *config.MustNewDuration(30 * time.Second),
+		TokenPriceAsyncObserverSyncTimeout: *config.MustNewDuration(40 * time.Second),
+		TransmissionDelayMultiplier:        50 * time.Second,
+	}
+
+	// Act
+	result := withCommitOffchainOverrides(baseConfig, overrideConfig)
+
+	// Assert
+	// Overridden fields should have new values
+	assert.Equal(t, 10*time.Second, result.ChainFeeAsyncObserverSyncFreq)
+	assert.Equal(t, 20*time.Second, result.ChainFeeAsyncObserverSyncTimeout)
+	assert.Equal(t, *config.MustNewDuration(30 * time.Second), result.TokenPriceAsyncObserverSyncFreq)
+	assert.Equal(t, *config.MustNewDuration(40 * time.Second), result.TokenPriceAsyncObserverSyncTimeout)
+	assert.Equal(t, 50*time.Second, result.TransmissionDelayMultiplier)
+
+	// Non-overridden fields should retain base values
+	assert.False(t, result.RMNEnabled)
+	assert.Equal(t, uint(5), result.MaxReportTransmissionCheckAttempts)
+}
+
+func TestWithCommitOffchainOverrides_EmptyOverrides(t *testing.T) {
+	baseConfig := pluginconfig.CommitOffchainConfig{
+		ChainFeeAsyncObserverSyncFreq:      1 * time.Second,
+		ChainFeeAsyncObserverSyncTimeout:   2 * time.Second,
+		TokenPriceAsyncObserverSyncFreq:    *config.MustNewDuration(3 * time.Second),
+		TokenPriceAsyncObserverSyncTimeout: *config.MustNewDuration(4 * time.Second),
+		TransmissionDelayMultiplier:        5 * time.Second,
+		RMNEnabled:                         true,
+	}
+
+	emptyOverrides := pluginconfig.CommitOffchainConfig{}
+
+	// Act
+	result := withCommitOffchainOverrides(baseConfig, emptyOverrides)
+
+	// Assert - check each field individually
+	assert.Equal(t, baseConfig.ChainFeeAsyncObserverSyncFreq, result.ChainFeeAsyncObserverSyncFreq)
+	assert.Equal(t, baseConfig.ChainFeeAsyncObserverSyncTimeout, result.ChainFeeAsyncObserverSyncTimeout)
+	assert.Equal(t, baseConfig.TokenPriceAsyncObserverSyncFreq.Duration(), result.TokenPriceAsyncObserverSyncFreq.Duration())
+	assert.Equal(t, baseConfig.TokenPriceAsyncObserverSyncTimeout.Duration(), result.TokenPriceAsyncObserverSyncTimeout.Duration())
+	assert.Equal(t, baseConfig.TransmissionDelayMultiplier, result.TransmissionDelayMultiplier)
+	assert.Equal(t, baseConfig.RMNEnabled, result.RMNEnabled)
+}
+
+func TestCommitOffChainCfgForEthereum(t *testing.T) {
+	// This tests that the Ethereum-specific config correctly overrides the default config
+
+	// Assert that the Ethereum config has different values for the overridden fields
+	assert.NotEqual(t, DefaultCommitOffChainCfg.ChainFeeAsyncObserverSyncFreq,
+		CommitOffChainCfgForEthereum.ChainFeeAsyncObserverSyncFreq)
+	assert.NotEqual(t, DefaultCommitOffChainCfg.ChainFeeAsyncObserverSyncTimeout,
+		CommitOffChainCfgForEthereum.ChainFeeAsyncObserverSyncTimeout)
+	assert.NotEqual(t, DefaultCommitOffChainCfg.TokenPriceAsyncObserverSyncFreq,
+		CommitOffChainCfgForEthereum.TokenPriceAsyncObserverSyncFreq)
+	assert.NotEqual(t, DefaultCommitOffChainCfg.TokenPriceAsyncObserverSyncTimeout,
+		CommitOffChainCfgForEthereum.TokenPriceAsyncObserverSyncTimeout)
+
+	// Check the expected values
+	assert.Equal(t, 4*time.Second, CommitOffChainCfgForEthereum.ChainFeeAsyncObserverSyncFreq)
+	assert.Equal(t, 3*time.Second, CommitOffChainCfgForEthereum.ChainFeeAsyncObserverSyncTimeout)
+	assert.Equal(t, *config.MustNewDuration(4 * time.Second), CommitOffChainCfgForEthereum.TokenPriceAsyncObserverSyncFreq)
+	assert.Equal(t, *config.MustNewDuration(3 * time.Second), CommitOffChainCfgForEthereum.TokenPriceAsyncObserverSyncTimeout)
+
+	// Non-overridden fields should remain the same
+	assert.Equal(t, DefaultCommitOffChainCfg.RMNEnabled, CommitOffChainCfgForEthereum.RMNEnabled)
+	assert.Equal(t, DefaultCommitOffChainCfg.MaxReportTransmissionCheckAttempts,
+		CommitOffChainCfgForEthereum.MaxReportTransmissionCheckAttempts)
+}

--- a/deployment/ccip/changeset/v1_6/config.go
+++ b/deployment/ccip/changeset/v1_6/config.go
@@ -151,3 +151,24 @@ func DeriveOCRParamsForExec(
 	}
 	return override(params)
 }
+
+// DeriveCommitSyncTimeoutForEthereumChains creates an override function for optimizing cache sync timeouts
+// for Ethereum chains where OCR rounds occur every ~6 seconds
+func DeriveCommitSyncTimeoutForEthereumChains(
+	baseOverride func(params CCIPOCRParams) CCIPOCRParams) func(params CCIPOCRParams) CCIPOCRParams {
+	return func(params CCIPOCRParams) CCIPOCRParams {
+		// Optimize cache timing for Ethereum chains (4s refresh with 3s timeout)
+		params.CommitOffChainConfig.ChainFeeAsyncObserverSyncFreq = 4 * time.Second
+		params.CommitOffChainConfig.ChainFeeAsyncObserverSyncTimeout = 3 * time.Second
+
+		params.CommitOffChainConfig.TokenPriceAsyncObserverSyncFreq = *config.MustNewDuration(4 * time.Second)
+		params.CommitOffChainConfig.TokenPriceAsyncObserverSyncTimeout = *config.MustNewDuration(3 * time.Second)
+
+		// Apply any additional chain-specific overrides if provided
+		if baseOverride != nil {
+			params = baseOverride(params)
+		}
+
+		return params
+	}
+}

--- a/deployment/ccip/changeset/v1_6/config.go
+++ b/deployment/ccip/changeset/v1_6/config.go
@@ -23,7 +23,7 @@ var (
 
 	DefaultOCRParamsForCommitForETH = CCIPOCRParams{
 		OCRParameters:        globals.CommitOCRParamsForEthereum,
-		CommitOffChainConfig: &globals.DefaultCommitOffChainCfg,
+		CommitOffChainConfig: &globals.CommitOffChainCfgForEthereum,
 	}
 
 	DefaultOCRParamsForExecForNonETH = CCIPOCRParams{
@@ -150,25 +150,4 @@ func DeriveOCRParamsForExec(
 		return params
 	}
 	return override(params)
-}
-
-// DeriveCommitSyncTimeoutForEthereumChains creates an override function for optimizing cache sync timeouts
-// for Ethereum chains where OCR rounds occur every ~6 seconds
-func DeriveCommitSyncTimeoutForEthereumChains(
-	baseOverride func(params CCIPOCRParams) CCIPOCRParams) func(params CCIPOCRParams) CCIPOCRParams {
-	return func(params CCIPOCRParams) CCIPOCRParams {
-		// Optimize cache timing for Ethereum chains (4s refresh with 3s timeout)
-		params.CommitOffChainConfig.ChainFeeAsyncObserverSyncFreq = 4 * time.Second
-		params.CommitOffChainConfig.ChainFeeAsyncObserverSyncTimeout = 3 * time.Second
-
-		params.CommitOffChainConfig.TokenPriceAsyncObserverSyncFreq = *config.MustNewDuration(4 * time.Second)
-		params.CommitOffChainConfig.TokenPriceAsyncObserverSyncTimeout = *config.MustNewDuration(3 * time.Second)
-
-		// Apply any additional chain-specific overrides if provided
-		if baseOverride != nil {
-			params = baseOverride(params)
-		}
-
-		return params
-	}
 }


### PR DESCRIPTION
Discovered inconsitent price/gas reporting due to frequency caching too high for the OCR delta round of:
*  ETH: 6s
* Other chains: 2s