### PR TITLE
ccip - fix log issue related to json encoding

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/ccipdb/price_service.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdb/price_service.go
@@ -345,9 +345,8 @@ func (p *priceService) observeTokenPriceUpdates(
 		if price == nil {
 			return nil, fmt.Errorf("token price is nil for token %v", tokenID)
 		}
+		lggr.Infow("fetched raw token price", "tokenID", tokenID, "price", price)
 	}
-
-	lggr.Infow("Raw token prices", "rawTokenPrices", rawTokenPricesUSD)
 
 	// at this point the rawTokenPricesUSD contains both source native and dest tokens, we only want to observe
 	// destination chain tokens.


### PR DESCRIPTION
`Logw` uses json encoding for the provided objects.
If one of the provided objects cannot be json encoded it displays an error.
In this case the provided object was a map with the key being a struct, this cannot be json encoded.
This PR fixes the issue, I checked and no similar issues exists in the codebase.