### PR TITLE
[CRE-403] Remove dependency on cltest from orm_test.

### DIFF
--- a/core/chains/evm/log/orm_test.go
+++ b/core/chains/evm/log/orm_test.go
@@ -19,9 +19,6 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/log"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	"github.com/smartcontractkit/chainlink/v2/core/services/job"
-	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 )
 
 func TestORM_broadcasts(t *testing.T) {
@@ -34,7 +31,7 @@ func TestORM_broadcasts(t *testing.T) {
 	const selectQuery = `SELECT consumed FROM log_broadcasts
 		WHERE block_hash = $1 AND block_number = $2 AND log_index = $3 AND job_id = $4 AND evm_chain_id = $5`
 
-	listener := &mockListener{specV2.ID}
+	listener := &mockListener{specV2}
 
 	rawLog := randomLog(t)
 	queryArgs := []interface{}{rawLog.BlockHash, rawLog.BlockNumber, rawLog.Index, listener.JobID(), testutils.FixtureChainID.String()}
@@ -122,36 +119,36 @@ func TestORM_MarkUnconsumed(t *testing.T) {
 	logBefore := randomLog(t)
 	logBefore.BlockNumber = 34
 	require.NoError(t,
-		orm.CreateBroadcast(ctx, logBefore.BlockHash, logBefore.BlockNumber, logBefore.Index, job1.ID))
+		orm.CreateBroadcast(ctx, logBefore.BlockHash, logBefore.BlockNumber, logBefore.Index, job1))
 	require.NoError(t,
-		orm.MarkBroadcastConsumed(ctx, logBefore.BlockHash, logBefore.BlockNumber, logBefore.Index, job1.ID))
+		orm.MarkBroadcastConsumed(ctx, logBefore.BlockHash, logBefore.BlockNumber, logBefore.Index, job1))
 
 	logAt := randomLog(t)
 	logAt.BlockNumber = 38
 	require.NoError(t,
-		orm.CreateBroadcast(ctx, logAt.BlockHash, logAt.BlockNumber, logAt.Index, job1.ID))
+		orm.CreateBroadcast(ctx, logAt.BlockHash, logAt.BlockNumber, logAt.Index, job1))
 	require.NoError(t,
-		orm.MarkBroadcastConsumed(ctx, logAt.BlockHash, logAt.BlockNumber, logAt.Index, job1.ID))
+		orm.MarkBroadcastConsumed(ctx, logAt.BlockHash, logAt.BlockNumber, logAt.Index, job1))
 
 	logAfter := randomLog(t)
 	logAfter.BlockNumber = 40
 	require.NoError(t,
-		orm.CreateBroadcast(ctx, logAfter.BlockHash, logAfter.BlockNumber, logAfter.Index, job2.ID))
+		orm.CreateBroadcast(ctx, logAfter.BlockHash, logAfter.BlockNumber, logAfter.Index, job2))
 	require.NoError(t,
-		orm.MarkBroadcastConsumed(ctx, logAfter.BlockHash, logAfter.BlockNumber, logAfter.Index, job2.ID))
+		orm.MarkBroadcastConsumed(ctx, logAfter.BlockHash, logAfter.BlockNumber, logAfter.Index, job2))
 
 	// logAt and logAfter should now be marked unconsumed. logBefore is still consumed.
 	require.NoError(t, orm.MarkBroadcastsUnconsumed(ctx, 38))
 
-	consumed, err := orm.WasBroadcastConsumed(ctx, logBefore.BlockHash, logBefore.Index, job1.ID)
+	consumed, err := orm.WasBroadcastConsumed(ctx, logBefore.BlockHash, logBefore.Index, job1)
 	require.NoError(t, err)
 	require.True(t, consumed)
 
-	consumed, err = orm.WasBroadcastConsumed(ctx, logAt.BlockHash, logAt.Index, job1.ID)
+	consumed, err = orm.WasBroadcastConsumed(ctx, logAt.BlockHash, logAt.Index, job1)
 	require.NoError(t, err)
 	require.False(t, consumed)
 
-	consumed, err = orm.WasBroadcastConsumed(ctx, logAfter.BlockHash, logAfter.Index, job2.ID)
+	consumed, err = orm.WasBroadcastConsumed(ctx, logAfter.BlockHash, logAfter.Index, job2)
 	require.NoError(t, err)
 	require.False(t, consumed)
 }
@@ -209,7 +206,7 @@ func TestORM_Reinitialize(t *testing.T) {
 			ctx := testutils.Context(t)
 			orm := log.NewORM(db, *testutils.FixtureChainID)
 
-			jobID := mustInsertV2JobSpec(t, db, common.BigToAddress(big.NewInt(rand.Int63()))).ID
+			jobID := mustInsertV2JobSpec(t, db, common.BigToAddress(big.NewInt(rand.Int63())))
 
 			for _, b := range tt.broadcasts {
 				if b.Consumed {
@@ -277,32 +274,19 @@ func randomBytes(t *testing.T, n int) []byte {
 	return b
 }
 
-func mustInsertV2JobSpec(t *testing.T, db *sqlx.DB, transmitterAddress common.Address) job.Job {
+func mustInsertV2JobSpec(t *testing.T, db *sqlx.DB, transmitterAddress common.Address) int32 {
 	t.Helper()
 
 	addr := evmtypes.MustEIP55Address(transmitterAddress.Hex())
 
-	ocrKeyID := []byte{}
+	var oracleSpecId int32
+	require.NoError(t, db.Get(&oracleSpecId, `INSERT INTO ocr_oracle_specs (created_at, updated_at, contract_address, p2pv2_bootstrappers, is_bootstrap_peer, transmitter_address, evm_chain_id, contract_config_confirmations) VALUES (
+	NOW(),NOW(),$1,'{}',false,$2,0,0
+	) RETURNING id`, evmtypes.MustEIP55Address(testutils.NewAddress().Hex()), &addr))
 
-	oracleSpec := job.OCROracleSpec{}
-	require.NoError(t, db.Get(&oracleSpec, `INSERT INTO ocr_oracle_specs (created_at, updated_at, contract_address, p2pv2_bootstrappers, is_bootstrap_peer, encrypted_ocr_key_bundle_id, transmitter_address, observation_timeout, blockchain_timeout, contract_config_tracker_subscribe_interval, contract_config_tracker_poll_interval, contract_config_confirmations, database_timeout, observation_grace_period, contract_transmitter_transmit_timeout, evm_chain_id) VALUES (
-	NOW(),NOW(),$1,'{}',false,$2,$3,0,0,0,0,0,0,0,0,0
-	) RETURNING *`, evmtypes.MustEIP55Address(testutils.NewAddress().Hex()), &ocrKeyID, &addr))
+	var jobSpecId int32
+	require.NoError(t, db.Get(&jobSpecId, `INSERT INTO jobs (schema_version, created_at, type, ocr_oracle_spec_id, external_job_id) VALUES (
+    1, NOW(), 1, $1, $2) RETURNING id`, oracleSpecId, uuid.New()))
 
-	pipelineSpec := pipeline.Spec{}
-	require.NoError(t, db.Get(&pipelineSpec, `INSERT INTO pipeline_specs (dot_dag_source,created_at) VALUES ('',NOW()) RETURNING *`))
-
-	jb := job.Job{
-		OCROracleSpec:   &oracleSpec,
-		OCROracleSpecID: &oracleSpec.ID,
-		ExternalJobID:   uuid.New(),
-		Type:            job.OffchainReporting,
-		SchemaVersion:   1,
-		PipelineSpec:    &pipelineSpec,
-		PipelineSpecID:  pipelineSpec.ID,
-	}
-
-	jorm := job.NewORM(db, nil, nil, nil, logger.TestLogger(t))
-	require.NoError(t, jorm.InsertJob(testutils.Context(t), &jb))
-	return jb
+	return jobSpecId
 }

--- a/core/chains/evm/log/orm_test.go
+++ b/core/chains/evm/log/orm_test.go
@@ -286,7 +286,7 @@ func mustInsertV2JobSpec(t *testing.T, db *sqlx.DB, transmitterAddress common.Ad
 
 	var jobSpecId int32
 	require.NoError(t, db.Get(&jobSpecId, `INSERT INTO jobs (schema_version, created_at, type, ocr_oracle_spec_id, external_job_id) VALUES (
-    1, NOW(), 1, $1, $2) RETURNING id`, oracleSpecId, uuid.New()))
+    1,NOW(),1,$1,$2) RETURNING id`, oracleSpecId, uuid.New()))
 
 	return jobSpecId
 }

--- a/core/chains/evm/log/orm_test.go
+++ b/core/chains/evm/log/orm_test.go
@@ -286,7 +286,7 @@ func mustInsertV2JobSpec(t *testing.T, db *sqlx.DB, transmitterAddress common.Ad
 
 	var jobSpecId int32
 	require.NoError(t, db.Get(&jobSpecId, `INSERT INTO jobs (schema_version, created_at, type, ocr_oracle_spec_id, external_job_id) VALUES (
-    1,NOW(),1,$1,$2) RETURNING id`, oracleSpecId, uuid.New()))
+    1,NOW(),0,$1,$2) RETURNING id`, oracleSpecId, uuid.New()))
 
 	return jobSpecId
 }

--- a/core/chains/evm/log/orm_test.go
+++ b/core/chains/evm/log/orm_test.go
@@ -9,24 +9,27 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
+	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/log"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 )
 
 func TestORM_broadcasts(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
 	orm := log.NewORM(db, *testutils.FixtureChainID)
 
-	_, addr := cltest.MustInsertRandomKey(t, ethKeyStore)
-	specV2 := cltest.MustInsertV2JobSpec(t, db, addr)
+	specV2 := mustInsertV2JobSpec(t, db, testutils.NewAddress())
 
 	const selectQuery = `SELECT consumed FROM log_broadcasts
 		WHERE block_hash = $1 AND block_number = $2 AND log_index = $3 AND job_id = $4 AND evm_chain_id = $5`
@@ -109,15 +112,12 @@ func TestORM_pending(t *testing.T) {
 func TestORM_MarkUnconsumed(t *testing.T) {
 	ctx := testutils.Context(t)
 	db := testutils.NewSqlxDB(t)
-	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
 	orm := log.NewORM(db, *testutils.FixtureChainID)
 
-	_, addr1 := cltest.MustInsertRandomKey(t, ethKeyStore)
-	job1 := cltest.MustInsertV2JobSpec(t, db, addr1)
+	job1 := mustInsertV2JobSpec(t, db, testutils.NewAddress())
 
-	_, addr2 := cltest.MustInsertRandomKey(t, ethKeyStore)
-	job2 := cltest.MustInsertV2JobSpec(t, db, addr2)
+	job2 := mustInsertV2JobSpec(t, db, testutils.NewAddress())
 
 	logBefore := randomLog(t)
 	logBefore.BlockNumber = 34
@@ -209,7 +209,7 @@ func TestORM_Reinitialize(t *testing.T) {
 			ctx := testutils.Context(t)
 			orm := log.NewORM(db, *testutils.FixtureChainID)
 
-			jobID := cltest.MustInsertV2JobSpec(t, db, common.BigToAddress(big.NewInt(rand.Int63()))).ID
+			jobID := mustInsertV2JobSpec(t, db, common.BigToAddress(big.NewInt(rand.Int63()))).ID
 
 			for _, b := range tt.broadcasts {
 				if b.Consumed {
@@ -275,4 +275,34 @@ func randomBytes(t *testing.T, n int) []byte {
 		t.Fatal(err)
 	}
 	return b
+}
+
+func mustInsertV2JobSpec(t *testing.T, db *sqlx.DB, transmitterAddress common.Address) job.Job {
+	t.Helper()
+
+	addr := evmtypes.MustEIP55Address(transmitterAddress.Hex())
+
+	ocrKeyID := []byte{}
+
+	oracleSpec := job.OCROracleSpec{}
+	require.NoError(t, db.Get(&oracleSpec, `INSERT INTO ocr_oracle_specs (created_at, updated_at, contract_address, p2pv2_bootstrappers, is_bootstrap_peer, encrypted_ocr_key_bundle_id, transmitter_address, observation_timeout, blockchain_timeout, contract_config_tracker_subscribe_interval, contract_config_tracker_poll_interval, contract_config_confirmations, database_timeout, observation_grace_period, contract_transmitter_transmit_timeout, evm_chain_id) VALUES (
+	NOW(),NOW(),$1,'{}',false,$2,$3,0,0,0,0,0,0,0,0,0
+	) RETURNING *`, evmtypes.MustEIP55Address(testutils.NewAddress().Hex()), &ocrKeyID, &addr))
+
+	pipelineSpec := pipeline.Spec{}
+	require.NoError(t, db.Get(&pipelineSpec, `INSERT INTO pipeline_specs (dot_dag_source,created_at) VALUES ('',NOW()) RETURNING *`))
+
+	jb := job.Job{
+		OCROracleSpec:   &oracleSpec,
+		OCROracleSpecID: &oracleSpec.ID,
+		ExternalJobID:   uuid.New(),
+		Type:            job.OffchainReporting,
+		SchemaVersion:   1,
+		PipelineSpec:    &pipelineSpec,
+		PipelineSpecID:  pipelineSpec.ID,
+	}
+
+	jorm := job.NewORM(db, nil, nil, nil, logger.TestLogger(t))
+	require.NoError(t, jorm.InsertJob(testutils.Context(t), &jb))
+	return jb
 }

--- a/core/chains/evm/log/orm_test.go
+++ b/core/chains/evm/log/orm_test.go
@@ -26,12 +26,12 @@ func TestORM_broadcasts(t *testing.T) {
 
 	orm := log.NewORM(db, *testutils.FixtureChainID)
 
-	specV2 := mustInsertV2JobSpec(t, db, testutils.NewAddress())
+	jobID := mustInsertV2JobSpec(t, db, testutils.NewAddress())
 
 	const selectQuery = `SELECT consumed FROM log_broadcasts
 		WHERE block_hash = $1 AND block_number = $2 AND log_index = $3 AND job_id = $4 AND evm_chain_id = $5`
 
-	listener := &mockListener{specV2}
+	listener := &mockListener{jobID}
 
 	rawLog := randomLog(t)
 	queryArgs := []interface{}{rawLog.BlockHash, rawLog.BlockNumber, rawLog.Index, listener.JobID(), testutils.FixtureChainID.String()}

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -328,33 +328,6 @@ func MustInsertHead(t *testing.T, ds sqlutil.DataSource, number int64) *evmtypes
 	return &h
 }
 
-func MustInsertV2JobSpec(t *testing.T, db *sqlx.DB, transmitterAddress common.Address) job.Job {
-	t.Helper()
-
-	addr, err := evmtypes.NewEIP55Address(transmitterAddress.Hex())
-	require.NoError(t, err)
-
-	pipelineSpec := pipeline.Spec{}
-	err = db.Get(&pipelineSpec, `INSERT INTO pipeline_specs (dot_dag_source,created_at) VALUES ('',NOW()) RETURNING *`)
-	require.NoError(t, err)
-
-	oracleSpec := MustInsertOffchainreportingOracleSpec(t, db, addr)
-	jb := job.Job{
-		OCROracleSpec:   &oracleSpec,
-		OCROracleSpecID: &oracleSpec.ID,
-		ExternalJobID:   uuid.New(),
-		Type:            job.OffchainReporting,
-		SchemaVersion:   1,
-		PipelineSpec:    &pipelineSpec,
-		PipelineSpecID:  pipelineSpec.ID,
-	}
-
-	jorm := job.NewORM(db, nil, nil, nil, logger.TestLogger(t))
-	err = jorm.InsertJob(testutils.Context(t), &jb)
-	require.NoError(t, err)
-	return jb
-}
-
 func MustInsertOffchainreportingOracleSpec(t *testing.T, db *sqlx.DB, transmitterAddress evmtypes.EIP55Address) job.OCROracleSpec {
 	t.Helper()
 


### PR DESCRIPTION
cltest was used for the following purposes:

1. to create keys - in this PR we now create keys directly.
2. to insert job spec - in this PR we now inlined this method and refactored it to be pure SQL with no deps.