### PR TITLE
fix(compute): extends the default timeout for custom compute

### DIFF
--- a/core/capabilities/compute/compute.go
+++ b/core/capabilities/compute/compute.go
@@ -398,7 +398,7 @@ const (
 	defaultNumWorkers                = 3
 	defaultMaxMemoryMBs              = 128
 	defaultMaxTickInterval           = 100 * time.Millisecond
-	defaultMaxTimeout                = 10 * time.Second
+	defaultMaxTimeout                = 120 * time.Second // 2 minutes
 	defaultMaxCompressedBinarySize   = 20 * 1024 * 1024  // 20 MB
 	defaultMaxDecompressedBinarySize = 100 * 1024 * 1024 // 100 MB
 	defaultMaxResponseSizeBytes      = 5 * 1024 * 1024   // 5 MB
@@ -406,8 +406,11 @@ const (
 
 type Config struct {
 	webapi.ServiceConfig
-	NumWorkers                int
-	MaxMemoryMBs              uint64
+	NumWorkers   int
+	MaxMemoryMBs uint64
+
+	// MaxTimeout is the maximum time that the WASM module may run to complete
+	// a custom compute step.
 	MaxTimeout                time.Duration
 	MaxTickInterval           time.Duration
 	MaxCompressedBinarySize   uint64


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

v1 workflows execute wasm guests in the custom compute step.  The max timeout for the wasm guest is optionally set via the custom compute job spec.  When this value is not set, the default is used instead.  The default is too low especially as custom compute steps are used to execute network fetch requests to gateways.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
