### PR TITLE
Using e2e changesets in e2e tests

### DIFF
--- a/deployment/ccip/changeset/solana/cs_e2e.go
+++ b/deployment/ccip/changeset/solana/cs_e2e.go
@@ -38,7 +38,7 @@ func E2ETokenPool(e cldf.Environment, cfg E2ETokenPoolConfig) (cldf.ChangesetOut
 		e.Logger.Info("Final output: ", finalOutput.AddressBook) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
 	}(e)
 
-	var addressBookToRemove cldf.AddressBook //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+	var addressBookToRemove cldf.AddressBook
 	for _, tokenPoolConfig := range cfg.AddTokenPoolAndLookupTable {
 		output, err := AddTokenPoolAndLookupTable(e, tokenPoolConfig)
 		if err != nil {
@@ -51,7 +51,7 @@ func E2ETokenPool(e cldf.Environment, cfg E2ETokenPoolConfig) (cldf.ChangesetOut
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book: %w", err)
 			}
 			// later remove from in memory address book so that we can use the finalOutput address book to update the disk/in-memory address book
-			addressBookToRemove = output.AddressBook
+			addressBookToRemove = output.AddressBook //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
 
 			err = finalOutput.AddressBook.Merge(output.AddressBook) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
 			if err != nil {
@@ -150,9 +150,9 @@ func E2ETokenPool(e cldf.Environment, cfg E2ETokenPoolConfig) (cldf.ChangesetOut
 		finalOutput.MCMSTimelockProposals = []mcms.TimelockProposal{*proposal}
 	}
 
-	err := e.ExistingAddresses.Remove(addressBookToRemove) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+	err := e.ExistingAddresses.Remove(addressBookToRemove)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to remove address book: %w", err)
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to remove temp address book from env: %w", err)
 	}
 
 	return finalOutput, nil

--- a/deployment/ccip/changeset/solana/cs_e2e.go
+++ b/deployment/ccip/changeset/solana/cs_e2e.go
@@ -11,7 +11,13 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
-// use this changeset to add a token pool and lookup table
+// use this changeset to
+// add a token pool and lookup table
+// register the deployer key as the token admin to the token admin registry
+// accept the admin role as the deployer key
+// call setPool on the token admin registry
+// configure evm pools on the solana side
+// configure solana pools on the evm side
 var _ cldf.ChangeSet[E2ETokenPoolConfig] = E2ETokenPool
 
 type E2ETokenPoolConfig struct {

--- a/deployment/ccip/changeset/solana/cs_e2e.go
+++ b/deployment/ccip/changeset/solana/cs_e2e.go
@@ -16,7 +16,6 @@ var _ cldf.ChangeSet[E2ETokenPoolConfig] = E2ETokenPool
 
 type E2ETokenPoolConfig struct {
 	AddTokenPoolAndLookupTable            []TokenPoolConfig
-	AddTokenPoolLookupTable               []TokenPoolLookupTableConfig
 	RegisterTokenAdminRegistry            []RegisterTokenAdminRegistryConfig
 	AcceptAdminRoleTokenAdminRegistry     []AcceptAdminRoleTokenAdminRegistryConfig
 	SetPool                               []SetPoolConfig
@@ -39,22 +38,7 @@ func E2ETokenPool(e cldf.Environment, cfg E2ETokenPoolConfig) (cldf.ChangesetOut
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to add token pool lookup table: %w", err)
 		}
 		if output.AddressBook != nil { //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
-			err = finalOutput.AddressBook.Merge(output.AddressBook) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book: %w", err)
-			}
-		}
-		if len(output.MCMSTimelockProposals) > 0 {
-			finalOutput.MCMSTimelockProposals = append(finalOutput.MCMSTimelockProposals, output.MCMSTimelockProposals...)
-		}
-	}
-	for _, tokenPoolConfig := range cfg.AddTokenPoolLookupTable {
-		output, err := AddTokenPoolLookupTable(e, tokenPoolConfig)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to add token pool lookup table: %w", err)
-		}
-		if output.AddressBook != nil { //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
-			err = finalOutput.AddressBook.Merge(output.AddressBook) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+			err = e.ExistingAddresses.Merge(output.AddressBook) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book: %w", err)
 			}

--- a/deployment/ccip/changeset/solana/cs_e2e.go
+++ b/deployment/ccip/changeset/solana/cs_e2e.go
@@ -38,13 +38,22 @@ func E2ETokenPool(e cldf.Environment, cfg E2ETokenPoolConfig) (cldf.ChangesetOut
 		e.Logger.Info("Final output: ", finalOutput.AddressBook) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
 	}(e)
 
+	var addressBookToRemove cldf.AddressBook //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
 	for _, tokenPoolConfig := range cfg.AddTokenPoolAndLookupTable {
 		output, err := AddTokenPoolAndLookupTable(e, tokenPoolConfig)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to add token pool lookup table: %w", err)
 		}
 		if output.AddressBook != nil { //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+			// merge into in memory address book for below changesets
 			err = e.ExistingAddresses.Merge(output.AddressBook) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book: %w", err)
+			}
+			// later remove from in memory address book so that we can use the finalOutput address book to update the disk/in-memory address book
+			addressBookToRemove = output.AddressBook
+
+			err = finalOutput.AddressBook.Merge(output.AddressBook) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book: %w", err)
 			}
@@ -139,6 +148,11 @@ func E2ETokenPool(e cldf.Environment, cfg E2ETokenPoolConfig) (cldf.ChangesetOut
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to aggregate proposals: %w", err)
 		}
 		finalOutput.MCMSTimelockProposals = []mcms.TimelockProposal{*proposal}
+	}
+
+	err := e.ExistingAddresses.Remove(addressBookToRemove) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to remove address book: %w", err)
 	}
 
 	return finalOutput, nil

--- a/deployment/ccip/changeset/solana/cs_token_pool_test.go
+++ b/deployment/ccip/changeset/solana/cs_token_pool_test.go
@@ -20,9 +20,11 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
 	ccipChangesetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -423,6 +425,116 @@ func doTestTokenPool(t *testing.T, e cldf.Environment, mcms bool, tokenMetadata 
 			}
 		}
 	}
+}
+
+func TestAddTokenPoolE2EWithoutMcms(t *testing.T) {
+	t.Parallel()
+	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
+	solChain := tenv.Env.AllChainSelectorsSolana()[0]
+	evmChain := tenv.Env.AllChainSelectors()[0]
+	deployerKey := tenv.Env.SolChains[solChain].DeployerKey.PublicKey()
+	poolType := solTestTokenPool.BurnAndMint_PoolType
+	e, newTokenAddress, err := deployTokenAndMint(t, tenv.Env, solChain, []string{deployerKey.String()})
+	require.NoError(t, err)
+	// evm deployment
+	e, _, err = deployEVMTokenPool(t, e, evmChain)
+	require.NoError(t, err)
+	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			cldf.CreateLegacyChangeSet(ccipChangesetSolana.E2ETokenPool),
+			ccipChangesetSolana.E2ETokenPoolConfig{
+				AddTokenPoolAndLookupTable: []ccipChangesetSolana.TokenPoolConfig{
+					{
+						ChainSelector: solChain,
+						TokenPubKey:   newTokenAddress,
+						PoolType:      &poolType,
+						Metadata:      shared.CLLMetadata,
+					},
+				},
+				RegisterTokenAdminRegistry: []ccipChangesetSolana.RegisterTokenAdminRegistryConfig{
+					{
+						ChainSelector:           solChain,
+						TokenPubKey:             newTokenAddress,
+						TokenAdminRegistryAdmin: deployerKey.String(),
+						RegisterType:            ccipChangesetSolana.ViaGetCcipAdminInstruction,
+					},
+				},
+				AcceptAdminRoleTokenAdminRegistry: []ccipChangesetSolana.AcceptAdminRoleTokenAdminRegistryConfig{
+					{
+						ChainSelector: solChain,
+						TokenPubKey:   newTokenAddress,
+					},
+				},
+				SetPool: []ccipChangesetSolana.SetPoolConfig{
+					{
+						ChainSelector:   solChain,
+						TokenPubKey:     newTokenAddress,
+						PoolType:        &poolType,
+						Metadata:        shared.CLLMetadata,
+						WritableIndexes: []uint8{3, 4, 7},
+					},
+				},
+				RemoteChainTokenPool: []ccipChangesetSolana.RemoteChainTokenPoolConfig{
+					{
+						SolChainSelector: solChain,
+						SolTokenPubKey:   newTokenAddress,
+						SolPoolType:      &poolType,
+						Metadata:         shared.CLLMetadata,
+						EVMRemoteConfigs: map[uint64]ccipChangesetSolana.EVMRemoteConfig{
+							evmChain: {
+								TokenSymbol: testhelpers.TestTokenSymbol,
+								PoolType:    shared.BurnMintTokenPool,
+								PoolVersion: shared.CurrentTokenPoolVersion,
+								RateLimiterConfig: ccipChangesetSolana.RateLimiterConfig{
+									Inbound: solBaseTokenPool.RateLimitConfig{
+										Enabled:  false,
+										Capacity: 0,
+										Rate:     0,
+									},
+									Outbound: solBaseTokenPool.RateLimitConfig{
+										Enabled:  false,
+										Capacity: 0,
+										Rate:     0,
+									},
+								},
+							},
+						},
+					},
+				},
+				ConfigureTokenPoolContractsChangesets: []v1_5_1.ConfigureTokenPoolContractsConfig{
+					{
+						TokenSymbol: testhelpers.TestTokenSymbol,
+						PoolUpdates: map[uint64]v1_5_1.TokenPoolConfig{
+							evmChain: {
+								Type:    shared.BurnMintTokenPool,
+								Version: shared.CurrentTokenPoolVersion,
+								SolChainUpdates: map[uint64]v1_5_1.SolChainUpdate{
+									solChain: {
+										RateLimiterConfig: v1_5_1.RateLimiterConfig{
+											Inbound: token_pool.RateLimiterConfig{
+												IsEnabled: false,
+												Capacity:  big.NewInt(0),
+												Rate:      big.NewInt(0),
+											},
+											Outbound: token_pool.RateLimiterConfig{
+												IsEnabled: false,
+												Capacity:  big.NewInt(0),
+												Rate:      big.NewInt(0),
+											},
+										},
+										TokenAddress: newTokenAddress.String(),
+										Type:         shared.BurnMintTokenPool,
+										Metadata:     shared.CLLMetadata,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		),
+	})
+	require.NoError(t, err)
 }
 
 func TestPartnerTokenPools(t *testing.T) {

--- a/deployment/ccip/changeset/solana/cs_token_pool_test.go
+++ b/deployment/ccip/changeset/solana/cs_token_pool_test.go
@@ -439,7 +439,7 @@ func TestAddTokenPoolE2EWithoutMcms(t *testing.T) {
 	// evm deployment
 	e, _, err = deployEVMTokenPool(t, e, evmChain)
 	require.NoError(t, err)
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	_, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.E2ETokenPool),
 			ccipChangesetSolana.E2ETokenPoolConfig{

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1301,7 +1301,7 @@ func DeployTransferableTokenSolana(
 		return nil, nil, solana.PublicKey{}, err
 	}
 	// find solana token address
-	solAddresses, err := e.ExistingAddresses.AddressesForChain(solChainSel) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+	solAddresses, err := e.ExistingAddresses.AddressesForChain(solChainSel)
 	if err != nil {
 		return nil, nil, solana.PublicKey{}, err
 	}

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1301,7 +1301,7 @@ func DeployTransferableTokenSolana(
 		return nil, nil, solana.PublicKey{}, err
 	}
 	// find solana token address
-	solAddresses, err := e.ExistingAddresses.AddressesForChain(solChainSel) //nolint:staticcheck // addressbook still valid
+	solAddresses, err := e.ExistingAddresses.AddressesForChain(solChainSel) //nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
 	if err != nil {
 		return nil, nil, solana.PublicKey{}, err
 	}

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1268,17 +1268,19 @@ func DeployTransferableTokenSolana(
 	}
 
 	addresses := e.ExistingAddresses //nolint:staticcheck // addressbook still valid
-	// deploy evm token
+	// deploy evm token and pool
 	evmToken, evmPool, err := deployTransferTokenOneEnd(lggr, e.Chains[evmChainSel], evmDeployer, addresses, evmTokenName)
 	if err != nil {
 		return nil, nil, solana.PublicKey{}, err
 	}
+	// attach token and pool to the registry
 	if err := attachTokenToTheRegistry(e.Chains[evmChainSel], state.Chains[evmChainSel], evmDeployer, evmToken.Address(), evmPool.Address()); err != nil {
 		return nil, nil, solana.PublicKey{}, err
 	}
 	solDeployerKey := e.SolChains[solChainSel].DeployerKey.PublicKey()
 
 	// deploy solana token
+	solTokenName := evmTokenName
 	e, err = commoncs.Apply(nil, e, nil,
 		commoncs.Configure(
 			// this makes the deployer the mint authority by default
@@ -1287,6 +1289,7 @@ func DeployTransferableTokenSolana(
 				ChainSelector:    solChainSel,
 				TokenProgramName: shared.SPL2022Tokens,
 				TokenDecimals:    9,
+				TokenSymbol:      solTokenName,
 				ATAList:          []string{solDeployerKey.String()},
 				MintAmountToAddress: map[string]uint64{
 					solDeployerKey.String(): uint64(1000e9),
@@ -1297,23 +1300,85 @@ func DeployTransferableTokenSolana(
 	if err != nil {
 		return nil, nil, solana.PublicKey{}, err
 	}
-
-	state, err = stateview.LoadOnchainState(e)
+	// find solana token address
+	solAddresses, err := e.ExistingAddresses.AddressesForChain(solChainSel) //nolint:staticcheck // addressbook still valid
 	if err != nil {
 		return nil, nil, solana.PublicKey{}, err
 	}
-	solTokenAddress := state.SolChains[solChainSel].SPL2022Tokens[0]
+	solTokenAddress := solanastateview.FindSolanaAddress(
+		cldf.TypeAndVersion{
+			Type:    shared.SPL2022Tokens,
+			Version: deployment.Version1_0_0,
+			Labels:  cldf.NewLabelSet(solTokenName),
+		},
+		solAddresses,
+	)
 	bnm := solTestTokenPool.BurnAndMint_PoolType
 
+	// deploy and configure solana token pool
 	e, err = commoncs.Apply(nil, e, nil,
 		commoncs.Configure(
 			// deploy token pool and set the burn/mint authority to the tokenPool
-			cldf.CreateLegacyChangeSet(ccipChangeSetSolana.AddTokenPoolAndLookupTable),
-			ccipChangeSetSolana.TokenPoolConfig{
-				ChainSelector: solChainSel,
-				TokenPubKey:   solTokenAddress,
-				PoolType:      &bnm,
-				Metadata:      shared.CLLMetadata,
+			cldf.CreateLegacyChangeSet(ccipChangeSetSolana.E2ETokenPool),
+			ccipChangeSetSolana.E2ETokenPoolConfig{
+				AddTokenPoolAndLookupTable: []ccipChangeSetSolana.TokenPoolConfig{
+					{
+						ChainSelector: solChainSel,
+						TokenPubKey:   solTokenAddress,
+						PoolType:      &bnm,
+						Metadata:      shared.CLLMetadata,
+					},
+				},
+				RegisterTokenAdminRegistry: []ccipChangeSetSolana.RegisterTokenAdminRegistryConfig{
+					{
+						ChainSelector:           solChainSel,
+						TokenPubKey:             solTokenAddress,
+						TokenAdminRegistryAdmin: solDeployerKey.String(),
+						RegisterType:            ccipChangeSetSolana.ViaGetCcipAdminInstruction,
+					},
+				},
+				AcceptAdminRoleTokenAdminRegistry: []ccipChangeSetSolana.AcceptAdminRoleTokenAdminRegistryConfig{
+					{
+						ChainSelector: solChainSel,
+						TokenPubKey:   solTokenAddress,
+					},
+				},
+				SetPool: []ccipChangeSetSolana.SetPoolConfig{
+					{
+						ChainSelector:   solChainSel,
+						TokenPubKey:     solTokenAddress,
+						PoolType:        &bnm,
+						Metadata:        shared.CLLMetadata,
+						WritableIndexes: []uint8{3, 4, 7},
+					},
+				},
+				RemoteChainTokenPool: []ccipChangeSetSolana.RemoteChainTokenPoolConfig{
+					{
+						SolChainSelector: solChainSel,
+						SolTokenPubKey:   solTokenAddress,
+						SolPoolType:      &bnm,
+						Metadata:         shared.CLLMetadata,
+						EVMRemoteConfigs: map[uint64]ccipChangeSetSolana.EVMRemoteConfig{
+							evmChainSel: {
+								TokenSymbol: shared.TokenSymbol(evmTokenName),
+								PoolType:    shared.BurnMintTokenPool,
+								PoolVersion: shared.CurrentTokenPoolVersion,
+								RateLimiterConfig: ccipChangeSetSolana.RateLimiterConfig{
+									Inbound: solTestTokenPool.RateLimitConfig{
+										Enabled:  false,
+										Capacity: 0,
+										Rate:     0,
+									},
+									Outbound: solTestTokenPool.RateLimitConfig{
+										Enabled:  false,
+										Capacity: 0,
+										Rate:     0,
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		),
 	)
@@ -1336,74 +1401,6 @@ func DeployTransferableTokenSolana(
 		return nil, nil, solana.PublicKey{}, err
 	}
 
-	// configure solana
-	e, err = commoncs.Apply(nil, e, nil,
-		commoncs.Configure(
-			cldf.CreateLegacyChangeSet(ccipChangeSetSolana.SetupTokenPoolForRemoteChain),
-			ccipChangeSetSolana.RemoteChainTokenPoolConfig{
-				SolChainSelector: solChainSel,
-				SolTokenPubKey:   solTokenAddress,
-				SolPoolType:      &bnm,
-				Metadata:         shared.CLLMetadata,
-				EVMRemoteConfigs: map[uint64]ccipChangeSetSolana.EVMRemoteConfig{
-					evmChainSel: {
-						TokenSymbol: shared.TokenSymbol(evmTokenName),
-						PoolType:    shared.BurnMintTokenPool,
-						PoolVersion: shared.CurrentTokenPoolVersion,
-						RateLimiterConfig: ccipChangeSetSolana.RateLimiterConfig{
-							Inbound:  solTestTokenPool.RateLimitConfig{},
-							Outbound: solTestTokenPool.RateLimitConfig{},
-						},
-					},
-				},
-			},
-		),
-		commoncs.Configure(
-			cldf.CreateLegacyChangeSet(ccipChangeSetSolana.AddTokenTransferFeeForRemoteChain),
-			ccipChangeSetSolana.TokenTransferFeeForRemoteChainConfig{
-				ChainSelector:       solChainSel,
-				RemoteChainSelector: evmChainSel,
-				TokenPubKey:         solTokenAddress.String(),
-				Config: solFeeQuoter.TokenTransferFeeConfig{
-					MinFeeUsdcents:    800,
-					MaxFeeUsdcents:    1600,
-					DeciBps:           0,
-					DestGasOverhead:   90000,
-					DestBytesOverhead: 100,
-					IsEnabled:         true,
-				},
-			},
-		),
-		commoncs.Configure(
-			cldf.CreateLegacyChangeSet(ccipChangeSetSolana.RegisterTokenAdminRegistry),
-			ccipChangeSetSolana.RegisterTokenAdminRegistryConfig{
-				ChainSelector:           solChainSel,
-				TokenPubKey:             solTokenAddress,
-				TokenAdminRegistryAdmin: e.SolChains[solChainSel].DeployerKey.PublicKey().String(),
-				RegisterType:            ccipChangeSetSolana.ViaGetCcipAdminInstruction,
-			},
-		),
-		commoncs.Configure(
-			cldf.CreateLegacyChangeSet(ccipChangeSetSolana.AcceptAdminRoleTokenAdminRegistry),
-			ccipChangeSetSolana.AcceptAdminRoleTokenAdminRegistryConfig{
-				ChainSelector: solChainSel,
-				TokenPubKey:   solTokenAddress,
-			},
-		),
-		commoncs.Configure(
-			cldf.CreateLegacyChangeSet(ccipChangeSetSolana.SetPool),
-			ccipChangeSetSolana.SetPoolConfig{
-				ChainSelector:   solChainSel,
-				PoolType:        &bnm,
-				TokenPubKey:     solTokenAddress,
-				WritableIndexes: []uint8{3, 4, 7},
-				Metadata:        shared.CLLMetadata,
-			},
-		),
-	)
-	if err != nil {
-		return nil, nil, solana.PublicKey{}, err
-	}
 	return evmToken, evmPool, solTokenAddress, nil
 }
 


### PR DESCRIPTION
```
[DEBUG] freeport: Test "TestTokenTransfer_Solana2EVM" returned ports [48915 48916 48917 48918 48919]
[DEBUG] freeport: Test "TestTokenTransfer_Solana2EVM" returned ports [48913 48914]
PASS
ok      github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip      291.025s

[DEBUG] freeport: Test "TestTokenTransfer_EVM2Solana" returned ports [25235 25236 25237 25238 25239]
[DEBUG] freeport: Test "TestTokenTransfer_EVM2Solana" returned ports [25233 25234]
PASS
ok      github.com/smartcontractkit/chainlink/integration-tests/smoke/ccip      294.493s
```
