### PR TITLE
chore: removes remaining usages of legacy proposal

### DIFF
--- a/deployment/.golangci.yml
+++ b/deployment/.golangci.yml
@@ -140,6 +140,8 @@ linters-settings:
             desc: Use github.com/jmoiron/sqlx directly instead
           - pkg: github.com/smartcontractkit/chainlink-integrations/evm
             desc: Use github.com/smartcontractkit/chainlink-evm instead
+          - pkg: github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal
+            desc: Use github.com/smartcontractkit/mcms instead
   loggercheck:
     # Check that *w logging functions have even number of args (i.e., well formed key-value pairs).
     rules:
@@ -192,7 +194,7 @@ issues:
       text: "^confusing-naming:"
       linters:
         - revive
-    # ignore false positive by revive on function names for BaseDataStore interface implementations 
+    # ignore false positive by revive on function names for BaseDataStore interface implementations
     - path: datastore/memory_datastore.go
       text: "^confusing-naming:"
       linters:

--- a/deployment/ccip/changeset/v1_6/cs_ccip_home.go
+++ b/deployment/ccip/changeset/v1_6/cs_ccip_home.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"golang.org/x/exp/maps"
 
@@ -1516,7 +1515,6 @@ func deployDonIDClaimerChangesetLogic(e cldf.Environment, _ DeployDonIDClaimerCo
 		}, fmt.Errorf("failed to deploy donIDClaimer contract: %w", err)
 	}
 	return cldf.ChangesetOutput{
-		Proposals:   []timelock.MCMSWithTimelockProposal{},
 		AddressBook: ab,
 	}, nil
 }

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -106,27 +106,7 @@ func ApplyChangesets(t *testing.T, e cldf.Environment, timelockContractsPerChain
 		if out.Jobs != nil {
 			// do nothing, as these jobs auto-accept.
 		}
-		if out.Proposals != nil {
-			for _, prop := range out.Proposals {
-				chains := mapset.NewSet[uint64]()
-				for _, op := range prop.Transactions {
-					chains.Add(uint64(op.ChainIdentifier))
-				}
 
-				signed := proposalutils.SignProposal(t, e, &prop)
-				for _, sel := range chains.ToSlice() {
-					timelockContracts, ok := timelockContractsPerChain[sel]
-					if !ok || timelockContracts == nil {
-						return cldf.Environment{}, fmt.Errorf("timelock contracts not found for chain %d", sel)
-					}
-
-					err := proposalutils.ExecuteProposal(t, e, signed, timelockContracts, sel) //nolint:staticcheck //SA1019 ignoring deprecated function for compatibility; we don't have tools to generate the new field
-					if err != nil {
-						return e, fmt.Errorf("failed to execute proposal: %w", err)
-					}
-				}
-			}
-		}
 		if out.MCMSTimelockProposals != nil {
 			for _, prop := range out.MCMSTimelockProposals {
 				mcmProp := proposalutils.SignMCMSTimelockProposal(t, e, &prop)

--- a/deployment/keystone/changeset/add_capabilities_test.go
+++ b/deployment/keystone/changeset/add_capabilities_test.go
@@ -43,7 +43,7 @@ func TestAddCapabilities(t *testing.T) {
 			RegistryRef:      te.CapabilityRegistryAddressRef(),
 		})
 		require.NoError(t, err)
-		require.Empty(t, csOut.Proposals)
+		require.Empty(t, csOut.MCMSTimelockProposals)
 		require.Nil(t, csOut.AddressBook)
 		assertCapabilitiesExist(t, te.CapabilitiesRegistry(), capabilitiesToAdd...)
 	})

--- a/deployment/keystone/changeset/deploy_forwarder_test.go
+++ b/deployment/keystone/changeset/deploy_forwarder_test.go
@@ -150,7 +150,7 @@ func TestConfigureForwarders(t *testing.T) {
 				csOut, err := changeset.ConfigureForwardContracts(te.Env, cfg)
 				require.NoError(t, err)
 				require.Nil(t, csOut.AddressBook)
-				require.Empty(t, csOut.Proposals)
+				require.Empty(t, csOut.MCMSTimelockProposals)
 				// check that forwarder
 				// TODO set up a listener to check that the forwarder is configured
 				forwardersByChain := te.OwnedForwarders()

--- a/deployment/keystone/changeset/update_nodes_test.go
+++ b/deployment/keystone/changeset/update_nodes_test.go
@@ -46,7 +46,7 @@ func TestUpdateNodes(t *testing.T) {
 
 		csOut, err := changeset.UpdateNodes(te.Env, &cfg)
 		require.NoError(t, err)
-		require.Empty(t, csOut.Proposals)
+		require.Empty(t, csOut.MCMSTimelockProposals)
 		require.Nil(t, csOut.AddressBook)
 
 		validateUpdate(t, te, updates)


### PR DESCRIPTION
This PR removes legacy references to the `ccip-owner-contracts` proposal and timelock code in favor of using the new MCMS-based implementations. It deletes deprecated code, cleans up imports, and updates test helpers and assertions to use MCMS timelock proposal structures and utilities. Additionally, it adds a linter rule to enforce the use of MCMS instead of the `ccip-owner-contracts` proposal package.