### PR TITLE
fix: increase resources for deployment tests

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -640,6 +640,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SH_TEST_RUNNER: runs-on=${{ github.run_id }}/cpu=32+64/ram=64+128/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+      SH_DEPLOYMENT_TEST_RUNNER: runs-on=${{ github.run_id }}/cpu=48/ram=96/family=c6id/spot=false/extras=s3-cache
       SH_FUZZ_RUNNER: runs-on=${{ github.run_id}}/cpu=8+16/ram=32+64/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
       SH_RACE_TEST_RUNNER: runs-on=${{ github.run_id}}/cpu=64+128/ram=128+128/family=c7+m7/disk=large/spot=false/extras=s3-cache
       GH_TEST_RUNNER: ubuntu22.04-32cores-128GB
@@ -716,7 +717,7 @@ jobs:
 
           echo "Opt-out is false for current run. Using self-hosted runner for deployment tests."
           echo "deployment-tests-is-self-hosted=true" | tee -a $GITHUB_OUTPUT
-          echo "deployment-tests-runner=${SH_TEST_RUNNER}" | tee -a $GITHUB_OUTPUT
+          echo "deployment-tests-runner=${SH_DEPLOYMENT_TEST_RUNNER}" | tee -a $GITHUB_OUTPUT
 
       - name: Select runners for core tests
         id: core-tests


### PR DESCRIPTION
### Changes

- Increase runner resources allocated to deployment tests (32 -> 48 cores, 64GB -> 96GB)

### Motivation

We're seeing many failures for deployments tests - exiting with code `143`. This suggests the VM is being killed due to  memory usage. When using a GH runner, it passed first try (128GB of RAM).

- https://github.com/smartcontractkit/chainlink/actions/runs/14976883871/job/42071402400?pr=17672
- https://github.com/smartcontractkit/chainlink/actions/runs/14976564197/job/42070370401?pr=17583
- https://github.com/smartcontractkit/chainlink/actions/runs/14974776756/job/42065188099?pr=17613
- https://github.com/smartcontractkit/chainlink/actions/runs/14973993729/job/42061538437
- https://github.com/smartcontractkit/chainlink/actions/runs/14972353710/job/42056085060

### Testing

- GH Runner 128GB RAM: https://github.com/smartcontractkit/chainlink/actions/runs/14984775965?pr=17681
- Self-hosted 128GB RAM: https://github.com/smartcontractkit/chainlink/actions/runs/14985487769/job/42098572217?pr=17687
	- Added telemetry here, and saw ~50GB of RAM usage and very high CPU usage so figured I'd increase cores to 48 and RAM to 96GB, rather than use 32 cores 128GB ram 
- Self-hosted 48core/96GB RAM: https://github.com/smartcontractkit/chainlink/actions/runs/14985631079/job/42098968712?pr=17687
- This PR: https://github.com/smartcontractkit/chainlink/actions/runs/14985736759/job/42099243618?pr=17688


