### PR TITLE
[CR-403] Move cltest functions from txmgr tests into its own package

### DIFF
--- a/core/chains/evm/txmgr/broadcaster_benchmark_test.go
+++ b/core/chains/evm/txmgr/broadcaster_benchmark_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys/keystest"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -36,7 +36,7 @@ func BenchmarkEthBroadcaster_ProcessUnstartedEthTxs_Success(b *testing.B) {
 	ctx := tests.Context(b)
 
 	ethClient := clienttest.NewClientWithDefaultChainID(b)
-	txStore := evmtxmgrtestutils.NewTestTxStore(b, db)
+	txStore := txmgrtest.NewTestTxStore(b, db)
 	memKeystore := keystest.NewMemoryChainStore()
 	ethKeyStore := keys.NewChainStore(memKeystore, ethClient.ConfiguredChainID())
 	fromAddress := memKeystore.MustCreate(b)

--- a/core/chains/evm/txmgr/broadcaster_benchmark_test.go
+++ b/core/chains/evm/txmgr/broadcaster_benchmark_test.go
@@ -9,8 +9,11 @@ import (
 
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/jmoiron/sqlx"
+
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys/keystest"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -25,7 +28,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
 
 // happy path
@@ -34,7 +36,7 @@ func BenchmarkEthBroadcaster_ProcessUnstartedEthTxs_Success(b *testing.B) {
 	ctx := tests.Context(b)
 
 	ethClient := clienttest.NewClientWithDefaultChainID(b)
-	txStore := cltest.NewTestTxStore(b, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(b, db)
 	memKeystore := keystest.NewMemoryChainStore()
 	ethKeyStore := keys.NewChainStore(memKeystore, ethClient.ConfiguredChainID())
 	fromAddress := memKeystore.MustCreate(b)

--- a/core/chains/evm/txmgr/broadcaster_test.go
+++ b/core/chains/evm/txmgr/broadcaster_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commonutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	"github.com/smartcontractkit/chainlink-framework/chains/fees"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
@@ -49,7 +50,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
 
 var dbListenerCfg txmgr.ListenerConfig = testListenerConfig{}
@@ -100,7 +100,7 @@ func NewTestEthBroadcaster(
 
 func TestEthBroadcaster_Lifecycle(t *testing.T) {
 	db := testutils.NewIndependentSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	evmcfg := configtest.NewChainScopedConfig(t, nil)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	memKS := keystest.NewMemoryChainStore()
@@ -163,7 +163,7 @@ func TestEthBroadcaster_Lifecycle(t *testing.T) {
 // Failure to load next sequnce map should not fail Broadcaster startup
 func TestEthBroadcaster_LoadNextSequenceMapFailure_StartupSuccess(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	evmcfg := configtest.NewChainScopedConfig(t, nil)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	memKS := keystest.NewMemoryChainStore()
@@ -201,7 +201,7 @@ func TestEthBroadcaster_LoadNextSequenceMapFailure_StartupSuccess(t *testing.T) 
 func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
 	ctx := t.Context()
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -574,7 +574,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 func TestEthBroadcaster_TransmitChecking(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
 	ctx := t.Context()
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -657,7 +657,7 @@ func TestEthBroadcaster_TransmitChecking(t *testing.T) {
 func TestEthBroadcaster_ProcessUnstartedEthTxs_OptimisticLockingOnEthTx(t *testing.T) {
 	// non-transactional DB needed because we deliberately test for FK violation
 	db := testutils.NewIndependentSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ccfg := configtest.NewChainScopedConfig(t, nil)
 	evmcfg := txmgr.NewEvmTxmConfig(ccfg.EVM())
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -722,7 +722,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_OptimisticLockingOnEthTx(t *testi
 
 func TestEthBroadcaster_ProcessUnstartedEthTxs_Success_WithMultiplier(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -774,7 +774,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("cannot be more than one transaction per address in an unfinished state", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 
 		firstInProgress := txmgr.Tx{
@@ -807,7 +807,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce but never broadcast", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		evmcfg := configtest.NewChainScopedConfig(t, nil)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -847,7 +847,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce and broadcast but it fatally errored before we could save", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		evmcfg := configtest.NewChainScopedConfig(t, nil)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -885,7 +885,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce and broadcast and is now in mempool", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		evmcfg := configtest.NewChainScopedConfig(t, nil)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -922,7 +922,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce and broadcast and now the transaction has been confirmed", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		evmcfg := configtest.NewChainScopedConfig(t, nil)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -960,7 +960,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 	t.Run("previous run assigned nonce and then failed to reach node for some reason and node is still down", func(t *testing.T) {
 		failedToReachNodeError := context.DeadlineExceeded
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		evmcfg := configtest.NewChainScopedConfig(t, nil)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -997,7 +997,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce and broadcast transaction then crashed and rebooted with a different configured gas price", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -1065,7 +1065,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 	encodedPayload := []byte{0, 1}
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -1692,7 +1692,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_GasEstimationError(t *testing.T) 
 	encodedPayload := []byte{0, 1}
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -1763,7 +1763,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_KeystoreErrors(t *testing.T) {
 	localNonce := 0
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	fromAddress := keystest.NewMemoryChainStore().MustCreate(t)
 	kst := &keystest.FakeChainStore{
@@ -1814,7 +1814,7 @@ func TestEthBroadcaster_Trigger(t *testing.T) {
 	// Simple sanity check to make sure it doesn't block
 	db := testutils.NewSqlxDB(t)
 
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	evmcfg := configtest.NewChainScopedConfig(t, nil)
 	ethKeyStore := &keystest.FakeChainStore{}
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -1836,7 +1836,7 @@ func TestEthBroadcaster_SyncNonce(t *testing.T) {
 		c.NonceAutoSync = ptr(true)
 	})
 	evmTxmCfg := txmgr.NewEvmTxmConfig(evmcfg.EVM())
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -1871,7 +1871,7 @@ func TestEthBroadcaster_NonceTracker_InProgressTx(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
@@ -1910,7 +1910,7 @@ func TestEthBroadcaster_HederaBroadcastValidation(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
 	evmcfg := configtest.NewChainScopedConfig(t, nil)

--- a/core/chains/evm/txmgr/broadcaster_test.go
+++ b/core/chains/evm/txmgr/broadcaster_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commonutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	"github.com/smartcontractkit/chainlink-framework/chains/fees"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
@@ -100,7 +100,7 @@ func NewTestEthBroadcaster(
 
 func TestEthBroadcaster_Lifecycle(t *testing.T) {
 	db := testutils.NewIndependentSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	evmcfg := configtest.NewChainScopedConfig(t, nil)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	memKS := keystest.NewMemoryChainStore()
@@ -163,7 +163,7 @@ func TestEthBroadcaster_Lifecycle(t *testing.T) {
 // Failure to load next sequnce map should not fail Broadcaster startup
 func TestEthBroadcaster_LoadNextSequenceMapFailure_StartupSuccess(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	evmcfg := configtest.NewChainScopedConfig(t, nil)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	memKS := keystest.NewMemoryChainStore()
@@ -201,7 +201,7 @@ func TestEthBroadcaster_LoadNextSequenceMapFailure_StartupSuccess(t *testing.T) 
 func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
 	ctx := t.Context()
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -574,7 +574,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 func TestEthBroadcaster_TransmitChecking(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
 	ctx := t.Context()
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -657,7 +657,7 @@ func TestEthBroadcaster_TransmitChecking(t *testing.T) {
 func TestEthBroadcaster_ProcessUnstartedEthTxs_OptimisticLockingOnEthTx(t *testing.T) {
 	// non-transactional DB needed because we deliberately test for FK violation
 	db := testutils.NewIndependentSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ccfg := configtest.NewChainScopedConfig(t, nil)
 	evmcfg := txmgr.NewEvmTxmConfig(ccfg.EVM())
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -722,7 +722,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_OptimisticLockingOnEthTx(t *testi
 
 func TestEthBroadcaster_ProcessUnstartedEthTxs_Success_WithMultiplier(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -774,7 +774,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("cannot be more than one transaction per address in an unfinished state", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 
 		firstInProgress := txmgr.Tx{
@@ -807,7 +807,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce but never broadcast", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		evmcfg := configtest.NewChainScopedConfig(t, nil)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -847,7 +847,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce and broadcast but it fatally errored before we could save", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		evmcfg := configtest.NewChainScopedConfig(t, nil)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -885,7 +885,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce and broadcast and is now in mempool", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		evmcfg := configtest.NewChainScopedConfig(t, nil)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -922,7 +922,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce and broadcast and now the transaction has been confirmed", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		evmcfg := configtest.NewChainScopedConfig(t, nil)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -960,7 +960,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 	t.Run("previous run assigned nonce and then failed to reach node for some reason and node is still down", func(t *testing.T) {
 		failedToReachNodeError := context.DeadlineExceeded
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		evmcfg := configtest.NewChainScopedConfig(t, nil)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -997,7 +997,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 	t.Run("previous run assigned nonce and broadcast transaction then crashed and rebooted with a different configured gas price", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
@@ -1065,7 +1065,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 	encodedPayload := []byte{0, 1}
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -1692,7 +1692,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_GasEstimationError(t *testing.T) 
 	encodedPayload := []byte{0, 1}
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -1763,7 +1763,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_KeystoreErrors(t *testing.T) {
 	localNonce := 0
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	fromAddress := keystest.NewMemoryChainStore().MustCreate(t)
 	kst := &keystest.FakeChainStore{
@@ -1814,7 +1814,7 @@ func TestEthBroadcaster_Trigger(t *testing.T) {
 	// Simple sanity check to make sure it doesn't block
 	db := testutils.NewSqlxDB(t)
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	evmcfg := configtest.NewChainScopedConfig(t, nil)
 	ethKeyStore := &keystest.FakeChainStore{}
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -1836,7 +1836,7 @@ func TestEthBroadcaster_SyncNonce(t *testing.T) {
 		c.NonceAutoSync = ptr(true)
 	})
 	evmTxmCfg := txmgr.NewEvmTxmConfig(evmcfg.EVM())
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -1871,7 +1871,7 @@ func TestEthBroadcaster_NonceTracker_InProgressTx(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
@@ -1910,7 +1910,7 @@ func TestEthBroadcaster_HederaBroadcastValidation(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
 	evmcfg := configtest.NewChainScopedConfig(t, nil)

--- a/core/chains/evm/txmgr/confirmer_benchmark_test.go
+++ b/core/chains/evm/txmgr/confirmer_benchmark_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -21,7 +21,7 @@ import (
 
 func BenchmarkEthConfirmer(b *testing.B) {
 	db := testutils.NewSqlxDB(b)
-	txStore := evmtxmgrtestutils.NewTestTxStore(b, db)
+	txStore := txmgrtest.NewTestTxStore(b, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(b)
 	evmcfg := configtest.NewChainScopedConfig(b, func(c *toml.EVMConfig) {
 		c.GasEstimator.PriceMax = assets.GWei(500)

--- a/core/chains/evm/txmgr/confirmer_benchmark_test.go
+++ b/core/chains/evm/txmgr/confirmer_benchmark_test.go
@@ -13,15 +13,15 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
 
 func BenchmarkEthConfirmer(b *testing.B) {
 	db := testutils.NewSqlxDB(b)
-	txStore := cltest.NewTestTxStore(b, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(b, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(b)
 	evmcfg := configtest.NewChainScopedConfig(b, func(c *toml.EVMConfig) {
 		c.GasEstimator.PriceMax = assets.GWei(500)

--- a/core/chains/evm/txmgr/confirmer_test.go
+++ b/core/chains/evm/txmgr/confirmer_test.go
@@ -26,6 +26,7 @@ import (
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
 	"github.com/smartcontractkit/chainlink-framework/multinode"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
@@ -40,11 +41,10 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
 
 func newBroadcastLegacyEthTxAttempt(t testing.TB, etxID int64, gasPrice ...int64) txmgr.TxAttempt {
-	attempt := cltest.NewLegacyEthTxAttempt(t, etxID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etxID)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	if len(gasPrice) > 0 {
 		gp := gasPrice[0]
@@ -64,7 +64,7 @@ func newTxReceipt(hash gethCommon.Hash, blockNumber int, txIndex uint) evmtypes.
 }
 
 func newInProgressLegacyEthTxAttempt(t *testing.T, etxID int64, gasPrice ...int64) txmgr.TxAttempt {
-	attempt := cltest.NewLegacyEthTxAttempt(t, etxID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etxID)
 	attempt.State = txmgrtypes.TxAttemptInProgress
 	if len(gasPrice) > 0 {
 		gp := gasPrice[0]
@@ -74,7 +74,7 @@ func newInProgressLegacyEthTxAttempt(t *testing.T, etxID int64, gasPrice ...int6
 }
 
 func mustInsertInProgressEthTx(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress gethCommon.Address) txmgr.Tx {
-	etx := cltest.NewEthTx(fromAddress)
+	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 	etx.State = txmgrcommon.TxInProgress
 	n := evmtypes.Nonce(nonce)
 	etx.Sequence = &n
@@ -84,7 +84,7 @@ func mustInsertInProgressEthTx(t *testing.T, txStore txmgr.TestEvmTxStore, nonce
 }
 
 func mustInsertConfirmedEthTx(t testing.TB, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress gethCommon.Address) txmgr.Tx {
-	etx := cltest.NewEthTx(fromAddress)
+	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 	etx.State = txmgrcommon.TxConfirmed
 	n := evmtypes.Nonce(nonce)
 	etx.Sequence = &n
@@ -182,7 +182,7 @@ func TestEthConfirmer_CheckForConfirmation(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	evmcfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 		c.GasEstimator.PriceMax = assets.GWei(500)
@@ -416,7 +416,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := t.Context()
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -461,7 +461,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 	})
 
 	// This one has BroadcastBeforeBlockNum set as nil... which can happen, but it should be ignored
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 
 	t.Run("ignores unconfirmed transactions with nil BroadcastBeforeBlockNum", func(t *testing.T) {
@@ -471,7 +471,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 		require.Empty(t, etxs)
 	})
 
-	etx1 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	etx1 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 	attempt1_1 := etx1.TxAttempts[0]
 	var dbAttempt txmgr.DbEthTxAttempt
@@ -489,7 +489,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 		assert.Empty(t, etxs)
 	})
 
-	etx2 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	etx2 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 	attempt2_1 := etx2.TxAttempts[0]
 	dbAttempt = txmgr.DbEthTxAttempt{}
@@ -503,7 +503,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 		assert.Empty(t, etxs)
 	})
 
-	etxWithoutAttempts := cltest.NewEthTx(fromAddress)
+	etxWithoutAttempts := evmtxmgrtestutils.NewEthTx(fromAddress)
 	{
 		n := evmtypes.Nonce(nonce)
 		etxWithoutAttempts.Sequence = &n
@@ -537,7 +537,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 		require.Empty(t, etxs)
 	})
 
-	etx3 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	etx3 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 	attempt3_1 := etx3.TxAttempts[0]
 	dbAttempt = txmgr.DbEthTxAttempt{}
@@ -545,7 +545,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 	require.NoError(t, db.Get(&dbAttempt, `UPDATE evm.tx_attempts SET broadcast_before_block_num=$1 WHERE id=$2 RETURNING *`, oldEnough, attempt3_1.ID))
 
 	// NOTE: It should ignore qualifying eth_txes from a different address
-	etxOther := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, evmOtherAddress)
+	etxOther := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, evmOtherAddress)
 	attemptOther1 := etxOther.TxAttempts[0]
 	dbAttempt = txmgr.DbEthTxAttempt{}
 	dbAttempt.FromTxAttempt(&attemptOther1)
@@ -595,7 +595,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 		require.Len(t, etxs, 2) // includes etxWithoutAttempts, etx3 and etx4
 	})
 
-	etx4 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	etx4 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 	attempt4_1 := etx4.TxAttempts[0]
 	dbAttempt = txmgr.DbEthTxAttempt{}
@@ -604,7 +604,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 
 	t.Run("ignores pending transactions for another key", func(t *testing.T) {
 		// Re-use etx3 nonce for another key, it should not affect the results for this key
-		etxOther := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, (*etx3.Sequence).Int64(), evmOtherAddress)
+		etxOther := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, (*etx3.Sequence).Int64(), evmOtherAddress)
 		aOther := etxOther.TxAttempts[0]
 		dbAttempt = txmgr.DbEthTxAttempt{}
 		dbAttempt.FromTxAttempt(&aOther)
@@ -659,7 +659,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 	// This attempt has insufficient_eth, but there is also another attempt4_1
 	// which is old enough, so this will be caught by both queries and should
 	// not be duplicated
-	attempt4_2 := cltest.NewLegacyEthTxAttempt(t, etx4.ID)
+	attempt4_2 := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx4.ID)
 	attempt4_2.State = txmgrtypes.TxAttemptInsufficientFunds
 	attempt4_2.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(40000)}
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt4_2))
@@ -718,7 +718,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 		})
 
 		ctx := t.Context()
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 
 		estimator := gasmocks.NewEvmEstimator(t)
@@ -739,7 +739,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 		nonce := int64(0)
 		originalBroadcastAt := time.Unix(1616509100, 0)
 
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
 		attempt1 := etx.TxAttempts[0]
 		var dbAttempt txmgr.DbEthTxAttempt
 		dbAttempt.FromTxAttempt(&attempt1)
@@ -764,7 +764,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 		})
 
 		ctx := t.Context()
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 
 		estimator := gasmocks.NewEvmEstimator(t)
@@ -807,7 +807,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_MaxFeeScenario(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := t.Context()
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -826,7 +826,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_MaxFeeScenario(t *testing.T) {
 	nonce := int64(0)
 
 	originalBroadcastAt := time.Unix(1616509100, 0)
-	etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
+	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
 	attempt1_1 := etx.TxAttempts[0]
 	var dbAttempt txmgr.DbEthTxAttempt
 	require.NoError(t, db.Get(&dbAttempt, `UPDATE evm.tx_attempts SET broadcast_before_block_num=$1 WHERE id=$2 RETURNING *`, oldEnough, attempt1_1.ID))
@@ -865,7 +865,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("does nothing if no transactions require bumping", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -876,7 +876,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("re-sends previous transaction on keystore error", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := keystest.NewMemoryChainStore().MustCreate(t)
 		kst := &keystest.FakeChainStore{
 			Addresses: keystest.Addresses{fromAddress},
@@ -906,7 +906,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("does nothing and continues on fatal error", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -926,7 +926,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("creates new attempt with higher gas price if transaction has an attempt older than threshold", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -954,7 +954,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("does nothing if there is an attempt without BroadcastBeforeBlockNum set", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -971,7 +971,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("creates new attempt with higher gas price if transaction is already in mempool (e.g. due to previous crash before we could save the new attempt)", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -999,7 +999,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("saves new attempt even for transaction that has already been confirmed (nonce already used)", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -1030,7 +1030,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("saves in-progress attempt on temporary error and returns error", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -1082,7 +1082,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("re-bumps attempt if initial bump is underpriced because the bumped gas price is insufficiently higher than the previous one", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -1114,7 +1114,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("resubmits at the old price and does not create a new attempt if one of the bumped transactions would exceed EVM.GasEstimator.PriceMax", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		priceMax := assets.GWei(30)
 		newCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.GasEstimator.PriceMax = priceMax
@@ -1146,7 +1146,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("resubmits at the old price and does not create a new attempt if the current price is exactly EVM.GasEstimator.PriceMax", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		priceMax := assets.GWei(30)
 		newCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.GasEstimator.PriceMax = priceMax
@@ -1177,7 +1177,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("EIP-1559: bumps using EIP-1559 rules when existing attempts are of type 0x2", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		newCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.GasEstimator.BumpMin = assets.GWei(1)
 		})
@@ -1209,7 +1209,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("EIP-1559: resubmits at the old price and does not create a new attempt if one of the bumped EIP-1559 transactions would have its tip cap exceed EVM.GasEstimator.PriceMax", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		newCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.GasEstimator.PriceMax = assets.NewWeiI(1)
 		})
@@ -1239,7 +1239,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("EIP-1559: re-bumps attempt if initial bump is underpriced because the bumped gas price is insufficiently higher than the previous one", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		newCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.GasEstimator.BumpMin = assets.GWei(1)
 		})
@@ -1277,7 +1277,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyUnderpriced_ThenGoesTh
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -1314,7 +1314,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyUnderpriced_ThenGoesTh
 		ethClient := clienttest.NewClientWithDefaultChainID(t)
 		ec := newEthConfirmer(t, txStore, ethClient, evmcfg, kst, nil)
 
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 		nonce++
 		legacyAttempt := etx.TxAttempts[0]
 		var dbAttempt txmgr.DbEthTxAttempt
@@ -1356,7 +1356,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyUnderpriced_ThenGoesTh
 func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 	t.Parallel()
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := t.Context()
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -1369,7 +1369,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 	oldEnough := int64(19)
 	nonce := int64(0)
 
-	etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 	attempt1_1 := etx.TxAttempts[0]
 	var dbAttempt txmgr.DbEthTxAttempt
@@ -1490,7 +1490,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyStuckError(t *testing.
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := t.Context()
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -1511,7 +1511,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyStuckError(t *testing.
 
 	t.Run("terminally stuck transaction replaced with purge attempt", func(t *testing.T) {
 		originalBroadcastAt := time.Unix(1616509100, 0)
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
 		nonce++
 		attempt1_1 := etx.TxAttempts[0]
 		var dbAttempt txmgr.DbEthTxAttempt
@@ -1542,7 +1542,7 @@ func TestEthConfirmer_ForceRebroadcast(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -1551,8 +1551,8 @@ func TestEthConfirmer_ForceRebroadcast(t *testing.T) {
 
 	mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, config.EVM().ChainID())
 	mustInsertInProgressEthTx(t, txStore, 0, fromAddress)
-	etx1 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
-	etx2 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
+	etx1 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
+	etx2 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
 
 	gasPriceWei := gas.EvmFee{GasPrice: assets.GWei(52)}
 	overrideGasLimit := uint64(20000)
@@ -1643,7 +1643,7 @@ func TestEthConfirmer_ProcessStuckTransactions(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	ethKeyStore := &keystest.FakeChainStore{Addresses: keystest.Addresses{fromAddress}}
 	ethClient := clienttest.NewClientWithDefaultChainID(t)

--- a/core/chains/evm/txmgr/confirmer_test.go
+++ b/core/chains/evm/txmgr/confirmer_test.go
@@ -26,7 +26,7 @@ import (
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
 	"github.com/smartcontractkit/chainlink-framework/multinode"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
@@ -44,7 +44,7 @@ import (
 )
 
 func newBroadcastLegacyEthTxAttempt(t testing.TB, etxID int64, gasPrice ...int64) txmgr.TxAttempt {
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etxID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, etxID)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	if len(gasPrice) > 0 {
 		gp := gasPrice[0]
@@ -64,7 +64,7 @@ func newTxReceipt(hash gethCommon.Hash, blockNumber int, txIndex uint) evmtypes.
 }
 
 func newInProgressLegacyEthTxAttempt(t *testing.T, etxID int64, gasPrice ...int64) txmgr.TxAttempt {
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etxID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, etxID)
 	attempt.State = txmgrtypes.TxAttemptInProgress
 	if len(gasPrice) > 0 {
 		gp := gasPrice[0]
@@ -74,7 +74,7 @@ func newInProgressLegacyEthTxAttempt(t *testing.T, etxID int64, gasPrice ...int6
 }
 
 func mustInsertInProgressEthTx(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress gethCommon.Address) txmgr.Tx {
-	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+	etx := txmgrtest.NewEthTx(fromAddress)
 	etx.State = txmgrcommon.TxInProgress
 	n := evmtypes.Nonce(nonce)
 	etx.Sequence = &n
@@ -84,7 +84,7 @@ func mustInsertInProgressEthTx(t *testing.T, txStore txmgr.TestEvmTxStore, nonce
 }
 
 func mustInsertConfirmedEthTx(t testing.TB, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress gethCommon.Address) txmgr.Tx {
-	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+	etx := txmgrtest.NewEthTx(fromAddress)
 	etx.State = txmgrcommon.TxConfirmed
 	n := evmtypes.Nonce(nonce)
 	etx.Sequence = &n
@@ -182,7 +182,7 @@ func TestEthConfirmer_CheckForConfirmation(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	evmcfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 		c.GasEstimator.PriceMax = assets.GWei(500)
@@ -416,7 +416,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := t.Context()
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -461,7 +461,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 	})
 
 	// This one has BroadcastBeforeBlockNum set as nil... which can happen, but it should be ignored
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 
 	t.Run("ignores unconfirmed transactions with nil BroadcastBeforeBlockNum", func(t *testing.T) {
@@ -471,7 +471,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 		require.Empty(t, etxs)
 	})
 
-	etx1 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	etx1 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 	attempt1_1 := etx1.TxAttempts[0]
 	var dbAttempt txmgr.DbEthTxAttempt
@@ -489,7 +489,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 		assert.Empty(t, etxs)
 	})
 
-	etx2 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	etx2 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 	attempt2_1 := etx2.TxAttempts[0]
 	dbAttempt = txmgr.DbEthTxAttempt{}
@@ -503,7 +503,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 		assert.Empty(t, etxs)
 	})
 
-	etxWithoutAttempts := evmtxmgrtestutils.NewEthTx(fromAddress)
+	etxWithoutAttempts := txmgrtest.NewEthTx(fromAddress)
 	{
 		n := evmtypes.Nonce(nonce)
 		etxWithoutAttempts.Sequence = &n
@@ -537,7 +537,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 		require.Empty(t, etxs)
 	})
 
-	etx3 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	etx3 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 	attempt3_1 := etx3.TxAttempts[0]
 	dbAttempt = txmgr.DbEthTxAttempt{}
@@ -545,7 +545,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 	require.NoError(t, db.Get(&dbAttempt, `UPDATE evm.tx_attempts SET broadcast_before_block_num=$1 WHERE id=$2 RETURNING *`, oldEnough, attempt3_1.ID))
 
 	// NOTE: It should ignore qualifying eth_txes from a different address
-	etxOther := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, evmOtherAddress)
+	etxOther := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, evmOtherAddress)
 	attemptOther1 := etxOther.TxAttempts[0]
 	dbAttempt = txmgr.DbEthTxAttempt{}
 	dbAttempt.FromTxAttempt(&attemptOther1)
@@ -595,7 +595,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 		require.Len(t, etxs, 2) // includes etxWithoutAttempts, etx3 and etx4
 	})
 
-	etx4 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	etx4 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 	attempt4_1 := etx4.TxAttempts[0]
 	dbAttempt = txmgr.DbEthTxAttempt{}
@@ -604,7 +604,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 
 	t.Run("ignores pending transactions for another key", func(t *testing.T) {
 		// Re-use etx3 nonce for another key, it should not affect the results for this key
-		etxOther := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, (*etx3.Sequence).Int64(), evmOtherAddress)
+		etxOther := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, (*etx3.Sequence).Int64(), evmOtherAddress)
 		aOther := etxOther.TxAttempts[0]
 		dbAttempt = txmgr.DbEthTxAttempt{}
 		dbAttempt.FromTxAttempt(&aOther)
@@ -659,7 +659,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 	// This attempt has insufficient_eth, but there is also another attempt4_1
 	// which is old enough, so this will be caught by both queries and should
 	// not be duplicated
-	attempt4_2 := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx4.ID)
+	attempt4_2 := txmgrtest.NewLegacyEthTxAttempt(t, etx4.ID)
 	attempt4_2.State = txmgrtypes.TxAttemptInsufficientFunds
 	attempt4_2.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(40000)}
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt4_2))
@@ -718,7 +718,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 		})
 
 		ctx := t.Context()
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 
 		estimator := gasmocks.NewEvmEstimator(t)
@@ -739,7 +739,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 		nonce := int64(0)
 		originalBroadcastAt := time.Unix(1616509100, 0)
 
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
 		attempt1 := etx.TxAttempts[0]
 		var dbAttempt txmgr.DbEthTxAttempt
 		dbAttempt.FromTxAttempt(&attempt1)
@@ -764,7 +764,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 		})
 
 		ctx := t.Context()
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 
 		estimator := gasmocks.NewEvmEstimator(t)
@@ -807,7 +807,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_MaxFeeScenario(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := t.Context()
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -826,7 +826,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_MaxFeeScenario(t *testing.T) {
 	nonce := int64(0)
 
 	originalBroadcastAt := time.Unix(1616509100, 0)
-	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
+	etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
 	attempt1_1 := etx.TxAttempts[0]
 	var dbAttempt txmgr.DbEthTxAttempt
 	require.NoError(t, db.Get(&dbAttempt, `UPDATE evm.tx_attempts SET broadcast_before_block_num=$1 WHERE id=$2 RETURNING *`, oldEnough, attempt1_1.ID))
@@ -865,7 +865,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("does nothing if no transactions require bumping", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -876,7 +876,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("re-sends previous transaction on keystore error", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := keystest.NewMemoryChainStore().MustCreate(t)
 		kst := &keystest.FakeChainStore{
 			Addresses: keystest.Addresses{fromAddress},
@@ -906,7 +906,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("does nothing and continues on fatal error", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -926,7 +926,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("creates new attempt with higher gas price if transaction has an attempt older than threshold", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -954,7 +954,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("does nothing if there is an attempt without BroadcastBeforeBlockNum set", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -971,7 +971,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("creates new attempt with higher gas price if transaction is already in mempool (e.g. due to previous crash before we could save the new attempt)", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -999,7 +999,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("saves new attempt even for transaction that has already been confirmed (nonce already used)", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -1030,7 +1030,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("saves in-progress attempt on temporary error and returns error", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -1082,7 +1082,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("re-bumps attempt if initial bump is underpriced because the bumped gas price is insufficiently higher than the previous one", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		memKS := keystest.NewMemoryChainStore()
 		fromAddress := memKS.MustCreate(t)
 		ethKeyStore := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
@@ -1114,7 +1114,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("resubmits at the old price and does not create a new attempt if one of the bumped transactions would exceed EVM.GasEstimator.PriceMax", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		priceMax := assets.GWei(30)
 		newCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.GasEstimator.PriceMax = priceMax
@@ -1146,7 +1146,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("resubmits at the old price and does not create a new attempt if the current price is exactly EVM.GasEstimator.PriceMax", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		priceMax := assets.GWei(30)
 		newCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.GasEstimator.PriceMax = priceMax
@@ -1177,7 +1177,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("EIP-1559: bumps using EIP-1559 rules when existing attempts are of type 0x2", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		newCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.GasEstimator.BumpMin = assets.GWei(1)
 		})
@@ -1209,7 +1209,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("EIP-1559: resubmits at the old price and does not create a new attempt if one of the bumped EIP-1559 transactions would have its tip cap exceed EVM.GasEstimator.PriceMax", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		newCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.GasEstimator.PriceMax = assets.NewWeiI(1)
 		})
@@ -1239,7 +1239,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 	t.Run("EIP-1559: re-bumps attempt if initial bump is underpriced because the bumped gas price is insufficiently higher than the previous one", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		newCfg := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.GasEstimator.BumpMin = assets.GWei(1)
 		})
@@ -1277,7 +1277,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyUnderpriced_ThenGoesTh
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -1314,7 +1314,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyUnderpriced_ThenGoesTh
 		ethClient := clienttest.NewClientWithDefaultChainID(t)
 		ec := newEthConfirmer(t, txStore, ethClient, evmcfg, kst, nil)
 
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 		nonce++
 		legacyAttempt := etx.TxAttempts[0]
 		var dbAttempt txmgr.DbEthTxAttempt
@@ -1356,7 +1356,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyUnderpriced_ThenGoesTh
 func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 	t.Parallel()
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := t.Context()
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -1369,7 +1369,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 	oldEnough := int64(19)
 	nonce := int64(0)
 
-	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
+	etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress)
 	nonce++
 	attempt1_1 := etx.TxAttempts[0]
 	var dbAttempt txmgr.DbEthTxAttempt
@@ -1490,7 +1490,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyStuckError(t *testing.
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := t.Context()
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -1511,7 +1511,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_TerminallyStuckError(t *testing.
 
 	t.Run("terminally stuck transaction replaced with purge attempt", func(t *testing.T) {
 		originalBroadcastAt := time.Unix(1616509100, 0)
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, nonce, fromAddress, originalBroadcastAt)
 		nonce++
 		attempt1_1 := etx.TxAttempts[0]
 		var dbAttempt txmgr.DbEthTxAttempt
@@ -1542,7 +1542,7 @@ func TestEthConfirmer_ForceRebroadcast(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -1551,8 +1551,8 @@ func TestEthConfirmer_ForceRebroadcast(t *testing.T) {
 
 	mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, config.EVM().ChainID())
 	mustInsertInProgressEthTx(t, txStore, 0, fromAddress)
-	etx1 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
-	etx2 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
+	etx1 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
+	etx2 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
 
 	gasPriceWei := gas.EvmFee{GasPrice: assets.GWei(52)}
 	overrideGasLimit := uint64(20000)
@@ -1643,7 +1643,7 @@ func TestEthConfirmer_ProcessStuckTransactions(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	ethKeyStore := &keystest.FakeChainStore{Addresses: keystest.Addresses{fromAddress}}
 	ethClient := clienttest.NewClientWithDefaultChainID(t)

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
@@ -36,17 +37,17 @@ import (
 
 func TestORM_TransactionsWithAttempts(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
 
-	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)        // tx1
-	tx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, fromAddress) // tx2
+	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)        // tx1
+	tx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, fromAddress) // tx2
 
 	// add 2nd attempt to tx2
 	blockNum := int64(3)
-	attempt := cltest.NewLegacyEthTxAttempt(t, tx2.ID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx2.ID)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(3)}
 	attempt.BroadcastBeforeBlockNum = &blockNum
@@ -80,17 +81,17 @@ func TestORM_TransactionsWithAttempts(t *testing.T) {
 
 func TestORM_Transactions(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
 
-	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)        // tx1
-	tx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, fromAddress) // tx2
+	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)        // tx1
+	tx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, fromAddress) // tx2
 
 	// add 2nd attempt to tx2
 	blockNum := int64(3)
-	attempt := cltest.NewLegacyEthTxAttempt(t, tx2.ID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx2.ID)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(3)}
 	attempt.BroadcastBeforeBlockNum = &blockNum
@@ -118,13 +119,13 @@ func TestORM(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	orm := cltest.NewTestTxStore(t, db)
+	orm := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	ctx := tests.Context(t)
 
 	var etx txmgr.Tx
 	t.Run("InsertTx", func(t *testing.T) {
-		etx = cltest.NewEthTx(fromAddress)
+		etx = evmtxmgrtestutils.NewEthTx(fromAddress)
 		require.NoError(t, orm.InsertTx(ctx, &etx))
 		assert.Greater(t, int(etx.ID), 0)
 		cltest.AssertCount(t, db, "evm.txes", 1)
@@ -132,12 +133,12 @@ func TestORM(t *testing.T) {
 	var attemptL txmgr.TxAttempt
 	var attemptD txmgr.TxAttempt
 	t.Run("InsertTxAttempt", func(t *testing.T) {
-		attemptD = cltest.NewDynamicFeeEthTxAttempt(t, etx.ID)
+		attemptD = evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
 		require.NoError(t, orm.InsertTxAttempt(ctx, &attemptD))
 		assert.Greater(t, int(attemptD.ID), 0)
 		cltest.AssertCount(t, db, "evm.tx_attempts", 1)
 
-		attemptL = cltest.NewLegacyEthTxAttempt(t, etx.ID)
+		attemptL = evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 		attemptL.State = txmgrtypes.TxAttemptBroadcast
 		attemptL.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(42)}
 		require.NoError(t, orm.InsertTxAttempt(ctx, &attemptL))
@@ -184,17 +185,17 @@ func TestORM(t *testing.T) {
 
 func TestORM_FindTxAttemptConfirmedByTxIDs(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	orm := cltest.NewTestTxStore(t, db)
+	orm := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
 
-	tx1 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, orm, 0, 1, fromAddress) // tx1
-	tx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, orm, 1, 2, fromAddress) // tx2
+	tx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, orm, 0, 1, fromAddress) // tx1
+	tx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, orm, 1, 2, fromAddress) // tx2
 
 	// add 2nd attempt to tx2
 	blockNum := int64(3)
-	attempt := cltest.NewLegacyEthTxAttempt(t, tx2.ID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx2.ID)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(3)}
 	attempt.BroadcastBeforeBlockNum = &blockNum
@@ -207,8 +208,8 @@ func TestORM_FindTxAttemptConfirmedByTxIDs(t *testing.T) {
 	// tx 3 has no attempts
 	mustCreateUnstartedGeneratedTx(t, orm, fromAddress, testutils.FixtureChainID)
 
-	cltest.MustInsertUnconfirmedEthTx(t, orm, 3, fromAddress)                           // tx4
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, orm, 4, fromAddress) // tx5
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, orm, 3, fromAddress)                           // tx4
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, orm, 4, fromAddress) // tx5
 
 	var count int
 	err = db.Get(&count, `SELECT count(*) FROM evm.txes`)
@@ -233,7 +234,7 @@ func TestORM_FindTxAttemptsRequiringResend(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
@@ -246,10 +247,10 @@ func TestORM_FindTxAttemptsRequiringResend(t *testing.T) {
 	})
 
 	// Mix up the insert order to assure that they come out sorted by nonce not implicitly or by ID
-	e1 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, time.Unix(1616509200, 0))
+	e1 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, time.Unix(1616509200, 0))
 	e3 := mustInsertUnconfirmedEthTxWithBroadcastDynamicFeeAttempt(t, txStore, 3, fromAddress, time.Unix(1616509400, 0))
-	e0 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, time.Unix(1616509100, 0))
-	e2 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress, time.Unix(1616509300, 0))
+	e0 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, time.Unix(1616509100, 0))
+	e2 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress, time.Unix(1616509300, 0))
 
 	etxs := []txmgr.Tx{
 		e0,
@@ -265,17 +266,17 @@ func TestORM_FindTxAttemptsRequiringResend(t *testing.T) {
 	attempt3_2.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(10)}
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt3_2))
 
-	attempt4_2 := cltest.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
+	attempt4_2 := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
 	attempt4_2.TxFee.GasTipCap = assets.NewWeiI(10)
 	attempt4_2.TxFee.GasFeeCap = assets.NewWeiI(20)
 	attempt4_2.State = txmgrtypes.TxAttemptBroadcast
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt4_2))
-	attempt4_4 := cltest.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
+	attempt4_4 := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
 	attempt4_4.TxFee.GasTipCap = assets.NewWeiI(30)
 	attempt4_4.TxFee.GasFeeCap = assets.NewWeiI(40)
 	attempt4_4.State = txmgrtypes.TxAttemptBroadcast
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt4_4))
-	attempt4_3 := cltest.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
+	attempt4_3 := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
 	attempt4_3.TxFee.GasTipCap = assets.NewWeiI(20)
 	attempt4_3.TxFee.GasFeeCap = assets.NewWeiI(30)
 	attempt4_3.State = txmgrtypes.TxAttemptBroadcast
@@ -318,7 +319,7 @@ func TestORM_UpdateBroadcastAts(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	orm := cltest.NewTestTxStore(t, db)
+	orm := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("does not update when broadcast_at is NULL", func(t *testing.T) {
@@ -343,7 +344,7 @@ func TestORM_UpdateBroadcastAts(t *testing.T) {
 
 		ctx := tests.Context(t)
 		time1 := time.Now()
-		etx := cltest.NewEthTx(fromAddress)
+		etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 		etx.Sequence = new(types.Nonce)
 		etx.State = txmgrcommon.TxUnconfirmed
 		etx.BroadcastAt = &time1
@@ -366,10 +367,10 @@ func TestORM_SetBroadcastBeforeBlockNum(t *testing.T) {
 
 	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewChainScopedConfig(t, nil)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
-	etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
 	chainID := ethClient.ConfiguredChainID()
 	ctx := tests.Context(t)
 
@@ -406,8 +407,8 @@ func TestORM_SetBroadcastBeforeBlockNum(t *testing.T) {
 	})
 
 	t.Run("only updates evm.tx_attempts for the current chain", func(t *testing.T) {
-		etxThisChain := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, cfg.EVM().ChainID())
-		etxOtherChain := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, testutils.SimulatedChainID)
+		etxThisChain := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, cfg.EVM().ChainID())
+		etxOtherChain := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, testutils.SimulatedChainID)
 
 		require.NoError(t, txStore.SetBroadcastBeforeBlockNum(tests.Context(t), headNum, chainID))
 
@@ -432,7 +433,7 @@ func TestORM_UpdateTxConfirmed(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	etx0 := mustInsertUnconfirmedEthTxWithAttemptState(t, txStore, 0, fromAddress, txmgrtypes.TxAttemptBroadcast)
@@ -458,11 +459,11 @@ func TestORM_SaveFetchedReceipts(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	ctx := tests.Context(t)
 
-	tx1 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 100, fromAddress)
+	tx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 100, fromAddress)
 	require.Len(t, tx1.TxAttempts, 1)
 
 	tx2 := mustInsertTerminallyStuckTxWithAttempt(t, txStore, fromAddress, 1, 100)
@@ -504,12 +505,12 @@ func TestORM_PreloadTxes(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("loads eth transaction", func(t *testing.T) {
 		// insert etx with attempt
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(7), fromAddress)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(7), fromAddress)
 
 		// create unloaded attempt
 		unloadedAttempt := txmgr.TxAttempt{TxID: etx.ID}
@@ -536,7 +537,7 @@ func TestORM_GetInProgressTxAttempts(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -555,7 +556,7 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -582,7 +583,7 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	runID1 := testutils.MustInsertPipelineRun(t, db)
 	trID1 := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID1)
 	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, runID1)
-	etx1 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 1, fromAddress)
+	etx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": true}'`)
 	attempt1 := etx1.TxAttempts[0]
 	etxBlockNum := mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, attempt1.Hash).BlockNumber
@@ -592,7 +593,7 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	runID2 := testutils.MustInsertPipelineRun(t, db)
 	trID2 := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID2)
 	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'completed', outputs = '""'::jsonb, finished_at = NOW() WHERE id = $1`, runID2)
-	etx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 1, fromAddress)
+	etx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
 	attempt2 := etx2.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, attempt2.Hash)
@@ -602,20 +603,20 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	runID3 := testutils.MustInsertPipelineRun(t, db)
 	trID3 := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID3)
 	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, runID3)
-	etx3 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 5, 1, fromAddress)
+	etx3 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 5, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
 	attempt3 := etx3.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number, head.Hash, attempt3.Hash)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &trID3, minConfirmations, etx3.ID)
 
 	// Tx not marked for callback. Should be ignore
-	etx4 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 6, 1, fromAddress)
+	etx4 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 6, 1, fromAddress)
 	attempt4 := etx4.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number, head.Hash, attempt4.Hash)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET min_confirmations = $1 WHERE id = $2`, minConfirmations, etx4.ID)
 
 	// Unconfirmed Tx without receipts. Should be ignored
-	etx5 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 7, 1, fromAddress)
+	etx5 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 7, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET min_confirmations = $1 WHERE id = $2`, minConfirmations, etx5.ID)
 
 	// Search evm.txes table for tx requiring callback
@@ -645,7 +646,7 @@ func Test_FindTxWithIdempotencyKey(t *testing.T) {
 	t.Parallel()
 	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewChainScopedConfig(t, nil)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("returns nil error if no results", func(t *testing.T) {
@@ -673,7 +674,7 @@ func Test_FindReceiptWithIdempotencyKey(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	ctx := t.Context()
 
@@ -687,7 +688,7 @@ func Test_FindReceiptWithIdempotencyKey(t *testing.T) {
 	t.Run("returns receipt if it exists", func(t *testing.T) {
 		var etx txmgr.Tx
 		// insert tx
-		etx = cltest.NewEthTx(fromAddress)
+		etx = evmtxmgrtestutils.NewEthTx(fromAddress)
 		etx.IdempotencyKey = &idempotencyKey
 		require.NoError(t, txStore.InsertTx(ctx, &etx))
 		assert.Greater(t, int(etx.ID), 0)
@@ -696,12 +697,12 @@ func Test_FindReceiptWithIdempotencyKey(t *testing.T) {
 		// insert attempt
 		var attemptL txmgr.TxAttempt
 		var attemptD txmgr.TxAttempt
-		attemptD = cltest.NewDynamicFeeEthTxAttempt(t, etx.ID)
+		attemptD = evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attemptD))
 		assert.Greater(t, int(attemptD.ID), 0)
 		cltest.AssertCount(t, db, "evm.tx_attempts", 1)
 
-		attemptL = cltest.NewLegacyEthTxAttempt(t, etx.ID)
+		attemptL = evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 		attemptL.State = txmgrtypes.TxAttemptBroadcast
 		attemptL.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(42)}
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attemptL))
@@ -729,7 +730,7 @@ func TestORM_FindTxWithSequence(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("returns nil if no results", func(t *testing.T) {
@@ -739,7 +740,7 @@ func TestORM_FindTxWithSequence(t *testing.T) {
 	})
 
 	t.Run("returns transaction if it exists", func(t *testing.T) {
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 777, 1, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 777, 1, fromAddress)
 		require.Equal(t, types.Nonce(777), *etx.Sequence)
 
 		res, err := txStore.FindTxWithSequence(tests.Context(t), fromAddress, types.Nonce(777))
@@ -752,7 +753,7 @@ func TestORM_UpdateTxForRebroadcast(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	ctx := tests.Context(t)
 
@@ -823,7 +824,7 @@ func TestORM_FindEarliestUnconfirmedBroadcastTime(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -834,7 +835,7 @@ func TestORM_FindEarliestUnconfirmedBroadcastTime(t *testing.T) {
 	})
 
 	t.Run("verify broadcast time", func(t *testing.T) {
-		tx := cltest.MustInsertUnconfirmedEthTx(t, txStore, 123, fromAddress)
+		tx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, 123, fromAddress)
 		broadcastAt, err := txStore.FindEarliestUnconfirmedBroadcastTime(tests.Context(t), ethClient.ConfiguredChainID())
 		require.NoError(t, err)
 		require.True(t, broadcastAt.Ptr().Equal(*tx.BroadcastAt))
@@ -845,7 +846,7 @@ func TestORM_FindEarliestUnconfirmedTxAttemptBlock(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 	fromAddress2 := testutils.NewAddress()
@@ -875,7 +876,7 @@ func TestORM_SaveInsufficientEthAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	defaultDuration, err := time.ParseDuration("5s")
 	require.NoError(t, err)
@@ -898,7 +899,7 @@ func TestORM_SaveSentAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	defaultDuration, err := time.ParseDuration("5s")
 	require.NoError(t, err)
@@ -922,7 +923,7 @@ func TestORM_SaveConfirmedAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	defaultDuration, err := time.ParseDuration("5s")
 	require.NoError(t, err)
@@ -946,7 +947,7 @@ func TestORM_DeleteInProgressAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("deletes in_progress attempt", func(t *testing.T) {
@@ -967,13 +968,13 @@ func TestORM_SaveInProgressAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("saves new in_progress attempt if attempt is new", func(t *testing.T) {
-		etx := cltest.MustInsertUnconfirmedEthTx(t, txStore, 1, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, 1, fromAddress)
 
-		attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 		require.Equal(t, int64(0), attempt.ID)
 
 		err := txStore.SaveInProgressAttempt(tests.Context(t), &attempt)
@@ -1006,7 +1007,7 @@ func TestORM_FindTxsRequiringGasBump(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -1044,7 +1045,7 @@ func TestEthConfirmer_FindTxsRequiringResubmissionDueToInsufficientEth(t *testin
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
@@ -1052,16 +1053,16 @@ func TestEthConfirmer_FindTxsRequiringResubmissionDueToInsufficientEth(t *testin
 
 	// Insert order is mixed up to test sorting
 	etx2 := mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t, txStore, 1, fromAddress)
-	etx3 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
-	attempt3_2 := cltest.NewLegacyEthTxAttempt(t, etx3.ID)
+	etx3 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
+	attempt3_2 := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx3.ID)
 	attempt3_2.State = txmgrtypes.TxAttemptInsufficientFunds
 	attempt3_2.TxFee.GasPrice = assets.NewWeiI(100)
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt3_2))
 	etx1 := mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t, txStore, 0, fromAddress)
 
 	// These should never be returned
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 3, fromAddress)
-	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 100, fromAddress)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 3, fromAddress)
+	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 100, fromAddress)
 	mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t, txStore, 0, otherAddress)
 
 	t.Run("returns all eth_txes with at least one attempt that is in insufficient_eth state", func(t *testing.T) {
@@ -1104,7 +1105,7 @@ func TestORM_LoadEthTxesAttempts(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("load eth tx attempt", func(t *testing.T) {
@@ -1118,7 +1119,7 @@ func TestORM_LoadEthTxesAttempts(t *testing.T) {
 
 	t.Run("load new attempt inserted in current postgres transaction", func(t *testing.T) {
 		etx := mustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(t, txStore, 3, 9, time.Now(), fromAddress)
-		newAttempt := cltest.NewDynamicFeeEthTxAttempt(t, etx.ID)
+		newAttempt := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
 		var dbAttempt txmgr.DbEthTxAttempt
 		dbAttempt.FromTxAttempt(&newAttempt)
 
@@ -1156,14 +1157,14 @@ func TestORM_SaveReplacementInProgressAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("replace eth tx attempt", func(t *testing.T) {
 		etx := mustInsertInProgressEthTxWithAttempt(t, txStore, 123, fromAddress)
 		oldAttempt := etx.TxAttempts[0]
 
-		newAttempt := cltest.NewDynamicFeeEthTxAttempt(t, etx.ID)
+		newAttempt := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
 		err := txStore.SaveReplacementInProgressAttempt(tests.Context(t), oldAttempt, &newAttempt)
 		require.NoError(t, err)
 
@@ -1178,7 +1179,7 @@ func TestORM_FindNextUnstartedTransactionFromAddress(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -1203,7 +1204,7 @@ func TestORM_UpdateTxFatalErrorAndDeleteAttempts(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("update successful", func(t *testing.T) {
@@ -1225,7 +1226,7 @@ func TestORM_UpdateTxAttemptInProgressToBroadcast(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("update successful", func(t *testing.T) {
@@ -1255,14 +1256,14 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	nonce := types.Nonce(123)
 
 	t.Run("update successful", func(t *testing.T) {
 		etx := mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
 		etx.Sequence = &nonce
-		attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 
 		err := txStore.UpdateTxUnstartedToInProgress(tests.Context(t), &etx, &attempt)
 		require.NoError(t, err)
@@ -1277,7 +1278,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 		etx := mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
 		etx.Sequence = &nonce
 
-		attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 
 		_, err := db.ExecContext(ctx, "DELETE FROM evm.txes WHERE id = $1", etx.ID)
 		require.NoError(t, err)
@@ -1287,7 +1288,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 	})
 
 	db = testutils.NewSqlxDB(t)
-	txStore = cltest.NewTestTxStore(t, db)
+	txStore = evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress = testutils.NewAddress()
 
 	t.Run("update replaces abandoned tx with same hash", func(t *testing.T) {
@@ -1309,7 +1310,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 
 		etx2 := mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
 		etx2.Sequence = &nonce
-		attempt2 := cltest.NewLegacyEthTxAttempt(t, etx2.ID)
+		attempt2 := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx2.ID)
 		attempt2.Hash = etx.TxAttempts[0].Hash
 
 		// Even though this will initially fail due to idx_eth_tx_attempts_hash constraint, because the conflicting tx has been abandoned
@@ -1330,7 +1331,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 		// Should fail due to idx_eth_tx_attempt_hash constraint
 		err := txStore.UpdateTxUnstartedToInProgress(tests.Context(t), &etx, &etx.TxAttempts[0])
 		assert.ErrorContains(t, err, "idx_eth_tx_attempts_hash")
-		txStore = cltest.NewTestTxStore(t, db) // current txStore is poisened now, next test will need fresh one
+		txStore = evmtxmgrtestutils.NewTestTxStore(t, db) // current txStore is poisened now, next test will need fresh one
 	})
 }
 
@@ -1338,7 +1339,7 @@ func TestORM_GetTxInProgress(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("gets 0 in progress eth transaction", func(t *testing.T) {
@@ -1360,7 +1361,7 @@ func TestORM_GetAbandonedTransactionsByBatch(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 	enabled := testutils.NewAddress()
@@ -1416,7 +1417,7 @@ func TestORM_GetTxByID(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("no transaction", func(t *testing.T) {
@@ -1437,7 +1438,7 @@ func TestORM_GetFatalTransactions(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("gets 0 fatal eth transactions", func(t *testing.T) {
@@ -1458,7 +1459,7 @@ func TestORM_HasInProgressTransaction(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -1481,15 +1482,15 @@ func TestORM_CountUnconfirmedTransactions(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	fromAddress := testutils.NewAddress()
 	otherAddress := testutils.NewAddress()
 
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, otherAddress)
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, otherAddress)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
 
 	count, err := txStore.CountUnconfirmedTransactions(tests.Context(t), fromAddress, testutils.FixtureChainID)
 	require.NoError(t, err)
@@ -1500,15 +1501,15 @@ func TestORM_CountTransactionsByState(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	fromAddress1 := testutils.NewAddress()
 	fromAddress2 := testutils.NewAddress()
 	fromAddress3 := testutils.NewAddress()
 
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress1)
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress2)
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress3)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress1)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress2)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress3)
 
 	count, err := txStore.CountTransactionsByState(tests.Context(t), txmgrcommon.TxUnconfirmed, testutils.FixtureChainID)
 	require.NoError(t, err)
@@ -1519,7 +1520,7 @@ func TestORM_CountUnstartedTransactions(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	fromAddress := testutils.NewAddress()
 	otherAddress := testutils.NewAddress()
@@ -1527,7 +1528,7 @@ func TestORM_CountUnstartedTransactions(t *testing.T) {
 	mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
 	mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
 	mustCreateUnstartedGeneratedTx(t, txStore, otherAddress, testutils.FixtureChainID)
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
 
 	count, err := txStore.CountUnstartedTransactions(tests.Context(t), fromAddress, testutils.FixtureChainID)
 	require.NoError(t, err)
@@ -1538,7 +1539,7 @@ func TestORM_CheckTxQueueCapacity(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	otherAddress := testutils.NewAddress()
 
@@ -1575,7 +1576,7 @@ func TestORM_CheckTxQueueCapacity(t *testing.T) {
 	var n int64
 	mustInsertInProgressEthTxWithAttempt(t, txStore, types.Nonce(n), fromAddress)
 	n++
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, n, fromAddress)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, n, fromAddress)
 	n++
 
 	t.Run("unconfirmed and in_progress transactions do not count", func(t *testing.T) {
@@ -1585,7 +1586,7 @@ func TestORM_CheckTxQueueCapacity(t *testing.T) {
 
 	// deliberately one extra to exceed limit
 	for i := 0; i <= int(maxUnconfirmedTransactions); i++ {
-		cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, n, 42, fromAddress)
+		evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, n, 42, fromAddress)
 		n++
 	}
 
@@ -1754,12 +1755,12 @@ func TestORM_FindTxesWithAttemptsAndReceiptsByIdsAndState(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
 
-	tx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)
+	tx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)
 	r := newEthReceipt(4, utils.NewHash(), tx.TxAttempts[0].Hash, 0x1)
 	_, err := txStore.InsertReceipt(ctx, &r.Receipt)
 	require.NoError(t, err)
@@ -1786,7 +1787,7 @@ func TestORM_FindAttemptsRequiringReceiptFetch(t *testing.T) {
 
 	t.Run("finds confirmed transaction requiring receipt fetch", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		// Transactions whose attempts should not be picked up for receipt fetch
 		mustInsertFatalErrorEthTx(t, txStore, fromAddress)
@@ -1817,7 +1818,7 @@ func TestORM_FindAttemptsRequiringReceiptFetch(t *testing.T) {
 
 	t.Run("finds terminally stuck transaction requiring receipt fetch", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		// Transactions whose attempts should not be picked up for receipt fetch
 		mustInsertFatalErrorEthTx(t, txStore, fromAddress)
@@ -1849,7 +1850,7 @@ func TestORM_UpdateTxStatesToFinalizedUsingTxHashes(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	broadcast := time.Now()
 	fromAddress := testutils.NewAddress()
 
@@ -1882,7 +1883,7 @@ func TestORM_FindReorgOrIncludedTxs(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	blockNum := int64(100)
 	t.Run("finds re-org'd transactions using the mined tx count", func(t *testing.T) {
 		fromAddress := testutils.NewAddress()
@@ -1944,7 +1945,7 @@ func TestORM_UpdateTxFatalError(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	t.Run("successfully marks transaction as fatal with error message", func(t *testing.T) {
 		// Unconfirmed with purge attempt with nonce less than mined tx cound is newly included
@@ -1969,7 +1970,7 @@ func TestORM_FindTxesByIDs(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	fromAddress := testutils.NewAddress()
 
@@ -1992,7 +1993,7 @@ func TestORM_DeleteReceiptsByTxHash(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	fromAddress := testutils.NewAddress()
 
@@ -2018,7 +2019,7 @@ func TestORM_Abandon(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	fromAddress := testutils.NewAddress()
 	etx1 := mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
@@ -2062,7 +2063,7 @@ func mustInsertTerminallyStuckTxWithAttempt(t testing.TB, txStore txmgr.TestEvmT
 		Error:              null.StringFrom(client.TerminallyStuckMsg),
 	}
 	require.NoError(t, txStore.InsertTx(ctx, &tx))
-	attempt := cltest.NewLegacyEthTxAttempt(t, tx.ID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx.ID)
 	attempt.BroadcastBeforeBlockNum = &broadcastBeforeBlockNum
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.IsPurgeAttempt = true

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -128,7 +128,7 @@ func TestORM(t *testing.T) {
 		etx = evmtxmgrtestutils.NewEthTx(fromAddress)
 		require.NoError(t, orm.InsertTx(ctx, &etx))
 		assert.Greater(t, int(etx.ID), 0)
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 	})
 	var attemptL txmgr.TxAttempt
 	var attemptD txmgr.TxAttempt
@@ -136,14 +136,14 @@ func TestORM(t *testing.T) {
 		attemptD = evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
 		require.NoError(t, orm.InsertTxAttempt(ctx, &attemptD))
 		assert.Greater(t, int(attemptD.ID), 0)
-		cltest.AssertCount(t, db, "evm.tx_attempts", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.tx_attempts", 1)
 
 		attemptL = evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 		attemptL.State = txmgrtypes.TxAttemptBroadcast
 		attemptL.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(42)}
 		require.NoError(t, orm.InsertTxAttempt(ctx, &attemptL))
 		assert.Greater(t, int(attemptL.ID), 0)
-		cltest.AssertCount(t, db, "evm.tx_attempts", 2)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.tx_attempts", 2)
 	})
 	var r txmgr.Receipt
 	t.Run("InsertReceipt", func(t *testing.T) {
@@ -152,7 +152,7 @@ func TestORM(t *testing.T) {
 		r.ID = id
 		require.NoError(t, err)
 		assert.Greater(t, int(r.ID), 0)
-		cltest.AssertCount(t, db, "evm.receipts", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.receipts", 1)
 	})
 	t.Run("FindTxWithAttempts", func(t *testing.T) {
 		var err error
@@ -692,7 +692,7 @@ func Test_FindReceiptWithIdempotencyKey(t *testing.T) {
 		etx.IdempotencyKey = &idempotencyKey
 		require.NoError(t, txStore.InsertTx(ctx, &etx))
 		assert.Greater(t, int(etx.ID), 0)
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 
 		// insert attempt
 		var attemptL txmgr.TxAttempt
@@ -700,14 +700,14 @@ func Test_FindReceiptWithIdempotencyKey(t *testing.T) {
 		attemptD = evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attemptD))
 		assert.Greater(t, int(attemptD.ID), 0)
-		cltest.AssertCount(t, db, "evm.tx_attempts", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.tx_attempts", 1)
 
 		attemptL = evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 		attemptL.State = txmgrtypes.TxAttemptBroadcast
 		attemptL.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(42)}
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attemptL))
 		assert.Greater(t, int(attemptL.ID), 0)
-		cltest.AssertCount(t, db, "evm.tx_attempts", 2)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.tx_attempts", 2)
 
 		// insert receipt
 		var r txmgr.Receipt
@@ -716,7 +716,7 @@ func Test_FindReceiptWithIdempotencyKey(t *testing.T) {
 		r.ID = id
 		require.NoError(t, err)
 		assert.Greater(t, int(r.ID), 0)
-		cltest.AssertCount(t, db, "evm.receipts", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.receipts", 1)
 
 		res, err := txStore.FindReceiptWithIdempotencyKey(ctx, idempotencyKey, etx.ChainID)
 		require.NoError(t, err)
@@ -1663,7 +1663,7 @@ func TestORM_CreateTransaction(t *testing.T) {
 		assert.Equal(t, big.Int(assets.NewEthValue(0)), etx.Value)
 		assert.Equal(t, subject, etx.Subject.UUID)
 
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 
 		var dbEthTx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEthTx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))
@@ -1715,7 +1715,7 @@ func TestORM_CreateTransaction(t *testing.T) {
 		assert.Equal(t, fromAddress, etx.FromAddress)
 		assert.True(t, etx.SignalCallback)
 
-		cltest.AssertCount(t, db, "evm.txes", 3)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 3)
 
 		var dbEthTx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEthTx, `SELECT * FROM evm.txes ORDER BY id DESC LIMIT 1`))

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
 
 func TestORM_TransactionsWithAttempts(t *testing.T) {

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
@@ -36,17 +36,17 @@ import (
 
 func TestORM_TransactionsWithAttempts(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
 
-	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)        // tx1
-	tx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, fromAddress) // tx2
+	txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)        // tx1
+	tx2 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, fromAddress) // tx2
 
 	// add 2nd attempt to tx2
 	blockNum := int64(3)
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx2.ID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, tx2.ID)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(3)}
 	attempt.BroadcastBeforeBlockNum = &blockNum
@@ -80,17 +80,17 @@ func TestORM_TransactionsWithAttempts(t *testing.T) {
 
 func TestORM_Transactions(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
 
-	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)        // tx1
-	tx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, fromAddress) // tx2
+	txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)        // tx1
+	tx2 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, fromAddress) // tx2
 
 	// add 2nd attempt to tx2
 	blockNum := int64(3)
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx2.ID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, tx2.ID)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(3)}
 	attempt.BroadcastBeforeBlockNum = &blockNum
@@ -118,31 +118,31 @@ func TestORM(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	orm := evmtxmgrtestutils.NewTestTxStore(t, db)
+	orm := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	ctx := tests.Context(t)
 
 	var etx txmgr.Tx
 	t.Run("InsertTx", func(t *testing.T) {
-		etx = evmtxmgrtestutils.NewEthTx(fromAddress)
+		etx = txmgrtest.NewEthTx(fromAddress)
 		require.NoError(t, orm.InsertTx(ctx, &etx))
 		assert.Greater(t, int(etx.ID), 0)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 	})
 	var attemptL txmgr.TxAttempt
 	var attemptD txmgr.TxAttempt
 	t.Run("InsertTxAttempt", func(t *testing.T) {
-		attemptD = evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
+		attemptD = txmgrtest.NewDynamicFeeEthTxAttempt(t, etx.ID)
 		require.NoError(t, orm.InsertTxAttempt(ctx, &attemptD))
 		assert.Greater(t, int(attemptD.ID), 0)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.tx_attempts", 1)
+		txmgrtest.AssertCount(t, db, "evm.tx_attempts", 1)
 
-		attemptL = evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+		attemptL = txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 		attemptL.State = txmgrtypes.TxAttemptBroadcast
 		attemptL.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(42)}
 		require.NoError(t, orm.InsertTxAttempt(ctx, &attemptL))
 		assert.Greater(t, int(attemptL.ID), 0)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.tx_attempts", 2)
+		txmgrtest.AssertCount(t, db, "evm.tx_attempts", 2)
 	})
 	var r txmgr.Receipt
 	t.Run("InsertReceipt", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestORM(t *testing.T) {
 		r.ID = id
 		require.NoError(t, err)
 		assert.Greater(t, int(r.ID), 0)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.receipts", 1)
+		txmgrtest.AssertCount(t, db, "evm.receipts", 1)
 	})
 	t.Run("FindTxWithAttempts", func(t *testing.T) {
 		var err error
@@ -184,17 +184,17 @@ func TestORM(t *testing.T) {
 
 func TestORM_FindTxAttemptConfirmedByTxIDs(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	orm := evmtxmgrtestutils.NewTestTxStore(t, db)
+	orm := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
 
-	tx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, orm, 0, 1, fromAddress) // tx1
-	tx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, orm, 1, 2, fromAddress) // tx2
+	tx1 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, orm, 0, 1, fromAddress) // tx1
+	tx2 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, orm, 1, 2, fromAddress) // tx2
 
 	// add 2nd attempt to tx2
 	blockNum := int64(3)
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx2.ID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, tx2.ID)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(3)}
 	attempt.BroadcastBeforeBlockNum = &blockNum
@@ -207,8 +207,8 @@ func TestORM_FindTxAttemptConfirmedByTxIDs(t *testing.T) {
 	// tx 3 has no attempts
 	mustCreateUnstartedGeneratedTx(t, orm, fromAddress, testutils.FixtureChainID)
 
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, orm, 3, fromAddress)                           // tx4
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, orm, 4, fromAddress) // tx5
+	txmgrtest.MustInsertUnconfirmedEthTx(t, orm, 3, fromAddress)                           // tx4
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, orm, 4, fromAddress) // tx5
 
 	var count int
 	err = db.Get(&count, `SELECT count(*) FROM evm.txes`)
@@ -233,7 +233,7 @@ func TestORM_FindTxAttemptsRequiringResend(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
@@ -246,10 +246,10 @@ func TestORM_FindTxAttemptsRequiringResend(t *testing.T) {
 	})
 
 	// Mix up the insert order to assure that they come out sorted by nonce not implicitly or by ID
-	e1 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, time.Unix(1616509200, 0))
+	e1 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, time.Unix(1616509200, 0))
 	e3 := mustInsertUnconfirmedEthTxWithBroadcastDynamicFeeAttempt(t, txStore, 3, fromAddress, time.Unix(1616509400, 0))
-	e0 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, time.Unix(1616509100, 0))
-	e2 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress, time.Unix(1616509300, 0))
+	e0 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, time.Unix(1616509100, 0))
+	e2 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress, time.Unix(1616509300, 0))
 
 	etxs := []txmgr.Tx{
 		e0,
@@ -265,17 +265,17 @@ func TestORM_FindTxAttemptsRequiringResend(t *testing.T) {
 	attempt3_2.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(10)}
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt3_2))
 
-	attempt4_2 := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
+	attempt4_2 := txmgrtest.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
 	attempt4_2.TxFee.GasTipCap = assets.NewWeiI(10)
 	attempt4_2.TxFee.GasFeeCap = assets.NewWeiI(20)
 	attempt4_2.State = txmgrtypes.TxAttemptBroadcast
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt4_2))
-	attempt4_4 := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
+	attempt4_4 := txmgrtest.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
 	attempt4_4.TxFee.GasTipCap = assets.NewWeiI(30)
 	attempt4_4.TxFee.GasFeeCap = assets.NewWeiI(40)
 	attempt4_4.State = txmgrtypes.TxAttemptBroadcast
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt4_4))
-	attempt4_3 := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
+	attempt4_3 := txmgrtest.NewDynamicFeeEthTxAttempt(t, etxs[3].ID)
 	attempt4_3.TxFee.GasTipCap = assets.NewWeiI(20)
 	attempt4_3.TxFee.GasFeeCap = assets.NewWeiI(30)
 	attempt4_3.State = txmgrtypes.TxAttemptBroadcast
@@ -318,7 +318,7 @@ func TestORM_UpdateBroadcastAts(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	orm := evmtxmgrtestutils.NewTestTxStore(t, db)
+	orm := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("does not update when broadcast_at is NULL", func(t *testing.T) {
@@ -343,7 +343,7 @@ func TestORM_UpdateBroadcastAts(t *testing.T) {
 
 		ctx := tests.Context(t)
 		time1 := time.Now()
-		etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+		etx := txmgrtest.NewEthTx(fromAddress)
 		etx.Sequence = new(types.Nonce)
 		etx.State = txmgrcommon.TxUnconfirmed
 		etx.BroadcastAt = &time1
@@ -366,10 +366,10 @@ func TestORM_SetBroadcastBeforeBlockNum(t *testing.T) {
 
 	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewChainScopedConfig(t, nil)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
-	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+	etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
 	chainID := ethClient.ConfiguredChainID()
 	ctx := tests.Context(t)
 
@@ -406,8 +406,8 @@ func TestORM_SetBroadcastBeforeBlockNum(t *testing.T) {
 	})
 
 	t.Run("only updates evm.tx_attempts for the current chain", func(t *testing.T) {
-		etxThisChain := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, cfg.EVM().ChainID())
-		etxOtherChain := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, testutils.SimulatedChainID)
+		etxThisChain := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, cfg.EVM().ChainID())
+		etxOtherChain := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, testutils.SimulatedChainID)
 
 		require.NoError(t, txStore.SetBroadcastBeforeBlockNum(tests.Context(t), headNum, chainID))
 
@@ -432,7 +432,7 @@ func TestORM_UpdateTxConfirmed(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	etx0 := mustInsertUnconfirmedEthTxWithAttemptState(t, txStore, 0, fromAddress, txmgrtypes.TxAttemptBroadcast)
@@ -458,11 +458,11 @@ func TestORM_SaveFetchedReceipts(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	ctx := tests.Context(t)
 
-	tx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 100, fromAddress)
+	tx1 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 100, fromAddress)
 	require.Len(t, tx1.TxAttempts, 1)
 
 	tx2 := mustInsertTerminallyStuckTxWithAttempt(t, txStore, fromAddress, 1, 100)
@@ -504,12 +504,12 @@ func TestORM_PreloadTxes(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("loads eth transaction", func(t *testing.T) {
 		// insert etx with attempt
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(7), fromAddress)
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(7), fromAddress)
 
 		// create unloaded attempt
 		unloadedAttempt := txmgr.TxAttempt{TxID: etx.ID}
@@ -536,7 +536,7 @@ func TestORM_GetInProgressTxAttempts(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -555,7 +555,7 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -582,7 +582,7 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	runID1 := testutils.MustInsertPipelineRun(t, db)
 	trID1 := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID1)
 	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, runID1)
-	etx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 1, fromAddress)
+	etx1 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": true}'`)
 	attempt1 := etx1.TxAttempts[0]
 	etxBlockNum := mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, attempt1.Hash).BlockNumber
@@ -592,7 +592,7 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	runID2 := testutils.MustInsertPipelineRun(t, db)
 	trID2 := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID2)
 	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'completed', outputs = '""'::jsonb, finished_at = NOW() WHERE id = $1`, runID2)
-	etx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 1, fromAddress)
+	etx2 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
 	attempt2 := etx2.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, attempt2.Hash)
@@ -602,20 +602,20 @@ func TestORM_FindTxesPendingCallback(t *testing.T) {
 	runID3 := testutils.MustInsertPipelineRun(t, db)
 	trID3 := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID3)
 	testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, runID3)
-	etx3 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 5, 1, fromAddress)
+	etx3 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 5, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": false}'`)
 	attempt3 := etx3.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number, head.Hash, attempt3.Hash)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &trID3, minConfirmations, etx3.ID)
 
 	// Tx not marked for callback. Should be ignore
-	etx4 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 6, 1, fromAddress)
+	etx4 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 6, 1, fromAddress)
 	attempt4 := etx4.TxAttempts[0]
 	mustInsertEthReceipt(t, txStore, head.Number, head.Hash, attempt4.Hash)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET min_confirmations = $1 WHERE id = $2`, minConfirmations, etx4.ID)
 
 	// Unconfirmed Tx without receipts. Should be ignored
-	etx5 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 7, 1, fromAddress)
+	etx5 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 7, 1, fromAddress)
 	testutils.MustExec(t, db, `UPDATE evm.txes SET min_confirmations = $1 WHERE id = $2`, minConfirmations, etx5.ID)
 
 	// Search evm.txes table for tx requiring callback
@@ -645,7 +645,7 @@ func Test_FindTxWithIdempotencyKey(t *testing.T) {
 	t.Parallel()
 	db := testutils.NewSqlxDB(t)
 	cfg := configtest.NewChainScopedConfig(t, nil)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("returns nil error if no results", func(t *testing.T) {
@@ -673,7 +673,7 @@ func Test_FindReceiptWithIdempotencyKey(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	ctx := t.Context()
 
@@ -687,26 +687,26 @@ func Test_FindReceiptWithIdempotencyKey(t *testing.T) {
 	t.Run("returns receipt if it exists", func(t *testing.T) {
 		var etx txmgr.Tx
 		// insert tx
-		etx = evmtxmgrtestutils.NewEthTx(fromAddress)
+		etx = txmgrtest.NewEthTx(fromAddress)
 		etx.IdempotencyKey = &idempotencyKey
 		require.NoError(t, txStore.InsertTx(ctx, &etx))
 		assert.Greater(t, int(etx.ID), 0)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 
 		// insert attempt
 		var attemptL txmgr.TxAttempt
 		var attemptD txmgr.TxAttempt
-		attemptD = evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
+		attemptD = txmgrtest.NewDynamicFeeEthTxAttempt(t, etx.ID)
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attemptD))
 		assert.Greater(t, int(attemptD.ID), 0)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.tx_attempts", 1)
+		txmgrtest.AssertCount(t, db, "evm.tx_attempts", 1)
 
-		attemptL = evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+		attemptL = txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 		attemptL.State = txmgrtypes.TxAttemptBroadcast
 		attemptL.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(42)}
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attemptL))
 		assert.Greater(t, int(attemptL.ID), 0)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.tx_attempts", 2)
+		txmgrtest.AssertCount(t, db, "evm.tx_attempts", 2)
 
 		// insert receipt
 		var r txmgr.Receipt
@@ -715,7 +715,7 @@ func Test_FindReceiptWithIdempotencyKey(t *testing.T) {
 		r.ID = id
 		require.NoError(t, err)
 		assert.Greater(t, int(r.ID), 0)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.receipts", 1)
+		txmgrtest.AssertCount(t, db, "evm.receipts", 1)
 
 		res, err := txStore.FindReceiptWithIdempotencyKey(ctx, idempotencyKey, etx.ChainID)
 		require.NoError(t, err)
@@ -729,7 +729,7 @@ func TestORM_FindTxWithSequence(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("returns nil if no results", func(t *testing.T) {
@@ -739,7 +739,7 @@ func TestORM_FindTxWithSequence(t *testing.T) {
 	})
 
 	t.Run("returns transaction if it exists", func(t *testing.T) {
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 777, 1, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 777, 1, fromAddress)
 		require.Equal(t, types.Nonce(777), *etx.Sequence)
 
 		res, err := txStore.FindTxWithSequence(tests.Context(t), fromAddress, types.Nonce(777))
@@ -752,7 +752,7 @@ func TestORM_UpdateTxForRebroadcast(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	ctx := tests.Context(t)
 
@@ -823,7 +823,7 @@ func TestORM_FindEarliestUnconfirmedBroadcastTime(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -834,7 +834,7 @@ func TestORM_FindEarliestUnconfirmedBroadcastTime(t *testing.T) {
 	})
 
 	t.Run("verify broadcast time", func(t *testing.T) {
-		tx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, 123, fromAddress)
+		tx := txmgrtest.MustInsertUnconfirmedEthTx(t, txStore, 123, fromAddress)
 		broadcastAt, err := txStore.FindEarliestUnconfirmedBroadcastTime(tests.Context(t), ethClient.ConfiguredChainID())
 		require.NoError(t, err)
 		require.True(t, broadcastAt.Ptr().Equal(*tx.BroadcastAt))
@@ -845,7 +845,7 @@ func TestORM_FindEarliestUnconfirmedTxAttemptBlock(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 	fromAddress2 := testutils.NewAddress()
@@ -875,7 +875,7 @@ func TestORM_SaveInsufficientEthAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	defaultDuration, err := time.ParseDuration("5s")
 	require.NoError(t, err)
@@ -898,7 +898,7 @@ func TestORM_SaveSentAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	defaultDuration, err := time.ParseDuration("5s")
 	require.NoError(t, err)
@@ -922,7 +922,7 @@ func TestORM_SaveConfirmedAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	defaultDuration, err := time.ParseDuration("5s")
 	require.NoError(t, err)
@@ -946,7 +946,7 @@ func TestORM_DeleteInProgressAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("deletes in_progress attempt", func(t *testing.T) {
@@ -967,13 +967,13 @@ func TestORM_SaveInProgressAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("saves new in_progress attempt if attempt is new", func(t *testing.T) {
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, 1, fromAddress)
+		etx := txmgrtest.MustInsertUnconfirmedEthTx(t, txStore, 1, fromAddress)
 
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 		require.Equal(t, int64(0), attempt.ID)
 
 		err := txStore.SaveInProgressAttempt(tests.Context(t), &attempt)
@@ -1006,7 +1006,7 @@ func TestORM_FindTxsRequiringGasBump(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -1044,7 +1044,7 @@ func TestEthConfirmer_FindTxsRequiringResubmissionDueToInsufficientEth(t *testin
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
@@ -1052,16 +1052,16 @@ func TestEthConfirmer_FindTxsRequiringResubmissionDueToInsufficientEth(t *testin
 
 	// Insert order is mixed up to test sorting
 	etx2 := mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t, txStore, 1, fromAddress)
-	etx3 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
-	attempt3_2 := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx3.ID)
+	etx3 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
+	attempt3_2 := txmgrtest.NewLegacyEthTxAttempt(t, etx3.ID)
 	attempt3_2.State = txmgrtypes.TxAttemptInsufficientFunds
 	attempt3_2.TxFee.GasPrice = assets.NewWeiI(100)
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt3_2))
 	etx1 := mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t, txStore, 0, fromAddress)
 
 	// These should never be returned
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 3, fromAddress)
-	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 100, fromAddress)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 3, fromAddress)
+	txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 100, fromAddress)
 	mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t, txStore, 0, otherAddress)
 
 	t.Run("returns all eth_txes with at least one attempt that is in insufficient_eth state", func(t *testing.T) {
@@ -1104,7 +1104,7 @@ func TestORM_LoadEthTxesAttempts(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("load eth tx attempt", func(t *testing.T) {
@@ -1118,7 +1118,7 @@ func TestORM_LoadEthTxesAttempts(t *testing.T) {
 
 	t.Run("load new attempt inserted in current postgres transaction", func(t *testing.T) {
 		etx := mustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(t, txStore, 3, 9, time.Now(), fromAddress)
-		newAttempt := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
+		newAttempt := txmgrtest.NewDynamicFeeEthTxAttempt(t, etx.ID)
 		var dbAttempt txmgr.DbEthTxAttempt
 		dbAttempt.FromTxAttempt(&newAttempt)
 
@@ -1156,14 +1156,14 @@ func TestORM_SaveReplacementInProgressAttempt(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("replace eth tx attempt", func(t *testing.T) {
 		etx := mustInsertInProgressEthTxWithAttempt(t, txStore, 123, fromAddress)
 		oldAttempt := etx.TxAttempts[0]
 
-		newAttempt := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
+		newAttempt := txmgrtest.NewDynamicFeeEthTxAttempt(t, etx.ID)
 		err := txStore.SaveReplacementInProgressAttempt(tests.Context(t), oldAttempt, &newAttempt)
 		require.NoError(t, err)
 
@@ -1178,7 +1178,7 @@ func TestORM_FindNextUnstartedTransactionFromAddress(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -1203,7 +1203,7 @@ func TestORM_UpdateTxFatalErrorAndDeleteAttempts(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("update successful", func(t *testing.T) {
@@ -1225,7 +1225,7 @@ func TestORM_UpdateTxAttemptInProgressToBroadcast(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("update successful", func(t *testing.T) {
@@ -1255,14 +1255,14 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	nonce := types.Nonce(123)
 
 	t.Run("update successful", func(t *testing.T) {
 		etx := mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
 		etx.Sequence = &nonce
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 
 		err := txStore.UpdateTxUnstartedToInProgress(tests.Context(t), &etx, &attempt)
 		require.NoError(t, err)
@@ -1277,7 +1277,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 		etx := mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
 		etx.Sequence = &nonce
 
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 
 		_, err := db.ExecContext(ctx, "DELETE FROM evm.txes WHERE id = $1", etx.ID)
 		require.NoError(t, err)
@@ -1287,7 +1287,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 	})
 
 	db = testutils.NewSqlxDB(t)
-	txStore = evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore = txmgrtest.NewTestTxStore(t, db)
 	fromAddress = testutils.NewAddress()
 
 	t.Run("update replaces abandoned tx with same hash", func(t *testing.T) {
@@ -1309,7 +1309,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 
 		etx2 := mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
 		etx2.Sequence = &nonce
-		attempt2 := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx2.ID)
+		attempt2 := txmgrtest.NewLegacyEthTxAttempt(t, etx2.ID)
 		attempt2.Hash = etx.TxAttempts[0].Hash
 
 		// Even though this will initially fail due to idx_eth_tx_attempts_hash constraint, because the conflicting tx has been abandoned
@@ -1330,7 +1330,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 		// Should fail due to idx_eth_tx_attempt_hash constraint
 		err := txStore.UpdateTxUnstartedToInProgress(tests.Context(t), &etx, &etx.TxAttempts[0])
 		assert.ErrorContains(t, err, "idx_eth_tx_attempts_hash")
-		txStore = evmtxmgrtestutils.NewTestTxStore(t, db) // current txStore is poisened now, next test will need fresh one
+		txStore = txmgrtest.NewTestTxStore(t, db) // current txStore is poisened now, next test will need fresh one
 	})
 }
 
@@ -1338,7 +1338,7 @@ func TestORM_GetTxInProgress(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("gets 0 in progress eth transaction", func(t *testing.T) {
@@ -1360,7 +1360,7 @@ func TestORM_GetAbandonedTransactionsByBatch(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 	enabled := testutils.NewAddress()
@@ -1416,7 +1416,7 @@ func TestORM_GetTxByID(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("no transaction", func(t *testing.T) {
@@ -1437,7 +1437,7 @@ func TestORM_GetFatalTransactions(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	t.Run("gets 0 fatal eth transactions", func(t *testing.T) {
@@ -1458,7 +1458,7 @@ func TestORM_HasInProgressTransaction(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	fromAddress := testutils.NewAddress()
 
@@ -1481,15 +1481,15 @@ func TestORM_CountUnconfirmedTransactions(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	fromAddress := testutils.NewAddress()
 	otherAddress := testutils.NewAddress()
 
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, otherAddress)
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, otherAddress)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
 
 	count, err := txStore.CountUnconfirmedTransactions(tests.Context(t), fromAddress, testutils.FixtureChainID)
 	require.NoError(t, err)
@@ -1500,15 +1500,15 @@ func TestORM_CountTransactionsByState(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	fromAddress1 := testutils.NewAddress()
 	fromAddress2 := testutils.NewAddress()
 	fromAddress3 := testutils.NewAddress()
 
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress1)
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress2)
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress3)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress1)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress2)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress3)
 
 	count, err := txStore.CountTransactionsByState(tests.Context(t), txmgrcommon.TxUnconfirmed, testutils.FixtureChainID)
 	require.NoError(t, err)
@@ -1519,7 +1519,7 @@ func TestORM_CountUnstartedTransactions(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	fromAddress := testutils.NewAddress()
 	otherAddress := testutils.NewAddress()
@@ -1527,7 +1527,7 @@ func TestORM_CountUnstartedTransactions(t *testing.T) {
 	mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
 	mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
 	mustCreateUnstartedGeneratedTx(t, txStore, otherAddress, testutils.FixtureChainID)
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
 
 	count, err := txStore.CountUnstartedTransactions(tests.Context(t), fromAddress, testutils.FixtureChainID)
 	require.NoError(t, err)
@@ -1538,7 +1538,7 @@ func TestORM_CheckTxQueueCapacity(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	otherAddress := testutils.NewAddress()
 
@@ -1575,7 +1575,7 @@ func TestORM_CheckTxQueueCapacity(t *testing.T) {
 	var n int64
 	mustInsertInProgressEthTxWithAttempt(t, txStore, types.Nonce(n), fromAddress)
 	n++
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, n, fromAddress)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, n, fromAddress)
 	n++
 
 	t.Run("unconfirmed and in_progress transactions do not count", func(t *testing.T) {
@@ -1585,7 +1585,7 @@ func TestORM_CheckTxQueueCapacity(t *testing.T) {
 
 	// deliberately one extra to exceed limit
 	for i := 0; i <= int(maxUnconfirmedTransactions); i++ {
-		evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, n, 42, fromAddress)
+		txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, n, 42, fromAddress)
 		n++
 	}
 
@@ -1662,7 +1662,7 @@ func TestORM_CreateTransaction(t *testing.T) {
 		assert.Equal(t, big.Int(assets.NewEthValue(0)), etx.Value)
 		assert.Equal(t, subject, etx.Subject.UUID)
 
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 
 		var dbEthTx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEthTx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))
@@ -1714,7 +1714,7 @@ func TestORM_CreateTransaction(t *testing.T) {
 		assert.Equal(t, fromAddress, etx.FromAddress)
 		assert.True(t, etx.SignalCallback)
 
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 3)
+		txmgrtest.AssertCount(t, db, "evm.txes", 3)
 
 		var dbEthTx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEthTx, `SELECT * FROM evm.txes ORDER BY id DESC LIMIT 1`))
@@ -1754,12 +1754,12 @@ func TestORM_FindTxesWithAttemptsAndReceiptsByIdsAndState(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	fromAddress := testutils.NewAddress()
 
-	tx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)
+	tx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, fromAddress)
 	r := newEthReceipt(4, utils.NewHash(), tx.TxAttempts[0].Hash, 0x1)
 	_, err := txStore.InsertReceipt(ctx, &r.Receipt)
 	require.NoError(t, err)
@@ -1786,7 +1786,7 @@ func TestORM_FindAttemptsRequiringReceiptFetch(t *testing.T) {
 
 	t.Run("finds confirmed transaction requiring receipt fetch", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		// Transactions whose attempts should not be picked up for receipt fetch
 		mustInsertFatalErrorEthTx(t, txStore, fromAddress)
@@ -1817,7 +1817,7 @@ func TestORM_FindAttemptsRequiringReceiptFetch(t *testing.T) {
 
 	t.Run("finds terminally stuck transaction requiring receipt fetch", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		// Transactions whose attempts should not be picked up for receipt fetch
 		mustInsertFatalErrorEthTx(t, txStore, fromAddress)
@@ -1849,7 +1849,7 @@ func TestORM_UpdateTxStatesToFinalizedUsingTxHashes(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	broadcast := time.Now()
 	fromAddress := testutils.NewAddress()
 
@@ -1882,7 +1882,7 @@ func TestORM_FindReorgOrIncludedTxs(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	blockNum := int64(100)
 	t.Run("finds re-org'd transactions using the mined tx count", func(t *testing.T) {
 		fromAddress := testutils.NewAddress()
@@ -1944,7 +1944,7 @@ func TestORM_UpdateTxFatalError(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	t.Run("successfully marks transaction as fatal with error message", func(t *testing.T) {
 		// Unconfirmed with purge attempt with nonce less than mined tx cound is newly included
@@ -1969,7 +1969,7 @@ func TestORM_FindTxesByIDs(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	fromAddress := testutils.NewAddress()
 
@@ -1992,7 +1992,7 @@ func TestORM_DeleteReceiptsByTxHash(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	fromAddress := testutils.NewAddress()
 
@@ -2018,7 +2018,7 @@ func TestORM_Abandon(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	fromAddress := testutils.NewAddress()
 	etx1 := mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, testutils.FixtureChainID)
@@ -2062,7 +2062,7 @@ func mustInsertTerminallyStuckTxWithAttempt(t testing.TB, txStore txmgr.TestEvmT
 		Error:              null.StringFrom(client.TerminallyStuckMsg),
 	}
 	require.NoError(t, txStore.InsertTx(ctx, &tx))
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx.ID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, tx.ID)
 	attempt.BroadcastBeforeBlockNum = &broadcastBeforeBlockNum
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.IsPurgeAttempt = true

--- a/core/chains/evm/txmgr/finalizer_benchmark_test.go
+++ b/core/chains/evm/txmgr/finalizer_benchmark_test.go
@@ -18,13 +18,13 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 )
 
 func BenchmarkFinalizer(b *testing.B) {
 	ctx := tests.Context(b)
 	db := testutils.NewSqlxDB(b)
-	txStore := cltest.NewTestTxStore(b, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(b, db)
 	feeLimit := uint64(10_000)
 	ethClient := clienttest.NewClientWithDefaultChainID(b)
 	txmClient := txmgr.NewEvmTxmClient(ethClient, nil)

--- a/core/chains/evm/txmgr/finalizer_benchmark_test.go
+++ b/core/chains/evm/txmgr/finalizer_benchmark_test.go
@@ -18,13 +18,13 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 )
 
 func BenchmarkFinalizer(b *testing.B) {
 	ctx := tests.Context(b)
 	db := testutils.NewSqlxDB(b)
-	txStore := evmtxmgrtestutils.NewTestTxStore(b, db)
+	txStore := txmgrtest.NewTestTxStore(b, db)
 	feeLimit := uint64(10_000)
 	ethClient := clienttest.NewClientWithDefaultChainID(b)
 	txmClient := txmgr.NewEvmTxmClient(ethClient, nil)

--- a/core/chains/evm/txmgr/finalizer_test.go
+++ b/core/chains/evm/txmgr/finalizer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
@@ -34,14 +35,13 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
 
 func TestFinalizer_MarkTxFinalized(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	feeLimit := uint64(10_000)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	txmClient := txmgr.NewEvmTxmClient(ethClient, nil)
@@ -247,7 +247,7 @@ func insertTxAndAttemptWithIdempotencyKey(tb testing.TB, txStore txmgr.TestEvmTx
 	require.NoError(tb, err)
 	tx, err = txStore.FindTxWithIdempotencyKey(ctx, idempotencyKey, testutils.FixtureChainID)
 	require.NoError(tb, err)
-	attempt := cltest.NewLegacyEthTxAttempt(tb, tx.ID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(tb, tx.ID)
 	err = txStore.InsertTxAttempt(ctx, &attempt)
 	require.NoError(tb, err)
 	return attempt.Hash
@@ -257,7 +257,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	txmClient := txmgr.NewEvmTxmClient(ethClient, nil)
 	rpcBatchSize := uint32(1)
@@ -297,7 +297,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 		runID := testutils.MustInsertPipelineRun(t, db)
 		trID := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 1, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 1, fromAddress)
 		mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, etx.TxAttempts[0].Hash)
 		// Setting both signal_callback and callback_completed to TRUE to simulate a completed pipeline task
 		// It would only be in a state past suspended if the resume callback was called and callback_completed was set to TRUE
@@ -319,7 +319,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 		runID := testutils.MustInsertPipelineRun(t, db)
 		trID := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 2, 1, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 2, 1, fromAddress)
 		mustInsertEthReceipt(t, txStore, head.Number, head.Hash, etx.TxAttempts[0].Hash)
 
 		testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &trID, minConfirmations, etx.ID)
@@ -345,7 +345,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 		trID := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 		testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, runID)
 
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
 		testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": true}'`)
 		receipt := mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, etx.TxAttempts[0].Hash)
 
@@ -398,7 +398,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 		trID := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 		testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, runID)
 
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
 		testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": true}'`)
 
 		// receipt is not passed through as a value since it reverted and caused an error
@@ -444,7 +444,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 		runID := testutils.MustInsertPipelineRun(t, db)
 		trID := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
 		mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, etx.TxAttempts[0].Hash)
 		testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &trID, minConfirmations, etx.ID)
 
@@ -483,7 +483,7 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("does nothing if no confirmed transactions without receipts found", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, config.EVM().RPCDefaultBatchSize(), false, txStore, txmClient, ht, metrics)
 
@@ -501,11 +501,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("fetches receipt for confirmed transaction without a receipt", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		// Transaction not confirmed yet, receipt is nil
 		ethClient.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
 			return len(b) == 1 && matchTranscationReceipt(b[0], etx.TxAttempts[0].Hash)
@@ -527,11 +527,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("saves nothing if returned receipt does not match the attempt", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		txmReceipt := types.Receipt{
 			TxHash:           testutils.NewHash(),
 			BlockHash:        testutils.NewHash(),
@@ -559,11 +559,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("saves nothing if query returns error", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		txmReceipt := types.Receipt{
 			TxHash:           etx.TxAttempts[0].Hash,
 			BlockHash:        testutils.NewHash(),
@@ -592,13 +592,13 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("saves valid receipt returned by client", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx1 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		// Insert confirmed transaction without receipt
-		etx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, head.Number, fromAddress)
+		etx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, head.Number, fromAddress)
 		txmReceipt := types.Receipt{
 			TxHash:           etx1.TxAttempts[0].Hash,
 			BlockHash:        testutils.NewHash(),
@@ -646,11 +646,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("fetches and saves receipts for several attempts in gas price order", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		attempt1 := etx.TxAttempts[0]
 		attempt2 := newBroadcastLegacyEthTxAttempt(t, etx.ID, 2)
 		attempt3 := newBroadcastLegacyEthTxAttempt(t, etx.ID, 3)
@@ -698,11 +698,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("ignores receipt missing BlockHash that comes from querying parity too early", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		receipt := types.Receipt{
 			TxHash: etx.TxAttempts[0].Hash,
 			Status: uint64(1),
@@ -729,11 +729,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("does not panic if receipt has BlockHash but is missing some other fields somehow", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		// NOTE: This should never happen, but we shouldn't panic regardless
 		receipt := types.Receipt{
 			TxHash:    etx.TxAttempts[0].Hash,
@@ -761,11 +761,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("simulate on revert", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		attempt := etx.TxAttempts[0]
 		txmReceipt := types.Receipt{
 			TxHash:           attempt.Hash,
@@ -807,12 +807,12 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("find receipt for old transaction, avoid marking as fatal", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, true, txStore, txmClient, ht, metrics)
 
 		// Insert confirmed transaction without receipt
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
 
 		txmReceipt := types.Receipt{
 			TxHash:           etx.TxAttempts[0].Hash,
@@ -841,12 +841,12 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("old transaction failed to find receipt, marked as fatal", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, true, txStore, txmClient, ht, metrics)
 
 		// Insert confirmed transaction without receipt
-		etx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
 
 		// Transaction receipt is nil
 		ethClient.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
@@ -881,7 +881,7 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 		ethClient.On("BatchCallContext", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 		// Should fetch attempts list from txstore
-		attempt := cltest.NewLegacyEthTxAttempt(t, 0)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, 0)
 		txStore.On("FindAttemptsRequiringReceiptFetch", mock.Anything, mock.Anything).Return([]txmgr.TxAttempt{attempt}, nil).Once()
 		require.NoError(t, finalizer.FetchAndStoreReceipts(ctx, head, latestFinalizedHead))
 		// Should use the attempts cache for receipt fetch
@@ -912,7 +912,7 @@ func TestFinalizer_FetchAndStoreReceipts_batching(t *testing.T) {
 
 	t.Run("fetch and store receipts from multiple batch calls", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		rpcBatchSize := uint32(2)
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
@@ -959,14 +959,14 @@ func TestFinalizer_FetchAndStoreReceipts_batching(t *testing.T) {
 
 	t.Run("continue to fetch and store receipts after batch call error", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		rpcBatchSize := uint32(1)
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 
 		// Insert confirmed transactions without receipts
-		etx1 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
-		etx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, head.Number, fromAddress)
+		etx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, head.Number, fromAddress)
 
 		txmReceipt := types.Receipt{
 			TxHash:           etx2.TxAttempts[0].Hash,
@@ -1020,7 +1020,7 @@ func TestFinalizer_FetchAndStoreReceipts_HandlesNonFwdTxsWithForwardingEnabled(t
 	head.Parent.Store(latestFinalizedHead)
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, 1, true, txStore, txmClient, ht, metrics)
 
@@ -1078,20 +1078,20 @@ func TestFinalizer_ProcessOldTxsWithoutReceipts(t *testing.T) {
 
 	t.Run("does nothing if no old transactions found", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, 1, true, txStore, txmClient, ht, metrics)
 		require.NoError(t, finalizer.ProcessOldTxsWithoutReceipts(ctx, []int64{}, head, latestFinalizedHead))
 	})
 
 	t.Run("marks multiple old transactions as fatal", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, 1, true, txStore, txmClient, ht, metrics)
 
 		// Insert confirmed transaction without receipt
-		etx1 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
-		etx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, latestFinalizedHead.Number, fromAddress)
+		etx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
+		etx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, latestFinalizedHead.Number, fromAddress)
 
 		etxIDs := []int64{etx1.ID, etx2.ID}
 		require.NoError(t, finalizer.ProcessOldTxsWithoutReceipts(ctx, etxIDs, head, latestFinalizedHead))
@@ -1111,13 +1111,13 @@ func TestFinalizer_ProcessOldTxsWithoutReceipts(t *testing.T) {
 
 	t.Run("marks old transaction as fatal, resumes pending task as failed", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, 1, true, txStore, txmClient, ht, metrics)
 		finalizer.SetResumeCallback(func(context.Context, uuid.UUID, interface{}, error) error { return nil })
 
 		// Insert confirmed transaction with pending task run
-		etx := cltest.NewEthTx(fromAddress)
+		etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 		etx.State = txmgrcommon.TxConfirmed
 		n := types.Nonce(0)
 		etx.Sequence = &n
@@ -1145,13 +1145,13 @@ func TestFinalizer_ProcessOldTxsWithoutReceipts(t *testing.T) {
 
 	t.Run("transaction stays confirmed if failure to resume pending task", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, 1, true, txStore, txmClient, ht, metrics)
 		finalizer.SetResumeCallback(func(context.Context, uuid.UUID, interface{}, error) error { return errors.New("failure") })
 
 		// Insert confirmed transaction with pending task run
-		etx := cltest.NewEthTx(fromAddress)
+		etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 		etx.State = txmgrcommon.TxConfirmed
 		n := types.Nonce(0)
 		etx.Sequence = &n

--- a/core/chains/evm/txmgr/finalizer_test.go
+++ b/core/chains/evm/txmgr/finalizer_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
@@ -41,7 +41,7 @@ func TestFinalizer_MarkTxFinalized(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	feeLimit := uint64(10_000)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	txmClient := txmgr.NewEvmTxmClient(ethClient, nil)
@@ -247,7 +247,7 @@ func insertTxAndAttemptWithIdempotencyKey(tb testing.TB, txStore txmgr.TestEvmTx
 	require.NoError(tb, err)
 	tx, err = txStore.FindTxWithIdempotencyKey(ctx, idempotencyKey, testutils.FixtureChainID)
 	require.NoError(tb, err)
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(tb, tx.ID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(tb, tx.ID)
 	err = txStore.InsertTxAttempt(ctx, &attempt)
 	require.NoError(tb, err)
 	return attempt.Hash
@@ -257,7 +257,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	txmClient := txmgr.NewEvmTxmClient(ethClient, nil)
 	rpcBatchSize := uint32(1)
@@ -297,7 +297,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 		runID := testutils.MustInsertPipelineRun(t, db)
 		trID := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 1, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 1, fromAddress)
 		mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, etx.TxAttempts[0].Hash)
 		// Setting both signal_callback and callback_completed to TRUE to simulate a completed pipeline task
 		// It would only be in a state past suspended if the resume callback was called and callback_completed was set to TRUE
@@ -319,7 +319,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 		runID := testutils.MustInsertPipelineRun(t, db)
 		trID := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 2, 1, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 2, 1, fromAddress)
 		mustInsertEthReceipt(t, txStore, head.Number, head.Hash, etx.TxAttempts[0].Hash)
 
 		testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &trID, minConfirmations, etx.ID)
@@ -345,7 +345,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 		trID := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 		testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, runID)
 
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
 		testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": true}'`)
 		receipt := mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, etx.TxAttempts[0].Hash)
 
@@ -398,7 +398,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 		trID := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 		testutils.MustExec(t, db, `UPDATE pipeline_runs SET state = 'suspended' WHERE id = $1`, runID)
 
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
 		testutils.MustExec(t, db, `UPDATE evm.txes SET meta='{"FailOnRevert": true}'`)
 
 		// receipt is not passed through as a value since it reverted and caused an error
@@ -444,7 +444,7 @@ func TestFinalizer_ResumePendingRuns(t *testing.T) {
 		runID := testutils.MustInsertPipelineRun(t, db)
 		trID := testutils.MustInsertUnfinishedPipelineTaskRun(t, db, runID)
 
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(nonce), 1, fromAddress)
 		mustInsertEthReceipt(t, txStore, head.Number-minConfirmations, head.Hash, etx.TxAttempts[0].Hash)
 		testutils.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &trID, minConfirmations, etx.ID)
 
@@ -483,7 +483,7 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("does nothing if no confirmed transactions without receipts found", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, config.EVM().RPCDefaultBatchSize(), false, txStore, txmClient, ht, metrics)
 
@@ -501,11 +501,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("fetches receipt for confirmed transaction without a receipt", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		// Transaction not confirmed yet, receipt is nil
 		ethClient.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
 			return len(b) == 1 && matchTranscationReceipt(b[0], etx.TxAttempts[0].Hash)
@@ -527,11 +527,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("saves nothing if returned receipt does not match the attempt", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		txmReceipt := types.Receipt{
 			TxHash:           testutils.NewHash(),
 			BlockHash:        testutils.NewHash(),
@@ -559,11 +559,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("saves nothing if query returns error", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		txmReceipt := types.Receipt{
 			TxHash:           etx.TxAttempts[0].Hash,
 			BlockHash:        testutils.NewHash(),
@@ -592,13 +592,13 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("saves valid receipt returned by client", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx1 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		// Insert confirmed transaction without receipt
-		etx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, head.Number, fromAddress)
+		etx2 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, head.Number, fromAddress)
 		txmReceipt := types.Receipt{
 			TxHash:           etx1.TxAttempts[0].Hash,
 			BlockHash:        testutils.NewHash(),
@@ -646,11 +646,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("fetches and saves receipts for several attempts in gas price order", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		attempt1 := etx.TxAttempts[0]
 		attempt2 := newBroadcastLegacyEthTxAttempt(t, etx.ID, 2)
 		attempt3 := newBroadcastLegacyEthTxAttempt(t, etx.ID, 3)
@@ -698,11 +698,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("ignores receipt missing BlockHash that comes from querying parity too early", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		receipt := types.Receipt{
 			TxHash: etx.TxAttempts[0].Hash,
 			Status: uint64(1),
@@ -729,11 +729,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("does not panic if receipt has BlockHash but is missing some other fields somehow", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		// NOTE: This should never happen, but we shouldn't panic regardless
 		receipt := types.Receipt{
 			TxHash:    etx.TxAttempts[0].Hash,
@@ -761,11 +761,11 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("simulate on revert", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 		// Insert confirmed transaction without receipt
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
 		attempt := etx.TxAttempts[0]
 		txmReceipt := types.Receipt{
 			TxHash:           attempt.Hash,
@@ -807,12 +807,12 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("find receipt for old transaction, avoid marking as fatal", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, true, txStore, txmClient, ht, metrics)
 
 		// Insert confirmed transaction without receipt
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
 
 		txmReceipt := types.Receipt{
 			TxHash:           etx.TxAttempts[0].Hash,
@@ -841,12 +841,12 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 
 	t.Run("old transaction failed to find receipt, marked as fatal", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, true, txStore, txmClient, ht, metrics)
 
 		// Insert confirmed transaction without receipt
-		etx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
+		etx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
 
 		// Transaction receipt is nil
 		ethClient.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
@@ -881,7 +881,7 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 		ethClient.On("BatchCallContext", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 		// Should fetch attempts list from txstore
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, 0)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, 0)
 		txStore.On("FindAttemptsRequiringReceiptFetch", mock.Anything, mock.Anything).Return([]txmgr.TxAttempt{attempt}, nil).Once()
 		require.NoError(t, finalizer.FetchAndStoreReceipts(ctx, head, latestFinalizedHead))
 		// Should use the attempts cache for receipt fetch
@@ -912,7 +912,7 @@ func TestFinalizer_FetchAndStoreReceipts_batching(t *testing.T) {
 
 	t.Run("fetch and store receipts from multiple batch calls", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		rpcBatchSize := uint32(2)
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
@@ -959,14 +959,14 @@ func TestFinalizer_FetchAndStoreReceipts_batching(t *testing.T) {
 
 	t.Run("continue to fetch and store receipts after batch call error", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		rpcBatchSize := uint32(1)
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 
 		// Insert confirmed transactions without receipts
-		etx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
-		etx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, head.Number, fromAddress)
+		etx1 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, head.Number, fromAddress)
+		etx2 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, head.Number, fromAddress)
 
 		txmReceipt := types.Receipt{
 			TxHash:           etx2.TxAttempts[0].Hash,
@@ -1020,7 +1020,7 @@ func TestFinalizer_FetchAndStoreReceipts_HandlesNonFwdTxsWithForwardingEnabled(t
 	head.Parent.Store(latestFinalizedHead)
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, 1, true, txStore, txmClient, ht, metrics)
 
@@ -1078,20 +1078,20 @@ func TestFinalizer_ProcessOldTxsWithoutReceipts(t *testing.T) {
 
 	t.Run("does nothing if no old transactions found", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, 1, true, txStore, txmClient, ht, metrics)
 		require.NoError(t, finalizer.ProcessOldTxsWithoutReceipts(ctx, []int64{}, head, latestFinalizedHead))
 	})
 
 	t.Run("marks multiple old transactions as fatal", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, 1, true, txStore, txmClient, ht, metrics)
 
 		// Insert confirmed transaction without receipt
-		etx1 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
-		etx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, latestFinalizedHead.Number, fromAddress)
+		etx1 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, latestFinalizedHead.Number, fromAddress)
+		etx2 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, latestFinalizedHead.Number, fromAddress)
 
 		etxIDs := []int64{etx1.ID, etx2.ID}
 		require.NoError(t, finalizer.ProcessOldTxsWithoutReceipts(ctx, etxIDs, head, latestFinalizedHead))
@@ -1111,13 +1111,13 @@ func TestFinalizer_ProcessOldTxsWithoutReceipts(t *testing.T) {
 
 	t.Run("marks old transaction as fatal, resumes pending task as failed", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, 1, true, txStore, txmClient, ht, metrics)
 		finalizer.SetResumeCallback(func(context.Context, uuid.UUID, interface{}, error) error { return nil })
 
 		// Insert confirmed transaction with pending task run
-		etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+		etx := txmgrtest.NewEthTx(fromAddress)
 		etx.State = txmgrcommon.TxConfirmed
 		n := types.Nonce(0)
 		etx.Sequence = &n
@@ -1145,13 +1145,13 @@ func TestFinalizer_ProcessOldTxsWithoutReceipts(t *testing.T) {
 
 	t.Run("transaction stays confirmed if failure to resume pending task", func(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
 		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, 1, true, txStore, txmClient, ht, metrics)
 		finalizer.SetResumeCallback(func(context.Context, uuid.UUID, interface{}, error) error { return errors.New("failure") })
 
 		// Insert confirmed transaction with pending task run
-		etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+		etx := txmgrtest.NewEthTx(fromAddress)
 		etx.State = txmgrcommon.TxConfirmed
 		n := types.Nonce(0)
 		etx.Sequence = &n

--- a/core/chains/evm/txmgr/reaper_test.go
+++ b/core/chains/evm/txmgr/reaper_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
@@ -42,7 +43,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	var nonce int64
 	oneDayAgo := time.Now().Add(-24 * time.Hour)

--- a/core/chains/evm/txmgr/reaper_test.go
+++ b/core/chains/evm/txmgr/reaper_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
@@ -42,7 +42,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 	var nonce int64
 	oneDayAgo := time.Now().Add(-24 * time.Hour)
@@ -67,7 +67,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 		err := r.ReapTxes(42)
 		assert.NoError(t, err)
 
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 	})
 
 	t.Run("doesn't touch ethtxes with different chain ID", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 		err := r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Didn't delete because eth_tx has chain ID of 0
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 	})
 
 	t.Run("deletes finalized evm.txes that exceed the age threshold", func(t *testing.T) {
@@ -89,14 +89,14 @@ func TestReaper_ReapTxes(t *testing.T) {
 		err := r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Didn't delete because eth_tx was not old enough
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 
 		testutils.MustExec(t, db, `UPDATE evm.txes SET created_at=$1, state='finalized'`, oneDayAgo)
 
 		err = r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Now it deleted because the eth_tx was past the age threshold
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 0)
+		txmgrtest.AssertCount(t, db, "evm.txes", 0)
 	})
 
 	mustInsertFatalErrorEthTx(t, txStore, fromAddress)
@@ -109,14 +109,14 @@ func TestReaper_ReapTxes(t *testing.T) {
 		err := r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Didn't delete because eth_tx was not old enough
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 
 		require.NoError(t, utils.JustError(db.Exec(`UPDATE evm.txes SET created_at=$1`, oneDayAgo)))
 
 		err = r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Deleted because it is old enough now
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 0)
+		txmgrtest.AssertCount(t, db, "evm.txes", 0)
 	})
 
 	mustInsertConfirmedEthTxWithReceipt(t, txStore, fromAddress, 0, 42)
@@ -129,13 +129,13 @@ func TestReaper_ReapTxes(t *testing.T) {
 		err := r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Didn't delete because eth_tx was not old enough
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 
 		testutils.MustExec(t, db, `UPDATE evm.txes SET created_at=$1`, oneDayAgo)
 
 		err = r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Now it deleted because the eth_tx was past the age threshold
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 0)
+		txmgrtest.AssertCount(t, db, "evm.txes", 0)
 	})
 }

--- a/core/chains/evm/txmgr/reaper_test.go
+++ b/core/chains/evm/txmgr/reaper_test.go
@@ -68,7 +68,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 		err := r.ReapTxes(42)
 		assert.NoError(t, err)
 
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 	})
 
 	t.Run("doesn't touch ethtxes with different chain ID", func(t *testing.T) {
@@ -79,7 +79,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 		err := r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Didn't delete because eth_tx has chain ID of 0
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 	})
 
 	t.Run("deletes finalized evm.txes that exceed the age threshold", func(t *testing.T) {
@@ -90,14 +90,14 @@ func TestReaper_ReapTxes(t *testing.T) {
 		err := r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Didn't delete because eth_tx was not old enough
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 
 		testutils.MustExec(t, db, `UPDATE evm.txes SET created_at=$1, state='finalized'`, oneDayAgo)
 
 		err = r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Now it deleted because the eth_tx was past the age threshold
-		cltest.AssertCount(t, db, "evm.txes", 0)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 0)
 	})
 
 	mustInsertFatalErrorEthTx(t, txStore, fromAddress)
@@ -110,14 +110,14 @@ func TestReaper_ReapTxes(t *testing.T) {
 		err := r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Didn't delete because eth_tx was not old enough
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 
 		require.NoError(t, utils.JustError(db.Exec(`UPDATE evm.txes SET created_at=$1`, oneDayAgo)))
 
 		err = r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Deleted because it is old enough now
-		cltest.AssertCount(t, db, "evm.txes", 0)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 0)
 	})
 
 	mustInsertConfirmedEthTxWithReceipt(t, txStore, fromAddress, 0, 42)
@@ -130,13 +130,13 @@ func TestReaper_ReapTxes(t *testing.T) {
 		err := r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Didn't delete because eth_tx was not old enough
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 
 		testutils.MustExec(t, db, `UPDATE evm.txes SET created_at=$1`, oneDayAgo)
 
 		err = r.ReapTxes(42)
 		assert.NoError(t, err)
 		// Now it deleted because the eth_tx was past the age threshold
-		cltest.AssertCount(t, db, "evm.txes", 0)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 0)
 	})
 }

--- a/core/chains/evm/txmgr/reaper_test.go
+++ b/core/chains/evm/txmgr/reaper_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
 
 func newReaperWithChainID(t *testing.T, db txmgrtypes.TxHistoryReaper[*big.Int], txConfig txmgrtypes.ReaperTransactionsConfig, cid *big.Int) *txmgr.Reaper {

--- a/core/chains/evm/txmgr/resender_test.go
+++ b/core/chains/evm/txmgr/resender_test.go
@@ -18,13 +18,13 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys/keystest"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
 
 func Test_EthResender_resendUnconfirmed(t *testing.T) {
@@ -43,7 +43,7 @@ func Test_EthResender_resendUnconfirmed(t *testing.T) {
 	fromAddress3 := memKS.MustCreate(t)
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
 
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	originalBroadcastAt := time.Unix(1616509100, 0)
 
@@ -51,19 +51,19 @@ func Test_EthResender_resendUnconfirmed(t *testing.T) {
 	var addr1TxesRawHex, addr2TxesRawHex, addr3TxesRawHex []string
 	// fewer than EvmMaxInFlightTransactions
 	for i := uint32(0); i < txConfig.MaxInFlight()/2; i++ {
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress, originalBroadcastAt)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress, originalBroadcastAt)
 		addr1TxesRawHex = append(addr1TxesRawHex, hexutil.Encode(etx.TxAttempts[0].SignedRawTx))
 	}
 
 	// exactly EvmMaxInFlightTransactions
 	for i := uint32(0); i < txConfig.MaxInFlight(); i++ {
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress2, originalBroadcastAt)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress2, originalBroadcastAt)
 		addr2TxesRawHex = append(addr2TxesRawHex, hexutil.Encode(etx.TxAttempts[0].SignedRawTx))
 	}
 
 	// more than EvmMaxInFlightTransactions
 	for i := uint32(0); i < txConfig.MaxInFlight()*2; i++ {
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress3, originalBroadcastAt)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress3, originalBroadcastAt)
 		addr3TxesRawHex = append(addr3TxesRawHex, hexutil.Encode(etx.TxAttempts[0].SignedRawTx))
 	}
 
@@ -119,13 +119,13 @@ func Test_EthResender_alertUnconfirmed(t *testing.T) {
 		})
 	})
 
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	originalBroadcastAt := time.Unix(1616509100, 0)
 	er := txmgr.NewEvmResender(lggr, txStore, txmgr.NewEvmTxmClient(ethClient, nil), txmgr.NewEvmTracker(txStore, ethKeyStore, big.NewInt(0), lggr), ethKeyStore, 100*time.Millisecond, ccfg.EVM(), ccfg.EVM().Transactions())
 
 	t.Run("alerts only once for unconfirmed transaction attempt within the unconfirmedTxAlertDelay duration", func(t *testing.T) {
-		_ = cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(1), fromAddress, originalBroadcastAt)
+		_ = evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(1), fromAddress, originalBroadcastAt)
 
 		ethClient.On("BatchCallContextAll", mock.Anything, mock.Anything).Return(nil)
 
@@ -150,7 +150,7 @@ func Test_EthResender_Start(t *testing.T) {
 		c.RPCDefaultBatchSize = ptr[uint32](1)
 	})
 
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
@@ -164,9 +164,9 @@ func Test_EthResender_Start(t *testing.T) {
 		er := txmgr.NewEvmResender(lggr, txStore, txmgr.NewEvmTxmClient(ethClient, nil), txmgr.NewEvmTracker(txStore, ethKeyStore, big.NewInt(0), lggr), ethKeyStore, 100*time.Millisecond, ccfg.EVM(), ccfg.EVM().Transactions())
 
 		originalBroadcastAt := time.Unix(1616509100, 0)
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, originalBroadcastAt)
-		etx2 := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, originalBroadcastAt)
-		cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress, time.Now().Add(1*time.Hour))
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, originalBroadcastAt)
+		etx2 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, originalBroadcastAt)
+		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress, time.Now().Add(1*time.Hour))
 
 		// First batch of 1
 		ethClient.On("BatchCallContextAll", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {

--- a/core/chains/evm/txmgr/resender_test.go
+++ b/core/chains/evm/txmgr/resender_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys/keystest"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
@@ -43,7 +43,7 @@ func Test_EthResender_resendUnconfirmed(t *testing.T) {
 	fromAddress3 := memKS.MustCreate(t)
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	originalBroadcastAt := time.Unix(1616509100, 0)
 
@@ -51,19 +51,19 @@ func Test_EthResender_resendUnconfirmed(t *testing.T) {
 	var addr1TxesRawHex, addr2TxesRawHex, addr3TxesRawHex []string
 	// fewer than EvmMaxInFlightTransactions
 	for i := uint32(0); i < txConfig.MaxInFlight()/2; i++ {
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress, originalBroadcastAt)
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress, originalBroadcastAt)
 		addr1TxesRawHex = append(addr1TxesRawHex, hexutil.Encode(etx.TxAttempts[0].SignedRawTx))
 	}
 
 	// exactly EvmMaxInFlightTransactions
 	for i := uint32(0); i < txConfig.MaxInFlight(); i++ {
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress2, originalBroadcastAt)
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress2, originalBroadcastAt)
 		addr2TxesRawHex = append(addr2TxesRawHex, hexutil.Encode(etx.TxAttempts[0].SignedRawTx))
 	}
 
 	// more than EvmMaxInFlightTransactions
 	for i := uint32(0); i < txConfig.MaxInFlight()*2; i++ {
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress3, originalBroadcastAt)
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(i), fromAddress3, originalBroadcastAt)
 		addr3TxesRawHex = append(addr3TxesRawHex, hexutil.Encode(etx.TxAttempts[0].SignedRawTx))
 	}
 
@@ -119,13 +119,13 @@ func Test_EthResender_alertUnconfirmed(t *testing.T) {
 		})
 	})
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	originalBroadcastAt := time.Unix(1616509100, 0)
 	er := txmgr.NewEvmResender(lggr, txStore, txmgr.NewEvmTxmClient(ethClient, nil), txmgr.NewEvmTracker(txStore, ethKeyStore, big.NewInt(0), lggr), ethKeyStore, 100*time.Millisecond, ccfg.EVM(), ccfg.EVM().Transactions())
 
 	t.Run("alerts only once for unconfirmed transaction attempt within the unconfirmedTxAlertDelay duration", func(t *testing.T) {
-		_ = evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(1), fromAddress, originalBroadcastAt)
+		_ = txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, int64(1), fromAddress, originalBroadcastAt)
 
 		ethClient.On("BatchCallContextAll", mock.Anything, mock.Anything).Return(nil)
 
@@ -150,7 +150,7 @@ func Test_EthResender_Start(t *testing.T) {
 		c.RPCDefaultBatchSize = ptr[uint32](1)
 	})
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
@@ -164,9 +164,9 @@ func Test_EthResender_Start(t *testing.T) {
 		er := txmgr.NewEvmResender(lggr, txStore, txmgr.NewEvmTxmClient(ethClient, nil), txmgr.NewEvmTracker(txStore, ethKeyStore, big.NewInt(0), lggr), ethKeyStore, 100*time.Millisecond, ccfg.EVM(), ccfg.EVM().Transactions())
 
 		originalBroadcastAt := time.Unix(1616509100, 0)
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, originalBroadcastAt)
-		etx2 := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, originalBroadcastAt)
-		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress, time.Now().Add(1*time.Hour))
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress, originalBroadcastAt)
+		etx2 := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress, originalBroadcastAt)
+		txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress, time.Now().Add(1*time.Hour))
 
 		// First batch of 1
 		ethClient.On("BatchCallContextAll", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {

--- a/core/chains/evm/txmgr/stuck_tx_detector_test.go
+++ b/core/chains/evm/txmgr/stuck_tx_detector_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/configtest"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
@@ -30,7 +31,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
 
 var (
@@ -42,7 +42,7 @@ func TestStuckTxDetector_Disabled(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	lggr := logger.Test(t)
@@ -64,7 +64,7 @@ func TestStuckTxDetector_LoadPurgeBlockNumMap(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	blockNum := int64(100)
 
@@ -108,7 +108,7 @@ func TestStuckTxDetector_FindPotentialStuckTxs(t *testing.T) {
 
 	db := testutils.NewSqlxDB(t)
 	config := configtest.NewChainScopedConfig(t, nil)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	lggr := logger.Test(t)
@@ -127,10 +127,10 @@ func TestStuckTxDetector_FindPotentialStuckTxs(t *testing.T) {
 		fromAddress1 := testutils.NewAddress()
 		fromAddress2 := testutils.NewAddress()
 		// Insert 2 txs for from address, should only return the lowest nonce txs
-		cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress1)
-		cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress1)
+		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress1)
+		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress1)
 		// Insert 1 tx for other from address, should return a tx
-		cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress2)
+		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress2)
 		stuckTxs, err := stuckTxDetector.FindUnconfirmedTxWithLowestNonce(ctx, []common.Address{fromAddress1, fromAddress2})
 		require.NoError(t, err)
 
@@ -157,8 +157,8 @@ func TestStuckTxDetector_FindPotentialStuckTxs(t *testing.T) {
 
 	t.Run("excludes transactions with a in-progress attempt", func(t *testing.T) {
 		fromAddress := testutils.NewAddress()
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
-		attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 		attempt.TxFee.GasPrice = assets.NewWeiI(2)
 		attempt.State = txmgrtypes.TxAttemptInProgress
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
@@ -169,8 +169,8 @@ func TestStuckTxDetector_FindPotentialStuckTxs(t *testing.T) {
 
 	t.Run("excludes transactions with an insufficient funds attempt", func(t *testing.T) {
 		fromAddress := testutils.NewAddress()
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
-		attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 		attempt.TxFee.GasPrice = assets.NewWeiI(2)
 		attempt.State = txmgrtypes.TxAttemptInsufficientFunds
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
@@ -184,7 +184,7 @@ func TestStuckTxDetector_DetectStuckTransactionsHeuristic(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	lggr := logger.Test(t)
@@ -291,7 +291,7 @@ func TestStuckTxDetector_DetectStuckTransactionsZircuit(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	lggr := logger.Test(t)
@@ -392,7 +392,7 @@ func TestStuckTxDetector_DetectStuckTransactionsZkEVM(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	lggr := logger.Test(t)
@@ -456,7 +456,7 @@ func TestStuckTxDetector_DetectStuckTransactionsZkEVM(t *testing.T) {
 		// Insert tx with enough attempts for detection
 		fromAddress1 := testutils.NewAddress()
 		etx1 := mustInsertUnconfirmedTxWithBroadcastAttempts(t, txStore, 0, fromAddress1, 1, blockNum, tenGwei)
-		attempt := cltest.NewLegacyEthTxAttempt(t, etx1.ID)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx1.ID)
 		attempt.TxFee.GasPrice = assets.NewWeiI(2)
 		attempt.State = txmgrtypes.TxAttemptBroadcast
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
@@ -483,7 +483,7 @@ func TestStuckTxDetector_DetectStuckTransactionsScroll(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	lggr := logger.Test(t)
@@ -525,11 +525,11 @@ func TestStuckTxDetector_DetectStuckTransactionsScroll(t *testing.T) {
 
 func mustInsertUnconfirmedTxWithBroadcastAttempts(t testing.TB, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, numAttempts uint32, latestBroadcastBlockNum int64, latestGasPrice *assets.Wei) txmgr.Tx {
 	ctx := tests.Context(t)
-	etx := cltest.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
+	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
 	// Insert attempts from oldest to newest
 	for i := int64(numAttempts - 1); i >= 0; i-- {
 		blockNum := latestBroadcastBlockNum - i
-		attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 
 		attempt.State = txmgrtypes.TxAttemptBroadcast
 		attempt.BroadcastBeforeBlockNum = &blockNum
@@ -544,10 +544,10 @@ func mustInsertUnconfirmedTxWithBroadcastAttempts(t testing.TB, txStore txmgr.Te
 // helper function for edge case where broadcast attempt contains empty pointer
 func mustInsertUnconfirmedTxWithBroadcastAttemptsContainsEmptyBroadcastBeforeBlockNum(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, numAttempts uint32, latestGasPrice *assets.Wei) txmgr.Tx {
 	ctx := tests.Context(t)
-	etx := cltest.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
+	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
 	// Insert attempts from oldest to newest
 	for i := int64(numAttempts - 1); i >= 0; i-- {
-		attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 		attempt.State = txmgrtypes.TxAttemptBroadcast
 		attempt.BroadcastBeforeBlockNum = nil
 		attempt.TxFee = gas.EvmFee{GasPrice: latestGasPrice.Sub(assets.NewWeiI(i))}
@@ -559,7 +559,7 @@ func mustInsertUnconfirmedTxWithBroadcastAttemptsContainsEmptyBroadcastBeforeBlo
 }
 
 func mustInsertFatalErrorTxWithError(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, blockNum int64) txmgr.Tx {
-	etx := cltest.NewEthTx(fromAddress)
+	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 	etx.State = txmgrcommon.TxFatalError
 	etx.Error = null.StringFrom("fatal error")
 	broadcastAt := time.Now()
@@ -570,7 +570,7 @@ func mustInsertFatalErrorTxWithError(t *testing.T, txStore txmgr.TestEvmTxStore,
 	etx.ChainID = testutils.FixtureChainID
 	require.NoError(t, txStore.InsertTx(tests.Context(t), &etx))
 
-	attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 	ctx := tests.Context(t)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.IsPurgeAttempt = true
@@ -586,8 +586,8 @@ func mustInsertFatalErrorTxWithError(t *testing.T, txStore txmgr.TestEvmTxStore,
 }
 
 func mustInsertUnconfirmedEthTxWithBroadcastPurgeAttempt(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address) txmgr.Tx {
-	etx := cltest.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
-	attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 	ctx := tests.Context(t)
 
 	attempt.State = txmgrtypes.TxAttemptBroadcast

--- a/core/chains/evm/txmgr/stuck_tx_detector_test.go
+++ b/core/chains/evm/txmgr/stuck_tx_detector_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-evm/pkg/config/configtest"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
@@ -42,7 +42,7 @@ func TestStuckTxDetector_Disabled(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
 	lggr := logger.Test(t)
@@ -64,7 +64,7 @@ func TestStuckTxDetector_LoadPurgeBlockNumMap(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 	blockNum := int64(100)
 
@@ -108,7 +108,7 @@ func TestStuckTxDetector_FindPotentialStuckTxs(t *testing.T) {
 
 	db := testutils.NewSqlxDB(t)
 	config := configtest.NewChainScopedConfig(t, nil)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	lggr := logger.Test(t)
@@ -127,10 +127,10 @@ func TestStuckTxDetector_FindPotentialStuckTxs(t *testing.T) {
 		fromAddress1 := testutils.NewAddress()
 		fromAddress2 := testutils.NewAddress()
 		// Insert 2 txs for from address, should only return the lowest nonce txs
-		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress1)
-		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress1)
+		txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress1)
+		txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress1)
 		// Insert 1 tx for other from address, should return a tx
-		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress2)
+		txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress2)
 		stuckTxs, err := stuckTxDetector.FindUnconfirmedTxWithLowestNonce(ctx, []common.Address{fromAddress1, fromAddress2})
 		require.NoError(t, err)
 
@@ -157,8 +157,8 @@ func TestStuckTxDetector_FindPotentialStuckTxs(t *testing.T) {
 
 	t.Run("excludes transactions with a in-progress attempt", func(t *testing.T) {
 		fromAddress := testutils.NewAddress()
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 		attempt.TxFee.GasPrice = assets.NewWeiI(2)
 		attempt.State = txmgrtypes.TxAttemptInProgress
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
@@ -169,8 +169,8 @@ func TestStuckTxDetector_FindPotentialStuckTxs(t *testing.T) {
 
 	t.Run("excludes transactions with an insufficient funds attempt", func(t *testing.T) {
 		fromAddress := testutils.NewAddress()
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 		attempt.TxFee.GasPrice = assets.NewWeiI(2)
 		attempt.State = txmgrtypes.TxAttemptInsufficientFunds
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
@@ -184,7 +184,7 @@ func TestStuckTxDetector_DetectStuckTransactionsHeuristic(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	lggr := logger.Test(t)
@@ -291,7 +291,7 @@ func TestStuckTxDetector_DetectStuckTransactionsZircuit(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	lggr := logger.Test(t)
@@ -392,7 +392,7 @@ func TestStuckTxDetector_DetectStuckTransactionsZkEVM(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	lggr := logger.Test(t)
@@ -456,7 +456,7 @@ func TestStuckTxDetector_DetectStuckTransactionsZkEVM(t *testing.T) {
 		// Insert tx with enough attempts for detection
 		fromAddress1 := testutils.NewAddress()
 		etx1 := mustInsertUnconfirmedTxWithBroadcastAttempts(t, txStore, 0, fromAddress1, 1, blockNum, tenGwei)
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx1.ID)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx1.ID)
 		attempt.TxFee.GasPrice = assets.NewWeiI(2)
 		attempt.State = txmgrtypes.TxAttemptBroadcast
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
@@ -483,7 +483,7 @@ func TestStuckTxDetector_DetectStuckTransactionsScroll(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	ctx := tests.Context(t)
 
 	lggr := logger.Test(t)
@@ -525,11 +525,11 @@ func TestStuckTxDetector_DetectStuckTransactionsScroll(t *testing.T) {
 
 func mustInsertUnconfirmedTxWithBroadcastAttempts(t testing.TB, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, numAttempts uint32, latestBroadcastBlockNum int64, latestGasPrice *assets.Wei) txmgr.Tx {
 	ctx := tests.Context(t)
-	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
+	etx := txmgrtest.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
 	// Insert attempts from oldest to newest
 	for i := int64(numAttempts - 1); i >= 0; i-- {
 		blockNum := latestBroadcastBlockNum - i
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 
 		attempt.State = txmgrtypes.TxAttemptBroadcast
 		attempt.BroadcastBeforeBlockNum = &blockNum
@@ -544,10 +544,10 @@ func mustInsertUnconfirmedTxWithBroadcastAttempts(t testing.TB, txStore txmgr.Te
 // helper function for edge case where broadcast attempt contains empty pointer
 func mustInsertUnconfirmedTxWithBroadcastAttemptsContainsEmptyBroadcastBeforeBlockNum(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, numAttempts uint32, latestGasPrice *assets.Wei) txmgr.Tx {
 	ctx := tests.Context(t)
-	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
+	etx := txmgrtest.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
 	// Insert attempts from oldest to newest
 	for i := int64(numAttempts - 1); i >= 0; i-- {
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 		attempt.State = txmgrtypes.TxAttemptBroadcast
 		attempt.BroadcastBeforeBlockNum = nil
 		attempt.TxFee = gas.EvmFee{GasPrice: latestGasPrice.Sub(assets.NewWeiI(i))}
@@ -559,7 +559,7 @@ func mustInsertUnconfirmedTxWithBroadcastAttemptsContainsEmptyBroadcastBeforeBlo
 }
 
 func mustInsertFatalErrorTxWithError(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, blockNum int64) txmgr.Tx {
-	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+	etx := txmgrtest.NewEthTx(fromAddress)
 	etx.State = txmgrcommon.TxFatalError
 	etx.Error = null.StringFrom("fatal error")
 	broadcastAt := time.Now()
@@ -570,7 +570,7 @@ func mustInsertFatalErrorTxWithError(t *testing.T, txStore txmgr.TestEvmTxStore,
 	etx.ChainID = testutils.FixtureChainID
 	require.NoError(t, txStore.InsertTx(tests.Context(t), &etx))
 
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 	ctx := tests.Context(t)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.IsPurgeAttempt = true
@@ -586,8 +586,8 @@ func mustInsertFatalErrorTxWithError(t *testing.T, txStore txmgr.TestEvmTxStore,
 }
 
 func mustInsertUnconfirmedEthTxWithBroadcastPurgeAttempt(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address) txmgr.Tx {
-	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+	etx := txmgrtest.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 	ctx := tests.Context(t)
 
 	attempt.State = txmgrtypes.TxAttemptBroadcast

--- a/core/chains/evm/txmgr/testutils/utils.go
+++ b/core/chains/evm/txmgr/testutils/utils.go
@@ -1,0 +1,130 @@
+package testutils
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
+	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
+	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
+	"github.com/smartcontractkit/chainlink-evm/pkg/types"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+	txmgr2 "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
+	types2 "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
+)
+
+func NewTestTxStore(t testing.TB, ds sqlutil.DataSource) txmgr.TestEvmTxStore {
+	return txmgr.NewTxStore(ds, logger.Test(t))
+}
+
+func NewEthTx(fromAddress common.Address) txmgr.Tx {
+	return txmgr.Tx{
+		FromAddress:    fromAddress,
+		ToAddress:      evmtestutils.NewAddress(),
+		EncodedPayload: []byte{1, 2, 3},
+		Value:          big.Int(assets.NewEthValue(142)),
+		FeeLimit:       uint64(1000000000),
+		State:          txmgr2.TxUnstarted,
+	}
+}
+
+func MustInsertUnconfirmedEthTx(t testing.TB, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, opts ...interface{}) txmgr.Tx {
+	broadcastAt := time.Now()
+	chainID := evmtestutils.FixtureChainID
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case time.Time:
+			broadcastAt = v
+		case *big.Int:
+			chainID = v
+		}
+	}
+	etx := NewEthTx(fromAddress)
+
+	etx.BroadcastAt = &broadcastAt
+	etx.InitialBroadcastAt = &broadcastAt
+	n := types.Nonce(nonce)
+	etx.Sequence = &n
+	etx.State = txmgr2.TxUnconfirmed
+	etx.ChainID = chainID
+	require.NoError(t, txStore.InsertTx(evmtestutils.Context(t), &etx))
+	return etx
+}
+
+func MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, opts ...interface{}) txmgr.Tx {
+	etx := MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress, opts...)
+	attempt := NewLegacyEthTxAttempt(t, etx.ID)
+	ctx := evmtestutils.Context(t)
+
+	tx := evmtestutils.NewLegacyTransaction(uint64(nonce), evmtestutils.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
+	rlp := new(bytes.Buffer)
+	require.NoError(t, tx.EncodeRLP(rlp))
+	attempt.SignedRawTx = rlp.Bytes()
+
+	attempt.State = types2.TxAttemptBroadcast
+	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
+	etx, err := txStore.FindTxWithAttempts(ctx, etx.ID)
+	require.NoError(t, err)
+	return etx
+}
+
+func MustInsertConfirmedEthTxWithLegacyAttempt(t testing.TB, txStore txmgr.TestEvmTxStore, nonce int64, broadcastBeforeBlockNum int64, fromAddress common.Address) txmgr.Tx {
+	timeNow := time.Now()
+	etx := NewEthTx(fromAddress)
+	ctx := evmtestutils.Context(t)
+
+	etx.BroadcastAt = &timeNow
+	etx.InitialBroadcastAt = &timeNow
+	n := types.Nonce(nonce)
+	etx.Sequence = &n
+	etx.State = txmgr2.TxConfirmed
+	etx.MinConfirmations.SetValid(6)
+	require.NoError(t, txStore.InsertTx(ctx, &etx))
+	attempt := NewLegacyEthTxAttempt(t, etx.ID)
+	attempt.BroadcastBeforeBlockNum = &broadcastBeforeBlockNum
+	attempt.State = types2.TxAttemptBroadcast
+	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
+	etx.TxAttempts = append(etx.TxAttempts, attempt)
+	return etx
+}
+
+func NewLegacyEthTxAttempt(t testing.TB, etxID int64) txmgr.TxAttempt {
+	gasPrice := assets.NewWeiI(1)
+	return txmgr.TxAttempt{
+		ChainSpecificFeeLimit: 42,
+		TxID:                  etxID,
+		TxFee:                 gas.EvmFee{GasPrice: gasPrice},
+		// Just a random signed raw tx that decodes correctly
+		// Ignore all actual values
+		SignedRawTx: hexutil.MustDecode("0xf889808504a817c8008307a12094000000000000000000000000000000000000000080a400000000000000000000000000000000000000000000000000000000000000000000000025a0838fe165906e2547b9a052c099df08ec891813fea4fcdb3c555362285eb399c5a070db99322490eb8a0f2270be6eca6e3aedbc49ff57ef939cf2774f12d08aa85e"),
+		Hash:        utils.NewHash(),
+		State:       types2.TxAttemptInProgress,
+	}
+}
+
+func NewDynamicFeeEthTxAttempt(t *testing.T, etxID int64) txmgr.TxAttempt {
+	gasTipCap := assets.NewWeiI(1)
+	gasFeeCap := assets.NewWeiI(1)
+	return txmgr.TxAttempt{
+		TxType: 0x2,
+		TxID:   etxID,
+		TxFee: gas.EvmFee{
+			DynamicFee: gas.DynamicFee{GasTipCap: gasTipCap, GasFeeCap: gasFeeCap},
+		},
+		// Just a random signed raw tx that decodes correctly
+		// Ignore all actual values
+		SignedRawTx:           hexutil.MustDecode("0xf889808504a817c8008307a12094000000000000000000000000000000000000000080a400000000000000000000000000000000000000000000000000000000000000000000000025a0838fe165906e2547b9a052c099df08ec891813fea4fcdb3c555362285eb399c5a070db99322490eb8a0f2270be6eca6e3aedbc49ff57ef939cf2774f12d08aa85e"),
+		Hash:                  utils.NewHash(),
+		State:                 types2.TxAttemptInProgress,
+		ChainSpecificFeeLimit: 42,
+	}
+}

--- a/core/chains/evm/txmgr/testutils/utils.go
+++ b/core/chains/evm/txmgr/testutils/utils.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"bytes"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -127,4 +128,13 @@ func NewDynamicFeeEthTxAttempt(t *testing.T, etxID int64) txmgr.TxAttempt {
 		State:                 types2.TxAttemptInProgress,
 		ChainSpecificFeeLimit: 42,
 	}
+}
+
+func AssertCount(t testing.TB, ds sqlutil.DataSource, tableName string, expected int64) {
+	t.Helper()
+	ctx := evmtestutils.Context(t)
+	var count int64
+	err := ds.GetContext(ctx, &count, fmt.Sprintf(`SELECT count(*) FROM %s;`, tableName))
+	require.NoError(t, err)
+	require.Equal(t, expected, count)
 }

--- a/core/chains/evm/txmgr/testutils/utils.go
+++ b/core/chains/evm/txmgr/testutils/utils.go
@@ -18,8 +18,8 @@ import (
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	txmgr2 "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
-	types2 "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
+	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
+	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 )
 
@@ -34,7 +34,7 @@ func NewEthTx(fromAddress common.Address) txmgr.Tx {
 		EncodedPayload: []byte{1, 2, 3},
 		Value:          big.Int(assets.NewEthValue(142)),
 		FeeLimit:       uint64(1000000000),
-		State:          txmgr2.TxUnstarted,
+		State:          txmgrcommon.TxUnstarted,
 	}
 }
 
@@ -55,7 +55,7 @@ func MustInsertUnconfirmedEthTx(t testing.TB, txStore txmgr.TestEvmTxStore, nonc
 	etx.InitialBroadcastAt = &broadcastAt
 	n := types.Nonce(nonce)
 	etx.Sequence = &n
-	etx.State = txmgr2.TxUnconfirmed
+	etx.State = txmgrcommon.TxUnconfirmed
 	etx.ChainID = chainID
 	require.NoError(t, txStore.InsertTx(evmtestutils.Context(t), &etx))
 	return etx
@@ -71,7 +71,7 @@ func MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t *testing.T, txStore 
 	require.NoError(t, tx.EncodeRLP(rlp))
 	attempt.SignedRawTx = rlp.Bytes()
 
-	attempt.State = types2.TxAttemptBroadcast
+	attempt.State = txmgrtypes.TxAttemptBroadcast
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
 	etx, err := txStore.FindTxWithAttempts(ctx, etx.ID)
 	require.NoError(t, err)
@@ -87,12 +87,12 @@ func MustInsertConfirmedEthTxWithLegacyAttempt(t testing.TB, txStore txmgr.TestE
 	etx.InitialBroadcastAt = &timeNow
 	n := types.Nonce(nonce)
 	etx.Sequence = &n
-	etx.State = txmgr2.TxConfirmed
+	etx.State = txmgrcommon.TxConfirmed
 	etx.MinConfirmations.SetValid(6)
 	require.NoError(t, txStore.InsertTx(ctx, &etx))
 	attempt := NewLegacyEthTxAttempt(t, etx.ID)
 	attempt.BroadcastBeforeBlockNum = &broadcastBeforeBlockNum
-	attempt.State = types2.TxAttemptBroadcast
+	attempt.State = txmgrtypes.TxAttemptBroadcast
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
 	etx.TxAttempts = append(etx.TxAttempts, attempt)
 	return etx
@@ -108,7 +108,7 @@ func NewLegacyEthTxAttempt(t testing.TB, etxID int64) txmgr.TxAttempt {
 		// Ignore all actual values
 		SignedRawTx: hexutil.MustDecode("0xf889808504a817c8008307a12094000000000000000000000000000000000000000080a400000000000000000000000000000000000000000000000000000000000000000000000025a0838fe165906e2547b9a052c099df08ec891813fea4fcdb3c555362285eb399c5a070db99322490eb8a0f2270be6eca6e3aedbc49ff57ef939cf2774f12d08aa85e"),
 		Hash:        utils.NewHash(),
-		State:       types2.TxAttemptInProgress,
+		State:       txmgrtypes.TxAttemptInProgress,
 	}
 }
 
@@ -125,7 +125,7 @@ func NewDynamicFeeEthTxAttempt(t *testing.T, etxID int64) txmgr.TxAttempt {
 		// Ignore all actual values
 		SignedRawTx:           hexutil.MustDecode("0xf889808504a817c8008307a12094000000000000000000000000000000000000000080a400000000000000000000000000000000000000000000000000000000000000000000000025a0838fe165906e2547b9a052c099df08ec891813fea4fcdb3c555362285eb399c5a070db99322490eb8a0f2270be6eca6e3aedbc49ff57ef939cf2774f12d08aa85e"),
 		Hash:                  utils.NewHash(),
-		State:                 types2.TxAttemptInProgress,
+		State:                 txmgrtypes.TxAttemptInProgress,
 		ChainSpecificFeeLimit: 42,
 	}
 }

--- a/core/chains/evm/txmgr/tracker_test.go
+++ b/core/chains/evm/txmgr/tracker_test.go
@@ -17,12 +17,12 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys/keystest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 )
 
 func newTestEvmTrackerSetup(t *testing.T) (*txmgr.Tracker, txmgr.TestEvmTxStore) {
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	chainID := big.NewInt(0)
 	memKS := keystest.NewMemoryChainStore()
 	addr1 := memKS.MustCreate(t)
@@ -68,7 +68,7 @@ func TestEvmTracker_AddressTracking(t *testing.T) {
 		unconfirmedAddr := testutils.NewAddress()
 		confirmedAddr := testutils.NewAddress()
 		_ = mustInsertInProgressEthTxWithAttempt(t, txStore, 123, inProgressAddr)
-		_ = evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, 123, unconfirmedAddr)
+		_ = txmgrtest.MustInsertUnconfirmedEthTx(t, txStore, 123, unconfirmedAddr)
 		_ = mustInsertConfirmedEthTxWithReceipt(t, txStore, confirmedAddr, 123, 1)
 		_ = mustCreateUnstartedTx(t, txStore, unstartedAddr, testutils.NewAddress(), []byte{}, 0, big.Int{}, ethClient.ConfiguredChainID())
 
@@ -121,7 +121,7 @@ func TestEvmTracker_ExceedingTTL(t *testing.T) {
 	addr1 := testutils.NewAddress()
 	addr2 := testutils.NewAddress()
 	tx1 := mustInsertInProgressEthTxWithAttempt(t, txStore, 123, addr1)
-	tx2 := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, 123, addr2)
+	tx2 := txmgrtest.MustInsertUnconfirmedEthTx(t, txStore, 123, addr2)
 
 	tracker.XXXTestSetTTL(time.Nanosecond)
 	servicetest.Run(t, tracker)

--- a/core/chains/evm/txmgr/tracker_test.go
+++ b/core/chains/evm/txmgr/tracker_test.go
@@ -17,12 +17,12 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys/keystest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 )
 
 func newTestEvmTrackerSetup(t *testing.T) (*txmgr.Tracker, txmgr.TestEvmTxStore) {
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	chainID := big.NewInt(0)
 	memKS := keystest.NewMemoryChainStore()
 	addr1 := memKS.MustCreate(t)
@@ -68,7 +68,7 @@ func TestEvmTracker_AddressTracking(t *testing.T) {
 		unconfirmedAddr := testutils.NewAddress()
 		confirmedAddr := testutils.NewAddress()
 		_ = mustInsertInProgressEthTxWithAttempt(t, txStore, 123, inProgressAddr)
-		_ = cltest.MustInsertUnconfirmedEthTx(t, txStore, 123, unconfirmedAddr)
+		_ = evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, 123, unconfirmedAddr)
 		_ = mustInsertConfirmedEthTxWithReceipt(t, txStore, confirmedAddr, 123, 1)
 		_ = mustCreateUnstartedTx(t, txStore, unstartedAddr, testutils.NewAddress(), []byte{}, 0, big.Int{}, ethClient.ConfiguredChainID())
 
@@ -121,7 +121,7 @@ func TestEvmTracker_ExceedingTTL(t *testing.T) {
 	addr1 := testutils.NewAddress()
 	addr2 := testutils.NewAddress()
 	tx1 := mustInsertInProgressEthTxWithAttempt(t, txStore, 123, addr1)
-	tx2 := cltest.MustInsertUnconfirmedEthTx(t, txStore, 123, addr2)
+	tx2 := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, 123, addr2)
 
 	tracker.XXXTestSetTTL(time.Nanosecond)
 	servicetest.Run(t, tracker)

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -48,7 +48,6 @@ import (
 	evmtxm "github.com/smartcontractkit/chainlink-evm/pkg/txm"
 	commontxmmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/types/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 )
 
 func makeTestEvmTxm(
@@ -529,8 +528,8 @@ func TestTxm_Lifecycle(t *testing.T) {
 
 	kst := &keystest.FakeChainStore{}
 
-	head := cltest.Head(42)
-	finalizedHead := cltest.Head(0)
+	head := makeHead(42)
+	finalizedHead := makeHead(0)
 
 	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(head, nil).Maybe()
 	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(finalizedHead, nil).Maybe()
@@ -1227,4 +1226,9 @@ func txRequestWithIdempotencyKey(idempotencyKey string) func(*txmgr.TxRequest) {
 	return func(tx *txmgr.TxRequest) {
 		tx.IdempotencyKey = &idempotencyKey
 	}
+}
+
+func makeHead(num int64) *evmtypes.Head {
+	h := evmtypes.NewHead(big.NewInt(num), evmtestutils.NewHash(), evmtestutils.NewHash(), ubig.New(evmtestutils.FixtureChainID))
+	return &h
 }

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -158,7 +158,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 		assert.Equal(t, big.Int(assets.NewEthValue(0)), etx.Value)
 		assert.Equal(t, subject, etx.Subject.UUID)
 
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 
 		var dbEtx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEtx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))
@@ -248,7 +248,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 			Checker:        checker,
 		})
 		assert.NoError(t, err)
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 		var dbEtx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEtx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))
 
@@ -292,7 +292,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 			Checker:        checker,
 		})
 		assert.NoError(t, err)
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 		var dbEtx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEtx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))
 
@@ -327,7 +327,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 			Strategy:         txmgrcommon.NewSendEveryStrategy(),
 		})
 		assert.NoError(t, err)
-		cltest.AssertCount(t, db, "evm.txes", 1)
+		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
 
 		var dbEtx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEtx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -42,7 +42,7 @@ import (
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/forwarders"
 	evmtxm "github.com/smartcontractkit/chainlink-evm/pkg/txm"
@@ -115,7 +115,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
@@ -157,7 +157,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 		assert.Equal(t, big.Int(assets.NewEthValue(0)), etx.Value)
 		assert.Equal(t, subject, etx.Subject.UUID)
 
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 
 		var dbEtx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEtx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))
@@ -247,7 +247,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 			Checker:        checker,
 		})
 		assert.NoError(t, err)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 		var dbEtx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEtx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))
 
@@ -291,7 +291,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 			Checker:        checker,
 		})
 		assert.NoError(t, err)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 		var dbEtx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEtx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))
 
@@ -326,7 +326,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 			Strategy:         txmgrcommon.NewSendEveryStrategy(),
 		})
 		assert.NoError(t, err)
-		evmtxmgrtestutils.AssertCount(t, db, "evm.txes", 1)
+		txmgrtest.AssertCount(t, db, "evm.txes", 1)
 
 		var dbEtx txmgr.DbEthTx
 		require.NoError(t, db.Get(&dbEtx, `SELECT * FROM evm.txes ORDER BY id ASC LIMIT 1`))
@@ -427,7 +427,7 @@ func newMockTxStrategy(t testing.TB) *commontxmmocks.TxStrategy {
 
 func TestTxm_CreateTransaction_OutOfEth(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -494,7 +494,7 @@ func TestTxm_CreateTransaction_OutOfEth(t *testing.T) {
 
 	t.Run("if this key has transactions but no insufficient eth errors, transmits as normal", func(t *testing.T) {
 		payload := []byte("payload3")
-		evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 42, fromAddress)
+		txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 42, fromAddress)
 		strategy := newMockTxStrategy(t)
 		strategy.On("Subject").Return(uuid.NullUUID{})
 		strategy.On("PruneQueue", mock.Anything, mock.Anything).Return(nil, nil)
@@ -568,14 +568,14 @@ func TestTxm_Reset(t *testing.T) {
 	addr2 := memKS.MustCreate(t)
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	// 4 confirmed tx from addr1
 	for i := int64(0); i < 4; i++ {
-		evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, i, i*42+1, addr)
+		txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, i, i*42+1, addr)
 	}
 	// 2 confirmed from addr2
 	for i := int64(0); i < 2; i++ {
-		evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, i, i*42+1, addr2)
+		txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, i, i*42+1, addr2)
 	}
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -589,9 +589,9 @@ func TestTxm_Reset(t *testing.T) {
 	txm, err := makeTestEvmTxm(t, db, ethClient, estimator, evmConfig, evmConfig.GasEstimator(), evmConfig.Transactions(), dbConfig, dbConfig.Listener(), ethKeyStore)
 	require.NoError(t, err)
 
-	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, addr2)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, addr2)
 	for i := 0; i < 1000; i++ {
-		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 4+int64(i), addr)
+		txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 4+int64(i), addr)
 	}
 
 	t.Run("returns error if not started", func(t *testing.T) {
@@ -629,7 +629,7 @@ func TestTxm_GetTransactionFee(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
 	feeLimit := uint64(10_000)
@@ -681,7 +681,7 @@ func TestTxm_GetTransactionFee(t *testing.T) {
 		err := txStore.InsertTx(ctx, tx)
 		require.NoError(t, err)
 
-		attemptD := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, tx.ID)
+		attemptD := txmgrtest.NewDynamicFeeEthTxAttempt(t, tx.ID)
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attemptD))
 
 		// insert receipt
@@ -713,7 +713,7 @@ func TestTxm_GetTransactionFee(t *testing.T) {
 		err := txStore.InsertTx(ctx, tx)
 		require.NoError(t, err)
 
-		attemptD := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, tx.ID)
+		attemptD := txmgrtest.NewDynamicFeeEthTxAttempt(t, tx.ID)
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attemptD))
 
 		// insert receipt
@@ -734,7 +734,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	txStore := txmgrtest.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
 	feeLimit := uint64(10_000)
@@ -851,7 +851,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 		require.NoError(t, err)
 		tx, err = txStore.FindTxWithIdempotencyKey(ctx, idempotencyKey, testutils.FixtureChainID)
 		require.NoError(t, err)
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx.ID)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, tx.ID)
 		err = txStore.InsertTxAttempt(ctx, &attempt)
 		require.NoError(t, err)
 		// Insert receipt for unfinalized block num
@@ -880,7 +880,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 		require.NoError(t, err)
 		tx, err = txStore.FindTxWithIdempotencyKey(ctx, idempotencyKey, testutils.FixtureChainID)
 		require.NoError(t, err)
-		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx.ID)
+		attempt := txmgrtest.NewLegacyEthTxAttempt(t, tx.ID)
 		err = txStore.InsertTxAttempt(ctx, &attempt)
 		require.NoError(t, err)
 		// Insert receipt for finalized block num
@@ -1024,13 +1024,13 @@ func mustInsertRevertedEthReceipt(t *testing.T, txStore txmgr.TestEvmTxStore, bl
 
 // Inserts into evm.receipts but does not update evm.txes or evm.tx_attempts
 func mustInsertConfirmedEthTxWithReceipt(t testing.TB, txStore txmgr.TestEvmTxStore, fromAddress common.Address, nonce, blockNum int64) (etx txmgr.Tx) {
-	etx = evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, nonce, blockNum, fromAddress)
+	etx = txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, nonce, blockNum, fromAddress)
 	mustInsertEthReceipt(t, txStore, blockNum, utils.NewHash(), etx.TxAttempts[0].Hash)
 	return etx
 }
 
 func mustInsertFatalErrorEthTx(t testing.TB, txStore txmgr.TestEvmTxStore, fromAddress common.Address) txmgr.Tx {
-	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+	etx := txmgrtest.NewEthTx(fromAddress)
 	etx.Error = null.StringFrom("something exploded")
 	etx.State = txmgrcommon.TxFatalError
 
@@ -1039,8 +1039,8 @@ func mustInsertFatalErrorEthTx(t testing.TB, txStore txmgr.TestEvmTxStore, fromA
 }
 
 func mustInsertUnconfirmedEthTxWithAttemptState(t testing.TB, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, txAttemptState txmgrtypes.TxAttemptState, opts ...interface{}) txmgr.Tx {
-	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress, opts...)
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+	etx := txmgrtest.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress, opts...)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 	ctx := tests.Context(t)
 
 	tx := testutils.NewLegacyTransaction(uint64(nonce), testutils.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
@@ -1057,8 +1057,8 @@ func mustInsertUnconfirmedEthTxWithAttemptState(t testing.TB, txStore txmgr.Test
 }
 
 func mustInsertUnconfirmedEthTxWithBroadcastDynamicFeeAttempt(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, opts ...interface{}) txmgr.Tx {
-	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress, opts...)
-	attempt := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
+	etx := txmgrtest.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress, opts...)
+	attempt := txmgrtest.NewDynamicFeeEthTxAttempt(t, etx.ID)
 	ctx := tests.Context(t)
 
 	addr := testutils.NewAddress()
@@ -1087,7 +1087,7 @@ func mustInsertUnconfirmedEthTxWithBroadcastDynamicFeeAttempt(t *testing.T, txSt
 
 func mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address) txmgr.Tx {
 	timeNow := time.Now()
-	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+	etx := txmgrtest.NewEthTx(fromAddress)
 	ctx := tests.Context(t)
 
 	etx.BroadcastAt = &timeNow
@@ -1096,7 +1096,7 @@ func mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t *testing.T, txStore 
 	etx.Sequence = &n
 	etx.State = txmgrcommon.TxUnconfirmed
 	require.NoError(t, txStore.InsertTx(ctx, &etx))
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 
 	tx := testutils.NewLegacyTransaction(uint64(nonce), testutils.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
 	rlp := new(bytes.Buffer)
@@ -1114,7 +1114,7 @@ func mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t *testing.T, txStore 
 func mustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(
 	t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, broadcastBeforeBlockNum int64,
 	broadcastAt time.Time, fromAddress common.Address) txmgr.Tx {
-	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+	etx := txmgrtest.NewEthTx(fromAddress)
 	ctx := tests.Context(t)
 
 	etx.BroadcastAt = &broadcastAt
@@ -1123,7 +1123,7 @@ func mustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(
 	etx.Sequence = &n
 	etx.State = txmgrcommon.TxConfirmedMissingReceipt
 	require.NoError(t, txStore.InsertTx(ctx, &etx))
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 	attempt.BroadcastBeforeBlockNum = &broadcastBeforeBlockNum
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
@@ -1132,13 +1132,13 @@ func mustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(
 }
 
 func mustInsertInProgressEthTxWithAttempt(t testing.TB, txStore txmgr.TestEvmTxStore, nonce evmtypes.Nonce, fromAddress common.Address) txmgr.Tx {
-	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+	etx := txmgrtest.NewEthTx(fromAddress)
 	ctx := tests.Context(t)
 
 	etx.Sequence = &nonce
 	etx.State = txmgrcommon.TxInProgress
 	require.NoError(t, txStore.InsertTx(ctx, &etx))
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, etx.ID)
 	tx := evmtestutils.NewLegacyTransaction(uint64(nonce), testutils.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
 	rlp := new(bytes.Buffer)
 	require.NoError(t, tx.EncodeRLP(rlp))
@@ -1200,7 +1200,7 @@ func mustCreateUnstartedTxFromEvmTxRequest(t testing.TB, txStore txmgr.EvmTxStor
 }
 
 func mustInsertUnstartedTx(t testing.TB, txStore txmgr.TestEvmTxStore, fromAddress common.Address) {
-	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
+	etx := txmgrtest.NewEthTx(fromAddress)
 	ctx := tests.Context(t)
 	require.NoError(t, txStore.InsertTx(ctx, &etx))
 }

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -42,6 +42,7 @@ import (
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/forwarders"
 	evmtxm "github.com/smartcontractkit/chainlink-evm/pkg/txm"
@@ -115,7 +116,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
@@ -427,7 +428,7 @@ func newMockTxStrategy(t testing.TB) *commontxmmocks.TxStrategy {
 
 func TestTxm_CreateTransaction_OutOfEth(t *testing.T) {
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 
 	memKS := keystest.NewMemoryChainStore()
 	fromAddress := memKS.MustCreate(t)
@@ -494,7 +495,7 @@ func TestTxm_CreateTransaction_OutOfEth(t *testing.T) {
 
 	t.Run("if this key has transactions but no insufficient eth errors, transmits as normal", func(t *testing.T) {
 		payload := []byte("payload3")
-		cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 42, fromAddress)
+		evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 42, fromAddress)
 		strategy := newMockTxStrategy(t)
 		strategy.On("Subject").Return(uuid.NullUUID{})
 		strategy.On("PruneQueue", mock.Anything, mock.Anything).Return(nil, nil)
@@ -568,14 +569,14 @@ func TestTxm_Reset(t *testing.T) {
 	addr2 := memKS.MustCreate(t)
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
 
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	// 4 confirmed tx from addr1
 	for i := int64(0); i < 4; i++ {
-		cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, i, i*42+1, addr)
+		evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, i, i*42+1, addr)
 	}
 	// 2 confirmed from addr2
 	for i := int64(0); i < 2; i++ {
-		cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, i, i*42+1, addr2)
+		evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, i, i*42+1, addr2)
 	}
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
@@ -589,9 +590,9 @@ func TestTxm_Reset(t *testing.T) {
 	txm, err := makeTestEvmTxm(t, db, ethClient, estimator, evmConfig, evmConfig.GasEstimator(), evmConfig.Transactions(), dbConfig, dbConfig.Listener(), ethKeyStore)
 	require.NoError(t, err)
 
-	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, addr2)
+	evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, addr2)
 	for i := 0; i < 1000; i++ {
-		cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 4+int64(i), addr)
+		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 4+int64(i), addr)
 	}
 
 	t.Run("returns error if not started", func(t *testing.T) {
@@ -629,7 +630,7 @@ func TestTxm_GetTransactionFee(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
 	feeLimit := uint64(10_000)
@@ -681,7 +682,7 @@ func TestTxm_GetTransactionFee(t *testing.T) {
 		err := txStore.InsertTx(ctx, tx)
 		require.NoError(t, err)
 
-		attemptD := cltest.NewDynamicFeeEthTxAttempt(t, tx.ID)
+		attemptD := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, tx.ID)
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attemptD))
 
 		// insert receipt
@@ -713,7 +714,7 @@ func TestTxm_GetTransactionFee(t *testing.T) {
 		err := txStore.InsertTx(ctx, tx)
 		require.NoError(t, err)
 
-		attemptD := cltest.NewDynamicFeeEthTxAttempt(t, tx.ID)
+		attemptD := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, tx.ID)
 		require.NoError(t, txStore.InsertTxAttempt(ctx, &attemptD))
 
 		// insert receipt
@@ -734,7 +735,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 
 	ctx := tests.Context(t)
 	db := testutils.NewSqlxDB(t)
-	txStore := cltest.NewTestTxStore(t, db)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 	memKS := keystest.NewMemoryChainStore()
 	ethKeyStore := keys.NewChainStore(memKS, big.NewInt(0))
 	feeLimit := uint64(10_000)
@@ -851,7 +852,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 		require.NoError(t, err)
 		tx, err = txStore.FindTxWithIdempotencyKey(ctx, idempotencyKey, testutils.FixtureChainID)
 		require.NoError(t, err)
-		attempt := cltest.NewLegacyEthTxAttempt(t, tx.ID)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx.ID)
 		err = txStore.InsertTxAttempt(ctx, &attempt)
 		require.NoError(t, err)
 		// Insert receipt for unfinalized block num
@@ -880,7 +881,7 @@ func TestTxm_GetTransactionStatus(t *testing.T) {
 		require.NoError(t, err)
 		tx, err = txStore.FindTxWithIdempotencyKey(ctx, idempotencyKey, testutils.FixtureChainID)
 		require.NoError(t, err)
-		attempt := cltest.NewLegacyEthTxAttempt(t, tx.ID)
+		attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx.ID)
 		err = txStore.InsertTxAttempt(ctx, &attempt)
 		require.NoError(t, err)
 		// Insert receipt for finalized block num
@@ -1024,13 +1025,13 @@ func mustInsertRevertedEthReceipt(t *testing.T, txStore txmgr.TestEvmTxStore, bl
 
 // Inserts into evm.receipts but does not update evm.txes or evm.tx_attempts
 func mustInsertConfirmedEthTxWithReceipt(t testing.TB, txStore txmgr.TestEvmTxStore, fromAddress common.Address, nonce, blockNum int64) (etx txmgr.Tx) {
-	etx = cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, nonce, blockNum, fromAddress)
+	etx = evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, nonce, blockNum, fromAddress)
 	mustInsertEthReceipt(t, txStore, blockNum, utils.NewHash(), etx.TxAttempts[0].Hash)
 	return etx
 }
 
 func mustInsertFatalErrorEthTx(t testing.TB, txStore txmgr.TestEvmTxStore, fromAddress common.Address) txmgr.Tx {
-	etx := cltest.NewEthTx(fromAddress)
+	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 	etx.Error = null.StringFrom("something exploded")
 	etx.State = txmgrcommon.TxFatalError
 
@@ -1039,8 +1040,8 @@ func mustInsertFatalErrorEthTx(t testing.TB, txStore txmgr.TestEvmTxStore, fromA
 }
 
 func mustInsertUnconfirmedEthTxWithAttemptState(t testing.TB, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, txAttemptState txmgrtypes.TxAttemptState, opts ...interface{}) txmgr.Tx {
-	etx := cltest.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress, opts...)
-	attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress, opts...)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 	ctx := tests.Context(t)
 
 	tx := testutils.NewLegacyTransaction(uint64(nonce), testutils.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
@@ -1057,8 +1058,8 @@ func mustInsertUnconfirmedEthTxWithAttemptState(t testing.TB, txStore txmgr.Test
 }
 
 func mustInsertUnconfirmedEthTxWithBroadcastDynamicFeeAttempt(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, opts ...interface{}) txmgr.Tx {
-	etx := cltest.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress, opts...)
-	attempt := cltest.NewDynamicFeeEthTxAttempt(t, etx.ID)
+	etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTx(t, txStore, nonce, fromAddress, opts...)
+	attempt := evmtxmgrtestutils.NewDynamicFeeEthTxAttempt(t, etx.ID)
 	ctx := tests.Context(t)
 
 	addr := testutils.NewAddress()
@@ -1087,7 +1088,7 @@ func mustInsertUnconfirmedEthTxWithBroadcastDynamicFeeAttempt(t *testing.T, txSt
 
 func mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address) txmgr.Tx {
 	timeNow := time.Now()
-	etx := cltest.NewEthTx(fromAddress)
+	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 	ctx := tests.Context(t)
 
 	etx.BroadcastAt = &timeNow
@@ -1096,7 +1097,7 @@ func mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t *testing.T, txStore 
 	etx.Sequence = &n
 	etx.State = txmgrcommon.TxUnconfirmed
 	require.NoError(t, txStore.InsertTx(ctx, &etx))
-	attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 
 	tx := testutils.NewLegacyTransaction(uint64(nonce), testutils.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
 	rlp := new(bytes.Buffer)
@@ -1114,7 +1115,7 @@ func mustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t *testing.T, txStore 
 func mustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(
 	t *testing.T, txStore txmgr.TestEvmTxStore, nonce int64, broadcastBeforeBlockNum int64,
 	broadcastAt time.Time, fromAddress common.Address) txmgr.Tx {
-	etx := cltest.NewEthTx(fromAddress)
+	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 	ctx := tests.Context(t)
 
 	etx.BroadcastAt = &broadcastAt
@@ -1123,7 +1124,7 @@ func mustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(
 	etx.Sequence = &n
 	etx.State = txmgrcommon.TxConfirmedMissingReceipt
 	require.NoError(t, txStore.InsertTx(ctx, &etx))
-	attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 	attempt.BroadcastBeforeBlockNum = &broadcastBeforeBlockNum
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	require.NoError(t, txStore.InsertTxAttempt(ctx, &attempt))
@@ -1132,13 +1133,13 @@ func mustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(
 }
 
 func mustInsertInProgressEthTxWithAttempt(t testing.TB, txStore txmgr.TestEvmTxStore, nonce evmtypes.Nonce, fromAddress common.Address) txmgr.Tx {
-	etx := cltest.NewEthTx(fromAddress)
+	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 	ctx := tests.Context(t)
 
 	etx.Sequence = &nonce
 	etx.State = txmgrcommon.TxInProgress
 	require.NoError(t, txStore.InsertTx(ctx, &etx))
-	attempt := cltest.NewLegacyEthTxAttempt(t, etx.ID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, etx.ID)
 	tx := evmtestutils.NewLegacyTransaction(uint64(nonce), testutils.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
 	rlp := new(bytes.Buffer)
 	require.NoError(t, tx.EncodeRLP(rlp))
@@ -1200,7 +1201,7 @@ func mustCreateUnstartedTxFromEvmTxRequest(t testing.TB, txStore txmgr.EvmTxStor
 }
 
 func mustInsertUnstartedTx(t testing.TB, txStore txmgr.TestEvmTxStore, fromAddress common.Address) {
-	etx := cltest.NewEthTx(fromAddress)
+	etx := evmtxmgrtestutils.NewEthTx(fromAddress)
 	ctx := tests.Context(t)
 	require.NoError(t, txStore.InsertTx(ctx, &etx))
 }

--- a/core/chains/evm/txmgr/txmgrtest/utils.go
+++ b/core/chains/evm/txmgr/txmgrtest/utils.go
@@ -1,4 +1,4 @@
-package testutils
+package txmgrtest
 
 import (
 	"bytes"

--- a/core/cmd/evm_transaction_commands_test.go
+++ b/core/cmd/evm_transaction_commands_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/urfave/cli"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
@@ -33,8 +33,8 @@ func TestShell_IndexTransactions(t *testing.T) {
 
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
-	tx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
+	txStore := txmgrtest.NewTestTxStore(t, app.GetDB())
+	tx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
 	attempt := tx.TxAttempts[0]
 
 	// page 1
@@ -74,8 +74,8 @@ func TestShell_ShowTransaction(t *testing.T) {
 	db := app.GetDB()
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
-	tx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
+	txStore := txmgrtest.NewTestTxStore(t, db)
+	tx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
 	attempt := tx.TxAttempts[0]
 
 	set := flag.NewFlagSet("test get tx", 0)
@@ -98,8 +98,8 @@ func TestShell_IndexTxAttempts(t *testing.T) {
 
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
-	tx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
+	txStore := txmgrtest.NewTestTxStore(t, app.GetDB())
+	tx := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
 
 	// page 1
 	set := flag.NewFlagSet("test txattempts", 0)

--- a/core/cmd/evm_transaction_commands_test.go
+++ b/core/cmd/evm_transaction_commands_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/urfave/cli"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
@@ -32,8 +33,8 @@ func TestShell_IndexTransactions(t *testing.T) {
 
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
-	txStore := cltest.NewTestTxStore(t, app.GetDB())
-	tx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
+	tx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
 	attempt := tx.TxAttempts[0]
 
 	// page 1
@@ -73,8 +74,8 @@ func TestShell_ShowTransaction(t *testing.T) {
 	db := app.GetDB()
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
-	txStore := cltest.NewTestTxStore(t, db)
-	tx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+	tx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
 	attempt := tx.TxAttempts[0]
 
 	set := flag.NewFlagSet("test get tx", 0)
@@ -97,8 +98,8 @@ func TestShell_IndexTxAttempts(t *testing.T) {
 
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
-	txStore := cltest.NewTestTxStore(t, app.GetDB())
-	tx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
+	tx := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
 
 	// page 1
 	set := flag.NewFlagSet("test txattempts", 0)

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
@@ -286,8 +287,8 @@ func TestShell_RebroadcastTransactions_Txm(t *testing.T) {
 	keyStore := cltest.NewKeyStore(t, sqlxDB)
 	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth())
 
-	txStore := cltest.NewTestTxStore(t, sqlxDB)
-	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 7, 42, fromAddress)
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, sqlxDB)
+	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 7, 42, fromAddress)
 
 	lggr := logger.TestLogger(t)
 
@@ -368,8 +369,8 @@ func TestShell_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
 
 			_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth())
 
-			txStore := cltest.NewTestTxStore(t, sqlxDB)
-			cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(test.nonce), 42, fromAddress)
+			txStore := evmtxmgrtestutils.NewTestTxStore(t, sqlxDB)
+			evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(test.nonce), 42, fromAddress)
 
 			lggr := logger.TestLogger(t)
 

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
@@ -287,8 +287,8 @@ func TestShell_RebroadcastTransactions_Txm(t *testing.T) {
 	keyStore := cltest.NewKeyStore(t, sqlxDB)
 	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth())
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, sqlxDB)
-	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 7, 42, fromAddress)
+	txStore := txmgrtest.NewTestTxStore(t, sqlxDB)
+	txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 7, 42, fromAddress)
 
 	lggr := logger.TestLogger(t)
 
@@ -369,8 +369,8 @@ func TestShell_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
 
 			_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth())
 
-			txStore := evmtxmgrtestutils.NewTestTxStore(t, sqlxDB)
-			evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(test.nonce), 42, fromAddress)
+			txStore := txmgrtest.NewTestTxStore(t, sqlxDB)
+			txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(test.nonce), 42, fromAddress)
 
 			lggr := logger.TestLogger(t)
 

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -1473,10 +1473,6 @@ func MustWebURL(t *testing.T, s string) *models.WebURL {
 	return (*models.WebURL)(uri)
 }
 
-func NewTestTxStore(t testing.TB, ds sqlutil.DataSource) txmgr.TestEvmTxStore {
-	return txmgr.NewTxStore(ds, logger.TestLogger(t))
-}
-
 // ClearDBTables deletes all rows from the given tables
 func ClearDBTables(t *testing.T, db *sqlx.DB, tables ...string) {
 	tx, err := db.Beginx()

--- a/core/services/headreporter/prometheus_reporter_test.go
+++ b/core/services/headreporter/prometheus_reporter_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys/keystest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
@@ -64,13 +64,13 @@ func Test_PrometheusReporter(t *testing.T) {
 
 	t.Run("with unconfirmed evm.txes", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		txStore := txmgrtest.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 
-		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
-		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
-		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
+		etx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+		txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
+		txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
 		require.NoError(t, txStore.UpdateTxAttemptBroadcastBeforeBlockNum(testutils.Context(t), etx.ID, 7))
 
 		backend := headreporter.NewMockPrometheusBackend(t)

--- a/core/services/headreporter/prometheus_reporter_test.go
+++ b/core/services/headreporter/prometheus_reporter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys/keystest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtestutils "github.com/smartcontractkit/chainlink-evm/pkg/testutils"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
@@ -63,13 +64,13 @@ func Test_PrometheusReporter(t *testing.T) {
 
 	t.Run("with unconfirmed evm.txes", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		txStore := cltest.NewTestTxStore(t, db)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
 		ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 		_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 
-		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
-		cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
-		cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
+		etx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
+		evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 2, fromAddress)
 		require.NoError(t, txStore.UpdateTxAttemptBroadcastBeforeBlockNum(testutils.Context(t), etx.ID, 7))
 
 		backend := headreporter.NewMockPrometheusBackend(t)

--- a/core/services/keystore/eth_test.go
+++ b/core/services/keystore/eth_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commonutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
@@ -116,8 +116,8 @@ func Test_EthKeyStore(t *testing.T) {
 		cltest.AssertCount(t, db, statesTableName, 1)
 
 		// add one eth_tx
-		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
-		evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 42, key.Address)
+		txStore := txmgrtest.NewTestTxStore(t, db)
+		txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 42, key.Address)
 
 		_, err = ethKeyStore.Delete(ctx, key.ID())
 		require.NoError(t, err)

--- a/core/services/keystore/eth_test.go
+++ b/core/services/keystore/eth_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commonutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
@@ -115,8 +116,8 @@ func Test_EthKeyStore(t *testing.T) {
 		cltest.AssertCount(t, db, statesTableName, 1)
 
 		// add one eth_tx
-		txStore := cltest.NewTestTxStore(t, db)
-		cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 42, key.Address)
+		txStore := evmtxmgrtestutils.NewTestTxStore(t, db)
+		evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 42, key.Address)
 
 		_, err = ethKeyStore.Delete(ctx, key.ID())
 		require.NoError(t, err)

--- a/core/web/evm_transactions_controller_test.go
+++ b/core/web/evm_transactions_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/web"
@@ -26,18 +27,18 @@ func TestTransactionsController_Index_Success(t *testing.T) {
 	require.NoError(t, app.Start(ctx))
 
 	db := app.GetDB()
-	txStore := cltest.NewTestTxStore(t, app.GetDB())
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	client := app.NewHTTPClient(nil)
 	_, from := cltest.MustInsertRandomKey(t, ethKeyStore)
 
-	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)        // tx1
-	tx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 2, from) // tx2
-	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 4, from)        // tx3
+	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)        // tx1
+	tx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 2, from) // tx2
+	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 4, from)        // tx3
 
 	// add second tx attempt for tx2
 	blockNum := int64(3)
-	attempt := cltest.NewLegacyEthTxAttempt(t, tx2.ID)
+	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx2.ID)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(3)}
 	attempt.BroadcastBeforeBlockNum = &blockNum
@@ -84,11 +85,11 @@ func TestTransactionsController_Show_Success(t *testing.T) {
 	ctx := testutils.Context(t)
 	require.NoError(t, app.Start(ctx))
 
-	txStore := cltest.NewTestTxStore(t, app.GetDB())
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
 	client := app.NewHTTPClient(nil)
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
-	tx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, from)
+	tx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, from)
 	require.Len(t, tx.TxAttempts, 1)
 	attempt := tx.TxAttempts[0]
 	attempt.Tx = tx
@@ -118,10 +119,10 @@ func TestTransactionsController_Show_NotFound(t *testing.T) {
 	ctx := testutils.Context(t)
 	require.NoError(t, app.Start(ctx))
 
-	txStore := cltest.NewTestTxStore(t, app.GetDB())
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
 	client := app.NewHTTPClient(nil)
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
-	tx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, from)
+	tx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, from)
 	require.Len(t, tx.TxAttempts, 1)
 	attempt := tx.TxAttempts[0]
 

--- a/core/web/evm_transactions_controller_test.go
+++ b/core/web/evm_transactions_controller_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/web"
@@ -27,18 +27,18 @@ func TestTransactionsController_Index_Success(t *testing.T) {
 	require.NoError(t, app.Start(ctx))
 
 	db := app.GetDB()
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
+	txStore := txmgrtest.NewTestTxStore(t, app.GetDB())
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	client := app.NewHTTPClient(nil)
 	_, from := cltest.MustInsertRandomKey(t, ethKeyStore)
 
-	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)        // tx1
-	tx2 := evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 2, from) // tx2
-	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 4, from)        // tx3
+	txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)        // tx1
+	tx2 := txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 2, from) // tx2
+	txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 4, 4, from)        // tx3
 
 	// add second tx attempt for tx2
 	blockNum := int64(3)
-	attempt := evmtxmgrtestutils.NewLegacyEthTxAttempt(t, tx2.ID)
+	attempt := txmgrtest.NewLegacyEthTxAttempt(t, tx2.ID)
 	attempt.State = txmgrtypes.TxAttemptBroadcast
 	attempt.TxFee = gas.EvmFee{GasPrice: assets.NewWeiI(3)}
 	attempt.BroadcastBeforeBlockNum = &blockNum
@@ -85,11 +85,11 @@ func TestTransactionsController_Show_Success(t *testing.T) {
 	ctx := testutils.Context(t)
 	require.NoError(t, app.Start(ctx))
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
+	txStore := txmgrtest.NewTestTxStore(t, app.GetDB())
 	client := app.NewHTTPClient(nil)
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
-	tx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, from)
+	tx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, from)
 	require.Len(t, tx.TxAttempts, 1)
 	attempt := tx.TxAttempts[0]
 	attempt.Tx = tx
@@ -119,10 +119,10 @@ func TestTransactionsController_Show_NotFound(t *testing.T) {
 	ctx := testutils.Context(t)
 	require.NoError(t, app.Start(ctx))
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
+	txStore := txmgrtest.NewTestTxStore(t, app.GetDB())
 	client := app.NewHTTPClient(nil)
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
-	tx := evmtxmgrtestutils.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, from)
+	tx := txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, from)
 	require.Len(t, tx.TxAttempts, 1)
 	attempt := tx.TxAttempts[0]
 

--- a/core/web/evm_tx_attempts_controller_test.go
+++ b/core/web/evm_tx_attempts_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/txmgrtest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/web"
@@ -21,14 +21,14 @@ func TestTxAttemptsController_Index_Success(t *testing.T) {
 	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
-	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
+	txStore := txmgrtest.NewTestTxStore(t, app.GetDB())
 	client := app.NewHTTPClient(nil)
 
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
-	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
-	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, from)
-	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 2, 3, from)
+	txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
+	txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, from)
+	txmgrtest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 2, 3, from)
 
 	resp, cleanup := client.Get("/v2/tx_attempts?size=2")
 	t.Cleanup(cleanup)

--- a/core/web/evm_tx_attempts_controller_test.go
+++ b/core/web/evm_tx_attempts_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	evmtxmgrtestutils "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/web"
@@ -20,14 +21,14 @@ func TestTxAttemptsController_Index_Success(t *testing.T) {
 	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
-	txStore := cltest.NewTestTxStore(t, app.GetDB())
+	txStore := evmtxmgrtestutils.NewTestTxStore(t, app.GetDB())
 	client := app.NewHTTPClient(nil)
 
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
-	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
-	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, from)
-	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 2, 3, from)
+	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
+	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, from)
+	evmtxmgrtestutils.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 2, 3, from)
 
 	resp, cleanup := client.Get("/v2/tx_attempts?size=2")
 	t.Cleanup(cleanup)


### PR DESCRIPTION
Moved functions:

- NewTestTxStore
- NewEthTx
- MustInsertUnconfirmedEthTx
- MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt
- MustInsertConfirmedEthTxWithLegacyAttempt
- NewLegacyEthTxAttempt
- NewDynamicFeeEthTxAttempt

Copied functions

- AssertCount (too common and simple to become API of chainlink-evm)

Inlined functions:

- Head (too simple to export)