### PR TITLE
feat(CRE-428): enable boot of old app version

### DIFF
--- a/.changeset/better-buckets-hang.md
+++ b/.changeset/better-buckets-hang.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal add env var SKIP_APP_VERSION_CHECK to enable booting prior app versions

--- a/.changeset/better-buckets-hang.md
+++ b/.changeset/better-buckets-hang.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-#internal add env var SKIP_APP_VERSION_CHECK to enable booting prior app versions
+#internal add env var CL_SKIP_APP_VERSION_CHECK to enable booting prior app versions

--- a/core/services/versioning/orm.go
+++ b/core/services/versioning/orm.go
@@ -47,7 +47,7 @@ func (o *orm) UpsertNodeVersion(ctx context.Context, version NodeVersion) error 
 	}
 
 	return sqlutil.TransactDataSource(ctx, o.ds, nil, func(tx sqlutil.DataSource) error {
-		if os.Getenv("SKIP_APP_VERSION_CHECK") == "true" {
+		if os.Getenv("CL_SKIP_APP_VERSION_CHECK") == "true" {
 			o.lggr.Warnw("Skipping app version check", "appVersion", version.Version)
 		} else if _, _, err := CheckVersion(ctx, tx, logger.NullLogger, version.Version); err != nil {
 			return err

--- a/core/services/versioning/orm.go
+++ b/core/services/versioning/orm.go
@@ -3,6 +3,7 @@ package versioning
 import (
 	"context"
 	"database/sql"
+	"os"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -46,7 +47,9 @@ func (o *orm) UpsertNodeVersion(ctx context.Context, version NodeVersion) error 
 	}
 
 	return sqlutil.TransactDataSource(ctx, o.ds, nil, func(tx sqlutil.DataSource) error {
-		if _, _, err := CheckVersion(ctx, tx, logger.NullLogger, version.Version); err != nil {
+		if os.Getenv("SKIP_APP_VERSION_CHECK") == "true" {
+			o.lggr.Infow("Skipping app version check", "appVersion", version.Version)
+		} else if _, _, err := CheckVersion(ctx, tx, logger.NullLogger, version.Version); err != nil {
 			return err
 		}
 

--- a/core/services/versioning/orm.go
+++ b/core/services/versioning/orm.go
@@ -48,7 +48,7 @@ func (o *orm) UpsertNodeVersion(ctx context.Context, version NodeVersion) error 
 
 	return sqlutil.TransactDataSource(ctx, o.ds, nil, func(tx sqlutil.DataSource) error {
 		if os.Getenv("SKIP_APP_VERSION_CHECK") == "true" {
-			o.lggr.Infow("Skipping app version check", "appVersion", version.Version)
+			o.lggr.Warnw("Skipping app version check", "appVersion", version.Version)
 		} else if _, _, err := CheckVersion(ctx, tx, logger.NullLogger, version.Version); err != nil {
 			return err
 		}

--- a/core/services/versioning/orm_test.go
+++ b/core/services/versioning/orm_test.go
@@ -63,7 +63,7 @@ func TestORM_NodeVersion_UpsertNodeVersion(t *testing.T) {
 	t.Run("Without App Version Check", func(t *testing.T) {
 		orm := NewORM(db, logger.TestLogger(t))
 		// Set the environment variable to skip the app version check
-		t.Setenv("SKIP_APP_VERSION_CHECK", "true")
+		t.Setenv("CL_SKIP_APP_VERSION_CHECK", "true")
 
 		err := orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.8"))
 		require.NoError(t, err)

--- a/core/services/versioning/orm_test.go
+++ b/core/services/versioning/orm_test.go
@@ -14,49 +14,77 @@ import (
 )
 
 func TestORM_NodeVersion_UpsertNodeVersion(t *testing.T) {
-	ctx := testutils.Context(t)
+	ctx := t.Context()
 	db := pgtest.NewSqlxDB(t)
-	orm := NewORM(db, logger.TestLogger(t))
 
-	err := orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.8"))
-	require.NoError(t, err)
+	t.Run("With App Version Check", func(t *testing.T) {
+		orm := NewORM(db, logger.TestLogger(t))
 
-	ver, err := orm.FindLatestNodeVersion(ctx)
+		err := orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.8"))
+		require.NoError(t, err)
 
-	require.NoError(t, err)
-	require.NotNil(t, ver)
-	require.Equal(t, "9.9.8", ver.Version)
-	require.NotZero(t, ver.CreatedAt)
+		ver, err := orm.FindLatestNodeVersion(ctx)
 
-	// Testing Upsert
-	require.NoError(t, orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.8")))
+		require.NoError(t, err)
+		require.NotNil(t, ver)
+		require.Equal(t, "9.9.8", ver.Version)
+		require.NotZero(t, ver.CreatedAt)
 
-	err = orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.7"))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Application version (9.9.7) is lower than database version (9.9.8). Only Chainlink 9.9.8 or higher can be run on this database")
+		// Testing Upsert
+		require.NoError(t, orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.8")))
 
-	require.NoError(t, orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.9")))
+		err = orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.7"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Application version (9.9.7) is lower than database version (9.9.8). Only Chainlink 9.9.8 or higher can be run on this database")
 
-	var count int
-	err = db.QueryRowx(`SELECT count(*) FROM node_versions`).Scan(&count)
-	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+		require.NoError(t, orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.9")))
 
-	ver, err = orm.FindLatestNodeVersion(ctx)
+		var count int
+		err = db.QueryRowx(`SELECT count(*) FROM node_versions`).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
 
-	require.NoError(t, err)
-	require.NotNil(t, ver)
-	require.Equal(t, "9.9.9", ver.Version)
+		ver, err = orm.FindLatestNodeVersion(ctx)
 
-	// invalid semver returns error
-	err = orm.UpsertNodeVersion(ctx, NewNodeVersion("random_12345"))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "\"random_12345\" is not valid semver: Invalid Semantic Version")
+		require.NoError(t, err)
+		require.NotNil(t, ver)
+		require.Equal(t, "9.9.9", ver.Version)
 
-	ver, err = orm.FindLatestNodeVersion(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, ver)
-	require.Equal(t, "9.9.9", ver.Version)
+		// invalid semver returns error
+		err = orm.UpsertNodeVersion(ctx, NewNodeVersion("random_12345"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "\"random_12345\" is not valid semver: Invalid Semantic Version")
+
+		ver, err = orm.FindLatestNodeVersion(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, ver)
+		require.Equal(t, "9.9.9", ver.Version)
+	})
+	t.Run("Without App Version Check", func(t *testing.T) {
+		orm := NewORM(db, logger.TestLogger(t))
+		// Set the environment variable to skip the app version check
+		t.Setenv("SKIP_APP_VERSION_CHECK", "true")
+
+		err := orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.8"))
+		require.NoError(t, err)
+
+		ver, err := orm.FindLatestNodeVersion(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, ver)
+		require.Equal(t, "9.9.8", ver.Version)
+		require.NotZero(t, ver.CreatedAt)
+
+		// previous version allowed
+		err = orm.UpsertNodeVersion(ctx, NewNodeVersion("9.9.7"))
+		require.NoError(t, err)
+		ver, err = orm.FindLatestNodeVersion(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, ver)
+		require.Equal(t, "9.9.7", ver.Version)
+		require.NotZero(t, ver.CreatedAt)
+	})
 }
 
 func Test_Version_CheckVersion(t *testing.T) {
@@ -95,6 +123,7 @@ func Test_Version_CheckVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "9.9.9", appv.String())
 	assert.Equal(t, "9.9.8", dbv.String())
+
 }
 
 func TestORM_CheckVersion_CCIP(t *testing.T) {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[CRE-428](https://smartcontract-it.atlassian.net/browse/CRE-428)

add an env var to enable boot'ing previous node version.

choose an env because this should not be public facing, but rather an testing hook
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-428]: https://smartcontract-it.atlassian.net/browse/CRE-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ