### PR TITLE
Unskip flaky tests (testscripts)

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -48,11 +48,8 @@ func TestMain(m *testing.M) {
 var (
 	// Temporary workaround for skipping flaky tests as we improve our tracking process
 	skipFlakyTests = map[string]string{ // test name: issue number
-		"TestScripts/nodes/evm/list/list":       "https://smartcontract-it.atlassian.net/browse/DX-107",
-		"TestScripts/keys/eth/list/unavailable": "https://smartcontract-it.atlassian.net/browse/DX-110",
-		"TestScripts/nodes/solana/list/list":    "https://smartcontract-it.atlassian.net/browse/CRE-155",
-		"TestScripts/health/multi-chain":        "https://smartcontract-it.atlassian.net/browse/CRE-159",
-		"TestScripts/health/default":            "https://smartcontract-it.atlassian.net/browse/DX-109",
+		// "TestScripts/nodes/evm/list/list":       "https://smartcontract-it.atlassian.net/browse/DX-107",
+		// "TestScripts/keys/eth/list/unavailable": "https://smartcontract-it.atlassian.net/browse/DX-110",
 	}
 )
 


### PR DESCRIPTION
[CRE-159](https://smartcontract-it.atlassian.net/browse/CRE-159) - Un-skip earlier flaky tests due to resource limits.


[CRE-159]: https://smartcontract-it.atlassian.net/browse/CRE-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ