### PR TITLE
Potential fix for code scanning alert no. 211: Potentially unsafe quoting

### DIFF
--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"text/template"
+	"strconv"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -234,14 +235,10 @@ func (params CCIPJobSpecParams) CommitJobSpec() (*OCR2TaskJobSpec, error) {
 		"offRamp": fmt.Sprintf(`"%s"`, params.OffRamp.Hex()),
 	}
 	if params.TokenPricesUSDPipeline != "" {
-		pluginConfig["tokenPricesUSDPipeline"] = fmt.Sprintf(`"""
-%s
-"""`, params.TokenPricesUSDPipeline)
+		pluginConfig["tokenPricesUSDPipeline"] = strconv.Quote(params.TokenPricesUSDPipeline)
 	}
 	if params.PriceGetterConfig != "" {
-		pluginConfig["priceGetterConfig"] = fmt.Sprintf(`"""
-%s
-"""`, params.PriceGetterConfig)
+		pluginConfig["priceGetterConfig"] = strconv.Quote(params.PriceGetterConfig)
 	}
 
 	ocrSpec := job.OCR2OracleSpec{


### PR DESCRIPTION
Potential fix for [https://github.com/smartcontractkit/chainlink/security/code-scanning/211](https://github.com/smartcontractkit/chainlink/security/code-scanning/211)

To fix the issue, we need to ensure that any user-provided data embedded into strings is properly sanitized or escaped. In this case, we can use `strconv.Quote` to escape the values of `params.TokenPricesUSDPipeline` and `params.PriceGetterConfig`. This function ensures that any special characters, including quotes, are properly escaped, making the resulting string safe for embedding.

The changes will be made in the `CommitJobSpec` function in the file `core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go`. Specifically:
1. Replace the use of `fmt.Sprintf` for `params.TokenPricesUSDPipeline` and `params.PriceGetterConfig` with `strconv.Quote`.
2. Ensure that the resulting strings are correctly formatted for the JSON structure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
