### PR TITLE
Contract config validation for OCR1 jobs

### DIFF
--- a/.changeset/gold-toys-matter.md
+++ b/.changeset/gold-toys-matter.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#changed Added validation to ensure the RPC node used can fetch the required config logs for OCR1 jobs

--- a/.changeset/gold-toys-matter.md
+++ b/.changeset/gold-toys-matter.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-#changed Added validation to ensure the RPC node used can fetch the required config logs for OCR1 jobs
+#nops Added validation to ensure the RPC node used can fetch the required config logs for OCR1 jobs. This behavior can be toggled on/off by using the new `OCR.ConfigLogValidation` setting

--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -404,6 +404,8 @@ TransmitterAddress = '0xa0788FC17B1dEe36f057c42B6F373A34B014687e' # Example
 CaptureEATelemetry = false # Default
 # TraceLogging enables trace level logging.
 TraceLogging = false # Default
+# ConfigLogValidation ensures contract configuration logs are accessible when validating OCR jobs. Enable this when using RPC providers that don't maintain complete historical logs.
+ConfigLogValidation = false # Default
 
 # P2P has a versioned networking stack. Currenly only `[P2P.V2]` is supported.
 # All nodes in the OCR network should share the same networking stack.

--- a/core/config/ocr_config.go
+++ b/core/config/ocr_config.go
@@ -21,4 +21,5 @@ type OCR interface {
 	TraceLogging() bool
 	DefaultTransactionQueueDepth() uint32
 	CaptureEATelemetry() bool
+	ConfigLogValidation() bool
 }

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -1137,6 +1137,7 @@ type OCR struct {
 	TransmitterAddress   *types.EIP55Address
 	CaptureEATelemetry   *bool
 	TraceLogging         *bool
+	ConfigLogValidation  *bool
 }
 
 func (o *OCR) setFrom(f *OCR) {
@@ -1172,6 +1173,9 @@ func (o *OCR) setFrom(f *OCR) {
 	}
 	if v := f.TraceLogging; v != nil {
 		o.TraceLogging = v
+	}
+	if v := f.ConfigLogValidation; v != nil {
+		o.ConfigLogValidation = v
 	}
 }
 

--- a/core/services/chainlink/config_ocr.go
+++ b/core/services/chainlink/config_ocr.go
@@ -67,3 +67,7 @@ func (o *ocrConfig) DefaultTransactionQueueDepth() uint32 {
 func (o *ocrConfig) CaptureEATelemetry() bool {
 	return *o.c.CaptureEATelemetry
 }
+
+func (o *ocrConfig) ConfigLogValidation() bool {
+	return *o.c.ConfigLogValidation
+}

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -433,6 +433,7 @@ func TestConfig_Marshal(t *testing.T) {
 		TransmitterAddress:           ptr(types.MustEIP55Address("0xa0788FC17B1dEe36f057c42B6F373A34B014687e")),
 		CaptureEATelemetry:           ptr(false),
 		TraceLogging:                 ptr(false),
+		ConfigLogValidation:          ptr(false),
 	}
 	full.P2P = toml.P2P{
 		IncomingMessageBufferSize: ptr[int64](13),
@@ -994,6 +995,7 @@ SimulateTransactions = true
 TransmitterAddress = '0xa0788FC17B1dEe36f057c42B6F373A34B014687e'
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 `},
 		{"OCR2", Config{Core: toml.Core{OCR2: full.OCR2}}, `[OCR2]
 Enabled = true

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -157,6 +157,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -163,6 +163,7 @@ SimulateTransactions = true
 TransmitterAddress = '0xa0788FC17B1dEe36f057c42B6F373A34B014687e'
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 13

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -157,6 +157,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 999

--- a/core/services/ocr/validate.go
+++ b/core/services/ocr/validate.go
@@ -1,20 +1,26 @@
 package ocr
 
 import (
+	"context"
+	"fmt"
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/lib/pq"
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
-
+	"github.com/smartcontractkit/libocr/gethwrappers/offchainaggregator"
 	"github.com/smartcontractkit/libocr/offchainreporting"
 
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/offchain_aggregator_wrapper"
+	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	evmconfig "github.com/smartcontractkit/chainlink-evm/pkg/config"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/chaintype"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
 	coreconfig "github.com/smartcontractkit/chainlink/v2/core/config"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 )
@@ -44,16 +50,21 @@ type insecureConfig interface {
 
 // ValidatedOracleSpecToml validates an oracle spec that came from TOML
 func ValidatedOracleSpecToml(gcfg GeneralConfig, legacyChains legacyevm.LegacyChainContainer, tomlString string) (job.Job, error) {
-	return ValidatedOracleSpecTomlCfg(gcfg, func(id *big.Int) (evmconfig.ChainScopedConfig, error) {
+	return ValidatedOracleSpecTomlCfg(gcfg, func(id *big.Int, contractAddress types.EIP55Address) (evmconfig.ChainScopedConfig, error) {
 		c, err := legacyChains.Get(id.String())
 		if err != nil {
 			return nil, err
 		}
+		_, err = validateContractConfig(legacyChains, id, contractAddress)
+		if err != nil {
+			return nil, err
+		}
+
 		return c.Config(), nil
 	}, tomlString)
 }
 
-func ValidatedOracleSpecTomlCfg(gcfg GeneralConfig, configFn func(id *big.Int) (evmconfig.ChainScopedConfig, error), tomlString string) (job.Job, error) {
+func ValidatedOracleSpecTomlCfg(gcfg GeneralConfig, configFn func(id *big.Int, contractAddress types.EIP55Address) (evmconfig.ChainScopedConfig, error), tomlString string) (job.Job, error) {
 	var jb = job.Job{}
 	var spec job.OCROracleSpec
 	tree, err := toml.Load(tomlString)
@@ -91,7 +102,7 @@ func ValidatedOracleSpecTomlCfg(gcfg GeneralConfig, configFn func(id *big.Int) (
 		}
 	}
 
-	cfg, err := configFn(jb.OCROracleSpec.EVMChainID.ToInt())
+	cfg, err := configFn(jb.OCROracleSpec.EVMChainID.ToInt(), spec.ContractAddress)
 	if err != nil {
 		return jb, err
 	}
@@ -106,6 +117,7 @@ func ValidatedOracleSpecTomlCfg(gcfg GeneralConfig, configFn func(id *big.Int) (
 	if err := validateTimingParameters(cfg.EVM(), cfg.EVM().OCR(), gcfg.Insecure(), spec, gcfg.OCR()); err != nil {
 		return jb, err
 	}
+
 	return jb, nil
 }
 
@@ -165,5 +177,84 @@ func validateNonBootstrapSpec(tree *toml.Tree, spec job.Job, ocrObservationTimeo
 			return errors.Errorf("individual max task duration must be < observation timeout")
 		}
 	}
+	return nil
+}
+
+func validateContractConfig(legacyChains legacyevm.LegacyChainContainer, id *big.Int, contractAddress types.EIP55Address) (evmconfig.ChainScopedConfig, error) {
+	chain, err := legacyChains.Get(id.String())
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if contract exists
+	isDeployed, err := isContractDeployed(chain.Client(), contractAddress.Address())
+	if err != nil {
+		return nil, err
+	}
+	if !isDeployed {
+		return chain.Config(), nil
+	}
+
+	ct, err := newContractTracker(chain, contractAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate contract configuration
+	if err := validateContractLogs(ct, contractAddress); err != nil {
+		return nil, err
+	}
+
+	return chain.Config(), nil
+}
+
+func isContractDeployed(client client.Client, address common.Address) (bool, error) {
+	code, err := client.CodeAt(context.Background(), address, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to get code at address: %w", err)
+	}
+	return len(code) > 0, nil
+}
+
+func newContractTracker(chain legacyevm.Chain, contractAddress types.EIP55Address) (*OCRContractTracker, error) {
+	contractCaller, err := offchainaggregator.NewOffchainAggregatorCaller(contractAddress.Address(), chain.Client())
+	if err != nil {
+		return nil, errors.Wrap(err, "could not instantiate NewOffchainAggregatorCaller")
+	}
+
+	contract, err := offchain_aggregator_wrapper.NewOffchainAggregator(contractAddress.Address(), chain.Client())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create OffchainAggregator wrapper")
+	}
+
+	filterer, err := offchainaggregator.NewOffchainAggregatorFilterer(contractAddress.Address(), chain.Client())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create OffchainAggregator filterer")
+	}
+
+	return &OCRContractTracker{
+		contractCaller:   contractCaller,
+		blockTranslator:  ocrcommon.NewBlockTranslator(chain.Config().EVM(), chain.Client(), logger.NullLogger),
+		ethClient:        chain.Client(),
+		contract:         contract,
+		contractFilterer: filterer,
+	}, nil
+}
+
+func validateContractLogs(ct *OCRContractTracker, contractAddress types.EIP55Address) error {
+	ctx := context.Background()
+	changedInBlock, _, err := ct.LatestConfigDetails(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get config at address %s: %w", contractAddress.String(), err)
+	}
+
+	if changedInBlock == 0 {
+		return nil // Contract is not configured, skip validation
+	}
+
+	if _, configErr := ct.ConfigFromLogs(ctx, changedInBlock); configErr != nil {
+		return errors.Wrap(configErr, "could not fetch OCR contract config, try switching to an archive node")
+	}
+
 	return nil
 }

--- a/core/services/ocr/validate.go
+++ b/core/services/ocr/validate.go
@@ -55,11 +55,12 @@ func ValidatedOracleSpecToml(gcfg GeneralConfig, legacyChains legacyevm.LegacyCh
 		if err != nil {
 			return nil, err
 		}
-		_, err = validateContractConfig(legacyChains, id, contractAddress)
-		if err != nil {
-			return nil, err
+		if gcfg.OCR().ConfigLogValidation() {
+			_, err = validateContractConfig(legacyChains, id, contractAddress)
+			if err != nil {
+				return nil, err
+			}
 		}
-
 		return c.Config(), nil
 	}, tomlString)
 }

--- a/core/services/ocr/validate_test.go
+++ b/core/services/ocr/validate_test.go
@@ -24,6 +24,7 @@ import (
 	evmconfig "github.com/smartcontractkit/chainlink-evm/pkg/config"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -458,6 +459,7 @@ func TestOnChainContractAvailability(t *testing.T) {
 	require.NoError(t, err, "could not decode contract binary")
 
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.OCR.ConfigLogValidation = testutils.Ptr(true)
 	})
 	legacyChain := cltest.NewLegacyChainsWithMockChain(t, client, cfg)
 	jobSpec := `

--- a/core/services/ocr/validate_test.go
+++ b/core/services/ocr/validate_test.go
@@ -447,10 +447,10 @@ answer1      [type=median index=0];
 func TestOnChainContractAvailability(t *testing.T) {
 	// Because some RPCs prune logs we have scenarios in which a job spec update will lead to outages because of the inability to get the logs. We need to safeguard against these outages by checking if the node can access the OCR configuration
 	// There are 4 possible scenarios:
-	// 1. Contract is deployed and config log event is accessible
-	// 2. Contract is deployed but config log event is NOT accessible
-	// 3. Contract is deployed but NOT configured
-	// 3. Contract is not deployed
+	// 1. Contract is not deployed
+	// 2. Contract is deployed but NOT configured
+	// 3. Contract is deployed but config log event is NOT accessible
+	// 4. Contract is deployed and config log event is accessible
 
 	// Mock chain
 	client := clienttest.NewClient(t)
@@ -505,12 +505,9 @@ answer1      [type=median index=0];
 	// Contract is configured
 	client.On("CodeAt", mock.Anything, mock.Anything, mock.Anything).Return(contractBytes, nil).Once()
 	client.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Return(goodConfigDetails, nil).Once()
-	client.On("FilterLogs", mock.Anything, mock.Anything, mock.Anything).Return([]types2.Log{configLog}, nil).Once()
+	client.On("FilterLogs", mock.Anything, mock.Anything, mock.Anything).Return([]types2.Log{{
+		Address: common.HexToAddress("0x613a38ac1659769640aae063c651f48e0250454c"),
+		Topics:  []common.Hash{common.HexToHash("0x25d719d88a4512dd76c7442b910a83360845505894eb444ef299409e180f8fb9")}}}, nil).Once()
 	_, err = ocr.ValidatedOracleSpecToml(cfg, legacyChain, jobSpec)
 	require.NoError(t, err)
-}
-
-var configLog = types2.Log{
-	Address: common.HexToAddress("0x613a38ac1659769640aae063c651f48e0250454c"),
-	Topics:  []common.Hash{common.HexToHash("0x25d719d88a4512dd76c7442b910a83360845505894eb444ef299409e180f8fb9")},
 }

--- a/core/services/ocr/validate_test.go
+++ b/core/services/ocr/validate_test.go
@@ -1,18 +1,29 @@
 package ocr_test
 
 import (
+	"encoding/hex"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	types2 "github.com/ethereum/go-ethereum/core/types"
 	"github.com/manyminds/api2go/jsonapi"
+	"github.com/smartcontractkit/libocr/gethwrappers/offchainaggregator"
+	"github.com/smartcontractkit/libocr/gethwrappers/testoffchainaggregator"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	evmconfig "github.com/smartcontractkit/chainlink-evm/pkg/config"
+	"github.com/smartcontractkit/chainlink-evm/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -425,10 +436,81 @@ answer1      [type=median index=0];
 				}
 			})
 
-			s, err := ocr.ValidatedOracleSpecTomlCfg(c, func(id *big.Int) (evmconfig.ChainScopedConfig, error) {
+			s, err := ocr.ValidatedOracleSpecTomlCfg(c, func(id *big.Int, contractAddress types.EIP55Address) (evmconfig.ChainScopedConfig, error) {
 				return evmtest.NewChainScopedConfig(t, c), nil
 			}, tc.toml)
 			tc.assertion(t, s, err)
 		})
 	}
+}
+
+func TestOnChainContractAvailability(t *testing.T) {
+	// Because some RPCs prune logs we have scenarios in which a job spec update will lead to outages because of the inability to get the logs. We need to safeguard against these outages by checking if the node can access the OCR configuration
+	// There are 4 possible scenarios:
+	// 1. Contract is deployed and config log event is accessible
+	// 2. Contract is deployed but config log event is NOT accessible
+	// 3. Contract is deployed but NOT configured
+	// 3. Contract is not deployed
+
+	// Mock chain
+	client := clienttest.NewClient(t)
+	contractBytes, err := hex.DecodeString(strings.TrimPrefix(testoffchainaggregator.OffchainAggregatorMetaData.Bin, "0x"))
+	require.NoError(t, err, "could not decode contract binary")
+
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+	})
+	legacyChain := cltest.NewLegacyChainsWithMockChain(t, client, cfg)
+	jobSpec := `
+type               = "offchainreporting"
+schemaVersion      = 1
+evmChainID		   = 0
+contractAddress    = "0x613a38AC1659769640aaE063C651F48E0250454C"
+isBootstrapPeer    = false
+observationSource = """
+ds1          [type=bridge name=voter_turnout];
+ds1_parse    [type=jsonparse path="one,two"];
+ds1_multiply [type=multiply times=1.23];
+ds1 -> ds1_parse -> ds1_multiply -> answer1;
+answer1      [type=median index=0];
+"""
+`
+
+	// Contract is not deployed
+	client.On("CodeAt", mock.Anything, mock.Anything, mock.Anything).Return([]byte{}, nil).Once()
+	_, err = ocr.ValidatedOracleSpecToml(cfg, legacyChain, jobSpec)
+	require.NoError(t, err)
+
+	abi, err := abi.JSON(strings.NewReader(offchainaggregator.OffchainAggregatorMetaData.ABI))
+	require.NoError(t, err, "could not parse ABI")
+
+	noConfigDetails, err := abi.Methods["latestConfigDetails"].Outputs.Pack(uint32(0), uint32(0), [16]byte{})
+	require.NoError(t, err, "could not pack outputs for latestConfigDetails")
+
+	// Contract is deployed but not configured
+	client.On("CodeAt", mock.Anything, mock.Anything, mock.Anything).Return(contractBytes, nil).Once()
+	client.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Return(noConfigDetails, nil).Once()
+	_, err = ocr.ValidatedOracleSpecToml(cfg, legacyChain, jobSpec)
+	require.NoError(t, err)
+
+	// Contract is deployed but config log event is NOT accessible
+	goodConfigDetails, err := abi.Methods["latestConfigDetails"].Outputs.Pack(uint32(1), uint32(1), [16]byte{})
+	require.NoError(t, err, "could not pack outputs for latestConfigDetails")
+
+	client.On("CodeAt", mock.Anything, mock.Anything, mock.Anything).Return(contractBytes, nil).Once()
+	client.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Return(goodConfigDetails, nil).Once()
+	client.On("FilterLogs", mock.Anything, mock.Anything, mock.Anything).Return([]types2.Log{}, nil).Once() // When the RPC has pruned the data the logs will come back empty
+	_, err = ocr.ValidatedOracleSpecToml(cfg, legacyChain, jobSpec)
+	require.ErrorContains(t, err, "could not fetch OCR contract config, try switching to an archive node")
+
+	// Contract is configured
+	client.On("CodeAt", mock.Anything, mock.Anything, mock.Anything).Return(contractBytes, nil).Once()
+	client.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Return(goodConfigDetails, nil).Once()
+	client.On("FilterLogs", mock.Anything, mock.Anything, mock.Anything).Return([]types2.Log{configLog}, nil).Once()
+	_, err = ocr.ValidatedOracleSpecToml(cfg, legacyChain, jobSpec)
+	require.NoError(t, err)
+}
+
+var configLog = types2.Log{
+	Address: common.HexToAddress("0x613a38ac1659769640aae063c651f48e0250454c"),
+	Topics:  []common.Hash{common.HexToHash("0x25d719d88a4512dd76c7442b910a83360845505894eb444ef299409e180f8fb9")},
 }

--- a/core/web/resolver/testdata/config-empty-effective.toml
+++ b/core/web/resolver/testdata/config-empty-effective.toml
@@ -157,6 +157,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -163,6 +163,7 @@ SimulateTransactions = true
 TransmitterAddress = '0xa0788FC17B1dEe36f057c42B6F373A34B014687e'
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 13

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -157,6 +157,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 999

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1049,6 +1049,7 @@ SimulateTransactions = false # Default
 TransmitterAddress = '0xa0788FC17B1dEe36f057c42B6F373A34B014687e' # Example
 CaptureEATelemetry = false # Default
 TraceLogging = false # Default
+ConfigLogValidation = false # Default
 ```
 This section applies only if you are running off-chain reporting jobs.
 
@@ -1126,6 +1127,12 @@ CaptureEATelemetry toggles collecting extra information from External Adaptares
 TraceLogging = false # Default
 ```
 TraceLogging enables trace level logging.
+
+### ConfigLogValidation
+```toml
+ConfigLogValidation = false # Default
+```
+ConfigLogValidation ensures contract configuration logs are accessible when validating OCR jobs. Enable this when using RPC providers that don't maintain complete historical logs.
 
 ## P2P
 ```toml

--- a/testdata/scripts/config/merge_raw_configs.txtar
+++ b/testdata/scripts/config/merge_raw_configs.txtar
@@ -304,6 +304,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/testdata/scripts/node/validate/default.txtar
+++ b/testdata/scripts/node/validate/default.txtar
@@ -169,6 +169,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/testdata/scripts/node/validate/defaults-override.txtar
+++ b/testdata/scripts/node/validate/defaults-override.txtar
@@ -230,6 +230,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -213,6 +213,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -213,6 +213,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -213,6 +213,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/testdata/scripts/node/validate/fallback-override.txtar
+++ b/testdata/scripts/node/validate/fallback-override.txtar
@@ -308,6 +308,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
+++ b/testdata/scripts/node/validate/invalid-ocr-p2p.txtar
@@ -198,6 +198,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -203,6 +203,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -210,6 +210,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10

--- a/testdata/scripts/node/validate/warnings.txtar
+++ b/testdata/scripts/node/validate/warnings.txtar
@@ -192,6 +192,7 @@ SimulateTransactions = false
 TransmitterAddress = ''
 CaptureEATelemetry = false
 TraceLogging = false
+ConfigLogValidation = false
 
 [P2P]
 IncomingMessageBufferSize = 10


### PR DESCRIPTION
This PR addresses the issue of RPC nodes pruning historical data, which affects OCR1 jobs that rely on retrieving contract configuration from logs. When RPC nodes do not retain the necessary logs, the configuration fetch fails, leading to issues during job execution.

Details:
Currently, the workaround is to ask NOPs to use archive nodes when starting OCR1 jobs to ensure access to historical logs. This change introduces a validation step that checks whether the node can successfully fetch the required config logs. If the logs are unavailable, the job validation will fail early, preventing misconfigured jobs from being created.