### PR TITLE
fix: ci-core core test timeouts

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -307,6 +307,7 @@ jobs:
 
       - name: Run tests
         if: ${{ matrix.type.should-run == 'true' }}
+        timeout-minutes: ${{ github.event_name == 'schedule' && 38 || 18 }} # leave 2 minute for remaining steps
         id: run-tests
         shell: bash
         env:

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -4,7 +4,7 @@ set +e
 
 SCRIPT_PATH=`dirname "$0"`; SCRIPT_PATH=`eval "cd \"$SCRIPT_PATH\" && pwd"`
 OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
-EXTRA_FLAGS="-timeout 20m"
+EXTRA_FLAGS="-timeout 16m"
 
 
 if [[ -n "$USE_FLAKEGUARD" ]]; then
@@ -23,7 +23,7 @@ if [[ -n "$USE_FLAKEGUARD" ]]; then
     --run-count=1 \
     --rerun-failed-count=3 \
     --min-pass-ratio=1 \
-    --go-test-timeout=20m \
+    --go-test-timeout=16m \
     --omit-test-outputs-on-success=true \
     --main-results-path="go_core_tests_flakeguard_results/main/test_results.json" \
     --rerun-results-path="go_core_tests_flakeguard_results/rerun/test_results.json"


### PR DESCRIPTION
This sets timeouts on the run tests step, and reduces go/flakeguard's timeout so we can hopefully determine which tests are hanging.

### Changes

- Add a 38/18 minute step timeout for "Run tests" (scheduled/regular - for scheduled race tests)
- Make flakeguard timeout 16 minutes
- Make regular go test timeout 16 minutes

### Motivation

We have seen a few failures due to job-level timeouts, and with the output we have we cannot figure out which test(s) are hanging. By reducing the timeout we should be able to have flakeguard/go exit the testing process gracefully, so we can actually see the failing tests.

Example failures:
- https://github.com/smartcontractkit/chainlink/actions/runs/14845689198
- https://github.com/smartcontractkit/chainlink/actions/runs/14803524051
- https://github.com/smartcontractkit/chainlink/actions/runs/14843720173
