### PR TITLE
fix: address encoding based on family

### DIFF
--- a/deployment/ccip/view/shared/common.go
+++ b/deployment/ccip/view/shared/common.go
@@ -1,6 +1,8 @@
 package shared
 
 import (
+	"strings"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/mr-tron/base58"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
@@ -37,7 +39,7 @@ func GetAddressFromBytes(chainSelector uint64, address []byte) string {
 
 	switch family {
 	case chain_selectors.FamilyEVM:
-		return common.BytesToAddress(address).Hex()
+		return strings.ToLower(common.BytesToAddress(address).Hex())
 	case chain_selectors.FamilySolana:
 		return base58.Encode(address)
 	default:

--- a/deployment/ccip/view/shared/common.go
+++ b/deployment/ccip/view/shared/common.go
@@ -2,6 +2,8 @@ package shared
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/mr-tron/base58"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
 )
@@ -25,4 +27,20 @@ func GetSupportedTokens(taContract *token_admin_registry.TokenAdminRegistry) ([]
 		}
 	}
 	return allTokens, nil
+}
+
+func GetAddressFromBytes(chainSelector uint64, address []byte) string {
+	family, err := chain_selectors.GetSelectorFamily(chainSelector)
+	if err != nil {
+		return "invalid chain selector"
+	}
+
+	switch family {
+	case chain_selectors.FamilyEVM:
+		return common.BytesToAddress(address).Hex()
+	case chain_selectors.FamilySolana:
+		return base58.Encode(address)
+	default:
+		return "unsupported chain family"
+	}
 }

--- a/deployment/ccip/view/solana/offramp.go
+++ b/deployment/ccip/view/solana/offramp.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
-	"github.com/mr-tron/base58"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
 )
 
 type OffRampView struct {
@@ -81,24 +79,8 @@ func GenerateOffRampView(chain deployment.SolChain, program solana.PublicKey, re
 			IsEnabled:                 chainStateAccount.Config.IsEnabled,
 			IsRmnVerificationDisabled: chainStateAccount.Config.IsRmnVerificationDisabled,
 			LaneCodeVersion:           chainStateAccount.Config.LaneCodeVersion.String(),
-			OnRamp:                    GetAddressFromBytes(remote, onRamp.Bytes[:onRamp.Len]),
+			OnRamp:                    shared.GetAddressFromBytes(remote, onRamp.Bytes[:onRamp.Len]),
 		}
 	}
 	return view, nil
-}
-
-func GetAddressFromBytes(chainSelector uint64, address []byte) string {
-	family, err := chain_selectors.GetSelectorFamily(chainSelector)
-	if err != nil {
-		return "invalid chain selector"
-	}
-
-	switch family {
-	case chain_selectors.FamilyEVM:
-		return common.BytesToAddress(address).Hex()
-	case chain_selectors.FamilySolana:
-		return base58.Encode(address)
-	default:
-		return "unsupported chain family"
-	}
 }

--- a/deployment/ccip/view/solana/tokenpool.go
+++ b/deployment/ccip/view/solana/tokenpool.go
@@ -8,6 +8,7 @@ import (
 	solTokenUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
 	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
 )
 
 type TokenPoolView struct {
@@ -65,7 +66,7 @@ func GenerateTokenPoolView(chain deployment.SolChain, program solana.PublicKey, 
 			if err := chain.GetAccountDataBorshInto(context.Background(), remoteChainConfigPDA, &remoteChainConfigAccount); err == nil {
 				view.TokenPoolChainConfig[remote][token.String()] = TokenPoolChainConfig{
 					PoolAddresses: make([]string, len(remoteChainConfigAccount.Base.Remote.PoolAddresses)),
-					TokenAddress:  GetAddressFromBytes(remote, remoteChainConfigAccount.Base.Remote.TokenAddress.Address),
+					TokenAddress:  shared.GetAddressFromBytes(remote, remoteChainConfigAccount.Base.Remote.TokenAddress.Address),
 					Decimals:      remoteChainConfigAccount.Base.Remote.Decimals,
 					InboundRateLimit: TokenPoolRateLimitTokenBucket{
 						Tokens:      remoteChainConfigAccount.Base.InboundRateLimit.Tokens,
@@ -81,7 +82,7 @@ func GenerateTokenPoolView(chain deployment.SolChain, program solana.PublicKey, 
 						Rate:        remoteChainConfigAccount.Base.OutboundRateLimit.Cfg.Rate},
 				}
 				for i, addr := range remoteChainConfigAccount.Base.Remote.PoolAddresses {
-					view.TokenPoolChainConfig[remote][token.String()].PoolAddresses[i] = GetAddressFromBytes(remote, addr.Address)
+					view.TokenPoolChainConfig[remote][token.String()].PoolAddresses[i] = shared.GetAddressFromBytes(remote, addr.Address)
 				}
 			}
 		}

--- a/deployment/ccip/view/v1_5_1/token_pool.go
+++ b/deployment/ccip/view/v1_5_1/token_pool.go
@@ -13,6 +13,8 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/lock_release_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/usdc_token_pool"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
 	"github.com/smartcontractkit/chainlink/deployment/common/view/types"
 )
 
@@ -74,9 +76,9 @@ func GetCurrentOutboundRateLimiterState(t TokenPoolContract, remoteChainSelector
 
 type RemoteChainConfig struct {
 	// RemoteTokenAddress is the raw representation of the token address on the remote chain.
-	RemoteTokenAddress []byte
+	RemoteTokenAddress string
 	// RemotePoolAddresses are raw addresses of valid token pools on the remote chain.
-	RemotePoolAddresses [][]byte
+	RemotePoolAddresses []string
 	// InboundRateLimiterConfig is the rate limiter config for inbound transfers from the remote chain.
 	InboundRateLimterConfig token_pool.RateLimiterConfig
 	// OutboundRateLimiterConfig is the rate limiter config for outbound transfers to the remote chain.
@@ -138,7 +140,11 @@ func GenerateTokenPoolView(pool TokenPoolContract, priceFeed common.Address) (To
 	}
 	remoteChainConfigs := make(map[uint64]RemoteChainConfig)
 	for _, remoteChain := range remoteChains {
-		remotePools, err := pool.GetRemotePools(nil, remoteChain)
+		remotePoolsBytes, err := pool.GetRemotePools(nil, remoteChain)
+		remotePools := make([]string, len(remotePoolsBytes))
+		for i, remotePoolBytes := range remotePoolsBytes {
+			remotePools[i] = shared.GetAddressFromBytes(remoteChain, remotePoolBytes)
+		}
 		if err != nil {
 			return TokenPoolView{}, err
 		}
@@ -155,7 +161,7 @@ func GenerateTokenPoolView(pool TokenPoolContract, priceFeed common.Address) (To
 			return TokenPoolView{}, err
 		}
 		remoteChainConfigs[remoteChain] = RemoteChainConfig{
-			RemoteTokenAddress:  remoteToken,
+			RemoteTokenAddress:  shared.GetAddressFromBytes(remoteChain, remoteToken),
 			RemotePoolAddresses: remotePools,
 			InboundRateLimterConfig: token_pool.RateLimiterConfig{
 				IsEnabled: inboundState.IsEnabled,

--- a/deployment/ccip/view/v1_5_1/token_pool.go
+++ b/deployment/ccip/view/v1_5_1/token_pool.go
@@ -140,11 +140,7 @@ func GenerateTokenPoolView(pool TokenPoolContract, priceFeed common.Address) (To
 	}
 	remoteChainConfigs := make(map[uint64]RemoteChainConfig)
 	for _, remoteChain := range remoteChains {
-		remotePoolsBytes, err := pool.GetRemotePools(nil, remoteChain)
-		remotePools := make([]string, len(remotePoolsBytes))
-		for i, remotePoolBytes := range remotePoolsBytes {
-			remotePools[i] = shared.GetAddressFromBytes(remoteChain, remotePoolBytes)
-		}
+		remotePools, err := pool.GetRemotePools(nil, remoteChain)
 		if err != nil {
 			return TokenPoolView{}, err
 		}
@@ -162,7 +158,7 @@ func GenerateTokenPoolView(pool TokenPoolContract, priceFeed common.Address) (To
 		}
 		remoteChainConfigs[remoteChain] = RemoteChainConfig{
 			RemoteTokenAddress:  shared.GetAddressFromBytes(remoteChain, remoteToken),
-			RemotePoolAddresses: remotePools,
+			RemotePoolAddresses: make([]string, len(remotePools)),
 			InboundRateLimterConfig: token_pool.RateLimiterConfig{
 				IsEnabled: inboundState.IsEnabled,
 				Capacity:  inboundState.Capacity,
@@ -173,6 +169,9 @@ func GenerateTokenPoolView(pool TokenPoolContract, priceFeed common.Address) (To
 				Capacity:  outboundState.Capacity,
 				Rate:      outboundState.Rate,
 			},
+		}
+		for i, remotePool := range remotePools {
+			remoteChainConfigs[remoteChain].RemotePoolAddresses[i] = shared.GetAddressFromBytes(remoteChain, remotePool)
 		}
 	}
 

--- a/deployment/ccip/view/v1_6/offramp.go
+++ b/deployment/ccip/view/v1_6/offramp.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
-
 	router1_2 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/v1_2"
 	"github.com/smartcontractkit/chainlink/deployment/common/view/types"
 )
@@ -63,7 +63,7 @@ func GenerateOffRampView(
 			IsEnabled:                 sourceChainConfig.IsEnabled,
 			MinSeqNr:                  sourceChainConfig.MinSeqNr,
 			IsRMNVerificationDisabled: sourceChainConfig.IsRMNVerificationDisabled,
-			OnRamp:                    ccipocr3.UnknownAddress(sourceChainConfig.OnRamp).String(),
+			OnRamp:                    shared.GetAddressFromBytes(sourceChainSelector, sourceChainConfig.OnRamp),
 		}
 	}
 


### PR DESCRIPTION
Encode address in view state.json based on chain family
When we don't know to which chain address belongs, we encode it with 64 bytes (evm needs 20 bytes, solana needs 64 bytes), so here is the proposed change

1) poolByTokens -> remoteChainConfigs
Now:
```
      "remoteChainConfigs": {
       (evm) "10344971235874465080": { 
        "RemoteTokenAddress": "AAAAAAAAAAAAAAAAZJW1HtelJs095slXN2VW57iPLXk=", (base64)
        "RemotePoolAddresses": [
         "AAAAAAAAAAAAAAAAPDuuPASiqn6uPKrNKfDsMn7Xfk4=" (base64)
        ],
        ....
       (solana) "16423721717087811551": {
        "RemoteTokenAddress": "W4DeDIGqBj7WccIVC46JPxPv1MIol2+z9EZ4IzsTI2I=", (base64)
        "RemotePoolAddresses": [
         "1NMksooAfQJiAdqlqRe0JW6SK4unv/Fcb/GQ4XUX4bo=" (base64)
        ],
        ....
```
Will be: 
```
      "remoteChainConfigs": {
       (evm) "10344971235874465080": { 
        "RemoteTokenAddress": "0x6495b51ed7a526cd3de6c957376556e7b88f2d79", (crop left 0-bytes to have 20-bytes hex)
        "RemotePoolAddresses": [
         "0x3c3bae3c04a2aa7eae3caacd29f0ec327ed77e4e" (crop left 0-bytes to have 20-bytes hex)
        ],
        ....
       (solana) "16423721717087811551": {
        "RemoteTokenAddress": "OaiGXVvdcKCtBP7K4CGv97AcBtXTmTupq8hSH2rZV1ei", (base58)
        "RemotePoolAddresses": [
         "vH6d0stLW3IIZITthBa8TLoBDeFNl1uODpHaf8lCagh2" (base58)
        ],
        ....
```

2) offRamp -> sourceChainConfigs
Now:
```
     "sourceChainConfigs": {
      (evm) "11344663589394136015": {
       ...
       "OnRamp": "0x000000000000000000000000f09afe78d3c7d359b334d7cb88995751f7ec5e13" (always 64-sized hex)
      },
      (solana) "16423721717087811551": {
	   ...
       "OnRamp": "0x5b80de0c81aa063ed671c2150b8e893f13efd4c228976fb3f44678233b132362" (always 64-sized hex)
      },
     ...
```
Will be:
```
     "sourceChainConfigs": {
      (evm) "11344663589394136015": {
       ...
       "OnRamp": "0xf09afe78d3c7d359b334d7cb88995751f7ec5e13" (crop left 0-bytes to have 20-bytes hex)
      },
      (solana) "16423721717087811551": {
	   ...
       "OnRamp": "7AC59PVvR64EoMnLX45FHnJAYzPsxdViyYBsaGEQPFvh" (base58)
      },
     ...
```

Advantage: you can navigate state.json without conversions + encoding on local chain matches encoding on remote chain within same state.json
I use this for firedrill for example when looking for connected onramp/offramp/router

Disadvantage: we need to support this everywhere, it requires some efforts.
\+ when we will have more chain families, this conversion will grow

Alternative approach: choose one format (hex for example) as cross-chain reference format and convert to it everywhere