### PR TITLE
Solana CCIP e2e test tweaks

### DIFF
--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -191,7 +191,8 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 	}
 	out.MsgSentEvent = msgSentEvent
 
-	// hack
+	// HACK: if the node booted or the logpoller filters got registered after ccipSend,
+	// we need to replay missed logs
 	if !tc.Replayed {
 		require.NotNil(tc.T, tc.DeployedEnv)
 		sleepAndReplay(tc.T, tc.DeployedEnv, tc.SourceChain, tc.DestChain)

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -135,7 +135,10 @@ func getLatestNonce(tc TestCase) uint64 {
 }
 
 // Run runs a messaging test case.
-func Run(tc TestCase) (out TestCaseOutput) {
+func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
+	// we need to reference the inner testing.T inside a t.Run
+	tc.T = t
+
 	if tc.ValidateResp {
 		// check latest nonce
 		latestNonce := getLatestNonce(tc)

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -99,6 +99,7 @@ func Test_CCIPMessaging_EVM2EVM(t *testing.T) {
 
 	t.Run("data message to eoa", func(t *testing.T) {
 		out = mt.Run(
+			t,
 			mt.TestCase{
 				TestSetup:              setup,
 				Replayed:               replayed,
@@ -118,6 +119,7 @@ func Test_CCIPMessaging_EVM2EVM(t *testing.T) {
 
 	t.Run("message to contract not implementing CCIPReceiver", func(t *testing.T) {
 		out = mt.Run(
+			t,
 			mt.TestCase{
 				TestSetup:              setup,
 				Replayed:               out.Replayed,
@@ -134,6 +136,7 @@ func Test_CCIPMessaging_EVM2EVM(t *testing.T) {
 		latestHead, err := testhelpers.LatestBlock(ctx, e.Env, destChain)
 		require.NoError(t, err)
 		out = mt.Run(
+			t,
 			mt.TestCase{
 				TestSetup:              setup,
 				Replayed:               out.Replayed,
@@ -159,6 +162,7 @@ func Test_CCIPMessaging_EVM2EVM(t *testing.T) {
 
 	t.Run("message to contract implementing CCIPReceiver with low exec gas", func(t *testing.T) {
 		out = mt.Run(
+			t,
 			mt.TestCase{
 				TestSetup:              setup,
 				Replayed:               out.Replayed,
@@ -272,6 +276,7 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 		require.Equal(t, uint8(0), receiverCounterAccount.Value)
 
 		out = mt.Run(
+			t,
 			mt.TestCase{
 				TestSetup:              setup,
 				Replayed:               replayed,
@@ -369,6 +374,7 @@ func Test_CCIPMessaging_Solana2EVM(t *testing.T) {
 		latestHead, err := testhelpers.LatestBlock(ctx, e.Env, destChain)
 		require.NoError(t, err)
 		out = mt.Run(
+			t,
 			mt.TestCase{
 				TestSetup:              setup,
 				Replayed:               replayed,

--- a/integration-tests/smoke/ccip/ccip_token_transfer_test.go
+++ b/integration-tests/smoke/ccip/ccip_token_transfer_test.go
@@ -3,6 +3,7 @@ package ccip
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/exp/maps"
@@ -28,6 +29,16 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
+
+// duplicated from messagingtest
+func sleepAndReplay(t *testing.T, e testhelpers.DeployedEnv, chainSelectors ...uint64) {
+	time.Sleep(30 * time.Second)
+	replayBlocks := make(map[uint64]uint64)
+	for _, selector := range chainSelectors {
+		replayBlocks[selector] = 1
+	}
+	testhelpers.ReplayLogs(t, e.Env.Offchain, replayBlocks)
+}
 
 func TestTokenTransfer_EVM2EVM(t *testing.T) {
 	lggr := logger.TestLogger(t)
@@ -511,6 +522,9 @@ func TestTokenTransfer_Solana2EVM(t *testing.T) {
 
 	startBlocks, expectedSeqNums, expectedExecutionStates, expectedTokenBalances :=
 		testhelpers.TransferMultiple(ctx, t, e, state, tcs)
+
+	// HACK: we need to replay blocks only after the CCIP plugin has already properly booted
+	sleepAndReplay(t, tenv, sourceChain, destChain)
 
 	err = testhelpers.ConfirmMultipleCommits(
 		t,


### PR DESCRIPTION
- Test cases ran with the parent test case context, so if a test failed the subcase was marked as succeeded but the parent test case failed
- There is a race condition if replay is called before the CCIP plugin is started and filters are registered. Messaging test already works around this by introducing a delay which isn't ideal but it does prevent most flakes