### PR TITLE
fix: e2e cron test config

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -1023,7 +1023,7 @@ runner-test-matrix:
     triggers:
       - Nightly E2E Tests
       - Push E2E Core Tests
-    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "TestCronV2Pipeline|TestCronV2Schedule" -timeout 30m -count=1 -test.parallel=2 -json
+    test_cmd: go test github.com/smartcontractkit/chainlink/integration-tests/smoke -v -run "TestCronBasic|TestCronJobReplacement" -timeout 30m -count=1 -test.parallel=2 -json
     pyroscope_env: ci-smoke-cron-evm-simulated
     test_go_project_path: integration-tests
 
@@ -1369,7 +1369,7 @@ runner-test-matrix:
       E2E_RMN_AFN2PROXY_VERSION: master-amd64-10b42b2
       CCIP_V16_TEST_ENV: docker
     test_go_project_path: integration-tests
-  
+
   - id: smoke/ccip/ccip_rmn_test.go:^Test_CCIPReorg_BelowFinality_OnSource_WithRMN_Block$
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker


### PR DESCRIPTION
We are seeing constant failures on develop for this job: https://github.com/smartcontractkit/chainlink/actions/runs/14650366838/job/41114880256

```
ERR No tests were run.
Error: Process completed with exit code 2.
```

### Changes

- Update the name of the cron tests to match that of the file: https://github.com/smartcontractkit/chainlink/blob/develop/integration-tests/smoke/cron_test.go
  - The names currently there refer to unit tests: https://github.com/smartcontractkit/chainlink/blob/develop/core/services/cron/cron_test.go





