### PR TITLE
feat: add token deployment implementation for EVM and Solana

### DIFF
--- a/deployment/tokens/changesets/deploy_evm_link_tokens.go
+++ b/deployment/tokens/changesets/deploy_evm_link_tokens.go
@@ -1,0 +1,98 @@
+package changesets
+
+import (
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/seqs"
+)
+
+// DeployLinkTokensInput contains the selectors of the chains to which the Link Token contract
+// should be deployed.
+//
+// This input is shared between all changesets that deploy Link Token contracts on a specific
+// chain.
+type DeployLinkTokensInput struct {
+	// Required: ChainSelectors are the chain selectors of the chains to which the Link Token contract
+	// should be deployed.
+	ChainSelectors []uint64
+	// Optional: The Qualifier is a string that will be used to tag the deployed contracts in the datastore
+	// to uniquely identify multiple versions of the same contract on the same chain.
+	//
+	// Default: "" (empty string)
+	Qualifier string
+	// Optional: The Labels are a list of labels that will be used to tag the deployed contracts in the
+	// address book and datastore.
+	//
+	// Default: []string{}
+	Labels []string
+}
+
+// DeployEVMLinkTokens deploys burn/mint Link Token contracts to the specified chains in the
+// DeployLinkTokenInput and adds the addresses to the addressbook and datastore. The qualifiers and
+// labels will be used to tag all deployed contracts in the address book and datastore.
+//
+// This changeset should be used to deploy Link Tokens for all new deployments.
+var DeployEVMLinkTokens cldf.ChangeSetV2[DeployLinkTokensInput] = deployEVMLinkTokens{}
+
+// deployEVMLinkTokens is the implementation of the DeployEVMLinkTokens changeset.
+type deployEVMLinkTokens struct{}
+
+// VerifyPreconditions ensures that all listed chain selectors are valid and available in the
+// environment chains.
+func (deployEVMLinkTokens) VerifyPreconditions(
+	e cldf.Environment, input DeployLinkTokensInput,
+) error {
+	if err := validateNoDupeSelectors(input.ChainSelectors); err != nil {
+		return err
+	}
+
+	if err := validateChainSelectorsFamily(
+		input.ChainSelectors, chain_selectors.FamilyEVM,
+	); err != nil {
+		return err
+	}
+
+	if err := validateNoExistingLinkToken(
+		input.ChainSelectors, input.Qualifier, e.ExistingAddresses, e.DataStore,
+	); err != nil {
+		return err
+	}
+
+	return deployment.ValidateSelectorsInEnvironment(e, input.ChainSelectors)
+}
+
+// Apply executes the SeqDeployEVMTokens sequence to deploy Link Token contracts to the specified
+// chains.
+func (deployEVMLinkTokens) Apply(
+	e cldf.Environment, input DeployLinkTokensInput,
+) (cldf.ChangesetOutput, error) {
+	var (
+		out = cldf.ChangesetOutput{
+			AddressBook: cldf.NewMemoryAddressBook(),
+			DataStore:   datastore.NewMemoryDataStore(),
+		}
+
+		seqDeps = seqs.SeqDeployEVMTokensDeps{
+			EVMChains: e.BlockChains.EVMChains(),
+			AddrBook:  out.AddressBook, //nolint:staticcheck // Will be removed once the address book is no longer required.
+			Datastore: out.DataStore,
+		}
+		seqInput = seqs.SeqDeployEVMTokensInput{
+			ChainSelectors: input.ChainSelectors,
+			Qualifier:      input.Qualifier,
+			Labels:         input.Labels,
+		}
+	)
+
+	seqReport, err := operations.ExecuteSequence(
+		e.OperationsBundle, seqs.SeqDeployEVMTokens, seqDeps, seqInput,
+	)
+
+	out.Reports = seqReport.ExecutionReports
+
+	return out, err
+}

--- a/deployment/tokens/changesets/deploy_evm_link_tokens_test.go
+++ b/deployment/tokens/changesets/deploy_evm_link_tokens_test.go
@@ -1,0 +1,191 @@
+package changesets
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/ops"
+)
+
+func Test_DeployEVMLinkTokens_VerifyPreconditions(t *testing.T) {
+	t.Parallel()
+
+	var (
+		csel    = chain_selectors.TEST_1000.Selector
+		ethAddr = "0xeC91988D7dD84d8adE801b739172ad15c860A700"
+	)
+
+	tests := []struct {
+		name       string
+		beforeFunc func(t *testing.T, e *cldf.Environment)
+		input      DeployLinkTokensInput
+		wantErr    string
+	}{
+		{
+			name: "valid input",
+			beforeFunc: func(t *testing.T, e *cldf.Environment) {
+				e.BlockChains = cldf_chain.NewBlockChainsFromSlice([]cldf_chain.BlockChain{
+					cldf_evm.Chain{
+						Selector: csel,
+					},
+				})
+
+				// Inject empty address book and datastore
+				e.ExistingAddresses = cldf.NewMemoryAddressBook()
+				e.DataStore = datastore.NewMemoryDataStore().Seal()
+			},
+			input: DeployLinkTokensInput{
+				ChainSelectors: []uint64{csel},
+			},
+		},
+		{
+			name: "error: duplicate chain selectors",
+			input: DeployLinkTokensInput{
+				ChainSelectors: []uint64{1, 1},
+			},
+			wantErr: "duplicate chain selector found",
+		},
+		{
+			name: "error: invalid chain selector family",
+			input: DeployLinkTokensInput{
+				ChainSelectors: []uint64{
+					chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector,
+				}, // Uses an invalid Solana chain selector
+			},
+			wantErr: fmt.Sprintf(
+				"chain selector %d is not in the evm family",
+				chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector,
+			),
+		},
+		{
+			name: "error: link token contracts exists in address book",
+			beforeFunc: func(t *testing.T, e *cldf.Environment) {
+				t.Helper()
+
+				e.ExistingAddresses = cldf.NewMemoryAddressBook()
+				err := e.ExistingAddresses.Save(csel, ethAddr, ops.LinkTokenTypeAndVersion1)
+				require.NoError(t, err)
+			},
+			input: DeployLinkTokensInput{
+				ChainSelectors: []uint64{csel},
+			},
+			wantErr: "link token contract already exists for chain selector",
+		},
+		{
+			name: "error: link token contract exists in datastore",
+			beforeFunc: func(t *testing.T, e *cldf.Environment) {
+				t.Helper()
+
+				// Insert the selector with no addresses to pass address book check
+				e.ExistingAddresses = cldf.NewMemoryAddressBookFromMap(
+					map[uint64]map[string]cldf.TypeAndVersion{
+						csel: {},
+					},
+				)
+
+				ds := datastore.NewMemoryDataStore()
+				err := ds.Addresses().Add(datastore.AddressRef{
+					ChainSelector: csel,
+					Address:       "0xeC91988D7dD84d8adE801b739172ad15c860A700",
+					Type:          datastore.ContractType(ops.LinkTokenTypeAndVersion1.Type.String()),
+					Version:       &ops.LinkTokenTypeAndVersion1.Version,
+				})
+				require.NoError(t, err)
+
+				e.DataStore = ds.Seal()
+			},
+			input: DeployLinkTokensInput{
+				ChainSelectors: []uint64{csel},
+			},
+			wantErr: "link token contract already exists for chain selector",
+		},
+		{
+			name: "error: chain selector not found in environment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				cs  = deployEVMLinkTokens{}
+				env = &cldf.Environment{}
+			)
+
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(t, env)
+			}
+
+			err := cs.VerifyPreconditions(*env, tt.input)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_DeployEVMLinkTokens_Apply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		giveFunc func(e cldf.Environment) DeployLinkTokensInput
+	}{
+		{
+			name: "valid input",
+			giveFunc: func(e cldf.Environment) DeployLinkTokensInput {
+				csels := e.BlockChains.ListChainSelectors()
+
+				return DeployLinkTokensInput{
+					ChainSelectors: csels,
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				lggr = logger.Test(t)
+				e    = memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+					Chains: 1,
+				})
+				cs = deployEVMLinkTokens{}
+			)
+
+			got, err := cs.Apply(e, tt.giveFunc(e))
+			require.NoError(t, err)
+
+			// Check that the address book has the link token contract for each chain
+			for _, csel := range e.BlockChains.ListChainSelectors() {
+				addrBookByChain, err := got.AddressBook.AddressesForChain(csel) //nolint:staticcheck // Will be removed once the address book is no longer required.
+				require.NoError(t, err)
+				require.NotEmpty(t, addrBookByChain)
+				require.Len(t, addrBookByChain, 1)
+			}
+
+			// Check the address book has the link token contract for each chain
+			addrRefs, err := got.DataStore.Addresses().Fetch()
+			require.NoError(t, err)
+			require.Len(t, addrRefs, 1)
+		})
+	}
+}

--- a/deployment/tokens/changesets/deploy_sol_link_tokens.go
+++ b/deployment/tokens/changesets/deploy_sol_link_tokens.go
@@ -1,0 +1,74 @@
+package changesets
+
+import (
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/seqs"
+)
+
+// DeploySolLinkTokens deploys Link Token contracts to the specified Solana chains in the
+// DeployLinkTokenInput. The qualifiers and labels will be used to tag all deployed contracts in
+var DeploySolLinkTokens cldf.ChangeSetV2[DeployLinkTokensInput] = deploySolLinkTokens{}
+
+// deploySolLinkTokens is the implementation of the DeploySolLinkTokens changeset.
+type deploySolLinkTokens struct{}
+
+// VerifyPreconditions ensures that all listed chain selectors are valid and available in the
+// environment chains.
+func (deploySolLinkTokens) VerifyPreconditions(
+	e cldf.Environment, input DeployLinkTokensInput,
+) error {
+	if err := validateNoDupeSelectors(input.ChainSelectors); err != nil {
+		return err
+	}
+
+	if err := validateChainSelectorsFamily(
+		input.ChainSelectors, chain_selectors.FamilySolana,
+	); err != nil {
+		return err
+	}
+
+	if err := validateNoExistingLinkToken(
+		input.ChainSelectors, input.Qualifier, e.ExistingAddresses, e.DataStore,
+	); err != nil {
+		return err
+	}
+
+	return deployment.ValidateSelectorsInEnvironment(e, input.ChainSelectors)
+}
+
+// Apply executes the SeqDeploySolTokens sequence to deploy Link Token contracts to the specified
+// chains.
+func (deploySolLinkTokens) Apply(
+	e cldf.Environment, input DeployLinkTokensInput,
+) (cldf.ChangesetOutput, error) {
+	var (
+		out = cldf.ChangesetOutput{
+			AddressBook: cldf.NewMemoryAddressBook(),
+			DataStore:   datastore.NewMemoryDataStore(),
+		}
+
+		seqDeps = seqs.SeqDeploySolTokensDeps{
+			SolChains: e.BlockChains.SolanaChains(),
+			AddrBook:  out.AddressBook, //nolint:staticcheck // Will be removed once the address book is no longer required.
+			Datastore: out.DataStore,
+		}
+		seqInput = seqs.SeqDeploySolTokensInput{
+			ChainSelectors: input.ChainSelectors,
+			Qualifier:      input.Qualifier,
+			Labels:         input.Labels,
+		}
+	)
+
+	seqReport, err := operations.ExecuteSequence(
+		e.OperationsBundle, seqs.SeqDeploySolTokens, seqDeps, seqInput,
+	)
+
+	out.Reports = seqReport.ExecutionReports
+
+	return out, err
+}

--- a/deployment/tokens/changesets/deploy_sol_link_tokens_test.go
+++ b/deployment/tokens/changesets/deploy_sol_link_tokens_test.go
@@ -1,0 +1,190 @@
+package changesets
+
+import (
+	"fmt"
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/ops"
+)
+
+func Test_DeploySolLinkTokens_VerifyPreconditions(t *testing.T) {
+	t.Parallel()
+
+	var (
+		csel    = chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
+		solAddr = "J6oVJ42pE6eXdTCcCidhjzHWS7Sxz6yMsXHxXphT1U7Y"
+	)
+
+	tests := []struct {
+		name       string
+		beforeFunc func(t *testing.T, e *cldf.Environment)
+		input      DeployLinkTokensInput
+		wantErr    string
+	}{
+		{
+			name: "valid input",
+			beforeFunc: func(t *testing.T, e *cldf.Environment) {
+				e.BlockChains = cldf_chain.NewBlockChainsFromSlice([]cldf_chain.BlockChain{
+					cldf_solana.Chain{
+						Selector: csel,
+					},
+				})
+
+				// Inject empty address book and datastore
+				e.ExistingAddresses = cldf.NewMemoryAddressBook()
+				e.DataStore = datastore.NewMemoryDataStore().Seal()
+			},
+			input: DeployLinkTokensInput{
+				ChainSelectors: []uint64{csel},
+			},
+		},
+		{
+			name: "error: duplicate chain selectors",
+			input: DeployLinkTokensInput{
+				ChainSelectors: []uint64{1, 1},
+			},
+			wantErr: "duplicate chain selector found",
+		},
+		{
+			name: "error: invalid chain selector family",
+			input: DeployLinkTokensInput{
+				ChainSelectors: []uint64{
+					chain_selectors.TEST_1000.Selector,
+				}, // Uses an invalid EVM chain selector
+			},
+			wantErr: fmt.Sprintf(
+				"chain selector %d is not in the solana family",
+				chain_selectors.TEST_1000.Selector,
+			),
+		},
+		{
+			name: "error: link token contracts exists in address book",
+			beforeFunc: func(t *testing.T, e *cldf.Environment) {
+				t.Helper()
+
+				e.ExistingAddresses = cldf.NewMemoryAddressBook()
+				err := e.ExistingAddresses.Save(csel, solAddr, ops.LinkTokenTypeAndVersion1)
+				require.NoError(t, err)
+			},
+			input: DeployLinkTokensInput{
+				ChainSelectors: []uint64{csel},
+			},
+			wantErr: "link token contract already exists for chain selector",
+		},
+		{
+			name: "error: link token contract exists in datastore",
+			beforeFunc: func(t *testing.T, e *cldf.Environment) {
+				t.Helper()
+
+				// Insert the selector with no addresses to pass address book check
+				e.ExistingAddresses = cldf.NewMemoryAddressBookFromMap(
+					map[uint64]map[string]cldf.TypeAndVersion{
+						csel: {},
+					},
+				)
+
+				ds := datastore.NewMemoryDataStore()
+				err := ds.Addresses().Add(datastore.AddressRef{
+					ChainSelector: csel,
+					Address:       solAddr,
+					Type:          datastore.ContractType(ops.LinkTokenTypeAndVersion1.Type.String()),
+					Version:       &ops.LinkTokenTypeAndVersion1.Version,
+				})
+				require.NoError(t, err)
+
+				e.DataStore = ds.Seal()
+			},
+			input: DeployLinkTokensInput{
+				ChainSelectors: []uint64{csel},
+			},
+			wantErr: "link token contract already exists for chain selector",
+		},
+		{
+			name: "error: chain selector not found in environment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				cs  = deploySolLinkTokens{}
+				env = &cldf.Environment{}
+			)
+
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(t, env)
+			}
+
+			err := cs.VerifyPreconditions(*env, tt.input)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_DeploySolLinkTokens_Apply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		giveFunc func(e cldf.Environment) DeployLinkTokensInput
+	}{
+		{
+			name: "valid input",
+			giveFunc: func(e cldf.Environment) DeployLinkTokensInput {
+				csels := e.BlockChains.ListChainSelectors()
+
+				return DeployLinkTokensInput{
+					ChainSelectors: csels,
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				lggr = logger.Test(t)
+				e    = memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
+					SolChains: 1,
+				})
+				cs = deploySolLinkTokens{}
+			)
+
+			got, err := cs.Apply(e, tt.giveFunc(e))
+			require.NoError(t, err)
+
+			// Check that the address book has the link token contract for each chain
+			for _, csel := range e.BlockChains.ListChainSelectors() {
+				addrBookByChain, err := got.AddressBook.AddressesForChain(csel) //nolint:staticcheck // Will be removed once the address book is no longer required.
+				require.NoError(t, err)
+				require.NotEmpty(t, addrBookByChain)
+				require.Len(t, addrBookByChain, 1)
+			}
+
+			// Check the address book has the link token contract for each chain
+			addrRefs, err := got.DataStore.Addresses().Fetch()
+			require.NoError(t, err)
+			require.Len(t, addrRefs, 1)
+		})
+	}
+}

--- a/deployment/tokens/changesets/validate.go
+++ b/deployment/tokens/changesets/validate.go
@@ -1,0 +1,86 @@
+package changesets
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/ops"
+)
+
+// validateNoDupeSelectors checks that there are no duplicate chain selectors in
+// the slice.
+func validateNoDupeSelectors(csels []uint64) error {
+	// Validate there are no duplicate chain selectors
+	seen := make(map[uint64]bool)
+	for _, csel := range csels {
+		if seen[csel] {
+			return fmt.Errorf("duplicate chain selector found: %d", csel)
+		}
+		seen[csel] = true
+	}
+
+	return nil
+}
+
+// validateNoExistingLinkToken checks that there are no existing Link Token
+// contracts in the address book or datastore for the given chain selectors.
+func validateNoExistingLinkToken(
+	csels []uint64,
+	qualifier string,
+	addrBook cldf.AddressBook,
+	ds datastore.DataStore,
+) error {
+	// Validate there is no existing Link Token contract in the address book
+	for _, csel := range csels {
+		addrBookByChain, err := addrBook.AddressesForChain(csel)
+		if err != nil {
+			// If the chain selector is not found in the address book, it means that
+			// no contract record exists. This is not an error and we can continue.
+			continue
+		}
+
+		if incl := slices.ContainsFunc(
+			slices.Collect(maps.Values(addrBookByChain)),
+			func(tv cldf.TypeAndVersion) bool {
+				return tv.Equal(ops.LinkTokenTypeAndVersion1)
+			},
+		); incl {
+			return fmt.Errorf("link token contract already exists for chain selector %d in address book", csel)
+		}
+	}
+
+	// Validate there is no existing token contract in the datastore
+	for _, csel := range csels {
+		if _, err := ds.Addresses().Get(datastore.NewAddressRefKey(
+			csel,
+			datastore.ContractType(ops.LinkTokenTypeAndVersion1.Type.String()),
+			&ops.LinkTokenTypeAndVersion1.Version,
+			qualifier,
+		)); err == nil {
+			return fmt.Errorf("link token contract already exists for chain selector %d in datastore", csel)
+		}
+	}
+
+	return nil
+}
+
+// validateChainSelectorFamily checks that all chain selectors are in the provided family.
+func validateChainSelectorsFamily(csels []uint64, fam string) error {
+	for _, csel := range csels {
+		cselFam, err := chain_selectors.GetSelectorFamily(csel)
+		if err != nil {
+			return fmt.Errorf("failed to get family for chain selector %d: %w", csel, err)
+		}
+
+		if cselFam != fam {
+			return fmt.Errorf("chain selector %d is not in the %s family", csel, fam)
+		}
+	}
+
+	return nil
+}

--- a/deployment/tokens/changesets/validate_test.go
+++ b/deployment/tokens/changesets/validate_test.go
@@ -1,0 +1,190 @@
+package changesets
+
+import (
+	"fmt"
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/ops"
+)
+
+func Test_validateNoDupeSelectors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    []uint64
+		wantErr string
+	}{
+		{
+			name: "valid input",
+			give: []uint64{
+				1, 2, 3,
+			},
+		},
+		{
+			name: "duplicate input",
+			give: []uint64{
+				1, 2, 3, 1,
+			},
+			wantErr: fmt.Sprintf("duplicate chain selector found: %d", 1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateNoDupeSelectors(tt.give)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_validateNoExistingLinkToken(t *testing.T) {
+	var (
+		csel    = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
+		ethAddr = "0xeC91988D7dD84d8adE801b739172ad15c860A700"
+	)
+
+	tests := []struct {
+		name          string
+		beforeFunc    func(*testing.T, *cldf.AddressBookMap, *datastore.MemoryDataStore)
+		give          []uint64
+		giveQualifier string
+		wantErr       string
+	}{
+		{
+			name: "no existing link token found",
+			give: []uint64{csel},
+		},
+		{
+			name: "no existing link token found with qualifier",
+			beforeFunc: func(
+				t *testing.T,
+				_ *cldf.AddressBookMap,
+				ds *datastore.MemoryDataStore,
+			) {
+				err := ds.Addresses().Add(datastore.AddressRef{
+					ChainSelector: csel,
+					Address:       ethAddr,
+					Qualifier:     "test",
+					Type:          datastore.ContractType(ops.LinkTokenTypeAndVersion1.Type.String()),
+					Version:       &ops.LinkTokenTypeAndVersion1.Version,
+				})
+				require.NoError(t, err)
+			},
+			give: []uint64{csel},
+		},
+		{
+			name: "existing in address book",
+			beforeFunc: func(
+				t *testing.T,
+				ab *cldf.AddressBookMap,
+				_ *datastore.MemoryDataStore,
+			) {
+				err := ab.Save(csel, ethAddr, ops.LinkTokenTypeAndVersion1)
+				require.NoError(t, err)
+			},
+			give: []uint64{csel},
+			wantErr: fmt.Sprintf(
+				"link token contract already exists for chain selector %d in address book", csel,
+			),
+		},
+		{
+			name: "existing in datastore",
+			beforeFunc: func(
+				t *testing.T,
+				_ *cldf.AddressBookMap,
+				ds *datastore.MemoryDataStore,
+			) {
+				err := ds.Addresses().Add(datastore.AddressRef{
+					ChainSelector: csel,
+					Address:       ethAddr,
+					Qualifier:     "test",
+					Type:          datastore.ContractType(ops.LinkTokenTypeAndVersion1.Type.String()),
+					Version:       &ops.LinkTokenTypeAndVersion1.Version,
+				})
+				require.NoError(t, err)
+			},
+			give:          []uint64{csel},
+			giveQualifier: "test",
+			wantErr: fmt.Sprintf(
+				"link token contract already exists for chain selector %d in datastore", csel,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ab := cldf.NewMemoryAddressBook()
+			ds := datastore.NewMemoryDataStore()
+
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(t, ab, ds)
+			}
+
+			err := validateNoExistingLinkToken(tt.give, tt.giveQualifier, ab, ds.Seal())
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_validateChainSelectorsFamily(t *testing.T) {
+	t.Parallel()
+
+	var (
+		csel = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
+	)
+
+	tests := []struct {
+		name    string
+		give    []uint64
+		giveFam string
+		wantErr string
+	}{
+		{
+			name:    "valid input",
+			give:    []uint64{csel},
+			giveFam: "evm",
+		},
+		{
+			name:    "invalid input",
+			give:    []uint64{csel},
+			giveFam: "solana",
+			wantErr: fmt.Sprintf("chain selector %d is not in the solana family", csel),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateChainSelectorsFamily(tt.give, tt.giveFam)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/deployment/tokens/internal/ops/ops_evm.go
+++ b/deployment/tokens/internal/ops/ops_evm.go
@@ -1,0 +1,98 @@
+package ops
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	cldf_chain_utils "github.com/smartcontractkit/chainlink-deployments-framework/chain/utils"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/link_token"
+)
+
+var (
+	// LinkToken is the burn/mint link token which is now used in all new deployments.
+	// https://github.com/smartcontractkit/chainlink/blob/develop/core/gethwrappers/shared/generated/link_token/link_token.go#L34
+	LinkTokenTypeAndVersion1 = cldf.NewTypeAndVersion(
+		"LinkToken",
+		*semver.MustParse("1.0.0"),
+	)
+)
+
+// OpEVMDeployLinkTokenDeps defines the dependencies to perform the OpEVMDeployLinkToken
+// operation.
+type OpEVMDeployLinkTokenDeps struct {
+	Auth        *bind.TransactOpts
+	Backend     bind.ContractBackend
+	ConfirmFunc func(tx *types.Transaction) (uint64, error)
+}
+
+// OpEVMDeployLinkTokenInput represents the input parameters for the OpEVMDeployLinkToken operation.
+type OpEVMDeployLinkTokenInput struct {
+	// ChainSelector is the unique identifier for the chain where the operation will be executed.
+	// It is used as part of the unique cache key for the report and in logging, but is not used
+	// in the operation logic itself.
+	ChainSelector uint64 `json:"chainSelector"`
+}
+
+// OpEvmDeployLinkTokenOutput represents the output of the OpEVMDeployLinkToken operation.
+type OpEvmDeployLinkTokenOutput struct {
+	Address common.Address `json:"address"`
+	Type    string         `json:"type"`
+	Version string         `json:"version"`
+}
+
+// OpEVMDeployLinkToken is an operation that deploys the burn/mint LINK token
+// contract on an EVM-compatible blockchain.
+var OpEVMDeployLinkToken = operations.NewOperation(
+	"evm-deploy-link-token",
+	semver.MustParse("1.0.0"),
+	"Deploy EVM LINK Token Contract",
+	func(b operations.Bundle, deps OpEVMDeployLinkTokenDeps, in OpEVMDeployLinkTokenInput) (OpEvmDeployLinkTokenOutput, error) {
+		out := OpEvmDeployLinkTokenOutput{}
+
+		chainInfo, err := cldf_chain_utils.ChainInfo(in.ChainSelector)
+		if err != nil {
+			b.Logger.Errorw("Failed to get chain info",
+				"chainSelector", in.ChainSelector,
+				"err", err,
+			)
+
+			return out, err
+		}
+
+		// Deploy the link token
+		addr, tx, _, err := link_token.DeployLinkToken(
+			deps.Auth,
+			deps.Backend,
+		)
+		if err != nil {
+			b.Logger.Errorw("Failed to deploy link token",
+				"chainSelector", in.ChainSelector,
+				"chainName", chainInfo.ChainName,
+				"err", err,
+			)
+
+			return out, err
+		}
+
+		// Confirm the transaction
+		if _, err = deps.ConfirmFunc(tx); err != nil {
+			b.Logger.Errorw("Failed to confirm deployment",
+				"chainSelector", in.ChainSelector,
+				"chainName", chainInfo.ChainName,
+				"contractAddr", addr.String(),
+				"err", err,
+			)
+
+			return out, err
+		}
+
+		return OpEvmDeployLinkTokenOutput{
+			Address: addr,
+			Type:    LinkTokenTypeAndVersion1.Type.String(),
+			Version: LinkTokenTypeAndVersion1.Version.String(),
+		}, nil
+	})

--- a/deployment/tokens/internal/ops/ops_evm_test.go
+++ b/deployment/tokens/internal/ops/ops_evm_test.go
@@ -1,0 +1,78 @@
+package ops
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+)
+
+func Test_OpEVMDeployLinkToken(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chainID       uint64 = 11155111
+		chainSelector uint64 = 16015286601757825753
+	)
+
+	tests := []struct {
+		name    string
+		give    OpEVMDeployLinkTokenInput
+		want    OpEvmDeployLinkTokenOutput
+		wantErr string
+	}{
+		{
+			name: "deploys LinkToken on EVM chain",
+			give: OpEVMDeployLinkTokenInput{
+				ChainSelector: chainSelector,
+			},
+			want: OpEvmDeployLinkTokenOutput{
+				Type:    LinkTokenTypeAndVersion1.Type.String(),
+				Version: LinkTokenTypeAndVersion1.Version.String(),
+			},
+		},
+		{
+			name: "error: invalid chain selector",
+			give: OpEVMDeployLinkTokenInput{
+				ChainSelector: 1, // Invalid chain selector
+			},
+			wantErr: "unknown chain selector 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				chains, bindings = memory.NewMemoryChainsWithChainIDs(t, []uint64{chainID}, 1)
+				chain            = chains[chainSelector]
+				auth             = bindings[chainSelector][0]
+				deps             = OpEVMDeployLinkTokenDeps{
+					Auth:        auth,
+					Backend:     chain.Client,
+					ConfirmFunc: chain.Confirm,
+				}
+			)
+
+			got, err := operations.ExecuteOperation(
+				optest.NewBundle(t), OpEVMDeployLinkToken, deps, tt.give,
+			)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+
+				assert.NotEmpty(t, got.Output.Address.String())
+				assert.Equal(t, tt.want.Type, got.Output.Type)
+				assert.Equal(t, tt.want.Version, got.Output.Version)
+			}
+		})
+	}
+}

--- a/deployment/tokens/internal/ops/ops_sol.go
+++ b/deployment/tokens/internal/ops/ops_sol.go
@@ -1,0 +1,115 @@
+package ops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	cldf_chain_utils "github.com/smartcontractkit/chainlink-deployments-framework/chain/utils"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+const (
+	// linkTokenDecimalsSolana is the number of decimals for the Solana LINK token.
+	linkTokenDecimalsSolana = 9
+)
+
+// OpSolDeployLinkToken deploys a LINK token contract on Solana.
+type OpSolDeployLinkTokenDeps struct {
+	Client      *rpc.Client
+	ConfirmFunc func(instructions []solana.Instruction, opts ...common.TxModifier) error
+}
+
+// OpSolDeployLinkTokenInput represents the input parameters for the OpSolDeployLinkToken operation.
+type OpSolDeployLinkTokenInput struct {
+	// ChainSelector is the unique identifier for the chain where the operation will be executed.
+	// It is used as part of the unique cache key for the report and in logging, but is not used
+	// in the operation logic itself.
+	ChainSelector uint64 `json:"chainSelector"`
+	// TokenAdminPublicKey is the public key of the admin account for the token.
+	TokenAdminPublicKey solana.PublicKey `json:"tokenAdminPublicKey"`
+}
+
+// OpSolDeployLinkTokenOutput represents the output of the OpSolDeployLinkToken operation.
+type OpSolDeployLinkTokenOutput struct {
+	// MintPublicKey is represents the token's address
+	MintPublicKey solana.PublicKey `json:"mintPublicKey"`
+	Type          string           `json:"type"`
+	Version       string           `json:"version"`
+}
+
+// OpSolDeployLinkToken is an operation that deploys the LINK token contract on the Solana
+// blockchain. The token is deployed as a Token2022 token with 9 decimals.
+var OpSolDeployLinkToken = operations.NewOperation(
+	"sol-deploy-link-token",
+	semver.MustParse("1.0.0"),
+	"Deploy Solana LINK Token Contract",
+	func(b operations.Bundle, deps OpSolDeployLinkTokenDeps, in OpSolDeployLinkTokenInput) (OpSolDeployLinkTokenOutput, error) {
+		out := OpSolDeployLinkTokenOutput{}
+
+		chainInfo, err := cldf_chain_utils.ChainInfo(in.ChainSelector)
+		if err != nil {
+			b.Logger.Errorw("Failed to get chain info",
+				"chainSelector", in.ChainSelector,
+				"err", err,
+			)
+
+			return out, err
+		}
+
+		// Generate the publicKey of the new token mint
+		mint, err := solana.NewRandomPrivateKey()
+		if err != nil {
+			b.Logger.Errorw("Failed to generate mint public key",
+				"chainSelector", in.ChainSelector,
+				"chainName", chainInfo.ChainName,
+				"err", err,
+			)
+
+			return out, fmt.Errorf("failed to generate mint public key: %w", err)
+		}
+
+		mintPublicKey := mint.PublicKey() // This is the token address
+
+		// Create the token
+		instructions, err := tokens.CreateToken(
+			b.GetContext(),
+			solana.TokenProgramID,
+			mintPublicKey,
+			in.TokenAdminPublicKey,
+			linkTokenDecimalsSolana,
+			deps.Client,
+			cldf_solana.SolDefaultCommitment,
+		)
+		if err != nil {
+			b.Logger.Errorw("Failed to generate instructions for link token deployment",
+				"chainSelector", in.ChainSelector,
+				"chainName", chainInfo.ChainName,
+				"err", err,
+			)
+
+			return out, fmt.Errorf("failed to generate instructions for link token deployment: %w", err)
+		}
+
+		// Confirm the transaction
+		if err = deps.ConfirmFunc(instructions, common.AddSigners(mint)); err != nil {
+			b.Logger.Errorw("Failed to confirm instructions for link token deployment",
+				"chainSelector", in.ChainSelector,
+				"chainName", chainInfo.ChainName,
+				"err", err,
+			)
+
+			return out, err
+		}
+
+		return OpSolDeployLinkTokenOutput{
+			MintPublicKey: mintPublicKey,
+			Type:          LinkTokenTypeAndVersion1.Type.String(),
+			Version:       LinkTokenTypeAndVersion1.Version.String(),
+		}, nil
+	})

--- a/deployment/tokens/internal/ops/ops_sol_test.go
+++ b/deployment/tokens/internal/ops/ops_sol_test.go
@@ -1,0 +1,69 @@
+package ops
+
+import (
+	"testing"
+
+	solRpc "github.com/gagliardetto/solana-go/rpc"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
+)
+
+// Note: This test does not perform an actual token deployment, as it would require a running
+// Solana node via CTF containers. Such scenarios are already thoroughly covered by integration
+// tests in the changeset and sequence suites. Until there is a way to simulate or mock a Solana
+// client, this is the best we can do for unit tests.
+//
+// This test is limited to verifying operation error handling.
+func Test_OpSolDeployLinkToken(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chainSelector = chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
+	)
+
+	tests := []struct {
+		name      string
+		giveDeps  OpSolDeployLinkTokenDeps
+		giveInput OpSolDeployLinkTokenInput
+		wantErr   string
+	}{
+		{
+			name:     "error: invalid chain selector",
+			giveDeps: OpSolDeployLinkTokenDeps{},
+			giveInput: OpSolDeployLinkTokenInput{
+				ChainSelector: 1, // Invalid chain selector
+			},
+			wantErr: "unknown chain selector 1",
+		},
+		{
+			name: "failed to create token",
+			giveDeps: OpSolDeployLinkTokenDeps{
+				Client: solRpc.New("bad-url"),
+			},
+			giveInput: OpSolDeployLinkTokenInput{
+				ChainSelector: chainSelector,
+			},
+			wantErr: "failed to generate instructions for link token deployment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := operations.ExecuteOperation(
+				optest.NewBundle(t), OpSolDeployLinkToken, tt.giveDeps, tt.giveInput,
+			)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/deployment/tokens/internal/ops/ops_storage.go
+++ b/deployment/tokens/internal/ops/ops_storage.go
@@ -1,0 +1,107 @@
+package ops
+
+import (
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+// OpAddAddrBookRecordDeps defines the dependencies to perform the OpAddAddrBookRecord.
+type OpAddAddrBookRecordDeps struct {
+	AddrBook cldf.AddressBook
+}
+
+// OpAddAddrBookRecordInput is the input to the OpAddAddrBookRecord operation.
+type OpAddAddrBookRecordInput struct {
+	ChainSelector uint64   `json:"chainSelector"`
+	Address       string   `json:"address"`
+	Type          string   `json:"type"`
+	Version       string   `json:"version"`
+	Labels        []string `json:"labels"`
+}
+
+// OpAddAddrBookRecordOutput is the output of the OpAddAddrBookRecord operation.
+type OpAddAddrBookRecordOutput struct {
+	ChainSelector  uint64 `json:"chainSelector"`
+	Address        string `json:"address"`
+	TypeAndVersion string `json:"typeAndVersion"`
+}
+
+// OpAddAddrBookRecord adds a new address record to the address book.
+var OpAddAddrBookRecord = operations.NewOperation(
+	"add-address-book-record",
+	semver.MustParse("1.0.0"),
+	"Adds an address record to address book",
+	func(b operations.Bundle, deps OpAddAddrBookRecordDeps, in OpAddAddrBookRecordInput) (OpAddAddrBookRecordOutput, error) {
+		out := OpAddAddrBookRecordOutput{}
+
+		tv := cldf.NewTypeAndVersion(
+			cldf.ContractType(in.Type),
+			*semver.MustParse(in.Version),
+		)
+
+		for _, label := range in.Labels {
+			tv.AddLabel(label)
+		}
+
+		if err := deps.AddrBook.Save(in.ChainSelector, in.Address, tv); err != nil {
+			return out, err
+		}
+
+		return OpAddAddrBookRecordOutput{
+			ChainSelector:  in.ChainSelector,
+			Address:        in.Address,
+			TypeAndVersion: tv.String(),
+		}, nil
+	})
+
+// OpAddDatastoreAddrRefDeps defines the dependencies to perform the OpAddDatastoreAddrRef
+// operation.
+type OpAddDatastoreAddrRefDeps struct {
+	Datastore datastore.MutableDataStore
+}
+
+// OpAddDatastoreAddrRefInput is the input to the OpAddDatastoreAddrRef operation.
+type OpAddDatastoreAddrRefInput struct {
+	ChainSelector uint64   `json:"chainSelector"`
+	Address       string   `json:"address"`
+	Qualifier     string   `json:"qualifier"`
+	Type          string   `json:"type"`
+	Version       string   `json:"version"`
+	Labels        []string `json:"labels"`
+}
+
+// OpAddDatastoreAddrRefOutput is the output of the OpAddDatastoreAddrRef operation.
+type OpAddDatastoreAddrRefOutput struct {
+	ChainSelector uint64 `json:"chainSelector"`
+	Address       string `json:"address"`
+}
+
+// OpAddDatastoreAddrRef adds a new address reference to the datastore.
+var OpAddDatastoreAddrRef = operations.NewOperation(
+	"add-datastore-address-reference",
+	semver.MustParse("1.0.0"),
+	"Adds an address reference to the datastore",
+	func(b operations.Bundle, deps OpAddDatastoreAddrRefDeps, in OpAddDatastoreAddrRefInput) (OpAddDatastoreAddrRefOutput, error) {
+		out := OpAddDatastoreAddrRefOutput{}
+
+		if err := deps.Datastore.Addresses().Add(
+			datastore.AddressRef{
+				ChainSelector: in.ChainSelector,
+				Address:       in.Address,
+				Type:          datastore.ContractType(in.Type),
+				Version:       semver.MustParse(in.Version),
+				Qualifier:     in.Qualifier,
+				Labels:        datastore.NewLabelSet(in.Labels...),
+			},
+		); err != nil {
+			return out, err
+		}
+
+		return OpAddDatastoreAddrRefOutput{
+			ChainSelector: in.ChainSelector,
+			Address:       in.Address,
+		}, nil
+	})

--- a/deployment/tokens/internal/ops/ops_storage_test.go
+++ b/deployment/tokens/internal/ops/ops_storage_test.go
@@ -1,0 +1,190 @@
+package ops
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
+)
+
+func Test_OpAddAddrBookRecord(t *testing.T) {
+	t.Parallel()
+
+	var (
+		csel = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
+		addr = "0x1234567890123456789012345678901234567890"
+	)
+
+	tests := []struct {
+		name    string
+		give    OpAddAddrBookRecordInput
+		want    OpAddAddrBookRecordOutput
+		wantErr string
+	}{
+		{
+			name: "adds to the address book",
+			give: OpAddAddrBookRecordInput{
+				ChainSelector: csel,
+				Address:       addr,
+				Type:          "LinkToken",
+				Version:       "1.0.0",
+				Labels:        []string{"test", "label"},
+			},
+			want: OpAddAddrBookRecordOutput{
+				ChainSelector:  csel,
+				Address:        addr,
+				TypeAndVersion: "LinkToken 1.0.0 label test",
+			},
+		},
+		{
+			name: "fail: could not save to address book",
+			give: OpAddAddrBookRecordInput{
+				ChainSelector: 1,
+				Address:       addr,
+				Type:          "LinkToken",
+				Version:       "1.0.0",
+				Labels:        []string{"test", "label"},
+			},
+			wantErr: "chain selector 1: invalid chain selector",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				addrBook = cldf.NewMemoryAddressBook()
+				deps     = OpAddAddrBookRecordDeps{AddrBook: addrBook}
+			)
+
+			got, err := operations.ExecuteOperation(
+				optest.NewBundle(t), OpAddAddrBookRecord, deps, tt.give,
+			)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got.Output)
+
+				// Check the address book for the record
+				addresses, err := addrBook.AddressesForChain(tt.give.ChainSelector)
+				require.NoError(t, err)
+
+				gotVal, ok := addresses[tt.give.Address]
+				require.True(t, ok)
+				require.Equal(t, got.Output.TypeAndVersion, gotVal.String())
+			}
+		})
+	}
+}
+
+func Test_OpAddDatastoreAddrRef(t *testing.T) {
+	t.Parallel()
+
+	var (
+		csel = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
+		addr = "0x1234567890123456789012345678901234567890"
+	)
+
+	tests := []struct {
+		name       string
+		beforeFunc func(*testing.T, datastore.MutableDataStore)
+		give       OpAddDatastoreAddrRefInput
+		want       OpAddDatastoreAddrRefOutput
+		wantErr    string
+	}{
+		{
+			name: "adds to the address book",
+			give: OpAddDatastoreAddrRefInput{
+				ChainSelector: csel,
+				Address:       addr,
+				Type:          "LinkToken",
+				Version:       "1.0.0",
+				Labels:        []string{"test", "label"},
+				Qualifier:     "test",
+			},
+			want: OpAddDatastoreAddrRefOutput{
+				ChainSelector: csel,
+				Address:       addr,
+			},
+		},
+		{
+			name: "fail: could not save to address book due to duplicate record key",
+			beforeFunc: func(t *testing.T, ds datastore.MutableDataStore) {
+				// Pre-populate the datastore with an existing record
+				err := ds.Addresses().Add(datastore.AddressRef{
+					ChainSelector: csel,
+					Address:       addr,
+					Type:          "LinkToken",
+					Version:       semver.MustParse("1.0.0"),
+					Labels:        datastore.NewLabelSet("test", "label"),
+					Qualifier:     "test",
+				})
+				require.NoError(t, err)
+			},
+			give: OpAddDatastoreAddrRefInput{
+				ChainSelector: csel,
+				Address:       addr,
+				Type:          "LinkToken",
+				Version:       "1.0.0",
+				Labels:        []string{"test", "label"},
+				Qualifier:     "test",
+			},
+			wantErr: "an address ref with the supplied key already exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				ds   = datastore.NewMemoryDataStore()
+				deps = OpAddDatastoreAddrRefDeps{
+					Datastore: ds,
+				}
+			)
+
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(t, ds)
+			}
+
+			got, err := operations.ExecuteOperation(
+				optest.NewBundle(t), OpAddDatastoreAddrRef, deps, tt.give,
+			)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got.Output)
+
+				// Check the datastore for the record
+				addrRef, err := ds.Addresses().Get(datastore.NewAddressRefKey(
+					tt.give.ChainSelector,
+					datastore.ContractType(tt.give.Type),
+					semver.MustParse(tt.give.Version),
+					tt.give.Qualifier,
+				))
+				require.NoError(t, err)
+
+				require.Equal(t, tt.give.ChainSelector, addrRef.ChainSelector)
+				require.Equal(t, tt.give.Address, addrRef.Address)
+				require.Equal(t, tt.give.Type, addrRef.Type.String())
+				require.Equal(t, tt.give.Version, addrRef.Version.String())
+				require.Equal(t, tt.give.Qualifier, addrRef.Qualifier)
+				require.Equal(t, datastore.NewLabelSet(tt.give.Labels...), addrRef.Labels)
+			}
+		})
+	}
+}

--- a/deployment/tokens/internal/seqs/seq_deploy_evm_tokens.go
+++ b/deployment/tokens/internal/seqs/seq_deploy_evm_tokens.go
@@ -1,0 +1,101 @@
+package seqs
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/ops"
+)
+
+// SeqDeployEVMTokensDeps contains the dependencies for the SeqDeployEVMTokensDeps sequence.
+type SeqDeployEVMTokensDeps struct {
+	EVMChains map[uint64]cldf_evm.Chain
+	AddrBook  cldf.AddressBook
+	Datastore datastore.MutableDataStore
+}
+
+// SeqDeployEVMTokensInput is the input to the SeqDeployEVMTokensInput sequence.
+type SeqDeployEVMTokensInput struct {
+	// ChainSelectors are the chain selectors of the chains to which the Link Token contract
+	ChainSelectors []uint64 `json:"chainSelectors"`
+
+	// Qualifier is a string that will be used to tag the deployed contracts in the address book and datastore.
+	Qualifier string `json:"qualifier"`
+
+	// Labels are a list of labels that will be used to tag the deployed contracts in the address book and datastore.
+	Labels []string `json:"labels"`
+}
+
+// SeqDeployEVMTokensOutput is the output of the SeqDeployTokens sequence.
+type SeqDeployEVMTokensOutput struct {
+	// Addresses are the addresses of the deployed Link Token contracts.
+	Addresses []string `json:"address"`
+}
+
+// SeqDeployEVMTokens is a sequence that deploys LINK token contracts across EVM chains.
+var SeqDeployEVMTokens = operations.NewSequence(
+	"seq-deploy-tokens",
+	semver.MustParse("1.0.0"),
+	"Deploy LINK token contracts across multiple chains",
+	func(b operations.Bundle, deps SeqDeployEVMTokensDeps, in SeqDeployEVMTokensInput) (SeqDeployEVMTokensOutput, error) {
+		out := SeqDeployEVMTokensOutput{
+			Addresses: make([]string, 0),
+		}
+
+		for _, csel := range in.ChainSelectors {
+			fam, err := chainsel.GetSelectorFamily(csel)
+			if err != nil {
+				return out, err
+			}
+
+			if fam != chainsel.FamilyEVM {
+				return out, fmt.Errorf("chain selector %d is not an evm chain", csel)
+			}
+
+			chain := deps.EVMChains[csel]
+
+			// Deploy the link token
+			deployReport, err := operations.ExecuteOperation(b, ops.OpEVMDeployLinkToken,
+				ops.OpEVMDeployLinkTokenDeps{
+					Auth:        chain.DeployerKey,
+					Backend:     chain.Client,
+					ConfirmFunc: chain.Confirm,
+				},
+				ops.OpEVMDeployLinkTokenInput{
+					ChainSelector: csel,
+				},
+			)
+			if err != nil {
+				return out, err
+			}
+
+			out.Addresses = append(out.Addresses, deployReport.Output.Address.String())
+
+			_, err = operations.ExecuteSequence(b, SeqPersistAddress,
+				SeqPersistAddressDeps{
+					AddrBook:  deps.AddrBook,
+					Datastore: deps.Datastore,
+				},
+				SeqPersistAddressInput{
+					ChainSelector: csel,
+					Address:       deployReport.Output.Address.String(),
+					Type:          deployReport.Output.Type,
+					Version:       deployReport.Output.Version,
+					Qualifier:     in.Qualifier,
+					Labels:        in.Labels,
+				},
+			)
+			if err != nil {
+				return out, err
+			}
+		}
+
+		return out, nil
+	},
+)

--- a/deployment/tokens/internal/seqs/seq_deploy_evm_tokens_test.go
+++ b/deployment/tokens/internal/seqs/seq_deploy_evm_tokens_test.go
@@ -1,0 +1,101 @@
+package seqs
+
+import (
+	"fmt"
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+)
+
+func Test_SeqDeployEVMTokens(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chainID       = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.EvmChainID
+		chainSelector = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
+	)
+
+	tests := []struct {
+		name    string
+		give    SeqDeployEVMTokensInput
+		wantErr string
+	}{
+		{
+			name: "valid input",
+			give: SeqDeployEVMTokensInput{
+				ChainSelectors: []uint64{chainSelector},
+			},
+		},
+		{
+			name: "error: failed to get family",
+			give: SeqDeployEVMTokensInput{
+				ChainSelectors: []uint64{1},
+			},
+			wantErr: "unknown chain selector 1",
+		},
+		{
+			name: "error: not an EVM chain",
+			give: SeqDeployEVMTokensInput{
+				ChainSelectors: []uint64{
+					chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector,
+				}, // Solana test chain
+			},
+			wantErr: fmt.Sprintf(
+				"chain selector %d is not an evm chain",
+				chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				ab = cldf.NewMemoryAddressBook()
+				ds = datastore.NewMemoryDataStore()
+
+				chains, _ = memory.NewMemoryChainsWithChainIDs(t, []uint64{chainID}, 1)
+
+				b    = optest.NewBundle(t)
+				deps = SeqDeployEVMTokensDeps{
+					EVMChains: chains,
+					AddrBook:  ab,
+					Datastore: ds,
+				}
+			)
+
+			got, err := operations.ExecuteSequence(b, SeqDeployEVMTokens, deps, tt.give)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+
+				// Check that the output has the address
+				require.Len(t, got.Output.Addresses, len(tt.give.ChainSelectors))
+
+				// Check that the address book has the link token contract for each chain
+				for _, csel := range tt.give.ChainSelectors {
+					addrBookByChain, err := ab.AddressesForChain(csel)
+					require.NoError(t, err)
+					require.NotEmpty(t, addrBookByChain)
+					require.Len(t, addrBookByChain, 1)
+				}
+
+				// Check the address book has the link token contract for each chain
+				addrRefs, err := ds.Addresses().Fetch()
+				require.NoError(t, err)
+				require.Len(t, addrRefs, 1)
+			}
+		})
+	}
+}

--- a/deployment/tokens/internal/seqs/seq_deploy_solana_tokens.go
+++ b/deployment/tokens/internal/seqs/seq_deploy_solana_tokens.go
@@ -1,0 +1,104 @@
+package seqs
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/ops"
+)
+
+// SeqDeploySolTokensDeps contains the dependencies for the sequence to deploy LINK token contracts
+// on Solana.
+type SeqDeploySolTokensDeps struct {
+	SolChains map[uint64]cldf_solana.Chain
+	AddrBook  cldf.AddressBook
+	Datastore datastore.MutableDataStore
+}
+
+// SeqDeploySolTokensInput is the input to the SeqDeploySolTokensInput sequence.
+type SeqDeploySolTokensInput struct {
+	// ChainSelectors are the chain selectors of the chains to which the Link Token contract
+	ChainSelectors []uint64 `json:"chainSelectors"`
+
+	// Qualifier is a string that will be used to tag the deployed contracts in the address book and datastore.
+	Qualifier string `json:"qualifier"`
+
+	// Labels are a list of labels that will be used to tag the deployed contracts in the address book and datastore.
+	Labels []string `json:"labels"`
+}
+
+// SeqDeploySolTokensOutput is the output of the SeqDeploySolTokensOutput sequence.
+type SeqDeploySolTokensOutput struct {
+	// Addresses are the addresses of the deployed Link Token contracts.
+	Addresses []string `json:"address"`
+}
+
+// SeqDeploySolTokens is a sequence that deploys LINK token contracts across multiple Solana
+// chains.
+//
+// All provided chain selectors must reference Solana chains.
+var SeqDeploySolTokens = operations.NewSequence(
+	"seq-deploy-sol-tokens",
+	semver.MustParse("1.0.0"),
+	"Deploy Solana LINK token contracts across multiple chains",
+	func(b operations.Bundle, deps SeqDeploySolTokensDeps, in SeqDeploySolTokensInput) (SeqDeploySolTokensOutput, error) {
+		out := SeqDeploySolTokensOutput{
+			Addresses: make([]string, 0),
+		}
+
+		for _, csel := range in.ChainSelectors {
+			fam, err := chainsel.GetSelectorFamily(csel)
+			if err != nil {
+				return out, err
+			}
+
+			if fam != chainsel.FamilySolana {
+				return out, fmt.Errorf("chain selector %d is not a Solana chain", csel)
+			}
+
+			chain := deps.SolChains[csel]
+
+			deployReport, err := operations.ExecuteOperation(b, ops.OpSolDeployLinkToken,
+				ops.OpSolDeployLinkTokenDeps{
+					Client:      chain.Client,
+					ConfirmFunc: chain.Confirm,
+				},
+				ops.OpSolDeployLinkTokenInput{
+					ChainSelector:       csel,
+					TokenAdminPublicKey: chain.DeployerKey.PublicKey(),
+				},
+			)
+			if err != nil {
+				return out, err
+			}
+
+			_, err = operations.ExecuteSequence(b, SeqPersistAddress,
+				SeqPersistAddressDeps{
+					AddrBook:  deps.AddrBook,
+					Datastore: deps.Datastore,
+				},
+				SeqPersistAddressInput{
+					ChainSelector: csel,
+					Address:       deployReport.Output.MintPublicKey.String(),
+					Type:          deployReport.Output.Type,
+					Version:       deployReport.Output.Version,
+					Qualifier:     in.Qualifier,
+					Labels:        in.Labels,
+				},
+			)
+			if err != nil {
+				return out, err
+			}
+
+			out.Addresses = append(out.Addresses, deployReport.Output.MintPublicKey.String())
+		}
+
+		return out, nil
+	},
+)

--- a/deployment/tokens/internal/seqs/seq_deploy_solana_tokens_test.go
+++ b/deployment/tokens/internal/seqs/seq_deploy_solana_tokens_test.go
@@ -1,0 +1,105 @@
+package seqs
+
+import (
+	"fmt"
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
+	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
+)
+
+func Test_SeqDeploySolTokens(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chainSelector = chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
+	)
+
+	// Boots up a Solana testing chain in a container. This is done outside of the tests to
+	// avoid booting up the container for each test.
+	chains := memory.NewMemoryChainsSol(t, 1)
+
+	tests := []struct {
+		name               string
+		skipGenerateChains bool // Used to avoid generating chains which boots up containers
+		give               SeqDeploySolTokensInput
+		wantErr            string
+	}{
+		{
+			name: "valid input",
+			give: SeqDeploySolTokensInput{
+				ChainSelectors: []uint64{chainSelector},
+			},
+		},
+		{
+			name:               "error: failed to get family",
+			skipGenerateChains: true,
+			give: SeqDeploySolTokensInput{
+				ChainSelectors: []uint64{1},
+			},
+			wantErr: "unknown chain selector 1",
+		},
+		{
+			name:               "error: not a Solana chain",
+			skipGenerateChains: true,
+			give: SeqDeploySolTokensInput{
+				ChainSelectors: []uint64{
+					chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
+				},
+			},
+			wantErr: fmt.Sprintf(
+				"chain selector %d is not a Solana chain",
+				chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				ab = cldf.NewMemoryAddressBook()
+				ds = datastore.NewMemoryDataStore()
+
+				b    = optest.NewBundle(t)
+				deps = SeqDeploySolTokensDeps{
+					SolChains: chains,
+					AddrBook:  ab,
+					Datastore: ds,
+				}
+			)
+
+			got, err := operations.ExecuteSequence(b, SeqDeploySolTokens, deps, tt.give)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+
+				// Check that the output has the address
+				require.Len(t, got.Output.Addresses, len(tt.give.ChainSelectors))
+
+				// Check that the address book has the link token contract for each chain
+				for _, csel := range tt.give.ChainSelectors {
+					addrBookByChain, err := ab.AddressesForChain(csel)
+					require.NoError(t, err)
+					require.NotEmpty(t, addrBookByChain)
+					require.Len(t, addrBookByChain, 1)
+				}
+
+				// Check the address book has the link token contract for each chain
+				addrRefs, err := ds.Addresses().Fetch()
+				require.NoError(t, err)
+				require.Len(t, addrRefs, 1)
+			}
+		})
+	}
+}

--- a/deployment/tokens/internal/seqs/seq_persist_address.go
+++ b/deployment/tokens/internal/seqs/seq_persist_address.go
@@ -1,0 +1,71 @@
+package seqs
+
+import (
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/ops"
+)
+
+// SeqPersistAddressDeps contains the dependencies for the SeqPersistAddress sequence.
+type SeqPersistAddressDeps struct {
+	AddrBook  cldf.AddressBook
+	Datastore datastore.MutableDataStore
+}
+
+// SeqPersistAddressInput is the input to the SeqPersistAddress sequence.
+type SeqPersistAddressInput struct {
+	ChainSelector uint64   `json:"chainSelector"`
+	Address       string   `json:"address"`
+	Type          string   `json:"type"`
+	Version       string   `json:"version"`
+	Qualifier     string   `json:"qualifier"`
+	Labels        []string `json:"labels"`
+}
+
+// SeqPersistAddressOutput is the output of the SeqPersistAddress sequence.
+// It does not return any data, but it is included for consistency with other sequences.
+type SeqPersistAddressOutput struct{}
+
+// SeqPersistAddress is a sequence that persists the address of a deployed contract
+// in the address book and datastore.
+var SeqPersistAddress = operations.NewSequence(
+	"seq-persist-address",
+	semver.MustParse("1.0.0"),
+	"Persist address of deployed contract in address book and datastore",
+	func(b operations.Bundle, deps SeqPersistAddressDeps, in SeqPersistAddressInput) (SeqPersistAddressOutput, error) {
+		out := SeqPersistAddressOutput{}
+
+		// Store it in the legacy address book
+		if _, err := operations.ExecuteOperation(b, ops.OpAddAddrBookRecord,
+			ops.OpAddAddrBookRecordDeps{AddrBook: deps.AddrBook},
+			ops.OpAddAddrBookRecordInput{
+				ChainSelector: in.ChainSelector,
+				Address:       in.Address,
+				Type:          in.Type,
+				Version:       in.Version,
+				Labels:        in.Labels,
+			},
+		); err != nil {
+			return out, err
+		}
+
+		// Store the address reference in the datastore
+		if _, err := operations.ExecuteOperation(b, ops.OpAddDatastoreAddrRef,
+			ops.OpAddDatastoreAddrRefDeps{Datastore: deps.Datastore},
+			ops.OpAddDatastoreAddrRefInput{
+				ChainSelector: in.ChainSelector,
+				Address:       in.Address,
+				Type:          in.Type,
+				Version:       in.Version,
+				Qualifier:     in.Qualifier,
+				Labels:        in.Labels,
+			},
+		); err != nil {
+			return out, err
+		}
+
+		return out, nil
+	})

--- a/deployment/tokens/internal/seqs/seq_persist_address_test.go
+++ b/deployment/tokens/internal/seqs/seq_persist_address_test.go
@@ -1,0 +1,131 @@
+package seqs
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
+)
+
+func Test_PersistAddress(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chainSelector   = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
+		addr            = "0xeC91988D7dD84d8adE801b739172ad15c860A700"
+		contractType    = "SomeContract"
+		contractVersion = "1.0.0"
+		qualifier       = "test"
+		labels          = []string{"label1", "label2"}
+	)
+
+	tests := []struct {
+		name       string
+		beforeFunc func(*testing.T, datastore.MutableDataStore)
+		give       SeqPersistAddressInput
+		want       SeqPersistAddressOutput
+		wantErr    string
+	}{
+		{
+			name: "adds to address book and data store",
+			give: SeqPersistAddressInput{
+				ChainSelector: chainSelector,
+				Address:       addr,
+				Type:          contractType,
+				Version:       contractVersion,
+				Qualifier:     qualifier,
+				Labels:        labels,
+			},
+			want: SeqPersistAddressOutput{},
+		},
+		{
+			name: "err: cannot save to address book",
+			give: SeqPersistAddressInput{
+				ChainSelector: 1, // invalid chain selector
+				Address:       addr,
+				Type:          contractType,
+				Version:       contractVersion,
+				Qualifier:     qualifier,
+				Labels:        labels,
+			},
+			wantErr: "invalid chain selector",
+		},
+		{
+			name: "err: cannot save to data store",
+			beforeFunc: func(t *testing.T, ds datastore.MutableDataStore) {
+				// Pre-populate the datastore with an existing record
+				err := ds.Addresses().Add(datastore.AddressRef{
+					ChainSelector: chainSelector,
+					Address:       addr,
+					Type:          datastore.ContractType(contractType),
+					Version:       semver.MustParse(contractVersion),
+					Qualifier:     qualifier,
+					Labels:        datastore.NewLabelSet(labels...),
+				})
+				require.NoError(t, err)
+			},
+			give: SeqPersistAddressInput{
+				ChainSelector: chainSelector,
+				Address:       addr,
+				Type:          contractType,
+				Version:       contractVersion,
+				Qualifier:     qualifier,
+				Labels:        labels,
+			},
+			wantErr: "an address ref with the supplied key already exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				addrBook = cldf.NewMemoryAddressBook()
+				ds       = datastore.NewMemoryDataStore()
+				deps     = SeqPersistAddressDeps{
+					AddrBook:  addrBook,
+					Datastore: ds,
+				}
+			)
+
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(t, ds)
+			}
+
+			got, err := operations.ExecuteSequence(
+				optest.NewBundle(t), SeqPersistAddress, deps, tt.give,
+			)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got.Output)
+
+				// Check that the address book has the link token contract for each chain
+				addrBookByChain, err := addrBook.AddressesForChain(tt.give.ChainSelector)
+				require.NoError(t, err)
+				require.NotEmpty(t, addrBookByChain)
+				require.Len(t, addrBookByChain, 1)
+
+				// Check that the address reference is in the datastore
+				addrRef, err := ds.Addresses().Get(datastore.NewAddressRefKey(
+					tt.give.ChainSelector,
+					datastore.ContractType(tt.give.Type),
+					semver.MustParse(tt.give.Version),
+					tt.give.Qualifier,
+				))
+				require.NoError(t, err)
+				require.Equal(t, tt.give.Address, addrRef.Address)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces the implementation for deploying tokens on EVM and Solana networks using the Operations API. These changesets will eventually replace the existing token deployment logic in the `common` package.

By introducing a new `tokens` package, we aim to provide more structure to how changesets related to tokens are handled, and this also serves as an example of how to use ChangeSetV2 and Operations API for building Changesets.

