### PR TITLE
Add support for medianizing LLO TimestampedStreamValue timestamps

### DIFF
--- a/.changeset/large-knives-learn.md
+++ b/.changeset/large-knives-learn.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#updated Add support for medianizing TimestampedStreamValue timestamps

--- a/core/services/llo/observation/observation_context.go
+++ b/core/services/llo/observation/observation_context.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"strconv"
 	"sync"
 	"time"
@@ -252,8 +253,20 @@ func toUint64(v interface{}) (uint64, error) {
 			return 0, fmt.Errorf("expected positive int64, got: %d", v)
 		}
 		return uint64(v), nil
+	case decimal.Decimal:
+		if v.IsNegative() {
+			return 0, fmt.Errorf("expected positive decimal, got: %s", v.String())
+		}
+		// Convert the integer part of the decimal to a big.Int, discard fractional part
+		bigIntVal := v.BigInt()
+
+		// Check if the value is greater than maxUint64
+		if bigIntVal.Cmp(new(big.Int).SetUint64(math.MaxUint64)) > 0 {
+			return 0, fmt.Errorf("decimal too large, got: %s", v.String())
+		}
+		return bigIntVal.Uint64(), nil
 	default:
-		return 0, fmt.Errorf("expected float64 or string, got: %T", v)
+		return 0, fmt.Errorf("expected float64, int64, string, or decimal, got: %T", v)
 	}
 }
 

--- a/core/services/llo/observation/observation_context.go
+++ b/core/services/llo/observation/observation_context.go
@@ -204,10 +204,10 @@ func resultMapToTimestampedStreamValue(m map[string]interface{}) (*llo.Timestamp
 	// providerIndicatedTimeUnixMs is the best option, with providerDataReceivedUnixMs as a fallback
 	k := "providerIndicatedTimeUnixMs"
 	rawObservedAtMillis, exists := ts[k]
-	if !exists {
+	if !exists || rawObservedAtMillis == nil {
 		k = "providerDataReceivedUnixMs"
 		rawObservedAtMillis, exists = ts[k]
-		if !exists {
+		if !exists || rawObservedAtMillis == nil {
 			return nil, errors.New("expected a key labeled 'providerIndicatedTimeUnixMs' or 'providerDataReceivedUnixMs'")
 		}
 	}

--- a/core/services/ocr2/plugins/llo/helpers_test.go
+++ b/core/services/ocr2/plugins/llo/helpers_test.go
@@ -454,12 +454,11 @@ func createSingleDecimalBridge(t *testing.T, name string, i int, p decimal.Decim
 	return bridgeName
 }
 
-func createBridge(t *testing.T, bridgeName string, resultJSON string, borm bridges.ORM) {
+func createBridge(t *testing.T, bridgeName string, responseJSON string, borm bridges.ORM) {
 	ctx := testutils.Context(t)
 	bridge := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusOK)
-		resp := fmt.Sprintf(`{"result": %s}`, resultJSON)
-		_, err := res.Write([]byte(resp))
+		_, err := res.Write([]byte(responseJSON))
 		if err != nil {
 			t.Fatalf("failed to write response: %v", err)
 		}

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -1034,24 +1034,28 @@ dp -> market_status_parse;
 
 provider_indicated_time_parse [type=jsonparse lax=true path="timestamps,providerIndicatedTimeUnixMs"];
 provider_data_received_parse [type=jsonparse lax=true path="timestamps,providerDataReceivedUnixMs"];
-stonk_price_timestamped [type=merge left="{}" right="{\\"streamValueType\\": %d, \\"timestamps\\":{\\"providerIndicatedTimeUnixMs\\":$(provider_indicated_time_parse),\\"providerDataReceivedUnixMs\\":$(provider_data_received_parse)}, \\"result\\": $(stonk_price_parse)}" streamID=%d];
+provider_indicated_time [type=median lax=true];
+provider_data_received [type=median lax=true];
+stonk_price_timestamped [type=merge left="{}" right="{\\"streamValueType\\": %d, \\"timestamps\\":{\\"providerIndicatedTimeUnixMs\\":$(provider_indicated_time),\\"providerDataReceivedUnixMs\\":$(provider_data_received)}, \\"result\\": $(stonk_price_parse)}" streamID=%d];
 
-dp -> provider_indicated_time_parse;
-dp -> provider_data_received_parse;
+dp -> provider_indicated_time_parse -> provider_indicated_time;
+dp -> provider_data_received_parse -> provider_data_received;
 dp -> stonk_price_parse -> stonk_price_timestamped;
 
 # test null providerIndicatedTimeUnixMs
 null_provider_indicated_time_parse [type=jsonparse lax=true path="timestamps,providerIndicatedTimeUnixMs_TestNull"];
-stonk_price_timestamped_null_indicated_time [type=merge left="{}" right="{\\"streamValueType\\": %d, \\"timestamps\\":{\\"providerIndicatedTimeUnixMs\\":$(null_provider_indicated_time_parse),\\"providerDataReceivedUnixMs\\":$(provider_data_received_parse)}, \\"result\\": $(stonk_price_parse)}" streamID=%d];
+null_provider_indicated_time [type=median lax=true];
+stonk_price_timestamped_null_indicated_time [type=merge left="{}" right="{\\"streamValueType\\": %d, \\"timestamps\\":{\\"providerIndicatedTimeUnixMs\\":$(null_provider_indicated_time),\\"providerDataReceivedUnixMs\\":$(provider_data_received)}, \\"result\\": $(stonk_price_parse)}" streamID=%d];
 
-dp -> null_provider_indicated_time_parse;
+dp -> null_provider_indicated_time_parse -> null_provider_indicated_time;
 dp -> stonk_price_parse -> stonk_price_timestamped_null_indicated_time;
 
 # test missing providerIndicatedTimeUnixMs
 missing_provider_indicated_time_parse [type=jsonparse lax=true path="timestamps,providerIndicatedTimeUnixMs_TestMissing"];
-stonk_price_timestamped_missing_indicated_time [type=merge left="{}" right="{\\"streamValueType\\": %d, \\"timestamps\\":{\\"providerIndicatedTimeUnixMs\\":$(missing_provider_indicated_time_parse),\\"providerDataReceivedUnixMs\\":$(provider_data_received_parse)}, \\"result\\": $(stonk_price_parse)}" streamID=%d];
+missing_provider_indicated_time [type=median lax=true];
+stonk_price_timestamped_missing_indicated_time [type=merge left="{}" right="{\\"streamValueType\\": %d, \\"timestamps\\":{\\"providerIndicatedTimeUnixMs\\":$(missing_provider_indicated_time),\\"providerDataReceivedUnixMs\\":$(provider_data_received)}, \\"result\\": $(stonk_price_parse)}" streamID=%d];
 
-dp -> missing_provider_indicated_time_parse;
+dp -> missing_provider_indicated_time_parse -> missing_provider_indicated_time;
 dp -> stonk_price_parse -> stonk_price_timestamped_missing_indicated_time;
 `, bridgeName, marketStatusStreamID,
 			datastreamsllo.LLOStreamValue_TimestampedStreamValue, timestampedStonkPriceStreamID,

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -962,25 +962,27 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 
 		bridgeName := "superbridge"
 
-		resultJSON := `{
-	"benchmarkPrice": "2976.39",
-	"baseMarketDepth": "1000.1212",
-	"quoteMarketDepth": "998.5431",
-	"marketStatus": 1,
-	"binanceFundingRate": "1234.5678",
-	"binanceFundingTime": "1630000000",
-	"binanceFundingIntervalHours": "8",
-	"deribitFundingRate": "5432.2345",
-	"deribitFundingTime": "1630000000",
-	"deribitFundingIntervalHours": "8",
-	"ethPrice": "3976.39",
-	"linkPrice": "23.45",
-	"stonk": {
-	  "result": "1234.5678",
-	  "timestamps": {
+		responseJSON := `{
+	"data": {
+		"benchmarkPrice": "111.22",
+		"marketStatus": 1
+	},
+	"result": {
+		"benchmarkPrice": "2976.39",
+		"baseMarketDepth": "1000.1212",
+		"quoteMarketDepth": "998.5431",
+		"binanceFundingRate": "1234.5678",
+		"binanceFundingTime": "1630000000",
+		"binanceFundingIntervalHours": "8",
+		"deribitFundingRate": "5432.2345",
+		"deribitFundingTime": "1630000000",
+		"deribitFundingIntervalHours": "8",
+		"ethPrice": "3976.39",
+		"linkPrice": "23.45"
+	},
+	"timestamps": {
 		"providerIndicatedTimeUnixMs": 1742314713000,
 		"providerDataReceivedUnixMs": 1742314713050
-	  }
 	}
 }`
 
@@ -1012,15 +1014,17 @@ dp -> quote_market_depth_parse -> quote_market_depth_decimal;
 
 		// Don't use a multiply task so that the task result has int64 type.
 		rwaPipeline := fmt.Sprintf(`
-dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
+dp [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
 
-market_status_parse   [type=jsonparse path="result,marketStatus" streamID=%d];
+market_status_parse [type=jsonparse path="data,marketStatus" streamID=%d];
+stonk_price_parse [type=jsonparse path="data,benchmarkPrice"];
 
-stonk_price_parse   [type=jsonparse path="result,stonk"];
-merge [type=merge left="$(stonk_price_parse)" right="{\\"streamValueType\\":%d}" streamID=%d];
+# Left is the raw response from the DP which contains the "timestamps" top level field.
+# Right contains streamValueType: 2, indicating a timestamped field, and the stream value as the "result".
+stonk_price_timestamped [type=merge left="$(dp)" right="{\\"streamValueType\\": %d, \\"result\\": $(stonk_price_parse)}" streamID=%d];
 
 dp -> market_status_parse;
-dp -> stonk_price_parse -> merge;
+dp -> stonk_price_parse -> stonk_price_timestamped;
 `, bridgeName, marketStatusStreamID, datastreamsllo.LLOStreamValue_TimestampedStreamValue, timestampedStonkPriceStreamID)
 
 		benchmarkPricePipeline := fmt.Sprintf(`
@@ -1065,7 +1069,7 @@ dp -> deribit_funding_interval_hours_parse -> deribit_funding_interval_hours_dec
 		for i, node := range nodes {
 			// superBridge returns a JSON with everything you want in it,
 			// stream specs can just pick the individual fields they need
-			createBridge(t, bridgeName, resultJSON, node.App.BridgeORM())
+			createBridge(t, bridgeName, responseJSON, node.App.BridgeORM())
 			addStreamSpec(t, node, "pricePipeline", nil, pricePipeline)
 			addStreamSpec(t, node, "dexBasedAssetPipeline", nil, dexBasedAssetPipeline)
 			addStreamSpec(t, node, "rwaPipeline", nil, rwaPipeline)
@@ -1254,7 +1258,7 @@ dp -> deribit_funding_interval_hours_parse -> deribit_funding_interval_hours_dec
 				assert.Len(t, report["Values"].([]interface{}), 1)
 				tsv := report["Values"].([]interface{})[0].(map[string]interface{})
 				assert.Equal(t, 2, int(tsv["t"].(float64)))
-				assert.Equal(t, `TSV{ObservedAtNanoseconds: 1742314713000000000, StreamValue: {"t":0,"v":"1234.5678"}}`, tsv["v"].(string))
+				assert.Equal(t, `TSV{ObservedAtNanoseconds: 1742314713000000000, StreamValue: {"t":0,"v":"111.22"}}`, tsv["v"].(string))
 			default:
 				t.Fatalf("unexpected report format: %d", req.ReportFormat)
 			}

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -735,6 +735,8 @@ lloConfigMode = "bluegreen"
 		deribitFundingTimeStreamID := uint32(10)
 		deribitFundingIntervalHoursStreamID := uint32(11)
 		timestampedStonkPriceStreamID := uint32(12)
+		nullTimestampPriceStreamID := uint32(13)
+		missingTimestampPriceStreamID := uint32(14)
 
 		mustEncodeOpts := func(opts any) []byte {
 			encoded, err := json.Marshal(opts)
@@ -945,6 +947,14 @@ lloConfigMode = "bluegreen"
 						StreamID:   timestampedStonkPriceStreamID,
 						Aggregator: llotypes.AggregatorMedian,
 					},
+					{
+						StreamID:   nullTimestampPriceStreamID,
+						Aggregator: llotypes.AggregatorMedian,
+					},
+					{
+						StreamID:   missingTimestampPriceStreamID,
+						Aggregator: llotypes.AggregatorMedian,
+					},
 				},
 			},
 		}
@@ -982,6 +992,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 	},
 	"timestamps": {
 		"providerIndicatedTimeUnixMs": 1742314713000,
+		"providerIndicatedTimeUnixMs_TestNull": null,
 		"providerDataReceivedUnixMs": 1742314713050
 	}
 }`
@@ -1019,13 +1030,34 @@ dp [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
 market_status_parse [type=jsonparse path="data,marketStatus" streamID=%d];
 stonk_price_parse [type=jsonparse path="data,benchmarkPrice"];
 
-# Left is the raw response from the DP which contains the "timestamps" top level field.
-# Right contains streamValueType: 2, indicating a timestamped field, and the stream value as the "result".
-stonk_price_timestamped [type=merge left="$(dp)" right="{\\"streamValueType\\": %d, \\"result\\": $(stonk_price_parse)}" streamID=%d];
-
 dp -> market_status_parse;
+
+provider_indicated_time_parse [type=jsonparse lax=true path="timestamps,providerIndicatedTimeUnixMs"];
+provider_data_received_parse [type=jsonparse lax=true path="timestamps,providerDataReceivedUnixMs"];
+stonk_price_timestamped [type=merge left="{}" right="{\\"streamValueType\\": %d, \\"timestamps\\":{\\"providerIndicatedTimeUnixMs\\":$(provider_indicated_time_parse),\\"providerDataReceivedUnixMs\\":$(provider_data_received_parse)}, \\"result\\": $(stonk_price_parse)}" streamID=%d];
+
+dp -> provider_indicated_time_parse;
+dp -> provider_data_received_parse;
 dp -> stonk_price_parse -> stonk_price_timestamped;
-`, bridgeName, marketStatusStreamID, datastreamsllo.LLOStreamValue_TimestampedStreamValue, timestampedStonkPriceStreamID)
+
+# test null providerIndicatedTimeUnixMs
+null_provider_indicated_time_parse [type=jsonparse lax=true path="timestamps,providerIndicatedTimeUnixMs_TestNull"];
+stonk_price_timestamped_null_indicated_time [type=merge left="{}" right="{\\"streamValueType\\": %d, \\"timestamps\\":{\\"providerIndicatedTimeUnixMs\\":$(null_provider_indicated_time_parse),\\"providerDataReceivedUnixMs\\":$(provider_data_received_parse)}, \\"result\\": $(stonk_price_parse)}" streamID=%d];
+
+dp -> null_provider_indicated_time_parse;
+dp -> stonk_price_parse -> stonk_price_timestamped_null_indicated_time;
+
+# test missing providerIndicatedTimeUnixMs
+missing_provider_indicated_time_parse [type=jsonparse lax=true path="timestamps,providerIndicatedTimeUnixMs_TestMissing"];
+stonk_price_timestamped_missing_indicated_time [type=merge left="{}" right="{\\"streamValueType\\": %d, \\"timestamps\\":{\\"providerIndicatedTimeUnixMs\\":$(missing_provider_indicated_time_parse),\\"providerDataReceivedUnixMs\\":$(provider_data_received_parse)}, \\"result\\": $(stonk_price_parse)}" streamID=%d];
+
+dp -> missing_provider_indicated_time_parse;
+dp -> stonk_price_parse -> stonk_price_timestamped_missing_indicated_time;
+`, bridgeName, marketStatusStreamID,
+			datastreamsllo.LLOStreamValue_TimestampedStreamValue, timestampedStonkPriceStreamID,
+			datastreamsllo.LLOStreamValue_TimestampedStreamValue, nullTimestampPriceStreamID,
+			datastreamsllo.LLOStreamValue_TimestampedStreamValue, missingTimestampPriceStreamID,
+		)
 
 		benchmarkPricePipeline := fmt.Sprintf(`
 dp          [type=bridge name="%s" requestData="{\\"data\\":{\\"data\\":\\"foo\\"}}"];
@@ -1255,10 +1287,19 @@ dp -> deribit_funding_interval_hours_parse -> deribit_funding_interval_hours_dec
 				report := v["report"].(map[string]interface{})
 				cid := report["ChannelID"].(float64)
 				delete(feedIDs, pad32bytes(uint32(cid)))
-				assert.Len(t, report["Values"].([]interface{}), 1)
-				tsv := report["Values"].([]interface{})[0].(map[string]interface{})
-				assert.Equal(t, 2, int(tsv["t"].(float64)))
-				assert.Equal(t, `TSV{ObservedAtNanoseconds: 1742314713000000000, StreamValue: {"t":0,"v":"111.22"}}`, tsv["v"].(string))
+				assert.Len(t, report["Values"].([]interface{}), 3)
+				// default uses provider indicated time
+				tsv1 := report["Values"].([]interface{})[0].(map[string]interface{})
+				assert.Equal(t, 2, int(tsv1["t"].(float64)))
+				assert.Equal(t, `TSV{ObservedAtNanoseconds: 1742314713000000000, StreamValue: {"t":0,"v":"111.22"}}`, tsv1["v"].(string))
+				// null provider indicated time - uses data received time fallback
+				tsv2 := report["Values"].([]interface{})[1].(map[string]interface{})
+				assert.Equal(t, 2, int(tsv2["t"].(float64)))
+				assert.Equal(t, `TSV{ObservedAtNanoseconds: 1742314713050000000, StreamValue: {"t":0,"v":"111.22"}}`, tsv2["v"].(string))
+				// missing provider indicated time - uses data received time fallback
+				tsv3 := report["Values"].([]interface{})[2].(map[string]interface{})
+				assert.Equal(t, 2, int(tsv3["t"].(float64)))
+				assert.Equal(t, `TSV{ObservedAtNanoseconds: 1742314713050000000, StreamValue: {"t":0,"v":"111.22"}}`, tsv3["v"].(string))
 			default:
 				t.Fatalf("unexpected report format: %d", req.ReportFormat)
 			}

--- a/core/services/pipeline/task.median.go
+++ b/core/services/pipeline/task.median.go
@@ -18,6 +18,9 @@ type MedianTask struct {
 	BaseTask      `mapstructure:",squash"`
 	Values        string `json:"values"`
 	AllowedFaults string `json:"allowedFaults"`
+	// Lax when disabled (default) will return an error if there are no values to medianize or if the input includes nil values.
+	// Lax when enabled will return nil with no error if there are no valid values to medianize. If the input includes nil values, they will be excluded from the median calculation and do not count as a fault.
+	Lax string
 }
 
 var _ Task = (*MedianTask)(nil)
@@ -33,24 +36,34 @@ func (t *MedianTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs [
 		decimalValues      DecimalSliceParam
 		allowedFaults      int
 		faults             int
+		lax                BoolParam
 	)
 	err := multierr.Combine(
 		errors.Wrap(ResolveParam(&maybeAllowedFaults, From(t.AllowedFaults)), "allowedFaults"),
 		errors.Wrap(ResolveParam(&valuesAndErrs, From(VarExpr(t.Values, vars), JSONWithVarExprs(t.Values, vars, true), Inputs(inputs))), "values"),
+		errors.Wrap(ResolveParam(&lax, From(NonemptyString(t.Lax), false)), "lax"),
 	)
 	if err != nil {
 		return Result{Error: err}, runInfo
 	}
 
+	// if lax is enabled, filter out nil values
+	// nil values are not included in the fault calculations
+	if bool(lax) {
+		valuesAndErrs, _ = valuesAndErrs.FilterNils()
+	}
+
 	if allowed, isSet := maybeAllowedFaults.Uint64(); isSet {
 		allowedFaults = int(allowed)
 	} else {
-		allowedFaults = len(valuesAndErrs) - 1
+		allowedFaults = max(len(valuesAndErrs)-1, 0)
 	}
 
 	values, faults := valuesAndErrs.FilterErrors()
 	if faults > allowedFaults {
 		return Result{Error: errors.Wrapf(ErrTooManyErrors, "Number of faulty inputs %v to median task > number allowed faults %v", faults, allowedFaults)}, runInfo
+	} else if len(values) == 0 && bool(lax) {
+		return Result{}, runInfo // if lax is enabled, return nil result with no error
 	} else if len(values) == 0 {
 		return Result{Error: errors.Wrap(ErrWrongInputCardinality, "no values to medianize")}, runInfo
 	}

--- a/core/services/pipeline/task_params.go
+++ b/core/services/pipeline/task_params.go
@@ -556,6 +556,19 @@ func (s SliceParam) FilterErrors() (SliceParam, int) {
 	return s2, errs
 }
 
+func (s SliceParam) FilterNils() (SliceParam, int) {
+	var s2 SliceParam
+	var nils int
+	for _, x := range s {
+		if x == nil {
+			nils++
+		} else {
+			s2 = append(s2, x)
+		}
+	}
+	return s2, nils
+}
+
 type DecimalSliceParam []decimal.Decimal
 
 func (s *DecimalSliceParam) UnmarshalPipelineParam(val interface{}) error {

--- a/core/services/pipeline/task_params_test.go
+++ b/core/services/pipeline/task_params_test.go
@@ -601,6 +601,15 @@ func TestSliceParam_FilterErrors(t *testing.T) {
 	require.Equal(t, pipeline.SliceParam{"foo", "baz"}, vals)
 }
 
+func TestSliceParam_FilterNils(t *testing.T) {
+	t.Parallel()
+	testErr := errors.New("bar")
+	s := pipeline.SliceParam{"foo", testErr, nil, "baz", nil}
+	vals, n := s.FilterNils()
+	require.Equal(t, 2, n)
+	require.Equal(t, pipeline.SliceParam{"foo", testErr, "baz"}, vals)
+}
+
 func TestDecimalSliceParam_UnmarshalPipelineParam(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Updates the LLO integration test to use a more realistic bridge response. Rather than relying on there being a single `"result"` value which is not true in practice (result can be null), we can explicitly set the result in the merge. Include tests for parsing and medianizing null/missing `providerIndicatedTimeUnix` fields.
- Handle nil timestamp fields when parsing TimestampedStreamValue
- Add `Lax` option to the `median` pipeline task and `FilterNils()` in order to medianize potentially nil timestamp values