### PR TITLE
[CRE-462] (feat): Add balance store to metering

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/platform"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/events"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/internal"
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/ratelimiter"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/store"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncerlimiter"
@@ -146,7 +147,7 @@ type Engine struct {
 	clock          clockwork.Clock
 	ratelimiter    *ratelimiter.RateLimiter
 	workflowLimits *syncerlimiter.Limits
-	meterReports   *MeterReports
+	meterReports   *metering.MeterReports
 }
 
 func (e *Engine) Start(_ context.Context) error {
@@ -494,7 +495,7 @@ func (e *Engine) stepUpdateLoop(ctx context.Context, executionID string, stepUpd
 
 // startExecution kicks off a new workflow execution when a trigger event is received.
 func (e *Engine) startExecution(ctx context.Context, executionID string, triggerID string, event *values.Map) error {
-	e.meterReports.Add(executionID, NewMeteringReport())
+	e.meterReports.Add(executionID, metering.NewMeteringReport(e.logger))
 
 	err := events.EmitExecutionStartedEvent(ctx, e.cma, triggerID, executionID)
 	if err != nil {
@@ -585,7 +586,7 @@ func (e *Engine) handleStepUpdate(ctx context.Context, stepUpdate store.Workflow
 
 		// this case is only for resuming executions and should be updated when metering is added to save execution state
 		if _, ok := e.meterReports.Get(stepUpdate.ExecutionID); !ok {
-			e.meterReports.Add(stepUpdate.ExecutionID, NewMeteringReport())
+			e.meterReports.Add(stepUpdate.ExecutionID, metering.NewMeteringReport(e.logger))
 		}
 
 		return e.finishExecution(ctx, cma, state.ExecutionID, status)
@@ -810,16 +811,16 @@ func (e *Engine) workerForStepRequest(ctx context.Context, msg stepRequest) {
 		stepStatus = store.StatusCompleted
 	}
 
-	meteringSteps := make([]MeteringReportStep, len(response.Metadata.Metering))
+	meteringSteps := make([]metering.MeteringReportStep, len(response.Metadata.Metering))
 
 	for idx, detail := range response.Metadata.Metering {
-		unit := MeteringSpendUnit(detail.SpendUnit)
+		unit := metering.MeteringSpendUnit(detail.SpendUnit)
 		value, err := unit.StringToSpendValue(detail.SpendValue)
 		if err != nil {
 			l.Error(fmt.Sprintf("failed to get spend value from %s: %s", detail.SpendValue, err))
 		}
 
-		meteringSteps[idx] = MeteringReportStep{
+		meteringSteps[idx] = metering.MeteringReportStep{
 			Peer2PeerID: detail.Peer2PeerID,
 			SpendUnit:   unit,
 			SpendValue:  value,
@@ -827,7 +828,7 @@ func (e *Engine) workerForStepRequest(ctx context.Context, msg stepRequest) {
 	}
 
 	if rpt, ok := e.meterReports.Get(msg.state.ExecutionID); ok {
-		if err := rpt.SetStep(MeteringReportStepRef(stepState.Ref), meteringSteps); err != nil {
+		if err := rpt.SetStep(metering.MeteringReportStepRef(stepState.Ref), meteringSteps); err != nil {
 			l.Error(fmt.Sprintf("failed to set metering report step for ref %s: %s", stepState.Ref, err))
 		}
 		e.metrics.with(platform.KeyWorkflowID, e.workflow.id, platform.KeyWorkflowExecutionID, msg.state.ExecutionID).incrementWorkflowMissingMeteringReport(ctx)
@@ -1187,7 +1188,7 @@ func (e *Engine) heartbeat(ctx context.Context) {
 	}
 }
 
-func (e *Engine) sendMeteringReportToBilling(ctx context.Context, report *MeteringReport, workflowID string, executionID string) error {
+func (e *Engine) sendMeteringReportToBilling(ctx context.Context, report *metering.MeteringReport, workflowID string, executionID string) error {
 	if e.billingClient != nil {
 		req := billing.SubmitWorkflowReceiptRequest{
 			AccountId:           e.workflow.owner,
@@ -1452,9 +1453,11 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 	workflow.owner = cfg.WorkflowOwner
 	workflow.name = cfg.WorkflowName
 
+	lggr := cfg.Lggr.With("workflowID", cfg.WorkflowID)
+
 	engine = &Engine{
 		cma:            cma,
-		logger:         cfg.Lggr.Named("WorkflowEngine").With("workflowID", cfg.WorkflowID),
+		logger:         lggr.Named("WorkflowEngine"),
 		metrics:        workflowsMetricLabeler{metrics.NewLabeler().With(platform.KeyWorkflowID, cfg.WorkflowID, platform.KeyWorkflowOwner, cfg.WorkflowOwner, platform.KeyWorkflowName, cfg.WorkflowName.String()), *em},
 		registry:       cfg.Registry,
 		workflow:       workflow,
@@ -1481,7 +1484,7 @@ func NewEngine(ctx context.Context, cfg Config) (engine *Engine, err error) {
 		clock:                cfg.clock,
 		ratelimiter:          cfg.RateLimiter,
 		workflowLimits:       cfg.WorkflowLimits,
-		meterReports:         NewMeterReports(),
+		meterReports:         metering.NewMeterReports(),
 		billingClient:        cfg.BillingClient,
 	}
 

--- a/core/services/workflows/metering/balance_store.go
+++ b/core/services/workflows/metering/balance_store.go
@@ -1,0 +1,156 @@
+package metering
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+var (
+	ErrInsufficientBalance = errors.New("insufficient balance")
+	ErrInvalidAmount       = errors.New("amount must be greater than 0")
+)
+
+type balanceStore struct {
+	// Whether negative balances should return an error
+	allowNegative bool
+	// A balance of credits
+	balance int64
+	// Conversion rates of resource type to number of credits
+	conversions map[string]decimal.Decimal
+	lggr        logger.Logger
+	mu          sync.RWMutex
+}
+
+type BalanceStore interface {
+	Get() (balance int64)
+	GetAs(unit string) (balance int64)
+	Minus(amount int64) error
+	MinusAs(unit string, amount int64) error
+	Add(amount int64) error
+	AddAs(unit string, amount int64) error
+	AllowNegative()
+}
+
+var _ BalanceStore = (BalanceStore)(nil)
+
+func NewBalanceStore(startingBalance int64, conversions map[string]decimal.Decimal, lggr logger.Logger) *balanceStore {
+	// validations
+	for resource, rate := range conversions {
+		if rate.IsNegative() {
+			// fail open
+			lggr.Errorw("conversion rates must be a positive number, not using conversion", "resource", resource, "rate", rate)
+			delete(conversions, resource)
+		}
+	}
+
+	return &balanceStore{
+		allowNegative: false,
+		balance:       startingBalance,
+		conversions:   conversions,
+		lggr:          lggr,
+	}
+}
+
+// convertToBalance converts a resource type amount to a credit amount
+// This method should only be used under a read lock
+func (bs *balanceStore) convertToBalance(fromUnit string, amount int64) (credits int64) {
+	rate, ok := bs.conversions[fromUnit]
+	if !ok {
+		// Fail open, continue optimistically
+		bs.lggr.Errorw("could not find conversion rate, continuing as 1:1", "unit", fromUnit)
+		rate = decimal.NewFromInt(1)
+	}
+	return decimal.NewFromInt(amount).Mul(rate).RoundUp(0).IntPart()
+}
+
+// convertFromBalance converts a credit amount to a resource type amount
+// This method should only be used under a read lock
+func (bs *balanceStore) convertFromBalance(toUnit string, amount int64) (resources int64) {
+	rate, ok := bs.conversions[toUnit]
+	if !ok {
+		// Fail open, continue optimistically
+		bs.lggr.Errorw("could not find conversion rate, continuing as 1:1", "unit", toUnit)
+		rate = decimal.NewFromInt(1)
+	}
+	return decimal.NewFromInt(amount).Div(rate).RoundUp(0).IntPart()
+}
+
+// Get returns the current credit balance
+func (bs *balanceStore) Get() (balance int64) {
+	bs.mu.RLock()
+	defer bs.mu.RUnlock()
+	return bs.balance
+}
+
+// GetAs returns the current universal credit balance expressed as a resource
+func (bs *balanceStore) GetAs(unit string) (balance int64) {
+	bs.mu.RLock()
+	defer bs.mu.RUnlock()
+	if bs.balance <= 0 {
+		return 0
+	}
+	return bs.convertFromBalance(unit, bs.balance)
+}
+
+// Minus lowers the current credit balance
+func (bs *balanceStore) Minus(amount int64) error {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if amount <= 0 {
+		return ErrInvalidAmount
+	}
+	if amount > bs.balance && !bs.allowNegative {
+		return ErrInsufficientBalance
+	}
+	bs.balance -= amount
+	return nil
+}
+
+// MinusAs lowers the current credit balance based on an amount of a type of resource
+func (bs *balanceStore) MinusAs(unit string, amount int64) error {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if amount <= 0 {
+		return ErrInvalidAmount
+	}
+	balToMinus := bs.convertToBalance(unit, amount)
+	if balToMinus > bs.balance && !bs.allowNegative {
+		return ErrInsufficientBalance
+	}
+	bs.balance -= balToMinus
+	return nil
+}
+
+// Add increases the current credit balance
+func (bs *balanceStore) Add(amount int64) error {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if amount <= 0 {
+		return ErrInvalidAmount
+	}
+	bs.balance += amount
+	return nil
+}
+
+// AddAs increases the current credit balance based on an amount of a type of resource
+func (bs *balanceStore) AddAs(unit string, amount int64) error {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if amount <= 0 {
+		return ErrInvalidAmount
+	}
+	balToAdd := bs.convertToBalance(unit, amount)
+	bs.balance += balToAdd
+	return nil
+}
+
+// AllowNegative turns on the flag to allow negative balances
+func (bs *balanceStore) AllowNegative() {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	bs.allowNegative = true
+}

--- a/core/services/workflows/metering/balance_store_test.go
+++ b/core/services/workflows/metering/balance_store_test.go
@@ -1,0 +1,145 @@
+package metering
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestBalanceStore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 of resourceA is worth 2 credits
+		// 2 credits is worth 1 of resourceA
+		rate := decimal.NewFromInt(2)
+		balanceStore := NewBalanceStore(10, map[string]decimal.Decimal{"resourceA": rate}, logger.TestLogger(t))
+
+		balance := balanceStore.Get()
+		require.Equal(t, int64(10), balance)
+
+		balanceAs := balanceStore.GetAs("resourceA")
+		require.Equal(t, int64(5), balanceAs)
+
+		err := balanceStore.Add(1)
+		require.NoError(t, err)
+		balance = balanceStore.Get()
+		require.Equal(t, int64(11), balance)
+
+		err = balanceStore.Minus(2)
+		require.NoError(t, err)
+		balance = balanceStore.Get()
+		require.Equal(t, int64(9), balance)
+
+		err = balanceStore.AddAs("resourceA", 1)
+		require.NoError(t, err)
+		balance = balanceStore.Get()
+		require.Equal(t, int64(11), balance)
+
+		err = balanceStore.MinusAs("resourceA", 2)
+		require.NoError(t, err)
+		balance = balanceStore.Get()
+		require.Equal(t, int64(7), balance)
+	})
+
+	t.Run("handles unknown resources as 1:1", func(t *testing.T) {
+		t.Parallel()
+
+		balanceStore := NewBalanceStore(10, map[string]decimal.Decimal{}, logger.TestLogger(t))
+
+		balanceAs := balanceStore.GetAs("")
+		require.Equal(t, int64(10), balanceAs)
+
+		err := balanceStore.MinusAs("", 1)
+		require.NoError(t, err)
+		balance := balanceStore.Get()
+		require.Equal(t, int64(9), balance)
+	})
+
+	t.Run("throws out negative conversion rates", func(t *testing.T) {
+		t.Parallel()
+
+		balanceStore := NewBalanceStore(10, map[string]decimal.Decimal{"resourceA": decimal.NewFromInt(-1)}, logger.TestLogger(t))
+
+		balanceAs := balanceStore.GetAs("resourceA")
+		require.Equal(t, int64(10), balanceAs)
+
+		err := balanceStore.MinusAs("resourceA", 1)
+		require.NoError(t, err)
+		balance := balanceStore.Get()
+		require.Equal(t, int64(9), balance)
+	})
+
+	t.Run("cannot go negative by default", func(t *testing.T) {
+		t.Parallel()
+
+		balanceStore := NewBalanceStore(0, map[string]decimal.Decimal{"resourceA": decimal.NewFromInt(1)}, logger.TestLogger(t))
+
+		err := balanceStore.Minus(1)
+		require.ErrorIs(t, ErrInsufficientBalance, err)
+	})
+
+	t.Run("can go negative after allowNegative", func(t *testing.T) {
+		t.Parallel()
+
+		balanceStore := NewBalanceStore(0, map[string]decimal.Decimal{"resourceA": decimal.NewFromInt(1)}, logger.TestLogger(t))
+
+		balanceStore.AllowNegative()
+		err := balanceStore.Minus(1)
+		require.NoError(t, err)
+		balance := balanceStore.Get()
+		require.Equal(t, int64(-1), balance)
+	})
+
+	t.Run("returns negative balances as 0 when converted to a resource", func(t *testing.T) {
+		t.Parallel()
+
+		balanceStore := NewBalanceStore(0, map[string]decimal.Decimal{"resourceA": decimal.NewFromInt(10)}, logger.TestLogger(t))
+
+		balanceStore.AllowNegative()
+		err := balanceStore.Minus(1)
+		require.NoError(t, err)
+		balance := balanceStore.Get()
+		require.Equal(t, int64(-1), balance)
+
+		balanceAs := balanceStore.GetAs("resourceA")
+		require.Equal(t, int64(0), balanceAs)
+	})
+
+	t.Run("handles decimal rates", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 of resource A is worth 0.1 credits
+		rate, err := decimal.NewFromString("0.1")
+		require.NoError(t, err)
+		balanceStore := NewBalanceStore(10, map[string]decimal.Decimal{"resourceA": rate}, logger.TestLogger(t))
+
+		balance := balanceStore.Get()
+		require.Equal(t, int64(10), balance)
+
+		balanceAs := balanceStore.GetAs("resourceA")
+		require.Equal(t, int64(100), balanceAs)
+	})
+
+	t.Run("rounds up decimals due to conversion to nearest integer", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 of resource A is worth 0.2 credits
+		rate, err := decimal.NewFromString("0.2")
+		require.NoError(t, err)
+		balanceStore := NewBalanceStore(2, map[string]decimal.Decimal{"resourceA": rate}, logger.TestLogger(t))
+
+		balance := balanceStore.Get()
+		require.Equal(t, int64(2), balance)
+
+		err = balanceStore.MinusAs("resourceA", 1)
+		require.NoError(t, err)
+		balance = balanceStore.Get()
+		require.Equal(t, int64(1), balance)
+	})
+}

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -1,4 +1,4 @@
-package workflows
+package metering
 
 import (
 	"errors"
@@ -8,6 +8,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/smartcontractkit/chainlink-protos/workflows/go/events"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 type MeteringReportStepRef string
@@ -79,13 +80,19 @@ type MeteringReportStep struct {
 }
 
 type MeteringReport struct {
-	mu    sync.RWMutex
-	steps map[MeteringReportStepRef][]MeteringReportStep
+	balance *balanceStore
+	mu      sync.RWMutex
+	steps   map[MeteringReportStepRef][]MeteringReportStep
+	lggr    logger.Logger
 }
 
-func NewMeteringReport() *MeteringReport {
+func NewMeteringReport(lggr logger.Logger) *MeteringReport {
+	logger := lggr.Named("Metering")
+	balanceStore := NewBalanceStore(0, map[string]decimal.Decimal{}, logger)
 	return &MeteringReport{
-		steps: make(map[MeteringReportStepRef][]MeteringReportStep),
+		balance: balanceStore,
+		steps:   make(map[MeteringReportStepRef][]MeteringReportStep),
+		lggr:    logger,
 	}
 }
 

--- a/core/services/workflows/metering/metering_test.go
+++ b/core/services/workflows/metering/metering_test.go
@@ -1,4 +1,4 @@
-package workflows
+package metering
 
 import (
 	"strconv"
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
+
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func TestMeteringReport(t *testing.T) {
@@ -20,7 +22,7 @@ func TestMeteringReport(t *testing.T) {
 	t.Run("MedianSpend returns median for multiple spend units", func(t *testing.T) {
 		t.Parallel()
 
-		report := NewMeteringReport()
+		report := NewMeteringReport(logger.TestLogger(t))
 		steps := []MeteringReportStep{
 			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
 			{"xyz", testUnitA, testUnitA.IntToSpendValue(2)},
@@ -52,7 +54,7 @@ func TestMeteringReport(t *testing.T) {
 	t.Run("MedianSpend returns median single spend value", func(t *testing.T) {
 		t.Parallel()
 
-		report := NewMeteringReport()
+		report := NewMeteringReport(logger.TestLogger(t))
 		steps := []MeteringReportStep{
 			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
 		}
@@ -76,7 +78,7 @@ func TestMeteringReport(t *testing.T) {
 	t.Run("MedianSpend returns median odd number of spend values", func(t *testing.T) {
 		t.Parallel()
 
-		report := NewMeteringReport()
+		report := NewMeteringReport(logger.TestLogger(t))
 		steps := []MeteringReportStep{
 			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
 			{"abc", testUnitA, testUnitA.IntToSpendValue(3)},
@@ -102,7 +104,7 @@ func TestMeteringReport(t *testing.T) {
 	t.Run("MedianSpend returns median as average for even number of spend values", func(t *testing.T) {
 		t.Parallel()
 
-		report := NewMeteringReport()
+		report := NewMeteringReport(logger.TestLogger(t))
 		steps := []MeteringReportStep{
 			{"xyz", testUnitA, testUnitA.IntToSpendValue(42)},
 			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
@@ -128,7 +130,7 @@ func TestMeteringReport(t *testing.T) {
 
 	t.Run("SetStep returns error if step already exists", func(t *testing.T) {
 		t.Parallel()
-		report := NewMeteringReport()
+		report := NewMeteringReport(logger.TestLogger(t))
 		steps := []MeteringReportStep{
 			{"xyz", testUnitA, testUnitA.IntToSpendValue(42)},
 			{"abc", testUnitA, testUnitA.IntToSpendValue(1)},
@@ -148,7 +150,7 @@ func Test_MeterReports(t *testing.T) {
 	wg.Add(3)
 	go func() {
 		defer wg.Done()
-		mr.Add("exec1", NewMeteringReport())
+		mr.Add("exec1", NewMeteringReport(logger.TestLogger(t)))
 		r, ok := mr.Get("exec1")
 		assert.True(t, ok)
 		//nolint:errcheck // depending on the concurrent timing, this may or may not err
@@ -157,7 +159,7 @@ func Test_MeterReports(t *testing.T) {
 	}()
 	go func() {
 		defer wg.Done()
-		mr.Add("exec2", NewMeteringReport())
+		mr.Add("exec2", NewMeteringReport(logger.TestLogger(t)))
 		r, ok := mr.Get("exec2")
 		assert.True(t, ok)
 		err := r.SetStep("ref1", []MeteringReportStep{})
@@ -166,7 +168,7 @@ func Test_MeterReports(t *testing.T) {
 	}()
 	go func() {
 		defer wg.Done()
-		mr.Add("exec1", NewMeteringReport())
+		mr.Add("exec1", NewMeteringReport(logger.TestLogger(t)))
 		r, ok := mr.Get("exec1")
 		assert.True(t, ok)
 		//nolint:errcheck // depending on the concurrent timing, this may or may not err
@@ -181,9 +183,9 @@ func Test_MeterReports(t *testing.T) {
 func Test_MeterReportsLength(t *testing.T) {
 	mr := NewMeterReports()
 
-	mr.Add("exec1", NewMeteringReport())
-	mr.Add("exec2", NewMeteringReport())
-	mr.Add("exec3", NewMeteringReport())
+	mr.Add("exec1", NewMeteringReport(logger.TestLogger(t)))
+	mr.Add("exec2", NewMeteringReport(logger.TestLogger(t)))
+	mr.Add("exec3", NewMeteringReport(logger.TestLogger(t)))
 	assert.Equal(t, 3, mr.Len())
 
 	mr.Delete("exec2")


### PR DESCRIPTION
### Description
Add a concurrency safe store for reserved balance. On calling the billing service, the engine will receive back the conversion rates. These rates are to be plugged into the balance store, along with the amount of universal credits that the Engine reserved based on its Workflow execution limits.

Also, moves metering to its own package within in the engine to promote code isolation.