### PR TITLE
[CLD-215]: fix(environment): remove migrated_environment.go

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -316,9 +316,7 @@ jobs:
           USE_FLAKEGUARD: ${{ matrix.type.use-flakeguard == 'true' && 'true' || '' }}
         run: |
           # See: https://github.com/golang/go/issues/69179
-          GODEBUG=goindex=0
-
-          ./tools/bin/${{ matrix.type.cmd }} ./...
+          GODEBUG=goindex=0 ./tools/bin/${{ matrix.type.cmd }} ./...
 
       - name: Generate Flakeguard Test Reports
         if: ${{ always() && steps.run-tests.outcome != 'skipped' && matrix.type.should-run == 'true' && matrix.type.use-flakeguard == 'true' }}

--- a/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane.go
+++ b/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane.go
@@ -13,7 +13,6 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -227,7 +226,7 @@ var (
 )
 
 type Dependencies struct {
-	Env             deployment.Environment
+	Env             cldf.Environment
 	EVMMCMSState    map[uint64]commonstate.MCMSWithTimelockState
 	SolanaMCMSState map[uint64]commonstate.MCMSWithTimelockStateSolana
 
@@ -269,7 +268,7 @@ type AddRemoteChainE2EConfig struct {
 	MCMSConfig *proposalutils.TimelockConfig
 }
 
-func (cfg *AddRemoteChainE2EConfig) populateAndValidateIndividualCSConfig(env deployment.Environment, evmState stateview.CCIPOnChainState) (csInputs, error) {
+func (cfg *AddRemoteChainE2EConfig) populateAndValidateIndividualCSConfig(env cldf.Environment, evmState stateview.CCIPOnChainState) (csInputs, error) {
 	var timelockConfig *proposalutils.TimelockConfig
 	if cfg.MCMSConfig != nil {
 		timelockConfig = cfg.MCMSConfig
@@ -380,7 +379,7 @@ func (cfg *AddRemoteChainE2EConfig) populateAndValidateIndividualCSConfig(env de
 	return input, nil
 }
 
-func addEVMSolanaPreconditions(env deployment.Environment, input AddRemoteChainE2EConfig) error {
+func addEVMSolanaPreconditions(env cldf.Environment, input AddRemoteChainE2EConfig) error {
 	evmState, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain evm state: %w", err)
@@ -406,7 +405,7 @@ func addEVMSolanaPreconditions(env deployment.Environment, input AddRemoteChainE
 	return nil
 }
 
-func addEVMAndSolanaLaneLogic(env deployment.Environment, input AddRemoteChainE2EConfig) (cldf.ChangesetOutput, error) {
+func addEVMAndSolanaLaneLogic(env cldf.Environment, input AddRemoteChainE2EConfig) (cldf.ChangesetOutput, error) {
 	evmState, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load evm onchain state: %w", err)

--- a/deployment/ccip/changeset/solana/cs_add_remote_chain.go
+++ b/deployment/ccip/changeset/solana/cs_add_remote_chain.go
@@ -50,7 +50,7 @@ type RouterConfig struct {
 	IsUpdate bool
 }
 
-func (cfg *AddRemoteChainToRouterConfig) Validate(e deployment.Environment) error {
+func (cfg *AddRemoteChainToRouterConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -98,7 +98,7 @@ func (cfg *AddRemoteChainToRouterConfig) Validate(e deployment.Environment) erro
 }
 
 // Adds new remote chain configurations
-func AddRemoteChainToRouter(e deployment.Environment, cfg AddRemoteChainToRouterConfig) (cldf.ChangesetOutput, error) {
+func AddRemoteChainToRouter(e cldf.Environment, cfg AddRemoteChainToRouterConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -130,7 +130,7 @@ func AddRemoteChainToRouter(e deployment.Environment, cfg AddRemoteChainToRouter
 }
 
 func doAddRemoteChainToRouter(
-	e deployment.Environment,
+	e cldf.Environment,
 	s stateview.CCIPOnChainState,
 	cfg AddRemoteChainToRouterConfig,
 	ab cldf.AddressBook) ([]mcmsTypes.Transaction, error) {
@@ -276,7 +276,7 @@ type FeeQuoterConfig struct {
 	IsUpdate bool
 }
 
-func (cfg *AddRemoteChainToFeeQuoterConfig) Validate(e deployment.Environment) error {
+func (cfg *AddRemoteChainToFeeQuoterConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -316,7 +316,7 @@ func (cfg *AddRemoteChainToFeeQuoterConfig) Validate(e deployment.Environment) e
 }
 
 // Adds new remote chain configurations
-func AddRemoteChainToFeeQuoter(e deployment.Environment, cfg AddRemoteChainToFeeQuoterConfig) (cldf.ChangesetOutput, error) {
+func AddRemoteChainToFeeQuoter(e cldf.Environment, cfg AddRemoteChainToFeeQuoterConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -348,7 +348,7 @@ func AddRemoteChainToFeeQuoter(e deployment.Environment, cfg AddRemoteChainToFee
 }
 
 func doAddRemoteChainToFeeQuoter(
-	e deployment.Environment,
+	e cldf.Environment,
 	s stateview.CCIPOnChainState,
 	cfg AddRemoteChainToFeeQuoterConfig,
 	ab cldf.AddressBook) ([]mcmsTypes.Transaction, error) {
@@ -451,7 +451,7 @@ type OffRampConfig struct {
 	IsUpdate bool
 }
 
-func (cfg *AddRemoteChainToOffRampConfig) Validate(e deployment.Environment) error {
+func (cfg *AddRemoteChainToOffRampConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -492,7 +492,7 @@ func (cfg *AddRemoteChainToOffRampConfig) Validate(e deployment.Environment) err
 }
 
 // Adds new remote chain configurations
-func AddRemoteChainToOffRamp(e deployment.Environment, cfg AddRemoteChainToOffRampConfig) (cldf.ChangesetOutput, error) {
+func AddRemoteChainToOffRamp(e cldf.Environment, cfg AddRemoteChainToOffRampConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -524,7 +524,7 @@ func AddRemoteChainToOffRamp(e deployment.Environment, cfg AddRemoteChainToOffRa
 }
 
 func doAddRemoteChainToOffRamp(
-	e deployment.Environment,
+	e cldf.Environment,
 	s stateview.CCIPOnChainState,
 	cfg AddRemoteChainToOffRampConfig,
 	ab cldf.AddressBook) ([]mcmsTypes.Transaction, error) {
@@ -637,7 +637,7 @@ func getSourceChainConfig(s stateview.CCIPOnChainState, remoteChainSel uint64, e
 	return validSourceChainConfig, nil
 }
 
-func extendLookupTable(e deployment.Environment, chain deployment.SolChain, offRampID solana.PublicKey, lookUpTableEntries []solana.PublicKey) error {
+func extendLookupTable(e cldf.Environment, chain cldf.SolChain, offRampID solana.PublicKey, lookUpTableEntries []solana.PublicKey) error {
 	addressLookupTable, err := solanastateview.FetchOfframpLookupTable(e.GetContext(), chain, offRampID)
 	if err != nil {
 		return fmt.Errorf("failed to get offramp reference addresses: %w", err)

--- a/deployment/ccip/changeset/solana/cs_billing.go
+++ b/deployment/ccip/changeset/solana/cs_billing.go
@@ -19,7 +19,6 @@ import (
 
 	ata "github.com/gagliardetto/solana-go/programs/associated-token-account"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
@@ -42,7 +41,7 @@ type BillingTokenConfig struct {
 	MCMS     *proposalutils.TimelockConfig
 }
 
-func (cfg *BillingTokenConfig) Validate(e deployment.Environment) error {
+func (cfg *BillingTokenConfig) Validate(e cldf.Environment) error {
 	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.TokenPubKey)
 	if err := commonValidation(e, cfg.ChainSelector, tokenPubKey); err != nil {
 		return err
@@ -74,8 +73,8 @@ func (cfg *BillingTokenConfig) Validate(e deployment.Environment) error {
 }
 
 func AddBillingToken(
-	e deployment.Environment,
-	chain deployment.SolChain,
+	e cldf.Environment,
+	chain cldf.SolChain,
 	chainState solanastateview.CCIPChainState,
 	billingTokenConfig solFeeQuoter.BillingTokenConfig,
 	mcms *proposalutils.TimelockConfig,
@@ -149,7 +148,7 @@ func AddBillingToken(
 	return txns, nil
 }
 
-func AddBillingTokenChangeset(e deployment.Environment, cfg BillingTokenConfig) (cldf.ChangesetOutput, error) {
+func AddBillingTokenChangeset(e cldf.Environment, cfg BillingTokenConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -195,7 +194,7 @@ type TokenTransferFeeForRemoteChainConfig struct {
 	MCMS                *proposalutils.TimelockConfig
 }
 
-func (cfg TokenTransferFeeForRemoteChainConfig) Validate(e deployment.Environment) error {
+func (cfg TokenTransferFeeForRemoteChainConfig) Validate(e cldf.Environment) error {
 	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.TokenPubKey)
 	if err := commonValidation(e, cfg.ChainSelector, tokenPubKey); err != nil {
 		return err
@@ -211,7 +210,7 @@ func (cfg TokenTransferFeeForRemoteChainConfig) Validate(e deployment.Environmen
 }
 
 // TODO: rename this, i dont think this is for billing, this is more for token transfer config/fees
-func AddTokenTransferFeeForRemoteChain(e deployment.Environment, cfg TokenTransferFeeForRemoteChainConfig) (cldf.ChangesetOutput, error) {
+func AddTokenTransferFeeForRemoteChain(e cldf.Environment, cfg TokenTransferFeeForRemoteChainConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -288,7 +287,7 @@ type UpdatePricesConfig struct {
 	MCMS              *proposalutils.TimelockConfig
 }
 
-func (cfg UpdatePricesConfig) Validate(e deployment.Environment) error {
+func (cfg UpdatePricesConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -324,7 +323,7 @@ func (cfg UpdatePricesConfig) Validate(e deployment.Environment) error {
 	return nil
 }
 
-func UpdatePrices(e deployment.Environment, cfg UpdatePricesConfig) (cldf.ChangesetOutput, error) {
+func UpdatePrices(e cldf.Environment, cfg UpdatePricesConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -414,7 +413,7 @@ const (
 	RemoveUpdater
 )
 
-func (cfg ModifyPriceUpdaterConfig) Validate(e deployment.Environment) error {
+func (cfg ModifyPriceUpdaterConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -433,7 +432,7 @@ func (cfg ModifyPriceUpdaterConfig) Validate(e deployment.Environment) error {
 	return nil
 }
 
-func ModifyPriceUpdater(e deployment.Environment, cfg ModifyPriceUpdaterConfig) (cldf.ChangesetOutput, error) {
+func ModifyPriceUpdater(e cldf.Environment, cfg ModifyPriceUpdaterConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -520,7 +519,7 @@ type WithdrawBilledFundsConfig struct {
 	MCMS          *proposalutils.TimelockConfig
 }
 
-func (cfg WithdrawBilledFundsConfig) Validate(e deployment.Environment) error {
+func (cfg WithdrawBilledFundsConfig) Validate(e cldf.Environment) error {
 	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.TokenPubKey)
 	if err := commonValidation(e, cfg.ChainSelector, tokenPubKey); err != nil {
 		return err
@@ -540,7 +539,7 @@ func (cfg WithdrawBilledFundsConfig) Validate(e deployment.Environment) error {
 	return ValidateMCMSConfigSolana(e, cfg.MCMS, chain, chainState, solana.PublicKey{}, "", map[cldf.ContractType]bool{shared.Router: true})
 }
 
-func WithdrawBilledFunds(e deployment.Environment, cfg WithdrawBilledFundsConfig) (cldf.ChangesetOutput, error) {
+func WithdrawBilledFunds(e cldf.Environment, cfg WithdrawBilledFundsConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -622,7 +621,7 @@ type SetMaxFeeJuelsPerMsgConfig struct {
 	MCMS              *proposalutils.TimelockConfig
 }
 
-func (cfg SetMaxFeeJuelsPerMsgConfig) Validate(e deployment.Environment) error {
+func (cfg SetMaxFeeJuelsPerMsgConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -640,7 +639,7 @@ func (cfg SetMaxFeeJuelsPerMsgConfig) Validate(e deployment.Environment) error {
 	return ValidateMCMSConfigSolana(e, cfg.MCMS, chain, chainState, solana.PublicKey{}, "", map[cldf.ContractType]bool{shared.FeeQuoter: true})
 }
 
-func SetMaxFeeJuelsPerMsg(e deployment.Environment, cfg SetMaxFeeJuelsPerMsgConfig) (cldf.ChangesetOutput, error) {
+func SetMaxFeeJuelsPerMsg(e cldf.Environment, cfg SetMaxFeeJuelsPerMsgConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}

--- a/deployment/ccip/changeset/solana/cs_build_solana.go
+++ b/deployment/ccip/changeset/solana/cs_build_solana.go
@@ -13,7 +13,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -82,7 +81,7 @@ func runCommand(command string, args []string, workDir string) (string, error) {
 }
 
 // Clone and checkout the specific revision of the repo
-func cloneRepo(e deployment.Environment, revision string, forceClean bool) error {
+func cloneRepo(e cldf.Environment, revision string, forceClean bool) error {
 	// Check if the repository already exists
 	if forceClean {
 		e.Logger.Debugw("Cleaning repository", "dir", cloneDir)
@@ -123,7 +122,7 @@ func cloneRepo(e deployment.Environment, revision string, forceClean bool) error
 }
 
 // Replace keys in Rust files
-func replaceKeys(e deployment.Environment) error {
+func replaceKeys(e cldf.Environment) error {
 	solanaDir := filepath.Join(cloneDir, anchorDir, "..")
 	e.Logger.Debugw("Replacing keys", "solanaDir", solanaDir)
 	output, err := runCommand("make", []string{"docker-update-contracts"}, solanaDir)
@@ -133,7 +132,7 @@ func replaceKeys(e deployment.Environment) error {
 	return nil
 }
 
-func replaceKeysForUpgrade(e deployment.Environment, keys map[cldf.ContractType]string) error {
+func replaceKeysForUpgrade(e cldf.Environment, keys map[cldf.ContractType]string) error {
 	e.Logger.Debug("Replacing keys in Rust files...")
 	for program, key := range keys {
 		programStr := string(program)
@@ -196,7 +195,7 @@ func syncRouterAndCommon() error {
 	return os.WriteFile(commonFile, []byte(updatedContent), 0600)
 }
 
-func generateVanityKeys(e deployment.Environment, keys map[cldf.ContractType]string) error {
+func generateVanityKeys(e cldf.Environment, keys map[cldf.ContractType]string) error {
 	e.Logger.Debug("Generating vanity keys...")
 	for program, prefix := range programToVanityKey {
 		_, exists := keys[program]
@@ -260,7 +259,7 @@ func copyFile(srcFile string, destDir string) error {
 }
 
 // Build the project with Anchor
-func buildProject(e deployment.Environment) error {
+func buildProject(e cldf.Environment) error {
 	solanaDir := filepath.Join(cloneDir, anchorDir, "..")
 	e.Logger.Debugw("Building project", "solanaDir", solanaDir)
 	args := []string{"docker-build-contracts"}
@@ -271,7 +270,7 @@ func buildProject(e deployment.Environment) error {
 	return nil
 }
 
-func buildLocally(e deployment.Environment, config BuildSolanaConfig) error {
+func buildLocally(e cldf.Environment, config BuildSolanaConfig) error {
 	e.Logger.Debugw("Starting local build process", "destinationDir", config.DestinationDir)
 	// Clone the repository
 	if err := cloneRepo(e, config.GitCommitSha, config.LocalBuild.CleanGitDir); err != nil {
@@ -344,7 +343,7 @@ func buildLocally(e deployment.Environment, config BuildSolanaConfig) error {
 	return nil
 }
 
-func BuildSolana(e deployment.Environment, config BuildSolanaConfig) error {
+func BuildSolana(e cldf.Environment, config BuildSolanaConfig) error {
 	if !config.LocalBuild.BuildLocally {
 		e.Logger.Debug("Downloading Solana CCIP program artifacts...")
 		err := memory.DownloadSolanaCCIPProgramArtifacts(e.GetContext(), config.DestinationDir, e.Logger, config.GitCommitSha)

--- a/deployment/ccip/changeset/solana/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts.go
@@ -51,7 +51,7 @@ func GetTokenProgramID(programName cldf.ContractType) (solana.PublicKey, error) 
 	return programID, nil
 }
 
-func commonValidation(e deployment.Environment, selector uint64, tokenPubKey solana.PublicKey) error {
+func commonValidation(e cldf.Environment, selector uint64, tokenPubKey solana.PublicKey) error {
 	chain, ok := e.SolChains[selector]
 	if !ok {
 		return fmt.Errorf("chain selector %d not found in environment", selector)
@@ -82,7 +82,7 @@ func commonValidation(e deployment.Environment, selector uint64, tokenPubKey sol
 	return nil
 }
 
-func validateRouterConfig(chain deployment.SolChain, chainState solanastateview.CCIPChainState) error {
+func validateRouterConfig(chain cldf.SolChain, chainState solanastateview.CCIPChainState) error {
 	_, routerConfigPDA, err := chainState.GetRouterInfo()
 	if err != nil {
 		return err
@@ -95,14 +95,14 @@ func validateRouterConfig(chain deployment.SolChain, chainState solanastateview.
 	return nil
 }
 
-func validateFeeAggregatorConfig(chain deployment.SolChain, chainState solanastateview.CCIPChainState) error {
+func validateFeeAggregatorConfig(chain cldf.SolChain, chainState solanastateview.CCIPChainState) error {
 	if chainState.GetFeeAggregator(chain).IsZero() {
 		return fmt.Errorf("fee aggregator not found in existing state, set the fee aggregator first for chain %d", chain.Selector)
 	}
 	return nil
 }
 
-func validateFeeQuoterConfig(chain deployment.SolChain, chainState solanastateview.CCIPChainState) error {
+func validateFeeQuoterConfig(chain cldf.SolChain, chainState solanastateview.CCIPChainState) error {
 	if chainState.FeeQuoter.IsZero() {
 		return fmt.Errorf("fee quoter not found in existing state, deploy the fee quoter first for chain %d", chain.Selector)
 	}
@@ -115,7 +115,7 @@ func validateFeeQuoterConfig(chain deployment.SolChain, chainState solanastatevi
 	return nil
 }
 
-func validateOffRampConfig(chain deployment.SolChain, chainState solanastateview.CCIPChainState) error {
+func validateOffRampConfig(chain cldf.SolChain, chainState solanastateview.CCIPChainState) error {
 	if chainState.OffRamp.IsZero() {
 		return fmt.Errorf("offramp not found in existing state, deploy the offramp first for chain %d", chain.Selector)
 	}
@@ -138,7 +138,7 @@ type OffRampRefAddressesConfig struct {
 	MCMS               *proposalutils.TimelockConfig
 }
 
-func (cfg OffRampRefAddressesConfig) Validate(e deployment.Environment) error {
+func (cfg OffRampRefAddressesConfig) Validate(e cldf.Environment) error {
 	chain := e.SolChains[cfg.ChainSelector]
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
@@ -152,7 +152,7 @@ func (cfg OffRampRefAddressesConfig) Validate(e deployment.Environment) error {
 }
 
 func UpdateOffRampRefAddresses(
-	e deployment.Environment,
+	e cldf.Environment,
 	config OffRampRefAddressesConfig,
 ) (cldf.ChangesetOutput, error) {
 	state, err := stateview.LoadOnchainStateSolana(e)
@@ -257,7 +257,7 @@ type SetUpgradeAuthorityConfig struct {
 }
 
 func SetUpgradeAuthorityChangeset(
-	e deployment.Environment,
+	e cldf.Environment,
 	config SetUpgradeAuthorityConfig,
 ) (cldf.ChangesetOutput, error) {
 	chain := e.SolChains[config.ChainSelector]
@@ -342,8 +342,8 @@ func SetUpgradeAuthorityChangeset(
 
 // setUpgradeAuthority creates a transaction to set the upgrade authority for a program
 func setUpgradeAuthority(
-	e *deployment.Environment,
-	chain *deployment.SolChain,
+	e *cldf.Environment,
+	chain *cldf.SolChain,
 	programID solana.PublicKey,
 	currentUpgradeAuthority solana.PublicKey,
 	newUpgradeAuthority solana.PublicKey,
@@ -380,7 +380,7 @@ type SetFeeAggregatorConfig struct {
 	MCMS          *proposalutils.TimelockConfig
 }
 
-func (cfg SetFeeAggregatorConfig) Validate(e deployment.Environment) error {
+func (cfg SetFeeAggregatorConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -415,7 +415,7 @@ func (cfg SetFeeAggregatorConfig) Validate(e deployment.Environment) error {
 	return nil
 }
 
-func SetFeeAggregator(e deployment.Environment, cfg SetFeeAggregatorConfig) (cldf.ChangesetOutput, error) {
+func SetFeeAggregator(e cldf.Environment, cfg SetFeeAggregatorConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -484,7 +484,7 @@ type DeployForTestConfig struct {
 	IsUpgrade       bool
 }
 
-func (cfg DeployForTestConfig) Validate(e deployment.Environment) error {
+func (cfg DeployForTestConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -498,7 +498,7 @@ func (cfg DeployForTestConfig) Validate(e deployment.Environment) error {
 	return validateRouterConfig(chain, chainState)
 }
 
-func DeployReceiverForTest(e deployment.Environment, cfg DeployForTestConfig) (cldf.ChangesetOutput, error) {
+func DeployReceiverForTest(e cldf.Environment, cfg DeployForTestConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -576,7 +576,7 @@ type SetLinkTokenConfig struct {
 	ChainSelector uint64
 }
 
-func (cfg SetLinkTokenConfig) Validate(e deployment.Environment) error {
+func (cfg SetLinkTokenConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -590,7 +590,7 @@ func (cfg SetLinkTokenConfig) Validate(e deployment.Environment) error {
 	return validateRouterConfig(chain, chainState)
 }
 
-func SetLinkToken(e deployment.Environment, cfg SetLinkTokenConfig) (cldf.ChangesetOutput, error) {
+func SetLinkToken(e cldf.Environment, cfg SetLinkTokenConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}

--- a/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 // token setup
-func deployTokenAndMint(t *testing.T, tenv deployment.Environment, solChain uint64, walletPubKeys []string) (deployment.Environment, solana.PublicKey, error) {
+func deployTokenAndMint(t *testing.T, tenv cldf.Environment, solChain uint64, walletPubKeys []string) (cldf.Environment, solana.PublicKey, error) {
 	mintMap := make(map[string]uint64)
 	for _, key := range walletPubKeys {
 		mintMap[key] = uint64(1000)
@@ -721,7 +721,7 @@ func TestTokenAdminRegistryWithoutMcms(t *testing.T) {
 }
 
 // pool lookup table test
-func doTestPoolLookupTable(t *testing.T, e deployment.Environment, mcms bool, tokenMetadata string) {
+func doTestPoolLookupTable(t *testing.T, e cldf.Environment, mcms bool, tokenMetadata string) {
 	ctx := testcontext.Get(t)
 
 	solChain := e.AllChainSelectorsSolana()[0]

--- a/deployment/ccip/changeset/solana/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain.go
@@ -102,7 +102,7 @@ type UpgradeConfig struct {
 	MCMS *proposalutils.TimelockConfig
 }
 
-func (cfg UpgradeConfig) Validate(e deployment.Environment, chainSelector uint64) error {
+func (cfg UpgradeConfig) Validate(e cldf.Environment, chainSelector uint64) error {
 	if cfg.NewFeeQuoterVersion == nil && cfg.NewRouterVersion == nil && cfg.NewOffRampVersion == nil {
 		return nil
 	}
@@ -118,11 +118,11 @@ func (cfg UpgradeConfig) Validate(e deployment.Environment, chainSelector uint64
 	return nil
 }
 
-func (c DeployChainContractsConfig) Validate(e deployment.Environment) error {
-	if err := deployment.IsValidChainSelector(c.HomeChainSelector); err != nil {
+func (c DeployChainContractsConfig) Validate(e cldf.Environment) error {
+	if err := cldf.IsValidChainSelector(c.HomeChainSelector); err != nil {
 		return fmt.Errorf("invalid home chain selector: %d - %w", c.HomeChainSelector, err)
 	}
-	if err := deployment.IsValidChainSelector(c.ChainSelector); err != nil {
+	if err := cldf.IsValidChainSelector(c.ChainSelector); err != nil {
 		return fmt.Errorf("invalid chain selector: %d - %w", c.ChainSelector, err)
 	}
 	family, _ := chainsel.GetSelectorFamily(c.ChainSelector)
@@ -156,7 +156,7 @@ func (c DeployChainContractsConfig) Validate(e deployment.Environment) error {
 	return nil
 }
 
-func DeployChainContractsChangeset(e deployment.Environment, c DeployChainContractsConfig) (cldf.ChangesetOutput, error) {
+func DeployChainContractsChangeset(e cldf.Environment, c DeployChainContractsConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid DeployChainContractsConfig: %w", err)
 	}
@@ -233,8 +233,8 @@ func DeployChainContractsChangeset(e deployment.Environment, c DeployChainContra
 // DeployAndMaybeSaveToAddressBook deploys a program to the Solana chain and saves it to the address book
 // if it is not an upgrade. It returns the program ID of the deployed program.
 func DeployAndMaybeSaveToAddressBook(
-	e deployment.Environment,
-	chain deployment.SolChain,
+	e cldf.Environment,
+	chain cldf.SolChain,
 	ab cldf.AddressBook,
 	contractType cldf.ContractType,
 	version semver.Version,
@@ -269,8 +269,8 @@ func DeployAndMaybeSaveToAddressBook(
 }
 
 func deployChainContractsSolana(
-	e deployment.Environment,
-	chain deployment.SolChain,
+	e cldf.Environment,
+	chain cldf.SolChain,
 	ab cldf.AddressBook,
 	config DeployChainContractsConfig,
 ) ([]mcmsTypes.BatchOperation, error) {
@@ -681,8 +681,8 @@ func deployChainContractsSolana(
 
 // INITIALIZE FUNCTIONS
 func initializeRouter(
-	e deployment.Environment,
-	chain deployment.SolChain,
+	e cldf.Environment,
+	chain cldf.SolChain,
 	ccipRouterProgram solana.PublicKey,
 	linkTokenAddress solana.PublicKey,
 	feeQuoterAddress solana.PublicKey,
@@ -721,8 +721,8 @@ func initializeRouter(
 }
 
 func initializeFeeQuoter(
-	e deployment.Environment,
-	chain deployment.SolChain,
+	e cldf.Environment,
+	chain cldf.SolChain,
 	ccipRouterProgram solana.PublicKey,
 	linkTokenAddress solana.PublicKey,
 	feeQuoterAddress solana.PublicKey,
@@ -772,8 +772,8 @@ func initializeFeeQuoter(
 }
 
 func initializeOffRamp(
-	e deployment.Environment,
-	chain deployment.SolChain,
+	e cldf.Environment,
+	chain cldf.SolChain,
 	ccipRouterProgram solana.PublicKey,
 	feeQuoterAddress solana.PublicKey,
 	rmnRemoteAddress solana.PublicKey,
@@ -828,8 +828,8 @@ func initializeOffRamp(
 }
 
 func initializeRMNRemote(
-	e deployment.Environment,
-	chain deployment.SolChain,
+	e cldf.Environment,
+	chain cldf.SolChain,
 	rmnRemoteProgram solana.PublicKey,
 ) error {
 	e.Logger.Debugw("Initializing rmn remote", "chain", chain.String(), "rmnRemoteProgram", rmnRemoteProgram.String())
@@ -859,8 +859,8 @@ func initializeRMNRemote(
 
 // UPGRADE FUNCTIONS
 func generateUpgradeTxns(
-	e deployment.Environment,
-	chain deployment.SolChain,
+	e cldf.Environment,
+	chain cldf.SolChain,
 	ab cldf.AddressBook,
 	config DeployChainContractsConfig,
 	newVersion *semver.Version,
@@ -942,7 +942,7 @@ func generateUpgradeTxns(
 }
 
 func generateUpgradeIxn(
-	e *deployment.Environment,
+	e *cldf.Environment,
 	programID solana.PublicKey,
 	bufferAddress solana.PublicKey,
 	spillAddress solana.PublicKey,
@@ -973,8 +973,8 @@ func generateUpgradeIxn(
 }
 
 func generateExtendIxn(
-	e *deployment.Environment,
-	chain deployment.SolChain,
+	e *cldf.Environment,
+	chain cldf.SolChain,
 	programID solana.PublicKey,
 	bufferAddress solana.PublicKey,
 	payer solana.PublicKey,
@@ -1023,7 +1023,7 @@ func generateExtendIxn(
 }
 
 func generateCloseBufferIxn(
-	e *deployment.Environment,
+	e *cldf.Environment,
 	bufferAddress solana.PublicKey,
 	recipient solana.PublicKey,
 	upgradeAuthority solana.PublicKey,
@@ -1045,7 +1045,7 @@ func generateCloseBufferIxn(
 }
 
 // HELPER FUNCTIONS
-func GetSolProgramSize(e *deployment.Environment, chain deployment.SolChain, programID solana.PublicKey) (int, error) {
+func GetSolProgramSize(e *cldf.Environment, chain cldf.SolChain, programID solana.PublicKey) (int, error) {
 	accountInfo, err := chain.Client.GetAccountInfoWithOpts(e.GetContext(), programID, &rpc.GetAccountInfoOpts{
 		Commitment: cldf.SolDefaultCommitment,
 	})
@@ -1059,7 +1059,7 @@ func GetSolProgramSize(e *deployment.Environment, chain deployment.SolChain, pro
 	return programBytes, nil
 }
 
-func getSolProgramData(e deployment.Environment, chain deployment.SolChain, programID solana.PublicKey) (struct {
+func getSolProgramData(e cldf.Environment, chain cldf.SolChain, programID solana.PublicKey) (struct {
 	DataType uint32
 	Address  solana.PublicKey
 }, error) {
@@ -1086,7 +1086,7 @@ type CloseBuffersConfig struct {
 	Buffers       []string
 }
 
-func CloseBuffersChangeset(e deployment.Environment, cfg CloseBuffersConfig) (cldf.ChangesetOutput, error) {
+func CloseBuffersChangeset(e cldf.Environment, cfg CloseBuffersConfig) (cldf.ChangesetOutput, error) {
 	for _, buffer := range cfg.Buffers {
 		if err := e.SolChains[cfg.ChainSelector].CloseBuffers(e.Logger, buffer); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to close buffer: %w", err)

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -36,7 +36,7 @@ const (
 	NewSha = "cb02e90f9d6d1dd65f534c60a77bb1e3384a42cb"
 )
 
-func verifyProgramSizes(t *testing.T, e deployment.Environment) {
+func verifyProgramSizes(t *testing.T, e cldf.Environment) {
 	state, err := stateview.LoadOnchainStateSolana(e)
 	require.NoError(t, err)
 	addresses, err := e.ExistingAddresses.AddressesForChain(e.AllChainSelectorsSolana()[0])
@@ -54,7 +54,7 @@ func verifyProgramSizes(t *testing.T, e deployment.Environment) {
 		deployment.McmProgramName:                  chainState.McmProgram,
 		deployment.RMNRemoteProgramName:            state.SolChains[e.AllChainSelectorsSolana()[0]].RMNRemote,
 	}
-	for program, sizeBytes := range deployment.GetSolanaProgramBytes() {
+	for program, sizeBytes := range cldf.GetSolanaProgramBytes() {
 		t.Logf("Verifying program %s size is at least %d bytes", program, sizeBytes)
 		programDataAccount, _, _ := solana.FindProgramAddress([][]byte{programsToState[program].Bytes()}, solana.BPFLoaderUpgradeableProgramID)
 		programDataSize, err := ccipChangesetSolana.GetSolProgramSize(&e, e.SolChains[e.AllChainSelectorsSolana()[0]], programDataAccount)
@@ -63,7 +63,7 @@ func verifyProgramSizes(t *testing.T, e deployment.Environment) {
 	}
 }
 
-func initialDeployCS(t *testing.T, e deployment.Environment, buildConfig *ccipChangesetSolana.BuildSolanaConfig) []commonchangeset.ConfiguredChangeSet {
+func initialDeployCS(t *testing.T, e cldf.Environment, buildConfig *ccipChangesetSolana.BuildSolanaConfig) []commonchangeset.ConfiguredChangeSet {
 	evmSelectors := e.AllChainSelectors()
 	homeChainSel := evmSelectors[0]
 	solChainSelectors := e.AllChainSelectorsSolana()

--- a/deployment/ccip/changeset/solana/cs_disable_remote_chain.go
+++ b/deployment/ccip/changeset/solana/cs_disable_remote_chain.go
@@ -16,7 +16,6 @@ import (
 	solFeeQuoter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
@@ -32,7 +31,7 @@ type DisableRemoteChainConfig struct {
 	MCMS          *proposalutils.TimelockConfig
 }
 
-func (cfg DisableRemoteChainConfig) Validate(e deployment.Environment) error {
+func (cfg DisableRemoteChainConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -79,7 +78,7 @@ func (cfg DisableRemoteChainConfig) Validate(e deployment.Environment) error {
 	return nil
 }
 
-func DisableRemoteChain(e deployment.Environment, cfg DisableRemoteChainConfig) (cldf.ChangesetOutput, error) {
+func DisableRemoteChain(e cldf.Environment, cfg DisableRemoteChainConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -109,7 +108,7 @@ func DisableRemoteChain(e deployment.Environment, cfg DisableRemoteChainConfig) 
 }
 
 func doDisableRemoteChain(
-	e deployment.Environment,
+	e cldf.Environment,
 	s stateview.CCIPOnChainState,
 	cfg DisableRemoteChainConfig) ([]mcmsTypes.Transaction, error) {
 	txns := make([]mcmsTypes.Transaction, 0)

--- a/deployment/ccip/changeset/solana/cs_ops.go
+++ b/deployment/ccip/changeset/solana/cs_ops.go
@@ -16,7 +16,6 @@ import (
 	solFeeQuoter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
@@ -44,7 +43,7 @@ type SetDefaultCodeVersionConfig struct {
 	MCMS          *proposalutils.TimelockConfig
 }
 
-func (cfg SetDefaultCodeVersionConfig) Validate(e deployment.Environment) error {
+func (cfg SetDefaultCodeVersionConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -63,7 +62,7 @@ func (cfg SetDefaultCodeVersionConfig) Validate(e deployment.Environment) error 
 	return ValidateMCMSConfigSolana(e, cfg.MCMS, chain, chainState, solana.PublicKey{}, "", map[cldf.ContractType]bool{shared.FeeQuoter: true, shared.OffRamp: true, shared.Router: true})
 }
 
-func SetDefaultCodeVersion(e deployment.Environment, cfg SetDefaultCodeVersionConfig) (cldf.ChangesetOutput, error) {
+func SetDefaultCodeVersion(e cldf.Environment, cfg SetDefaultCodeVersionConfig) (cldf.ChangesetOutput, error) {
 	e.Logger.Infow("Setting default code version", "chain_selector", cfg.ChainSelector, "new_code_version", cfg.VersionEnum)
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -207,7 +206,7 @@ type UpdateSvmChainSelectorConfig struct {
 	MCMS             *proposalutils.TimelockConfig
 }
 
-func (cfg UpdateSvmChainSelectorConfig) Validate(e deployment.Environment) error {
+func (cfg UpdateSvmChainSelectorConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -223,7 +222,7 @@ func (cfg UpdateSvmChainSelectorConfig) Validate(e deployment.Environment) error
 	return ValidateMCMSConfigSolana(e, cfg.MCMS, chain, chainState, solana.PublicKey{}, "", map[cldf.ContractType]bool{shared.Router: true, shared.OffRamp: true})
 }
 
-func UpdateSvmChainSelector(e deployment.Environment, cfg UpdateSvmChainSelectorConfig) (cldf.ChangesetOutput, error) {
+func UpdateSvmChainSelector(e cldf.Environment, cfg UpdateSvmChainSelectorConfig) (cldf.ChangesetOutput, error) {
 	e.Logger.Infow("Updating SVM chain selector", "old_chain_selector", cfg.OldChainSelector, "new_chain_selector", cfg.NewChainSelector)
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -333,7 +332,7 @@ type UpdateEnableManualExecutionAfterConfig struct {
 	MCMS                  *proposalutils.TimelockConfig
 }
 
-func (cfg UpdateEnableManualExecutionAfterConfig) Validate(e deployment.Environment) error {
+func (cfg UpdateEnableManualExecutionAfterConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -346,7 +345,7 @@ func (cfg UpdateEnableManualExecutionAfterConfig) Validate(e deployment.Environm
 	return ValidateMCMSConfigSolana(e, cfg.MCMS, chain, chainState, solana.PublicKey{}, "", map[cldf.ContractType]bool{shared.OffRamp: true})
 }
 
-func UpdateEnableManualExecutionAfter(e deployment.Environment, cfg UpdateEnableManualExecutionAfterConfig) (cldf.ChangesetOutput, error) {
+func UpdateEnableManualExecutionAfter(e cldf.Environment, cfg UpdateEnableManualExecutionAfterConfig) (cldf.ChangesetOutput, error) {
 	e.Logger.Infow("Updating enable manual execution after", "chain_selector", cfg.ChainSelector, "enable_manual_execution_after", cfg.EnableManualExecution)
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -427,7 +426,7 @@ type ConfigureCCIPVersionConfig struct {
 	MCMS              *proposalutils.TimelockConfig
 }
 
-func (cfg ConfigureCCIPVersionConfig) Validate(e deployment.Environment) error {
+func (cfg ConfigureCCIPVersionConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -449,7 +448,7 @@ func (cfg ConfigureCCIPVersionConfig) Validate(e deployment.Environment) error {
 	return ValidateMCMSConfigSolana(e, cfg.MCMS, chain, chainState, solana.PublicKey{}, "", map[cldf.ContractType]bool{shared.Router: true})
 }
 
-func ConfigureCCIPVersion(e deployment.Environment, cfg ConfigureCCIPVersionConfig) (cldf.ChangesetOutput, error) {
+func ConfigureCCIPVersion(e cldf.Environment, cfg ConfigureCCIPVersionConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -537,7 +536,7 @@ type RemoveOffRampConfig struct {
 	MCMS          *proposalutils.TimelockConfig
 }
 
-func (cfg RemoveOffRampConfig) Validate(e deployment.Environment) error {
+func (cfg RemoveOffRampConfig) Validate(e cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -550,7 +549,7 @@ func (cfg RemoveOffRampConfig) Validate(e deployment.Environment) error {
 	return ValidateMCMSConfigSolana(e, cfg.MCMS, chain, chainState, solana.PublicKey{}, "", map[cldf.ContractType]bool{shared.Router: true})
 }
 
-func RemoveOffRamp(e deployment.Environment, cfg RemoveOffRampConfig) (cldf.ChangesetOutput, error) {
+func RemoveOffRamp(e cldf.Environment, cfg RemoveOffRampConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}

--- a/deployment/ccip/changeset/solana/cs_set_ocr3.go
+++ b/deployment/ccip/changeset/solana/cs_set_ocr3.go
@@ -16,7 +16,6 @@ import (
 
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/internal"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
@@ -48,7 +47,7 @@ func btoi(b bool) uint8 {
 // run after the candidate is confirmed to be working correctly.
 // Multichain is especially helpful for NOP rotations where we have
 // to touch all the chain to change signers.
-func SetOCR3ConfigSolana(e deployment.Environment, cfg v1_6.SetOCR3OffRampConfig) (cldf.ChangesetOutput, error) {
+func SetOCR3ConfigSolana(e cldf.Environment, cfg v1_6.SetOCR3OffRampConfig) (cldf.ChangesetOutput, error) {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
@@ -179,8 +178,8 @@ func SetOCR3ConfigSolana(e deployment.Environment, cfg v1_6.SetOCR3OffRampConfig
 }
 
 func isOCR3ConfigSetOnOffRampSolana(
-	e deployment.Environment,
-	chain deployment.SolChain,
+	e cldf.Environment,
+	chain cldf.SolChain,
 	chainState solanastateview.CCIPChainState,
 	args []internal.MultiOCR3BaseOCRConfigArgsSolana,
 ) (bool, error) {

--- a/deployment/ccip/changeset/solana/cs_solana_token.go
+++ b/deployment/ccip/changeset/solana/cs_solana_token.go
@@ -30,7 +30,7 @@ var _ cldf.ChangeSet[CreateSolanaTokenATAConfig] = CreateSolanaTokenATA
 // use this changeset to set the authority of a token
 var _ cldf.ChangeSet[SetTokenAuthorityConfig] = SetTokenAuthority
 
-func getMintIxs(e deployment.Environment, chain deployment.SolChain, tokenprogramID, mint solana.PublicKey, amountToAddress map[string]uint64) ([]solana.Instruction, error) {
+func getMintIxs(e cldf.Environment, chain cldf.SolChain, tokenprogramID, mint solana.PublicKey, amountToAddress map[string]uint64) ([]solana.Instruction, error) {
 	instructions := []solana.Instruction{}
 	for toAddress, amount := range amountToAddress {
 		e.Logger.Infof("Minting %d to %s", amount, toAddress)
@@ -46,7 +46,7 @@ func getMintIxs(e deployment.Environment, chain deployment.SolChain, tokenprogra
 	return instructions, nil
 }
 
-func createATAIx(e deployment.Environment, chain deployment.SolChain, tokenprogramID, mint solana.PublicKey, ataList []string) ([]solana.Instruction, error) {
+func createATAIx(e cldf.Environment, chain cldf.SolChain, tokenprogramID, mint solana.PublicKey, ataList []string) ([]solana.Instruction, error) {
 	instructions := []solana.Instruction{}
 	for _, ata := range ataList {
 		e.Logger.Infof("Creating ATA for account %s for token %s", ata, mint.String())
@@ -76,7 +76,7 @@ type DeploySolanaTokenConfig struct {
 	MintAmountToAddress map[string]uint64 // address -> amount
 }
 
-func NewTokenInstruction(chain deployment.SolChain, cfg DeploySolanaTokenConfig) ([]solana.Instruction, solana.PrivateKey, error) {
+func NewTokenInstruction(chain cldf.SolChain, cfg DeploySolanaTokenConfig) ([]solana.Instruction, solana.PrivateKey, error) {
 	tokenprogramID, err := GetTokenProgramID(cfg.TokenProgramName)
 	if err != nil {
 		return nil, nil, err
@@ -112,7 +112,7 @@ func NewTokenInstruction(chain deployment.SolChain, cfg DeploySolanaTokenConfig)
 	return instructions, mintPrivKey, nil
 }
 
-func DeploySolanaToken(e deployment.Environment, cfg DeploySolanaTokenConfig) (cldf.ChangesetOutput, error) {
+func DeploySolanaToken(e cldf.Environment, cfg DeploySolanaTokenConfig) (cldf.ChangesetOutput, error) {
 	chain, ok := e.SolChains[cfg.ChainSelector]
 	if !ok {
 		return cldf.ChangesetOutput{}, fmt.Errorf("chain %d not found in environment", cfg.ChainSelector)
@@ -171,7 +171,7 @@ type MintSolanaTokenConfig struct {
 	AmountToAddress map[string]uint64 // address -> amount
 }
 
-func (cfg MintSolanaTokenConfig) Validate(e deployment.Environment) error {
+func (cfg MintSolanaTokenConfig) Validate(e cldf.Environment) error {
 	chain := e.SolChains[cfg.ChainSelector]
 	tokenAddress := solana.MustPublicKeyFromBase58(cfg.TokenPubkey)
 	state, err := stateview.LoadOnchainState(e)
@@ -200,7 +200,7 @@ func (cfg MintSolanaTokenConfig) Validate(e deployment.Environment) error {
 	return nil
 }
 
-func MintSolanaToken(e deployment.Environment, cfg MintSolanaTokenConfig) (cldf.ChangesetOutput, error) {
+func MintSolanaToken(e cldf.Environment, cfg MintSolanaTokenConfig) (cldf.ChangesetOutput, error) {
 	err := cfg.Validate(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -237,7 +237,7 @@ type CreateSolanaTokenATAConfig struct {
 	ATAList       []string // addresses to create ATAs for
 }
 
-func CreateSolanaTokenATA(e deployment.Environment, cfg CreateSolanaTokenATAConfig) (cldf.ChangesetOutput, error) {
+func CreateSolanaTokenATA(e cldf.Environment, cfg CreateSolanaTokenATAConfig) (cldf.ChangesetOutput, error) {
 	chain := e.SolChains[cfg.ChainSelector]
 	state, _ := stateview.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
@@ -271,7 +271,7 @@ type SetTokenAuthorityConfig struct {
 	NewAuthority  solana.PublicKey
 }
 
-func SetTokenAuthority(e deployment.Environment, cfg SetTokenAuthorityConfig) (cldf.ChangesetOutput, error) {
+func SetTokenAuthority(e cldf.Environment, cfg SetTokenAuthorityConfig) (cldf.ChangesetOutput, error) {
 	chain := e.SolChains[cfg.ChainSelector]
 	state, _ := stateview.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]
@@ -309,7 +309,7 @@ type UploadTokenMetadataConfig struct {
 	TokenMetaDataFile string
 }
 
-func UploadTokenMetadata(e deployment.Environment, cfg UploadTokenMetadataConfig) (cldf.ChangesetOutput, error) {
+func UploadTokenMetadata(e cldf.Environment, cfg UploadTokenMetadataConfig) (cldf.ChangesetOutput, error) {
 	chain := e.SolChains[cfg.ChainSelector]
 	e.Logger.Infow("Uploading token metadata", "tokenPubkey", cfg.TokenPubkey.String())
 	_, _ = runCommand("solana", []string{"config", "set", "--url", chain.URL}, chain.ProgramsPath)

--- a/deployment/ccip/changeset/solana/cs_token_admin_registry.go
+++ b/deployment/ccip/changeset/solana/cs_token_admin_registry.go
@@ -16,7 +16,6 @@ import (
 	solRouter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
@@ -44,7 +43,7 @@ type RegisterTokenAdminRegistryConfig struct {
 	MCMS                    *proposalutils.TimelockConfig
 }
 
-func (cfg RegisterTokenAdminRegistryConfig) Validate(e deployment.Environment) error {
+func (cfg RegisterTokenAdminRegistryConfig) Validate(e cldf.Environment) error {
 	if cfg.RegisterType != ViaGetCcipAdminInstruction && cfg.RegisterType != ViaOwnerInstruction {
 		return fmt.Errorf("invalid register type, valid types are %d and %d", ViaGetCcipAdminInstruction, ViaOwnerInstruction)
 	}
@@ -78,7 +77,7 @@ func (cfg RegisterTokenAdminRegistryConfig) Validate(e deployment.Environment) e
 	return nil
 }
 
-func RegisterTokenAdminRegistry(e deployment.Environment, cfg RegisterTokenAdminRegistryConfig) (cldf.ChangesetOutput, error) {
+func RegisterTokenAdminRegistry(e cldf.Environment, cfg RegisterTokenAdminRegistryConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -197,7 +196,7 @@ type TransferAdminRoleTokenAdminRegistryConfig struct {
 	MCMS                      *proposalutils.TimelockConfig
 }
 
-func (cfg TransferAdminRoleTokenAdminRegistryConfig) Validate(e deployment.Environment) error {
+func (cfg TransferAdminRoleTokenAdminRegistryConfig) Validate(e cldf.Environment) error {
 	tokenPubKey := solana.MustPublicKeyFromBase58(cfg.TokenPubKey)
 	if err := commonValidation(e, cfg.ChainSelector, tokenPubKey); err != nil {
 		return err
@@ -243,7 +242,7 @@ func (cfg TransferAdminRoleTokenAdminRegistryConfig) Validate(e deployment.Envir
 	return nil
 }
 
-func TransferAdminRoleTokenAdminRegistry(e deployment.Environment, cfg TransferAdminRoleTokenAdminRegistryConfig) (cldf.ChangesetOutput, error) {
+func TransferAdminRoleTokenAdminRegistry(e cldf.Environment, cfg TransferAdminRoleTokenAdminRegistryConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -310,7 +309,7 @@ type AcceptAdminRoleTokenAdminRegistryConfig struct {
 	MCMS          *proposalutils.TimelockConfig
 }
 
-func (cfg AcceptAdminRoleTokenAdminRegistryConfig) Validate(e deployment.Environment) error {
+func (cfg AcceptAdminRoleTokenAdminRegistryConfig) Validate(e cldf.Environment) error {
 	tokenPubKey := cfg.TokenPubKey
 	if err := commonValidation(e, cfg.ChainSelector, tokenPubKey); err != nil {
 		return err
@@ -354,7 +353,7 @@ func (cfg AcceptAdminRoleTokenAdminRegistryConfig) Validate(e deployment.Environ
 	return nil
 }
 
-func AcceptAdminRoleTokenAdminRegistry(e deployment.Environment, cfg AcceptAdminRoleTokenAdminRegistryConfig) (cldf.ChangesetOutput, error) {
+func AcceptAdminRoleTokenAdminRegistry(e cldf.Environment, cfg AcceptAdminRoleTokenAdminRegistryConfig) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}

--- a/deployment/ccip/changeset/solana/cs_token_pool_test.go
+++ b/deployment/ccip/changeset/solana/cs_token_pool_test.go
@@ -43,10 +43,10 @@ func TestAddTokenPoolWithMcms(t *testing.T) {
 	doTestTokenPool(t, tenv.Env, true, shared.CLLMetadata)
 }
 
-func deployEVMTokenPool(t *testing.T, e deployment.Environment, evmChain uint64) (deployment.Environment, common.Address, error) {
+func deployEVMTokenPool(t *testing.T, e cldf.Environment, evmChain uint64) (cldf.Environment, common.Address, error) {
 	addressBook := cldf.NewMemoryAddressBook()
 	evmToken, err := cldf.DeployContract(e.Logger, e.Chains[evmChain], addressBook,
-		func(chain deployment.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
+		func(chain cldf.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 			tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 				e.Chains[evmChain].DeployerKey,
 				e.Chains[evmChain].Client,
@@ -75,7 +75,7 @@ func deployEVMTokenPool(t *testing.T, e deployment.Environment, evmChain uint64)
 	return e, evmToken.Address, nil
 }
 
-func doTestTokenPool(t *testing.T, e deployment.Environment, mcms bool, tokenMetadata string) {
+func doTestTokenPool(t *testing.T, e cldf.Environment, mcms bool, tokenMetadata string) {
 	ctx := testcontext.Get(t)
 	evmChain := e.AllChainSelectors()[0]
 	solChain := e.AllChainSelectorsSolana()[0]

--- a/deployment/ccip/changeset/solana/cs_verify_contracts.go
+++ b/deployment/ccip/changeset/solana/cs_verify_contracts.go
@@ -33,7 +33,7 @@ type VerifyBuildConfig struct {
 	MCMS                         *proposalutils.TimelockConfig
 }
 
-func runSolanaVerify(chain deployment.SolChain, programID, libraryName, commitHash, mountPath string, remote bool) error {
+func runSolanaVerify(chain cldf.SolChain, programID, libraryName, commitHash, mountPath string, remote bool) error {
 	params := map[string]string{
 		"Keypair Path": chain.KeypairPath,
 		"Network URL":  chain.URL,
@@ -95,7 +95,7 @@ func runSolanaVerify(chain deployment.SolChain, programID, libraryName, commitHa
 	return nil
 }
 
-func VerifyBuild(e deployment.Environment, cfg VerifyBuildConfig) (cldf.ChangesetOutput, error) {
+func VerifyBuild(e cldf.Environment, cfg VerifyBuildConfig) (cldf.ChangesetOutput, error) {
 	chain := e.SolChains[cfg.ChainSelector]
 	state, _ := stateview.LoadOnchainState(e)
 	chainState := state.SolChains[cfg.ChainSelector]

--- a/deployment/ccip/changeset/solana/ownership_transfer_helpers.go
+++ b/deployment/ccip/changeset/solana/ownership_transfer_helpers.go
@@ -15,7 +15,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
@@ -44,7 +43,7 @@ func transferAndWrapAcceptOwnership(
 	proposedOwner solana.PublicKey, // e.g. usually, the timelock signer PDA
 	configPDA solana.PublicKey, // e.g. for routerConfigPDA or a token-pool config
 	currentOwner solana.PublicKey, // the “from” authority
-	solChain deployment.SolChain, // used for solChain.Confirm
+	solChain cldf.SolChain, // used for solChain.Confirm
 	label cldf.ContractType, // e.g. "Router" or "TokenPool"
 	timelockSigner solana.PublicKey, // the timelock signer PDA
 ) (mcmsTypes.Transaction, error) {
@@ -95,7 +94,7 @@ func transferAndWrapAcceptOwnership(
 func transferOwnershipRouter(
 	ccipState stateview.CCIPOnChainState,
 	chainSelector uint64,
-	solChain deployment.SolChain,
+	solChain cldf.SolChain,
 	currentOwner solana.PublicKey,
 	proposedOwner solana.PublicKey,
 	timelockSigner solana.PublicKey,
@@ -165,7 +164,7 @@ func transferOwnershipRouter(
 func transferOwnershipFeeQuoter(
 	ccipState stateview.CCIPOnChainState,
 	chainSelector uint64,
-	solChain deployment.SolChain,
+	solChain cldf.SolChain,
 	currentOwner solana.PublicKey,
 	proposedOwner solana.PublicKey,
 	timelockSigner solana.PublicKey,
@@ -235,7 +234,7 @@ func transferOwnershipFeeQuoter(
 func transferOwnershipOffRamp(
 	ccipState stateview.CCIPOnChainState,
 	chainSelector uint64,
-	solChain deployment.SolChain,
+	solChain cldf.SolChain,
 	currentOwner solana.PublicKey,
 	proposedOwner solana.PublicKey,
 	timelockSigner solana.PublicKey,
@@ -307,7 +306,7 @@ func transferOwnershipBurnMintTokenPools(
 	tokenPoolConfigPDA solana.PublicKey,
 	tokenMint solana.PublicKey,
 	chainSelector uint64,
-	solChain deployment.SolChain,
+	solChain cldf.SolChain,
 	tokenPoolMetadata string,
 	currentOwner solana.PublicKey,
 	proposedOwner solana.PublicKey,
@@ -376,7 +375,7 @@ func transferOwnershipLockReleaseTokenPools(
 	tokenPoolConfigPDA solana.PublicKey,
 	tokenMint solana.PublicKey,
 	chainSelector uint64,
-	solChain deployment.SolChain,
+	solChain cldf.SolChain,
 	tokenPoolMetadata string,
 	currentOwner solana.PublicKey,
 	proposedOwner solana.PublicKey,
@@ -443,7 +442,7 @@ func transferOwnershipLockReleaseTokenPools(
 func transferOwnershipRMNRemote(
 	ccipState stateview.CCIPOnChainState,
 	chainSelector uint64,
-	solChain deployment.SolChain,
+	solChain cldf.SolChain,
 	currentOwner solana.PublicKey,
 	proposedOwner solana.PublicKey,
 	timelockSigner solana.PublicKey,

--- a/deployment/ccip/changeset/solana/save_existing_test.go
+++ b/deployment/ccip/changeset/solana/save_existing_test.go
@@ -59,11 +59,11 @@ func TestSaveExistingCCIP(t *testing.T) {
 
 func TestSaveExisting(t *testing.T) {
 	t.Parallel()
-	dummyEnv := deployment.Environment{
+	dummyEnv := cldf.Environment{
 		Name:              "dummy",
 		Logger:            logger.TestLogger(t),
 		ExistingAddresses: cldf.NewMemoryAddressBook(),
-		SolChains: map[uint64]deployment.SolChain{
+		SolChains: map[uint64]cldf.SolChain{
 			chainsel.SOLANA_DEVNET.Selector: {},
 		},
 	}

--- a/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock.go
+++ b/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock.go
@@ -13,7 +13,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -70,7 +69,7 @@ func ValidateContracts(state solanastateview.CCIPChainState, chainSelector uint6
 	return nil
 }
 
-func (cfg TransferCCIPToMCMSWithTimelockSolanaConfig) Validate(e deployment.Environment) error {
+func (cfg TransferCCIPToMCMSWithTimelockSolanaConfig) Validate(e cldf.Environment) error {
 	ccipState, err := stateview.LoadOnchainStateSolana(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -136,7 +135,7 @@ func (cfg TransferCCIPToMCMSWithTimelockSolanaConfig) Validate(e deployment.Envi
 // the timelock and mcms exist on the chain and that the proposed addresses to transfer ownership
 // are currently owned by the deployer key.
 func TransferCCIPToMCMSWithTimelockSolana(
-	e deployment.Environment,
+	e cldf.Environment,
 	cfg TransferCCIPToMCMSWithTimelockSolanaConfig,
 ) (cldf.ChangesetOutput, error) {
 	if err := cfg.Validate(e); err != nil {

--- a/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock_test.go
+++ b/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock_test.go
@@ -124,7 +124,7 @@ func TestValidate(t *testing.T) {
 		SolChains:  1,
 		Nodes:      4,
 	})
-	envWithInvalidSolChain.SolChains[chainselectors.ETHEREUM_TESTNET_SEPOLIA_LENS_1.Selector] = deployment.SolChain{}
+	envWithInvalidSolChain.SolChains[chainselectors.ETHEREUM_TESTNET_SEPOLIA_LENS_1.Selector] = cldf.SolChain{}
 	timelockID := mcmsSolana.ContractAddress(solana.MustPublicKeyFromBase58(TimelockProgramID), [32]byte{'t', 'e', 's', 't'})
 	mcmsID := mcmsSolana.ContractAddress(solana.MustPublicKeyFromBase58(MCMProgramID), [32]byte{'t', 'e', 's', 't'})
 	err := env.ExistingAddresses.Save(env.AllChainSelectorsSolana()[0], timelockID, cldf.TypeAndVersion{Type: commontypes.RBACTimelock, Version: deployment.Version1_0_0})
@@ -134,7 +134,7 @@ func TestValidate(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		env              deployment.Environment
+		env              cldf.Environment
 		contractsByChain map[uint64]solanachangesets.CCIPContractsToTransfer
 		expectedError    string
 	}{
@@ -194,7 +194,7 @@ func TestValidate(t *testing.T) {
 
 // prepareEnvironmentForOwnershipTransfer helper that deploys the necessary contracts as pre-requisite to
 // the transfer ownership changeset.
-func prepareEnvironmentForOwnershipTransfer(t *testing.T) (deployment.Environment, stateview.CCIPOnChainState) {
+func prepareEnvironmentForOwnershipTransfer(t *testing.T) (cldf.Environment, stateview.CCIPOnChainState) {
 	t.Helper()
 	lggr := logger.TestLogger(t)
 	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{

--- a/deployment/ccip/changeset/solana/utils.go
+++ b/deployment/ccip/changeset/solana/utils.go
@@ -13,7 +13,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
@@ -21,9 +20,9 @@ import (
 )
 
 func ValidateMCMSConfigSolana(
-	e deployment.Environment,
+	e cldf.Environment,
 	mcms *proposalutils.TimelockConfig,
-	chain deployment.SolChain,
+	chain cldf.SolChain,
 	chainState solanastateview.CCIPChainState,
 	tokenAddress solana.PublicKey,
 	tokenPoolMetadata string,
@@ -70,7 +69,7 @@ func ValidateMCMSConfigSolana(
 }
 
 func BuildProposalsForTxns(
-	e deployment.Environment,
+	e cldf.Environment,
 	chainSelector uint64,
 	description string,
 	minDelay time.Duration,
@@ -131,7 +130,7 @@ func BuildMCMSTxn(ixn solana.Instruction, programID string, contractType cldf.Co
 	return &tx, nil
 }
 
-func FetchTimelockSigner(e deployment.Environment, chainSelector uint64) (solana.PublicKey, error) {
+func FetchTimelockSigner(e cldf.Environment, chainSelector uint64) (solana.PublicKey, error) {
 	addresses, err := e.ExistingAddresses.AddressesForChain(chainSelector)
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("failed to load addresses for chain %d: %w", chainSelector, err)
@@ -145,8 +144,8 @@ func FetchTimelockSigner(e deployment.Environment, chainSelector uint64) (solana
 }
 
 func GetAuthorityForIxn(
-	e *deployment.Environment,
-	chain deployment.SolChain,
+	e *cldf.Environment,
+	chain cldf.SolChain,
 	chainState solanastateview.CCIPChainState,
 	mcms *proposalutils.TimelockConfig,
 	contractType cldf.ContractType,

--- a/deployment/ccip/changeset/testhelpers/feestest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/feestest/helpers.go
@@ -15,7 +15,8 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -24,7 +25,7 @@ import (
 // NewFeeTokenTestCase creates a new FeeTokenTestCase to test fee token usage scenarios.
 func NewFeeTokenTestCase(
 	t *testing.T,
-	env deployment.Environment,
+	env cldf.Environment,
 	src, dst uint64,
 	feeToken common.Address,
 	tokenAmounts []router.ClientEVMTokenAmount,
@@ -52,7 +53,7 @@ func NewFeeTokenTestCase(
 type FeeTokenTestCase struct {
 	t                  *testing.T
 	src, dst           uint64
-	env                deployment.Environment
+	env                cldf.Environment
 	srcToken, dstToken *burn_mint_erc677.BurnMintERC677
 	tokenAmounts       []router.ClientEVMTokenAmount
 	feeToken           common.Address
@@ -100,7 +101,7 @@ func RunFeeTokenTestCase(tc FeeTokenTestCase) {
 
 			srcChain.DeployerKey.Value = assets.Ether(100).ToInt()
 			tx, err := weth9.Deposit(srcChain.DeployerKey)
-			_, err = deployment.ConfirmIfNoError(srcChain, tx, err)
+			_, err = cldf.ConfirmIfNoError(srcChain, tx, err)
 			require.NoError(tc.t, err)
 			srcChain.DeployerKey.Value = big.NewInt(0)
 		}
@@ -119,7 +120,7 @@ func RunFeeTokenTestCase(tc FeeTokenTestCase) {
 		// Approve the router to spend fee token
 		tx, err := feeTokenWrapper.Approve(srcChain.DeployerKey, state.Chains[tc.src].Router.Address(), math.MaxBig256)
 
-		_, err = deployment.ConfirmIfNoError(srcChain, tx, err)
+		_, err = cldf.ConfirmIfNoError(srcChain, tx, err)
 		require.NoError(tc.t, err)
 	}
 

--- a/deployment/ccip/changeset/testhelpers/messagelimitationstest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagelimitationstest/helpers.go
@@ -10,7 +10,8 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
@@ -54,7 +55,7 @@ func WithDeployedEnv(de testhelpers.DeployedEnv) TestSetupOpts {
 	}
 }
 
-func WithEnv(env deployment.Environment) TestSetupOpts {
+func WithEnv(env cldf.Environment) TestSetupOpts {
 	return func(ts *TestSetup) {
 		ts.Env = env
 	}
@@ -62,7 +63,7 @@ func WithEnv(env deployment.Environment) TestSetupOpts {
 
 type TestSetup struct {
 	T                           *testing.T
-	Env                         deployment.Environment
+	Env                         cldf.Environment
 	DeployedEnv                 *testhelpers.DeployedEnv
 	OnchainState                stateview.CCIPOnChainState
 	SrcChain                    uint64

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -18,7 +18,8 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
@@ -48,7 +49,7 @@ func NewTestSetupWithDeployedEnv(
 // Use this when testhelpers.DeployedEnv is not available (usually in long-running test environments like staging).
 func NewTestSetup(
 	t *testing.T,
-	env deployment.Environment,
+	env cldf.Environment,
 	onchainState stateview.CCIPOnChainState,
 	sourceChain,
 	destChain uint64,
@@ -70,7 +71,7 @@ func NewTestSetup(
 type TestSetup struct {
 	T            *testing.T
 	Sender       []byte
-	Env          deployment.Environment
+	Env          cldf.Environment
 	DeployedEnv  testhelpers.DeployedEnv
 	OnchainState stateview.CCIPOnChainState
 	SourceChain  uint64

--- a/deployment/ccip/changeset/testhelpers/test_assertions.go
+++ b/deployment/ccip/changeset/testhelpers/test_assertions.go
@@ -31,18 +31,18 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 func ConfirmGasPriceUpdatedForAll(
 	t *testing.T,
-	e deployment.Environment,
+	e cldf.Environment,
 	state stateview.CCIPOnChainState,
 	startBlocks map[uint64]*uint64,
 	gasPrice *big.Int,
@@ -75,7 +75,7 @@ func ConfirmGasPriceUpdatedForAll(
 
 func ConfirmGasPriceUpdated(
 	t *testing.T,
-	dest deployment.Chain,
+	dest cldf.Chain,
 	srcFeeQuoter *fee_quoter.FeeQuoter,
 	startBlock uint64,
 	gasPrice *big.Int,
@@ -95,7 +95,7 @@ func ConfirmGasPriceUpdated(
 
 func ConfirmTokenPriceUpdatedForAll(
 	t *testing.T,
-	e deployment.Environment,
+	e cldf.Environment,
 	state stateview.CCIPOnChainState,
 	startBlocks map[uint64]*uint64,
 	linkPrice *big.Int,
@@ -128,7 +128,7 @@ func ConfirmTokenPriceUpdatedForAll(
 
 func ConfirmTokenPriceUpdated(
 	t *testing.T,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	feeQuoter *fee_quoter.FeeQuoter,
 	startBlock uint64,
 	tokenToInitialPrice map[common.Address]*big.Int,
@@ -180,7 +180,7 @@ type SourceDestPair struct {
 // If startBlocks is nil, it will start watching from the latest block.
 func ConfirmCommitForAllWithExpectedSeqNums(
 	t *testing.T,
-	e deployment.Environment,
+	e cldf.Environment,
 	state stateview.CCIPOnChainState,
 	expectedSeqNums map[SourceDestPair]uint64,
 	startBlocks map[uint64]*uint64,
@@ -296,7 +296,7 @@ func (c *CommitReportTracker) allCommited(sourceChainSelector uint64) bool {
 // Waiting is done in parallel per every sourceChain/destChain (lane) passed as argument.
 func ConfirmMultipleCommits(
 	t *testing.T,
-	env deployment.Environment,
+	env cldf.Environment,
 	state stateview.CCIPOnChainState,
 	startBlocks map[uint64]*uint64,
 	enforceSingleCommit bool,
@@ -356,7 +356,7 @@ func ConfirmMultipleCommits(
 func ConfirmCommitWithExpectedSeqNumRange(
 	t *testing.T,
 	srcSelector uint64,
-	dest deployment.Chain,
+	dest cldf.Chain,
 	offRamp offramp.OffRampInterface,
 	startBlock *uint64,
 	expectedSeqNumRange ccipocr3.SeqNumRange,
@@ -541,7 +541,7 @@ func SolEventEmitter[T any](
 func ConfirmCommitWithExpectedSeqNumRangeSol(
 	t *testing.T,
 	srcSelector uint64,
-	dest deployment.SolChain,
+	dest cldf.SolChain,
 	offrampAddress solana.PublicKey,
 	startSlot uint64,
 	expectedSeqNumRange ccipocr3.SeqNumRange,
@@ -597,7 +597,7 @@ func ConfirmCommitWithExpectedSeqNumRangeSol(
 // If startBlocks is nil, it will start watching from the latest block.
 func ConfirmExecWithSeqNrsForAll(
 	t *testing.T,
-	e deployment.Environment,
+	e cldf.Environment,
 	state stateview.CCIPOnChainState,
 	expectedSeqNums map[SourceDestPair][]uint64,
 	startBlocks map[uint64]*uint64,
@@ -676,7 +676,7 @@ func ConfirmExecWithSeqNrsForAll(
 func ConfirmExecWithSeqNrs(
 	t *testing.T,
 	sourceSelector uint64,
-	dest deployment.Chain,
+	dest cldf.Chain,
 	offRamp offramp.OffRampInterface,
 	startBlock *uint64,
 	expectedSeqNrs []uint64,
@@ -751,7 +751,7 @@ func ConfirmExecWithSeqNrs(
 func ConfirmExecWithSeqNrsSol(
 	t *testing.T,
 	srcSelector uint64,
-	dest deployment.SolChain,
+	dest cldf.SolChain,
 	offrampAddress solana.PublicKey,
 	startSlot uint64,
 	expectedSeqNrs []uint64,
@@ -802,7 +802,7 @@ func ConfirmExecWithSeqNrsSol(
 func ConfirmNoExecConsistentlyWithSeqNr(
 	t *testing.T,
 	sourceSelector uint64,
-	dest deployment.Chain,
+	dest cldf.Chain,
 	offRamp offramp.OffRampInterface,
 	expectedSeqNr uint64,
 	timeout time.Duration,

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -293,7 +293,7 @@ type TestEnvironment interface {
 }
 
 type DeployedEnv struct {
-	Env                    deployment.Environment
+	Env                    cldf.Environment
 	HomeChainSel           uint64
 	FeedChainSel           uint64
 	ReplayBlocks           map[uint64]uint64
@@ -325,9 +325,9 @@ type MemoryEnvironment struct {
 	DeployedEnv
 	nodes       map[string]memory.Node
 	TestConfig  *TestConfigs
-	Chains      map[uint64]deployment.Chain
-	SolChains   map[uint64]deployment.SolChain
-	AptosChains map[uint64]deployment.AptosChain
+	Chains      map[uint64]cldf.Chain
+	SolChains   map[uint64]cldf.SolChain
+	AptosChains map[uint64]cldf.AptosChain
 }
 
 func (m *MemoryEnvironment) TestConfigs() *TestConfigs {
@@ -345,7 +345,7 @@ func (m *MemoryEnvironment) UpdateDeployedEnvironment(env DeployedEnv) {
 func (m *MemoryEnvironment) StartChains(t *testing.T) {
 	ctx := testcontext.Get(t)
 	tc := m.TestConfig
-	var chains map[uint64]deployment.Chain
+	var chains map[uint64]cldf.Chain
 	var users map[uint64][]*bind.TransactOpts
 	if len(tc.ChainIDs) > 0 {
 		chains, users = memory.NewMemoryChainsWithChainIDs(t, tc.ChainIDs, tc.NumOfUsersPerChain)
@@ -365,7 +365,7 @@ func (m *MemoryEnvironment) StartChains(t *testing.T) {
 	m.Chains = chains
 	m.SolChains = memory.NewMemoryChainsSol(t, tc.SolChains)
 	m.AptosChains = memory.NewMemoryChainsAptos(t, tc.AptosChains)
-	env := deployment.Environment{
+	env := cldf.Environment{
 		Chains:      m.Chains,
 		SolChains:   m.SolChains,
 		AptosChains: m.AptosChains,

--- a/deployment/ccip/changeset/testhelpers/test_token_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_token_helpers.go
@@ -56,7 +56,7 @@ func SetupTwoChainEnvironmentWithTokens(
 	t *testing.T,
 	lggr logger.Logger,
 	transferToTimelock bool,
-) (env deployment.Environment, sel1 uint64, sel2 uint64, ercmap map[uint64]*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677], contractmap map[uint64]*proposalutils.TimelockExecutionContracts) {
+) (env cldf.Environment, sel1 uint64, sel2 uint64, ercmap map[uint64]*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677], contractmap map[uint64]*proposalutils.TimelockExecutionContracts) {
 	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 2,
 	})
@@ -79,7 +79,7 @@ func SetupTwoChainEnvironmentWithTokens(
 	tokens := make(map[uint64]*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677])
 	for _, selector := range selectors {
 		token, err := cldf.DeployContract(e.Logger, e.Chains[selector], addressBook,
-			func(chain deployment.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
+			func(chain cldf.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 				tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 					e.Chains[selector].DeployerKey,
 					e.Chains[selector].Client,
@@ -152,7 +152,7 @@ func SetupTwoChainEnvironmentWithTokens(
 }
 
 // getPoolsOwnedByDeployer returns any pools that need to be transferred to timelock.
-func getPoolsOwnedByDeployer[T commonchangeset.Ownable](t *testing.T, contracts map[semver.Version]T, chain deployment.Chain) []common.Address {
+func getPoolsOwnedByDeployer[T commonchangeset.Ownable](t *testing.T, contracts map[semver.Version]T, chain cldf.Chain) []common.Address {
 	var addresses []common.Address
 	for _, contract := range contracts {
 		owner, err := contract.Owner(nil)
@@ -167,10 +167,10 @@ func getPoolsOwnedByDeployer[T commonchangeset.Ownable](t *testing.T, contracts 
 // DeployTestTokenPools deploys token pools tied for the TEST token across multiple chains.
 func DeployTestTokenPools(
 	t *testing.T,
-	e deployment.Environment,
+	e cldf.Environment,
 	newPools map[uint64]v1_5_1.DeployTokenPoolInput,
 	transferToTimelock bool,
-) deployment.Environment {
+) cldf.Environment {
 	selectors := e.AllChainSelectors()
 
 	e, err := commonchangeset.Apply(t, e, nil,

--- a/deployment/ccip/changeset/testhelpers/test_usdc_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_usdc_helpers.go
@@ -25,7 +25,7 @@ import (
 
 func ConfigureUSDCTokenPools(
 	lggr logger.Logger,
-	chains map[uint64]deployment.Chain,
+	chains map[uint64]cldf.Chain,
 	src, dst uint64,
 	state stateview.CCIPOnChainState,
 ) (*burn_mint_erc677.BurnMintERC677, *burn_mint_erc677.BurnMintERC677, error) {
@@ -35,7 +35,7 @@ func ConfigureUSDCTokenPools(
 	dstPool := state.Chains[dst].USDCTokenPools[deployment.Version1_5_1]
 
 	args := []struct {
-		sourceChain deployment.Chain
+		sourceChain cldf.Chain
 		dstChainSel uint64
 		state       evm.CCIPChainState
 		srcToken    *burn_mint_erc677.BurnMintERC677
@@ -75,7 +75,7 @@ func ConfigureUSDCTokenPools(
 
 func configureSingleChain(
 	lggr logger.Logger,
-	sourceChain deployment.Chain,
+	sourceChain cldf.Chain,
 	dstChainSel uint64,
 	state evm.CCIPChainState,
 	srcToken *burn_mint_erc677.BurnMintERC677,
@@ -110,9 +110,9 @@ func configureSingleChain(
 
 func UpdateFeeQuoterForUSDC(
 	t *testing.T,
-	e deployment.Environment,
+	e cldf.Environment,
 	lggr logger.Logger,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	dstChain uint64,
 ) error {
 	config := fee_quoter.FeeQuoterTokenTransferFeeConfig{

--- a/deployment/ccip/changeset/testhelpers/v1_5/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/v1_5/test_helpers.go
@@ -27,14 +27,13 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	v1_5changeset "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	plugintesthelpers "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/testhelpers"
 )
 
-func AddLanes(t *testing.T, e deployment.Environment, state stateview.CCIPOnChainState, pairs []testhelpers.SourceDestPair) deployment.Environment {
+func AddLanes(t *testing.T, e cldf.Environment, state stateview.CCIPOnChainState, pairs []testhelpers.SourceDestPair) cldf.Environment {
 	addLanesCfg, commitOCR2Configs, execOCR2Configs, jobspecs := LaneConfigsForChains(t, e, state, pairs)
 	var err error
 	e, err = commonchangeset.Apply(t, e, nil,
@@ -55,7 +54,7 @@ func AddLanes(t *testing.T, e deployment.Environment, state stateview.CCIPOnChai
 	return e
 }
 
-func LaneConfigsForChains(t *testing.T, env deployment.Environment, state stateview.CCIPOnChainState, pairs []testhelpers.SourceDestPair) (
+func LaneConfigsForChains(t *testing.T, env cldf.Environment, state stateview.CCIPOnChainState, pairs []testhelpers.SourceDestPair) (
 	[]v1_5changeset.DeployLaneConfig,
 	[]v1_5changeset.CommitOCR2ConfigParams,
 	[]v1_5changeset.ExecuteOCR2ConfigParams,
@@ -276,7 +275,7 @@ func DefaultOCRParams() confighelper.PublicConfig {
 
 func SendRequest(
 	t *testing.T,
-	e deployment.Environment,
+	e cldf.Environment,
 	state stateview.CCIPOnChainState,
 	opts ...testhelpers.SendReqOpts,
 ) (*evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested, error) {
@@ -320,8 +319,8 @@ func SendRequest(
 
 func WaitForCommit(
 	t *testing.T,
-	src deployment.Chain,
-	dest deployment.Chain,
+	src cldf.Chain,
+	dest cldf.Chain,
 	commitStore *commit_store.CommitStore,
 	seqNr uint64,
 ) {
@@ -348,8 +347,8 @@ func WaitForCommit(
 
 func WaitForNoCommit(
 	t *testing.T,
-	src deployment.Chain,
-	dest deployment.Chain,
+	src cldf.Chain,
+	dest cldf.Chain,
 	commitStore *commit_store.CommitStore,
 	seqNr uint64,
 ) {
@@ -376,8 +375,8 @@ func WaitForNoCommit(
 
 func WaitForExecute(
 	t *testing.T,
-	src deployment.Chain,
-	dest deployment.Chain,
+	src cldf.Chain,
+	dest cldf.Chain,
 	offRamp *evm_2_evm_offramp.EVM2EVMOffRamp,
 	seqNrs []uint64,
 	blockNum uint64,

--- a/deployment/ccip/changeset/v1_5/cs_jobspec.go
+++ b/deployment/ccip/changeset/v1_5/cs_jobspec.go
@@ -41,10 +41,10 @@ type JobSpecInput struct {
 }
 
 func (j JobSpecInput) Validate() error {
-	if err := deployment.IsValidChainSelector(j.SourceChainSelector); err != nil {
+	if err := cldf.IsValidChainSelector(j.SourceChainSelector); err != nil {
 		return fmt.Errorf("SourceChainSelector is invalid: %w", err)
 	}
-	if err := deployment.IsValidChainSelector(j.DestinationChainSelector); err != nil {
+	if err := cldf.IsValidChainSelector(j.DestinationChainSelector); err != nil {
 		return fmt.Errorf("DestinationChainSelector is invalid: %w", err)
 	}
 	if j.TokenPricesUSDPipeline == "" && j.PriceGetterConfigJson == "" {
@@ -61,7 +61,7 @@ func (j JobSpecInput) Validate() error {
 	return nil
 }
 
-func JobSpecsForLanesChangeset(env deployment.Environment, c JobSpecsForLanesConfig) (cldf.ChangesetOutput, error) {
+func JobSpecsForLanesChangeset(env cldf.Environment, c JobSpecsForLanesConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid JobSpecsForLanesConfig: %w", err)
 	}
@@ -103,7 +103,7 @@ func JobSpecsForLanesChangeset(env deployment.Environment, c JobSpecsForLanesCon
 }
 
 func jobSpecsForLane(
-	env deployment.Environment,
+	env cldf.Environment,
 	state stateview.CCIPOnChainState,
 	lanesCfg JobSpecsForLanesConfig,
 ) (map[string][]string, error) {

--- a/deployment/ccip/changeset/v1_5/cs_ocr2_config.go
+++ b/deployment/ccip/changeset/v1_5/cs_ocr2_config.go
@@ -69,10 +69,10 @@ func (c *CommitOCR2ConfigParams) PopulateOffChainAndOnChainCfg(priceReg common.A
 }
 
 func (c *CommitOCR2ConfigParams) Validate(state stateview.CCIPOnChainState) error {
-	if err := deployment.IsValidChainSelector(c.DestinationChainSelector); err != nil {
+	if err := cldf.IsValidChainSelector(c.DestinationChainSelector); err != nil {
 		return fmt.Errorf("invalid DestinationChainSelector: %w", err)
 	}
-	if err := deployment.IsValidChainSelector(c.SourceChainSelector); err != nil {
+	if err := cldf.IsValidChainSelector(c.SourceChainSelector); err != nil {
 		return fmt.Errorf("invalid SourceChainSelector: %w", err)
 	}
 
@@ -136,10 +136,10 @@ func (e *ExecuteOCR2ConfigParams) PopulateOffChainAndOnChainCfg(router, priceReg
 }
 
 func (e *ExecuteOCR2ConfigParams) Validate(state stateview.CCIPOnChainState) error {
-	if err := deployment.IsValidChainSelector(e.SourceChainSelector); err != nil {
+	if err := cldf.IsValidChainSelector(e.SourceChainSelector); err != nil {
 		return fmt.Errorf("invalid SourceChainSelector: %w", err)
 	}
-	if err := deployment.IsValidChainSelector(e.DestinationChainSelector); err != nil {
+	if err := cldf.IsValidChainSelector(e.DestinationChainSelector); err != nil {
 		return fmt.Errorf("invalid DestinationChainSelector: %w", err)
 	}
 	chain, exists := state.Chains[e.DestinationChainSelector]
@@ -183,7 +183,7 @@ func (o OCR2Config) Validate(state stateview.CCIPOnChainState) error {
 
 // SetOCR2ConfigForTestChangeset sets the OCR2 config on the chain for commit and offramp
 // This is currently not suitable for prod environments it's only for testing
-func SetOCR2ConfigForTestChangeset(env deployment.Environment, c OCR2Config) (cldf.ChangesetOutput, error) {
+func SetOCR2ConfigForTestChangeset(env cldf.Environment, c OCR2Config) (cldf.ChangesetOutput, error) {
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load CCIP onchain state: %w", err)
@@ -212,7 +212,7 @@ func SetOCR2ConfigForTestChangeset(env deployment.Environment, c OCR2Config) (cl
 		)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to set OCR2 config for commit store %s on chain %s: %w",
-				commitStore.Address().String(), chain.String(), deployment.MaybeDataErr(err))
+				commitStore.Address().String(), chain.String(), cldf.MaybeDataErr(err))
 		}
 		_, err = chain.Confirm(tx)
 		if err != nil {
@@ -255,7 +255,7 @@ func SetOCR2ConfigForTestChangeset(env deployment.Environment, c OCR2Config) (cl
 }
 
 func deriveOCR2Config(
-	env deployment.Environment,
+	env cldf.Environment,
 	chainSel uint64,
 	ocrParams confighelper.PublicConfig,
 ) (FinalOCR2Config, error) {

--- a/deployment/ccip/changeset/v1_5_1/commonconfig.go
+++ b/deployment/ccip/changeset/v1_5_1/commonconfig.go
@@ -12,7 +12,8 @@ import (
 	deployment2 "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/evm"
@@ -33,14 +34,14 @@ type TokenAdminRegistryChangesetConfig struct {
 
 // validateTokenAdminRegistryChangeset validates all token admin registry changesets.
 func (c TokenAdminRegistryChangesetConfig) Validate(
-	env deployment.Environment,
+	env cldf.Environment,
 	mustBeOwner bool,
 	registryConfigCheck func(
 		config token_admin_registry.TokenAdminRegistryTokenConfig,
 		sender common.Address,
 		externalAdmin common.Address,
 		symbol shared.TokenSymbol,
-		chain deployment.Chain,
+		chain cldf.Chain,
 	) error,
 ) error {
 	state, err := stateview.LoadOnchainState(env)
@@ -130,7 +131,7 @@ func (t TokenPoolInfo) Validate() error {
 func (t TokenPoolInfo) GetConfigOnRegistry(
 	ctx context.Context,
 	symbol shared.TokenSymbol,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	state evm.CCIPChainState,
 ) (token_admin_registry.TokenAdminRegistryTokenConfig, error) {
 	_, tokenAddress, err := t.GetPoolAndTokenAddress(ctx, symbol, chain, state)
@@ -149,7 +150,7 @@ func (t TokenPoolInfo) GetConfigOnRegistry(
 func (t TokenPoolInfo) GetPoolAndTokenAddress(
 	ctx context.Context,
 	symbol shared.TokenSymbol,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	state evm.CCIPChainState,
 ) (*token_pool.TokenPool, common.Address, error) {
 	tokenPoolAddress, ok := GetTokenPoolAddressFromSymbolTypeAndVersion(state, chain, symbol, t.Type, t.Version)
@@ -170,7 +171,7 @@ func (t TokenPoolInfo) GetPoolAndTokenAddress(
 // GetTokenPoolAddressFromSymbolTypeAndVersion returns the token pool address in the environment linked to a particular symbol, type, and version
 func GetTokenPoolAddressFromSymbolTypeAndVersion(
 	chainState evm.CCIPChainState,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	symbol shared.TokenSymbol,
 	poolType deployment2.ContractType,
 	version semver.Version,

--- a/deployment/ccip/changeset/v1_5_1/cs_accept_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_accept_admin_role.go
@@ -9,7 +9,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -22,7 +21,7 @@ func validateAcceptAdminRole(
 	sender common.Address,
 	externalAdmin common.Address,
 	symbol shared.TokenSymbol,
-	chain deployment.Chain,
+	chain cldf.Chain,
 ) error {
 	// We must be the pending administrator
 	if config.PendingAdministrator != sender {
@@ -32,7 +31,7 @@ func validateAcceptAdminRole(
 }
 
 // AcceptAdminRoleChangeset accepts admin rights for tokens on the token admin registry.
-func AcceptAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistryChangesetConfig) (cldf.ChangesetOutput, error) {
+func AcceptAdminRoleChangeset(env cldf.Environment, c TokenAdminRegistryChangesetConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(env, false, validateAcceptAdminRole); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid TokenAdminRegistryChangesetConfig: %w", err)
 	}

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -83,7 +83,7 @@ type AddTokenE2EConfig struct {
 // newConfigurePoolAndTokenAdminRegConfig populated internal fields in AddTokenE2EConfig.
 // It creates the configuration for deploying and configuring token pools and token admin registry.
 // It then validates the configuration.
-func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e deployment.Environment, symbol shared.TokenSymbol, timelockCfg *proposalutils.TimelockConfig) error {
+func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Environment, symbol shared.TokenSymbol, timelockCfg *proposalutils.TimelockConfig) error {
 	c.deployPool = DeployTokenPoolContractsConfig{
 		TokenSymbol:  symbol,
 		NewPools:     make(map[uint64]DeployTokenPoolInput),
@@ -185,7 +185,7 @@ type AddTokensE2EConfig struct {
 	MCMS   *proposalutils.TimelockConfig
 }
 
-func addTokenE2EPreconditionValidation(e deployment.Environment, config AddTokensE2EConfig) error {
+func addTokenE2EPreconditionValidation(e cldf.Environment, config AddTokensE2EConfig) error {
 	if len(config.Tokens) == 0 {
 		return nil
 	}
@@ -228,7 +228,7 @@ func addTokenE2EPreconditionValidation(e deployment.Environment, config AddToken
 	return nil
 }
 
-func addTokenE2ELogic(env deployment.Environment, config AddTokensE2EConfig) (cldf.ChangesetOutput, error) {
+func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.ChangesetOutput, error) {
 	if len(config.Tokens) == 0 {
 		return cldf.ChangesetOutput{}, nil
 	}
@@ -360,14 +360,14 @@ func addTokenE2ELogic(env deployment.Environment, config AddTokensE2EConfig) (cl
 	return *finalCSOut, nil
 }
 
-func deployTokens(e deployment.Environment, tokenDeployCfg map[uint64]DeployTokenConfig) (map[uint64]common.Address, cldf.AddressBook, error) {
+func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfig) (map[uint64]common.Address, cldf.AddressBook, error) {
 	ab := cldf.NewMemoryAddressBook()
 	tokenAddresses := make(map[uint64]common.Address) // This will hold the token addresses for each chain.
 	for selector, cfg := range tokenDeployCfg {
 		switch cfg.Type {
 		case shared.BurnMintToken:
 			token, err := cldf.DeployContract(e.Logger, e.Chains[selector], ab,
-				func(chain deployment.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
+				func(chain cldf.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 					tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 						e.Chains[selector].DeployerKey,
 						e.Chains[selector].Client,
@@ -407,7 +407,7 @@ func deployTokens(e deployment.Environment, tokenDeployCfg map[uint64]DeployToke
 			tokenAddresses[selector] = token.Address
 		case shared.ERC20Token:
 			token, err := cldf.DeployContract(e.Logger, e.Chains[selector], ab,
-				func(chain deployment.Chain) cldf.ContractDeploy[*erc20.ERC20] {
+				func(chain cldf.Chain) cldf.ContractDeploy[*erc20.ERC20] {
 					tokenAddress, tx, token, err := erc20.DeployERC20(
 						e.Chains[selector].DeployerKey,
 						e.Chains[selector].Client,
@@ -430,7 +430,7 @@ func deployTokens(e deployment.Environment, tokenDeployCfg map[uint64]DeployToke
 			tokenAddresses[selector] = token.Address
 		case shared.ERC677Token:
 			token, err := cldf.DeployContract(e.Logger, e.Chains[selector], ab,
-				func(chain deployment.Chain) cldf.ContractDeploy[*erc677.ERC677] {
+				func(chain cldf.Chain) cldf.ContractDeploy[*erc677.ERC677] {
 					tokenAddress, tx, token, err := erc677.DeployERC677(
 						e.Chains[selector].DeployerKey,
 						e.Chains[selector].Client,
@@ -461,7 +461,7 @@ func deployTokens(e deployment.Environment, tokenDeployCfg map[uint64]DeployToke
 // grantAccessToPool grants the token pool contract access to mint and burn tokens.
 func grantAccessToPool(
 	ctx context.Context,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	tpAddress common.Address,
 	tokenAddress common.Address,
 ) error {
@@ -488,7 +488,7 @@ func grantAccessToPool(
 }
 
 // addMinterAndMintToken adds the minter role to the recipient and mints the specified amount of tokens to the recipient's address.
-func addMinterAndMintToken(env deployment.Environment, selector uint64, token *burn_mint_erc677.BurnMintERC677, recipient common.Address, amount *big.Int) error {
+func addMinterAndMintToken(env cldf.Environment, selector uint64, token *burn_mint_erc677.BurnMintERC677, recipient common.Address, amount *big.Int) error {
 	deployerKey := env.Chains[selector].DeployerKey
 	ctx := env.GetContext()
 	// check if owner is the deployer key

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
@@ -75,7 +75,7 @@ func TestAddTokenE2E(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := testutils.Context(t)
 			var (
-				e                    deployment.Environment
+				e                    cldf.Environment
 				selectorA, selectorB uint64
 				mcmsConfig           *proposalutils.TimelockConfig
 				err                  error

--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
@@ -14,7 +14,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -154,7 +153,7 @@ type TokenPoolConfig struct {
 	OverrideTokenSymbol shared.TokenSymbol
 }
 
-func (c TokenPoolConfig) Validate(ctx context.Context, chain deployment.Chain, ccipState stateview.CCIPOnChainState, useMcms bool, tokenSymbol shared.TokenSymbol) error {
+func (c TokenPoolConfig) Validate(ctx context.Context, chain cldf.Chain, ccipState stateview.CCIPOnChainState, useMcms bool, tokenSymbol shared.TokenSymbol) error {
 	chainState := ccipState.Chains[chain.Selector]
 	// Ensure that the inputted type is known
 	if _, ok := shared.TokenPoolTypes[c.Type]; !ok {
@@ -214,7 +213,7 @@ type ConfigureTokenPoolContractsConfig struct {
 	TokenSymbol shared.TokenSymbol
 }
 
-func (c ConfigureTokenPoolContractsConfig) Validate(env deployment.Environment) error {
+func (c ConfigureTokenPoolContractsConfig) Validate(env cldf.Environment) error {
 	if c.TokenSymbol == "" {
 		return errors.New("token symbol must be defined")
 	}
@@ -223,7 +222,7 @@ func (c ConfigureTokenPoolContractsConfig) Validate(env deployment.Environment) 
 		return fmt.Errorf("failed to load onchain state: %w", err)
 	}
 	for chainSelector, poolUpdate := range c.PoolUpdates {
-		err := deployment.IsValidChainSelector(chainSelector)
+		err := cldf.IsValidChainSelector(chainSelector)
 		if err != nil {
 			return fmt.Errorf("failed to validate chain selector %d: %w", chainSelector, err)
 		}
@@ -270,7 +269,7 @@ func (c ConfigureTokenPoolContractsConfig) Validate(env deployment.Environment) 
 // ConfigureTokenPoolContractsChangeset configures pools for a given token across multiple chains.
 // The outputted MCMS proposal will update chain configurations on each pool, encompassing new chain additions and rate limit changes.
 // Removing chain support is not in scope for this changeset.
-func ConfigureTokenPoolContractsChangeset(env deployment.Environment, c ConfigureTokenPoolContractsConfig) (cldf.ChangesetOutput, error) {
+func ConfigureTokenPoolContractsChangeset(env cldf.Environment, c ConfigureTokenPoolContractsConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(env); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid ConfigureTokenPoolContractsConfig: %w", err)
 	}
@@ -311,7 +310,7 @@ func ConfigureTokenPoolContractsChangeset(env deployment.Environment, c Configur
 func configureTokenPool(
 	ctx context.Context,
 	opts *bind.TransactOpts,
-	chains map[uint64]deployment.Chain,
+	chains map[uint64]cldf.Chain,
 	state stateview.CCIPOnChainState,
 	config ConfigureTokenPoolContractsConfig,
 	chainSelector uint64,
@@ -467,7 +466,7 @@ func GetTokenStateFromPoolEVM(
 	symbol shared.TokenSymbol,
 	poolType cldf.ContractType,
 	version semver.Version,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	state evm.CCIPChainState,
 ) (*token_pool.TokenPool, common.Address, token_admin_registry.TokenAdminRegistryTokenConfig, error) {
 	tokenPoolAddress, ok := GetTokenPoolAddressFromSymbolTypeAndVersion(state, chain, symbol, poolType, version)

--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools_test.go
@@ -694,7 +694,7 @@ func TestValidateConfigureTokenPoolContractsForSolana(t *testing.T) {
 	///////////////////////////
 	for _, selector := range evmSelectors {
 		token, err := cldf.DeployContract(e.Logger, e.Chains[selector], addressBook,
-			func(chain deployment.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
+			func(chain cldf.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 				tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 					e.Chains[selector].DeployerKey,
 					e.Chains[selector].Client,

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pool_factory.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pool_factory.go
@@ -28,7 +28,7 @@ type DeployTokenPoolFactoryConfig struct {
 	RegistryModule1_6Addresses map[uint64]common.Address
 }
 
-func deployTokenPoolFactoryPrecondition(e deployment.Environment, config DeployTokenPoolFactoryConfig) error {
+func deployTokenPoolFactoryPrecondition(e cldf.Environment, config DeployTokenPoolFactoryConfig) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -80,7 +80,7 @@ func deployTokenPoolFactoryPrecondition(e deployment.Environment, config DeployT
 	return nil
 }
 
-func deployTokenPoolFactoryLogic(e deployment.Environment, config DeployTokenPoolFactoryConfig) (cldf.ChangesetOutput, error) {
+func deployTokenPoolFactoryLogic(e cldf.Environment, config DeployTokenPoolFactoryConfig) (cldf.ChangesetOutput, error) {
 	addressBook := cldf.NewMemoryAddressBook()
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
@@ -97,7 +97,7 @@ func deployTokenPoolFactoryLogic(e deployment.Environment, config DeployTokenPoo
 		}
 
 		tokenPoolFactory, err := cldf.DeployContract(e.Logger, chain, addressBook,
-			func(chain deployment.Chain) cldf.ContractDeploy[*token_pool_factory.TokenPoolFactory] {
+			func(chain cldf.Chain) cldf.ContractDeploy[*token_pool_factory.TokenPoolFactory] {
 				address, tx, tokenPoolFactory, err := token_pool_factory.DeployTokenPoolFactory(
 					chain.DeployerKey,
 					chain.Client,

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pool_factory_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pool_factory_test.go
@@ -107,7 +107,7 @@ func TestDeployTokenPoolFactoryChangeset(t *testing.T) {
 				for _, selector := range selectors {
 					// Deploy token admin registry
 					tokenAdminRegistry, err := cldf.DeployContract(e.Logger, e.Chains[selector], e.ExistingAddresses,
-						func(chain deployment.Chain) cldf.ContractDeploy[*token_admin_registry.TokenAdminRegistry] {
+						func(chain cldf.Chain) cldf.ContractDeploy[*token_admin_registry.TokenAdminRegistry] {
 							tokenAdminRegistryAddr, tx2, tokenAdminRegistry, err2 := token_admin_registry.DeployTokenAdminRegistry(
 								chain.DeployerKey,
 								chain.Client)
@@ -118,7 +118,7 @@ func TestDeployTokenPoolFactoryChangeset(t *testing.T) {
 					require.NoError(t, err, "failed to deploy token admin registry")
 					// Deploy RMN proxy
 					rmnProxy, err := cldf.DeployContract(lggr, e.Chains[selector], e.ExistingAddresses,
-						func(chain deployment.Chain) cldf.ContractDeploy[*rmn_proxy_contract.RMNProxy] {
+						func(chain cldf.Chain) cldf.ContractDeploy[*rmn_proxy_contract.RMNProxy] {
 							rmnProxyAddr, tx2, rmnProxy2, err2 := rmn_proxy_contract.DeployRMNProxy(
 								chain.DeployerKey,
 								chain.Client,
@@ -133,7 +133,7 @@ func TestDeployTokenPoolFactoryChangeset(t *testing.T) {
 					require.NoError(t, err, "failed to deploy RMN proxy")
 					// Deploy router
 					_, err = cldf.DeployContract(e.Logger, e.Chains[selector], e.ExistingAddresses,
-						func(chain deployment.Chain) cldf.ContractDeploy[*router.Router] {
+						func(chain cldf.Chain) cldf.ContractDeploy[*router.Router] {
 							routerAddr, tx2, routerC, err2 := router.DeployRouter(
 								chain.DeployerKey,
 								chain.Client,
@@ -149,7 +149,7 @@ func TestDeployTokenPoolFactoryChangeset(t *testing.T) {
 					require.NoError(t, err, "failed to deploy router")
 					// Deploy registry module
 					_, err = cldf.DeployContract(e.Logger, e.Chains[selector], e.ExistingAddresses,
-						func(chain deployment.Chain) cldf.ContractDeploy[*registry_module_owner_custom.RegistryModuleOwnerCustom] {
+						func(chain cldf.Chain) cldf.ContractDeploy[*registry_module_owner_custom.RegistryModuleOwnerCustom] {
 							regModAddr, tx2, regMod, err2 := registry_module_owner_custom.DeployRegistryModuleOwnerCustom(
 								chain.DeployerKey,
 								chain.Client,
@@ -169,7 +169,7 @@ func TestDeployTokenPoolFactoryChangeset(t *testing.T) {
 				require.NoError(t, err, "failed to load onchain state")
 				for _, selector := range selectors {
 					_, err := cldf.DeployContract(e.Logger, e.Chains[selector], e.ExistingAddresses,
-						func(chain deployment.Chain) cldf.ContractDeploy[*registry_module_owner_custom.RegistryModuleOwnerCustom] {
+						func(chain cldf.Chain) cldf.ContractDeploy[*registry_module_owner_custom.RegistryModuleOwnerCustom] {
 							regModAddr, tx2, regMod, err2 := registry_module_owner_custom.DeployRegistryModuleOwnerCustom(
 								chain.DeployerKey,
 								chain.Client,

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools.go
@@ -18,7 +18,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/evm"
@@ -47,7 +46,7 @@ type DeployTokenPoolInput struct {
 	AcceptLiquidity *bool
 }
 
-func (i DeployTokenPoolInput) Validate(ctx context.Context, chain deployment.Chain, state evm.CCIPChainState, tokenSymbol shared.TokenSymbol) error {
+func (i DeployTokenPoolInput) Validate(ctx context.Context, chain cldf.Chain, state evm.CCIPChainState, tokenSymbol shared.TokenSymbol) error {
 	// Ensure that required fields are populated
 	if i.TokenAddress == utils.ZeroAddress {
 		return errors.New("token address must be defined")
@@ -110,7 +109,7 @@ type DeployTokenPoolContractsConfig struct {
 	IsTestRouter bool
 }
 
-func (c DeployTokenPoolContractsConfig) Validate(env deployment.Environment) error {
+func (c DeployTokenPoolContractsConfig) Validate(env cldf.Environment) error {
 	// Ensure that required fields are populated
 	if c.TokenSymbol == shared.TokenSymbol("") {
 		return errors.New("token symbol must be defined")
@@ -121,7 +120,7 @@ func (c DeployTokenPoolContractsConfig) Validate(env deployment.Environment) err
 		return fmt.Errorf("failed to load onchain state: %w", err)
 	}
 	for chainSelector, poolConfig := range c.NewPools {
-		err := deployment.IsValidChainSelector(chainSelector)
+		err := cldf.IsValidChainSelector(chainSelector)
 		if err != nil {
 			return fmt.Errorf("failed to validate chain selector %d: %w", chainSelector, err)
 		}
@@ -154,7 +153,7 @@ func (c DeployTokenPoolContractsConfig) Validate(env deployment.Environment) err
 }
 
 // DeployTokenPoolContractsChangeset deploys new pools for a given token across multiple chains.
-func DeployTokenPoolContractsChangeset(env deployment.Environment, c DeployTokenPoolContractsConfig) (cldf.ChangesetOutput, error) {
+func DeployTokenPoolContractsChangeset(env cldf.Environment, c DeployTokenPoolContractsConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(env); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid DeployTokenPoolContractsConfig: %w", err)
 	}
@@ -199,7 +198,7 @@ func DeployTokenPoolContractsChangeset(env deployment.Environment, c DeployToken
 // deployTokenPool deploys a token pool contract based on a given type & configuration.
 func deployTokenPool(
 	logger logger.Logger,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	chainState evm.CCIPChainState,
 	addressBook cldf.AddressBook,
 	poolConfig DeployTokenPoolInput,
@@ -212,7 +211,7 @@ func deployTokenPool(
 	rmnProxy := chainState.RMNProxy
 
 	return cldf.DeployContract(logger, chain, addressBook,
-		func(chain deployment.Chain) cldf.ContractDeploy[*token_pool.TokenPool] {
+		func(chain cldf.Chain) cldf.ContractDeploy[*token_pool.TokenPool] {
 			var tpAddr common.Address
 			var tx *types.Transaction
 			var err error

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools.go
@@ -35,7 +35,7 @@ type DeployUSDCTokenPoolInput struct {
 	AllowList []common.Address
 }
 
-func (i DeployUSDCTokenPoolInput) Validate(ctx context.Context, chain deployment.Chain, state evm.CCIPChainState) error {
+func (i DeployUSDCTokenPoolInput) Validate(ctx context.Context, chain cldf.Chain, state evm.CCIPChainState) error {
 	// Ensure that required fields are populated
 	if i.TokenAddress == utils.ZeroAddress {
 		return errors.New("token address must be defined")
@@ -89,13 +89,13 @@ type DeployUSDCTokenPoolContractsConfig struct {
 	IsTestRouter bool
 }
 
-func (c DeployUSDCTokenPoolContractsConfig) Validate(env deployment.Environment) error {
+func (c DeployUSDCTokenPoolContractsConfig) Validate(env cldf.Environment) error {
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
 	}
 	for chainSelector, poolConfig := range c.USDCPools {
-		err := deployment.IsValidChainSelector(chainSelector)
+		err := cldf.IsValidChainSelector(chainSelector)
 		if err != nil {
 			return fmt.Errorf("failed to validate chain selector %d: %w", chainSelector, err)
 		}
@@ -125,7 +125,7 @@ func (c DeployUSDCTokenPoolContractsConfig) Validate(env deployment.Environment)
 }
 
 // DeployUSDCTokenPoolContractsChangeset deploys new USDC pools across multiple chains.
-func DeployUSDCTokenPoolContractsChangeset(env deployment.Environment, c DeployUSDCTokenPoolContractsConfig) (cldf.ChangesetOutput, error) {
+func DeployUSDCTokenPoolContractsChangeset(env cldf.Environment, c DeployUSDCTokenPoolContractsConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(env); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid DeployUSDCTokenPoolContractsConfig: %w", err)
 	}
@@ -144,7 +144,7 @@ func DeployUSDCTokenPoolContractsChangeset(env deployment.Environment, c DeployU
 			router = chainState.TestRouter
 		}
 		_, err := cldf.DeployContract(env.Logger, chain, newAddresses,
-			func(chain deployment.Chain) cldf.ContractDeploy[*usdc_token_pool.USDCTokenPool] {
+			func(chain cldf.Chain) cldf.ContractDeploy[*usdc_token_pool.USDCTokenPool] {
 				poolAddress, tx, usdcTokenPool, err := usdc_token_pool.DeployUSDCTokenPool(
 					chain.DeployerKey, chain.Client, poolConfig.TokenMessenger, poolConfig.TokenAddress,
 					poolConfig.AllowList, chainState.RMNProxy.Address(), router.Address(),

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
@@ -31,11 +31,11 @@ import (
 func deployUSDCPrerequisites(
 	t *testing.T,
 	logger logger.Logger,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	addressBook cldf.AddressBook,
 ) (*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677], *cldf.ContractDeploy[*mock_usdc_token_messenger.MockE2EUSDCTokenMessenger]) {
 	usdcToken, err := cldf.DeployContract(logger, chain, addressBook,
-		func(chain deployment.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
+		func(chain cldf.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 			tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 				chain.DeployerKey,
 				chain.Client,
@@ -56,7 +56,7 @@ func deployUSDCPrerequisites(
 	require.NoError(t, err)
 
 	transmitter, err := cldf.DeployContract(logger, chain, addressBook,
-		func(chain deployment.Chain) cldf.ContractDeploy[*mock_usdc_token_transmitter.MockE2EUSDCTransmitter] {
+		func(chain cldf.Chain) cldf.ContractDeploy[*mock_usdc_token_transmitter.MockE2EUSDCTransmitter] {
 			transmitterAddress, tx, transmitter, err := mock_usdc_token_transmitter.DeployMockE2EUSDCTransmitter(chain.DeployerKey, chain.Client, 0, 1, usdcToken.Address)
 			return cldf.ContractDeploy[*mock_usdc_token_transmitter.MockE2EUSDCTransmitter]{
 				Address:  transmitterAddress,
@@ -70,7 +70,7 @@ func deployUSDCPrerequisites(
 	require.NoError(t, err)
 
 	messenger, err := cldf.DeployContract(logger, chain, addressBook,
-		func(chain deployment.Chain) cldf.ContractDeploy[*mock_usdc_token_messenger.MockE2EUSDCTokenMessenger] {
+		func(chain cldf.Chain) cldf.ContractDeploy[*mock_usdc_token_messenger.MockE2EUSDCTokenMessenger] {
 			messengerAddress, tx, messenger, err := mock_usdc_token_messenger.DeployMockE2EUSDCTokenMessenger(chain.DeployerKey, chain.Client, 0, transmitter.Address)
 			return cldf.ContractDeploy[*mock_usdc_token_messenger.MockE2EUSDCTokenMessenger]{
 				Address:  messengerAddress,
@@ -150,7 +150,7 @@ func TestValidateDeployUSDCTokenPoolInput(t *testing.T) {
 	usdcToken, tokenMessenger := deployUSDCPrerequisites(t, lggr, chain, addressBook)
 
 	nonUsdcToken, err := cldf.DeployContract(e.Logger, chain, addressBook,
-		func(chain deployment.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
+		func(chain cldf.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 			tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 				chain.DeployerKey,
 				chain.Client,

--- a/deployment/ccip/changeset/v1_5_1/cs_propose_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_propose_admin_role.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -27,7 +26,7 @@ func validateProposeAdminRole(
 	sender common.Address,
 	externalAdmin common.Address,
 	symbol shared.TokenSymbol,
-	chain deployment.Chain,
+	chain cldf.Chain,
 ) error {
 	// To propose ourselves as admin of the token, two things must be true.
 	//   1. We own the token admin registry
@@ -40,7 +39,7 @@ func validateProposeAdminRole(
 }
 
 // ProposeAdminRoleChangeset proposes admin rights for tokens on the token admin registry.
-func ProposeAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistryChangesetConfig) (cldf.ChangesetOutput, error) {
+func ProposeAdminRoleChangeset(env cldf.Environment, c TokenAdminRegistryChangesetConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(env, true, validateProposeAdminRole); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid TokenAdminRegistryChangesetConfig: %w", err)
 	}

--- a/deployment/ccip/changeset/v1_5_1/cs_set_pool.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_pool.go
@@ -9,7 +9,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -22,7 +21,7 @@ func validateSetPool(
 	sender common.Address,
 	externalAdmin common.Address,
 	symbol shared.TokenSymbol,
-	chain deployment.Chain,
+	chain cldf.Chain,
 ) error {
 	// We must be the administrator
 	if config.Administrator != sender {
@@ -32,7 +31,7 @@ func validateSetPool(
 }
 
 // SetPoolChangeset sets pools for tokens on the token admin registry.
-func SetPoolChangeset(env deployment.Environment, c TokenAdminRegistryChangesetConfig) (cldf.ChangesetOutput, error) {
+func SetPoolChangeset(env cldf.Environment, c TokenAdminRegistryChangesetConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(env, false, validateSetPool); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid TokenAdminRegistryChangesetConfig: %w", err)
 	}

--- a/deployment/ccip/changeset/v1_5_1/cs_sync_usdc_domains_with_chains.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_sync_usdc_domains_with_chains.go
@@ -12,7 +12,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -31,7 +30,7 @@ type SyncUSDCDomainsWithChainsConfig struct {
 	MCMS *proposalutils.TimelockConfig
 }
 
-func (c SyncUSDCDomainsWithChainsConfig) Validate(env deployment.Environment, state stateview.CCIPOnChainState) error {
+func (c SyncUSDCDomainsWithChainsConfig) Validate(env cldf.Environment, state stateview.CCIPOnChainState) error {
 	ctx := env.GetContext()
 
 	if c.ChainSelectorToUSDCDomain == nil {
@@ -40,7 +39,7 @@ func (c SyncUSDCDomainsWithChainsConfig) Validate(env deployment.Environment, st
 
 	// Validate that all USDC configs inputted are for valid chains that define USDC pools.
 	for chainSelector, version := range c.USDCVersionByChain {
-		err := deployment.IsValidChainSelector(chainSelector)
+		err := cldf.IsValidChainSelector(chainSelector)
 		if err != nil {
 			return fmt.Errorf("failed to validate chain selector %d: %w", chainSelector, err)
 		}
@@ -95,7 +94,7 @@ func (c SyncUSDCDomainsWithChainsConfig) Validate(env deployment.Environment, st
 
 // SyncUSDCDomainsWithChainsChangeset syncs domain support on specified USDC token pools with its chain support.
 // As such, it is expected that ConfigureTokenPoolContractsChangeset is executed before running this changeset.
-func SyncUSDCDomainsWithChainsChangeset(env deployment.Environment, c SyncUSDCDomainsWithChainsConfig) (cldf.ChangesetOutput, error) {
+func SyncUSDCDomainsWithChainsChangeset(env cldf.Environment, c SyncUSDCDomainsWithChainsConfig) (cldf.ChangesetOutput, error) {
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)

--- a/deployment/ccip/changeset/v1_5_1/cs_transfer_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_transfer_admin_role.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -25,7 +24,7 @@ func validateTransferAdminRole(
 	sender common.Address,
 	externalAdmin common.Address,
 	symbol shared.TokenSymbol,
-	chain deployment.Chain,
+	chain cldf.Chain,
 ) error {
 	if externalAdmin == utils.ZeroAddress {
 		return errors.New("external admin must be defined")
@@ -38,7 +37,7 @@ func validateTransferAdminRole(
 }
 
 // TransferAdminRoleChangeset transfers the admin role for tokens on the token admin registry to 3rd parties.
-func TransferAdminRoleChangeset(env deployment.Environment, c TokenAdminRegistryChangesetConfig) (cldf.ChangesetOutput, error) {
+func TransferAdminRoleChangeset(env cldf.Environment, c TokenAdminRegistryChangesetConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(env, false, validateTransferAdminRole); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid TokenAdminRegistryChangesetConfig: %w", err)
 	}

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -12,7 +12,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -149,7 +148,7 @@ func (c AddCandidatesForNewChainConfig) updateChainConfig() UpdateChainConfigCon
 	}
 }
 
-func addCandidatesForNewChainPrecondition(e deployment.Environment, c AddCandidatesForNewChainConfig) error {
+func addCandidatesForNewChainPrecondition(e cldf.Environment, c AddCandidatesForNewChainConfig) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -207,7 +206,7 @@ func addCandidatesForNewChainPrecondition(e deployment.Environment, c AddCandida
 	return nil
 }
 
-func addCandidatesForNewChainLogic(e deployment.Environment, c AddCandidatesForNewChainConfig) (cldf.ChangesetOutput, error) {
+func addCandidatesForNewChainLogic(e cldf.Environment, c AddCandidatesForNewChainConfig) (cldf.ChangesetOutput, error) {
 	newAddresses := cldf.NewMemoryAddressBook()
 	var allProposals []mcmslib.TimelockProposal
 
@@ -390,7 +389,7 @@ func addCandidatesForNewChainLogic(e deployment.Environment, c AddCandidatesForN
 	txOpts := e.Chains[c.HomeChainSelector].DeployerKey
 
 	tx, err := state.Chains[c.HomeChainSelector].DonIDClaimer.ClaimNextDONId(txOpts)
-	if _, err := deployment.ConfirmIfNoErrorWithABI(e.Chains[c.HomeChainSelector], tx, don_id_claimer.DonIDClaimerABI, err); err != nil {
+	if _, err := cldf.ConfirmIfNoErrorWithABI(e.Chains[c.HomeChainSelector], tx, don_id_claimer.DonIDClaimerABI, err); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
 
@@ -511,7 +510,7 @@ func (c PromoteNewChainForConfig) connectNewChainConfig(testRouter bool) Connect
 	}
 }
 
-func promoteNewChainForConfigPrecondition(e deployment.Environment, c PromoteNewChainForConfig) error {
+func promoteNewChainForConfigPrecondition(e cldf.Environment, c PromoteNewChainForConfig) error {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return fmt.Errorf("failed to load onchain state: %w", err)
@@ -542,7 +541,7 @@ func promoteNewChainForConfigPrecondition(e deployment.Environment, c PromoteNew
 	return nil
 }
 
-func promoteNewChainForConfigLogic(e deployment.Environment, c PromoteNewChainForConfig) (cldf.ChangesetOutput, error) {
+func promoteNewChainForConfigLogic(e cldf.Environment, c PromoteNewChainForConfig) (cldf.ChangesetOutput, error) {
 	var allProposals []mcmslib.TimelockProposal
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
@@ -633,7 +632,7 @@ type ConnectNewChainConfig struct {
 	MCMSConfig *proposalutils.TimelockConfig `json:"mcmsConfig,omitempty"`
 }
 
-func (c ConnectNewChainConfig) validateNewChain(env deployment.Environment, state stateview.CCIPOnChainState) error {
+func (c ConnectNewChainConfig) validateNewChain(env cldf.Environment, state stateview.CCIPOnChainState) error {
 	// When running this changeset, there is no case in which the new chain contract should be owned by MCMS,
 	// which is why we do not use MCMSConfig to determine the ownedByMCMS variable.
 	err := c.validateChain(env, state, c.NewChainSelector, false)
@@ -644,7 +643,7 @@ func (c ConnectNewChainConfig) validateNewChain(env deployment.Environment, stat
 	return nil
 }
 
-func (c ConnectNewChainConfig) validateRemoteChains(env deployment.Environment, state stateview.CCIPOnChainState) error {
+func (c ConnectNewChainConfig) validateRemoteChains(env cldf.Environment, state stateview.CCIPOnChainState) error {
 	for remoteChainSelector := range c.RemoteChains {
 		// The remote chain may or may not be owned by MCMS, as MCMS is not really used in staging.
 		// Therefore, we use the presence of MCMSConfig to determine the ownedByMCMS variable.
@@ -657,7 +656,7 @@ func (c ConnectNewChainConfig) validateRemoteChains(env deployment.Environment, 
 	return nil
 }
 
-func (c ConnectNewChainConfig) validateChain(e deployment.Environment, state stateview.CCIPOnChainState, chainSelector uint64, ownedByMCMS bool) error {
+func (c ConnectNewChainConfig) validateChain(e cldf.Environment, state stateview.CCIPOnChainState, chainSelector uint64, ownedByMCMS bool) error {
 	err := stateview.ValidateChain(e, state, chainSelector, c.MCMSConfig)
 	if err != nil {
 		return fmt.Errorf("failed to validate chain with selector %d: %w", chainSelector, err)
@@ -700,7 +699,7 @@ func (c ConnectNewChainConfig) validateChain(e deployment.Environment, state sta
 	return nil
 }
 
-func connectNewChainPrecondition(env deployment.Environment, c ConnectNewChainConfig) error {
+func connectNewChainPrecondition(env cldf.Environment, c ConnectNewChainConfig) error {
 	if c.TestRouter == nil {
 		return errors.New("must define whether to use the test router")
 	}
@@ -723,7 +722,7 @@ func connectNewChainPrecondition(env deployment.Environment, c ConnectNewChainCo
 	return nil
 }
 
-func connectNewChainLogic(env deployment.Environment, c ConnectNewChainConfig) (cldf.ChangesetOutput, error) {
+func connectNewChainLogic(env cldf.Environment, c ConnectNewChainConfig) (cldf.ChangesetOutput, error) {
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
@@ -826,7 +825,7 @@ func connectNewChainLogic(env deployment.Environment, c ConnectNewChainConfig) (
 // It also sets the onRamp and offRamp on the router for the given remote chains.
 // This function will add the proposals required to make these changes to the proposalAggregate slice.
 func connectRampsAndRouters(
-	e deployment.Environment,
+	e cldf.Environment,
 	chainSelector uint64,
 	remoteChains map[uint64]ConnectionConfig,
 	mcmsConfig *proposalutils.TimelockConfig,

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
@@ -34,7 +34,7 @@ import (
 
 func checkConnectivity(
 	t *testing.T,
-	e deployment.Environment,
+	e cldf.Environment,
 	state stateview.CCIPOnChainState,
 	selector uint64,
 	remoteChainSelector uint64,
@@ -451,7 +451,7 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 				tx, err := state.Chains[deployedEnvironment.HomeChainSel].DonIDClaimer.ClaimNextDONId(e.Chains[deployedEnvironment.HomeChainSel].DeployerKey)
 				require.NoError(t, err)
 
-				_, err = deployment.ConfirmIfNoErrorWithABI(e.Chains[deployedEnvironment.HomeChainSel], tx, don_id_claimer.DonIDClaimerABI, err)
+				_, err = cldf.ConfirmIfNoErrorWithABI(e.Chains[deployedEnvironment.HomeChainSel], tx, don_id_claimer.DonIDClaimerABI, err)
 				require.NoError(t, err)
 			}
 

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts_test.go
@@ -961,7 +961,7 @@ func TestApplyFeeTokensUpdatesFeeQuoterChangeset(t *testing.T) {
 			ab := cldf.NewMemoryAddressBook()
 			for _, selector := range allChains {
 				_, err := cldf.DeployContract(tenv.Env.Logger, tenv.Env.Chains[selector], ab,
-					func(chain deployment.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
+					func(chain cldf.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 						tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 							tenv.Env.Chains[selector].DeployerKey,
 							tenv.Env.Chains[selector].Client,
@@ -1080,7 +1080,7 @@ func TestApplyPremiumMultiplierWeiPerEthUpdatesFeeQuoterChangeset(t *testing.T) 
 			ab := cldf.NewMemoryAddressBook()
 			for _, selector := range allChains {
 				_, err := cldf.DeployContract(tenv.Env.Logger, tenv.Env.Chains[selector], ab,
-					func(chain deployment.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
+					func(chain cldf.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 						tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 							tenv.Env.Chains[selector].DeployerKey,
 							tenv.Env.Chains[selector].Client,
@@ -1159,7 +1159,7 @@ func TestUpdateTokenPriceFeedsFeeQuoterChangeset(t *testing.T) {
 			// deploy a new token
 			ab := cldf.NewMemoryAddressBook()
 			_, err := cldf.DeployContract(tenv.Env.Logger, tenv.Env.Chains[source], ab,
-				func(chain deployment.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
+				func(chain cldf.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
 					tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 						tenv.Env.Chains[source].DeployerKey,
 						tenv.Env.Chains[source].Client,

--- a/deployment/ccip/changeset/v1_6/cs_jobspec.go
+++ b/deployment/ccip/changeset/v1_6/cs_jobspec.go
@@ -23,7 +23,7 @@ var _ cldf.ChangeSet[any] = CCIPCapabilityJobspecChangeset
 
 // CCIPCapabilityJobspecChangeset returns the job specs for the CCIP capability.
 // The caller needs to propose these job specs to the offchain system.
-func CCIPCapabilityJobspecChangeset(env deployment.Environment, _ any) (cldf.ChangesetOutput, error) {
+func CCIPCapabilityJobspecChangeset(env cldf.Environment, _ any) (cldf.ChangesetOutput, error) {
 	nodes, err := deployment.NodeInfo(env.NodeIDs, env.Offchain)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -190,7 +190,7 @@ func areCCIPSpecsEqual(existingSpecStr, newSpecStr string) (bool, error) {
 
 // acceptedOrPendingAcceptedJobSpecs returns a map of nodeID to job specs that are either accepted or pending review
 // or proposed
-func acceptedOrPendingAcceptedJobSpecs(env deployment.Environment, nodes deployment.Nodes) (map[string][]string, error) {
+func acceptedOrPendingAcceptedJobSpecs(env cldf.Environment, nodes deployment.Nodes) (map[string][]string, error) {
 	existingSpecs := make(map[string][]string)
 	for _, node := range nodes {
 		jobs, err := env.Offchain.ListJobs(env.GetContext(), &jobv1.ListJobsRequest{
@@ -232,7 +232,7 @@ func acceptedOrPendingAcceptedJobSpecs(env deployment.Environment, nodes deploym
 // so we return false TODO implement this check when it is available
 // there is no downside to proposing the same job spec to a node multiple times
 // It will only be accepted once by node
-func isJobProposed(env deployment.Environment, nodeID string, spec string) bool {
+func isJobProposed(env cldf.Environment, nodeID string, spec string) bool {
 	// implement this when it is available
 	return false
 }

--- a/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go
+++ b/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go
@@ -10,7 +10,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
@@ -157,7 +156,7 @@ func (c UpdateBidirectionalLanesConfig) BuildConfigs() UpdateBidirectionalLanesC
 	}
 }
 
-func updateBidirectionalLanesPrecondition(e deployment.Environment, c UpdateBidirectionalLanesConfig) error {
+func updateBidirectionalLanesPrecondition(e cldf.Environment, c UpdateBidirectionalLanesConfig) error {
 	configs := c.BuildConfigs()
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
@@ -192,7 +191,7 @@ func updateBidirectionalLanesPrecondition(e deployment.Environment, c UpdateBidi
 	return nil
 }
 
-func updateBidirectionalLanesLogic(e deployment.Environment, c UpdateBidirectionalLanesConfig) (cldf.ChangesetOutput, error) {
+func updateBidirectionalLanesLogic(e cldf.Environment, c UpdateBidirectionalLanesConfig) (cldf.ChangesetOutput, error) {
 	proposals := make([]mcms.TimelockProposal, 0)
 	configs := c.BuildConfigs()
 

--- a/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes_test.go
@@ -14,7 +14,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -75,7 +74,7 @@ func getRemoteChains(chains []v1_6.ChainDefinition, currentIndex int) []v1_6.Cha
 
 func checkBidirectionalLaneConnectivity(
 	t *testing.T,
-	e deployment.Environment,
+	e cldf.Environment,
 	state stateview.CCIPOnChainState,
 	chainOne v1_6.ChainDefinition,
 	chainTwo v1_6.ChainDefinition,

--- a/deployment/ccip/manualexechelpers/exec.go
+++ b/deployment/ccip/manualexechelpers/exec.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	defaults "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common/default"
@@ -21,7 +23,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm/manualexeclib"
 )
@@ -116,7 +117,7 @@ func durationToBlocks(srcChainSel uint64, lookbackDuration time.Duration) uint64
 func getCommitRootAcceptedEvent(
 	ctx context.Context,
 	lggr logger.Logger,
-	env deployment.Environment,
+	env cldf.Environment,
 	state stateview.CCIPOnChainState,
 	srcChainSel uint64,
 	destChainSel uint64,
@@ -210,7 +211,7 @@ func findCommitRoot(
 func getCCIPMessageSentEvents(
 	ctx context.Context,
 	lggr logger.Logger,
-	env deployment.Environment,
+	env cldf.Environment,
 	state stateview.CCIPOnChainState,
 	srcChainSel uint64,
 	destChainSel uint64,
@@ -303,7 +304,7 @@ func manuallyExecuteSingle(
 	ctx context.Context,
 	lggr logger.Logger,
 	state stateview.CCIPOnChainState,
-	env deployment.Environment,
+	env cldf.Environment,
 	srcChainSel uint64,
 	destChainSel uint64,
 	msgSeqNr uint64,
@@ -526,7 +527,7 @@ func manuallyExecuteSingle(
 			},
 		},
 	)
-	_, err = deployment.ConfirmIfNoErrorWithABI(env.Chains[destChainSel], tx, offramp.OffRampABI, err)
+	_, err = cldf.ConfirmIfNoErrorWithABI(env.Chains[destChainSel], tx, offramp.OffRampABI, err)
 	if err != nil {
 		return fmt.Errorf("failed to execute message: %w", err)
 	}
@@ -543,7 +544,7 @@ func ManuallyExecuteAll(
 	ctx context.Context,
 	lggr logger.Logger,
 	state stateview.CCIPOnChainState,
-	env deployment.Environment,
+	env cldf.Environment,
 	srcChainSel uint64,
 	destChainSel uint64,
 	msgSeqNrs []int64,

--- a/deployment/ccip/shared/deployergroup/deployer_group_test.go
+++ b/deployment/ccip/shared/deployergroup/deployer_group_test.go
@@ -15,7 +15,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -45,7 +44,7 @@ type dummyEmptyBatchChangesetConfig struct {
 	MCMS *proposalutils.TimelockConfig
 }
 
-func dummyEmptyBatchChangeset(e deployment.Environment, cfg dummyEmptyBatchChangesetConfig) (cldf.ChangesetOutput, error) {
+func dummyEmptyBatchChangeset(e cldf.Environment, cfg dummyEmptyBatchChangesetConfig) (cldf.ChangesetOutput, error) {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -55,7 +54,7 @@ func dummyEmptyBatchChangeset(e deployment.Environment, cfg dummyEmptyBatchChang
 	return group.Enact()
 }
 
-func dummyDeployerGroupGrantMintChangeset(e deployment.Environment, cfg dummyDeployerGroupChangesetConfig) (cldf.ChangesetOutput, error) {
+func dummyDeployerGroupGrantMintChangeset(e cldf.Environment, cfg dummyDeployerGroupChangesetConfig) (cldf.ChangesetOutput, error) {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -77,7 +76,7 @@ func dummyDeployerGroupGrantMintChangeset(e deployment.Environment, cfg dummyDep
 	return group.Enact()
 }
 
-func dummyDeployerGroupMintChangeset(e deployment.Environment, cfg dummyDeployerGroupChangesetConfig) (cldf.ChangesetOutput, error) {
+func dummyDeployerGroupMintChangeset(e cldf.Environment, cfg dummyDeployerGroupChangesetConfig) (cldf.ChangesetOutput, error) {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -101,7 +100,7 @@ func dummyDeployerGroupMintChangeset(e deployment.Environment, cfg dummyDeployer
 	return group.Enact()
 }
 
-func dummyDeployerGroupGrantMintMultiChainChangeset(e deployment.Environment, cfg dummyMultiChainDeployerGroupChangesetConfig) (cldf.ChangesetOutput, error) {
+func dummyDeployerGroupGrantMintMultiChainChangeset(e cldf.Environment, cfg dummyMultiChainDeployerGroupChangesetConfig) (cldf.ChangesetOutput, error) {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -126,7 +125,7 @@ func dummyDeployerGroupGrantMintMultiChainChangeset(e deployment.Environment, cf
 	return group.Enact()
 }
 
-func dummyDeployerGroupMintMultiDeploymentContextChangeset(e deployment.Environment, cfg dummyMultiChainDeployerGroupChangesetConfig) (cldf.ChangesetOutput, error) {
+func dummyDeployerGroupMintMultiDeploymentContextChangeset(e cldf.Environment, cfg dummyMultiChainDeployerGroupChangesetConfig) (cldf.ChangesetOutput, error) {
 	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err

--- a/deployment/ccip/shared/stateview/aptos/state.go
+++ b/deployment/ccip/shared/stateview/aptos/state.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip_offramp"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
@@ -27,7 +26,7 @@ type CCIPChainState struct {
 }
 
 // LoadOnchainStateAptos loads chain state for Aptos chains from env
-func LoadOnchainStateAptos(env deployment.Environment) (map[uint64]CCIPChainState, error) {
+func LoadOnchainStateAptos(env cldf.Environment) (map[uint64]CCIPChainState, error) {
 	aptosChains := make(map[uint64]CCIPChainState)
 	for chainSelector := range env.AptosChains {
 		addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
@@ -71,7 +70,7 @@ func loadAptosChainStateFromAddresses(addresses map[string]cldf.TypeAndVersion) 
 	return chainState, nil
 }
 
-func GetOfframpDynamicConfig(c deployment.AptosChain, ccipAddress aptos.AccountAddress) (module_offramp.DynamicConfig, error) {
+func GetOfframpDynamicConfig(c cldf.AptosChain, ccipAddress aptos.AccountAddress) (module_offramp.DynamicConfig, error) {
 	offrampBind := ccip_offramp.Bind(ccipAddress, c.Client)
 	return offrampBind.Offramp().GetDynamicConfig(&bind.CallOpts{})
 }

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -49,6 +49,8 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/multicall3"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/weth9"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
@@ -129,7 +131,7 @@ type CCIPChainState struct {
 // ValidateHomeChain validates the home chain contracts and their configurations after complete set up
 // It cross-references the config across CCIPHome and OffRamps to ensure they are in sync
 // This should be called after the complete deployment is done
-func (c CCIPChainState) ValidateHomeChain(e deployment.Environment, nodes deployment.Nodes, offRampsByChain map[uint64]offramp.OffRampInterface) error {
+func (c CCIPChainState) ValidateHomeChain(e cldf.Environment, nodes deployment.Nodes, offRampsByChain map[uint64]offramp.OffRampInterface) error {
 	if c.RMNHome == nil {
 		return errors.New("no RMNHome contract found in the state for home chain")
 	}
@@ -185,7 +187,7 @@ func (c CCIPChainState) ValidateHomeChain(e deployment.Environment, nodes deploy
 
 // validateCCIPHomeVersionedActiveConfig validates the CCIPHomeVersionedConfig based on corresponding chain selector and its state
 // The validation related to correctness of F and node length is omitted here as it is already validated in the contract
-func (c CCIPChainState) validateCCIPHomeVersionedActiveConfig(e deployment.Environment, nodes deployment.Nodes, homeCfg ccip_home.CCIPHomeVersionedConfig, offRampsByChain map[uint64]offramp.OffRampInterface) error {
+func (c CCIPChainState) validateCCIPHomeVersionedActiveConfig(e cldf.Environment, nodes deployment.Nodes, homeCfg ccip_home.CCIPHomeVersionedConfig, offRampsByChain map[uint64]offramp.OffRampInterface) error {
 	if homeCfg.ConfigDigest == [32]byte{} {
 		return errors.New("active config digest is empty")
 	}
@@ -276,7 +278,7 @@ func (c CCIPChainState) validateCCIPHomeVersionedActiveConfig(e deployment.Envir
 
 // ValidateOnRamp validates whether the contract addresses configured in static and dynamic config are in sync with state
 func (c CCIPChainState) ValidateOnRamp(
-	e deployment.Environment,
+	e cldf.Environment,
 	selector uint64,
 	connectedChains []uint64,
 ) error {
@@ -351,7 +353,7 @@ func (c CCIPChainState) ValidateOnRamp(
 }
 
 // ValidateFeeQuoter validates whether the fee quoter contract address configured in static config is in sync with state
-func (c CCIPChainState) ValidateFeeQuoter(e deployment.Environment) error {
+func (c CCIPChainState) ValidateFeeQuoter(e cldf.Environment) error {
 	if c.FeeQuoter == nil {
 		return errors.New("no FeeQuoter contract found in the state")
 	}
@@ -374,7 +376,7 @@ func (c CCIPChainState) ValidateFeeQuoter(e deployment.Environment) error {
 
 // ValidateRouter validates the router contract to check if all wired contracts are synced with state
 // and returns all connected chains with respect to the router
-func (c CCIPChainState) ValidateRouter(e deployment.Environment, isTestRouter bool) ([]uint64, error) {
+func (c CCIPChainState) ValidateRouter(e cldf.Environment, isTestRouter bool) ([]uint64, error) {
 	if c.Router == nil && c.TestRouter == nil {
 		return nil, errors.New("no Router or TestRouter contract found in the state")
 	}
@@ -443,7 +445,7 @@ func (c CCIPChainState) ValidateRouter(e deployment.Environment, isTestRouter bo
 // and returns whether RMN is enabled for the chain on the RMNRemote
 // It validates whether RMNRemote is in sync with the RMNHome contract
 func (c CCIPChainState) ValidateRMNRemote(
-	e deployment.Environment,
+	e cldf.Environment,
 	selector uint64,
 	rmnHomeActiveDigest [32]byte,
 ) (bool, error) {
@@ -478,7 +480,7 @@ func (c CCIPChainState) ValidateRMNRemote(
 
 // ValidateOffRamp validates the offRamp contract to check if all wired contracts are synced with state
 func (c CCIPChainState) ValidateOffRamp(
-	e deployment.Environment,
+	e cldf.Environment,
 	selector uint64,
 	onRampsBySelector map[uint64]common.Address,
 	isRMNEnabledBySource map[uint64]bool,

--- a/deployment/ccip/shared/stateview/solana/state.go
+++ b/deployment/ccip/shared/stateview/solana/state.go
@@ -19,7 +19,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view"
 	solanaview "github.com/smartcontractkit/chainlink/deployment/ccip/view/solana"
@@ -88,7 +87,7 @@ func (s CCIPChainState) GetRouterInfo() (router, routerConfigPDA solana.PublicKe
 	return s.Router, routerConfigPDA, nil
 }
 
-func (s CCIPChainState) GenerateView(solChain deployment.SolChain) (view.SolChainView, error) {
+func (s CCIPChainState) GenerateView(solChain cldf.SolChain) (view.SolChainView, error) {
 	chainView := view.NewSolChain()
 	var remoteChains []uint64
 	for selector := range s.DestChainStatePDAs {
@@ -167,7 +166,7 @@ func (s CCIPChainState) GenerateView(solChain deployment.SolChain) (view.SolChai
 	return chainView, nil
 }
 
-func (s CCIPChainState) GetFeeAggregator(chain deployment.SolChain) solana.PublicKey {
+func (s CCIPChainState) GetFeeAggregator(chain cldf.SolChain) solana.PublicKey {
 	var config ccip_router.Config
 	configPDA, _, _ := state.FindConfigPDA(s.Router)
 	err := chain.GetAccountDataBorshInto(context.Background(), configPDA, &config)
@@ -177,7 +176,7 @@ func (s CCIPChainState) GetFeeAggregator(chain deployment.SolChain) solana.Publi
 	return config.FeeAggregator
 }
 
-func FetchOfframpLookupTable(ctx context.Context, chain deployment.SolChain, offRampAddress solana.PublicKey) (solana.PublicKey, error) {
+func FetchOfframpLookupTable(ctx context.Context, chain cldf.SolChain, offRampAddress solana.PublicKey) (solana.PublicKey, error) {
 	var referenceAddressesAccount ccip_offramp.ReferenceAddresses
 	offRampReferenceAddressesPDA, _, _ := state.FindOfframpReferenceAddressesPDA(offRampAddress)
 	err := chain.GetAccountDataBorshInto(ctx, offRampReferenceAddressesPDA, &referenceAddressesAccount)
@@ -188,7 +187,7 @@ func FetchOfframpLookupTable(ctx context.Context, chain deployment.SolChain, off
 }
 
 // LoadChainStateSolana Loads all state for a SolChain into state
-func LoadChainStateSolana(chain deployment.SolChain, addresses map[string]cldf.TypeAndVersion) (CCIPChainState, error) {
+func LoadChainStateSolana(chain cldf.SolChain, addresses map[string]cldf.TypeAndVersion) (CCIPChainState, error) {
 	solState := CCIPChainState{
 		SourceChainStatePDAs:  make(map[uint64]solana.PublicKey),
 		DestChainStatePDAs:    make(map[uint64]solana.PublicKey),
@@ -369,8 +368,8 @@ func FindSolanaAddress(tv cldf.TypeAndVersion, addresses map[string]cldf.TypeAnd
 }
 
 func ValidateOwnershipSolana(
-	e *deployment.Environment,
-	chain deployment.SolChain,
+	e *cldf.Environment,
+	chain cldf.SolChain,
 	mcms bool,
 	programID solana.PublicKey,
 	contractType cldf.ContractType,
@@ -453,8 +452,8 @@ func ValidateOwnershipSolana(
 }
 
 func IsSolanaProgramOwnedByTimelock(
-	e *deployment.Environment,
-	chain deployment.SolChain,
+	e *cldf.Environment,
+	chain cldf.SolChain,
 	chainState CCIPChainState,
 	contractType cldf.ContractType,
 	tokenAddress solana.PublicKey, // for token pools only

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -99,7 +99,7 @@ type CCIPOnChainState struct {
 // ValidatePostDeploymentState should be called after the deployment and configuration for all contracts
 // in environment is complete.
 // It validates the state of the contracts and ensures that they are correctly configured and wired with each other.
-func (c CCIPOnChainState) ValidatePostDeploymentState(e deployment.Environment) error {
+func (c CCIPOnChainState) ValidatePostDeploymentState(e cldf.Environment) error {
 	onRampsBySelector := make(map[uint64]common.Address)
 	offRampsBySelector := make(map[uint64]offramp.OffRampInterface)
 	for selector, chainState := range c.Chains {
@@ -200,7 +200,7 @@ func (c CCIPOnChainState) EVMMCMSStateByChain() map[uint64]commonstate.MCMSWithT
 	return mcmsStateByChain
 }
 
-func (c CCIPOnChainState) OffRampPermissionLessExecutionThresholdSeconds(ctx context.Context, env deployment.Environment, selector uint64) (uint32, error) {
+func (c CCIPOnChainState) OffRampPermissionLessExecutionThresholdSeconds(ctx context.Context, env cldf.Environment, selector uint64) (uint32, error) {
 	family, err := chain_selectors.GetSelectorFamily(selector)
 	if err != nil {
 		return 0, err
@@ -375,7 +375,7 @@ func (c CCIPOnChainState) EnforceMCMSUsageIfProd(ctx context.Context, mcmsConfig
 // ValidateOwnershipOfChain validates the ownership of every CCIP contract on a chain.
 // If mcmsConfig is nil, the expected owner of each contract is the chain's deployer key.
 // If provided, the expected owner is the Timelock contract.
-func (c CCIPOnChainState) ValidateOwnershipOfChain(e deployment.Environment, chainSel uint64, mcmsConfig *proposalutils.TimelockConfig) error {
+func (c CCIPOnChainState) ValidateOwnershipOfChain(e cldf.Environment, chainSel uint64, mcmsConfig *proposalutils.TimelockConfig) error {
 	chain, ok := e.Chains[chainSel]
 	if !ok {
 		return fmt.Errorf("chain with selector %d not found in the environment", chainSel)
@@ -428,7 +428,7 @@ func (c CCIPOnChainState) ValidateOwnershipOfChain(e deployment.Environment, cha
 	return nil
 }
 
-func (c CCIPOnChainState) View(e *deployment.Environment, chains []uint64) (map[string]view.ChainView, map[string]view.SolChainView, error) {
+func (c CCIPOnChainState) View(e *cldf.Environment, chains []uint64) (map[string]view.ChainView, map[string]view.SolChainView, error) {
 	m := sync.Map{}
 	sm := sync.Map{}
 	grp := errgroup.Group{}
@@ -440,7 +440,7 @@ func (c CCIPOnChainState) View(e *deployment.Environment, chains []uint64) (map[
 			if err != nil {
 				return err
 			}
-			chainInfo, err := deployment.ChainInfo(chainSelector)
+			chainInfo, err := cldf.ChainInfo(chainSelector)
 			if err != nil {
 				return err
 			}
@@ -611,7 +611,7 @@ func (c CCIPOnChainState) ValidateRamp(chainSelector uint64, rampType cldf.Contr
 	return nil
 }
 
-func LoadOnchainState(e deployment.Environment) (CCIPOnChainState, error) {
+func LoadOnchainState(e cldf.Environment) (CCIPOnChainState, error) {
 	solanaState, err := LoadOnchainStateSolana(e)
 	if err != nil {
 		return CCIPOnChainState{}, err
@@ -644,7 +644,7 @@ func LoadOnchainState(e deployment.Environment) (CCIPOnChainState, error) {
 }
 
 // LoadChainState Loads all state for a chain into state
-func LoadChainState(ctx context.Context, chain deployment.Chain, addresses map[string]cldf.TypeAndVersion) (evm.CCIPChainState, error) {
+func LoadChainState(ctx context.Context, chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (evm.CCIPChainState, error) {
 	var state evm.CCIPChainState
 	mcmsWithTimelock, err := commonstate.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 	if err != nil {
@@ -1043,8 +1043,8 @@ func LoadChainState(ctx context.Context, chain deployment.Chain, addresses map[s
 	return state, nil
 }
 
-func ValidateChain(env deployment.Environment, state CCIPOnChainState, chainSel uint64, mcmsCfg *proposalutils.TimelockConfig) error {
-	err := deployment.IsValidChainSelector(chainSel)
+func ValidateChain(env cldf.Environment, state CCIPOnChainState, chainSel uint64, mcmsCfg *proposalutils.TimelockConfig) error {
+	err := cldf.IsValidChainSelector(chainSel)
 	if err != nil {
 		return fmt.Errorf("is not valid chain selector %d: %w", chainSel, err)
 	}
@@ -1071,7 +1071,7 @@ func ValidateChain(env deployment.Environment, state CCIPOnChainState, chainSel 
 	return nil
 }
 
-func LoadOnchainStateSolana(e deployment.Environment) (CCIPOnChainState, error) {
+func LoadOnchainStateSolana(e cldf.Environment) (CCIPOnChainState, error) {
 	state := CCIPOnChainState{
 		SolChains: make(map[uint64]solana.CCIPChainState),
 	}

--- a/deployment/ccip/shared/stateview/state_test.go
+++ b/deployment/ccip/shared/stateview/state_test.go
@@ -168,7 +168,7 @@ func TestEnforceMCMSUsageIfProd(t *testing.T) {
 
 			if test.DeployCCIPHome {
 				_, err = cldf.DeployContract(e.Logger, e.Chains[homeChainSelector], e.ExistingAddresses,
-					func(chain deployment.Chain) cldf.ContractDeploy[*ccip_home.CCIPHome] {
+					func(chain cldf.Chain) cldf.ContractDeploy[*ccip_home.CCIPHome] {
 						address, tx2, contract, err2 := ccip_home.DeployCCIPHome(
 							chain.DeployerKey,
 							chain.Client,
@@ -183,7 +183,7 @@ func TestEnforceMCMSUsageIfProd(t *testing.T) {
 
 			if test.DeployCapReg {
 				_, err = cldf.DeployContract(e.Logger, e.Chains[homeChainSelector], e.ExistingAddresses,
-					func(chain deployment.Chain) cldf.ContractDeploy[*capabilities_registry.CapabilitiesRegistry] {
+					func(chain cldf.Chain) cldf.ContractDeploy[*capabilities_registry.CapabilitiesRegistry] {
 						address, tx2, contract, err2 := capabilities_registry.DeployCapabilitiesRegistry(
 							chain.DeployerKey,
 							chain.Client,

--- a/deployment/ccip/shared/token_pools.go
+++ b/deployment/ccip/shared/token_pools.go
@@ -54,7 +54,7 @@ func NewTokenPoolWithMetadata[P tokenPool](
 	ctx context.Context,
 	newTokenPool func(address common.Address, backend bind.ContractBackend) (P, error),
 	poolAddress common.Address,
-	chainClient deployment.OnchainClient,
+	chainClient cldf.OnchainClient,
 ) (P, TokenPoolMetadata, error) {
 	pool, err := newTokenPool(poolAddress, chainClient)
 	if err != nil {

--- a/deployment/ccip/view/solana/feequoter.go
+++ b/deployment/ccip/view/solana/feequoter.go
@@ -8,7 +8,8 @@ import (
 
 	solFeeQuoter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 type FeeQuoterView struct {
@@ -62,7 +63,7 @@ type FeeQuoterTokenTransferConfig struct {
 	IsEnabled         bool   `json:"isEnabled,omitempty"`
 }
 
-func GenerateFeeQuoterView(chain deployment.SolChain, program solana.PublicKey, remoteChains []uint64, tokens []solana.PublicKey) (FeeQuoterView, error) {
+func GenerateFeeQuoterView(chain cldf.SolChain, program solana.PublicKey, remoteChains []uint64, tokens []solana.PublicKey) (FeeQuoterView, error) {
 	fq := FeeQuoterView{}
 	var fqConfig solFeeQuoter.Config
 	feeQuoterConfigPDA, _, _ := solState.FindFqConfigPDA(program)

--- a/deployment/ccip/view/solana/offramp.go
+++ b/deployment/ccip/view/solana/offramp.go
@@ -8,7 +8,8 @@ import (
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
 )
 
@@ -38,7 +39,7 @@ type OffRampSourceChainConfig struct {
 	OnRamp                    string `json:"onRamp,omitempty"`
 }
 
-func GenerateOffRampView(chain deployment.SolChain, program solana.PublicKey, remoteChains []uint64, tokens []solana.PublicKey) (OffRampView, error) {
+func GenerateOffRampView(chain cldf.SolChain, program solana.PublicKey, remoteChains []uint64, tokens []solana.PublicKey) (OffRampView, error) {
 	view := OffRampView{}
 	var config solOffRamp.Config
 	configPDA, _, _ := solState.FindOfframpConfigPDA(program)

--- a/deployment/ccip/view/solana/rmnremote.go
+++ b/deployment/ccip/view/solana/rmnremote.go
@@ -9,7 +9,8 @@ import (
 
 	solRmnRemote "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/rmn_remote"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 type RMNRemoteView struct {
@@ -20,7 +21,7 @@ type RMNRemoteView struct {
 	CurseSubjects      []string `json:"curses,omitempty"`
 }
 
-func GenerateRMNRemoteView(chain deployment.SolChain, program solana.PublicKey, remoteChains []uint64, tokens []solana.PublicKey) (RMNRemoteView, error) {
+func GenerateRMNRemoteView(chain cldf.SolChain, program solana.PublicKey, remoteChains []uint64, tokens []solana.PublicKey) (RMNRemoteView, error) {
 	view := RMNRemoteView{}
 	var config solRmnRemote.Config
 	configPDA, _, _ := solState.FindRMNRemoteConfigPDA(program)

--- a/deployment/ccip/view/solana/router.go
+++ b/deployment/ccip/view/solana/router.go
@@ -9,7 +9,8 @@ import (
 	solCommon "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_common"
 	solRouter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 type RouterView struct {
@@ -41,7 +42,7 @@ type RouterTokenAdminRegistry struct {
 	Mint                 string   `json:"mint,omitempty"`
 }
 
-func GenerateRouterView(chain deployment.SolChain, program solana.PublicKey, remoteChains []uint64, tokens []solana.PublicKey) (RouterView, error) {
+func GenerateRouterView(chain cldf.SolChain, program solana.PublicKey, remoteChains []uint64, tokens []solana.PublicKey) (RouterView, error) {
 	view := RouterView{}
 	var config solRouter.Config
 	configPDA, _, _ := solState.FindConfigPDA(program)

--- a/deployment/ccip/view/solana/token.go
+++ b/deployment/ccip/view/solana/token.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	solToken "github.com/gagliardetto/solana-go/programs/token"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 type TokenView struct {
@@ -19,7 +19,7 @@ type TokenView struct {
 	FreezeAuthority  string `json:"freezeAuthority,omitempty"`
 }
 
-func GenerateTokenView(chain deployment.SolChain, tokenAddress solana.PublicKey, tokenProgram string) (TokenView, error) {
+func GenerateTokenView(chain cldf.SolChain, tokenAddress solana.PublicKey, tokenProgram string) (TokenView, error) {
 	view := TokenView{}
 	view.TokenProgramName = tokenProgram
 	var tokenMint solToken.Mint

--- a/deployment/ccip/view/solana/tokenpool.go
+++ b/deployment/ccip/view/solana/tokenpool.go
@@ -7,7 +7,8 @@ import (
 	solTestTokenPool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/test_token_pool"
 	solTokenUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view/shared"
 )
 
@@ -53,7 +54,7 @@ type TokenPoolRateLimitTokenBucket struct {
 	Rate        uint64 `json:"rate"`
 }
 
-func GenerateTokenPoolView(chain deployment.SolChain, program solana.PublicKey, remoteChains []uint64, tokens []solana.PublicKey, poolType string, poolMetadata string) (TokenPoolView, error) {
+func GenerateTokenPoolView(chain cldf.SolChain, program solana.PublicKey, remoteChains []uint64, tokens []solana.PublicKey, poolType string, poolMetadata string) (TokenPoolView, error) {
 	view := TokenPoolView{}
 	view.PoolType = poolType
 	view.PoolMetadata = poolMetadata

--- a/deployment/ccip/view/v1_2/price_registry_test.go
+++ b/deployment/ccip/view/v1_2/price_registry_test.go
@@ -10,7 +10,9 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	price_registry_1_2_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/price_registry"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -23,7 +25,7 @@ func TestGeneratePriceRegistryView(t *testing.T) {
 	f1, f2 := common.HexToAddress("0x1"), common.HexToAddress("0x2")
 	_, tx, c, err := price_registry_1_2_0.DeployPriceRegistry(
 		chain.DeployerKey, chain.Client, []common.Address{chain.DeployerKey.From}, []common.Address{f1, f2}, uint32(10))
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	v, err := GeneratePriceRegistryView(c)

--- a/deployment/ccip/view/v1_5/offramp_test.go
+++ b/deployment/ccip/view/v1_5/offramp_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/commit_store"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_offramp"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -30,7 +32,7 @@ func TestOffRampView(t *testing.T) {
 			OnRamp:              common.HexToAddress("0x4"),
 			RmnProxy:            common.HexToAddress("0x1"),
 		})
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 	sc := evm_2_evm_offramp.EVM2EVMOffRampStaticConfig{
 		ChainSelector:       chainsel.TEST_90000002.Selector,
@@ -47,7 +49,7 @@ func TestOffRampView(t *testing.T) {
 	}
 	_, tx, c2, err := evm_2_evm_offramp.DeployEVM2EVMOffRamp(
 		chain.DeployerKey, chain.Client, sc, rl)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	v, err := GenerateOffRampView(c2)

--- a/deployment/ccip/view/v1_5/onramp_test.go
+++ b/deployment/ccip/view/v1_5/onramp_test.go
@@ -11,7 +11,9 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -57,7 +59,7 @@ func TestOnRampView(t *testing.T) {
 		[]evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{},
 		[]evm_2_evm_onramp.EVM2EVMOnRampNopAndWeight{},
 	)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 	v, err := GenerateOnRampView(c)
 	require.NoError(t, err)

--- a/deployment/ccip/view/v1_6/ccip_home_test.go
+++ b/deployment/ccip/view/v1_6/ccip_home_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -23,12 +25,12 @@ func TestCCIPHomeView(t *testing.T) {
 	_, tx, cr, err := capabilities_registry.DeployCapabilitiesRegistry(
 		chain.DeployerKey, chain.Client)
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	_, tx, ch, err := ccip_home.DeployCCIPHome(
 		chain.DeployerKey, chain.Client, cr.Address())
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	v, err := GenerateCCIPHomeView(cr, ch)

--- a/deployment/ccip/view/v1_6/rmnremote_test.go
+++ b/deployment/ccip/view/v1_6/rmnremote_test.go
@@ -10,7 +10,9 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -22,18 +24,18 @@ func Test_RMNRemote_Curse_View(t *testing.T) {
 	})
 	chain := e.Chains[e.AllChainSelectors()[0]]
 	_, tx, remote, err := rmn_remote.DeployRMNRemote(chain.DeployerKey, chain.Client, e.AllChainSelectors()[0], common.Address{})
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	tx, err = remote.Curse(chain.DeployerKey, globals.GlobalCurseSubject())
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	family, err := chainsel.GetSelectorFamily(e.AllChainSelectors()[0])
 	require.NoError(t, err)
 
 	tx, err = remote.Curse(chain.DeployerKey, globals.FamilyAwareSelectorToSubject(e.AllChainSelectors()[0], family))
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	view, err := GenerateRMNRemoteView(remote)

--- a/deployment/cldf/migrated_environment.go
+++ b/deployment/cldf/migrated_environment.go
@@ -1,4 +1,4 @@
-package deployment
+package cldf
 
 import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"

--- a/deployment/common/changeset/deploy_link_token.go
+++ b/deployment/common/changeset/deploy_link_token.go
@@ -26,7 +26,7 @@ import (
 var _ cldf.ChangeSet[[]uint64] = DeployLinkToken
 
 // DeployLinkToken deploys a link token contract to the chain identified by the ChainSelector.
-func DeployLinkToken(e deployment.Environment, chains []uint64) (cldf.ChangesetOutput, error) {
+func DeployLinkToken(e cldf.Environment, chains []uint64) (cldf.ChangesetOutput, error) {
 	err := deployment.ValidateSelectorsInEnvironment(e, chains)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -64,7 +64,7 @@ func DeployLinkToken(e deployment.Environment, chains []uint64) (cldf.ChangesetO
 }
 
 // DeployStaticLinkToken deploys a static link token contract to the chain identified by the ChainSelector.
-func DeployStaticLinkToken(e deployment.Environment, chains []uint64) (cldf.ChangesetOutput, error) {
+func DeployStaticLinkToken(e cldf.Environment, chains []uint64) (cldf.ChangesetOutput, error) {
 	err := deployment.ValidateSelectorsInEnvironment(e, chains)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -76,7 +76,7 @@ func DeployStaticLinkToken(e deployment.Environment, chains []uint64) (cldf.Chan
 			return cldf.ChangesetOutput{}, fmt.Errorf("chain not found in environment: %d", chainSel)
 		}
 		_, err := cldf.DeployContract[*link_token_interface.LinkToken](e.Logger, chain, newAddresses,
-			func(chain deployment.Chain) cldf.ContractDeploy[*link_token_interface.LinkToken] {
+			func(chain cldf.Chain) cldf.ContractDeploy[*link_token_interface.LinkToken] {
 				linkTokenAddr, tx, linkToken, err2 := link_token_interface.DeployLinkToken(
 					chain.DeployerKey,
 					chain.Client,
@@ -99,11 +99,11 @@ func DeployStaticLinkToken(e deployment.Environment, chains []uint64) (cldf.Chan
 
 func deployLinkTokenContractEVM(
 	lggr logger.Logger,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	ab cldf.AddressBook,
 ) (*cldf.ContractDeploy[*link_token.LinkToken], error) {
 	linkToken, err := cldf.DeployContract[*link_token.LinkToken](lggr, chain, ab,
-		func(chain deployment.Chain) cldf.ContractDeploy[*link_token.LinkToken] {
+		func(chain cldf.Chain) cldf.ContractDeploy[*link_token.LinkToken] {
 			linkTokenAddr, tx, linkToken, err2 := link_token.DeployLinkToken(
 				chain.DeployerKey,
 				chain.Client,
@@ -129,7 +129,7 @@ type DeploySolanaLinkTokenConfig struct {
 	TokenDecimals uint8
 }
 
-func DeploySolanaLinkToken(e deployment.Environment, cfg DeploySolanaLinkTokenConfig) (cldf.ChangesetOutput, error) {
+func DeploySolanaLinkToken(e cldf.Environment, cfg DeploySolanaLinkTokenConfig) (cldf.ChangesetOutput, error) {
 	chain := e.SolChains[cfg.ChainSelector]
 	mint := cfg.TokenPrivKey
 	instructions, err := solTokenUtil.CreateToken(

--- a/deployment/common/changeset/deploy_mcms_with_timelock.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock.go
@@ -40,7 +40,7 @@ var (
 
 // DeployMCMSWithTimelockV2 deploys and initializes the MCM and Timelock contracts
 func DeployMCMSWithTimelockV2(
-	env deployment.Environment, cfgByChain map[uint64]types.MCMSWithTimelockConfigV2,
+	env cldf.Environment, cfgByChain map[uint64]types.MCMSWithTimelockConfigV2,
 ) (cldf.ChangesetOutput, error) {
 	newAddresses := cldf.NewMemoryAddressBook()
 
@@ -97,7 +97,7 @@ type GrantRoleInput struct {
 	MCMS                    *proposalutils.TimelockConfig
 }
 
-func grantRolePreconditions(e deployment.Environment, cfg GrantRoleInput) error {
+func grantRolePreconditions(e cldf.Environment, cfg GrantRoleInput) error {
 	mcmsState, err := state.MaybeLoadMCMSWithTimelockState(e, maps.Keys(cfg.ExistingProposerByChain))
 	if err != nil {
 		return err
@@ -133,7 +133,7 @@ func grantRolePreconditions(e deployment.Environment, cfg GrantRoleInput) error 
 	return nil
 }
 
-func grantRoleLogic(e deployment.Environment, cfg GrantRoleInput) (cldf.ChangesetOutput, error) {
+func grantRoleLogic(e cldf.Environment, cfg GrantRoleInput) (cldf.ChangesetOutput, error) {
 	mcmsState, err := state.MaybeLoadMCMSWithTimelockState(e, maps.Keys(cfg.ExistingProposerByChain))
 	if err != nil {
 		return cldf.ChangesetOutput{}, err

--- a/deployment/common/changeset/deploy_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock_test.go
@@ -552,7 +552,7 @@ func timelockSignerPDA(programID solana.PublicKey, seed mcmschangesetstate.PDASe
 }
 
 func solanaTimelockConfig(
-	ctx context.Context, t *testing.T, chain deployment.SolChain, programID solana.PublicKey, seed mcmschangesetstate.PDASeed,
+	ctx context.Context, t *testing.T, chain cldf.SolChain, programID solana.PublicKey, seed mcmschangesetstate.PDASeed,
 ) timelockBindings.Config {
 	t.Helper()
 

--- a/deployment/common/changeset/example/add_mint_burners_link.go
+++ b/deployment/common/changeset/example/add_mint_burners_link.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 )
 
@@ -18,7 +18,7 @@ type AddMintersBurnersLinkConfig struct {
 var _ cldf.ChangeSet[*AddMintersBurnersLinkConfig] = AddMintersBurnersLink
 
 // AddMintersBurnersLink grants the minter / burner role to the provided addresses.
-func AddMintersBurnersLink(e deployment.Environment, cfg *AddMintersBurnersLinkConfig) (cldf.ChangesetOutput, error) {
+func AddMintersBurnersLink(e cldf.Environment, cfg *AddMintersBurnersLinkConfig) (cldf.ChangesetOutput, error) {
 	chain := e.Chains[cfg.ChainSelector]
 	addresses, err := e.ExistingAddresses.AddressesForChain(cfg.ChainSelector)
 	if err != nil {
@@ -42,7 +42,7 @@ func AddMintersBurnersLink(e deployment.Environment, cfg *AddMintersBurnersLinkC
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
-		_, err = deployment.ConfirmIfNoError(chain, tx, err)
+		_, err = cldf.ConfirmIfNoError(chain, tx, err)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -60,7 +60,7 @@ func AddMintersBurnersLink(e deployment.Environment, cfg *AddMintersBurnersLinkC
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
-		_, err = deployment.ConfirmIfNoError(chain, tx, err)
+		_, err = cldf.ConfirmIfNoError(chain, tx, err)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}

--- a/deployment/common/changeset/example/link_transfer_test.go
+++ b/deployment/common/changeset/example/link_transfer_test.go
@@ -11,6 +11,7 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/example"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -18,14 +19,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
 // setupLinkTransferContracts deploys all required contracts for the link transfer tests and returns the updated env.
-func setupLinkTransferTestEnv(t *testing.T) deployment.Environment {
+func setupLinkTransferTestEnv(t *testing.T) cldf.Environment {
 	lggr := logger.TestLogger(t)
 	cfg := memory.MemoryEnvironmentConfig{
 		Nodes:  1,
@@ -80,12 +80,12 @@ func TestLinkTransferMCMS(t *testing.T) {
 	// grant minter permissions
 	tx, err := linkState.LinkToken.GrantMintRole(chain.DeployerKey, chain.DeployerKey.From)
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	tx, err = linkState.LinkToken.Mint(chain.DeployerKey, timelockAddress, big.NewInt(750))
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	timelocks := map[uint64]*proposalutils.TimelockExecutionContracts{
@@ -154,12 +154,12 @@ func TestLinkTransfer(t *testing.T) {
 	// grant minter permissions
 	tx, err := linkState.LinkToken.GrantMintRole(chain.DeployerKey, chain.DeployerKey.From)
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	tx, err = linkState.LinkToken.Mint(chain.DeployerKey, chain.DeployerKey.From, big.NewInt(750))
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	timelocks := map[uint64]*proposalutils.TimelockExecutionContracts{
@@ -217,11 +217,11 @@ func TestValidate(t *testing.T) {
 	require.NoError(t, err)
 	tx, err := linkState.LinkToken.GrantMintRole(chain.DeployerKey, chain.DeployerKey.From)
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 	tx, err = linkState.LinkToken.Mint(chain.DeployerKey, chain.DeployerKey.From, big.NewInt(750))
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 
 	require.NoError(t, err)
 	tests := []struct {
@@ -393,12 +393,12 @@ func TestLinkTransferMCMSV2(t *testing.T) {
 	// grant minter permissions
 	tx, err := linkState.LinkToken.GrantMintRole(chain.DeployerKey, chain.DeployerKey.From)
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	tx, err = linkState.LinkToken.Mint(chain.DeployerKey, timelockAddress, big.NewInt(750))
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	timelocks := map[uint64]*proposalutils.TimelockExecutionContracts{

--- a/deployment/common/changeset/example/mint_link.go
+++ b/deployment/common/changeset/example/mint_link.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 )
 
@@ -19,7 +19,7 @@ type MintLinkConfig struct {
 var _ cldf.ChangeSet[*MintLinkConfig] = MintLink
 
 // MintLink mints LINK to the provided contract.
-func MintLink(e deployment.Environment, cfg *MintLinkConfig) (cldf.ChangesetOutput, error) {
+func MintLink(e cldf.Environment, cfg *MintLinkConfig) (cldf.ChangesetOutput, error) {
 	chain := e.Chains[cfg.ChainSelector]
 	addresses, err := e.ExistingAddresses.AddressesForChain(cfg.ChainSelector)
 	if err != nil {
@@ -34,7 +34,7 @@ func MintLink(e deployment.Environment, cfg *MintLinkConfig) (cldf.ChangesetOutp
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}

--- a/deployment/common/changeset/example/operations/deploy_and_mint_example.go
+++ b/deployment/common/changeset/example/operations/deploy_and_mint_example.go
@@ -9,8 +9,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 /**
@@ -35,18 +33,18 @@ type SqDeployLinkOutput struct {
 
 type EthereumDeps struct {
 	Auth  *bind.TransactOpts
-	Chain deployment.Chain
+	Chain cldf.Chain
 	AB    cldf.AddressBook
 }
 
 type DeployAndMintExampleChangeset struct{}
 
-func (l DeployAndMintExampleChangeset) VerifyPreconditions(e deployment.Environment, config SqDeployLinkInput) error {
+func (l DeployAndMintExampleChangeset) VerifyPreconditions(e cldf.Environment, config SqDeployLinkInput) error {
 	// perform any preconditions checks here
 	return nil
 }
 
-func (l DeployAndMintExampleChangeset) Apply(e deployment.Environment, config SqDeployLinkInput) (cldf.ChangesetOutput, error) {
+func (l DeployAndMintExampleChangeset) Apply(e cldf.Environment, config SqDeployLinkInput) (cldf.ChangesetOutput, error) {
 	auth := e.Chains[config.ChainID].DeployerKey
 	ab := cldf.NewMemoryAddressBook()
 

--- a/deployment/common/changeset/example/operations/operation.go
+++ b/deployment/common/changeset/example/operations/operation.go
@@ -22,7 +22,7 @@ var DeployLinkOp = operations.NewOperation(
 	"Deploy LINK Contract Operation",
 	func(b operations.Bundle, deps EthereumDeps, input operations.EmptyInput) (common.Address, error) {
 		linkToken, err := cldf.DeployContract[*link_token.LinkToken](b.Logger, deps.Chain, deps.AB,
-			func(chain deployment.Chain) cldf.ContractDeploy[*link_token.LinkToken] {
+			func(chain cldf.Chain) cldf.ContractDeploy[*link_token.LinkToken] {
 				linkTokenAddr, tx, linkToken, err2 := link_token.DeployLinkToken(
 					chain.DeployerKey,
 					chain.Client,
@@ -57,7 +57,7 @@ var GrantMintOp = operations.NewOperation(
 			return nil, err
 		}
 		tx, err := contract.GrantMintRole(deps.Auth, input.To)
-		_, err = deployment.ConfirmIfNoError(deps.Chain, tx, err)
+		_, err = cldf.ConfirmIfNoError(deps.Chain, tx, err)
 		if err != nil {
 			return nil, err
 		}
@@ -81,7 +81,7 @@ var MintLinkOp = operations.NewOperation(
 			return nil, err
 		}
 		tx, err := contract.Mint(deps.Auth, input.To, input.Amount)
-		_, err = deployment.ConfirmIfNoError(deps.Chain, tx, err)
+		_, err = cldf.ConfirmIfNoError(deps.Chain, tx, err)
 		if err != nil {
 			return nil, err
 		}

--- a/deployment/common/changeset/example/operations/retry_config_example.go
+++ b/deployment/common/changeset/example/operations/retry_config_example.go
@@ -7,8 +7,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 /**
@@ -20,12 +18,12 @@ var _ cldf.ChangeSetV2[operations.EmptyInput] = DisableRetryExampleChangeset{}
 
 type DisableRetryExampleChangeset struct{}
 
-func (l DisableRetryExampleChangeset) VerifyPreconditions(e deployment.Environment, config operations.EmptyInput) error {
+func (l DisableRetryExampleChangeset) VerifyPreconditions(e cldf.Environment, config operations.EmptyInput) error {
 	// perform any preconditions checks here
 	return nil
 }
 
-func (l DisableRetryExampleChangeset) Apply(e deployment.Environment, config operations.EmptyInput) (cldf.ChangesetOutput, error) {
+func (l DisableRetryExampleChangeset) Apply(e cldf.Environment, config operations.EmptyInput) (cldf.ChangesetOutput, error) {
 	ab := cldf.NewMemoryAddressBook()
 
 	operationInput := SuccessFailOperationInput{ShouldFail: true}
@@ -45,12 +43,12 @@ var _ cldf.ChangeSetV2[operations.EmptyInput] = UpdateInputExampleChangeset{}
 
 type UpdateInputExampleChangeset struct{}
 
-func (l UpdateInputExampleChangeset) VerifyPreconditions(e deployment.Environment, config operations.EmptyInput) error {
+func (l UpdateInputExampleChangeset) VerifyPreconditions(e cldf.Environment, config operations.EmptyInput) error {
 	// perform any preconditions checks here
 	return nil
 }
 
-func (l UpdateInputExampleChangeset) Apply(e deployment.Environment, config operations.EmptyInput) (cldf.ChangesetOutput, error) {
+func (l UpdateInputExampleChangeset) Apply(e cldf.Environment, config operations.EmptyInput) (cldf.ChangesetOutput, error) {
 	ab := cldf.NewMemoryAddressBook()
 
 	operationInput := SuccessFailOperationInput{ShouldFail: true}

--- a/deployment/common/changeset/example/operations/terminal_error_example.go
+++ b/deployment/common/changeset/example/operations/terminal_error_example.go
@@ -7,8 +7,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 /**
@@ -21,12 +19,12 @@ var _ cldf.ChangeSetV2[operations.EmptyInput] = TerminalErrorExampleChangeset{}
 
 type TerminalErrorExampleChangeset struct{}
 
-func (l TerminalErrorExampleChangeset) VerifyPreconditions(e deployment.Environment, config operations.EmptyInput) error {
+func (l TerminalErrorExampleChangeset) VerifyPreconditions(e cldf.Environment, config operations.EmptyInput) error {
 	// perform any preconditions checks here
 	return nil
 }
 
-func (l TerminalErrorExampleChangeset) Apply(e deployment.Environment, config operations.EmptyInput) (cldf.ChangesetOutput, error) {
+func (l TerminalErrorExampleChangeset) Apply(e cldf.Environment, config operations.EmptyInput) (cldf.ChangesetOutput, error) {
 	ab := cldf.NewMemoryAddressBook()
 
 	_, err := operations.ExecuteOperation(e.OperationsBundle, TerminalErrorOperation, nil, operations.EmptyInput{})

--- a/deployment/common/changeset/example/solana_transfer_mcm.go
+++ b/deployment/common/changeset/example/solana_transfer_mcm.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smartcontractkit/mcms/types"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	solanachangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -34,7 +34,7 @@ type TransferFromTimelockConfig struct {
 type TransferFromTimelock struct{}
 
 // VerifyPreconditions checks if the deployer has enough SOL to fund the MCMS signers on each chain.
-func (f TransferFromTimelock) VerifyPreconditions(e deployment.Environment, config TransferFromTimelockConfig) error {
+func (f TransferFromTimelock) VerifyPreconditions(e cldf.Environment, config TransferFromTimelockConfig) error {
 	// the number of accounts to fund per chain (bypasser, canceller, proposer, timelock)
 	for chainSelector, amountCfg := range config.AmountsPerChain {
 		solChain, ok := e.SolChains[chainSelector]
@@ -72,7 +72,7 @@ func (f TransferFromTimelock) VerifyPreconditions(e deployment.Environment, conf
 }
 
 // Apply funds the MCMS signers on each chain.
-func (f TransferFromTimelock) Apply(e deployment.Environment, config TransferFromTimelockConfig) (cldf.ChangesetOutput, error) {
+func (f TransferFromTimelock) Apply(e cldf.Environment, config TransferFromTimelockConfig) (cldf.ChangesetOutput, error) {
 	timelocks := map[uint64]string{}
 	proposers := map[uint64]string{}
 	var batches []types.BatchOperation

--- a/deployment/common/changeset/example/solana_transfer_mcm_test.go
+++ b/deployment/common/changeset/example/solana_transfer_mcm_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // setupFundingTestEnv deploys all required contracts for the funding test
-func setupFundingTestEnv(t *testing.T) deployment.Environment {
+func setupFundingTestEnv(t *testing.T) cldf.Environment {
 	lggr := logger.TestLogger(t)
 	cfg := memory.MemoryEnvironmentConfig{
 		SolChains: 1,
@@ -61,7 +61,7 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 	t.Parallel()
 	lggr := logger.TestLogger(t)
 	validEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{SolChains: 1})
-	validEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
+	validEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = cldf.SolChain{}
 	validSolChainSelector := validEnv.AllChainSelectorsSolana()[0]
 	receiverKey := solana.NewWallet().PublicKey()
 	cs := example.TransferFromTimelock{}
@@ -80,7 +80,7 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 	noTimelockEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		SolChains: 1,
 	})
-	noTimelockEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
+	noTimelockEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = cldf.SolChain{}
 	err = noTimelockEnv.ExistingAddresses.Save(chainselectors.SOLANA_DEVNET.Selector, "dummy", cldf.TypeAndVersion{
 		Type:    "Sometype",
 		Version: deployment.Version1_0_0,
@@ -91,11 +91,11 @@ func TestTransferFromTimelockConfig_VerifyPreconditions(t *testing.T) {
 	invalidSolChainEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		SolChains: 0,
 	})
-	invalidSolChainEnv.SolChains[validSolChainSelector] = deployment.SolChain{}
+	invalidSolChainEnv.SolChains[validSolChainSelector] = cldf.SolChain{}
 
 	tests := []struct {
 		name          string
-		env           deployment.Environment
+		env           cldf.Environment
 		config        example.TransferFromTimelockConfig
 		expectedError string
 	}{

--- a/deployment/common/changeset/internal/evm/mcms.go
+++ b/deployment/common/changeset/internal/evm/mcms.go
@@ -50,7 +50,7 @@ type MCMSWithTimelockEVMDeploy struct {
 func DeployMCMSWithConfigEVM(
 	contractType cldf.ContractType,
 	lggr logger.Logger,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	ab cldf.AddressBook,
 	mcmConfig mcmsTypes.Config,
 	options ...DeployMCMSOption,
@@ -61,7 +61,7 @@ func DeployMCMSWithConfigEVM(
 		return nil, err
 	}
 	mcm, err := cldf.DeployContract(lggr, chain, ab,
-		func(chain deployment.Chain) cldf.ContractDeploy[*bindings.ManyChainMultiSig] {
+		func(chain cldf.Chain) cldf.ContractDeploy[*bindings.ManyChainMultiSig] {
 			mcmAddr, tx, mcm, err2 := bindings.DeployManyChainMultiSig(
 				chain.DeployerKey,
 				chain.Client,
@@ -88,7 +88,7 @@ func DeployMCMSWithConfigEVM(
 		groupParents,
 		false,
 	)
-	if _, err := deployment.ConfirmIfNoError(chain, mcmsTx, err); err != nil {
+	if _, err := cldf.ConfirmIfNoError(chain, mcmsTx, err); err != nil {
 		lggr.Errorw("Failed to confirm mcm config", "chain", chain.String(), "err", err)
 		return mcm, err
 	}
@@ -103,7 +103,7 @@ func DeployMCMSWithConfigEVM(
 func DeployMCMSWithTimelockContractsEVM(
 	ctx context.Context,
 	lggr logger.Logger,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	ab cldf.AddressBook,
 	config commontypes.MCMSWithTimelockConfigV2,
 	state *state.MCMSWithTimelockState,
@@ -157,7 +157,7 @@ func DeployMCMSWithTimelockContractsEVM(
 
 	if timelock == nil {
 		timelockC, err := cldf.DeployContract(lggr, chain, ab,
-			func(chain deployment.Chain) cldf.ContractDeploy[*bindings.RBACTimelock] {
+			func(chain cldf.Chain) cldf.ContractDeploy[*bindings.RBACTimelock] {
 				timelock, tx2, cc, err2 := bindings.DeployRBACTimelock(
 					chain.DeployerKey,
 					chain.Client,
@@ -195,7 +195,7 @@ func DeployMCMSWithTimelockContractsEVM(
 
 	if callProxy == nil {
 		callProxyC, err := cldf.DeployContract(lggr, chain, ab,
-			func(chain deployment.Chain) cldf.ContractDeploy[*bindings.CallProxy] {
+			func(chain cldf.Chain) cldf.ContractDeploy[*bindings.CallProxy] {
 				callProxy, tx2, cc, err2 := bindings.DeployCallProxy(
 					chain.DeployerKey,
 					chain.Client,
@@ -269,7 +269,7 @@ func getAdminAddresses(ctx context.Context, timelock *bindings.RBACTimelock) ([]
 func GrantRolesForTimelock(
 	ctx context.Context,
 	lggr logger.Logger,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	timelockContracts *proposalutils.MCMSWithTimelockContracts,
 	skipIfDeployerKeyNotAdmin bool, // If true, skip role grants if the deployer key is not an admin.
 ) ([]mcmsTypes.Transaction, error) {
@@ -389,12 +389,12 @@ func GrantRolesForTimelock(
 func grantRoleTx(
 	lggr logger.Logger,
 	timelock *bindings.RBACTimelock,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	isDeployerKeyAdmin bool,
 	roleID [32]byte,
 	address common.Address,
 ) (mcmsTypes.Transaction, error) {
-	txOpts := deployment.SimTransactOpts()
+	txOpts := cldf.SimTransactOpts()
 	if isDeployerKeyAdmin {
 		txOpts = chain.DeployerKey
 	}
@@ -402,7 +402,7 @@ func grantRoleTx(
 		txOpts, roleID, address,
 	)
 	if isDeployerKeyAdmin {
-		if _, err2 := deployment.ConfirmIfNoErrorWithABI(chain, grantRoleTx, bindings.RBACTimelockABI, err); err != nil {
+		if _, err2 := cldf.ConfirmIfNoErrorWithABI(chain, grantRoleTx, bindings.RBACTimelockABI, err); err != nil {
 			lggr.Errorw("Failed to grant timelock role",
 				"chain", chain.String(),
 				"timelock", timelock.Address().Hex(),

--- a/deployment/common/changeset/jobspec.go
+++ b/deployment/common/changeset/jobspec.go
@@ -8,7 +8,6 @@ import (
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 var (
@@ -23,7 +22,7 @@ var (
 	DeleteJobChangeset = cldf.CreateChangeSet(deleteJobsLogic, deleteJobsPrecondition)
 )
 
-func revokeJobsPrecondition(env deployment.Environment, jobIDs []string) error {
+func revokeJobsPrecondition(env cldf.Environment, jobIDs []string) error {
 	proposals, err := env.Offchain.ListProposals(env.GetContext(), &jobv1.ListProposalsRequest{
 		Filter: &jobv1.ListProposalsRequest_Filter{
 			JobIds: jobIDs,
@@ -40,7 +39,7 @@ func revokeJobsPrecondition(env deployment.Environment, jobIDs []string) error {
 	return nil
 }
 
-func revokeJobsLogic(env deployment.Environment, jobIDs []string) (cldf.ChangesetOutput, error) {
+func revokeJobsLogic(env cldf.Environment, jobIDs []string) (cldf.ChangesetOutput, error) {
 	var successfullyRevoked []string
 	for _, jobID := range jobIDs {
 		res, err := env.Offchain.RevokeJob(env.GetContext(), &jobv1.RevokeJobRequest{
@@ -67,7 +66,7 @@ func revokeJobsLogic(env deployment.Environment, jobIDs []string) (cldf.Changese
 	return cldf.ChangesetOutput{}, nil
 }
 
-func deleteJobsPrecondition(env deployment.Environment, jobIDs []string) error {
+func deleteJobsPrecondition(env cldf.Environment, jobIDs []string) error {
 	jobs, err := env.Offchain.ListJobs(env.GetContext(), &jobv1.ListJobsRequest{
 		Filter: &jobv1.ListJobsRequest_Filter{
 			Ids: jobIDs,
@@ -91,7 +90,7 @@ func deleteJobsPrecondition(env deployment.Environment, jobIDs []string) error {
 
 // DeleteJobChangeset sends the delete job request to nodes for the given jobID.
 // nops needs to cancel the job once the request is sent by JD.
-func deleteJobsLogic(env deployment.Environment, jobIDs []string) (cldf.ChangesetOutput, error) {
+func deleteJobsLogic(env cldf.Environment, jobIDs []string) (cldf.ChangesetOutput, error) {
 	jobIDsToDelete, err := jobsToDelete(env, jobIDs)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get jobIDs to delete: %w", err)
@@ -114,7 +113,7 @@ func deleteJobsLogic(env deployment.Environment, jobIDs []string) (cldf.Changese
 	return cldf.ChangesetOutput{}, nil
 }
 
-func jobsToDelete(env deployment.Environment, jobIDs []string) ([]string, error) {
+func jobsToDelete(env cldf.Environment, jobIDs []string) ([]string, error) {
 	jobs, err := env.Offchain.ListProposals(env.GetContext(), &jobv1.ListProposalsRequest{
 		Filter: &jobv1.ListProposalsRequest_Filter{
 			JobIds: jobIDs,

--- a/deployment/common/changeset/mcms_firedrill.go
+++ b/deployment/common/changeset/mcms_firedrill.go
@@ -12,7 +12,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
@@ -23,7 +22,7 @@ type FireDrillConfig struct {
 }
 
 // buildNoOPEVM builds a dummy tx that transfers 0 to the RBACTimelock
-func buildNoOPEVM(e deployment.Environment, selector uint64) (mcmstypes.Transaction, error) {
+func buildNoOPEVM(e cldf.Environment, selector uint64) (mcmstypes.Transaction, error) {
 	chain, ok := e.Chains[selector]
 	if !ok {
 		return mcmstypes.Transaction{}, nil
@@ -73,7 +72,7 @@ func buildNoOPSolana() (mcmstypes.Transaction, error) {
 // MCMSSignFireDrillChangeset creates a changeset for a MCMS signing Fire Drill.
 // It is used to make sure team member can effectively sign proposal and that the execution pipelines are healthy.
 // The changeset will create a NO-OP transaction for each chain selector in the environment and create a proposal for it.
-func MCMSSignFireDrillChangeset(e deployment.Environment, cfg FireDrillConfig) (cldf.ChangesetOutput, error) {
+func MCMSSignFireDrillChangeset(e cldf.Environment, cfg FireDrillConfig) (cldf.ChangesetOutput, error) {
 	allSelectors := cfg.Selectors
 	if len(allSelectors) == 0 {
 		solSelectors := e.AllChainSelectorsSolana()

--- a/deployment/common/changeset/mcms_firedrill_test.go
+++ b/deployment/common/changeset/mcms_firedrill_test.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -19,7 +19,7 @@ import (
 )
 
 // setupFiredrillTestEnv deploys all required contracts for the firedrill proposal execution
-func setupFiredrillTestEnv(t *testing.T) deployment.Environment {
+func setupFiredrillTestEnv(t *testing.T) cldf.Environment {
 	lggr := logger.TestLogger(t)
 	cfg := memory.MemoryEnvironmentConfig{
 		Chains:    2,

--- a/deployment/common/changeset/save_existing.go
+++ b/deployment/common/changeset/save_existing.go
@@ -8,8 +8,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	"github.com/mr-tron/base58"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 )
@@ -30,7 +28,7 @@ type ExistingContractsConfig struct {
 
 func (cfg ExistingContractsConfig) Validate() error {
 	for _, ec := range cfg.ExistingContracts {
-		if err := deployment.IsValidChainSelector(ec.ChainSelector); err != nil {
+		if err := cldf.IsValidChainSelector(ec.ChainSelector); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", ec.ChainSelector, err)
 		}
 		if ec.Address == "" {
@@ -69,7 +67,7 @@ func (cfg ExistingContractsConfig) Validate() error {
 
 // SaveExistingContractsChangeset saves the existing contracts to the address book.
 // Caller should update the environment's address book with the returned addresses.
-func SaveExistingContractsChangeset(env deployment.Environment, cfg ExistingContractsConfig) (cldf.ChangesetOutput, error) {
+func SaveExistingContractsChangeset(env cldf.Environment, cfg ExistingContractsConfig) (cldf.ChangesetOutput, error) {
 	err := cfg.Validate()
 	if err != nil {
 		return cldf.ChangesetOutput{}, errors.Wrapf(cldf.ErrInvalidConfig, "%v", err)

--- a/deployment/common/changeset/save_existing_test.go
+++ b/deployment/common/changeset/save_existing_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 func TestSaveExisting(t *testing.T) {
-	dummyEnv := deployment.Environment{
+	dummyEnv := cldf.Environment{
 		Name:              "dummy",
 		Logger:            logger.TestLogger(t),
 		ExistingAddresses: cldf.NewMemoryAddressBook(),
-		Chains: map[uint64]deployment.Chain{
+		Chains: map[uint64]cldf.Chain{
 			chainsel.TEST_90000001.Selector: {},
 			chainsel.TEST_90000002.Selector: {},
 		},
@@ -58,11 +58,11 @@ func TestSaveExisting(t *testing.T) {
 }
 
 func TestSaveExistingAddressWithLabels(t *testing.T) {
-	dummyEnv := deployment.Environment{
+	dummyEnv := cldf.Environment{
 		Name:              "dummy",
 		Logger:            logger.TestLogger(t),
 		ExistingAddresses: cldf.NewMemoryAddressBook(),
-		Chains: map[uint64]deployment.Chain{
+		Chains: map[uint64]cldf.Chain{
 			chainsel.TEST_90000001.Selector: {},
 			chainsel.TEST_90000002.Selector: {},
 		},
@@ -96,11 +96,11 @@ func TestSaveExistingAddressWithLabels(t *testing.T) {
 }
 
 func TestSaveExistingMCMSAddressWithLabels(t *testing.T) {
-	dummyEnv := deployment.Environment{
+	dummyEnv := cldf.Environment{
 		Name:              "dummy",
 		Logger:            logger.TestLogger(t),
 		ExistingAddresses: cldf.NewMemoryAddressBook(),
-		Chains: map[uint64]deployment.Chain{
+		Chains: map[uint64]cldf.Chain{
 			chainsel.TEST_90000001.Selector: {},
 			chainsel.TEST_90000002.Selector: {},
 		},

--- a/deployment/common/changeset/set_config_mcms_test.go
+++ b/deployment/common/changeset/set_config_mcms_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	commonchangesetsolana "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
@@ -27,7 +27,7 @@ import (
 )
 
 // setupSetConfigTestEnv deploys all required contracts for the setConfig MCMS contract call.
-func setupSetConfigTestEnv(t *testing.T) deployment.Environment {
+func setupSetConfigTestEnv(t *testing.T) cldf.Environment {
 	lggr := logger.TestLogger(t)
 	cfg := memory.MemoryEnvironmentConfig{
 		Chains:    2,
@@ -424,7 +424,7 @@ func TestValidateV2(t *testing.T) {
 }
 
 func fundSignerPDAs(
-	t *testing.T, env deployment.Environment, chainSelector uint64, chainState *state.MCMSWithTimelockStateSolana,
+	t *testing.T, env cldf.Environment, chainSelector uint64, chainState *state.MCMSWithTimelockStateSolana,
 ) {
 	t.Helper()
 	solChain := env.SolChains[chainSelector]

--- a/deployment/common/changeset/solana/fund_mcm_pdas.go
+++ b/deployment/common/changeset/solana/fund_mcm_pdas.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gagliardetto/solana-go/rpc"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 )
 
@@ -30,7 +30,7 @@ type FundMCMSignerConfig struct {
 type FundMCMSignersChangeset struct{}
 
 // VerifyPreconditions checks if the deployer has enough SOL to fund the MCMS signers on each chain.
-func (f FundMCMSignersChangeset) VerifyPreconditions(e deployment.Environment, config FundMCMSignerConfig) error {
+func (f FundMCMSignersChangeset) VerifyPreconditions(e cldf.Environment, config FundMCMSignerConfig) error {
 	// the number of accounts to fund per chain (bypasser, canceller, proposer, timelock)
 	for chainSelector, chainCfg := range config.AmountsPerChain {
 		solChain, ok := e.SolChains[chainSelector]
@@ -66,7 +66,7 @@ func (f FundMCMSignersChangeset) VerifyPreconditions(e deployment.Environment, c
 }
 
 // Apply funds the MCMS signers on each chain.
-func (f FundMCMSignersChangeset) Apply(e deployment.Environment, config FundMCMSignerConfig) (cldf.ChangesetOutput, error) {
+func (f FundMCMSignersChangeset) Apply(e cldf.Environment, config FundMCMSignerConfig) (cldf.ChangesetOutput, error) {
 	for chainSelector, cfgAmounts := range config.AmountsPerChain {
 		solChain := e.SolChains[chainSelector]
 		addreses, err := e.ExistingAddresses.AddressesForChain(chainSelector)

--- a/deployment/common/changeset/solana/fund_mcm_pdas_test.go
+++ b/deployment/common/changeset/solana/fund_mcm_pdas_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 // setupFundingTestEnv deploys all required contracts for the funding test
-func setupFundingTestEnv(t *testing.T) deployment.Environment {
+func setupFundingTestEnv(t *testing.T) cldf.Environment {
 	lggr := logger.TestLogger(t)
 	cfg := memory.MemoryEnvironmentConfig{
 		Nodes:     1,
@@ -61,7 +61,7 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 	t.Parallel()
 	lggr := logger.TestLogger(t)
 	validEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{SolChains: 1})
-	validEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
+	validEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = cldf.SolChain{}
 	validSolChainSelector := validEnv.AllChainSelectorsSolana()[0]
 
 	timelockID := mcmsSolana.ContractAddress(
@@ -115,7 +115,7 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 		SolChains: 1,
 		Nodes:     1,
 	})
-	noMCMSEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
+	noMCMSEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = cldf.SolChain{}
 	err = noMCMSEnv.ExistingAddresses.Save(chainselectors.SOLANA_DEVNET.Selector, mcmsProposerIDEmpty, cldf.TypeAndVersion{
 		Type:    types.BypasserManyChainMultisig,
 		Version: deployment.Version1_0_0,
@@ -128,11 +128,11 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 		SolChains: 0,
 		Nodes:     1,
 	})
-	invalidSolChainEnv.SolChains[validSolChainSelector] = deployment.SolChain{}
+	invalidSolChainEnv.SolChains[validSolChainSelector] = cldf.SolChain{}
 
 	tests := []struct {
 		name          string
-		env           deployment.Environment
+		env           cldf.Environment
 		config        commonSolana.FundMCMSignerConfig
 		expectedError string
 	}{

--- a/deployment/common/changeset/solana/helpers.go
+++ b/deployment/common/changeset/solana/helpers.go
@@ -6,11 +6,11 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/programs/system"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 // FundFromAddressIxs transfers SOL from the given address to each provided account and waits for confirmations.
-func FundFromAddressIxs(solChain deployment.SolChain, from solana.PublicKey, accounts []solana.PublicKey, amount uint64) ([]solana.Instruction, error) {
+func FundFromAddressIxs(solChain cldf.SolChain, from solana.PublicKey, accounts []solana.PublicKey, amount uint64) ([]solana.Instruction, error) {
 	var ixs []solana.Instruction
 	for _, account := range accounts {
 		// Create a transfer instruction using the provided builder.
@@ -29,7 +29,7 @@ func FundFromAddressIxs(solChain deployment.SolChain, from solana.PublicKey, acc
 }
 
 // FundFromDeployerKey transfers SOL from the deployer to each provided account and waits for confirmations.
-func FundFromDeployerKey(solChain deployment.SolChain, accounts []solana.PublicKey, amount uint64) error {
+func FundFromDeployerKey(solChain cldf.SolChain, accounts []solana.PublicKey, amount uint64) error {
 	ixs, err := FundFromAddressIxs(solChain, solChain.DeployerKey.PublicKey(), accounts, amount)
 	if err != nil {
 		return fmt.Errorf("failed to create transfer instructions: %w", err)

--- a/deployment/common/changeset/solana/mcms/access_controller.go
+++ b/deployment/common/changeset/solana/mcms/access_controller.go
@@ -21,8 +21,8 @@ import (
 )
 
 func deployAccessControllerProgram(
-	e deployment.Environment, chainState *state.MCMSWithTimelockStateSolana,
-	chain deployment.SolChain, addressBook cldf.AddressBook,
+	e cldf.Environment, chainState *state.MCMSWithTimelockStateSolana,
+	chain cldf.SolChain, addressBook cldf.AddressBook,
 ) error {
 	typeAndVersion := cldf.NewTypeAndVersion(commontypes.AccessControllerProgram, deployment.Version1_0_0)
 	log := logger.With(e.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
@@ -62,8 +62,8 @@ func deployAccessControllerProgram(
 }
 
 func initAccessController(
-	e deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, contractType cldf.ContractType,
-	chain deployment.SolChain, addressBook cldf.AddressBook,
+	e cldf.Environment, chainState *state.MCMSWithTimelockStateSolana, contractType cldf.ContractType,
+	chain cldf.SolChain, addressBook cldf.AddressBook,
 ) error {
 	if chainState.AccessControllerProgram.IsZero() {
 		return errors.New("access controller program is not deployed")
@@ -121,7 +121,7 @@ func initAccessController(
 const accessControllerAccountSize = uint64(8 + 32 + 32 + ((32 * 64) + 8))
 
 func initializeAccessController(
-	e deployment.Environment, chain deployment.SolChain, programID solana.PublicKey, roleAccount solana.PrivateKey,
+	e cldf.Environment, chain cldf.SolChain, programID solana.PublicKey, roleAccount solana.PrivateKey,
 ) error {
 	rentExemption, err := chain.Client.GetMinimumBalanceForRentExemption(e.GetContext(),
 		accessControllerAccountSize, rpc.CommitmentConfirmed)
@@ -158,7 +158,7 @@ func initializeAccessController(
 	return nil
 }
 
-func setupRoles(chainState *state.MCMSWithTimelockStateSolana, chain deployment.SolChain) error {
+func setupRoles(chainState *state.MCMSWithTimelockStateSolana, chain cldf.SolChain) error {
 	proposerPDA := state.GetMCMSignerPDA(chainState.McmProgram, chainState.ProposerMcmSeed)
 	cancellerPDA := state.GetMCMSignerPDA(chainState.McmProgram, chainState.CancellerMcmSeed)
 	bypasserPDA := state.GetMCMSignerPDA(chainState.McmProgram, chainState.BypasserMcmSeed)
@@ -187,7 +187,7 @@ func setupRoles(chainState *state.MCMSWithTimelockStateSolana, chain deployment.
 }
 
 func addAccess(
-	chain deployment.SolChain, chainState *state.MCMSWithTimelockStateSolana,
+	chain cldf.SolChain, chainState *state.MCMSWithTimelockStateSolana,
 	role timelockBindings.Role, accounts ...solana.PublicKey,
 ) error {
 	timelockConfigPDA := state.GetTimelockConfigPDA(chainState.TimelockProgram, chainState.TimelockSeed)

--- a/deployment/common/changeset/solana/mcms/mcm.go
+++ b/deployment/common/changeset/solana/mcms/mcm.go
@@ -24,8 +24,8 @@ import (
 )
 
 func deployMCMProgram(
-	env deployment.Environment, chainState *state.MCMSWithTimelockStateSolana,
-	chain deployment.SolChain, addressBook cldf.AddressBook,
+	env cldf.Environment, chainState *state.MCMSWithTimelockStateSolana,
+	chain cldf.SolChain, addressBook cldf.AddressBook,
 ) error {
 	typeAndVersion := cldf.NewTypeAndVersion(commontypes.ManyChainMultisigProgram, deployment.Version1_0_0)
 	log := logger.With(env.Logger, "chain", chain.String(), "contract", typeAndVersion.String())
@@ -65,8 +65,8 @@ func deployMCMProgram(
 }
 
 func initMCM(
-	env deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, contractType cldf.ContractType,
-	chain deployment.SolChain, addressBook cldf.AddressBook, mcmConfig *mcmsTypes.Config,
+	env cldf.Environment, chainState *state.MCMSWithTimelockStateSolana, contractType cldf.ContractType,
+	chain cldf.SolChain, addressBook cldf.AddressBook, mcmConfig *mcmsTypes.Config,
 ) error {
 	if chainState.McmProgram.IsZero() {
 		return errors.New("mcm program is not deployed")
@@ -124,7 +124,7 @@ func initMCM(
 	return nil
 }
 
-func initializeMCM(e deployment.Environment, chain deployment.SolChain, mcmProgram solana.PublicKey, multisigID state.PDASeed) error {
+func initializeMCM(e cldf.Environment, chain cldf.SolChain, mcmProgram solana.PublicKey, multisigID state.PDASeed) error {
 	var mcmConfig mcmBindings.MultisigConfig
 	err := chain.GetAccountDataBorshInto(e.GetContext(), state.GetMCMConfigPDA(mcmProgram, multisigID), &mcmConfig)
 	if err == nil {

--- a/deployment/common/changeset/solana/mcms/mcms.go
+++ b/deployment/common/changeset/solana/mcms/mcms.go
@@ -6,7 +6,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 )
@@ -16,8 +15,8 @@ import (
 // as well as the timelock program. It's not necessarily the only way to use
 // the timelock and MCMS, but its reasonable pattern.
 func DeployMCMSWithTimelockProgramsSolana(
-	e deployment.Environment,
-	chain deployment.SolChain,
+	e cldf.Environment,
+	chain cldf.SolChain,
 	addressBook cldf.AddressBook,
 	config commontypes.MCMSWithTimelockConfigV2,
 ) (*state.MCMSWithTimelockStateSolana, error) {

--- a/deployment/common/changeset/solana/mcms/timelock.go
+++ b/deployment/common/changeset/solana/mcms/timelock.go
@@ -20,7 +20,7 @@ import (
 )
 
 func deployTimelockProgram(
-	e deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, chain deployment.SolChain,
+	e cldf.Environment, chainState *state.MCMSWithTimelockStateSolana, chain cldf.SolChain,
 	addressBook cldf.AddressBook,
 ) error {
 	typeAndVersion := cldf.NewTypeAndVersion(commontypes.RBACTimelockProgram, deployment.Version1_0_0)
@@ -61,7 +61,7 @@ func deployTimelockProgram(
 }
 
 func initTimelock(
-	e deployment.Environment, chainState *state.MCMSWithTimelockStateSolana, chain deployment.SolChain,
+	e cldf.Environment, chainState *state.MCMSWithTimelockStateSolana, chain cldf.SolChain,
 	addressBook cldf.AddressBook, minDelay *big.Int,
 ) error {
 	if chainState.TimelockProgram.IsZero() {
@@ -114,7 +114,7 @@ func initTimelock(
 }
 
 func initializeTimelock(
-	e deployment.Environment, chain deployment.SolChain, timelockProgram solana.PublicKey, timelockID state.PDASeed,
+	e cldf.Environment, chain cldf.SolChain, timelockProgram solana.PublicKey, timelockID state.PDASeed,
 	chainState *state.MCMSWithTimelockStateSolana, minDelay *big.Int,
 ) error {
 	if minDelay == nil {

--- a/deployment/common/changeset/solana/transfer_ownership.go
+++ b/deployment/common/changeset/solana/transfer_ownership.go
@@ -17,7 +17,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -46,7 +45,7 @@ type OwnableContract struct {
 type TransferToTimelockSolana struct{}
 
 func (t *TransferToTimelockSolana) VerifyPreconditions(
-	env deployment.Environment, config TransferToTimelockSolanaConfig,
+	env cldf.Environment, config TransferToTimelockSolanaConfig,
 ) error {
 	for chainSelector, contracts := range config.ContractsByChain {
 		err := addressBookContains(env.ExistingAddresses, chainSelector,
@@ -99,7 +98,7 @@ func (t *TransferToTimelockSolana) VerifyPreconditions(
 }
 
 func (t *TransferToTimelockSolana) Apply(
-	env deployment.Environment, cfg TransferToTimelockSolanaConfig,
+	env cldf.Environment, cfg TransferToTimelockSolanaConfig,
 ) (cldf.ChangesetOutput, error) {
 	mcmsState, err := state.MaybeLoadMCMSWithTimelockStateSolana(env, slices.Collect(maps.Keys(env.SolChains)))
 	if err != nil {
@@ -190,7 +189,7 @@ type TransferMCMSToTimelockSolanaConfig struct {
 type TransferMCMSToTimelockSolana struct{}
 
 func (t TransferMCMSToTimelockSolana) VerifyPreconditions(
-	env deployment.Environment, config TransferMCMSToTimelockSolanaConfig,
+	env cldf.Environment, config TransferMCMSToTimelockSolanaConfig,
 ) error {
 	for _, chainSelector := range config.Chains {
 		err := addressBookContains(env.ExistingAddresses, chainSelector,
@@ -207,7 +206,7 @@ func (t TransferMCMSToTimelockSolana) VerifyPreconditions(
 }
 
 func (t TransferMCMSToTimelockSolana) Apply(
-	env deployment.Environment, cfg TransferMCMSToTimelockSolanaConfig,
+	env cldf.Environment, cfg TransferMCMSToTimelockSolanaConfig,
 ) (cldf.ChangesetOutput, error) {
 	mcmsState, err := state.MaybeLoadMCMSWithTimelockStateSolana(env, cfg.Chains)
 	if err != nil {

--- a/deployment/common/changeset/solana/transfer_ownership_test.go
+++ b/deployment/common/changeset/solana/transfer_ownership_test.go
@@ -15,7 +15,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	solanachangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana"
 	solanaMCMS "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana/mcms"
@@ -58,7 +57,7 @@ func TestTransferToMCMSToTimelockSolana(t *testing.T) {
 	assertOwner(t, env, solanaSelector, chainState, timelockSignerPDA)
 }
 
-func deployMCMS(t *testing.T, env deployment.Environment, selector uint64) *state.MCMSWithTimelockStateSolana {
+func deployMCMS(t *testing.T, env cldf.Environment, selector uint64) *state.MCMSWithTimelockStateSolana {
 	t.Helper()
 
 	solanaChain := env.SolChains[selector]
@@ -79,7 +78,7 @@ func deployMCMS(t *testing.T, env deployment.Environment, selector uint64) *stat
 }
 
 func assertOwner(
-	t *testing.T, env deployment.Environment, selector uint64, chainState *state.MCMSWithTimelockStateSolana, owner solana.PublicKey,
+	t *testing.T, env cldf.Environment, selector uint64, chainState *state.MCMSWithTimelockStateSolana, owner solana.PublicKey,
 ) {
 	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.ProposerMcmSeed), env, selector)
 	assertMCMOwner(t, owner, state.GetMCMConfigPDA(chainState.McmProgram, chainState.CancellerMcmSeed), env, selector)
@@ -92,7 +91,7 @@ func assertOwner(
 }
 
 func assertMCMOwner(
-	t *testing.T, want solana.PublicKey, configPDA solana.PublicKey, env deployment.Environment, selector uint64,
+	t *testing.T, want solana.PublicKey, configPDA solana.PublicKey, env cldf.Environment, selector uint64,
 ) {
 	t.Helper()
 	var config mcmBindings.MultisigConfig
@@ -102,7 +101,7 @@ func assertMCMOwner(
 }
 
 func assertTimelockOwner(
-	t *testing.T, want solana.PublicKey, configPDA solana.PublicKey, env deployment.Environment, selector uint64,
+	t *testing.T, want solana.PublicKey, configPDA solana.PublicKey, env cldf.Environment, selector uint64,
 ) {
 	t.Helper()
 	var config timelockBindings.Config
@@ -112,7 +111,7 @@ func assertTimelockOwner(
 }
 
 func assertAccessControllerOwner(
-	t *testing.T, want solana.PublicKey, account solana.PublicKey, env deployment.Environment, selector uint64,
+	t *testing.T, want solana.PublicKey, account solana.PublicKey, env cldf.Environment, selector uint64,
 ) {
 	t.Helper()
 	var config accessControllerBindings.AccessController
@@ -122,7 +121,7 @@ func assertAccessControllerOwner(
 }
 
 func fundSignerPDAs(
-	t *testing.T, env deployment.Environment, chainSelector uint64, chainState *state.MCMSWithTimelockStateSolana,
+	t *testing.T, env cldf.Environment, chainSelector uint64, chainState *state.MCMSWithTimelockStateSolana,
 ) {
 	t.Helper()
 	solChain := env.SolChains[chainSelector]

--- a/deployment/common/changeset/solana/update_delay_timelock.go
+++ b/deployment/common/changeset/solana/update_delay_timelock.go
@@ -10,7 +10,6 @@ import (
 	timelockBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 )
 
@@ -22,7 +21,7 @@ type UpdateTimelockDelaySolanaCfg struct {
 }
 
 func (t UpdateTimelockDelaySolana) VerifyPreconditions(
-	env deployment.Environment, config UpdateTimelockDelaySolanaCfg,
+	env cldf.Environment, config UpdateTimelockDelaySolanaCfg,
 ) error {
 	if len(config.DelayPerChain) == 0 {
 		return errors.New("no delay configs provided")
@@ -57,7 +56,7 @@ func (t UpdateTimelockDelaySolana) VerifyPreconditions(
 }
 
 func (t UpdateTimelockDelaySolana) Apply(
-	env deployment.Environment, cfg UpdateTimelockDelaySolanaCfg,
+	env cldf.Environment, cfg UpdateTimelockDelaySolanaCfg,
 ) (cldf.ChangesetOutput, error) {
 	for chainSelector, delay := range cfg.DelayPerChain {
 		solChain := env.SolChains[chainSelector]

--- a/deployment/common/changeset/solana/update_delay_timelock_test.go
+++ b/deployment/common/changeset/solana/update_delay_timelock_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 // setupUpdateDelayTestEnv deploys all required contracts for set \delay test
-func setupUpdateDelayTestEnv(t *testing.T) deployment.Environment {
+func setupUpdateDelayTestEnv(t *testing.T) cldf.Environment {
 	lggr := logger.TestLogger(t)
 	cfg := memory.MemoryEnvironmentConfig{
 		SolChains: 1,
@@ -63,7 +63,7 @@ func TestUpdateTimelockDelaySolana_VerifyPreconditions(t *testing.T) {
 	t.Parallel()
 	lggr := logger.TestLogger(t)
 	validEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{SolChains: 1})
-	validEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
+	validEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = cldf.SolChain{}
 	validSolChainSelector := validEnv.AllChainSelectorsSolana()[0]
 
 	timelockID := mcmsSolana.ContractAddress(
@@ -90,7 +90,7 @@ func TestUpdateTimelockDelaySolana_VerifyPreconditions(t *testing.T) {
 		SolChains: 1,
 		Nodes:     1,
 	})
-	noTimelockEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = deployment.SolChain{}
+	noTimelockEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = cldf.SolChain{}
 
 	//nolint:staticcheck // will wait till we can migrate from address book before using data store
 	err = noTimelockEnv.ExistingAddresses.Save(chainselectors.SOLANA_DEVNET.Selector, mcmsProposerIDEmpty, cldf.TypeAndVersion{
@@ -105,11 +105,11 @@ func TestUpdateTimelockDelaySolana_VerifyPreconditions(t *testing.T) {
 		SolChains: 0,
 		Nodes:     1,
 	})
-	invalidSolChainEnv.SolChains[validSolChainSelector] = deployment.SolChain{}
+	invalidSolChainEnv.SolChains[validSolChainSelector] = cldf.SolChain{}
 
 	tests := []struct {
 		name          string
-		env           deployment.Environment
+		env           cldf.Environment
 		config        commonSolana.UpdateTimelockDelaySolanaCfg
 		expectedError string
 	}{

--- a/deployment/common/changeset/state.go
+++ b/deployment/common/changeset/state.go
@@ -66,7 +66,7 @@ func (state MCMSWithTimelockState) GenerateMCMSWithTimelockView() (v1_0.MCMSWith
 // MaybeLoadMCMSWithTimelockState loads the MCMSWithTimelockState state for each chain in the given environment.
 // Deprecated: use MaybeLoadMCMSWithTimelockState from deployment/common/changeset/state/evm.go instead
 // if you are changing this, please make the similar changes in deployment/common/changeset/state
-func MaybeLoadMCMSWithTimelockState(env deployment.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
+func MaybeLoadMCMSWithTimelockState(env cldf.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
 	result := map[uint64]*MCMSWithTimelockState{}
 	for _, chainSelector := range chainSelectors {
 		chain, ok := env.Chains[chainSelector]
@@ -97,7 +97,7 @@ func MaybeLoadMCMSWithTimelockState(env deployment.Environment, chainSelectors [
 // Deprecated: use MaybeLoadMCMSWithTimelockChainState from deployment/common/changeset/state/evm.go instead
 // if you are changing this, please make the similar changes in deployment/common/changeset/state
 func MaybeLoadMCMSWithTimelockChainState(
-	chain deployment.Chain,
+	chain cldf.Chain,
 	addresses map[string]cldf.TypeAndVersion,
 ) (*MCMSWithTimelockState, error) {
 	var (
@@ -203,7 +203,7 @@ func (s LinkTokenState) GenerateLinkView() (v1_0.LinkTokenView, error) {
 // MaybeLoadLinkTokenState loads the LinkTokenState state for each chain in the given environment.
 // Deprecated: use MaybeLoadLinkTokenState from deployment/common/changeset/state/evm.go instead
 // if you are changing this, please make the similar changes in deployment/common/changeset/state
-func MaybeLoadLinkTokenState(env deployment.Environment, chainSelectors []uint64) (map[uint64]*LinkTokenState, error) {
+func MaybeLoadLinkTokenState(env cldf.Environment, chainSelectors []uint64) (map[uint64]*LinkTokenState, error) {
 	result := map[uint64]*LinkTokenState{}
 	for _, chainSelector := range chainSelectors {
 		chain, ok := env.Chains[chainSelector]
@@ -225,7 +225,7 @@ func MaybeLoadLinkTokenState(env deployment.Environment, chainSelectors []uint64
 
 // Deprecated: use MaybeLoadLinkTokenChainState from deployment/common/changeset/state/evm.go instead
 // if you are changing this, please make the similar changes in deployment/common/changeset/state
-func MaybeLoadLinkTokenChainState(chain deployment.Chain, addresses map[string]cldf.TypeAndVersion) (*LinkTokenState, error) {
+func MaybeLoadLinkTokenChainState(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*LinkTokenState, error) {
 	state := LinkTokenState{}
 	linkToken := cldf.NewTypeAndVersion(types.LinkToken, deployment.Version1_0_0)
 
@@ -265,7 +265,7 @@ func (s StaticLinkTokenState) GenerateStaticLinkView() (v1_0.StaticLinkTokenView
 
 // Deprecated: use MaybeLoadStaticLinkTokenState from deployment/common/changeset/state/evm.go instead
 // if you are changing this, please make the similar changes in deployment/common/changeset/state
-func MaybeLoadStaticLinkTokenState(chain deployment.Chain, addresses map[string]cldf.TypeAndVersion) (*StaticLinkTokenState, error) {
+func MaybeLoadStaticLinkTokenState(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*StaticLinkTokenState, error) {
 	state := StaticLinkTokenState{}
 	staticLinkToken := cldf.NewTypeAndVersion(types.StaticLinkToken, deployment.Version1_0_0)
 

--- a/deployment/common/changeset/state/evm.go
+++ b/deployment/common/changeset/state/evm.go
@@ -60,7 +60,7 @@ func (state MCMSWithTimelockState) GenerateMCMSWithTimelockView() (view.MCMSWith
 }
 
 // MaybeLoadMCMSWithTimelockState loads the MCMSWithTimelockState state for each chain in the given environment.
-func MaybeLoadMCMSWithTimelockState(env deployment.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
+func MaybeLoadMCMSWithTimelockState(env cldf.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
 	result := map[uint64]*MCMSWithTimelockState{}
 	for _, chainSelector := range chainSelectors {
 		chain, ok := env.Chains[chainSelector]
@@ -81,7 +81,7 @@ func MaybeLoadMCMSWithTimelockState(env deployment.Environment, chainSelectors [
 }
 
 // MaybeLoadMCMSWithTimelockStateDataStore loads the MCMSWithTimelockState state for each chain in the given environment from the DataStore.
-func MaybeLoadMCMSWithTimelockStateDataStore(env deployment.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
+func MaybeLoadMCMSWithTimelockStateDataStore(env cldf.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
 	result := map[uint64]*MCMSWithTimelockState{}
 	for _, chainSelector := range chainSelectors {
 		chain, ok := env.Chains[chainSelector]
@@ -127,7 +127,7 @@ func loadAddressesFromDataStore(ds datastore.DataStore[datastore.DefaultMetadata
 // - Found but was unable to load a contract
 // - It only found part of the bundle of contracts
 // - If found more than one instance of a contract (we expect one bundle in the given addresses)
-func MaybeLoadMCMSWithTimelockChainState(chain deployment.Chain, addresses map[string]cldf.TypeAndVersion) (*MCMSWithTimelockState, error) {
+func MaybeLoadMCMSWithTimelockChainState(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*MCMSWithTimelockState, error) {
 	state := MCMSWithTimelockState{}
 	var (
 		// We expect one of each contract on the chain.
@@ -224,7 +224,7 @@ func (s LinkTokenState) GenerateLinkView() (view.LinkTokenView, error) {
 }
 
 // MaybeLoadLinkTokenState loads the LinkTokenState state for each chain in the given environment.
-func MaybeLoadLinkTokenState(env deployment.Environment, chainSelectors []uint64) (map[uint64]*LinkTokenState, error) {
+func MaybeLoadLinkTokenState(env cldf.Environment, chainSelectors []uint64) (map[uint64]*LinkTokenState, error) {
 	result := map[uint64]*LinkTokenState{}
 	for _, chainSelector := range chainSelectors {
 		chain, ok := env.Chains[chainSelector]
@@ -244,7 +244,7 @@ func MaybeLoadLinkTokenState(env deployment.Environment, chainSelectors []uint64
 	return result, nil
 }
 
-func MaybeLoadLinkTokenChainState(chain deployment.Chain, addresses map[string]cldf.TypeAndVersion) (*LinkTokenState, error) {
+func MaybeLoadLinkTokenChainState(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*LinkTokenState, error) {
 	state := LinkTokenState{}
 	linkToken := cldf.NewTypeAndVersion(types.LinkToken, deployment.Version1_0_0)
 
@@ -280,7 +280,7 @@ func (s StaticLinkTokenState) GenerateStaticLinkView() (view.StaticLinkTokenView
 	return view.GenerateStaticLinkTokenView(s.StaticLinkToken)
 }
 
-func MaybeLoadStaticLinkTokenState(chain deployment.Chain, addresses map[string]cldf.TypeAndVersion) (*StaticLinkTokenState, error) {
+func MaybeLoadStaticLinkTokenState(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*StaticLinkTokenState, error) {
 	state := StaticLinkTokenState{}
 	staticLinkToken := cldf.NewTypeAndVersion(types.StaticLinkToken, deployment.Version1_0_0)
 

--- a/deployment/common/changeset/state/evm_test.go
+++ b/deployment/common/changeset/state/evm_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -135,7 +136,7 @@ func toJSON[T any](t *testing.T, value T) string {
 }
 
 func deployMCMEvm(
-	t *testing.T, chain deployment.Chain, config *mcmstypes.Config,
+	t *testing.T, chain cldf.Chain, config *mcmstypes.Config,
 ) *bindings.ManyChainMultiSig {
 	t.Helper()
 
@@ -155,7 +156,7 @@ func deployMCMEvm(
 }
 
 func deployTimelockEvm(
-	t *testing.T, chain deployment.Chain, minDelay *big.Int, admin common.Address,
+	t *testing.T, chain cldf.Chain, minDelay *big.Int, admin common.Address,
 	proposers, executors, cancellers, bypassers []common.Address,
 ) *bindings.RBACTimelock {
 	t.Helper()
@@ -169,7 +170,7 @@ func deployTimelockEvm(
 }
 
 func deployCallProxyEvm(
-	t *testing.T, chain deployment.Chain, target common.Address,
+	t *testing.T, chain cldf.Chain, target common.Address,
 ) *bindings.CallProxy {
 	t.Helper()
 	_, tx, contract, err := bindings.DeployCallProxy(chain.DeployerKey, chain.Client, target)

--- a/deployment/common/changeset/state/solana.go
+++ b/deployment/common/changeset/state/solana.go
@@ -142,7 +142,7 @@ func (s *MCMSWithTimelockProgramsSolana) RoleAccount(role timelockBindings.Role)
 }
 
 func (s *MCMSWithTimelockProgramsSolana) GenerateView(
-	ctx context.Context, chain deployment.SolChain,
+	ctx context.Context, chain cldf.SolChain,
 ) (view.MCMSWithTimelockViewSolana, error) {
 	if err := s.Validate(); err != nil {
 		return view.MCMSWithTimelockViewSolana{}, fmt.Errorf("unable to validate state: %w", err)
@@ -164,7 +164,7 @@ type MCMSWithTimelockStateSolana struct {
 }
 
 // MaybeLoadMCMSWithTimelockState loads the MCMSWithTimelockState state for each chain in the given environment.
-func MaybeLoadMCMSWithTimelockStateSolana(env deployment.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockStateSolana, error) {
+func MaybeLoadMCMSWithTimelockStateSolana(env cldf.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockStateSolana, error) {
 	result := map[uint64]*MCMSWithTimelockStateSolana{}
 	for _, chainSelector := range chainSelectors {
 		chain, ok := env.SolChains[chainSelector]
@@ -196,7 +196,7 @@ func MaybeLoadMCMSWithTimelockStateSolana(env deployment.Environment, chainSelec
 // - Found but was unable to load a contract
 // - It only found part of the bundle of contracts
 // - If found more than one instance of a contract (we expect one bundle in the given addresses)
-func MaybeLoadMCMSWithTimelockChainStateSolana(chain deployment.SolChain, addresses map[string]cldf.TypeAndVersion) (*MCMSWithTimelockStateSolana, error) {
+func MaybeLoadMCMSWithTimelockChainStateSolana(chain cldf.SolChain, addresses map[string]cldf.TypeAndVersion) (*MCMSWithTimelockStateSolana, error) {
 	state := MCMSWithTimelockStateSolana{MCMSWithTimelockProgramsSolana: &MCMSWithTimelockProgramsSolana{}}
 
 	mcmProgram := cldf.NewTypeAndVersion(types.ManyChainMultisigProgram, deployment.Version1_0_0)

--- a/deployment/common/changeset/state_test.go
+++ b/deployment/common/changeset/state_test.go
@@ -20,13 +20,13 @@ import (
 func TestMaybeLoadMCMSWithTimelockChainState(t *testing.T) {
 	type testCase struct {
 		name      string
-		chain     deployment.Chain
+		chain     cldf.Chain
 		addresses map[string]cldf.TypeAndVersion
 		wantState *MCMSWithTimelockState // Expected state
 		wantErr   string
 	}
 
-	defaultChain := deployment.Chain{
+	defaultChain := cldf.Chain{
 		Selector: chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector,
 	}
 	tests := []testCase{

--- a/deployment/common/changeset/test_helpers_test.go
+++ b/deployment/common/changeset/test_helpers_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
@@ -25,11 +23,11 @@ func TestChangeSetLegacyFunction_PassingCase(t *testing.T) {
 	executedValidator := false
 
 	csv2 := cldf.CreateChangeSet(
-		func(e deployment.Environment, config uint32) (cldf.ChangesetOutput, error) {
+		func(e cldf.Environment, config uint32) (cldf.ChangesetOutput, error) {
 			executedCs = true
 			return cldf.ChangesetOutput{AddressBook: cldf.NewMemoryAddressBook()}, nil
 		},
-		func(e deployment.Environment, config uint32) error {
+		func(e cldf.Environment, config uint32) error {
 			executedValidator = true
 			return nil
 		},
@@ -50,11 +48,11 @@ func TestChangeSetLegacyFunction_ErrorCase(t *testing.T) {
 	executedValidator := false
 
 	csv2 := cldf.CreateChangeSet(
-		func(e deployment.Environment, config uint32) (cldf.ChangesetOutput, error) {
+		func(e cldf.Environment, config uint32) (cldf.ChangesetOutput, error) {
 			executedCs = true
 			return cldf.ChangesetOutput{AddressBook: cldf.NewMemoryAddressBook()}, nil
 		},
-		func(e deployment.Environment, config uint32) error {
+		func(e cldf.Environment, config uint32) error {
 			executedValidator = true
 			return errors.New("you shall not pass")
 		},
@@ -67,8 +65,8 @@ func TestChangeSetLegacyFunction_ErrorCase(t *testing.T) {
 	require.Equal(t, "failed to apply changeset at index 0: you shall not pass", err.Error())
 }
 
-func NewNoopEnvironment(t *testing.T) deployment.Environment {
-	return *deployment.NewEnvironment(
+func NewNoopEnvironment(t *testing.T) cldf.Environment {
+	return *cldf.NewEnvironment(
 		"noop",
 		logger.TestLogger(t),
 		cldf.NewMemoryAddressBook(),
@@ -76,9 +74,9 @@ func NewNoopEnvironment(t *testing.T) deployment.Environment {
 			datastore.DefaultMetadata,
 			datastore.DefaultMetadata,
 		]().Seal(),
-		map[uint64]deployment.Chain{},
-		map[uint64]deployment.SolChain{},
-		map[uint64]deployment.AptosChain{},
+		map[uint64]cldf.Chain{},
+		map[uint64]cldf.SolChain{},
+		map[uint64]cldf.AptosChain{},
 		[]string{},
 		nil,
 		func() context.Context { return tests.Context(t) },
@@ -91,7 +89,7 @@ func TestApplyChangesetsHelpers(t *testing.T) {
 
 	changesets := []ConfiguredChangeSet{
 		Configure(cldf.CreateChangeSet(
-			func(e deployment.Environment, config uint32) (cldf.ChangesetOutput, error) {
+			func(e cldf.Environment, config uint32) (cldf.ChangesetOutput, error) {
 				ds := datastore.NewMemoryDataStore[
 					datastore.DefaultMetadata,
 					datastore.DefaultMetadata,
@@ -125,7 +123,7 @@ func TestApplyChangesetsHelpers(t *testing.T) {
 					DataStore:   ds,
 				}, nil
 			},
-			func(e deployment.Environment, config uint32) error {
+			func(e cldf.Environment, config uint32) error {
 				return nil
 			},
 		), 1),
@@ -134,7 +132,7 @@ func TestApplyChangesetsHelpers(t *testing.T) {
 	csTests := []struct {
 		name                   string
 		changesets             []ConfiguredChangeSet
-		validate               func(t *testing.T, e deployment.Environment)
+		validate               func(t *testing.T, e cldf.Environment)
 		wantError              bool
 		changesetApplyFunction string
 	}{
@@ -142,7 +140,7 @@ func TestApplyChangesetsHelpers(t *testing.T) {
 			name:                   "ApplyChangesets validates datastore is merged after apply",
 			changesets:             changesets,
 			changesetApplyFunction: "V2",
-			validate: func(t *testing.T, e deployment.Environment) {
+			validate: func(t *testing.T, e cldf.Environment) {
 				// Check address was stored correctly
 				record, err := e.DataStore.Addresses().Get(
 					datastore.NewAddressRefKey(
@@ -168,7 +166,7 @@ func TestApplyChangesetsHelpers(t *testing.T) {
 			name:                   "ApplyChangesetsV2 validates datastore is merged after apply",
 			changesets:             changesets,
 			changesetApplyFunction: "V1",
-			validate: func(t *testing.T, e deployment.Environment) {
+			validate: func(t *testing.T, e cldf.Environment) {
 				// Check address was stored correctly
 				record, err := e.DataStore.Addresses().Get(
 					datastore.NewAddressRefKey(

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -179,7 +179,7 @@ func TestRenounceTimelockDeployerConfigValidate(t *testing.T) {
 	for _, test := range []struct {
 		name   string
 		config RenounceTimelockDeployerConfig
-		env    deployment.Environment
+		env    cldf.Environment
 		err    string
 	}{
 		{

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -37,7 +37,7 @@ type TimelockExecutionContracts struct {
 // NewTimelockExecutionContracts creates a new TimelockExecutionContracts struct.
 // If there are multiple timelocks or call proxy on the chain, an error is returned.
 // Used by CLD'S cli
-func NewTimelockExecutionContracts(env deployment.Environment, chainSelector uint64) (*TimelockExecutionContracts, error) {
+func NewTimelockExecutionContracts(env cldf.Environment, chainSelector uint64) (*TimelockExecutionContracts, error) {
 	addrTypeVer, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	if err != nil {
 		return nil, fmt.Errorf("error getting addresses for chain: %w", err)
@@ -115,7 +115,7 @@ func (cfg RunTimelockExecutorConfig) Validate() error {
 // If the block start is not provided, it assumes that the operations have not been scheduled yet
 // and executes all the operations for the given chain.
 // It is an error if there are no operations for the given chain.
-func RunTimelockExecutor(env deployment.Environment, cfg RunTimelockExecutorConfig) error {
+func RunTimelockExecutor(env cldf.Environment, cfg RunTimelockExecutorConfig) error {
 	// TODO: This sort of helper probably should move to the MCMS lib.
 	// Execute all the transactions in the proposal which are for this chain.
 	if err := cfg.Validate(); err != nil {
@@ -231,7 +231,7 @@ func (state MCMSWithTimelockContracts) Validate() error {
 // - Found but was unable to load a contract
 // - It only found part of the bundle of contracts
 // - If found more than one instance of a contract (we expect one bundle in the given addresses)
-func MaybeLoadMCMSWithTimelockContracts(chain deployment.Chain, addresses map[string]cldf.TypeAndVersion) (*MCMSWithTimelockContracts, error) {
+func MaybeLoadMCMSWithTimelockContracts(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*MCMSWithTimelockContracts, error) {
 	state := MCMSWithTimelockContracts{}
 	// We expect one of each contract on the chain.
 	timelock := cldf.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
@@ -300,7 +300,7 @@ func McmsTimelockConverterForChain(chain uint64) (mcmssdk.TimelockConverter, err
 	}
 }
 
-func McmsTimelockConverters(env deployment.Environment) (map[uint64]mcmssdk.TimelockConverter, error) {
+func McmsTimelockConverters(env cldf.Environment) (map[uint64]mcmssdk.TimelockConverter, error) {
 	converters := make(map[uint64]mcmssdk.TimelockConverter, len(env.Chains)+len(env.SolChains))
 
 	for _, chain := range env.Chains {
@@ -322,7 +322,7 @@ func McmsTimelockConverters(env deployment.Environment) (map[uint64]mcmssdk.Time
 	return converters, nil
 }
 
-func McmsInspectorForChain(env deployment.Environment, chain uint64) (mcmssdk.Inspector, error) {
+func McmsInspectorForChain(env cldf.Environment, chain uint64) (mcmssdk.Inspector, error) {
 	chainFamily, err := mcmstypes.GetChainSelectorFamily(mcmstypes.ChainSelector(chain))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain family for chain %d: %w", chain, err)
@@ -338,7 +338,7 @@ func McmsInspectorForChain(env deployment.Environment, chain uint64) (mcmssdk.In
 	}
 }
 
-func McmsInspectors(env deployment.Environment) (map[uint64]mcmssdk.Inspector, error) {
+func McmsInspectors(env cldf.Environment) (map[uint64]mcmssdk.Inspector, error) {
 	inspectors := make(map[uint64]mcmssdk.Inspector, len(env.Chains)+len(env.SolChains))
 
 	for _, chain := range env.Chains {

--- a/deployment/common/proposalutils/mcms_test_helpers.go
+++ b/deployment/common/proposalutils/mcms_test_helpers.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 )
@@ -63,7 +65,7 @@ func SingleGroupMCMSV2(t *testing.T) mcmstypes.Config {
 }
 
 // Deprecated: Use SignMCMSTimelockProposal instead.
-func SignProposal(t *testing.T, env deployment.Environment, proposal *timelock.MCMSWithTimelockProposal) *mcms.Executor {
+func SignProposal(t *testing.T, env cldf.Environment, proposal *timelock.MCMSWithTimelockProposal) *mcms.Executor {
 	executorClients := make(map[mcms.ChainIdentifier]mcms.ContractDeployBackend)
 	for _, chain := range env.Chains {
 		chainselc, exists := chainsel.ChainBySelector(chain.Selector)
@@ -86,13 +88,13 @@ func SignProposal(t *testing.T, env deployment.Environment, proposal *timelock.M
 }
 
 // Deprecated: Use ExecuteMCMSTimelockProposalV2 instead.
-func ExecuteProposal(t *testing.T, env deployment.Environment, executor *mcms.Executor,
+func ExecuteProposal(t *testing.T, env cldf.Environment, executor *mcms.Executor,
 	timelockContracts *TimelockExecutionContracts, sel uint64) error {
 	t.Log("Executing proposal on chain", sel)
 	// Set the root.
 	tx, err2 := executor.SetRootOnChain(env.Chains[sel].Client, env.Chains[sel].DeployerKey, mcms.ChainIdentifier(sel))
 	if err2 != nil {
-		require.NoError(t, deployment.MaybeDataErr(err2), "failed to set root")
+		require.NoError(t, cldf.MaybeDataErr(err2), "failed to set root")
 	}
 
 	_, err2 = env.Chains[sel].Confirm(tx)
@@ -107,7 +109,7 @@ func ExecuteProposal(t *testing.T, env deployment.Environment, executor *mcms.Ex
 }
 
 // SignMCMSTimelockProposal - Signs an MCMS timelock proposal.
-func SignMCMSTimelockProposal(t *testing.T, env deployment.Environment, proposal *mcmslib.TimelockProposal) *mcmslib.Proposal {
+func SignMCMSTimelockProposal(t *testing.T, env cldf.Environment, proposal *mcmslib.TimelockProposal) *mcmslib.Proposal {
 	converters := make(map[mcmstypes.ChainSelector]mcmssdk.TimelockConverter)
 	inspectorsMap := make(map[mcmstypes.ChainSelector]mcmssdk.Inspector)
 	for _, chain := range env.Chains {
@@ -160,7 +162,7 @@ func SignMCMSTimelockProposal(t *testing.T, env deployment.Environment, proposal
 }
 
 // SignMCMSProposal - Signs an MCMS proposal. For timelock proposal, use SignMCMSTimelockProposal instead.
-func SignMCMSProposal(t *testing.T, env deployment.Environment, proposal *mcmslib.Proposal) *mcmslib.Proposal {
+func SignMCMSProposal(t *testing.T, env cldf.Environment, proposal *mcmslib.Proposal) *mcmslib.Proposal {
 	converters := make(map[mcmstypes.ChainSelector]mcmssdk.TimelockConverter)
 	inspectorsMap := make(map[mcmstypes.ChainSelector]mcmssdk.Inspector)
 	for _, chain := range env.Chains {
@@ -199,7 +201,7 @@ func SignMCMSProposal(t *testing.T, env deployment.Environment, proposal *mcmsli
 }
 
 // ExecuteMCMSProposalV2 - Executes an MCMS proposal on a chain. For timelock proposal, use ExecuteMCMSTimelockProposalV2 instead.
-func ExecuteMCMSProposalV2(t *testing.T, env deployment.Environment, proposal *mcmslib.Proposal) error {
+func ExecuteMCMSProposalV2(t *testing.T, env cldf.Environment, proposal *mcmslib.Proposal) error {
 	t.Log("Executing proposal")
 
 	encoders, err := proposal.GetEncoders()
@@ -316,7 +318,7 @@ func ExecuteMCMSProposalV2(t *testing.T, env deployment.Environment, proposal *m
 
 // ExecuteMCMSTimelockProposalV2 - Includes an option to set callProxy to execute the calls through a proxy.
 // If the callProxy is not set, the calls will be executed directly to the timelock.
-func ExecuteMCMSTimelockProposalV2(t *testing.T, env deployment.Environment, timelockProposal *mcmslib.TimelockProposal, opts ...mcmslib.Option) error {
+func ExecuteMCMSTimelockProposalV2(t *testing.T, env cldf.Environment, timelockProposal *mcmslib.TimelockProposal, opts ...mcmslib.Option) error {
 	t.Log("Executing timelock proposal")
 
 	// build a "chainSelector => executor" map
@@ -415,7 +417,7 @@ func SingleGroupTimelockConfigV2(t *testing.T) commontypes.MCMSWithTimelockConfi
 	}
 }
 
-func findCallProxyAddress(t *testing.T, env deployment.Environment, chainSelector uint64) string {
+func findCallProxyAddress(t *testing.T, env cldf.Environment, chainSelector uint64) string {
 	addressesForChain, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	require.NoError(t, err)
 

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -20,7 +20,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	ccipTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 )
@@ -94,7 +93,7 @@ func (tc *TimelockConfig) validateCommon() error {
 	return nil
 }
 
-func (tc *TimelockConfig) Validate(chain deployment.Chain, s state.MCMSWithTimelockState) error {
+func (tc *TimelockConfig) Validate(chain cldf.Chain, s state.MCMSWithTimelockState) error {
 	err := tc.validateCommon()
 	if err != nil {
 		return err
@@ -120,7 +119,7 @@ func (tc *TimelockConfig) Validate(chain deployment.Chain, s state.MCMSWithTimel
 	return nil
 }
 
-func (tc *TimelockConfig) ValidateSolana(e deployment.Environment, chainSelector uint64) error {
+func (tc *TimelockConfig) ValidateSolana(e cldf.Environment, chainSelector uint64) error {
 	err := tc.validateCommon()
 	if err != nil {
 		return err
@@ -241,7 +240,7 @@ func BuildProposalFromBatches(
 
 // BuildProposalFromBatchesV2 uses the new MCMS library which replaces the implementation in BuildProposalFromBatches.
 func BuildProposalFromBatchesV2(
-	e deployment.Environment,
+	e cldf.Environment,
 	timelockAddressPerChain map[uint64]string,
 	mcmsAddressPerChain map[uint64]string, inspectorPerChain map[uint64]mcmssdk.Inspector,
 	batches []types.BatchOperation,
@@ -293,7 +292,7 @@ func BuildProposalFromBatchesV2(
 }
 
 func buildProposalMetadataV2(
-	env deployment.Environment,
+	env cldf.Environment,
 	chainSelectors []uint64,
 	inspectorPerChain map[uint64]mcmssdk.Inspector,
 	mcmsPerChain map[uint64]string, // can be proposer, canceller or bypasser
@@ -361,7 +360,7 @@ func buildProposalMetadataV2(
 // AggregateProposals aggregates proposals from the legacy and new formats into a single proposal.
 // Required if you are merging multiple changesets that have different proposal formats.
 func AggregateProposals(
-	env deployment.Environment,
+	env cldf.Environment,
 	mcmsEVMState map[uint64]state.MCMSWithTimelockState,
 	mcmsSolanaState map[uint64]state.MCMSWithTimelockStateSolana,
 	proposals []mcmslib.TimelockProposal,

--- a/deployment/data-feeds/changeset/accept_ownership.go
+++ b/deployment/data-feeds/changeset/accept_ownership.go
@@ -7,7 +7,7 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
@@ -17,7 +17,7 @@ import (
 // Once proposal is executed, new owned contracts can be imported into the addressbook.
 var AcceptOwnershipChangeset = cldf.CreateChangeSet(acceptOwnershipLogic, acceptOwnershipPrecondition)
 
-func acceptOwnershipLogic(env deployment.Environment, c types.AcceptOwnershipConfig) (cldf.ChangesetOutput, error) {
+func acceptOwnershipLogic(env cldf.Environment, c types.AcceptOwnershipConfig) (cldf.ChangesetOutput, error) {
 	chain := env.Chains[c.ChainSelector]
 
 	var mcmsProposals []ProposalData
@@ -27,7 +27,7 @@ func acceptOwnershipLogic(env deployment.Environment, c types.AcceptOwnershipCon
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to load the contract %w", err)
 		}
 
-		tx, err := contract.AcceptOwnership(deployment.SimTransactOpts())
+		tx, err := contract.AcceptOwnership(cldf.SimTransactOpts())
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to create accept transfer ownership tx %w", err)
 		}
@@ -46,7 +46,7 @@ func acceptOwnershipLogic(env deployment.Environment, c types.AcceptOwnershipCon
 	return cldf.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 }
 
-func acceptOwnershipPrecondition(env deployment.Environment, c types.AcceptOwnershipConfig) error {
+func acceptOwnershipPrecondition(env cldf.Environment, c types.AcceptOwnershipConfig) error {
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)

--- a/deployment/data-feeds/changeset/confirm_aggregator.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator.go
@@ -8,7 +8,7 @@ import (
 	proxy "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/aggregator_proxy"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -16,7 +16,7 @@ import (
 // This changeset may return a timelock proposal if the MCMS config is provided, otherwise it will execute the transaction with the deployer key.
 var ConfirmAggregatorChangeset = cldf.CreateChangeSet(confirmAggregatorLogic, confirmAggregatorPrecondition)
 
-func confirmAggregatorLogic(env deployment.Environment, c types.ProposeConfirmAggregatorConfig) (cldf.ChangesetOutput, error) {
+func confirmAggregatorLogic(env cldf.Environment, c types.ProposeConfirmAggregatorConfig) (cldf.ChangesetOutput, error) {
 	chain := env.Chains[c.ChainSelector]
 
 	aggregatorProxy, err := proxy.NewAggregatorProxy(c.ProxyAddress, chain.Client)
@@ -26,7 +26,7 @@ func confirmAggregatorLogic(env deployment.Environment, c types.ProposeConfirmAg
 
 	txOpt := chain.DeployerKey
 	if c.McmsConfig != nil {
-		txOpt = deployment.SimTransactOpts()
+		txOpt = cldf.SimTransactOpts()
 	}
 
 	tx, err := aggregatorProxy.ConfirmAggregator(txOpt, c.NewAggregatorAddress)
@@ -48,14 +48,14 @@ func confirmAggregatorLogic(env deployment.Environment, c types.ProposeConfirmAg
 		return cldf.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
 
-	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
+	if _, err := cldf.ConfirmIfNoError(chain, tx, err); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 
 	return cldf.ChangesetOutput{}, nil
 }
 
-func confirmAggregatorPrecondition(env deployment.Environment, c types.ProposeConfirmAggregatorConfig) error {
+func confirmAggregatorPrecondition(env cldf.Environment, c types.ProposeConfirmAggregatorConfig) error {
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)

--- a/deployment/data-feeds/changeset/deploy.go
+++ b/deployment/data-feeds/changeset/deploy.go
@@ -12,11 +12,10 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
-func DeployCache(chain deployment.Chain, labels []string) (*types.DeployCacheResponse, error) {
+func DeployCache(chain cldf.Chain, labels []string) (*types.DeployCacheResponse, error) {
 	cacheAddr, tx, cacheContract, err := cache.DeployDataFeedsCache(chain.DeployerKey, chain.Client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy DataFeedsCache: %w", err)
@@ -50,7 +49,7 @@ func DeployCache(chain deployment.Chain, labels []string) (*types.DeployCacheRes
 	return resp, nil
 }
 
-func DeployAggregatorProxy(chain deployment.Chain, aggregator common.Address, accessController common.Address, labels []string) (*types.DeployProxyResponse, error) {
+func DeployAggregatorProxy(chain cldf.Chain, aggregator common.Address, accessController common.Address, labels []string) (*types.DeployProxyResponse, error) {
 	proxyAddr, tx, proxyContract, err := proxy.DeployAggregatorProxy(chain.DeployerKey, chain.Client, aggregator, accessController)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy AggregatorProxy: %w", err)
@@ -81,7 +80,7 @@ func DeployAggregatorProxy(chain deployment.Chain, aggregator common.Address, ac
 	return resp, nil
 }
 
-func DeployBundleAggregatorProxy(chain deployment.Chain, aggregator common.Address, owner common.Address, labels []string) (*types.DeployBundleAggregatorProxyResponse, error) {
+func DeployBundleAggregatorProxy(chain cldf.Chain, aggregator common.Address, owner common.Address, labels []string) (*types.DeployBundleAggregatorProxyResponse, error) {
 	proxyAddr, tx, proxyContract, err := bundleproxy.DeployBundleAggregatorProxy(chain.DeployerKey, chain.Client, aggregator, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy BundleAggregatorProxy: %w", err)

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy.go
@@ -8,8 +8,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -17,7 +15,7 @@ import (
 // from addressbook to set it in the AggregatorProxy constructor. Returns a new addressbook with deploy AggregatorProxy contract addresses.
 var DeployAggregatorProxyChangeset = cldf.CreateChangeSet(deployAggregatorProxyLogic, deployAggregatorProxyPrecondition)
 
-func deployAggregatorProxyLogic(env deployment.Environment, c types.DeployAggregatorProxyConfig) (cldf.ChangesetOutput, error) {
+func deployAggregatorProxyLogic(env cldf.Environment, c types.DeployAggregatorProxyConfig) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
 	ab := cldf.NewMemoryAddressBook()
 
@@ -44,7 +42,7 @@ func deployAggregatorProxyLogic(env deployment.Environment, c types.DeployAggreg
 	return cldf.ChangesetOutput{AddressBook: ab}, nil
 }
 
-func deployAggregatorProxyPrecondition(env deployment.Environment, c types.DeployAggregatorProxyConfig) error {
+func deployAggregatorProxyPrecondition(env cldf.Environment, c types.DeployAggregatorProxyConfig) error {
 	if len(c.AccessController) != len(c.ChainsToDeploy) {
 		return errors.New("AccessController addresses must be provided for each chain to deploy")
 	}

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy.go
@@ -8,8 +8,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -18,7 +16,7 @@ import (
 // Returns a new addressbook with deploy BundleAggregatorProxy contract addresses.
 var DeployBundleAggregatorProxyChangeset = cldf.CreateChangeSet(deployBundleAggregatorProxyLogic, deployBundleAggregatorProxyPrecondition)
 
-func deployBundleAggregatorProxyLogic(env deployment.Environment, c types.DeployBundleAggregatorProxyConfig) (cldf.ChangesetOutput, error) {
+func deployBundleAggregatorProxyLogic(env cldf.Environment, c types.DeployBundleAggregatorProxyConfig) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
 	ab := cldf.NewMemoryAddressBook()
 
@@ -45,7 +43,7 @@ func deployBundleAggregatorProxyLogic(env deployment.Environment, c types.Deploy
 	return cldf.ChangesetOutput{AddressBook: ab}, nil
 }
 
-func deployBundleAggregatorProxyPrecondition(env deployment.Environment, c types.DeployBundleAggregatorProxyConfig) error {
+func deployBundleAggregatorProxyPrecondition(env cldf.Environment, c types.DeployBundleAggregatorProxyConfig) error {
 	for _, chainSelector := range c.ChainsToDeploy {
 		_, ok := env.Chains[chainSelector]
 		if !ok {

--- a/deployment/data-feeds/changeset/deploy_cache.go
+++ b/deployment/data-feeds/changeset/deploy_cache.go
@@ -6,8 +6,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -15,7 +13,7 @@ import (
 // Returns a new addressbook with deployed DataFeedsCache contracts
 var DeployCacheChangeset = cldf.CreateChangeSet(deployCacheLogic, deployCachePrecondition)
 
-func deployCacheLogic(env deployment.Environment, c types.DeployConfig) (cldf.ChangesetOutput, error) {
+func deployCacheLogic(env cldf.Environment, c types.DeployConfig) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
 	ab := cldf.NewMemoryAddressBook()
 	for _, chainSelector := range c.ChainsToDeploy {
@@ -35,7 +33,7 @@ func deployCacheLogic(env deployment.Environment, c types.DeployConfig) (cldf.Ch
 	return cldf.ChangesetOutput{AddressBook: ab}, nil
 }
 
-func deployCachePrecondition(env deployment.Environment, c types.DeployConfig) error {
+func deployCachePrecondition(env cldf.Environment, c types.DeployConfig) error {
 	for _, chainSelector := range c.ChainsToDeploy {
 		_, ok := env.Chains[chainSelector]
 		if !ok {

--- a/deployment/data-feeds/changeset/import_to_addressbook.go
+++ b/deployment/data-feeds/changeset/import_to_addressbook.go
@@ -6,8 +6,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -21,7 +19,7 @@ type AddressesSchema struct {
 	Label          string              `json:"label"`
 }
 
-func importToAddressbookLogic(env deployment.Environment, c types.ImportToAddressbookConfig) (cldf.ChangesetOutput, error) {
+func importToAddressbookLogic(env cldf.Environment, c types.ImportToAddressbookConfig) (cldf.ChangesetOutput, error) {
 	ab := cldf.NewMemoryAddressBook()
 
 	addresses, _ := LoadJSON[[]*AddressesSchema](c.InputFileName, c.InputFS)
@@ -41,7 +39,7 @@ func importToAddressbookLogic(env deployment.Environment, c types.ImportToAddres
 	return cldf.ChangesetOutput{AddressBook: ab}, nil
 }
 
-func importToAddressbookPrecondition(env deployment.Environment, c types.ImportToAddressbookConfig) error {
+func importToAddressbookPrecondition(env cldf.Environment, c types.ImportToAddressbookConfig) error {
 	_, evmOK := env.Chains[c.ChainSelector]
 	_, aptosOK := env.AptosChains[c.ChainSelector]
 	_, solOK := env.SolChains[c.ChainSelector]

--- a/deployment/data-feeds/changeset/jd_delete_jobs.go
+++ b/deployment/data-feeds/changeset/jd_delete_jobs.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/offchain"
 )
@@ -18,7 +18,7 @@ const (
 // DeleteJobsJDChangeset is a changeset that deletes jobs from JD either using job ids or workflow name
 var DeleteJobsJDChangeset = cldf.CreateChangeSet(deleteJobsJDLogic, deleteJobsJDPrecondition)
 
-func deleteJobsJDLogic(env deployment.Environment, c types.DeleteJobsConfig) (cldf.ChangesetOutput, error) {
+func deleteJobsJDLogic(env cldf.Environment, c types.DeleteJobsConfig) (cldf.ChangesetOutput, error) {
 	ctx, cancel := context.WithTimeout(env.GetContext(), deleteJobTimeout)
 	defer cancel()
 
@@ -26,7 +26,7 @@ func deleteJobsJDLogic(env deployment.Environment, c types.DeleteJobsConfig) (cl
 	return cldf.ChangesetOutput{}, nil
 }
 
-func deleteJobsJDPrecondition(_ deployment.Environment, c types.DeleteJobsConfig) error {
+func deleteJobsJDPrecondition(_ cldf.Environment, c types.DeleteJobsConfig) error {
 	if len(c.JobIDs) == 0 && c.WorkflowName == "" {
 		return errors.New("job ids or workflow name are required")
 	}

--- a/deployment/data-feeds/changeset/jd_propose_bt_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_bt_jobs.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/offchain"
 )
@@ -19,7 +19,7 @@ const (
 // ProposeBtJobsToJDChangeset is a changeset that reads a boostrap spec from a file and proposes jobs to JD
 var ProposeBtJobsToJDChangeset = cldf.CreateChangeSet(proposeBtJobsToJDLogic, proposeBtJobsToJDPrecondition)
 
-func proposeBtJobsToJDLogic(env deployment.Environment, c types.ProposeBtJobsConfig) (cldf.ChangesetOutput, error) {
+func proposeBtJobsToJDLogic(env cldf.Environment, c types.ProposeBtJobsConfig) (cldf.ChangesetOutput, error) {
 	ctx, cancel := context.WithTimeout(env.GetContext(), btTimeout)
 	defer cancel()
 
@@ -31,7 +31,7 @@ func proposeBtJobsToJDLogic(env deployment.Environment, c types.ProposeBtJobsCon
 	return offchain.ProposeJobs(ctx, env, bootstrapJobSpec, nil, c.NodeFilter)
 }
 
-func proposeBtJobsToJDPrecondition(env deployment.Environment, c types.ProposeBtJobsConfig) error {
+func proposeBtJobsToJDPrecondition(env cldf.Environment, c types.ProposeBtJobsConfig) error {
 	if c.NodeFilter == nil {
 		return errors.New("node labels are required")
 	}

--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/offchain"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/view/v1_0"
@@ -23,11 +23,11 @@ const (
 // ProposeWFJobsToJDChangeset is a changeset that reads a feed state file, creates a workflow job spec from it and proposes it to JD.
 var ProposeWFJobsToJDChangeset = cldf.CreateChangeSet(proposeWFJobsToJDLogic, proposeWFJobsToJDPrecondition)
 
-func proposeWFJobsToJDLogic(env deployment.Environment, c types.ProposeWFJobsConfig) (cldf.ChangesetOutput, error) {
+func proposeWFJobsToJDLogic(env cldf.Environment, c types.ProposeWFJobsConfig) (cldf.ChangesetOutput, error) {
 	ctx, cancel := context.WithTimeout(env.GetContext(), timeout)
 	defer cancel()
 
-	chainInfo, _ := deployment.ChainInfo(c.ChainSelector)
+	chainInfo, _ := cldf.ChainInfo(c.ChainSelector)
 
 	feedStatePath := filepath.Join("feeds", chainInfo.ChainName+".json")
 	feedState, _ := LoadJSON[*v1_0.FeedState](feedStatePath, c.InputFS)
@@ -132,7 +132,7 @@ func proposeWFJobsToJDLogic(env deployment.Environment, c types.ProposeWFJobsCon
 	return out, nil
 }
 
-func proposeWFJobsToJDPrecondition(env deployment.Environment, c types.ProposeWFJobsConfig) error {
+func proposeWFJobsToJDPrecondition(env cldf.Environment, c types.ProposeWFJobsConfig) error {
 	if c.MigrationName == "" {
 		return errors.New("migration name is required")
 	}
@@ -166,7 +166,7 @@ func proposeWFJobsToJDPrecondition(env deployment.Environment, c types.ProposeWF
 		return fmt.Errorf("failed to get consensus encoder abi: %w", err)
 	}
 
-	chainInfo, err := deployment.ChainInfo(c.ChainSelector)
+	chainInfo, err := cldf.ChainInfo(c.ChainSelector)
 	if err != nil {
 		return fmt.Errorf("failed to get chain info for chain %d: %w", c.ChainSelector, err)
 	}

--- a/deployment/data-feeds/changeset/jd_register_nodes.go
+++ b/deployment/data-feeds/changeset/jd_register_nodes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/pointer"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
@@ -34,7 +34,7 @@ type DONConfigSchema struct {
 
 const productLabel = "data-feeds"
 
-func registerNodesToJDLogic(env deployment.Environment, c types.NodeConfig) (cldf.ChangesetOutput, error) {
+func registerNodesToJDLogic(env cldf.Environment, c types.NodeConfig) (cldf.ChangesetOutput, error) {
 	dons, _ := LoadJSON[[]*DONConfigSchema](c.InputFileName, c.InputFS)
 
 	for _, don := range dons {
@@ -101,7 +101,7 @@ func registerNodesToJDLogic(env deployment.Environment, c types.NodeConfig) (cld
 	return cldf.ChangesetOutput{}, nil
 }
 
-func registerNodesToJDLogicPrecondition(env deployment.Environment, c types.NodeConfig) error {
+func registerNodesToJDLogicPrecondition(env cldf.Environment, c types.NodeConfig) error {
 	if c.InputFileName == "" {
 		return errors.New("input file name is required")
 	}

--- a/deployment/data-feeds/changeset/jd_update_nodes.go
+++ b/deployment/data-feeds/changeset/jd_update_nodes.go
@@ -8,7 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -22,7 +22,7 @@ type NodeConfigSchema struct {
 	AppendLabels bool            `json:"append_labels"` // if true, append new labels to existing labels, otherwise replace
 }
 
-func updatesNodesJDLogic(env deployment.Environment, c types.NodeConfig) (cldf.ChangesetOutput, error) {
+func updatesNodesJDLogic(env cldf.Environment, c types.NodeConfig) (cldf.ChangesetOutput, error) {
 	nodes, _ := LoadJSON[[]*NodeConfigSchema](c.InputFileName, c.InputFS)
 
 	for _, node := range nodes {
@@ -58,7 +58,7 @@ func updatesNodesJDLogic(env deployment.Environment, c types.NodeConfig) (cldf.C
 	return cldf.ChangesetOutput{}, nil
 }
 
-func updatesNodesJDLogicPrecondition(env deployment.Environment, c types.NodeConfig) error {
+func updatesNodesJDLogicPrecondition(env cldf.Environment, c types.NodeConfig) error {
 	if c.InputFileName == "" {
 		return errors.New("input file name is required")
 	}

--- a/deployment/data-feeds/changeset/migrate_feeds.go
+++ b/deployment/data-feeds/changeset/migrate_feeds.go
@@ -8,8 +8,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -26,7 +24,7 @@ type MigrationSchema struct {
 	Description    string              `json:"description"`
 }
 
-func migrateFeedsLogic(env deployment.Environment, c types.MigrationConfig) (cldf.ChangesetOutput, error) {
+func migrateFeedsLogic(env cldf.Environment, c types.MigrationConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
 	chain := env.Chains[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
@@ -58,20 +56,20 @@ func migrateFeedsLogic(env deployment.Environment, c types.MigrationConfig) (cld
 
 	// Set the feed config
 	tx, err := contract.SetDecimalFeedConfigs(chain.DeployerKey, dataIDs, descriptions, c.WorkflowMetadata)
-	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
+	if _, err := cldf.ConfirmIfNoError(chain, tx, err); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 
 	// Set the proxy to dataId mapping
 	tx, err = contract.UpdateDataIdMappingsForProxies(chain.DeployerKey, addresses, dataIDs)
-	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
+	if _, err := cldf.ConfirmIfNoError(chain, tx, err); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 
 	return cldf.ChangesetOutput{AddressBook: ab}, nil
 }
 
-func migrateFeedsPrecondition(env deployment.Environment, c types.MigrationConfig) error {
+func migrateFeedsPrecondition(env cldf.Environment, c types.MigrationConfig) error {
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)

--- a/deployment/data-feeds/changeset/proposal.go
+++ b/deployment/data-feeds/changeset/proposal.go
@@ -10,7 +10,8 @@ import (
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
@@ -22,7 +23,7 @@ type ProposalData struct {
 // MultiChainProposalConfig is a map of chain selector to a list of proposals to be executed on that chain
 type MultiChainProposalConfig map[uint64][]ProposalData
 
-func BuildMultiChainProposals(env deployment.Environment, description string, proposalConfig MultiChainProposalConfig, minDelay time.Duration) (*mcmslib.TimelockProposal, error) {
+func BuildMultiChainProposals(env cldf.Environment, description string, proposalConfig MultiChainProposalConfig, minDelay time.Duration) (*mcmslib.TimelockProposal, error) {
 	state, _ := LoadOnchainState(env)
 
 	var timelocksPerChain = map[uint64]string{}

--- a/deployment/data-feeds/changeset/remove_dataid_proxy_mapping.go
+++ b/deployment/data-feeds/changeset/remove_dataid_proxy_mapping.go
@@ -7,7 +7,7 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -15,7 +15,7 @@ import (
 // This changeset may return a timelock proposal if the MCMS config is provided, otherwise it will execute the transaction with the deployer key.
 var RemoveFeedProxyMappingChangeset = cldf.CreateChangeSet(removeFeedProxyMappingLogic, removeFeedFeedProxyMappingPrecondition)
 
-func removeFeedProxyMappingLogic(env deployment.Environment, c types.RemoveFeedProxyConfig) (cldf.ChangesetOutput, error) {
+func removeFeedProxyMappingLogic(env cldf.Environment, c types.RemoveFeedProxyConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
 	chain := env.Chains[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
@@ -23,7 +23,7 @@ func removeFeedProxyMappingLogic(env deployment.Environment, c types.RemoveFeedP
 
 	txOpt := chain.DeployerKey
 	if c.McmsConfig != nil {
-		txOpt = deployment.SimTransactOpts()
+		txOpt = cldf.SimTransactOpts()
 	}
 
 	tx, err := contract.RemoveDataIdMappingsForProxies(txOpt, c.ProxyAddresses)
@@ -45,14 +45,14 @@ func removeFeedProxyMappingLogic(env deployment.Environment, c types.RemoveFeedP
 		return cldf.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
 
-	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
+	if _, err := cldf.ConfirmIfNoError(chain, tx, err); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 
 	return cldf.ChangesetOutput{}, nil
 }
 
-func removeFeedFeedProxyMappingPrecondition(env deployment.Environment, c types.RemoveFeedProxyConfig) error {
+func removeFeedFeedProxyMappingPrecondition(env cldf.Environment, c types.RemoveFeedProxyConfig) error {
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)

--- a/deployment/data-feeds/changeset/remove_feed.go
+++ b/deployment/data-feeds/changeset/remove_feed.go
@@ -7,7 +7,7 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -15,7 +15,7 @@ import (
 // This changeset may return a timelock proposal if the MCMS config is provided, otherwise it will execute the transactions with the deployer key.
 var RemoveFeedChangeset = cldf.CreateChangeSet(removeFeedLogic, removeFeedPrecondition)
 
-func removeFeedLogic(env deployment.Environment, c types.RemoveFeedConfig) (cldf.ChangesetOutput, error) {
+func removeFeedLogic(env cldf.Environment, c types.RemoveFeedConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
 	chain := env.Chains[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
@@ -23,7 +23,7 @@ func removeFeedLogic(env deployment.Environment, c types.RemoveFeedConfig) (cldf
 
 	txOpt := chain.DeployerKey
 	if c.McmsConfig != nil {
-		txOpt = deployment.SimTransactOpts()
+		txOpt = cldf.SimTransactOpts()
 	}
 	dataIDs, _ := FeedIDsToBytes16(c.DataIDs)
 
@@ -34,7 +34,7 @@ func removeFeedLogic(env deployment.Environment, c types.RemoveFeedConfig) (cldf
 	}
 
 	if c.McmsConfig == nil {
-		if _, err := deployment.ConfirmIfNoError(chain, removeConfigTx, err); err != nil {
+		if _, err := cldf.ConfirmIfNoError(chain, removeConfigTx, err); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", removeConfigTx.Hash().String(), err)
 		}
 	}
@@ -46,7 +46,7 @@ func removeFeedLogic(env deployment.Environment, c types.RemoveFeedConfig) (cldf
 	}
 
 	if c.McmsConfig == nil {
-		if _, err := deployment.ConfirmIfNoError(chain, removeProxyMappingTx, err); err != nil {
+		if _, err := cldf.ConfirmIfNoError(chain, removeProxyMappingTx, err); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", removeProxyMappingTx.Hash().String(), err)
 		}
 		return cldf.ChangesetOutput{}, nil
@@ -72,7 +72,7 @@ func removeFeedLogic(env deployment.Environment, c types.RemoveFeedConfig) (cldf
 	return cldf.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 }
 
-func removeFeedPrecondition(env deployment.Environment, c types.RemoveFeedConfig) error {
+func removeFeedPrecondition(env cldf.Environment, c types.RemoveFeedConfig) error {
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)

--- a/deployment/data-feeds/changeset/remove_feed_config.go
+++ b/deployment/data-feeds/changeset/remove_feed_config.go
@@ -7,7 +7,7 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -15,7 +15,7 @@ import (
 // This changeset may return a timelock proposal if the MCMS config is provided, otherwise it will execute the transaction with the deployer key.
 var RemoveFeedConfigChangeset = cldf.CreateChangeSet(removeFeedConfigLogic, removeFeedConfigPrecondition)
 
-func removeFeedConfigLogic(env deployment.Environment, c types.RemoveFeedConfigCSConfig) (cldf.ChangesetOutput, error) {
+func removeFeedConfigLogic(env cldf.Environment, c types.RemoveFeedConfigCSConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
 	chain := env.Chains[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
@@ -23,7 +23,7 @@ func removeFeedConfigLogic(env deployment.Environment, c types.RemoveFeedConfigC
 
 	txOpt := chain.DeployerKey
 	if c.McmsConfig != nil {
-		txOpt = deployment.SimTransactOpts()
+		txOpt = cldf.SimTransactOpts()
 	}
 
 	dataIDs, _ := FeedIDsToBytes16(c.DataIDs)
@@ -46,14 +46,14 @@ func removeFeedConfigLogic(env deployment.Environment, c types.RemoveFeedConfigC
 		return cldf.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
 
-	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
+	if _, err := cldf.ConfirmIfNoError(chain, tx, err); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 
 	return cldf.ChangesetOutput{}, nil
 }
 
-func removeFeedConfigPrecondition(env deployment.Environment, c types.RemoveFeedConfigCSConfig) error {
+func removeFeedConfigPrecondition(env cldf.Environment, c types.RemoveFeedConfigCSConfig) error {
 	if len(c.DataIDs) == 0 {
 		return errors.New("dataIDs must not be empty")
 	}

--- a/deployment/data-feeds/changeset/set_bundle_feed_config.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config.go
@@ -7,7 +7,7 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -15,7 +15,7 @@ import (
 // This changeset may return a timelock proposal if the MCMS config is provided, otherwise it will execute the transaction with the deployer key.
 var SetBundleFeedConfigChangeset = cldf.CreateChangeSet(setBundleFeedConfigLogic, setBundleFeedConfigPrecondition)
 
-func setBundleFeedConfigLogic(env deployment.Environment, c types.SetFeedBundleConfig) (cldf.ChangesetOutput, error) {
+func setBundleFeedConfigLogic(env cldf.Environment, c types.SetFeedBundleConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
 	chain := env.Chains[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
@@ -23,7 +23,7 @@ func setBundleFeedConfigLogic(env deployment.Environment, c types.SetFeedBundleC
 
 	txOpt := chain.DeployerKey
 	if c.McmsConfig != nil {
-		txOpt = deployment.SimTransactOpts()
+		txOpt = cldf.SimTransactOpts()
 	}
 
 	dataIDs, _ := FeedIDsToBytes16(c.DataIDs)
@@ -45,7 +45,7 @@ func setBundleFeedConfigLogic(env deployment.Environment, c types.SetFeedBundleC
 		return cldf.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
 
-	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
+	if _, err := cldf.ConfirmIfNoError(chain, tx, err); err != nil {
 		if tx != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 		}
@@ -56,7 +56,7 @@ func setBundleFeedConfigLogic(env deployment.Environment, c types.SetFeedBundleC
 	return cldf.ChangesetOutput{}, nil
 }
 
-func setBundleFeedConfigPrecondition(env deployment.Environment, c types.SetFeedBundleConfig) error {
+func setBundleFeedConfigPrecondition(env cldf.Environment, c types.SetFeedBundleConfig) error {
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)

--- a/deployment/data-feeds/changeset/set_feed_admin.go
+++ b/deployment/data-feeds/changeset/set_feed_admin.go
@@ -6,7 +6,7 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -14,7 +14,7 @@ import (
 // This changeset may return a timelock proposal if the MCMS config is provided, otherwise it will execute the transaction with the deployer key.
 var SetFeedAdminChangeset = cldf.CreateChangeSet(setFeedAdminLogic, setFeedAdminPrecondition)
 
-func setFeedAdminLogic(env deployment.Environment, c types.SetFeedAdminConfig) (cldf.ChangesetOutput, error) {
+func setFeedAdminLogic(env cldf.Environment, c types.SetFeedAdminConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
 	chain := env.Chains[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
@@ -22,7 +22,7 @@ func setFeedAdminLogic(env deployment.Environment, c types.SetFeedAdminConfig) (
 
 	txOpt := chain.DeployerKey
 	if c.McmsConfig != nil {
-		txOpt = deployment.SimTransactOpts()
+		txOpt = cldf.SimTransactOpts()
 	}
 
 	tx, err := contract.SetFeedAdmin(txOpt, c.AdminAddress, c.IsAdmin)
@@ -44,14 +44,14 @@ func setFeedAdminLogic(env deployment.Environment, c types.SetFeedAdminConfig) (
 		return cldf.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
 
-	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
+	if _, err := cldf.ConfirmIfNoError(chain, tx, err); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 
 	return cldf.ChangesetOutput{}, nil
 }
 
-func setFeedAdminPrecondition(env deployment.Environment, c types.SetFeedAdminConfig) error {
+func setFeedAdminPrecondition(env cldf.Environment, c types.SetFeedAdminConfig) error {
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)

--- a/deployment/data-feeds/changeset/set_feed_config.go
+++ b/deployment/data-feeds/changeset/set_feed_config.go
@@ -7,7 +7,7 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -15,7 +15,7 @@ import (
 // This changeset may return a timelock proposal if the MCMS config is provided, otherwise it will execute the transaction with the deployer key.
 var SetFeedConfigChangeset = cldf.CreateChangeSet(setFeedConfigLogic, setFeedConfigPrecondition)
 
-func setFeedConfigLogic(env deployment.Environment, c types.SetFeedDecimalConfig) (cldf.ChangesetOutput, error) {
+func setFeedConfigLogic(env cldf.Environment, c types.SetFeedDecimalConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
 	chain := env.Chains[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
@@ -23,7 +23,7 @@ func setFeedConfigLogic(env deployment.Environment, c types.SetFeedDecimalConfig
 
 	txOpt := chain.DeployerKey
 	if c.McmsConfig != nil {
-		txOpt = deployment.SimTransactOpts()
+		txOpt = cldf.SimTransactOpts()
 	}
 
 	dataIDs, _ := FeedIDsToBytes16(c.DataIDs)
@@ -45,7 +45,7 @@ func setFeedConfigLogic(env deployment.Environment, c types.SetFeedDecimalConfig
 		return cldf.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
 
-	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
+	if _, err := cldf.ConfirmIfNoError(chain, tx, err); err != nil {
 		if tx != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 		}
@@ -56,7 +56,7 @@ func setFeedConfigLogic(env deployment.Environment, c types.SetFeedDecimalConfig
 	return cldf.ChangesetOutput{}, nil
 }
 
-func setFeedConfigPrecondition(env deployment.Environment, c types.SetFeedDecimalConfig) error {
+func setFeedConfigPrecondition(env cldf.Environment, c types.SetFeedDecimalConfig) error {
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)

--- a/deployment/data-feeds/changeset/state.go
+++ b/deployment/data-feeds/changeset/state.go
@@ -43,7 +43,7 @@ type DataFeedsOnChainState struct {
 	Chains map[uint64]DataFeedsChainState
 }
 
-func LoadOnchainState(e deployment.Environment) (DataFeedsOnChainState, error) {
+func LoadOnchainState(e cldf.Environment) (DataFeedsOnChainState, error) {
 	state := DataFeedsOnChainState{
 		Chains: make(map[uint64]DataFeedsChainState),
 	}
@@ -66,7 +66,7 @@ func LoadOnchainState(e deployment.Environment) (DataFeedsOnChainState, error) {
 }
 
 // LoadChainState Loads all state for a chain into state
-func LoadChainState(logger logger.Logger, chain deployment.Chain, addresses map[string]cldf.TypeAndVersion) (*DataFeedsChainState, error) {
+func LoadChainState(logger logger.Logger, chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*DataFeedsChainState, error) {
 	var state DataFeedsChainState
 
 	mcmsWithTimelock, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
@@ -114,10 +114,10 @@ func LoadChainState(logger logger.Logger, chain deployment.Chain, addresses map[
 	return &state, nil
 }
 
-func (s DataFeedsOnChainState) View(chains []uint64, e deployment.Environment) (map[string]view.ChainView, error) {
+func (s DataFeedsOnChainState) View(chains []uint64, e cldf.Environment) (map[string]view.ChainView, error) {
 	m := make(map[string]view.ChainView)
 	for _, chainSelector := range chains {
-		chainInfo, err := deployment.ChainInfo(chainSelector)
+		chainInfo, err := cldf.ChainInfo(chainSelector)
 		if err != nil {
 			return m, err
 		}
@@ -139,7 +139,7 @@ func (s DataFeedsOnChainState) View(chains []uint64, e deployment.Environment) (
 	return m, nil
 }
 
-func GenerateFeedConfigView(e deployment.Environment, chainName string) *v1_0.FeedState {
+func GenerateFeedConfigView(e cldf.Environment, chainName string) *v1_0.FeedState {
 	baseDir := ".."
 	envName := e.Name
 

--- a/deployment/data-feeds/changeset/update_data_id_proxy.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy.go
@@ -7,7 +7,7 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -15,7 +15,7 @@ import (
 // This changeset may return a timelock proposal if the MCMS config is provided, otherwise it will execute the transaction with the deployer key.
 var UpdateDataIDProxyChangeset = cldf.CreateChangeSet(updateDataIDProxyLogic, updateDataIDProxyPrecondition)
 
-func updateDataIDProxyLogic(env deployment.Environment, c types.UpdateDataIDProxyConfig) (cldf.ChangesetOutput, error) {
+func updateDataIDProxyLogic(env cldf.Environment, c types.UpdateDataIDProxyConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
 	chain := env.Chains[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
@@ -23,7 +23,7 @@ func updateDataIDProxyLogic(env deployment.Environment, c types.UpdateDataIDProx
 
 	txOpt := chain.DeployerKey
 	if c.McmsConfig != nil {
-		txOpt = deployment.SimTransactOpts()
+		txOpt = cldf.SimTransactOpts()
 	}
 
 	dataIDs, _ := FeedIDsToBytes16(c.DataIDs)
@@ -46,14 +46,14 @@ func updateDataIDProxyLogic(env deployment.Environment, c types.UpdateDataIDProx
 		return cldf.ChangesetOutput{MCMSTimelockProposals: []mcmslib.TimelockProposal{*proposal}}, nil
 	}
 
-	if _, err := deployment.ConfirmIfNoError(chain, tx, err); err != nil {
+	if _, err := cldf.ConfirmIfNoError(chain, tx, err); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 
 	return cldf.ChangesetOutput{}, nil
 }
 
-func updateDataIDProxyPrecondition(env deployment.Environment, c types.UpdateDataIDProxyConfig) error {
+func updateDataIDProxyPrecondition(env cldf.Environment, c types.UpdateDataIDProxyConfig) error {
 	_, ok := env.Chains[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)

--- a/deployment/data-feeds/changeset/validation.go
+++ b/deployment/data-feeds/changeset/validation.go
@@ -9,11 +9,9 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonTypes "github.com/smartcontractkit/chainlink/deployment/common/types"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
-func ValidateCacheForChain(env deployment.Environment, chainSelector uint64, cacheAddress common.Address) error {
+func ValidateCacheForChain(env cldf.Environment, chainSelector uint64, cacheAddress common.Address) error {
 	state, err := LoadOnchainState(env)
 	if err != nil {
 		return fmt.Errorf("failed to load on chain state %w", err)

--- a/deployment/data-feeds/offchain/jd.go
+++ b/deployment/data-feeds/offchain/jd.go
@@ -11,7 +11,7 @@ import (
 	jdtypesv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/pointer"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 )
@@ -62,7 +62,7 @@ func (f *NodesFilter) filter() *nodeapiv1.ListNodesRequest_Filter {
 	}
 }
 
-func fetchNodesFromJD(ctx context.Context, env deployment.Environment, nodeFilters *NodesFilter) (nodes []*nodeapiv1.Node, err error) {
+func fetchNodesFromJD(ctx context.Context, env cldf.Environment, nodeFilters *NodesFilter) (nodes []*nodeapiv1.Node, err error) {
 	filter := nodeFilters.filter()
 
 	resp, err := env.Offchain.ListNodes(ctx, &nodeapiv1.ListNodesRequest{Filter: filter})
@@ -76,7 +76,7 @@ func fetchNodesFromJD(ctx context.Context, env deployment.Environment, nodeFilte
 	return resp.Nodes, nil
 }
 
-func ProposeJobs(ctx context.Context, env deployment.Environment, workflowJobSpec string, workflowName *string, nodeFilters *NodesFilter) (cldf.ChangesetOutput, error) {
+func ProposeJobs(ctx context.Context, env cldf.Environment, workflowJobSpec string, workflowName *string, nodeFilters *NodesFilter) (cldf.ChangesetOutput, error) {
 	out := cldf.ChangesetOutput{
 		Jobs: []cldf.ProposedJob{},
 	}
@@ -119,7 +119,7 @@ func ProposeJobs(ctx context.Context, env deployment.Environment, workflowJobSpe
 	return out, nil
 }
 
-func DeleteJobs(ctx context.Context, env deployment.Environment, jobIDs []string, workflowName string) {
+func DeleteJobs(ctx context.Context, env cldf.Environment, jobIDs []string, workflowName string) {
 	if len(jobIDs) == 0 {
 		env.Logger.Debugf("jobIDs not present. Listing jobs to delete via workflow name")
 		jobSelectors := []*jdtypesv1.Selector{

--- a/deployment/data-streams/changeset/channel-config-store/call_set_channel_definitions.go
+++ b/deployment/data-streams/changeset/channel-config-store/call_set_channel_definitions.go
@@ -8,6 +8,7 @@ import (
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
 
@@ -53,19 +54,19 @@ func (cfg SetChannelDefinitionsConfig) Validate() error {
 	return nil
 }
 
-func callSetChannelDefinitionsPrecondition(e deployment.Environment, cfg SetChannelDefinitionsConfig) error {
+func callSetChannelDefinitionsPrecondition(e cldf.Environment, cfg SetChannelDefinitionsConfig) error {
 	if len(cfg.DefinitionsByChain) == 0 {
 		return errors.New("DefinitionsByChain cannot be empty")
 	}
 	for chainSel := range cfg.DefinitionsByChain {
-		if err := deployment.IsValidChainSelector(chainSel); err != nil {
+		if err := cldf.IsValidChainSelector(chainSel); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", chainSel, err)
 		}
 	}
 	return nil
 }
 
-func callSetChannelDefinitions(e deployment.Environment, cfg SetChannelDefinitionsConfig) (cldf.ChangesetOutput, error) {
+func callSetChannelDefinitions(e cldf.Environment, cfg SetChannelDefinitionsConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.ChannelConfigStore.String(),
@@ -80,7 +81,7 @@ func callSetChannelDefinitions(e deployment.Environment, cfg SetChannelDefinitio
 	return mcmsutil.ExecuteOrPropose(e, txs, cfg.MCMSConfig, "SetNativeSurcharge proposal")
 }
 
-func maybeLoadChannelConfigStoreState(e deployment.Environment, chainSel uint64, contractAddr string) (*channel_config_store.ChannelConfigStore, error) {
+func maybeLoadChannelConfigStoreState(e cldf.Environment, chainSel uint64, contractAddr string) (*channel_config_store.ChannelConfigStore, error) {
 	if err := utils.ValidateContract(e, chainSel, contractAddr, types.ChannelConfigStore, deployment.Version1_0_0); err != nil {
 		return nil, err
 	}
@@ -101,7 +102,7 @@ func doSetChannelDefinitions(
 	c ChannelDefinition,
 ) (*ethTypes.Transaction, error) {
 	return ccs.SetChannelDefinitions(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		c.DonID,
 		c.S3URL,
 		c.Hash,

--- a/deployment/data-streams/changeset/channel-config-store/deploy_channel_config_store.go
+++ b/deployment/data-streams/changeset/channel-config-store/deploy_channel_config_store.go
@@ -6,6 +6,7 @@ import (
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/metadata"
@@ -35,19 +36,19 @@ func (cc DeployChannelConfigStoreConfig) Validate() error {
 		return errors.New("ChainsToDeploy is empty")
 	}
 	for _, chain := range cc.ChainsToDeploy {
-		if err := deployment.IsValidChainSelector(chain); err != nil {
+		if err := cldf.IsValidChainSelector(chain); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", chain, err)
 		}
 	}
 	return nil
 }
 
-func deployChannelConfigStoreLogic(e deployment.Environment, cc DeployChannelConfigStoreConfig) (cldf.ChangesetOutput, error) {
+func deployChannelConfigStoreLogic(e cldf.Environment, cc DeployChannelConfigStoreConfig) (cldf.ChangesetOutput, error) {
 	dataStore := ds.NewMemoryDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata]()
 	err := deploy(e, dataStore, cc)
 	if err != nil {
 		e.Logger.Errorw("Failed to deploy ChannelConfigStore", "err", err)
-		return cldf.ChangesetOutput{}, deployment.MaybeDataErr(err)
+		return cldf.ChangesetOutput{}, cldf.MaybeDataErr(err)
 	}
 
 	records, err := dataStore.Addresses().Fetch()
@@ -69,7 +70,7 @@ func deployChannelConfigStoreLogic(e deployment.Environment, cc DeployChannelCon
 	}, nil
 }
 
-func deployChannelConfigStorePrecondition(_ deployment.Environment, cc DeployChannelConfigStoreConfig) error {
+func deployChannelConfigStorePrecondition(_ cldf.Environment, cc DeployChannelConfigStoreConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid DeployChannelConfigStoreConfig: %w", err)
 	}
@@ -77,7 +78,7 @@ func deployChannelConfigStorePrecondition(_ deployment.Environment, cc DeployCha
 	return nil
 }
 
-func deploy(e deployment.Environment, dataStore ds.MutableDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata], cc DeployChannelConfigStoreConfig) error {
+func deploy(e cldf.Environment, dataStore ds.MutableDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata], cc DeployChannelConfigStoreConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid DeployChannelConfigStoreConfig: %w", err)
 	}
@@ -118,7 +119,7 @@ func deploy(e deployment.Environment, dataStore ds.MutableDataStore[metadata.Ser
 
 // channelConfigStoreDeployFn returns a function that deploys a ChannelConfigStore contract.
 func channelConfigStoreDeployFn() changeset.ContractDeployFn[*channel_config_store.ChannelConfigStore] {
-	return func(chain deployment.Chain) *changeset.ContractDeployment[*channel_config_store.ChannelConfigStore] {
+	return func(chain cldf.Chain) *changeset.ContractDeployment[*channel_config_store.ChannelConfigStore] {
 		ccsAddr, ccsTx, ccs, err := channel_config_store.DeployChannelConfigStore(
 			chain.DeployerKey,
 			chain.Client,

--- a/deployment/data-streams/changeset/common.go
+++ b/deployment/data-streams/changeset/common.go
@@ -14,14 +14,13 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 const (
 	defaultJobSpecsTimeout = 120 * time.Second
 )
 
-func chainAndAddresses(e deployment.Environment, chainSel uint64) (chainID string, addresses map[string]cldf.TypeAndVersion, err error) {
+func chainAndAddresses(e cldf.Environment, chainSel uint64) (chainID string, addresses map[string]cldf.TypeAndVersion, err error) {
 	chainID, err = chainsel.GetChainIDFromSelector(chainSel)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get chain ID from selector: %w", err)
@@ -72,7 +71,7 @@ func proposeAllOrNothing(ctx context.Context, oc cldf.OffchainClient, prs []*job
 
 // fetchExternalJobID looks for an existing job that matches the given labels and returns its ID.
 // If no job is found, it returns a nil UUID.
-func fetchExternalJobID(e deployment.Environment, nodeID string, selectors []*ptypes.Selector) (externalJobID uuid.UUID, err error) {
+func fetchExternalJobID(e cldf.Environment, nodeID string, selectors []*ptypes.Selector) (externalJobID uuid.UUID, err error) {
 	var nodeIDs []string
 	if nodeID != "" {
 		nodeIDs = []string{nodeID}

--- a/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_promote_staging_config.go
+++ b/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_promote_staging_config.go
@@ -7,13 +7,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/configurator"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 )
@@ -46,14 +47,14 @@ func (cfg PromoteStagingConfigConfig) Validate() error {
 
 func (pc PromoteStagingConfig) GetContractAddress() common.Address { return pc.ConfiguratorAddress }
 
-func promoteStagingConfigPrecondition(_ deployment.Environment, cc PromoteStagingConfigConfig) error {
+func promoteStagingConfigPrecondition(_ cldf.Environment, cc PromoteStagingConfigConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid DeployConfiguratorConfig: %w", err)
 	}
 	return nil
 }
 
-func promoteStagingConfigLogic(e deployment.Environment, cfg PromoteStagingConfigConfig) (cldf.ChangesetOutput, error) {
+func promoteStagingConfigLogic(e cldf.Environment, cfg PromoteStagingConfigConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.Configurator.String(),
@@ -72,10 +73,10 @@ func doPromoteStagingConfig(
 	c *configurator.Configurator,
 	cfg PromoteStagingConfig,
 ) (*ethTypes.Transaction, error) {
-	return c.PromoteStagingConfig(deployment.SimTransactOpts(), cfg.ConfigID, cfg.IsGreenProduction)
+	return c.PromoteStagingConfig(cldf.SimTransactOpts(), cfg.ConfigID, cfg.IsGreenProduction)
 }
 
-func LoadConfigurator(e deployment.Environment, chainSel uint64, contractAddr string) (*configurator.Configurator, error) {
+func LoadConfigurator(e cldf.Environment, chainSel uint64, contractAddr string) (*configurator.Configurator, error) {
 	chain, ok := e.Chains[chainSel]
 	if !ok {
 		return nil, fmt.Errorf("chain %d not found", chainSel)

--- a/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_set_production_config.go
+++ b/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_set_production_config.go
@@ -6,14 +6,13 @@ import (
 
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/configurator"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 var SetProductionConfigChangeset = cldf.CreateChangeSet(setProductionConfigLogic, setProductionConfigPrecondition)
@@ -31,7 +30,7 @@ func (cfg SetProductionConfigConfig) Validate() error {
 	return nil
 }
 
-func setProductionConfigPrecondition(_ deployment.Environment, cfg SetProductionConfigConfig) error {
+func setProductionConfigPrecondition(_ cldf.Environment, cfg SetProductionConfigConfig) error {
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("invalid DeployConfiguratorConfig: %w", err)
 	}
@@ -39,7 +38,7 @@ func setProductionConfigPrecondition(_ deployment.Environment, cfg SetProduction
 	return nil
 }
 
-func setProductionConfigLogic(e deployment.Environment, cfg SetProductionConfigConfig) (cldf.ChangesetOutput, error) {
+func setProductionConfigLogic(e cldf.Environment, cfg SetProductionConfigConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.Configurator.String(),
@@ -58,7 +57,7 @@ func doSetProductionConfig(
 	c *configurator.Configurator,
 	prodCfg ConfiguratorConfig,
 ) (*ethTypes.Transaction, error) {
-	return c.SetProductionConfig(deployment.SimTransactOpts(),
+	return c.SetProductionConfig(cldf.SimTransactOpts(),
 		prodCfg.ConfigID,
 		prodCfg.Signers,
 		prodCfg.OffchainTransmitters,

--- a/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_set_staging_config.go
+++ b/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_set_staging_config.go
@@ -7,13 +7,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/configurator"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 )
 
@@ -28,7 +28,7 @@ type SetStagingConfigConfig struct {
 	MCMSConfig            *types.MCMSConfig
 }
 
-func setStagingConfigPrecondition(_ deployment.Environment, ss SetStagingConfigConfig) error {
+func setStagingConfigPrecondition(_ cldf.Environment, ss SetStagingConfigConfig) error {
 	if err := ss.Validate(); err != nil {
 		return fmt.Errorf("invalid SetStagingConfigConfig: %w", err)
 	}
@@ -43,7 +43,7 @@ func (cfg SetStagingConfigConfig) Validate() error {
 	return nil
 }
 
-func setStagingConfigLogic(e deployment.Environment, cfg SetStagingConfigConfig) (cldf.ChangesetOutput, error) {
+func setStagingConfigLogic(e cldf.Environment, cfg SetStagingConfigConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.Configurator.String(),
@@ -62,7 +62,7 @@ func doSetStagingConfig(
 	c *configurator.Configurator,
 	cfg ConfiguratorConfig,
 ) (*ethTypes.Transaction, error) {
-	return c.SetStagingConfig(deployment.SimTransactOpts(),
+	return c.SetStagingConfig(cldf.SimTransactOpts(),
 		cfg.ConfigID,
 		cfg.Signers,
 		cfg.OffchainTransmitters,

--- a/deployment/data-streams/changeset/deploy.go
+++ b/deployment/data-streams/changeset/deploy.go
@@ -11,7 +11,7 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/metadata"
 )
 
@@ -27,7 +27,7 @@ type (
 		TransferOwnership(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error)
 	}
 
-	ContractDeployFn[C Contract] func(chain deployment.Chain) *ContractDeployment[C]
+	ContractDeployFn[C Contract] func(chain cldf.Chain) *ContractDeployment[C]
 
 	ContractDeployment[C Contract] struct {
 		Address  common.Address
@@ -50,9 +50,9 @@ type DeploymentOutput[C Contract] struct {
 
 // DeployContract deploys a contract and saves the address to datastore.
 func DeployContract[C Contract](
-	e deployment.Environment,
+	e cldf.Environment,
 	dataStore ds.MutableDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata],
-	chain deployment.Chain,
+	chain cldf.Chain,
 	deployFn ContractDeployFn[C],
 	options *DeployOptions,
 ) (*ContractDeployment[C], error) {

--- a/deployment/data-streams/changeset/fee-manager/call_pay_link_deficit.go
+++ b/deployment/data-streams/changeset/fee-manager/call_pay_link_deficit.go
@@ -10,7 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/fee_manager_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -35,7 +35,7 @@ func (a PayLinkDeficit) GetContractAddress() common.Address {
 	return a.FeeManagerAddress
 }
 
-func (cs payLinkDeficit) Apply(e deployment.Environment, cfg PayLinkDeficitConfig) (cldf.ChangesetOutput, error) {
+func (cs payLinkDeficit) Apply(e cldf.Environment, cfg PayLinkDeficitConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.FeeManager.String(),
@@ -50,12 +50,12 @@ func (cs payLinkDeficit) Apply(e deployment.Environment, cfg PayLinkDeficitConfi
 	return mcmsutil.ExecuteOrPropose(e, txs, cfg.MCMSConfig, "Withdraw proposal")
 }
 
-func (cs payLinkDeficit) VerifyPreconditions(e deployment.Environment, cfg PayLinkDeficitConfig) error {
+func (cs payLinkDeficit) VerifyPreconditions(e cldf.Environment, cfg PayLinkDeficitConfig) error {
 	if len(cfg.ConfigPerChain) == 0 {
 		return errors.New("ConfigPerChain is empty")
 	}
 	for cs := range cfg.ConfigPerChain {
-		if err := deployment.IsValidChainSelector(cs); err != nil {
+		if err := cldf.IsValidChainSelector(cs); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", cs, err)
 		}
 	}
@@ -67,6 +67,6 @@ func doPayLinkDeficit(
 	c PayLinkDeficit,
 ) (*goEthTypes.Transaction, error) {
 	return fm.PayLinkDeficit(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		c.ConfigDigest)
 }

--- a/deployment/data-streams/changeset/fee-manager/call_pay_link_deficit_test.go
+++ b/deployment/data-streams/changeset/fee-manager/call_pay_link_deficit_test.go
@@ -10,6 +10,7 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/metadata"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/mock_fee_manager_v0_5_0"
@@ -43,7 +44,7 @@ func TestPayLinkDeficit(t *testing.T) {
 
 	deployMockCs := []commonChangesets.ConfiguredChangeSet{
 		commonChangesets.Configure(cldf.CreateChangeSet(
-			func(e deployment.Environment, config uint32) (cldf.ChangesetOutput, error) {
+			func(e cldf.Environment, config uint32) (cldf.ChangesetOutput, error) {
 				dataStore := ds.NewMemoryDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata]()
 				// This uses a MockFeeManager. The subject under test here is the PayLinkDeficit changeset.
 				// This is modeled as a client/server test where the "client" is the PayLinkDeficit changeset
@@ -62,7 +63,7 @@ func TestPayLinkDeficit(t *testing.T) {
 					DataStore: sealedDS,
 				}, nil
 			},
-			func(e deployment.Environment, config uint32) error {
+			func(e cldf.Environment, config uint32) error {
 				return nil
 			},
 		), 1),
@@ -117,7 +118,7 @@ func TestPayLinkDeficit(t *testing.T) {
 }
 
 func MockFeeManagerDeployFn(cfg DeployFeeManager) changeset.ContractDeployFn[*mock_fee_manager_v0_5_0.MockFeeManager] {
-	return func(chain deployment.Chain) *changeset.ContractDeployment[*mock_fee_manager_v0_5_0.MockFeeManager] {
+	return func(chain cldf.Chain) *changeset.ContractDeployment[*mock_fee_manager_v0_5_0.MockFeeManager] {
 		ccsAddr, ccsTx, ccs, err := mock_fee_manager_v0_5_0.DeployMockFeeManager(
 			chain.DeployerKey,
 			chain.Client,

--- a/deployment/data-streams/changeset/fee-manager/call_set_native_surcharge.go
+++ b/deployment/data-streams/changeset/fee-manager/call_set_native_surcharge.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/fee_manager_v0_5_0"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -34,7 +33,7 @@ func (a SetNativeSurcharge) GetContractAddress() common.Address {
 	return a.FeeManagerAddress
 }
 
-func setNativeSurchargeLogic(e deployment.Environment, cfg SetNativeSurchargeConfig) (cldf.ChangesetOutput, error) {
+func setNativeSurchargeLogic(e cldf.Environment, cfg SetNativeSurchargeConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.FeeManager.String(),
@@ -49,12 +48,12 @@ func setNativeSurchargeLogic(e deployment.Environment, cfg SetNativeSurchargeCon
 	return mcmsutil.ExecuteOrPropose(e, txs, cfg.MCMSConfig, "SetNativeSurcharge proposal")
 }
 
-func setNativeSurchargePrecondition(e deployment.Environment, cfg SetNativeSurchargeConfig) error {
+func setNativeSurchargePrecondition(e cldf.Environment, cfg SetNativeSurchargeConfig) error {
 	if len(cfg.ConfigPerChain) == 0 {
 		return errors.New("ConfigPerChain is empty")
 	}
 	for cs := range cfg.ConfigPerChain {
-		if err := deployment.IsValidChainSelector(cs); err != nil {
+		if err := cldf.IsValidChainSelector(cs); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", cs, err)
 		}
 	}
@@ -66,6 +65,6 @@ func doSetNativeSurcharge(
 	c SetNativeSurcharge,
 ) (*goEthTypes.Transaction, error) {
 	return fm.SetNativeSurcharge(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		c.Surcharge)
 }

--- a/deployment/data-streams/changeset/fee-manager/call_update_subscriber_discount.go
+++ b/deployment/data-streams/changeset/fee-manager/call_update_subscriber_discount.go
@@ -10,7 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/fee_manager_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -38,7 +38,7 @@ func (a UpdateSubscriberDiscount) GetContractAddress() common.Address {
 	return a.FeeManagerAddress
 }
 
-func (cs discount) Apply(e deployment.Environment, cfg UpdateSubscriberDiscountConfig) (cldf.ChangesetOutput, error) {
+func (cs discount) Apply(e cldf.Environment, cfg UpdateSubscriberDiscountConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.FeeManager.String(),
@@ -53,12 +53,12 @@ func (cs discount) Apply(e deployment.Environment, cfg UpdateSubscriberDiscountC
 	return mcmsutil.ExecuteOrPropose(e, txs, cfg.MCMSConfig, "UpdateSubscriberDiscount proposal")
 }
 
-func (cs discount) VerifyPreconditions(e deployment.Environment, cfg UpdateSubscriberDiscountConfig) error {
+func (cs discount) VerifyPreconditions(e cldf.Environment, cfg UpdateSubscriberDiscountConfig) error {
 	if len(cfg.ConfigPerChain) == 0 {
 		return errors.New("ConfigPerChain is empty")
 	}
 	for cs := range cfg.ConfigPerChain {
-		if err := deployment.IsValidChainSelector(cs); err != nil {
+		if err := cldf.IsValidChainSelector(cs); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", cs, err)
 		}
 	}
@@ -70,7 +70,7 @@ func doUpdateSubscriberDiscount(
 	c UpdateSubscriberDiscount,
 ) (*goEthTypes.Transaction, error) {
 	return fm.UpdateSubscriberDiscount(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		c.SubscriberAddress,
 		c.FeedID,
 		c.TokenAddress,

--- a/deployment/data-streams/changeset/fee-manager/call_update_subscriber_global_discount.go
+++ b/deployment/data-streams/changeset/fee-manager/call_update_subscriber_global_discount.go
@@ -10,7 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/fee_manager_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -37,7 +37,7 @@ func (a UpdateSubscriberGlobalDiscount) GetContractAddress() common.Address {
 	return a.FeeManagerAddress
 }
 
-func (cs globalDiscount) Apply(e deployment.Environment, cfg UpdateSubscriberGlobalDiscountConfig) (cldf.ChangesetOutput, error) {
+func (cs globalDiscount) Apply(e cldf.Environment, cfg UpdateSubscriberGlobalDiscountConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.FeeManager.String(),
@@ -52,12 +52,12 @@ func (cs globalDiscount) Apply(e deployment.Environment, cfg UpdateSubscriberGlo
 	return mcmsutil.ExecuteOrPropose(e, txs, cfg.MCMSConfig, "UpdateSubscriberGlobalDiscount proposal")
 }
 
-func (cs globalDiscount) VerifyPreconditions(e deployment.Environment, cfg UpdateSubscriberGlobalDiscountConfig) error {
+func (cs globalDiscount) VerifyPreconditions(e cldf.Environment, cfg UpdateSubscriberGlobalDiscountConfig) error {
 	if len(cfg.ConfigPerChain) == 0 {
 		return errors.New("ConfigPerChain is empty")
 	}
 	for cs := range cfg.ConfigPerChain {
-		if err := deployment.IsValidChainSelector(cs); err != nil {
+		if err := cldf.IsValidChainSelector(cs); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", cs, err)
 		}
 	}
@@ -69,7 +69,7 @@ func doUpdateSubscriberGlobalDiscount(
 	c UpdateSubscriberGlobalDiscount,
 ) (*goEthTypes.Transaction, error) {
 	return fm.UpdateSubscriberGlobalDiscount(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		c.SubscriberAddress,
 		c.TokenAddress,
 		c.Discount)

--- a/deployment/data-streams/changeset/fee-manager/call_withdraw.go
+++ b/deployment/data-streams/changeset/fee-manager/call_withdraw.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/fee_manager_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -38,7 +38,7 @@ func (a Withdraw) GetContractAddress() common.Address {
 	return a.FeeManagerAddress
 }
 
-func (cs withdraw) Apply(e deployment.Environment, cfg FeeManagerWithdrawConfig) (cldf.ChangesetOutput, error) {
+func (cs withdraw) Apply(e cldf.Environment, cfg FeeManagerWithdrawConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.FeeManager.String(),
@@ -53,12 +53,12 @@ func (cs withdraw) Apply(e deployment.Environment, cfg FeeManagerWithdrawConfig)
 	return mcmsutil.ExecuteOrPropose(e, txs, cfg.MCMSConfig, "Withdraw proposal")
 }
 
-func (cs withdraw) VerifyPreconditions(e deployment.Environment, cfg FeeManagerWithdrawConfig) error {
+func (cs withdraw) VerifyPreconditions(e cldf.Environment, cfg FeeManagerWithdrawConfig) error {
 	if len(cfg.ConfigPerChain) == 0 {
 		return errors.New("ConfigPerChain is empty")
 	}
 	for cs := range cfg.ConfigPerChain {
-		if err := deployment.IsValidChainSelector(cs); err != nil {
+		if err := cldf.IsValidChainSelector(cs); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", cs, err)
 		}
 	}
@@ -70,7 +70,7 @@ func doWithdraw(
 	c Withdraw,
 ) (*goEthTypes.Transaction, error) {
 	return fm.Withdraw(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		c.AssetAddress,
 		c.RecipientAddress,
 		c.Quantity)

--- a/deployment/data-streams/changeset/fee-manager/state.go
+++ b/deployment/data-streams/changeset/fee-manager/state.go
@@ -5,15 +5,18 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/fee_manager_v0_5_0"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 )
 
 func LoadFeeManagerState(
-	e deployment.Environment,
+	e cldf.Environment,
 	chainSel uint64,
 	contractAddr string,
 ) (*fee_manager_v0_5_0.FeeManager, error) {

--- a/deployment/data-streams/changeset/fee-manager/test_helpers.go
+++ b/deployment/data-streams/changeset/fee-manager/test_helpers.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/testutil"
@@ -14,7 +17,7 @@ import (
 )
 
 type DataStreamsTestEnvSetupOutput struct {
-	Env               deployment.Environment
+	Env               cldf.Environment
 	LinkTokenAddress  common.Address
 	FeeManagerAddress common.Address
 }

--- a/deployment/data-streams/changeset/jd_distribute_llo_jobs.go
+++ b/deployment/data-streams/changeset/jd_distribute_llo_jobs.go
@@ -14,7 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/jd"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/jobs"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
@@ -52,7 +52,7 @@ type CsDistributeLLOJobSpecsConfig struct {
 
 type CsDistributeLLOJobSpecs struct{}
 
-func (CsDistributeLLOJobSpecs) Apply(e deployment.Environment, cfg CsDistributeLLOJobSpecsConfig) (cldf.ChangesetOutput, error) {
+func (CsDistributeLLOJobSpecs) Apply(e cldf.Environment, cfg CsDistributeLLOJobSpecsConfig) (cldf.ChangesetOutput, error) {
 	ctx, cancel := context.WithTimeout(e.GetContext(), defaultJobSpecsTimeout)
 	defer cancel()
 
@@ -91,7 +91,7 @@ func (CsDistributeLLOJobSpecs) Apply(e deployment.Environment, cfg CsDistributeL
 	}, nil
 }
 
-func generateBootstrapProposals(ctx context.Context, e deployment.Environment, cfg CsDistributeLLOJobSpecsConfig, chainID string, labels []*ptypes.Label) ([]*jobv1.ProposeJobRequest, error) {
+func generateBootstrapProposals(ctx context.Context, e cldf.Environment, cfg CsDistributeLLOJobSpecsConfig, chainID string, labels []*ptypes.Label) ([]*jobv1.ProposeJobRequest, error) {
 	bootstrapNodes, err := jd.FetchDONBootstrappersFromJD(ctx, e.Offchain, cfg.Filter, cfg.NodeNames)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get bootstrap nodes: %w", err)
@@ -152,7 +152,7 @@ func generateBootstrapProposals(ctx context.Context, e deployment.Environment, c
 	return proposals, nil
 }
 
-func generateOracleProposals(ctx context.Context, e deployment.Environment, cfg CsDistributeLLOJobSpecsConfig, chainID string, labels []*ptypes.Label) ([]*jobv1.ProposeJobRequest, error) {
+func generateOracleProposals(ctx context.Context, e cldf.Environment, cfg CsDistributeLLOJobSpecsConfig, chainID string, labels []*ptypes.Label) ([]*jobv1.ProposeJobRequest, error) {
 	// nils will be filled out later with n-specific values:
 	lloSpec := &jobs.LLOJobSpec{
 		Base: jobs.Base{
@@ -252,7 +252,7 @@ func generateOracleProposals(ctx context.Context, e deployment.Environment, cfg 
 }
 
 // chainConfigs returns a map of node IDs to their chain configs for the given chain ID.
-func chainConfigs(ctx context.Context, e deployment.Environment, chainID string, nodes []*node.Node) (map[string]*node.OCR2Config, error) {
+func chainConfigs(ctx context.Context, e cldf.Environment, chainID string, nodes []*node.Node) (map[string]*node.OCR2Config, error) {
 	nodeConfigMap := make(map[string]*node.OCR2Config)
 	for _, n := range nodes {
 		ncf, err := e.Offchain.ListNodeChainConfigs(ctx,
@@ -275,7 +275,7 @@ func chainConfigs(ctx context.Context, e deployment.Environment, chainID string,
 }
 
 // getBootstrapMultiAddr fetches the bootstrap node from Job Distributor and returns its multiaddr.
-func getBootstrapMultiAddr(ctx context.Context, e deployment.Environment, cfg CsDistributeLLOJobSpecsConfig) (string, error) {
+func getBootstrapMultiAddr(ctx context.Context, e cldf.Environment, cfg CsDistributeLLOJobSpecsConfig) (string, error) {
 	// Get all bootstrap nodes for this DON.
 	// We fetch these with a custom filter because the filter in the config defines which nodes need to be sent jobs
 	// and this might not cover any bootstrap nodes.
@@ -325,7 +325,7 @@ func getBootstrapMultiAddr(ctx context.Context, e deployment.Environment, cfg Cs
 	return resp.ChainConfigs[0].Ocr2Config.Multiaddr, nil
 }
 
-func (f CsDistributeLLOJobSpecs) VerifyPreconditions(_ deployment.Environment, config CsDistributeLLOJobSpecsConfig) error {
+func (f CsDistributeLLOJobSpecs) VerifyPreconditions(_ cldf.Environment, config CsDistributeLLOJobSpecsConfig) error {
 	if config.ChainSelectorEVM == 0 {
 		return errors.New("chain selector is required")
 	}

--- a/deployment/data-streams/changeset/jd_distribute_stream_jobs.go
+++ b/deployment/data-streams/changeset/jd_distribute_stream_jobs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/jd"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/jobs"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
@@ -48,7 +48,7 @@ type EARequestParams struct {
 
 type CsDistributeStreamJobSpecs struct{}
 
-func (CsDistributeStreamJobSpecs) Apply(e deployment.Environment, cfg CsDistributeStreamJobSpecsConfig) (cldf.ChangesetOutput, error) {
+func (CsDistributeStreamJobSpecs) Apply(e cldf.Environment, cfg CsDistributeStreamJobSpecsConfig) (cldf.ChangesetOutput, error) {
 	ctx, cancel := context.WithTimeout(e.GetContext(), defaultJobSpecsTimeout)
 	defer cancel()
 
@@ -155,7 +155,7 @@ func generateDatasources(cc StreamSpecConfig) []jobs.Datasource {
 	return dss
 }
 
-func (f CsDistributeStreamJobSpecs) VerifyPreconditions(_ deployment.Environment, config CsDistributeStreamJobSpecsConfig) error {
+func (f CsDistributeStreamJobSpecs) VerifyPreconditions(_ cldf.Environment, config CsDistributeStreamJobSpecsConfig) error {
 	if config.Filter == nil {
 		return errors.New("filter is required")
 	}

--- a/deployment/data-streams/changeset/jd_register_nodes.go
+++ b/deployment/data-streams/changeset/jd_register_nodes.go
@@ -8,7 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/pointer"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
@@ -46,7 +46,7 @@ func validateNodeSlice(nodes []NodeCfg, nodeType string, donIndex int) error {
 	return nil
 }
 
-func registerNodesForDON(e deployment.Environment, donName string, donID uint64, nodes []NodeCfg, baseLabels []*ptypes.Label, nodeType string) {
+func registerNodesForDON(e cldf.Environment, donName string, donID uint64, nodes []NodeCfg, baseLabels []*ptypes.Label, nodeType string) {
 	for _, node := range nodes {
 		labels := append([]*ptypes.Label(nil), baseLabels...)
 
@@ -72,7 +72,7 @@ func registerNodesForDON(e deployment.Environment, donName string, donID uint64,
 	}
 }
 
-func registerNodesWithJDLogic(e deployment.Environment, cfg RegisterNodesInput) (cldf.ChangesetOutput, error) {
+func registerNodesWithJDLogic(e cldf.Environment, cfg RegisterNodesInput) (cldf.ChangesetOutput, error) {
 	baseLabels := []*ptypes.Label{
 		{
 			Key:   devenv.LabelProductKey,
@@ -124,6 +124,6 @@ func (cfg RegisterNodesInput) Validate() error {
 	return nil
 }
 
-func registerNodesWithJDPrecondition(_ deployment.Environment, cfg RegisterNodesInput) error {
+func registerNodesWithJDPrecondition(_ cldf.Environment, cfg RegisterNodesInput) error {
 	return cfg.Validate()
 }

--- a/deployment/data-streams/changeset/mcms/deploy_and_transfer_mcms.go
+++ b/deployment/data-streams/changeset/mcms/deploy_and_transfer_mcms.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/metadata"
@@ -27,7 +27,7 @@ func (cc DeployMCMSConfig) GetOwnershipConfig() types.OwnershipSettings {
 	return cc.Ownership
 }
 
-func deployAndTransferMcmsLogic(e deployment.Environment, cc DeployMCMSConfig) (cldf.ChangesetOutput, error) {
+func deployAndTransferMcmsLogic(e cldf.Environment, cc DeployMCMSConfig) (cldf.ChangesetOutput, error) {
 	cfgByChain := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 	for _, chain := range cc.ChainsToDeploy {
 		cfgByChain[chain] = cc.Config
@@ -88,7 +88,7 @@ func deployAndTransferMcmsLogic(e deployment.Environment, cc DeployMCMSConfig) (
 		MCMSTimelockProposals: proposals}, nil
 }
 
-func deployAndTransferMcmsPrecondition(_ deployment.Environment, cc DeployMCMSConfig) error {
+func deployAndTransferMcmsPrecondition(_ cldf.Environment, cc DeployMCMSConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid DeployMCMSConfig: %w", err)
 	}
@@ -100,7 +100,7 @@ func (cc DeployMCMSConfig) Validate() error {
 		return errors.New("ChainsToDeploy is empty")
 	}
 	for _, chain := range cc.ChainsToDeploy {
-		if err := deployment.IsValidChainSelector(chain); err != nil {
+		if err := cldf.IsValidChainSelector(chain); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", chain, err)
 		}
 	}

--- a/deployment/data-streams/changeset/reward-manager/call_claim_rewards.go
+++ b/deployment/data-streams/changeset/reward-manager/call_claim_rewards.go
@@ -11,7 +11,7 @@ import (
 	rewardManager "github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/reward_manager_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -41,14 +41,14 @@ func (cfg ClaimRewardsConfig) Validate() error {
 	return nil
 }
 
-func claimRewardsPrecondition(_ deployment.Environment, cc ClaimRewardsConfig) error {
+func claimRewardsPrecondition(_ cldf.Environment, cc ClaimRewardsConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid ClaimRewards config: %w", err)
 	}
 	return nil
 }
 
-func claimRewardsLogic(e deployment.Environment, cfg ClaimRewardsConfig) (cldf.ChangesetOutput, error) {
+func claimRewardsLogic(e cldf.Environment, cfg ClaimRewardsConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.RewardManager.String(),
@@ -65,7 +65,7 @@ func claimRewardsLogic(e deployment.Environment, cfg ClaimRewardsConfig) (cldf.C
 
 func doClaimRewards(vs *rewardManager.RewardManager, cr ClaimRewards) (*goEthTypes.Transaction, error) {
 	return vs.ClaimRewards(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		cr.PoolIDs,
 	)
 }

--- a/deployment/data-streams/changeset/reward-manager/call_pay_recipients.go
+++ b/deployment/data-streams/changeset/reward-manager/call_pay_recipients.go
@@ -11,7 +11,7 @@ import (
 	rewardManager "github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/reward_manager_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -42,14 +42,14 @@ func (cfg PayRecipientsConfig) Validate() error {
 	return nil
 }
 
-func PayRecipientsPrecondition(_ deployment.Environment, cc PayRecipientsConfig) error {
+func PayRecipientsPrecondition(_ cldf.Environment, cc PayRecipientsConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid PayRecipients config: %w", err)
 	}
 	return nil
 }
 
-func PayRecipientsLogic(e deployment.Environment, cfg PayRecipientsConfig) (cldf.ChangesetOutput, error) {
+func PayRecipientsLogic(e cldf.Environment, cfg PayRecipientsConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.RewardManager.String(),
@@ -66,7 +66,7 @@ func PayRecipientsLogic(e deployment.Environment, cfg PayRecipientsConfig) (cldf
 
 func doPayRecipients(vs *rewardManager.RewardManager, pr PayRecipients) (*goEthTypes.Transaction, error) {
 	return vs.PayRecipients(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		pr.PoolID,
 		pr.Recipients,
 	)

--- a/deployment/data-streams/changeset/reward-manager/call_set_fee_manager.go
+++ b/deployment/data-streams/changeset/reward-manager/call_set_fee_manager.go
@@ -44,7 +44,7 @@ func (cfg SetFeeManagerConfig) Validate() error {
 	return nil
 }
 
-func SetFeeManagerPrecondition(e deployment.Environment, sf SetFeeManagerConfig) error {
+func SetFeeManagerPrecondition(e cldf.Environment, sf SetFeeManagerConfig) error {
 	for chainSelector, configs := range sf.ConfigsByChain {
 		for _, config := range configs {
 			confState, err := loadRewardManagerState(e, chainSelector, config.RewardManagerAddress.Hex())
@@ -72,7 +72,7 @@ func SetFeeManagerPrecondition(e deployment.Environment, sf SetFeeManagerConfig)
 	return nil
 }
 
-func SetFeeManagerLogic(e deployment.Environment, cfg SetFeeManagerConfig) (cldf.ChangesetOutput, error) {
+func SetFeeManagerLogic(e cldf.Environment, cfg SetFeeManagerConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.FeeManager.String(),
@@ -89,7 +89,7 @@ func SetFeeManagerLogic(e deployment.Environment, cfg SetFeeManagerConfig) (cldf
 
 func doSetFeeManager(vs *rewardManager.RewardManager, sf SetFeeManager) (*goEthTypes.Transaction, error) {
 	return vs.SetFeeManager(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		sf.FeeManagerAddress,
 	)
 }

--- a/deployment/data-streams/changeset/reward-manager/call_set_reward_recipients.go
+++ b/deployment/data-streams/changeset/reward-manager/call_set_reward_recipients.go
@@ -11,7 +11,7 @@ import (
 	rewardManager "github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/reward_manager_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -42,14 +42,14 @@ func (cfg SetRewardRecipientsConfig) Validate() error {
 	return nil
 }
 
-func setRewardRecipientsPrecondition(_ deployment.Environment, cc SetRewardRecipientsConfig) error {
+func setRewardRecipientsPrecondition(_ cldf.Environment, cc SetRewardRecipientsConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid SetRewardRecipients config: %w", err)
 	}
 	return nil
 }
 
-func setRewardRecipientsLogic(e deployment.Environment, cfg SetRewardRecipientsConfig) (cldf.ChangesetOutput, error) {
+func setRewardRecipientsLogic(e cldf.Environment, cfg SetRewardRecipientsConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.RewardManager.String(),
@@ -66,7 +66,7 @@ func setRewardRecipientsLogic(e deployment.Environment, cfg SetRewardRecipientsC
 
 func doSetRewardRecipients(vs *rewardManager.RewardManager, sr SetRewardRecipients) (*goEthTypes.Transaction, error) {
 	return vs.SetRewardRecipients(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		sr.PoolID,
 		sr.RewardRecipientAndWeights,
 	)

--- a/deployment/data-streams/changeset/reward-manager/call_update_reward_recipients.go
+++ b/deployment/data-streams/changeset/reward-manager/call_update_reward_recipients.go
@@ -11,7 +11,7 @@ import (
 	rewardManager "github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/reward_manager_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -42,14 +42,14 @@ func (cfg UpdateRewardRecipientsConfig) Validate() error {
 	return nil
 }
 
-func updateRewardRecipientsPrecondition(_ deployment.Environment, cc UpdateRewardRecipientsConfig) error {
+func updateRewardRecipientsPrecondition(_ cldf.Environment, cc UpdateRewardRecipientsConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid UpdateRewardRecipients config: %w", err)
 	}
 	return nil
 }
 
-func updateRewardRecipientsLogic(e deployment.Environment, cfg UpdateRewardRecipientsConfig) (cldf.ChangesetOutput, error) {
+func updateRewardRecipientsLogic(e cldf.Environment, cfg UpdateRewardRecipientsConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.RewardManager.String(),
@@ -66,7 +66,7 @@ func updateRewardRecipientsLogic(e deployment.Environment, cfg UpdateRewardRecip
 
 func doUpdateRewardRecipients(vs *rewardManager.RewardManager, ur UpdateRewardRecipients) (*goEthTypes.Transaction, error) {
 	return vs.UpdateRewardRecipients(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		ur.PoolID,
 		ur.RewardRecipientAndWeights,
 	)

--- a/deployment/data-streams/changeset/reward-manager/reward_manager.go
+++ b/deployment/data-streams/changeset/reward-manager/reward_manager.go
@@ -5,15 +5,18 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
 
 	rewardManager "github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/reward_manager_v0_5_0"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 func loadRewardManagerState(
-	e deployment.Environment,
+	e cldf.Environment,
 	chainSel uint64,
 	contractAddr string,
 ) (*rewardManager.RewardManager, error) {

--- a/deployment/data-streams/changeset/reward-manager/test_helpers.go
+++ b/deployment/data-streams/changeset/reward-manager/test_helpers.go
@@ -6,6 +6,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 
 	dsTypes "github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
@@ -22,7 +25,7 @@ import (
 func RewardManagerDeploy(
 	t *testing.T,
 	cfg testutil.MemoryEnv,
-) (deployment.Environment, common.Address) {
+) (cldf.Environment, common.Address) {
 	t.Helper()
 
 	chainSelector := testutil.TestChain.Selector

--- a/deployment/data-streams/changeset/save_contract_views.go
+++ b/deployment/data-streams/changeset/save_contract_views.go
@@ -8,7 +8,7 @@ import (
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/metadata"
 	dsstate "github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
@@ -30,11 +30,11 @@ func (cfg SaveContractViewsConfig) Validate() error {
 	return nil
 }
 
-func saveViewsPrecondition(_ deployment.Environment, cc SaveContractViewsConfig) error {
+func saveViewsPrecondition(_ cldf.Environment, cc SaveContractViewsConfig) error {
 	return cc.Validate()
 }
 
-func saveViewsLogic(e deployment.Environment, cfg SaveContractViewsConfig) (cldf.ChangesetOutput, error) {
+func saveViewsLogic(e cldf.Environment, cfg SaveContractViewsConfig) (cldf.ChangesetOutput, error) {
 	updatedDataStore := ds.NewMemoryDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata]()
 	records, err := e.DataStore.Addresses().Fetch()
 	if err != nil {

--- a/deployment/data-streams/changeset/sequence/deploy_chain_contracts.go
+++ b/deployment/data-streams/changeset/sequence/deploy_chain_contracts.go
@@ -9,10 +9,10 @@ import (
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/metadata"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/verification"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
@@ -32,7 +32,7 @@ type DeployDataStreams struct {
 	Ownership      types.OwnershipFeature
 }
 
-func deployDataStreamsLogic(e deployment.Environment, cc DeployDataStreamsConfig) (cldf.ChangesetOutput, error) {
+func deployDataStreamsLogic(e cldf.Environment, cc DeployDataStreamsConfig) (cldf.ChangesetOutput, error) {
 	deployedAddresses := ds.NewMemoryDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata]()
 
 	// Prevents mutating environment state - injected environment is not expected to be updated during changeset Apply
@@ -82,7 +82,7 @@ func deployDataStreamsLogic(e deployment.Environment, cc DeployDataStreamsConfig
 	}, nil
 }
 
-func deployDataStreamsPrecondition(_ deployment.Environment, cc DeployDataStreamsConfig) error {
+func deployDataStreamsPrecondition(_ cldf.Environment, cc DeployDataStreamsConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid DeployDataStreams config: %w", err)
 	}
@@ -101,7 +101,7 @@ func (cc DeployDataStreamsConfig) Validate() error {
 	}
 
 	for chain, cfg := range cc.ChainsToDeploy {
-		if err := deployment.IsValidChainSelector(chain); err != nil {
+		if err := cldf.IsValidChainSelector(chain); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", chain, err)
 		}
 

--- a/deployment/data-streams/changeset/sequence/deploy_chain_contracts_evm.go
+++ b/deployment/data-streams/changeset/sequence/deploy_chain_contracts_evm.go
@@ -7,6 +7,9 @@ import (
 	"github.com/smartcontractkit/mcms"
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	mcms2 "github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/mcms"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/metadata"
 	dsutil "github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
@@ -19,7 +22,7 @@ import (
 )
 
 // deployChainComponentsEVM deploys all necessary components for a single evm chain
-func deployChainComponentsEVM(env *deployment.Environment, chain uint64, cfg DeployDataStreams,
+func deployChainComponentsEVM(env *cldf.Environment, chain uint64, cfg DeployDataStreams,
 	newAddresses metadata.DataStreamsMutableDataStore) ([]mcms.TimelockProposal, error) {
 	var timelockProposals []mcms.TimelockProposal
 	// Step 1: Deploy MCMS if configured
@@ -68,7 +71,7 @@ func deployChainComponentsEVM(env *deployment.Environment, chain uint64, cfg Dep
 }
 
 // deployVerifierProxy deploys VerifierProxy contract
-func deployVerifierProxy(env *deployment.Environment, chain uint64, cfg DeployDataStreams, newAddresses metadata.DataStreamsMutableDataStore) (common.Address, []mcms.TimelockProposal, error) {
+func deployVerifierProxy(env *cldf.Environment, chain uint64, cfg DeployDataStreams, newAddresses metadata.DataStreamsMutableDataStore) (common.Address, []mcms.TimelockProposal, error) {
 	verifierProxyCfg := verification.DeployVerifierProxyConfig{
 		ChainsToDeploy: map[uint64]verification.DeployVerifierProxy{
 			chain: {},
@@ -96,7 +99,7 @@ func deployVerifierProxy(env *deployment.Environment, chain uint64, cfg DeployDa
 }
 
 // deployVerifier deploys Verifier contract
-func deployVerifier(env *deployment.Environment, chain uint64, cfg DeployDataStreams, verifierProxyAddr common.Address, newAddresses metadata.DataStreamsMutableDataStore) (common.Address, []mcms.TimelockProposal, error) {
+func deployVerifier(env *cldf.Environment, chain uint64, cfg DeployDataStreams, verifierProxyAddr common.Address, newAddresses metadata.DataStreamsMutableDataStore) (common.Address, []mcms.TimelockProposal, error) {
 	verifierCfg := verification.DeployVerifierConfig{
 		ChainsToDeploy: map[uint64]verification.DeployVerifier{
 			chain: {VerifierProxyAddress: verifierProxyAddr},
@@ -124,7 +127,7 @@ func deployVerifier(env *deployment.Environment, chain uint64, cfg DeployDataStr
 }
 
 // initializeVerifier initializes the Verifier in VerifierProxy
-func initializeVerifier(env *deployment.Environment, chain uint64, verifierProxyAddr, verifierAddr common.Address) error {
+func initializeVerifier(env *cldf.Environment, chain uint64, verifierProxyAddr, verifierAddr common.Address) error {
 	initVerifierCfg := verification.VerifierProxyInitializeVerifierConfig{
 		ConfigPerChain: map[uint64][]verification.InitializeVerifierConfig{
 			chain: {{
@@ -143,7 +146,7 @@ func initializeVerifier(env *deployment.Environment, chain uint64, verifierProxy
 }
 
 // setVerifierConfig sets the configuration for the Verifier
-func setVerifierConfig(env *deployment.Environment, chain uint64, cfg DeployDataStreams, verifierAddr common.Address) error {
+func setVerifierConfig(env *cldf.Environment, chain uint64, cfg DeployDataStreams, verifierAddr common.Address) error {
 	setCfg := verification.SetConfigConfig{
 		ConfigsByChain: map[uint64][]verification.SetConfig{
 			chain: {verification.SetConfig{
@@ -165,7 +168,7 @@ func setVerifierConfig(env *deployment.Environment, chain uint64, cfg DeployData
 }
 
 // deployBillingComponents deploys and configures RewardManager and FeeManager
-func deployBillingComponents(env *deployment.Environment, chain uint64, cfg DeployDataStreams, verifierProxyAddr common.Address, newAddresses metadata.DataStreamsMutableDataStore) ([]mcms.TimelockProposal, error) {
+func deployBillingComponents(env *cldf.Environment, chain uint64, cfg DeployDataStreams, verifierProxyAddr common.Address, newAddresses metadata.DataStreamsMutableDataStore) ([]mcms.TimelockProposal, error) {
 	var timelockProposals []mcms.TimelockProposal
 
 	// Step 1: Deploy RewardManager
@@ -201,7 +204,7 @@ func deployBillingComponents(env *deployment.Environment, chain uint64, cfg Depl
 }
 
 // deployRewardManager deploys the RewardManager contract
-func deployRewardManager(env *deployment.Environment, chain uint64, cfg DeployDataStreams, newAddresses metadata.DataStreamsMutableDataStore) (common.Address, []mcms.TimelockProposal, error) {
+func deployRewardManager(env *cldf.Environment, chain uint64, cfg DeployDataStreams, newAddresses metadata.DataStreamsMutableDataStore) (common.Address, []mcms.TimelockProposal, error) {
 	rewardMgrCfg := rewardmanager.DeployRewardManagerConfig{
 		ChainsToDeploy: map[uint64]rewardmanager.DeployRewardManager{
 			chain: {LinkTokenAddress: cfg.Billing.Config.LinkTokenAddress},
@@ -229,7 +232,7 @@ func deployRewardManager(env *deployment.Environment, chain uint64, cfg DeployDa
 }
 
 // deployFeeManager deploys the FeeManager contract
-func deployFeeManager(env *deployment.Environment, chain uint64, cfg DeployDataStreams, verifierProxyAddr, rewardMgrAddr common.Address, newAddresses metadata.DataStreamsMutableDataStore) (common.Address, []mcms.TimelockProposal, error) {
+func deployFeeManager(env *cldf.Environment, chain uint64, cfg DeployDataStreams, verifierProxyAddr, rewardMgrAddr common.Address, newAddresses metadata.DataStreamsMutableDataStore) (common.Address, []mcms.TimelockProposal, error) {
 	feeMgrCfg := feemanager.DeployFeeManagerConfig{
 		ChainsToDeploy: map[uint64]feemanager.DeployFeeManager{
 			chain: {
@@ -262,7 +265,7 @@ func deployFeeManager(env *deployment.Environment, chain uint64, cfg DeployDataS
 }
 
 // setNativeSurcharge sets the native surcharge on the FeeManager
-func setNativeSurcharge(env *deployment.Environment, chain uint64, cfg DeployDataStreams, feeManagerAddr common.Address) error {
+func setNativeSurcharge(env *cldf.Environment, chain uint64, cfg DeployDataStreams, feeManagerAddr common.Address) error {
 	setNativeCfg := feemanager.SetNativeSurchargeConfig{
 		ConfigPerChain: map[uint64][]feemanager.SetNativeSurcharge{
 			chain: {
@@ -283,7 +286,7 @@ func setNativeSurcharge(env *deployment.Environment, chain uint64, cfg DeployDat
 }
 
 // setFeeManagerOnVerifierProxy sets the FeeManager address on the VerifierProxy
-func setFeeManagerOnVerifierProxy(env *deployment.Environment, chain uint64, verifierProxyAddr, feeManagerAddr common.Address) error {
+func setFeeManagerOnVerifierProxy(env *cldf.Environment, chain uint64, verifierProxyAddr, feeManagerAddr common.Address) error {
 	setFeeManagerCfg := verification.VerifierProxySetFeeManagerConfig{
 		ConfigPerChain: map[uint64][]verification.SetFeeManagerConfig{
 			chain: {
@@ -304,7 +307,7 @@ func setFeeManagerOnVerifierProxy(env *deployment.Environment, chain uint64, ver
 }
 
 // setFeeManagerOnRewardManager sets the FeeManager address on the RewardManager
-func setFeeManagerOnRewardManager(env *deployment.Environment, chain uint64, rewardMgrAddr, feeManagerAddr common.Address) error {
+func setFeeManagerOnRewardManager(env *cldf.Environment, chain uint64, rewardMgrAddr, feeManagerAddr common.Address) error {
 	rmSetFeeManagerCfg := rewardmanager.SetFeeManagerConfig{
 		ConfigsByChain: map[uint64][]rewardmanager.SetFeeManager{
 			chain: {
@@ -326,12 +329,12 @@ func setFeeManagerOnRewardManager(env *deployment.Environment, chain uint64, rew
 
 type DeployOutput struct {
 	Addresses   []string
-	Environment deployment.Environment
+	Environment cldf.Environment
 	Proposals   []mcms.TimelockProposal
 }
 
 // deployMCMS deploys the MCMS contracts
-func deployMCMS(env *deployment.Environment, chain uint64, cfg DeployDataStreams, cumulativeAddresses metadata.DataStreamsMutableDataStore) ([]mcms.TimelockProposal, error) {
+func deployMCMS(env *cldf.Environment, chain uint64, cfg DeployDataStreams, cumulativeAddresses metadata.DataStreamsMutableDataStore) ([]mcms.TimelockProposal, error) {
 	mcmsDeployCfg := mcms2.DeployMCMSConfig{
 		ChainsToDeploy: []uint64{chain},
 		Ownership:      cfg.Ownership.AsSettings(),
@@ -353,7 +356,7 @@ func deployMCMS(env *deployment.Environment, chain uint64, cfg DeployDataStreams
 // mergeNewAddresses merges new addresses into the existing environment and cumulative address book
 // This is used when chaining together changesets and accumulating addresses while also updating
 // the environment with new addresses so that downstream operations can use them
-func mergeNewAddresses(env *deployment.Environment,
+func mergeNewAddresses(env *cldf.Environment,
 	cumulativeAddrs metadata.DataStreamsMutableDataStore,
 	newAddrs ds.DataStore[ds.DefaultMetadata, ds.DefaultMetadata]) error {
 	// Step 1 is update the existing environment to reflect newly deployed addresses

--- a/deployment/data-streams/changeset/state/evm.go
+++ b/deployment/data-streams/changeset/state/evm.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/metadata"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/contracts/evm"
 
@@ -25,8 +28,6 @@ import (
 	rewardManager "github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/reward_manager_v0_5_0"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_proxy_v0_5_0"
 	verifier "github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_v0_5_0"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 type DataStreamsEVMChainState struct {
@@ -48,7 +49,7 @@ type DataStreamsOnChainState struct {
 	Chains map[uint64]DataStreamsEVMChainState
 }
 
-func LoadOnchainState(e deployment.Environment) (DataStreamsOnChainState, error) {
+func LoadOnchainState(e cldf.Environment) (DataStreamsOnChainState, error) {
 	state := DataStreamsOnChainState{
 		Chains: make(map[uint64]DataStreamsEVMChainState),
 	}
@@ -74,7 +75,7 @@ func LoadOnchainState(e deployment.Environment) (DataStreamsOnChainState, error)
 }
 
 func LoadChainState(logger logger.Logger,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	addresses map[string]cldf.TypeAndVersion,
 	mdStore datastore.ContractMetadataStore[metadata.SerializedContractMetadata]) (*DataStreamsEVMChainState, error) {
 	var cc DataStreamsEVMChainState

--- a/deployment/data-streams/changeset/testutil/test_helpers.go
+++ b/deployment/data-streams/changeset/testutil/test_helpers.go
@@ -10,12 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	dsCs "github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/mcms"
 
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	commonstate "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/pointer"
@@ -25,7 +26,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	dsTypes "github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
@@ -43,7 +43,7 @@ var TestChain = chainselectors.Chain{
 
 // NewMemoryEnv Deploys a memory environment with the provided number of nodes and optionally deploys MCMS and Timelock.
 // Deprecated: use NewMemoryEnvV2 instead.
-func NewMemoryEnv(t *testing.T, deployMCMS bool, optionalNumNodes ...int) deployment.Environment {
+func NewMemoryEnv(t *testing.T, deployMCMS bool, optionalNumNodes ...int) cldf.Environment {
 	lggr := logger.TestLogger(t)
 
 	// Default to 0 if no extra argument is provided
@@ -89,7 +89,7 @@ type MemoryEnvConfig struct {
 }
 
 type MemoryEnv struct {
-	Environment    deployment.Environment
+	Environment    cldf.Environment
 	Timelocks      map[uint64]*proposalutils.TimelockExecutionContracts
 	LinkTokenState *commonstate.LinkTokenState
 }
@@ -189,9 +189,9 @@ func NewMemoryEnvV2(t *testing.T, cfg MemoryEnvConfig) MemoryEnv {
 // Deploy MCMS and Timelock, optionally transferring ownership of the provided contracts to Timelock
 func DeployMCMS(
 	t *testing.T,
-	e deployment.Environment,
+	e cldf.Environment,
 	addressesToTransfer ...map[uint64][]common.Address,
-) (env deployment.Environment, mcmsState *commonChangesets.MCMSWithTimelockState, timelocks map[uint64]*proposalutils.TimelockExecutionContracts) {
+) (env cldf.Environment, mcmsState *commonChangesets.MCMSWithTimelockState, timelocks map[uint64]*proposalutils.TimelockExecutionContracts) {
 	t.Helper()
 
 	chainSelector := TestChain.Selector

--- a/deployment/data-streams/changeset/verification/call_activate_config.go
+++ b/deployment/data-streams/changeset/verification/call_activate_config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -39,11 +39,11 @@ func (cfg ActivateConfigConfig) Validate() error {
 	return nil
 }
 
-func activateConfigPrecondition(_ deployment.Environment, cc ActivateConfigConfig) error {
+func activateConfigPrecondition(_ cldf.Environment, cc ActivateConfigConfig) error {
 	return cc.Validate()
 }
 
-func activateConfigLogic(e deployment.Environment, cfg ActivateConfigConfig) (cldf.ChangesetOutput, error) {
+func activateConfigLogic(e cldf.Environment, cfg ActivateConfigConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.VerifierProxy.String(),
@@ -63,7 +63,7 @@ func doActivateConfig(
 	ac ActivateConfig,
 ) (*goEthTypes.Transaction, error) {
 	return v.ActivateConfig(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		ac.ConfigDigest,
 	)
 }

--- a/deployment/data-streams/changeset/verification/call_deactivate_config.go
+++ b/deployment/data-streams/changeset/verification/call_deactivate_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -40,14 +40,14 @@ func (cfg DeactivateConfigConfig) Validate() error {
 	return nil
 }
 
-func deactivateConfigPrecondition(_ deployment.Environment, cc DeactivateConfigConfig) error {
+func deactivateConfigPrecondition(_ cldf.Environment, cc DeactivateConfigConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid ActivateConfig config: %w", err)
 	}
 	return nil
 }
 
-func deactivateConfigLogic(e deployment.Environment, cfg DeactivateConfigConfig) (cldf.ChangesetOutput, error) {
+func deactivateConfigLogic(e cldf.Environment, cfg DeactivateConfigConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.VerifierProxy.String(),
@@ -64,7 +64,7 @@ func deactivateConfigLogic(e deployment.Environment, cfg DeactivateConfigConfig)
 
 func doDeactivateConfig(v *verifier_v0_5_0.Verifier, ac DeactivateConfig) (*goEthTypes.Transaction, error) {
 	return v.DeactivateConfig(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		ac.ConfigDigest,
 	)
 }

--- a/deployment/data-streams/changeset/verification/call_initialize_verifier.go
+++ b/deployment/data-streams/changeset/verification/call_initialize_verifier.go
@@ -10,7 +10,6 @@ import (
 
 	mcmslib "github.com/smartcontractkit/mcms"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -29,7 +28,7 @@ type InitializeVerifierConfig struct {
 	VerifierAddress      common.Address
 }
 
-func verifierProxyInitializeVerifierLogic(e deployment.Environment, cfg VerifierProxyInitializeVerifierConfig) (cldf.ChangesetOutput, error) {
+func verifierProxyInitializeVerifierLogic(e cldf.Environment, cfg VerifierProxyInitializeVerifierConfig) (cldf.ChangesetOutput, error) {
 	txs, err := GetInitializeVerifierTxs(e, cfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -51,7 +50,7 @@ func verifierProxyInitializeVerifierLogic(e deployment.Environment, cfg Verifier
 
 // GetInitializeVerifierTxs - returns the transactions to set a verifier on the verifier proxy.
 // Does not sign the TXs
-func GetInitializeVerifierTxs(e deployment.Environment, cfg VerifierProxyInitializeVerifierConfig) ([]*txutil.PreparedTx, error) {
+func GetInitializeVerifierTxs(e cldf.Environment, cfg VerifierProxyInitializeVerifierConfig) ([]*txutil.PreparedTx, error) {
 	var preparedTxs []*txutil.PreparedTx
 	for chainSelector, configs := range cfg.ConfigPerChain {
 		for _, config := range configs {
@@ -59,7 +58,7 @@ func GetInitializeVerifierTxs(e deployment.Environment, cfg VerifierProxyInitial
 			if err != nil {
 				return nil, fmt.Errorf("failed to load verifier proxy state: %w", err)
 			}
-			tx, err := state.VerifierProxy.InitializeVerifier(deployment.SimTransactOpts(), config.VerifierAddress)
+			tx, err := state.VerifierProxy.InitializeVerifier(cldf.SimTransactOpts(), config.VerifierAddress)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create InitializeVerifier transaction: %w", err)
 			}
@@ -74,12 +73,12 @@ func GetInitializeVerifierTxs(e deployment.Environment, cfg VerifierProxyInitial
 	return preparedTxs, nil
 }
 
-func verifierProxyInitializeVerifierPrecondition(e deployment.Environment, cfg VerifierProxyInitializeVerifierConfig) error {
+func verifierProxyInitializeVerifierPrecondition(e cldf.Environment, cfg VerifierProxyInitializeVerifierConfig) error {
 	if len(cfg.ConfigPerChain) == 0 {
 		return errors.New("ConfigPerChain is empty")
 	}
 	for cs := range cfg.ConfigPerChain {
-		if err := deployment.IsValidChainSelector(cs); err != nil {
+		if err := cldf.IsValidChainSelector(cs); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", cs, err)
 		}
 	}

--- a/deployment/data-streams/changeset/verification/call_set_access_controller.go
+++ b/deployment/data-streams/changeset/verification/call_set_access_controller.go
@@ -9,7 +9,7 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -30,7 +30,7 @@ type SetAccessControllerConfig struct {
 	AccessControllerAddress common.Address
 }
 
-func (v verifierProxySetAccessController) Apply(e deployment.Environment, cfg VerifierProxySetAccessControllerConfig) (cldf.ChangesetOutput, error) {
+func (v verifierProxySetAccessController) Apply(e cldf.Environment, cfg VerifierProxySetAccessControllerConfig) (cldf.ChangesetOutput, error) {
 	txs, err := GetSetAccessControllerTxs(e, cfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -52,7 +52,7 @@ func (v verifierProxySetAccessController) Apply(e deployment.Environment, cfg Ve
 
 // GetSetAccessControllerTxs - returns the transactions to set the access controller on the verifier proxy.
 // Does not sign the TXs
-func GetSetAccessControllerTxs(e deployment.Environment, cfg VerifierProxySetAccessControllerConfig) ([]*txutil.PreparedTx, error) {
+func GetSetAccessControllerTxs(e cldf.Environment, cfg VerifierProxySetAccessControllerConfig) ([]*txutil.PreparedTx, error) {
 	var preparedTxs []*txutil.PreparedTx
 	for chainSelector, configs := range cfg.ConfigPerChain {
 		for _, config := range configs {
@@ -60,7 +60,7 @@ func GetSetAccessControllerTxs(e deployment.Environment, cfg VerifierProxySetAcc
 			if err != nil {
 				return nil, fmt.Errorf("failed to load verifier proxy state: %w", err)
 			}
-			tx, err := state.VerifierProxy.SetAccessController(deployment.SimTransactOpts(), config.AccessControllerAddress)
+			tx, err := state.VerifierProxy.SetAccessController(cldf.SimTransactOpts(), config.AccessControllerAddress)
 
 			if err != nil {
 				return nil, fmt.Errorf("failed to create SetAccessController transaction: %w", err)
@@ -76,12 +76,12 @@ func GetSetAccessControllerTxs(e deployment.Environment, cfg VerifierProxySetAcc
 	return preparedTxs, nil
 }
 
-func (v verifierProxySetAccessController) VerifyPreconditions(e deployment.Environment, cfg VerifierProxySetAccessControllerConfig) error {
+func (v verifierProxySetAccessController) VerifyPreconditions(e cldf.Environment, cfg VerifierProxySetAccessControllerConfig) error {
 	if len(cfg.ConfigPerChain) == 0 {
 		return errors.New("ConfigPerChain is empty")
 	}
 	for cs := range cfg.ConfigPerChain {
-		if err := deployment.IsValidChainSelector(cs); err != nil {
+		if err := cldf.IsValidChainSelector(cs); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", cs, err)
 		}
 	}

--- a/deployment/data-streams/changeset/verification/call_set_config.go
+++ b/deployment/data-streams/changeset/verification/call_set_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -43,14 +43,14 @@ func (cfg SetConfigConfig) Validate() error {
 	return nil
 }
 
-func setConfigPrecondition(_ deployment.Environment, cc SetConfigConfig) error {
+func setConfigPrecondition(_ cldf.Environment, cc SetConfigConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid SetConfig config: %w", err)
 	}
 	return nil
 }
 
-func setConfigLogic(e deployment.Environment, cfg SetConfigConfig) (cldf.ChangesetOutput, error) {
+func setConfigLogic(e cldf.Environment, cfg SetConfigConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.Verifier.String(),
@@ -67,7 +67,7 @@ func setConfigLogic(e deployment.Environment, cfg SetConfigConfig) (cldf.Changes
 
 func doSetConfig(v *verifier_v0_5_0.Verifier, ac SetConfig) (*goEthTypes.Transaction, error) {
 	return v.SetConfig(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		ac.ConfigDigest,
 		ac.Signers,
 		ac.F,

--- a/deployment/data-streams/changeset/verification/call_set_fee_manager.go
+++ b/deployment/data-streams/changeset/verification/call_set_fee_manager.go
@@ -9,7 +9,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -28,7 +27,7 @@ type SetFeeManagerConfig struct {
 	FeeManagerAddress    common.Address
 }
 
-func verifierProxySetFeeManagerLogic(e deployment.Environment, cfg VerifierProxySetFeeManagerConfig) (cldf.ChangesetOutput, error) {
+func verifierProxySetFeeManagerLogic(e cldf.Environment, cfg VerifierProxySetFeeManagerConfig) (cldf.ChangesetOutput, error) {
 	txs, err := GetSetFeeManagerTxs(e, cfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -50,7 +49,7 @@ func verifierProxySetFeeManagerLogic(e deployment.Environment, cfg VerifierProxy
 
 // GetSetFeeManagerTxs - returns the transactions to set fee manager on the verifier proxy.
 // Does not sign the TXs
-func GetSetFeeManagerTxs(e deployment.Environment, cfg VerifierProxySetFeeManagerConfig) ([]*txutil.PreparedTx, error) {
+func GetSetFeeManagerTxs(e cldf.Environment, cfg VerifierProxySetFeeManagerConfig) ([]*txutil.PreparedTx, error) {
 	var preparedTxs []*txutil.PreparedTx
 	for chainSelector, configs := range cfg.ConfigPerChain {
 		for _, config := range configs {
@@ -58,7 +57,7 @@ func GetSetFeeManagerTxs(e deployment.Environment, cfg VerifierProxySetFeeManage
 			if err != nil {
 				return nil, fmt.Errorf("failed to load verifier proxy state: %w", err)
 			}
-			tx, err := state.VerifierProxy.SetFeeManager(deployment.SimTransactOpts(), config.FeeManagerAddress)
+			tx, err := state.VerifierProxy.SetFeeManager(cldf.SimTransactOpts(), config.FeeManagerAddress)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create SetFeeManager transaction: %w", err)
 			}
@@ -73,12 +72,12 @@ func GetSetFeeManagerTxs(e deployment.Environment, cfg VerifierProxySetFeeManage
 	return preparedTxs, nil
 }
 
-func verifierProxySetFeeManagerPrecondition(e deployment.Environment, cfg VerifierProxySetFeeManagerConfig) error {
+func verifierProxySetFeeManagerPrecondition(e cldf.Environment, cfg VerifierProxySetFeeManagerConfig) error {
 	if len(cfg.ConfigPerChain) == 0 {
 		return errors.New("ConfigPerChain is empty")
 	}
 	for cs := range cfg.ConfigPerChain {
-		if err := deployment.IsValidChainSelector(cs); err != nil {
+		if err := cldf.IsValidChainSelector(cs); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", cs, err)
 		}
 	}

--- a/deployment/data-streams/changeset/verification/call_unset_verifier.go
+++ b/deployment/data-streams/changeset/verification/call_unset_verifier.go
@@ -9,7 +9,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -30,7 +29,7 @@ type UnsetVerifierConfig struct {
 	ConfigDigest    [32]byte
 }
 
-func (v verifierProxyUnsetVerifier) Apply(e deployment.Environment, cfg VerifierProxyUnsetVerifierConfig) (cldf.ChangesetOutput, error) {
+func (v verifierProxyUnsetVerifier) Apply(e cldf.Environment, cfg VerifierProxyUnsetVerifierConfig) (cldf.ChangesetOutput, error) {
 	txs, err := GetUnsetVerifierTxs(e, cfg)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -52,7 +51,7 @@ func (v verifierProxyUnsetVerifier) Apply(e deployment.Environment, cfg Verifier
 
 // GetUnsetVerifierTxs - returns the transactions to run the operation on the verifier proxy.
 // Does not sign the TXs
-func GetUnsetVerifierTxs(e deployment.Environment, cfg VerifierProxyUnsetVerifierConfig) ([]*txutil.PreparedTx, error) {
+func GetUnsetVerifierTxs(e cldf.Environment, cfg VerifierProxyUnsetVerifierConfig) ([]*txutil.PreparedTx, error) {
 	var preparedTxs []*txutil.PreparedTx
 	for chainSelector, configs := range cfg.ConfigPerChain {
 		for _, config := range configs {
@@ -60,7 +59,7 @@ func GetUnsetVerifierTxs(e deployment.Environment, cfg VerifierProxyUnsetVerifie
 			if err != nil {
 				return nil, fmt.Errorf("failed to load verifier proxy state: %w", err)
 			}
-			tx, err := state.VerifierProxy.UnsetVerifier(deployment.SimTransactOpts(), config.ConfigDigest)
+			tx, err := state.VerifierProxy.UnsetVerifier(cldf.SimTransactOpts(), config.ConfigDigest)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create UnsetVerifier transaction: %w", err)
 			}
@@ -75,12 +74,12 @@ func GetUnsetVerifierTxs(e deployment.Environment, cfg VerifierProxyUnsetVerifie
 	return preparedTxs, nil
 }
 
-func (v verifierProxyUnsetVerifier) VerifyPreconditions(e deployment.Environment, cfg VerifierProxyUnsetVerifierConfig) error {
+func (v verifierProxyUnsetVerifier) VerifyPreconditions(e cldf.Environment, cfg VerifierProxyUnsetVerifierConfig) error {
 	if len(cfg.ConfigPerChain) == 0 {
 		return errors.New("ConfigPerChain is empty")
 	}
 	for cs := range cfg.ConfigPerChain {
-		if err := deployment.IsValidChainSelector(cs); err != nil {
+		if err := cldf.IsValidChainSelector(cs); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", cs, err)
 		}
 	}

--- a/deployment/data-streams/changeset/verification/call_update_config.go
+++ b/deployment/data-streams/changeset/verification/call_update_config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_v0_5_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/mcmsutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/txutil"
@@ -42,14 +42,14 @@ func (cfg UpdateConfigConfig) Validate() error {
 	return nil
 }
 
-func updateConfigPrecondition(_ deployment.Environment, cc UpdateConfigConfig) error {
+func updateConfigPrecondition(_ cldf.Environment, cc UpdateConfigConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid UpdateConfig config: %w", err)
 	}
 	return nil
 }
 
-func updateConfigLogic(e deployment.Environment, cfg UpdateConfigConfig) (cldf.ChangesetOutput, error) {
+func updateConfigLogic(e cldf.Environment, cfg UpdateConfigConfig) (cldf.ChangesetOutput, error) {
 	txs, err := txutil.GetTxs(
 		e,
 		types.VerifierProxy.String(),
@@ -66,7 +66,7 @@ func updateConfigLogic(e deployment.Environment, cfg UpdateConfigConfig) (cldf.C
 
 func doUpdateConfig(v *verifier_v0_5_0.Verifier, ac UpdateConfig) (*goEthTypes.Transaction, error) {
 	return v.UpdateConfig(
-		deployment.SimTransactOpts(),
+		cldf.SimTransactOpts(),
 		ac.ConfigDigest,
 		ac.PrevSigners,
 		ac.NewSigners,

--- a/deployment/data-streams/changeset/verification/deploy_verifier_proxy.go
+++ b/deployment/data-streams/changeset/verification/deploy_verifier_proxy.go
@@ -8,11 +8,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/view/v0_5"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_proxy_v0_5_0"
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/metadata"
@@ -49,19 +51,19 @@ func (cfg DeployVerifierProxyConfig) Validate() error {
 		return errors.New("ChainsToDeploy is empty")
 	}
 	for chain := range cfg.ChainsToDeploy {
-		if err := deployment.IsValidChainSelector(chain); err != nil {
+		if err := cldf.IsValidChainSelector(chain); err != nil {
 			return fmt.Errorf("invalid chain selector: %d - %w", chain, err)
 		}
 	}
 	return nil
 }
 
-func verifierProxyDeployLogic(e deployment.Environment, cc DeployVerifierProxyConfig) (cldf.ChangesetOutput, error) {
+func verifierProxyDeployLogic(e cldf.Environment, cc DeployVerifierProxyConfig) (cldf.ChangesetOutput, error) {
 	dataStore := ds.NewMemoryDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata]()
 	err := deploy(e, dataStore, cc)
 	if err != nil {
 		e.Logger.Errorw("Failed to deploy VerifierProxy", "err", err)
-		return cldf.ChangesetOutput{}, deployment.MaybeDataErr(err)
+		return cldf.ChangesetOutput{}, cldf.MaybeDataErr(err)
 	}
 
 	records, err := dataStore.Addresses().Fetch()
@@ -88,14 +90,14 @@ type HasOwnershipConfig interface {
 	GetOwnershipConfig() types.OwnershipSettings
 }
 
-func verifierProxyDeployPrecondition(_ deployment.Environment, cc DeployVerifierProxyConfig) error {
+func verifierProxyDeployPrecondition(_ cldf.Environment, cc DeployVerifierProxyConfig) error {
 	if err := cc.Validate(); err != nil {
 		return fmt.Errorf("invalid DeployVerifierProxyConfig: %w", err)
 	}
 	return nil
 }
 
-func deploy(e deployment.Environment,
+func deploy(e cldf.Environment,
 	dataStore ds.MutableDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata],
 	cfg DeployVerifierProxyConfig) error {
 	if err := cfg.Validate(); err != nil {
@@ -139,7 +141,7 @@ func deploy(e deployment.Environment,
 
 // verifyProxyDeployFn returns a function that deploys a VerifyProxy contract.
 func verifyProxyDeployFn(cfg DeployVerifierProxy) changeset.ContractDeployFn[*verifier_proxy_v0_5_0.VerifierProxy] {
-	return func(chain deployment.Chain) *changeset.ContractDeployment[*verifier_proxy_v0_5_0.VerifierProxy] {
+	return func(chain cldf.Chain) *changeset.ContractDeployment[*verifier_proxy_v0_5_0.VerifierProxy] {
 		addr, tx, contract, err := verifier_proxy_v0_5_0.DeployVerifierProxy(
 			chain.DeployerKey,
 			chain.Client,

--- a/deployment/data-streams/changeset/verification/state.go
+++ b/deployment/data-streams/changeset/verification/state.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_v0_5_0"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_proxy_v0_5_0"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 )
 
@@ -18,7 +21,7 @@ type VerifierProxyState struct {
 	VerifierProxy *verifier_proxy_v0_5_0.VerifierProxy
 }
 
-func maybeLoadVerifierProxyState(e deployment.Environment, chainSel uint64, contractAddr string) (*VerifierProxyState, error) {
+func maybeLoadVerifierProxyState(e cldf.Environment, chainSel uint64, contractAddr string) (*VerifierProxyState, error) {
 	if err := utils.ValidateContract(e, chainSel, contractAddr, types.VerifierProxy, deployment.Version0_5_0); err != nil {
 		return nil, err
 	}
@@ -35,7 +38,7 @@ func maybeLoadVerifierProxyState(e deployment.Environment, chainSel uint64, cont
 		VerifierProxy: vp,
 	}, nil
 }
-func loadVerifierState(e deployment.Environment, chainSel uint64, contractAddr string) (*verifier_v0_5_0.Verifier, error) {
+func loadVerifierState(e cldf.Environment, chainSel uint64, contractAddr string) (*verifier_v0_5_0.Verifier, error) {
 	chain, ok := e.Chains[chainSel]
 	if !ok {
 		return nil, fmt.Errorf("chain %d not found", chainSel)

--- a/deployment/data-streams/changeset/verification/test_helpers.go
+++ b/deployment/data-streams/changeset/verification/test_helpers.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	dsutil "github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/view/v0_5"
 
@@ -24,8 +26,8 @@ import (
 // environment and the addresses of VerifierProxy and Verifier.
 func DeployVerifierProxyAndVerifier(
 	t *testing.T,
-	e deployment.Environment,
-) (env deployment.Environment, verifierProxyAddr common.Address, verifierAddr common.Address) {
+	e cldf.Environment,
+) (env cldf.Environment, verifierProxyAddr common.Address, verifierAddr common.Address) {
 	t.Helper()
 
 	chainSelector := testutil.TestChain.Selector

--- a/deployment/data-streams/utils/mcmsutil/mcmsutil.go
+++ b/deployment/data-streams/utils/mcmsutil/mcmsutil.go
@@ -11,12 +11,13 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	commonstate "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	dsTypes "github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
@@ -24,7 +25,7 @@ import (
 )
 
 // CreateMCMSProposal creates a new MCMS proposal with prepared (but not sent) transactions.
-func CreateMCMSProposal(e deployment.Environment, preparedTxs []*txutil.PreparedTx, mcmsMinDelay time.Duration, proposalName string) (*mcmslib.TimelockProposal, error) {
+func CreateMCMSProposal(e cldf.Environment, preparedTxs []*txutil.PreparedTx, mcmsMinDelay time.Duration, proposalName string) (*mcmslib.TimelockProposal, error) {
 	var chainSelectors []uint64
 	for _, tx := range preparedTxs {
 		chainSelectors = append(chainSelectors, tx.ChainSelector)
@@ -78,7 +79,7 @@ func CreateMCMSProposal(e deployment.Environment, preparedTxs []*txutil.Prepared
 
 // ExecuteOrPropose executes the transactions if no MCMS is configured, otherwise creates a proposal.
 func ExecuteOrPropose(
-	e deployment.Environment,
+	e cldf.Environment,
 	txs []*txutil.PreparedTx,
 	mcmsCfg *dsTypes.MCMSConfig,
 	proposalName string,
@@ -105,7 +106,7 @@ func ExecuteOrPropose(
 // The output will contain an MCMS timelock proposal for "AcceptOwnership" of those contracts
 // The newAddresses should be recently deployed addresses that are being transferred to MCMS and
 // should not be in `e` Environment
-func TransferToMCMSWithTimelock(e deployment.Environment, newAddresses []ds.AddressRef,
+func TransferToMCMSWithTimelock(e cldf.Environment, newAddresses []ds.AddressRef,
 	mcmsConfig proposalutils.TimelockConfig) (cldf.ChangesetOutput, error) {
 	// Map: chainselector -> List[Address]
 	contractAddressesToTransfer := make(map[uint64][]common.Address)
@@ -235,7 +236,7 @@ type HasOwnershipConfig interface {
 }
 
 func GetTransferOwnershipProposals[T HasOwnershipConfig](
-	e deployment.Environment, cfg T, addresses []ds.AddressRef) ([]mcms.TimelockProposal, error) {
+	e cldf.Environment, cfg T, addresses []ds.AddressRef) ([]mcms.TimelockProposal, error) {
 	var proposals []mcms.TimelockProposal
 	if cfg.GetOwnershipConfig().ShouldTransfer && cfg.GetOwnershipConfig().MCMSProposalConfig != nil {
 		res, err := TransferToMCMSWithTimelock(e, addresses, *cfg.GetOwnershipConfig().MCMSProposalConfig)

--- a/deployment/data-streams/utils/txutil/get-tx.go
+++ b/deployment/data-streams/utils/txutil/get-tx.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	goEthTypes "github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 // HasContractAddress is the generic interface for anything
@@ -18,7 +18,7 @@ type HasContractAddress interface {
 // ContractLoader is a function that, given an Environment, chain selector,
 // and contract address, returns the strongly-typed contract “state”
 type ContractLoader[S any] func(
-	e deployment.Environment,
+	e cldf.Environment,
 	chainSelector uint64,
 	contractAddr string,
 ) (*S, error)
@@ -37,7 +37,7 @@ type ContractMethod[S any, T any] func(
 // Calls the method function to build the transaction
 // Accumulates them into a slice of PreparedTx.
 func GetTxs[S any, T HasContractAddress](
-	e deployment.Environment,
+	e cldf.Environment,
 	contractType string,
 	configsByChain map[uint64][]T,
 	loader ContractLoader[S],

--- a/deployment/data-streams/utils/txutil/transaction.go
+++ b/deployment/data-streams/utils/txutil/transaction.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 // PreparedTx represents a transaction that was prepared but not sent to the chain. This is intended to be
@@ -26,7 +26,7 @@ type ExecuteTxResult struct {
 
 // SignAndExecute signs and then executes transactions directly on the chain with the given deployer key configured
 // for the chain. The transactions should not be already sent to the chain.
-func SignAndExecute(e deployment.Environment, preparedTxs []*PreparedTx) ([]ExecuteTxResult, error) {
+func SignAndExecute(e cldf.Environment, preparedTxs []*PreparedTx) ([]ExecuteTxResult, error) {
 	var executeTxResults []ExecuteTxResult
 	// To execute the txs in parallel this would need to batch up the txs by chain to avoid nonce issues
 	for _, tx := range preparedTxs {
@@ -60,7 +60,7 @@ func SignAndExecute(e deployment.Environment, preparedTxs []*PreparedTx) ([]Exec
 }
 
 // reconfigureTx takes the tx `call data` and reconfigures the transaction to use valid nonce, gas price and gas limit
-func reconfigureTx(ctx context.Context, chain deployment.Chain, preparedTx *PreparedTx) (*gethtypes.Transaction, error) {
+func reconfigureTx(ctx context.Context, chain cldf.Chain, preparedTx *PreparedTx) (*gethtypes.Transaction, error) {
 	nonce, err := chain.Client.NonceAt(ctx, chain.DeployerKey.From, nil)
 	if err != nil {
 		return nil, fmt.Errorf("chain %d: failed to get nonce: %w", chain.Selector, err)

--- a/deployment/data-streams/utils/txutil/transaction_test.go
+++ b/deployment/data-streams/utils/txutil/transaction_test.go
@@ -12,9 +12,9 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	commonstate "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -90,13 +90,13 @@ func TestSignAndExecute_ContractInteraction(t *testing.T) {
 	// grant minter permissions
 	tx, err := linkState.LinkToken.GrantMintRole(chain.DeployerKey, chain.DeployerKey.From)
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	// Mint the deployer address some tokens
 	tx, err = linkState.LinkToken.Mint(chain.DeployerKey, chain.DeployerKey.From, big.NewInt(500))
 	require.NoError(t, err)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	// Deployer should have the tokens
@@ -114,7 +114,7 @@ func TestSignAndExecute_ContractInteraction(t *testing.T) {
 	// Transfer some tokens to multiple receivers
 	for _, receiver := range receivers {
 		// This is the key part - generate a transaction with call data / arguments but do not send it
-		tx, err = linkState.LinkToken.Transfer(deployment.SimTransactOpts(), receiver, big.NewInt(100))
+		tx, err = linkState.LinkToken.Transfer(cldf.SimTransactOpts(), receiver, big.NewInt(100))
 		require.NoError(t, err)
 		preparedTxs = append(preparedTxs, &PreparedTx{
 			Tx:            tx,

--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -277,7 +277,7 @@ func FundCCIPTransmitters(ctx context.Context, lggr logger.Logger, envConfig dev
 	}, nil
 }
 
-func setupChains(lggr logger.Logger, e *deployment.Environment, homeChainSel uint64) (deployment.Environment, error) {
+func setupChains(lggr logger.Logger, e *cldf.Environment, homeChainSel uint64) (cldf.Environment, error) {
 	chainSelectors := e.AllChainSelectors()
 	chainConfigs := make(map[uint64]v1_6.ChainConfig)
 	nodeInfo, err := deployment.NodeInfo(e.NodeIDs, e.Offchain)
@@ -350,7 +350,7 @@ func setupChains(lggr logger.Logger, e *deployment.Environment, homeChainSel uin
 	return setupLinkPools(&env)
 }
 
-func setupLinkPools(e *deployment.Environment) (deployment.Environment, error) {
+func setupLinkPools(e *cldf.Environment) (cldf.Environment, error) {
 	state, err := stateview.LoadOnchainState(*e)
 	if err != nil {
 		return *e, fmt.Errorf("failed to load onchain state: %w", err)
@@ -414,7 +414,7 @@ func setupLinkPools(e *deployment.Environment) (deployment.Environment, error) {
 		linkPool := state.Chains[chain].BurnMintTokenPools[shared.LinkSymbol][deployment.Version1_5_1]
 		linkToken := state.Chains[chain].LinkToken
 		tx, err := linkToken.GrantMintAndBurnRoles(e.Chains[chain].DeployerKey, linkPool.Address())
-		_, err = deployment.ConfirmIfNoError(e.Chains[chain], tx, err)
+		_, err = cldf.ConfirmIfNoError(e.Chains[chain], tx, err)
 		if err != nil {
 			return *e, fmt.Errorf("failed to grant mint and burn roles for link pool: %w", err)
 		}
@@ -422,7 +422,7 @@ func setupLinkPools(e *deployment.Environment) (deployment.Environment, error) {
 	return env, err
 }
 
-func setupLanes(e *deployment.Environment, state stateview.CCIPOnChainState) (deployment.Environment, error) {
+func setupLanes(e *cldf.Environment, state stateview.CCIPOnChainState) (cldf.Environment, error) {
 	eg := xerrgroup.Group{}
 	poolUpdates := make(map[uint64]v1_5_1.TokenPoolConfig)
 	rateLimitPerChain := make(v1_5_1.RateLimiterPerChain)
@@ -542,7 +542,7 @@ func setupLanes(e *deployment.Environment, state stateview.CCIPOnChainState) (de
 	return *e, err
 }
 
-func mustOCR(e *deployment.Environment, homeChainSel uint64, feedChainSel uint64, newDons bool, rmnEnabled bool) (deployment.Environment, error) {
+func mustOCR(e *cldf.Environment, homeChainSel uint64, feedChainSel uint64, newDons bool, rmnEnabled bool) (cldf.Environment, error) {
 	chainSelectors := e.AllChainSelectors()
 	var commitOCRConfigPerSelector = make(map[uint64]v1_6.CCIPOCRParams)
 	var execOCRConfigPerSelector = make(map[uint64]v1_6.CCIPOCRParams)

--- a/deployment/environment/crib/helpers.go
+++ b/deployment/environment/crib/helpers.go
@@ -2,6 +2,7 @@ package crib
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -9,14 +10,15 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"golang.org/x/sync/errgroup"
 
-	"math/big"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 )
 
-func distributeTransmitterFunds(lggr logger.Logger, nodeInfo []devenv.Node, env deployment.Environment) error {
+func distributeTransmitterFunds(lggr logger.Logger, nodeInfo []devenv.Node, env cldf.Environment) error {
 	transmittersStr := make([]common.Address, 0)
 	fundingAmount := new(big.Int).Mul(deployment.UBigInt(100), deployment.UBigInt(1e18)) // 100 ETH
 
@@ -40,7 +42,7 @@ func distributeTransmitterFunds(lggr logger.Logger, nodeInfo []devenv.Node, env 
 	return g.Wait()
 }
 
-func SendFundsToAccounts(ctx context.Context, lggr logger.Logger, chain deployment.Chain, accounts []common.Address, fundingAmount *big.Int, sel uint64) error {
+func SendFundsToAccounts(ctx context.Context, lggr logger.Logger, chain cldf.Chain, accounts []common.Address, fundingAmount *big.Int, sel uint64) error {
 	latesthdr, err := chain.Client.HeaderByNumber(ctx, nil)
 	if err != nil {
 		lggr.Errorw("could not get header, skipping chain", "chain", sel, "err", err)

--- a/deployment/environment/crib/types.go
+++ b/deployment/environment/crib/types.go
@@ -8,8 +8,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 )
 
@@ -28,12 +26,12 @@ type DeployCCIPOutput struct {
 	NodeIDs     []string
 }
 
-func NewDeployEnvironmentFromCribOutput(lggr logger.Logger, output DeployOutput) (*deployment.Environment, error) {
+func NewDeployEnvironmentFromCribOutput(lggr logger.Logger, output DeployOutput) (*cldf.Environment, error) {
 	chains, err := devenv.NewChains(lggr, output.Chains)
 	if err != nil {
 		return nil, err
 	}
-	return deployment.NewEnvironment(
+	return cldf.NewEnvironment(
 		CRIB_ENV_NAME,
 		lggr,
 		output.AddressBook,

--- a/deployment/environment/devenv/environment.go
+++ b/deployment/environment/devenv/environment.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 const (
@@ -22,7 +20,7 @@ type EnvironmentConfig struct {
 	JDConfig JDConfig
 }
 
-func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config EnvironmentConfig) (*deployment.Environment, *DON, error) {
+func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config EnvironmentConfig) (*cldf.Environment, *DON, error) {
 	chains, err := NewChains(lggr, config.Chains)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create chains: %w", err)
@@ -53,7 +51,7 @@ func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config Envir
 		nodeIDs = jd.don.NodeIds()
 	}
 
-	return deployment.NewEnvironment(
+	return cldf.NewEnvironment(
 		DevEnv,
 		lggr,
 		cldf.NewMemoryAddressBook(),

--- a/deployment/environment/memory/aptos_chains.go
+++ b/deployment/environment/memory/aptos_chains.go
@@ -21,7 +21,8 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
@@ -54,12 +55,12 @@ func createAptosAccount(t *testing.T, useDefault bool) *aptos.Account {
 	}
 }
 
-func GenerateChainsAptos(t *testing.T, numChains int) map[uint64]deployment.AptosChain {
+func GenerateChainsAptos(t *testing.T, numChains int) map[uint64]cldf.AptosChain {
 	testAptosChainSelectors := getTestAptosChainSelectors()
 	if len(testAptosChainSelectors) < numChains {
 		t.Fatalf("not enough test aptos chain selectors available")
 	}
-	chains := make(map[uint64]deployment.AptosChain)
+	chains := make(map[uint64]cldf.AptosChain)
 	for i := 0; i < numChains; i++ {
 		selector := testAptosChainSelectors[i]
 		chainID, err := chainsel.GetChainIDFromSelector(selector)
@@ -67,7 +68,7 @@ func GenerateChainsAptos(t *testing.T, numChains int) map[uint64]deployment.Apto
 		account := createAptosAccount(t, true)
 
 		url, nodeClient := aptosChain(t, chainID, account.Address)
-		chains[selector] = deployment.AptosChain{
+		chains[selector] = cldf.AptosChain{
 			Selector:       selector,
 			Client:         nodeClient,
 			DeployerSigner: account,
@@ -150,7 +151,7 @@ func aptosChain(t *testing.T, chainID string, adminAddress aptos.AccountAddress)
 	return url, client
 }
 
-func createAptosChainConfig(chainID string, chain deployment.AptosChain) chainlink.RawConfig {
+func createAptosChainConfig(chainID string, chain cldf.AptosChain) chainlink.RawConfig {
 	chainConfig := chainlink.RawConfig{}
 
 	chainConfig["Enabled"] = true

--- a/deployment/environment/memory/node.go
+++ b/deployment/environment/memory/node.go
@@ -36,6 +36,8 @@ import (
 
 	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/pointer"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
@@ -229,11 +231,11 @@ type NewNodeConfig struct {
 	// Port for the P2P V2 listener.
 	Port int
 	// EVM chains to be configured. Optional.
-	Chains map[uint64]deployment.Chain
+	Chains map[uint64]cldf.Chain
 	// Solana chains to be configured. Optional.
-	Solchains map[uint64]deployment.SolChain
+	Solchains map[uint64]cldf.SolChain
 	// Aptos chains to be configured. Optional.
-	Aptoschains    map[uint64]deployment.AptosChain
+	Aptoschains    map[uint64]cldf.AptosChain
 	LogLevel       zapcore.Level
 	Bootstrap      bool
 	RegistryConfig deployment.CapabilityRegistryConfig
@@ -424,9 +426,9 @@ type Keys struct {
 
 func CreateKeys(t *testing.T,
 	app chainlink.Application,
-	chains map[uint64]deployment.Chain,
-	solchains map[uint64]deployment.SolChain,
-	aptoschains map[uint64]deployment.AptosChain,
+	chains map[uint64]cldf.Chain,
+	solchains map[uint64]cldf.SolChain,
+	aptoschains map[uint64]cldf.AptosChain,
 ) Keys {
 	ctx := t.Context()
 	_, err := app.GetKeyStore().P2P().Create(ctx)
@@ -606,7 +608,7 @@ func createConfigV2Chain(chainID uint64) *v2toml.EVMConfig {
 	}
 }
 
-func createSolanaChainConfig(chainID string, chain deployment.SolChain) *solcfg.TOMLConfig {
+func createSolanaChainConfig(chainID string, chain cldf.SolChain) *solcfg.TOMLConfig {
 	chainConfig := solcfg.Chain{}
 	chainConfig.SetDefaults()
 

--- a/deployment/helpers.go
+++ b/deployment/helpers.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 func GetErrorReasonFromTx(client bind.ContractBackend, from common.Address, tx *types.Transaction, receipt *types.Receipt) (string, error) {
@@ -60,7 +62,7 @@ func parseError(txError error) (string, error) {
 	return callErr.Data, nil
 }
 
-func ValidateSelectorsInEnvironment(e Environment, chains []uint64) error {
+func ValidateSelectorsInEnvironment(e cldf.Environment, chains []uint64) error {
 	for _, chain := range chains {
 		_, evmOk := e.Chains[chain]
 		_, solOk := e.SolChains[chain]

--- a/deployment/keystone/changeset/accept_ownership.go
+++ b/deployment/keystone/changeset/accept_ownership.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
@@ -19,14 +19,14 @@ type AcceptAllOwnershipRequest struct {
 var _ cldf.ChangeSet[*AcceptAllOwnershipRequest] = AcceptAllOwnershipsProposal
 
 // AcceptAllOwnershipsProposal creates a MCMS proposal to call accept ownership on all the Keystone contracts in the address book.
-func AcceptAllOwnershipsProposal(e deployment.Environment, req *AcceptAllOwnershipRequest) (cldf.ChangesetOutput, error) {
+func AcceptAllOwnershipsProposal(e cldf.Environment, req *AcceptAllOwnershipRequest) (cldf.ChangesetOutput, error) {
 	chainSelector := req.ChainSelector
 	minDelay := req.MinDelay
 	chain := e.Chains[chainSelector]
 	addrBook := e.ExistingAddresses
 
 	r, err := getContractSetsV2(e.Logger, getContractSetsRequestV2{
-		Chains: map[uint64]deployment.Chain{
+		Chains: map[uint64]cldf.Chain{
 			req.ChainSelector: chain,
 		},
 		AddressBook: addrBook,

--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
@@ -28,7 +28,7 @@ type AddCapabilitiesRequest struct {
 	RegistryRef datastore.AddressRefKey
 }
 
-func (r *AddCapabilitiesRequest) Validate(env deployment.Environment) error {
+func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 	if r.RegistryChainSel == 0 {
 		return errors.New("registry chain selector must be set")
 	}
@@ -44,7 +44,7 @@ func (r *AddCapabilitiesRequest) Validate(env deployment.Environment) error {
 
 // if the environment has a non-empty datastore, the registry ref must be set
 // prevents accidental usage of the old address book
-func shouldUseDatastore(env deployment.Environment, ref datastore.AddressRefKey) error {
+func shouldUseDatastore(env cldf.Environment, ref datastore.AddressRefKey) error {
 	if addrs, err := env.DataStore.Addresses().Fetch(); err == nil {
 		if len(addrs) != 0 && ref == nil {
 			return errors.New("This environment has been migrated to DataStore: address ref key must not be nil")
@@ -66,7 +66,7 @@ var _ cldf.ChangeSet[*AddCapabilitiesRequest] = AddCapabilities
 //
 // When using MCMS, the output will contain a single proposal with a single batch containing all capabilities to be added.
 // When not using MCMS, each capability will be added in a separate transaction.
-func AddCapabilities(env deployment.Environment, req *AddCapabilitiesRequest) (cldf.ChangesetOutput, error) {
+func AddCapabilities(env cldf.Environment, req *AddCapabilitiesRequest) (cldf.ChangesetOutput, error) {
 	err := req.Validate(env)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to validate request: %w", err)

--- a/deployment/keystone/changeset/add_dons.go
+++ b/deployment/keystone/changeset/add_dons.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
@@ -91,7 +92,7 @@ type AddDonsRequest struct {
 	RegistryRef datastore.AddressRefKey
 }
 
-func (r *AddDonsRequest) Validate(e deployment.Environment) error {
+func (r *AddDonsRequest) Validate(e cldf.Environment) error {
 	for _, don := range r.DONs {
 		if err := don.Validate(); err != nil {
 			return fmt.Errorf("invalid DON to register: %w", err)
@@ -139,7 +140,7 @@ func (r AddDonsRequest) convertInternal(registry *kcr.CapabilitiesRegistry) (don
 // See [AddNodes] and [AddCapabilities] for more detail
 // If the DON already exists, it will do nothing. The DON is identified by the P2P addresses of the nodes.
 // If you need to update the DON, use [UpdateDon].
-func AddDons(env deployment.Environment, req *AddDonsRequest) (cldf.ChangesetOutput, error) {
+func AddDons(env cldf.Environment, req *AddDonsRequest) (cldf.ChangesetOutput, error) {
 	if err := req.Validate(env); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}

--- a/deployment/keystone/changeset/add_nodes.go
+++ b/deployment/keystone/changeset/add_nodes.go
@@ -197,7 +197,7 @@ type AddNodesRequest struct {
 	RegistryRef datastore.AddressRefKey
 }
 
-func (r *AddNodesRequest) Validate(env deployment.Environment) error {
+func (r *AddNodesRequest) Validate(env cldf.Environment) error {
 	if len(r.CreateNodeRequests) == 0 {
 		return errors.New("must provide create node requests")
 	}
@@ -214,7 +214,7 @@ func (r *AddNodesRequest) Validate(env deployment.Environment) error {
 
 var _ cldf.ChangeSet[*AddNodesRequest] = AddNodes
 
-func AddNodes(env deployment.Environment, req *AddNodesRequest) (cldf.ChangesetOutput, error) {
+func AddNodes(env cldf.Environment, req *AddNodesRequest) (cldf.ChangesetOutput, error) {
 	err := req.Validate(env)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid request: %w", err)

--- a/deployment/keystone/changeset/add_nops.go
+++ b/deployment/keystone/changeset/add_nops.go
@@ -13,7 +13,6 @@ import (
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
@@ -27,7 +26,7 @@ type AddNopsRequest struct {
 	RegistryRef datastore.AddressRefKey
 }
 
-func (req *AddNopsRequest) Validate(env deployment.Environment) error {
+func (req *AddNopsRequest) Validate(env cldf.Environment) error {
 	if len(req.Nops) == 0 {
 		return errors.New("no NOPs provided")
 	}
@@ -42,7 +41,7 @@ func (req *AddNopsRequest) Validate(env deployment.Environment) error {
 
 var _ cldf.ChangeSet[*AddNopsRequest] = AddNops
 
-func AddNops(env deployment.Environment, req *AddNopsRequest) (cldf.ChangesetOutput, error) {
+func AddNops(env cldf.Environment, req *AddNopsRequest) (cldf.ChangesetOutput, error) {
 	if err := req.Validate(env); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid request: %w", err)
 	}

--- a/deployment/keystone/changeset/addrbook_utils.go
+++ b/deployment/keystone/changeset/addrbook_utils.go
@@ -9,8 +9,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	capReg "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	feeds_consumer "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/feeds_consumer_1_0_0"
 	keystoneForwarder "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/forwarder_1_0_0"
@@ -27,7 +25,7 @@ type contractConstructor[T any] func(address common.Address, client bind.Contrac
 // It uses the provided constructor to initialize matching contracts for the given chain.
 func getContractsFromAddrBook[T any](
 	addrBook cldf.AddressBook,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	desiredType cldf.ContractType,
 	constructor contractConstructor[T],
 ) ([]*T, error) {
@@ -56,7 +54,7 @@ func getContractsFromAddrBook[T any](
 }
 
 // capRegistriesFromAddrBook retrieves CapabilitiesRegistry contracts for the given chain.
-func capRegistriesFromAddrBook(addrBook cldf.AddressBook, chain deployment.Chain) ([]*capReg.CapabilitiesRegistry, error) {
+func capRegistriesFromAddrBook(addrBook cldf.AddressBook, chain cldf.Chain) ([]*capReg.CapabilitiesRegistry, error) {
 	return getContractsFromAddrBook[capReg.CapabilitiesRegistry](
 		addrBook,
 		chain,
@@ -66,7 +64,7 @@ func capRegistriesFromAddrBook(addrBook cldf.AddressBook, chain deployment.Chain
 }
 
 // ocr3FromAddrBook retrieves OCR3Capability contracts for the given chain.
-func ocr3FromAddrBook(addrBook cldf.AddressBook, chain deployment.Chain) ([]*ocr3Capability.OCR3Capability, error) {
+func ocr3FromAddrBook(addrBook cldf.AddressBook, chain cldf.Chain) ([]*ocr3Capability.OCR3Capability, error) {
 	return getContractsFromAddrBook[ocr3Capability.OCR3Capability](
 		addrBook,
 		chain,
@@ -76,7 +74,7 @@ func ocr3FromAddrBook(addrBook cldf.AddressBook, chain deployment.Chain) ([]*ocr
 }
 
 // forwardersFromAddrBook retrieves KeystoneForwarder contracts for the given chain.
-func forwardersFromAddrBook(addrBook cldf.AddressBook, chain deployment.Chain) ([]*keystoneForwarder.KeystoneForwarder, error) {
+func forwardersFromAddrBook(addrBook cldf.AddressBook, chain cldf.Chain) ([]*keystoneForwarder.KeystoneForwarder, error) {
 	return getContractsFromAddrBook[keystoneForwarder.KeystoneForwarder](
 		addrBook,
 		chain,
@@ -86,7 +84,7 @@ func forwardersFromAddrBook(addrBook cldf.AddressBook, chain deployment.Chain) (
 }
 
 // feedsConsumersFromAddrBook retrieves FeedsConsumer contracts for the given chain.
-func feedsConsumersFromAddrBook(addrBook cldf.AddressBook, chain deployment.Chain) ([]*feeds_consumer.KeystoneFeedsConsumer, error) {
+func feedsConsumersFromAddrBook(addrBook cldf.AddressBook, chain cldf.Chain) ([]*feeds_consumer.KeystoneFeedsConsumer, error) {
 	return getContractsFromAddrBook[feeds_consumer.KeystoneFeedsConsumer](
 		addrBook,
 		chain,
@@ -96,7 +94,7 @@ func feedsConsumersFromAddrBook(addrBook cldf.AddressBook, chain deployment.Chai
 }
 
 // proposersFromAddrBook retrieves ManyChainMultiSig proposer contracts for the given chain.
-func proposersFromAddrBook(addrBook cldf.AddressBook, chain deployment.Chain) ([]*ccipowner.ManyChainMultiSig, error) {
+func proposersFromAddrBook(addrBook cldf.AddressBook, chain cldf.Chain) ([]*ccipowner.ManyChainMultiSig, error) {
 	return getContractsFromAddrBook[ccipowner.ManyChainMultiSig](
 		addrBook,
 		chain,
@@ -106,7 +104,7 @@ func proposersFromAddrBook(addrBook cldf.AddressBook, chain deployment.Chain) ([
 }
 
 // timelocksFromAddrBook retrieves RBACTimelock contracts for the given chain.
-func timelocksFromAddrBook(addrBook cldf.AddressBook, chain deployment.Chain) ([]*ccipowner.RBACTimelock, error) {
+func timelocksFromAddrBook(addrBook cldf.AddressBook, chain cldf.Chain) ([]*ccipowner.RBACTimelock, error) {
 	return getContractsFromAddrBook[ccipowner.RBACTimelock](
 		addrBook,
 		chain,

--- a/deployment/keystone/changeset/append_node_capabilities.go
+++ b/deployment/keystone/changeset/append_node_capabilities.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
@@ -25,7 +24,7 @@ type AppendNodeCapabilitiesRequest = MutateNodeCapabilitiesRequest
 
 // AppendNodeCapabilities adds any new capabilities to the registry, merges the new capabilities with the existing capabilities
 // of the node, and updates the nodes in the registry host the union of the new and existing capabilities.
-func AppendNodeCapabilities(env deployment.Environment, req *AppendNodeCapabilitiesRequest) (cldf.ChangesetOutput, error) {
+func AppendNodeCapabilities(env cldf.Environment, req *AppendNodeCapabilitiesRequest) (cldf.ChangesetOutput, error) {
 	c, capReg, err := req.convert(env, req.RegistryRef)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
@@ -70,7 +69,7 @@ func AppendNodeCapabilities(env deployment.Environment, req *AppendNodeCapabilit
 	return out, nil
 }
 
-func (req *AppendNodeCapabilitiesRequest) convert(e deployment.Environment, ref datastore.AddressRefKey) (*internal.AppendNodeCapabilitiesRequest, *OwnedContract[*kcr.CapabilitiesRegistry], error) {
+func (req *AppendNodeCapabilitiesRequest) convert(e cldf.Environment, ref datastore.AddressRefKey) (*internal.AppendNodeCapabilitiesRequest, *OwnedContract[*kcr.CapabilitiesRegistry], error) {
 	if err := req.Validate(e); err != nil {
 		return nil, nil, fmt.Errorf("failed to validate UpdateNodeCapabilitiesRequest: %w", err)
 	}

--- a/deployment/keystone/changeset/configure_contracts.go
+++ b/deployment/keystone/changeset/configure_contracts.go
@@ -8,7 +8,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	kslib "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
 
@@ -20,7 +19,7 @@ type InitialContractsCfg struct {
 	OCR3Config       *kslib.OracleConfig
 }
 
-func ConfigureInitialContractsChangeset(e deployment.Environment, cfg InitialContractsCfg) (cldf.ChangesetOutput, error) {
+func ConfigureInitialContractsChangeset(e cldf.Environment, cfg InitialContractsCfg) (cldf.ChangesetOutput, error) {
 	req := &kslib.ConfigureContractsRequest{
 		Env:              &e,
 		RegistryChainSel: cfg.RegistryChainSel,

--- a/deployment/keystone/changeset/contract_set.go
+++ b/deployment/keystone/changeset/contract_set.go
@@ -29,7 +29,7 @@ type contractSetV2 struct {
 // getContractSetsRequestV2 is the request structure for getting contract sets.
 type getContractSetsRequestV2 struct {
 	AddressBook cldf.AddressBook
-	Chains      map[uint64]deployment.Chain
+	Chains      map[uint64]cldf.Chain
 	Labels      []string
 }
 
@@ -108,7 +108,7 @@ func getContractSetsV2(lggr logger.Logger, req getContractSetsRequestV2) (*getCo
 	return out, nil
 }
 
-func loadContractSetV2(lggr logger.Logger, addressBook cldf.AddressBook, chain deployment.Chain, addresses map[string]cldf.TypeAndVersion) (*contractSetV2, error) {
+func loadContractSetV2(lggr logger.Logger, addressBook cldf.AddressBook, chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*contractSetV2, error) {
 	var out contractSetV2
 
 	handlers := map[cldf.ContractType]func(string) error{

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -37,7 +37,7 @@ type OwnedContract[T Ownable] struct {
 
 // NewOwnable creates an OwnedContract instance.
 // It checks if the contract is owned by a timelock contract and loads the MCMS state if necessary.
-func NewOwnable[T Ownable](contract T, ab cldf.AddressBook, chain deployment.Chain) (*OwnedContract[T], error) {
+func NewOwnable[T Ownable](contract T, ab cldf.AddressBook, chain cldf.Chain) (*OwnedContract[T], error) {
 	var timelockTV = cldf.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
 
 	// Look for MCMS contracts that might be owned by the contract
@@ -74,7 +74,7 @@ func NewOwnable[T Ownable](contract T, ab cldf.AddressBook, chain deployment.Cha
 
 // NewOwnable creates an OwnedContract instance.
 // It checks if the contract is owned by a timelock contract and loads the MCMS state if necessary.
-func NewOwnableV2[T Ownable](contract T, ab datastore.AddressRefStore, chain deployment.Chain) (*OwnedContract[T], error) {
+func NewOwnableV2[T Ownable](contract T, ab datastore.AddressRefStore, chain cldf.Chain) (*OwnedContract[T], error) {
 	var timelockTV = cldf.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
 
 	// Look for MCMS contracts that might be owned by the contract
@@ -116,7 +116,7 @@ func NewOwnableV2[T Ownable](contract T, ab datastore.AddressRefStore, chain dep
 }
 
 // GetOwnerTypeAndVersion retrieves the owner type and version of a contract.
-func GetOwnerTypeAndVersion[T Ownable](contract T, ab cldf.AddressBook, chain deployment.Chain) (*cldf.TypeAndVersion, error) {
+func GetOwnerTypeAndVersion[T Ownable](contract T, ab cldf.AddressBook, chain cldf.Chain) (*cldf.TypeAndVersion, error) {
 	// Get the contract owner
 	owner, err := contract.Owner(nil)
 	if err != nil {
@@ -148,7 +148,7 @@ func GetOwnerTypeAndVersion[T Ownable](contract T, ab cldf.AddressBook, chain de
 }
 
 // GetOwnerTypeAndVersionV2 retrieves the owner type and version of a contract using the datastore instead of the address book.
-func GetOwnerTypeAndVersionV2[T Ownable](contract T, ab datastore.AddressRefStore, chain deployment.Chain) (*cldf.TypeAndVersion, error) {
+func GetOwnerTypeAndVersionV2[T Ownable](contract T, ab datastore.AddressRefStore, chain cldf.Chain) (*cldf.TypeAndVersion, error) {
 	// Get the contract owner
 	owner, err := contract.Owner(nil)
 	if err != nil {
@@ -177,7 +177,7 @@ func GetOwnerTypeAndVersionV2[T Ownable](contract T, ab datastore.AddressRefStor
 // GetOwnableContract retrieves a contract instance of type T from the address book.
 // If `targetAddr` is provided, it will look for that specific address.
 // If not, it will default to looking one contract of type T, and if it doesn't find exactly one, it will error.
-func GetOwnableContract[T Ownable](ab cldf.AddressBook, chain deployment.Chain, targetAddr *string) (*T, error) {
+func GetOwnableContract[T Ownable](ab cldf.AddressBook, chain cldf.Chain, targetAddr *string) (*T, error) {
 	var contractType cldf.ContractType
 	// Determine contract type based on T
 	switch any(*new(T)).(type) {
@@ -237,7 +237,7 @@ func GetOwnableContract[T Ownable](ab cldf.AddressBook, chain deployment.Chain, 
 // GetOwnableContractV2 retrieves a contract instance of type T from the datastore.
 // If `targetAddr` is provided, it will look for that specific address.
 // If not, it will default to looking one contract of type T, and if it doesn't find exactly one, it will error.
-func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain deployment.Chain, targetAddr string) (*T, error) {
+func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf.Chain, targetAddr string) (*T, error) {
 	// Determine contract type based on T
 	switch any(*new(T)).(type) {
 	case *forwarder.KeystoneForwarder:
@@ -265,7 +265,7 @@ func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain depl
 }
 
 // createContractInstance is a helper function to create contract instances
-func createContractInstance[T Ownable](addr string, chain deployment.Chain) (*T, error) {
+func createContractInstance[T Ownable](addr string, chain cldf.Chain) (*T, error) {
 	var instance T
 	var err error
 
@@ -294,7 +294,7 @@ func createContractInstance[T Ownable](addr string, chain deployment.Chain) (*T,
 }
 
 // GetOwnedContract is a helper function that gets a contract and wraps it in OwnedContract
-func GetOwnedContract[T Ownable](addressBook cldf.AddressBook, chain deployment.Chain, addr string) (*OwnedContract[T], error) {
+func GetOwnedContract[T Ownable](addressBook cldf.AddressBook, chain cldf.Chain, addr string) (*OwnedContract[T], error) {
 	contract, err := GetOwnableContract[T](addressBook, chain, &addr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get contract at %s: %w", addr, err)
@@ -308,7 +308,7 @@ func GetOwnedContract[T Ownable](addressBook cldf.AddressBook, chain deployment.
 	return ownedContract, nil
 }
 
-func GetOwnedContractV2[T Ownable](addrs datastore.AddressRefStore, chain deployment.Chain, addr string) (*OwnedContract[T], error) {
+func GetOwnedContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf.Chain, addr string) (*OwnedContract[T], error) {
 	addresses := addrs.Filter(datastore.AddressRefByChainSelector(chain.Selector))
 
 	var foundAddr bool
@@ -335,7 +335,7 @@ func GetOwnedContractV2[T Ownable](addrs datastore.AddressRefStore, chain deploy
 }
 
 // loadCapabilityRegistry loads the CapabilitiesRegistry contract from the address book or datastore.
-func loadCapabilityRegistry(registryChain deployment.Chain, env deployment.Environment, ref datastore.AddressRefKey) (*OwnedContract[*capabilities_registry.CapabilitiesRegistry], error) {
+func loadCapabilityRegistry(registryChain cldf.Chain, env cldf.Environment, ref datastore.AddressRefKey) (*OwnedContract[*capabilities_registry.CapabilitiesRegistry], error) {
 	err := shouldUseDatastore(env, ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check registry ref: %w", err)
@@ -354,7 +354,7 @@ func loadCapabilityRegistry(registryChain deployment.Chain, env deployment.Envir
 		// TODO: CRE-400 remove this once we have migrated all environments to use datastore
 		// This is a temporary backward compatibility until all the CLD environments are migrated to use datastore
 		cs, err := getContractSetsV2(env.Logger, getContractSetsRequestV2{
-			Chains:      map[uint64]deployment.Chain{registryChain.Selector: registryChain},
+			Chains:      map[uint64]cldf.Chain{registryChain.Selector: registryChain},
 			AddressBook: env.ExistingAddresses, //nolint:staticcheck  // TODO CRE-400 remove this once we have migrated all environments to use datastore
 		})
 		if err != nil {

--- a/deployment/keystone/changeset/deploy_balance_reader.go
+++ b/deployment/keystone/changeset/deploy_balance_reader.go
@@ -9,7 +9,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
 
@@ -22,7 +21,7 @@ type DeployBalanceReaderRequest struct {
 // DeployBalanceReader deploys the BalanceReader contract to all chains in the environment
 // callers must merge the output addressbook with the existing one
 // Deprecated: use DeployBalanceReaderV2 instead
-func DeployBalanceReader(env deployment.Environment, cfg DeployBalanceReaderRequest) (cldf.ChangesetOutput, error) {
+func DeployBalanceReader(env cldf.Environment, cfg DeployBalanceReaderRequest) (cldf.ChangesetOutput, error) {
 	out := cldf.ChangesetOutput{
 		AddressBook: cldf.NewMemoryAddressBook(),
 		DataStore:   datastore.NewMemoryDataStore[datastore.DefaultMetadata, datastore.DefaultMetadata](),
@@ -52,7 +51,7 @@ func DeployBalanceReader(env deployment.Environment, cfg DeployBalanceReaderRequ
 	return out, nil
 }
 
-func DeployBalanceReaderV2(env deployment.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
+func DeployBalanceReaderV2(env cldf.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
 	req.deployFn = internal.DeployBalanceReader
 	return deploy(env, req)
 }

--- a/deployment/keystone/changeset/deploy_consumer.go
+++ b/deployment/keystone/changeset/deploy_consumer.go
@@ -2,7 +2,7 @@ package changeset
 
 import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	kslib "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
 
@@ -13,13 +13,13 @@ type DeployFeedsConsumerRequest struct {
 var _ cldf.ChangeSet[*DeployFeedsConsumerRequest] = DeployFeedsConsumer
 
 // DeployFeedsConsumer deploys the FeedsConsumer contract to the chain with the given chainSelector.
-func DeployFeedsConsumer(env deployment.Environment, req *DeployFeedsConsumerRequest) (cldf.ChangesetOutput, error) {
+func DeployFeedsConsumer(env cldf.Environment, req *DeployFeedsConsumerRequest) (cldf.ChangesetOutput, error) {
 	return DeployFeedsConsumerV2(env, &DeployRequestV2{
 		ChainSel: req.ChainSelector,
 	})
 }
 
-func DeployFeedsConsumerV2(env deployment.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
+func DeployFeedsConsumerV2(env cldf.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
 	req.deployFn = kslib.DeployFeedsConsumer
 	return deploy(env, req)
 }

--- a/deployment/keystone/changeset/deploy_forwarder.go
+++ b/deployment/keystone/changeset/deploy_forwarder.go
@@ -13,7 +13,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
@@ -28,7 +27,7 @@ type DeployForwarderRequest struct {
 // callers must merge the output addressbook with the existing one
 // TODO: add selectors to deploy only to specific chains
 // Deprecated: use DeployForwarderV2 instead
-func DeployForwarderX(env deployment.Environment, cfg DeployForwarderRequest) (cldf.ChangesetOutput, error) {
+func DeployForwarderX(env cldf.Environment, cfg DeployForwarderRequest) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
 	ab := cldf.NewMemoryAddressBook()
 	selectors := cfg.ChainSelectors
@@ -51,7 +50,7 @@ func DeployForwarderX(env deployment.Environment, cfg DeployForwarderRequest) (c
 	return cldf.ChangesetOutput{AddressBook: ab}, nil
 }
 
-func DeployForwarder(env deployment.Environment, cfg DeployForwarderRequest) (cldf.ChangesetOutput, error) {
+func DeployForwarder(env cldf.Environment, cfg DeployForwarderRequest) (cldf.ChangesetOutput, error) {
 	var out cldf.ChangesetOutput
 	out.AddressBook = cldf.NewMemoryAddressBook() //nolint:staticcheck // TODO CRE-400
 	out.DataStore = datastore.NewMemoryDataStore[datastore.DefaultMetadata, datastore.DefaultMetadata]()
@@ -82,7 +81,7 @@ func DeployForwarder(env deployment.Environment, cfg DeployForwarderRequest) (cl
 }
 
 // DeployForwarderV2 deploys the KeystoneForwarder contract to the specified chain
-func DeployForwarderV2(env deployment.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
+func DeployForwarderV2(env cldf.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
 	req.deployFn = internal.DeployForwarder
 	return deploy(env, req)
 }
@@ -112,7 +111,7 @@ func (r ConfigureForwardContractsRequest) UseMCMS() bool {
 	return r.MCMSConfig != nil
 }
 
-func ConfigureForwardContracts(env deployment.Environment, req ConfigureForwardContractsRequest) (cldf.ChangesetOutput, error) {
+func ConfigureForwardContracts(env cldf.Environment, req ConfigureForwardContractsRequest) (cldf.ChangesetOutput, error) {
 	wfDon, err := internal.NewRegisteredDon(env, internal.RegisteredDonConfig{
 		NodeIDs:          req.WFNodeIDs,
 		Name:             req.WFDonName,

--- a/deployment/keystone/changeset/deploy_forwarder_test.go
+++ b/deployment/keystone/changeset/deploy_forwarder_test.go
@@ -15,8 +15,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
-
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -79,7 +77,7 @@ func TestConfigureForwarders(t *testing.T) {
 		},
 	}
 
-	excludeChainsIfNeeded := func(excludeChains bool, env deployment.Environment) (uint64, map[uint64]struct{}) {
+	excludeChainsIfNeeded := func(excludeChains bool, env cldf.Environment) (uint64, map[uint64]struct{}) {
 		if !excludeChains {
 			return 0, nil
 		}

--- a/deployment/keystone/changeset/deploy_ocr3.go
+++ b/deployment/keystone/changeset/deploy_ocr3.go
@@ -14,15 +14,14 @@ import (
 	"github.com/smartcontractkit/mcms/sdk"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
-	internal "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
+	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
 
 var _ cldf.ChangeSet[uint64] = DeployOCR3
 
 // Deprecated: use DeployOCR3V2 instead
-func DeployOCR3(env deployment.Environment, registryChainSel uint64) (cldf.ChangesetOutput, error) {
+func DeployOCR3(env cldf.Environment, registryChainSel uint64) (cldf.ChangesetOutput, error) {
 	return DeployOCR3V2(env, &DeployRequestV2{
 		ChainSel: registryChainSel,
 	})
@@ -30,7 +29,7 @@ func DeployOCR3(env deployment.Environment, registryChainSel uint64) (cldf.Chang
 
 var _ cldf.ChangeSet[ConfigureOCR3Config] = ConfigureOCR3Contract
 
-func DeployOCR3V2(env deployment.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
+func DeployOCR3V2(env cldf.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
 	req.deployFn = internal.DeployOCR3
 	return deploy(env, req)
 }
@@ -51,7 +50,7 @@ func (cfg ConfigureOCR3Config) UseMCMS() bool {
 	return cfg.MCMSConfig != nil
 }
 
-func ConfigureOCR3Contract(env deployment.Environment, cfg ConfigureOCR3Config) (cldf.ChangesetOutput, error) {
+func ConfigureOCR3Contract(env cldf.Environment, cfg ConfigureOCR3Config) (cldf.ChangesetOutput, error) {
 	resp, err := internal.ConfigureOCR3ContractFromJD(&env, internal.ConfigureOCR3Config{
 		ChainSel:   cfg.ChainSel,
 		NodeIDs:    cfg.NodeIDs,

--- a/deployment/keystone/changeset/deploy_registry.go
+++ b/deployment/keystone/changeset/deploy_registry.go
@@ -9,20 +9,19 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	kslib "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
 
 var _ cldf.ChangeSet[uint64] = DeployCapabilityRegistry
 
 // Depreciated: use DeployCapabilityRegistryV2 instead
-func DeployCapabilityRegistry(env deployment.Environment, registrySelector uint64) (cldf.ChangesetOutput, error) {
+func DeployCapabilityRegistry(env cldf.Environment, registrySelector uint64) (cldf.ChangesetOutput, error) {
 	return DeployCapabilityRegistryV2(env, &DeployRequestV2{
 		ChainSel: registrySelector,
 	})
 }
 
-func DeployCapabilityRegistryV2(env deployment.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
+func DeployCapabilityRegistryV2(env cldf.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
 	req.deployFn = kslib.DeployCapabilitiesRegistry
 	return deploy(env, req)
 }
@@ -33,10 +32,10 @@ type DeployRequestV2 = struct {
 	Qualifier string
 	Labels    *datastore.LabelSet
 
-	deployFn func(ctx context.Context, chain deployment.Chain, ab cldf.AddressBook) (*kslib.DeployResponse, error)
+	deployFn func(ctx context.Context, chain cldf.Chain, ab cldf.AddressBook) (*kslib.DeployResponse, error)
 }
 
-func deploy(env deployment.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
+func deploy(env cldf.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
 	chain, ok := env.Chains[req.ChainSel]
 	if !ok {

--- a/deployment/keystone/changeset/internal/append_node_capabilities.go
+++ b/deployment/keystone/changeset/internal/append_node_capabilities.go
@@ -5,14 +5,16 @@ import (
 	"fmt"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 )
 
 type AppendNodeCapabilitiesRequest struct {
-	Chain                deployment.Chain
+	Chain                cldf.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 
 	P2pToCapabilities map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability

--- a/deployment/keystone/changeset/internal/append_node_capabilities_test.go
+++ b/deployment/keystone/changeset/internal/append_node_capabilities_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
@@ -58,7 +57,7 @@ func TestAppendNodeCapabilities(t *testing.T) {
 			args: args{
 				lggr: lggr,
 				req: &internal.AppendNodeCapabilitiesRequest{
-					Chain: deployment.Chain{},
+					Chain: cldf.Chain{},
 				},
 				initialState: &kstest.SetupTestRegistryRequest{},
 			},

--- a/deployment/keystone/changeset/internal/capability_management.go
+++ b/deployment/keystone/changeset/internal/capability_management.go
@@ -9,14 +9,16 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
 // AddCapabilities adds the capabilities to the registry
 //
 // It is idempotent. It deduplicates the input capabilities.
-func AddCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, chain deployment.Chain, capabilities []kcr.CapabilitiesRegistryCapability, useMCMS bool) (*mcmstypes.BatchOperation, error) {
+func AddCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, chain cldf.Chain, capabilities []kcr.CapabilitiesRegistryCapability, useMCMS bool) (*mcmstypes.BatchOperation, error) {
 	if len(capabilities) == 0 {
 		return nil, nil
 	}
@@ -31,7 +33,7 @@ func AddCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, cha
 
 	tx, err := registry.AddCapabilities(chain.DeployerKey, deduped)
 	if err != nil {
-		err = deployment.DecodeErr(kcr.CapabilitiesRegistryABI, err)
+		err = cldf.DecodeErr(kcr.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to add capabilities: %w", err)
 	}
 
@@ -44,10 +46,10 @@ func AddCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, cha
 	return nil, nil
 }
 
-func addCapabilitiesMCMSProposal(registry *kcr.CapabilitiesRegistry, caps []kcr.CapabilitiesRegistryCapability, regChain deployment.Chain) (*mcmstypes.BatchOperation, error) {
-	tx, err := registry.AddCapabilities(deployment.SimTransactOpts(), caps)
+func addCapabilitiesMCMSProposal(registry *kcr.CapabilitiesRegistry, caps []kcr.CapabilitiesRegistryCapability, regChain cldf.Chain) (*mcmstypes.BatchOperation, error) {
+	tx, err := registry.AddCapabilities(cldf.SimTransactOpts(), caps)
 	if err != nil {
-		err = deployment.DecodeErr(kcr.CapabilitiesRegistryABI, err)
+		err = cldf.DecodeErr(kcr.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to call AddNodeOperators: %w", err)
 	}
 

--- a/deployment/keystone/changeset/internal/capability_registry_deployer.go
+++ b/deployment/keystone/changeset/internal/capability_registry_deployer.go
@@ -13,8 +13,6 @@ import (
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 type CapabilitiesRegistryDeployer struct {
@@ -70,7 +68,7 @@ func (c *CapabilitiesRegistryDeployer) Deploy(req DeployRequest) (*DeployRespons
 	return resp, nil
 }
 
-func estimateDeploymentGas(client deployment.OnchainClient, bytecode string) (uint64, error) {
+func estimateDeploymentGas(client cldf.OnchainClient, bytecode string) (uint64, error) {
 	// fake contract address required for gas estimation, otherwise it will fail
 	contractAddress := common.HexToAddress("0x0000000000000000000000000000000000000000")
 

--- a/deployment/keystone/changeset/internal/contract_set.go
+++ b/deployment/keystone/changeset/internal/contract_set.go
@@ -5,19 +5,17 @@ import (
 	"fmt"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 type deployContractsRequest struct {
-	chain           deployment.Chain
+	chain           cldf.Chain
 	isRegistryChain bool
 	ad              cldf.AddressBook
 }
 
 // DeployCapabilitiesRegistry deploys the CapabilitiesRegistry contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func DeployCapabilitiesRegistry(_ context.Context, chain deployment.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
+func DeployCapabilitiesRegistry(_ context.Context, chain cldf.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
 	capabilitiesRegistryDeployer, err := NewCapabilitiesRegistryDeployer()
 	capabilitiesRegistryResp, err := capabilitiesRegistryDeployer.Deploy(DeployRequest{Chain: chain})
 	if err != nil {
@@ -32,7 +30,7 @@ func DeployCapabilitiesRegistry(_ context.Context, chain deployment.Chain, ab cl
 
 // DeployOCR3 deploys the OCR3Capability contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func DeployOCR3(_ context.Context, chain deployment.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
+func DeployOCR3(_ context.Context, chain cldf.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
 	ocr3Deployer, err := NewOCR3Deployer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OCR3Deployer: %w", err)
@@ -51,7 +49,7 @@ func DeployOCR3(_ context.Context, chain deployment.Chain, ab cldf.AddressBook) 
 
 // DeployForwarder deploys the KeystoneForwarder contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func DeployForwarder(ctx context.Context, chain deployment.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
+func DeployForwarder(ctx context.Context, chain cldf.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
 	forwarderDeployer, err := NewKeystoneForwarderDeployer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create KeystoneForwarderDeployer: %w", err)
@@ -69,7 +67,7 @@ func DeployForwarder(ctx context.Context, chain deployment.Chain, ab cldf.Addres
 
 // DeployFeedsConsumer deploys the KeystoneFeedsConsumer contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func DeployFeedsConsumer(_ context.Context, chain deployment.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
+func DeployFeedsConsumer(_ context.Context, chain cldf.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
 	consumerDeploy, err := NewKeystoneFeedsConsumerDeployer()
 	if err != nil {
 		return nil, err
@@ -87,7 +85,7 @@ func DeployFeedsConsumer(_ context.Context, chain deployment.Chain, ab cldf.Addr
 
 // DeployForwarder deploys the BalanceReader contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func DeployBalanceReader(_ context.Context, chain deployment.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
+func DeployBalanceReader(_ context.Context, chain cldf.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
 	balanceReaderDeployer, err := NewBalanceReaderDeployer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BalanceReaderDeployer: %w", err)

--- a/deployment/keystone/changeset/internal/deploy_test.go
+++ b/deployment/keystone/changeset/internal/deploy_test.go
@@ -37,9 +37,9 @@ func Test_RegisterNOPS(t *testing.T) {
 			Name: "test-nop",
 		})
 		useMCMS = true
-		env := &deployment.Environment{
+		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]deployment.Chain{
+			Chains: map[uint64]cldf.Chain{
 				chain.Selector: chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -240,9 +240,9 @@ func Test_RegisterNodes(t *testing.T) {
 			rc, _ := kstest.MustAddCapabilities(t, lggr, caps2Add, chain, registry)
 
 			t.Run(tc.name, func(t *testing.T) {
-				env := &deployment.Environment{
+				env := &cldf.Environment{
 					Logger: lggr,
-					Chains: map[uint64]deployment.Chain{
+					Chains: map[uint64]cldf.Chain{
 						chain.Selector: chain,
 					},
 					ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -301,9 +301,9 @@ func Test_RegisterNodes(t *testing.T) {
 
 	t.Run("no ops in proposal if node already exists", func(t *testing.T) {
 		useMCMS = true
-		env := &deployment.Environment{
+		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]deployment.Chain{
+			Chains: map[uint64]cldf.Chain{
 				chain.Selector: chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -352,9 +352,9 @@ func Test_RegisterNodes(t *testing.T) {
 
 	t.Run("no new nodes to add results in no mcms ops", func(t *testing.T) {
 		useMCMS = true
-		env := &deployment.Environment{
+		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]deployment.Chain{
+			Chains: map[uint64]cldf.Chain{
 				chain.Selector: chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -398,9 +398,9 @@ func Test_RegisterDons(t *testing.T) {
 	)
 	t.Run("success create add DONs mcms proposal", func(t *testing.T) {
 		useMCMS = true
-		env := &deployment.Environment{
+		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]deployment.Chain{
+			Chains: map[uint64]cldf.Chain{
 				chain.Selector: chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -494,9 +494,9 @@ func Test_RegisterDons(t *testing.T) {
 			regContract = setupResp.CapabilitiesRegistry
 		)
 
-		env := &deployment.Environment{
+		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]deployment.Chain{
+			Chains: map[uint64]cldf.Chain{
 				setupResp.Chain.Selector: setupResp.Chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -531,9 +531,9 @@ func Test_RegisterDons(t *testing.T) {
 
 	t.Run("success create add DONs mcms proposal with multiple DONs", func(t *testing.T) {
 		useMCMS = true
-		env := &deployment.Environment{
+		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]deployment.Chain{
+			Chains: map[uint64]cldf.Chain{
 				chain.Selector: chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{

--- a/deployment/keystone/changeset/internal/forwarder_deployer.go
+++ b/deployment/keystone/changeset/internal/forwarder_deployer.go
@@ -12,8 +12,6 @@ import (
 	forwarder "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/forwarder_1_0_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 const (
@@ -88,7 +86,7 @@ type ConfigureForwarderContractsResponse struct {
 // Depreciated: use [changeset.ConfigureForwardContracts] instead
 // ConfigureForwardContracts configures the forwarder contracts on all chains for the given DONS
 // the address book is required to contain the an address of the deployed forwarder contract for every chain in the environment
-func ConfigureForwardContracts(env *deployment.Environment, req ConfigureForwarderContractsRequest) (*ConfigureForwarderContractsResponse, error) {
+func ConfigureForwardContracts(env *cldf.Environment, req ConfigureForwarderContractsRequest) (*ConfigureForwarderContractsResponse, error) {
 	contractSetsResp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,

--- a/deployment/keystone/changeset/internal/ocr3config.go
+++ b/deployment/keystone/changeset/internal/ocr3config.go
@@ -26,6 +26,7 @@ import (
 	kocr3 "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
@@ -350,7 +351,7 @@ func GenerateOCR3Config(cfg OracleConfig, nca []NodeKeys, secrets cldf.OCRSecret
 
 type configureOCR3Request struct {
 	cfg        *OracleConfig
-	chain      deployment.Chain
+	chain      cldf.Chain
 	contract   *kocr3.OCR3Capability
 	nodes      []deployment.Node
 	dryRun     bool
@@ -383,7 +384,7 @@ func configureOCR3contract(req configureOCR3Request) (*configureOCR3Response, er
 
 	txOpt := req.chain.DeployerKey
 	if req.useMCMS {
-		txOpt = deployment.SimTransactOpts()
+		txOpt = cldf.SimTransactOpts()
 	}
 
 	tx, err := req.contract.SetConfig(txOpt,
@@ -395,7 +396,7 @@ func configureOCR3contract(req configureOCR3Request) (*configureOCR3Response, er
 		ocrConfig.OffchainConfig,
 	)
 	if err != nil {
-		err = deployment.DecodeErr(kocr3.OCR3CapabilityABI, err)
+		err = cldf.DecodeErr(kocr3.OCR3CapabilityABI, err)
 		return nil, fmt.Errorf("failed to call SetConfig for OCR3 contract %s using mcms: %T: %w", req.contract.Address().String(), req.useMCMS, err)
 	}
 
@@ -403,7 +404,7 @@ func configureOCR3contract(req configureOCR3Request) (*configureOCR3Response, er
 	if !req.useMCMS {
 		_, err = req.chain.Confirm(tx)
 		if err != nil {
-			err = deployment.DecodeErr(kocr3.OCR3CapabilityABI, err)
+			err = cldf.DecodeErr(kocr3.OCR3CapabilityABI, err)
 			return nil, fmt.Errorf("failed to confirm SetConfig for OCR3 contract %s: %w", req.contract.Address().String(), err)
 		}
 	} else {

--- a/deployment/keystone/changeset/internal/ocr3config_test.go
+++ b/deployment/keystone/changeset/internal/ocr3config_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/view"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -92,7 +93,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 	r := configureOCR3Request{
 		cfg:   &cfg,
 		nodes: nodes,
-		chain: deployment.Chain{
+		chain: cldf.Chain{
 			Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 		},
 		ocrSecrets: cldf.XXXGenerateTestOCRSecrets(),
@@ -112,7 +113,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 		r := configureOCR3Request{
 			cfg:   &cfg2,
 			nodes: nodes,
-			chain: deployment.Chain{
+			chain: cldf.Chain{
 				Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 			},
 			ocrSecrets: cldf.XXXGenerateTestOCRSecrets(),
@@ -126,7 +127,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 		r := configureOCR3Request{
 			cfg:   &cfg2,
 			nodes: nodes,
-			chain: deployment.Chain{
+			chain: cldf.Chain{
 				Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 			},
 			ocrSecrets: cldf.XXXGenerateTestOCRSecrets(),

--- a/deployment/keystone/changeset/internal/remove_dons.go
+++ b/deployment/keystone/changeset/internal/remove_dons.go
@@ -9,13 +9,15 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
 // RemoveDONsRequest holds the parameters for the RemoveDONs operation.
 type RemoveDONsRequest struct {
-	Chain                deployment.Chain
+	Chain                cldf.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 	DONs                 []uint32
 	UseMCMS              bool
@@ -58,12 +60,12 @@ func RemoveDONs(lggr logger.Logger, req *RemoveDONsRequest) (*RemoveDONsResponse
 	}
 
 	if req.UseMCMS {
-		txOpts = deployment.SimTransactOpts()
+		txOpts = cldf.SimTransactOpts()
 	}
 
 	tx, err := req.CapabilitiesRegistry.RemoveDONs(txOpts, req.DONs)
 	if err != nil {
-		err = deployment.DecodeErr(kcr.CapabilitiesRegistryABI, err)
+		err = cldf.DecodeErr(kcr.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to call RemoveDONs: %w", err)
 	}
 

--- a/deployment/keystone/changeset/internal/remove_dons_test.go
+++ b/deployment/keystone/changeset/internal/remove_dons_test.go
@@ -13,6 +13,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/pointer"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
@@ -23,7 +26,7 @@ import (
 func Test_RemoveDONsRequest_validate(t *testing.T) {
 	type fields struct {
 		DONs                 []uint32
-		chain                deployment.Chain
+		chain                cldf.Chain
 		capabilitiesRegistry *kcr.CapabilitiesRegistry
 	}
 	tests := []struct {
@@ -35,7 +38,7 @@ func Test_RemoveDONsRequest_validate(t *testing.T) {
 			name: "missing capabilities registry",
 			fields: fields{
 				DONs:                 []uint32{1},
-				chain:                deployment.Chain{},
+				chain:                cldf.Chain{},
 				capabilitiesRegistry: nil,
 			},
 			wantErr: true,
@@ -44,7 +47,7 @@ func Test_RemoveDONsRequest_validate(t *testing.T) {
 			name: "empty DONs list",
 			fields: fields{
 				DONs:                 []uint32{},
-				chain:                deployment.Chain{},
+				chain:                cldf.Chain{},
 				capabilitiesRegistry: &kcr.CapabilitiesRegistry{},
 			},
 			wantErr: true,
@@ -53,7 +56,7 @@ func Test_RemoveDONsRequest_validate(t *testing.T) {
 			name: "success",
 			fields: fields{
 				DONs:                 []uint32{1},
-				chain:                deployment.Chain{},
+				chain:                cldf.Chain{},
 				capabilitiesRegistry: &kcr.CapabilitiesRegistry{},
 			},
 			wantErr: false,
@@ -140,7 +143,7 @@ func TestRemoveDONs(t *testing.T) {
 		initialCapCfg = kstest.GetDefaultCapConfig(t, initialCap)
 	)
 
-	setupEnv := func(t *testing.T) (deployment.Chain, *kcr.CapabilitiesRegistry, []kcr.CapabilitiesRegistryDONInfo) {
+	setupEnv := func(t *testing.T) (cldf.Chain, *kcr.CapabilitiesRegistry, []kcr.CapabilitiesRegistryDONInfo) {
 		// 1) Set up chain + registry
 		cfg := setupUpdateDonTestConfig{
 			dons: []internal.DonInfo{

--- a/deployment/keystone/changeset/internal/state.go
+++ b/deployment/keystone/changeset/internal/state.go
@@ -20,7 +20,7 @@ import (
 )
 
 type GetContractSetsRequest struct {
-	Chains      map[uint64]deployment.Chain
+	Chains      map[uint64]cldf.Chain
 	AddressBook cldf.AddressBook
 
 	// Labels indicates the label set that a contract must include to be considered as a member
@@ -90,7 +90,7 @@ func GetContractSets(lggr logger.Logger, req *GetContractSetsRequest) (*GetContr
 // loadContractSet loads the MCMS state and then sets the Keystone contract state.
 func loadContractSet(
 	lggr logger.Logger,
-	chain deployment.Chain,
+	chain cldf.Chain,
 	addresses map[string]cldf.TypeAndVersion,
 ) (*ContractSet, error) {
 	var out ContractSet
@@ -112,7 +112,7 @@ func loadContractSet(
 func setContracts(
 	lggr logger.Logger,
 	addresses map[string]cldf.TypeAndVersion,
-	client deployment.OnchainClient,
+	client cldf.OnchainClient,
 	set *ContractSet,
 ) error {
 	for addr, tv := range addresses {

--- a/deployment/keystone/changeset/internal/state_test.go
+++ b/deployment/keystone/changeset/internal/state_test.go
@@ -54,7 +54,7 @@ func Test_GetContractSet(t *testing.T) {
 					giveAB,
 				)
 				req := &GetContractSetsRequest{
-					Chains: map[uint64]deployment.Chain{
+					Chains: map[uint64]cldf.Chain{
 						chain.Selector: {
 							Selector: chain.Selector,
 						},
@@ -101,7 +101,7 @@ func Test_GetContractSet(t *testing.T) {
 					giveAB,
 				)
 				req := &GetContractSetsRequest{
-					Chains: map[uint64]deployment.Chain{
+					Chains: map[uint64]cldf.Chain{
 						chain.Selector: {
 							Selector: chain.Selector,
 						},

--- a/deployment/keystone/changeset/internal/types.go
+++ b/deployment/keystone/changeset/internal/types.go
@@ -41,7 +41,7 @@ type DeployResponse struct {
 }
 
 type DeployRequest struct {
-	Chain deployment.Chain
+	Chain cldf.Chain
 }
 
 type DonNode struct {
@@ -253,7 +253,7 @@ type RegisteredDonConfig struct {
 	RegistryChainSel uint64
 }
 
-func NewRegisteredDon(env deployment.Environment, cfg RegisteredDonConfig) (*RegisteredDon, error) {
+func NewRegisteredDon(env cldf.Environment, cfg RegisteredDonConfig) (*RegisteredDon, error) {
 	// load the don info from the capabilities registry
 	r, err := GetContractSets(env.Logger, &GetContractSetsRequest{
 		Chains:      env.Chains,

--- a/deployment/keystone/changeset/internal/update_don.go
+++ b/deployment/keystone/changeset/internal/update_don.go
@@ -16,7 +16,9 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 )
@@ -28,7 +30,7 @@ type CapabilityConfig struct {
 }
 
 type UpdateDonRequest struct {
-	Chain                deployment.Chain
+	Chain                cldf.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 
 	P2PIDs            []p2pkey.PeerID    // this is the unique identifier for the don
@@ -100,11 +102,11 @@ func UpdateDon(_ logger.Logger, req *UpdateDonRequest) (*UpdateDonResponse, erro
 
 	txOpts := req.Chain.DeployerKey
 	if req.UseMCMS {
-		txOpts = deployment.SimTransactOpts()
+		txOpts = cldf.SimTransactOpts()
 	}
 	tx, err := registry.UpdateDON(txOpts, don.Id, don.NodeP2PIds, cfgs, don.IsPublic, don.F)
 	if err != nil {
-		err = deployment.DecodeErr(kcr.CapabilitiesRegistryABI, err)
+		err = cldf.DecodeErr(kcr.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to call UpdateDON: %w", err)
 	}
 	var ops types.BatchOperation

--- a/deployment/keystone/changeset/internal/update_don_test.go
+++ b/deployment/keystone/changeset/internal/update_don_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	kscs "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
@@ -236,7 +239,7 @@ type setupUpdateDonTestConfig struct {
 
 type setupUpdateDonTestResult struct {
 	registry *kcr.CapabilitiesRegistry
-	chain    deployment.Chain
+	chain    cldf.Chain
 }
 
 func registerTestDon(t *testing.T, lggr logger.Logger, cfg setupUpdateDonTestConfig) *kstest.SetupTestRegistryResponse {

--- a/deployment/keystone/changeset/internal/update_node_capabilities.go
+++ b/deployment/keystone/changeset/internal/update_node_capabilities.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 )
 
 type UpdateNodeCapabilitiesImplRequest struct {
-	Chain                deployment.Chain
+	Chain                cldf.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 	P2pToCapabilities    map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability
 

--- a/deployment/keystone/changeset/internal/update_node_capabilities_test.go
+++ b/deployment/keystone/changeset/internal/update_node_capabilities_test.go
@@ -10,7 +10,6 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 	kstest "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/test"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -56,7 +55,7 @@ func TestUpdateNodeCapabilities(t *testing.T) {
 			args: args{
 				lggr: lggr,
 				req: &internal.UpdateNodeCapabilitiesImplRequest{
-					Chain: deployment.Chain{},
+					Chain: cldf.Chain{},
 				},
 				initialState: &kstest.SetupTestRegistryRequest{},
 			},

--- a/deployment/keystone/changeset/internal/update_nodes.go
+++ b/deployment/keystone/changeset/internal/update_nodes.go
@@ -14,10 +14,11 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 type NodeUpdate struct {
@@ -29,7 +30,7 @@ type NodeUpdate struct {
 }
 
 type UpdateNodesRequest struct {
-	Chain                deployment.Chain
+	Chain                cldf.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 
 	P2pToUpdates map[p2pkey.PeerID]NodeUpdate
@@ -103,17 +104,17 @@ func UpdateNodes(lggr logger.Logger, req *UpdateNodesRequest) (*UpdateNodesRespo
 
 	params, err := req.NodeParams()
 	if err != nil {
-		err = deployment.DecodeErr(kcr.CapabilitiesRegistryABI, err)
+		err = cldf.DecodeErr(kcr.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to make node params: %w", err)
 	}
 	txOpts := req.Chain.DeployerKey
 	if req.UseMCMS {
-		txOpts = deployment.SimTransactOpts()
+		txOpts = cldf.SimTransactOpts()
 	}
 	registry := req.CapabilitiesRegistry
 	tx, err := registry.UpdateNodes(txOpts, params)
 	if err != nil {
-		err = deployment.DecodeErr(kcr.CapabilitiesRegistryABI, err)
+		err = cldf.DecodeErr(kcr.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to call UpdateNodes: %w", err)
 	}
 
@@ -145,7 +146,7 @@ func UpdateNodes(lggr logger.Logger, req *UpdateNodesRequest) (*UpdateNodesRespo
 }
 
 // AppendCapabilities appends the capabilities to the existing capabilities of the nodes listed in p2pIds in the registry
-func AppendCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, chain deployment.Chain, p2pIds []p2pkey.PeerID, capabilities []kcr.CapabilitiesRegistryCapability) (map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability, error) {
+func AppendCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, chain cldf.Chain, p2pIds []p2pkey.PeerID, capabilities []kcr.CapabilitiesRegistryCapability) (map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability, error) {
 	out := make(map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability)
 	allCapabilities, err := registry.GetCapabilities(&bind.CallOpts{})
 	if err != nil {
@@ -202,7 +203,7 @@ func makeNodeParams(registry *kcr.CapabilitiesRegistry,
 
 	nodes, err := registry.GetNodesByP2PIds(&bind.CallOpts{}, PeerIDsToBytes(p2pIds))
 	if err != nil {
-		err = deployment.DecodeErr(kcr.CapabilitiesRegistryABI, err)
+		err = cldf.DecodeErr(kcr.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to get nodes by p2p ids: %w", err)
 	}
 	for _, node := range nodes {

--- a/deployment/keystone/changeset/internal/update_nodes_test.go
+++ b/deployment/keystone/changeset/internal/update_nodes_test.go
@@ -20,7 +20,9 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-	"github.com/smartcontractkit/chainlink/deployment"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 	kstest "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/test"
@@ -31,7 +33,7 @@ func Test_UpdateNodesRequest_validate(t *testing.T) {
 	type fields struct {
 		p2pToUpdates         map[p2pkey.PeerID]internal.NodeUpdate
 		nopToNodes           map[kcr.CapabilitiesRegistryNodeOperator][]*internal.P2PSignerEnc
-		chain                deployment.Chain
+		chain                cldf.Chain
 		capabilitiesRegistry *kcr.CapabilitiesRegistry
 	}
 	tests := []struct {
@@ -44,7 +46,7 @@ func Test_UpdateNodesRequest_validate(t *testing.T) {
 			fields: fields{
 				p2pToUpdates:         map[p2pkey.PeerID]internal.NodeUpdate{},
 				nopToNodes:           nil,
-				chain:                deployment.Chain{},
+				chain:                cldf.Chain{},
 				capabilitiesRegistry: nil,
 			},
 			wantErr: true,
@@ -58,7 +60,7 @@ func Test_UpdateNodesRequest_validate(t *testing.T) {
 					},
 				},
 				nopToNodes:           nil,
-				chain:                deployment.Chain{},
+				chain:                cldf.Chain{},
 				capabilitiesRegistry: nil,
 			},
 			wantErr: true,
@@ -72,7 +74,7 @@ func Test_UpdateNodesRequest_validate(t *testing.T) {
 					},
 				},
 				nopToNodes:           nil,
-				chain:                deployment.Chain{},
+				chain:                cldf.Chain{},
 				capabilitiesRegistry: nil,
 			},
 			wantErr: true,
@@ -582,7 +584,7 @@ func TestUpdateNodes(t *testing.T) {
 		toRegister := p2pToCapabilitiesUpdated[testPeerID(t, "peerID_1")]
 		tx, err := registry.AddCapabilities(chain.DeployerKey, toRegister)
 		if err != nil {
-			err2 := deployment.DecodeErr(kcr.CapabilitiesRegistryABI, err)
+			err2 := cldf.DecodeErr(kcr.CapabilitiesRegistryABI, err)
 			require.Fail(t, fmt.Sprintf("failed to call AddCapabilities: %s:  %s", err, err2))
 		}
 		_, err = chain.Confirm(tx)
@@ -690,9 +692,9 @@ func testPeerID(t *testing.T, s string) p2pkey.PeerID {
 	return p2pkey.PeerID(out)
 }
 
-func testChain(t *testing.T) deployment.Chain {
+func testChain(t *testing.T) cldf.Chain {
 	chains, _ := memory.NewMemoryChains(t, 1, 5)
-	var chain deployment.Chain
+	var chain cldf.Chain
 	for _, c := range chains {
 		chain = c
 		break

--- a/deployment/keystone/changeset/remove_dons.go
+++ b/deployment/keystone/changeset/remove_dons.go
@@ -12,7 +12,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
@@ -29,7 +28,7 @@ type RemoveDONsRequest struct {
 	RegistryRef datastore.AddressRefKey
 }
 
-func (r *RemoveDONsRequest) Validate(e deployment.Environment) error {
+func (r *RemoveDONsRequest) Validate(e cldf.Environment) error {
 	if len(r.DONs) == 0 {
 		return errors.New("dons is required")
 	}
@@ -54,7 +53,7 @@ func (r RemoveDONsRequest) UseMCMS() bool {
 }
 
 // RemoveDONs removes a DON from the capabilities registry
-func RemoveDONs(env deployment.Environment, req *RemoveDONsRequest) (cldf.ChangesetOutput, error) {
+func RemoveDONs(env cldf.Environment, req *RemoveDONsRequest) (cldf.ChangesetOutput, error) {
 	if err := req.Validate(env); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}

--- a/deployment/keystone/changeset/state.go
+++ b/deployment/keystone/changeset/state.go
@@ -21,7 +21,7 @@ import (
 )
 
 type GetContractSetsRequest struct {
-	Chains      map[uint64]deployment.Chain
+	Chains      map[uint64]cldf.Chain
 	AddressBook cldf.AddressBook
 
 	// Labels indicates the label set that a contract must include to be considered as a member
@@ -115,7 +115,7 @@ func GetContractSets(lggr logger.Logger, req *GetContractSetsRequest) (*GetContr
 	return resp, nil
 }
 
-func loadContractSet(lggr logger.Logger, chain deployment.Chain, addresses map[string]cldf.TypeAndVersion) (*ContractSet, error) {
+func loadContractSet(lggr logger.Logger, chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*ContractSet, error) {
 	var out ContractSet
 	mcmsWithTimelock, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 	if err != nil {

--- a/deployment/keystone/changeset/update_don.go
+++ b/deployment/keystone/changeset/update_don.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
@@ -30,7 +29,7 @@ type UpdateDonRequest struct {
 	RegistryRef datastore.AddressRefKey
 }
 
-func (r *UpdateDonRequest) Validate(env deployment.Environment) error {
+func (r *UpdateDonRequest) Validate(env cldf.Environment) error {
 	if len(r.P2PIDs) == 0 {
 		return errors.New("p2pIDs is required")
 	}
@@ -54,7 +53,7 @@ type UpdateDonResponse struct {
 // UpdateDon updates the capabilities of a Don
 // This a complex action in practice that involves registering missing capabilities, adding the nodes, and updating
 // the capabilities of the DON
-func UpdateDon(env deployment.Environment, req *UpdateDonRequest) (cldf.ChangesetOutput, error) {
+func UpdateDon(env cldf.Environment, req *UpdateDonRequest) (cldf.ChangesetOutput, error) {
 	if err := req.Validate(env); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid request: %w", err)
 	}
@@ -109,7 +108,7 @@ func appendRequest(r *UpdateDonRequest) *AppendNodeCapabilitiesRequest {
 	return out
 }
 
-func updateDonRequest(env deployment.Environment, r *UpdateDonRequest) (*internal.UpdateDonRequest, error) {
+func updateDonRequest(env cldf.Environment, r *UpdateDonRequest) (*internal.UpdateDonRequest, error) {
 	capReg, err := loadCapabilityRegistry(env.Chains[r.RegistryChainSel], env, r.RegistryRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load capability registry: %w", err)

--- a/deployment/keystone/changeset/update_node_capabilities.go
+++ b/deployment/keystone/changeset/update_node_capabilities.go
@@ -67,7 +67,7 @@ type MutateNodeCapabilitiesRequest struct {
 	RegistryRef datastore.AddressRefKey
 }
 
-func (req *MutateNodeCapabilitiesRequest) Validate(e deployment.Environment) error {
+func (req *MutateNodeCapabilitiesRequest) Validate(e cldf.Environment) error {
 	if len(req.P2pToCapabilities) == 0 {
 		return errors.New("p2pToCapabilities is empty")
 	}
@@ -90,7 +90,7 @@ func (req *MutateNodeCapabilitiesRequest) UseMCMS() bool {
 	return req.MCMSConfig != nil
 }
 
-func (req *MutateNodeCapabilitiesRequest) updateNodeCapabilitiesImplRequest(e deployment.Environment) (*internal.UpdateNodeCapabilitiesImplRequest, *OwnedContract[*kcr.CapabilitiesRegistry], error) {
+func (req *MutateNodeCapabilitiesRequest) updateNodeCapabilitiesImplRequest(e cldf.Environment) (*internal.UpdateNodeCapabilitiesImplRequest, *OwnedContract[*kcr.CapabilitiesRegistry], error) {
 	if err := req.Validate(e); err != nil {
 		return nil, nil, fmt.Errorf("failed to validate UpdateNodeCapabilitiesRequest: %w", err)
 	}
@@ -109,7 +109,7 @@ func (req *MutateNodeCapabilitiesRequest) updateNodeCapabilitiesImplRequest(e de
 }
 
 // UpdateNodeCapabilities updates the capabilities of nodes in the registry
-func UpdateNodeCapabilities(env deployment.Environment, req *UpdateNodeCapabilitiesRequest) (cldf.ChangesetOutput, error) {
+func UpdateNodeCapabilities(env cldf.Environment, req *UpdateNodeCapabilitiesRequest) (cldf.ChangesetOutput, error) {
 	c, capReg, err := req.updateNodeCapabilitiesImplRequest(env)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to convert request: %w", err)

--- a/deployment/keystone/changeset/update_nodes.go
+++ b/deployment/keystone/changeset/update_nodes.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
@@ -36,7 +35,7 @@ type UpdateNodesRequest struct {
 	RegistryRef datastore.AddressRefKey
 }
 
-func (r *UpdateNodesRequest) Validate(e deployment.Environment) error {
+func (r *UpdateNodesRequest) Validate(e cldf.Environment) error {
 	if r.P2pToUpdates == nil {
 		return errors.New("P2pToUpdates must be non-nil")
 	}
@@ -65,7 +64,7 @@ type NodeUpdate = internal.NodeUpdate
 
 // UpdateNodes updates a set of nodes.
 // The nodes and capabilities in the request must already exist in the registry contract.
-func UpdateNodes(env deployment.Environment, req *UpdateNodesRequest) (cldf.ChangesetOutput, error) {
+func UpdateNodes(env cldf.Environment, req *UpdateNodesRequest) (cldf.ChangesetOutput, error) {
 	if err := req.Validate(env); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid request: %w", err)
 	}

--- a/deployment/keystone/changeset/workflowregistry/deploy.go
+++ b/deployment/keystone/changeset/workflowregistry/deploy.go
@@ -8,13 +8,12 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 
 var _ cldf.ChangeSet[uint64] = Deploy
 
-func Deploy(env deployment.Environment, registrySelector uint64) (cldf.ChangesetOutput, error) {
+func Deploy(env cldf.Environment, registrySelector uint64) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
 	chain, ok := env.Chains[registrySelector]
 	if !ok {
@@ -30,7 +29,7 @@ func Deploy(env deployment.Environment, registrySelector uint64) (cldf.Changeset
 	return cldf.ChangesetOutput{AddressBook: ab}, nil
 }
 
-func DeployV2(env deployment.Environment, req *changeset.DeployRequestV2) (cldf.ChangesetOutput, error) {
+func DeployV2(env cldf.Environment, req *changeset.DeployRequestV2) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
 	chain, ok := env.Chains[req.ChainSel]
 	if !ok {

--- a/deployment/keystone/changeset/workflowregistry/setup_test.go
+++ b/deployment/keystone/changeset/workflowregistry/setup_test.go
@@ -10,14 +10,13 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 
 type SetupTestWorkflowRegistryResponse struct {
 	Registry         *workflow_registry.WorkflowRegistry
-	Chain            deployment.Chain
+	Chain            cldf.Chain
 	RegistrySelector uint64
 	AddressBook      cldf.AddressBook
 }
@@ -46,9 +45,9 @@ func SetupTestWorkflowRegistry(t *testing.T, lggr logger.Logger, chainSel uint64
 	}
 }
 
-func testChain(t *testing.T) deployment.Chain {
+func testChain(t *testing.T) cldf.Chain {
 	chains, _ := memory.NewMemoryChains(t, 1, 5)
-	var chain deployment.Chain
+	var chain cldf.Chain
 	for _, c := range chains {
 		chain = c
 		break

--- a/deployment/keystone/changeset/workflowregistry/strategies.go
+++ b/deployment/keystone/changeset/workflowregistry/strategies.go
@@ -12,7 +12,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
@@ -22,7 +21,7 @@ type strategy interface {
 }
 
 type simpleTransaction struct {
-	chain deployment.Chain
+	chain cldf.Chain
 }
 
 func (s *simpleTransaction) Apply(callFn func(opts *bind.TransactOpts) (*types.Transaction, error)) (cldf.ChangesetOutput, error) {
@@ -41,11 +40,11 @@ type mcmsTransaction struct {
 	Address     common.Address
 	ChainSel    uint64
 	ContractSet *changeset.ContractSet
-	Env         deployment.Environment
+	Env         cldf.Environment
 }
 
 func (m *mcmsTransaction) Apply(callFn func(opts *bind.TransactOpts) (*types.Transaction, error)) (cldf.ChangesetOutput, error) {
-	opts := deployment.SimTransactOpts()
+	opts := cldf.SimTransactOpts()
 
 	tx, err := callFn(opts)
 	if err != nil {

--- a/deployment/keystone/changeset/workflowregistry/update_allowed_dons.go
+++ b/deployment/keystone/changeset/workflowregistry/update_allowed_dons.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
 
 	workflow_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper"
 
@@ -33,7 +32,7 @@ func (r *UpdateAllowedDonsRequest) Validate() error {
 }
 
 // UpdateAllowedDons updates the list of DONs that workflows can be sent to.
-func UpdateAllowedDons(env deployment.Environment, req *UpdateAllowedDonsRequest) (cldf.ChangesetOutput, error) {
+func UpdateAllowedDons(env cldf.Environment, req *UpdateAllowedDonsRequest) (cldf.ChangesetOutput, error) {
 	if err := req.Validate(); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -76,7 +75,7 @@ func UpdateAllowedDons(env deployment.Environment, req *UpdateAllowedDonsRequest
 	return s.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		tx, err := registry.UpdateAllowedDONs(opts, req.DonIDs, req.Allowed)
 		if err != nil {
-			err = deployment.DecodeErr(workflow_registry.WorkflowRegistryABI, err)
+			err = cldf.DecodeErr(workflow_registry.WorkflowRegistryABI, err)
 		}
 		return tx, err
 	})

--- a/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
@@ -12,7 +12,7 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -32,9 +32,9 @@ func TestUpdateAllowedDons(t *testing.T) {
 
 	assert.Empty(t, dons)
 
-	env := deployment.Environment{
+	env := cldf.Environment{
 		Logger: lggr,
-		Chains: map[uint64]deployment.Chain{
+		Chains: map[uint64]cldf.Chain{
 			chainSel: resp.Chain,
 		},
 		ExistingAddresses: resp.AddressBook,

--- a/deployment/keystone/changeset/workflowregistry/update_authorized_addresses.go
+++ b/deployment/keystone/changeset/workflowregistry/update_authorized_addresses.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
 
 	workflow_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper"
 
@@ -35,7 +34,7 @@ func (r *UpdateAuthorizedAddressesRequest) Validate() error {
 	return nil
 }
 
-func getWorkflowRegistry(env deployment.Environment, chainSel uint64) (*workflow_registry.WorkflowRegistry, error) {
+func getWorkflowRegistry(env cldf.Environment, chainSel uint64) (*workflow_registry.WorkflowRegistry, error) {
 	resp, err := changeset.GetContractSets(env.Logger, &changeset.GetContractSetsRequest{
 		Chains:      env.Chains,
 		AddressBook: env.ExistingAddresses,
@@ -53,7 +52,7 @@ func getWorkflowRegistry(env deployment.Environment, chainSel uint64) (*workflow
 }
 
 // UpdateAuthorizedAddresses updates the list of DONs that workflows can be sent to.
-func UpdateAuthorizedAddresses(env deployment.Environment, req *UpdateAuthorizedAddressesRequest) (cldf.ChangesetOutput, error) {
+func UpdateAuthorizedAddresses(env cldf.Environment, req *UpdateAuthorizedAddressesRequest) (cldf.ChangesetOutput, error) {
 	if err := req.Validate(); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -101,7 +100,7 @@ func UpdateAuthorizedAddresses(env deployment.Environment, req *UpdateAuthorized
 	return s.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		tx, err := registry.UpdateAuthorizedAddresses(opts, addr, req.Allowed)
 		if err != nil {
-			err = deployment.DecodeErr(workflow_registry.WorkflowRegistryABI, err)
+			err = cldf.DecodeErr(workflow_registry.WorkflowRegistryABI, err)
 		}
 		return tx, err
 	})

--- a/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -33,9 +33,9 @@ func TestUpdateAuthorizedAddresses(t *testing.T) {
 
 	assert.Empty(t, authorizedAddresses)
 
-	env := deployment.Environment{
+	env := cldf.Environment{
 		Logger: lggr,
-		Chains: map[uint64]deployment.Chain{
+		Chains: map[uint64]cldf.Chain{
 			chainSel: resp.Chain,
 		},
 		ExistingAddresses: resp.AddressBook,

--- a/deployment/keystone/changeset/workflowregistry/workflow_registry_deployer.go
+++ b/deployment/keystone/changeset/workflowregistry/workflow_registry_deployer.go
@@ -11,7 +11,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 
@@ -37,7 +36,7 @@ func (c *workflowRegistryDeployer) Deploy(req changeset.DeployRequest) (*changes
 		req.Chain.DeployerKey,
 		req.Chain.Client)
 	if err != nil {
-		return nil, deployment.DecodeErr(workflow_registry.WorkflowRegistryABI, err)
+		return nil, cldf.DecodeErr(workflow_registry.WorkflowRegistryABI, err)
 	}
 
 	_, err = req.Chain.Confirm(tx)
@@ -64,7 +63,7 @@ func (c *workflowRegistryDeployer) Deploy(req changeset.DeployRequest) (*changes
 
 // deployWorkflowRegistry deploys the WorkflowRegistry contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func deployWorkflowRegistry(chain deployment.Chain, ab cldf.AddressBook) (*changeset.DeployResponse, error) {
+func deployWorkflowRegistry(chain cldf.Chain, ab cldf.AddressBook) (*changeset.DeployResponse, error) {
 	deployer, err := newWorkflowRegistryDeployer()
 	resp, err := deployer.Deploy(changeset.DeployRequest{Chain: chain})
 	if err != nil {

--- a/deployment/keystone/test/changeset/capability_registry.go
+++ b/deployment/keystone/test/changeset/capability_registry.go
@@ -6,11 +6,12 @@ import (
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/view/v1_0"
 
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 
@@ -19,7 +20,7 @@ type HydrateConfig struct {
 }
 
 // HydrateCapabilityRegistry deploys a new capabilities registry contract and hydrates it with the provided data.
-func HydrateCapabilityRegistry(t *testing.T, v v1_0.CapabilityRegistryView, env deployment.Environment, cfg HydrateConfig) (*capabilities_registry.CapabilitiesRegistry, error) {
+func HydrateCapabilityRegistry(t *testing.T, v v1_0.CapabilityRegistryView, env cldf.Environment, cfg HydrateConfig) (*capabilities_registry.CapabilitiesRegistry, error) {
 	t.Helper()
 	chainSelector, err := chainsel.SelectorFromChainId(cfg.ChainID)
 	if err != nil {
@@ -50,13 +51,13 @@ func HydrateCapabilityRegistry(t *testing.T, v v1_0.CapabilityRegistryView, env 
 
 	nopsParams := v.NopsToNopsParams()
 	tx, err := deployedContract.AddNodeOperators(chain.DeployerKey, nopsParams)
-	if _, err = deployment.ConfirmIfNoError(chain, tx, deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)); err != nil {
+	if _, err = cldf.ConfirmIfNoError(chain, tx, cldf.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)); err != nil {
 		return nil, fmt.Errorf("failed to add node operators: %w", err)
 	}
 
 	capabilitiesParams := v.CapabilitiesToCapabilitiesParams()
 	tx, err = deployedContract.AddCapabilities(chain.DeployerKey, capabilitiesParams)
-	if _, err = deployment.ConfirmIfNoError(chain, tx, deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)); err != nil {
+	if _, err = cldf.ConfirmIfNoError(chain, tx, cldf.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)); err != nil {
 		return nil, fmt.Errorf("failed to add capabilities: %w", err)
 	}
 
@@ -65,7 +66,7 @@ func HydrateCapabilityRegistry(t *testing.T, v v1_0.CapabilityRegistryView, env 
 		return nil, fmt.Errorf("failed to convert nodes to nodes params: %w", err)
 	}
 	tx, err = deployedContract.AddNodes(chain.DeployerKey, nodesParams)
-	if _, err = deployment.ConfirmIfNoError(chain, tx, deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)); err != nil {
+	if _, err = cldf.ConfirmIfNoError(chain, tx, cldf.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)); err != nil {
 		return nil, fmt.Errorf("failed to add nodes: %w", err)
 	}
 
@@ -79,7 +80,7 @@ func HydrateCapabilityRegistry(t *testing.T, v v1_0.CapabilityRegistryView, env 
 			peerIds = append(peerIds, id)
 		}
 		tx, err = deployedContract.AddDON(chain.DeployerKey, peerIds, cfgs, don.IsPublic, don.AcceptsWorkflows, don.F)
-		if _, err = deployment.ConfirmIfNoError(chain, tx, deployment.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)); err != nil {
+		if _, err = cldf.ConfirmIfNoError(chain, tx, cldf.DecodeErr(capabilities_registry.CapabilitiesRegistryABI, err)); err != nil {
 			return nil, fmt.Errorf("failed to add don: %w", err)
 		}
 	}

--- a/integration-tests/load/ccip/ccip_test.go
+++ b/integration-tests/load/ccip/ccip_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	"github.com/smartcontractkit/chainlink/integration-tests/testconfig/ccip"
 
@@ -20,8 +22,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-testing-framework/wasp"
-
-	"github.com/smartcontractkit/chainlink/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/crib"
 	tc "github.com/smartcontractkit/chainlink/integration-tests/testconfig"
@@ -278,7 +278,7 @@ func TestCCIPLoad_RPS(t *testing.T) {
 func prepareAccountToSendLink(
 	t *testing.T,
 	state stateview.CCIPOnChainState,
-	e deployment.Environment,
+	e cldf.Environment,
 	src uint64,
 	srcAccount *bind.TransactOpts) error {
 	lggr := logger.Test(t)
@@ -288,7 +288,7 @@ func prepareAccountToSendLink(
 
 	lggr.Infow("Granting mint and burn roles")
 	tx, err := srcLink.GrantMintAndBurnRoles(srcDeployer, srcAccount.From)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
 	if err != nil {
 		return err
 	}
@@ -300,7 +300,7 @@ func prepareAccountToSendLink(
 		srcAccount.From,
 		big.NewInt(20_000),
 	)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
 	if err != nil {
 		return err
 	}
@@ -310,6 +310,6 @@ func prepareAccountToSendLink(
 	// Approve the router to spend the tokens and confirm the tx's
 	// To prevent having to approve the router for every transfer, we approve a sufficiently large amount
 	tx, err = srcLink.Approve(srcAccount, state.Chains[src].Router.Address(), math.MaxBig256)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
 	return err
 }

--- a/integration-tests/load/ccip/destination_gun.go
+++ b/integration-tests/load/ccip/destination_gun.go
@@ -31,7 +31,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	"github.com/smartcontractkit/chainlink/integration-tests/testconfig/ccip"
 )
@@ -43,7 +44,7 @@ type SeqNumRange struct {
 
 type DestinationGun struct {
 	l                logger.Logger
-	env              deployment.Environment
+	env              cldf.Environment
 	state            *stateview.CCIPOnChainState
 	roundNum         *atomic.Int32
 	chainSelector    uint64
@@ -58,7 +59,7 @@ type DestinationGun struct {
 func NewDestinationGun(
 	l logger.Logger,
 	chainSelector uint64,
-	env deployment.Environment,
+	env cldf.Environment,
 	state *stateview.CCIPOnChainState,
 	receiver common.Address,
 	overrides *ccip.LoadConfig,
@@ -107,7 +108,7 @@ func (m *DestinationGun) Call(_ *wasp.Generator) *wasp.Response {
 		m.l.Errorw("Failed to transmit message",
 			"gun", waspGroup,
 			"sourceChainFamily", selectorFamily,
-			err, deployment.MaybeDataErr(err))
+			err, cldf.MaybeDataErr(err))
 		if m.metricPipe != nil {
 			// in the event of an error, still push a metric
 			// sequence numbers start at 1 so using 0 as a sentinel value
@@ -160,7 +161,7 @@ func (m *DestinationGun) sendEVMMessage(src uint64) error {
 		m.l.Errorw("could not get fee ",
 			"dstChainSelector", m.chainSelector,
 			"fee", fee,
-			"err", deployment.MaybeDataErr(err))
+			"err", cldf.MaybeDataErr(err))
 		return err
 	}
 	if msg.FeeToken == common.HexToAddress("0x0") {
@@ -182,13 +183,13 @@ func (m *DestinationGun) sendEVMMessage(src uint64) error {
 		m.l.Errorw("execution reverted from ",
 			"sourceChain", src,
 			"destchain", m.chainSelector,
-			"err", deployment.MaybeDataErr(err))
+			"err", cldf.MaybeDataErr(err))
 		return err
 	}
 
 	_, err = m.env.Chains[src].Confirm(tx)
 	if err != nil {
-		m.l.Errorw("could not confirm tx on source", "tx", tx, "err", deployment.MaybeDataErr(err))
+		m.l.Errorw("could not confirm tx on source", "tx", tx, "err", cldf.MaybeDataErr(err))
 		return err
 	}
 
@@ -366,7 +367,7 @@ func (m *DestinationGun) sendSolanaMessage(src uint64) error {
 		m.l.Errorw("failed to build instruction",
 			"src", src,
 			"dest", m.chainSelector,
-			"err", deployment.MaybeDataErr(err))
+			"err", cldf.MaybeDataErr(err))
 		return err
 	}
 

--- a/integration-tests/load/ccip/helpers.go
+++ b/integration-tests/load/ccip/helpers.go
@@ -28,6 +28,9 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/nonce_manager"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/environment/crib"
@@ -58,7 +61,7 @@ func subscribeTransmitEvents(
 	startBlock *uint64,
 	srcChainSel uint64,
 	loadFinished chan struct{},
-	client deployment.OnchainClient,
+	client cldf.OnchainClient,
 	wg *sync.WaitGroup,
 	metricPipe chan messageData,
 	finalSeqNrCommitChannels map[uint64]chan finalSeqNrReport,
@@ -168,7 +171,7 @@ func subscribeCommitEvents(
 	srcChains []uint64,
 	startBlock *uint64,
 	chainSelector uint64,
-	client deployment.OnchainClient,
+	client cldf.OnchainClient,
 	finalSeqNrs chan finalSeqNrReport,
 	wg *sync.WaitGroup,
 	metricPipe chan messageData,
@@ -297,7 +300,7 @@ func subscribeExecutionEvents(
 	srcChains []uint64,
 	startBlock *uint64,
 	chainSelector uint64,
-	client deployment.OnchainClient,
+	client cldf.OnchainClient,
 	finalSeqNrs chan finalSeqNrReport,
 	wg *sync.WaitGroup,
 	metricPipe chan messageData,
@@ -479,7 +482,7 @@ func subscribeSkippedIncorrectNonce(
 }
 
 // fundAdditionalKeys will create len(targetChains) new addresses, and send funds to them on every targetChain
-func fundAdditionalKeys(lggr logger.Logger, e deployment.Environment, destChains []uint64) (map[uint64][]*bind.TransactOpts, error) {
+func fundAdditionalKeys(lggr logger.Logger, e cldf.Environment, destChains []uint64) (map[uint64][]*bind.TransactOpts, error) {
 	deployerMap := make(map[uint64][]*bind.TransactOpts)
 	addressMap := make(map[uint64][]common.Address)
 	numAccounts := len(destChains)
@@ -522,8 +525,8 @@ func fundAdditionalKeys(lggr logger.Logger, e deployment.Environment, destChains
 	}
 	return deployerMap, nil
 }
-func reclaimFunds(lggr logger.Logger, e deployment.Environment, addressesByChain map[uint64][]*bind.TransactOpts, returnAddress common.Address) error {
-	removeFundsFromAccounts := func(ctx context.Context, lggr logger.Logger, chain deployment.Chain, addresses []*bind.TransactOpts, returnAddress common.Address, sel uint64) error {
+func reclaimFunds(lggr logger.Logger, e cldf.Environment, addressesByChain map[uint64][]*bind.TransactOpts, returnAddress common.Address) error {
+	removeFundsFromAccounts := func(ctx context.Context, lggr logger.Logger, chain cldf.Chain, addresses []*bind.TransactOpts, returnAddress common.Address, sel uint64) error {
 		for _, deployer := range addresses {
 			balance, err := chain.Client.BalanceAt(ctx, deployer.From, nil)
 			if err != nil {

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250513174048-af3e6b6d21fb
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250513174048-af3e6b6d21fb
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250513180746-113c305fde94
+	github.com/smartcontractkit/chainlink-deployments-framework v0.0.15-0.20250508081139-ee24199564bd
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250512171455-818eb49fe8ee
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.4
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5
@@ -440,7 +441,6 @@ require (
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250414155853-651b4e583ee9 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 // indirect
-	github.com/smartcontractkit/chainlink-deployments-framework v0.0.15-0.20250508081139-ee24199564bd // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250509160340-4f4a9265e657 // indirect
 	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20250502210357-2df484128afa // indirect

--- a/integration-tests/smoke/ccip/ccip_batching_test.go
+++ b/integration-tests/smoke/ccip/ccip_batching_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
@@ -24,7 +26,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/multicall3"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 )
 
@@ -459,7 +460,7 @@ func sendMessagesAsync(
 func sendMessages(
 	ctx context.Context,
 	t *testing.T,
-	sourceChain deployment.Chain,
+	sourceChain cldf.Chain,
 	sourceTransactOpts *bind.TransactOpts,
 	sourceOnRamp onramp.OnRampInterface,
 	sourceRouter *router.Router,
@@ -494,7 +495,7 @@ func sendMessages(
 		},
 		calls,
 	)
-	_, err = deployment.ConfirmIfNoError(sourceChain, tx, err)
+	_, err = cldf.ConfirmIfNoError(sourceChain, tx, err)
 	if err != nil {
 		return fmt.Errorf("send messages via multicall3: %w", err)
 	}

--- a/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
@@ -327,7 +327,7 @@ func updateRMNConfig(t *testing.T, tc updateRMNConfigTestCase) {
 	}
 }
 
-func buildRMNRemoteAddressPerChain(e deployment.Environment, state stateview.CCIPOnChainState) map[uint64]common.Address {
+func buildRMNRemoteAddressPerChain(e cldf.Environment, state stateview.CCIPOnChainState) map[uint64]common.Address {
 	rmnRemotePerChain := v1_6.BuildRMNRemotePerChain(e, state)
 	rmnRemoteAddressPerChain := make(map[uint64]common.Address)
 	for chain, remote := range rmnRemotePerChain {

--- a/integration-tests/smoke/ccip/ccip_fees_test.go
+++ b/integration-tests/smoke/ccip/ccip_fees_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/feestest"
@@ -41,27 +43,27 @@ func setupNewFeeToken(
 		tokenDecimals,
 		big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 	)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 	lggr.Infow("Deployed new fee token", "tokenAddress", tokenAddress)
 
 	// grant mint role
 	tx, err = token.GrantMintRole(deployer, deployer.From)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	// mint token and approve to router
 	tx, err = token.Mint(deployer, deployer.From, deployment.E18Mult(10_000))
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	tx, err = token.Approve(deployer, state.Chains[chainSelector].Router.Address(), math.MaxBig256)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
 	// add this new fee token to fee quoter
 	tx, err = state.Chains[chain.Selector].FeeQuoter.ApplyFeeTokensUpdates(deployer, []common.Address{}, []common.Address{tokenAddress})
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 	lggr.Infow("Added new fee token to fee quoter", "tokenAddress", tokenAddress)
 
@@ -78,7 +80,7 @@ func setupNewFeeToken(
 			GasPriceUpdates: []fee_quoter.InternalGasPriceUpdate{},
 		},
 	)
-	_, err = deployment.ConfirmIfNoError(chain, tx, err)
+	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 	lggr.Infow("Set price for new fee token", "tokenAddress", tokenAddress)
 
@@ -122,7 +124,7 @@ func setupTokens(
 		e.Chains[src].DeployerKey.From,
 		transferTokenMintAmount,
 	)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
 	require.NoError(t, err)
 
 	// Mint a destination token
@@ -131,23 +133,23 @@ func setupTokens(
 		e.Chains[dest].DeployerKey.From,
 		transferTokenMintAmount,
 	)
-	_, err = deployment.ConfirmIfNoError(e.Chains[dest], tx, err)
+	_, err = cldf.ConfirmIfNoError(e.Chains[dest], tx, err)
 	require.NoError(t, err)
 
 	// Approve the router to spend the tokens and confirm the tx's
 	// To prevent having to approve the router for every transfer, we approve a sufficiently large amount
 	tx, err = srcToken.Approve(e.Chains[src].DeployerKey, state.Chains[src].Router.Address(), math.MaxBig256)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
 	require.NoError(t, err)
 
 	tx, err = dstToken.Approve(e.Chains[dest].DeployerKey, state.Chains[dest].Router.Address(), math.MaxBig256)
-	_, err = deployment.ConfirmIfNoError(e.Chains[dest], tx, err)
+	_, err = cldf.ConfirmIfNoError(e.Chains[dest], tx, err)
 	require.NoError(t, err)
 
 	// Grant mint and burn roles to the deployer key for the newly deployed linkToken
 	// Since those roles are not granted automatically
 	tx, err = linkToken.GrantMintAndBurnRoles(e.Chains[src].DeployerKey, e.Chains[src].DeployerKey.From)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
 	require.NoError(t, err)
 
 	// Mint link token and confirm the tx
@@ -156,7 +158,7 @@ func setupTokens(
 		e.Chains[src].DeployerKey.From,
 		feeTokenMintAmount,
 	)
-	_, err = deployment.ConfirmIfNoError(e.Chains[src], tx, err)
+	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
 	require.NoError(t, err)
 
 	return srcToken, dstToken

--- a/integration-tests/smoke/ccip/ccip_ooo_execution_test.go
+++ b/integration-tests/smoke/ccip/ccip_ooo_execution_test.go
@@ -17,7 +17,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
@@ -267,7 +268,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 func pickFirstAvailableUser(
 	tenv testhelpers.DeployedEnv,
 	sourceChain uint64,
-	e deployment.Environment,
+	e cldf.Environment,
 ) (*bind.TransactOpts, error) {
 	for _, user := range tenv.Users[sourceChain] {
 		if user == nil {

--- a/integration-tests/smoke/ccip/ccip_reorg_test.go
+++ b/integration-tests/smoke/ccip/ccip_reorg_test.go
@@ -27,6 +27,8 @@ import (
 	ctf_client "github.com/smartcontractkit/chainlink-testing-framework/lib/client"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/logging"
 
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -378,7 +380,7 @@ func getHeadTrackerService(t *testing.T, chainSelector uint64) string {
 // Send CCIP message helper
 func sendCCIPMessage(
 	t *testing.T,
-	env deployment.Environment,
+	env cldf.Environment,
 	state stateview.CCIPOnChainState,
 	sourceSelector, destSelector uint64,
 	l logging.Logger,

--- a/integration-tests/smoke/ccip/ccip_token_price_updates_test.go
+++ b/integration-tests/smoke/ccip/ccip_token_price_updates_test.go
@@ -21,7 +21,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -93,7 +92,7 @@ func Test_CCIPTokenPriceUpdates(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = deployment.ConfirmIfNoError(e.Env.Chains[sourceChain1], tx, err)
+		_, err = cldf.ConfirmIfNoError(e.Env.Chains[sourceChain1], tx, err)
 		require.NoError(t, err)
 		t.Logf("manually editing token prices")
 

--- a/integration-tests/smoke/ccip/ccip_usdc_test.go
+++ b/integration-tests/smoke/ccip/ccip_usdc_test.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
@@ -239,7 +240,7 @@ func TestUSDCTokenTransfer(t *testing.T) {
 func updateFeeQuoters(
 	t *testing.T,
 	lggr logger.Logger,
-	e deployment.Environment,
+	e cldf.Environment,
 	state stateview.CCIPOnChainState,
 	chainA, chainB, chainC uint64,
 	aChainUSDC, bChainUSDC, cChainUSDC *burn_mint_erc677.BurnMintERC677,

--- a/integration-tests/testconfig/ccip/chaos.go
+++ b/integration-tests/testconfig/ccip/chaos.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ type ChaosConfig struct {
 	ExperimentInjectionInterval string
 }
 
-func (l *ChaosConfig) Validate(t *testing.T, e *deployment.Environment) {
+func (l *ChaosConfig) Validate(t *testing.T, e *cldf.Environment) {
 	require.NotEmpty(t, l.Namespace, "k8s namespace can't be empty")
 	require.NotEmpty(t, l.DashboardUIDs, "dashboard UIDs can't be empty")
 	require.NotEmpty(t, l.ExperimentFullInterval, "experiment full interval can't be null, use Go time format 1h2m3s")

--- a/integration-tests/testconfig/ccip/load.go
+++ b/integration-tests/testconfig/ccip/load.go
@@ -3,13 +3,12 @@ package ccip
 import (
 	"errors"
 	"fmt"
-
 	"testing"
 	"time"
 
 	"github.com/AlekSi/pointer"
 
-	"github.com/smartcontractkit/chainlink/deployment"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +40,7 @@ const (
 	ChaosModeTypeFull
 )
 
-func (l *LoadConfig) Validate(t *testing.T, e *deployment.Environment) {
+func (l *LoadConfig) Validate(t *testing.T, e *cldf.Environment) {
 	_, err := time.ParseDuration(*l.LoadDuration)
 	require.NoError(t, err, "LoadDuration must be a valid duration")
 

--- a/system-tests/lib/cre/devenv/devenv.go
+++ b/system-tests/lib/cre/devenv/devenv.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 
@@ -28,7 +28,7 @@ func BuildFullCLDEnvironment(lgr logger.Logger, input *types.FullCLDEnvironmentI
 		return nil, errors.Wrap(err, "input validation failed")
 	}
 
-	envs := make([]*deployment.Environment, len(input.NodeSetOutput))
+	envs := make([]*cldf.Environment, len(input.NodeSetOutput))
 	dons := make([]*devenv.DON, len(input.NodeSetOutput))
 
 	var allNodesInfo []devenv.NodeInfo
@@ -143,7 +143,7 @@ func BuildFullCLDEnvironment(lgr logger.Logger, input *types.FullCLDEnvironmentI
 
 	// we assume that all DONs run on the same chain and that there's only one chain
 	output := &types.FullCLDEnvironmentOutput{
-		Environment: &deployment.Environment{
+		Environment: &cldf.Environment{
 			Name:              envs[0].Name,
 			Logger:            envs[0].Logger,
 			ExistingAddresses: input.ExistingAddresses,

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -24,7 +24,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	workflow_registry_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/workflowregistry"
@@ -66,7 +65,7 @@ const (
 
 type SetupOutput struct {
 	WorkflowRegistryConfigurationOutput *keystonetypes.WorkflowRegistryOutput
-	CldEnvironment                      *deployment.Environment
+	CldEnvironment                      *cldf.Environment
 	BlockchainOutput                    []*BlockchainOutput
 	DonTopology                         *keystonetypes.DonTopology
 	NodeOutput                          []*keystonetypes.WrappedNodeOutput
@@ -155,7 +154,7 @@ func SetupTestEnvironment(
 		return nil, pkgerrors.Wrap(allChainsErr, "failed to create chains")
 	}
 
-	allChainsCLDEnvironment := &deployment.Environment{
+	allChainsCLDEnvironment := &cldf.Environment{
 		Logger:            singeFileLogger,
 		Chains:            allChains,
 		ExistingAddresses: cldf.NewMemoryAddressBook(),

--- a/system-tests/lib/cre/types/keystone.go
+++ b/system-tests/lib/cre/types/keystone.go
@@ -11,7 +11,6 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/nix"
@@ -44,7 +43,7 @@ type NodeIndexToSecretsOverride = map[int]string
 
 type WorkflowRegistryInput struct {
 	ChainSelector  uint64                  `toml:"-"`
-	CldEnv         *deployment.Environment `toml:"-"`
+	CldEnv         *cldf.Environment       `toml:"-"`
 	AllowedDonIDs  []uint32                `toml:"-"`
 	WorkflowOwners []common.Address        `toml:"-"`
 	Out            *WorkflowRegistryOutput `toml:"out"`
@@ -86,7 +85,7 @@ type ConfigureDataFeedsCacheOutput struct {
 }
 
 type ConfigureDataFeedsCacheInput struct {
-	CldEnv                *deployment.Environment        `toml:"-"`
+	CldEnv                *cldf.Environment              `toml:"-"`
 	ChainSelector         uint64                         `toml:"-"`
 	FeedIDs               []string                       `toml:"-"`
 	Descriptions          []string                       `toml:"-"`
@@ -138,7 +137,7 @@ type WrappedNodeOutput struct {
 }
 
 type CreateJobsInput struct {
-	CldEnv        *deployment.Environment
+	CldEnv        *cldf.Environment
 	DonTopology   *DonTopology
 	DonToJobSpecs DonsToJobSpecs
 }
@@ -203,7 +202,7 @@ func (d *DebugInput) Validate() error {
 type ConfigureKeystoneInput struct {
 	ChainSelector uint64
 	Topology      *Topology
-	CldEnv        *deployment.Environment
+	CldEnv        *cldf.Environment
 	OCR3Config    keystone_changeset.OracleConfig
 }
 
@@ -458,7 +457,7 @@ func (f *FullCLDEnvironmentInput) Validate() error {
 }
 
 type FullCLDEnvironmentOutput struct {
-	Environment *deployment.Environment
+	Environment *cldf.Environment
 	DonTopology *DonTopology
 }
 
@@ -548,7 +547,7 @@ type CapabilitiesBinaryPathFactoryFn = func(donMetadata *DonMetadata) ([]string,
 type JobSpecFactoryFn = func(input *JobSpecFactoryInput) (DonsToJobSpecs, error)
 
 type JobSpecFactoryInput struct {
-	CldEnvironment   *deployment.Environment
+	CldEnvironment   *cldf.Environment
 	BlockchainOutput *blockchain.Output
 	DonTopology      *DonTopology
 	AddressBook      cldf.AddressBook

--- a/system-tests/tests/smoke/cre/por_test.go
+++ b/system-tests/tests/smoke/cre/por_test.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
-	"github.com/smartcontractkit/chainlink/deployment"
 	cldlogger "github.com/smartcontractkit/chainlink/deployment/logger"
 	corevm "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 
@@ -241,7 +240,7 @@ type registerPoRWorkflowInput struct {
 type configureDataFeedsCacheInput struct {
 	useCRECLI          bool
 	chainSelector      uint64
-	fullCldEnvironment *deployment.Environment
+	fullCldEnvironment *cldf.Environment
 	workflowName       string
 	feedID             string
 	sethClient         *seth.Client


### PR DESCRIPTION
Remove type alias in migrated_environment.go now that dependent repository like CLD are migrated off from using the alias

- removed [migrated_environment.go
](https://github.com/smartcontractkit/chainlink/blob/develop/deployment/migrated_environment.go)

Due to an issue documented [here](https://github.com/golang/go/issues/69179), this occurs when adding a new import for chainlink-deployments-framework/deployments, i need to set the goindex=0 for godebug. There was a line setting it already but it didn not apply correctly. Found some historical PR related to this - [here](https://github.com/smartcontractkit/chainlink/pull/16393) and [here](https://github.com/smartcontractkit/chainlink/pull/16362)

Slack thread: https://chainlink-core.slack.com/archives/C0117GGJB6Y/p1747107991420549

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-215

**Lint issues are expected as i touched a range of files and those are existing lint issues that were picked up, i am ignoring them using `allow-lint-issues`**


