### PR TITLE
Avoid subshell and dir change for installing loopinstall

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -63,8 +63,7 @@ chainlink-test: ## Build a test build of chainlink binary.
 
 .PHONY: install-loopinstall
 install-loopinstall:
-	cd $(shell go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-common) && \
-	go install $(GOFLAGS) ./pkg/loop/cmd/loopinstall
+	go install github.com/smartcontractkit/chainlink-common/pkg/loop/cmd/loopinstall
 
 .PHONY: install-plugins-public
 install-plugins-public: ## Build & install public remote LOOPP binaries (plugins).


### PR DESCRIPTION
An attempt to fix these errors:

```shell
0.150 Git configured to use authentication token for GitHub repositories
0.259 cd  && \
0.259 go install -ldflags "-X github.com/smartcontractkit/chainlink/v2/core/static.Version=2.22.0 -X github.com/smartcontractkit/chainlink/v2/core/static.Sha=4f1bf60bda41397a6cac055eb109531df170bf2f" ./pkg/loop/cmd/loopinstall
0.262 go: go.mod file not found in current directory or any parent directory; see 'go help modules'
0.263 make: *** [GNUmakefile:66: install-loopinstall] Error 1
```

Tested by running 20 workflows before (current) and 20 with this change:

- [Before](https://github.com/smartcontractkit/chainlink/actions/workflows/docker-build.yml?query=branch%3Adx-583%2Ftest1%2Fgomoddownloadinstall) (2 related failures)
- [Now](https://github.com/smartcontractkit/chainlink/actions/workflows/docker-build.yml?query=branch%3Adx-583%2Ftest2%2Fgoinstall) (0 related failures)