### PR TITLE
[CRE-403] Remove cltest.NewKeyStore from txmgr.

### DIFF
--- a/core/chains/evm/txmgr/broadcaster_test.go
+++ b/core/chains/evm/txmgr/broadcaster_test.go
@@ -775,9 +775,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 	t.Run("cannot be more than one transaction per address in an unfinished state", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
 		txStore := cltest.NewTestTxStore(t, db)
-
-		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
-		_, fromAddress := cltest.RandomKey{Nonce: nextNonce.Int64()}.MustInsertWithState(t, ethKeyStore)
+		fromAddress := testutils.NewAddress()
 
 		firstInProgress := txmgr.Tx{
 			FromAddress:    fromAddress,

--- a/core/chains/evm/txmgr/confirmer_test.go
+++ b/core/chains/evm/txmgr/confirmer_test.go
@@ -719,8 +719,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 
 		ctx := t.Context()
 		txStore := cltest.NewTestTxStore(t, db)
-		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
-		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
+		fromAddress := testutils.NewAddress()
 
 		estimator := gasmocks.NewEvmEstimator(t)
 		newEst := func(logger.Logger) gas.EvmEstimator { return estimator }
@@ -766,8 +765,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 
 		ctx := t.Context()
 		txStore := cltest.NewTestTxStore(t, db)
-		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
-		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
+		fromAddress := testutils.NewAddress()
 
 		estimator := gasmocks.NewEvmEstimator(t)
 		estimator.On("BumpDynamicFee", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gas.DynamicFee{}, pkgerrors.Wrapf(fees.ErrConnectivity, "transaction..."))
@@ -813,14 +811,12 @@ func TestEthConfirmer_RebroadcastWhereNecessary_MaxFeeScenario(t *testing.T) {
 	ctx := t.Context()
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
-	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
 	evmcfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 		c.GasEstimator.PriceMax = assets.GWei(500)
 	})
 
-	_, _ = cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
+	fromAddress := testutils.NewAddress()
 
 	kst := &keystest.FakeChainStore{Addresses: keystest.Addresses{fromAddress}}
 	// Use a mock keystore for this test

--- a/core/chains/evm/txmgr/evm_tx_store_benchmark_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_benchmark_test.go
@@ -39,8 +39,7 @@ func BenchmarkTxStoreCreateTransaction(b *testing.B) {
 		b.Run(bs.name, func(b *testing.B) {
 			db := testutils.NewSqlxDB(b)
 			txStore := newTxStore(b, db)
-			kst := cltest.NewKeyStore(b, db)
-			_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
+			fromAddress := testutils.NewAddress()
 			gasLimit := uint64(1000)
 			payload := []byte{1, 2, 3}
 			ethClient := clienttest.NewClientWithDefaultChainID(b)
@@ -87,8 +86,7 @@ func BenchmarkTxStoreFindAttemptsRequiringReceiptFetch(b *testing.B) {
 			txStore := NewTestTxStore(b, db)
 			ctx := tests.Context(b)
 			blockNum := int64(100)
-			kst := cltest.NewKeyStore(b, db)
-			_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
+			fromAddress := testutils.NewAddress()
 
 			var nonce = evmtypes.Nonce(0)
 			for i := 0; i < bs.size; i++ {
@@ -132,8 +130,7 @@ func BenchmarkFindTxesByIDs(b *testing.B) {
 			db := testutils.NewSqlxDB(b)
 			txStore := NewTestTxStore(b, db)
 			ctx := tests.Context(b)
-			ethKeyStore := cltest.NewKeyStore(b, db).Eth()
-			_, fromAddress := cltest.MustInsertRandomKeyReturningState(b, ethKeyStore)
+			fromAddress := testutils.NewAddress()
 
 			var etxIDs []int64
 			for i := 0; i < bs.size; i++ {
@@ -159,8 +156,7 @@ func BenchmarkFindConfirmedTxesReceipts(b *testing.B) {
 			db := testutils.NewSqlxDB(b)
 			txStore := NewTestTxStore(b, db)
 			finalizedBlockNum := int64(100)
-			kst := cltest.NewKeyStore(b, db)
-			_, fromAddress := cltest.MustInsertRandomKey(b, kst.Eth())
+			fromAddress := testutils.NewAddress()
 
 			for i := 0; i < bs.size; i++ {
 				mustInsertConfirmedEthTxWithReceipt(b, txStore, fromAddress, int64(i), finalizedBlockNum)

--- a/core/chains/evm/txmgr/finalizer_benchmark_test.go
+++ b/core/chains/evm/txmgr/finalizer_benchmark_test.go
@@ -5,6 +5,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
@@ -16,15 +19,12 @@ import (
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkFinalizer(b *testing.B) {
 	ctx := tests.Context(b)
 	db := testutils.NewSqlxDB(b)
 	txStore := cltest.NewTestTxStore(b, db)
-	ethKeyStore := cltest.NewKeyStore(b, db).Eth()
 	feeLimit := uint64(10_000)
 	ethClient := clienttest.NewClientWithDefaultChainID(b)
 	txmClient := txmgr.NewEvmTxmClient(ethClient, nil)
@@ -46,7 +46,7 @@ func BenchmarkFinalizer(b *testing.B) {
 	finalizer := txmgr.NewEvmFinalizer(logger.Test(b), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 	servicetest.Run(b, finalizer)
 
-	_, fromAddress := cltest.MustInsertRandomKey(b, ethKeyStore)
+	fromAddress := testutils.NewAddress()
 
 	broadcast := time.Now()
 	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(head, nil)

--- a/core/chains/evm/txmgr/reaper_test.go
+++ b/core/chains/evm/txmgr/reaper_test.go
@@ -43,9 +43,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 
 	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
-	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
-
-	_, from := cltest.MustInsertRandomKey(t, ethKeyStore)
+	fromAddress := testutils.NewAddress()
 	var nonce int64
 	oneDayAgo := time.Now().Add(-24 * time.Hour)
 
@@ -59,7 +57,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 	})
 
 	// Confirmed in block number 5
-	mustInsertConfirmedEthTxWithReceipt(t, txStore, from, nonce, 5)
+	mustInsertConfirmedEthTxWithReceipt(t, txStore, fromAddress, nonce, 5)
 
 	t.Run("skips if threshold=0", func(t *testing.T) {
 		tc := &reaperConfig{reaperThreshold: 0 * time.Second}
@@ -101,7 +99,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 		cltest.AssertCount(t, db, "evm.txes", 0)
 	})
 
-	mustInsertFatalErrorEthTx(t, txStore, from)
+	mustInsertFatalErrorEthTx(t, txStore, fromAddress)
 
 	t.Run("deletes errored evm.txes that exceed the age threshold", func(t *testing.T) {
 		tc := &reaperConfig{reaperThreshold: 1 * time.Hour}
@@ -121,7 +119,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 		cltest.AssertCount(t, db, "evm.txes", 0)
 	})
 
-	mustInsertConfirmedEthTxWithReceipt(t, txStore, from, 0, 42)
+	mustInsertConfirmedEthTxWithReceipt(t, txStore, fromAddress, 0, 42)
 
 	t.Run("deletes confirmed evm.txes that exceed the age threshold", func(t *testing.T) {
 		tc := &reaperConfig{reaperThreshold: 1 * time.Hour}

--- a/core/chains/evm/txmgr/tracker_test.go
+++ b/core/chains/evm/txmgr/tracker_test.go
@@ -14,24 +14,23 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
+	"github.com/smartcontractkit/chainlink-evm/pkg/keys/keystest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
-	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 )
 
 func newTestEvmTrackerSetup(t *testing.T) (*txmgr.Tracker, txmgr.TestEvmTxStore) {
 	db := testutils.NewSqlxDB(t)
 	txStore := cltest.NewTestTxStore(t, db)
 	chainID := big.NewInt(0)
-	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
+	memKS := keystest.NewMemoryChainStore()
+	addr1 := memKS.MustCreate(t)
+	addr2 := memKS.MustCreate(t)
 	var enabledAddresses []common.Address
-	_, addr1 := cltest.MustInsertRandomKey(t, ethKeyStore, *ubig.NewI(chainID.Int64()))
-	_, addr2 := cltest.MustInsertRandomKey(t, ethKeyStore, *ubig.NewI(chainID.Int64()))
 	enabledAddresses = append(enabledAddresses, addr1, addr2)
 	lggr := logger.Test(t)
-	return txmgr.NewEvmTracker(txStore, keys.NewStore(keystore.NewEthSigner(ethKeyStore, chainID)), chainID, lggr), txStore
+	return txmgr.NewEvmTracker(txStore, keys.NewStore(memKS), chainID, lggr), txStore
 }
 
 func containsID(txes []*txmgr.Tx, id int64) bool {


### PR DESCRIPTION
There were 2 usages of NewKeyStore:
 1. (99% of the cases) NewKeyStore was used to generate new addresses - now we do this explicitly using `testutils.NewAddress()`
 2. NewKeyStore was used to sign messages / check enabled addresses - now we use the new testing class `NewMemoryChainStore` for that