### PR TITLE
[DX-815] polish nightly local CRE env test

### DIFF
--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: chainlink/system-tests/tests/go.mod
+          go-version-file: system-tests/tests/go.mod
 
       # We need to login to ECR to allow the test to pull the Job Distributor and Chainlink images
       - name: Configure AWS Credentials
@@ -59,7 +59,7 @@ jobs:
       - name: Overwrite chainlink version in TOML config
         shell: bash
         run: |
-          cat > chainlink/system-tests/tests/smoke/cre/cmd/configs/ci-override.toml<< EOF
+          cat > system-tests/tests/smoke/cre/cmd/configs/ci-override.toml<< EOF
           [jd]
             image = "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.9.0"
 
@@ -81,7 +81,7 @@ jobs:
       - name: Start the CLI
         shell: bash
         run: |
-          cd chainlink/system-tests/tests/smoke/cre/cmd
+          cd system-tests/tests/smoke/cre/cmd
           CTF_CONFIGS="./configs/single-don.toml,./configs/ci-override.toml" go run main.go env start
 
   notify-test-failure:
@@ -99,7 +99,7 @@ jobs:
           token: ${{ secrets.QA_SLACK_API_KEY }}
           payload: |
             {
-              "channel": "C023GJUSQ0H",
+              "channel": "C0364FG2CN9",
               "text": "Local CRE environment failed to start",
               "blocks": [
                 {

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           cat > system-tests/tests/smoke/cre/cmd/configs/ci-override.toml<< EOF
           [jd]
-            image = "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.9.0"
+            image = "injected-at-runtime"
 
           [[nodesets]]
             nodes = 5
@@ -68,7 +68,7 @@ jobs:
 
             [[nodesets.node_specs]]
               [nodesets.node_specs.node]
-                image = "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:${{ inputs.chainlink_image_tag }}"
+                image = "injected-at-runtime"
           EOF
 
       - name: Start the CLI
@@ -77,6 +77,8 @@ jobs:
           CTF_CONFIGS: "./configs/single-don.toml,./configs/ci-override.toml"
           E2E_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor"
           E2E_JD_VERSION: "0.9.0"
+          E2E_TEST_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink"
+          E2E_TEST_CHAINLINK_VERSION: ${{ inputs.chainlink_image_tag }}
         run: |
           cd system-tests/tests/smoke/cre/cmd
           go run main.go env start

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -65,18 +65,18 @@ jobs:
             image = "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor:0.9.0"
 
           [[nodesets]]
-          nodes = 5
-          override_mode = "all"
-          http_port_range_start = 10100
-          name = "workflow"
+            nodes = 5
+            override_mode = "all"
+            http_port_range_start = 10100
+            name = "workflow"
 
-          [nodesets.db]
-            image = "postgres:12.0"
-            port = 13000
+            [nodesets.db]
+              image = "postgres:12.0"
+              port = 13000
 
-          [[nodesets.node_specs]]
-            [nodesets.node_specs.node]
-              image = "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:${{ inputs.chainlink_image_tag }}"
+            [[nodesets.node_specs]]
+              [nodesets.node_specs.node]
+                image = "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:${{ inputs.chainlink_image_tag }}"
           EOF
 
       - name: Start the CLI
@@ -85,40 +85,40 @@ jobs:
           cd system-tests/tests/smoke/cre/cmd
           CTF_CONFIGS="./configs/single-don.toml,./configs/ci-override.toml" go run main.go env start
 
-  notify-test-failure:
-    name: Notify about local env startup failure
-    if: failure()
-    needs: [test-cli]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send slack notification for failed local env startup
-        id: send-slack-notification
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-        with:
-          errors: "true"
-          method: chat.postMessage
-          token: ${{ secrets.QA_SLACK_API_KEY }}
-          payload: |
-            {
-              "channel": "C0364FG2CN9",
-              "text": "Local CRE environment failed to start",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*:rotating_light: Local CRE environment failed to start :rotating_light:*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Alerting <@U060CGGPY8H> local CRE environment failed to start for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>. This commit was already merged to develop."
-                  }
-                }
-              ]
-            }
+  # notify-test-failure:
+  #   name: Notify about local env startup failure
+  #   if: failure()
+  #   needs: [test-cli]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Send slack notification for failed local env startup
+  #       id: send-slack-notification
+  #       uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+  #       with:
+  #         errors: "true"
+  #         method: chat.postMessage
+  #         token: ${{ secrets.QA_SLACK_API_KEY }}
+  #         payload: |
+  #           {
+  #             "channel": "C0364FG2CN9",
+  #             "text": "Local CRE environment failed to start",
+  #             "blocks": [
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": "*:rotating_light: Local CRE environment failed to start :rotating_light:*"
+  #                 }
+  #               },
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": "Alerting <@U060CGGPY8H> local CRE environment failed to start for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>. This commit was already merged to develop."
+  #                 }
+  #               }
+  #             ]
+  #           }
 
 
 

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -12,14 +12,6 @@ on:
         type: string
         description: "The version of Chainlink repository to use for the tests."
         default: "develop"
-      env_type:
-        required: true
-        type: choice
-        options:
-          - simplified
-          - full
-        description: "Either a simplified or full environment."
-        default: "simplified"
 
 jobs:
   test-cli:
@@ -81,9 +73,13 @@ jobs:
 
       - name: Start the CLI
         shell: bash
+        env:
+          CTF_CONFIGS: "./configs/single-don.toml,./configs/ci-override.toml"
+          E2E_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor"
+          E2E_JD_VERSION: "0.9.0"
         run: |
           cd system-tests/tests/smoke/cre/cmd
-          CTF_CONFIGS="./configs/single-don.toml,./configs/ci-override.toml" go run main.go env start
+          go run main.go env start
 
   # notify-test-failure:
   #   name: Notify about local env startup failure

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -114,7 +114,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Alerting <@U060CGGPY8H|Bartek Tofel> local CRE environment failed to start for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>. This commit was already merged to develop."
+                    "text": "Alerting <@U060CGGPY8H> local CRE environment failed to start for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>. This commit was already merged to develop."
                   }
                 }
               ]

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -24,6 +24,7 @@ on:
 jobs:
   test-cli:
     runs-on: ubuntu-latest
+    environment: "integration"
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -12,6 +12,17 @@ on:
         type: string
         description: "The version of Chainlink repository to use for the tests."
         default: "develop"
+  workflow_call:
+    inputs:
+      chainlink_image_tag:
+        required: true
+        type: string
+        description: "The tag of the Chainlink image to use for the tests."
+      chainlink_version:
+        required: true
+        type: string
+        description: "The version of Chainlink repository to use for the tests."
+        default: "develop"
 
 jobs:
   test-cli:

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -94,40 +94,40 @@ jobs:
           cd system-tests/tests/smoke/cre/cmd
           go run main.go env start
 
-  # notify-test-failure:
-  #   name: Notify about local env startup failure
-  #   if: failure()
-  #   needs: [test-cli]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Send slack notification for failed local env startup
-  #       id: send-slack-notification
-  #       uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-  #       with:
-  #         errors: "true"
-  #         method: chat.postMessage
-  #         token: ${{ secrets.QA_SLACK_API_KEY }}
-  #         payload: |
-  #           {
-  #             "channel": "C0364FG2CN9",
-  #             "text": "Local CRE environment failed to start",
-  #             "blocks": [
-  #               {
-  #                 "type": "section",
-  #                 "text": {
-  #                   "type": "mrkdwn",
-  #                   "text": "*:rotating_light: Local CRE environment failed to start :rotating_light:*"
-  #                 }
-  #               },
-  #               {
-  #                 "type": "section",
-  #                 "text": {
-  #                   "type": "mrkdwn",
-  #                   "text": "Alerting <@U060CGGPY8H> local CRE environment failed to start for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>. This commit was already merged to develop."
-  #                 }
-  #               }
-  #             ]
-  #           }
+  notify-test-failure:
+    name: Notify about local env startup failure
+    if: failure()
+    needs: [test-cli]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send slack notification for failed local env startup
+        id: send-slack-notification
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          errors: "true"
+          method: chat.postMessage
+          token: ${{ secrets.QA_SLACK_API_KEY }}
+          payload: |
+            {
+              "channel": "C0364FG2CN9",
+              "text": "Local CRE environment failed to start",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*:rotating_light: Local CRE environment failed to start :rotating_light:*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Alerting <@U060CGGPY8H> local CRE environment failed to start for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>. This commit was already merged to develop."
+                  }
+                }
+              ]
+            }
 
 
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -162,29 +162,25 @@ jobs:
       AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
-  # TODO: change to step that prepares date
-  prepare-short-sha:
+  prepare-nightly-image-tag:
     needs: [init]
     runs-on: ubuntu-24.04
     outputs:
-      short-sha: ${{ steps.short-sha.outputs.short-sha }}
+      image-tag: ${{ steps.image-tag.outputs.image-tag }}
     steps:
-      - name: Set Short SHA
-        id: short-sha
+      - name: Set Image Tag
+        id: image-tag
         shell: bash
         run: |
-          SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
-          echo "short-sha=${SHORT_SHA}" | tee -a "$GITHUB_OUTPUT"
+          DATE=$(date +%Y%m%d)
+          echo "image-tag=nightly-${DATE}-plugins" | tee -a "$GITHUB_OUTPUT"
   call-nightly-e2e-tests:
-    # TODO change to schedule once it is tested
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    needs: [docker-core-plugins, prepare-short-sha]
+    if: ${{ github.event_name == 'schedule' }}
+    needs: [docker-core-plugins, prepare-nightly-image-tag]
     uses: smartcontractkit/chainlink/.github/workflows/cre-local-env-tests.yaml@830af050dc5d9388a728c8be63586011cec181e6
     with:
-      # TODO: change to nightly once it is tested
-      chainlink_image_tag: ${{ format('manual-{0}-plugins', needs.prepare-short-sha.outputs.short-sha) }}
-      # TODO: change to develop once it is tested
-      chainlink_version: dx-815-polish-nightly-cli
+      chainlink_image_tag: ${{ needs.prepare-nightly-image-tag.outputs.image-tag }}
+      chainlink_version: develop
     secrets:
       inherit
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -178,11 +178,13 @@ jobs:
   call-nightly-e2e-tests:
     # TODO change to schedule once it is tested
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    needs: [docker-core, docker-core-plugins, docker-ccip, docker-ccip-plugins, prepare-short-sha]
+    needs: [docker-core-plugins, prepare-short-sha]
     uses: smartcontractkit/chainlink/.github/workflows/cre-local-env-tests.yaml@830af050dc5d9388a728c8be63586011cec181e6
     with:
       # TODO: change to nightly once it is tested
-      chainlink_image_tag: ${{ format('manual-{0}', needs.prepare-short-sha.outputs.short-sha) }}
+      chainlink_image_tag: ${{ format('manual-{0}-plugins', needs.prepare-short-sha.outputs.short-sha) }}
       # TODO: change to develop once it is tested
       chainlink_version: dx-815-polish-nightly-cli
+    secrets:
+      inherit
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -161,3 +161,28 @@ jobs:
       AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
       AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+
+  # TODO: change to step that prepares date
+  prepare-short-sha:
+    needs: [init]
+    runs-on: ubuntu-24.04
+    outputs:
+      short-sha: ${{ steps.short-sha.outputs.short-sha }}
+    steps:
+      - name: Set Short SHA
+        id: short-sha
+        shell: bash
+        run: |
+          SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
+          echo "short-sha=${SHORT_SHA}" | tee -a "$GITHUB_OUTPUT"
+  call-nightly-e2e-tests:
+    # TODO change to schedule once it is tested
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: [docker-core, docker-core-plugins, docker-ccip, docker-ccip-plugins, prepare-short-sha]
+    uses: smartcontractkit/chainlink/.github/workflows/cre-local-env-tests.yaml@830af050dc5d9388a728c8be63586011cec181e6
+    with:
+      # TODO: change to nightly once it is tested
+      chainlink_image_tag: ${{ format('manual-{0}', needs.prepare-short-sha.outputs.short-sha) }}
+      # TODO: change to develop once it is tested
+      chainlink_version: dx-815-polish-nightly-cli
+

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -162,24 +162,12 @@ jobs:
       AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
-  prepare-nightly-image-tag:
-    needs: [init]
-    runs-on: ubuntu-24.04
-    outputs:
-      image-tag: ${{ steps.image-tag.outputs.image-tag }}
-    steps:
-      - name: Set Image Tag
-        id: image-tag
-        shell: bash
-        run: |
-          DATE=$(date +%Y%m%d)
-          echo "image-tag=nightly-${DATE}-plugins" | tee -a "$GITHUB_OUTPUT"
   call-nightly-e2e-tests:
     if: ${{ github.event_name == 'schedule' }}
-    needs: [docker-core-plugins, prepare-nightly-image-tag]
+    needs: [docker-core-plugins]
     uses: smartcontractkit/chainlink/.github/workflows/cre-local-env-tests.yaml@830af050dc5d9388a728c8be63586011cec181e6
     with:
-      chainlink_image_tag: ${{ needs.prepare-nightly-image-tag.outputs.image-tag }}
+      chainlink_image_tag: ${{ needs.docker-core-plugins.outputs.docker-manifest-tag }}
       chainlink_version: develop
     secrets:
       inherit

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -648,6 +648,8 @@ func CreateJobDistributor(input *jd.Input) (*jd.Output, error) {
 		input.Image = fmt.Sprintf("%s:%s", jdImage, jdVersion)
 	}
 
+	fmt.Println("JD image", input.Image)
+
 	jdOutput, err := jd.NewJD(input)
 	if err != nil {
 		return nil, pkgerrors.Wrap(err, "failed to create new job distributor")

--- a/system-tests/tests/smoke/cre/cmd/environment/environment.go
+++ b/system-tests/tests/smoke/cre/cmd/environment/environment.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
@@ -266,13 +265,6 @@ func startCLIEnvironment(topologyFlag string, extraAllowedPorts []int) (*creenv.
 	if err != nil {
 		return nil, fmt.Errorf("failed to load test configuration: %w", err)
 	}
-
-	marhsalled, err := json.Marshal(in)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal test configuration: %w", err)
-	}
-
-	fmt.Println(string(marhsalled))
 
 	capabilitiesBinaryPaths := map[cretypes.CapabilityFlag]string{}
 	var capabilitiesAwareNodeSets []*cretypes.CapabilitiesAwareNodeSet

--- a/system-tests/tests/smoke/cre/cmd/environment/environment.go
+++ b/system-tests/tests/smoke/cre/cmd/environment/environment.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
@@ -265,6 +266,13 @@ func startCLIEnvironment(topologyFlag string, extraAllowedPorts []int) (*creenv.
 	if err != nil {
 		return nil, fmt.Errorf("failed to load test configuration: %w", err)
 	}
+
+	marhsalled, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal test configuration: %w", err)
+	}
+
+	fmt.Println(string(marhsalled))
 
 	capabilitiesBinaryPaths := map[cretypes.CapabilityFlag]string{}
 	var capabilitiesAwareNodeSets []*cretypes.CapabilitiesAwareNodeSet


### PR DESCRIPTION
This PR chains nightly local CRE env test to `Docker Build` workflow that builds nightly `plugins` image.

Successful run of a version that used `workflow_dispatch` as a trigger: https://github.com/smartcontractkit/chainlink/actions/runs/15073091986/job/42374633643