### PR TITLE
TXStore Benchmarks & Optimizations

### DIFF
--- a/core/chains/evm/txmgr/evm_tx_store.go
+++ b/core/chains/evm/txmgr/evm_tx_store.go
@@ -1938,15 +1938,19 @@ func (o *evmTxStore) FindAttemptsRequiringReceiptFetch(ctx context.Context, chai
 	*/
 
 	optimized := `
-				SELECT a.* FROM evm.tx_attempts a
-				JOIN evm.txes t ON t.ID = a.eth_tx_id
-				LEFT JOIN evm.receipts r ON r.tx_hash = a.hash
-				WHERE a.state = 'broadcast'
-		  			AND t.nonce IS NOT NULL
-		  			AND t.state IN ('confirmed', 'confirmed_missing_receipt', 'fatal_error')
-		  			AND t.evm_chain_id = $1
-		  			AND r.ID IS NULL
-				ORDER BY t.nonce ASC, a.gas_price DESC, a.gas_tip_cap DESC`
+		SELECT a.*
+		FROM evm.tx_attempts a
+		JOIN evm.txes t ON t.ID = a.eth_tx_id
+		WHERE a.state = 'broadcast'
+  			AND t.nonce IS NOT NULL
+  			AND t.state IN ('confirmed', 'confirmed_missing_receipt', 'fatal_error')
+  			AND t.evm_chain_id = $1
+  			AND NOT EXISTS (
+    		SELECT 1
+    		FROM evm.receipts r
+    		JOIN evm.tx_attempts a2 ON r.tx_hash = a2.hash
+    		WHERE a2.eth_tx_id = t.ID)
+		ORDER BY t.nonce ASC, a.gas_price DESC, a.gas_tip_cap DESC`
 
 	err = o.q.SelectContext(ctx, &dbTxAttempts, optimized, chainID.String())
 	attempts = dbEthTxAttemptsToEthTxAttempts(dbTxAttempts)

--- a/core/chains/evm/txmgr/evm_tx_store.go
+++ b/core/chains/evm/txmgr/evm_tx_store.go
@@ -1923,23 +1923,8 @@ func (o *evmTxStore) FindAttemptsRequiringReceiptFetch(ctx context.Context, chai
 	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbTxAttempts []DbEthTxAttempt
-	/*
-		query := `
-			SELECT evm.tx_attempts.* FROM evm.tx_attempts
-			JOIN evm.txes ON evm.txes.ID = evm.tx_attempts.eth_tx_id
-			WHERE evm.tx_attempts.state = 'broadcast' AND evm.txes.nonce IS NOT NULL AND evm.txes.state IN ('confirmed', 'confirmed_missing_receipt', 'fatal_error') AND evm.txes.evm_chain_id = $1 AND evm.txes.ID NOT IN (
-				SELECT DISTINCT evm.txes.ID FROM evm.txes
-				JOIN evm.tx_attempts ON evm.tx_attempts.eth_tx_id = evm.txes.ID
-				JOIN evm.receipts ON evm.receipts.tx_hash = evm.tx_attempts.hash
-				WHERE evm.txes.evm_chain_id = $1 AND evm.txes.state IN ('confirmed', 'confirmed_missing_receipt', 'fatal_error') AND evm.receipts.ID IS NOT NULL
-			)
-			ORDER BY evm.txes.nonce ASC, evm.tx_attempts.gas_price DESC, evm.tx_attempts.gas_tip_cap DESC
-		`
-	*/
-
-	optimized := `
-		SELECT a.*
-		FROM evm.tx_attempts a
+	query := `
+		SELECT a.* FROM evm.tx_attempts a
 		JOIN evm.txes t ON t.ID = a.eth_tx_id
 		WHERE a.state = 'broadcast'
   			AND t.nonce IS NOT NULL
@@ -1952,7 +1937,7 @@ func (o *evmTxStore) FindAttemptsRequiringReceiptFetch(ctx context.Context, chai
     		WHERE a2.eth_tx_id = t.ID)
 		ORDER BY t.nonce ASC, a.gas_price DESC, a.gas_tip_cap DESC`
 
-	err = o.q.SelectContext(ctx, &dbTxAttempts, optimized, chainID.String())
+	err = o.q.SelectContext(ctx, &dbTxAttempts, query, chainID.String())
 	attempts = dbEthTxAttemptsToEthTxAttempts(dbTxAttempts)
 	return attempts, err
 }

--- a/core/chains/evm/txmgr/evm_tx_store.go
+++ b/core/chains/evm/txmgr/evm_tx_store.go
@@ -1923,18 +1923,32 @@ func (o *evmTxStore) FindAttemptsRequiringReceiptFetch(ctx context.Context, chai
 	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbTxAttempts []DbEthTxAttempt
-	query := `
-		SELECT evm.tx_attempts.* FROM evm.tx_attempts
-		JOIN evm.txes ON evm.txes.ID = evm.tx_attempts.eth_tx_id
-		WHERE evm.tx_attempts.state = 'broadcast' AND evm.txes.nonce IS NOT NULL AND evm.txes.state IN ('confirmed', 'confirmed_missing_receipt', 'fatal_error') AND evm.txes.evm_chain_id = $1 AND evm.txes.ID NOT IN (
-			SELECT DISTINCT evm.txes.ID FROM evm.txes
-			JOIN evm.tx_attempts ON evm.tx_attempts.eth_tx_id = evm.txes.ID
-			JOIN evm.receipts ON evm.receipts.tx_hash = evm.tx_attempts.hash
-			WHERE evm.txes.evm_chain_id = $1 AND evm.txes.state IN ('confirmed', 'confirmed_missing_receipt', 'fatal_error') AND evm.receipts.ID IS NOT NULL
-		)
-		ORDER BY evm.txes.nonce ASC, evm.tx_attempts.gas_price DESC, evm.tx_attempts.gas_tip_cap DESC
-	`
-	err = o.q.SelectContext(ctx, &dbTxAttempts, query, chainID.String())
+	/*
+		query := `
+			SELECT evm.tx_attempts.* FROM evm.tx_attempts
+			JOIN evm.txes ON evm.txes.ID = evm.tx_attempts.eth_tx_id
+			WHERE evm.tx_attempts.state = 'broadcast' AND evm.txes.nonce IS NOT NULL AND evm.txes.state IN ('confirmed', 'confirmed_missing_receipt', 'fatal_error') AND evm.txes.evm_chain_id = $1 AND evm.txes.ID NOT IN (
+				SELECT DISTINCT evm.txes.ID FROM evm.txes
+				JOIN evm.tx_attempts ON evm.tx_attempts.eth_tx_id = evm.txes.ID
+				JOIN evm.receipts ON evm.receipts.tx_hash = evm.tx_attempts.hash
+				WHERE evm.txes.evm_chain_id = $1 AND evm.txes.state IN ('confirmed', 'confirmed_missing_receipt', 'fatal_error') AND evm.receipts.ID IS NOT NULL
+			)
+			ORDER BY evm.txes.nonce ASC, evm.tx_attempts.gas_price DESC, evm.tx_attempts.gas_tip_cap DESC
+		`
+	*/
+
+	optimized := `
+				SELECT a.* FROM evm.tx_attempts a
+				JOIN evm.txes t ON t.ID = a.eth_tx_id
+				LEFT JOIN evm.receipts r ON r.tx_hash = a.hash
+				WHERE a.state = 'broadcast'
+		  			AND t.nonce IS NOT NULL
+		  			AND t.state IN ('confirmed', 'confirmed_missing_receipt', 'fatal_error')
+		  			AND t.evm_chain_id = $1
+		  			AND r.ID IS NULL
+				ORDER BY t.nonce ASC, a.gas_price DESC, a.gas_tip_cap DESC`
+
+	err = o.q.SelectContext(ctx, &dbTxAttempts, optimized, chainID.String())
 	attempts = dbEthTxAttemptsToEthTxAttempts(dbTxAttempts)
 	return attempts, err
 }

--- a/core/chains/evm/txmgr/evm_tx_store_benchmark_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_benchmark_test.go
@@ -24,16 +24,19 @@ func NewTestTxStore(t testing.TB, db *sqlx.DB) txmgr.TestEvmTxStore {
 	return txmgr.NewTxStore(db, logger.Test(t))
 }
 
-var benchmarkSizes = map[string]int{
-	"Factor_1":    1,
-	"Factor_10":   10,
-	"Factor_100":  100,
-	"Factor_1000": 1000,
+var benchmarkSizes = []struct {
+	name string
+	size int
+}{
+	{"Factor_1", 1},
+	{"Factor_10", 10},
+	{"Factor_100", 100},
+	{"Factor_1000", 1000},
 }
 
-func BenchmarkCreateTransactionTxStore(b *testing.B) {
-	for name, size := range benchmarkSizes {
-		b.Run(name, func(b *testing.B) {
+func BenchmarkTxStoreCreateTransaction(b *testing.B) {
+	for _, bs := range benchmarkSizes {
+		b.Run(bs.name, func(b *testing.B) {
 			db := testutils.NewSqlxDB(b)
 			txStore := newTxStore(b, db)
 			kst := cltest.NewKeyStore(b, db)
@@ -46,7 +49,7 @@ func BenchmarkCreateTransactionTxStore(b *testing.B) {
 			strategy := newMockTxStrategy(b)
 			strategy.On("Subject").Return(uuid.NullUUID{UUID: subject, Valid: true})
 
-			for i := 0; i < size; i++ {
+			for i := 0; i < bs.size; i++ {
 				toAddress := testutils.NewAddress()
 				_, err := txStore.CreateTransaction(tests.Context(b), txmgr.TxRequest{
 					FromAddress:    fromAddress,
@@ -77,9 +80,9 @@ func BenchmarkCreateTransactionTxStore(b *testing.B) {
 	}
 }
 
-func BenchmarkFindAttemptsRequiringReceiptFetch(b *testing.B) {
-	for name, size := range benchmarkSizes {
-		b.Run(name, func(b *testing.B) {
+func BenchmarkTxStoreFindAttemptsRequiringReceiptFetch(b *testing.B) {
+	for _, bs := range benchmarkSizes {
+		b.Run(bs.name, func(b *testing.B) {
 			db := testutils.NewSqlxDB(b)
 			txStore := NewTestTxStore(b, db)
 			ctx := tests.Context(b)
@@ -87,15 +90,18 @@ func BenchmarkFindAttemptsRequiringReceiptFetch(b *testing.B) {
 			kst := cltest.NewKeyStore(b, db)
 			_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
 
-			for i := 0; i < size; i++ {
-				nonce := evmtypes.Nonce(i * 5) // Generate unique nonces each iteration
+			var nonce = evmtypes.Nonce(0)
+			for i := 0; i < bs.size; i++ {
 				// Transactions whose attempts should not be picked up for receipt fetch
 				mustInsertFatalErrorEthTx(b, txStore, fromAddress)
 				mustInsertUnstartedTx(b, txStore, fromAddress)
-				mustInsertUnconfirmedEthTxWithAttemptState(b, txStore, nonce.Int64()+3, fromAddress, txmgrtypes.TxAttemptBroadcast)
-				mustInsertConfirmedEthTxWithReceipt(b, txStore, fromAddress, nonce.Int64()+2, blockNum)
+				mustInsertUnconfirmedEthTxWithAttemptState(b, txStore, nonce.Int64(), fromAddress, txmgrtypes.TxAttemptBroadcast)
+				nonce++
+				mustInsertConfirmedEthTxWithReceipt(b, txStore, fromAddress, nonce.Int64(), blockNum)
+				nonce++
 				// Terminally stuck transaction with receipt should NOT be picked up for receipt fetch
-				stuckTx := mustInsertTerminallyStuckTxWithAttempt(b, txStore, fromAddress, nonce.Int64()+1, blockNum)
+				stuckTx := mustInsertTerminallyStuckTxWithAttempt(b, txStore, fromAddress, nonce.Int64(), blockNum)
+				nonce++
 				mustInsertEthReceipt(b, txStore, blockNum, utils.NewHash(), stuckTx.TxAttempts[0].Hash)
 				// Fatal transactions with nil nonce and stored attempts should NOT be picked up for receipt fetch
 				fatalTx := mustInsertFatalErrorEthTx(b, txStore, fromAddress)
@@ -103,6 +109,7 @@ func BenchmarkFindAttemptsRequiringReceiptFetch(b *testing.B) {
 				require.NoError(b, txStore.InsertTxAttempt(ctx, &attempt))
 				// Confirmed transaction without receipt should be picked up for receipt fetch
 				confirmedTx := mustInsertConfirmedEthTx(b, txStore, nonce.Int64(), fromAddress)
+				nonce++
 				attempt = newBroadcastLegacyEthTxAttempt(b, confirmedTx.ID)
 				require.NoError(b, txStore.InsertTxAttempt(ctx, &attempt))
 			}
@@ -113,15 +120,15 @@ func BenchmarkFindAttemptsRequiringReceiptFetch(b *testing.B) {
 				attempts, err := txStore.FindAttemptsRequiringReceiptFetch(ctx, testutils.FixtureChainID)
 				b.StopTimer()
 				require.NoError(b, err)
-				require.Equal(b, size, len(attempts))
+				require.Equal(b, bs.size, len(attempts))
 			}
 		})
 	}
 }
 
 func BenchmarkFindTxesByIDs(b *testing.B) {
-	for name, size := range benchmarkSizes {
-		b.Run(name, func(b *testing.B) {
+	for _, bs := range benchmarkSizes {
+		b.Run(bs.name, func(b *testing.B) {
 			db := testutils.NewSqlxDB(b)
 			txStore := NewTestTxStore(b, db)
 			ctx := tests.Context(b)
@@ -129,7 +136,7 @@ func BenchmarkFindTxesByIDs(b *testing.B) {
 			_, fromAddress := cltest.MustInsertRandomKeyReturningState(b, ethKeyStore)
 
 			var etxIDs []int64
-			for i := 0; i < size; i++ {
+			for i := 0; i < bs.size; i++ {
 				etx := mustInsertUnconfirmedEthTxWithAttemptState(b, txStore, int64(i), fromAddress, txmgrtypes.TxAttemptBroadcast)
 				etxIDs = append(etxIDs, etx.ID)
 			}
@@ -147,15 +154,15 @@ func BenchmarkFindTxesByIDs(b *testing.B) {
 }
 
 func BenchmarkFindConfirmedTxesReceipts(b *testing.B) {
-	for name, size := range benchmarkSizes {
-		b.Run(name, func(b *testing.B) {
+	for _, bs := range benchmarkSizes {
+		b.Run(bs.name, func(b *testing.B) {
 			db := testutils.NewSqlxDB(b)
 			txStore := NewTestTxStore(b, db)
 			finalizedBlockNum := int64(100)
 			kst := cltest.NewKeyStore(b, db)
 			_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
 
-			for i := 0; i < size; i++ {
+			for i := 0; i < bs.size; i++ {
 				mustInsertConfirmedEthTxWithReceipt(b, txStore, fromAddress, int64(i), finalizedBlockNum)
 			}
 
@@ -165,7 +172,7 @@ func BenchmarkFindConfirmedTxesReceipts(b *testing.B) {
 				receipts, err := txStore.FindConfirmedTxesReceipts(tests.Context(b), finalizedBlockNum, &cltest.FixtureChainID)
 				b.StopTimer()
 				require.NoError(b, err)
-				require.Len(b, receipts, size)
+				require.Len(b, receipts, bs.size)
 			}
 		})
 	}

--- a/core/chains/evm/txmgr/evm_tx_store_benchmark_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_benchmark_test.go
@@ -1,7 +1,6 @@
 package txmgr_test
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/google/uuid"
@@ -11,161 +10,150 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
+	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
-
-func BenchmarkCreateTransactionTxStore(b *testing.B) {
-	db := testutils.NewSqlxDB(b)
-	txStore := newTxStore(b, db)
-	kst := cltest.NewKeyStore(b, db)
-
-	_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
-	toAddress := testutils.NewAddress()
-	gasLimit := uint64(1000)
-	payload := []byte{1, 2, 3}
-
-	ethClient := clienttest.NewClientWithDefaultChainID(b)
-
-	// queue under capacity inserts eth_tx
-	subject := uuid.New()
-	strategy := newMockTxStrategy(b)
-	strategy.On("Subject").Return(uuid.NullUUID{UUID: subject, Valid: true})
-
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		txCount := n + 1
-		b.StartTimer()
-		etx, err := txStore.CreateTransaction(tests.Context(b), txmgr.TxRequest{
-			FromAddress:    fromAddress,
-			ToAddress:      toAddress,
-			EncodedPayload: payload,
-			FeeLimit:       gasLimit,
-			Meta:           nil,
-			Strategy:       strategy,
-		}, ethClient.ConfiguredChainID())
-		b.StopTimer()
-
-		assert.NoError(b, err)
-		assert.Greater(b, etx.ID, int64(0))
-		assert.Equal(b, etx.State, txmgrcommon.TxUnstarted)
-		assert.Equal(b, gasLimit, etx.FeeLimit)
-		assert.Equal(b, fromAddress, etx.FromAddress)
-		assert.Equal(b, toAddress, etx.ToAddress)
-		assert.Equal(b, payload, etx.EncodedPayload)
-		assert.Equal(b, big.Int(assets.NewEthValue(0)), etx.Value)
-		assert.Equal(b, subject, etx.Subject.UUID)
-
-		cltest.AssertCount(b, db, "evm.txes", int64(txCount))
-
-		var dbEthTx txmgr.DbEthTx
-		require.NoError(b, db.Get(&dbEthTx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))
-
-		assert.Equal(b, dbEthTx.State, txmgrcommon.TxUnstarted)
-		assert.Equal(b, gasLimit, dbEthTx.GasLimit)
-		assert.Equal(b, fromAddress, dbEthTx.FromAddress)
-		assert.Equal(b, toAddress, dbEthTx.ToAddress)
-		assert.Equal(b, payload, dbEthTx.EncodedPayload)
-		assert.Equal(b, assets.NewEthValue(0), dbEthTx.Value)
-		assert.Equal(b, subject, dbEthTx.Subject.UUID)
-	}
-}
 
 func NewTestTxStore(t testing.TB, db *sqlx.DB) txmgr.TestEvmTxStore {
 	t.Helper()
 	return txmgr.NewTxStore(db, logger.Test(t))
 }
 
+var benchmarkSizes = map[string]int{
+	"Factor_1":    1,
+	"Factor_10":   10,
+	"Factor_100":  100,
+	"Factor_1000": 1000,
+}
+
+func BenchmarkCreateTransactionTxStore(b *testing.B) {
+	for name, size := range benchmarkSizes {
+		b.Run(name, func(b *testing.B) {
+			db := testutils.NewSqlxDB(b)
+			txStore := newTxStore(b, db)
+			kst := cltest.NewKeyStore(b, db)
+			_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
+			toAddress := testutils.NewAddress()
+			gasLimit := uint64(1000)
+			payload := []byte{1, 2, 3}
+			ethClient := clienttest.NewClientWithDefaultChainID(b)
+
+			subject := uuid.New()
+			strategy := newMockTxStrategy(b)
+			strategy.On("Subject").Return(uuid.NullUUID{UUID: subject, Valid: true})
+
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				for i := 0; i < size; i++ {
+					_, err := txStore.CreateTransaction(tests.Context(b), txmgr.TxRequest{
+						FromAddress:    fromAddress,
+						ToAddress:      toAddress,
+						EncodedPayload: payload,
+						FeeLimit:       gasLimit,
+						Strategy:       strategy,
+					}, ethClient.ConfiguredChainID())
+					assert.NoError(b, err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkFindAttemptsRequiringReceiptFetch(b *testing.B) {
-	db := testutils.NewSqlxDB(b)
-	txStore := NewTestTxStore(b, db)
-	ctx := tests.Context(b)
+	for name, size := range benchmarkSizes {
+		b.Run(name, func(b *testing.B) {
+			db := testutils.NewSqlxDB(b)
+			txStore := NewTestTxStore(b, db)
+			ctx := tests.Context(b)
+			blockNum := int64(100)
+			kst := cltest.NewKeyStore(b, db)
+			_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
 
-	blockNum := int64(100)
+			for i := 0; i < size; i++ {
+				nonce := evmtypes.Nonce(i * 5) // Generate unique nonces each iteration
+				// Transactions whose attempts should not be picked up for receipt fetch
+				mustInsertFatalErrorEthTx(b, txStore, fromAddress)
+				mustInsertUnstartedTx(b, txStore, fromAddress)
+				mustInsertUnconfirmedEthTxWithAttemptState(b, txStore, nonce.Int64()+3, fromAddress, txmgrtypes.TxAttemptBroadcast)
+				mustInsertConfirmedEthTxWithReceipt(b, txStore, fromAddress, nonce.Int64()+2, blockNum)
+				// Terminally stuck transaction with receipt should NOT be picked up for receipt fetch
+				stuckTx := mustInsertTerminallyStuckTxWithAttempt(b, txStore, fromAddress, nonce.Int64()+1, blockNum)
+				mustInsertEthReceipt(b, txStore, blockNum, utils.NewHash(), stuckTx.TxAttempts[0].Hash)
+				// Fatal transactions with nil nonce and stored attempts should NOT be picked up for receipt fetch
+				fatalTx := mustInsertFatalErrorEthTx(b, txStore, fromAddress)
+				attempt := newBroadcastLegacyEthTxAttempt(b, fatalTx.ID)
+				require.NoError(b, txStore.InsertTxAttempt(ctx, &attempt))
+				// Confirmed transaction without receipt should be picked up for receipt fetch
+				confirmedTx := mustInsertConfirmedEthTx(b, txStore, nonce.Int64(), fromAddress)
+				attempt = newBroadcastLegacyEthTxAttempt(b, confirmedTx.ID)
+				require.NoError(b, txStore.InsertTxAttempt(ctx, &attempt))
+			}
 
-	kst := cltest.NewKeyStore(b, db)
-	_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
-
-	// Transactions whose attempts should not be picked up for receipt fetch
-	mustInsertFatalErrorEthTx(b, txStore, fromAddress)
-	mustInsertUnstartedTx(b, txStore, fromAddress)
-	mustInsertInProgressEthTxWithAttempt(b, txStore, 4, fromAddress)
-	mustInsertUnconfirmedEthTxWithAttemptState(b, txStore, 3, fromAddress, txmgrtypes.TxAttemptBroadcast)
-	mustInsertConfirmedEthTxWithReceipt(b, txStore, fromAddress, 2, blockNum)
-	// Terminally stuck transaction with receipt should NOT be picked up for receipt fetch
-	stuckTx := mustInsertTerminallyStuckTxWithAttempt(b, txStore, fromAddress, 1, blockNum)
-	mustInsertEthReceipt(b, txStore, blockNum, utils.NewHash(), stuckTx.TxAttempts[0].Hash)
-	// Fatal transactions with nil nonce and stored attempts should NOT be picked up for receipt fetch
-	fatalTxWithAttempt := mustInsertFatalErrorEthTx(b, txStore, fromAddress)
-	attempt := newBroadcastLegacyEthTxAttempt(b, fatalTxWithAttempt.ID)
-	err := txStore.InsertTxAttempt(ctx, &attempt)
-	require.NoError(b, err)
-
-	// Confirmed transaction without receipt should be picked up for receipt fetch
-	confirmedTx := mustInsertConfirmedEthTx(b, txStore, 0, fromAddress)
-	attempt = newBroadcastLegacyEthTxAttempt(b, confirmedTx.ID)
-	err = txStore.InsertTxAttempt(ctx, &attempt)
-	require.NoError(b, err)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StartTimer()
-		attempts, err := txStore.FindAttemptsRequiringReceiptFetch(ctx, testutils.FixtureChainID)
-		b.StopTimer()
-
-		require.NoError(b, err)
-		require.Len(b, attempts, 1)
-		require.Equal(b, attempt.Hash.String(), attempts[0].Hash.String())
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				attempts, err := txStore.FindAttemptsRequiringReceiptFetch(ctx, testutils.FixtureChainID)
+				b.StopTimer()
+				require.NoError(b, err)
+				require.Equal(b, size, len(attempts))
+			}
+		})
 	}
 }
 
 func BenchmarkFindTxesByIDs(b *testing.B) {
-	db := testutils.NewSqlxDB(b)
-	txStore := NewTestTxStore(b, db)
-	ctx := tests.Context(b)
-	ethKeyStore := cltest.NewKeyStore(b, db).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(b, ethKeyStore)
+	for name, size := range benchmarkSizes {
+		b.Run(name, func(b *testing.B) {
+			db := testutils.NewSqlxDB(b)
+			txStore := NewTestTxStore(b, db)
+			ctx := tests.Context(b)
+			ethKeyStore := cltest.NewKeyStore(b, db).Eth()
+			_, fromAddress := cltest.MustInsertRandomKeyReturningState(b, ethKeyStore)
 
-	etx1 := mustInsertInProgressEthTxWithAttempt(b, txStore, 3, fromAddress)
-	etx2 := mustInsertUnconfirmedEthTxWithAttemptState(b, txStore, 2, fromAddress, txmgrtypes.TxAttemptBroadcast)
-	etx3 := mustInsertTerminallyStuckTxWithAttempt(b, txStore, fromAddress, 1, 100)
-	etx4 := mustInsertConfirmedEthTxWithReceipt(b, txStore, fromAddress, 0, 100)
-	etxIDs := []int64{etx1.ID, etx2.ID, etx3.ID, etx4.ID}
+			var etxIDs []int64
+			for i := 0; i < size; i++ {
+				etx := mustInsertUnconfirmedEthTxWithAttemptState(b, txStore, int64(i), fromAddress, txmgrtypes.TxAttemptBroadcast)
+				etxIDs = append(etxIDs, etx.ID)
+			}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StartTimer()
-		oldTxs, err := txStore.FindTxesByIDs(ctx, etxIDs, testutils.FixtureChainID)
-		b.StopTimer()
-
-		require.NoError(b, err)
-		require.Len(b, oldTxs, 4)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				txs, err := txStore.FindTxesByIDs(ctx, etxIDs, testutils.FixtureChainID)
+				b.StopTimer()
+				require.NoError(b, err)
+				require.Len(b, txs, len(etxIDs))
+			}
+		})
 	}
 }
 
 func BenchmarkFindConfirmedTxesReceipts(b *testing.B) {
-	db := testutils.NewSqlxDB(b)
-	txStore := NewTestTxStore(b, db)
-	finalizedBlockNum := int64(100)
-	kst := cltest.NewKeyStore(b, db)
+	for name, size := range benchmarkSizes {
+		b.Run(name, func(b *testing.B) {
+			db := testutils.NewSqlxDB(b)
+			txStore := NewTestTxStore(b, db)
+			finalizedBlockNum := int64(100)
+			kst := cltest.NewKeyStore(b, db)
+			_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
 
-	_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
-	for i := 0; i < 100; i++ {
-		mustInsertConfirmedEthTxWithReceipt(b, txStore, fromAddress, int64(i), finalizedBlockNum)
-	}
+			for i := 0; i < size; i++ {
+				mustInsertConfirmedEthTxWithReceipt(b, txStore, fromAddress, int64(i), finalizedBlockNum)
+			}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StartTimer()
-		receipts, err := txStore.FindConfirmedTxesReceipts(tests.Context(b), finalizedBlockNum, &cltest.FixtureChainID)
-		b.StopTimer()
-		require.NoError(b, err)
-		require.Len(b, receipts, 100)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				receipts, err := txStore.FindConfirmedTxesReceipts(tests.Context(b), finalizedBlockNum, &cltest.FixtureChainID)
+				b.StopTimer()
+				require.NoError(b, err)
+				require.Len(b, receipts, size)
+			}
+		})
 	}
 }

--- a/core/chains/evm/txmgr/evm_tx_store_benchmark_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_benchmark_test.go
@@ -38,7 +38,6 @@ func BenchmarkCreateTransactionTxStore(b *testing.B) {
 			txStore := newTxStore(b, db)
 			kst := cltest.NewKeyStore(b, db)
 			_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
-			toAddress := testutils.NewAddress()
 			gasLimit := uint64(1000)
 			payload := []byte{1, 2, 3}
 			ethClient := clienttest.NewClientWithDefaultChainID(b)
@@ -47,18 +46,32 @@ func BenchmarkCreateTransactionTxStore(b *testing.B) {
 			strategy := newMockTxStrategy(b)
 			strategy.On("Subject").Return(uuid.NullUUID{UUID: subject, Valid: true})
 
+			for i := 0; i < size; i++ {
+				toAddress := testutils.NewAddress()
+				_, err := txStore.CreateTransaction(tests.Context(b), txmgr.TxRequest{
+					FromAddress:    fromAddress,
+					ToAddress:      toAddress,
+					EncodedPayload: payload,
+					FeeLimit:       gasLimit,
+					Strategy:       strategy,
+				}, ethClient.ConfiguredChainID())
+				assert.NoError(b, err)
+			}
+
+			b.StopTimer()
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				for i := 0; i < size; i++ {
-					_, err := txStore.CreateTransaction(tests.Context(b), txmgr.TxRequest{
-						FromAddress:    fromAddress,
-						ToAddress:      toAddress,
-						EncodedPayload: payload,
-						FeeLimit:       gasLimit,
-						Strategy:       strategy,
-					}, ethClient.ConfiguredChainID())
-					assert.NoError(b, err)
-				}
+				toAddress := testutils.NewAddress()
+				b.StartTimer()
+				_, err := txStore.CreateTransaction(tests.Context(b), txmgr.TxRequest{
+					FromAddress:    fromAddress,
+					ToAddress:      toAddress,
+					EncodedPayload: payload,
+					FeeLimit:       gasLimit,
+					Strategy:       strategy,
+				}, ethClient.ConfiguredChainID())
+				b.StopTimer()
+				assert.NoError(b, err)
 			}
 		})
 	}

--- a/core/store/migrate/migrations/0267_evm_txstore_indexes.sql
+++ b/core/store/migrate/migrations/0267_evm_txstore_indexes.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+CREATE INDEX IF NOT EXISTS idx_txes_evm_chain_id_state_nonce
+    ON evm.txes (evm_chain_id, state, nonce);
+
+CREATE INDEX IF NOT EXISTS idx_tx_attempts_eth_tx_id_state_hash
+    ON evm.tx_attempts (eth_tx_id, state, hash);
+
+CREATE INDEX IF NOT EXISTS idx_receipts_tx_hash_id
+    ON evm.receipts (tx_hash, id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_txes_evm_chain_id_state_nonce;
+DROP INDEX IF EXISTS idx_tx_attempts_eth_tx_id_state_hash;
+DROP INDEX IF EXISTS idx_receipts_tx_hash_id;

--- a/core/store/migrate/migrations/0267_evm_txstore_indexes.sql
+++ b/core/store/migrate/migrations/0267_evm_txstore_indexes.sql
@@ -8,7 +8,15 @@ CREATE INDEX IF NOT EXISTS idx_tx_attempts_eth_tx_id_state_hash
 CREATE INDEX IF NOT EXISTS idx_receipts_tx_hash_id
     ON evm.receipts (tx_hash, id);
 
+CREATE INDEX IF NOT EXISTS idx_receipts_tx_hash
+    ON evm.receipts (tx_hash);
+
+CREATE INDEX IF NOT EXISTS idx_tx_attempts_eth_tx_id_hash
+    ON evm.tx_attempts (eth_tx_id, hash);
+
 -- +goose Down
 DROP INDEX IF EXISTS idx_txes_evm_chain_id_state_nonce;
 DROP INDEX IF EXISTS idx_tx_attempts_eth_tx_id_state_hash;
 DROP INDEX IF EXISTS idx_receipts_tx_hash_id;
+DROP INDEX IF EXISTS idx_receipts_tx_hash;
+DROP INDEX IF EXISTS idx_tx_attempts_eth_tx_id_hash;


### PR DESCRIPTION
## Description
Added Database Size Scaling to TXStore Benchmark Tests.
The new benchmarks are being tracked in [TXStore Benchmarks & Optimizations](https://smartcontract-it.atlassian.net/wiki/spaces/Framework/pages/1488158874/TxStore+Benchmarks+Optimizations).
Ticket: https://smartcontract-it.atlassian.net/browse/BCFR-1218

## Resulting Optimizations

### Find Attempts Requiring Receipt Fetch
⚙️ Optimized Query + Added DB Indexes

🗃️ DB Size Factor | ⏳ Before | ⚡ After | 🚀 Improvement
-- | -- | -- | --
1x | 94,166 ns/op | 90,521 ns/op | 🟢 3.9% faster
10x | 265,812 ns/op | 174,333 ns/op | 🟢 34.4% faster
100x | 3,094,477 ns/op | 1,180,665 ns/op | 🟢 61.8% faster
1000x | 17,026,631 ns/op | 10,385,318 ns/op | 🟢 39.0% faster
