### PR TITLE
experimental observation cache seqNr aware

### DIFF
--- a/core/services/llo/mercurytransmitter/transmitter.go
+++ b/core/services/llo/mercurytransmitter/transmitter.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/grpc"
+	"github.com/smartcontractkit/chainlink/v2/core/services/llo/observation"
 )
 
 const (
@@ -269,6 +270,7 @@ func (mt *transmitter) Transmit(
 				err = fmt.Errorf("failed to add transmission to commit channel: %w", ctx.Err())
 			}
 		}
+		observation.GetCache(digest).SetLastTransmissionSeqNr(seqNr)
 	})
 
 	if !ok {

--- a/core/services/llo/observation/cache.go
+++ b/core/services/llo/observation/cache.go
@@ -1,0 +1,160 @@
+package observation
+
+import (
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2/types"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+	"github.com/smartcontractkit/chainlink-data-streams/llo"
+)
+
+var (
+	registryMu = sync.Mutex{}
+	registry   = map[ocr2types.ConfigDigest]*Cache{}
+
+	promCacheHitCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "llo",
+		Subsystem: "datasource",
+		Name:      "cache_hit_count",
+		Help:      "Number of local observation cache hits",
+	},
+		[]string{"configDigest", "streamID"},
+	)
+	promCacheMissCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "llo",
+		Subsystem: "datasource",
+		Name:      "cache_miss_count",
+		Help:      "Number of local observation cache misses",
+	},
+		[]string{"configDigest", "streamID", "reason"},
+	)
+)
+
+func GetCache(configDigest ocr2types.ConfigDigest) *Cache {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	cache, ok := registry[configDigest]
+	if !ok {
+		cache = NewCache(configDigest, 500*time.Millisecond, time.Minute)
+		registry[configDigest] = cache
+	}
+
+	return cache
+}
+
+// Cache of stream values.
+// It maintains a cache of stream values fetched from adapters until the last
+// transmission sequence number is greater or equal the sequence number at which
+// the value was observed or until the maxAge is reached.
+//
+// The cache is cleaned up periodically to remove decommissioned stream values
+// if the provided cleanupInterval is greater than 0.
+type Cache struct {
+	mu sync.RWMutex
+
+	configDigestStr string
+	values          map[llotypes.StreamID]item
+	maxAge          time.Duration
+	cleanupInterval time.Duration
+
+	lastTransmissionSeqNr atomic.Uint64
+	closeChan             chan struct{}
+}
+
+type item struct {
+	value     llo.StreamValue
+	seqNr     uint64
+	createdAt time.Time
+}
+
+// NewCache creates a new cache.
+//
+// maxAge is the maximum age of a stream value to keep in the cache.
+// cleanupInterval is the interval to clean up the cache.
+func NewCache(configDigest ocr2types.ConfigDigest, maxAge time.Duration, cleanupInterval time.Duration) *Cache {
+	c := &Cache{
+		configDigestStr: configDigest.Hex(),
+		values:          make(map[llotypes.StreamID]item),
+		maxAge:          maxAge,
+		cleanupInterval: cleanupInterval,
+		closeChan:       make(chan struct{}),
+	}
+
+	if cleanupInterval > 0 {
+		go func() {
+			ticker := time.NewTicker(cleanupInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					c.cleanup()
+				case <-c.closeChan:
+					return
+				}
+			}
+		}()
+
+		runtime.AddCleanup(c, func(ch chan struct{}) {
+			close(ch)
+		}, c.closeChan)
+	}
+
+	return c
+}
+
+// SetLastTransmissionSeqNr sets the last transmission sequence number.
+func (c *Cache) SetLastTransmissionSeqNr(seqNr uint64) {
+	c.lastTransmissionSeqNr.Store(seqNr)
+}
+
+// Add adds a stream value to the cache.
+func (c *Cache) Add(id llotypes.StreamID, value llo.StreamValue, seqNr uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values[id] = item{value: value, seqNr: seqNr, createdAt: time.Now()}
+}
+
+func (c *Cache) Get(id llotypes.StreamID) (llo.StreamValue, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	label := strconv.FormatUint(uint64(id), 10)
+	item, ok := c.values[id]
+	if !ok {
+		promCacheMissCount.WithLabelValues(c.configDigestStr, label, "notFound").Inc()
+		return nil, false
+	}
+
+	if item.seqNr <= c.lastTransmissionSeqNr.Load() {
+		promCacheMissCount.WithLabelValues(c.configDigestStr, label, "seqNr").Inc()
+		return nil, false
+	}
+
+	if time.Since(item.createdAt) >= c.maxAge {
+		promCacheMissCount.WithLabelValues(c.configDigestStr, label, "maxAge").Inc()
+		return nil, false
+	}
+
+	promCacheHitCount.WithLabelValues(c.configDigestStr, label).Inc()
+	return item.value, true
+}
+
+func (c *Cache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	lastTransmissionSeqNr := c.lastTransmissionSeqNr.Load()
+	for id, item := range c.values {
+		if item.seqNr <= lastTransmissionSeqNr || time.Since(item.createdAt) >= c.maxAge {
+			delete(c.values, id)
+		}
+	}
+}

--- a/core/services/llo/observation/cache_test.go
+++ b/core/services/llo/observation/cache_test.go
@@ -1,0 +1,272 @@
+package observation
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2/types"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+	"github.com/smartcontractkit/chainlink-data-streams/llo"
+)
+
+type mockStreamValue struct {
+	value []byte
+}
+
+func (m *mockStreamValue) Value() interface{} {
+	return m.value
+}
+
+func (m *mockStreamValue) MarshalBinary() ([]byte, error) {
+	return m.value, nil
+}
+
+func (m *mockStreamValue) UnmarshalBinary(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("empty data")
+	}
+	m.value = data
+	return nil
+}
+
+func (m *mockStreamValue) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("%d", m.value)), nil
+}
+
+func (m *mockStreamValue) UnmarshalText(data []byte) error {
+	m.value = data
+	return nil
+}
+
+func (m *mockStreamValue) Type() llo.LLOStreamValue_Type {
+	return llo.LLOStreamValue_TimestampedStreamValue
+}
+
+func TestNewCache(t *testing.T) {
+	tests := []struct {
+		name            string
+		maxAge          time.Duration
+		cleanupInterval time.Duration
+		wantErr         bool
+	}{
+		{
+			name:            "valid cache with cleanup",
+			maxAge:          time.Second,
+			cleanupInterval: time.Millisecond * 100,
+			wantErr:         false,
+		},
+		{
+			name:            "valid cache without cleanup",
+			maxAge:          time.Second,
+			cleanupInterval: 0,
+			wantErr:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := NewCache(ocr2types.ConfigDigest{}, tt.maxAge, tt.cleanupInterval)
+			require.NotNil(t, cache)
+			assert.Equal(t, tt.maxAge, cache.maxAge)
+			assert.Equal(t, tt.cleanupInterval, cache.cleanupInterval)
+			assert.NotNil(t, cache.values)
+			assert.NotNil(t, cache.closeChan)
+		})
+	}
+}
+
+func TestCache_Add_Get(t *testing.T) {
+	tests := []struct {
+		name      string
+		streamID  llotypes.StreamID
+		value     llo.StreamValue
+		seqNr     uint64
+		maxAge    time.Duration
+		wantValue llo.StreamValue
+		wantFound bool
+		beforeGet func(cache *Cache)
+	}{
+		{
+			name:      "get existing value",
+			streamID:  1,
+			value:     &mockStreamValue{value: []byte{42}},
+			seqNr:     10,
+			maxAge:    time.Second,
+			wantValue: &mockStreamValue{value: []byte{42}},
+			wantFound: true,
+		},
+		{
+			name:      "get non-existent value",
+			streamID:  1,
+			value:     &mockStreamValue{value: []byte{42}},
+			seqNr:     10,
+			maxAge:    time.Second,
+			wantValue: nil,
+			wantFound: false,
+		},
+		{
+			name:      "get expired by sequence number",
+			streamID:  1,
+			value:     &mockStreamValue{value: []byte{42}},
+			seqNr:     5,
+			maxAge:    time.Second,
+			wantValue: nil,
+			wantFound: false,
+			beforeGet: func(cache *Cache) {
+				cache.SetLastTransmissionSeqNr(10)
+			},
+		},
+		{
+			name:      "get expired by age",
+			streamID:  1,
+			value:     &mockStreamValue{value: []byte{42}},
+			seqNr:     10,
+			maxAge:    time.Nanosecond * 100,
+			wantValue: nil,
+			wantFound: false,
+			beforeGet: func(_ *Cache) {
+				time.Sleep(time.Millisecond)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := NewCache(ocr2types.ConfigDigest{}, tt.maxAge, 0)
+
+			if tt.wantFound {
+				cache.Add(tt.streamID, tt.value, tt.seqNr)
+			}
+
+			if tt.beforeGet != nil {
+				tt.beforeGet(cache)
+			}
+
+			gotValue, gotFound := cache.Get(tt.streamID)
+			assert.Equal(t, tt.wantFound, gotFound)
+			if tt.wantFound {
+				assert.Equal(t, tt.wantValue, gotValue)
+			}
+		})
+	}
+}
+
+func TestCache_Cleanup(t *testing.T) {
+	cache := NewCache(ocr2types.ConfigDigest{}, time.Nanosecond*100, time.Millisecond)
+	streamID := llotypes.StreamID(1)
+	value := &mockStreamValue{value: []byte{42}}
+
+	cache.Add(streamID, value, 10)
+	time.Sleep(time.Millisecond * 2)
+
+	gotValue, gotFound := cache.Get(streamID)
+	assert.False(t, gotFound)
+	assert.Nil(t, gotValue)
+
+	_, ok := cache.values[streamID]
+	assert.False(t, ok)
+}
+
+func TestCache_ConcurrentAccess(t *testing.T) {
+	cache := NewCache(ocr2types.ConfigDigest{}, time.Second, 0)
+	const numGoroutines = 10
+	const numOperations = uint32(1000)
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Test concurrent Add operations
+	for i := uint32(0); i < numGoroutines; i++ {
+		go func(id uint32) {
+			defer wg.Done()
+			for j := uint32(0); j < numOperations; j++ {
+				streamID := id*numOperations + j
+				cache.Add(streamID, &mockStreamValue{value: []byte{byte(id)}}, 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify all values were added correctly
+	for i := uint32(0); i < numGoroutines; i++ {
+		for j := uint32(0); j < numOperations; j++ {
+			streamID := i*numOperations + j
+			value, found := cache.Get(streamID)
+			assert.True(t, found)
+			assert.Equal(t, &mockStreamValue{value: []byte{byte(i)}}, value)
+		}
+	}
+}
+
+func TestCache_ConcurrentReadWrite(t *testing.T) {
+	cache := NewCache(ocr2types.ConfigDigest{}, time.Second, 0)
+	const numGoroutines = 10
+	const numOperations = uint32(1000)
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 2) // Double for read and write goroutines
+
+	// Start write goroutines
+	for i := uint32(0); i < numGoroutines; i++ {
+		go func(id uint32) {
+			defer wg.Done()
+			for j := uint32(0); j < numOperations; j++ {
+				streamID := id*numOperations + j
+				cache.Add(streamID, &mockStreamValue{value: []byte{byte(id)}}, uint64(j))
+			}
+		}(i)
+	}
+
+	// Start read goroutines
+	for i := uint32(0); i < numGoroutines; i++ {
+		go func(id uint32) {
+			defer wg.Done()
+			for j := uint32(0); j < numOperations; j++ {
+				streamID := id*numOperations + j
+				cache.Get(streamID)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestCache_ConcurrentAddGet(t *testing.T) {
+	cache := NewCache(ocr2types.ConfigDigest{}, time.Second, 0)
+	const numGoroutines = 10
+	const numOperations = uint32(1000)
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 2) // Double for Add and Get goroutines
+
+	// Start Add goroutines
+	for i := uint32(0); i < numGoroutines; i++ {
+		go func(id uint32) {
+			defer wg.Done()
+			for j := uint32(0); j < numOperations; j++ {
+				streamID := id*numOperations + j
+				cache.Add(streamID, &mockStreamValue{value: []byte{byte(id)}}, 1)
+			}
+		}(i)
+	}
+
+	// Start Get goroutines
+	for i := uint32(0); i < numGoroutines; i++ {
+		go func(id uint32) {
+			defer wg.Done()
+			for j := uint32(0); j < numOperations; j++ {
+				streamID := id*numOperations + j
+				cache.Get(streamID)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/core/services/llo/observation/data_source_test.go
+++ b/core/services/llo/observation/data_source_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	gocache "github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -80,19 +79,37 @@ func makeStreamValues() llo.StreamValues {
 }
 
 type mockOpts struct {
-	verboseLogging bool
+	verboseLogging       bool
+	seqNr                uint64
+	outCtx               ocr3types.OutcomeContext
+	configDigest         ocr2types.ConfigDigest
+	observationTimestamp time.Time
 }
 
 func (m *mockOpts) VerboseLogging() bool { return m.verboseLogging }
-func (m *mockOpts) SeqNr() uint64        { return 1042 }
+func (m *mockOpts) SeqNr() uint64 {
+	if m.seqNr == 0 {
+		return 1042
+	}
+	return m.seqNr
+}
 func (m *mockOpts) OutCtx() ocr3types.OutcomeContext {
-	return ocr3types.OutcomeContext{SeqNr: 1042, PreviousOutcome: ocr3types.Outcome([]byte("foo"))}
+	if m.outCtx.SeqNr == 0 {
+		return ocr3types.OutcomeContext{SeqNr: 1042, PreviousOutcome: ocr3types.Outcome([]byte("foo"))}
+	}
+	return m.outCtx
 }
 func (m *mockOpts) ConfigDigest() ocr2types.ConfigDigest {
-	return ocr2types.ConfigDigest{6, 5, 4}
+	if m.configDigest.Hex() == "" {
+		return ocr2types.ConfigDigest{6, 5, 4}
+	}
+	return m.configDigest
 }
 func (m *mockOpts) ObservationTimestamp() time.Time {
-	return time.Unix(1737936858, 0)
+	if m.observationTimestamp.IsZero() {
+		return time.Unix(1737936858, 0)
+	}
+	return m.observationTimestamp
 }
 
 type mockTelemeter struct {
@@ -267,7 +284,8 @@ func Test_DataSource(t *testing.T) {
 			reg.pipelines[2] = makePipelineWithSingleResult[*big.Int](2, big.NewInt(40602), nil)
 
 			vals := makeStreamValues()
-			err := ds.Observe(ctx, vals, opts)
+			opts2 := &mockOpts{configDigest: ocr2types.ConfigDigest{6, 5, 7}}
+			err := ds.Observe(ctx, vals, opts2)
 			require.NoError(t, err)
 
 			// Verify initial values
@@ -283,7 +301,7 @@ func Test_DataSource(t *testing.T) {
 
 			// Second observation should use cached values
 			vals = makeStreamValues()
-			err = ds.Observe(ctx, vals, opts)
+			err = ds.Observe(ctx, vals, opts2)
 			require.NoError(t, err)
 
 			// Should still have original values from cache
@@ -294,26 +312,29 @@ func Test_DataSource(t *testing.T) {
 			}, vals)
 
 			// Verify cache metrics
-			assert.InEpsilon(t, float64(1), testutil.ToFloat64(promCacheHitCount.WithLabelValues("1")), 0.0001)
-			assert.InEpsilon(t, float64(1), testutil.ToFloat64(promCacheHitCount.WithLabelValues("2")), 0.0001)
-			assert.InEpsilon(t, float64(1), testutil.ToFloat64(promCacheMissCount.WithLabelValues("1")), 0.0001)
-			assert.InEpsilon(t, float64(1), testutil.ToFloat64(promCacheMissCount.WithLabelValues("2")), 0.0001)
+			assert.InEpsilon(t, float64(1), testutil.ToFloat64(
+				promCacheHitCount.WithLabelValues(opts2.ConfigDigest().Hex(), "1")), 0.0001)
+			assert.InEpsilon(t, float64(1), testutil.ToFloat64(
+				promCacheHitCount.WithLabelValues(opts2.ConfigDigest().Hex(), "2")), 0.0001)
+			assert.InEpsilon(t, float64(1), testutil.ToFloat64(
+				promCacheMissCount.WithLabelValues(opts2.ConfigDigest().Hex(), "1", "notFound")), 0.0001)
+			assert.InEpsilon(t, float64(1), testutil.ToFloat64(
+				promCacheMissCount.WithLabelValues(opts2.ConfigDigest().Hex(), "2", "notFound")), 0.0001)
 		})
 
 		t.Run("refreshes cache after expiration", func(t *testing.T) {
-			// Create a new data source with a very short cache TTL
 			ds := newDataSource(lggr, reg, telem.NullTelemeter, true)
-			ds.cache = gocache.New(10*time.Millisecond, 1*time.Minute)
 
 			// First observation
 			reg.pipelines[1] = makePipelineWithSingleResult[*big.Int](1, big.NewInt(100), nil)
 			vals := llo.StreamValues{1: nil}
 
-			err := ds.Observe(ctx, vals, opts)
+			opts2 := &mockOpts{configDigest: ocr2types.ConfigDigest{6, 5, 9}}
+			err := ds.Observe(ctx, vals, opts2)
 			require.NoError(t, err)
 
 			// Wait for cache to expire
-			time.Sleep(20 * time.Millisecond)
+			time.Sleep(501 * time.Millisecond)
 
 			// Change pipeline result
 			reg.pipelines[1] = makePipelineWithSingleResult[*big.Int](1, big.NewInt(200), nil)
@@ -335,7 +356,9 @@ func Test_DataSource(t *testing.T) {
 
 			// First observation to cache
 			vals := llo.StreamValues{1: nil}
-			err := ds.Observe(ctx, vals, opts)
+			opts2 := &mockOpts{configDigest: ocr2types.ConfigDigest{6, 5, 6}}
+
+			err := ds.Observe(ctx, vals, opts2)
 			require.NoError(t, err)
 
 			// Run multiple observations concurrently
@@ -345,7 +368,7 @@ func Test_DataSource(t *testing.T) {
 				go func() {
 					defer wg.Done()
 					vals := llo.StreamValues{1: nil}
-					err := ds.Observe(ctx, vals, opts)
+					err := ds.Observe(ctx, vals, opts2)
 					assert.NoError(t, err)
 					assert.Equal(t, llo.StreamValues{1: llo.ToDecimal(decimal.NewFromInt(100))}, vals)
 				}()
@@ -358,18 +381,20 @@ func Test_DataSource(t *testing.T) {
 
 		t.Run("handles cache errors gracefully", func(t *testing.T) {
 			ds := newDataSource(lggr, reg, telem.NullTelemeter, true)
-			ds.cache = gocache.New(100*time.Millisecond, 1*time.Minute)
 
 			// First observation with error
 			reg.pipelines[1] = makePipelineWithSingleResult[*big.Int](1, nil, errors.New("pipeline error"))
 			vals := makeStreamValues()
-			err := ds.Observe(ctx, vals, opts)
+			opts2 := &mockOpts{configDigest: ocr2types.ConfigDigest{6, 5, 2}}
+			err := ds.Observe(ctx, vals, opts2)
 			require.NoError(t, err) // Observe returns nil error even if some streams fail
+
+			time.Sleep(501 * time.Millisecond)
 
 			// Second observation should try again (not use cache for error case)
 			reg.pipelines[1] = makePipelineWithSingleResult[*big.Int](1, big.NewInt(100), nil)
 			vals = llo.StreamValues{1: nil}
-			err = ds.Observe(ctx, vals, opts)
+			err = ds.Observe(ctx, vals, opts2)
 			require.NoError(t, err)
 
 			assert.Equal(t, llo.StreamValues{1: llo.ToDecimal(decimal.NewFromInt(100))}, vals)


### PR DESCRIPTION
* Make the observations cache isolated to each OCR instance config_digest to better handle blue/green handovers, reconfigurations and multiple LLO reporting plugin instances
* Ensure better fairness by discarding cached items where their observation seqNr is equal or lower than the last transmission seqNr.