### PR TITLE
CCIP-5906 Ignoring fee boosting outcomes

### DIFF
--- a/.changeset/two-comics-kick.md
+++ b/.changeset/two-comics-kick.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Fee boosting removed from CCIP 1.5 Execution plugin #removed

--- a/core/services/ocr2/plugins/ccip/ccipexec/batching.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/batching.go
@@ -530,7 +530,6 @@ const (
 	TokenDataFetchError                  messageStatus = "token_data_fetch_error"
 	TokenNotInDestTokenPrices            messageStatus = "token_not_in_dest_token_prices"
 	TokenNotInSrcTokenPrices             messageStatus = "token_not_in_src_token_prices"
-	InsufficientRemainingFee             messageStatus = "insufficient_remaining_fee"
 	AddedToBatch                         messageStatus = "added_to_batch"
 	TXMCheckError                        messageStatus = "txm_check_error"
 	TXMFatalStatus                       messageStatus = "txm_fatal_status"

--- a/core/services/ocr2/plugins/ccip/ccipexec/batching.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/batching.go
@@ -296,14 +296,13 @@ func performCommonChecks(
 	availableFeeUsd := waitBoostedFee(time.Since(msg.BlockTimestamp), availableFee, batchCtx.offchainConfig.RelativeBoostPerWaitHour)
 	if availableFeeUsd.Cmp(execCostUsd) < 0 {
 		msgLggr.Infow(
-			"Skipping message - insufficient remaining fee",
+			"Message underpaid - insufficient remaining fee",
 			"availableFeeUsd", availableFeeUsd,
 			"execCostUsd", execCostUsd,
 			"sourceBlockTimestamp", msg.BlockTimestamp,
 			"waitTime", time.Since(msg.BlockTimestamp),
 			"boost", batchCtx.offchainConfig.RelativeBoostPerWaitHour,
 		)
-		return InsufficientRemainingFee, 0, nil, nil, nil
 	}
 
 	return SuccesfullyValidated, messageMaxGas, tokenData, msgValue, nil


### PR DESCRIPTION
### Description

Removing FeeBoosting from CCIP 1.5 with minimal impact on the codebase. The entire execution path in the Exec plugin is basically the same; the only difference is logging the difference when a message is underpaid instead of skipping the execution. What is more, there is one more test to the batching logic to confirm costly messages are not ignored but executed.