### PR TITLE
Avoid enabling CL_SOLANA_CMD for ccip

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -98,6 +98,7 @@ runs:
         else
           SHARED_BUILD_ARGS=$(cat << EOF
         COMMIT_SHA=${GIT_COMMIT_SHA}
+        CL_SOLANA_CMD=chainlink-solana
         EOF
         )
         fi

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -116,6 +116,7 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_APTOS_CMD=chainlink-aptos
+        CL_SOLANA_CMD=chainlink-solana
       docker-build-cache-disabled: "true"
       docker-image-type: tag
       docker-manifest-sign: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,6 +58,7 @@ jobs:
       docker-build-args: |
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
+        CL_SOLANA_CMD=chainlink-solana
       docker-build-cache-disabled: "true"
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true
@@ -86,6 +87,7 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_APTOS_CMD=chainlink-aptos
+        CL_SOLANA_CMD=chainlink-solana
       docker-build-cache-disabled: "true"
       docker-image-type: ${{ needs.init.outputs.build-type }}
       docker-manifest-sign: true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -114,6 +114,7 @@ docker-plugins:
 	docker buildx build \
 	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
 	--build-arg CL_APTOS_CMD=chainlink-aptos \
+	--build-arg CL_SOLANA_CMD=chainlink-solana \
 	--build-arg CL_INSTALL_PRIVATE_PLUGINS=$(CL_INSTALL_PRIVATE_PLUGINS) \
 	$(PRIVATE_PLUGIN_ARGS) \
 	-f plugins/chainlink.Dockerfile . \

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -69,9 +69,11 @@ COPY --from=buildgo /go/bin/chainlink /usr/local/bin/
 
 # Install (but don't enable) feeds LOOP Plugin
 COPY --from=buildplugins /go/bin/chainlink-feeds /usr/local/bin/
-# Install and enable Solana LOOP Plugin
+# Install Solana LOOP Plugin
 COPY --from=buildplugins /go/bin/chainlink-solana /usr/local/bin/
-ENV CL_SOLANA_CMD=chainlink-solana
+# Optionally enable the Solana LOOP Plugin
+ARG CL_SOLANA_CMD
+ENV CL_SOLANA_CMD=${CL_SOLANA_CMD}
 
 # CCIP specific
 COPY ./cci[p]/confi[g] /ccip-config

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -75,7 +75,8 @@ COPY --from=buildgo /go/bin/dlv /usr/local/bin/dlv
 # Set plugin environment variable configuration.
 ENV CL_MEDIAN_CMD=chainlink-feeds
 ENV CL_MERCURY_CMD=chainlink-mercury
-ENV CL_SOLANA_CMD=chainlink-solana
+ARG CL_SOLANA_CMD
+ENV CL_SOLANA_CMD=${CL_SOLANA_CMD}
 ARG CL_APTOS_CMD
 ENV CL_APTOS_CMD=${CL_APTOS_CMD}
 


### PR DESCRIPTION
1. Explicitly set CL_SOLANA_CMD=chainlink-solana for all non-CCIP builds
2. Remove setting CL_SOLANA_CMD as the default (to avoid using it for CCIP)