### PR TITLE
fix(deployment): move ocr secrets to cldf

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -355,7 +355,6 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.52 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250425163923-16aa375957b7 // indirect
-	github.com/smartcontractkit/chainlink-deployments-framework v0.0.5 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250408161305-721208f43882 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250421203809-e0f5602c126c // indirect

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250422205932-c33527859fd6
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250424173217-3df386365d0f
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
+	github.com/smartcontractkit/chainlink-deployments-framework v0.0.5
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4
 	github.com/smartcontractkit/libocr v0.0.0-20250408131511-c90716988ee0

--- a/core/scripts/keystone/src/02_provision_ocr3_capability.go
+++ b/core/scripts/keystone/src/02_provision_ocr3_capability.go
@@ -2,20 +2,20 @@ package src
 
 import (
 	"bytes"
-	"strconv"
-	"text/template"
-
 	"context"
 	"flag"
 	"fmt"
+	"strconv"
+	"text/template"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	ksdeploy "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/ocr3_capability"
+
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 )

--- a/core/scripts/keystone/src/02_provision_streams_trigger_capability.go
+++ b/core/scripts/keystone/src/02_provision_streams_trigger_capability.go
@@ -19,9 +19,8 @@ import (
 	"html/template"
 	"math"
 	"math/big"
-	"time"
-
 	"net/url"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/shopspring/decimal"
@@ -37,7 +36,8 @@ import (
 	datastreamsmercury "github.com/smartcontractkit/chainlink-data-streams/mercury"
 
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury"
@@ -467,7 +467,7 @@ func generateMercuryOCR2Config(nca []NodeKeys) MercuryOCR2Config {
 		})
 	}
 
-	secrets := deployment.XXXGenerateTestOCRSecrets()
+	secrets := cldf.XXXGenerateTestOCRSecrets()
 	// Values were taken from Data Streams 250ms feeds, given by @austinborn
 	signers, _, _, onchainConfig, offchainConfigVersion, offchainConfig, err := ocr3confighelper.ContractSetConfigArgsDeterministic(
 		secrets.EphemeralSk,

--- a/core/scripts/keystone/src/generate_local_ocr3_config.go
+++ b/core/scripts/keystone/src/generate_local_ocr3_config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 

--- a/deployment/ccip/changeset/internal/deploy_home_chain.go
+++ b/deployment/ccip/changeset/internal/deploy_home_chain.go
@@ -25,6 +25,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -295,7 +296,7 @@ func BuildSetOCR3ConfigArgsSolana(
 
 func BuildOCR3ConfigForCCIPHome(
 	ccipHome *ccip_home.CCIPHome,
-	ocrSecrets deployment.OCRSecrets,
+	ocrSecrets cldf.OCRSecrets,
 	offRampAddress []byte,
 	destSelector uint64,
 	nodes deployment.Nodes,

--- a/deployment/changeset_test.go
+++ b/deployment/changeset_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
@@ -107,6 +108,6 @@ func NewNoopEnvironment(t *testing.T) Environment {
 		[]string{},
 		nil,
 		t.Context,
-		XXXGenerateTestOCRSecrets(),
+		deployment.XXXGenerateTestOCRSecrets(),
 	)
 }

--- a/deployment/common/changeset/test_helpers_test.go
+++ b/deployment/common/changeset/test_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -81,7 +82,7 @@ func NewNoopEnvironment(t *testing.T) deployment.Environment {
 		[]string{},
 		nil,
 		func() context.Context { return tests.Context(t) },
-		deployment.XXXGenerateTestOCRSecrets(),
+		cldf.XXXGenerateTestOCRSecrets(),
 	)
 }
 

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 
@@ -100,7 +101,7 @@ type Environment struct {
 	NodeIDs     []string
 	Offchain    deployment.OffchainClient
 	GetContext  func() context.Context
-	OCRSecrets  OCRSecrets
+	OCRSecrets  deployment.OCRSecrets
 	// OperationsBundle contains dependencies required by the operations API.
 	OperationsBundle operations.Bundle
 }
@@ -119,7 +120,7 @@ func NewEnvironment(
 	nodeIDs []string,
 	offchain deployment.OffchainClient,
 	ctx func() context.Context,
-	secrets OCRSecrets,
+	secrets deployment.OCRSecrets,
 ) *Environment {
 	return &Environment{
 		Name:              name,

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -32,8 +32,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 // Chain represents an EVM chain.

--- a/deployment/environment/crib/types.go
+++ b/deployment/environment/crib/types.go
@@ -44,6 +44,8 @@ func NewDeployEnvironmentFromCribOutput(lggr logger.Logger, output DeployOutput)
 		nil, // nil for aptos chains, can use memory solana chain example when required
 		output.NodeIDs,
 		nil, // todo: populate the offchain client using output.DON
-		func() context.Context { return context.Background() }, cldf.XXXGenerateTestOCRSecrets(),
+		//nolint:gocritic // intentionally use a lambda to allow dynamic context replacement in Environment Commit 90ee880
+		func() context.Context { return context.Background() },
+		cldf.XXXGenerateTestOCRSecrets(),
 	), nil
 }

--- a/deployment/environment/crib/types.go
+++ b/deployment/environment/crib/types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 )
@@ -43,6 +44,6 @@ func NewDeployEnvironmentFromCribOutput(lggr logger.Logger, output DeployOutput)
 		nil, // nil for aptos chains, can use memory solana chain example when required
 		output.NodeIDs,
 		nil, // todo: populate the offchain client using output.DON
-		func() context.Context { return context.Background() }, deployment.XXXGenerateTestOCRSecrets(),
+		func() context.Context { return context.Background() }, cldf.XXXGenerateTestOCRSecrets(),
 	), nil
 }

--- a/deployment/environment/devenv/environment.go
+++ b/deployment/environment/devenv/environment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 )
 
@@ -65,6 +66,6 @@ func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config Envir
 		nodeIDs,
 		offChain,
 		ctx,
-		deployment.XXXGenerateTestOCRSecrets(),
+		cldf.XXXGenerateTestOCRSecrets(),
 	), jd.don, nil
 }

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -19,6 +19,7 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 
 	solRpc "github.com/gagliardetto/solana-go/rpc"
@@ -225,7 +226,7 @@ func NewMemoryEnvironmentFromChainsNodes(
 		nodeIDs, // Note these have the p2p_ prefix.
 		NewMemoryJobClient(nodes),
 		ctx,
-		deployment.XXXGenerateTestOCRSecrets(),
+		cldf.XXXGenerateTestOCRSecrets(),
 	)
 }
 
@@ -253,6 +254,6 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 		nodeIDs,
 		NewMemoryJobClient(nodes),
 		t.Context,
-		deployment.XXXGenerateTestOCRSecrets(),
+		cldf.XXXGenerateTestOCRSecrets(),
 	)
 }

--- a/deployment/helpers.go
+++ b/deployment/helpers.go
@@ -13,33 +13,12 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/pkg/errors"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
-
-// OCRSecrets are used to disseminate a shared secret to OCR nodes
-// through the blockchain where OCR configuration is stored. Its a low value secret used
-// to derive transmission order etc. They are extracted here such that they can common
-// across signers when multiple signers are signing the same OCR config.
-type OCRSecrets struct {
-	SharedSecret [16]byte
-	EphemeralSk  [32]byte
-}
-
-func (s OCRSecrets) IsEmpty() bool {
-	return s.SharedSecret == [16]byte{} || s.EphemeralSk == [32]byte{}
-}
-
-func XXXGenerateTestOCRSecrets() OCRSecrets {
-	var s OCRSecrets
-	copy(s.SharedSecret[:], crypto.Keccak256([]byte("shared"))[:16])
-	copy(s.EphemeralSk[:], crypto.Keccak256([]byte("ephemeral")))
-	return s
-}
 
 // SimTransactOpts is useful to generate just the calldata for a given gethwrapper method.
 func SimTransactOpts() *bind.TransactOpts {

--- a/deployment/keystone/changeset/internal/ocr3config.go
+++ b/deployment/keystone/changeset/internal/ocr3config.go
@@ -24,11 +24,13 @@ import (
 	capocr3types "github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/types"
 
 	kocr3 "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 type TopLevelConfigSource struct {
@@ -190,7 +192,7 @@ func (c *OCR2OracleConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func GenerateOCR3Config(cfg OracleConfig, nca []NodeKeys, secrets deployment.OCRSecrets) (OCR2OracleConfig, error) {
+func GenerateOCR3Config(cfg OracleConfig, nca []NodeKeys, secrets cldf.OCRSecrets) (OCR2OracleConfig, error) {
 	// the transmission schedule is very specific; arguably it should be not be a parameter
 	if len(cfg.TransmissionSchedule) != 1 || cfg.TransmissionSchedule[0] != len(nca) {
 		return OCR2OracleConfig{}, fmt.Errorf("transmission schedule must have exactly one entry, matching the len of the number of nodes want [%d], got %v", len(nca), cfg.TransmissionSchedule)
@@ -352,7 +354,7 @@ type configureOCR3Request struct {
 	contract   *kocr3.OCR3Capability
 	nodes      []deployment.Node
 	dryRun     bool
-	ocrSecrets deployment.OCRSecrets
+	ocrSecrets cldf.OCRSecrets
 
 	useMCMS bool
 }

--- a/deployment/keystone/changeset/internal/ocr3config.go
+++ b/deployment/keystone/changeset/internal/ocr3config.go
@@ -25,12 +25,12 @@ import (
 
 	kocr3 "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 type TopLevelConfigSource struct {

--- a/deployment/keystone/changeset/internal/ocr3config_test.go
+++ b/deployment/keystone/changeset/internal/ocr3config_test.go
@@ -16,6 +16,7 @@ import (
 	types3 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/require"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/view"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -94,7 +95,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 		chain: deployment.Chain{
 			Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 		},
-		ocrSecrets: deployment.XXXGenerateTestOCRSecrets(),
+		ocrSecrets: cldf.XXXGenerateTestOCRSecrets(),
 	}
 	got, err := r.generateOCR3Config()
 	require.NoError(t, err)
@@ -114,7 +115,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 			chain: deployment.Chain{
 				Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 			},
-			ocrSecrets: deployment.XXXGenerateTestOCRSecrets(),
+			ocrSecrets: cldf.XXXGenerateTestOCRSecrets(),
 		}
 		_, err := r.generateOCR3Config()
 		require.Error(t, err)
@@ -128,7 +129,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 			chain: deployment.Chain{
 				Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 			},
-			ocrSecrets: deployment.XXXGenerateTestOCRSecrets(),
+			ocrSecrets: cldf.XXXGenerateTestOCRSecrets(),
 		}
 		_, err := r.generateOCR3Config()
 		require.Error(t, err)

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -399,7 +400,7 @@ func setupViewOnlyNodeTest(t *testing.T, registryChainSel uint64, chains map[uin
 		dons.NodeList().IDs(),
 		envtest.NewJDService(dons.NodeList()),
 		t.Context,
-		deployment.XXXGenerateTestOCRSecrets(),
+		cldf.XXXGenerateTestOCRSecrets(),
 	)
 
 	return dons, *env


### PR DESCRIPTION
Remove the OCRSecrets here and reference the migrated version at https://github.com/smartcontractkit/chainlink-deployments-framework

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-153