### PR TITLE
Add force option in curse/uncurse changeset

### DIFF
--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -277,6 +277,16 @@ runner-test-matrix:
     test_cmd: go test smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go -run "^TestRMNCurseOneConnectedLanesLaneOnlyOnSource$" -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
 
+  - id: smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go:TestRMNUncurseForceOption
+    path: integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+    test_env_type: in-memory
+    runs_on: ubuntu-latest
+    triggers:
+      - PR Integration CCIP Tests
+      - Nightly Integration CCIP Tests
+    test_cmd: go test smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go -run "^TestRMNUncurseForceOption$" -timeout 20m -test.parallel=1 -count=1 -json
+    test_go_project_path: integration-tests    
+
   - id: smoke/ccip/ccip_disable_lane_test.go:*
     path: integration-tests/smoke/ccip/ccip_disable_lane_test.go
     test_env_type: in-memory

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -40,7 +40,9 @@ type RMNCurseConfig struct {
 	CurseActions []CurseAction
 	// Use this if you need to include lanes that are not in sourcechain in the offramp. i.e. not yet migrated lane from 1.5
 	IncludeNotConnectedLanes bool
-	Reason                   string
+	// Use this if you want to include curse subject even when they are already cursed (CurseChangeset) or already uncursed (UncurseChangeset)
+	Force  bool
+	Reason string
 }
 
 func (c RMNCurseConfig) Validate(e deployment.Environment) error {
@@ -377,7 +379,7 @@ func RMNCurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployment
 					return deployment.ChangesetOutput{}, fmt.Errorf("failed to check if chain %d is cursed: %w", selector, err)
 				}
 
-				if !cursed {
+				if !cursed || cfg.Force {
 					notAlreadyCursedSubjects = append(notAlreadyCursedSubjects, subject)
 				} else {
 					e.Logger.Warnf("chain %s subject %x is already cursed, ignoring it while cursing", cursableChains[selector].Name(), subject)
@@ -460,7 +462,7 @@ func RMNUncurseChangeset(e deployment.Environment, cfg RMNCurseConfig) (deployme
 					return deployment.ChangesetOutput{}, fmt.Errorf("failed to check if chain %d is cursed: %w", selector, err)
 				}
 
-				if cursed {
+				if cursed || cfg.Force {
 					actuallyCursedSubjects = append(actuallyCursedSubjects, subject)
 				} else {
 					e.Logger.Warnf("chain %s subject %x is not cursed, ignoring it while uncursing", cursableChains[selector].Name(), subject)

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -22,6 +22,12 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
+const (
+	EVM_1 = uint64(0)
+	EVM_2 = uint64(1)
+	SOL_1 = uint64(2)
+)
+
 type curseAssertion struct {
 	chainID     uint64
 	subject     uint64
@@ -41,114 +47,114 @@ var testCases = []CurseTestCase{
 	{
 		name: "lane",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(0), mapIDToSelector(1))}
+			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(EVM_1), mapIDToSelector(EVM_2))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: 0, subject: 1, cursed: true},
-			{chainID: 0, subject: 2, cursed: false},
-			{chainID: 1, subject: 0, cursed: true},
-			{chainID: 1, subject: 2, cursed: false},
-			{chainID: 2, subject: 0, cursed: false},
-			{chainID: 2, subject: 1, cursed: false},
+			{chainID: EVM_1, subject: EVM_2, cursed: true},
+			{chainID: EVM_1, subject: SOL_1, cursed: false},
+			{chainID: EVM_2, subject: EVM_1, cursed: true},
+			{chainID: EVM_2, subject: SOL_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_2, cursed: false},
 		},
 	},
 	{
 		name: "solana lane",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(0), mapIDToSelector(2))}
+			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(EVM_1), mapIDToSelector(SOL_1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: 0, subject: 1, cursed: false},
-			{chainID: 0, subject: 2, cursed: true},
-			{chainID: 1, subject: 0, cursed: false},
-			{chainID: 1, subject: 2, cursed: false},
-			{chainID: 2, subject: 0, cursed: true},
-			{chainID: 2, subject: 1, cursed: false},
+			{chainID: EVM_1, subject: EVM_2, cursed: false},
+			{chainID: EVM_1, subject: SOL_1, cursed: true},
+			{chainID: EVM_2, subject: EVM_1, cursed: false},
+			{chainID: EVM_2, subject: SOL_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_2, cursed: false},
 		},
 	},
 	{
 		name: "lane duplicate",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
 			return []v1_6.CurseAction{
-				v1_6.CurseLaneBidirectionally(mapIDToSelector(0), mapIDToSelector(2)),
-				v1_6.CurseLaneBidirectionally(mapIDToSelector(0), mapIDToSelector(2))}
+				v1_6.CurseLaneBidirectionally(mapIDToSelector(EVM_1), mapIDToSelector(SOL_1)),
+				v1_6.CurseLaneBidirectionally(mapIDToSelector(EVM_1), mapIDToSelector(SOL_1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: 0, subject: 1, cursed: false},
-			{chainID: 0, subject: 2, cursed: true},
-			{chainID: 1, subject: 0, cursed: false},
-			{chainID: 1, subject: 2, cursed: false},
-			{chainID: 2, subject: 0, cursed: true},
-			{chainID: 2, subject: 1, cursed: false},
+			{chainID: EVM_1, subject: EVM_2, cursed: false},
+			{chainID: EVM_1, subject: SOL_1, cursed: true},
+			{chainID: EVM_2, subject: EVM_1, cursed: false},
+			{chainID: EVM_2, subject: SOL_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_2, cursed: false},
 		},
 	},
 	{
 		name: "chain",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(0))}
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(EVM_1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: 0, globalCurse: true, cursed: true},
-			{chainID: 1, subject: 0, cursed: true},
-			{chainID: 1, subject: 2, cursed: false},
-			{chainID: 2, subject: 0, cursed: true},
-			{chainID: 2, subject: 1, cursed: false},
+			{chainID: EVM_1, globalCurse: true, cursed: true},
+			{chainID: EVM_2, subject: EVM_1, cursed: true},
+			{chainID: EVM_2, subject: SOL_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_2, cursed: false},
 		},
 	},
 	{
 		name: "solana chain",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(2))}
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(SOL_1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: 2, globalCurse: true, cursed: true},
-			{chainID: 0, subject: 1, cursed: false},
-			{chainID: 0, subject: 2, cursed: true},
-			{chainID: 1, subject: 0, cursed: false},
-			{chainID: 1, subject: 2, cursed: true},
-			{chainID: 2, subject: 0, cursed: true},
-			{chainID: 2, subject: 1, cursed: true},
+			{chainID: SOL_1, globalCurse: true, cursed: true},
+			{chainID: EVM_1, subject: EVM_2, cursed: false},
+			{chainID: EVM_1, subject: SOL_1, cursed: true},
+			{chainID: EVM_2, subject: EVM_1, cursed: false},
+			{chainID: EVM_2, subject: SOL_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_2, cursed: true},
 		},
 	},
 	{
 		name: "chain duplicate",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(0)), v1_6.CurseChain(mapIDToSelector(0))}
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(EVM_1)), v1_6.CurseChain(mapIDToSelector(EVM_1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: 0, globalCurse: true, cursed: true},
-			{chainID: 1, subject: 0, cursed: true},
-			{chainID: 1, subject: 2, cursed: false},
-			{chainID: 2, subject: 0, cursed: true},
-			{chainID: 2, subject: 1, cursed: false},
+			{chainID: EVM_1, globalCurse: true, cursed: true},
+			{chainID: EVM_2, subject: EVM_1, cursed: true},
+			{chainID: EVM_2, subject: SOL_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_2, cursed: false},
 		},
 	},
 	{
 		name: "solana chain duplicate",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(2)), v1_6.CurseChain(mapIDToSelector(2))}
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(SOL_1)), v1_6.CurseChain(mapIDToSelector(SOL_1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: 2, globalCurse: true, cursed: true},
-			{chainID: 0, subject: 1, cursed: false},
-			{chainID: 0, subject: 2, cursed: true},
-			{chainID: 1, subject: 0, cursed: false},
-			{chainID: 1, subject: 2, cursed: true},
-			{chainID: 2, subject: 0, cursed: true},
-			{chainID: 2, subject: 1, cursed: true},
+			{chainID: SOL_1, globalCurse: true, cursed: true},
+			{chainID: EVM_1, subject: EVM_2, cursed: false},
+			{chainID: EVM_1, subject: SOL_1, cursed: true},
+			{chainID: EVM_2, subject: EVM_1, cursed: false},
+			{chainID: EVM_2, subject: SOL_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_2, cursed: true},
 		},
 	},
 	{
 		name: "chain and lanes",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(0)), v1_6.CurseLaneBidirectionally(mapIDToSelector(1), mapIDToSelector(2))}
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(EVM_1)), v1_6.CurseLaneBidirectionally(mapIDToSelector(EVM_2), mapIDToSelector(SOL_1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: 0, globalCurse: true, cursed: true},
-			{chainID: 1, subject: 0, cursed: true},
-			{chainID: 1, subject: 2, cursed: true},
-			{chainID: 2, subject: 0, cursed: true},
-			{chainID: 2, subject: 1, cursed: true},
+			{chainID: EVM_1, globalCurse: true, cursed: true},
+			{chainID: EVM_2, subject: EVM_1, cursed: true},
+			{chainID: EVM_2, subject: SOL_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_2, cursed: true},
 		},
 	},
 }
@@ -226,7 +232,7 @@ func TestRMNCurseNoConnectedLanes(t *testing.T) {
 
 	config := v1_6.RMNCurseConfig{
 		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseChain(mapIDToSelector(0)),
+			v1_6.CurseChain(mapIDToSelector(EVM_1)),
 		},
 		Reason:                   "test curse",
 		IncludeNotConnectedLanes: false, // This will filter out non connected lanes
@@ -237,13 +243,13 @@ func TestRMNCurseNoConnectedLanes(t *testing.T) {
 
 	verifyTestCaseAssertions(t, &e, CurseTestCase{
 		curseAssertions: []curseAssertion{
-			{chainID: 0, globalCurse: true, cursed: true},
-			{chainID: 0, subject: 1, cursed: true}, // 0 is globally cursed return true for everything
-			{chainID: 0, subject: 2, cursed: true}, // 0 is globally cursed return true for everything
-			{chainID: 1, subject: 0, cursed: false},
-			{chainID: 1, subject: 2, cursed: false},
-			{chainID: 2, subject: 0, cursed: false},
-			{chainID: 2, subject: 1, cursed: false},
+			{chainID: EVM_1, globalCurse: true, cursed: true},
+			{chainID: EVM_1, subject: EVM_2, cursed: true}, // 0 is globally cursed return true for everything
+			{chainID: EVM_1, subject: SOL_1, cursed: true}, // 0 is globally cursed return true for everything
+			{chainID: EVM_2, subject: EVM_1, cursed: false},
+			{chainID: EVM_2, subject: SOL_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_2, cursed: false},
 		},
 	}, mapIDToSelector)
 }
@@ -258,8 +264,8 @@ func TestRMNCurseOneConnectedLanes(t *testing.T) {
 	_, err := v1_6.UpdateOffRampSourcesChangeset(e.Env,
 		v1_6.UpdateOffRampSourcesConfig{
 			UpdatesByChain: map[uint64]map[uint64]v1_6.OffRampSourceUpdate{
-				mapIDToSelector(0): { // to
-					mapIDToSelector(1): { // from
+				mapIDToSelector(EVM_1): { // to
+					mapIDToSelector(EVM_2): { // from
 						IsEnabled:                 true,
 						TestRouter:                false,
 						IsRMNVerificationDisabled: true,
@@ -274,7 +280,7 @@ func TestRMNCurseOneConnectedLanes(t *testing.T) {
 
 	config := v1_6.RMNCurseConfig{
 		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseChain(mapIDToSelector(0)),
+			v1_6.CurseChain(mapIDToSelector(EVM_1)),
 		},
 		Reason:                   "test curse",
 		IncludeNotConnectedLanes: false, // This will filter out non connected lanes
@@ -285,13 +291,13 @@ func TestRMNCurseOneConnectedLanes(t *testing.T) {
 
 	verifyTestCaseAssertions(t, &e, CurseTestCase{
 		curseAssertions: []curseAssertion{
-			{chainID: 0, globalCurse: true, cursed: true},
-			{chainID: 0, subject: 1, cursed: true},
-			{chainID: 0, subject: 2, cursed: true}, // 2 is not connected to 0 but 0 is globally cursed return true for everything
-			{chainID: 1, subject: 0, cursed: true},
-			{chainID: 1, subject: 2, cursed: false},
-			{chainID: 2, subject: 0, cursed: false}, // 2 is not connected to 0
-			{chainID: 2, subject: 1, cursed: false},
+			{chainID: EVM_1, globalCurse: true, cursed: true},
+			{chainID: EVM_1, subject: EVM_2, cursed: true},
+			{chainID: EVM_1, subject: SOL_1, cursed: true}, // 2 is not connected to 0 but 0 is globally cursed return true for everything
+			{chainID: EVM_2, subject: EVM_1, cursed: true},
+			{chainID: EVM_2, subject: SOL_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_1, cursed: false}, // 2 is not connected to 0
+			{chainID: SOL_1, subject: EVM_2, cursed: false},
 		},
 	}, mapIDToSelector)
 }
@@ -306,8 +312,8 @@ func TestRMNCurseOneConnectedLanesGlobalOnly(t *testing.T) {
 	_, err := v1_6.UpdateOffRampSourcesChangeset(e.Env,
 		v1_6.UpdateOffRampSourcesConfig{
 			UpdatesByChain: map[uint64]map[uint64]v1_6.OffRampSourceUpdate{
-				mapIDToSelector(0): { // to
-					mapIDToSelector(1): { // from
+				mapIDToSelector(EVM_1): { // to
+					mapIDToSelector(EVM_2): { // from
 						IsEnabled:                 true,
 						TestRouter:                false,
 						IsRMNVerificationDisabled: true,
@@ -322,7 +328,7 @@ func TestRMNCurseOneConnectedLanesGlobalOnly(t *testing.T) {
 
 	config := v1_6.RMNCurseConfig{
 		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseGloballyOnlyOnChain(mapIDToSelector(0)),
+			v1_6.CurseGloballyOnlyOnChain(mapIDToSelector(EVM_1)),
 		},
 		Reason:                   "test curse",
 		IncludeNotConnectedLanes: false, // This will filter out non connected lanes
@@ -333,13 +339,13 @@ func TestRMNCurseOneConnectedLanesGlobalOnly(t *testing.T) {
 
 	verifyTestCaseAssertions(t, &e, CurseTestCase{
 		curseAssertions: []curseAssertion{
-			{chainID: 0, globalCurse: true, cursed: true},
-			{chainID: 0, subject: 1, cursed: true},
-			{chainID: 0, subject: 2, cursed: true}, // 2 is not connected to 0 but 0 is globally cursed return true for everything
-			{chainID: 1, subject: 0, cursed: false},
-			{chainID: 1, subject: 2, cursed: false},
-			{chainID: 2, subject: 0, cursed: false},
-			{chainID: 2, subject: 1, cursed: false},
+			{chainID: EVM_1, globalCurse: true, cursed: true},
+			{chainID: EVM_1, subject: EVM_2, cursed: true},
+			{chainID: EVM_1, subject: SOL_1, cursed: true}, // 2 is not connected to 0 but 0 is globally cursed return true for everything
+			{chainID: EVM_2, subject: EVM_1, cursed: false},
+			{chainID: EVM_2, subject: SOL_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_2, cursed: false},
 		},
 	}, mapIDToSelector)
 }
@@ -354,8 +360,8 @@ func TestRMNCurseOneConnectedLanesLaneOnlyOnSource(t *testing.T) {
 	_, err := v1_6.UpdateOffRampSourcesChangeset(e.Env,
 		v1_6.UpdateOffRampSourcesConfig{
 			UpdatesByChain: map[uint64]map[uint64]v1_6.OffRampSourceUpdate{
-				mapIDToSelector(0): { // to
-					mapIDToSelector(1): { // from
+				mapIDToSelector(EVM_1): { // to
+					mapIDToSelector(EVM_2): { // from
 						IsEnabled:                 true,
 						TestRouter:                false,
 						IsRMNVerificationDisabled: true,
@@ -370,7 +376,7 @@ func TestRMNCurseOneConnectedLanesLaneOnlyOnSource(t *testing.T) {
 
 	config := v1_6.RMNCurseConfig{
 		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseLaneOnlyOnSource(mapIDToSelector(0), mapIDToSelector(1)),
+			v1_6.CurseLaneOnlyOnSource(mapIDToSelector(EVM_1), mapIDToSelector(EVM_2)),
 		},
 		Reason:                   "test curse",
 		IncludeNotConnectedLanes: false, // This will filter out non connected lanes
@@ -381,12 +387,12 @@ func TestRMNCurseOneConnectedLanesLaneOnlyOnSource(t *testing.T) {
 
 	verifyTestCaseAssertions(t, &e, CurseTestCase{
 		curseAssertions: []curseAssertion{
-			{chainID: 0, subject: 1, cursed: true},
-			{chainID: 0, subject: 2, cursed: false},
-			{chainID: 1, subject: 0, cursed: false},
-			{chainID: 1, subject: 2, cursed: false},
-			{chainID: 2, subject: 0, cursed: false},
-			{chainID: 2, subject: 1, cursed: false},
+			{chainID: EVM_1, subject: EVM_2, cursed: true},
+			{chainID: EVM_1, subject: SOL_1, cursed: false},
+			{chainID: EVM_2, subject: EVM_1, cursed: false},
+			{chainID: EVM_2, subject: SOL_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_2, cursed: false},
 		},
 	}, mapIDToSelector)
 }
@@ -399,9 +405,9 @@ func TestRMNCurseOneConnectedLanesSolana(t *testing.T) {
 	}
 
 	_, err := ccipChangesetSolana.AddRemoteChainToOffRamp(e.Env, ccipChangesetSolana.AddRemoteChainToOffRampConfig{
-		ChainSelector: mapIDToSelector(2),
+		ChainSelector: mapIDToSelector(SOL_1),
 		UpdatesByChain: map[uint64]ccipChangesetSolana.OffRampConfig{
-			mapIDToSelector(0): {
+			mapIDToSelector(EVM_1): {
 				EnabledAsSource: true,
 				IsUpdate:        false,
 			},
@@ -413,7 +419,7 @@ func TestRMNCurseOneConnectedLanesSolana(t *testing.T) {
 
 	config := v1_6.RMNCurseConfig{
 		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseChain(mapIDToSelector(0)),
+			v1_6.CurseChain(mapIDToSelector(EVM_1)),
 		},
 		Reason:                   "test curse",
 		IncludeNotConnectedLanes: false, // This will filter out non connected lanes
@@ -424,13 +430,13 @@ func TestRMNCurseOneConnectedLanesSolana(t *testing.T) {
 
 	verifyTestCaseAssertions(t, &e, CurseTestCase{
 		curseAssertions: []curseAssertion{
-			{chainID: 0, globalCurse: true, cursed: true},
-			{chainID: 0, subject: 1, cursed: true},
-			{chainID: 0, subject: 2, cursed: true},
-			{chainID: 1, subject: 0, cursed: false},
-			{chainID: 1, subject: 2, cursed: false},
-			{chainID: 2, subject: 0, cursed: true},
-			{chainID: 2, subject: 1, cursed: false},
+			{chainID: EVM_1, globalCurse: true, cursed: true},
+			{chainID: EVM_1, subject: EVM_2, cursed: true},
+			{chainID: EVM_1, subject: SOL_1, cursed: true},
+			{chainID: EVM_2, subject: EVM_1, cursed: false},
+			{chainID: EVM_2, subject: SOL_1, cursed: false},
+			{chainID: SOL_1, subject: EVM_1, cursed: true},
+			{chainID: SOL_1, subject: EVM_2, cursed: false},
 		},
 	}, mapIDToSelector)
 }

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -11,6 +11,7 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/mcms/types"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
@@ -735,5 +736,121 @@ func verifyNoActiveCurseOnAllChains(t *testing.T, e *testhelpers.DeployedEnv) {
 			require.NoError(t, err)
 			require.False(t, isCursed, "chain %d subject %d", chainSelector, globals.FamilyAwareSelectorToSubject(selector, family))
 		}
+	}
+}
+
+type ForceOptionTestCase struct {
+	name               string
+	force              bool
+	expectedOperations int
+	expectProposal     bool
+	applyChangeset     func(
+		env *testhelpers.DeployedEnv,
+		config v1_6.RMNCurseConfig,
+		t *testing.T,
+	) deployment.ChangesetOutput
+}
+
+var forceOptionTestCases = []ForceOptionTestCase{
+	{
+		name: "RMNUncurseForceOptionFalse",
+		applyChangeset: func(env *testhelpers.DeployedEnv, config v1_6.RMNCurseConfig, t *testing.T) deployment.ChangesetOutput {
+			cs, err := v1_6.RMNUncurseChangeset(env.Env, config)
+			require.NoError(t, err)
+			return cs
+		},
+		force:          false,
+		expectProposal: false,
+	},
+	{
+		name: "RMNCurseForceOptionFalse",
+		applyChangeset: func(env *testhelpers.DeployedEnv, config v1_6.RMNCurseConfig, t *testing.T) deployment.ChangesetOutput {
+			_, _, err := commonchangeset.ApplyChangesetsV2(t, env.Env,
+				[]commonchangeset.ConfiguredChangeSet{
+					commonchangeset.Configure(
+						cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset),
+						config,
+					)},
+			)
+			require.NoError(t, err)
+
+			cs, err := v1_6.RMNCurseChangeset(env.Env, config)
+			require.NoError(t, err)
+
+			return cs
+		},
+		force:          false,
+		expectProposal: false,
+	},
+	{
+		name: "RMNUncurseForceOptionTrue",
+		applyChangeset: func(env *testhelpers.DeployedEnv, config v1_6.RMNCurseConfig, t *testing.T) deployment.ChangesetOutput {
+			cs, err := v1_6.RMNUncurseChangeset(env.Env, config)
+			require.NoError(t, err)
+			return cs
+		},
+		force:              true,
+		expectProposal:     true,
+		expectedOperations: 3, // 3 operations for 3 chains
+	},
+	{
+		name: "RMNCurseForceOptionTrue",
+		applyChangeset: func(env *testhelpers.DeployedEnv, config v1_6.RMNCurseConfig, t *testing.T) deployment.ChangesetOutput {
+			_, _, err := commonchangeset.ApplyChangesetsV2(t, env.Env,
+				[]commonchangeset.ConfiguredChangeSet{
+					commonchangeset.Configure(
+						cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset),
+						config,
+					)},
+			)
+			require.NoError(t, err)
+
+			cs, err := v1_6.RMNCurseChangeset(env.Env, config)
+			require.NoError(t, err)
+
+			return cs
+		},
+		force:              true,
+		expectProposal:     true,
+		expectedOperations: 3, // 3 operations for 3 chains
+	},
+}
+
+func TestRMNUncurseForceOption(t *testing.T) {
+	for _, tc := range forceOptionTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			e, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithNumOfChains(2), testhelpers.WithSolChains(1))
+
+			mapIDToSelector := func(id uint64) uint64 {
+				return v1_6.GetAllCursableChainsSelector(e.Env)[id]
+			}
+
+			state, err := changeset.LoadOnchainState(e.Env)
+			require.NoError(t, err)
+
+			transferRMNContractToMCMS(t, &e, state)
+
+			// Apply a curse changeset to create an active curse
+			config := v1_6.RMNCurseConfig{
+				CurseActions:             []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(EVM_1))},
+				Reason:                   "test curse",
+				IncludeNotConnectedLanes: true,
+				MCMS: &proposalutils.TimelockConfig{
+					MinDelay: 1 * time.Second,
+				},
+				Force: tc.force,
+			}
+
+			cs := tc.applyChangeset(&e, config, t)
+
+			if tc.expectProposal {
+				require.Len(t, cs.MCMSTimelockProposals, 1)
+				proposal := cs.MCMSTimelockProposals[0]
+				require.Len(t, proposal.Operations, tc.expectedOperations)
+			} else {
+				require.Len(t, cs.MCMSTimelockProposals, 0)
+			}
+		})
 	}
 }

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	EVM_1 = uint64(0)
-	EVM_2 = uint64(1)
-	SOL_1 = uint64(2)
+	Evm1 = uint64(0)
+	Evm2 = uint64(1)
+	Sol1 = uint64(2)
 )
 
 type curseAssertion struct {
@@ -48,114 +48,114 @@ var testCases = []CurseTestCase{
 	{
 		name: "lane",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(EVM_1), mapIDToSelector(EVM_2))}
+			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Evm2))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, subject: EVM_2, cursed: true},
-			{chainID: EVM_1, subject: SOL_1, cursed: false},
-			{chainID: EVM_2, subject: EVM_1, cursed: true},
-			{chainID: EVM_2, subject: SOL_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_2, cursed: false},
+			{chainID: Evm1, subject: Evm2, cursed: true},
+			{chainID: Evm1, subject: Sol1, cursed: false},
+			{chainID: Evm2, subject: Evm1, cursed: true},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: false},
+			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	},
 	{
 		name: "solana lane",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(EVM_1), mapIDToSelector(SOL_1))}
+			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, subject: EVM_2, cursed: false},
-			{chainID: EVM_1, subject: SOL_1, cursed: true},
-			{chainID: EVM_2, subject: EVM_1, cursed: false},
-			{chainID: EVM_2, subject: SOL_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_2, cursed: false},
+			{chainID: Evm1, subject: Evm2, cursed: false},
+			{chainID: Evm1, subject: Sol1, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	},
 	{
 		name: "lane duplicate",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
 			return []v1_6.CurseAction{
-				v1_6.CurseLaneBidirectionally(mapIDToSelector(EVM_1), mapIDToSelector(SOL_1)),
-				v1_6.CurseLaneBidirectionally(mapIDToSelector(EVM_1), mapIDToSelector(SOL_1))}
+				v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1)),
+				v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, subject: EVM_2, cursed: false},
-			{chainID: EVM_1, subject: SOL_1, cursed: true},
-			{chainID: EVM_2, subject: EVM_1, cursed: false},
-			{chainID: EVM_2, subject: SOL_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_2, cursed: false},
+			{chainID: Evm1, subject: Evm2, cursed: false},
+			{chainID: Evm1, subject: Sol1, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	},
 	{
 		name: "chain",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(EVM_1))}
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, globalCurse: true, cursed: true},
-			{chainID: EVM_2, subject: EVM_1, cursed: true},
-			{chainID: EVM_2, subject: SOL_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_2, cursed: false},
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: true},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	},
 	{
 		name: "solana chain",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(SOL_1))}
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Sol1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: SOL_1, globalCurse: true, cursed: true},
-			{chainID: EVM_1, subject: EVM_2, cursed: false},
-			{chainID: EVM_1, subject: SOL_1, cursed: true},
-			{chainID: EVM_2, subject: EVM_1, cursed: false},
-			{chainID: EVM_2, subject: SOL_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_2, cursed: true},
+			{chainID: Sol1, globalCurse: true, cursed: true},
+			{chainID: Evm1, subject: Evm2, cursed: false},
+			{chainID: Evm1, subject: Sol1, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: true},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: true},
 		},
 	},
 	{
 		name: "chain duplicate",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(EVM_1)), v1_6.CurseChain(mapIDToSelector(EVM_1))}
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1)), v1_6.CurseChain(mapIDToSelector(Evm1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, globalCurse: true, cursed: true},
-			{chainID: EVM_2, subject: EVM_1, cursed: true},
-			{chainID: EVM_2, subject: SOL_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_2, cursed: false},
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: true},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	},
 	{
 		name: "solana chain duplicate",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(SOL_1)), v1_6.CurseChain(mapIDToSelector(SOL_1))}
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Sol1)), v1_6.CurseChain(mapIDToSelector(Sol1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: SOL_1, globalCurse: true, cursed: true},
-			{chainID: EVM_1, subject: EVM_2, cursed: false},
-			{chainID: EVM_1, subject: SOL_1, cursed: true},
-			{chainID: EVM_2, subject: EVM_1, cursed: false},
-			{chainID: EVM_2, subject: SOL_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_2, cursed: true},
+			{chainID: Sol1, globalCurse: true, cursed: true},
+			{chainID: Evm1, subject: Evm2, cursed: false},
+			{chainID: Evm1, subject: Sol1, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: true},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: true},
 		},
 	},
 	{
 		name: "chain and lanes",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(EVM_1)), v1_6.CurseLaneBidirectionally(mapIDToSelector(EVM_2), mapIDToSelector(SOL_1))}
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1)), v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm2), mapIDToSelector(Sol1))}
 		},
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, globalCurse: true, cursed: true},
-			{chainID: EVM_2, subject: EVM_1, cursed: true},
-			{chainID: EVM_2, subject: SOL_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_2, cursed: true},
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: true},
+			{chainID: Evm2, subject: Sol1, cursed: true},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: true},
 		},
 	},
 }
@@ -233,7 +233,7 @@ func TestRMNCurseNoConnectedLanes(t *testing.T) {
 
 	config := v1_6.RMNCurseConfig{
 		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseChain(mapIDToSelector(EVM_1)),
+			v1_6.CurseChain(mapIDToSelector(Evm1)),
 		},
 		Reason:                   "test curse",
 		IncludeNotConnectedLanes: false, // This will filter out non connected lanes
@@ -244,13 +244,13 @@ func TestRMNCurseNoConnectedLanes(t *testing.T) {
 
 	verifyTestCaseAssertions(t, &e, CurseTestCase{
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, globalCurse: true, cursed: true},
-			{chainID: EVM_1, subject: EVM_2, cursed: true}, // 0 is globally cursed return true for everything
-			{chainID: EVM_1, subject: SOL_1, cursed: true}, // 0 is globally cursed return true for everything
-			{chainID: EVM_2, subject: EVM_1, cursed: false},
-			{chainID: EVM_2, subject: SOL_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_2, cursed: false},
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm1, subject: Evm2, cursed: true}, // 0 is globally cursed return true for everything
+			{chainID: Evm1, subject: Sol1, cursed: true}, // 0 is globally cursed return true for everything
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: false},
+			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	}, mapIDToSelector)
 }
@@ -265,8 +265,8 @@ func TestRMNCurseOneConnectedLanes(t *testing.T) {
 	_, err := v1_6.UpdateOffRampSourcesChangeset(e.Env,
 		v1_6.UpdateOffRampSourcesConfig{
 			UpdatesByChain: map[uint64]map[uint64]v1_6.OffRampSourceUpdate{
-				mapIDToSelector(EVM_1): { // to
-					mapIDToSelector(EVM_2): { // from
+				mapIDToSelector(Evm1): { // to
+					mapIDToSelector(Evm2): { // from
 						IsEnabled:                 true,
 						TestRouter:                false,
 						IsRMNVerificationDisabled: true,
@@ -281,7 +281,7 @@ func TestRMNCurseOneConnectedLanes(t *testing.T) {
 
 	config := v1_6.RMNCurseConfig{
 		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseChain(mapIDToSelector(EVM_1)),
+			v1_6.CurseChain(mapIDToSelector(Evm1)),
 		},
 		Reason:                   "test curse",
 		IncludeNotConnectedLanes: false, // This will filter out non connected lanes
@@ -292,13 +292,13 @@ func TestRMNCurseOneConnectedLanes(t *testing.T) {
 
 	verifyTestCaseAssertions(t, &e, CurseTestCase{
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, globalCurse: true, cursed: true},
-			{chainID: EVM_1, subject: EVM_2, cursed: true},
-			{chainID: EVM_1, subject: SOL_1, cursed: true}, // 2 is not connected to 0 but 0 is globally cursed return true for everything
-			{chainID: EVM_2, subject: EVM_1, cursed: true},
-			{chainID: EVM_2, subject: SOL_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_1, cursed: false}, // 2 is not connected to 0
-			{chainID: SOL_1, subject: EVM_2, cursed: false},
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm1, subject: Evm2, cursed: true},
+			{chainID: Evm1, subject: Sol1, cursed: true}, // 2 is not connected to 0 but 0 is globally cursed return true for everything
+			{chainID: Evm2, subject: Evm1, cursed: true},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: false}, // 2 is not connected to 0
+			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	}, mapIDToSelector)
 }
@@ -313,8 +313,8 @@ func TestRMNCurseOneConnectedLanesGlobalOnly(t *testing.T) {
 	_, err := v1_6.UpdateOffRampSourcesChangeset(e.Env,
 		v1_6.UpdateOffRampSourcesConfig{
 			UpdatesByChain: map[uint64]map[uint64]v1_6.OffRampSourceUpdate{
-				mapIDToSelector(EVM_1): { // to
-					mapIDToSelector(EVM_2): { // from
+				mapIDToSelector(Evm1): { // to
+					mapIDToSelector(Evm2): { // from
 						IsEnabled:                 true,
 						TestRouter:                false,
 						IsRMNVerificationDisabled: true,
@@ -329,7 +329,7 @@ func TestRMNCurseOneConnectedLanesGlobalOnly(t *testing.T) {
 
 	config := v1_6.RMNCurseConfig{
 		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseGloballyOnlyOnChain(mapIDToSelector(EVM_1)),
+			v1_6.CurseGloballyOnlyOnChain(mapIDToSelector(Evm1)),
 		},
 		Reason:                   "test curse",
 		IncludeNotConnectedLanes: false, // This will filter out non connected lanes
@@ -340,13 +340,13 @@ func TestRMNCurseOneConnectedLanesGlobalOnly(t *testing.T) {
 
 	verifyTestCaseAssertions(t, &e, CurseTestCase{
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, globalCurse: true, cursed: true},
-			{chainID: EVM_1, subject: EVM_2, cursed: true},
-			{chainID: EVM_1, subject: SOL_1, cursed: true}, // 2 is not connected to 0 but 0 is globally cursed return true for everything
-			{chainID: EVM_2, subject: EVM_1, cursed: false},
-			{chainID: EVM_2, subject: SOL_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_2, cursed: false},
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm1, subject: Evm2, cursed: true},
+			{chainID: Evm1, subject: Sol1, cursed: true}, // 2 is not connected to 0 but 0 is globally cursed return true for everything
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: false},
+			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	}, mapIDToSelector)
 }
@@ -361,8 +361,8 @@ func TestRMNCurseOneConnectedLanesLaneOnlyOnSource(t *testing.T) {
 	_, err := v1_6.UpdateOffRampSourcesChangeset(e.Env,
 		v1_6.UpdateOffRampSourcesConfig{
 			UpdatesByChain: map[uint64]map[uint64]v1_6.OffRampSourceUpdate{
-				mapIDToSelector(EVM_1): { // to
-					mapIDToSelector(EVM_2): { // from
+				mapIDToSelector(Evm1): { // to
+					mapIDToSelector(Evm2): { // from
 						IsEnabled:                 true,
 						TestRouter:                false,
 						IsRMNVerificationDisabled: true,
@@ -377,7 +377,7 @@ func TestRMNCurseOneConnectedLanesLaneOnlyOnSource(t *testing.T) {
 
 	config := v1_6.RMNCurseConfig{
 		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseLaneOnlyOnSource(mapIDToSelector(EVM_1), mapIDToSelector(EVM_2)),
+			v1_6.CurseLaneOnlyOnSource(mapIDToSelector(Evm1), mapIDToSelector(Evm2)),
 		},
 		Reason:                   "test curse",
 		IncludeNotConnectedLanes: false, // This will filter out non connected lanes
@@ -388,12 +388,12 @@ func TestRMNCurseOneConnectedLanesLaneOnlyOnSource(t *testing.T) {
 
 	verifyTestCaseAssertions(t, &e, CurseTestCase{
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, subject: EVM_2, cursed: true},
-			{chainID: EVM_1, subject: SOL_1, cursed: false},
-			{chainID: EVM_2, subject: EVM_1, cursed: false},
-			{chainID: EVM_2, subject: SOL_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_2, cursed: false},
+			{chainID: Evm1, subject: Evm2, cursed: true},
+			{chainID: Evm1, subject: Sol1, cursed: false},
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: false},
+			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	}, mapIDToSelector)
 }
@@ -406,9 +406,9 @@ func TestRMNCurseOneConnectedLanesSolana(t *testing.T) {
 	}
 
 	_, err := ccipChangesetSolana.AddRemoteChainToOffRamp(e.Env, ccipChangesetSolana.AddRemoteChainToOffRampConfig{
-		ChainSelector: mapIDToSelector(SOL_1),
+		ChainSelector: mapIDToSelector(Sol1),
 		UpdatesByChain: map[uint64]ccipChangesetSolana.OffRampConfig{
-			mapIDToSelector(EVM_1): {
+			mapIDToSelector(Evm1): {
 				EnabledAsSource: true,
 				IsUpdate:        false,
 			},
@@ -420,7 +420,7 @@ func TestRMNCurseOneConnectedLanesSolana(t *testing.T) {
 
 	config := v1_6.RMNCurseConfig{
 		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseChain(mapIDToSelector(EVM_1)),
+			v1_6.CurseChain(mapIDToSelector(Evm1)),
 		},
 		Reason:                   "test curse",
 		IncludeNotConnectedLanes: false, // This will filter out non connected lanes
@@ -431,13 +431,13 @@ func TestRMNCurseOneConnectedLanesSolana(t *testing.T) {
 
 	verifyTestCaseAssertions(t, &e, CurseTestCase{
 		curseAssertions: []curseAssertion{
-			{chainID: EVM_1, globalCurse: true, cursed: true},
-			{chainID: EVM_1, subject: EVM_2, cursed: true},
-			{chainID: EVM_1, subject: SOL_1, cursed: true},
-			{chainID: EVM_2, subject: EVM_1, cursed: false},
-			{chainID: EVM_2, subject: SOL_1, cursed: false},
-			{chainID: SOL_1, subject: EVM_1, cursed: true},
-			{chainID: SOL_1, subject: EVM_2, cursed: false},
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm1, subject: Evm2, cursed: true},
+			{chainID: Evm1, subject: Sol1, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	}, mapIDToSelector)
 }
@@ -819,7 +819,6 @@ var forceOptionTestCases = []ForceOptionTestCase{
 func TestRMNUncurseForceOption(t *testing.T) {
 	for _, tc := range forceOptionTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			e, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithNumOfChains(2), testhelpers.WithSolChains(1))
 
 			mapIDToSelector := func(id uint64) uint64 {
@@ -833,7 +832,7 @@ func TestRMNUncurseForceOption(t *testing.T) {
 
 			// Apply a curse changeset to create an active curse
 			config := v1_6.RMNCurseConfig{
-				CurseActions:             []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(EVM_1))},
+				CurseActions:             []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1))},
 				Reason:                   "test curse",
 				IncludeNotConnectedLanes: true,
 				MCMS: &proposalutils.TimelockConfig{
@@ -849,7 +848,7 @@ func TestRMNUncurseForceOption(t *testing.T) {
 				proposal := cs.MCMSTimelockProposals[0]
 				require.Len(t, proposal.Operations, tc.expectedOperations)
 			} else {
-				require.Len(t, cs.MCMSTimelockProposals, 0)
+				require.Empty(t, cs.MCMSTimelockProposals)
 			}
 		})
 	}


### PR DESCRIPTION
The force option will ignore curses that are already active and just uncurse or curse subject provided by the configuration without filtering for active curses

Add const for chain id in curse/uncurse tests