### PR TITLE
[CR-403] Refactor InsertPipeline* methods.

### DIFF
--- a/core/chains/evm/txmgr/broadcaster_test.go
+++ b/core/chains/evm/txmgr/broadcaster_test.go
@@ -1151,8 +1151,8 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 		})
 
 		t.Run("with callback", func(t *testing.T) {
-			run := cltest.MustInsertPipelineRun(t, db)
-			tr := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, run.ID)
+			runID := cltest.MustInsertPipelineRun(t, db)
+			trID := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 			etx := txmgr.Tx{
 				FromAddress:       fromAddress,
 				ToAddress:         toAddress,
@@ -1160,7 +1160,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 				Value:             value,
 				FeeLimit:          gasLimit,
 				State:             txmgrcommon.TxUnstarted,
-				PipelineTaskRunID: uuid.NullUUID{UUID: tr.ID, Valid: true},
+				PipelineTaskRunID: uuid.NullUUID{UUID: trID, Valid: true},
 				SignalCallback:    true,
 			}
 
@@ -1184,7 +1184,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 
 			t.Run("calls resume with error", func(t *testing.T) {
 				fn := func(ctx context.Context, id uuid.UUID, result interface{}, err error) error {
-					require.Equal(t, id, tr.ID)
+					require.Equal(t, id, trID)
 					require.Nil(t, result)
 					require.Error(t, err)
 					require.Contains(t, err.Error(), "fatal error while sending transaction: exceeds block gas limit")

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -589,8 +589,9 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &trID1, minConfirmations, etx1.ID)
 
 	// Callback to pipeline service completed. Should be ignored
-	runID2 := cltest.MustInsertPipelineRun(t, db, "completed")
+	runID2 := cltest.MustInsertPipelineRun(t, db)
 	trID2 := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, runID2)
+	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'completed', outputs = '""'::jsonb, finished_at = NOW() WHERE id = $1`, runID2)
 	etx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
 	attempt2 := etx2.TxAttempts[0]

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -579,33 +579,33 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	minConfirmations := int64(2)
 
 	// Suspended run waiting for callback
-	run1 := cltest.MustInsertPipelineRun(t, db)
-	tr1 := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, run1.ID)
-	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, run1.ID)
+	runID1 := cltest.MustInsertPipelineRun(t, db)
+	trID1 := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, runID1)
+	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, runID1)
 	etx1 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": true}'`)
 	attempt1 := etx1.TxAttempts[0]
 	etxBlockNum := mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, attempt1.Hash).BlockNumber
-	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &tr1.ID, minConfirmations, etx1.ID)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &trID1, minConfirmations, etx1.ID)
 
 	// Callback to pipeline service completed. Should be ignored
-	run2 := cltest.MustInsertPipelineRunWithStatus(t, db, 0, "completed", 0)
-	tr2 := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, run2.ID)
+	runID2 := cltest.MustInsertPipelineRun(t, db, "completed")
+	trID2 := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, runID2)
 	etx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
 	attempt2 := etx2.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, attempt2.Hash)
-	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE, callback_completed = TRUE WHERE id = $3`, &tr2.ID, minConfirmations, etx2.ID)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE, callback_completed = TRUE WHERE id = $3`, &trID2, minConfirmations, etx2.ID)
 
 	// Suspended run younger than minConfirmations. Should be ignored
-	run3 := cltest.MustInsertPipelineRun(t, db)
-	tr3 := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, run3.ID)
-	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, run3.ID)
+	runID3 := cltest.MustInsertPipelineRun(t, db)
+	trID3 := cltest.MustInsertUnfinishedPipelineTaskRun(t, db, runID3)
+	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, runID3)
 	etx3 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 5, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
 	attempt3 := etx3.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number, head.Hash, attempt3.Hash)
-	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &tr3.ID, minConfirmations, etx3.ID)
+	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &trID3, minConfirmations, etx3.ID)
 
 	// Tx not marked for callback. Should be ignore
 	etx4 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 6, 1, fromAddress)
@@ -621,7 +621,7 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	receiptsPlus, err := txStore.FindTxesPendingCallback(tests.Context(t), head.Number, 0, ethClient.ConfiguredChainID())
 	require.NoError(t, err)
 	if assert.Len(t, receiptsPlus, 1) {
-		assert.Equal(t, tr1.ID, receiptsPlus[0].ID)
+		assert.Equal(t, trID1, receiptsPlus[0].ID)
 	}
 
 	// Clear min_confirmations
@@ -636,7 +636,7 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	receiptsPlus, err = txStore.FindTxesPendingCallback(tests.Context(t), head.Number, etxBlockNum, ethClient.ConfiguredChainID())
 	require.NoError(t, err)
 	if assert.Len(t, receiptsPlus, 1) {
-		assert.Equal(t, tr1.ID, receiptsPlus[0].ID)
+		assert.Equal(t, trID1, receiptsPlus[0].ID)
 	}
 }
 

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -20,10 +20,8 @@ import (
 	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
-	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/jsonserializable"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
@@ -410,35 +408,13 @@ func MustInsertUpkeepForRegistry(t *testing.T, db *sqlx.DB, registry keeper.Regi
 	return upkeep
 }
 
-func MustInsertPipelineRun(t *testing.T, db *sqlx.DB) (run pipeline.Run) {
-	require.NoError(t, db.Get(&run, `INSERT INTO pipeline_runs (state,pipeline_spec_id,pruning_key,created_at) VALUES ($1, 0, 0, NOW()) RETURNING *`, pipeline.RunStatusRunning))
-	return run
-}
-
-func MustInsertPipelineRunWithStatus(t *testing.T, db *sqlx.DB, pipelineSpecID int32, status pipeline.RunStatus, jobID int32) (run pipeline.Run) {
-	var finishedAt *time.Time
-	var outputs jsonserializable.JSONSerializable
-	var allErrors pipeline.RunErrors
-	var fatalErrors pipeline.RunErrors
-	now := time.Now()
-	switch status {
-	case pipeline.RunStatusCompleted:
-		finishedAt = &now
-		outputs = jsonserializable.JSONSerializable{
-			Val:   "foo",
-			Valid: true,
-		}
-	case pipeline.RunStatusErrored:
-		finishedAt = &now
-		allErrors = []null.String{null.StringFrom("oh no!")}
-		fatalErrors = []null.String{null.StringFrom("oh no!")}
-	case pipeline.RunStatusRunning, pipeline.RunStatusSuspended:
-		// leave empty
-	default:
-		t.Fatalf("unknown status: %s", status)
+func MustInsertPipelineRun(t *testing.T, db *sqlx.DB, statusArgs ...string) (runID int64) {
+	status := "running"
+	if len(statusArgs) > 0 {
+		status = statusArgs[0]
 	}
-	require.NoError(t, db.Get(&run, `INSERT INTO pipeline_runs (state,pipeline_spec_id,pruning_key,finished_at,outputs,all_errors,fatal_errors,created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW()) RETURNING *`, status, pipelineSpecID, jobID, finishedAt, outputs, allErrors, fatalErrors))
-	return run
+	require.NoError(t, db.Get(&runID, `INSERT INTO pipeline_runs (state,pipeline_spec_id,pruning_key,created_at) VALUES ($1, 0, 0, NOW()) RETURNING id`, status))
+	return runID
 }
 
 func MustInsertPipelineSpec(t *testing.T, db *sqlx.DB) (spec pipeline.Spec) {
@@ -447,10 +423,10 @@ func MustInsertPipelineSpec(t *testing.T, db *sqlx.DB) (spec pipeline.Spec) {
 	return
 }
 
-func MustInsertUnfinishedPipelineTaskRun(t *testing.T, db *sqlx.DB, pipelineRunID int64) (tr pipeline.TaskRun) {
+func MustInsertUnfinishedPipelineTaskRun(t *testing.T, db *sqlx.DB, pipelineRunID int64) (trID uuid.UUID) {
 	/* #nosec G404 */
-	require.NoError(t, db.Get(&tr, `INSERT INTO pipeline_task_runs (dot_id, pipeline_run_id, id, type, created_at) VALUES ($1,$2,$3, '', NOW()) RETURNING *`, strconv.Itoa(mathrand.Int()), pipelineRunID, uuid.New()))
-	return tr
+	require.NoError(t, db.Get(&trID, `INSERT INTO pipeline_task_runs (dot_id, pipeline_run_id, id, type, created_at) VALUES ($1,$2,$3, '', NOW()) RETURNING id`, strconv.Itoa(mathrand.Int()), pipelineRunID, uuid.New()))
+	return trID
 }
 
 func RawNewRoundLog(t *testing.T, contractAddr common.Address, blockHash common.Hash, blockNumber uint64, logIndex uint, removed bool) types.Log {

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -408,12 +408,8 @@ func MustInsertUpkeepForRegistry(t *testing.T, db *sqlx.DB, registry keeper.Regi
 	return upkeep
 }
 
-func MustInsertPipelineRun(t *testing.T, db *sqlx.DB, statusArgs ...string) (runID int64) {
-	status := "running"
-	if len(statusArgs) > 0 {
-		status = statusArgs[0]
-	}
-	require.NoError(t, db.Get(&runID, `INSERT INTO pipeline_runs (state,pipeline_spec_id,pruning_key,created_at) VALUES ($1, 0, 0, NOW()) RETURNING id`, status))
+func MustInsertPipelineRun(t *testing.T, db *sqlx.DB) (runID int64) {
+	require.NoError(t, db.Get(&runID, `INSERT INTO pipeline_runs (state,pipeline_spec_id,pruning_key,created_at) VALUES ($1, 0, 0, NOW()) RETURNING id`, "running"))
 	return runID
 }
 


### PR DESCRIPTION
First, made MustInsertPipelineRun and MustInsertUnfinishedPipelineTaskRun return id instead of a corresponding full structure. Second, changed the only invocation of MustInsertPipelineRunWithStatus in core/chains/evm to also use MustInsertPipelineRun. (This has enabled us to move `mustInsertPipelineRunWithStatus` to the core/services/pipeline/orm_test.go test)