### PR TITLE
feat(deployment):chain adapter aptos for product extensions

### DIFF
--- a/deployment/aptos_chain.go
+++ b/deployment/aptos_chain.go
@@ -2,20 +2,28 @@ package deployment
 
 import (
 	"github.com/aptos-labs/aptos-go-sdk"
-
 	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
-
 	ccip_offramp "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_offramp"
 	module_offramp "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_offramp/offramp"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
-type PAptosChain struct {
+// ChainAdapterAptos is a Chainlink-specific extension of the generic AptosChain.
+// It wraps the shared deployment.AptosChain and adds product-specific methods
+// (e.g. for interacting with CCIP modules). This type should be the sole
+// entry point for Aptos chain logic that depends on Chainlink bindings or behaviors.
+type ChainAdapterAptos struct {
 	deployment.AptosChain
 }
 
-func (c PAptosChain) GetOfframpDynamicConfig(ccipAddress aptos.AccountAddress) (module_offramp.DynamicConfig, error) {
-	offrampBind := ccip_offramp.Bind(ccipAddress, c.Client)
-	return offrampBind.Offramp().GetDynamicConfig(&bind.CallOpts{})
+func NewChainAdapterAptos(chain deployment.AptosChain) ChainAdapterAptos {
+	return ChainAdapterAptos{AptosChain: chain}
+}
+
+func (a ChainAdapterAptos) GetOfframpDynamicConfig(ccipAddr aptos.AccountAddress) (module_offramp.DynamicConfig, error) {
+	return ccip_offramp.
+		Bind(ccipAddr, a.Client).
+		Offramp().
+		GetDynamicConfig(&bind.CallOpts{})
 }

--- a/deployment/ccip/changeset/state.go
+++ b/deployment/ccip/changeset/state.go
@@ -761,19 +761,23 @@ func (c CCIPOnChainState) OffRampPermissionLessExecutionThresholdSeconds(ctx con
 		if !ok {
 			return 0, fmt.Errorf("chain %d does not exist in state", selector)
 		}
-		chain, ok := env.AptosChains[selector]
+
+		coreChain, ok := env.AptosChains[selector]
 		if !ok {
 			return 0, fmt.Errorf("chain %d does not exist in env", selector)
 		}
+
 		if chainState.CCIPAddress == (aptos.AccountAddress{}) {
 			return 0, fmt.Errorf("ccip not found in existing state, deploy the ccip first for Aptos chain %d", selector)
 		}
-		pChain := deployment.PAptosChain{AptosChain: chain}
-		offrampDynamicConfig, err := pChain.GetOfframpDynamicConfig(chainState.CCIPAddress)
+
+		chain := deployment.NewChainAdapterAptos(coreChain)
+		dCfg, err := chain.GetOfframpDynamicConfig(chainState.CCIPAddress)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get offramp dynamic config for Aptos chain %d: %w", selector, err)
 		}
-		return offrampDynamicConfig.PermissionlessExecutionThresholdSeconds, nil
+
+		return dCfg.PermissionlessExecutionThresholdSeconds, nil
 	}
 	return 0, fmt.Errorf("unsupported chain family %s", family)
 }


### PR DESCRIPTION
This pull request refactors the Aptos chain integration in the deployment framework by introducing a new `ChainAdapterAptos` type to encapsulate Chainlink-specific logic. It replaces the older `PAptosChain` type and updates related methods to improve clarity and maintainability.

### Refactoring Aptos chain integration:

* **Introduced `ChainAdapterAptos` type**: Replaced the `PAptosChain` type with `ChainAdapterAptos`, which extends `deployment.AptosChain` and provides Chainlink-specific functionality, such as interacting with CCIP modules. Added a constructor `NewChainAdapterAptos` to initialize this type. (`deployment/aptos_chain.go`, [deployment/aptos_chain.goL5-R28](diffhunk://#diff-7855eec209a4049540450da757e621250342d93569e65dc5f6e1807496dd8c00L5-R28))

* **Updated method calls to use `ChainAdapterAptos`**: Refactored the `OffRampPermissionLessExecutionThresholdSeconds` function to use the new `ChainAdapterAptos` type and its methods for retrieving dynamic configuration, replacing the older `PAptosChain` logic. (`deployment/ccip/changeset/state.go`, [deployment/ccip/changeset/state.goL764-R780](diffhunk://#diff-3ffa1bc87e6cc32eec90790e415ed537931e1287da7d042d21a845d13e70e8dfL764-R780))