### PR TITLE
feat: self-hosted runners for e2e tests

### DIFF
--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -181,7 +181,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu22-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu22-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -197,7 +197,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu22-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu22-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -215,7 +215,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -237,7 +237,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -259,7 +259,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -1234,7 +1234,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1255,7 +1255,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1274,7 +1274,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1293,7 +1293,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1312,7 +1312,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1331,7 +1331,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1350,7 +1350,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1369,7 +1369,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1389,7 +1389,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1408,7 +1408,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1427,7 +1427,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1446,7 +1446,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1465,7 +1465,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -1543,6 +1543,7 @@ runner-test-matrix:
     path: integration-tests/ccip-tests/smoke/ccip_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP Tests
       - Merge Queue E2E CCIP Tests
@@ -1559,6 +1560,7 @@ runner-test-matrix:
     path: integration-tests/ccip-tests/smoke/ccip_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP Tests
       - Merge Queue E2E CCIP Tests
@@ -1576,6 +1578,7 @@ runner-test-matrix:
     path: integration-tests/ccip-tests/smoke/ccip_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP Tests
       - Merge Queue E2E CCIP Tests
@@ -1676,6 +1679,7 @@ runner-test-matrix:
     path: integration-tests/ccip-tests/smoke/ccip_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP Tests
       - Merge Queue E2E CCIP Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -181,7 +181,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu22-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -197,7 +197,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu22-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -215,7 +215,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -237,7 +237,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -259,7 +259,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -1034,6 +1034,7 @@ runner-test-matrix:
     path: integration-tests/smoke/log_poller_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1048,6 +1049,7 @@ runner-test-matrix:
     path: integration-tests/smoke/log_poller_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1234,7 +1236,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1255,7 +1257,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1274,7 +1276,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1293,7 +1295,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1312,7 +1314,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1331,7 +1333,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1350,7 +1352,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1369,7 +1371,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1389,7 +1391,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1408,7 +1410,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1427,7 +1429,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1446,7 +1448,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1465,7 +1467,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -181,7 +181,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu22-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu22-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -197,7 +197,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu22-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu22-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -215,7 +215,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -237,7 +237,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -259,7 +259,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -1234,7 +1234,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1255,7 +1255,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1274,7 +1274,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1293,7 +1293,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1312,7 +1312,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1331,7 +1331,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1350,7 +1350,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1369,7 +1369,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1389,7 +1389,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1408,7 +1408,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1427,7 +1427,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1446,7 +1446,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1465,7 +1465,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=32/family=c6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6id/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -181,6 +181,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -196,6 +197,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -213,6 +215,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/image=ubuntu24-full-x64
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -234,6 +237,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -255,6 +259,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -1229,6 +1234,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1249,6 +1255,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1267,6 +1274,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1285,6 +1293,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1303,6 +1312,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1321,6 +1331,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1339,6 +1350,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1357,6 +1369,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1376,6 +1389,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1394,6 +1408,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1412,6 +1427,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1430,6 +1446,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1448,6 +1465,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
+    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -181,7 +181,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -197,7 +197,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -215,7 +215,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/image=ubuntu24-full-x64
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -237,7 +237,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -259,7 +259,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -1234,7 +1234,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1255,7 +1255,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1274,7 +1274,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1293,7 +1293,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1312,7 +1312,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1331,7 +1331,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1350,7 +1350,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1369,7 +1369,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1389,7 +1389,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1408,7 +1408,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1427,7 +1427,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1446,7 +1446,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1465,7 +1465,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -181,7 +181,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu22-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -197,7 +197,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu22-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -259,7 +259,7 @@ runner-test-matrix:
     path: system-tests/tests/smoke/cre/por_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR CRE E2E Core Tests
       - Merge Queue CRE E2E Core Tests
@@ -1234,7 +1234,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1255,7 +1255,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1274,7 +1274,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1293,7 +1293,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1312,7 +1312,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1331,7 +1331,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1350,7 +1350,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1369,7 +1369,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1389,7 +1389,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1408,7 +1408,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1427,7 +1427,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1446,7 +1446,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1465,7 +1465,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs_on_self_hosted: runs-on/cpu=16+32/ram=32+64/family=c6id+m6id+m6idn/spot=false/image=ubuntu24-full-x64/extras=s3-cache
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -167,6 +167,7 @@ runner-test-matrix:
     path: integration-tests/smoke/forwarders_ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -669,6 +670,7 @@ runner-test-matrix:
     path: integration-tests/smoke/automation_upgrade_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-8cores-32GB
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Automation Nightly Tests
       - Push E2E Core Tests
@@ -686,6 +688,7 @@ runner-test-matrix:
     path: integration-tests/smoke/automation_upgrade_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-8cores-32GB
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Automation Nightly Tests
       - Push E2E Core Tests
@@ -703,6 +706,7 @@ runner-test-matrix:
     path: integration-tests/smoke/automation_upgrade_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-8cores-32GB
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Automation Nightly Tests
       - Push E2E Core Tests
@@ -822,6 +826,7 @@ runner-test-matrix:
   - id: smoke/vrfv2_test.go:TestVRFv2Basic
     path: integration-tests/smoke/vrfv2_test.go
     runs_on: ubuntu22.04-8cores-32GB
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
     test_env_type: docker
     test_cmd: cd smoke && go test -v -test.run TestVRFv2Basic -test.parallel=1 -timeout 30m -count=1 -json
     test_secrets_required: true
@@ -832,6 +837,7 @@ runner-test-matrix:
   - id: load/vrfv2plus/vrfv2plus_test.go:^TestVRFV2PlusPerformance$Smoke
     path: integration-tests/load/vrfv2plus/vrfv2plus_test.go
     runs_on: ubuntu22.04-8cores-32GB
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
     test_env_type: docker
     test_cmd: cd load/vrfv2plus && go test -v -test.run ^TestVRFV2PlusPerformance$ -test.parallel=1 -timeout 24h -count=1 -json
     test_config_override_required: true
@@ -845,6 +851,7 @@ runner-test-matrix:
   - id: load/vrfv2plus/vrfv2plus_test.go:^TestVRFV2PlusBHSPerformance$Smoke
     path: integration-tests/load/vrfv2plus/vrfv2plus_test.go
     runs_on: ubuntu22.04-8cores-32GB
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
     test_env_type: docker
     test_cmd: cd load/vrfv2plus && go test -v -test.run ^TestVRFV2PlusBHSPerformance$ -test.parallel=1 -timeout 24h -count=1 -json
     test_config_override_required: true
@@ -858,6 +865,7 @@ runner-test-matrix:
   - id: load/vrfv2/vrfv2_test.go:^TestVRFV2Performance$Smoke
     path: integration-tests/load/vrfv2/vrfv2_test.go
     runs_on: ubuntu22.04-8cores-32GB
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
     test_env_type: docker
     test_cmd: cd load/vrfv2 && go test -v -test.run ^TestVRFV2Performance$ -test.parallel=1 -timeout 24h -count=1 -json
     test_config_override_required: true
@@ -871,6 +879,7 @@ runner-test-matrix:
   - id: load/vrfv2/vrfv2_test.go:^TestVRFV2PlusBHSPerformance$Smoke
     path: integration-tests/load/vrfv2/vrfv2_test.go
     runs_on: ubuntu22.04-8cores-32GB
+    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
     test_env_type: docker
     test_cmd: cd load/vrfv2 && go test -v -test.run ^TestVRFV2PlusBHSPerformance$ -test.parallel=1 -timeout 24h -count=1 -json
     test_config_override_required: true
@@ -899,6 +908,7 @@ runner-test-matrix:
     path: integration-tests/smoke/vrfv2_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -950,6 +960,7 @@ runner-test-matrix:
     path: integration-tests/smoke/log_poller_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -964,6 +975,7 @@ runner-test-matrix:
     path: integration-tests/smoke/log_poller_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -978,6 +990,7 @@ runner-test-matrix:
     path: integration-tests/smoke/log_poller_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -992,6 +1005,7 @@ runner-test-matrix:
     path: integration-tests/smoke/log_poller_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1020,6 +1034,7 @@ runner-test-matrix:
     path: integration-tests/smoke/log_poller_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1182,6 +1197,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_token_price_updates_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1200,6 +1216,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1624,6 +1641,7 @@ runner-test-matrix:
     path: integration-tests/ccip-tests/smoke/ccip_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP Tests
       - Merge Queue E2E CCIP Tests
@@ -1640,6 +1658,7 @@ runner-test-matrix:
     path: integration-tests/ccip-tests/smoke/ccip_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E CCIP Tests
       - Merge Queue E2E CCIP Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -182,7 +182,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -198,7 +198,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1254,7 +1254,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1275,7 +1275,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1294,7 +1294,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1313,7 +1313,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1332,7 +1332,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1351,7 +1351,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1370,7 +1370,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1389,7 +1389,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1409,7 +1409,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1428,7 +1428,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1447,7 +1447,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1466,7 +1466,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1485,7 +1485,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=48/ram=96/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests

--- a/.github/e2e-tests.yml
+++ b/.github/e2e-tests.yml
@@ -182,7 +182,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -198,7 +198,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ocr2_test.go
     test_env_type: docker
     runs_on: ubuntu22.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -923,6 +923,7 @@ runner-test-matrix:
     path: integration-tests/smoke/vrfv2plus_test.go
     test_env_type: docker
     runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1253,7 +1254,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Merge Queue E2E Core Tests
@@ -1274,7 +1275,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1293,7 +1294,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1312,7 +1313,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1331,7 +1332,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1350,7 +1351,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1369,7 +1370,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1388,7 +1389,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - PR E2E Core Tests
       - Nightly E2E Tests
@@ -1408,7 +1409,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1427,7 +1428,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1446,7 +1447,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1465,7 +1466,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests
@@ -1484,7 +1485,7 @@ runner-test-matrix:
     path: integration-tests/smoke/ccip/ccip_rmn_test.go
     test_env_type: docker
     runs_on: ubuntu24.04-16cores-64GB
-    runs_on_self_hosted: runs-on/cpu=16/ram=64/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    runs_on_self_hosted: runs-on/cpu=32/ram=128/family=c6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     triggers:
       - Nightly E2E Tests
       - Push E2E CCIP Tests

--- a/.github/workflows/integration-in-memory-tests.yml
+++ b/.github/workflows/integration-in-memory-tests.yml
@@ -47,7 +47,6 @@ jobs:
         with:
           filters: |
             github_ci_changes:
-              - '.github/workflows/integration-tests.yml'
               - '.github/workflows/integration-in-memory-tests.yml'
               - '.github/integration-in-memory-tests.yml'
             core_changes:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,20 +82,50 @@ jobs:
           go-project-path: ./integration-tests
           module-name: github.com/smartcontractkit/chainlink-testing-framework/lib
           enforce-semantic-tag: "true"
+
   changes:
-    # Don't run E2E tests on PR, unless it's tagged with "run-e2e-tests"
-    if: ${{ github.event_name != 'pull_request' || contains(join(github.event.pull_request.labels.*.name, ' '), 'run-e2e-tests') }}
-    environment: integration
-    name: Check Paths That Require Tests To Run
+    name: Check Run Conditions
     runs-on: ubuntu-latest
     outputs:
-      github_ci_changes: ${{ steps.ignore-filter.outputs.changes || steps.changes.outputs.github_ci_changes }}
-      core_changes: ${{ steps.ignore-filter.outputs.changes || steps.changes.outputs.core_changes }}
-      ccip_changes: ${{ steps.ignore-filter.outputs.changes || steps.changes.outputs.ccip_changes }}
-      cre_changes: ${{ steps.ignore-filter.outputs.changes || steps.changes.outputs.cre_changes }}
+      should-run-ccip-tests: >-
+        ${{
+          steps.ignore-filter.outputs.changes == 'true' ||
+          steps.label-run-e2e-tests.outputs.check-label-found  == 'true' ||
+          steps.changes.outputs.ccip_changes == 'true' ||
+          steps.changes.outputs.github_ci_changes == 'true'
+        }}
+      should-run-cre-tests: >-
+        ${{
+          steps.ignore-filter.outputs.changes == 'true' ||
+          steps.label-run-e2e-tests.outputs.check-label-found  == 'true' ||
+          steps.changes.outputs.cre_changes == 'true' ||
+          steps.changes.outputs.github_ci_changes == 'true'
+        }}
+      should-run-core-tests: >-
+        ${{
+          steps.ignore-filter.outputs.changes == 'true' ||
+          steps.label-run-e2e-tests.outputs.check-label-found  == 'true' ||
+          steps.changes.outputs.core_changes == 'true' ||
+          steps.changes.outputs.github_ci_changes == 'true'
+        }}
       builder-runner-label: ${{ steps.runner-labels.outputs.runner-label }}
+      should-use-self-hosted-runners: ${{ steps.label-runs-on-opt-out.outputs.check-label-found == 'true' }}
     steps:
+      - name: Get PR Labels (run-e2e-tests)
+        id: label-run-e2e-tests
+        uses: smartcontractkit/.github/actions/get-pr-labels@get-pr-labels/v1
+        with:
+          check-label: "run-e2e-tests"
+          skip-merge-group: "true"
+
+      - name: Get PR Labels (runs-on-opt-out)
+        id: label-runs-on-opt-out
+        uses: smartcontractkit/.github/actions/get-pr-labels@get-pr-labels/v1
+        with:
+          check-label: "runs-on-opt-out"
+
       - name: Checkout the repo
+        if: ${{ github.event_name != 'pull_request' || steps.label-run-e2e-tests.outputs.check-label-found == 'true' }}
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -104,6 +134,7 @@ jobs:
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
+        if: ${{ github.event_name != 'pull_request' || steps.label-run-e2e-tests.outputs.check-label-found == 'true' }}
         with:
           filters: |
             github_ci_changes:
@@ -216,7 +247,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.cre_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core CRE Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -225,6 +256,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners == 'true' }}
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -259,7 +291,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.cre_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core CRE Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -302,7 +334,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'push'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core E2E CRE Tests For Push
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -345,7 +377,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'workflow_dispatch'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core E2E CRE Tests For Workflow Dispatch
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -388,7 +420,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -397,6 +429,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners == 'true' }}
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -429,7 +462,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -472,7 +505,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'push'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core E2E Tests For Push
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -515,7 +548,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'workflow_dispatch'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core E2E Tests For Workflow Dispatch
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -557,7 +590,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -566,6 +599,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners == 'true' }}
       team: "CCIP"
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
@@ -601,7 +635,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -647,7 +681,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'push'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run CCIP E2E Tests For Push
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -693,7 +727,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'workflow_dispatch'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run CCIP E2E Tests For Workflow Dispatch
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -1075,8 +1109,9 @@ jobs:
           persist-credentials: false
           repository: smartcontractkit/chainlink-solana
           ref: ${{ needs.get_solana_sha.outputs.sha }}
+
       - name: Run Setup
-        if: needs.changes.outputs.core_changes == 'true' || github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.should-run-core-tests == 'true' || github.event_name == 'workflow_dispatch'
         uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@4ff522b1aef76519d2ced17b5d052927754fd34b # ctf-setup-run-tests-environment@v0.2.1
         with:
           go_mod_path: ./integration-tests/go.mod
@@ -1089,8 +1124,9 @@ jobs:
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
           k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
+
       - name: Pull Artifacts
-        if: needs.changes.outputs.core_changes == 'true' || github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
         run: |
           IMAGE_NAME=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ needs.get_solana_sha.outputs.sha }}
           # Pull the Docker image
@@ -1105,15 +1141,19 @@ jobs:
 
           # Remove the created container
           docker rm "$CONTAINER_ID"
+
       - name: Install Solana CLI # required for ensuring the local test validator is configured correctly
+        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
         run: ./scripts/install-solana-ci.sh
 
       - name: Install gauntlet
+        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
         run: |
           yarn --cwd ./gauntlet install --frozen-lockfile
           yarn --cwd ./gauntlet build
           yarn --cwd ./gauntlet gauntlet
       - name: Generate config overrides
+        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
         env:
           GH_INPUTS_EVM_REF: ${{ inputs.evm-ref }}
           GH_SHA: ${{ inputs.cl_ref || github.sha }}
@@ -1132,8 +1172,9 @@ jobs:
           echo ::add-mask::$BASE64_CONFIG_OVERRIDE
           # shellcheck disable=SC2086
           echo "BASE64_CONFIG_OVERRIDE=$BASE64_CONFIG_OVERRIDE" >> $GITHUB_ENV
+
       - name: Run Tests
-        if: needs.changes.outputs.core_changes == 'true' || github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
         uses: smartcontractkit/.github/actions/ctf-run-tests@725dd141dd77cc87dad420e9484416fc4ae26be2 # ctf-run-tests@v0.5.0
         with:
           test_command_to_run: export ENV_JOB_IMAGE=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ needs.get_solana_sha.outputs.sha }} && make test_smoke
@@ -1158,13 +1199,13 @@ jobs:
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
           k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
-
         env:
           E2E_TEST_CHAINLINK_IMAGE: ${{ env.CHAINLINK_IMAGE }}
           E2E_TEST_SOLANA_SECRET: thisisatestingonlysecret
           CHAINLINK_USER_TEAM: "BIX"
 
       - name: Upload Coverage Data
+        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         timeout-minutes: 2
         continue-on-error: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -108,8 +108,8 @@ jobs:
           steps.changes.outputs.core_changes == 'true' ||
           steps.changes.outputs.github_ci_changes == 'true'
         }}
-      builder-runner-label: ${{ steps.runner-labels.outputs.runner-label }}
-      should-use-self-hosted-runners: ${{ steps.label-runs-on-opt-out.outputs.check-label-found == 'true' }}
+      builder-runner-label: ${{ steps.image-build-runner-labels.outputs.runner-label }}
+      should-use-self-hosted-runners: ${{ steps.label-runs-on-opt-out.outputs.check-label-found == 'false' }}
     steps:
       - name: Get PR Labels (run-e2e-tests)
         id: label-run-e2e-tests
@@ -163,8 +163,8 @@ jobs:
         with:
           check-label: "runs-on-opt-out"
 
-      - name: Set Runner Labels
-        id: runner-labels
+      - name: Set image builder runner labels
+        id: image-build-runner-labels
         env:
           OPT_OUT: ${{ steps.label-runs-on-opt-out.outputs.check-label-found || 'false' }}
           GH_BUILDER_RUNNER: ubuntu22.04-8cores-32GB
@@ -248,7 +248,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
-      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners == 'true' }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -292,6 +292,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -335,6 +336,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -378,6 +380,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -421,7 +424,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
-      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners == 'true' }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -465,6 +468,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -508,6 +512,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -550,6 +555,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -591,7 +597,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
-      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners == 'true' }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
       team: "CCIP"
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
@@ -638,6 +644,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
       team: "CCIP"
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
@@ -684,6 +691,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
       team: "CCIP"
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
@@ -729,6 +737,7 @@ jobs:
       upload_cl_node_coverage_artifact: true
       upload_cl_node_coverage_artifact_prefix: cl_node_coverage_data_
       enable_otel_traces_for_ocr2_plugins: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'enable tracing') }}
+      use-self-hosted-runners: ${{ needs.changes.outputs.should-use-self-hosted-runners }}
       team: "CCIP"
     secrets:
       QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -558,7 +558,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025 # june 2, 2025
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@31ea968c2fff6582e95cd51b0f7f95932a3bf25f # june 2, 2025
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -108,7 +108,8 @@ jobs:
           steps.changes.outputs.core_changes == 'true' ||
           steps.changes.outputs.github_ci_changes == 'true'
         }}
-      builder-runner-label: ${{ steps.image-build-runner-labels.outputs.runner-label }}
+      builder-runner-label: ${{ steps.runner-labels.outputs.builder-runner-label }}
+      solana-runner-label: ${{ steps.runner-labels.outputs.solana-runner-label }}
       should-use-self-hosted-runners: ${{ steps.label-runs-on-opt-out.outputs.check-label-found == 'false' }}
     steps:
       - name: Get PR Labels (run-e2e-tests)
@@ -163,17 +164,21 @@ jobs:
         with:
           check-label: "runs-on-opt-out"
 
-      - name: Set image builder runner labels
-        id: image-build-runner-labels
+      - name: Set runner labels
+        id: runner-labels
         env:
           OPT_OUT: ${{ steps.label-runs-on-opt-out.outputs.check-label-found || 'false' }}
           GH_BUILDER_RUNNER: ubuntu22.04-8cores-32GB
           SH_BUILDER_RUNNER: runs-on=${{ github.run_id }}/cpu=32/memory=64/family=c6i/extras=s3-cache+tmpfs
+          GH_SOLANA_RUNNER: ubuntu22.04-8cores-32GB
+          SH_SOLANA_RUNNER: runs-on=${{ github.run_id }}/cpu=32/ram=64/family=c6i/spot=false/image=ubuntu22-full-x64/extras=s3-cache+tmpfs
         run: |
           if [[ "${OPT_OUT}" == "true" ]]; then
-            echo "runner-label=${GH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
+            echo "builder-runner-label=${GH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
+            echo "solana-runner-label=${GH_SOLANA_RUNNER}" | tee -a "$GITHUB_OUTPUT"
           else
-            echo "runner-label=${SH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
+            echo "builder-runner-labe=${SH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
+            echo "solana-runner-label=${SH_SOLANA_RUNNER}" | tee -a "$GITHUB_OUTPUT"
           fi
 
   build-chainlink:
@@ -1092,7 +1097,7 @@ jobs:
       id-token: write
       contents: read
     name: Solana Smoke Tests
-    runs-on: ubuntu22.04-8cores-32GB
+    runs-on: ${{ needs.changes.outputs.builder-runner-label || 'ubuntu22.04-8cores-32GB' }}
     needs:
       [
         build-chainlink,
@@ -1107,6 +1112,11 @@ jobs:
       TEST_LOG_LEVEL: debug
       CONTRACT_ARTIFACTS_PATH: contracts/target/deploy
     steps:
+      - name: Enable S3 Cache for Self-Hosted Runners
+        # these env vars are set (and exposed) when it is a self-hosted runner with extras=s3-cache
+        if: ${{ env.RUNS_ON_INSTANCE_ID != '' && env.ACTIONS_CACHE_URL != '' }}
+        uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
+
       - name: Checkout the repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -177,7 +177,7 @@ jobs:
             echo "builder-runner-label=${GH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
             echo "solana-runner-label=${GH_SOLANA_RUNNER}" | tee -a "$GITHUB_OUTPUT"
           else
-            echo "builder-runner-labe=${SH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
+            echo "builder-runner-label=${SH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
             echo "solana-runner-label=${SH_SOLANA_RUNNER}" | tee -a "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -118,14 +118,7 @@ jobs:
           check-label: "run-e2e-tests"
           skip-merge-group: "true"
 
-      - name: Get PR Labels (runs-on-opt-out)
-        id: label-runs-on-opt-out
-        uses: smartcontractkit/.github/actions/get-pr-labels@get-pr-labels/v1
-        with:
-          check-label: "runs-on-opt-out"
-
       - name: Checkout the repo
-        if: ${{ github.event_name != 'pull_request' || steps.label-run-e2e-tests.outputs.check-label-found == 'true' }}
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -134,7 +127,6 @@ jobs:
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
-        if: ${{ github.event_name != 'pull_request' || steps.label-run-e2e-tests.outputs.check-label-found == 'true' }}
         with:
           filters: |
             github_ci_changes:
@@ -163,7 +155,7 @@ jobs:
       - name: Ignore Filter On Workflow Dispatch or Tag
         if: ${{ github.event_name == 'workflow_dispatch' || github.ref_type == 'tag' }}
         id: ignore-filter
-        run: echo "changes=true" >> $GITHUB_OUTPUT
+        run: echo "changes=true" | tee -a "$GITHUB_OUTPUT"
 
       - name: Get PR Labels (runs-on-opt-out)
         id: label-runs-on-opt-out
@@ -179,9 +171,9 @@ jobs:
           SH_BUILDER_RUNNER: runs-on=${{ github.run_id }}/cpu=32/memory=64/family=c6i/extras=s3-cache+tmpfs
         run: |
           if [[ "${OPT_OUT}" == "true" ]]; then
-            echo "runner-label=${GH_BUILDER_RUNNER}" | tee -a $GITHUB_OUTPUT
+            echo "runner-label=${GH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
           else
-            echo "runner-label=${SH_BUILDER_RUNNER}" | tee -a $GITHUB_OUTPUT
+            echo "runner-label=${SH_BUILDER_RUNNER}" | tee -a "$GITHUB_OUTPUT"
           fi
 
   build-chainlink:
@@ -227,7 +219,7 @@ jobs:
           set-git-config: "true"
 
       - name: Build Chainlink Image
-        if: needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.cre_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true' || github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.should-run-core-tests == 'true' || needs.changes.outputs.should-run-cre-tests == 'true' || needs.changes.outputs.should-run-ccip-tests == 'true'
         uses: ./.github/actions/build-chainlink-image
         with:
           tag_suffix: ${{ matrix.image.tag-suffix }}
@@ -246,7 +238,7 @@ jobs:
       id-token: write
       contents: read
     needs: [build-chainlink, changes]
-    if: github.event_name == 'pull_request' && ( needs.changes.outputs.cre_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
+    if: github.event_name == 'pull_request' && needs.changes.outputs.should-run-cre-tests == 'true'
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core CRE Tests For PR
@@ -290,7 +282,7 @@ jobs:
       id-token: write
       contents: read
     needs: [build-chainlink, changes]
-    if: github.event_name == 'merge_group' && ( needs.changes.outputs.cre_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
+    if: github.event_name == 'merge_group' && needs.changes.outputs.should-run-cre-tests == 'true'
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core CRE Tests For Merge Queue
@@ -419,7 +411,7 @@ jobs:
       id-token: write
       contents: read
     needs: [build-chainlink, changes]
-    if: github.event_name == 'pull_request' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
+    if: github.event_name == 'pull_request' && needs.changes.outputs.should-run-core-tests == 'true'
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core E2E Tests For PR
@@ -461,7 +453,7 @@ jobs:
       id-token: write
       contents: read
     needs: [build-chainlink, changes]
-    if: github.event_name == 'merge_group' && ( needs.changes.outputs.core_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
+    if: github.event_name == 'merge_group' && needs.changes.outputs.should-run-core-tests == 'true'
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
@@ -589,7 +581,7 @@ jobs:
       id-token: write
       contents: read
     needs: [build-chainlink, changes]
-    if: github.event_name == 'pull_request' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
+    if: github.event_name == 'pull_request' && needs.changes.outputs.should-run-ccip-tests == 'true'
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run CCIP E2E Tests For PR
@@ -634,7 +626,7 @@ jobs:
       id-token: write
       contents: read
     needs: [build-chainlink, changes]
-    if: github.event_name == 'merge_group' && (needs.changes.outputs.ccip_changes == 'true' || needs.changes.outputs.github_ci_changes == 'true')
+    if: github.event_name == 'merge_group' && needs.changes.outputs.should-run-ccip-tests == 'true'
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@c734fdbb7feec263c481af58ac562d6c0544abae # june 6, 2025
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
@@ -1028,7 +1020,7 @@ jobs:
           repository: smartcontractkit/chainlink-solana
           ref: ${{ needs.get_solana_sha.outputs.sha }}
       - name: Build contracts
-        if: (needs.changes.outputs.core_changes == 'true' || github.event_name == 'workflow_dispatch') && needs.solana-test-image-exists.outputs.exists == 'false'
+        if: needs.changes.outputs.should-run-core-tests == 'true' && needs.solana-test-image-exists.outputs.exists == 'false'
         uses: smartcontractkit/chainlink-solana/.github/actions/build_contract_artifacts@841f6229b6a0be0114c47cb676b1136d92f935c9 # node20 update on may 10, 2024
         with:
           ref: ${{ needs.get_solana_sha.outputs.sha }}
@@ -1055,20 +1047,21 @@ jobs:
       GOTOOLCHAIN: auto
     steps:
       - name: Checkout the repo
-        if: (needs.changes.outputs.core_changes == 'true' || github.event_name == 'workflow_dispatch') && needs.solana-test-image-exists.outputs.exists == 'false'
+        if: needs.changes.outputs.should-run-core-tests == 'true' && needs.solana-test-image-exists.outputs.exists == 'false'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
           repository: smartcontractkit/chainlink-solana
           ref: ${{ needs.get_solana_sha.outputs.sha }}
       - name: Download Artifacts
-        if: (needs.changes.outputs.core_changes == 'true' || github.event_name == 'workflow_dispatch') && needs.solana-test-image-exists.outputs.exists == 'false'
+        if: needs.changes.outputs.should-run-core-tests == 'true' && needs.solana-test-image-exists.outputs.exists == 'false'
         uses: actions/download-artifact@v4
         with:
           name: artifacts
           path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
+
       - name: Build Test Image
-        if: (needs.changes.outputs.core_changes == 'true' || github.event_name == 'workflow_dispatch') && needs.solana-test-image-exists.outputs.exists == 'false'
+        if: needs.changes.outputs.should-run-core-tests == 'true' && needs.solana-test-image-exists.outputs.exists == 'false'
         uses: smartcontractkit/.github/actions/ctf-build-test-image@a5e4f4c8fbb8e15ab2ad131552eca6ac83c4f4b3 # ctf-build-test-image@0.1.0
         with:
           repository: chainlink-solana-tests
@@ -1077,8 +1070,10 @@ jobs:
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
-      - run: echo "this exists so we don't have to run anything else if the build is skipped"
-        if: needs.changes.outputs.core_changes == 'false' || needs.solana-test-image-exists.outputs.exists == 'true'
+
+      - name: Echo Output
+        if: needs.changes.outputs.should-run-core-tests == 'false' || needs.solana-test-image-exists.outputs.exists == 'true'
+        run: echo "this exists so we don't have to run anything else if the build is skipped"
 
   solana-smoke-tests:
     environment: integration
@@ -1126,7 +1121,7 @@ jobs:
           k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
 
       - name: Pull Artifacts
-        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.should-run-core-tests
         run: |
           IMAGE_NAME=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ needs.get_solana_sha.outputs.sha }}
           # Pull the Docker image
@@ -1143,17 +1138,17 @@ jobs:
           docker rm "$CONTAINER_ID"
 
       - name: Install Solana CLI # required for ensuring the local test validator is configured correctly
-        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.should-run-core-tests
         run: ./scripts/install-solana-ci.sh
 
       - name: Install gauntlet
-        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.should-run-core-tests
         run: |
           yarn --cwd ./gauntlet install --frozen-lockfile
           yarn --cwd ./gauntlet build
           yarn --cwd ./gauntlet gauntlet
       - name: Generate config overrides
-        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.should-run-core-tests
         env:
           GH_INPUTS_EVM_REF: ${{ inputs.evm-ref }}
           GH_SHA: ${{ inputs.cl_ref || github.sha }}
@@ -1174,7 +1169,7 @@ jobs:
           echo "BASE64_CONFIG_OVERRIDE=$BASE64_CONFIG_OVERRIDE" >> $GITHUB_ENV
 
       - name: Run Tests
-        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.should-run-core-tests
         uses: smartcontractkit/.github/actions/ctf-run-tests@725dd141dd77cc87dad420e9484416fc4ae26be2 # ctf-run-tests@v0.5.0
         with:
           test_command_to_run: export ENV_JOB_IMAGE=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ needs.get_solana_sha.outputs.sha }} && make test_smoke
@@ -1205,7 +1200,7 @@ jobs:
           CHAINLINK_USER_TEAM: "BIX"
 
       - name: Upload Coverage Data
-        if: needs.changes.outputs.should-run-core-tests || github.event_name == 'workflow_dispatch'
+        if: needs.changes.outputs.should-run-core-tests
         uses: actions/upload-artifact@v4
         timeout-minutes: 2
         continue-on-error: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -153,7 +153,6 @@ jobs:
             echo "runner-label=${SH_BUILDER_RUNNER}" | tee -a $GITHUB_OUTPUT
           fi
 
-
   build-chainlink:
     environment: integration
     permissions:


### PR DESCRIPTION
### Changes

- Add support for running e2e tests with self-hosted runners
- Refactor conditionals for readability

### Testing

#### Merge group baseline (21m41s)

https://github.com/smartcontractkit/chainlink/actions/runs/15542534328

<details>
<summary>Longer running jobs</summary>

```
Run Core E2E Tests For Merge Queue / smoke/log_poller_test.go:^TestLogPollerReplayFixedDepth$: 929s (completed/success)
Solana Smoke Tests: 829s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/log_poller_test.go:^TestLogPollerReplayFinalityTag$: 783s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/log_poller_test.go:^TestLogPollerFewFiltersFixedDepth$: 777s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/log_poller_test.go:^TestLogPollerWithChaosPostgresFixedDepth$: 771s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/log_poller_test.go:^TestLogPollerWithChaosFixedDepth$: 769s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/log_poller_test.go:^TestLogPollerFewFiltersFinalityTag$: 762s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/vrfv2plus_test.go:*: 749s (completed/success)
Run CCIP E2E Tests For Merge Queue / ccip-tests/smoke/ccip_test.go:^TestSmokeCCIPTokenPoolRateLimits$: 716s (completed/success)
Run CCIP E2E Tests For Merge Queue / ccip-tests/smoke/ccip_test.go:^TestSmokeCCIPMulticall$: 700s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/ccip/ccip_gas_price_updates_test.go:^Test_CCIPGasPriceUpdatesWriteFrequency$: 695s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/ccip/ccip_rmn_test.go:^TestRMN_TwoMessagesOnTwoLanesIncludingBatching$: 687s (completed/success)
Run CCIP E2E Tests For Merge Queue / ccip-tests/smoke/ccip_test.go:^TestSmokeCCIPManuallyExecuteAfterExecutionFailingDueToInsufficientGas$: 682s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/forwarders_ocr2_test.go:*: 673s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/ccip/ccip_token_price_updates_test.go:*: 671s (completed/success)
Run CCIP E2E Tests For Merge Queue / ccip-smoke-db-compatibility: 670s (completed/success)
Run Core CRE E2E Tests For Merge Queue / system-tests/smoke/cre/por_test.go:TestCRE_OCR3_PoR_Workflow_SingleDon_MultipleWriters_MockedPrice: 620s (completed/success)
Run CCIP E2E Tests For Merge Queue / ccip-smoke: 607s (completed/success)
Run CCIP E2E Tests For Merge Queue / ccip-smoke-lbtc-non32bytes-destination-pool-data: 600s (completed/success)
Run CCIP E2E Tests For Merge Queue / ccip-smoke-usdc: 599s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/vrfv2_test.go:*: 598s (completed/success)
Run Core E2E Tests For Merge Queue / smoke/ocr_test.go:*: 596s (completed/success)
Run CCIP E2E Tests For Merge Queue / ccip-smoke-lbtc-32bytes-destination-pool-data: 586s (completed/success)
Run CCIP E2E Tests For Merge Queue / ccip-tests/smoke/ccip_test.go:^TestSmokeCCIPReorgBelowFinality$: 568s (completed/success)
Run Core CRE E2E Tests For Merge Queue / system-tests/smoke/cre/por_test.go:TestCRE_OCR3_PoR_Workflow_CapabilitiesDons_LivePrice: 557s (completed/success)
```

</details>

#### Pull Request Baseline (23m23s)

https://github.com/smartcontractkit/chainlink/actions/runs/15467331432

These are typically 1-2 minutes longer because of the "cleanup deployments" job, which deletes all the "deployed to integration" spam. ([example](https://github.com/smartcontractkit/chainlink/actions/runs/15467331432/job/43543930561))

<details>
<summary>Longer running jobs</summary>

```
Solana Smoke Tests: 877s (completed/success)
Run Core E2E Tests For PR / smoke/log_poller_test.go:^TestLogPollerWithChaosFixedDepth$: 850s (completed/success)
Run Core E2E Tests For PR / smoke/log_poller_test.go:^TestLogPollerWithChaosPostgresFixedDepth$: 840s (completed/success)
Run Core E2E Tests For PR / smoke/log_poller_test.go:^TestLogPollerFewFiltersFinalityTag$: 825s (completed/success)
Run Core E2E Tests For PR / smoke/log_poller_test.go:^TestLogPollerReplayFixedDepth$: 815s (completed/success)
Run Core E2E Tests For PR / smoke/log_poller_test.go:^TestLogPollerReplayFinalityTag$: 814s (completed/success)
Run Core E2E Tests For PR / smoke/log_poller_test.go:^TestLogPollerFewFiltersFixedDepth$: 809s (completed/success)
Run Core E2E Tests For PR / smoke/vrfv2plus_test.go:*: 804s (completed/success)
Run Core E2E Tests For PR / smoke/forwarders_ocr2_test.go:*: 745s (completed/success)
Run Core E2E Tests For PR / smoke/ccip/ccip_gas_price_updates_test.go:^Test_CCIPGasPriceUpdatesWriteFrequency$: 742s (completed/success)
Run Core E2E Tests For PR / smoke/ccip/ccip_token_price_updates_test.go:*: 681s (completed/success)
Run Core E2E Tests For PR / smoke/vrfv2_test.go:*: 645s (completed/success)
Run Core E2E Tests For PR / smoke/ocr_test.go:*: 601s (completed/success)
```

</details>


#### This PR (18m53s)

https://github.com/smartcontractkit/chainlink/actions/runs/15545524998?pr=17650

This is a sub 19 minute run for PRs, with 3m27s of [deployment cleanup](https://github.com/smartcontractkit/chainlink/actions/runs/15545524998/job/43766839819?pr=17650). So this could translate to a ~15m30s run in the merge queue.

However, this does migrate 44 jobs to self-hosted runners. This seems like an aggressive migration in one swoop.
