### PR TITLE
feat: add fire drill changeset

### DIFF
--- a/deployment/common/changeset/mcms_firedrill.go
+++ b/deployment/common/changeset/mcms_firedrill.go
@@ -20,6 +20,7 @@ type FireDrillConfig struct {
 	TimelockCfg proposalutils.TimelockConfig
 }
 
+// buildNoOPEVM builds a dummy tx that transfers 0 to the RBACTimelock
 func buildNoOPEVM(e deployment.Environment, selector uint64) (mcmstypes.Transaction, error) {
 	chain, ok := e.Chains[selector]
 	if !ok {
@@ -45,7 +46,7 @@ func buildNoOPEVM(e deployment.Environment, selector uint64) (mcmstypes.Transact
 	return tx, nil
 }
 
-// buildNoOPSolana builds a dummy tx that safely calls getMinDelay on the RBACTimelock
+// buildNoOPSolana builds a dummy tx that calls the memo program
 func buildNoOPSolana() (mcmstypes.Transaction, error) {
 	contractID := solana.MemoProgramID
 	memo := []byte("noop")
@@ -65,6 +66,8 @@ func buildNoOPSolana() (mcmstypes.Transaction, error) {
 
 	return tx, nil
 }
+
+// getMcmAddressFromActionEVM gets the MCM address based on the action type for EVM chains
 func getMcmAddressFromActionEVM(action mcmstypes.TimelockAction, state *state.MCMSWithTimelockState) (string, error) {
 	switch action {
 	case mcmstypes.TimelockActionBypass:
@@ -76,6 +79,8 @@ func getMcmAddressFromActionEVM(action mcmstypes.TimelockAction, state *state.MC
 	}
 	return "", errors.New("invalid action")
 }
+
+// getMcmAddressFromActionSol gets the MCM address based on the action type for Solana chains
 func getMcmAddressFromActionSol(action mcmstypes.TimelockAction, state *state.MCMSWithTimelockStateSolana) (string, error) {
 	switch action {
 	case mcmstypes.TimelockActionBypass:

--- a/deployment/common/changeset/mcms_firedrill.go
+++ b/deployment/common/changeset/mcms_firedrill.go
@@ -1,7 +1,6 @@
 package changeset
 
 import (
-	"errors"
 	"math/big"
 
 	"github.com/gagliardetto/solana-go"
@@ -68,35 +67,6 @@ func buildNoOPSolana() (mcmstypes.Transaction, error) {
 	return tx, nil
 }
 
-// getMcmAddressFromActionEVM gets the MCM address based on the action type for EVM chains
-func getMcmAddressFromActionEVM(action mcmstypes.TimelockAction, state *state.MCMSWithTimelockState) (string, error) {
-	switch action {
-	case mcmstypes.TimelockActionBypass:
-		return state.BypasserMcm.Address().String(), nil
-	case mcmstypes.TimelockActionSchedule:
-		return state.ProposerMcm.Address().String(), nil
-	case mcmstypes.TimelockActionCancel:
-		return state.CancellerMcm.Address().String(), nil
-	}
-	return "", errors.New("invalid action")
-}
-
-// getMcmAddressFromActionSol gets the MCM address based on the action type for Solana chains
-func getMcmAddressFromActionSol(action mcmstypes.TimelockAction, state *state.MCMSWithTimelockStateSolana) (string, error) {
-	switch action {
-	case mcmstypes.TimelockActionBypass:
-		contractID := mcmssolanasdk.ContractAddress(state.McmProgram, mcmssolanasdk.PDASeed(state.BypasserMcmSeed))
-		return contractID, nil
-	case mcmstypes.TimelockActionSchedule:
-		contractID := mcmssolanasdk.ContractAddress(state.McmProgram, mcmssolanasdk.PDASeed(state.ProposerMcmSeed))
-		return contractID, nil
-	case mcmstypes.TimelockActionCancel:
-		contractID := mcmssolanasdk.ContractAddress(state.McmProgram, mcmssolanasdk.PDASeed(state.CancellerMcmSeed))
-		return contractID, nil
-	}
-	return "", errors.New("invalid action")
-}
-
 // MCMSSignFireDrillChangeset creates a changeset for a MCMS signing Fire Drill.
 // It is used to make sure team member can effectively sign proposal and that the execution pipelines are healthy.
 // The changeset will create a NO-OP transaction for each chain selector in the environment and create a proposal for it.
@@ -126,11 +96,11 @@ func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (
 				return deployment.ChangesetOutput{}, err
 			}
 			timelocks[selector] = state.Timelock.Address().String()
-			mcmAddress, err := getMcmAddressFromActionEVM(cfg.TimelockCfg.MCMSAction, state)
+			mcmAddress, err := cfg.TimelockCfg.MCMBasedOnAction(*state)
 			if err != nil {
 				return deployment.ChangesetOutput{}, err
 			}
-			mcmAddresses[selector] = mcmAddress
+			mcmAddresses[selector] = mcmAddress.Address().String()
 			tx, err := buildNoOPEVM(e, selector)
 			if err != nil {
 				return deployment.ChangesetOutput{}, err
@@ -150,7 +120,7 @@ func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (
 				return deployment.ChangesetOutput{}, err
 			}
 			timelocks[selector] = mcmssolanasdk.ContractAddress(state.TimelockProgram, mcmssolanasdk.PDASeed(state.TimelockSeed))
-			mcmAddress, err := getMcmAddressFromActionSol(cfg.TimelockCfg.MCMSAction, state)
+			mcmAddress, err := cfg.TimelockCfg.MCMBasedOnActionSolana(*state)
 			if err != nil {
 				return deployment.ChangesetOutput{}, err
 			}

--- a/deployment/common/changeset/mcms_firedrill.go
+++ b/deployment/common/changeset/mcms_firedrill.go
@@ -1,0 +1,169 @@
+package changeset
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/gagliardetto/solana-go"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/mcms"
+	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
+	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+)
+
+type FireDrillConfig struct {
+	TimelockCfg proposalutils.TimelockConfig
+}
+
+func buildNoOPEVM(e deployment.Environment, selector uint64) (mcmstypes.Transaction, error) {
+	chain, ok := e.Chains[selector]
+	if !ok {
+		return mcmstypes.Transaction{}, nil
+	}
+	addresses, err := e.ExistingAddresses.AddressesForChain(selector)
+	if err != nil {
+		return mcmstypes.Transaction{}, err
+	}
+	state, err := state.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
+	if err != nil {
+		return mcmstypes.Transaction{}, err
+	}
+
+	// No-op: empty call to timelock (will hit the receive() function)
+	tx := mcmsevmsdk.NewTransaction(
+		state.Timelock.Address(),
+		[]byte{},      // empty calldata
+		big.NewInt(0), // no value
+		"FireDrillNoop",
+		nil,
+	)
+	return tx, nil
+}
+
+// buildNoOPSolana builds a dummy tx that safely calls getMinDelay on the RBACTimelock
+func buildNoOPSolana() (mcmstypes.Transaction, error) {
+	contractID := solana.MemoProgramID
+	memo := []byte("noop")
+
+	// Create transaction
+	tx, err := mcmssolanasdk.NewTransaction(
+		contractID.String(),
+		memo,
+		big.NewInt(0),           // No lamports
+		[]*solana.AccountMeta{}, // No account metas at the transaction level either
+		"Memo",
+		[]string{}, // Attach the no-op instruction
+	)
+	if err != nil {
+		return mcmstypes.Transaction{}, err
+	}
+
+	return tx, nil
+}
+func getMcmAddressFromActionEVM(action mcmstypes.TimelockAction, state *state.MCMSWithTimelockState) (string, error) {
+	switch action {
+	case mcmstypes.TimelockActionBypass:
+		return state.BypasserMcm.Address().String(), nil
+	case mcmstypes.TimelockActionSchedule:
+		return state.ProposerMcm.Address().String(), nil
+	case mcmstypes.TimelockActionCancel:
+		return state.CancellerMcm.Address().String(), nil
+	}
+	return "", errors.New("invalid action")
+}
+func getMcmAddressFromActionSol(action mcmstypes.TimelockAction, state *state.MCMSWithTimelockStateSolana) (string, error) {
+	switch action {
+	case mcmstypes.TimelockActionBypass:
+		contractID := mcmssolanasdk.ContractAddress(state.McmProgram, mcmssolanasdk.PDASeed(state.BypasserMcmSeed))
+		return contractID, nil
+	case mcmstypes.TimelockActionSchedule:
+		contractID := mcmssolanasdk.ContractAddress(state.McmProgram, mcmssolanasdk.PDASeed(state.ProposerMcmSeed))
+		return contractID, nil
+	case mcmstypes.TimelockActionCancel:
+		contractID := mcmssolanasdk.ContractAddress(state.McmProgram, mcmssolanasdk.PDASeed(state.CancellerMcmSeed))
+		return contractID, nil
+	}
+	return "", errors.New("invalid action")
+}
+
+// MCMSSignFireDrillChangeset creates a changeset for a MCMS signing Fire Drill.
+// It is used to make sure team member can effectively sign proposal and that the execution pipelines are healthy.
+// The changeset will create a NO-OP transaction for each chain selector in the environment and create a proposal for it.
+func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (deployment.ChangesetOutput, error) {
+	allSelectors := e.AllChainSelectors()
+	operations := make([]mcmstypes.BatchOperation, 0, len(allSelectors))
+	timelocks := map[uint64]string{}
+	mcmAddresses := map[uint64]string{}
+	inspectors, err := proposalutils.McmsInspectors(e)
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+	for _, selector := range allSelectors {
+		family, err := chainsel.GetSelectorFamily(selector)
+		if err != nil {
+			return deployment.ChangesetOutput{}, err
+		}
+		switch family {
+		case chainsel.FamilyEVM:
+			addresses, err := e.ExistingAddresses.AddressesForChain(selector)
+			if err != nil {
+				return deployment.ChangesetOutput{}, err
+			}
+			state, err := state.MaybeLoadMCMSWithTimelockChainState(e.Chains[selector], addresses)
+			if err != nil {
+				return deployment.ChangesetOutput{}, err
+			}
+			timelocks[selector] = state.Timelock.Address().String()
+			mcmAddress, err := getMcmAddressFromActionEVM(cfg.TimelockCfg.MCMSAction, state)
+			mcmAddresses[selector] = mcmAddress
+			tx, err := buildNoOPEVM(e, selector)
+			if err != nil {
+				return deployment.ChangesetOutput{}, err
+			}
+			operations = append(operations, mcmstypes.BatchOperation{
+				ChainSelector: mcmstypes.ChainSelector(selector),
+				Transactions:  []mcmstypes.Transaction{tx},
+			})
+		case chainsel.FamilySolana:
+			addresses, err := e.ExistingAddresses.AddressesForChain(selector)
+			if err != nil {
+				return deployment.ChangesetOutput{}, err
+			}
+			state, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(e.SolChains[selector], addresses)
+			if err != nil {
+				return deployment.ChangesetOutput{}, err
+			}
+			timelocks[selector] = mcmssolanasdk.ContractAddress(state.TimelockProgram, mcmssolanasdk.PDASeed(state.TimelockSeed))
+			mcmAddress, err := getMcmAddressFromActionSol(cfg.TimelockCfg.MCMSAction, state)
+			mcmAddresses[selector] = mcmAddress
+			tx, err := buildNoOPSolana()
+			if err != nil {
+				return deployment.ChangesetOutput{}, err
+			}
+			operations = append(operations, mcmstypes.BatchOperation{
+				ChainSelector: mcmstypes.ChainSelector(selector),
+				Transactions:  []mcmstypes.Transaction{tx},
+			})
+		}
+	}
+	proposal, err := proposalutils.BuildProposalFromBatchesV2(
+		e,
+		timelocks,
+		mcmAddresses,
+		inspectors,
+		operations,
+		"firedrill proposal",
+		cfg.TimelockCfg)
+	if err != nil {
+		return deployment.ChangesetOutput{}, err
+	}
+
+	return deployment.ChangesetOutput{
+		MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
+	}, nil
+}

--- a/deployment/common/changeset/mcms_firedrill.go
+++ b/deployment/common/changeset/mcms_firedrill.go
@@ -26,7 +26,7 @@ func buildNoOPEVM(e deployment.Environment, selector uint64) (mcmstypes.Transact
 	if !ok {
 		return mcmstypes.Transaction{}, nil
 	}
-	//nolint
+	//nolint:staticcheck
 	addresses, err := e.ExistingAddresses.AddressesForChain(selector)
 	if err != nil {
 		return mcmstypes.Transaction{}, err
@@ -116,7 +116,7 @@ func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (
 		}
 		switch family {
 		case chainsel.FamilyEVM:
-			//nolint
+			//nolint:staticcheck
 			addresses, err := e.ExistingAddresses.AddressesForChain(selector)
 			if err != nil {
 				return deployment.ChangesetOutput{}, err
@@ -140,7 +140,7 @@ func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (
 				Transactions:  []mcmstypes.Transaction{tx},
 			})
 		case chainsel.FamilySolana:
-			//nolint
+			//nolint:staticcheck
 			addresses, err := e.ExistingAddresses.AddressesForChain(selector)
 			if err != nil {
 				return deployment.ChangesetOutput{}, err

--- a/deployment/common/changeset/mcms_firedrill.go
+++ b/deployment/common/changeset/mcms_firedrill.go
@@ -26,7 +26,7 @@ func buildNoOPEVM(e deployment.Environment, selector uint64) (mcmstypes.Transact
 	if !ok {
 		return mcmstypes.Transaction{}, nil
 	}
-	//nolint:staticcheck
+	//nolint:staticcheck  // need to migrate CCIP changesets so we can do it alongside this too
 	addresses, err := e.ExistingAddresses.AddressesForChain(selector)
 	if err != nil {
 		return mcmstypes.Transaction{}, err
@@ -116,7 +116,7 @@ func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (
 		}
 		switch family {
 		case chainsel.FamilyEVM:
-			//nolint:staticcheck
+			//nolint:staticcheck  // need to migrate CCIP changesets so we can do it alongside this too
 			addresses, err := e.ExistingAddresses.AddressesForChain(selector)
 			if err != nil {
 				return deployment.ChangesetOutput{}, err
@@ -140,7 +140,7 @@ func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (
 				Transactions:  []mcmstypes.Transaction{tx},
 			})
 		case chainsel.FamilySolana:
-			//nolint:staticcheck
+			//nolint:staticcheck // need to migrate CCIP changesets so we can do it alongside this too
 			addresses, err := e.ExistingAddresses.AddressesForChain(selector)
 			if err != nil {
 				return deployment.ChangesetOutput{}, err

--- a/deployment/common/changeset/mcms_firedrill.go
+++ b/deployment/common/changeset/mcms_firedrill.go
@@ -26,6 +26,7 @@ func buildNoOPEVM(e deployment.Environment, selector uint64) (mcmstypes.Transact
 	if !ok {
 		return mcmstypes.Transaction{}, nil
 	}
+	//nolint
 	addresses, err := e.ExistingAddresses.AddressesForChain(selector)
 	if err != nil {
 		return mcmstypes.Transaction{}, err
@@ -115,6 +116,7 @@ func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (
 		}
 		switch family {
 		case chainsel.FamilyEVM:
+			//nolint
 			addresses, err := e.ExistingAddresses.AddressesForChain(selector)
 			if err != nil {
 				return deployment.ChangesetOutput{}, err
@@ -125,6 +127,9 @@ func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (
 			}
 			timelocks[selector] = state.Timelock.Address().String()
 			mcmAddress, err := getMcmAddressFromActionEVM(cfg.TimelockCfg.MCMSAction, state)
+			if err != nil {
+				return deployment.ChangesetOutput{}, err
+			}
 			mcmAddresses[selector] = mcmAddress
 			tx, err := buildNoOPEVM(e, selector)
 			if err != nil {
@@ -135,6 +140,7 @@ func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (
 				Transactions:  []mcmstypes.Transaction{tx},
 			})
 		case chainsel.FamilySolana:
+			//nolint
 			addresses, err := e.ExistingAddresses.AddressesForChain(selector)
 			if err != nil {
 				return deployment.ChangesetOutput{}, err
@@ -145,6 +151,9 @@ func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (
 			}
 			timelocks[selector] = mcmssolanasdk.ContractAddress(state.TimelockProgram, mcmssolanasdk.PDASeed(state.TimelockSeed))
 			mcmAddress, err := getMcmAddressFromActionSol(cfg.TimelockCfg.MCMSAction, state)
+			if err != nil {
+				return deployment.ChangesetOutput{}, err
+			}
 			mcmAddresses[selector] = mcmAddress
 			tx, err := buildNoOPSolana()
 			if err != nil {

--- a/deployment/common/changeset/mcms_firedrill_test.go
+++ b/deployment/common/changeset/mcms_firedrill_test.go
@@ -1,0 +1,78 @@
+package changeset_test
+
+import (
+	"testing"
+
+	mcmsTypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+// setupFiredrillTestEnv deploys all required contracts for the firedrill proposal execution
+func setupFiredrillTestEnv(t *testing.T) deployment.Environment {
+	lggr := logger.TestLogger(t)
+	cfg := memory.MemoryEnvironmentConfig{
+		Chains:    2,
+		SolChains: 1,
+	}
+	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+	chainSelector := env.AllChainSelectors()[0]
+	chainSelector2 := env.AllChainSelectors()[1]
+	chainSelectorSolana := env.AllChainSelectorsSolana()[0]
+
+	commonchangeset.SetPreloadedSolanaAddresses(t, env, chainSelectorSolana)
+	config := proposalutils.SingleGroupTimelockConfigV2(t)
+	// Deploy MCMS and Timelock
+	env, err := commonchangeset.Apply(t, env, nil,
+		commonchangeset.Configure(
+			deployment.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
+			map[uint64]commontypes.MCMSWithTimelockConfigV2{
+				chainSelector:       config,
+				chainSelector2:      config,
+				chainSelectorSolana: config,
+			},
+		),
+	)
+	require.NoError(t, err)
+	return env
+}
+
+func TestMCMSSignFireDrillChangeset(t *testing.T) {
+	t.Parallel()
+	env := setupFiredrillTestEnv(t)
+	// Add the timelock as a signer to check state changes
+	for _, tc := range []struct {
+		name       string
+		changeSets func() []commonchangeset.ConfiguredChangeSet
+	}{
+		{
+			name: "MCMS Firedrill execution",
+			changeSets: func() []commonchangeset.ConfiguredChangeSet {
+				return []commonchangeset.ConfiguredChangeSet{
+					commonchangeset.Configure(
+						deployment.CreateLegacyChangeSet(commonchangeset.MCMSSignFireDrillChangeset),
+						commonchangeset.FireDrillConfig{
+							TimelockCfg: proposalutils.TimelockConfig{
+								MCMSAction: mcmsTypes.TimelockActionBypass,
+							},
+						},
+					),
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changesetsToApply := tc.changeSets()
+			_, _, err := commonchangeset.ApplyChangesetsV2(t, env, changesetsToApply)
+			require.NoError(t, err)
+
+		})
+	}
+}

--- a/deployment/common/changeset/mcms_firedrill_test.go
+++ b/deployment/common/changeset/mcms_firedrill_test.go
@@ -72,7 +72,6 @@ func TestMCMSSignFireDrillChangeset(t *testing.T) {
 			changesetsToApply := tc.changeSets()
 			_, _, err := commonchangeset.ApplyChangesetsV2(t, env, changesetsToApply)
 			require.NoError(t, err)
-
 		})
 	}
 }

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -8,6 +8,7 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	mcmsTypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -235,6 +236,11 @@ func ApplyChangesetsV2(t *testing.T, e deployment.Environment, changesetApplicat
 				err = proposalutils.ExecuteMCMSProposalV2(t, currentEnv, p)
 				if err != nil {
 					return deployment.Environment{}, nil, err
+				}
+				if prop.Action != mcmsTypes.TimelockActionSchedule {
+					// We don't need to execute the proposal if it's not a schedule action
+					// because the proposal is already executed in the previous step.
+					return currentEnv, outputs, nil
 				}
 				err = proposalutils.ExecuteMCMSTimelockProposalV2(t, currentEnv, &prop)
 				if err != nil {

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -31,6 +31,26 @@ type TimelockConfig struct {
 	OverrideRoot bool                 `json:"overrideRoot"` // if true, override the previous root with the new one.
 }
 
+func (tc *TimelockConfig) MCMBasedOnActionSolana(s state.MCMSWithTimelockStateSolana) (string, error) {
+	// if MCMSAction is not set, default to timelock.Schedule, this is to ensure no breaking changes for existing code
+	if tc.MCMSAction == "" {
+		tc.MCMSAction = types.TimelockActionSchedule
+	}
+	switch tc.MCMSAction {
+	case types.TimelockActionSchedule:
+		contractID := mcmssolanasdk.ContractAddress(s.McmProgram, mcmssolanasdk.PDASeed(s.ProposerMcmSeed))
+		return contractID, nil
+	case types.TimelockActionCancel:
+		contractID := mcmssolanasdk.ContractAddress(s.McmProgram, mcmssolanasdk.PDASeed(s.CancellerMcmSeed))
+		return contractID, nil
+	case types.TimelockActionBypass:
+		contractID := mcmssolanasdk.ContractAddress(s.McmProgram, mcmssolanasdk.PDASeed(s.BypasserMcmSeed))
+		return contractID, nil
+	default:
+		return "", errors.New("invalid MCMS action")
+	}
+}
+
 func (tc *TimelockConfig) MCMBasedOnAction(s state.MCMSWithTimelockState) (*gethwrappers.ManyChainMultiSig, error) {
 	// if MCMSAction is not set, default to timelock.Schedule, this is to ensure no breaking changes for existing code
 	if tc.MCMSAction == "" {


### PR DESCRIPTION
This PR adds a changeset to generate firedrill proposals so teams can run exercises to test their signing tools and the health of the execution pipelines. The changeset generates a proposal for each chain on the addressbook with a NO-OP transaction. For now only solana, and EVM chain families are supported.