### PR TITLE
Hotfix/price service fix v2.24.0

### DIFF
--- a/.changeset/popular-actors-carry.md
+++ b/.changeset/popular-actors-carry.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix Fixed canceled context inside of PriceService

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### Patch Changes
 
+- [#17628](https://github.com/smartcontractkit/chainlink/pull/17628) [`3b46213`](https://github.com/smartcontractkit/chainlink/commit/3b462133e068b5aadb5d9540040fb45f46f9c51a) - #bugfix PriceService context fix
+
 - [#17601](https://github.com/smartcontractkit/chainlink/pull/17601) [`1347d91`](https://github.com/smartcontractkit/chainlink/commit/1347d9125a814a2b8748141617cef3c65f982677) - #updated Bump chainlink-solana
 
 - [#17480](https://github.com/smartcontractkit/chainlink/pull/17480) [`b3e8cca`](https://github.com/smartcontractkit/chainlink/commit/b3e8ccac9609b860436bb7828279efd6268c451c) - Integrated framework metrics with beholder. #Added

--- a/core/services/ocr2/plugins/ccip/internal/ccipdb/price_service.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdb/price_service.go
@@ -122,13 +122,12 @@ func (p *priceService) Close() error {
 }
 
 func (p *priceService) run() {
-	ctx, cancel := p.stopChan.NewCtx()
-	defer cancel()
-
 	gasUpdateTicker := time.NewTicker(utils.WithJitter(p.gasUpdateInterval))
 	tokenUpdateTicker := time.NewTicker(utils.WithJitter(p.tokenUpdateInterval))
 
 	go func() {
+		ctx, cancel := p.stopChan.NewCtx()
+		defer cancel()
 		defer p.wg.Done()
 		defer gasUpdateTicker.Stop()
 		defer tokenUpdateTicker.Stop()


### PR DESCRIPTION
This PR cherry-picks a critical fix from [#17628](https://github.com/smartcontractkit/chainlink/pull/17628) into the release/2.24.0 branch. It resolves a bug where the PriceService component shuts down immediately after startup due to a missing context, preventing accurate gas and token prices from being written onchain by the CCIP plugin. Without this fix, CCIP may quote stale fees to users, potentially impacting PnL and undermining pricing reliability. Given the severity and isolation of the change, this is a safe inclusion for the 2.24.0 release.


<!--- Does this work have a corresponding ticket? Please link it here as well as one of: - the PR title - branch name - commit message [LINK-21965](https://smartcontract-it.atlassian.net/browse/LINK-21965) -->
Requires
<!--- Does this work depend on other open PRs? Please list them. -->
None.

Supports
<!--- Does this work support other open PRs? Please list them. -->
https://github.com/smartcontractkit/chainlink/pull/17628

