### PR TITLE
fix(gateway): http client respects request timeout longer than default

### DIFF
--- a/.changeset/dull-candles-rule.md
+++ b/.changeset/dull-candles-rule.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+(gateway): ensures the httpClient respects timeout passed via request if greater than default #bug_fix

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -89,7 +89,6 @@ func NewHTTPClient(config HTTPClientConfig, lggr logger.Logger) (HTTPClient, err
 	config.ApplyDefaults()
 	safeConfig := safeurl.
 		GetConfigBuilder().
-		SetTimeout(config.DefaultTimeout).
 		SetAllowedIPs(config.AllowedIPs...).
 		SetAllowedIPsCIDR(config.AllowedIPsCIDR...).
 		SetAllowedPorts(config.AllowedPorts...).
@@ -110,6 +109,9 @@ func disableRedirects(req *http.Request, via []*http.Request) error {
 	return errors.New("redirects are not allowed")
 }
 
+// Send executes an http request that is always time limited by at least the
+// default timeout.  Override the default timeout with a non-zero duration by
+// passing a Timeout value on the request.
 func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, error) {
 	to := req.Timeout
 	if to == 0 {
@@ -117,8 +119,10 @@ func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, 
 	}
 
 	c.lggr.Debugw("sending HTTP request with timeout", "url", req.URL, "request timeout", to)
+
 	timeoutCtx, cancel := context.WithTimeout(ctx, to)
 	defer cancel()
+
 	r, err := http.NewRequestWithContext(timeoutCtx, req.Method, req.URL, bytes.NewBuffer(req.Body))
 	if err != nil {
 		return nil, err

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -81,7 +81,7 @@ func TestHTTPClient_Send(t *testing.T) {
 			},
 		},
 		{
-			name: "request timeout",
+			name: "context canceled due to timeout passed in request",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					time.Sleep(10 * time.Second)
@@ -99,6 +99,47 @@ func TestHTTPClient_Send(t *testing.T) {
 			},
 			expectedError: context.DeadlineExceeded,
 			expectedResp:  nil,
+		},
+		{
+			name: "context canceled due to default timeout",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					time.Sleep(10 * time.Second)
+					w.WriteHeader(http.StatusOK)
+					_, err2 := w.Write([]byte("success"))
+					assert.NoError(t, err2)
+				}))
+			},
+			request: HTTPRequest{
+				Method:  "GET",
+				URL:     "/",
+				Headers: map[string]string{},
+				Body:    nil,
+			},
+			expectedError: context.DeadlineExceeded,
+		},
+		{
+			name: "success with long timeout passed in request",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					time.Sleep(1 * time.Second)
+					w.WriteHeader(http.StatusOK)
+					_, err2 := w.Write([]byte("success"))
+					assert.NoError(t, err2)
+				}))
+			},
+			request: HTTPRequest{
+				Method:  "GET",
+				URL:     "/",
+				Headers: map[string]string{},
+				Body:    nil,
+				Timeout: 2 * time.Second,
+			},
+			expectedResp: &HTTPResponse{
+				StatusCode: http.StatusOK,
+				Headers:    map[string]string{"Content-Length": "7"},
+				Body:       []byte("success"),
+			},
 		},
 		{
 			name: "server error",
@@ -205,7 +246,6 @@ func TestHTTPClient_Send(t *testing.T) {
 
 			config := HTTPClientConfig{
 				MaxResponseBytes: tt.giveMaxRespBytes,
-				DefaultTimeout:   5 * time.Second,
 				AllowedIPs:       []string{hostname},
 				AllowedPorts:     []int{int(portInt)},
 			}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

WASM `Fetch` requests with `TimeoutMs` field set were not respected because the `httpClient` in the `gateway` package had a non-zero default value for `*http.Client.Timeout`, which did not match the context's timeout.

This PR unsets the `Client.Timeout` value and leaves it at `0`.  All request cancelation is handled by the request's context alone. 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
