### PR TITLE
[CRE-406] (fix): WF Registry Syncer update

### DIFF
--- a/core/capabilities/integration_tests/framework/don.go
+++ b/core/capabilities/integration_tests/framework/don.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -94,6 +95,16 @@ func (c DonContext) WaitForCapabilitiesToBeExposed(t *testing.T, dons ...*DON) {
 
 		return true
 	}, 1*time.Minute, 1*time.Second, "timeout waiting for capabilities to be exposed")
+}
+
+func (c DonContext) WaitForWorkflowRegistryMetadata(t *testing.T, workflowName string, owner string, workflowID [32]byte) {
+	require.Eventually(t, func() bool {
+		wf, err := c.workflowRegistry.contract.GetWorkflowMetadata(&bind.CallOpts{}, common.HexToAddress(owner), workflowName)
+		if err != nil {
+			return false
+		}
+		return wf.WorkflowID == workflowID
+	}, 1*time.Minute, 5*time.Second, "timeout waiting for workflow")
 }
 
 type capabilityNode struct {
@@ -387,6 +398,24 @@ func (d *DON) AddWorkflow(workflow Workflow) error {
 	d.workflowRegistry.RegisterWorkflow(workflow, *d.id)
 
 	return nil
+}
+
+func (d *DON) UpdateWorkflow(workflow UpdatedWorkflow) error {
+	if !d.config.AcceptsWorkflows {
+		return errors.New("cannot add workflow to non-workflow DON")
+	}
+
+	if !d.initialised {
+		return errors.New("cannot add workflow to non-initialised DON")
+	}
+
+	d.workflowRegistry.UpdateWorkflow(workflow, *d.id)
+
+	return nil
+}
+
+func (d *DON) ComputeHashKey(owner string, field string) [32]byte {
+	return d.workflowRegistry.ComputeHashKey(owner, field)
 }
 
 type TriggerFactory interface {

--- a/core/capabilities/integration_tests/framework/don.go
+++ b/core/capabilities/integration_tests/framework/don.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 
-	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/artifacts"
-
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
@@ -42,6 +40,8 @@ import (
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
 	"github.com/smartcontractkit/chainlink/v2/core/services/standardcapabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/artifacts"
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/testutils/heavyweight"
 )
 
@@ -448,6 +448,7 @@ func startNewNode(ctx context.Context,
 		c.Capabilities.ExternalRegistry.ChainID = ptr(fmt.Sprintf("%d", testutils.SimulatedChainID))
 		c.Capabilities.ExternalRegistry.Address = ptr(capRegistryAddr.String())
 		c.Capabilities.Peering.V2.Enabled = ptr(true)
+		c.Capabilities.WorkflowRegistry.SyncStrategy = ptr(syncer.SyncStrategyReconciliation)
 		c.Feature.FeedsManager = ptr(false)
 		c.Feature.LogPoller = ptr(true)
 

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -546,6 +546,11 @@ func (h *eventHandler) workflowUpdatedEvent(
 	ctx context.Context,
 	payload WorkflowUpdatedV1,
 ) error {
+	// Remove the old workflow engine from the local registry if it exists
+	if err := h.tryEngineCleanup(payload.WorkflowOwner, payload.WorkflowName); err != nil {
+		return err
+	}
+
 	registeredEvent := WorkflowRegisteredV1{
 		WorkflowID:    payload.NewWorkflowID,
 		WorkflowOwner: payload.WorkflowOwner,

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -157,6 +157,7 @@ type WorkflowArtifactsStore interface {
 
 	// Secrets methods
 	GetSecrets(ctx context.Context, secretsURL string, WorkflowID [32]byte, WorkflowOwner []byte) ([]byte, error)
+	ValidateSecrets(ctx context.Context, workflowID, workflowOwner string) error
 	SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, decodedWorkflowName, workflowID string) (map[string]string, error)
 	GetSecretsURLHash(workflowOwner []byte, secretsURL []byte) ([]byte, error)
 	GetSecretsURLByID(ctx context.Context, id int64) (string, error)
@@ -444,12 +445,6 @@ func (h *eventHandler) createWorkflowSpec(ctx context.Context, payload WorkflowR
 		return nil, err
 	}
 
-	// Calculate the hash of the binary and config files
-	hash, err := pkgworkflows.GenerateWorkflowID(payload.WorkflowOwner, payload.WorkflowName, decodedBinary, config, payload.SecretsURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate workflow id: %w", err)
-	}
-
 	// Always fetch secrets from the SecretsURL
 	var secrets []byte
 	if payload.SecretsURL != "" {
@@ -457,11 +452,6 @@ func (h *eventHandler) createWorkflowSpec(ctx context.Context, payload WorkflowR
 		if err != nil {
 			return nil, fmt.Errorf("failed to get secrets: %w", err)
 		}
-	}
-
-	// Pre-check: verify that the workflowID matches; if it doesn't abort and log an error via Beholder.
-	if !types.WorkflowID(hash).Equal(payload.WorkflowID) {
-		return nil, fmt.Errorf("workflowID mismatch: %x != %x", hash, payload.WorkflowID)
 	}
 
 	status := toSpecStatus(payload.Status)
@@ -693,6 +683,38 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 	decodedBinary, err := hex.DecodeString(spec.Workflow)
 	if err != nil {
 		return fmt.Errorf("failed to decode workflow spec binary: %w", err)
+	}
+
+	secretsURL := ""
+	if spec.SecretsID.Valid {
+		secretsURL, err = h.workflowArtifactsStore.GetSecretsURLByID(ctx, spec.SecretsID.Int64)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Before running the engine, handle validations
+	// Workflow ID should match what is generated from the stored artifacts
+	owner, err := hex.DecodeString(spec.WorkflowOwner)
+	if err != nil {
+		return fmt.Errorf("failed to decode owner: %w", err)
+	}
+	hash, err := pkgworkflows.GenerateWorkflowID(owner, spec.WorkflowName, decodedBinary, []byte(spec.Config), secretsURL)
+	if err != nil {
+		return fmt.Errorf("failed to generate workflow id: %w", err)
+	}
+	wfID, err := types.WorkflowIDFromHex(spec.WorkflowID)
+	if err != nil {
+		return fmt.Errorf("invalid workflow id: %w", err)
+	}
+	if !types.WorkflowID(hash).Equal(wfID) {
+		return fmt.Errorf("workflowID mismatch: %x != %x", hash, wfID)
+	}
+
+	// Secrets should be valid
+	err = h.workflowArtifactsStore.ValidateSecrets(ctx, spec.WorkflowID, spec.WorkflowOwner)
+	if err != nil {
+		return err
 	}
 
 	// Start a new WorkflowEngine instance, and add it to local engine registry

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -695,20 +695,20 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 
 	// Before running the engine, handle validations
 	// Workflow ID should match what is generated from the stored artifacts
-	owner, err := hex.DecodeString(spec.WorkflowOwner)
+	ownerBytes, err := hex.DecodeString(spec.WorkflowOwner)
 	if err != nil {
 		return fmt.Errorf("failed to decode owner: %w", err)
 	}
-	hash, err := pkgworkflows.GenerateWorkflowID(owner, spec.WorkflowName, decodedBinary, []byte(spec.Config), secretsURL)
+	hash, err := pkgworkflows.GenerateWorkflowID(ownerBytes, spec.WorkflowName, decodedBinary, []byte(spec.Config), secretsURL)
 	if err != nil {
 		return fmt.Errorf("failed to generate workflow id: %w", err)
 	}
-	wfID, err := types.WorkflowIDFromHex(spec.WorkflowID)
+	wid, err := types.WorkflowIDFromHex(spec.WorkflowID)
 	if err != nil {
 		return fmt.Errorf("invalid workflow id: %w", err)
 	}
-	if !types.WorkflowID(hash).Equal(wfID) {
-		return fmt.Errorf("workflowID mismatch: %x != %x", hash, wfID)
+	if !types.WorkflowID(hash).Equal(wid) {
+		return fmt.Errorf("workflowID mismatch: %x != %x", hash, wid)
 	}
 
 	// Secrets should be valid
@@ -736,16 +736,6 @@ func (h *eventHandler) tryEngineCreate(ctx context.Context, spec *job.WorkflowSp
 
 	if err = engine.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start workflow engine: %w", err)
-	}
-
-	ownerBytes, err := hex.DecodeString(spec.WorkflowOwner)
-	if err != nil {
-		return err
-	}
-
-	wid, err := types.WorkflowIDFromHex(spec.WorkflowID)
-	if err != nil {
-		return err
 	}
 
 	if err := h.engineRegistry.Add(EngineRegistryKey{Owner: ownerBytes, Name: spec.WorkflowName}, engine, wid); err != nil {

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -799,6 +799,9 @@ func (m *mockArtifactStore) DeleteWorkflowArtifacts(ctx context.Context, workflo
 func (m *mockArtifactStore) GetSecrets(ctx context.Context, secretsURL string, workflowID [32]byte, workflowOwner []byte) ([]byte, error) {
 	return m.artifactStore.GetSecrets(ctx, secretsURL, workflowID, workflowOwner)
 }
+func (m *mockArtifactStore) ValidateSecrets(ctx context.Context, workflowID, workflowOwner string) error {
+	return m.artifactStore.ValidateSecrets(ctx, workflowID, workflowOwner)
+}
 func (m *mockArtifactStore) SecretsFor(ctx context.Context, workflowOwner, hexWorkflowName, decodedWorkflowName, workflowID string) (map[string]string, error) {
 	return m.artifactStore.SecretsFor(ctx, workflowOwner, hexWorkflowName, decodedWorkflowName, workflowID)
 }

--- a/core/services/workflows/syncer/handler_test.go
+++ b/core/services/workflows/syncer/handler_test.go
@@ -575,7 +575,9 @@ func Test_workflowRegisteredHandler(t *testing.T) {
 					BinaryURL:     event.BinaryURL,
 					ConfigURL:     event.ConfigURL,
 				}
-				_, err := s.UpsertWorkflowSpec(ctx, entry)
+				urlHash, err := crypto.Keccak256([]byte(event.SecretsURL))
+				require.NoError(t, err)
+				_, err = s.UpsertWorkflowSpecWithSecrets(ctx, entry, event.SecretsURL, hex.EncodeToString(urlHash), "secrets")
 				require.NoError(t, err)
 
 				err = h.workflowRegisteredEvent(ctx, event)


### PR DESCRIPTION
### Description

Fixes an issue with WF Registry Syncer updates: during updating a workflow, the old engine could never be shut down.

This happens because the logic was changed to no longer first clean up the previous engine before upserting the new DB record. During an engine shutting down, the config for the engine is retrieved. Because the DB entry is modified to the new workflow before shutting down the old one, the old engine's config couldn't be found anymore, leaving it stuck.

This fix restores removing the old engine before upserting the new DB record.

**IMPACT**:
This means that there will be a small downtime toward updating workflows (which is the previous behavior before the refactor). Zero downtime will be handled in another feature.

**Also covers:**

[CAPPL-804](https://smartcontract-it.atlassian.net/browse/CAPPL-804)
This issue didn't show in unit testing. Adds integration testing to protect against further regressions. The integration test now includes updating the workflow.

[CAPPL-811](https://smartcontract-it.atlassian.net/browse/CAPPL-811)
Moves validations to after the DB entry is saved. Currently, failure of these validations would lead to us repeatedly refetching the secrets, even though these errors would normally be unrecoverable.


[CRE-406]: https://smartcontract-it.atlassian.net/browse/CRE-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAPPL-804]: https://smartcontract-it.atlassian.net/browse/CAPPL-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAPPL-811]: https://smartcontract-it.atlassian.net/browse/CAPPL-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ