### PR TITLE
chore(devenv): fix freeport usage

### DIFF
--- a/deployment/environment/memory/aptos_chains.go
+++ b/deployment/environment/memory/aptos_chains.go
@@ -99,18 +99,20 @@ func aptosChain(t *testing.T, chainID string, adminAddress aptos.AccountAddress)
 	var url string
 	var containerName string
 	for i := 0; i < maxRetries; i++ {
-		port := freeport.GetOne(t)
+		// reserve all the ports we need explicitly to avoid port conflicts in other tests
+		ports := freeport.GetN(t, 2)
 
 		bcInput := &blockchain.Input{
 			Image:       "", // filled out by defaultAptos function
 			Type:        "aptos",
 			ChainID:     chainID,
 			PublicKey:   adminAddress.String(),
-			CustomPorts: []string{fmt.Sprintf("%d:8080", port), fmt.Sprintf("%d:8081", port+1)},
+			CustomPorts: []string{fmt.Sprintf("%d:8080", ports[0]), fmt.Sprintf("%d:8081", ports[1])},
 		}
 		output, err := blockchain.NewBlockchainNetwork(bcInput)
 		if err != nil {
 			t.Logf("Error creating Aptos network: %v", err)
+			freeport.Return(ports)
 			time.Sleep(time.Second)
 			maxRetries -= 1
 			continue

--- a/deployment/environment/memory/chain.go
+++ b/deployment/environment/memory/chain.go
@@ -266,7 +266,11 @@ func solChain(t *testing.T, chainID uint64, adminKey *solana.PrivateKey) (string
 	maxRetries := 10
 	var url, wsURL string
 	for i := 0; i < maxRetries; i++ {
-		port := freeport.GetOne(t)
+		// solana requires 2 ports, one for http and one for ws, but only allows one to be specified
+		// the other is +1 of the first one
+		// must reserve 2 to avoid port conflicts in the freeport library with other tests
+		// https://github.com/smartcontractkit/chainlink-testing-framework/blob/e109695d311e6ed42ca3194907571ce6454fae8d/framework/components/blockchain/blockchain.go#L39
+		ports := freeport.GetN(t, 2)
 
 		image := ""
 		if runtime.GOOS == "linux" {
@@ -278,13 +282,14 @@ func solChain(t *testing.T, chainID uint64, adminKey *solana.PrivateKey) (string
 			Type:           "solana",
 			ChainID:        strconv.FormatUint(chainID, 10),
 			PublicKey:      adminKey.PublicKey().String(),
-			Port:           strconv.Itoa(port),
+			Port:           strconv.Itoa(ports[0]),
 			ContractsDir:   ProgramsPath,
 			SolanaPrograms: SolanaProgramIDs,
 		}
 		output, err := blockchain.NewBlockchainNetwork(bcInput)
 		if err != nil {
 			t.Logf("Error creating solana network: %v", err)
+			freeport.Return(ports)
 			time.Sleep(time.Second)
 			maxRetries -= 1
 			continue


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[DX-681](https://smartcontract-it.atlassian.net/browse/DX-681)

This cryptic error is almost certainly solved by this PR.
```

            	Error Trace:	/home/runner/_work/chainlink/chainlink/deployment/ccip/changeset/testhelpers/test_environment.go:388
            	            				/home/runner/_work/chainlink/chainlink/deployment/ccip/changeset/testhelpers/test_environment.go:561
            	            				/home/runner/_work/chainlink/chainlink/deployment/ccip/changeset/testhelpers/test_environment.go:489
            	            				/home/runner/_work/chainlink/chainlink/deployment/ccip/changeset/testhelpers/test_environment.go:471
            	            				/home/runner/_work/chainlink/chainlink/deployment/ccip/changeset/v1_5_1/cs_sync_usdc_domains_with_chains_test.go:134
            	Error:      	Received unexpected error:
            	            	error calling NewPeer: failed to start ragep2p host: net.Listen("127.0.0.1:11804") failed: listen tcp 127.0.0.1:11804: bind: address already in use

```

The issue is that solana anvil integration assumes it's safe to take ports when it is not:
`[DEBUG] freeport: Test "TestValidateConfigureTokenPoolContractsForSolana" took ports [11803]`
https://github.com/smartcontractkit/chainlink/actions/runs/14805387416/job/41572704998?pr=17566
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[DX-681]: https://smartcontract-it.atlassian.net/browse/DX-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ