### PR TITLE
Normalize Tool Versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,10 +1,13 @@
-golang 1.23.3
-mockery 2.53.0
+# Languages
+golang 1.24.2
+python 3.10.5
 nodejs 20.13.1
 pnpm 10.6.5
+
+# Tools & other
+golangci-lint 1.64.7
+mockery 2.53.0
+protoc 29.3
 postgres 15.1
 helm 3.10.3
-golangci-lint 1.64.7
-protoc 29.3
-python 3.10.5
 act 0.2.30

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,6 +7,9 @@ GOFLAGS = -ldflags "$(GO_LDFLAGS)"
 GCFLAGS = -gcflags "$(GO_GCFLAGS)"
 # Set to true to install private plugins (will require GitHub auth).
 CL_INSTALL_PRIVATE_PLUGINS ?= false
+LINUX=LINUX
+OSX=OSX
+WINDOWS=WIN32
 
 # LOOP Plugin version defaults
 ifndef COSMOS_SHA
@@ -168,6 +171,38 @@ testscripts: chainlink-test ## Install and run testscript against testdata/scrip
 .PHONY: testscripts-update
 testscripts-update: ## Update testdata/scripts/* files via testscript.
 	make testscripts TS_FLAGS="-u"
+
+.PHONY: setup-tools
+setup-tools:
+ifeq ($(OSFLAG),$(WINDOWS))
+	@echo "Windows system detected - no automated setup available."
+	@echo "Please install your developer enviroment manually (@see .tool-versions)."
+	@echo
+	exit 1
+endif
+ifeq ($(OSFLAG),$(OSX))
+	@echo "MacOS system detected - installing the required toolchain via asdf (@see .tool-versions)."
+	@echo
+	brew install asdf
+	asdf plugin add golang || true
+	asdf plugin add mockery || true
+	asdf plugin add nodejs || true
+	asdf plugin add pnpm || true
+	asdf plugin add postgres || true
+	asdf plugin add helm || true
+	asdf plugin add golangci-lint || true
+	asdf plugin add protoc || true
+	asdf plugin add protoc-gen-go-grpc || true
+	asdf plugin add python || true
+	asdf plugin add act || true
+	@echo
+	asdf install
+endif
+ifeq ($(OSFLAG),$(LINUX))
+	@echo "Linux system detected - please install and use NIX (@see shell.nix)."
+	@echo
+endif
+endif
 
 .PHONY: start-testdb
 start-testdb:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -202,7 +202,6 @@ ifeq ($(OSFLAG),$(LINUX))
 	@echo "Linux system detected - please install and use NIX (@see shell.nix)."
 	@echo
 endif
-endif
 
 .PHONY: start-testdb
 start-testdb:


### PR DESCRIPTION
There is a move in multiple repos toward using `asdf` as a build/run tool manager. This commit updates the `.tool-versions` file to the latest versions used in build scripts and the Makefile. Additionally, a new task was added to the Makefile to assist in installing `asdf`.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
