### PR TITLE
refactor: use different fee tokens for SOL to EVM CCIP tests

### DIFF
--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -89,6 +89,7 @@ type TestCase struct {
 	Receiver               []byte
 	MsgData                []byte
 	ExtraArgs              []byte
+	FeeToken               string
 	ExpectedExecutionState int
 	ExtraAssertions        []func(t *testing.T)
 }
@@ -153,18 +154,29 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 	var msg any
 	switch family {
 	case chain_selectors.FamilyEVM:
+		feeToken := common.HexToAddress("0x0")
+		if len(tc.FeeToken) > 0 {
+			feeToken = common.HexToAddress(tc.FeeToken)
+		}
+
 		msg = router.ClientEVM2AnyMessage{
 			Receiver:     common.LeftPadBytes(tc.Receiver, 32),
 			Data:         tc.MsgData,
 			TokenAmounts: nil,
-			FeeToken:     common.HexToAddress("0x0"),
+			FeeToken:     feeToken,
 			ExtraArgs:    tc.ExtraArgs,
 		}
 	case chain_selectors.FamilySolana:
+		feeToken := solana.PublicKey{}
+		if len(tc.FeeToken) > 0 {
+			feeToken = solana.MustPublicKeyFromBase58(tc.FeeToken)
+		}
+
 		msg = ccip_router.SVM2AnyMessage{
 			Receiver:     common.LeftPadBytes(tc.Receiver, 32),
 			TokenAmounts: nil,
 			Data:         tc.MsgData,
+			FeeToken:     feeToken,
 			ExtraArgs:    tc.ExtraArgs,
 		}
 

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -169,7 +169,8 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 	case chain_selectors.FamilySolana:
 		feeToken := solana.PublicKey{}
 		if len(tc.FeeToken) > 0 {
-			feeToken = solana.MustPublicKeyFromBase58(tc.FeeToken)
+			feeToken, err = solana.PublicKeyFromBase58(tc.FeeToken)
+			require.NoError(t, err)
 		}
 
 		msg = ccip_router.SVM2AnyMessage{

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1392,7 +1392,6 @@ func DeployTransferableTokenSolana(
 			},
 		),
 	)
-
 	if err != nil {
 		return nil, nil, solana.PublicKey{}, err
 	}
@@ -1778,7 +1777,8 @@ func Transfer(
 	case chainsel.FamilySolana:
 		feeTokenAddr := solana.PublicKey{}
 		if len(feeToken) > 0 {
-			feeTokenAddr = solana.MustPublicKeyFromBase58(feeToken)
+			feeTokenAddr, err = solana.PublicKeyFromBase58(feeToken)
+			require.NoError(t, err)
 		}
 
 		msg = ccip_router.SVM2AnyMessage{

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1750,6 +1750,7 @@ func Transfer(
 	receiver []byte,
 	useTestRouter bool,
 	data, extraArgs []byte,
+	feeToken string,
 ) (*onramp.OnRampCCIPMessageSent, map[uint64]*uint64) {
 	startBlocks := make(map[uint64]*uint64)
 
@@ -1762,18 +1763,29 @@ func Transfer(
 	var msg any
 	switch family {
 	case chainsel.FamilyEVM:
+		feeTokenAddr := common.HexToAddress("0x0")
+		if len(feeToken) > 0 {
+			feeTokenAddr = common.HexToAddress(feeToken)
+		}
+
 		msg = router.ClientEVM2AnyMessage{
 			Receiver:     common.LeftPadBytes(receiver, 32),
 			Data:         data,
 			TokenAmounts: tokens.([]router.ClientEVMTokenAmount),
-			FeeToken:     common.HexToAddress("0x0"),
+			FeeToken:     feeTokenAddr,
 			ExtraArgs:    extraArgs,
 		}
 	case chainsel.FamilySolana:
+		feeTokenAddr := solana.PublicKey{}
+		if len(feeToken) > 0 {
+			feeTokenAddr = solana.MustPublicKeyFromBase58(feeToken)
+		}
+
 		msg = ccip_router.SVM2AnyMessage{
 			Receiver:     common.LeftPadBytes(receiver, 32),
 			Data:         data,
 			TokenAmounts: tokens.([]ccip_router.SVMTokenAmount),
+			FeeToken:     feeTokenAddr,
 			ExtraArgs:    extraArgs,
 		}
 
@@ -1799,6 +1811,7 @@ type TestTransferRequest struct {
 	ExpectedTokenBalances []ExpectedBalance
 	RouterAddress         common.Address // Expected for long-living environments
 	UseTestRouter         bool
+	FeeToken              string
 }
 
 // TransferMultiple sends multiple CCIPMessages (represented as TestTransferRequest) sequentially.
@@ -1866,7 +1879,7 @@ func TransferMultiple(
 			}
 
 			msg, blocks := Transfer(
-				ctx, t, env, state, tt.SourceChain, tt.DestChain, tokens, tt.Receiver, tt.UseTestRouter, tt.Data, tt.ExtraArgs)
+				ctx, t, env, state, tt.SourceChain, tt.DestChain, tokens, tt.Receiver, tt.UseTestRouter, tt.Data, tt.ExtraArgs, tt.FeeToken)
 			if _, ok := expectedExecutionStates[pairId]; !ok {
 				expectedExecutionStates[pairId] = make(map[uint64]int)
 			}

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -107,7 +107,6 @@ func Test_CCIPMessaging_EVM2EVM(t *testing.T) {
 				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS, // success because offRamp won't call an EOA
 				ExtraAssertions: []func(t *testing.T){
 					func(t *testing.T) {
-
 					},
 				},
 			},
@@ -350,6 +349,7 @@ func Test_CCIPMessaging_Solana2EVM(t *testing.T) {
 				Nonce:                  nonce,
 				Receiver:               state.Chains[destChain].Receiver.Address().Bytes(),
 				MsgData:                []byte("hello CCIPReceiver"),
+				FeeToken:               "",        // use native SOL - internally this will be converted to wSOL via Sync Native
 				ExtraArgs:              extraArgs, // default extraArgs
 				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
 				ExtraAssertions: []func(t *testing.T){

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -15,11 +15,8 @@ import (
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	solconfig "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
-	soltestutils "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/testutils"
 	solccip "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/ccip"
 	solcommon "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
-	solstate "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
-	soltokens "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/message_hasher"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
@@ -338,34 +335,6 @@ func Test_CCIPMessaging_Solana2EVM(t *testing.T) {
 			true,  // validateResp
 		)
 	)
-
-	// TODO: handle in setup
-	deployer := e.Env.SolChains[sourceChain].DeployerKey
-	rpcClient := e.Env.SolChains[sourceChain].Client
-
-	// create ATA for user
-	tokenProgram := solana.TokenProgramID
-	wSOL := solana.SolMint
-	ixAtaUser, deployerWSOL, uerr := soltokens.CreateAssociatedTokenAccount(tokenProgram, wSOL, deployer.PublicKey(), deployer.PublicKey())
-	require.NoError(t, uerr)
-
-	billingSignerPDA, _, err := solstate.FindFeeBillingSignerPDA(state.SolChains[sourceChain].Router)
-	require.NoError(t, err)
-
-	// Approve CCIP to transfer the user's token for billing
-	ixApprove, err := soltokens.TokenApproveChecked(1e9, 9, tokenProgram, deployerWSOL, wSOL, billingSignerPDA, deployer.PublicKey(), []solana.PublicKey{})
-	require.NoError(t, err)
-
-	soltestutils.SendAndConfirm(ctx, t, rpcClient, []solana.Instruction{ixAtaUser, ixApprove}, *deployer, solconfig.DefaultCommitment)
-
-	// fund user WSOL (transfer SOL + syncNative)
-	transferAmount := 1.0 * solana.LAMPORTS_PER_SOL
-	ixTransfer, err := soltokens.NativeTransfer(tokenProgram, transferAmount, deployer.PublicKey(), deployerWSOL)
-	require.NoError(t, err)
-	ixSync, err := soltokens.SyncNative(tokenProgram, deployerWSOL)
-	require.NoError(t, err)
-	soltestutils.SendAndConfirm(ctx, t, rpcClient, []solana.Instruction{ixTransfer, ixSync}, *deployer, solconfig.DefaultCommitment)
-	// END: handle in setup
 
 	emptyEVMExtraArgsV2 := []byte{}
 

--- a/integration-tests/smoke/ccip/ccip_ooo_execution_test.go
+++ b/integration-tests/smoke/ccip/ccip_ooo_execution_test.go
@@ -130,6 +130,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 		false,
 		nil,
 		testhelpers.MakeEVMExtraArgsV2(0, true),
+    "",
 	)
 	expectedStatuses[firstMessage.SequenceNumber] = testhelpers.EXECUTION_STATE_SUCCESS
 	t.Logf("Out of order messages sent from chain %d to chain %d with sequence number %d",
@@ -150,6 +151,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 		false,
 		nil,
 		nil,
+    "",
 	)
 	t.Logf("Ordered USDC transfer sent from chain %d to chain %d with sequence number %d",
 		sourceChain, destChain, secondMsg.SequenceNumber,
@@ -169,6 +171,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 		false,
 		nil,
 		testhelpers.MakeEVMExtraArgsV2(0, false),
+    "",
 	)
 	t.Logf("Ordered token transfer from chain %d to chain %d with sequence number %d",
 		sourceChain, destChain, thirdMessage.SequenceNumber,
@@ -188,6 +191,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 		false,
 		[]byte("this message has enough gas to execute"),
 		testhelpers.MakeEVMExtraArgsV2(300_000, true),
+    "",
 	)
 	expectedStatuses[fourthMessage.SequenceNumber] = testhelpers.EXECUTION_STATE_SUCCESS
 	t.Logf("Out of order programmable token transfer from chain %d to chain %d with sequence number %d",

--- a/integration-tests/smoke/ccip/ccip_ooo_execution_test.go
+++ b/integration-tests/smoke/ccip/ccip_ooo_execution_test.go
@@ -130,7 +130,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 		false,
 		nil,
 		testhelpers.MakeEVMExtraArgsV2(0, true),
-    "",
+		"",
 	)
 	expectedStatuses[firstMessage.SequenceNumber] = testhelpers.EXECUTION_STATE_SUCCESS
 	t.Logf("Out of order messages sent from chain %d to chain %d with sequence number %d",
@@ -151,7 +151,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 		false,
 		nil,
 		nil,
-    "",
+		"",
 	)
 	t.Logf("Ordered USDC transfer sent from chain %d to chain %d with sequence number %d",
 		sourceChain, destChain, secondMsg.SequenceNumber,
@@ -171,7 +171,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 		false,
 		nil,
 		testhelpers.MakeEVMExtraArgsV2(0, false),
-    "",
+		"",
 	)
 	t.Logf("Ordered token transfer from chain %d to chain %d with sequence number %d",
 		sourceChain, destChain, thirdMessage.SequenceNumber,
@@ -191,7 +191,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 		false,
 		[]byte("this message has enough gas to execute"),
 		testhelpers.MakeEVMExtraArgsV2(300_000, true),
-    "",
+		"",
 	)
 	expectedStatuses[fourthMessage.SequenceNumber] = testhelpers.EXECUTION_STATE_SUCCESS
 	t.Logf("Out of order programmable token transfer from chain %d to chain %d with sequence number %d",

--- a/integration-tests/smoke/ccip/ccip_token_transfer_test.go
+++ b/integration-tests/smoke/ccip/ccip_token_transfer_test.go
@@ -478,6 +478,7 @@ func TestTokenTransfer_Solana2EVM(t *testing.T) {
 			Name:        "Send token to contract",
 			SourceChain: sourceChain,
 			DestChain:   destChain,
+			FeeToken:    wSOL.String(),
 			SolTokens: []ccip_router.SVMTokenAmount{
 				{
 					Token:  srcToken,


### PR DESCRIPTION
## Primary Changes
- Allow `FeeToken` to be specified as an input for CCIP messaging tests
- Allow `FeeToken` to be specified as an input for CCIP token transfer tests
- In `Solana2EVM` messaging test, use native SOL as fee token and remove ATA + sync native setup
- In `Solana2EVM` token transfer test, use wrapped SOL as fee token