### PR TITLE
DPA-1666: Support Virtual Stream IDs

### DIFF
--- a/deployment/data-streams/changeset/jd_register_nodes.go
+++ b/deployment/data-streams/changeset/jd_register_nodes.go
@@ -56,7 +56,7 @@ func registerNodesForDON(e cldf.Environment, donName string, donID uint64, nodes
 		})
 
 		labels = append(labels, &ptypes.Label{
-			Key: utils.DonIdentifier(donID, donName),
+			Key: utils.DonIDLabel(donID, donName),
 		})
 
 		nodeID, err := e.Offchain.RegisterNode(e.GetContext(), &nodev1.RegisterNodeRequest{

--- a/deployment/data-streams/changeset/jobs/common.go
+++ b/deployment/data-streams/changeset/jobs/common.go
@@ -1,4 +1,4 @@
-package changeset
+package jobs
 
 import (
 	"context"

--- a/deployment/data-streams/changeset/jobs/helpers_test.go
+++ b/deployment/data-streams/changeset/jobs/helpers_test.go
@@ -7,8 +7,8 @@ package jobs
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -108,11 +108,11 @@ func sendTestStreamJobs(t *testing.T, e cldf.Environment, numOracles int, autoAp
 				ReportFields: jobs.QuoteReportFields{
 					Bid: jobs.ReportFieldLLO{
 						ResultPath: "data,bid",
-						StreamID:   pointer.To(fmt.Sprintf("%d", randomStreamID())),
+						StreamID:   pointer.To(strconv.FormatUint(uint64(randomStreamID()), 10)),
 					},
 					Benchmark: jobs.ReportFieldLLO{
 						ResultPath: "data,mid",
-						StreamID:   pointer.To(fmt.Sprintf("%d", randomStreamID())),
+						StreamID:   pointer.To(strconv.FormatUint(uint64(randomStreamID()), 10)),
 					},
 					Ask: jobs.ReportFieldLLO{
 						ResultPath: "data,ask",

--- a/deployment/data-streams/changeset/jobs/helpers_test.go
+++ b/deployment/data-streams/changeset/jobs/helpers_test.go
@@ -3,7 +3,7 @@ This file contains test helpers for the changeset package.
 The filename has a suffix of "_test.go" in order to not be included in the production build.
 */
 
-package changeset
+package jobs
 
 import (
 	"context"

--- a/deployment/data-streams/changeset/jobs/helpers_test.go
+++ b/deployment/data-streams/changeset/jobs/helpers_test.go
@@ -7,6 +7,8 @@ package jobs
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -22,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/testutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/jd"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/jobs"
+	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/pointer"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 	"github.com/smartcontractkit/chainlink/deployment/environment/test"
 )
@@ -99,15 +102,17 @@ func sendTestStreamJobs(t *testing.T, e cldf.Environment, numOracles int, autoAp
 		},
 		Streams: []StreamSpecConfig{
 			{
-				StreamID:   1000001038,
+				StreamID:   randomStreamID(),
 				Name:       "ICP/USD-RefPrice",
 				StreamType: jobs.StreamTypeQuote,
 				ReportFields: jobs.QuoteReportFields{
 					Bid: jobs.ReportFieldLLO{
 						ResultPath: "data,bid",
+						StreamID:   pointer.To(fmt.Sprintf("%d", randomStreamID())),
 					},
 					Benchmark: jobs.ReportFieldLLO{
 						ResultPath: "data,mid",
+						StreamID:   pointer.To(fmt.Sprintf("%d", randomStreamID())),
 					},
 					Ask: jobs.ReportFieldLLO{
 						ResultPath: "data,ask",
@@ -158,4 +163,19 @@ func collectNodeNames(t *testing.T, e cldf.Environment, numOracles, numBootstrap
 	}
 
 	return bootstrapNodeNames, oracleNodeNames
+}
+
+// Cache the streamIDs we've used during this test cycle, so we don't repeat them.
+var usedStreamIDs = make(map[uint32]struct{})
+
+func randomStreamID() uint32 {
+	var id uint32
+	for {
+		id = rand.Uint32()%1000000000 + 1000000000
+		if _, ok := usedStreamIDs[id]; !ok {
+			break
+		}
+	}
+	usedStreamIDs[id] = struct{}{}
+	return id
 }

--- a/deployment/data-streams/changeset/jobs/jd_distribute_llo_jobs.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_llo_jobs.go
@@ -1,4 +1,4 @@
-package changeset
+package jobs
 
 import (
 	"context"

--- a/deployment/data-streams/changeset/jobs/jd_distribute_llo_jobs.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_llo_jobs.go
@@ -65,7 +65,7 @@ func (CsDistributeLLOJobSpecs) Apply(e cldf.Environment, cfg CsDistributeLLOJobS
 	// Add a label to the job spec to identify the related DON
 	cfg.Labels = append(cfg.Labels,
 		&ptypes.Label{
-			Key: utils.DonIdentifier(cfg.Filter.DONID, cfg.Filter.DONName),
+			Key: utils.DonIDLabel(cfg.Filter.DONID, cfg.Filter.DONName),
 		},
 		&ptypes.Label{
 			Key:   devenv.LabelJobTypeKey,
@@ -93,7 +93,7 @@ func (CsDistributeLLOJobSpecs) Apply(e cldf.Environment, cfg CsDistributeLLOJobS
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to propose all jobs: %w", err)
 	}
 
-	err = labelNodesForProposals(e.GetContext(), e.Offchain, allProposals, utils.DonIdentifier(cfg.Filter.DONID, cfg.Filter.DONName))
+	err = labelNodesForProposals(e.GetContext(), e.Offchain, allProposals, utils.DonIDLabel(cfg.Filter.DONID, cfg.Filter.DONName))
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to label nodes for proposals: %w", err)
 	}
@@ -136,7 +136,7 @@ func generateBootstrapProposals(
 				Op:    ptypes.SelectorOp_EQ,
 			},
 			{
-				Key: utils.DonIdentifier(cfg.Filter.DONID, cfg.Filter.DONName),
+				Key: utils.DonIDLabel(cfg.Filter.DONID, cfg.Filter.DONName),
 				Op:  ptypes.SelectorOp_EXIST,
 			},
 		})
@@ -243,7 +243,7 @@ func generateOracleProposals(
 				Op:    ptypes.SelectorOp_EQ,
 			},
 			{
-				Key: utils.DonIdentifier(cfg.Filter.DONID, cfg.Filter.DONName),
+				Key: utils.DonIDLabel(cfg.Filter.DONID, cfg.Filter.DONName),
 				Op:  ptypes.SelectorOp_EXIST,
 			},
 		})
@@ -309,10 +309,10 @@ func getBootstrapMultiAddr(ctx context.Context, e cldf.Environment, cfg CsDistri
 		respBoots, err := e.Offchain.ListNodes(ctx, &node.ListNodesRequest{
 			Filter: &node.ListNodesRequest_Filter{
 				Selectors: []*ptypes.Selector{
-					// We can afford to filter by DonIdentifier here because if the caller didn't provide any bootstrap node IDs,
-					// then they are updating an existing job spec and the bootstrap nodes are already labeled with the DON ID.
+					// We can afford to filter by DonIDLabel here because if the caller didn't provide any bootstrap node IDs,
+					// then they are updating an existing job spec and the bootstrap nodes are already labelled with the DON ID.
 					{
-						Key: utils.DonIdentifier(cfg.Filter.DONID, cfg.Filter.DONName),
+						Key: utils.DonIDLabel(cfg.Filter.DONID, cfg.Filter.DONName),
 						Op:  ptypes.SelectorOp_EXIST,
 					},
 					{

--- a/deployment/data-streams/changeset/jobs/jd_distribute_llo_jobs_test.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_llo_jobs_test.go
@@ -69,7 +69,7 @@ donID = 1
 servers = {'mercury-pipeline-testnet-producer.TEST.cldev.cloud:1340' = '0000005187b1498c0ccb2e56d5ee8040a03a4955822ed208749b474058fc3f9c'}
 `
 
-	bootstrapSpec := `name = 'bootstrap'
+	bootstrapSpec := `name = 'don | 1'
 type = 'bootstrap'
 schemaVersion = 1
 contractID = '0x4170ed0880ac9a755fd29b2688956bd959f923f4'

--- a/deployment/data-streams/changeset/jobs/jd_distribute_llo_jobs_test.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_llo_jobs_test.go
@@ -1,4 +1,4 @@
-package changeset
+package jobs
 
 import (
 	"strings"

--- a/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs.go
@@ -1,4 +1,4 @@
-package changeset
+package jobs
 
 import (
 	"context"

--- a/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs.go
@@ -179,28 +179,26 @@ func generateDatasources(cc StreamSpecConfig) []jobs.Datasource {
 func streamIDLabelsFromReportFields(rf jobs.ReportFields) ([]*ptypes.Label, error) {
 	labels := []*ptypes.Label{}
 
-	switch rf.(type) {
+	switch rf := rf.(type) {
 	case jobs.MedianReportFields:
-		median := rf.(jobs.MedianReportFields)
-		l, err := streamIDLabelsFor(median.Benchmark.StreamID)
+		l, err := streamIDLabelsFor(rf.Benchmark.StreamID)
 		if err != nil {
 			return nil, err
 		}
 		labels = append(labels, l...)
 
 	case jobs.QuoteReportFields:
-		quote := rf.(jobs.QuoteReportFields)
-		l, err := streamIDLabelsFor(quote.Benchmark.StreamID)
+		l, err := streamIDLabelsFor(rf.Benchmark.StreamID)
 		if err != nil {
 			return nil, err
 		}
 		labels = append(labels, l...)
-		l, err = streamIDLabelsFor(quote.Bid.StreamID)
+		l, err = streamIDLabelsFor(rf.Bid.StreamID)
 		if err != nil {
 			return nil, err
 		}
 		labels = append(labels, l...)
-		l, err = streamIDLabelsFor(quote.Ask.StreamID)
+		l, err = streamIDLabelsFor(rf.Ask.StreamID)
 		if err != nil {
 			return nil, err
 		}

--- a/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -56,7 +57,11 @@ func (CsDistributeStreamJobSpecs) Apply(e cldf.Environment, cfg CsDistributeStre
 	// Add a label to the job spec to identify the related DON
 	cfg.Labels = append(cfg.Labels,
 		&ptypes.Label{
-			Key: utils.DonIdentifier(cfg.Filter.DONID, cfg.Filter.DONName),
+			Key: utils.DonIDLabel(cfg.Filter.DONID, cfg.Filter.DONName),
+		},
+		&ptypes.Label{
+			Key:   devenv.LabelJobTypeKey,
+			Value: pointer.To(devenv.LabelJobTypeValueStream),
 		},
 	)
 
@@ -67,24 +72,38 @@ func (CsDistributeStreamJobSpecs) Apply(e cldf.Environment, cfg CsDistributeStre
 
 	var proposals []*jobv1.ProposeJobRequest
 	for _, s := range cfg.Streams {
-		for _, n := range oracleNodes {
-			localLabels := append(cfg.Labels, //nolint: gocritic // locally modified copy of labels
-				&ptypes.Label{
-					Key:   devenv.LabelStreamIDKey,
-					Value: pointer.To(strconv.FormatUint(uint64(s.StreamID), 10)),
-				},
-				&ptypes.Label{
-					Key:   devenv.LabelJobTypeKey,
-					Value: pointer.To(devenv.LabelJobTypeValueStream),
-				},
-			)
+		// Start with the common labels.
+		streamLabels := append([]*ptypes.Label{}, cfg.Labels...)
+		// Some streams might not have an ID.
+		if s.StreamID > 0 {
+			streamLabels = append(streamLabels, &ptypes.Label{
+				Key:   utils.StreamIDLabel(s.StreamID),
+				Value: pointer.To(s.Name),
+			})
+		}
+		virtualStreamIDLabels, err := streamIDLabelsFromReportFields(s.ReportFields)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get streamID labels: %w", err)
+		}
+		streamLabels = append(streamLabels, virtualStreamIDLabels...)
 
+		for _, n := range oracleNodes {
+			// Check if there is already a job spec for this stream on this node:
+			streamID := s.StreamID
+			if streamID == 0 {
+				if len(virtualStreamIDLabels) == 0 {
+					return cldf.ChangesetOutput{}, fmt.Errorf("no top level or virtual streamID found for stream %s", s.Name)
+				}
+				streamID, err = utils.StreamIDFromLabel(virtualStreamIDLabels[0].Key)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to parse streamID from label: %w", err)
+				}
+			}
 			// Check if there is already a job spec for this stream on this node:
 			externalJobID, err := fetchExternalJobID(e, n.Id, []*ptypes.Selector{
 				{
-					Key:   devenv.LabelStreamIDKey,
-					Value: pointer.To(strconv.FormatUint(uint64(s.StreamID), 10)),
-					Op:    ptypes.SelectorOp_EQ,
+					Key: utils.StreamIDLabel(s.StreamID),
+					Op:  ptypes.SelectorOp_EXIST,
 				},
 			})
 			if err != nil {
@@ -104,7 +123,7 @@ func (CsDistributeStreamJobSpecs) Apply(e cldf.Environment, cfg CsDistributeStre
 			proposals = append(proposals, &jobv1.ProposeJobRequest{
 				NodeId: n.Id,
 				Spec:   string(renderedSpec),
-				Labels: localLabels,
+				Labels: streamLabels,
 			})
 		}
 	}
@@ -154,6 +173,67 @@ func generateDatasources(cc StreamSpecConfig) []jobs.Datasource {
 		}
 	}
 	return dss
+}
+
+// streamIDLabelsFromReportFields returns a list of labels for the virtual streamIDs from the report fields.
+// This function does NOT return nil, it returns an empty slice if no labels are found.
+func streamIDLabelsFromReportFields(rf jobs.ReportFields) ([]*ptypes.Label, error) {
+	labels := []*ptypes.Label{}
+
+	isIt := func(rf jobs.ReportFields, t jobs.ReportFields) bool {
+		return reflect.TypeOf(rf) == reflect.TypeOf(t)
+	}
+
+	switch {
+	case isIt(rf, jobs.MedianReportFields{}):
+		median := rf.(jobs.MedianReportFields)
+		l, err := streamIDLabelsFor(median.Benchmark.StreamID)
+		if err != nil {
+			return nil, err
+		}
+		labels = append(labels, l...)
+
+	case isIt(rf, jobs.QuoteReportFields{}):
+		quote := rf.(jobs.QuoteReportFields)
+		l, err := streamIDLabelsFor(quote.Benchmark.StreamID)
+		if err != nil {
+			return nil, err
+		}
+		labels = append(labels, l...)
+		l, err = streamIDLabelsFor(quote.Bid.StreamID)
+		if err != nil {
+			return nil, err
+		}
+		labels = append(labels, l...)
+		l, err = streamIDLabelsFor(quote.Ask.StreamID)
+		if err != nil {
+			return nil, err
+		}
+		labels = append(labels, l...)
+
+	default:
+		return nil, fmt.Errorf("unknown report fields type: %T", rf)
+	}
+
+	return labels, nil
+}
+
+// streamIDLabelsFor returns a list of labels for the streamID.
+// We intentionally return a list, so we can return an empty one.
+func streamIDLabelsFor(sid *string) ([]*ptypes.Label, error) {
+	if sid == nil {
+		// It's fine to not have a streamID in the report fields.
+		return nil, nil
+	}
+	id, err := strconv.ParseUint(*sid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse streamID: %w", err)
+	}
+	return []*ptypes.Label{
+		{
+			Key: utils.StreamIDLabel(uint32(id)),
+		},
+	}, nil
 }
 
 func (f CsDistributeStreamJobSpecs) VerifyPreconditions(_ cldf.Environment, config CsDistributeStreamJobSpecsConfig) error {

--- a/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -180,12 +179,8 @@ func generateDatasources(cc StreamSpecConfig) []jobs.Datasource {
 func streamIDLabelsFromReportFields(rf jobs.ReportFields) ([]*ptypes.Label, error) {
 	labels := []*ptypes.Label{}
 
-	isIt := func(rf jobs.ReportFields, t jobs.ReportFields) bool {
-		return reflect.TypeOf(rf) == reflect.TypeOf(t)
-	}
-
-	switch {
-	case isIt(rf, jobs.MedianReportFields{}):
+	switch rf.(type) {
+	case jobs.MedianReportFields:
 		median := rf.(jobs.MedianReportFields)
 		l, err := streamIDLabelsFor(median.Benchmark.StreamID)
 		if err != nil {
@@ -193,7 +188,7 @@ func streamIDLabelsFromReportFields(rf jobs.ReportFields) ([]*ptypes.Label, erro
 		}
 		labels = append(labels, l...)
 
-	case isIt(rf, jobs.QuoteReportFields{}):
+	case jobs.QuoteReportFields:
 		quote := rf.(jobs.QuoteReportFields)
 		l, err := streamIDLabelsFor(quote.Benchmark.StreamID)
 		if err != nil {

--- a/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs.go
@@ -102,7 +102,7 @@ func (CsDistributeStreamJobSpecs) Apply(e cldf.Environment, cfg CsDistributeStre
 			// Check if there is already a job spec for this stream on this node:
 			externalJobID, err := fetchExternalJobID(e, n.Id, []*ptypes.Selector{
 				{
-					Key: utils.StreamIDLabel(s.StreamID),
+					Key: utils.StreamIDLabel(streamID),
 					Op:  ptypes.SelectorOp_EXIST,
 				},
 			})

--- a/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs_test.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs_test.go
@@ -1,4 +1,4 @@
-package changeset
+package jobs
 
 import (
 	"testing"

--- a/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs_test.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs_test.go
@@ -96,7 +96,7 @@ ds1_payload -> ds1_benchmark -> benchmark_price;
 ds2_payload -> ds2_benchmark -> benchmark_price;
 ds3_payload -> ds3_benchmark -> benchmark_price;
 ds4_payload -> ds4_benchmark -> benchmark_price;
-benchmark_price [type=median allowedFaults=3 index=0];
+benchmark_price [type=median allowedFaults=3 streamID=1234 index=0];
 
 ds1_payload -> ds1_bid -> bid_price;
 ds2_payload -> ds2_bid -> bid_price;
@@ -130,6 +130,8 @@ ask_price [type=median allowedFaults=3 index=2];
 					},
 					Benchmark: jobs.ReportFieldLLO{
 						ResultPath: "data,mid",
+						// We intentionally set just one virtual stream ID.
+						StreamID: pointer.To("1234"),
 					},
 					Ask: jobs.ReportFieldLLO{
 						ResultPath: "data,ask",

--- a/deployment/data-streams/changeset/jobs/jd_revoke_jobs.go
+++ b/deployment/data-streams/changeset/jobs/jd_revoke_jobs.go
@@ -1,4 +1,4 @@
-package changeset
+package jobs
 
 import (
 	"errors"

--- a/deployment/data-streams/changeset/jobs/jd_revoke_jobs.go
+++ b/deployment/data-streams/changeset/jobs/jd_revoke_jobs.go
@@ -3,15 +3,12 @@ package jobs
 import (
 	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
-	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/pointer"
-	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
+	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils"
 )
 
 var _ cldf.ChangeSetV2[CsRevokeJobSpecsConfig] = CsRevokeJobSpecs{}
@@ -32,43 +29,13 @@ type CsRevokeJobSpecsConfig struct {
 type CsRevokeJobSpecs struct{}
 
 func (CsRevokeJobSpecs) Apply(e cldf.Environment, cfg CsRevokeJobSpecsConfig) (cldf.ChangesetOutput, error) {
-	var filter *jobv1.ListJobsRequest_Filter
-	switch {
-	case len(cfg.UUIDs) > 0 && len(cfg.StreamIDs) == 0:
-		filter = &jobv1.ListJobsRequest_Filter{
-			Uuids: cfg.UUIDs,
-		}
-	case len(cfg.StreamIDs) > 0 && len(cfg.UUIDs) == 0:
-		ids := make([]string, len(cfg.StreamIDs))
-		for i, id := range cfg.StreamIDs {
-			ids[i] = strconv.FormatUint(uint64(id), 10)
-		}
-		filter = &jobv1.ListJobsRequest_Filter{
-			Selectors: []*ptypes.Selector{
-				{
-					Key:   devenv.LabelStreamIDKey,
-					Op:    ptypes.SelectorOp_IN,
-					Value: pointer.To(strings.Join(ids, ",")),
-				},
-			},
-		}
-	default:
-		return cldf.ChangesetOutput{}, errors.New("either job ids or stream ids are required")
-	}
-
-	// Fetch the internal job IDs from the job distributor:
-	jobsResp, err := e.Offchain.ListJobs(e.GetContext(), &jobv1.ListJobsRequest{
-		Filter: filter,
-	})
+	jobs, err := findJobsForIDs(e, cfg.UUIDs, cfg.StreamIDs)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to list jobs: %w", err)
-	}
-	if len(cfg.UUIDs) > 0 && len(jobsResp.Jobs) != len(cfg.UUIDs) {
-		return cldf.ChangesetOutput{}, errors.New("failed to find jobs for all provided UUIDs")
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to find jobs: %w", err)
 	}
 
-	revokedJobs := make([]cldf.ProposedJob, 0, len(jobsResp.Jobs))
-	for _, job := range jobsResp.Jobs {
+	revokedJobs := make([]cldf.ProposedJob, 0, len(jobs))
+	for _, job := range jobs {
 		resp, err := e.Offchain.RevokeJob(e.GetContext(), &jobv1.RevokeJobRequest{
 			IdOneof: &jobv1.RevokeJobRequest_Id{
 				Id: job.GetId(),
@@ -86,6 +53,56 @@ func (CsRevokeJobSpecs) Apply(e cldf.Environment, cfg CsRevokeJobSpecsConfig) (c
 	return cldf.ChangesetOutput{
 		Jobs: revokedJobs,
 	}, nil
+}
+
+// findJobsForIDs finds jobs for either the given UUIDs or stream IDs.
+func findJobsForIDs(e cldf.Environment, uuids []string, streamIDs []uint32) ([]*jobv1.Job, error) {
+	if (len(uuids) == 0 && len(streamIDs) == 0) || (len(uuids) > 0 && len(streamIDs) > 0) {
+		return nil, errors.New("either job ids or stream ids are required")
+	}
+	if len(uuids) > 0 {
+		return findJobsForUUIDs(e, uuids)
+	}
+	return findJobsForStreamIDs(e, streamIDs)
+}
+
+func findJobsForUUIDs(e cldf.Environment, uuids []string) ([]*jobv1.Job, error) {
+	// Fetch the internal job IDs from the job distributor:
+	jobsResp, err := e.Offchain.ListJobs(e.GetContext(), &jobv1.ListJobsRequest{
+		Filter: &jobv1.ListJobsRequest_Filter{
+			Uuids: uuids,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list jobs: %w", err)
+	}
+	if len(jobsResp.Jobs) != len(uuids) {
+		return nil, errors.New("failed to find jobs for all provided UUIDs")
+	}
+	return jobsResp.Jobs, nil
+}
+
+func findJobsForStreamIDs(e cldf.Environment, streamIDs []uint32) ([]*jobv1.Job, error) {
+	var jobs []*jobv1.Job
+	// We need to collect the jobs for each stream ID separately because the label we use is a flag and we cannot
+	// select by "OR" logic.
+	for _, sid := range streamIDs {
+		jobsResp, err := e.Offchain.ListJobs(e.GetContext(), &jobv1.ListJobsRequest{
+			Filter: &jobv1.ListJobsRequest_Filter{
+				Selectors: []*ptypes.Selector{
+					{
+						Key: utils.StreamIDLabel(sid),
+						Op:  ptypes.SelectorOp_EXIST,
+					},
+				},
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list jobs: %w", err)
+		}
+		jobs = append(jobs, jobsResp.Jobs...)
+	}
+	return jobs, nil
 }
 
 func (f CsRevokeJobSpecs) VerifyPreconditions(_ cldf.Environment, config CsRevokeJobSpecsConfig) error {

--- a/deployment/data-streams/changeset/jobs/jd_revoke_jobs_test.go
+++ b/deployment/data-streams/changeset/jobs/jd_revoke_jobs_test.go
@@ -1,4 +1,4 @@
-package changeset
+package jobs
 
 import (
 	"regexp"

--- a/deployment/data-streams/changeset/jobs/jd_revoke_jobs_test.go
+++ b/deployment/data-streams/changeset/jobs/jd_revoke_jobs_test.go
@@ -38,7 +38,7 @@ func TestRevokeJobSpecs(t *testing.T) {
 				Value: pointer.To(testutil.TestDON.Env),
 			},
 			{
-				Key: utils.DonIdentifier(testutil.TestDON.ID, testutil.TestDON.Name),
+				Key: utils.DonIDLabel(testutil.TestDON.ID, testutil.TestDON.Name),
 			},
 		},
 		CustomDBSetup: []string{
@@ -80,11 +80,10 @@ func TestRevokeJobSpecs(t *testing.T) {
 	require.Len(t, sentStreamJobs[0].Jobs, numOracles)
 
 	streamIDFromJobSpec := func(jobSpec string) string {
-		matches := regexp.MustCompile(`streamID\s*=\s*([0-9]+)`).FindStringSubmatch(jobSpec)
+		matches := regexp.MustCompile(`\nstreamID\s*=\s*([0-9]+)\s*\n`).FindStringSubmatch(jobSpec)
 		require.Len(t, matches, 2, "expected to find a stream ID in the job spec")
 		return matches[1]
 	}
-
 	var streamIDs []uint32
 	streamIDsToJobIDs := make(map[uint32][]string)
 	for _, job := range sentStreamJobs[0].Jobs {
@@ -92,6 +91,30 @@ func TestRevokeJobSpecs(t *testing.T) {
 		require.NoError(t, e)
 		streamIDs = append(streamIDs, uint32(s))
 		streamIDsToJobIDs[uint32(s)] = append(streamIDsToJobIDs[uint32(s)], uuidFromJobSpec(job.Spec))
+	}
+
+	// Create more stream jobs, specifically to test virtual stream IDs:
+	sentVirtualStreamJobs := sendTestStreamJobs(t, env, numOracles, false)
+	virtualStreamIDsFromJobSpec := func(jobSpec string) []uint32 {
+		matches := regexp.MustCompile(`\sstreamID\s*=\s*([0-9]+)\s*index`).FindStringSubmatch(jobSpec)
+		require.Len(t, matches, 2, "expected to find a virtual stream ID in the job spec")
+
+		ids := make([]uint32, 0, len(matches)-1)
+		for _, match := range matches[1:] {
+			id, err := strconv.ParseUint(match, 10, 32)
+			require.NoError(t, err)
+			ids = append(ids, uint32(id))
+		}
+		return ids
+	}
+	var virtualStreamIDs []uint32
+	virtualStreamIDsToJobIDs := make(map[uint32][]string)
+	for _, job := range sentVirtualStreamJobs[0].Jobs {
+		jobSpecVirtualStreamIDs := virtualStreamIDsFromJobSpec(job.Spec)
+		for _, id := range jobSpecVirtualStreamIDs {
+			virtualStreamIDs = append(virtualStreamIDs, id)
+			virtualStreamIDsToJobIDs[id] = append(virtualStreamIDsToJobIDs[id], uuidFromJobSpec(job.Spec))
+		}
 	}
 
 	tests := []struct {
@@ -103,13 +126,13 @@ func TestRevokeJobSpecs(t *testing.T) {
 		wantNumJobs int
 	}{
 		{
-			name:        "Revoke an oracle job",
+			name:        "Revoke an oracle job by UUID",
 			uuids:       oracleJobUUIDs,
 			wantJobIDs:  oracleJobUUIDs,
 			wantNumJobs: numOracles,
 		},
 		{
-			name:        "Revoke the same job again",
+			name:        "Revoke the same job again by UUID",
 			uuids:       oracleJobUUIDs,
 			wantNumJobs: numOracles,
 			wantErr:     "failed to revoke job",
@@ -126,10 +149,16 @@ func TestRevokeJobSpecs(t *testing.T) {
 			wantErr: "failed to find jobs for all provided UUIDs",
 		},
 		{
-			name:        "Revoke a stream job",
+			name:        "Revoke a stream job by streamID",
 			streamIDs:   []uint32{streamIDs[0]},
 			wantNumJobs: numOracles,
 			wantJobIDs:  streamIDsToJobIDs[streamIDs[0]],
+		},
+		{
+			name:        "Revoke a stream job by virtual streamID",
+			streamIDs:   []uint32{virtualStreamIDs[0]},
+			wantNumJobs: numOracles,
+			wantJobIDs:  virtualStreamIDsToJobIDs[virtualStreamIDs[0]],
 		},
 		{
 			name:        "Fail when both stream ids and uuids are provided",

--- a/deployment/data-streams/changeset/testutil/test_helpers.go
+++ b/deployment/data-streams/changeset/testutil/test_helpers.go
@@ -267,8 +267,7 @@ func GetMCMSConfig(useMCMS bool) *dsTypes.MCMSConfig {
 func GetNodeLabels(donID uint64, donName string, env string) []*ptypes.Label {
 	return []*ptypes.Label{
 		{
-			Key:   utils.DonIdentifier(donID, donName),
-			Value: nil,
+			Key: utils.DonIDLabel(donID, donName),
 		},
 		{
 			Key:   devenv.LabelNodeTypeKey,

--- a/deployment/data-streams/jobs/templates/osrc_mercury_v1_median.go.tmpl
+++ b/deployment/data-streams/jobs/templates/osrc_mercury_v1_median.go.tmpl
@@ -10,4 +10,4 @@ ds{{$srcNum}}_benchmark [type=jsonparse path="{{$.ReportFields.Benchmark.ResultP
 {{- $srcNum:=inc $i -}}
 ds{{$srcNum}}_payload -> ds{{$srcNum}}_benchmark -> benchmark_price;
 {{end -}}
-benchmark_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Benchmark.StreamID}} streamID="{{.}}" {{end}}index=0];
+benchmark_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Benchmark.StreamID}}streamID={{.}} {{end}}index=0];

--- a/deployment/data-streams/jobs/templates/osrc_mercury_v1_median.go.tmpl
+++ b/deployment/data-streams/jobs/templates/osrc_mercury_v1_median.go.tmpl
@@ -10,4 +10,4 @@ ds{{$srcNum}}_benchmark [type=jsonparse path="{{$.ReportFields.Benchmark.ResultP
 {{- $srcNum:=inc $i -}}
 ds{{$srcNum}}_payload -> ds{{$srcNum}}_benchmark -> benchmark_price;
 {{end -}}
-benchmark_price [type=median allowedFaults={{.AllowedFaults}} index=0];
+benchmark_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Benchmark.StreamID}} streamID="{{.}}" {{end}}index=0];

--- a/deployment/data-streams/jobs/templates/osrc_mercury_v1_quote.go.tmpl
+++ b/deployment/data-streams/jobs/templates/osrc_mercury_v1_quote.go.tmpl
@@ -12,16 +12,16 @@ ds{{$srcNum}}_ask [type=jsonparse path="{{$.ReportFields.Ask.ResultPath}}"];
 {{- $srcNum:=inc $i -}}
 ds{{$srcNum}}_payload -> ds{{$srcNum}}_benchmark -> benchmark_price;
 {{end -}}
-benchmark_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Benchmark.StreamID}} streamID="{{.}}" {{end}}index=0];
+benchmark_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Benchmark.StreamID}}streamID={{.}} {{end}}index=0];
 
 {{range $i, $a := .Datasources}}
 {{- $srcNum:=inc $i -}}
 ds{{$srcNum}}_payload -> ds{{$srcNum}}_bid -> bid_price;
 {{end -}}
-bid_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Bid.StreamID}} streamID="{{.}}" {{end}}index=1];
+bid_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Bid.StreamID}}streamID={{.}} {{end}}index=1];
 
 {{range $i, $a := .Datasources}}
 {{- $srcNum:=inc $i -}}
 ds{{$srcNum}}_payload -> ds{{$srcNum}}_ask -> ask_price;
 {{end -}}
-ask_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Ask.StreamID}} streamID="{{.}}" {{end}}index=2];
+ask_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Ask.StreamID}}streamID={{.}} {{end}}index=2];

--- a/deployment/data-streams/jobs/templates/osrc_mercury_v1_quote.go.tmpl
+++ b/deployment/data-streams/jobs/templates/osrc_mercury_v1_quote.go.tmpl
@@ -12,16 +12,16 @@ ds{{$srcNum}}_ask [type=jsonparse path="{{$.ReportFields.Ask.ResultPath}}"];
 {{- $srcNum:=inc $i -}}
 ds{{$srcNum}}_payload -> ds{{$srcNum}}_benchmark -> benchmark_price;
 {{end -}}
-benchmark_price [type=median allowedFaults={{.AllowedFaults}} index=0];
+benchmark_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Benchmark.StreamID}} streamID="{{.}}" {{end}}index=0];
 
 {{range $i, $a := .Datasources}}
 {{- $srcNum:=inc $i -}}
 ds{{$srcNum}}_payload -> ds{{$srcNum}}_bid -> bid_price;
 {{end -}}
-bid_price [type=median allowedFaults={{.AllowedFaults}} index=1];
+bid_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Bid.StreamID}} streamID="{{.}}" {{end}}index=1];
 
 {{range $i, $a := .Datasources}}
 {{- $srcNum:=inc $i -}}
 ds{{$srcNum}}_payload -> ds{{$srcNum}}_ask -> ask_price;
 {{end -}}
-ask_price [type=median allowedFaults={{.AllowedFaults}} index=2];
+ask_price [type=median allowedFaults={{.AllowedFaults}} {{with $.ReportFields.Ask.StreamID}} streamID="{{.}}" {{end}}index=2];

--- a/deployment/data-streams/utils/identifiers.go
+++ b/deployment/data-streams/utils/identifiers.go
@@ -3,16 +3,33 @@ package utils
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 )
 
 const (
 	ProductLabel = "data-streams"
 )
 
-// DonIdentifier generates a unique identifier for a DON based on its ID and name.
+// DonIDLabel generates a unique identifier for a DON based on its ID and name.
 // All non-alphanumeric characters are replaced with underscores due to the limiting requirements of
 // Job Distributor label keys.
-func DonIdentifier(donID uint64, donName string) string {
+func DonIDLabel(donID uint64, donName string) string {
 	cleanDONName := regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(donName, "_")
 	return fmt.Sprintf("don-%d-%s", donID, cleanDONName)
+}
+
+func StreamIDLabel(streamID uint32) string {
+	return fmt.Sprintf("stream-id-%d", streamID)
+}
+
+func StreamIDFromLabel(streamIDLabel string) (uint32, error) {
+	matches := regexp.MustCompile(`stream-id-([0-9]+)`).FindStringSubmatch(streamIDLabel)
+	if len(matches) != 2 {
+		return 0, fmt.Errorf("invalid stream ID label: %s", streamIDLabel)
+	}
+	streamID, err := strconv.ParseUint(matches[1], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse stream ID: %w", err)
+	}
+	return uint32(streamID), nil
 }


### PR DESCRIPTION
[DPA-1666](https://smartcontract-it.atlassian.net/browse/DPA-1666)

In order to support virtual stream IDs, we do a couple of things:
- include them in the job spec
- label the produced job with them, so we can handle the job by its stream id

Additionally, we moved all job-handling changesets under a dedicated submodule in order to reduce the mess.

[DPA-1666]: https://smartcontract-it.atlassian.net/browse/DPA-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ