### PR TITLE
feat: self-hosted runners for PR built images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       build-type: ${{ steps.build-type.outputs.build-type }}
+      runner-arm64: ${{ steps.runner-labels.outputs.runner-arm64 }}
+      runner-amd64: ${{ steps.runner-labels.outputs.runner-amd64 }}
     steps:
       - name: Set Build Type
         id: build-type
@@ -41,6 +43,22 @@ jobs:
           else
             echo "::error::Unsupported build trigger: ${BUILD_TRIGGER}"
             exit 1
+          fi
+      - name: Set runner labels
+        id: runner-labels
+        shell: bash
+        env:
+          SH_RUNNER_LABEL_ARM64: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c7g/disk=large/image=ubuntu24-full-arm64
+          SH_RUNNER_LABEL_AMD64: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c7a/disk=large/image=ubuntu24-full-amd64
+          GH_RUNNER_LABEL_ARM64: ubuntu24.04-arm
+          GH_RUNNER_LABEL_AMD64: ubuntu24.04
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "runner-arm64=${SH_RUNNER_LABEL_ARM64}" | tee -a "$GITHUB_OUTPUT"
+            echo "runner-amd64=${SH_RUNNER_LABEL_AMD64}" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "runner-arm64=${GH_RUNNER_LABEL_ARM64}" | tee -a "$GITHUB_OUTPUT"
+            echo "runner-amd64=${GH_RUNNER_LABEL_AMD64}" | tee -a "$GITHUB_OUTPUT"
           fi
 
   docker-core:
@@ -66,6 +84,8 @@ jobs:
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-workflow-repository: ${{ github.repository }}
+      github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
+      github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
@@ -96,6 +116,8 @@ jobs:
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-workflow-repository: ${{ github.repository }}
+      github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
+      github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
@@ -126,6 +148,8 @@ jobs:
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-workflow-repository: ${{ github.repository }}
+      github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
+      github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
@@ -156,6 +180,8 @@ jobs:
       github-event-name: ${{ github.event_name }}
       github-ref-name: ${{ github.ref_name }}
       github-workflow-repository: ${{ github.repository }}
+      github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
+      github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
       AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,6 +22,12 @@ jobs:
   init:
     runs-on: ubuntu-24.04
     outputs:
+      should-run: >-
+        ${{
+          steps.pr-labels.outputs.check-label-found == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch'
+        }}
       build-type: ${{ steps.build-type.outputs.build-type }}
       runner-arm64: ${{ steps.runner-labels.outputs.runner-arm64 }}
       runner-amd64: ${{ steps.runner-labels.outputs.runner-amd64 }}
@@ -44,6 +50,14 @@ jobs:
             echo "::error::Unsupported build trigger: ${BUILD_TRIGGER}"
             exit 1
           fi
+
+      - name: Get PR Labels
+        id: pr-labels
+        uses: smartcontractkit/.github/actions/get-pr-labels@get-pr-labels/v1
+        with:
+          check-label: "build-publish"
+          skip-merge-group: "true"
+
       - name: Set runner labels
         id: runner-labels
         shell: bash
@@ -57,12 +71,14 @@ jobs:
             echo "runner-arm64=${SH_RUNNER_LABEL_ARM64}" | tee -a "$GITHUB_OUTPUT"
             echo "runner-amd64=${SH_RUNNER_LABEL_AMD64}" | tee -a "$GITHUB_OUTPUT"
           else
+            # Use GitHub runner labels for non-PR events
             echo "runner-arm64=${GH_RUNNER_LABEL_ARM64}" | tee -a "$GITHUB_OUTPUT"
             echo "runner-amd64=${GH_RUNNER_LABEL_AMD64}" | tee -a "$GITHUB_OUTPUT"
           fi
 
   docker-core:
     needs: [init]
+    if: ${{ needs.init.outputs.should-run }}
     permissions:
       contents: read
       id-token: write
@@ -92,6 +108,7 @@ jobs:
 
   docker-core-plugins:
     needs: [init]
+    if: ${{ needs.init.outputs.should-run }}
     permissions:
       contents: read
       id-token: write
@@ -126,6 +143,7 @@ jobs:
 
   docker-ccip:
     needs: [init]
+    if: ${{ needs.init.outputs.should-run }}
     permissions:
       contents: read
       id-token: write
@@ -156,6 +174,7 @@ jobs:
 
   docker-ccip-plugins:
     needs: [init]
+    if: ${{ needs.init.outputs.should-run }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,6 +22,9 @@ jobs:
   init:
     runs-on: ubuntu-24.04
     outputs:
+      # To get an image from a feature branch, do one of the following:
+      # 1. Use a workflow dispatch
+      # 2. Add the `build-publish` label to your PR, and re-run the workflow (or push a commit)
       should-run: >-
         ${{
           steps.pr-labels.outputs.check-label-found == 'true' ||

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -78,7 +78,7 @@ jobs:
 
   docker-core:
     needs: [init]
-    if: ${{ needs.init.outputs.should-run }}
+    if: ${{ needs.init.outputs.should-run == 'true' }}
     permissions:
       contents: read
       id-token: write
@@ -108,7 +108,7 @@ jobs:
 
   docker-core-plugins:
     needs: [init]
-    if: ${{ needs.init.outputs.should-run }}
+    if: ${{ needs.init.outputs.should-run == 'true' }}
     permissions:
       contents: read
       id-token: write
@@ -143,7 +143,7 @@ jobs:
 
   docker-ccip:
     needs: [init]
-    if: ${{ needs.init.outputs.should-run }}
+    if: ${{ needs.init.outputs.should-run == 'true' }}
     permissions:
       contents: read
       id-token: write
@@ -174,7 +174,7 @@ jobs:
 
   docker-ccip-plugins:
     needs: [init]
-    if: ${{ needs.init.outputs.should-run }}
+    if: ${{ needs.init.outputs.should-run == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         env:
           SH_RUNNER_LABEL_ARM64: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c7g/disk=large/image=ubuntu24-full-arm64
-          SH_RUNNER_LABEL_AMD64: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c7a/disk=large/image=ubuntu24-full-amd64
+          SH_RUNNER_LABEL_AMD64: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c7a/disk=large/image=ubuntu24-full-x64
           GH_RUNNER_LABEL_ARM64: ubuntu24.04-arm
           GH_RUNNER_LABEL_AMD64: ubuntu24.04
         run: |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ regarding Chainlink social accounts, news, and networking.
 
 For the latest information on setting up a development environment, see the [Development Setup Guide](https://github.com/smartcontractkit/chainlink/wiki/Development-Setup-Guide).
 
+### Build from PR
+
+To build an unofficial testing-only image from a feature branch or PR. You can do one of the following:
+1. Send a workflow dispatch event from our [`docker-build` workflow](https://github.com/smartcontractkit/chainlink/actions/workflows/docker-build.yml).
+2. Add the `build-publish` label to your PR and then either retry the `docker-build` workflow, or push a new commit.
+
 ### Build Plugins
 
 Plugins are defined in yaml files within the `plugins/` directory. Each plugin file is a yaml file and has a `plugins.` prefix name. Plugins are installed with [loopinstall](https://github.com/smartcontractkit/chainlink-common/tree/main/pkg/loop/cmd/loopinstall).


### PR DESCRIPTION
### Changes

- Add step to determine if this should be run for PRs (images for PRs are now opt-in)
- Add step to determine which runner label to use

### Motivation

- Decrease CI runtime for PRs

### Testing

- Before label: https://github.com/smartcontractkit/chainlink/actions/runs/15263566867/attempts/1?pr=17843
- After label: https://github.com/smartcontractkit/chainlink/actions/runs/15263566867/attempts/2?pr=17843 (cancelled due to subsequent push)
- Full build: https://github.com/smartcontractkit/chainlink/actions/runs/15263642604/job/42925510066?pr=17843

---

DX-842
