### PR TITLE
update cre local env SHA used in the nightly run

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -162,10 +162,10 @@ jobs:
       AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
-  call-nightly-e2e-tests:
+  call-cre-local-env-tests:
     if: ${{ github.event_name == 'schedule' }}
     needs: [docker-core-plugins]
-    uses: smartcontractkit/chainlink/.github/workflows/cre-local-env-tests.yaml@5256f32781ffbc7f754e2f3ab65b3d1c060775bf # develop SHA from 19th May 2025
+    uses: smartcontractkit/chainlink/.github/workflows/cre-local-env-tests.yaml@3274245a0b5b8bd5ea4bf0b6e507ac29e5571beb # develop SHA from 23rd May 2025
     with:
       chainlink_image_tag: ${{ needs.docker-core-plugins.outputs.docker-manifest-tag }}
       chainlink_version: develop


### PR DESCRIPTION
Fixes this failure using old SHA: https://github.com/smartcontractkit/chainlink/actions/runs/15201549807/job/42756854401 that doesn't match changed repo structure.