### PR TITLE
[CLD-272]: fix: bump CLDF package to v0.3.0

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250515091132-6c08936b29ab
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250519161208-80bc8b13c0e7
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
-	github.com/smartcontractkit/chainlink-deployments-framework v0.1.2
+	github.com/smartcontractkit/chainlink-deployments-framework v0.3.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4
 	github.com/smartcontractkit/libocr v0.0.0-20250513175559-61c382d6cee4

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1271,8 +1271,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2 h1:7zY0q1BjqCy6WJg/15m6gzkOt53IqkRgGSDoZnkZPmE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2/go.mod h1:UJpNSm264TN0OoM7LslGvABmrj1CvM3rO+WvzDgeocg=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0 h1:D7G1Pe5BqgJzhjwtOIjfYOZGSgSY374gxvNOzi8AzDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0/go.mod h1:7mUnJOht1vrPgpPNfe5IfalsYbxUsNJpjcGNw4ky5/s=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb h1:AZkVeFqO9QQJzRTw1ikZTVLxSUeR+p0CVUl0+WVKcVA=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb/go.mod h1:o1jMnrmYa2HwGGxh0DrjhUzipJPuvkrbr2HU1OoLioc=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250515091132-6c08936b29ab
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250519161208-80bc8b13c0e7
-	github.com/smartcontractkit/chainlink-deployments-framework v0.1.2
+	github.com/smartcontractkit/chainlink-deployments-framework v0.3.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250514200342-5169fbe9e28d
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1249,8 +1249,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2 h1:7zY0q1BjqCy6WJg/15m6gzkOt53IqkRgGSDoZnkZPmE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2/go.mod h1:UJpNSm264TN0OoM7LslGvABmrj1CvM3rO+WvzDgeocg=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0 h1:D7G1Pe5BqgJzhjwtOIjfYOZGSgSY374gxvNOzi8AzDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0/go.mod h1:7mUnJOht1vrPgpPNfe5IfalsYbxUsNJpjcGNw4ky5/s=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb h1:AZkVeFqO9QQJzRTw1ikZTVLxSUeR+p0CVUl0+WVKcVA=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb/go.mod h1:o1jMnrmYa2HwGGxh0DrjhUzipJPuvkrbr2HU1OoLioc=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250515091132-6c08936b29ab
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250519161208-80bc8b13c0e7
-	github.com/smartcontractkit/chainlink-deployments-framework v0.1.2
+	github.com/smartcontractkit/chainlink-deployments-framework v0.3.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1480,8 +1480,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2 h1:7zY0q1BjqCy6WJg/15m6gzkOt53IqkRgGSDoZnkZPmE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2/go.mod h1:UJpNSm264TN0OoM7LslGvABmrj1CvM3rO+WvzDgeocg=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0 h1:D7G1Pe5BqgJzhjwtOIjfYOZGSgSY374gxvNOzi8AzDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0/go.mod h1:7mUnJOht1vrPgpPNfe5IfalsYbxUsNJpjcGNw4ky5/s=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb h1:AZkVeFqO9QQJzRTw1ikZTVLxSUeR+p0CVUl0+WVKcVA=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb/go.mod h1:o1jMnrmYa2HwGGxh0DrjhUzipJPuvkrbr2HU1OoLioc=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250515091132-6c08936b29ab
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250519161208-80bc8b13c0e7
-	github.com/smartcontractkit/chainlink-deployments-framework v0.1.2
+	github.com/smartcontractkit/chainlink-deployments-framework v0.3.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1462,8 +1462,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2 h1:7zY0q1BjqCy6WJg/15m6gzkOt53IqkRgGSDoZnkZPmE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2/go.mod h1:UJpNSm264TN0OoM7LslGvABmrj1CvM3rO+WvzDgeocg=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0 h1:D7G1Pe5BqgJzhjwtOIjfYOZGSgSY374gxvNOzi8AzDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0/go.mod h1:7mUnJOht1vrPgpPNfe5IfalsYbxUsNJpjcGNw4ky5/s=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb h1:AZkVeFqO9QQJzRTw1ikZTVLxSUeR+p0CVUl0+WVKcVA=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb/go.mod h1:o1jMnrmYa2HwGGxh0DrjhUzipJPuvkrbr2HU1OoLioc=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/smartcontractkit/chain-selectors v1.0.57
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250519161208-80bc8b13c0e7
-	github.com/smartcontractkit/chainlink-deployments-framework v0.1.2
+	github.com/smartcontractkit/chainlink-deployments-framework v0.3.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1236,8 +1236,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2 h1:7zY0q1BjqCy6WJg/15m6gzkOt53IqkRgGSDoZnkZPmE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2/go.mod h1:UJpNSm264TN0OoM7LslGvABmrj1CvM3rO+WvzDgeocg=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0 h1:D7G1Pe5BqgJzhjwtOIjfYOZGSgSY374gxvNOzi8AzDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0/go.mod h1:7mUnJOht1vrPgpPNfe5IfalsYbxUsNJpjcGNw4ky5/s=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb h1:AZkVeFqO9QQJzRTw1ikZTVLxSUeR+p0CVUl0+WVKcVA=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb/go.mod h1:o1jMnrmYa2HwGGxh0DrjhUzipJPuvkrbr2HU1OoLioc=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250519161208-80bc8b13c0e7
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
-	github.com/smartcontractkit/chainlink-deployments-framework v0.1.2
+	github.com/smartcontractkit/chainlink-deployments-framework v0.3.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1436,8 +1436,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2 h1:7zY0q1BjqCy6WJg/15m6gzkOt53IqkRgGSDoZnkZPmE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.1.2/go.mod h1:UJpNSm264TN0OoM7LslGvABmrj1CvM3rO+WvzDgeocg=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0 h1:D7G1Pe5BqgJzhjwtOIjfYOZGSgSY374gxvNOzi8AzDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.3.0/go.mod h1:7mUnJOht1vrPgpPNfe5IfalsYbxUsNJpjcGNw4ky5/s=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb h1:AZkVeFqO9QQJzRTw1ikZTVLxSUeR+p0CVUl0+WVKcVA=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250515125821-cae192cd18bb/go.mod h1:o1jMnrmYa2HwGGxh0DrjhUzipJPuvkrbr2HU1OoLioc=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=


### PR DESCRIPTION
This is to bring in the latest [changes](https://github.com/smartcontractkit/chainlink-deployments-framework/pull/95) to support concurrency for operations API

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-272
