### PR TITLE
Fix private plugins gitRefs

### DIFF
--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -14,19 +14,19 @@ plugins:
       installPath: "github.com/smartcontractkit/chainlink-internal-integrations/aptos/relayer/cmd/chainlink-aptos"
   cron:
     - moduleURI: "github.com/smartcontractkit/capabilities/cron"
-      gitRef: "a5c33ddc76128b14117579a075ec9d239d3b2209"
+      gitRef: "6bb81bba0e44efbca20a1ba7a3d2fb4a4be575d5"
       installPath: "github.com/smartcontractkit/capabilities/cron"
   kvstore:
     - enabled: false
       moduleURI: "github.com/smartcontractkit/capabilities/kvstore"
-      gitRef: "a5c33ddc76128b14117579a075ec9d239d3b2209"
+      gitRef: "6bb81bba0e44efbca20a1ba7a3d2fb4a4be575d5"
       installPath: "github.com/smartcontractkit/capabilities/kvstore"
   readcontract:
     - moduleURI: "github.com/smartcontractkit/capabilities/readcontract"
-      gitRef: "a5c33ddc76128b14117579a075ec9d239d3b2209"
+      gitRef: "6bb81bba0e44efbca20a1ba7a3d2fb4a4be575d5"
       installPath: "github.com/smartcontractkit/capabilities/readcontract"
   workflowevent:
     - enabled: false
       moduleURI: "github.com/smartcontractkit/capabilities/workflowevent"
-      gitRef: "a5c33ddc76128b14117579a075ec9d239d3b2209"
+      gitRef: "6bb81bba0e44efbca20a1ba7a3d2fb4a4be575d5"
       installPath: "github.com/smartcontractkit/capabilities/workflowevent"


### PR DESCRIPTION
This updates the private plugin gitRefs to an existing commit [6bb81bba0e44efbca20a1ba7a3d2fb4a4be575d5](https://github.com/smartcontractkit/capabilities/commit/6bb81bba0e44efbca20a1ba7a3d2fb4a4be575d5)

The previous [commit](https://github.com/smartcontractkit/capabilities/commit/a5c33ddc76128b14117579a075ec9d239d3b2209) got squashed.

### Supports
https://github.com/smartcontractkit/chainlink/pull/17282
