### PR TITLE
fix: token program ID derivation for SendRequestSol 

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -84,7 +84,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
 
+	solbinary "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/token"
 	"github.com/gagliardetto/solana-go/rpc"
 )
 
@@ -542,14 +544,23 @@ func SendRequestSol(
 	sender := c.DeployerKey
 
 	// if fee token is 0, fallback to WSOL
-	feeTokenProgramID := solana.Token2022ProgramID
 	if message.FeeToken.IsZero() {
-		feeTokenProgramID = solana.TokenProgramID
 		message.FeeToken = s.WSOL
 	}
+	feeToken := message.FeeToken
 
 	e.Logger.Infof("Sending CCIP request from chain selector %d to chain selector %d from sender %s",
 		cfg.SourceChain, cfg.DestChain, sender.PublicKey().String())
+
+	feeTokenInfo, err := client.GetAccountInfo(ctx, feeToken)
+	if err != nil {
+		return nil, err
+	}
+	var mint token.Mint
+	if err := solbinary.NewBinDecoder(feeTokenInfo.Bytes()).Decode(&mint); err != nil {
+		return nil, fmt.Errorf("the provided fee token is not a valid token: (err = %w)", err)
+	}
+	feeTokenProgramID := feeTokenInfo.Value.Owner
 
 	destinationChainStatePDA, err := solstate.FindDestChainStatePDA(destinationChainSelector, s.Router)
 	if err != nil {
@@ -560,8 +571,6 @@ func SendRequestSol(
 	if err != nil {
 		return nil, err
 	}
-
-	feeToken := message.FeeToken
 
 	linkFqBillingConfigPDA, _, err := solstate.FindFqBillingTokenConfigPDA(s.LinkToken, s.FeeQuoter)
 	if err != nil {

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -542,7 +542,9 @@ func SendRequestSol(
 	sender := c.DeployerKey
 
 	// if fee token is 0, fallback to WSOL
+	feeTokenProgramID := solana.Token2022ProgramID
 	if message.FeeToken.IsZero() {
+		feeTokenProgramID = solana.TokenProgramID
 		message.FeeToken = s.WSOL
 	}
 
@@ -576,12 +578,12 @@ func SendRequestSol(
 		return nil, err
 	}
 
-	feeTokenUserATA, _, err := soltokens.FindAssociatedTokenAddress(solana.TokenProgramID, feeToken, sender.PublicKey())
+	feeTokenUserATA, _, err := soltokens.FindAssociatedTokenAddress(feeTokenProgramID, feeToken, sender.PublicKey())
 	if err != nil {
 		return nil, err
 	}
 
-	feeTokenReceiverATA, _, err := soltokens.FindAssociatedTokenAddress(solana.TokenProgramID, feeToken, billingSignerPDA)
+	feeTokenReceiverATA, _, err := soltokens.FindAssociatedTokenAddress(feeTokenProgramID, feeToken, billingSignerPDA)
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +607,7 @@ func SendRequestSol(
 		noncePDA,
 		sender.PublicKey(),
 		solana.SystemProgramID,
-		solana.TokenProgramID,
+		feeTokenProgramID,
 		feeToken,
 		feeTokenUserATA,
 		feeTokenReceiverATA,
@@ -1370,7 +1372,6 @@ func DeployTransferableTokenSolana(
 			},
 		),
 	)
-
 	if err != nil {
 		return nil, nil, solana.PublicKey{}, err
 	}

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1381,6 +1381,7 @@ func DeployTransferableTokenSolana(
 			},
 		),
 	)
+
 	if err != nil {
 		return nil, nil, solana.PublicKey{}, err
 	}


### PR DESCRIPTION
This PR adds a couple fixes / improvements for the `testhelpers.SendRequestSol` function including:
- basic validation that `msg.FeeToken` is a valid Solana token address
- support for inferring the program ID of `msg.FeeToken` via `solana.GetAccountInfo`