### PR TITLE
[chore] Use a temporary directory to avoid concurrent writes

### DIFF
--- a/core/capabilities/compute/cache_test.go
+++ b/core/capabilities/compute/cache_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,8 +18,7 @@ import (
 )
 
 const (
-	simpleBinaryLocation = "test/simple/cmd/testmodule.wasm"
-	simpleBinaryCmd      = "core/capabilities/compute/test/simple/cmd"
+	simpleBinaryCmd = "core/capabilities/compute/test/simple/cmd"
 )
 
 // Verify that cache evicts an expired module.
@@ -37,7 +37,7 @@ func TestCache(t *testing.T) {
 	cache.start()
 	defer cache.close()
 
-	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
+	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, false, t)
 	hmod, err := host.NewModule(&host.ModuleConfig{
 		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
@@ -76,7 +76,7 @@ func TestCache_EvictAfterSize(t *testing.T) {
 	cache.start()
 	defer cache.close()
 
-	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
+	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, false, t)
 	hmod, err := host.NewModule(&host.ModuleConfig{
 		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
@@ -121,7 +121,7 @@ func TestCache_AddDuplicatedModule(t *testing.T) {
 	cache.start()
 	defer cache.close()
 
-	simpleBinary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, false, t)
+	simpleBinary := wasmtest.CreateTestBinary(simpleBinaryCmd, false, t)
 	shmod, err := host.NewModule(&host.ModuleConfig{
 		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,
@@ -141,7 +141,7 @@ func TestCache_AddDuplicatedModule(t *testing.T) {
 	assert.Equal(t, got, smod)
 
 	// Adding a different module but with the same id should not overwrite the existing module
-	fetchBinary := wasmtest.CreateTestBinary(fetchBinaryCmd, fetchBinaryLocation, false, t)
+	fetchBinary := wasmtest.CreateTestBinary(fetchBinaryCmd, false, t)
 	fhmod, err := host.NewModule(&host.ModuleConfig{
 		Logger:         logger.TestLogger(t),
 		IsUncompressed: true,

--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/metering"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/wasmtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -32,9 +32,8 @@ import (
 )
 
 const (
-	fetchBinaryLocation = "test/fetch/cmd/testmodule.wasm"
-	fetchBinaryCmd      = "core/capabilities/compute/test/fetch/cmd"
-	validRequestUUID    = "d2fe6db9-beb4-47c9-b2d6-d3065ace111e"
+	fetchBinaryCmd   = "core/capabilities/compute/test/fetch/cmd"
+	validRequestUUID = "d2fe6db9-beb4-47c9-b2d6-d3065ace111e"
 )
 
 var defaultConfig = Config{
@@ -102,7 +101,7 @@ func TestComputeExecuteMissingConfig(t *testing.T) {
 	th := setup(t, defaultConfig)
 	require.NoError(t, th.compute.Start(t.Context()))
 
-	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, true, t)
+	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, true, t)
 
 	config, err := values.WrapMap(map[string]any{
 		"binary": binary,
@@ -140,14 +139,12 @@ func TestComputeExecuteMissingBinary(t *testing.T) {
 }
 
 func TestComputeExecute(t *testing.T) {
-	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-560")
-
 	t.Parallel()
 	th := setup(t, defaultConfig)
 
 	require.NoError(t, th.compute.Start(t.Context()))
 
-	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, simpleBinaryLocation, true, t)
+	binary := wasmtest.CreateTestBinary(simpleBinaryCmd, true, t)
 
 	config, err := values.WrapMap(map[string]any{
 		"config": []byte(""),
@@ -224,7 +221,7 @@ func TestComputeFetch(t *testing.T) {
 
 	require.NoError(t, th.compute.Start(t.Context()))
 
-	binary := wasmtest.CreateTestBinary(fetchBinaryCmd, fetchBinaryLocation, true, t)
+	binary := wasmtest.CreateTestBinary(fetchBinaryCmd, true, t)
 
 	config, err := values.WrapMap(map[string]any{
 		"config": []byte(""),
@@ -276,8 +273,6 @@ func TestComputeFetch(t *testing.T) {
 }
 
 func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
-	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-573")
-
 	t.Parallel()
 
 	tests := []struct {
@@ -299,7 +294,7 @@ func TestCompute_SpendValueRelativeToComputeTime(t *testing.T) {
 		validRequestUUID,
 	}, "/")
 	gatewayResp := gatewayResponse(t, msgID, []byte("response body"))
-	binary := wasmtest.CreateTestBinary(fetchBinaryCmd, fetchBinaryLocation, true, t)
+	binary := wasmtest.CreateTestBinary(fetchBinaryCmd, true, t)
 
 	config, err := values.WrapMap(map[string]any{
 		"config": []byte(""),
@@ -382,7 +377,7 @@ func TestComputeFetchMaxResponseSizeBytes(t *testing.T) {
 
 	require.NoError(t, th.compute.Start(t.Context()))
 
-	binary := wasmtest.CreateTestBinary(fetchBinaryCmd, fetchBinaryLocation, true, t)
+	binary := wasmtest.CreateTestBinary(fetchBinaryCmd, true, t)
 
 	config, err := values.WrapMap(map[string]any{
 		"config": []byte(""),

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	"github.com/shopspring/decimal"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	billing "github.com/smartcontractkit/chainlink-common/pkg/billing/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
@@ -488,11 +489,10 @@ func (m *mc) UnregisterFromWorkflow(ctx context.Context, request capabilities.Un
 
 func TestEngine_WriteStepHasZeroStepTimeout(t *testing.T) {
 	cmd := "core/services/workflows/test/zerotimeout/cmd"
-	binary := "test/zerotimeout/cmd/testmodule.wasm"
 
 	ctx := t.Context()
 	log := logger.TestLogger(t)
-	binaryB := wasmtest.CreateTestBinary(cmd, binary, true, t)
+	binaryB := wasmtest.CreateTestBinary(cmd, true, t)
 
 	spec, err := host.GetWorkflowSpec(
 		ctx,
@@ -1827,7 +1827,6 @@ func basicTestTrigger(t *testing.T) *mockTriggerCapability {
 
 func TestEngine_WithCustomComputeStep(t *testing.T) {
 	cmd := "core/services/workflows/test/wasm/cmd"
-	binary := "test/wasm/cmd/testmodule.wasm"
 
 	ctx := testutils.Context(t)
 	log := logger.TestLogger(t)
@@ -1867,7 +1866,7 @@ func TestEngine_WithCustomComputeStep(t *testing.T) {
 	trigger := basicTestTrigger(t)
 	require.NoError(t, reg.Add(ctx, trigger))
 
-	binaryB := wasmtest.CreateTestBinary(cmd, binary, true, t)
+	binaryB := wasmtest.CreateTestBinary(cmd, true, t)
 
 	spec, err := host.GetWorkflowSpec(
 		ctx,
@@ -1903,7 +1902,6 @@ func TestEngine_WithCustomComputeStep(t *testing.T) {
 
 func TestEngine_CustomComputePropagatesBreaks(t *testing.T) {
 	cmd := "core/services/workflows/test/break/cmd"
-	binary := "test/wasm/break/testmodule.wasm"
 
 	ctx := testutils.Context(t)
 	log := logger.TestLogger(t)
@@ -1942,7 +1940,7 @@ func TestEngine_CustomComputePropagatesBreaks(t *testing.T) {
 	trigger := basicTestTrigger(t)
 	require.NoError(t, reg.Add(ctx, trigger))
 
-	binaryB := wasmtest.CreateTestBinary(cmd, binary, true, t)
+	binaryB := wasmtest.CreateTestBinary(cmd, true, t)
 
 	spec, err := host.GetWorkflowSpec(
 		ctx,

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -295,7 +295,7 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 	var configURL = "http://example.com/config"
 	var config = []byte("")
 	var wfOwner = []byte("0xOwner")
-	var binary = wasmtest.CreateTestBinary(binaryCmd, binaryLocation, true, t)
+	var binary = wasmtest.CreateTestBinary(binaryCmd, true, t)
 	var encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
 	var workflowName = "workflow-name"
 
@@ -828,7 +828,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			orm     = artifacts.NewWorkflowRegistryDS(db, lggr)
 			emitter = custmsg.NewLabeler()
 
-			binary        = wasmtest.CreateTestBinary(binaryCmd, binaryLocation, true, t)
+			binary        = wasmtest.CreateTestBinary(binaryCmd, true, t)
 			encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
 			config        = []byte("")
 			secretsURL    = "http://example.com"
@@ -913,7 +913,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			orm     = artifacts.NewWorkflowRegistryDS(db, lggr)
 			emitter = custmsg.NewLabeler()
 
-			binary        = wasmtest.CreateTestBinary(binaryCmd, binaryLocation, true, t)
+			binary        = wasmtest.CreateTestBinary(binaryCmd, true, t)
 			encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
 			config        = []byte("")
 			secretsURL    = "http://example.com"
@@ -966,7 +966,7 @@ func Test_workflowDeletedHandler(t *testing.T) {
 			orm     = artifacts.NewWorkflowRegistryDS(db, lggr)
 			emitter = custmsg.NewLabeler()
 
-			binary        = wasmtest.CreateTestBinary(binaryCmd, binaryLocation, true, t)
+			binary        = wasmtest.CreateTestBinary(binaryCmd, true, t)
 			encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
 			config        = []byte("")
 			secretsURL    = "http://example.com"
@@ -1057,7 +1057,7 @@ func Test_workflowPausedActivatedUpdatedHandler(t *testing.T) {
 			orm     = artifacts.NewWorkflowRegistryDS(db, lggr)
 			emitter = custmsg.NewLabeler()
 
-			binary        = wasmtest.CreateTestBinary(binaryCmd, binaryLocation, true, t)
+			binary        = wasmtest.CreateTestBinary(binaryCmd, true, t)
 			encodedBinary = []byte(base64.StdEncoding.EncodeToString(binary))
 			config        = []byte("")
 			updateConfig  = []byte("updated")


### PR DESCRIPTION
Tests that depend on the wasmtest.CreateTestBinary function are failing due to being unable to find the generated binary.

I was unable to reproduce this locally, but suspect that it is caused by:
- the fact that multiple tests often reference the same output for the generated binary
- we now run tests in parallel
This could cause one of the tests to remove the binary before it writes it, and therefore remove it for one of the other tests.

The solution is to compile the binary to a temporary file.