### PR TITLE
chore: improve AddressBook deprecation comments

### DIFF
--- a/deployment/changeset.go
+++ b/deployment/changeset.go
@@ -114,7 +114,9 @@ type ChangesetOutput struct {
 	DescribedTimelockProposals []string
 	MCMSProposals              []mcms.Proposal
 	// Deprecated: AddressBook is deprecated and will be removed in future versions.
-	// Use DataStore instead
+	// Please use DataStore instead. If you still need to use AddressBook in your code,
+	// be aware that you may encounter CI failures due to linting errors.
+	// To work around this, you can disable the linter for that specific line using the //nolint directive.
 	AddressBook AddressBook
 	DataStore   datastore.MutableDataStore[datastore.DefaultMetadata, datastore.DefaultMetadata]
 	// Reports are populated by the Operations API with the

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -86,7 +86,9 @@ type Environment struct {
 	Name   string
 	Logger logger.Logger
 	// Deprecated: AddressBook is deprecated and will be removed in future versions.
-	// Use DataStore instead
+	// Please use DataStore instead. If you still need to use AddressBook in your code,
+	// be aware that you may encounter CI failures due to linting errors.
+	// To work around this, you can disable the linter for that specific line using the //nolint directive.
 	ExistingAddresses AddressBook
 	DataStore         datastore.DataStore[
 		datastore.DefaultMetadata,


### PR DESCRIPTION
This PR updates the `AddressBook` deprecation comments to improve clarity and suggest a workaround for potential CI failures caused by linting errors.