### PR TITLE
chore: deprecates AddressBook

### DIFF
--- a/deployment/changeset.go
+++ b/deployment/changeset.go
@@ -114,7 +114,7 @@ type ChangesetOutput struct {
 	DescribedTimelockProposals []string
 	MCMSProposals              []mcms.Proposal
 	// Deprecated: AddressBook is deprecated and will be removed in future versions.
-	// Prefer the new DataStore API instead
+	// Use DataStore instead
 	AddressBook AddressBook
 	DataStore   datastore.MutableDataStore[datastore.DefaultMetadata, datastore.DefaultMetadata]
 	// Reports are populated by the Operations API with the

--- a/deployment/changeset.go
+++ b/deployment/changeset.go
@@ -113,8 +113,10 @@ type ChangesetOutput struct {
 	MCMSTimelockProposals      []mcms.TimelockProposal
 	DescribedTimelockProposals []string
 	MCMSProposals              []mcms.Proposal
-	AddressBook                AddressBook
-	DataStore                  datastore.MutableDataStore[datastore.DefaultMetadata, datastore.DefaultMetadata]
+	// Deprecated: AddressBook is deprecated and will be removed in future versions.
+	// Prefer the new DataStore API instead
+	AddressBook AddressBook
+	DataStore   datastore.MutableDataStore[datastore.DefaultMetadata, datastore.DefaultMetadata]
 	// Reports are populated by the Operations API with the
 	// results of the operations executed in the changeset.
 	Reports []operations.Report[any, any]

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -104,8 +104,8 @@ func (c Chain) Name() string {
 type Environment struct {
 	Name   string
 	Logger logger.Logger
-	// Deprecated: ExistingAddresses is deprecated and will be removed in future versions.
-	// Prefer the new DataStore API instead
+	// Deprecated: AddressBook is deprecated and will be removed in future versions.
+	// Use DataStore instead
 	ExistingAddresses AddressBook
 	DataStore         datastore.DataStore[
 		datastore.DefaultMetadata,

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -102,8 +102,10 @@ func (c Chain) Name() string {
 // conjunction with the Offchain client to read/write relevant
 // offchain state (i.e. state in the DON(s)).
 type Environment struct {
-	Name              string
-	Logger            logger.Logger
+	Name   string
+	Logger logger.Logger
+	// Deprecated: ExistingAddresses is deprecated and will be removed in future versions.
+	// Prefer the new DataStore API instead
 	ExistingAddresses AddressBook
 	DataStore         datastore.DataStore[
 		datastore.DefaultMetadata,


### PR DESCRIPTION
This PR adds deprecation comments to `AddressBook` in `deployment.Environment` and `deployment.ChangesetOutput`, as it will gradually be replaced by the new `DataStore`.