### PR TITLE
Add nil-check when accessing MCMS contracts

### DIFF
--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -90,6 +90,9 @@ func AddCapabilities(env cldf.Environment, req *AddCapabilitiesRequest) (cldf.Ch
 		if ops == nil {
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
+		if cr.McmsContracts == nil {
+			return out, fmt.Errorf("expected capabiity registry contract %s to be owned by MCMS", cr.Contract.Address().String())
+		}
 		timelocksPerChain := map[uint64]string{
 			registryChain.Selector: cr.McmsContracts.Timelock.Address().Hex(),
 		}

--- a/deployment/keystone/changeset/add_dons.go
+++ b/deployment/keystone/changeset/add_dons.go
@@ -177,6 +177,10 @@ func AddDons(env cldf.Environment, req *AddDonsRequest) (cldf.ChangesetOutput, e
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 
+		if capReg.McmsContracts == nil {
+			return out, fmt.Errorf("expected capabiity registry contract %s to be owned by MCMS", capReg.Contract.Address().String())
+		}
+
 		timelocksPerChain := map[uint64]string{
 			req.RegistryChainSel: capReg.McmsContracts.Timelock.Address().Hex(),
 		}

--- a/deployment/keystone/changeset/add_nodes.go
+++ b/deployment/keystone/changeset/add_nodes.go
@@ -221,7 +221,6 @@ func AddNodes(env cldf.Environment, req *AddNodesRequest) (cldf.ChangesetOutput,
 	}
 
 	capReg, err := loadCapabilityRegistry(env.Chains[req.RegistryChainSel], env, req.RegistryRef)
-
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load capability registry sets: %w", err)
 	}
@@ -257,6 +256,9 @@ func AddNodes(env cldf.Environment, req *AddNodesRequest) (cldf.ChangesetOutput,
 	if useMCMS {
 		if resp.Ops == nil || len(resp.Ops.Transactions) == 0 {
 			return out, errors.New("expected MCMS operation to be non-nil")
+		}
+		if capReg.McmsContracts == nil {
+			return out, fmt.Errorf("expected capabiity registry contract %s to be owned by MCMS", capReg.Contract.Address().String())
 		}
 		timelocksPerChain := map[uint64]string{
 			registryChain.Selector: capReg.McmsContracts.Timelock.Address().Hex(),

--- a/deployment/keystone/changeset/add_nops.go
+++ b/deployment/keystone/changeset/add_nops.go
@@ -75,6 +75,9 @@ func AddNops(env cldf.Environment, req *AddNopsRequest) (cldf.ChangesetOutput, e
 		if resp.Ops == nil {
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
+		if capReg.McmsContracts == nil {
+			return out, fmt.Errorf("expected capabiity registry contract %s to be owned by MCMS", capReg.Contract.Address().String())
+		}
 		timelocksPerChain := map[uint64]string{
 			registryChain.Selector: capReg.McmsContracts.Timelock.Address().Hex(),
 		}

--- a/deployment/keystone/changeset/append_node_capabilities.go
+++ b/deployment/keystone/changeset/append_node_capabilities.go
@@ -38,6 +38,9 @@ func AppendNodeCapabilities(env cldf.Environment, req *AppendNodeCapabilitiesReq
 		if r.Ops == nil {
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
+		if capReg.McmsContracts == nil {
+			return out, fmt.Errorf("expected capabiity registry contract %s to be owned by MCMS", capReg.Contract.Address().String())
+		}
 		timelocksPerChain := map[uint64]string{
 			c.Chain.Selector: capReg.McmsContracts.Timelock.Address().Hex(),
 		}

--- a/deployment/keystone/changeset/deploy_ocr3.go
+++ b/deployment/keystone/changeset/deploy_ocr3.go
@@ -94,6 +94,10 @@ func ConfigureOCR3Contract(env cldf.Environment, cfg ConfigureOCR3Config) (cldf.
 			return out, fmt.Errorf("failed to get OCR3 contract: %w", err)
 		}
 
+		if contract.McmsContracts == nil {
+			return out, fmt.Errorf("expected OCR3 capabilty contract %s to be owned by MCMS", contract.Contract.Address().String())
+		}
+
 		timelocksPerChain := map[uint64]string{
 			cfg.ChainSel: contract.McmsContracts.Timelock.Address().Hex(),
 		}

--- a/deployment/keystone/changeset/remove_dons.go
+++ b/deployment/keystone/changeset/remove_dons.go
@@ -83,6 +83,10 @@ func RemoveDONs(env cldf.Environment, req *RemoveDONsRequest) (cldf.ChangesetOut
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 
+		if capReg.McmsContracts == nil {
+			return out, fmt.Errorf("expected capabiity registry contract %s to be owned by MCMS", capReg.Contract.Address().String())
+		}
+
 		timelocksPerChain := map[uint64]string{
 			req.RegistryChainSel: capReg.McmsContracts.Timelock.Address().Hex(),
 		}

--- a/deployment/keystone/changeset/update_node_capabilities.go
+++ b/deployment/keystone/changeset/update_node_capabilities.go
@@ -125,6 +125,9 @@ func UpdateNodeCapabilities(env cldf.Environment, req *UpdateNodeCapabilitiesReq
 		if r.Ops == nil {
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
+		if capReg.McmsContracts == nil {
+			return out, fmt.Errorf("expected capabiity registry contract %s to be owned by MCMS", capReg.Contract.Address().String())
+		}
 		timelocksPerChain := map[uint64]string{
 			c.Chain.Selector: capReg.McmsContracts.Timelock.Address().Hex(),
 		}

--- a/deployment/keystone/changeset/update_nodes.go
+++ b/deployment/keystone/changeset/update_nodes.go
@@ -93,6 +93,9 @@ func UpdateNodes(env cldf.Environment, req *UpdateNodesRequest) (cldf.ChangesetO
 		if resp.Ops == nil {
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
+		if capReg.McmsContracts == nil {
+			return out, fmt.Errorf("expected capabiity registry contract %s to be owned by MCMS", capReg.Contract.Address().String())
+		}
 		timelocksPerChain := map[uint64]string{
 			req.RegistryChainSel: capReg.McmsContracts.Timelock.Address().Hex(),
 		}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This PR addresses [CAPPL-862](https://smartcontract-it.atlassian.net/browse/CAPPL-862). We want to prevent panics when migrations using MCMS are using contracts that are not MCMS owned.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->

- <https://github.com/smartcontractkit/chainlink-deployments/pull/3269>

[CAPPL-862]: https://smartcontract-it.atlassian.net/browse/CAPPL-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ