### PR TITLE
llo: scaling improvements and safeguard channel definition version management

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -373,7 +373,7 @@ require (
 	github.com/smartcontractkit/mcms v0.18.0 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1243,8 +1243,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 h1:zxcODLrFytOKmAd8ty8S/XK6WcIEJEgRBaL7sY/7l4Y=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/core/services/llo/mercurytransmitter/orm.go
+++ b/core/services/llo/mercurytransmitter/orm.go
@@ -208,10 +208,10 @@ func (o *orm) Prune(ctx context.Context, serverURL string, maxSize, batchSize in
 		res, err = o.ds.ExecContext(ctx, `
 DELETE FROM llo_mercury_transmit_queue AS q
 USING (
-    SELECT transmission_hash 
+    SELECT transmission_hash
     FROM llo_mercury_transmit_queue
-    WHERE don_id = $1 
-      AND server_url = $2 
+    WHERE don_id = $1
+      AND server_url = $2
       AND seq_nr < $3
     ORDER BY seq_nr ASC
     LIMIT $4

--- a/core/services/llo/mercurytransmitter/queue.go
+++ b/core/services/llo/mercurytransmitter/queue.go
@@ -140,9 +140,16 @@ func (tq *transmitQueue) BlockingPop() (t *Transmission) {
 }
 
 func (tq *transmitQueue) IsEmpty() bool {
-	tq.mu.RLock()
-	defer tq.mu.RUnlock()
-	return tq.pq.Len() == 0
+	return tq.Len() == 0
+}
+
+func (tq *transmitQueue) Len() int {
+	tq.cond.L.Lock()
+	defer tq.cond.L.Unlock()
+
+	sz := tq.pq.Len()
+	tq.cond.Signal()
+	return sz
 }
 
 func (tq *transmitQueue) Start(context.Context) error {

--- a/core/services/llo/mercurytransmitter/queue_test.go
+++ b/core/services/llo/mercurytransmitter/queue_test.go
@@ -133,7 +133,7 @@ func Test_Queue(t *testing.T) {
 		}
 
 		tq.Push(testTransmissions[maxSize+3]) // push one more to trigger eviction
-		require.Equal(t, maxSize, tq.(*transmitQueue).pq.Len())
+		require.Equal(t, maxSize, tq.(*transmitQueue).Len())
 		require.Len(t, deleter.hashes, 4) // evicted overfill entries (3 oversize plus 1 more to make room)
 
 		// oldest entries removed

--- a/core/services/llo/mercurytransmitter/transmitter.go
+++ b/core/services/llo/mercurytransmitter/transmitter.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -29,7 +30,9 @@ import (
 
 const (
 	// Mercury server error codes
-	DuplicateReport = 2
+	DuplicateReport  = 2
+	commitInterval   = time.Millisecond * 25
+	commitBufferSize = 1000
 )
 
 var (
@@ -123,6 +126,8 @@ type transmitter struct {
 
 	stopCh services.StopChan
 	wg     *sync.WaitGroup
+
+	commitCh chan *Transmission
 }
 
 type Opts struct {
@@ -158,6 +163,7 @@ func newTransmitter(opts Opts) *transmitter {
 		opts.FromAccount,
 		make(services.StopChan),
 		&sync.WaitGroup{},
+		make(chan *Transmission, 1000*len(servers)),
 	}
 }
 
@@ -200,6 +206,7 @@ func (mt *transmitter) Start(ctx context.Context) (err error) {
 			})
 		}
 
+		mt.spawnCommitLoops()
 		return g.Wait()
 	})
 }
@@ -248,37 +255,36 @@ func (mt *transmitter) Transmit(
 	sigs []types.AttributedOnchainSignature,
 ) (err error) {
 	ok := mt.IfStarted(func() {
-		err = mt.transmit(ctx, digest, seqNr, report, sigs)
+		for serverURL := range mt.servers {
+			t := &Transmission{
+				ServerURL:    serverURL,
+				ConfigDigest: digest,
+				SeqNr:        seqNr,
+				Report:       report,
+				Sigs:         sigs,
+			}
+			select {
+			case mt.commitCh <- t:
+			case <-ctx.Done():
+				err = fmt.Errorf("failed to add transmission to commit channel: %w", ctx.Err())
+			}
+		}
 	})
+
 	if !ok {
 		return errors.New("transmitter is not started")
 	}
-	return
+
+	return err
 }
 
-func (mt *transmitter) transmit(
-	ctx context.Context,
-	digest types.ConfigDigest,
-	seqNr uint64,
-	report ocr3types.ReportWithInfo[llotypes.ReportInfo],
-	sigs []types.AttributedOnchainSignature,
-) error {
+func (mt *transmitter) transmit(ctx context.Context, transmissions []*Transmission) error {
 	// On shutdown appears that libocr can pass us a pre-canceled context;
 	// don't even bother trying to insert/transmit in this case
 	if ctx.Err() != nil {
 		return fmt.Errorf("cannot transmit; context already canceled: %w", ctx.Err())
 	}
 
-	transmissions := make([]*Transmission, 0, len(mt.servers))
-	for serverURL := range mt.servers {
-		transmissions = append(transmissions, &Transmission{
-			ServerURL:    serverURL,
-			ConfigDigest: digest,
-			SeqNr:        seqNr,
-			Report:       report,
-			Sigs:         sigs,
-		})
-	}
 	// NOTE: This insert on its own can leave orphaned records in the case of
 	// shutdown, because:
 	// 1. Transmitter is shut down after oracle
@@ -312,11 +318,15 @@ func (mt *transmitter) transmit(
 	for i := range transmissions {
 		t := transmissions[i]
 		if mt.verboseLogging {
-			mt.lggr.Debugw("Transmit report", "digest", digest.Hex(), "seqNr", seqNr, "reportFormat", report.Info.ReportFormat, "reportLifeCycleStage", report.Info.LifeCycleStage, "transmissionHash", fmt.Sprintf("%x", t.Hash()))
+			mt.lggr.Debugw("Transmit report",
+				"digest", t.ConfigDigest.Hex(), "seqNr", t.SeqNr, "reportFormat", t.Report.Info.ReportFormat,
+				"reportLifeCycleStage", t.Report.Info.LifeCycleStage,
+				"transmissionHash", fmt.Sprintf("%x", t.Hash()))
 		}
-		s := mt.servers[t.ServerURL]
+
 		// OK to do this synchronously since pushing to queue is just a mutex
 		// lock and array append and ought to be extremely fast
+		s := mt.servers[t.ServerURL]
 		if ok := s.q.Push(t); !ok {
 			s.transmitQueuePushErrorCount.Inc()
 			// This shouldn't be possible since transmitter is always shut down
@@ -331,4 +341,50 @@ func (mt *transmitter) transmit(
 // FromAccount returns the stringified (hex) CSA public key
 func (mt *transmitter) FromAccount(ctx context.Context) (ocrtypes.Account, error) {
 	return ocrtypes.Account(mt.fromAccount), nil
+}
+
+func (mt *transmitter) spawnCommitLoops() {
+	for x := 0; x < len(mt.servers); x++ {
+		mt.wg.Add(1)
+
+		go func() {
+			defer mt.wg.Done()
+
+			var err error
+			ctx := context.Background()
+			buff := cap(mt.commitCh) / 10
+			transmissions := make([]*Transmission, 0, buff)
+			ticker := time.NewTicker(commitInterval)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-mt.stopCh:
+					if len(transmissions) >= buff {
+						if err = mt.transmit(ctx, transmissions); err != nil {
+							mt.lggr.Error("Error transmitting records", "error", err)
+						}
+					}
+					return
+
+				case <-ticker.C:
+					if len(transmissions) > 0 {
+						err = mt.transmit(ctx, transmissions)
+						transmissions = make([]*Transmission, 0, buff)
+					}
+
+				case t := <-mt.commitCh:
+					transmissions = append(transmissions, t)
+					if len(transmissions) >= buff {
+						err = mt.transmit(ctx, transmissions)
+						transmissions = make([]*Transmission, 0, buff)
+					}
+				}
+
+				if err != nil {
+					mt.lggr.Error("Error transmitting records", "error", err)
+				}
+			}
+		}()
+	}
 }

--- a/core/services/llo/mercurytransmitter/transmitter_test.go
+++ b/core/services/llo/mercurytransmitter/transmitter_test.go
@@ -110,6 +110,7 @@ func Test_Transmitter_Transmit(t *testing.T) {
 				require.NoError(t, mt.servers[sURL].q.Init([]*Transmission{}))
 				require.NoError(t, mt.servers[sURL2].q.Init([]*Transmission{}))
 				require.NoError(t, mt.servers[sURL3].q.Init([]*Transmission{}))
+				mt.spawnCommitLoops()
 
 				return nil
 			})
@@ -125,8 +126,11 @@ func Test_Transmitter_Transmit(t *testing.T) {
 			err = mt.Transmit(testutils.Context(t), digest, seqNr, report, sigs)
 			require.NoError(t, err)
 
+			// wait for the commit loop to run
+			time.Sleep(2 * commitInterval)
+
 			// ensure it was added to the queue
-			require.Equal(t, 1, mt.servers[sURL].q.(*transmitQueue).pq.Len())
+			require.Equal(t, 1, mt.servers[sURL].q.(*transmitQueue).Len())
 			assert.Equal(t, &Transmission{
 				ServerURL:    sURL,
 				ConfigDigest: digest,
@@ -134,7 +138,7 @@ func Test_Transmitter_Transmit(t *testing.T) {
 				Report:       report,
 				Sigs:         sigs,
 			}, mt.servers[sURL].q.(*transmitQueue).pq.Pop().(*Transmission))
-			require.Equal(t, 1, mt.servers[sURL2].q.(*transmitQueue).pq.Len())
+			require.Equal(t, 1, mt.servers[sURL2].q.(*transmitQueue).Len())
 			assert.Equal(t, &Transmission{
 				ServerURL:    sURL2,
 				ConfigDigest: digest,
@@ -142,7 +146,7 @@ func Test_Transmitter_Transmit(t *testing.T) {
 				Report:       report,
 				Sigs:         sigs,
 			}, mt.servers[sURL2].q.(*transmitQueue).pq.Pop().(*Transmission))
-			require.Equal(t, 1, mt.servers[sURL3].q.(*transmitQueue).pq.Len())
+			require.Equal(t, 1, mt.servers[sURL3].q.(*transmitQueue).Len())
 			assert.Equal(t, &Transmission{
 				ServerURL:    sURL3,
 				ConfigDigest: digest,

--- a/core/services/llo/observation/data_source.go
+++ b/core/services/llo/observation/data_source.go
@@ -8,8 +8,10 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/exp/maps"
@@ -36,6 +38,22 @@ var (
 		Subsystem: "datasource",
 		Name:      "stream_observation_error_count",
 		Help:      "Number of times we tried to observe a stream, but it failed with an error",
+	},
+		[]string{"streamID"},
+	)
+	promCacheHitCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "llo",
+		Subsystem: "datasource",
+		Name:      "cache_hit_count",
+		Help:      "Number of local observation cache hits",
+	},
+		[]string{"streamID"},
+	)
+	promCacheMissCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "llo",
+		Subsystem: "datasource",
+		Name:      "cache_miss_count",
+		Help:      "Number of local observation cache misses",
 	},
 		[]string{"streamID"},
 	)
@@ -73,16 +91,32 @@ var _ llo.DataSource = &dataSource{}
 type dataSource struct {
 	lggr     logger.Logger
 	registry Registry
+	t        Telemeter
 
-	t Telemeter
+	shouldCache *atomic.Bool
+	cache       *cache.Cache
 }
 
 func NewDataSource(lggr logger.Logger, registry Registry, t Telemeter) llo.DataSource {
-	return newDataSource(lggr, registry, t)
+	return newDataSource(lggr, registry, t, true)
 }
 
-func newDataSource(lggr logger.Logger, registry Registry, t Telemeter) *dataSource {
-	return &dataSource{logger.Named(lggr, "DataSource"), registry, t}
+func newDataSource(lggr logger.Logger, registry Registry, t Telemeter, cacheEnabled bool) *dataSource {
+	shouldCache := &atomic.Bool{}
+	shouldCache.Store(cacheEnabled)
+
+	return &dataSource{
+		lggr:     logger.Named(lggr, "DataSource"),
+		registry: registry,
+		t:        t,
+
+		// Cache valid observations between rounds for 750ms to avoid exhausting
+		// node network and the underlying adapter's resources when dealing
+		// with a large number of streams. It is cleaned up every minute to
+		// remove stale observations for removed streams.
+		shouldCache: shouldCache,
+		cache:       cache.New(750*time.Millisecond, time.Minute),
+	}
 }
 
 // Observe looks up all streams in the registry and populates a map of stream ID => value
@@ -133,17 +167,26 @@ func (d *dataSource) Observe(ctx context.Context, streamValues llo.StreamValues,
 	for _, streamID := range maps.Keys(streamValues) {
 		go func(streamID llotypes.StreamID) {
 			defer wg.Done()
-			val, err := oc.Observe(ctx, streamID, opts)
-			if err != nil {
-				strmIDStr := strconv.FormatUint(uint64(streamID), 10)
-				if errors.As(err, &MissingStreamError{}) {
-					promMissingStreamCount.WithLabelValues(strmIDStr).Inc()
+			var val llo.StreamValue
+			var err error
+
+			// check for valid cached value before observing
+			if val = d.fromCache(streamID); val == nil {
+				// no valid cached value, observe the stream
+				if val, err = oc.Observe(ctx, streamID, opts); err != nil {
+					strmIDStr := strconv.FormatUint(uint64(streamID), 10)
+					if errors.As(err, &MissingStreamError{}) {
+						promMissingStreamCount.WithLabelValues(strmIDStr).Inc()
+					}
+					promObservationErrorCount.WithLabelValues(strmIDStr).Inc()
+					mu.Lock()
+					errs = append(errs, ErrObservationFailed{inner: err, streamID: streamID, reason: "failed to observe stream"})
+					mu.Unlock()
+					return
 				}
-				promObservationErrorCount.WithLabelValues(strmIDStr).Inc()
-				mu.Lock()
-				errs = append(errs, ErrObservationFailed{inner: err, streamID: streamID, reason: "failed to observe stream"})
-				mu.Unlock()
-				return
+
+				// cache the observed value
+				d.toCache(streamID, val)
 			}
 
 			mu.Lock()
@@ -187,4 +230,26 @@ func (d *dataSource) Observe(ctx context.Context, streamValues llo.StreamValues,
 	}
 
 	return nil
+}
+
+func (d *dataSource) fromCache(streamID llotypes.StreamID) llo.StreamValue {
+	if d.shouldCache.Load() {
+		cacheKey := strconv.FormatUint(uint64(streamID), 10)
+		if cachedVal, found := d.cache.Get(cacheKey); found && cachedVal != nil {
+			streamValue := cachedVal.(llo.StreamValue)
+			promCacheHitCount.WithLabelValues(cacheKey).Inc()
+			return streamValue
+		}
+		promCacheMissCount.WithLabelValues(cacheKey).Inc()
+	}
+	return nil
+}
+
+func (d *dataSource) toCache(streamID llotypes.StreamID, val llo.StreamValue) {
+	if d.shouldCache.Load() && val != nil {
+		cacheKey := strconv.FormatUint(uint64(streamID), 10)
+
+		// set with default expiration
+		d.cache.SetDefault(cacheKey, val)
+	}
 }

--- a/core/services/llo/observation/data_source.go
+++ b/core/services/llo/observation/data_source.go
@@ -216,7 +216,7 @@ func (d *dataSource) Observe(ctx context.Context, streamValues llo.StreamValues,
 			failedStreamIDs[i] = e.streamID
 		}
 
-		lggr = logger.With(lggr, "elapsed", elapsed, "nSuccessfulStreams", len(successfulStreamIDs), "nFailedStreams", len(failedStreamIDs), "successfulStreamIDs", successfulStreamIDs, "failedStreamIDs", failedStreamIDs, "errs", errStrs)
+		lggr = logger.With(lggr, "elapsed", elapsed, "nSuccessfulStreams", len(successfulStreamIDs), "nFailedStreams", len(failedStreamIDs), "successfulStreamIDs", "errs", errStrs)
 
 		if opts.VerboseLogging() {
 			lggr = logger.With(lggr, "streamValues", streamValues)

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -383,7 +383,7 @@ require (
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stephenlacy/go-ethereum-hdwallet v0.0.0-20230913225845-a4fa94429863 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1296,8 +1296,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 h1:zxcODLrFytOKmAd8ty8S/XK6WcIEJEgRBaL7sY/7l4Y=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/smartcontractkit/libocr v0.0.0-20250408131511-c90716988ee0
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945
 	github.com/spf13/cast v1.7.1
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1094,8 +1094,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 h1:zxcODLrFytOKmAd8ty8S/XK6WcIEJEgRBaL7sY/7l4Y=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -468,7 +468,7 @@ require (
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 // indirect
 	github.com/sony/gobreaker/v2 v2.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1538,8 +1538,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 h1:zxcODLrFytOKmAd8ty8S/XK6WcIEJEgRBaL7sY/7l4Y=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -460,7 +460,7 @@ require (
 	github.com/smartcontractkit/libocr v0.0.0-20250408131511-c90716988ee0 // indirect
 	github.com/smartcontractkit/mcms v0.18.0 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 // indirect
 	github.com/sony/gobreaker/v2 v2.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1517,8 +1517,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 h1:zxcODLrFytOKmAd8ty8S/XK6WcIEJEgRBaL7sY/7l4Y=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -377,7 +377,7 @@ require (
 	github.com/smartcontractkit/mcms v0.18.0 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1284,8 +1284,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 h1:zxcODLrFytOKmAd8ty8S/XK6WcIEJEgRBaL7sY/7l4Y=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -449,7 +449,7 @@ require (
 	github.com/smartcontractkit/mcms v0.18.0 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de // indirect
-	github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d // indirect
+	github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 // indirect
 	github.com/sony/gobreaker/v2 v2.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1492,8 +1492,8 @@ github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:Sl2MF/Fp3fgJIVzhdGhmZZX2BlnM0oUUyBP4s4xYb6o=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de h1:66VQxXx3lvTaAZrMBkIcdH9VEjujUEvmBQdnyOJnkOc=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20241009055228-33d0c0bf38de/go.mod h1:NSc7hgOQbXG3DAwkOdWnZzLTZENXSwDJ7Va1nBp0YU0=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d h1:B/LvtTIFwbkzoFE7723Q0IQBv/lcaTm0LgWBCZPUtvs=
-github.com/smartcontractkit/wsrpc v0.8.5-0.20250318131857-4568a0f8d12d/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945 h1:zxcODLrFytOKmAd8ty8S/XK6WcIEJEgRBaL7sY/7l4Y=
+github.com/smartcontractkit/wsrpc v0.8.5-0.20250502134807-c57d3d995945/go.mod h1:m3pdp17i4bD50XgktkzWetcV5yaLsi7Gunbv4ZgN6qg=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=


### PR DESCRIPTION
* between rounds (within 750ms) observation cache to ensure we don't ddos the EAs when dealing with thousands of streams (~3.5k rps -> ~1.7k rps reduction with 1k streams)
* pace and batch transmit commits to ensure we don't ddos the node database (100% cpu -> ~20% cpu reduction with 1k streams)
* ensure we don't store invalid block numbers for channel definitions
* update wsrpc to avoid transmit panic in telemetry client

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/b9368a20-d66b-4bb5-9d6f-189ddb7b1956" />

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/6571b223-b1f6-4b85-afcf-c20da4d90582" />

