### PR TITLE
chore: remove legacy SetConfigMCMS changeset

### DIFF
--- a/deployment/common/changeset/set_config_mcms.go
+++ b/deployment/common/changeset/set_config_mcms.go
@@ -6,35 +6,22 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	solanasdk "github.com/gagliardetto/solana-go"
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/config"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/mcms"
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	mcmslib "github.com/smartcontractkit/mcms"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonState "github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 )
-
-// Deprecated: use ConfigPerRoleV2 instead
-type ConfigPerRole struct {
-	Proposer  config.Config
-	Canceller config.Config
-	Bypasser  config.Config
-}
 
 type ConfigPerRoleV2 struct {
 	Proposer  mcmstypes.Config
@@ -42,57 +29,12 @@ type ConfigPerRoleV2 struct {
 	Bypasser  mcmstypes.Config
 }
 
-type MCMSConfig struct {
-	ConfigsPerChain map[uint64]ConfigPerRole
-	ProposalConfig  *proposalutils.TimelockConfig
-}
-
 type MCMSConfigV2 struct {
 	ConfigsPerChain map[uint64]ConfigPerRoleV2
 	ProposalConfig  *proposalutils.TimelockConfig
 }
 
-var _ cldf.ChangeSet[MCMSConfig] = SetConfigMCMS
 var _ cldf.ChangeSet[MCMSConfigV2] = SetConfigMCMSV2
-
-// Validate checks that the MCMSConfig is valid
-func (cfg MCMSConfig) Validate(e deployment.Environment, selectors []uint64) error {
-	if len(cfg.ConfigsPerChain) == 0 {
-		return errors.New("no chain configs provided")
-	}
-	// configs should have at least one chain
-	state, err := MaybeLoadMCMSWithTimelockState(e, selectors)
-	if err != nil {
-		return err
-	}
-	for chainSelector, c := range cfg.ConfigsPerChain {
-		family, err := chain_selectors.GetSelectorFamily(chainSelector)
-		if err != nil {
-			return err
-		}
-		if family != chain_selectors.FamilyEVM {
-			return fmt.Errorf("chain selector: %d is not an ethereum chain", chainSelector)
-		}
-		_, ok := e.Chains[chainSelector]
-		if !ok {
-			return fmt.Errorf("chain selector: %d not found in environment", chainSelector)
-		}
-		_, ok = state[chainSelector]
-		if !ok {
-			return fmt.Errorf("chain selector: %d not found for MCMS state", chainSelector)
-		}
-		if err := c.Proposer.Validate(); err != nil {
-			return err
-		}
-		if err := c.Canceller.Validate(); err != nil {
-			return err
-		}
-		if err := c.Bypasser.Validate(); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 // Validate checks that the MCMSConfigV2 is valid
 func (cfg MCMSConfigV2) Validate(e deployment.Environment, selectors []uint64) error {
@@ -151,29 +93,6 @@ func (cfg MCMSConfigV2) Validate(e deployment.Environment, selectors []uint64) e
 	return nil
 }
 
-// setConfigOrTxData executes set config tx or gets the tx data for the MCMS proposal
-// Deprecated: Use setConfigOrTxDataV2 instead.
-func setConfigOrTxData(ctx context.Context, lggr logger.Logger, chain deployment.Chain, cfg config.Config, contract *gethwrappers.ManyChainMultiSig, useMCMS bool) (*types.Transaction, error) {
-	groupQuorums, groupParents, signerAddresses, signerGroups := cfg.ExtractSetConfigInputs()
-	opts := deployment.SimTransactOpts()
-	if !useMCMS {
-		opts = chain.DeployerKey
-	}
-	opts.Context = ctx
-	tx, err := contract.SetConfig(opts, signerAddresses, signerGroups, groupQuorums, groupParents, false)
-	if err != nil {
-		return nil, err
-	}
-	if !useMCMS {
-		_, err = deployment.ConfirmIfNoErrorWithABI(chain, tx, gethwrappers.ManyChainMultiSigABI, err)
-		if err != nil {
-			return nil, err
-		}
-		lggr.Infow("SetConfigMCMS tx confirmed", "txHash", tx.Hash().Hex())
-	}
-	return tx, nil
-}
-
 // setConfigOrTxDataV2 executes set config tx or gets the tx data for the MCMS proposal
 func setConfigOrTxDataV2(ctx context.Context, lggr logger.Logger, chain deployment.Chain, cfg mcmstypes.Config, contract *gethwrappers.ManyChainMultiSig, useMCMS bool) (*types.Transaction, error) {
 	opts := deployment.SimTransactOpts()
@@ -205,32 +124,6 @@ type setConfigTxs struct {
 	bypasserTx  *types.Transaction
 }
 
-// setConfigPerRole sets the configuration for each of the MCMS contract roles on the mcmsState.
-// Deprecated: Use setConfigPerRoleV2 instead.
-func setConfigPerRole(ctx context.Context, lggr logger.Logger, chain deployment.Chain, cfg ConfigPerRole, mcmsState *MCMSWithTimelockState, useMCMS bool) (setConfigTxs, error) {
-	// Proposer set config
-	proposerTx, err := setConfigOrTxData(ctx, lggr, chain, cfg.Proposer, mcmsState.ProposerMcm, useMCMS)
-	if err != nil {
-		return setConfigTxs{}, err
-	}
-	// Canceller set config
-	cancellerTx, err := setConfigOrTxData(ctx, lggr, chain, cfg.Canceller, mcmsState.CancellerMcm, useMCMS)
-	if err != nil {
-		return setConfigTxs{}, err
-	}
-	// Bypasser set config
-	bypasserTx, err := setConfigOrTxData(ctx, lggr, chain, cfg.Bypasser, mcmsState.BypasserMcm, useMCMS)
-	if err != nil {
-		return setConfigTxs{}, err
-	}
-
-	return setConfigTxs{
-		proposerTx:  proposerTx,
-		cancellerTx: cancellerTx,
-		bypasserTx:  bypasserTx,
-	}, nil
-}
-
 // setConfigPerRoleV2 sets the configuration for each of the MCMS contract roles on the mcmsState.
 func setConfigPerRoleV2(ctx context.Context, lggr logger.Logger, chain deployment.Chain, cfg ConfigPerRoleV2, mcmsState *commonState.MCMSWithTimelockState, useMCMS bool) (setConfigTxs, error) {
 	// Proposer set config
@@ -254,84 +147,6 @@ func setConfigPerRoleV2(ctx context.Context, lggr logger.Logger, chain deploymen
 		cancellerTx: cancellerTx,
 		bypasserTx:  bypasserTx,
 	}, nil
-}
-
-func addTxsToProposalBatch(setConfigTxsChain setConfigTxs, chainSelector uint64, state MCMSWithTimelockState) timelock.BatchChainOperation {
-	result := timelock.BatchChainOperation{
-		ChainIdentifier: mcms.ChainIdentifier(chainSelector),
-		Batch:           []mcms.Operation{},
-	}
-	result.Batch = append(result.Batch, mcms.Operation{
-		To:           state.ProposerMcm.Address(),
-		Data:         setConfigTxsChain.proposerTx.Data(),
-		Value:        big.NewInt(0),
-		ContractType: string(commontypes.ProposerManyChainMultisig),
-	})
-	result.Batch = append(result.Batch, mcms.Operation{
-		To:           state.CancellerMcm.Address(),
-		Data:         setConfigTxsChain.cancellerTx.Data(),
-		Value:        big.NewInt(0),
-		ContractType: string(commontypes.CancellerManyChainMultisig),
-	})
-	result.Batch = append(result.Batch, mcms.Operation{
-		To:           state.BypasserMcm.Address(),
-		Data:         setConfigTxsChain.bypasserTx.Data(),
-		Value:        big.NewInt(0),
-		ContractType: string(commontypes.BypasserManyChainMultisig),
-	})
-	return result
-}
-
-// SetConfigMCMS sets the configuration of the MCMS contract on the chain identified by the chainSelector.
-// Deprecated: Use SetConfigMCMSV2 instead.
-func SetConfigMCMS(e deployment.Environment, cfg MCMSConfig) (cldf.ChangesetOutput, error) {
-	selectors := []uint64{}
-	lggr := e.Logger
-	ctx := e.GetContext()
-	for chainSelector := range cfg.ConfigsPerChain {
-		selectors = append(selectors, chainSelector)
-	}
-	useMCMS := cfg.ProposalConfig != nil
-	err := cfg.Validate(e, selectors)
-	if err != nil {
-		return cldf.ChangesetOutput{}, err
-	}
-
-	batches := []timelock.BatchChainOperation{}
-	timelocksPerChain := map[uint64]common.Address{}
-	proposerMcmsPerChain := map[uint64]*gethwrappers.ManyChainMultiSig{}
-
-	mcmsStatePerChain, err := MaybeLoadMCMSWithTimelockState(e, selectors)
-	if err != nil {
-		return cldf.ChangesetOutput{}, err
-	}
-
-	for chainSelector, c := range cfg.ConfigsPerChain {
-		chain := e.Chains[chainSelector]
-		state := mcmsStatePerChain[chainSelector]
-		timelocksPerChain[chainSelector] = state.Timelock.Address()
-		proposerMcmsPerChain[chainSelector] = state.ProposerMcm
-		setConfigTxsChain, err := setConfigPerRole(ctx, lggr, chain, c, state, useMCMS)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-		if useMCMS {
-			batch := addTxsToProposalBatch(setConfigTxsChain, chainSelector, *state)
-			batches = append(batches, batch)
-		}
-	}
-
-	if useMCMS {
-		// Create MCMS with timelock proposal
-		proposal, err := proposalutils.BuildProposalFromBatches(timelocksPerChain, proposerMcmsPerChain, batches, "Set config proposal", cfg.ProposalConfig.MinDelay)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal from batch: %w", err)
-		}
-		lggr.Infow("SetConfigMCMS proposal created", "proposal", proposal)
-		return cldf.ChangesetOutput{Proposals: []timelock.MCMSWithTimelockProposal{*proposal}}, nil
-	}
-
-	return cldf.ChangesetOutput{}, nil
 }
 
 // SetConfigMCMSV2 is a reimplementation of SetConfigMCMS that uses the new MCMS library.

--- a/deployment/common/changeset/set_config_mcms_test.go
+++ b/deployment/common/changeset/set_config_mcms_test.go
@@ -5,21 +5,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	solanasdk "github.com/gagliardetto/solana-go"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/config"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -60,117 +55,6 @@ func setupSetConfigTestEnv(t *testing.T) deployment.Environment {
 	)
 	require.NoError(t, err)
 	return env
-}
-
-// TestSetConfigMCMSVariants tests the SetConfigMCMS changeset variants.
-func TestSetConfigMCMSVariants(t *testing.T) {
-	t.Parallel()
-	// Add the timelock as a signer to check state changes
-	for _, tc := range []struct {
-		name       string
-		changeSets func(mcmsState *commonchangeset.MCMSWithTimelockState, chainSel uint64, cfgProp, cfgCancel, cfgBypass config.Config) []commonchangeset.ConfiguredChangeSet
-	}{
-		{
-			name: "MCMS disabled",
-			changeSets: func(mcmsState *commonchangeset.MCMSWithTimelockState, chainSel uint64, cfgProp, cfgCancel, cfgBypass config.Config) []commonchangeset.ConfiguredChangeSet {
-				return []commonchangeset.ConfiguredChangeSet{
-					commonchangeset.Configure(
-						cldf.CreateLegacyChangeSet(commonchangeset.SetConfigMCMS),
-						commonchangeset.MCMSConfig{
-							ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRole{
-								chainSel: {
-									Proposer:  cfgProp,
-									Canceller: cfgCancel,
-									Bypasser:  cfgBypass,
-								},
-							},
-						},
-					),
-				}
-			},
-		},
-		{
-			name: "MCMS enabled",
-			changeSets: func(mcmsState *commonchangeset.MCMSWithTimelockState, chainSel uint64, cfgProp, cfgCancel, cfgBypass config.Config) []commonchangeset.ConfiguredChangeSet {
-				return []commonchangeset.ConfiguredChangeSet{
-					commonchangeset.Configure(
-						cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelock),
-						commonchangeset.TransferToMCMSWithTimelockConfig{
-							ContractsByChain: map[uint64][]common.Address{
-								chainSel: {mcmsState.ProposerMcm.Address(), mcmsState.BypasserMcm.Address(), mcmsState.CancellerMcm.Address()},
-							},
-						},
-					),
-					commonchangeset.Configure(
-						cldf.CreateLegacyChangeSet(commonchangeset.SetConfigMCMS),
-						commonchangeset.MCMSConfig{
-							ProposalConfig: &proposalutils.TimelockConfig{
-								MinDelay: 0,
-							},
-							ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRole{
-								chainSel: {
-									Proposer:  cfgProp,
-									Canceller: cfgCancel,
-									Bypasser:  cfgBypass,
-								},
-							},
-						},
-					),
-				}
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := tests.Context(t)
-
-			env := setupSetConfigTestEnv(t)
-			chainSelector := env.AllChainSelectors()[0]
-			chain := env.Chains[chainSelector]
-			addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
-			require.NoError(t, err)
-			require.Len(t, addrs, 6)
-
-			mcmsState, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addrs)
-			require.NoError(t, err)
-			timelockAddress := mcmsState.Timelock.Address()
-			cfgProposer := proposalutils.SingleGroupMCMS(t)
-			cfgProposer.Signers = append(cfgProposer.Signers, timelockAddress)
-			cfgProposer.Quorum = 2 // quorum should change to 2 out of 2 signers
-			timelockMap := map[uint64]*proposalutils.TimelockExecutionContracts{
-				chainSelector: {
-					Timelock:  mcmsState.Timelock,
-					CallProxy: mcmsState.CallProxy,
-				},
-			}
-			cfgCanceller := proposalutils.SingleGroupMCMS(t)
-			cfgBypasser := proposalutils.SingleGroupMCMS(t)
-			cfgBypasser.Signers = append(cfgBypasser.Signers, timelockAddress)
-			cfgBypasser.Signers = append(cfgBypasser.Signers, mcmsState.ProposerMcm.Address())
-			cfgBypasser.Quorum = 3 // quorum should change to 3 out of 3 signers
-
-			// Set config on all 3 MCMS contracts
-			changesetsToApply := tc.changeSets(mcmsState, chainSelector, cfgProposer, cfgCanceller, cfgBypasser)
-			_, err = commonchangeset.ApplyChangesets(t, env, timelockMap, changesetsToApply)
-			require.NoError(t, err)
-
-			// Check new State
-			expected := cfgProposer.ToRawConfig()
-			opts := &bind.CallOpts{Context: ctx}
-			newConf, err := mcmsState.ProposerMcm.GetConfig(opts)
-			require.NoError(t, err)
-			require.Equal(t, expected, newConf)
-
-			expected = cfgBypasser.ToRawConfig()
-			newConf, err = mcmsState.BypasserMcm.GetConfig(opts)
-			require.NoError(t, err)
-			require.Equal(t, expected, newConf)
-
-			expected = cfgCanceller.ToRawConfig()
-			newConf, err = mcmsState.CancellerMcm.GetConfig(opts)
-			require.NoError(t, err)
-			require.Equal(t, expected, newConf)
-		})
-	}
 }
 
 func TestSetConfigMCMSV2EVM(t *testing.T) {
@@ -380,156 +264,6 @@ func TestSetConfigMCMSV2Solana(t *testing.T) {
 			require.NoError(t, err)
 			require.ElementsMatch(t, newCfgCanceller.Signers, confs.Signers)
 			require.Equal(t, newCfgCanceller.Quorum, confs.Quorum)
-		})
-	}
-}
-
-func TestValidate(t *testing.T) {
-	t.Parallel()
-	env := setupSetConfigTestEnv(t)
-
-	chainSelector := env.AllChainSelectors()[0]
-	chain := env.Chains[chainSelector]
-	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
-	require.NoError(t, err)
-	require.Len(t, addrs, 6)
-	mcmsState, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addrs)
-	require.NoError(t, err)
-	cfg := proposalutils.SingleGroupMCMS(t)
-	timelockAddress := mcmsState.Timelock.Address()
-	// Add the timelock as a signer to check state changes
-	cfg.Signers = append(cfg.Signers, timelockAddress)
-	cfg.Quorum = 2 // quorum
-
-	cfgInvalid := proposalutils.SingleGroupMCMS(t)
-	cfgInvalid.Quorum = 0
-	require.NoError(t, err)
-	tests := []struct {
-		name     string
-		cfg      commonchangeset.MCMSConfig
-		errorMsg string
-	}{
-		{
-			name: "valid config",
-			cfg: commonchangeset.MCMSConfig{
-				ProposalConfig: &proposalutils.TimelockConfig{
-					MinDelay: 0,
-				},
-				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRole{
-					chainSelector: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
-					},
-				},
-			},
-		},
-		{
-			name: "valid non mcms config",
-			cfg: commonchangeset.MCMSConfig{
-				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRole{
-					chainSelector: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
-					},
-				},
-			},
-		},
-		{
-			name: "no chain configurations",
-			cfg: commonchangeset.MCMSConfig{
-				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRole{},
-			},
-			errorMsg: "no chain configs provided",
-		},
-		{
-			name: "non evm chain",
-			cfg: commonchangeset.MCMSConfig{
-				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRole{
-					chain_selectors.APTOS_MAINNET.Selector: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
-					},
-				},
-			},
-			errorMsg: "chain selector: 4741433654826277614 is not an ethereum chain",
-		},
-		{
-			name: "chain selector not found in environment",
-			cfg: commonchangeset.MCMSConfig{
-				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRole{
-					123: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfg,
-					},
-				},
-			},
-			errorMsg: "unknown chain selector 123",
-		},
-		{
-			name: "invalid proposer config",
-			cfg: commonchangeset.MCMSConfig{
-				ProposalConfig: &proposalutils.TimelockConfig{
-					MinDelay: 0,
-				},
-				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRole{
-					chainSelector: {
-						Proposer:  cfgInvalid,
-						Canceller: cfg,
-						Bypasser:  cfg,
-					},
-				},
-			},
-			errorMsg: "invalid MCMS config: Quorum must be greater than 0",
-		},
-		{
-			name: "invalid canceller config",
-			cfg: commonchangeset.MCMSConfig{
-				ProposalConfig: &proposalutils.TimelockConfig{
-					MinDelay: 0,
-				},
-				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRole{
-					chainSelector: {
-						Proposer:  cfg,
-						Canceller: cfgInvalid,
-						Bypasser:  cfg,
-					},
-				},
-			},
-			errorMsg: "invalid MCMS config: Quorum must be greater than 0",
-		},
-		{
-			name: "invalid bypasser config",
-			cfg: commonchangeset.MCMSConfig{
-				ProposalConfig: &proposalutils.TimelockConfig{
-					MinDelay: 0,
-				},
-				ConfigsPerChain: map[uint64]commonchangeset.ConfigPerRole{
-					chainSelector: {
-						Proposer:  cfg,
-						Canceller: cfg,
-						Bypasser:  cfgInvalid,
-					},
-				},
-			},
-			errorMsg: "invalid MCMS config: Quorum must be greater than 0",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			selectors := []uint64{chainSelector}
-
-			err := tt.cfg.Validate(env, selectors)
-			if tt.errorMsg != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.errorMsg)
-			} else {
-				require.NoError(t, err)
-			}
 		})
 	}
 }


### PR DESCRIPTION
This commit removes the legacy `SetConfigMCMS` changeset which has been replaced by the new `SetConfigMCMS` changeset.
