### PR TITLE
feat: add update timelock delay changeset for solana

### DIFF
--- a/deployment/common/changeset/deploy_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock_test.go
@@ -444,8 +444,7 @@ func TestDeployMCMSWithTimelockV2(t *testing.T) {
 
 	timelockConfig := solanaTimelockConfig(ctx, t, solanaChain0, solanaState0.TimelockProgram, solanaState0.TimelockSeed)
 	require.NoError(t, err)
-	require.Equal(t, timelockConfig.ProposedOwner.String(),
-		timelockSignerPDA(solanaState0.TimelockProgram, solanaState0.TimelockSeed))
+	require.Equal(t, timelockConfig.ProposedOwner.String(), "11111111111111111111111111111111")
 }
 
 // TestDeployMCMSWithTimelockV2SkipInit tests calling the deploy changeset when accounts have already been initialized

--- a/deployment/common/changeset/solana/mcms/mcms.go
+++ b/deployment/common/changeset/solana/mcms/mcms.go
@@ -84,19 +84,5 @@ func DeployMCMSWithTimelockProgramsSolana(
 		return nil, fmt.Errorf("failed to setup roles and ownership: %w", err)
 	}
 
-	err = transferOwnership(chainState, chain)
-	if err != nil {
-		return nil, fmt.Errorf("failed to transfer ownership: %w", err)
-	}
-
 	return chainState, nil
-}
-
-func transferOwnership(chainState *state.MCMSWithTimelockStateSolana, chain deployment.SolChain) error {
-	err := transferOwnershipTimelock(chain, chainState.TimelockProgram, chainState.TimelockSeed)
-	if err != nil {
-		return fmt.Errorf("failed to transfer ownership of timelock: %w", err)
-	}
-
-	return nil
 }

--- a/deployment/common/changeset/solana/mcms/timelock.go
+++ b/deployment/common/changeset/solana/mcms/timelock.go
@@ -167,23 +167,3 @@ func initializeTimelock(
 
 	return nil
 }
-
-func transferOwnershipTimelock(chain deployment.SolChain, programID solana.PublicKey, seed state.PDASeed) error {
-	// transfer timelock ownership to itself
-	timelockConfigPDA := state.GetTimelockConfigPDA(programID, seed)
-	timelockSignerPDA := state.GetTimelockSignerPDA(programID, seed)
-
-	instructionBuilder := timelockBindings.NewTransferOwnershipInstruction([32]uint8(seed),
-		timelockSignerPDA, timelockConfigPDA, chain.DeployerKey.PublicKey())
-	instruction, err := instructionBuilder.ValidateAndBuild()
-	if err != nil {
-		return fmt.Errorf("failed to build TransferOwnership instruction: %w", err)
-	}
-
-	err = chain.Confirm([]solana.Instruction{instruction})
-	if err != nil {
-		return fmt.Errorf("failed to confirm TransferOwnership instruction: %w", err)
-	}
-
-	return nil
-}

--- a/deployment/common/changeset/solana/update_delay_timelock.go
+++ b/deployment/common/changeset/solana/update_delay_timelock.go
@@ -1,0 +1,75 @@
+package solana
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+)
+
+// UpdateTimelockDelaySolana updates the timelock delay for the given solana chains
+type UpdateTimelockDelaySolana struct{}
+
+type UpdateTimelockDelaySolanaCfg struct {
+	DelayPerChain map[uint64]time.Duration
+}
+
+func (t UpdateTimelockDelaySolana) VerifyPreconditions(
+	env deployment.Environment, config UpdateTimelockDelaySolanaCfg,
+) error {
+	if len(config.DelayPerChain) == 0 {
+		return fmt.Errorf("no delay configs provided")
+	}
+	if len(env.SolChains) == 0 {
+		return fmt.Errorf("no solana chains provided")
+	}
+	// check the timelock program is deployed
+	for chainSelector := range config.DelayPerChain {
+		solChain, ok := env.SolChains[chainSelector]
+		if !ok {
+			return fmt.Errorf("solana chain not found for selector %d", chainSelector)
+		}
+		addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+		if err != nil {
+			return fmt.Errorf("failed to get existing addresses: %w", err)
+		}
+		mcmState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(solChain, addresses)
+		if err != nil {
+			return fmt.Errorf("failed to load MCMS state: %w", err)
+		}
+		if mcmState.TimelockProgram.IsZero() {
+			return fmt.Errorf("timelock program not deployed for chain %d", chainSelector)
+		}
+		if mcmState.TimelockSeed == [32]byte{} {
+			return fmt.Errorf("timelock seed not found for chain %d", chainSelector)
+		}
+	}
+	return nil
+}
+
+func (t UpdateTimelockDelaySolana) Apply(
+	env deployment.Environment, cfg UpdateTimelockDelaySolanaCfg,
+) (deployment.ChangesetOutput, error) {
+	for chainSelector, delay := range cfg.DelayPerChain {
+		solChain := env.SolChains[chainSelector]
+		addreses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+		if err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
+		}
+		mcmState, _ := state.MaybeLoadMCMSWithTimelockChainStateSolana(solChain, addreses)
+		confiPDA := state.GetTimelockConfigPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
+		updateDelayIx := timelockBindings.NewUpdateDelayInstruction(mcmState.TimelockSeed, uint64(delay.Seconds()), confiPDA, solChain.DeployerKey.PublicKey())
+		ix, err := updateDelayIx.ValidateAndBuild()
+		if err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to create update delay instruction: %w", err)
+		}
+		if err := solChain.Confirm([]solana.Instruction{ix}); err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to confirm instructions: %w", err)
+		}
+	}
+	return deployment.ChangesetOutput{}, nil
+}

--- a/deployment/common/changeset/solana/update_delay_timelock.go
+++ b/deployment/common/changeset/solana/update_delay_timelock.go
@@ -36,7 +36,7 @@ func (t UpdateTimelockDelaySolana) VerifyPreconditions(
 			return fmt.Errorf("solana chain not found for selector %d", chainSelector)
 		}
 
-		//nolint:staticcheck // will wait till we can migrate from address book before using data store
+		//nolint:staticcheck // wait till we can migrate from address book before using data store
 		addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 		if err != nil {
 			return fmt.Errorf("failed to get existing addresses: %w", err)

--- a/deployment/common/changeset/solana/update_delay_timelock.go
+++ b/deployment/common/changeset/solana/update_delay_timelock.go
@@ -1,10 +1,12 @@
 package solana
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+
 	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -22,10 +24,10 @@ func (t UpdateTimelockDelaySolana) VerifyPreconditions(
 	env deployment.Environment, config UpdateTimelockDelaySolanaCfg,
 ) error {
 	if len(config.DelayPerChain) == 0 {
-		return fmt.Errorf("no delay configs provided")
+		return errors.New("no delay configs provided")
 	}
 	if len(env.SolChains) == 0 {
-		return fmt.Errorf("no solana chains provided")
+		return errors.New("no solana chains provided")
 	}
 	// check the timelock program is deployed
 	for chainSelector := range config.DelayPerChain {
@@ -33,6 +35,8 @@ func (t UpdateTimelockDelaySolana) VerifyPreconditions(
 		if !ok {
 			return fmt.Errorf("solana chain not found for selector %d", chainSelector)
 		}
+
+		//nolint:staticcheck // will wait till we can migrate from address book before using data store
 		addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 		if err != nil {
 			return fmt.Errorf("failed to get existing addresses: %w", err)
@@ -56,6 +60,7 @@ func (t UpdateTimelockDelaySolana) Apply(
 ) (deployment.ChangesetOutput, error) {
 	for chainSelector, delay := range cfg.DelayPerChain {
 		solChain := env.SolChains[chainSelector]
+		//nolint:staticcheck // will wait till we can migrate from address book before using data store
 		addreses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)

--- a/deployment/common/changeset/solana/update_delay_timelock.go
+++ b/deployment/common/changeset/solana/update_delay_timelock.go
@@ -61,13 +61,13 @@ func (t UpdateTimelockDelaySolana) Apply(
 	for chainSelector, delay := range cfg.DelayPerChain {
 		solChain := env.SolChains[chainSelector]
 		//nolint:staticcheck // will wait till we can migrate from address book before using data store
-		addreses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+		addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
 		}
-		mcmState, _ := state.MaybeLoadMCMSWithTimelockChainStateSolana(solChain, addreses)
-		confiPDA := state.GetTimelockConfigPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
-		updateDelayIx := timelockBindings.NewUpdateDelayInstruction(mcmState.TimelockSeed, uint64(delay.Seconds()), confiPDA, solChain.DeployerKey.PublicKey())
+		mcmState, _ := state.MaybeLoadMCMSWithTimelockChainStateSolana(solChain, addresses)
+		configPDA := state.GetTimelockConfigPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
+		updateDelayIx := timelockBindings.NewUpdateDelayInstruction(mcmState.TimelockSeed, uint64(delay.Seconds()), configPDA, solChain.DeployerKey.PublicKey())
 		ix, err := updateDelayIx.ValidateAndBuild()
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to create update delay instruction: %w", err)

--- a/deployment/common/changeset/solana/update_delay_timelock_test.go
+++ b/deployment/common/changeset/solana/update_delay_timelock_test.go
@@ -1,0 +1,200 @@
+package solana_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
+
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	commonSolana "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana"
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/deployment/common/types"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+// setupUpdateDelayTestEnv deploys all required contracts for set \delay test
+func setupUpdateDelayTestEnv(t *testing.T) deployment.Environment {
+	lggr := logger.TestLogger(t)
+	cfg := memory.MemoryEnvironmentConfig{
+		SolChains: 1,
+	}
+	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
+	chainSelector := env.AllChainSelectorsSolana()[0]
+
+	config := proposalutils.SingleGroupTimelockConfigV2(t)
+	err := testhelpers.SavePreloadedSolAddresses(env, chainSelector)
+	require.NoError(t, err)
+	// Initialize the address book with a dummy address to avoid deploy precondition errors.
+	err = env.ExistingAddresses.Save(chainSelector, "dummyAddress", deployment.TypeAndVersion{Type: "dummy", Version: deployment.Version1_0_0})
+	require.NoError(t, err)
+
+	// Deploy MCMS and Timelock
+	env, err = changeset.Apply(t, env, nil,
+		changeset.Configure(
+			deployment.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
+			map[uint64]types.MCMSWithTimelockConfigV2{
+				chainSelector: config,
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	return env
+}
+
+func TestUpdateTimelockDelaySolana_VerifyPreconditions(t *testing.T) {
+	t.Parallel()
+	lggr := logger.TestLogger(t)
+	validEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{SolChains: 1})
+	validEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
+	validSolChainSelector := validEnv.AllChainSelectorsSolana()[0]
+
+	timelockID := mcmsSolana.ContractAddress(
+		solana.NewWallet().PublicKey(),
+		[32]byte{'t', 'e', 's', 't'},
+	)
+	mcmDummyProgram := solana.NewWallet().PublicKey()
+
+	err := validEnv.ExistingAddresses.Save(validSolChainSelector, timelockID, deployment.TypeAndVersion{
+		Type:    types.RBACTimelock,
+		Version: deployment.Version1_0_0,
+	})
+	require.NoError(t, err)
+	mcmsProposerIDEmpty := mcmsSolana.ContractAddress(
+		mcmDummyProgram,
+		[32]byte{},
+	)
+
+	// Create an environment that simulates a chain where the timelock program has not been deployed,
+	// e.g. missing the required addresses so that the state loader returns empty seeds.
+	noTimelockEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+		Chains:    0,
+		SolChains: 1,
+		Nodes:     1,
+	})
+	noTimelockEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
+	err = noTimelockEnv.ExistingAddresses.Save(chainselectors.SOLANA_DEVNET.Selector, mcmsProposerIDEmpty, deployment.TypeAndVersion{
+		Type:    types.BypasserManyChainMultisig,
+		Version: deployment.Version1_0_0,
+	})
+	require.NoError(t, err)
+
+	// Create an environment with a Solana chain that has an invalid (zero) underlying chain.
+	invalidSolChainEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+		Chains:    0,
+		SolChains: 0,
+		Nodes:     1,
+	})
+	invalidSolChainEnv.SolChains[validSolChainSelector] = deployment.SolChain{}
+
+	tests := []struct {
+		name          string
+		env           deployment.Environment
+		config        commonSolana.UpdateTimelockDelaySolanaCfg
+		expectedError string
+	}{
+		{
+			name: "All preconditions satisfied",
+			env:  validEnv,
+			config: commonSolana.UpdateTimelockDelaySolanaCfg{
+				DelayPerChain: map[uint64]time.Duration{validSolChainSelector: 5 * time.Minute},
+			},
+			expectedError: "",
+		},
+		{
+			name: "No Solana chains found in environment",
+			env: memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+				Bootstraps: 1,
+				Chains:     1,
+				SolChains:  0,
+				Nodes:      1,
+			}),
+			config: commonSolana.UpdateTimelockDelaySolanaCfg{
+				DelayPerChain: map[uint64]time.Duration{validSolChainSelector: 5 * time.Minute},
+			},
+			expectedError: "no solana chains provided",
+		},
+		{
+			name: "Chain selector not found in environment",
+			env:  validEnv,
+			config: commonSolana.UpdateTimelockDelaySolanaCfg{
+				DelayPerChain: map[uint64]time.Duration{9999: 5 * time.Minute},
+			},
+			expectedError: "solana chain not found for selector 9999",
+		},
+		{
+			name: "Timelock not deployed (empty seeds)",
+			env:  noTimelockEnv,
+			config: commonSolana.UpdateTimelockDelaySolanaCfg{
+				DelayPerChain: map[uint64]time.Duration{chainselectors.SOLANA_DEVNET.Selector: 5 * time.Minute},
+			},
+			expectedError: "timelock program not deployed for chain 16423721717087811551",
+		},
+		{
+			name:          "empty config provided",
+			env:           invalidSolChainEnv,
+			config:        commonSolana.UpdateTimelockDelaySolanaCfg{},
+			expectedError: "no delay configs provided",
+		},
+	}
+
+	cs := commonSolana.UpdateTimelockDelaySolana{}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			err := cs.VerifyPreconditions(tt.env, tt.config)
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestUpdateTimelockDelaySolana_Apply(t *testing.T) {
+	t.Parallel()
+	env := setupUpdateDelayTestEnv(t)
+	newDelayDuration := 5 * time.Minute
+	config := commonSolana.UpdateTimelockDelaySolanaCfg{
+		DelayPerChain: map[uint64]time.Duration{
+			env.AllChainSelectorsSolana()[0]: newDelayDuration,
+		},
+	}
+
+	changesetInstance := commonSolana.UpdateTimelockDelaySolana{}
+
+	env, _, err := changeset.ApplyChangesetsV2(t, env, []changeset.ConfiguredChangeSet{
+		changeset.Configure(changesetInstance, config),
+	})
+	require.NoError(t, err)
+
+	chainSelector := env.AllChainSelectorsSolana()[0]
+	solChain := env.SolChains[chainSelector]
+	addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+	require.NoError(t, err)
+
+	// Check new delay config value
+	mcmState, err := state.MaybeLoadMCMSWithTimelockChainStateSolana(solChain, addresses)
+	require.NoError(t, err)
+
+	timelockConfigPDA := state.GetTimelockConfigPDA(mcmState.TimelockProgram, mcmState.TimelockSeed)
+	var timelockConfig timelockBindings.Config
+	err = solChain.GetAccountDataBorshInto(env.GetContext(), timelockConfigPDA, &timelockConfig)
+	require.NoError(t, err)
+	require.Equal(t, timelockConfig.MinDelay, uint64(newDelayDuration.Seconds()))
+
+}

--- a/deployment/common/changeset/solana/update_delay_timelock_test.go
+++ b/deployment/common/changeset/solana/update_delay_timelock_test.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
-	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
@@ -36,6 +37,7 @@ func setupUpdateDelayTestEnv(t *testing.T) deployment.Environment {
 	err := testhelpers.SavePreloadedSolAddresses(env, chainSelector)
 	require.NoError(t, err)
 	// Initialize the address book with a dummy address to avoid deploy precondition errors.
+	//nolint:staticcheck // will wait till we can migrate from address book before using data store
 	err = env.ExistingAddresses.Save(chainSelector, "dummyAddress", deployment.TypeAndVersion{Type: "dummy", Version: deployment.Version1_0_0})
 	require.NoError(t, err)
 
@@ -66,6 +68,7 @@ func TestUpdateTimelockDelaySolana_VerifyPreconditions(t *testing.T) {
 	)
 	mcmDummyProgram := solana.NewWallet().PublicKey()
 
+	//nolint:staticcheck // will wait till we can migrate from address book before using data store
 	err := validEnv.ExistingAddresses.Save(validSolChainSelector, timelockID, deployment.TypeAndVersion{
 		Type:    types.RBACTimelock,
 		Version: deployment.Version1_0_0,
@@ -84,6 +87,8 @@ func TestUpdateTimelockDelaySolana_VerifyPreconditions(t *testing.T) {
 		Nodes:     1,
 	})
 	noTimelockEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
+
+	//nolint:staticcheck // will wait till we can migrate from address book before using data store
 	err = noTimelockEnv.ExistingAddresses.Save(chainselectors.SOLANA_DEVNET.Selector, mcmsProposerIDEmpty, deployment.TypeAndVersion{
 		Type:    types.BypasserManyChainMultisig,
 		Version: deployment.Version1_0_0,
@@ -184,6 +189,7 @@ func TestUpdateTimelockDelaySolana_Apply(t *testing.T) {
 
 	chainSelector := env.AllChainSelectorsSolana()[0]
 	solChain := env.SolChains[chainSelector]
+	//nolint:staticcheck // will wait till we can migrate from address book before using data store
 	addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	require.NoError(t, err)
 
@@ -196,5 +202,4 @@ func TestUpdateTimelockDelaySolana_Apply(t *testing.T) {
 	err = solChain.GetAccountDataBorshInto(env.GetContext(), timelockConfigPDA, &timelockConfig)
 	require.NoError(t, err)
 	require.Equal(t, timelockConfig.MinDelay, uint64(newDelayDuration.Seconds()))
-
 }


### PR DESCRIPTION
* Adds a new timelock delay update changeset to allow updating the `min_delay` of a solana timelock instance.
* Removes unncessary code from the mcms deploy changeset in solana. It was doing a timelock ownership transfer instruction which is never accepted and thus is unnecessary. This is removed in favor of using the `TransferToMCMSWithTimelock` changeset


## AI Summary
This pull request introduces significant changes to the Solana deployment codebase, focusing on removing redundant ownership transfer logic and adding functionality for updating timelock delays. It also includes comprehensive tests for the new functionality. Below is a summary of the most important changes:

### Removal of Ownership Transfer Logic

* Removed the `transferOwnership` function from `mcms.go` and the associated `transferOwnershipTimelock` function from `timelock.go`. This eliminates redundant logic for transferring ownership of the timelock program, simplifying the deployment process. [[1]](diffhunk://#diff-90e56e55222caeab40bda731d32cfb9a95ffb183b7e36da48d5ad855d913f7d2L87-L102) [[2]](diffhunk://#diff-d6dfdb22bc79f22e2addae04c0928b16889f0048bb5332a5e4b7a22dfc396025L170-L189)

### Addition of Timelock Delay Update Functionality

* Added a new `UpdateTimelockDelaySolana` type in `update_delay_timelock.go`, which provides methods to verify preconditions and apply changes to update the timelock delay for Solana chains.

### Tests for Timelock Delay Update

* Added a comprehensive test suite in `update_delay_timelock_test.go` to validate the `UpdateTimelockDelaySolana` functionality. This includes tests for verifying preconditions, applying changes, and checking the correctness of the updated delay configuration.