### PR TITLE
core/services/keystore/keys/starkkey: add Fuzz test; fix padding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,9 +100,6 @@ go.work*
 # This sometimes shows up for some reason
 tools/flakeytests/coverage.txt
 
-# Fuzz tests can create these files
-**/testdata/fuzz/*
-
 # Runtime test configuration that might contain secrets
 override*.toml
 

--- a/core/services/keystore/keys/starkkey/ocr2key.go
+++ b/core/services/keystore/keys/starkkey/ocr2key.go
@@ -70,10 +70,10 @@ func (sk *OCR2Key) Sign(reportCtx types.ReportContext, report types.Report) ([]b
 
 	// encoding: public key (32 bytes) + r (32 bytes) + s (32 bytes)
 	buff := bytes.NewBuffer([]byte(sk.PublicKey()))
-	if _, err := buff.Write(padBytes(r.Bytes(), byteLen)); err != nil {
+	if _, err := buff.Write(padBytes(r.Bytes())); err != nil {
 		return []byte{}, err
 	}
-	if _, err := buff.Write(padBytes(s.Bytes(), byteLen)); err != nil {
+	if _, err := buff.Write(padBytes(s.Bytes())); err != nil {
 		return []byte{}, err
 	}
 
@@ -140,18 +140,16 @@ func (sk *OCR2Key) MaxSignatureLength() int {
 }
 
 func (sk *OCR2Key) Marshal() ([]byte, error) {
-	return padBytes(internal.Bytes(sk.raw), sk.privateKeyLen()), nil
+	return padBytes(internal.Bytes(sk.raw)), nil
 }
 
-func (sk *OCR2Key) privateKeyLen() int {
-	// https://github.com/NethermindEth/juno/blob/3e71279632d82689e5af03e26693ca5c58a2376e/pkg/crypto/weierstrass/weierstrass.go#L377
-	return 32
-}
+// https://github.com/NethermindEth/juno/blob/3e71279632d82689e5af03e26693ca5c58a2376e/pkg/crypto/weierstrass/weierstrass.go#L377
+const privateKeyLen = 32
 
 func (sk *OCR2Key) Unmarshal(in []byte) error {
 	// enforce byte length
-	if len(in) != sk.privateKeyLen() {
-		return errors.Errorf("unexpected seed size, got %d want %d", len(in), sk.privateKeyLen())
+	if len(in) != privateKeyLen {
+		return errors.Errorf("unexpected seed size, got %d want %d", len(in), privateKeyLen)
 	}
 
 	sk.Key = KeyFor(internal.NewRaw(in))

--- a/core/services/keystore/keys/starkkey/ocr2key_test.go
+++ b/core/services/keystore/keys/starkkey/ocr2key_test.go
@@ -3,7 +3,9 @@ package starkkey
 import (
 	cryptorand "crypto/rand"
 	"encoding/hex"
+	"io"
 	"math/big"
+	mathrand "math/rand"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -175,7 +177,11 @@ func TestStarknetKeyring_Sign_Verify(t *testing.T) {
 }
 
 func TestStarknetKeyring_Marshal(t *testing.T) {
-	kr1, err := NewOCR2Key(cryptorand.Reader)
+	testStarknetKeyringMarshal(t, cryptorand.Reader)
+}
+
+func testStarknetKeyringMarshal(t *testing.T, r io.Reader) {
+	kr1, err := NewOCR2Key(r)
 	require.NoError(t, err)
 	m, err := kr1.Marshal()
 	require.NoError(t, err)
@@ -186,4 +192,11 @@ func TestStarknetKeyring_Marshal(t *testing.T) {
 
 	// Invalid seed size should error
 	require.Error(t, kr2.Unmarshal([]byte{0x01}))
+}
+
+func FuzzStarknetKeyring_Marshal(f *testing.F) {
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := mathrand.New(mathrand.NewSource(seed))
+		testStarknetKeyringMarshal(t, r)
+	})
 }

--- a/core/services/keystore/keys/starkkey/testdata/fuzz/FuzzStarknetKeyring_Marshal/501f37c0ea01b291
+++ b/core/services/keystore/keys/starkkey/testdata/fuzz/FuzzStarknetKeyring_Marshal/501f37c0ea01b291
@@ -1,0 +1,2 @@
+go test fuzz v1
+int64(29)

--- a/core/services/keystore/keys/starkkey/utils.go
+++ b/core/services/keystore/keys/starkkey/utils.go
@@ -11,11 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 )
 
-// constants
-var (
-	byteLen = 32
-)
-
 // reimplements parts of
 // https://github.com/NethermindEth/starknet.go/blob/0bdaab716ce24a521304744a8fbd8e01800c241d/curve/curve.go#L702
 // generate the PK as a pseudo-random number in the interval [1, CurveOrder - 1]
@@ -39,15 +34,15 @@ func GenerateKey(material io.Reader) (k Key, err error) {
 	if !curve.Curve.IsOnCurve(k.pub.X, k.pub.Y) {
 		return k, errors.New("key gen is not on stark curve")
 	}
-	k.raw = internal.NewRaw(priv.Bytes())
+	k.raw = internal.NewRaw(padBytes(priv.Bytes()))
 
 	return k, nil
 }
 
-// pad bytes to specific length
-func padBytes(a []byte, length int) []byte {
-	if len(a) < length {
-		pad := make([]byte, length-len(a))
+// pad bytes to privateKeyLen
+func padBytes(a []byte) []byte {
+	if len(a) < privateKeyLen {
+		pad := make([]byte, privateKeyLen-len(a))
 		return append(pad, a...)
 	}
 


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/DX-559

Recent changes to the key types exposed an inconsistency where generated bytes are not padded until they are marshaled. This change introduces a fuzz test and a fix.