### PR TITLE
Disable docker build cache in CI

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -104,7 +104,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9a35eb4f56aa7a26c084eaedfa3dd88f983a9411 # 2025-04-15
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@b37583d758e3992e0d5bfdb5a36ca243ce53ff59 # 2025-04-22
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-east-1
@@ -116,6 +116,7 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_APTOS_CMD=chainlink-aptos
+      docker-build-cache-disabled: "true"
       docker-image-type: tag
       docker-manifest-sign: true
       docker-registry-url-override: public.ecr.aws/chainlink

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,7 +48,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9a35eb4f56aa7a26c084eaedfa3dd88f983a9411 # 2025-04-15
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@b37583d758e3992e0d5bfdb5a36ca243ce53ff59 # 2025-04-22
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -58,6 +58,7 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+      docker-build-cache-disabled: "true"
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
       git-sha: ${{ inputs.git-ref || github.sha }}
@@ -73,7 +74,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9a35eb4f56aa7a26c084eaedfa3dd88f983a9411 # 2025-04-15
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@b37583d758e3992e0d5bfdb5a36ca243ce53ff59 # 2025-04-22
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -85,6 +86,7 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_APTOS_CMD=chainlink-aptos
+      docker-build-cache-disabled: "true"
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"
@@ -103,7 +105,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9a35eb4f56aa7a26c084eaedfa3dd88f983a9411 # 2025-04-15
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@b37583d758e3992e0d5bfdb5a36ca243ce53ff59 # 2025-04-22
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -114,6 +116,7 @@ jobs:
         CHAINLINK_USER=chainlink
         CL_CHAIN_DEFAULTS=/ccip-config
         COMMIT_SHA=${{ github.sha }}
+      docker-build-cache-disabled: "true"
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
       git-sha: ${{ inputs.git-ref || github.sha }}
@@ -129,7 +132,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9a35eb4f56aa7a26c084eaedfa3dd88f983a9411 # 2025-04-15
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@b37583d758e3992e0d5bfdb5a36ca243ce53ff59 # 2025-04-22
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -142,6 +145,7 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_APTOS_CMD=chainlink-aptos
+      docker-build-cache-disabled: "true"
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"


### PR DESCRIPTION
We were seeing intermittent failures ([example](https://github.com/smartcontractkit/chainlink/actions/runs/14591879294/job/40928843312?pr=17096)) in CI at a ~10-15% rate with cache enabled. GitHub's cache is only 10 GB or so per repo so not a huge loss and build speeds don't seem to be impacted.