### PR TITLE
DF propose wf jobs to specific nodes

### DIFF
--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
@@ -192,6 +192,10 @@ func proposeWFJobsToJDPrecondition(env cldf.Environment, c types.ProposeWFJobsCo
 		return errors.New("failed to get data feeds cache address")
 	}
 
+	if c.NodeFilter == nil {
+		return errors.New("missing node filter")
+	}
+
 	return nil
 }
 

--- a/deployment/data-feeds/changeset/types/types.go
+++ b/deployment/data-feeds/changeset/types/types.go
@@ -182,14 +182,14 @@ type ProposeWFJobsConfig struct {
 	InputFS            embed.FS // filesystem to read the feeds json mapping
 	WorkflowJobName    string   // Required
 	WorkflowSpecConfig WorkflowSpecConfig
-	NodeFilter         *offchain.NodesFilter
+	NodeFilter         *offchain.NodesFilter // Required. Node filter to select the nodes to send the jobs to.
 }
 
 type ProposeBtJobsConfig struct {
 	ChainSelector    uint64
 	BootstrapJobName string
 	Contract         string
-	NodeFilter       *offchain.NodesFilter
+	NodeFilter       *offchain.NodesFilter // Node filter to select the nodes to send the jobs to.
 }
 
 type DeleteJobsConfig struct {

--- a/deployment/data-feeds/offchain/jd.go
+++ b/deployment/data-feeds/offchain/jd.go
@@ -77,9 +77,9 @@ func fetchNodesFromJD(ctx context.Context, env cldf.Environment, nodeFilters *No
 	return resp.Nodes, nil
 }
 
-func getNodes(ctx context.Context, env cldf.Environment, nodeIds []string) ([]*nodeapiv1.Node, error) {
-	nodes := make([]*nodeapiv1.Node, 0, len(nodeIds))
-	for _, nodeID := range nodeIds {
+func getNodes(ctx context.Context, env cldf.Environment, nodeIDs []string) ([]*nodeapiv1.Node, error) {
+	nodes := make([]*nodeapiv1.Node, 0, len(nodeIDs))
+	for _, nodeID := range nodeIDs {
 		resp, err := env.Offchain.GetNode(ctx, &nodeapiv1.GetNodeRequest{Id: nodeID})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get node %s: %w", nodeID, err)

--- a/deployment/data-feeds/offchain/jd.go
+++ b/deployment/data-feeds/offchain/jd.go
@@ -17,11 +17,12 @@ import (
 )
 
 type NodesFilter struct {
-	DONID        uint64
+	DONID        uint64 // Required
 	EnvLabel     string
 	ProductLabel string
 	Size         int
 	IsBootstrap  bool
+	NodeIDs      []string // Optional, if other filters are provided
 }
 
 func (f *NodesFilter) filter() *nodeapiv1.ListNodesRequest_Filter {
@@ -76,15 +77,40 @@ func fetchNodesFromJD(ctx context.Context, env cldf.Environment, nodeFilters *No
 	return resp.Nodes, nil
 }
 
+func getNodes(ctx context.Context, env cldf.Environment, nodeIds []string) ([]*nodeapiv1.Node, error) {
+	nodes := make([]*nodeapiv1.Node, 0, len(nodeIds))
+	for _, nodeID := range nodeIds {
+		resp, err := env.Offchain.GetNode(ctx, &nodeapiv1.GetNodeRequest{Id: nodeID})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get node %s: %w", nodeID, err)
+		}
+		nodes = append(nodes, resp.Node)
+	}
+	return nodes, nil
+}
+
 func ProposeJobs(ctx context.Context, env cldf.Environment, workflowJobSpec string, workflowName *string, nodeFilters *NodesFilter) (cldf.ChangesetOutput, error) {
 	out := cldf.ChangesetOutput{
 		Jobs: []cldf.ProposedJob{},
 	}
-	// Fetch nodes
-	nodes, err := fetchNodesFromJD(ctx, env, nodeFilters)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get nodes: %w", err)
+	var nodes []*nodeapiv1.Node
+	var err error
+
+	// Use node IDs if provided
+	if len(nodeFilters.NodeIDs) > 0 {
+		env.Logger.Debugf("nodeIDs provided. Fetching nodes for node IDs %s", nodeFilters.NodeIDs)
+		nodes, err = getNodes(ctx, env, nodeFilters.NodeIDs)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get nodes for ndoe Ids %s: %w", nodeFilters.NodeIDs, err)
+		}
+	} else {
+		// Fetch nodes based on filter
+		nodes, err = fetchNodesFromJD(ctx, env, nodeFilters)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to filter nodes: %w", err)
+		}
 	}
+
 	// Propose jobs
 	jobLabels := []*ptypes.Label{
 		&ptypes.Label{


### PR DESCRIPTION
Modified wf job proposal changeset to accept optional `NodeIDs` in the node filter in which case the jobs will be proposed to only specific nodes. 
Example usage 
```go
NodeFilter: &offchain.NodesFilter{
			DONID:   1,
			NodeIDs: []string{"node_22YUJbV4pQqzn1rFQfnQz", "node_UMAg39q2RLzzu3srhchq1"},
		},
	}))
```
The original logic still works, we can propose jobs by node labels as well 
```go
NodeFilter: &offchain.NodesFilter{
			DONID:        1,
			ProductLabel: "keystone", 
			EnvLabel:     "staging",
			Size:         7,
		},
```
`DONID` is required in either case
