### PR TITLE
fix: install gotestsum for flakeguard workflow

### DIFF
--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -322,9 +322,11 @@ jobs:
         id: gen_id
         run: echo "id=$(uuidgen)" >> "$GITHUB_OUTPUT"
 
-      - name: Install flakeguard
+      - name: Install flakeguard and gotestsum
         shell: bash
-        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25 # flakguard@0.1.0
+        run: |
+          go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25 # flakguard@0.1.0
+          go install gotest.tools/gotestsum@latest # needed for flakeguard output formatting
 
       - name: Run tests with flakeguard
         shell: bash

--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -326,7 +326,7 @@ jobs:
         shell: bash
         run: |
           go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25 # flakguard@0.1.0
-          go install gotest.tools/gotestsum@latest # needed for flakeguard output formatting
+          go install gotest.tools/gotestsum@v1.12.2 # needed for flakeguard output formatting
 
       - name: Run tests with flakeguard
         shell: bash

--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -10,7 +10,7 @@ if [[ -n "$USE_FLAKEGUARD" ]]; then
   # Install flakeguard
   go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25
   # Install gotestsum to parse JSON test outputs from flakeguard to console outputs
-  go install gotest.tools/gotestsum@latest
+  go install gotest.tools/gotestsum@v1.12.2
 
   # Make sure bins are in PATH
   PATH=$PATH:$(go env GOPATH)/bin

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -11,7 +11,7 @@ if [[ -n "$USE_FLAKEGUARD" ]]; then
   # Install flakeguard
   go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25
   # Install gotestsum to parse JSON test outputs from flakeguard to console outputs
-  go install gotest.tools/gotestsum@latest
+  go install gotest.tools/gotestsum@v1.12.2
   # Make sure bins are in PATH
   PATH=$PATH:$(go env GOPATH)/bin
   export PATH


### PR DESCRIPTION
Flakeguard now requires `gotestsum`, example failure:

https://github.com/smartcontractkit/chainlink/actions/runs/14978448461/job/42076825113?pr=17675
> Error:  Failed to print detailed initial run logs: gotestsum command failed for file /home/runner/work/chainlink/chainlink/flakeguard_raw_output/test-output-solana-0-4014894.json: exit status 127
> Output: bash: line 1: gotestsum: command not found


