### PR TITLE
Allow the destination lib directory in prebuilt Dockerfile to be overridden

### DIFF
--- a/plugins/chainlink.prebuilt.Dockerfile
+++ b/plugins/chainlink.prebuilt.Dockerfile
@@ -9,10 +9,11 @@ ARG BASE_IMAGE=public.ecr.aws/chainlink/chainlink:v2.23.0-plugins
 FROM ${BASE_IMAGE} AS final
 # This directory should contain a bin/ subdir with the plugins and an optional lib/ subdir with shared libraries.
 ARG PKG_PATH=./build
+ARG LIB_PATH_DEST=/usr/lib
 
 # Copy/override any (optional) additional shared libraries.
 # Square brackets in "li[b]" make this path optional - Docker build won't fail
 # if the directory doesn't exist.
-COPY ${PKG_PATH}/li[b] /usr/lib/
+COPY ${PKG_PATH}/li[b] ${LIB_PATH_DEST}
 # Copy/override plugins.
 COPY ${PKG_PATH}/bin /usr/local/bin


### PR DESCRIPTION
Certain teams install shared libs in a directory other than `/usr/lib`.