### PR TITLE
DF. Fix storing workflow job artifact 

### DIFF
--- a/deployment/data-feeds/changeset/types/types.go
+++ b/deployment/data-feeds/changeset/types/types.go
@@ -176,6 +176,7 @@ type WorkflowSpecConfig struct {
 type ProposeWFJobsConfig struct {
 	ChainSelector      uint64
 	CacheLabel         string   // Label for the DataFeedsCache contract in AB
+	MigrationName      string   // Name of the migration in CLD
 	InputFS            embed.FS // filesystem to read the feeds json mapping
 	WorkflowJobName    string   // Required
 	WorkflowSpecConfig WorkflowSpecConfig


### PR DESCRIPTION
1. CLD doesn't allow to write a file to top level `artifacts` folder. This PR changes the logic to write the workflow spec to migration folder. 
2.  introduces new required `MigrationName` parameter for the workflow generation changeset
3. Adds default value of '0.5' for `ConsensusAllowedPartialStaleness`   for workflow generation changeset