### PR TITLE
Deploy CCIPBnM Token during cs_add_token_e2e + allow e2e tokenConfig

### DIFF
--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -113,12 +113,6 @@ func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Enviro
 		Pools: make(map[uint64]map[shared.TokenSymbol]TokenPoolInfo),
 	}
 	for chain, poolCfg := range c.PoolConfig {
-		c.deployPool = &DeployTokenPoolContractsConfig{
-			TokenSymbol:  symbol,
-			NewPools:     make(map[uint64]DeployTokenPoolInput),
-			IsTestRouter: c.IsTestRouter,
-		}
-
 		tpCfg := TokenPoolConfig{
 			ChainUpdates:        poolCfg.RateLimiterConfig,
 			Version:             poolCfg.PoolVersion,
@@ -132,8 +126,14 @@ func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Enviro
 
 		if poolCfg.ExistingPoolType == nil {
 			// deploy new tokenPool
-			if poolCfg.DeployPoolConfig == nil {
+			if poolCfg.DeployPoolConfig != nil {
 				return fmt.Errorf("existing pool type must be provided for chain %d, if no deploy pool config is there", chain)
+			}
+
+			c.deployPool = &DeployTokenPoolContractsConfig{
+				TokenSymbol:  symbol,
+				NewPools:     make(map[uint64]DeployTokenPoolInput),
+				IsTestRouter: c.IsTestRouter,
 			}
 
 			c.deployPool.NewPools[chain] = *poolCfg.DeployPoolConfig
@@ -141,9 +141,8 @@ func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Enviro
 			poolInfo.Type = poolCfg.DeployPoolConfig.Type
 		} else {
 			// no need to deploy new tokenPool
-			c.deployPool.NewPools[chain] = *poolCfg.DeployPoolConfig
-			tpCfg.Type = poolCfg.DeployPoolConfig.Type
-			poolInfo.Type = poolCfg.DeployPoolConfig.Type
+			tpCfg.Type = *poolCfg.ExistingPoolType
+			poolInfo.Type = *poolCfg.ExistingPoolType
 		}
 
 		// Populate the TokenAdminRegistryChangesetConfig for each chain.

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -104,6 +104,13 @@ type AddTokenE2EConfig struct {
 // It creates the configuration for deploying and configuring token pools and token admin registry.
 // It then validates the configuration.
 func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Environment, symbol shared.TokenSymbol, timelockCfg *proposalutils.TimelockConfig, existingPool bool) error {
+
+	c.deployPool = &DeployTokenPoolContractsConfig{
+		TokenSymbol:  symbol,
+		NewPools:     make(map[uint64]DeployTokenPoolInput),
+		IsTestRouter: c.IsTestRouter,
+	}
+
 	// ensuring already existing pool has ownership transferred to MCMs
 	if existingPool {
 		c.ConfigurePools.MCMS = timelockCfg
@@ -113,12 +120,7 @@ func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Enviro
 		Pools: make(map[uint64]map[shared.TokenSymbol]TokenPoolInfo),
 	}
 	for chain, poolCfg := range c.PoolConfig {
-		tpCfg := TokenPoolConfig{
-			ChainUpdates:        poolCfg.RateLimiterConfig,
-			Version:             poolCfg.PoolVersion,
-			OverrideTokenSymbol: poolCfg.OverrideTokenSymbol,
-			SolChainUpdates:     poolCfg.SolChainUpdates,
-		}
+		tpCfg := TokenPoolConfig{}
 		poolInfo := TokenPoolInfo{
 			Version:       poolCfg.PoolVersion,
 			ExternalAdmin: poolCfg.ExternalAdmin,
@@ -126,14 +128,8 @@ func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Enviro
 
 		if poolCfg.ExistingPoolType == nil {
 			// deploy new tokenPool
-			if poolCfg.DeployPoolConfig != nil {
+			if poolCfg.DeployPoolConfig == nil {
 				return fmt.Errorf("existing pool type must be provided for chain %d, if no deploy pool config is there", chain)
-			}
-
-			c.deployPool = &DeployTokenPoolContractsConfig{
-				TokenSymbol:  symbol,
-				NewPools:     make(map[uint64]DeployTokenPoolInput),
-				IsTestRouter: c.IsTestRouter,
 			}
 
 			c.deployPool.NewPools[chain] = *poolCfg.DeployPoolConfig

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -14,15 +15,16 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc677_helper"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc677"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
@@ -39,47 +41,62 @@ import (
 //     populate DeployTokenPoolContractsConfig.
 //     If the token deployment config is not provided, pool deployment configuration DeployTokenPoolContractsConfig is mandatory.
 //
-//  3. Configures pools -
-//     If the chain is already supported -
+// 3. Proposes admin rights for the token on the token admin registry
 //
-//     i. it updates the rate limits for the chain
-//     ii. it adds a new remote pool if the token pool on the remote chain is being updated
+//		If the token admin is not an external address -
+//		3a. Accepts admin rights for the token on the token admin registry
+//		3b. Sets the pool for the token on the token admin registry
 //
-//     If the chain is not supported -
-//
-//     i. it adds chain support with the desired rate limits
-//     i. it adds the desired remote pool addresses to the token pool on the chain
-//     iii. if there used to be an existing token pool on tokenadmin_registry, it adds the remote pool addresses of that token pool to ensure 0 downtime
-//
-// 4. Proposes admin rights for the token on the token admin registry
-//
-// If the token admin is not an external address -
-// 5. Accepts admin rights for the token on the token admin registry
-// 6. Sets the pool for the token on the token admin registry
+//	 4. Configures pools -
+//		   The configuration is set by via the input field ConfigurePools. This is so that we can have flexibility during configuration.
+//		   For ex: deploy chainB token, pool and configure with already deployed chainA tokenPool.
+//		   If config is not provided in the input, it skips this step.
 var AddTokensE2E = cldf.CreateChangeSet(addTokenE2ELogic, addTokenE2EPreconditionValidation)
 
 type E2ETokenAndPoolConfig struct {
-	TokenDeploymentConfig *DeployTokenConfig    // TokenDeploymentConfig is optional. If provided, it will be used to deploy the token and populate the pool deployment configuration.
-	DeployPoolConfig      *DeployTokenPoolInput // Deployment configuration for pools is not needed if tokenDeploymentConfig is provided. This will be populated from the tokenDeploymentConfig if it is provided.
-	ExistingPoolType      *cldf.ContractType    // Provide if pool is already deployed and you want to just configure it
-	PoolVersion           semver.Version
-	ExternalAdmin         common.Address // ExternalAdmin is the external administrator of the token pool on the registry.
-	RateLimiterConfig     RateLimiterPerChain
+	// TokenDeploymentConfig is optional. If provided, it will be used to deploy the token
+	// and populate the pool deployment configuration.
+	TokenDeploymentConfig *DeployTokenConfig `json:"tokenDeploymentConfig,omitempty"`
+
+	// Deployment configuration for pools is not needed if tokenDeploymentConfig is provided.
+	// This will be populated from the tokenDeploymentConfig if it is provided.
+	DeployPoolConfig *DeployTokenPoolInput `json:"deployPoolConfig,omitempty"`
+
+	// Provide if pool is already deployed and you want to just configure it
+	ExistingPoolType *cldf.ContractType `json:"existingPoolType,omitempty"`
+
+	// Version of the pool being deployed.
+	PoolVersion semver.Version `json:"poolVersion"`
+
+	// ExternalAdmin is the external administrator of the token pool on the registry.
+	ExternalAdmin common.Address `json:"externalAdmin"`
+
+	// Configuration for the rate limiter per chain.
+	RateLimiterConfig RateLimiterPerChain `json:"rateLimiterConfig"`
+
 	// SolChainUpdates defines the Solana chains and corresponding rate limits that should be defined on the token pool.
-	SolChainUpdates map[uint64]SolChainUpdate
-	// OverrideTokenSymbol is the token symbol to use to override against main symbol (ex: override to clCCIP-LnM when the main token symbol is CCIP-LnM)
-	// WARNING: This should only be used in exceptional cases where the token symbol on a particular chain differs from the main tokenSymbol
-	OverrideTokenSymbol shared.TokenSymbol
+	SolChainUpdates map[uint64]SolChainUpdate `json:"solChainUpdates,omitempty"`
+
+	// OverrideTokenSymbol is the token symbol to use to override against main symbol
+	// (ex: override to clCCIP-LnM when the main token symbol is CCIP-LnM)
+	// WARNING: This should only be used in exceptional cases where the token symbol on
+	// a particular chain differs from the main tokenSymbol
+	OverrideTokenSymbol shared.TokenSymbol `json:"overrideTokenSymbol,omitempty"`
 }
 
 type AddTokenE2EConfig struct {
-	PoolConfig   map[uint64]E2ETokenAndPoolConfig
-	IsTestRouter bool
+	// Map of chain ID to E2ETokenAndPoolConfig.
+	PoolConfig map[uint64]E2ETokenAndPoolConfig `json:"poolConfig"`
+
+	// Whether this is a test router configuration.
+	IsTestRouter bool `json:"isTestRouter"`
+
+	// Configures the pools, if empty deployed pools aren't configured.
+	ConfigurePools ConfigureTokenPoolContractsConfig `json:"configurePools"`
 
 	// internal fields - To be populated from the PoolConfig.
-	// User do not need to populate these fields.
+	// User does not need to populate these fields.
 	deployPool             *DeployTokenPoolContractsConfig
-	configurePools         ConfigureTokenPoolContractsConfig
 	configureTokenAdminReg TokenAdminRegistryChangesetConfig
 }
 
@@ -87,26 +104,21 @@ type AddTokenE2EConfig struct {
 // It creates the configuration for deploying and configuring token pools and token admin registry.
 // It then validates the configuration.
 func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Environment, symbol shared.TokenSymbol, timelockCfg *proposalutils.TimelockConfig, existingPool bool) error {
-	if !existingPool {
-		c.deployPool = &DeployTokenPoolContractsConfig{
-			TokenSymbol:  symbol,
-			NewPools:     make(map[uint64]DeployTokenPoolInput),
-			IsTestRouter: c.IsTestRouter,
-		}
-	}
-	c.configurePools = ConfigureTokenPoolContractsConfig{
-		TokenSymbol: symbol,
-		MCMS:        nil, // as token pools are deployed as part of the changeset, the pools will still be owned by the deployer key
-		PoolUpdates: make(map[uint64]TokenPoolConfig),
-	}
+	// ensuring already existing pool has ownership transferred to MCMs
 	if existingPool {
-		c.configurePools.MCMS = timelockCfg
+		c.ConfigurePools.MCMS = timelockCfg
 	}
 	c.configureTokenAdminReg = TokenAdminRegistryChangesetConfig{
 		MCMS:  timelockCfg,
 		Pools: make(map[uint64]map[shared.TokenSymbol]TokenPoolInfo),
 	}
 	for chain, poolCfg := range c.PoolConfig {
+		c.deployPool = &DeployTokenPoolContractsConfig{
+			TokenSymbol:  symbol,
+			NewPools:     make(map[uint64]DeployTokenPoolInput),
+			IsTestRouter: c.IsTestRouter,
+		}
+
 		tpCfg := TokenPoolConfig{
 			ChainUpdates:        poolCfg.RateLimiterConfig,
 			Version:             poolCfg.PoolVersion,
@@ -117,18 +129,23 @@ func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Enviro
 			Version:       poolCfg.PoolVersion,
 			ExternalAdmin: poolCfg.ExternalAdmin,
 		}
-		if !existingPool {
+
+		if poolCfg.ExistingPoolType == nil {
+			// deploy new tokenPool
+			if poolCfg.DeployPoolConfig == nil {
+				return fmt.Errorf("existing pool type must be provided for chain %d, if no deploy pool config is there", chain)
+			}
+
 			c.deployPool.NewPools[chain] = *poolCfg.DeployPoolConfig
 			tpCfg.Type = poolCfg.DeployPoolConfig.Type
 			poolInfo.Type = poolCfg.DeployPoolConfig.Type
 		} else {
-			if poolCfg.ExistingPoolType == nil {
-				return fmt.Errorf("existing pool type must be provided for chain %d, if no deploy pool config is there", chain)
-			}
-			tpCfg.Type = *poolCfg.ExistingPoolType
-			poolInfo.Type = *poolCfg.ExistingPoolType
+			// no need to deploy new tokenPool
+			c.deployPool.NewPools[chain] = *poolCfg.DeployPoolConfig
+			tpCfg.Type = poolCfg.DeployPoolConfig.Type
+			poolInfo.Type = poolCfg.DeployPoolConfig.Type
 		}
-		c.configurePools.PoolUpdates[chain] = tpCfg
+
 		// Populate the TokenAdminRegistryChangesetConfig for each chain.
 		if _, ok := c.configureTokenAdminReg.Pools[chain]; !ok {
 			c.configureTokenAdminReg.Pools[chain] = make(map[shared.TokenSymbol]TokenPoolInfo)
@@ -140,6 +157,7 @@ func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Enviro
 			return fmt.Errorf("failed to validate deploy pool config: %w", err)
 		}
 	}
+
 	// rest of the validation should be done after token pools are deployed
 	return nil
 }
@@ -170,15 +188,35 @@ func (c *AddTokenE2EConfig) newDeployTokenPoolConfigAfterTokenDeployment(tokenAd
 }
 
 type DeployTokenConfig struct {
-	TokenName              string
-	TokenSymbol            shared.TokenSymbol
-	TokenDecimals          uint8    // needed for BurnMintToken only
-	MaxSupply              *big.Int // needed for BurnMintToken only
-	Type                   cldf.ContractType
-	PoolType               cldf.ContractType // This is the type of the token pool that will be deployed for this token.
-	PoolAllowList          []common.Address
-	AcceptLiquidity        *bool
-	MintTokenForRecipients map[common.Address]*big.Int // MintTokenForRecipients is a map of recipient address to amount to be transferred or minted and provided minting role after token deployment.
+	// TokenName is the full name of the token.
+	TokenName string `json:"tokenName"`
+
+	// TokenSymbol is the symbol for the token (e.g., LINK, USDC).
+	TokenSymbol shared.TokenSymbol `json:"tokenSymbol"`
+
+	// TokenDecimals specifies how many decimals the token uses.
+	// Needed for BurnMintToken only.
+	TokenDecimals uint8 `json:"tokenDecimals,omitempty"`
+
+	// MaxSupply defines the maximum supply for the token.
+	// Needed for BurnMintToken only.
+	MaxSupply *big.Int `json:"maxSupply,omitempty"`
+
+	// Type is the contract type of the token (e.g., BurnMintToken, StandardERC20).
+	Type cldf.ContractType `json:"type"`
+
+	// PoolType is the type of the token pool that will be deployed for this token.
+	PoolType cldf.ContractType `json:"poolType"`
+
+	// PoolAllowList is a list of addresses allowed to interact with the pool.
+	PoolAllowList []common.Address `json:"poolAllowList,omitempty"`
+
+	// AcceptLiquidity defines whether the pool should accept liquidity.
+	AcceptLiquidity *bool `json:"acceptLiquidity,omitempty"`
+
+	// MintTokenForRecipients is a map of recipient address to amount to be transferred or minted
+	// and provided minting role after token deployment.
+	MintTokenForRecipients map[common.Address]*big.Int `json:"mintTokenForRecipients,omitempty"`
 }
 
 func (c *DeployTokenConfig) Validate() error {
@@ -201,8 +239,11 @@ func (c *DeployTokenConfig) Validate() error {
 }
 
 type AddTokensE2EConfig struct {
-	Tokens map[shared.TokenSymbol]AddTokenE2EConfig
-	MCMS   *proposalutils.TimelockConfig
+	// Tokens is a map from token symbol to its E2E configuration.
+	Tokens map[shared.TokenSymbol]AddTokenE2EConfig `json:"tokens"`
+
+	// MCMS is the optional TimelockConfig used for governance proposals.
+	MCMS *proposalutils.TimelockConfig `json:"mcms,omitempty"`
 }
 
 func addTokenE2EPreconditionValidation(e cldf.Environment, config AddTokensE2EConfig) error {
@@ -218,6 +259,7 @@ func addTokenE2EPreconditionValidation(e cldf.Environment, config AddTokensE2ECo
 			if err := stateview.ValidateChain(e, state, chain, config.MCMS); err != nil {
 				return fmt.Errorf("failed to validate chain %d: %w", chain, err)
 			}
+
 			if poolCfg.ExistingPoolType == nil {
 				if (poolCfg.DeployPoolConfig != nil) == (poolCfg.TokenDeploymentConfig != nil) {
 					return fmt.Errorf("must provide either DeploymentConfig or TokenDeploymentConfig for token %s: cannot provide both or neither", token)
@@ -278,7 +320,9 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 				tokenDeployCfg[chain] = *poolCfg.TokenDeploymentConfig
 			}
 		}
-		// deploy token pools if token deployment config is provided and populate pool deployment configuration
+
+		//  1. Deploys tokens ( specifically TestTokens) optionally if DeployTokenConfig is provided and
+		//     populates the pool deployment configuration for each token.
 		if len(tokenDeployCfg) > 0 {
 			deployedTokens, ab, err := deployTokens(e, tokenDeployCfg)
 			if err != nil {
@@ -297,8 +341,13 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 					"deploying and configuring token pools and token admin registry: %w", err)
 			}
 		}
-		// deploy pool if pool deployment config is provided
+
 		if cfg.deployPool != nil {
+			//  2. Deploys token pool contracts for each token specified in the config.
+			//     If the token deployment config is provided, pool deployment configuration DeployTokenPoolContractsConfig is not required.
+			//     It will use the token deployment config to deploy the token and
+			//     populate DeployTokenPoolContractsConfig.
+			//     If the token deployment config is not provided, pool deployment configuration DeployTokenPoolContractsConfig is mandatory.
 			output, err := DeployTokenPoolContractsChangeset(e, *cfg.deployPool)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy token pool for token %s: %w", token, err)
@@ -311,26 +360,46 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to get addresses from address book: %w", err)
 			}
 			e.Logger.Infow("deployed token pool", "token", token, "addresses", newAddresses)
-		}
-		if err := cfg.configurePools.Validate(e); err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to validate configure pool config: %w", err)
-		}
-		// Validate the configure token admin reg config.
-		// As we will perform proposing admin, accepting admin and setting pool on same changeset
-		// we are only validating the propose admin role.
-		if err := cfg.configureTokenAdminReg.Validate(e, true, validateProposeAdminRole); err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to validate configure token admin reg config: %w", err)
-		}
-		output, err := ConfigureTokenPoolContractsChangeset(e, cfg.configurePools)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to configure token pool for token %s: %w", token, err)
-		}
-		if err := cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after configuring token pool for token %s: %w", token, err)
-		}
-		e.Logger.Infow("configured token pool", "token", token)
 
-		output, err = ProposeAdminRoleChangeset(e, cfg.configureTokenAdminReg)
+			// Validate the configure token admin reg config.
+			// As we will perform proposing admin, accepting admin and setting pool on same changeset
+			// we are only validating the propose admin role.
+			if err := cfg.configureTokenAdminReg.Validate(e, true, validateProposeAdminRole); err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to validate configure token admin reg config: %w", err)
+			}
+
+			// for each chain in pool config, trigger transfer ownership of the deployed poolAddress
+			if config.MCMS != nil {
+				for chainID, addrMap := range newAddresses {
+					var addresses []common.Address
+					for addr := range addrMap {
+						addresses = append(addresses, common.HexToAddress(addr))
+					}
+
+					transferOwnershipProposalOutput, err := commoncs.TransferToMCMSWithTimelockV2(e, commoncs.TransferToMCMSWithTimelockConfig{
+						ContractsByChain: map[uint64][]common.Address{
+							chainID: addresses,
+						},
+						MCMSConfig: *config.MCMS,
+					})
+					if err != nil {
+						return cldf.ChangesetOutput{}, fmt.Errorf("failed to run TransferToMCMSWithTimelock on chain with selector %d: %w", chainID, err)
+					}
+
+					if err := cldf.MergeChangesetOutput(e, finalCSOut, transferOwnershipProposalOutput); err != nil {
+						return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after transferring ownership of pool(s): %w", err)
+					}
+
+				}
+			}
+		}
+
+		// 3. Proposes admin rights for the token on the token admin registry
+		//
+		//		If the token admin is not an external address -
+		//		3a. Accepts admin rights for the token on the token admin registry
+		//		3b. Sets the pool for the token on the token admin registry
+		output, err := ProposeAdminRoleChangeset(e, cfg.configureTokenAdminReg)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to propose admin role for token %s: %w", token, err)
 		}
@@ -378,6 +447,31 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book for token %s: %w", token, err)
 		}
 		e.Logger.Infow("set pool", "token", token, "config", updatedConfigureTokenAdminReg)
+
+		//	 4. Configures pools -
+		//		   The configuration is set by via the input field ConfigurePools. This is so that we can have flexibility during configuration.
+		//		   For ex: deploy chainB token, pool and configure with already deployed chainA tokenPool.
+		//		   If config is not provided in the input, it skips this step.
+		if reflect.DeepEqual(
+			cfg.ConfigurePools,
+			ConfigureTokenPoolContractsConfig{},
+		) {
+			e.Logger.Infow("only deployment done, the pools haven't been configured")
+			continue
+		}
+
+		if err := cfg.ConfigurePools.Validate(e); err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to validate configure pool config: %w", err)
+		}
+
+		output, err = ConfigureTokenPoolContractsChangeset(e, cfg.ConfigurePools)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to configure token pool for token %s: %w", token, err)
+		}
+		if err := cldf.MergeChangesetOutput(e, finalCSOut, output); err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after configuring token pool for token %s: %w", token, err)
+		}
+		e.Logger.Infow("configured token pool", "token", token)
 	}
 	// if there are multiple proposals, aggregate them so that we don't have to propose them separately
 	if len(finalCSOut.MCMSTimelockProposals) > 1 {
@@ -421,14 +515,14 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 				return nil, ab, fmt.Errorf("failed to deploy BurnMintERC677 token "+
 					"%s on chain %d: %w", cfg.TokenName, selector, err)
 			}
-			if err := addMinterAndMintToken(e, selector, token.Contract, e.Chains[selector].DeployerKey.From,
+			if err := addMinterAndMintTokenERC677(e, selector, token.Contract, e.Chains[selector].DeployerKey.From,
 				new(big.Int).Mul(big.NewInt(1_000), big.NewInt(1_000_000_000))); err != nil {
 				return nil, ab, fmt.Errorf("failed to add minter and mint token "+
 					"%s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 			if len(cfg.MintTokenForRecipients) > 0 {
 				for recipient, amount := range cfg.MintTokenForRecipients {
-					if err := addMinterAndMintToken(e, selector, token.Contract, recipient,
+					if err := addMinterAndMintTokenERC677(e, selector, token.Contract, recipient,
 						amount); err != nil {
 						return nil, ab, fmt.Errorf("failed to add minter and mint "+
 							"token %s on chain %d: %w", cfg.TokenName, selector, err)
@@ -482,6 +576,43 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 				return nil, ab, fmt.Errorf("failed to deploy ERC677 token %s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 			tokenAddresses[selector] = token.Address
+		case shared.ERC677TokenHelper:
+			token, err := cldf.DeployContract(e.Logger, e.Chains[selector], ab,
+				func(chain cldf.Chain) cldf.ContractDeploy[*burn_mint_erc677_helper.BurnMintERC677Helper] {
+					tokenAddress, tx, token, err := burn_mint_erc677_helper.DeployBurnMintERC677Helper(
+						e.Chains[selector].DeployerKey,
+						e.Chains[selector].Client,
+						cfg.TokenName,
+						string(cfg.TokenSymbol),
+					)
+					return cldf.ContractDeploy[*burn_mint_erc677_helper.BurnMintERC677Helper]{
+						Address:  tokenAddress,
+						Contract: token,
+						Tv:       cldf.NewTypeAndVersion(shared.ERC677TokenHelper, deployment.Version1_0_0),
+						Tx:       tx,
+						Err:      err,
+					}
+				},
+			)
+			if err != nil {
+				return nil, ab, fmt.Errorf("failed to deploy ERC677 token %s on chain %d: %w", cfg.TokenName, selector, err)
+			}
+
+			if err := addMinterAndMintTokenERC677Helper(e, selector, token.Contract, e.Chains[selector].DeployerKey.From,
+				new(big.Int).Mul(big.NewInt(1_000), big.NewInt(1_000_000_000))); err != nil {
+				return nil, ab, fmt.Errorf("failed to add minter and mint token "+
+					"%s on chain %d: %w", cfg.TokenName, selector, err)
+			}
+			if len(cfg.MintTokenForRecipients) > 0 {
+				for recipient, amount := range cfg.MintTokenForRecipients {
+					if err := addMinterAndMintTokenERC677Helper(e, selector, token.Contract, recipient,
+						amount); err != nil {
+						return nil, ab, fmt.Errorf("failed to add minter and mint "+
+							"token %s on chain %d: %w", cfg.TokenName, selector, err)
+					}
+				}
+			}
+			tokenAddresses[selector] = token.Address
 		default:
 			return nil, ab, fmt.Errorf("unsupported token %s type %s for deployment on chain %d", cfg.TokenName, cfg.Type, selector)
 		}
@@ -519,8 +650,21 @@ func grantAccessToPool(
 	return nil
 }
 
-// addMinterAndMintToken adds the minter role to the recipient and mints the specified amount of tokens to the recipient's address.
-func addMinterAndMintToken(env cldf.Environment, selector uint64, token *burn_mint_erc677.BurnMintERC677, recipient common.Address, amount *big.Int) error {
+// addMinterAndMintTokenERC677 adds the minter role to the recipient and mints the specified amount of tokens to the recipient's address.
+func addMinterAndMintTokenERC677(env cldf.Environment, selector uint64, token *burn_mint_erc677.BurnMintERC677, recipient common.Address, amount *big.Int) error {
+	return addMinterAndMintTokenHelper(env, selector, token, recipient, amount)
+}
+
+// addMinterAndMintTokenERC677Helper adds the minter role to the recipient and mints the specified amount of tokens to the recipient's address.
+func addMinterAndMintTokenERC677Helper(env cldf.Environment, selector uint64, token *burn_mint_erc677_helper.BurnMintERC677Helper, recipient common.Address, amount *big.Int) error {
+	baseToken, err := burn_mint_erc677.NewBurnMintERC677(token.Address(), env.Chains[selector].Client)
+	if err != nil {
+		return fmt.Errorf("failed to cast helper to base token: %w", err)
+	}
+	return addMinterAndMintTokenHelper(env, selector, baseToken, recipient, amount)
+}
+
+func addMinterAndMintTokenHelper(env cldf.Environment, selector uint64, token *burn_mint_erc677.BurnMintERC677, recipient common.Address, amount *big.Int) error {
 	deployerKey := env.Chains[selector].DeployerKey
 	ctx := env.GetContext()
 	// check if owner is the deployer key

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -61,20 +61,11 @@ type E2ETokenAndPoolConfig struct {
 	// This will be populated from the tokenDeploymentConfig if it is provided.
 	DeployPoolConfig *DeployTokenPoolInput `json:"deployPoolConfig,omitempty"`
 
-	// Provide if pool is already deployed and you want to just configure it
-	ExistingPoolType *cldf.ContractType `json:"existingPoolType,omitempty"`
-
 	// Version of the pool being deployed.
 	PoolVersion semver.Version `json:"poolVersion"`
 
 	// ExternalAdmin is the external administrator of the token pool on the registry.
 	ExternalAdmin common.Address `json:"externalAdmin"`
-
-	// Configuration for the rate limiter per chain.
-	RateLimiterConfig RateLimiterPerChain `json:"rateLimiterConfig"`
-
-	// SolChainUpdates defines the Solana chains and corresponding rate limits that should be defined on the token pool.
-	SolChainUpdates map[uint64]SolChainUpdate `json:"solChainUpdates,omitempty"`
 
 	// OverrideTokenSymbol is the token symbol to use to override against main symbol
 	// (ex: override to clCCIP-LnM when the main token symbol is CCIP-LnM)
@@ -102,18 +93,13 @@ type AddTokenE2EConfig struct {
 // newConfigurePoolAndTokenAdminRegConfig populated internal fields in AddTokenE2EConfig.
 // It creates the configuration for deploying and configuring token pools and token admin registry.
 // It then validates the configuration.
-func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Environment, symbol shared.TokenSymbol, timelockCfg *proposalutils.TimelockConfig, existingPool bool) error {
-
+func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Environment, symbol shared.TokenSymbol, timelockCfg *proposalutils.TimelockConfig) error {
 	c.deployPool = &DeployTokenPoolContractsConfig{
 		TokenSymbol:  symbol,
 		NewPools:     make(map[uint64]DeployTokenPoolInput),
 		IsTestRouter: c.IsTestRouter,
 	}
 
-	// ensuring already existing pool has ownership transferred to MCMs
-	if existingPool {
-		c.ConfigurePools.MCMS = timelockCfg
-	}
 	c.configureTokenAdminReg = TokenAdminRegistryChangesetConfig{
 		MCMS:  timelockCfg,
 		Pools: make(map[uint64]map[shared.TokenSymbol]TokenPoolInfo),
@@ -125,20 +111,9 @@ func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Enviro
 			ExternalAdmin: poolCfg.ExternalAdmin,
 		}
 
-		if poolCfg.ExistingPoolType == nil {
-			// deploy new tokenPool
-			if poolCfg.DeployPoolConfig == nil {
-				return fmt.Errorf("existing pool type must be provided for chain %d, if no deploy pool config is there", chain)
-			}
-
-			c.deployPool.NewPools[chain] = *poolCfg.DeployPoolConfig
-			tpCfg.Type = poolCfg.DeployPoolConfig.Type
-			poolInfo.Type = poolCfg.DeployPoolConfig.Type
-		} else {
-			// no need to deploy new tokenPool
-			tpCfg.Type = *poolCfg.ExistingPoolType
-			poolInfo.Type = *poolCfg.ExistingPoolType
-		}
+		c.deployPool.NewPools[chain] = *poolCfg.DeployPoolConfig
+		tpCfg.Type = poolCfg.DeployPoolConfig.Type
+		poolInfo.Type = poolCfg.DeployPoolConfig.Type
 
 		// Populate the TokenAdminRegistryChangesetConfig for each chain.
 		if _, ok := c.configureTokenAdminReg.Pools[chain]; !ok {
@@ -146,10 +121,9 @@ func (c *AddTokenE2EConfig) newConfigurePoolAndTokenAdminRegConfig(e cldf.Enviro
 		}
 		c.configureTokenAdminReg.Pools[chain][symbol] = poolInfo
 	}
-	if !existingPool {
-		if err := c.deployPool.Validate(e); err != nil {
-			return fmt.Errorf("failed to validate deploy pool config: %w", err)
-		}
+
+	if err := c.deployPool.Validate(e); err != nil {
+		return fmt.Errorf("failed to validate deploy pool config: %w", err)
 	}
 
 	// rest of the validation should be done after token pools are deployed
@@ -254,40 +228,32 @@ func addTokenE2EPreconditionValidation(e cldf.Environment, config AddTokensE2ECo
 				return fmt.Errorf("failed to validate chain %d: %w", chain, err)
 			}
 
-			if poolCfg.ExistingPoolType == nil {
-				if (poolCfg.DeployPoolConfig != nil) == (poolCfg.TokenDeploymentConfig != nil) {
-					return fmt.Errorf("must provide either DeploymentConfig or TokenDeploymentConfig for token %s: cannot provide both or neither", token)
+			if (poolCfg.DeployPoolConfig != nil) == (poolCfg.TokenDeploymentConfig != nil) {
+				return fmt.Errorf("must provide either DeploymentConfig or TokenDeploymentConfig for token %s: cannot provide both or neither", token)
+			}
+			if poolCfg.TokenDeploymentConfig != nil {
+				if poolCfg.TokenDeploymentConfig.TokenSymbol != token {
+					return fmt.Errorf("token symbol %s in token deployment config does not match token %s", poolCfg.TokenDeploymentConfig.TokenSymbol, token)
 				}
-				if poolCfg.TokenDeploymentConfig != nil {
-					if poolCfg.TokenDeploymentConfig.TokenSymbol != token {
-						return fmt.Errorf("token symbol %s in token deployment config does not match token %s", poolCfg.TokenDeploymentConfig.TokenSymbol, token)
-					}
-					if err := poolCfg.TokenDeploymentConfig.Validate(); err != nil {
-						return fmt.Errorf("failed to validate token deployment config for token %s: %w", token, err)
-					}
-					// the rest of the internal fields are populated from the PoolConfig and it will be validated once the tokens are deployed
-				} else {
-					if poolCfg.DeployPoolConfig == nil {
-						return fmt.Errorf("must provide pool DeploymentConfig for token %s when TokenDeploymentConfig is not provided", token)
-					}
-					if err := poolCfg.DeployPoolConfig.Validate(e.GetContext(), e.Chains[chain], state.Chains[chain], token); err != nil {
-						return fmt.Errorf("failed to validate token pool config for token %s: %w", token, err)
-					}
-					// populate the internal fields for deploying and configuring token pools and token admin registry and validate them
-					err := cfg.newConfigurePoolAndTokenAdminRegConfig(e, token, config.MCMS, false)
-					if err != nil {
-						return err
-					}
-					config.Tokens[token] = cfg
+				if err := poolCfg.TokenDeploymentConfig.Validate(); err != nil {
+					return fmt.Errorf("failed to validate token deployment config for token %s: %w", token, err)
 				}
+				// the rest of the internal fields are populated from the PoolConfig and it will be validated once the tokens are deployed
 			} else {
+				if poolCfg.DeployPoolConfig == nil {
+					return fmt.Errorf("must provide pool DeploymentConfig for token %s when TokenDeploymentConfig is not provided", token)
+				}
+				if err := poolCfg.DeployPoolConfig.Validate(e.GetContext(), e.Chains[chain], state.Chains[chain], token); err != nil {
+					return fmt.Errorf("failed to validate token pool config for token %s: %w", token, err)
+				}
 				// populate the internal fields for deploying and configuring token pools and token admin registry and validate them
-				err := cfg.newConfigurePoolAndTokenAdminRegConfig(e, token, config.MCMS, true)
+				err := cfg.newConfigurePoolAndTokenAdminRegConfig(e, token, config.MCMS)
 				if err != nil {
 					return err
 				}
 				config.Tokens[token] = cfg
 			}
+
 		}
 	}
 	return nil
@@ -330,7 +296,7 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge address book for token %s: %w", token, err)
 			}
 			// populate the configuration for deploying and configuring token pools and token admin registry
-			if err := cfg.newConfigurePoolAndTokenAdminRegConfig(e, token, config.MCMS, false); err != nil {
+			if err := cfg.newConfigurePoolAndTokenAdminRegConfig(e, token, config.MCMS); err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate configuration for "+
 					"deploying and configuring token pools and token admin registry: %w", err)
 			}

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"reflect"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -447,10 +446,7 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 		//		   The configuration is set by via the input field ConfigurePools. This is so that we can have flexibility during configuration.
 		//		   For ex: deploy chainB token, pool and configure with already deployed chainA tokenPool.
 		//		   If config is not provided in the input, it skips this step.
-		if reflect.DeepEqual(
-			cfg.ConfigurePools,
-			ConfigureTokenPoolContractsConfig{},
-		) {
+		if len(cfg.ConfigurePools.PoolUpdates) == 0 {
 			e.Logger.Infow("only deployment done, the pools haven't been configured")
 			continue
 		}

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -383,7 +383,6 @@ func addTokenE2ELogic(env cldf.Environment, config AddTokensE2EConfig) (cldf.Cha
 					if err := cldf.MergeChangesetOutput(e, finalCSOut, transferOwnershipProposalOutput); err != nil {
 						return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output after transferring ownership of pool(s): %w", err)
 					}
-
 				}
 			}
 		}

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
@@ -32,11 +32,10 @@ func TestAddTokenE2E(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		externalAdmin    bool
-		withMCMS         bool
-		withNewToken     bool
-		withExistingPool bool
+		name          string
+		externalAdmin bool
+		withMCMS      bool
+		withNewToken  bool
 	}{
 		{
 			name:          "e2e token configuration with external admin",
@@ -57,18 +56,6 @@ func TestAddTokenE2E(t *testing.T) {
 			name:          "e2e token configuration with external token admin registry without MCMS",
 			externalAdmin: false,
 			withMCMS:      false,
-		},
-		{
-			name:             "e2e token configuration with admin as token admin registry with MCMS with existing token pool",
-			externalAdmin:    false,
-			withMCMS:         true,
-			withExistingPool: true,
-		},
-		{
-			name:             "e2e token configuration with external token admin registry without MCMS with existing token pool",
-			externalAdmin:    false,
-			withMCMS:         false,
-			withExistingPool: true,
 		},
 		{
 			name:          "e2e token configuration with admin as token admin registry with MCMS with new token",
@@ -105,24 +92,7 @@ func TestAddTokenE2E(t *testing.T) {
 			// we deploy the token separately as part of env set up
 			if !test.withNewToken {
 				e, selectorA, selectorB, tokens, timelockContracts = testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), test.withMCMS)
-				if test.withExistingPool {
-					e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
-						selectorA: {
-							Type:               shared.BurnMintTokenPool,
-							TokenAddress:       tokens[selectorA].Address,
-							LocalTokenDecimals: testhelpers.LocalTokenDecimals,
-						},
-						selectorB: {
-							Type:               shared.BurnMintTokenPool,
-							TokenAddress:       tokens[selectorB].Address,
-							LocalTokenDecimals: testhelpers.LocalTokenDecimals,
-						},
-					}, test.withMCMS)
-				}
 			} else {
-				if test.withExistingPool {
-					t.Fatalf("New token cannot be deployed with existing pool")
-				}
 				// we deploy the token as part of AddTokenE2E changeset
 				tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithPrerequisiteDeploymentOnly(nil))
 				e = tenv.Env
@@ -192,7 +162,7 @@ func TestAddTokenE2E(t *testing.T) {
 				poolConfig := addTokenE2EConfig.Tokens[testhelpers.TestTokenSymbol].PoolConfig
 				var deployPoolConfig *v1_5_1.DeployTokenPoolInput
 				var deployTokenConfig *v1_5_1.DeployTokenConfig
-				var existingPoolType *cldf.ContractType
+				var _ *cldf.ContractType
 				if test.withNewToken {
 					deployTokenConfig = &v1_5_1.DeployTokenConfig{
 						TokenName:     string(testhelpers.TestTokenSymbol),
@@ -205,24 +175,19 @@ func TestAddTokenE2E(t *testing.T) {
 							recipientAddress: topupAmount,
 						},
 					}
-				} else if !test.withExistingPool {
+				} else {
 					token := tokens[chain]
 					deployPoolConfig = &v1_5_1.DeployTokenPoolInput{
 						Type:               shared.BurnMintTokenPool,
 						TokenAddress:       token.Address,
 						LocalTokenDecimals: testhelpers.LocalTokenDecimals,
 					}
-				} else {
-					tv := shared.BurnMintTokenPool
-					existingPoolType = &tv
 				}
 				poolConfig[chain] = v1_5_1.E2ETokenAndPoolConfig{
 					TokenDeploymentConfig: deployTokenConfig,
 					DeployPoolConfig:      deployPoolConfig,
 					PoolVersion:           deployment.Version1_5_1,
 					ExternalAdmin:         externalAdmin,
-					RateLimiterConfig:     rateLimiterPerChain,
-					ExistingPoolType:      existingPoolType,
 				}
 			}
 
@@ -280,42 +245,27 @@ func TestAddTokenE2E(t *testing.T) {
 					remotePoolAddr = poolOnSelectorA.Address()
 					registry = registryOnB
 				}
-				if test.withExistingPool && test.withMCMS {
-					// check token pool is configured
-					validateMemberOfTokenPoolPair(
-						t,
-						state,
-						tokenPoolC,
-						[]common.Address{remotePoolAddr},
-						tokens,
-						testhelpers.TestTokenSymbol,
-						chain,
-						rateLimiterConfig.Inbound.Rate, // inbound & outbound are the same in this test
-						rateLimiterConfig.Inbound.Capacity,
-						state.Chains[chain].Timelock.Address(), // the pools are owned by the timelock
-					)
-				} else {
-					var poolOwner common.Address
-					if test.withMCMS {
-						poolOwner = state.Chains[chain].Timelock.Address()
-					} else {
-						poolOwner = e.Chains[chain].DeployerKey.From
-					}
 
-					// check token pool is configured
-					validateMemberOfTokenPoolPair(
-						t,
-						state,
-						tokenPoolC,
-						[]common.Address{remotePoolAddr},
-						tokens,
-						testhelpers.TestTokenSymbol,
-						chain,
-						rateLimiterConfig.Inbound.Rate, // inbound & outbound are the same in this test
-						rateLimiterConfig.Inbound.Capacity,
-						poolOwner, // the pools are owned by timelock now if mcms is enabled
-					)
+				var poolOwner common.Address
+				if test.withMCMS {
+					poolOwner = state.Chains[chain].Timelock.Address()
+				} else {
+					poolOwner = e.Chains[chain].DeployerKey.From
 				}
+
+				// check token pool is configured
+				validateMemberOfTokenPoolPair(
+					t,
+					state,
+					tokenPoolC,
+					[]common.Address{remotePoolAddr},
+					tokens,
+					testhelpers.TestTokenSymbol,
+					chain,
+					rateLimiterConfig.Inbound.Rate, // inbound & outbound are the same in this test
+					rateLimiterConfig.Inbound.Capacity,
+					poolOwner, // the pools are owned by timelock now if mcms is enabled
+				)
 
 				/*
 					This behavior is not currently enabled

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
@@ -225,6 +225,7 @@ func TestAddTokenE2E(t *testing.T) {
 					ExistingPoolType:      existingPoolType,
 				}
 			}
+
 			// apply the changeset
 			e, err = commonchangeset.Apply(t, e, timelockContracts,
 				commonchangeset.Configure(v1_5_1.AddTokensE2E, addTokenE2EConfig))
@@ -294,6 +295,13 @@ func TestAddTokenE2E(t *testing.T) {
 						state.Chains[chain].Timelock.Address(), // the pools are owned by the timelock
 					)
 				} else {
+					var poolOwner common.Address
+					if test.withMCMS {
+						poolOwner = state.Chains[chain].Timelock.Address()
+					} else {
+						poolOwner = e.Chains[chain].DeployerKey.From
+					}
+
 					// check token pool is configured
 					validateMemberOfTokenPoolPair(
 						t,
@@ -305,7 +313,7 @@ func TestAddTokenE2E(t *testing.T) {
 						chain,
 						rateLimiterConfig.Inbound.Rate, // inbound & outbound are the same in this test
 						rateLimiterConfig.Inbound.Capacity,
-						e.Chains[chain].DeployerKey.From, // the pools are still owned by the deployer
+						poolOwner, // the pools are owned by timelock now if mcms is enabled
 					)
 				}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
@@ -238,7 +238,7 @@ type ConfigureTokenPoolContractsConfig struct {
 
 func (c ConfigureTokenPoolContractsConfig) Validate(env cldf.Environment) error {
 	if c.TokenSymbol == "" {
-		return errors.New("token symbol must be defined")
+		return errors.New("token symbol must be defined SISHIR")
 	}
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {

--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools.go
@@ -238,7 +238,7 @@ type ConfigureTokenPoolContractsConfig struct {
 
 func (c ConfigureTokenPoolContractsConfig) Validate(env cldf.Environment) error {
 	if c.TokenSymbol == "" {
-		return errors.New("token symbol must be defined SISHIR")
+		return errors.New("token symbol must be defined")
 	}
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc677_helper"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/don_id_claimer"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/factory_burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/log_message_data_receiver"
@@ -93,6 +94,7 @@ type CCIPChainState struct {
 	FactoryBurnMintERC20Token  *factory_burn_mint_erc20.FactoryBurnMintERC20
 	ERC677Tokens               map[shared.TokenSymbol]*erc677.ERC677
 	BurnMintTokens677          map[shared.TokenSymbol]*burn_mint_erc677.BurnMintERC677
+	BurnMintTokens677Helper    map[shared.TokenSymbol]*burn_mint_erc677_helper.BurnMintERC677Helper
 	BurnMintTokenPools         map[shared.TokenSymbol]map[semver.Version]*burn_mint_token_pool.BurnMintTokenPool
 	BurnWithFromMintTokenPools map[shared.TokenSymbol]map[semver.Version]*burn_with_from_mint_token_pool.BurnWithFromMintTokenPool
 	BurnFromMintTokenPools     map[shared.TokenSymbol]map[semver.Version]*burn_from_mint_token_pool.BurnFromMintTokenPool

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -1059,7 +1059,7 @@ func LoadChainState(ctx context.Context, chain cldf.Chain, addresses map[string]
 				return state, fmt.Errorf("failed to get token symbol of token at %s: %w", address, err)
 			}
 			state.BurnMintTokens677Helper[ccipshared.TokenSymbol(symbol)] = ERC677HelperToken
-			state.ABIByAddress[address] = burn_mint_erc677_helper.BurnMintERC677HelperAB
+			state.ABIByAddress[address] = burn_mint_erc677_helper.BurnMintERC677HelperABI
 		default:
 			// ManyChainMultiSig 1.0.0 can have any of these labels, it can have either 1,2 or 3 of these -
 			// bypasser, proposer and canceller

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -64,6 +64,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc677_helper"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/don_id_claimer"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/maybe_revert_message_receiver"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_0_0/rmn_proxy_contract"
@@ -1044,6 +1045,21 @@ func LoadChainState(ctx context.Context, chain cldf.Chain, addresses map[string]
 			}
 			state.DonIDClaimer = donIDClaimer
 			state.ABIByAddress[address] = don_id_claimer.DonIDClaimerABI
+		case cldf.NewTypeAndVersion(ccipshared.ERC677TokenHelper, deployment.Version1_0_0).String():
+			ERC677HelperToken, err := burn_mint_erc677_helper.NewBurnMintERC677Helper(common.HexToAddress(address), chain.Client)
+			if err != nil {
+				return state, err
+			}
+
+			if state.BurnMintTokens677Helper == nil {
+				state.BurnMintTokens677Helper = make(map[ccipshared.TokenSymbol]*burn_mint_erc677_helper.BurnMintERC677Helper)
+			}
+			symbol, err := ERC677HelperToken.Symbol(nil)
+			if err != nil {
+				return state, fmt.Errorf("failed to get token symbol of token at %s: %w", address, err)
+			}
+			state.BurnMintTokens677Helper[ccipshared.TokenSymbol(symbol)] = ERC677HelperToken
+			state.ABIByAddress[address] = burn_mint_erc677_helper.BurnMintERC677HelperAB
 		default:
 			// ManyChainMultiSig 1.0.0 can have any of these labels, it can have either 1,2 or 3 of these -
 			// bypasser, proposer and canceller

--- a/deployment/ccip/shared/token_pools.go
+++ b/deployment/ccip/shared/token_pools.go
@@ -19,9 +19,10 @@ import (
 var CurrentTokenPoolVersion = deployment.Version1_5_1
 
 var TokenTypes = map[cldf.ContractType]struct{}{
-	BurnMintToken: {},
-	ERC20Token:    {},
-	ERC677Token:   {},
+	BurnMintToken:     {},
+	ERC20Token:        {},
+	ERC677Token:       {},
+	ERC677TokenHelper: {},
 }
 
 var TokenPoolTypes = map[cldf.ContractType]struct{}{

--- a/deployment/ccip/shared/types.go
+++ b/deployment/ccip/shared/types.go
@@ -41,6 +41,7 @@ var (
 	FactoryBurnMintERC20Token      deployment.ContractType = "FactoryBurnMintERC20Token"
 	ERC20Token                     deployment.ContractType = "ERC20Token"
 	ERC677Token                    deployment.ContractType = "ERC677Token"
+	ERC677TokenHelper              deployment.ContractType = "ERC677TokenHelper"
 	BurnMintTokenPool              deployment.ContractType = "BurnMintTokenPool"
 	BurnWithFromMintTokenPool      deployment.ContractType = "BurnWithFromMintTokenPool"
 	BurnFromMintTokenPool          deployment.ContractType = "BurnFromMintTokenPool"


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
Current cs_add_token_e2e handles deployment and configuration for new chains but doesnot take into account token pool config with an existing chain. In this PR, instead of internally creating ConfigureTokenPoolContractsConfig we let the use input what chains they want their newly deployed tokenPool to be configured with

Can be used for following;

- Deploy Token AND/OR Deploy Pool
- Deploy Pool + configure tokenAdminRegistry (proposeAdmin, setPool, AcceptRole)
- Deploy Pool + configure TokenAdminRegistry + configure Pool
- Cannot run configurePool separately. There is already a changeset to run this seperately
- Configure new tokenPool with existing TokenPool

Verbose changeset example in this doc(https://docs.google.com/document/d/1GTiPspyhCTVv_x0NJgkJ9i1lzCngiFTdeMRYD0VMQgE/edit?tab=t.0) 

Sample example below;

Current input deploys CCIPBnM token, BnM Token Pool on ArbSep and connects it with existing EthSep TokenPoool

	registry.Add("0014_token_pool_setup_configure_arb_sep", migrations.Configure(v1_5_1.AddTokensE2E).
		With(v1_5_1.AddTokensE2EConfig{
			Tokens: map[changeset.TokenSymbol]v1_5_1.AddTokenE2EConfig{
				ccipchangeset.CCIPBnMSymbol: {
					PoolConfig: map[uint64]v1_5_1.E2ETokenAndPoolConfig{
						chainsel.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector: {
							TokenDeploymentConfig: &v1_5_1.DeployTokenConfig{
								TokenName:     string(ccipchangeset.CCIPBnMSymbol),
								TokenSymbol:   ccipchangeset.CCIPBnMSymbol,
								TokenDecimals: ccipchangeset.LinkDecimals,
								Type:          changeset.ERC677TokenHelper,
								PoolType:      changeset.BurnMintTokenPool,
							},
							PoolVersion: deployment.Version1_5_1, 
						},
					},
					IsTestRouter: false,

					ConfigurePools: v1_5_1.ConfigureTokenPoolContractsConfig{
						TokenSymbol: ccipchangeset.CCIPBnMSymbol,
						PoolUpdates: map[uint64]v1_5_1.TokenPoolConfig{
							chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector: {
								ChainUpdates: map[uint64]v1_5_1.RateLimiterConfig{
									chainsel.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector: shared.DefaultRateLimiterConfigForTestTokens,
								},
								Type:                    ccipchangeset.BurnMintTokenPool,
								Version:                 deployment.Version1_5_1,
								SkipOwnershipValidation: true,
							},
							chainsel.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector: {
								ChainUpdates: map[uint64]v1_5_1.RateLimiterConfig{
									chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector: shared.DefaultRateLimiterConfigForTestTokens,
								},
								Type:                    ccipchangeset.BurnMintTokenPool,
								Version:                 deployment.Version1_5_1,
								SkipOwnershipValidation: true,
							},
						},
						MCMS: &McmsConfigForCS,
					},
				},
			},
			MCMS: &McmsConfigForCS,
		}))
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
