### PR TITLE
Street fix gateway http client

### DIFF
--- a/.changeset/shiny-candles-type.md
+++ b/.changeset/shiny-candles-type.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+fix(gateway/network): uses single timeout for request with default and max values #bugfix

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -89,7 +89,6 @@ func NewHTTPClient(config HTTPClientConfig, lggr logger.Logger) (HTTPClient, err
 	config.ApplyDefaults()
 	safeConfig := safeurl.
 		GetConfigBuilder().
-		SetTimeout(config.DefaultTimeout).
 		SetAllowedIPs(config.AllowedIPs...).
 		SetAllowedIPsCIDR(config.AllowedIPsCIDR...).
 		SetAllowedPorts(config.AllowedPorts...).
@@ -110,6 +109,9 @@ func disableRedirects(req *http.Request, via []*http.Request) error {
 	return errors.New("redirects are not allowed")
 }
 
+// Send executes an http request that is always time limited by at least the
+// default timeout.  Override the default timeout with a non-zero duration by
+// passing a Timeout value on the request.
 func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, error) {
 	to := req.Timeout
 	if to == 0 {
@@ -117,8 +119,10 @@ func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, 
 	}
 
 	c.lggr.Debugw("sending HTTP request with timeout", "url", req.URL, "request timeout", to)
+
 	timeoutCtx, cancel := context.WithTimeout(ctx, to)
 	defer cancel()
+
 	r, err := http.NewRequestWithContext(timeoutCtx, req.Method, req.URL, bytes.NewBuffer(req.Body))
 	if err != nil {
 		return nil, err

--- a/core/services/gateway/network/httpclient.go
+++ b/core/services/gateway/network/httpclient.go
@@ -23,19 +23,24 @@ type HTTPClient interface {
 type HTTPClientConfig struct {
 	MaxResponseBytes uint32
 	DefaultTimeout   time.Duration
-	BlockedIPs       []string
-	BlockedIPsCIDR   []string
-	AllowedPorts     []int
-	AllowedSchemes   []string
-	AllowedIPs       []string
-	AllowedIPsCIDR   []string
+
+	// An HTTPRequest may override the DefaultTimeout, but is capped by
+	// maxRequestDuration.
+	maxRequestDuration time.Duration
+	BlockedIPs         []string
+	BlockedIPsCIDR     []string
+	AllowedPorts       []int
+	AllowedSchemes     []string
+	AllowedIPs         []string
+	AllowedIPsCIDR     []string
 }
 
 var (
-	defaultAllowedPorts     = []int{80, 443}
-	defaultAllowedSchemes   = []string{"http", "https"}
-	defaultMaxResponseBytes = uint32(26.4 * utils.KB)
-	defaultTimeout          = 5 * time.Second
+	defaultAllowedPorts       = []int{80, 443}
+	defaultAllowedSchemes     = []string{"http", "https"}
+	defaultMaxResponseBytes   = uint32(26.4 * utils.KB)
+	defaultMaxRequestDuration = 60 * time.Second
+	defaultTimeout            = 5 * time.Second
 )
 
 func (c *HTTPClientConfig) ApplyDefaults() {
@@ -54,6 +59,8 @@ func (c *HTTPClientConfig) ApplyDefaults() {
 	if c.DefaultTimeout == 0 {
 		c.DefaultTimeout = defaultTimeout
 	}
+
+	c.maxRequestDuration = defaultMaxRequestDuration
 
 	// safeurl automatically blocks internal IPs so no need
 	// to set defaults here.
@@ -116,6 +123,10 @@ func (c *httpClient) Send(ctx context.Context, req HTTPRequest) (*HTTPResponse, 
 	to := req.Timeout
 	if to == 0 {
 		to = c.config.DefaultTimeout
+	}
+
+	if to > c.config.maxRequestDuration {
+		to = c.config.maxRequestDuration
 	}
 
 	c.lggr.Debugw("sending HTTP request with timeout", "url", req.URL, "request timeout", to)

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -26,6 +26,7 @@ func TestHTTPClient_Send(t *testing.T) {
 	tests := []struct {
 		name             string
 		setupServer      func() *httptest.Server
+		configOption     func(*HTTPClientConfig)
 		request          HTTPRequest
 		giveMaxRespBytes uint32
 		expectedError    error
@@ -142,6 +143,28 @@ func TestHTTPClient_Send(t *testing.T) {
 			},
 		},
 		{
+			name: "fails with long timeout capped by default",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					time.Sleep(1 * time.Second)
+					w.WriteHeader(http.StatusOK)
+					_, err2 := w.Write([]byte("success"))
+					assert.NoError(t, err2)
+				}))
+			},
+			request: HTTPRequest{
+				Method:  "GET",
+				URL:     "/",
+				Headers: map[string]string{},
+				Body:    nil,
+				Timeout: 5 * time.Second,
+			},
+			configOption: func(hc *HTTPClientConfig) {
+				hc.maxRequestDuration = 100 * time.Millisecond
+			},
+			expectedError: context.DeadlineExceeded,
+		},
+		{
 			name: "server error",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -244,14 +267,20 @@ func TestHTTPClient_Send(t *testing.T) {
 			portInt, err := strconv.ParseInt(port, 10, 32)
 			require.NoError(t, err)
 
-			config := HTTPClientConfig{
+			config := &HTTPClientConfig{
 				MaxResponseBytes: tt.giveMaxRespBytes,
 				AllowedIPs:       []string{hostname},
 				AllowedPorts:     []int{int(portInt)},
 			}
 
-			client, err := NewHTTPClient(config, lggr)
+			client, err := NewHTTPClient(*config, lggr)
 			require.NoError(t, err)
+
+			if tt.configOption != nil {
+				hc, ok := client.(*httpClient)
+				require.True(t, ok)
+				tt.configOption(&hc.config)
+			}
 
 			tt.request.URL = server.URL + tt.request.URL
 

--- a/core/services/gateway/network/httpclient_test.go
+++ b/core/services/gateway/network/httpclient_test.go
@@ -81,7 +81,7 @@ func TestHTTPClient_Send(t *testing.T) {
 			},
 		},
 		{
-			name: "request timeout",
+			name: "context canceled due to timeout passed in request",
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					time.Sleep(10 * time.Second)
@@ -99,6 +99,47 @@ func TestHTTPClient_Send(t *testing.T) {
 			},
 			expectedError: context.DeadlineExceeded,
 			expectedResp:  nil,
+		},
+		{
+			name: "context canceled due to default timeout",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					time.Sleep(10 * time.Second)
+					w.WriteHeader(http.StatusOK)
+					_, err2 := w.Write([]byte("success"))
+					assert.NoError(t, err2)
+				}))
+			},
+			request: HTTPRequest{
+				Method:  "GET",
+				URL:     "/",
+				Headers: map[string]string{},
+				Body:    nil,
+			},
+			expectedError: context.DeadlineExceeded,
+		},
+		{
+			name: "success with long timeout passed in request",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					time.Sleep(1 * time.Second)
+					w.WriteHeader(http.StatusOK)
+					_, err2 := w.Write([]byte("success"))
+					assert.NoError(t, err2)
+				}))
+			},
+			request: HTTPRequest{
+				Method:  "GET",
+				URL:     "/",
+				Headers: map[string]string{},
+				Body:    nil,
+				Timeout: 2 * time.Second,
+			},
+			expectedResp: &HTTPResponse{
+				StatusCode: http.StatusOK,
+				Headers:    map[string]string{"Content-Length": "7"},
+				Body:       []byte("success"),
+			},
 		},
 		{
 			name: "server error",
@@ -205,7 +246,6 @@ func TestHTTPClient_Send(t *testing.T) {
 
 			config := HTTPClientConfig{
 				MaxResponseBytes: tt.giveMaxRespBytes,
-				DefaultTimeout:   5 * time.Second,
 				AllowedIPs:       []string{hostname},
 				AllowedPorts:     []int{int(portInt)},
 			}


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

Fixes a bug where passing a `Timeout` value with a request that was greater than the default client timeout was ignored.  Leaves `Client.Timeout` at `0` and controls request with context cancelation only.  Adds maximum value for request duration to cap incoming `Timeout` values.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
