### PR TITLE
Remove burnmint grant from TP deployment

### DIFF
--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
@@ -257,17 +257,21 @@ func TestAddTokenE2E(t *testing.T) {
 					rateLimiterConfig.Inbound.Capacity,
 					e.Chains[chain].DeployerKey.From, // the pools are still owned by the deployer
 				)
-				if test.withNewToken {
-					// check token pool is added as minter
-					minterCheck, err := token.Contract.IsMinter(&bind.CallOpts{Context: ctx}, tokenPoolC.Address())
-					require.NoError(t, err)
-					require.True(t, minterCheck)
+				/*
+					This behavior is not currently enabled
 
-					// check token pool is added as burner
-					burnerCheck, err := token.Contract.IsBurner(&bind.CallOpts{Context: ctx}, tokenPoolC.Address())
-					require.NoError(t, err)
-					require.True(t, burnerCheck)
-				}
+						if test.withNewToken {
+							// check token pool is added as minter
+							minterCheck, err := token.Contract.IsMinter(&bind.CallOpts{Context: ctx}, tokenPoolC.Address())
+							require.NoError(t, err)
+							require.True(t, minterCheck)
+
+							// check token pool is added as burner
+							burnerCheck, err := token.Contract.IsBurner(&bind.CallOpts{Context: ctx}, tokenPoolC.Address())
+							require.NoError(t, err)
+							require.True(t, burnerCheck)
+						}
+				*/
 				// check if admin and set pool is set correctly
 				regConfig, err := registry.GetTokenConfig(&bind.CallOpts{Context: ctx}, token.Address)
 				require.NoError(t, err)

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools.go
@@ -171,15 +171,9 @@ func DeployTokenPoolContractsChangeset(env cldf.Environment, c DeployTokenPoolCo
 		deployGrp.Go(func() error {
 			chain := env.Chains[chainSelector]
 			chainState := state.Chains[chainSelector]
-			contract, err := deployTokenPool(env.Logger, chain, chainState, newAddresses, poolConfig, c.IsTestRouter)
+			_, err := deployTokenPool(env.Logger, chain, chainState, newAddresses, poolConfig, c.IsTestRouter)
 			if err != nil {
 				return fmt.Errorf("failed to deploy token pool contract: %w", err)
-			}
-			if poolConfig.Type == shared.BurnMintTokenPool {
-				err := grantAccessToPool(env.GetContext(), chain, contract.Address, poolConfig.TokenAddress)
-				if err != nil {
-					return fmt.Errorf("failed to grant token pool access to token: %s %w", poolConfig.TokenAddress, err)
-				}
 			}
 			return nil
 		})


### PR DESCRIPTION
This causes failures, because we cant grant burnmint rights for all token pools that we deploy. Also, the owner field is not always the dictator of who can grant burnmint. Approach needs revision, removing for now to unblock.
