### PR TITLE
Flaky Test: TestCompute_SpendValueRelativeToComputeTime

### DIFF
--- a/core/internal/testutils/wasmtest/wasm.go
+++ b/core/internal/testutils/wasmtest/wasm.go
@@ -8,23 +8,19 @@ import (
 	"testing"
 
 	"github.com/andybalholm/brotli"
-	"github.com/google/uuid"
 
 	"github.com/stretchr/testify/require"
 )
 
 func CreateTestBinary(outputPath string, compress bool, t *testing.T) []byte {
-	tempFile, err := os.CreateTemp("", uuid.New().String()+".wasm")
-	require.NoError(t, err)
-	defer os.Remove(tempFile.Name())
-
-	cmd := exec.Command("go", "build", "-o", tempFile.Name(), "github.com/smartcontractkit/chainlink/v2/"+outputPath) // #nosec
+	filePath := t.TempDir() + "/test_binary.wasm"
+	cmd := exec.Command("go", "build", "-o", filePath, "github.com/smartcontractkit/chainlink/v2/"+outputPath) // #nosec
 	cmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm")
 
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
-	binary, err := os.ReadFile(tempFile.Name())
+	binary, err := os.ReadFile(filePath)
 	require.NoError(t, err)
 
 	if !compress {


### PR DESCRIPTION
Creating the `wasm` test binary was using `os.CreateTemp` to create a temporary file. This may or may not have been the source of the flakes, but previously the same file was read and written to for multiple tests. This commit makes a small change to use `t.TempDir` to scope the temporary file to the active test life-cycle directly.
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
