### PR TITLE
fix(changeset): move duplicated run changeset code to common changese…

### DIFF
--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -316,7 +316,7 @@ func addCandidatesForNewChainLogic(e deployment.Environment, c AddCandidatesForN
 	}
 
 	if c.DonIDOffSet != nil {
-		_, err = deployment.RunChangeset(DonIDClaimerOffSetChangeset, e, DonIDClaimerOffSetConfig{
+		_, err = commoncs.RunChangeset(DonIDClaimerOffSetChangeset, e, DonIDClaimerOffSetConfig{
 			OffSet: *c.DonIDOffSet,
 		})
 

--- a/deployment/common/changeset/run_changeset.go
+++ b/deployment/common/changeset/run_changeset.go
@@ -1,4 +1,4 @@
-package deployment
+package changeset
 
 import (
 	"fmt"

--- a/deployment/data-feeds/changeset/new_feed_with_proxy.go
+++ b/deployment/data-feeds/changeset/new_feed_with_proxy.go
@@ -52,7 +52,7 @@ func newFeedWithProxyLogic(env deployment.Environment, c types.NewFeedWithProxyC
 			AccessController: []common.Address{c.AccessController},
 			Labels:           append([]string{c.Descriptions[index]}, c.Labels...),
 		}
-		newEnv, err := RunChangeset(DeployAggregatorProxyChangeset, env, proxyConfig)
+		newEnv, err := changeset.RunChangeset(DeployAggregatorProxyChangeset, env, proxyConfig)
 
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute DeployAggregatorProxyChangeset: %w", err)

--- a/deployment/data-feeds/changeset/utils.go
+++ b/deployment/data-feeds/changeset/utils.go
@@ -106,24 +106,3 @@ func GetDataFeedsCacheAddress(ab cldf.AddressBook, chainSelector uint64, label *
 
 	return dataFeedsCacheAddress
 }
-
-type WrappedChangeSet[C any] struct {
-	operation cldf.ChangeSetV2[C]
-}
-
-// RunChangeset is used to run a changeset in another changeset
-// It executes VerifyPreconditions internally to handle changeset errors.
-func RunChangeset[C any](
-	operation cldf.ChangeSetV2[C],
-	env deployment.Environment,
-	config C,
-) (cldf.ChangesetOutput, error) {
-	cs := WrappedChangeSet[C]{operation: operation}
-
-	err := cs.operation.VerifyPreconditions(env, config)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run precondition: %w", err)
-	}
-
-	return cs.operation.Apply(env, config)
-}

--- a/system-tests/lib/cre/contracts/contracts.go
+++ b/system-tests/lib/cre/contracts/contracts.go
@@ -15,6 +15,7 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	df_changeset "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	df_changeset_types "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -422,7 +423,7 @@ func ConfigureDataFeedsCache(testLogger zerolog.Logger, input *types.ConfigureDa
 			AdminAddress:  input.AdminAddress,
 			IsAdmin:       true,
 		}
-		_, setAdminErr := df_changeset.RunChangeset(df_changeset.SetFeedAdminChangeset, *input.CldEnv, setAdminConfig)
+		_, setAdminErr := changeset.RunChangeset(df_changeset.SetFeedAdminChangeset, *input.CldEnv, setAdminConfig)
 		if setAdminErr != nil {
 			return nil, errors.Wrap(setAdminErr, "failed to set feed admin")
 		}
@@ -442,7 +443,7 @@ func ConfigureDataFeedsCache(testLogger zerolog.Logger, input *types.ConfigureDa
 		feeIDs = append(feeIDs, feedID[:32])
 	}
 
-	_, setFeedConfigErr := df_changeset.RunChangeset(df_changeset.SetFeedConfigChangeset, *input.CldEnv, df_changeset_types.SetFeedDecimalConfig{
+	_, setFeedConfigErr := changeset.RunChangeset(df_changeset.SetFeedConfigChangeset, *input.CldEnv, df_changeset_types.SetFeedDecimalConfig{
 		ChainSelector:    input.ChainSelector,
 		CacheAddress:     input.DataFeedsCacheAddress,
 		DataIDs:          feeIDs,

--- a/system-tests/tests/smoke/cre/por_test.go
+++ b/system-tests/tests/smoke/cre/por_test.go
@@ -20,6 +20,7 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
+	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	df_changeset "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	df_changeset_types "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -545,7 +546,7 @@ func setupPoRTestEnvironment(
 			Labels:         []string{"data-feeds"}, // label required by the changeset
 		}
 
-		dfOutput, dfErr := df_changeset.RunChangeset(df_changeset.DeployCacheChangeset, *universalSetupOutput.CldEnvironment, deployConfig)
+		dfOutput, dfErr := changeset.RunChangeset(df_changeset.DeployCacheChangeset, *universalSetupOutput.CldEnvironment, deployConfig)
 		require.NoError(t, dfErr, "failed to deploy data feed cache contract")
 
 		mergeErr := universalSetupOutput.CldEnvironment.ExistingAddresses.Merge(dfOutput.AddressBook) //nolint:staticcheck // won't migrate now


### PR DESCRIPTION
This pull request refactors the `RunChangeset` function by relocating it to a new `common/changeset` package and updating all references across the codebase. It also removes the original implementation of `RunChangeset` from `data-feeds/changeset/utils.go`. Below is a summary of the most important changes:

### Refactoring and Code Relocation:

* Moved the `RunChangeset` function to the new `common/changeset` package (`deployment/common/changeset/run_changeset.go`) and updated its package declaration accordingly. The file was renamed from `deployment/migrated_changeset.go`.
* Removed the original implementation of `RunChangeset` and its associated `WrappedChangeSet` type from `data-feeds/changeset/utils.go`, as it is now handled in the `common/changeset` package.

### Updates to References:

* Updated all calls to `RunChangeset` to use the new `common/changeset` package. Examples include:
  - Modified `addCandidatesForNewChainLogic` to use `commoncs.RunChangeset` in `deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go`.
  - Updated `newFeedWithProxyLogic` to use `changeset.RunChangeset` in `deployment/data-feeds/changeset/new_feed_with_proxy.go`.
  - Adjusted `ConfigureDataFeedsCache` to use `changeset.RunChangeset` for multiple calls in `system-tests/lib/cre/contracts/contracts.go`. [[1]](diffhunk://#diff-febbfdc86aa400a79f61d8c941b49fce89d69e3eb00577a3c385fd46d3678ea7L425-R426) [[2]](diffhunk://#diff-febbfdc86aa400a79f61d8c941b49fce89d69e3eb00577a3c385fd46d3678ea7L445-R446)
  - Updated `setupPoRTestEnvironment` to use `changeset.RunChangeset` in `system-tests/tests/smoke/cre/por_test.go`.

### Import Adjustments:

* Added imports for the new `common/changeset` package in all affected files, such as `system-tests/lib/cre/contracts/contracts.go` and `system-tests/tests/smoke/cre/por_test.go`. [[1]](diffhunk://#diff-febbfdc86aa400a79f61d8c941b49fce89d69e3eb00577a3c385fd46d3678ea7R18) [[2]](diffhunk://#diff-f6d05677eaf0179c8a8937b80d5ce1b455f8a6564965d4549a8865dbbb36f08dR23)


https://smartcontract-it.atlassian.net/browse/CLD-241