### PR TITLE
Update the capabilities dispatcher to log a rate limit issue as an error instead of a debug

### DIFF
--- a/.changeset/famous-starfishes-return.md
+++ b/.changeset/famous-starfishes-return.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#bugfix Update the capabilities dispatcher to log a rate limit issue as an error instead of a debug message

--- a/core/capabilities/remote/dispatcher.go
+++ b/core/capabilities/remote/dispatcher.go
@@ -182,7 +182,7 @@ func (d *dispatcher) receive() {
 			return
 		case msg := <-recvCh:
 			if !d.rateLimiter.Allow(msg.Sender.String()) {
-				d.lggr.Debugw("rate limit exceeded, dropping message", "sender", msg.Sender)
+				d.lggr.Errorw("rate limit exceeded, dropping message", "sender", msg.Sender)
 				continue
 			}
 			body, err := ValidateMessage(msg, d.peerID)


### PR DESCRIPTION
The rate-limited workflow eventually breaks the consensus and halts the execution. The message should be of an error level not a debug one
[CRE-397](https://smartcontract-it.atlassian.net/browse/CRE-397)

[CRE-397]: https://smartcontract-it.atlassian.net/browse/CRE-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ