### PR TITLE
[CAPPL-720] Refactor internal data structures

### DIFF
--- a/core/services/relay/evm/capabilities/workflows/syncer/workflow_syncer_test.go
+++ b/core/services/relay/evm/capabilities/workflows/syncer/workflow_syncer_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jonboulle/clockwork"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
@@ -180,7 +181,7 @@ func Test_EventHandlerStateSync(t *testing.T) {
 	}, tests.WaitTimeout(t), time.Second)
 
 	for _, event := range testEventHandler.GetEvents() {
-		assert.Equal(t, syncer.WorkflowRegisteredEvent, event.GetEventType())
+		assert.Equal(t, syncer.WorkflowRegisteredEvent, event.EventType)
 	}
 
 	testEventHandler.ClearEvents()
@@ -228,15 +229,15 @@ func Test_EventHandlerStateSync(t *testing.T) {
 			for idx, event := range events {
 				switch idx % 5 {
 				case 0:
-					assert.Equal(t, syncer.WorkflowRegisteredEvent, event.GetEventType())
+					assert.Equal(t, syncer.WorkflowRegisteredEvent, event.EventType)
 				case 1:
-					assert.Equal(t, syncer.WorkflowActivatedEvent, event.GetEventType())
+					assert.Equal(t, syncer.WorkflowActivatedEvent, event.EventType)
 				case 2:
-					assert.Equal(t, syncer.WorkflowPausedEvent, event.GetEventType())
+					assert.Equal(t, syncer.WorkflowPausedEvent, event.EventType)
 				case 3:
-					assert.Equal(t, syncer.WorkflowUpdatedEvent, event.GetEventType())
+					assert.Equal(t, syncer.WorkflowUpdatedEvent, event.EventType)
 				case 4:
-					assert.Equal(t, syncer.WorkflowDeletedEvent, event.GetEventType())
+					assert.Equal(t, syncer.WorkflowDeletedEvent, event.EventType)
 				}
 			}
 			return true
@@ -306,7 +307,7 @@ func Test_InitialStateSync(t *testing.T) {
 	}, tests.WaitTimeout(t), time.Second)
 
 	for _, event := range testEventHandler.GetEvents() {
-		assert.Equal(t, syncer.WorkflowRegisteredEvent, event.GetEventType())
+		assert.Equal(t, syncer.WorkflowRegisteredEvent, event.EventType)
 	}
 }
 
@@ -792,7 +793,7 @@ func Test_StratReconciliation_InitialStateSync(t *testing.T) {
 		}, defaultTicker*2, 1*time.Second)
 
 		for _, event := range testEventHandler.GetEvents() {
-			assert.Equal(t, syncer.WorkflowRegisteredEvent, event.GetEventType())
+			assert.Equal(t, syncer.WorkflowRegisteredEvent, event.EventType)
 		}
 	})
 }
@@ -945,13 +946,13 @@ func (m *testSecretsWorkEventHandler) Close() error { return m.wrappedHandler.Cl
 
 func (m *testSecretsWorkEventHandler) Handle(ctx context.Context, event syncer.Event) error {
 	switch {
-	case event.GetEventType() == syncer.ForceUpdateSecretsEvent:
+	case event.EventType == syncer.ForceUpdateSecretsEvent:
 		return m.wrappedHandler.Handle(ctx, event)
-	case event.GetEventType() == syncer.WorkflowRegisteredEvent:
+	case event.EventType == syncer.WorkflowRegisteredEvent:
 		m.registeredCh <- event
 		return nil
 	default:
-		panic(fmt.Sprintf("unexpected event type: %v", event.GetEventType()))
+		panic(fmt.Sprintf("unexpected event type: %v", event.EventType))
 	}
 }
 

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -52,15 +52,15 @@ type ORM interface {
 	artifacts.WorkflowSpecsDS
 }
 
-// WorkflowRegistryForceUpdateSecretsRequestedV1 is a chain agnostic definition of the WorkflowRegistry
+// ForceUpdateSecretsRequestedV1 is a chain agnostic definition of the WorkflowRegistry
 // ForceUpdateSecretsRequested event.
-type WorkflowRegistryForceUpdateSecretsRequestedV1 struct {
+type ForceUpdateSecretsRequestedV1 struct {
 	SecretsURLHash []byte
 	Owner          []byte
 	WorkflowName   string
 }
 
-type WorkflowRegistryWorkflowRegisteredV1 struct {
+type WorkflowRegisteredV1 struct {
 	WorkflowID    types.WorkflowID
 	WorkflowOwner []byte
 	DonID         uint32
@@ -71,7 +71,7 @@ type WorkflowRegistryWorkflowRegisteredV1 struct {
 	SecretsURL    string
 }
 
-type WorkflowRegistryWorkflowUpdatedV1 struct {
+type WorkflowUpdatedV1 struct {
 	OldWorkflowID types.WorkflowID
 	WorkflowOwner []byte
 	DonID         uint32
@@ -83,21 +83,21 @@ type WorkflowRegistryWorkflowUpdatedV1 struct {
 	Status        uint8
 }
 
-type WorkflowRegistryWorkflowPausedV1 struct {
+type WorkflowPausedV1 struct {
 	WorkflowID    types.WorkflowID
 	WorkflowOwner []byte
 	DonID         uint32
 	WorkflowName  string
 }
 
-type WorkflowRegistryWorkflowActivatedV1 struct {
+type WorkflowActivatedV1 struct {
 	WorkflowID    types.WorkflowID
 	WorkflowOwner []byte
 	DonID         uint32
 	WorkflowName  string
 }
 
-type WorkflowRegistryWorkflowDeletedV1 struct {
+type WorkflowDeletedV1 struct {
 	WorkflowID    types.WorkflowID
 	WorkflowOwner []byte
 	DonID         uint32
@@ -121,9 +121,9 @@ type eventHandler struct {
 	workflowArtifactsStore WorkflowArtifactsStore
 }
 
-type Event interface {
-	GetEventType() WorkflowRegistryEventType
-	GetData() any
+type Event struct {
+	EventType WorkflowRegistryEventType
+	Data      any
 }
 
 func WithEngineRegistry(er *EngineRegistry) func(*eventHandler) {
@@ -202,11 +202,11 @@ func (h *eventHandler) Close() error {
 }
 
 func (h *eventHandler) Handle(ctx context.Context, event Event) error {
-	switch event.GetEventType() {
+	switch event.EventType {
 	case ForceUpdateSecretsEvent:
-		payload, ok := event.GetData().(WorkflowRegistryForceUpdateSecretsRequestedV1)
+		payload, ok := event.Data.(ForceUpdateSecretsRequestedV1)
 		if !ok {
-			return newHandlerTypeError(event.GetData())
+			return newHandlerTypeError(event.Data)
 		}
 
 		cma := h.emitter.With(
@@ -222,9 +222,9 @@ func (h *eventHandler) Handle(ctx context.Context, event Event) error {
 		h.lggr.Debugw("handled event", "urlHash", payload.SecretsURLHash, "workflowOwner", hex.EncodeToString(payload.Owner), "type", ForceUpdateSecretsEvent)
 		return nil
 	case WorkflowRegisteredEvent:
-		payload, ok := event.GetData().(WorkflowRegistryWorkflowRegisteredV1)
+		payload, ok := event.Data.(WorkflowRegisteredV1)
 		if !ok {
-			return newHandlerTypeError(event.GetData())
+			return newHandlerTypeError(event.Data)
 		}
 
 		wfID := payload.WorkflowID.Hex()
@@ -243,9 +243,9 @@ func (h *eventHandler) Handle(ctx context.Context, event Event) error {
 		h.lggr.Debugw("handled event", "workflowID", wfID, "workflowName", payload.WorkflowName, "workflowOwner", hex.EncodeToString(payload.WorkflowOwner), "type", WorkflowRegisteredEvent)
 		return nil
 	case WorkflowUpdatedEvent:
-		payload, ok := event.GetData().(WorkflowRegistryWorkflowUpdatedV1)
+		payload, ok := event.Data.(WorkflowUpdatedV1)
 		if !ok {
-			return fmt.Errorf("invalid data type %T for event", event.GetData())
+			return fmt.Errorf("invalid data type %T for event", event.Data)
 		}
 
 		newWorkflowID := payload.NewWorkflowID.Hex()
@@ -264,9 +264,9 @@ func (h *eventHandler) Handle(ctx context.Context, event Event) error {
 		h.lggr.Debugw("handled event", "newWorkflowID", newWorkflowID, "oldWorkflowID", oldWorkflowID, "workflowName", payload.WorkflowName, "workflowOwner", hex.EncodeToString(payload.WorkflowOwner), "type", WorkflowUpdatedEvent)
 		return nil
 	case WorkflowPausedEvent:
-		payload, ok := event.GetData().(WorkflowRegistryWorkflowPausedV1)
+		payload, ok := event.Data.(WorkflowPausedV1)
 		if !ok {
-			return fmt.Errorf("invalid data type %T for event", event.GetData())
+			return fmt.Errorf("invalid data type %T for event", event.Data)
 		}
 
 		wfID := payload.WorkflowID.Hex()
@@ -284,9 +284,9 @@ func (h *eventHandler) Handle(ctx context.Context, event Event) error {
 		h.lggr.Debugw("handled event", "workflowID", wfID, "type", WorkflowPausedEvent)
 		return nil
 	case WorkflowActivatedEvent:
-		payload, ok := event.GetData().(WorkflowRegistryWorkflowActivatedV1)
+		payload, ok := event.Data.(WorkflowActivatedV1)
 		if !ok {
-			return fmt.Errorf("invalid data type %T for event", event.GetData())
+			return fmt.Errorf("invalid data type %T for event", event.Data)
 		}
 
 		wfID := payload.WorkflowID.Hex()
@@ -304,9 +304,9 @@ func (h *eventHandler) Handle(ctx context.Context, event Event) error {
 		h.lggr.Debugw("handled event", "workflowID", wfID, "type", WorkflowActivatedEvent, "workflowName", payload.WorkflowName, "workflowOwner", wfOwner)
 		return nil
 	case WorkflowDeletedEvent:
-		payload, ok := event.GetData().(WorkflowRegistryWorkflowDeletedV1)
+		payload, ok := event.Data.(WorkflowDeletedV1)
 		if !ok {
-			return fmt.Errorf("invalid data type %T for event", event.GetData())
+			return fmt.Errorf("invalid data type %T for event", event.Data)
 		}
 
 		wfID := payload.WorkflowID.Hex()
@@ -326,7 +326,7 @@ func (h *eventHandler) Handle(ctx context.Context, event Event) error {
 		h.lggr.Debugw("handled event", "workflowID", wfID, "type", WorkflowDeletedEvent, "workflowName", payload.WorkflowName, "workflowOwner", wfOwner)
 		return nil
 	default:
-		return fmt.Errorf("event type unsupported: %v", event.GetEventType())
+		return fmt.Errorf("event type unsupported: %v", event.EventType)
 	}
 }
 
@@ -337,7 +337,7 @@ func (h *eventHandler) Handle(ctx context.Context, event Event) error {
 // - phase 2 synchronizes the state of the engine registry.
 func (h *eventHandler) workflowRegisteredEvent(
 	ctx context.Context,
-	payload WorkflowRegistryWorkflowRegisteredV1,
+	payload WorkflowRegisteredV1,
 ) error {
 	wfID := payload.WorkflowID.Hex()
 	owner := hex.EncodeToString(payload.WorkflowOwner)
@@ -412,7 +412,7 @@ func toSpecStatus(s uint8) job.WorkflowSpecStatus {
 	}
 }
 
-func (h *eventHandler) createWorkflowSpec(ctx context.Context, payload WorkflowRegistryWorkflowRegisteredV1) (*job.WorkflowSpec, error) {
+func (h *eventHandler) createWorkflowSpec(ctx context.Context, payload WorkflowRegisteredV1) (*job.WorkflowSpec, error) {
 	wfID := payload.WorkflowID.Hex()
 	owner := hex.EncodeToString(payload.WorkflowOwner)
 
@@ -519,9 +519,9 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, o
 // updated workflow spec.
 func (h *eventHandler) workflowUpdatedEvent(
 	ctx context.Context,
-	payload WorkflowRegistryWorkflowUpdatedV1,
+	payload WorkflowUpdatedV1,
 ) error {
-	registeredEvent := WorkflowRegistryWorkflowRegisteredV1{
+	registeredEvent := WorkflowRegisteredV1{
 		WorkflowID:    payload.NewWorkflowID,
 		WorkflowOwner: payload.WorkflowOwner,
 		DonID:         payload.DonID,
@@ -538,7 +538,7 @@ func (h *eventHandler) workflowUpdatedEvent(
 // workflowPausedEvent handles the WorkflowPausedEvent event type.
 func (h *eventHandler) workflowPausedEvent(
 	ctx context.Context,
-	payload WorkflowRegistryWorkflowPausedV1,
+	payload WorkflowPausedV1,
 ) error {
 	// Remove the workflow engine from the local registry if it exists
 	if err := h.tryEngineCleanup(payload.WorkflowOwner, payload.WorkflowName); err != nil {
@@ -563,7 +563,7 @@ func (h *eventHandler) workflowPausedEvent(
 // workflowActivatedEvent handles the WorkflowActivatedEvent event type.
 func (h *eventHandler) workflowActivatedEvent(
 	ctx context.Context,
-	payload WorkflowRegistryWorkflowActivatedV1,
+	payload WorkflowActivatedV1,
 ) error {
 	// fetch the workflow spec from the DB
 	spec, err := h.workflowArtifactsStore.GetWorkflowSpec(ctx, hex.EncodeToString(payload.WorkflowOwner), payload.WorkflowName)
@@ -586,7 +586,7 @@ func (h *eventHandler) workflowActivatedEvent(
 	}
 
 	// start a new workflow engine
-	registeredEvent := WorkflowRegistryWorkflowRegisteredV1{
+	registeredEvent := WorkflowRegisteredV1{
 		WorkflowID:    payload.WorkflowID,
 		WorkflowOwner: payload.WorkflowOwner,
 		DonID:         payload.DonID,
@@ -603,7 +603,7 @@ func (h *eventHandler) workflowActivatedEvent(
 // workflowDeletedEvent handles the WorkflowDeletedEvent event type. This method must remain idempotent.
 func (h *eventHandler) workflowDeletedEvent(
 	ctx context.Context,
-	payload WorkflowRegistryWorkflowDeletedV1,
+	payload WorkflowDeletedV1,
 ) error {
 	// The order in the handler is slightly different to the order in `tryEngineCleanup`.
 	// This is because the engine requires its corresponding DB record to be present to be successfully

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/utils/matches"
 
 	"github.com/jonboulle/clockwork"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -129,9 +130,9 @@ func Test_Handler(t *testing.T) {
 
 		giveHash := hex.EncodeToString(giveBytes)
 
-		giveEvent := WorkflowRegistryEvent{
+		giveEvent := Event{
 			EventType: ForceUpdateSecretsEvent,
-			Data: WorkflowRegistryForceUpdateSecretsRequestedV1{
+			Data: ForceUpdateSecretsRequestedV1{
 				SecretsURLHash: giveBytes,
 			},
 		}
@@ -160,7 +161,7 @@ func Test_Handler(t *testing.T) {
 		workflowLimits, err := syncerlimiter.NewWorkflowLimits(lggr, syncerlimiter.Config{Global: 200, PerOwner: 200})
 		require.NoError(t, err)
 
-		giveEvent := WorkflowRegistryEvent{}
+		giveEvent := Event{}
 		fetcher := func(_ context.Context, _ string, _ ghcapabilities.Request) ([]byte, error) {
 			return []byte("contents"), nil
 		}
@@ -196,9 +197,9 @@ func Test_Handler(t *testing.T) {
 
 		giveHash := hex.EncodeToString(giveBytes)
 
-		giveEvent := WorkflowRegistryEvent{
+		giveEvent := Event{
 			EventType: ForceUpdateSecretsEvent,
-			Data: WorkflowRegistryForceUpdateSecretsRequestedV1{
+			Data: ForceUpdateSecretsRequestedV1{
 				SecretsURLHash: giveBytes,
 			},
 		}
@@ -222,9 +223,9 @@ func Test_Handler(t *testing.T) {
 
 		giveHash := hex.EncodeToString(giveBytes)
 
-		giveEvent := WorkflowRegistryEvent{
+		giveEvent := Event{
 			EventType: ForceUpdateSecretsEvent,
-			Data: WorkflowRegistryForceUpdateSecretsRequestedV1{
+			Data: ForceUpdateSecretsRequestedV1{
 				SecretsURLHash: giveBytes,
 			},
 		}
@@ -257,9 +258,9 @@ func Test_Handler(t *testing.T) {
 
 		giveHash := hex.EncodeToString(giveBytes)
 
-		giveEvent := WorkflowRegistryEvent{
+		giveEvent := Event{
 			EventType: ForceUpdateSecretsEvent,
-			Data: WorkflowRegistryForceUpdateSecretsRequestedV1{
+			Data: ForceUpdateSecretsRequestedV1{
 				SecretsURLHash: giveBytes,
 			},
 		}
@@ -298,7 +299,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 	var encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
 	var workflowName = "workflow-name"
 
-	defaultValidationFn := func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
+	defaultValidationFn := func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
 		err := h.workflowRegisteredEvent(ctx, event)
 		require.NoError(t, err)
 
@@ -316,7 +317,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	defaultValidationFnWithFetch := func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
+	defaultValidationFnWithFetch := func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
 		defaultValidationFn(t, ctx, event, h, s, wfOwner, wfName, wfID, fetcher)
 
 		// Verify that the URLs have been called
@@ -342,8 +343,8 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 			BinaryURL:  binaryURL,
 			GiveBinary: binary,
 			WFOwner:    wfOwner,
-			Event: func(wfID []byte) WorkflowRegistryWorkflowRegisteredV1 {
-				return WorkflowRegistryWorkflowRegisteredV1{
+			Event: func(wfID []byte) WorkflowRegisteredV1 {
+				return WorkflowRegisteredV1{
 					Status:        uint8(0),
 					WorkflowID:    [32]byte(wfID),
 					WorkflowOwner: wfOwner,
@@ -378,8 +379,8 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 			BinaryURL:  binaryURL,
 			GiveBinary: binary,
 			WFOwner:    wfOwner,
-			Event: func(wfID []byte) WorkflowRegistryWorkflowRegisteredV1 {
-				return WorkflowRegistryWorkflowRegisteredV1{
+			Event: func(wfID []byte) WorkflowRegisteredV1 {
+				return WorkflowRegisteredV1{
 					Status:        uint8(0),
 					WorkflowID:    [32]byte(wfID),
 					WorkflowOwner: wfOwner,
@@ -407,8 +408,8 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 			BinaryURL:  binaryURL,
 			GiveBinary: binary,
 			WFOwner:    wfOwner,
-			Event: func(wfID []byte) WorkflowRegistryWorkflowRegisteredV1 {
-				return WorkflowRegistryWorkflowRegisteredV1{
+			Event: func(wfID []byte) WorkflowRegisteredV1 {
+				return WorkflowRegisteredV1{
 					Status:        uint8(0),
 					WorkflowID:    [32]byte(wfID),
 					WorkflowOwner: wfOwner,
@@ -418,7 +419,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					SecretsURL:    secretsURL,
 				}
 			},
-			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler,
+			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler,
 				s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
 				err := h.workflowRegisteredEvent(ctx, event)
 				require.Error(t, err)
@@ -438,8 +439,8 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 			BinaryURL:  binaryURL,
 			GiveBinary: binary,
 			WFOwner:    wfOwner,
-			Event: func(wfID []byte) WorkflowRegistryWorkflowRegisteredV1 {
-				return WorkflowRegistryWorkflowRegisteredV1{
+			Event: func(wfID []byte) WorkflowRegisteredV1 {
+				return WorkflowRegisteredV1{
 					Status:        uint8(0),
 					WorkflowID:    [32]byte(wfID),
 					WorkflowOwner: wfOwner,
@@ -449,7 +450,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					SecretsURL:    secretsURL,
 				}
 			},
-			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
+			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
 				me := &mockEngine{}
 				var wfIDBytes [32]byte
 				copy(wfIDBytes[:], wfID)
@@ -472,8 +473,8 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 			BinaryURL:  binaryURL,
 			GiveBinary: binary,
 			WFOwner:    wfOwner,
-			Event: func(wfID []byte) WorkflowRegistryWorkflowRegisteredV1 {
-				return WorkflowRegistryWorkflowRegisteredV1{
+			Event: func(wfID []byte) WorkflowRegisteredV1 {
+				return WorkflowRegisteredV1{
 					Status:        uint8(0),
 					WorkflowID:    [32]byte(wfID),
 					WorkflowOwner: wfOwner,
@@ -483,7 +484,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					SecretsURL:    secretsURL,
 				}
 			},
-			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
+			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
 				me := &mockEngine{}
 				oldWfIDBytes := [32]byte{0, 1, 2, 3, 5}
 				err := h.engineRegistry.Add(EngineRegistryKey{Owner: wfOwner, Name: workflowName}, me, oldWfIDBytes)
@@ -508,8 +509,8 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 			BinaryURL:  binaryURL,
 			GiveBinary: binary,
 			WFOwner:    wfOwner,
-			Event: func(wfID []byte) WorkflowRegistryWorkflowRegisteredV1 {
-				return WorkflowRegistryWorkflowRegisteredV1{
+			Event: func(wfID []byte) WorkflowRegisteredV1 {
+				return WorkflowRegisteredV1{
 					Status:        uint8(1),
 					WorkflowID:    [32]byte(wfID),
 					WorkflowOwner: wfOwner,
@@ -519,7 +520,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					SecretsURL:    secretsURL,
 				}
 			},
-			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler,
+			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler,
 				s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
 				err := h.workflowRegisteredEvent(ctx, event)
 				require.NoError(t, err)
@@ -549,8 +550,8 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 			BinaryURL:  binaryURL,
 			GiveBinary: binary,
 			WFOwner:    wfOwner,
-			Event: func(wfID []byte) WorkflowRegistryWorkflowRegisteredV1 {
-				return WorkflowRegistryWorkflowRegisteredV1{
+			Event: func(wfID []byte) WorkflowRegisteredV1 {
+				return WorkflowRegisteredV1{
 					Status:        uint8(0),
 					WorkflowID:    [32]byte(wfID),
 					WorkflowOwner: wfOwner,
@@ -560,7 +561,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					SecretsURL:    secretsURL,
 				}
 			},
-			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler,
+			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler,
 				s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
 				// Create the record in the database
 				entry := &job.WorkflowSpec{
@@ -605,7 +606,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 				binaryURL:  {Body: encodedBinary, Err: nil},
 				secretsURL: {Body: []byte("secrets"), Err: nil},
 			}),
-			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
+			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
 				defaultValidationFn(t, ctx, event, h, s, wfOwner, wfName, wfID, fetcher)
 
 				// Verify that the URLs have been called
@@ -613,8 +614,8 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 				require.Equal(t, 0, fetcher.Calls(event.ConfigURL))
 				require.Equal(t, 1, fetcher.Calls(event.SecretsURL))
 			},
-			Event: func(wfID []byte) WorkflowRegistryWorkflowRegisteredV1 {
-				return WorkflowRegistryWorkflowRegisteredV1{
+			Event: func(wfID []byte) WorkflowRegisteredV1 {
+				return WorkflowRegisteredV1{
 					Status:        uint8(0),
 					WorkflowID:    [32]byte(wfID),
 					WorkflowOwner: wfOwner,
@@ -635,7 +636,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 				binaryURL: {Body: encodedBinary, Err: nil},
 				configURL: {Body: config, Err: nil},
 			}),
-			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
+			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
 				defaultValidationFn(t, ctx, event, h, s, wfOwner, wfName, wfID, fetcher)
 
 				// Verify that the URLs have been called
@@ -643,8 +644,8 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 				require.Equal(t, 1, fetcher.Calls(event.ConfigURL))
 				require.Equal(t, 0, fetcher.Calls(event.SecretsURL))
 			},
-			Event: func(wfID []byte) WorkflowRegistryWorkflowRegisteredV1 {
-				return WorkflowRegistryWorkflowRegisteredV1{
+			Event: func(wfID []byte) WorkflowRegisteredV1 {
+				return WorkflowRegisteredV1{
 					Status:        uint8(0),
 					WorkflowID:    [32]byte(wfID),
 					WorkflowOwner: wfOwner,
@@ -665,7 +666,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 				binaryURL: {Body: encodedBinary, Err: nil},
 				configURL: {Body: config, Err: nil},
 			}),
-			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
+			validationFn: func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher) {
 				// Create the record in the database
 				entry := &job.WorkflowSpec{
 					Workflow:      hex.EncodeToString(binary),
@@ -688,8 +689,8 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 				require.Equal(t, 0, fetcher.Calls(event.ConfigURL))
 				require.Equal(t, 0, fetcher.Calls(event.SecretsURL))
 			},
-			Event: func(wfID []byte) WorkflowRegistryWorkflowRegisteredV1 {
-				return WorkflowRegistryWorkflowRegisteredV1{
+			Event: func(wfID []byte) WorkflowRegisteredV1 {
+				return WorkflowRegisteredV1{
 					Status:        uint8(0),
 					WorkflowID:    [32]byte(wfID),
 					WorkflowOwner: wfOwner,
@@ -715,8 +716,8 @@ type testCase struct {
 	ConfigURL       string
 	WFOwner         []byte
 	fetcher         *mockFetcher
-	Event           func([]byte) WorkflowRegistryWorkflowRegisteredV1
-	validationFn    func(t *testing.T, ctx context.Context, event WorkflowRegistryWorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher)
+	Event           func([]byte) WorkflowRegisteredV1
+	validationFn    func(t *testing.T, ctx context.Context, event WorkflowRegisteredV1, h *eventHandler, s *artifacts.Store, wfOwner []byte, wfName string, wfID string, fetcher *mockFetcher)
 	engineFactoryFn func(ctx context.Context, wfid string, owner string, name types.WorkflowName, config []byte, binary []byte) (services.Service, error)
 }
 
@@ -846,7 +847,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 
 		require.NoError(t, err)
 
-		active := WorkflowRegistryWorkflowRegisteredV1{
+		active := WorkflowRegisteredV1{
 			Status:        uint8(0),
 			WorkflowID:    giveWFID,
 			WorkflowOwner: wfOwner,
@@ -887,7 +888,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 		err = engine.Ready()
 		require.NoError(t, err)
 
-		deleteEvent := WorkflowRegistryWorkflowDeletedV1{
+		deleteEvent := WorkflowDeletedV1{
 			WorkflowID:    giveWFID,
 			WorkflowOwner: wfOwner,
 			WorkflowName:  "workflow-name",
@@ -944,7 +945,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 		h, err := NewEventHandler(lggr, store, registry, NewEngineRegistry(), emitter, rl, workflowLimits, artifactStore, WithEngineRegistry(er))
 		require.NoError(t, err)
 
-		deleteEvent := WorkflowRegistryWorkflowDeletedV1{
+		deleteEvent := WorkflowDeletedV1{
 			WorkflowID:    giveWFID,
 			WorkflowOwner: wfOwner,
 			WorkflowName:  "workflow-name",
@@ -986,7 +987,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 
 		require.NoError(t, err)
 
-		active := WorkflowRegistryWorkflowRegisteredV1{
+		active := WorkflowRegisteredV1{
 			Status:        uint8(0),
 			WorkflowID:    giveWFID,
 			WorkflowOwner: wfOwner,
@@ -1028,7 +1029,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 		err = engine.Ready()
 		require.NoError(t, err)
 
-		deleteEvent := WorkflowRegistryWorkflowDeletedV1{
+		deleteEvent := WorkflowDeletedV1{
 			WorkflowID:    giveWFID,
 			WorkflowOwner: wfOwner,
 			WorkflowName:  "workflow-name",
@@ -1080,7 +1081,7 @@ func Test_workflowPausedActivatedUpdatedHandler(t *testing.T) {
 		require.NoError(t, err)
 		newWFIDs := hex.EncodeToString(updatedWFID[:])
 
-		active := WorkflowRegistryWorkflowRegisteredV1{
+		active := WorkflowRegisteredV1{
 			Status:        uint8(0),
 			WorkflowID:    giveWFID,
 			WorkflowOwner: wfOwner,
@@ -1122,7 +1123,7 @@ func Test_workflowPausedActivatedUpdatedHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		// create a paused event
-		pauseEvent := WorkflowRegistryWorkflowPausedV1{
+		pauseEvent := WorkflowPausedV1{
 			WorkflowID:    giveWFID,
 			WorkflowOwner: wfOwner,
 			WorkflowName:  "workflow-name",
@@ -1143,7 +1144,7 @@ func Test_workflowPausedActivatedUpdatedHandler(t *testing.T) {
 		require.Error(t, err)
 
 		// create an updated event
-		updatedEvent := WorkflowRegistryWorkflowUpdatedV1{
+		updatedEvent := WorkflowUpdatedV1{
 			OldWorkflowID: giveWFID,
 			NewWorkflowID: updatedWFID,
 			WorkflowOwner: wfOwner,

--- a/core/services/workflows/syncer/workflow_registry_test.go
+++ b/core/services/workflows/syncer/workflow_registry_test.go
@@ -71,8 +71,8 @@ func Test_workflowMetadataToEvents(t *testing.T) {
 
 		// The only event is WorkflowRegisteredEvent
 		require.Len(t, events, 1)
-		require.Equal(t, WorkflowRegisteredEvent, events[0].GetEventType())
-		expectedRegisteredEvent := WorkflowRegistryWorkflowRegisteredV1{
+		require.Equal(t, WorkflowRegisteredEvent, events[0].EventType)
+		expectedRegisteredEvent := WorkflowRegisteredV1{
 			WorkflowID:    wfID,
 			WorkflowOwner: owner,
 			DonID:         donID,
@@ -82,7 +82,7 @@ func Test_workflowMetadataToEvents(t *testing.T) {
 			ConfigURL:     configURL,
 			SecretsURL:    secretsURL,
 		}
-		require.Equal(t, expectedRegisteredEvent, events[0].GetData())
+		require.Equal(t, expectedRegisteredEvent, events[0].Data)
 	})
 
 	t.Run("WorkflowUpdatedEvent", func(t *testing.T) {
@@ -136,8 +136,8 @@ func Test_workflowMetadataToEvents(t *testing.T) {
 
 		// The only event is WorkflowUpdatedEvent
 		require.Len(t, events, 1)
-		require.Equal(t, WorkflowUpdatedEvent, events[0].GetEventType())
-		expectedUpdatedEvent := WorkflowRegistryWorkflowUpdatedV1{
+		require.Equal(t, WorkflowUpdatedEvent, events[0].EventType)
+		expectedUpdatedEvent := WorkflowUpdatedV1{
 			OldWorkflowID: wfID,
 			NewWorkflowID: wfID2,
 			WorkflowOwner: owner,
@@ -147,7 +147,7 @@ func Test_workflowMetadataToEvents(t *testing.T) {
 			ConfigURL:     configURL,
 			SecretsURL:    secretsURL,
 		}
-		require.Equal(t, expectedUpdatedEvent, events[0].GetData())
+		require.Equal(t, expectedUpdatedEvent, events[0].Data)
 	})
 
 	t.Run("WorkflowDeletedEvent", func(t *testing.T) {
@@ -185,14 +185,14 @@ func Test_workflowMetadataToEvents(t *testing.T) {
 
 		// The only event is WorkflowDeletedEvent
 		require.Len(t, events, 1)
-		require.Equal(t, WorkflowDeletedEvent, events[0].GetEventType())
-		expectedUpdatedEvent := WorkflowRegistryWorkflowDeletedV1{
+		require.Equal(t, WorkflowDeletedEvent, events[0].EventType)
+		expectedUpdatedEvent := WorkflowDeletedV1{
 			WorkflowID:    wfID,
 			WorkflowOwner: owner,
 			DonID:         donID,
 			WorkflowName:  wfName,
 		}
-		require.Equal(t, expectedUpdatedEvent, events[0].GetData())
+		require.Equal(t, expectedUpdatedEvent, events[0].Data)
 	})
 
 	t.Run("No change", func(t *testing.T) {
@@ -242,8 +242,8 @@ func Test_workflowMetadataToEvents(t *testing.T) {
 
 		// The only event is WorkflowRegisteredEvent
 		require.Len(t, events, 1)
-		require.Equal(t, WorkflowRegisteredEvent, events[0].GetEventType())
-		expectedRegisteredEvent := WorkflowRegistryWorkflowRegisteredV1{
+		require.Equal(t, WorkflowRegisteredEvent, events[0].EventType)
+		expectedRegisteredEvent := WorkflowRegisteredV1{
 			WorkflowID:    wfID,
 			WorkflowOwner: owner,
 			DonID:         donID,
@@ -253,7 +253,7 @@ func Test_workflowMetadataToEvents(t *testing.T) {
 			ConfigURL:     configURL,
 			SecretsURL:    secretsURL,
 		}
-		require.Equal(t, expectedRegisteredEvent, events[0].GetData())
+		require.Equal(t, expectedRegisteredEvent, events[0].Data)
 
 		// Add the workflow to the engine registry as the handler would
 		err = er.Add(EngineRegistryKey{Owner: owner, Name: wfName}, &mockService{}, wfID)
@@ -362,13 +362,13 @@ func Test_workflowMetadataToEvents(t *testing.T) {
 
 		// The only event is WorkflowDeletedEvent
 		require.Len(t, events, 1)
-		require.Equal(t, WorkflowDeletedEvent, events[0].GetEventType())
-		expectedUpdatedEvent := WorkflowRegistryWorkflowDeletedV1{
+		require.Equal(t, WorkflowDeletedEvent, events[0].EventType)
+		expectedUpdatedEvent := WorkflowDeletedV1{
 			WorkflowID:    wfID,
 			WorkflowOwner: owner,
 			DonID:         donID,
 			WorkflowName:  wfName,
 		}
-		require.Equal(t, expectedUpdatedEvent, events[0].GetData())
+		require.Equal(t, expectedUpdatedEvent, events[0].Data)
 	})
 }


### PR DESCRIPTION
- Move from the Event interface to an Event struct
- Remove WorkflowRegistryEventResponse and ensure we handle a failure to convert the event correctly.
- Add a workflowRegistryEvent struct for use by the events based syncer; this contains the Event to send to the handler, plus specific metadata for use by events based syncing.
- Simplify event names by removing the WorkflowRegistry prefix.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
