### PR TITLE
CCIP - Add solana multi price reports test

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -1121,7 +1121,7 @@ runner-test-matrix:
       - Merge Queue E2E Core Tests
       - Nightly E2E Tests
       - Push E2E Core Tests
-    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run '^(Test_CCIPTokenPriceUpdates|Test_CCIPMultiTokenPriceUpdatesSolanaDest)$' -timeout 18m -count=1 -test.parallel=1 -json
+    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run '^Test_CCIPTokenPriceUpdates|Test_CCIPMultiTokenPriceUpdatesSolanaDest$' -timeout 18m -count=1 -test.parallel=1 -json
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -1121,7 +1121,7 @@ runner-test-matrix:
       - Merge Queue E2E Core Tests
       - Nightly E2E Tests
       - Push E2E Core Tests
-    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run ^Test_CCIPTokenPriceUpdates$ -timeout 18m -count=1 -test.parallel=1 -json
+    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run '^(Test_CCIPTokenPriceUpdates|Test_CCIPMultiTokenPriceUpdatesSolanaDest)$' -timeout 18m -count=1 -test.parallel=1 -json
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -1121,7 +1121,7 @@ runner-test-matrix:
       - Merge Queue E2E Core Tests
       - Nightly E2E Tests
       - Push E2E Core Tests
-    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run '^Test_CCIPTokenPriceUpdates|Test_CCIPMultiTokenPriceUpdatesSolanaDest$' -timeout 18m -count=1 -test.parallel=1 -json
+    test_cmd: cd smoke/ccip && go test github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip -v -run ^Test_CCIPTokenPriceUpdates$ -timeout 18m -count=1 -test.parallel=1 -json
     pyroscope_env: ci-smoke-ccipv1_6-evm-simulated
     test_env_vars:
       E2E_TEST_SELECTED_NETWORK: SIMULATED_1,SIMULATED_2

--- a/integration-tests/smoke/ccip/ccip_token_price_updates_test.go
+++ b/integration-tests/smoke/ccip/ccip_token_price_updates_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/gagliardetto/solana-go"
+	solRpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
@@ -18,6 +20,10 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
+	solFeeQuoter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
+	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -127,6 +133,120 @@ func Test_CCIPTokenPriceUpdates(t *testing.T) {
 		}
 		return true
 	}, tests.WaitTimeout(t), 500*time.Millisecond)
+}
+
+func Test_CCIPMultiTokenPriceUpdatesSolanaDest(t *testing.T) {
+	// This test validates whether the multiple price reports land onChain correctly.
+	// It verifies that reports landed onChain within the same ocr round and that no extra reporting round was required.
+
+	maxPricesPerReport := uint64(1)
+	tokenPriceExpiration := time.Hour // We wait only for the first Outcome and Reports
+	deltaRound := 20 * time.Second    // Prevent having frequent price reports which would make testing this harder
+
+	e, _, _ := testsetups.NewIntegrationEnvironment(
+		t,
+		testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
+			if params.CommitOffChainConfig != nil {
+				params.CommitOffChainConfig.MaxPricesPerReport = maxPricesPerReport
+				params.CommitOffChainConfig.MultipleReportsEnabled = true
+				params.CommitOffChainConfig.TokenPriceAsyncObserverDisabled = true
+				params.CommitOffChainConfig.ChainFeeAsyncObserverDisabled = true
+				params.CommitOffChainConfig.InflightPriceCheckRetries = 99999 // We prevent retries to validate success on first reports.
+				params.CommitOffChainConfig.TokenPriceBatchWriteFrequency = *config.MustNewDuration(tokenPriceExpiration)
+				params.OCRParameters.DeltaRound = deltaRound
+				params.OCRParameters.DeltaProgress = 5 * time.Minute
+				params.CommitOffChainConfig.TransmissionDelayMultiplier = 45 * time.Second // Prevent retried reports within delta round.
+			}
+			return params
+		}),
+		testhelpers.WithSolChains(1),
+	)
+	testhelpers.DeploySolanaCcipReceiver(t, e.Env)
+
+	state, err := changeset.LoadOnchainState(e.Env)
+	require.NoError(t, err)
+
+	allChainSelectors := maps.Keys(e.Env.Chains)
+	allSolChainSelectors := maps.Keys(e.Env.SolChains)
+	sourceChain := allChainSelectors[0]
+	destChain := allSolChainSelectors[0]
+
+	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &e, state, sourceChain, destChain, false)
+
+	feeQuoterAddr := state.SolChains[destChain].FeeQuoter
+	tokens := []string{state.SolChains[destChain].LinkToken.String(), solana.WrappedSol.String()}
+
+	priceUpdates := getAllSolanaTokenPriceUpdates(t, feeQuoterAddr, tokens, e.Env.SolChains[destChain].Client)
+	tokenPricesLastUpdatedAt := make(map[string]time.Time)
+	for tk, pu := range priceUpdates {
+		tokenPricesLastUpdatedAt[tk] = pu.Timestamp
+	}
+	t.Log("Initial token price updates:", tokenPricesLastUpdatedAt)
+
+	firstPriceUpdateDetectedAt := time.Time{}
+	firstPriceUpdateToken := ""
+	t.Logf("Waiting for the first price update...")
+	assert.Eventually(t, func() bool {
+		if !firstPriceUpdateDetectedAt.IsZero() && time.Since(firstPriceUpdateDetectedAt) > deltaRound {
+			t.Fatal("Second price update not seen onChain within allowed time")
+		}
+
+		tokenPricesNow := getAllSolanaTokenPriceUpdates(t, feeQuoterAddr, tokens, e.Env.SolChains[destChain].Client)
+		require.NoError(t, err)
+
+		for tk, up := range tokenPricesNow {
+			t.Logf("token %s price %s at %s", tk, up.Value.String(), up.Timestamp)
+		}
+
+		for i, tk := range tokens {
+			prevUpdatedAt, ok := tokenPricesLastUpdatedAt[tk]
+			require.True(t, ok)
+			if prevUpdatedAt.Before(tokenPricesNow[tk].Timestamp) {
+				tokenPricesLastUpdatedAt[tk] = tokenPricesNow[tk].Timestamp
+
+				t.Logf("Token price update detected for token %s at %s", tk, tokenPricesNow[tk].Timestamp)
+
+				if firstPriceUpdateDetectedAt.IsZero() {
+					t.Logf("This is the first detected price update")
+					firstPriceUpdateDetectedAt = time.Now()
+					firstPriceUpdateToken = tk
+					continue
+				}
+
+				t.Logf("This is the second detected price update, time since first update: %s", time.Since(firstPriceUpdateDetectedAt))
+				if tokens[i] == firstPriceUpdateToken {
+					t.Fatal("Second price update was for the same token as the first one, test failed")
+				}
+				t.Log("Test passed")
+				return true
+			}
+		}
+		return false
+	}, tests.WaitTimeout(t), 750*time.Millisecond)
+}
+
+func getAllSolanaTokenPriceUpdates(t *testing.T, feeQuoterAddr solana.PublicKey, tokens []string, client *solRpc.Client) map[string]ccipocr3.TimestampedBig {
+	res := make(map[string]ccipocr3.TimestampedBig)
+	for _, token := range tokens {
+		tokenPubKey := solana.MustPublicKeyFromBase58(token)
+		tokenBillingPDA, _, _ := solState.FindFqBillingTokenConfigPDA(tokenPubKey, feeQuoterAddr)
+		var token0ConfigAccount solFeeQuoter.BillingTokenConfigWrapper
+		err := solCommonUtil.GetAccountDataBorshInto(
+			context.Background(), client, tokenBillingPDA, cldf.SolDefaultCommitment, &token0ConfigAccount)
+		if err != nil {
+			t.Fatalf("error getting account data: %s", err)
+		}
+
+		price := big.NewInt(0).SetBytes(token0ConfigAccount.Config.UsdPerToken.Value[:])
+		ts := token0ConfigAccount.Config.UsdPerToken.Timestamp
+
+		res[token] = ccipocr3.TimestampedBig{
+			Timestamp: time.Unix(ts, 0).In(time.UTC),
+			Value:     ccipocr3.NewBigInt(price),
+		}
+	}
+
+	return res
 }
 
 func disableOracles(ctx context.Context, t *testing.T, client cldf.OffchainClient) []string {


### PR DESCRIPTION
Add a test that verifies if multi price reports are properly transmitted to the contracts within the expected OCR rounds.

> Test succeded 10 times in a row locally.