### PR TITLE
Deterministic ordering of transmission relative to peerIDs

### DIFF
--- a/core/capabilities/transmission/transmission.go
+++ b/core/capabilities/transmission/transmission.go
@@ -2,6 +2,8 @@ package transmission
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/smartcontractkit/libocr/permutation"
@@ -82,8 +84,15 @@ func GetPeerIDToTransmissionDelaysForConfig(donPeerIDs []types.PeerID, transmiss
 
 	picked := permutation.Permutation(donMemberCount, key)
 
+	// Sort PeerIDs lexicographically
+	sortedPeerIDs := make([]types.PeerID, len(donPeerIDs))
+	copy(sortedPeerIDs, donPeerIDs)
+	slices.SortFunc(sortedPeerIDs, func(a, b types.PeerID) int {
+		return strings.Compare(a.String(), b.String())
+	})
+
 	peerIDToTransmissionDelay := map[types.PeerID]time.Duration{}
-	for i, peerID := range donPeerIDs {
+	for i, peerID := range sortedPeerIDs {
 		delay := delayFor(i, schedule, picked, tc.DeltaStage)
 		if delay != nil {
 			peerIDToTransmissionDelay[peerID] = *delay

--- a/core/capabilities/transmission/transmission_test.go
+++ b/core/capabilities/transmission/transmission_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	types2 "github.com/smartcontractkit/libocr/ragep2p/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -98,5 +99,58 @@ func Test_GetPeerIDToTransmissionDelay(t *testing.T) {
 			assert.Equal(t, tc.expectedDelays["three"], peerIdToDelay[peer3])
 			assert.Equal(t, tc.expectedDelays["four"], peerIdToDelay[peer4])
 		})
+	}
+}
+
+func TestGetPeerIDToTransmissionDelaysForConfig_ConsistentSchedule(t *testing.T) {
+	// Create test peer IDs
+	peerIDs := make([]types2.PeerID, 5)
+	reversedPeerIDs := make([]types2.PeerID, 5)
+	for i := range peerIDs {
+		peerIDs[i] = [32]byte{byte(i)}
+		reversedPeerIDs[len(peerIDs)-1-i] = peerIDs[i]
+	}
+
+	// Test configuration
+	transmissionID := "test-transmission"
+	config := TransmissionConfig{
+		Schedule:   Schedule_OneAtATime,
+		DeltaStage: 1 * time.Second,
+	}
+
+	// Get first schedule
+	schedule1, err := GetPeerIDToTransmissionDelaysForConfig(peerIDs, transmissionID, config)
+	require.NoError(t, err)
+
+	// Get second schedule with same inputs
+	schedule2, err := GetPeerIDToTransmissionDelaysForConfig(peerIDs, transmissionID, config)
+	require.NoError(t, err)
+
+	// Verify each peer has the same delay in both schedules
+	for peerID, delay1 := range schedule1 {
+		delay2, exists := schedule2[peerID]
+		require.True(t, exists, "peer %v should exist in both schedules", peerID)
+		require.Equal(t, delay1, delay2, "peer %v should have same delay in both schedules", peerID)
+	}
+
+	// Verify the order of delays is consistent
+	delays1 := make([]time.Duration, 0, len(schedule1))
+	delays2 := make([]time.Duration, 0, len(schedule2))
+	for _, peerID := range peerIDs {
+		delays1 = append(delays1, schedule1[peerID])
+		delays2 = append(delays2, schedule2[peerID])
+	}
+	require.Equal(t, delays1, delays2, "delays should be in same order in both schedules")
+
+	// Verify with different transmission ID
+	differentSchedule, err := GetPeerIDToTransmissionDelaysForConfig(peerIDs, "different-transmission", config)
+	require.NoError(t, err)
+	require.NotEqual(t, schedule1, differentSchedule, "different transmission ID should produce different schedule")
+
+	// Verify with different peer order
+	reversedSchedule, err := GetPeerIDToTransmissionDelaysForConfig(reversedPeerIDs, transmissionID, config)
+	require.NoError(t, err)
+	for i := range peerIDs {
+		require.Equal(t, schedule1[[32]byte{byte(i)}], reversedSchedule[[32]byte{byte(i)}], "peer order should not affect schedule")
 	}
 }


### PR DESCRIPTION
Previously, the ordering of the peers at this layer would affect which delay was assigned to them. Maybe they were already implicitly ordered - this change is still valid. 

I noticed this while digging into transmission schedule logic. IMHO we want this change to lock the entropy down to the transmission ID.

transmissionID is set as the requestID:

```
	// the requestID must be delineated by the workflow execution ID and the reference ID
	// to ensure that it supports parallel step execution
	requestID := types.MethodExecute + ":" + workflowExecutionID + ":" + req.Metadata.ReferenceID
```

https://github.com/smartcontractkit/chainlink/blob/20bbaa71d2ff5286b7d921eae3bf770dda94e521/core/capabilities/remote/executable/request/client_request.go#L66

This approach is forwards compatible to us taking over stepRef to uniquely identify two calls to the same capability within a single workflow execution. 