### PR TITLE
solana: Always specify ComputeUnits in messaging tests

### DIFF
--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -260,6 +260,7 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 		extraArgs, err := testhelpers.SerializeSVMExtraArgs(message_hasher.ClientSVMExtraArgsV1{
 			AccountIsWritableBitmap: solccip.GenerateBitMapForIndexes([]int{0, 1}),
 			Accounts:                accounts,
+			ComputeUnits:            80_000,
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
Without this tests can potentially flake and fail