### PR TITLE
Update docker image type to "manual" for workflow dispatches

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -104,7 +104,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@16a9ca3a2352bcb47539ebbb6f6153d657f9f8d0 # 2025-03-31
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9a35eb4f56aa7a26c084eaedfa3dd88f983a9411 # 2025-04-15
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-east-1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,7 +37,7 @@ jobs:
           elif [[ "${BUILD_TRIGGER}" == 'pull_request' ]]; then
             echo "build-type=pr" | tee -a "$GITHUB_OUTPUT"
           elif [[ "${BUILD_TRIGGER}" == 'workflow_dispatch' ]]; then
-            echo "build-type=sha" | tee -a "$GITHUB_OUTPUT"
+            echo "build-type=manual" | tee -a "$GITHUB_OUTPUT"
           else
             echo "::error::Unsupported build trigger: ${BUILD_TRIGGER}"
             exit 1
@@ -48,7 +48,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@16a9ca3a2352bcb47539ebbb6f6153d657f9f8d0 # 2025-03-31
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9a35eb4f56aa7a26c084eaedfa3dd88f983a9411 # 2025-04-15
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@16a9ca3a2352bcb47539ebbb6f6153d657f9f8d0 # 2025-03-31
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9a35eb4f56aa7a26c084eaedfa3dd88f983a9411 # 2025-04-15
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -103,7 +103,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@16a9ca3a2352bcb47539ebbb6f6153d657f9f8d0 # 2025-03-31
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9a35eb4f56aa7a26c084eaedfa3dd88f983a9411 # 2025-04-15
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -129,7 +129,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@16a9ca3a2352bcb47539ebbb6f6153d657f9f8d0 # 2025-03-31
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9a35eb4f56aa7a26c084eaedfa3dd88f983a9411 # 2025-04-15
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2


### PR DESCRIPTION
Needs: https://github.com/smartcontractkit/.github/pull/998

When workflow dispatches (manually running a workflow) are ran, the docker image type will be set to "manual" which will give the docker image tag a prefix of "manual-" instead of "sha-" to allow for more accurate retention/lifecycle policies in ECR.