### PR TITLE
feat: runs-on 100% allocation

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -247,7 +247,6 @@ jobs:
             echo "Successfully mounted $SRC_DIR to $DEST_DIR"
           done
 
-
       - name: Checkout the repo
         uses: actions/checkout@v4
         with:
@@ -612,8 +611,7 @@ jobs:
       two-per-day-frequency: ${{ steps.check-time.outputs.two-per-day-frequency || 'false' }}
       four-per-day-frequency: ${{ steps.check-time.outputs.four-per-day-frequency || 'false' }}
       six-per-day-frequency: ${{ steps.check-time.outputs.six-per-day-frequency || 'false' }}
-      # frequencies for self-hosted runners
-      should-use-self-hosted: ${{ steps.use-self-hosted.outputs.self-hosted-runners || 'false' }}
+      should-use-self-hosted: ${{ steps.use-self-hosted.outputs.self-hosted-runners || 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check time and set frequencies
@@ -652,59 +650,30 @@ jobs:
         id: use-self-hosted
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          RUNS_ON_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'runs-on') }}
           RUNS_ON_OPT_OUT: ${{ contains(github.event.pull_request.labels.*.name, 'runs-on-opt-out') }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref || '' }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" == "merge_group" ]; then
-            echo "Not using self-hosted runners for merge queue events"
-            echo "self-hosted-runners=false" | tee -a $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          if [ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]; then
-            echo "Using self-hosted runners for workflow dispatch events"
-            echo "self-hosted-runners=true" | tee -a $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
-            echo "Using self-hosted runners for scheduled events"
-            echo "self-hosted-runners=true" | tee -a $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            echo "Not using self-hosted runners for event ${GITHUB_EVENT_NAME}"
-            echo "self-hosted-runners=false" | tee -a $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # PR Events
-
           if [ "$RUNS_ON_OPT_OUT" == "true" ]; then
-            echo "Not using self-hosted runners for PR with 'runs-on-opt-out' label"
             echo "self-hosted-runners=false" | tee -a $GITHUB_OUTPUT
             exit 0
           fi
 
-          if [ "$RUNS_ON_LABEL" == "true" ]; then
-            echo "Using self-hosted runners for PR with 'runs-on' label"
-            echo "self-hosted-runners=true" | tee -a $GITHUB_OUTPUT
+          PR_NUMBER=${PULL_REQUEST_NUMBER}
+          echo "Merge group head ref: ${MERGE_GROUP_HEAD_REF}"
+          if [ "$GITHUB_EVENT_NAME" == "merge_group" ] && [ -n "${MERGE_GROUP_HEAD_REF}" ]; then
+            PR_NUMBER=$(echo ${MERGE_GROUP_HEAD_REF} | grep -Eo "queue/develop/pr-[0-9]+" | cut -d '-' -f2)
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR number found, skipping self-hosted runner check. Defaulting to true."
             exit 0
           fi
 
-          # generate a deterministic random number based on the branch name
-          branch_name="${GITHUB_HEAD_REF:-$(echo $GITHUB_REF | sed 's/refs\/heads\///')}"
-          hash=$(echo -n "$branch_name" | sha256sum | cut -d' ' -f1)
-          deterministic_number=$((16#${hash:0:8} % 100))
-
-          echo "Branch name: $branch_name"
-          echo "Deterministic number: $deterministic_number"
-
-          # 75% of the time, use self-hosted runners
-          if [ "$deterministic_number" -lt 75 ]; then
-            gh pr edit --repo "${GITHUB_REPOSITORY}" "${PULL_REQUEST_NUMBER}" --add-label "runs-on"
-            echo "self-hosted-runners=true" | tee -a $GITHUB_OUTPUT
+          echo "PR number: $PR_NUMBER, checking for self-hosted runner opt-out"
+          OPT_OUT=$(gh pr view $PR_NUMBER --repo ${GITHUB_REPOSITORY} --json labels --jq 'any(.labels[].name; . == "runs-on-opt-out")')
+          if [[ "$OPT_OUT" == "true" ]]; then
+            echo "self-hosted-runners=false" | tee -a $GITHUB_OUTPUT
+            exit 0
           fi

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -47,13 +47,38 @@ jobs:
 
   go-cache-self-hosted:
     name: Go Cache
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=4core-8gb-large-ubuntu-s3
+    runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=16+32/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     steps:
       # enable runs-on magic cache
       - uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
+
+      - name: Setup self-hosted directory mounts
+        # For self-hosted runners - the volume mounted to / is too small to handle everything stored in
+        # /home/runner. So we mount certain directories to the larger volume.
+        run: |
+          if [ ! -d "/home/runner/_work" ]; then
+            echo "::warning::/home/runner/_work does not exist, skipping mount."
+            exit 0
+          fi
+
+          # Define the directories to mount as tuples of source:destination
+          DIRS=(
+            "/home/runner/_work/runner-go:/home/runner/go"
+            "/home/runner/_work/runner-cache:/home/runner/.cache"
+          )
+
+          # Process each directory pair
+          for DIR_PAIR in "${DIRS[@]}"; do
+            SRC_DIR=$(echo $DIR_PAIR | cut -d':' -f1)
+            DEST_DIR=$(echo $DIR_PAIR | cut -d':' -f2)
+
+            sudo mkdir -m 755 "$SRC_DIR"
+            sudo chown -R $(id -u):$(id -g) "$SRC_DIR"
+
+            mkdir -p "$DEST_DIR"
+            sudo mount --bind "$SRC_DIR" "$DEST_DIR"
+            echo "Successfully mounted $SRC_DIR to $DEST_DIR"
+          done
 
       - name: Checkout the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
This rolls out self-hosted runners for every CI core run. Every event.

### Changes

- Default all events to true for `should-use-self-hosted`
- In emergent situations allow the use of github hosted runners for PRs and merge queue events.
	- If the `runs-on-opt-out` label is on the PR then it will use github hosted runners
	- It extracts the PR number from the merge queue ref, and will check if the PR has the label
- Run the go-module cache update on every push

---

DX-365