### PR TITLE
remove default value of ConsensusAllowedPartialStaleness

### DIFF
--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
@@ -76,11 +76,6 @@ func proposeWFJobsToJDLogic(env deployment.Environment, c types.ProposeWFJobsCon
 		targetSchedule = "oneAtATime"
 	}
 
-	consensusPartialStaleness := workflowSpecConfig.ConsensusAllowedPartialStaleness
-	if consensusPartialStaleness == "" {
-		consensusPartialStaleness = "0.5"
-	}
-
 	// create the workflow YAML spec
 	workflowSpec, err := offchain.CreateWorkflowSpec(
 		feedState.Feeds,
@@ -91,7 +86,7 @@ func proposeWFJobsToJDLogic(env deployment.Environment, c types.ProposeWFJobsCon
 		workflowSpecConfig.ConsensusReportID,
 		workflowSpecConfig.ConsensusAggregationMethod,
 		consensusConfigKeyID,
-		consensusPartialStaleness,
+		workflowSpecConfig.ConsensusAllowedPartialStaleness,
 		consensusEncoderAbi,
 		deltaStageSec,
 		workflowSpecConfig.WriteTargetTrigger,

--- a/deployment/data-feeds/changeset/types/types.go
+++ b/deployment/data-feeds/changeset/types/types.go
@@ -167,7 +167,7 @@ type WorkflowSpecConfig struct {
 	WriteTargetTrigger               string // Required
 	ConsensusRef                     string // Default "data-feeds"
 	ConsensusConfigKeyID             string // Default "evm"
-	ConsensusAllowedPartialStaleness string // Default "0.5"
+	ConsensusAllowedPartialStaleness string
 	DeltaStageSec                    *int   // Default 45
 	TargetsSchedule                  string // Default "oneAtATime"
 	TriggersMaxFrequencyMs           *int   // Default 5000


### PR DESCRIPTION
Removed default value of ConsensusAllowedPartialStaleness workflow spec option when generating a workflow spec