### PR TITLE
feat: updates AggregateProposal to remove dependecy on legacy proposals

### DIFF
--- a/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane.go
+++ b/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane.go
@@ -31,7 +31,7 @@ var (
 		func(b operations.Bundle, deps Dependencies, input postOpsInput) ([]mcmslib.TimelockProposal, error) {
 			allProposals := input.Proposals
 			proposal, err := proposalutils.AggregateProposals(
-				deps.Env, deps.EVMMCMSState, deps.SolanaMCMSState, allProposals, nil,
+				deps.Env, deps.EVMMCMSState, deps.SolanaMCMSState, allProposals,
 				"Adding EVM and Solana lane", input.MCMSConfig)
 			if err != nil {
 				return nil, err

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -348,7 +348,7 @@ func addTokenE2ELogic(env deployment.Environment, config AddTokensE2EConfig) (cl
 	// if there are multiple proposals, aggregate them so that we don't have to propose them separately
 	if len(finalCSOut.MCMSTimelockProposals) > 1 {
 		aggregatedProposals, err := proposalutils.AggregateProposals(
-			e, state.EVMMCMSStateByChain(), nil, finalCSOut.MCMSTimelockProposals, nil,
+			e, state.EVMMCMSStateByChain(), nil, finalCSOut.MCMSTimelockProposals,
 			"Add Tokens E2E", config.MCMS)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to aggregate proposals: %w", err)

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -408,7 +408,6 @@ func addCandidatesForNewChainLogic(e deployment.Environment, c AddCandidatesForN
 		state.EVMMCMSStateByChain(),
 		nil,
 		allProposals,
-		nil,
 		fmt.Sprintf("Deploy and set candidates for chain with selector %d", c.NewChain.Selector),
 		c.MCMSConfig,
 	)
@@ -588,7 +587,6 @@ func promoteNewChainForConfigLogic(e deployment.Environment, c PromoteNewChainFo
 		state.EVMMCMSStateByChain(),
 		nil,
 		allProposals,
-		nil,
 		fmt.Sprintf("Promote chain with selector %d for testing", c.NewChain.Selector),
 		c.MCMSConfig,
 	)
@@ -729,7 +727,7 @@ func connectNewChainLogic(env deployment.Environment, c ConnectNewChainConfig) (
 	}
 	readOpts := &bind.CallOpts{Context: env.GetContext()}
 
-	var ownershipTransferProposals []timelock.MCMSWithTimelockProposal
+	var ownershipTransferProposals []mcmslib.TimelockProposal
 	if !*c.TestRouter && c.MCMSConfig != nil {
 		// If using the production router, transfer ownership of all contracts on the new chain to MCMS.
 		allContracts := []commoncs.Ownable{
@@ -755,7 +753,7 @@ func connectNewChainLogic(env deployment.Environment, c ConnectNewChainConfig) (
 				addressesToTransfer = append(addressesToTransfer, contract.Address())
 			}
 		}
-		out, err := commoncs.TransferToMCMSWithTimelock(env, commoncs.TransferToMCMSWithTimelockConfig{
+		out, err := commoncs.TransferToMCMSWithTimelockV2(env, commoncs.TransferToMCMSWithTimelockConfig{
 			ContractsByChain: map[uint64][]common.Address{
 				c.NewChainSelector: addressesToTransfer,
 			},
@@ -764,7 +762,7 @@ func connectNewChainLogic(env deployment.Environment, c ConnectNewChainConfig) (
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run TransferToMCMSWithTimelock on chain with selector %d: %w", c.NewChainSelector, err)
 		}
-		ownershipTransferProposals = out.Proposals //nolint:staticcheck //SA1019 ignoring deprecated function for compatibility
+		ownershipTransferProposals = out.MCMSTimelockProposals
 
 		// Also, renounce the admin role on the Timelock (if not already done).
 		adminRole, err := state.Chains[c.NewChainSelector].Timelock.ADMINROLE(readOpts)
@@ -802,12 +800,13 @@ func connectNewChainLogic(env deployment.Environment, c ConnectNewChainConfig) (
 		}
 	}
 
+	allProposals := slices.Concat(ownershipTransferProposals, allEnablementProposals)
+
 	proposal, err := proposalutils.AggregateProposals(
 		env,
 		state.EVMMCMSStateByChain(),
 		nil,
-		allEnablementProposals,
-		ownershipTransferProposals,
+		allProposals,
 		fmt.Sprintf("Connect chain with selector %d to other chains", c.NewChainSelector),
 		c.MCMSConfig,
 	)

--- a/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go
+++ b/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes.go
@@ -235,7 +235,7 @@ func updateBidirectionalLanesLogic(e deployment.Environment, c UpdateBidirection
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	proposal, err := proposalutils.AggregateProposals(e, state.EVMMCMSStateByChain(), nil, proposals, nil, "Update multiple bidirectional lanes", c.MCMSConfig)
+	proposal, err := proposalutils.AggregateProposals(e, state.EVMMCMSStateByChain(), nil, proposals, "Update multiple bidirectional lanes", c.MCMSConfig)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to aggregate proposals: %w", err)
 	}

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -3,7 +3,6 @@ package proposalutils
 import (
 	"errors"
 	"fmt"
-	"math/big"
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -358,14 +357,14 @@ func buildProposalMetadataV2(
 	return metaDataPerChain, nil
 }
 
-// AggregateProposals aggregates proposals from the legacy and new formats into a single proposal.
-// Required if you are merging multiple changesets that have different proposal formats.
+// AggregateProposals aggregates multiple MCMS proposals into a single proposal by combining their operations, and
+// setting up the proposers and inspectors for each chain. It returns a single MCMS proposal that can be executed
+// and signed.
 func AggregateProposals(
 	env deployment.Environment,
 	mcmsEVMState map[uint64]state.MCMSWithTimelockState,
 	mcmsSolanaState map[uint64]state.MCMSWithTimelockStateSolana,
 	proposals []mcmslib.TimelockProposal,
-	legacyProposals []timelock.MCMSWithTimelockProposal,
 	description string,
 	mcmsConfig *TimelockConfig,
 ) (*mcmslib.TimelockProposal, error) {
@@ -374,26 +373,8 @@ func AggregateProposals(
 	}
 
 	var batches []types.BatchOperation
-	// Add proposals that follow the legacy format to the aggregate.
-	for _, proposal := range legacyProposals {
-		for _, batchTransaction := range proposal.Transactions {
-			for _, transaction := range batchTransaction.Batch {
-				batchOperation, err := BatchOperationForChain(
-					uint64(batchTransaction.ChainIdentifier),
-					transaction.To.Hex(),
-					transaction.Data,
-					big.NewInt(0),
-					transaction.ContractType,
-					transaction.Tags,
-				)
-				if err != nil {
-					return &mcmslib.TimelockProposal{}, fmt.Errorf("failed to create batch operation on chain with selector %d: %w", batchTransaction.ChainIdentifier, err)
-				}
-				batches = append(batches, batchOperation)
-			}
-		}
-	}
-	// Add proposals that follow the new format to the aggregate.
+
+	// Add proposals to the aggregate.
 	for _, proposal := range proposals {
 		batches = append(batches, proposal.Operations...)
 	}


### PR DESCRIPTION
This commit updates the `AggregateProposal` function to remove the functionality to aggregate legacy proposals. The function now only aggregates new mcms lib proposals.

This change also requires changes to a Changeset to replace the creation of legacy proposals with the new mcms lib proposals.
