### PR TITLE
Consider endianness for Solana curse subject

### DIFF
--- a/deployment/ccip/changeset/globals/helpers.go
+++ b/deployment/ccip/changeset/globals/helpers.go
@@ -2,6 +2,8 @@ package globals
 
 import (
 	"encoding/binary"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
 )
 
 // GlobalCurseSubject as defined here: https://github.com/smartcontractkit/chainlink/blob/new-rmn-curse-changeset/contracts/src/v0.8/ccip/rmn/RMNRemote.sol#L15
@@ -11,16 +13,48 @@ func GlobalCurseSubject() Subject {
 
 type Subject = [16]byte
 
-func SelectorToSubject(selector uint64) Subject {
+func selectorToSubject(selector uint64) Subject {
 	var b Subject
 	binary.BigEndian.PutUint64(b[8:], selector)
 	return b
 }
 
-func SubjectToSelector(subject [16]byte) uint64 {
+func subjectToSelector(subject [16]byte) uint64 {
 	if subject == GlobalCurseSubject() {
 		return 0
 	}
 
 	return binary.BigEndian.Uint64(subject[8:])
+}
+
+func selectorToSolanaSubject(selector uint64) Subject {
+	var b Subject
+	binary.LittleEndian.PutUint64(b[0:], selector)
+	return b
+}
+
+func subjectToSolanaSelector(subject [16]byte) uint64 {
+	if subject == GlobalCurseSubject() {
+		return 0
+	}
+
+	return binary.LittleEndian.Uint64(subject[:])
+}
+
+func FamilyAwareSubjectToSelector(subject Subject, family string) uint64 {
+	switch family {
+	case chainsel.FamilySolana:
+		return subjectToSolanaSelector(subject)
+	default:
+		return subjectToSelector(subject)
+	}
+}
+
+func FamilyAwareSelectorToSubject(selector uint64, family string) Subject {
+	switch family {
+	case chainsel.FamilySolana:
+		return selectorToSolanaSubject(selector)
+	default:
+		return selectorToSubject(selector)
+	}
 }

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -1,6 +1,7 @@
 package v1_6
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -521,6 +522,11 @@ func (c SolanaCursableChain) IsSubjectCursed(subject globals.Subject) (bool, err
 }
 
 func (c SolanaCursableChain) Curse(deployerGroup *changeset.DeployerGroup, subjects []globals.Subject) error {
+	err := assertEndianness(subjects, chain_selectors.FamilySolana)
+	if err != nil {
+		return fmt.Errorf("failed to assert subject endianness: %w", err)
+	}
+
 	rmnRemoteConfigPDA := c.chain.RMNRemoteConfigPDA
 	solRmnRemote.SetProgramID(c.chain.RMNRemote)
 	rmnRemoteCursesPDA := c.chain.RMNRemoteCursesPDA
@@ -555,6 +561,11 @@ func (c SolanaCursableChain) Curse(deployerGroup *changeset.DeployerGroup, subje
 }
 
 func (c SolanaCursableChain) Uncurse(deployerGroup *changeset.DeployerGroup, subjects []globals.Subject) error {
+	err := assertEndianness(subjects, chain_selectors.FamilySolana)
+	if err != nil {
+		return fmt.Errorf("failed to assert subject endianness: %w", err)
+	}
+
 	rmnRemoteConfigPDA := c.chain.RMNRemoteConfigPDA
 	solRmnRemote.SetProgramID(c.chain.RMNRemote)
 	rmnRemoteCursesPDA := c.chain.RMNRemoteCursesPDA
@@ -640,6 +651,11 @@ func (c EvmCursableChain) IsSubjectCursed(subject globals.Subject) (bool, error)
 }
 
 func (c EvmCursableChain) Curse(deployerGroup *changeset.DeployerGroup, subjects []globals.Subject) error {
+	err := assertEndianness(subjects, chain_selectors.FamilyEVM)
+	if err != nil {
+		return fmt.Errorf("failed to assert subject endianness: %w", err)
+	}
+
 	deployer, err := deployerGroup.GetDeployer(c.selector)
 	if err != nil {
 		return fmt.Errorf("failed to get deployer for chain %d: %w", c.selector, err)
@@ -653,6 +669,11 @@ func (c EvmCursableChain) Curse(deployerGroup *changeset.DeployerGroup, subjects
 }
 
 func (c EvmCursableChain) Uncurse(deployerGroup *changeset.DeployerGroup, subjects []globals.Subject) error {
+	err := assertEndianness(subjects, chain_selectors.FamilyEVM)
+	if err != nil {
+		return fmt.Errorf("failed to assert subject endianness: %w", err)
+	}
+
 	deployer, err := deployerGroup.GetDeployer(c.selector)
 	if err != nil {
 		return fmt.Errorf("failed to get deployer for chain %d: %w", c.selector, err)
@@ -695,4 +716,25 @@ func GetAllCursableChainsSelector(env deployment.Environment) []uint64 {
 	selectors = append(selectors, env.AllChainSelectors()...)
 	selectors = append(selectors, env.AllChainSelectorsSolana()...)
 	return selectors
+}
+
+func assertEndianness(subjects []globals.Subject, family string) error {
+	for _, subject := range subjects {
+		if subject == globals.GlobalCurseSubject() {
+			continue
+		}
+		switch family {
+		case chain_selectors.FamilySolana:
+			// Solana uses little endian to encode the subject so we expect the last 8 bytes to be 0
+			if !bytes.Equal(subject[8:], []byte{0, 0, 0, 0, 0, 0, 0, 0}) {
+				return fmt.Errorf("endianness incorrect for Solana curse subject: %s", subject)
+			}
+		default:
+			// EVM uses big endian to encode the subject so we expect the first 8 bytes to be 0
+			if !bytes.Equal(subject[:8], []byte{0, 0, 0, 0, 0, 0, 0, 0}) {
+				return fmt.Errorf("endianness incorrect for curse subject: %s", subject)
+			}
+		}
+	}
+	return nil
 }

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -32,7 +32,7 @@ type RMNCurseAction struct {
 
 // CurseAction is a function that returns a list of RMNCurseAction to be applied on a chain
 // CurseChain, CurseLane, CurseGloballyOnlyOnSource are examples of function implementing CurseAction
-type CurseAction func(e deployment.Environment) []RMNCurseAction
+type CurseAction func(e deployment.Environment) ([]RMNCurseAction, error)
 
 type RMNCurseConfig struct {
 	MCMS         *proposalutils.TimelockConfig
@@ -61,22 +61,28 @@ func (c RMNCurseConfig) Validate(e deployment.Environment) error {
 		return errors.New("reason is required")
 	}
 
-	validSubjects := map[globals.Subject]struct{}{
+	validEVMSubjects := map[globals.Subject]struct{}{
 		globals.GlobalCurseSubject(): {},
 	}
+
+	validSolanaSubjects := map[globals.Subject]struct{}{
+		globals.GlobalCurseSubject(): {},
+	}
+
 	for _, selector := range GetAllCursableChainsSelector(e) {
-		validSubjects[globals.SelectorToSubject(selector)] = struct{}{}
+		validEVMSubjects[globals.FamilyAwareSelectorToSubject(selector, chain_selectors.FamilyEVM)] = struct{}{}
+		validSolanaSubjects[globals.FamilyAwareSelectorToSubject(selector, chain_selectors.FamilySolana)] = struct{}{}
 	}
 
 	for _, curseAction := range c.CurseActions {
-		result := curseAction(e)
+		result, err := curseAction(e)
+		if err != nil {
+			return fmt.Errorf("failed to generate curse actions: %w", err)
+		}
+
 		for _, action := range result {
 			if err = deployment.IsValidChainSelector(action.ChainSelector); err != nil {
 				return fmt.Errorf("invalid chain selector %d", action.ChainSelector)
-			}
-
-			if _, ok := validSubjects[action.SubjectToCurse]; !ok {
-				return fmt.Errorf("invalid subject %x", action.SubjectToCurse)
 			}
 
 			family, err := chain_selectors.GetSelectorFamily(action.ChainSelector)
@@ -87,6 +93,10 @@ func (c RMNCurseConfig) Validate(e deployment.Environment) error {
 			// TODO: Implement chain family agnostic validation
 			switch family {
 			case chain_selectors.FamilyEVM:
+				if _, ok := validEVMSubjects[action.SubjectToCurse]; !ok {
+					return fmt.Errorf("invalid subject %x", action.SubjectToCurse)
+				}
+
 				targetChain := e.Chains[action.ChainSelector]
 				targetChainState, ok := state.Chains[action.ChainSelector]
 				if !ok {
@@ -97,6 +107,10 @@ func (c RMNCurseConfig) Validate(e deployment.Environment) error {
 					return fmt.Errorf("chain %s: %w", targetChain.String(), err)
 				}
 			case chain_selectors.FamilySolana:
+				if _, ok := validSolanaSubjects[action.SubjectToCurse]; !ok {
+					return fmt.Errorf("invalid subject %x", action.SubjectToCurse)
+				}
+
 				targetChain := e.SolChains[action.ChainSelector]
 				targetChainState, ok := state.SolChains[action.ChainSelector]
 				if !ok {
@@ -119,13 +133,18 @@ func (c RMNCurseConfig) Validate(e deployment.Environment) error {
 // CurseLaneOnlyOnSource(A, B) will curse A with the curse subject of B
 func CurseLaneOnlyOnSource(sourceSelector uint64, destinationSelector uint64) CurseAction {
 	// Curse from source to destination
-	return func(e deployment.Environment) []RMNCurseAction {
+	return func(e deployment.Environment) ([]RMNCurseAction, error) {
+		family, err := chain_selectors.GetSelectorFamily(sourceSelector)
+		if err != nil {
+			return nil, err
+		}
+
 		return []RMNCurseAction{
 			{
 				ChainSelector:  sourceSelector,
-				SubjectToCurse: globals.SelectorToSubject(destinationSelector),
+				SubjectToCurse: globals.FamilyAwareSelectorToSubject(destinationSelector, family),
 			},
-		}
+		}, nil
 	}
 }
 
@@ -133,13 +152,13 @@ func CurseLaneOnlyOnSource(sourceSelector uint64, destinationSelector uint64) Cu
 // Given 3 chains A, B, C
 // CurseGloballyOnlyOnChain(A) will curse a with the global curse subject only
 func CurseGloballyOnlyOnChain(selector uint64) CurseAction {
-	return func(e deployment.Environment) []RMNCurseAction {
+	return func(e deployment.Environment) ([]RMNCurseAction, error) {
 		return []RMNCurseAction{
 			{
 				ChainSelector:  selector,
 				SubjectToCurse: globals.GlobalCurseSubject(),
 			},
-		}
+		}, nil
 	}
 }
 
@@ -147,12 +166,20 @@ func CurseGloballyOnlyOnChain(selector uint64) CurseAction {
 // Given 3 chains A, B, C
 // CurseLaneBidirectionally(A, B) will curse A with the curse subject of B and B with the curse subject of A
 func CurseLaneBidirectionally(sourceSelector uint64, destinationSelector uint64) CurseAction {
+
 	// Bidirectional curse between two chains
-	return func(e deployment.Environment) []RMNCurseAction {
-		return append(
-			CurseLaneOnlyOnSource(sourceSelector, destinationSelector)(e),
-			CurseLaneOnlyOnSource(destinationSelector, sourceSelector)(e)...,
-		)
+	return func(e deployment.Environment) ([]RMNCurseAction, error) {
+		curseActions1, err := CurseLaneOnlyOnSource(sourceSelector, destinationSelector)(e)
+		if err != nil {
+			return nil, err
+		}
+
+		curseActions2, err := CurseLaneOnlyOnSource(destinationSelector, sourceSelector)(e)
+		if err != nil {
+			return nil, err
+		}
+
+		return append(curseActions1, curseActions2...), nil
 	}
 }
 
@@ -160,24 +187,33 @@ func CurseLaneBidirectionally(sourceSelector uint64, destinationSelector uint64)
 // Given 3 chains A, B, C
 // CurseChain(A) will curse A with the global curse subject and curse B and C with the curse subject of A
 func CurseChain(chainSelector uint64) CurseAction {
-	return func(e deployment.Environment) []RMNCurseAction {
+	return func(e deployment.Environment) ([]RMNCurseAction, error) {
 		chainSelectors := GetAllCursableChainsSelector(e)
 
 		// Curse all other chains to prevent onramp from sending message to the cursed chain
 		var curseActions []RMNCurseAction
 		for _, otherChainSelector := range chainSelectors {
 			if otherChainSelector != chainSelector {
+				family, err := chain_selectors.GetSelectorFamily(otherChainSelector)
+				if err != nil {
+					return nil, err
+				}
+
 				curseActions = append(curseActions, RMNCurseAction{
 					ChainSelector:  otherChainSelector,
-					SubjectToCurse: globals.SelectorToSubject(chainSelector),
+					SubjectToCurse: globals.FamilyAwareSelectorToSubject(chainSelector, family),
 				})
 			}
 		}
 
 		// Curse the chain with a global curse to prevent any onramp or offramp message from send message in and out of the chain
-		curseActions = append(curseActions, CurseGloballyOnlyOnChain(chainSelector)(e)...)
+		globalCurse, err := CurseGloballyOnlyOnChain(chainSelector)(e)
+		if err != nil {
+			return nil, err
+		}
+		curseActions = append(curseActions, globalCurse...)
 
-		return curseActions
+		return curseActions, nil
 	}
 }
 
@@ -196,7 +232,14 @@ func FilterOutNotConnectedLanes(e deployment.Environment, curseActions []RMNCurs
 		}
 
 		targetChainSelector := action.ChainSelector
-		sourceChainSelector := globals.SubjectToSelector(action.SubjectToCurse)
+
+		targetFamily, err := chain_selectors.GetSelectorFamily(targetChainSelector)
+		if err != nil {
+			e.Logger.Errorf("failed to get family for chain %d: %v", targetChainSelector, err)
+			return nil, err
+		}
+
+		sourceChainSelector := globals.FamilyAwareSubjectToSelector(action.SubjectToCurse, targetFamily)
 
 		targetSourceConnected, err := cursableChains[targetChainSelector].IsConnectedToSourceChain(sourceChainSelector)
 		if err != nil {
@@ -225,11 +268,16 @@ func FilterOutNotConnectedLanes(e deployment.Environment, curseActions []RMNCurs
 	return returnActions, nil
 }
 
-func groupRMNSubjectBySelector(rmnSubjects []RMNCurseAction, avoidCursingSelf bool, onlyKeepGlobal bool) map[uint64][]globals.Subject {
+func groupRMNSubjectBySelector(rmnSubjects []RMNCurseAction, avoidCursingSelf bool, onlyKeepGlobal bool) (map[uint64][]globals.Subject, error) {
 	grouped := make(map[uint64][]globals.Subject)
 	for _, s := range rmnSubjects {
+		family, err := chain_selectors.GetSelectorFamily(s.ChainSelector)
+		if err != nil {
+			return nil, err
+		}
+
 		// Skip self-curse if needed
-		if s.SubjectToCurse == globals.SelectorToSubject(s.ChainSelector) && avoidCursingSelf {
+		if s.SubjectToCurse == globals.FamilyAwareSelectorToSubject(s.ChainSelector, family) && avoidCursingSelf {
 			continue
 		}
 		// Initialize slice for this chain if needed
@@ -258,7 +306,7 @@ func groupRMNSubjectBySelector(rmnSubjects []RMNCurseAction, avoidCursingSelf bo
 		}
 	}
 
-	return grouped
+	return grouped, nil
 }
 
 // RMNCurseChangeset creates a new changeset for cursing chains or lanes on RMNRemote contracts.
@@ -293,7 +341,12 @@ func RMNCurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployment
 	// Generate curse actions
 	var curseActions []RMNCurseAction
 	for _, curseAction := range cfg.CurseActions {
-		curseActions = append(curseActions, curseAction(e)...)
+		actions, err := curseAction(e)
+		if err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to generate curse actions: %w", err)
+		}
+
+		curseActions = append(curseActions, actions...)
 	}
 
 	if !cfg.IncludeNotConnectedLanes {
@@ -304,7 +357,10 @@ func RMNCurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployment
 	}
 
 	// Group curse actions by chain selector
-	grouped := groupRMNSubjectBySelector(curseActions, true, true)
+	grouped, err := groupRMNSubjectBySelector(curseActions, true, true)
+	if err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("failed to group curse actions: %w", err)
+	}
 	// For each chain in the environment get the RMNRemote contract and call curse
 	cursableChains, err := GetCursableChains(e)
 	if err != nil {
@@ -375,10 +431,18 @@ func RMNUncurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployme
 	// Generate curse actions
 	var curseActions []RMNCurseAction
 	for _, curseAction := range cfg.CurseActions {
-		curseActions = append(curseActions, curseAction(e)...)
+		actions, err := curseAction(e)
+		if err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to generate curse actions: %w", err)
+		}
+
+		curseActions = append(curseActions, actions...)
 	}
 	// Group curse actions by chain selector
-	grouped := groupRMNSubjectBySelector(curseActions, false, false)
+	grouped, err := groupRMNSubjectBySelector(curseActions, false, false)
+	if err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("failed to group curse actions: %w", err)
+	}
 
 	// For each chain in the environement get the RMNRemote contract and call uncurse
 	cursableChains, err := GetCursableChains(e)

--- a/deployment/ccip/view/v1_6/rmnremote.go
+++ b/deployment/ccip/view/v1_6/rmnremote.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	"github.com/smartcontractkit/chainlink/deployment/common/view/types"

--- a/deployment/ccip/view/v1_6/rmnremote.go
+++ b/deployment/ccip/view/v1_6/rmnremote.go
@@ -3,6 +3,7 @@ package v1_6
 import (
 	"encoding/hex"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	"github.com/smartcontractkit/chainlink/deployment/common/view/types"
@@ -31,12 +32,12 @@ type RMNRemoteSigner struct {
 	NodeIndex        uint64 `json:"node_index"`
 }
 
-func mapCurseSubjects(subjects [][16]byte) []RMNRemoteCurseEntry {
+func mapCurseSubjects(subjects [][16]byte, family string) []RMNRemoteCurseEntry {
 	res := make([]RMNRemoteCurseEntry, 0, len(subjects))
 	for _, subject := range subjects {
 		res = append(res, RMNRemoteCurseEntry{
 			Subject:  hex.EncodeToString(subject[:]),
-			Selector: globals.SubjectToSelector(subject),
+			Selector: globals.FamilyAwareSubjectToSelector(subject, family),
 		})
 	}
 	return res
@@ -76,6 +77,6 @@ func GenerateRMNRemoteView(rmnReader *rmn_remote.RMNRemote) (RMNRemoteView, erro
 		ContractMetaData:     tv,
 		IsCursed:             isCursed,
 		Config:               rmnConfig,
-		CursedSubjectEntries: mapCurseSubjects(curseSubjects),
+		CursedSubjectEntries: mapCurseSubjects(curseSubjects, chain_selectors.FamilyEVM),
 	}, nil
 }

--- a/deployment/ccip/view/v1_6/rmnremote_test.go
+++ b/deployment/ccip/view/v1_6/rmnremote_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
@@ -27,7 +28,10 @@ func Test_RMNRemote_Curse_View(t *testing.T) {
 	_, err = deployment.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
-	tx, err = remote.Curse(chain.DeployerKey, globals.SelectorToSubject(e.AllChainSelectors()[0]))
+	family, err := chainsel.GetSelectorFamily(e.AllChainSelectors()[0])
+	require.NoError(t, err)
+
+	tx, err = remote.Curse(chain.DeployerKey, globals.FamilyAwareSelectorToSubject(e.AllChainSelectors()[0], family))
 	_, err = deployment.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
@@ -39,4 +43,34 @@ func Test_RMNRemote_Curse_View(t *testing.T) {
 	require.Equal(t, "01000000000000000000000000000001", view.CursedSubjectEntries[0].Subject)
 	require.Equal(t, uint64(0), view.CursedSubjectEntries[0].Selector)
 	require.Equal(t, e.AllChainSelectors()[0], view.CursedSubjectEntries[1].Selector)
+}
+
+func Test_RMN_Selector_To_Solana_Subject(t *testing.T) {
+	subject := globals.FamilyAwareSelectorToSubject(chainsel.BINANCE_SMART_CHAIN_TESTNET.Selector, chainsel.FamilySolana)
+	require.Equal(t, []byte{251, 150, 143, 3, 112, 145, 21, 184, 0, 0, 0, 0, 0, 0, 0, 0}, subject[:])
+}
+
+func Test_RMN_Subject_To_Solana_Selector(t *testing.T) {
+	selector := globals.FamilyAwareSubjectToSelector([16]byte{251, 150, 143, 3, 112, 145, 21, 184, 0, 0, 0, 0, 0, 0, 0, 0}, chainsel.FamilySolana)
+	require.Equal(t, chainsel.BINANCE_SMART_CHAIN_TESTNET.Selector, selector)
+}
+
+func Test_RMN_Selector_To_Subject(t *testing.T) {
+	subject := globals.FamilyAwareSelectorToSubject(chainsel.BINANCE_SMART_CHAIN_TESTNET.Selector, chainsel.FamilyEVM)
+	require.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 0, 184, 21, 145, 112, 3, 143, 150, 251}, subject[:])
+}
+
+func Test_RMN_Subject_To_Selector(t *testing.T) {
+	selector := globals.FamilyAwareSubjectToSelector([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 184, 21, 145, 112, 3, 143, 150, 251}, chainsel.FamilyEVM)
+	require.Equal(t, chainsel.BINANCE_SMART_CHAIN_TESTNET.Selector, selector)
+}
+
+func Test_GlobalSubject_To_Selector(t *testing.T) {
+	selector := globals.FamilyAwareSubjectToSelector(globals.GlobalCurseSubject(), chainsel.FamilyEVM)
+	require.Equal(t, uint64(0), selector)
+}
+
+func Test_GlobalSubject_To_Selector_Solana(t *testing.T) {
+	selector := globals.FamilyAwareSubjectToSelector(globals.GlobalCurseSubject(), chainsel.FamilySolana)
+	require.Equal(t, uint64(0), selector)
 }

--- a/deployment/ccip/view/v1_6/rmnremote_test.go
+++ b/deployment/ccip/view/v1_6/rmnremote_test.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"


### PR DESCRIPTION
RMNRemote on Solana assume that the chain selector curse subject are unsigned int encoded using little endian while the rest of the chains treat it as unsigned int in big endian. This fix change RMN tooling to consider the chain where curse subject are applied to encode the curse subject properly

RMN specific tests: https://github.com/smartcontractkit/chainlink/actions/runs/14845602570