### PR TITLE
DF workflow gen fixes

### DIFF
--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
@@ -112,10 +112,8 @@ func proposeWFJobsToJDLogic(env cldf.Environment, c types.ProposeWFJobsConfig) (
 	}
 
 	// write the workflow spec to artifacts/migration_name folder. Do not exit on error as the jobs are already proposed
-	baseDir := ".."
-	envName := env.Name
-
-	wfSpecPath := filepath.Join(baseDir, envName, "artifacts", c.MigrationName, workflowState.Name+".yaml")
+	// using the absolute path to the file as the command is run from root in CLD pipeline
+	wfSpecPath := filepath.Join("domains", "data-feeds", env.Name, "artifacts", c.MigrationName, workflowState.Name+".yaml")
 	err = os.MkdirAll(filepath.Dir(wfSpecPath), 0755)
 	if err != nil {
 		env.Logger.Errorf("failed to create directory for workflow file: %s", err)

--- a/deployment/data-feeds/offchain/jd.go
+++ b/deployment/data-feeds/offchain/jd.go
@@ -100,14 +100,15 @@ func ProposeJobs(ctx context.Context, env cldf.Environment, workflowJobSpec stri
 	}
 
 	for _, node := range nodes {
-		env.Logger.Debugf("Proposing jof for node %s", node.Name)
+		env.Logger.Debugf("Proposing job for node %s", node.Name)
 		resp, err := env.Offchain.ProposeJob(ctx, &jobv1.ProposeJobRequest{
 			NodeId: node.Id,
 			Spec:   workflowJobSpec,
 			Labels: jobLabels,
 		})
 		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to propose job: %w", err)
+			env.Logger.Errorf("failed to propose job: %s", err)
+			continue
 		}
 		env.Logger.Debugf("Job proposed %s", resp.Proposal.JobId)
 		out.Jobs = append(out.Jobs, cldf.ProposedJob{


### PR DESCRIPTION
Fixed workflow artifact generation. Workflow artifact yaml spec should be automatically saved in CLD now
Changed workflow job generation logic to not exit on failed jobs.