### PR TITLE
feat: if fee token is empty, then use native sol for fees

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -530,7 +530,7 @@ func SendRequestSol(
 	e deployment.Environment,
 	state changeset.CCIPOnChainState,
 	cfg *CCIPSendReqConfig,
-) (*onramp.OnRampCCIPMessageSent, error) { // TODO: chain independent return vailue
+) (*onramp.OnRampCCIPMessageSent, error) { // TODO: chain independent return value
 	ctx := e.GetContext()
 
 	s := state.SolChains[cfg.SourceChain]
@@ -538,29 +538,39 @@ func SendRequestSol(
 
 	destinationChainSelector := cfg.DestChain
 	message := cfg.Message.(ccip_router.SVM2AnyMessage)
+	feeTok := message.FeeToken
 	client := c.Client
 
 	// TODO: sender from cfg is EVM specific - need to revisit for Solana
 	sender := c.DeployerKey
 
-	// if fee token is 0, fallback to WSOL
-	if message.FeeToken.IsZero() {
-		message.FeeToken = s.WSOL
-	}
-	feeToken := message.FeeToken
-
 	e.Logger.Infof("Sending CCIP request from chain selector %d to chain selector %d from sender %s",
 		cfg.SourceChain, cfg.DestChain, sender.PublicKey().String())
 
-	feeTokenInfo, err := client.GetAccountInfo(ctx, feeToken)
-	if err != nil {
-		return nil, err
+	feeTokenProgramID := solana.TokenProgramID
+	feeTokenUserATA := solana.PublicKey{}
+	if feeTok.IsZero() {
+		// If the fee token is native SOL (i.e. message.FeeToken is the zero address), then we will
+		// leave message.FeeToken as it is, but specify the WSOL mint account in the accounts list
+		feeTok = solana.SolMint
+	} else {
+		feeTokenInfo, err := client.GetAccountInfo(ctx, feeTok)
+		if err != nil {
+			return nil, err
+		}
+		feeTokenProgramID = feeTokenInfo.Value.Owner
+
+		var mint token.Mint
+		if err := solbinary.NewBinDecoder(feeTokenInfo.Bytes()).Decode(&mint); err != nil {
+			return nil, fmt.Errorf("the provided fee token is not a valid token: (err = %w)", err)
+		}
+
+		ata, _, err := soltokens.FindAssociatedTokenAddress(feeTokenProgramID, feeTok, sender.PublicKey())
+		if err != nil {
+			return nil, err
+		}
+		feeTokenUserATA = ata
 	}
-	var mint token.Mint
-	if err := solbinary.NewBinDecoder(feeTokenInfo.Bytes()).Decode(&mint); err != nil {
-		return nil, fmt.Errorf("the provided fee token is not a valid token: (err = %w)", err)
-	}
-	feeTokenProgramID := feeTokenInfo.Value.Owner
 
 	destinationChainStatePDA, err := solstate.FindDestChainStatePDA(destinationChainSelector, s.Router)
 	if err != nil {
@@ -577,7 +587,7 @@ func SendRequestSol(
 		return nil, err
 	}
 
-	feeTokenFqBillingConfigPDA, _, err := solstate.FindFqBillingTokenConfigPDA(feeToken, s.FeeQuoter)
+	feeTokenFqBillingConfigPDA, _, err := solstate.FindFqBillingTokenConfigPDA(feeTok, s.FeeQuoter)
 	if err != nil {
 		return nil, err
 	}
@@ -587,12 +597,7 @@ func SendRequestSol(
 		return nil, err
 	}
 
-	feeTokenUserATA, _, err := soltokens.FindAssociatedTokenAddress(feeTokenProgramID, feeToken, sender.PublicKey())
-	if err != nil {
-		return nil, err
-	}
-
-	feeTokenReceiverATA, _, err := soltokens.FindAssociatedTokenAddress(feeTokenProgramID, feeToken, billingSignerPDA)
+	feeTokenReceiverATA, _, err := soltokens.FindAssociatedTokenAddress(feeTokenProgramID, feeTok, billingSignerPDA)
 	if err != nil {
 		return nil, err
 	}
@@ -617,7 +622,7 @@ func SendRequestSol(
 		sender.PublicKey(),
 		solana.SystemProgramID,
 		feeTokenProgramID,
-		feeToken,
+		feeTok,
 		feeTokenUserATA,
 		feeTokenReceiverATA,
 		billingSignerPDA,
@@ -630,7 +635,13 @@ func SendRequestSol(
 		rmnRemoteCursesPDA,
 		s.RMNRemoteConfigPDA,
 	)
-	base.GetFeeTokenUserAssociatedAccountAccount().WRITE()
+
+	// When paying with a non-native token (i.e. any SPL token), the user ATA must be writable so we
+	// can debit the fees. If paying with native SOL, then the ATA passed in is just a zero-address
+	// placeholder, and that can't be marked as writable.
+	if !feeTokenUserATA.IsZero() {
+		base.GetFeeTokenUserAssociatedAccountAccount().WRITE()
+	}
 
 	addressTables := map[solana.PublicKey]solana.PublicKeySlice{}
 

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -538,7 +538,7 @@ func SendRequestSol(
 
 	destinationChainSelector := cfg.DestChain
 	message := cfg.Message.(ccip_router.SVM2AnyMessage)
-	feeTok := message.FeeToken
+	feeToken := message.FeeToken
 	client := c.Client
 
 	// TODO: sender from cfg is EVM specific - need to revisit for Solana
@@ -549,12 +549,12 @@ func SendRequestSol(
 
 	feeTokenProgramID := solana.TokenProgramID
 	feeTokenUserATA := solana.PublicKey{}
-	if feeTok.IsZero() {
+	if feeToken.IsZero() {
 		// If the fee token is native SOL (i.e. message.FeeToken is the zero address), then we will
 		// leave message.FeeToken as it is, but specify the WSOL mint account in the accounts list
-		feeTok = solana.SolMint
+		feeToken = solana.SolMint
 	} else {
-		feeTokenInfo, err := client.GetAccountInfo(ctx, feeTok)
+		feeTokenInfo, err := client.GetAccountInfo(ctx, feeToken)
 		if err != nil {
 			return nil, err
 		}
@@ -565,7 +565,7 @@ func SendRequestSol(
 			return nil, fmt.Errorf("the provided fee token is not a valid token: (err = %w)", err)
 		}
 
-		ata, _, err := soltokens.FindAssociatedTokenAddress(feeTokenProgramID, feeTok, sender.PublicKey())
+		ata, _, err := soltokens.FindAssociatedTokenAddress(feeTokenProgramID, feeToken, sender.PublicKey())
 		if err != nil {
 			return nil, err
 		}
@@ -587,7 +587,7 @@ func SendRequestSol(
 		return nil, err
 	}
 
-	feeTokenFqBillingConfigPDA, _, err := solstate.FindFqBillingTokenConfigPDA(feeTok, s.FeeQuoter)
+	feeTokenFqBillingConfigPDA, _, err := solstate.FindFqBillingTokenConfigPDA(feeToken, s.FeeQuoter)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +597,7 @@ func SendRequestSol(
 		return nil, err
 	}
 
-	feeTokenReceiverATA, _, err := soltokens.FindAssociatedTokenAddress(feeTokenProgramID, feeTok, billingSignerPDA)
+	feeTokenReceiverATA, _, err := soltokens.FindAssociatedTokenAddress(feeTokenProgramID, feeToken, billingSignerPDA)
 	if err != nil {
 		return nil, err
 	}
@@ -622,7 +622,7 @@ func SendRequestSol(
 		sender.PublicKey(),
 		solana.SystemProgramID,
 		feeTokenProgramID,
-		feeTok,
+		feeToken,
 		feeTokenUserATA,
 		feeTokenReceiverATA,
 		billingSignerPDA,


### PR DESCRIPTION
This PR adds further functionality on top of `testhelpers.SendRequestSol` - the main change being that if `message.FeeToken` is empty, then native SOL will be used (as opposed to defaulting to wrapped SOL)

These changes have been ported over from the `qa/scripts` branch [here](https://github.com/smartcontractkit/chainlink/compare/develop...qa/scripts). The primary difference is that it adds a few refactoring changes to make it compatible with the updates from [this](https://github.com/smartcontractkit/chainlink/pull/17540) PR and simplifies some of the logic

These changes have already been tested and validated during QA testing and I've also tested it today as well