### PR TITLE
fix: ci-core runner-config on push events

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -679,6 +679,7 @@ jobs:
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR number found."
             echo "opt-out=false" | tee -a $GITHUB_OUTPUT
+            exit 0
           fi
 
           OPT_OUT=$(gh pr view $PR_NUMBER --repo ${GITHUB_REPOSITORY} --json labels --jq 'any(.labels[].name; . == "runs-on-opt-out")')


### PR DESCRIPTION
Follow-up for #17332. This broke CI-Core on push because of a missed exit 0.

Example error: https://github.com/smartcontractkit/chainlink/actions/runs/14541283709/job/40799655852

