### PR TITLE
CCIP - PriceService context fix - move context deferred cancel inside go func

### DIFF
--- a/.changeset/popular-actors-carry.md
+++ b/.changeset/popular-actors-carry.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix Fixed canceled context inside of PriceService

--- a/core/services/ocr2/plugins/ccip/internal/ccipdb/price_service.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdb/price_service.go
@@ -122,13 +122,12 @@ func (p *priceService) Close() error {
 }
 
 func (p *priceService) run() {
-	ctx, cancel := p.stopChan.NewCtx()
-	defer cancel()
-
 	gasUpdateTicker := time.NewTicker(utils.WithJitter(p.gasUpdateInterval))
 	tokenUpdateTicker := time.NewTicker(utils.WithJitter(p.tokenUpdateInterval))
 
 	go func() {
+		ctx, cancel := p.stopChan.NewCtx()
+		defer cancel()
 		defer p.wg.Done()
 		defer gasUpdateTicker.Stop()
 		defer tokenUpdateTicker.Stop()


### PR DESCRIPTION
- Context was being canceled as soon as run() returned
- Move context creation and deferred cancelation inside the func
- Confirmed fix with a OneClick deployment