### PR TITLE
[DX-545] create cre CLI settings file after creating the local environment

### DIFF
--- a/system-tests/tests/.gitignore
+++ b/system-tests/tests/.gitignore
@@ -10,6 +10,8 @@ set-feed-*.yaml
 # chainlink cli binary, it should be downloaded by the test
 cre_v*
 
+.cre.settings.yaml
+
 # crib-specific CL node configuration and secrets that will be used to override the default configuration
 crib-configs/
 cache/

--- a/system-tests/tests/smoke/cre/cmd/configs/single-don.toml
+++ b/system-tests/tests/smoke/cre/cmd/configs/single-don.toml
@@ -40,9 +40,9 @@
       [Feature]
 			LogPoller = true
 
-            [Log]
-            Level = 'debug'
-            JSONConsole = true
+      [Log]
+      Level = 'debug'
+      JSONConsole = true
 
 			[OCR2]
 			Enabled = true

--- a/system-tests/tests/smoke/cre/cmd/configs/workflow-capabilities-don.toml
+++ b/system-tests/tests/smoke/cre/cmd/configs/workflow-capabilities-don.toml
@@ -40,9 +40,9 @@
       [Feature]
 			LogPoller = true
 
-            [Log]
-            Level = 'debug'
-            JSONConsole = true
+      [Log]
+      Level = 'debug'
+      JSONConsole = true
 
 			[OCR2]
 			Enabled = true
@@ -73,9 +73,9 @@
       [Feature]
 			LogPoller = true
 
-            [Log]
-            Level = 'debug'
-            JSONConsole = true
+      [Log]
+      Level = 'debug'
+      JSONConsole = true
 
 			[OCR2]
 			Enabled = true
@@ -106,9 +106,9 @@
       [Feature]
 			LogPoller = true
 
-            [Log]
-            Level = 'debug'
-            JSONConsole = true
+      [Log]
+      Level = 'debug'
+      JSONConsole = true
 
 			[OCR2]
 			Enabled = true

--- a/system-tests/tests/smoke/cre/cmd/environment/environment.go
+++ b/system-tests/tests/smoke/cre/cmd/environment/environment.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/jobs/webapi"
 	creenv "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment"
 	cretypes "github.com/smartcontractkit/chainlink/system-tests/lib/cre/types"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/crecli"
 	libtypes "github.com/smartcontractkit/chainlink/system-tests/lib/types"
 )
 
@@ -152,10 +153,43 @@ var startCmd = &cobra.Command{
 			return errors.Wrap(err, "failed to start environment")
 		}
 
-		// TODO print urls?
-		_ = output
+		creCLISettingsFile, settingsErr := crecli.PrepareCRECLISettingsFile(
+			output.BlockchainOutput.SethClient.MustGetRootKeyAddress(),
+			output.KeystoneContractsOutput.CapabilitiesRegistryAddress,
+			output.KeystoneContractsOutput.WorkflowRegistryAddress,
+			nil,
+			output.DonTopology.WorkflowDonID,
+			output.BlockchainOutput.ChainSelector,
+			output.BlockchainOutput.BlockchainOutput.Nodes[0].ExternalHTTPUrl)
 
+		if settingsErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to create CRE CLI settings file: %s", settingsErr)
+		} else {
+			// Copy the file to current directory as .cre.settings.yaml
+			currentDir, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to get current directory: %s", err)
+			} else {
+				targetPath := filepath.Join(currentDir, ".cre.settings.yaml")
+				input, err := os.ReadFile(creCLISettingsFile.Name())
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "failed to read temporary settings file: %s", err)
+				} else {
+					err = os.WriteFile(targetPath, input, 0600)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "failed to write settings file to current directory: %s", err)
+					} else {
+						fmt.Printf("CRE CLI settings file created: %s\n", targetPath)
+					}
+				}
+			}
+		}
+
+		// TODO print urls?
+
+		fmt.Println()
 		fmt.Println("Environment started successfully")
+		fmt.Println()
 		fmt.Println("To terminate execute: ctf d rm")
 
 		return nil

--- a/system-tests/tests/smoke/cre/cmd/environment/environment.go
+++ b/system-tests/tests/smoke/cre/cmd/environment/environment.go
@@ -170,7 +170,7 @@ var startCmd = &cobra.Command{
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to get current directory: %s", err)
 			} else {
-				targetPath := filepath.Join(currentDir, ".cre.settings.yaml")
+				targetPath := filepath.Join(currentDir, "cre.settings.yaml")
 				input, err := os.ReadFile(creCLISettingsFile.Name())
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "failed to read temporary settings file: %s", err)

--- a/system-tests/tests/smoke/cre/cmd/environment/environment.go
+++ b/system-tests/tests/smoke/cre/cmd/environment/environment.go
@@ -153,36 +153,43 @@ var startCmd = &cobra.Command{
 			return errors.Wrap(err, "failed to start environment")
 		}
 
-		creCLISettingsFile, settingsErr := crecli.PrepareCRECLISettingsFile(
-			output.BlockchainOutput.SethClient.MustGetRootKeyAddress(),
-			output.KeystoneContractsOutput.CapabilitiesRegistryAddress,
-			output.KeystoneContractsOutput.WorkflowRegistryAddress,
-			nil,
-			output.DonTopology.WorkflowDonID,
-			output.BlockchainOutput.ChainSelector,
-			output.BlockchainOutput.BlockchainOutput.Nodes[0].ExternalHTTPUrl)
+		sErr := func() error {
+			creCLISettingsFile, settingsErr := crecli.PrepareCRECLISettingsFile(
+				output.BlockchainOutput.SethClient.MustGetRootKeyAddress(),
+				output.KeystoneContractsOutput.CapabilitiesRegistryAddress,
+				output.KeystoneContractsOutput.WorkflowRegistryAddress,
+				nil,
+				output.DonTopology.WorkflowDonID,
+				output.BlockchainOutput.ChainSelector,
+				output.BlockchainOutput.BlockchainOutput.Nodes[0].ExternalHTTPUrl)
 
-		if settingsErr != nil {
-			fmt.Fprintf(os.Stderr, "failed to create CRE CLI settings file: %s", settingsErr)
-		} else {
-			// Copy the file to current directory as .cre.settings.yaml
-			currentDir, err := os.Getwd()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to get current directory: %s", err)
-			} else {
-				targetPath := filepath.Join(currentDir, "cre.settings.yaml")
-				input, err := os.ReadFile(creCLISettingsFile.Name())
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "failed to read temporary settings file: %s", err)
-				} else {
-					err = os.WriteFile(targetPath, input, 0600)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "failed to write settings file to current directory: %s", err)
-					} else {
-						fmt.Printf("CRE CLI settings file created: %s\n", targetPath)
-					}
-				}
+			if settingsErr != nil {
+				return settingsErr
 			}
+
+			// Copy the file to current directory as cre.settings.yaml
+			currentDir, cErr := os.Getwd()
+			if cErr != nil {
+				return cErr
+			}
+
+			targetPath := filepath.Join(currentDir, "cre.settings.yaml")
+			input, err := os.ReadFile(creCLISettingsFile.Name())
+			if err != nil {
+				return err
+			}
+			err = os.WriteFile(targetPath, input, 0600)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("CRE CLI settings file created: %s\n", targetPath)
+
+			return nil
+		}()
+
+		if sErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to create CRE CLI settings file: %s. You need to create it manually.", sErr)
 		}
 
 		// TODO print urls?


### PR DESCRIPTION
Why?

So that workflow developers don't have to create it manually and can proceed to workflow compilation and registration.

Now user will see this:
```
CRE CLI settings file created: /Users/bartektofel/Desktop/repos/chainlink/system-tests/tests/smoke/cre/cmd/.cre.settings.yaml

Environment started successfully

To terminate execute: ctf d rm
➜  cmd git:(dx-545-save-cre-cli) ✗ cat /Users/bartektofel/Desktop/repos/chainlink/system-tests/tests/smoke/cre/cmd/.cre.settings.yaml
dev-platform:
    capabilities-registry-contract-address: 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
    don-id: 1
    workflow-registry-contract-address: 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
user-workflow:
    workflow-owner-address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
logging:
    seth-config-path: ""
mcms-config:
    proposals-directory: ./
contracts:
    registries:
        - name: CapabilitiesRegistry
          address: 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
          chain-selector: 3379446385462418246
        - name: WorkflowRegistry
          address: 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
          chain-selector: 3379446385462418246
    data-feeds: []
rpcs:
    - chain-selector: 3379446385462418246
      url: http://127.0.0.1:8545
```