### PR TITLE
remove df commands in cre-cli

### DIFF
--- a/system-tests/lib/crecli/commands.go
+++ b/system-tests/lib/crecli/commands.go
@@ -3,11 +3,12 @@ package crecli
 import (
 	"bytes"
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+
+	"github.com/pkg/errors"
 )
 
 type CompilationResult struct {

--- a/system-tests/lib/crecli/commands.go
+++ b/system-tests/lib/crecli/commands.go
@@ -3,15 +3,11 @@ package crecli
 import (
 	"bytes"
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
-	"strings"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 )
 
 type CompilationResult struct {
@@ -151,77 +147,6 @@ func EncryptSecrets(creCLICommandPath, secretsFile string, secrets map[string]st
 	re = regexp.MustCompile(ansiEscapePattern)
 
 	return re.ReplaceAllString(matches[0][1], ""), nil
-}
-
-func SetFeedAdmin(creCLICommandPath string, chainID int, adminAddress common.Address, settingsFile *os.File) error {
-	setFeedAdminCmd := exec.Command(creCLICommandPath, "-S", settingsFile.Name(), "df", "set-feed-admin", "--chain-id", strconv.Itoa(chainID), "--feed-admin", adminAddress.Hex()) // #nosec G204
-	var outputBuffer bytes.Buffer
-	setFeedAdminCmd.Stdout = &outputBuffer
-	setFeedAdminCmd.Stderr = &outputBuffer
-	if err := setFeedAdminCmd.Start(); err != nil {
-		return errors.Wrap(err, "failed to start DF set feed admin command")
-	}
-
-	waitErr := setFeedAdminCmd.Wait()
-	fmt.Println("Set Feed Admin output:\n", outputBuffer.String())
-	if waitErr != nil {
-		return errors.Wrap(waitErr, "failed to wait for set feed admin command")
-	}
-
-	return nil
-}
-
-func SetFeedConfig(creCLICommandPath, feedID, feedDecimals, feedDescription string, chainID int, allowedSenders, allowedWorkflowOwners []common.Address, allowedWorkflowNames []string, settingsFile *os.File) error {
-	allowedSendersHex := make([]string, len(allowedSenders))
-	for i, addr := range allowedSenders {
-		allowedSendersHex[i] = addr.Hex()
-	}
-	allowedSendersStr := strings.Join(allowedSendersHex, ",")
-
-	allowedWorkflowOwnersHex := make([]string, len(allowedWorkflowOwners))
-	for i, addr := range allowedWorkflowOwners {
-		allowedWorkflowOwnersHex[i] = addr.Hex()
-	}
-	allowedWorkflowOwnersStr := strings.Join(allowedWorkflowOwnersHex, ",")
-
-	cleanFeedID := strings.TrimPrefix(feedID, "0x")
-	feedLength := len(cleanFeedID)
-
-	if feedLength < 32 {
-		return errors.Errorf("feed ID must be at least 32 characters long, but was %d", feedLength)
-	}
-
-	if feedLength > 32 {
-		cleanFeedID = cleanFeedID[:32]
-	}
-
-	setFeedConfigCmd := exec.Command(creCLICommandPath,
-		"-S", settingsFile.Name(),
-		"df",
-		"set-feed-config",
-		"--chain-id", strconv.Itoa(chainID),
-		"--allowed-senders", allowedSendersStr,
-		"--allowed-workflow-owners", allowedWorkflowOwnersStr,
-		"--allowed-workflow-names", strings.Join(allowedWorkflowNames, ","),
-		"--data-id", cleanFeedID,
-		"--decimals-arr", fmt.Sprintf("[%s]", feedDecimals),
-		"--description", feedDescription,
-	) // #nosec G204
-
-	var outputBuffer bytes.Buffer
-	setFeedConfigCmd.Stdout = &outputBuffer
-	setFeedConfigCmd.Stderr = &outputBuffer
-	if err := setFeedConfigCmd.Start(); err != nil {
-		return errors.Wrap(err, "failed to start DF set feed config command")
-	}
-
-	waitErr := setFeedConfigCmd.Wait()
-	fmt.Println("Set Feed Config output:\n", outputBuffer.String())
-	if waitErr != nil {
-		return errors.Wrap(waitErr, "failed to wait for set feed config command")
-	}
-
-	return nil
 }
 
 func PauseWorkflow(creCLICommandPath string, settingsFile *os.File) error {


### PR DESCRIPTION
Next version of the CRE CLI will no longer have the `df` specific commands to set-feed-config and set-feed-admin. This change reflects that.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
