### PR TITLE
[chore] Add Beholder message when the trigger event was a failure

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -734,6 +734,7 @@ func (e *Engine) worker(ctx context.Context) {
 
 			if resp.Err != nil {
 				e.logger.Errorf("trigger event was an error %v; not executing", resp.Err)
+				logCustMsg(ctx, e.cma, fmt.Sprintf("failed to resolve trigger: %s", resp.Err), e.logger)
 				continue
 			}
 


### PR DESCRIPTION
If a trigger emits an error we should log it to Beholder