### PR TITLE
CCIP-4856 Increasing hardware spec for runner to make tests work for longer durations - temporary fix until the root cause is found

### DIFF
--- a/integration-tests/ccip-tests/Makefile
+++ b/integration-tests/ccip-tests/Makefile
@@ -30,8 +30,8 @@ test_load_ccip: set_config
     TEST_SUITE=ccip-load \
     TEST_ARGS="-test.timeout 900h" \
     DETACH_RUNNER=true \
-    RR_MEM=16Gi \
-    RR_CPU=4 \
+    RR_MEM=40Gi \
+    RR_CPU=6 \
 	go test -timeout 24h -count=1 -v -run ^$(testname)$$ ./load
 
 

--- a/integration-tests/ccip-tests/Makefile
+++ b/integration-tests/ccip-tests/Makefile
@@ -30,7 +30,7 @@ test_load_ccip: set_config
     TEST_SUITE=ccip-load \
     TEST_ARGS="-test.timeout 900h" \
     DETACH_RUNNER=true \
-    RR_MEM=40Gi \
+    RR_MEM=45Gi \
     RR_CPU=6 \
 	go test -timeout 24h -count=1 -v -run ^$(testname)$$ ./load
 

--- a/integration-tests/ccip-tests/testconfig/tomls/load/baseline.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/load/baseline.toml
@@ -26,7 +26,7 @@ TokenPool = '1.4.0'
 CommitStore = '1.2.0'
 
 [CCIP.Env]
-TTL = '12h'
+TTL = '10h'
 
 [CCIP.Env.Network]
 selected_networks = ['PRIVATE-CHAIN-1', 'PRIVATE-CHAIN-2']
@@ -149,8 +149,8 @@ NoOfCommitNodes = 16
 PhaseTimeout = '40m'
 NodeFunding = 1000.0
 NoOfRoutersPerPair = 1
-NoOfNetworks = 60
-MaxNoOfLanes = 300
+NoOfNetworks = 70
+MaxNoOfLanes = 350
 
 [CCIP.Groups.load.OffRampConfig]
 BatchGasLimit = 11000000
@@ -163,7 +163,7 @@ DynamicPriceUpdateInterval = '15s'
 CCIPOwnerTokens = true
 
 [CCIP.Groups.load.LoadProfile]
-TestDuration = '10h'
+TestDuration = '8h'
 TimeUnit = '5s'
 RequestPerUnitTime = [1]
 OptimizeSpace = true


### PR DESCRIPTION
Temporary fix to enable load tests on higher number of chains until OOM problem in the test runner is fixed 