### PR TITLE
[CLD-266]: fix: migrate to ListChainSelectors func

### DIFF
--- a/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
@@ -10,8 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip_offramp"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -231,7 +234,7 @@ func TestDeployAptosChain_Apply(t *testing.T) {
 	})
 
 	// Get chain selectors
-	aptosChainSelectors := env.AllChainSelectorsAptos()
+	aptosChainSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyAptos))
 	require.Len(t, aptosChainSelectors, 1, "Expected exactly 1 Aptos chain")
 	chainSelector := aptosChainSelectors[0]
 	t.Log("Deployer: ", env.AptosChains[chainSelector].DeployerSigner)

--- a/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane_test.go
+++ b/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/require"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	solRouter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
 	solFeeQuoter "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/fee_quoter"
@@ -49,9 +53,9 @@ func TestAddEVMSolanaLaneBidirectional(t *testing.T) {
 			ctx := testcontext.Get(t)
 			tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
 			e := tenv.Env
-			solChains := tenv.Env.AllChainSelectorsSolana()
+			solChains := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
 			require.NotEmpty(t, solChains)
-			evmChains := tenv.Env.AllChainSelectors()
+			evmChains := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 			require.NotEmpty(t, evmChains)
 			solChain := solChains[0]
 			evmChain1 := evmChains[0]

--- a/deployment/ccip/changeset/cs_prerequisites_test.go
+++ b/deployment/ccip/changeset/cs_prerequisites_test.go
@@ -3,8 +3,11 @@ package changeset_test
 import (
 	"testing"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -40,7 +43,7 @@ func TestDeployPrerequisitesZk(t *testing.T) {
 }
 
 func testDeployPrerequisitesWithEnv(t *testing.T, e cldf.Environment) {
-	newChain := e.AllChainSelectors()[0]
+	newChain := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	cfg := changeset.DeployPrerequisiteConfig{
 		Configs: []changeset.DeployPrerequisiteConfigPerChain{
 			{

--- a/deployment/ccip/changeset/save_existing_test.go
+++ b/deployment/ccip/changeset/save_existing_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -27,7 +30,7 @@ func TestSaveExistingCCIP(t *testing.T) {
 		Chains:     2,
 		Nodes:      4,
 	})
-	chains := e.AllChainSelectors()
+	chains := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	chain1 := chains[0]
 	chain2 := chains[1]
 	cfg := commonchangeset.ExistingContractsConfig{

--- a/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
@@ -6,7 +6,10 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	solToken "github.com/gagliardetto/solana-go/programs/token"
 
@@ -88,8 +91,8 @@ func doTestAddRemoteChain(t *testing.T, mcms bool) {
 	e := tenv.Env
 	_, err := stateview.LoadOnchainStateSolana(tenv.Env)
 	require.NoError(t, err)
-	evmChains := tenv.Env.AllChainSelectors()
-	solChain := tenv.Env.AllChainSelectorsSolana()[0]
+	evmChains := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
+	solChain := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 	var mcmsConfig *proposalutils.TimelockConfig
 	if mcms {
 		_, _ = testhelpers.TransferOwnershipSolana(t, &e, solChain, true,
@@ -313,8 +316,8 @@ func doTestAddRemoteChain(t *testing.T, mcms bool) {
 func doTestBilling(t *testing.T, mcms bool) {
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
 
-	evmChain := tenv.Env.AllChainSelectors()[0]
-	solChain := tenv.Env.AllChainSelectorsSolana()[0]
+	evmChain := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	solChain := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 
 	e, tokenAddress, err := deployTokenAndMint(t, tenv.Env, solChain, []string{})
 	require.NoError(t, err)
@@ -585,7 +588,7 @@ func TestBillingWithoutMcms(t *testing.T) {
 func doTestTokenAdminRegistry(t *testing.T, mcms bool) {
 	ctx := testcontext.Get(t)
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
-	solChain := tenv.Env.AllChainSelectorsSolana()[0]
+	solChain := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 	e, tokenAddress, err := deployTokenAndMint(t, tenv.Env, solChain, []string{})
 	require.NoError(t, err)
 	state, err := stateview.LoadOnchainStateSolana(e)
@@ -727,7 +730,7 @@ func TestTokenAdminRegistryWithoutMcms(t *testing.T) {
 func doTestPoolLookupTable(t *testing.T, e cldf.Environment, mcms bool, tokenMetadata string) {
 	ctx := testcontext.Get(t)
 
-	solChain := e.AllChainSelectorsSolana()[0]
+	solChain := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 
 	var mcmsConfig *proposalutils.TimelockConfig
 	newAdmin := e.SolChains[solChain].DeployerKey.PublicKey()
@@ -840,9 +843,9 @@ func TestSetOcr3Active(t *testing.T) {
 		testhelpers.WithNumOfBootstrapNodes(3),
 		testhelpers.WithSolChains(1))
 	var err error
-	evmSelectors := tenv.Env.AllChainSelectors()
+	evmSelectors := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	homeChainSel := evmSelectors[0]
-	solChainSelectors := tenv.Env.AllChainSelectorsSolana()
+	solChainSelectors := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
 	_, _ = testhelpers.TransferOwnershipSolana(t, &tenv.Env, solChainSelectors[0], true,
 		ccipChangesetSolana.CCIPContractsToTransfer{
 			Router:    true,
@@ -869,9 +872,9 @@ func TestSetOcr3Candidate(t *testing.T) {
 	tenv, _ := testhelpers.NewMemoryEnvironment(t,
 		testhelpers.WithSolChains(1))
 	var err error
-	evmSelectors := tenv.Env.AllChainSelectors()
+	evmSelectors := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	homeChainSel := evmSelectors[0]
-	solChainSelectors := tenv.Env.AllChainSelectorsSolana()
+	solChainSelectors := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
 	_, _ = testhelpers.TransferOwnershipSolana(t, &tenv.Env, solChainSelectors[0], true,
 		ccipChangesetSolana.CCIPContractsToTransfer{
 			Router:    true,

--- a/deployment/ccip/changeset/solana/cs_ops_test.go
+++ b/deployment/ccip/changeset/solana/cs_ops_test.go
@@ -4,9 +4,13 @@ import (
 	"testing"
 	"time"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	ccipChangesetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -38,7 +42,7 @@ func TestGenericOps(t *testing.T) {
 				tutils.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-437")
 			}
 			tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
-			solChain := tenv.Env.AllChainSelectorsSolana()[0]
+			solChain := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 			e := tenv.Env
 
 			var mcmsConfig *proposalutils.TimelockConfig

--- a/deployment/ccip/changeset/solana/cs_solana_token_test.go
+++ b/deployment/ccip/changeset/solana/cs_solana_token_test.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	solRpc "github.com/gagliardetto/solana-go/rpc"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	solTokenUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
@@ -30,7 +33,7 @@ func TestSolanaTokenOps(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		SolChains: 1,
 	})
-	solChain1 := e.AllChainSelectorsSolana()[0]
+	solChain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 	e, err := commonchangeset.Apply(t, e, nil,
 		commonchangeset.Configure(
 			// deployer creates token

--- a/deployment/ccip/changeset/solana/save_existing_test.go
+++ b/deployment/ccip/changeset/solana/save_existing_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
@@ -31,7 +33,7 @@ func TestSaveExistingCCIP(t *testing.T) {
 		SolChains:  1,
 		Nodes:      4,
 	})
-	solChain := e.AllChainSelectorsSolana()[0]
+	solChain := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilySolana))[0]
 	solAddr1 := solana.NewWallet().PublicKey().String()
 	solAddr2 := solana.NewWallet().PublicKey().String()
 	cfg := commonchangeset.ExistingContractsConfig{

--- a/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock_test.go
+++ b/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock_test.go
@@ -10,6 +10,8 @@ import (
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	burnmint "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/burnmint_token_pool"
 	lockrelease "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/lockrelease_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/rmn_remote"
@@ -127,9 +129,10 @@ func TestValidate(t *testing.T) {
 	envWithInvalidSolChain.SolChains[chainselectors.ETHEREUM_TESTNET_SEPOLIA_LENS_1.Selector] = cldf.SolChain{}
 	timelockID := mcmsSolana.ContractAddress(solana.MustPublicKeyFromBase58(TimelockProgramID), [32]byte{'t', 'e', 's', 't'})
 	mcmsID := mcmsSolana.ContractAddress(solana.MustPublicKeyFromBase58(MCMProgramID), [32]byte{'t', 'e', 's', 't'})
-	err := env.ExistingAddresses.Save(env.AllChainSelectorsSolana()[0], timelockID, cldf.TypeAndVersion{Type: commontypes.RBACTimelock, Version: deployment.Version1_0_0})
+	solChain := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
+	err := env.ExistingAddresses.Save(solChain, timelockID, cldf.TypeAndVersion{Type: commontypes.RBACTimelock, Version: deployment.Version1_0_0})
 	require.NoError(t, err)
-	err = env.ExistingAddresses.Save(env.AllChainSelectorsSolana()[0], mcmsID, cldf.TypeAndVersion{Type: commontypes.ProposerManyChainMultisig, Version: deployment.Version1_0_0})
+	err = env.ExistingAddresses.Save(solChain, mcmsID, cldf.TypeAndVersion{Type: commontypes.ProposerManyChainMultisig, Version: deployment.Version1_0_0})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -203,10 +206,10 @@ func prepareEnvironmentForOwnershipTransfer(t *testing.T) (cldf.Environment, sta
 		SolChains:  1,
 		Nodes:      4,
 	})
-	evmSelectors := e.AllChainSelectors()
+	evmSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))
 	homeChainSel := evmSelectors[0]
-	solChainSelectors := e.AllChainSelectorsSolana()
-	solChain1 := e.AllChainSelectorsSolana()[0]
+	solChainSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))
+	solChain1 := solChainSelectors[0]
 	solChain := e.SolChains[solChain1]
 	selectors := make([]uint64, 0, len(evmSelectors)+len(solChainSelectors))
 	selectors = append(selectors, evmSelectors...)
@@ -319,7 +322,7 @@ func prepareEnvironmentForOwnershipTransfer(t *testing.T) (cldf.Environment, sta
 func TestTransferCCIPToMCMSWithTimelockSolana(t *testing.T) {
 	t.Parallel()
 	e, state := prepareEnvironmentForOwnershipTransfer(t)
-	solChain1 := e.AllChainSelectorsSolana()[0]
+	solChain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
 	solChain := e.SolChains[solChain1]
 
 	tokenAddressLockRelease := state.SolChains[solChain1].SPL2022Tokens[0]
@@ -408,7 +411,7 @@ func TestTransferCCIPToMCMSWithTimelockSolana(t *testing.T) {
 func TestTransferCCIPFromMCMSWithTimelockSolana(t *testing.T) {
 	t.Parallel()
 	e, state := prepareEnvironmentForOwnershipTransfer(t)
-	solChain1 := e.AllChainSelectorsSolana()[0]
+	solChain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
 	solChain := e.SolChains[solChain1]
 
 	tokenAddressLockRelease := state.SolChains[solChain1].SPL2022Tokens[0]

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/message_hasher"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	ccipChangeSetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
@@ -2311,7 +2312,11 @@ func DeployCCIPContractsTest(t *testing.T, solChains int) {
 	// Deploy all the CCIP contracts.
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
-	allChains := append(e.Env.AllChainSelectors(), e.Env.AllChainSelectorsSolana()...)
+	evmChainSelectors := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
+	solChainSelectors := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilySolana))
+	var allChains []uint64
+	allChains = append(allChains, evmChainSelectors...)
+	allChains = append(allChains, solChainSelectors...)
 	snap, solana, err := state.View(&e.Env, allChains)
 	require.NoError(t, err)
 	if solChains > 0 {

--- a/deployment/ccip/changeset/testhelpers/test_token_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_token_helpers.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -60,7 +63,7 @@ func SetupTwoChainEnvironmentWithTokens(
 	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 2,
 	})
-	selectors := e.AllChainSelectors()
+	selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 
 	addressBook := cldf.NewMemoryAddressBook()
 	prereqCfg := make([]changeset.DeployPrerequisiteConfigPerChain, len(selectors))
@@ -171,7 +174,7 @@ func DeployTestTokenPools(
 	newPools map[uint64]v1_5_1.DeployTokenPoolInput,
 	transferToTimelock bool,
 ) cldf.Environment {
-	selectors := e.AllChainSelectors()
+	selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 
 	e, err := commonchangeset.Apply(t, e, nil,
 		commoncs.Configure(

--- a/deployment/ccip/changeset/v1_5/e2e_test.go
+++ b/deployment/ccip/changeset/v1_5/e2e_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
@@ -48,8 +50,11 @@ func TestE2ELegacy(t *testing.T) {
 		testhelpers.WithChainIDs([]uint64{chainselectors.GETH_TESTNET.EvmChainID}))
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
-	allChains := e.Env.AllChainSelectorsExcluding([]uint64{chainselectors.GETH_TESTNET.Selector})
-	require.Contains(t, e.Env.AllChainSelectors(), chainselectors.GETH_TESTNET.Selector)
+	allChains := e.Env.BlockChains.ListChainSelectors(
+		cldf_chain.WithFamily(chainselectors.FamilyEVM),
+		cldf_chain.WithChainSelectorsExclusion([]uint64{chainselectors.GETH_TESTNET.Selector}),
+	)
+	require.Contains(t, e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)), chainselectors.GETH_TESTNET.Selector)
 	require.Len(t, allChains, 2)
 	src, dest := allChains[1], chainselectors.GETH_TESTNET.Selector
 	srcChain := e.Env.Chains[src]

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
@@ -98,7 +101,7 @@ func TestAddTokenE2E(t *testing.T) {
 				e = tenv.Env
 				state, err := stateview.LoadOnchainState(e)
 				require.NoError(t, err)
-				selectors := e.AllChainSelectors()
+				selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 				selectorA = selectors[0]
 				selectorB = selectors[1]
 				// We only need the token admin registry to be owned by the timelock in these tests
@@ -141,7 +144,7 @@ func TestAddTokenE2E(t *testing.T) {
 			recipientAddress := utils.RandomAddress()
 			topupAmount := big.NewInt(1000)
 			// form the changeset input config
-			for _, chain := range e.AllChainSelectors() {
+			for _, chain := range e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 				if addTokenE2EConfig.Tokens == nil {
 					addTokenE2EConfig.Tokens = make(map[shared.TokenSymbol]v1_5_1.AddTokenE2EConfig)
 				}

--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools_test.go
@@ -10,8 +10,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
 	solTestTokenPool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/test_token_pool"
@@ -287,27 +290,27 @@ func TestValidateConfigureTokenPoolContractsConfig(t *testing.T) {
 			Input: v1_5_1.ConfigureTokenPoolContractsConfig{
 				TokenSymbol: testhelpers.TestTokenSymbol,
 				PoolUpdates: map[uint64]v1_5_1.TokenPoolConfig{
-					e.AllChainSelectors()[0]: v1_5_1.TokenPoolConfig{
+					e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]: v1_5_1.TokenPoolConfig{
 						ChainUpdates: v1_5_1.RateLimiterPerChain{
-							e.AllChainSelectors()[1]: v1_5_1.RateLimiterConfig{},
+							e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1]: v1_5_1.RateLimiterConfig{},
 						},
 					},
 				},
 			},
 			ErrStr: "is expecting a pool update to be defined for chain with selector",
 		},
-		/* This test condition is flakey, as we will see "missing tokenAdminRegistry" if e.AllChainSelectors()[1] is checked first
+		/* This test condition is flakey, as we will see "missing tokenAdminRegistry" if e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1] is checked first
 		{
 			Msg: "Corresponding pool update missing a chain update",
 			Input: changeset.ConfigureTokenPoolContractsConfig{
 				TokenSymbol: testhelpers.TestTokenSymbol,
 				PoolUpdates: map[uint64]changeset.TokenPoolConfig{
-					e.AllChainSelectors()[0]: changeset.TokenPoolConfig{
+					e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]: changeset.TokenPoolConfig{
 						ChainUpdates: changeset.RateLimiterPerChain{
-							e.AllChainSelectors()[1]: changeset.RateLimiterConfig{},
+							e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1]: changeset.RateLimiterConfig{},
 						},
 					},
-					e.AllChainSelectors()[1]: changeset.TokenPoolConfig{},
+					e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1]: changeset.TokenPoolConfig{},
 				},
 			},
 			ErrStr: "to define a chain config pointing back to it",
@@ -318,14 +321,14 @@ func TestValidateConfigureTokenPoolContractsConfig(t *testing.T) {
 			Input: v1_5_1.ConfigureTokenPoolContractsConfig{
 				TokenSymbol: testhelpers.TestTokenSymbol,
 				PoolUpdates: map[uint64]v1_5_1.TokenPoolConfig{
-					e.AllChainSelectors()[0]: v1_5_1.TokenPoolConfig{
+					e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]: v1_5_1.TokenPoolConfig{
 						ChainUpdates: v1_5_1.RateLimiterPerChain{
-							e.AllChainSelectors()[1]: v1_5_1.RateLimiterConfig{},
+							e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1]: v1_5_1.RateLimiterConfig{},
 						},
 					},
-					e.AllChainSelectors()[1]: v1_5_1.TokenPoolConfig{
+					e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1]: v1_5_1.TokenPoolConfig{
 						ChainUpdates: v1_5_1.RateLimiterPerChain{
-							e.AllChainSelectors()[0]: v1_5_1.RateLimiterConfig{},
+							e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]: v1_5_1.RateLimiterConfig{},
 						},
 					},
 				},
@@ -614,7 +617,7 @@ func TestValidateConfigureTokenPoolContracts(t *testing.T) {
 					)
 					require.NoError(t, err)
 
-					for _, selector := range e.AllChainSelectors() {
+					for _, selector := range e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 						var remoteChainSelector uint64
 						var rateLimiterConfig v1_5_1.RateLimiterConfig
 						switch selector {
@@ -677,7 +680,7 @@ func TestValidateConfigureTokenPoolContracts(t *testing.T) {
 					)
 					require.NoError(t, err)
 
-					for _, selector := range e.AllChainSelectors() {
+					for _, selector := range e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 						var updatePool bool
 						var updateRemotePool bool
 						var remoteChainSelector uint64
@@ -731,8 +734,8 @@ func TestValidateConfigureTokenPoolContractsForSolana(t *testing.T) {
 	})
 	e := deployedEnvironment.Env
 
-	evmSelectors := []uint64{e.AllChainSelectors()[0]}
-	solanaSelectors := e.AllChainSelectorsSolana()
+	evmSelectors := []uint64{e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]}
+	solanaSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
 
 	addressBook := cldf.NewMemoryAddressBook()
 

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pool_factory_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pool_factory_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_0_0/rmn_proxy_contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
@@ -100,7 +103,7 @@ func TestDeployTokenPoolFactoryChangeset(t *testing.T) {
 			e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 				Chains: 2,
 			})
-			selectors := e.AllChainSelectors()
+			selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 
 			if !test.ForgetPrerequisites {
 				// NOTE: We don't use the DeployPrerequisites changeset because the TokenPoolFactory is a prerequisite in itself.

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools_test.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
@@ -70,7 +73,7 @@ func TestValidateDeployTokenPoolContractsConfig(t *testing.T) {
 			Input: v1_5_1.DeployTokenPoolContractsConfig{
 				TokenSymbol: "TEST",
 				NewPools: map[uint64]v1_5_1.DeployTokenPoolInput{
-					e.AllChainSelectors()[0]: v1_5_1.DeployTokenPoolInput{},
+					e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]: v1_5_1.DeployTokenPoolInput{},
 				},
 			},
 			ErrStr: "missing router",
@@ -80,7 +83,7 @@ func TestValidateDeployTokenPoolContractsConfig(t *testing.T) {
 			Input: v1_5_1.DeployTokenPoolContractsConfig{
 				TokenSymbol: "TEST",
 				NewPools: map[uint64]v1_5_1.DeployTokenPoolInput{
-					e.AllChainSelectors()[0]: v1_5_1.DeployTokenPoolInput{},
+					e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]: v1_5_1.DeployTokenPoolInput{},
 				},
 				IsTestRouter: true,
 			},

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
@@ -5,8 +5,11 @@ import (
 	"math/big"
 	"testing"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
@@ -121,7 +124,7 @@ func TestValidateDeployUSDCTokenPoolContractsConfig(t *testing.T) {
 			Msg: "Missing router",
 			Input: v1_5_1.DeployUSDCTokenPoolContractsConfig{
 				USDCPools: map[uint64]v1_5_1.DeployUSDCTokenPoolInput{
-					e.AllChainSelectors()[0]: v1_5_1.DeployUSDCTokenPoolInput{},
+					e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]: v1_5_1.DeployUSDCTokenPoolInput{},
 				},
 			},
 			ErrStr: "missing router",
@@ -143,7 +146,7 @@ func TestValidateDeployUSDCTokenPoolInput(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 2,
 	})
-	selector := e.AllChainSelectors()[0]
+	selector := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	chain := e.Chains[selector]
 	addressBook := cldf.NewMemoryAddressBook()
 
@@ -245,7 +248,7 @@ func TestDeployUSDCTokenPoolContracts(t *testing.T) {
 			e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 				Chains: 2,
 			})
-			selectors := e.AllChainSelectors()
+			selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 
 			addressBook := cldf.NewMemoryAddressBook()
 			prereqCfg := make([]changeset.DeployPrerequisiteConfigPerChain, len(selectors))

--- a/deployment/ccip/changeset/v1_5_1/cs_sync_usdc_domains_with_chains_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_sync_usdc_domains_with_chains_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -140,7 +143,7 @@ func TestValidateSyncUSDCDomainsWithChainsConfig(t *testing.T) {
 				testCfg.IsUSDC = test.DeployUSDC
 			})
 			e := deployedEnvironment.Env
-			selectors := deployedEnvironment.Env.AllChainSelectors()
+			selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 
 			if test.DeployUSDC {
 				var err error
@@ -199,7 +202,7 @@ func TestSyncUSDCDomainsWithChainsChangeset(t *testing.T) {
 				testCfg.IsUSDC = true
 			})
 			e := deployedEnvironment.Env
-			selectors := e.AllChainSelectors()
+			selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 
 			state, err := stateview.LoadOnchainState(e)
 			require.NoError(t, err)

--- a/deployment/ccip/changeset/v1_6/cs_add_lane_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_lane_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
@@ -21,7 +25,7 @@ func TestAddLanesWithTestRouter(t *testing.T) {
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
-	selectors := e.Env.AllChainSelectors()
+	selectors := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	chain1, chain2 := selectors[0], selectors[1]
 	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &e, state, chain1, chain2, true)
 	// Need to keep track of the block number for each chain so that event subscription can be done from that block.
@@ -54,9 +58,9 @@ func TestAddLanesWithSolana(t *testing.T) {
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
-	evmSelectors := e.Env.AllChainSelectors()
+	evmSelectors := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	chain1, chain2 := evmSelectors[0], evmSelectors[1]
-	solSelectors := e.Env.AllChainSelectorsSolana()
+	solSelectors := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
 	solChain := solSelectors[0]
 	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &e, state, chain1, solChain, true)
 	// AddLaneWithDefaultPricesAndFeeQuoterConfig involves calling AddRemoteChainToSolana

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
@@ -6,16 +6,18 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/don_id_claimer"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -123,7 +125,7 @@ func TestConnectNewChain(t *testing.T) {
 			state, err := stateview.LoadOnchainState(e)
 			require.NoError(t, err, "must load onchain state")
 
-			selectors := e.AllChainSelectors()
+			selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 			var newSelector uint64
 			remoteChainSelectors := make([]uint64, 0, len(selectors)-1)
 			for _, selector := range selectors {
@@ -295,7 +297,7 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 			var linkAddress common.Address
 			remoteChainSelectors := make([]uint64, 0, len(chainIDs)-1)
 			addressesByChain := make(map[uint64]map[string]cldf.TypeAndVersion, len(chainIDs)-1)
-			for _, selector := range e.AllChainSelectors() {
+			for _, selector := range e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 				if selector != deployedEnvironment.HomeChainSel && newChainSelector == 0 {
 					newChainSelector = selector
 					linkAddress = state.Chains[selector].LinkToken.Address()

--- a/deployment/ccip/changeset/v1_6/cs_ccip_home_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_ccip_home_test.go
@@ -7,8 +7,11 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/maps"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
@@ -37,7 +40,7 @@ import (
 func TestInvalidOCR3Params(t *testing.T) {
 	e, _ := testhelpers.NewMemoryEnvironment(t,
 		testhelpers.WithPrerequisiteDeploymentOnly(nil))
-	chain1 := e.Env.AllChainSelectors()[0]
+	chain1 := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	envNodes, err := deployment.NodeInfo(e.Env.NodeIDs, e.Env.Offchain)
 	require.NoError(t, err)
 	// Need to deploy prerequisites first so that we can form the USDC config

--- a/deployment/ccip/changeset/v1_6/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_deploy_chain_test.go
@@ -3,8 +3,11 @@ package v1_6_test
 import (
 	"testing"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -32,14 +35,14 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 		Chains:     2,
 		Nodes:      4,
 	})
-	evmSelectors := e.AllChainSelectors()
+	evmSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	homeChainSel := evmSelectors[0]
 	nodes, err := deployment.NodeInfo(e.NodeIDs, e.Offchain)
 	require.NoError(t, err)
 	p2pIds := nodes.NonBootstraps().PeerIDs()
 	cfg := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 	contractParams := make(map[uint64]ccipseq.ChainContractParams)
-	for _, chain := range e.AllChainSelectors() {
+	for _, chain := range e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 		cfg[chain] = proposalutils.SingleGroupTimelockConfigV2(t)
 		contractParams[chain] = ccipseq.ChainContractParams{
 			FeeQuoterParams: ccipops.DefaultFeeQuoterParams(),
@@ -47,7 +50,7 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 		}
 	}
 	prereqCfg := make([]changeset.DeployPrerequisiteConfigPerChain, 0)
-	for _, chain := range e.AllChainSelectors() {
+	for _, chain := range e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 		prereqCfg = append(prereqCfg, changeset.DeployPrerequisiteConfigPerChain{
 			ChainSelector: chain,
 		})
@@ -157,7 +160,7 @@ func TestDeployStaticLinkToken(t *testing.T) {
 	// load onchain state
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
-	for _, chain := range e.Env.AllChainSelectors() {
+	for _, chain := range e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 		require.NotNil(t, state.Chains[chain].StaticLinkToken)
 	}
 }

--- a/deployment/ccip/changeset/v1_6/cs_home_chain_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_home_chain_test.go
@@ -5,8 +5,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
@@ -37,7 +40,7 @@ func TestDeployHomeChain(t *testing.T) {
 		Chains:     2,
 		Nodes:      4,
 	})
-	homeChainSel := e.AllChainSelectors()[0]
+	homeChainSel := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	nodes, err := deployment.NodeInfo(e.NodeIDs, e.Offchain)
 	require.NoError(t, err)
 	p2pIds := nodes.NonBootstraps().PeerIDs()
@@ -278,7 +281,7 @@ func TestAddDonAfterRemoveDons(t *testing.T) {
 	e, _ := testhelpers.NewMemoryEnvironment(t)
 	s, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
-	allChains := e.Env.AllChainSelectors()
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	homeChain := s.Chains[e.HomeChainSel]
 	ocrConfigs := make(map[uint64]v1_6.CCIPOCRParams)
 	// Remove a don
@@ -542,7 +545,7 @@ func TestRemoveNodes(t *testing.T) {
 			state, err := stateview.LoadOnchainState(e.Env)
 			require.NoError(t, err)
 			homeChain := s.Chains[e.HomeChainSel]
-			allChains := e.Env.AllChainSelectors()
+			allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 
 			var mcmsConfig *proposalutils.TimelockConfig
 			if tc.mcmsEnabled {

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	solRmnRemote "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/rmn_remote"
@@ -17,6 +18,7 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
@@ -762,8 +764,9 @@ func GetCursableChains(env cldf.Environment) (map[uint64]CursableChain, error) {
 
 func GetAllCursableChainsSelector(env cldf.Environment) []uint64 {
 	selectors := make([]uint64, 0)
-	selectors = append(selectors, env.AllChainSelectors()...)
-	selectors = append(selectors, env.AllChainSelectorsSolana()...)
+	selectors = append(selectors, env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))...)
+	solSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
+	selectors = append(selectors, solSelectors...)
 	return selectors
 }
 

--- a/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes_test.go
@@ -6,8 +6,11 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
@@ -314,7 +317,7 @@ func TestUpdateBidirectiConalLanesChangeset(t *testing.T) {
 			state, err := stateview.LoadOnchainState(e)
 			require.NoError(t, err, "must load onchain state")
 
-			selectors := e.AllChainSelectors()
+			selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 
 			timelockContracts := make(map[uint64]*proposalutils.TimelockExecutionContracts, len(selectors))
 			for _, selector := range selectors {

--- a/deployment/ccip/shared/deployergroup/deployer_group_test.go
+++ b/deployment/ccip/shared/deployergroup/deployer_group_test.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
@@ -108,7 +111,7 @@ func dummyDeployerGroupGrantMintMultiChainChangeset(e cldf.Environment, cfg dumm
 
 	group := deployergroup.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("grant mint role")
 	for _, mint := range cfg.mints {
-		selector := e.AllChainSelectors()[mint.selectorIndex]
+		selector := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[mint.selectorIndex]
 		token := state.MustGetEVMChainState(selector).LinkToken
 
 		deployer, err := group.GetDeployer(selector)
@@ -135,7 +138,7 @@ func dummyDeployerGroupMintMultiDeploymentContextChangeset(e cldf.Environment, c
 	var deployer *bind.TransactOpts
 
 	for i, mint := range cfg.mints {
-		selector := e.AllChainSelectors()[mint.selectorIndex]
+		selector := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[mint.selectorIndex]
 		token := state.MustGetEVMChainState(selector).LinkToken
 
 		if group == nil {
@@ -316,7 +319,7 @@ func TestDeployerGroupGenerateMultipleProposals(t *testing.T) {
 	timelocksPerChain := deployergroup.BuildTimelockPerChain(e.Env, state)
 
 	contractsByChain := make(map[uint64][]common.Address)
-	for _, chain := range e.Env.AllChainSelectors() {
+	for _, chain := range e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 		contractsByChain[chain] = []common.Address{state.MustGetEVMChainState(chain).LinkToken.Address()}
 	}
 
@@ -347,9 +350,9 @@ func TestDeployerGroupGenerateMultipleProposals(t *testing.T) {
 	require.Equal(t, "mint tokens 1", cs.MCMSTimelockProposals[0].Description)
 	require.Equal(t, "mint tokens 2", cs.MCMSTimelockProposals[1].Description)
 	require.Equal(t, "mint tokens 3", cs.MCMSTimelockProposals[2].Description)
-	require.Equal(t, uint64(2), cs.MCMSTimelockProposals[0].ChainMetadata[mcmstypes.ChainSelector(e.Env.AllChainSelectors()[tc.mints[0].selectorIndex])].StartingOpCount)
-	require.Equal(t, uint64(3), cs.MCMSTimelockProposals[1].ChainMetadata[mcmstypes.ChainSelector(e.Env.AllChainSelectors()[tc.mints[1].selectorIndex])].StartingOpCount)
-	require.Equal(t, uint64(2), cs.MCMSTimelockProposals[2].ChainMetadata[mcmstypes.ChainSelector(e.Env.AllChainSelectors()[tc.mints[2].selectorIndex])].StartingOpCount)
+	require.Equal(t, uint64(2), cs.MCMSTimelockProposals[0].ChainMetadata[mcmstypes.ChainSelector(e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[tc.mints[0].selectorIndex])].StartingOpCount)
+	require.Equal(t, uint64(3), cs.MCMSTimelockProposals[1].ChainMetadata[mcmstypes.ChainSelector(e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[tc.mints[1].selectorIndex])].StartingOpCount)
+	require.Equal(t, uint64(2), cs.MCMSTimelockProposals[2].ChainMetadata[mcmstypes.ChainSelector(e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[tc.mints[2].selectorIndex])].StartingOpCount)
 	require.Len(t, cs.DescribedTimelockProposals, len(tc.mints))
 	require.NotEmpty(t, cs.DescribedTimelockProposals[0])
 	require.NotEmpty(t, cs.DescribedTimelockProposals[1])
@@ -382,7 +385,7 @@ func TestDeployerGroupMultipleProposalsMCMS(t *testing.T) {
 	timelocksPerChain := deployergroup.BuildTimelockPerChain(e.Env, currentState)
 
 	contractsByChain := make(map[uint64][]common.Address)
-	for _, chain := range e.Env.AllChainSelectors() {
+	for _, chain := range e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 		contractsByChain[chain] = []common.Address{currentState.MustGetEVMChainState(chain).LinkToken.Address()}
 	}
 

--- a/deployment/ccip/shared/stateview/state_test.go
+++ b/deployment/ccip/shared/stateview/state_test.go
@@ -5,8 +5,11 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
@@ -30,7 +33,7 @@ func TestSmokeState(t *testing.T) {
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithNumOfChains(3))
 	state, err := stateview.LoadOnchainState(tenv.Env)
 	require.NoError(t, err)
-	_, _, err = state.View(&tenv.Env, tenv.Env.AllChainSelectors())
+	_, _, err = state.View(&tenv.Env, tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)))
 	require.NoError(t, err)
 }
 
@@ -164,7 +167,7 @@ func TestEnforceMCMSUsageIfProd(t *testing.T) {
 			e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 				Chains: 1,
 			})
-			homeChainSelector := e.AllChainSelectors()[0]
+			homeChainSelector := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 			if test.DeployCCIPHome {
 				_, err = cldf.DeployContract(e.Logger, e.Chains[homeChainSelector], e.ExistingAddresses,

--- a/deployment/ccip/shared/stateview/view.go
+++ b/deployment/ccip/shared/stateview/view.go
@@ -3,6 +3,9 @@ package stateview
 import (
 	"encoding/json"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	ccipview "github.com/smartcontractkit/chainlink/deployment/ccip/view"
@@ -16,7 +19,8 @@ func ViewCCIP(e deployment.Environment) (json.Marshaler, error) {
 	if err != nil {
 		return nil, err
 	}
-	allChains := append(e.AllChainSelectors(), e.AllChainSelectorsSolana()...)
+	solSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))
+	allChains := append(e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)), solSelectors...)
 	chainView, solanaView, err := state.View(&e, allChains)
 	if err != nil {
 		return nil, err

--- a/deployment/ccip/view/v1_2/price_registry_test.go
+++ b/deployment/ccip/view/v1_2/price_registry_test.go
@@ -5,12 +5,16 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
 	price_registry_1_2_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/price_registry"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -21,7 +25,7 @@ func TestGeneratePriceRegistryView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.AllChainSelectors()[0]]
+	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	f1, f2 := common.HexToAddress("0x1"), common.HexToAddress("0x2")
 	_, tx, c, err := price_registry_1_2_0.DeployPriceRegistry(
 		chain.DeployerKey, chain.Client, []common.Address{chain.DeployerKey.From}, []common.Address{f1, f2}, uint32(10))

--- a/deployment/ccip/view/v1_5/offramp_test.go
+++ b/deployment/ccip/view/v1_5/offramp_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
@@ -14,6 +14,9 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/commit_store"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_offramp"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -24,7 +27,7 @@ func TestOffRampView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.AllChainSelectors()[0]]
+	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
 	_, tx, c, err := commit_store.DeployCommitStore(
 		chain.DeployerKey, chain.Client, commit_store.CommitStoreStaticConfig{
 			ChainSelector:       chainsel.TEST_90000002.Selector,

--- a/deployment/ccip/view/v1_5/onramp_test.go
+++ b/deployment/ccip/view/v1_5/onramp_test.go
@@ -6,12 +6,16 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -22,7 +26,7 @@ func TestOnRampView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.AllChainSelectors()[0]]
+	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	_, tx, c, err := evm_2_evm_onramp.DeployEVM2EVMOnRamp(
 		chain.DeployerKey, chain.Client,
 		evm_2_evm_onramp.EVM2EVMOnRampStaticConfig{

--- a/deployment/ccip/view/v1_5/rmn_test.go
+++ b/deployment/ccip/view/v1_5/rmn_test.go
@@ -5,11 +5,16 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/rmn_contract"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -18,7 +23,7 @@ func TestGenerateRMNView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.AllChainSelectors()[0]]
+	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	cfg := rmn_contract.RMNConfig{
 		Voters: []rmn_contract.RMNVoter{
 			{

--- a/deployment/ccip/view/v1_6/ccip_home_test.go
+++ b/deployment/ccip/view/v1_6/ccip_home_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -21,7 +24,7 @@ func TestCCIPHomeView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.AllChainSelectors()[0]]
+	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	_, tx, cr, err := capabilities_registry.DeployCapabilitiesRegistry(
 		chain.DeployerKey, chain.Client)
 	require.NoError(t, err)

--- a/deployment/ccip/view/v1_6/rmnremote_test.go
+++ b/deployment/ccip/view/v1_6/rmnremote_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
@@ -22,8 +24,8 @@ func Test_RMNRemote_Curse_View(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.AllChainSelectors()[0]]
-	_, tx, remote, err := rmn_remote.DeployRMNRemote(chain.DeployerKey, chain.Client, e.AllChainSelectors()[0], common.Address{})
+	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
+	_, tx, remote, err := rmn_remote.DeployRMNRemote(chain.DeployerKey, chain.Client, e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0], common.Address{})
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
@@ -31,10 +33,10 @@ func Test_RMNRemote_Curse_View(t *testing.T) {
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
-	family, err := chainsel.GetSelectorFamily(e.AllChainSelectors()[0])
+	family, err := chainsel.GetSelectorFamily(e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0])
 	require.NoError(t, err)
 
-	tx, err = remote.Curse(chain.DeployerKey, globals.FamilyAwareSelectorToSubject(e.AllChainSelectors()[0], family))
+	tx, err = remote.Curse(chain.DeployerKey, globals.FamilyAwareSelectorToSubject(e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0], family))
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
@@ -45,7 +47,7 @@ func Test_RMNRemote_Curse_View(t *testing.T) {
 	require.Len(t, view.CursedSubjectEntries, 2)
 	require.Equal(t, "01000000000000000000000000000001", view.CursedSubjectEntries[0].Subject)
 	require.Equal(t, uint64(0), view.CursedSubjectEntries[0].Selector)
-	require.Equal(t, e.AllChainSelectors()[0], view.CursedSubjectEntries[1].Selector)
+	require.Equal(t, e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0], view.CursedSubjectEntries[1].Selector)
 }
 
 func Test_RMN_Selector_To_Solana_Subject(t *testing.T) {

--- a/deployment/common/changeset/deploy_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock_test.go
@@ -9,8 +9,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
 	"github.com/google/go-cmp/cmp"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
@@ -41,7 +44,7 @@ func TestGrantRoleInTimeLock(t *testing.T) {
 		Chains:             2,
 		NumOfUsersPerChain: 2,
 	})
-	evmSelectors := env.AllChainSelectors()
+	evmSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	changesetConfig := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 	for _, chain := range evmSelectors {
 		changesetConfig[chain] = proposalutils.SingleGroupTimelockConfigV2(t)
@@ -102,7 +105,7 @@ func TestGrantRoleInTimeLock(t *testing.T) {
 func TestDeployMCMSWithTimelockV2WithFewExistingContracts(t *testing.T) {
 	ctx := testutils.Context(t)
 	env := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{Chains: 2})
-	evmSelectors := env.AllChainSelectors()
+	evmSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	changesetConfig := map[uint64]commontypes.MCMSWithTimelockConfigV2{
 		evmSelectors[0]: {
 			Proposer: mcmstypes.Config{
@@ -215,8 +218,8 @@ func TestDeployMCMSWithTimelockV2(t *testing.T) {
 	log := logger.TestLogger(t)
 	envConfig := memory.MemoryEnvironmentConfig{Chains: 2, SolChains: 1}
 	env := memory.NewMemoryEnvironment(t, log, zapcore.InfoLevel, envConfig)
-	evmSelectors := env.AllChainSelectors()
-	solanaSelectors := env.AllChainSelectorsSolana()
+	evmSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
+	solanaSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
 	changesetConfig := map[uint64]commontypes.MCMSWithTimelockConfigV2{
 		evmSelectors[0]: {
 			Proposer: mcmstypes.Config{
@@ -459,7 +462,7 @@ func TestDeployMCMSWithTimelockV2SkipInitSolana(t *testing.T) {
 	log := logger.TestLogger(t)
 	envConfig := memory.MemoryEnvironmentConfig{Chains: 0, SolChains: 1}
 	env := memory.NewMemoryEnvironment(t, log, zapcore.InfoLevel, envConfig)
-	solanaSelectors := env.AllChainSelectorsSolana()
+	solanaSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
 	changesetConfig := map[uint64]commontypes.MCMSWithTimelockConfigV2{
 		solanaSelectors[0]: {
 			Proposer: mcmstypes.Config{

--- a/deployment/common/changeset/example/add_mint_burners_link_test.go
+++ b/deployment/common/changeset/example/add_mint_burners_link_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/example"
 )
@@ -19,7 +23,7 @@ func TestAddMintersBurnersLink(t *testing.T) {
 	// Deploy Link Token and Timelock contracts and add addresses to environment
 	env := setupLinkTransferTestEnv(t)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	chain := env.Chains[chainSelector]
 	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	require.NoError(t, err)

--- a/deployment/common/changeset/example/link_transfer_test.go
+++ b/deployment/common/changeset/example/link_transfer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/example"
@@ -32,7 +33,7 @@ func setupLinkTransferTestEnv(t *testing.T) cldf.Environment {
 		Chains: 2,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	config := proposalutils.SingleGroupMCMSV2(t)
 
 	// Deploy MCMS and Timelock
@@ -59,7 +60,7 @@ func setupLinkTransferTestEnv(t *testing.T) cldf.Environment {
 
 func TestValidate(t *testing.T) {
 	env := setupLinkTransferTestEnv(t)
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	chain := env.Chains[chainSelector]
 	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	require.NoError(t, err)
@@ -230,7 +231,7 @@ func TestLinkTransferMCMSV2(t *testing.T) {
 	ctx := context.Background()
 
 	env := setupLinkTransferTestEnv(t)
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	chain := env.Chains[chainSelector]
 	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	require.NoError(t, err)

--- a/deployment/common/changeset/example/mint_link_test.go
+++ b/deployment/common/changeset/example/mint_link_test.go
@@ -6,9 +6,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/example"
 )
@@ -18,7 +23,7 @@ func TestMintLink(t *testing.T) {
 	t.Parallel()
 	env := setupLinkTransferTestEnv(t)
 	ctx := env.GetContext()
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	chain := env.Chains[chainSelector]
 
 	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)

--- a/deployment/common/changeset/example/operations/deploy_and_mint_example_test.go
+++ b/deployment/common/changeset/example/operations/deploy_and_mint_example_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -17,7 +20,7 @@ func TestDeployAndMintExampleChangeset(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain1 := e.AllChainSelectors()[0]
+	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	changesetInput := SqDeployLinkInput{
 		MintAmount: big.NewInt(1000000000000000000),

--- a/deployment/common/changeset/mcms_firedrill.go
+++ b/deployment/common/changeset/mcms_firedrill.go
@@ -10,6 +10,7 @@ import (
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
@@ -75,8 +76,8 @@ func buildNoOPSolana() (mcmstypes.Transaction, error) {
 func MCMSSignFireDrillChangeset(e cldf.Environment, cfg FireDrillConfig) (cldf.ChangesetOutput, error) {
 	allSelectors := cfg.Selectors
 	if len(allSelectors) == 0 {
-		solSelectors := e.AllChainSelectorsSolana()
-		evmSelectors := e.AllChainSelectors()
+		solSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilySolana))
+		evmSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
 		allSelectors = append(allSelectors, solSelectors...)
 		allSelectors = append(allSelectors, evmSelectors...)
 	}

--- a/deployment/common/changeset/set_config_mcms_test.go
+++ b/deployment/common/changeset/set_config_mcms_test.go
@@ -8,8 +8,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	solanasdk "github.com/gagliardetto/solana-go"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/sdk/solana"
@@ -35,8 +38,8 @@ func setupSetConfigTestEnv(t *testing.T) cldf.Environment {
 		SolChains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-	chainSelector := env.AllChainSelectors()[0]
-	chainSelectorSolana := env.AllChainSelectorsSolana()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	chainSelectorSolana := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 
 	commonchangeset.SetPreloadedSolanaAddresses(t, env, chainSelectorSolana)
 	config := proposalutils.SingleGroupTimelockConfigV2(t)
@@ -119,7 +122,7 @@ func TestSetConfigMCMSV2EVM(t *testing.T) {
 			ctx := t.Context()
 
 			env := setupSetConfigTestEnv(t)
-			chainSelector := env.AllChainSelectors()[0]
+			chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 			chain := env.Chains[chainSelector]
 			addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 			require.NoError(t, err)
@@ -212,7 +215,7 @@ func TestSetConfigMCMSV2Solana(t *testing.T) {
 			ctx := t.Context()
 
 			env := setupSetConfigTestEnv(t)
-			chainSelectorSolana := env.AllChainSelectorsSolana()[0]
+			chainSelectorSolana := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 			solChain := env.SolChains[chainSelectorSolana]
 
 			addrs, err := env.ExistingAddresses.AddressesForChain(chainSelectorSolana)
@@ -275,8 +278,8 @@ func TestValidateV2(t *testing.T) {
 	t.Parallel()
 	env := setupSetConfigTestEnv(t)
 
-	chainSelector := env.AllChainSelectors()[0]
-	chainSelectorSolana := env.AllChainSelectorsSolana()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	chainSelectorSolana := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 
 	cfg := proposalutils.SingleGroupMCMSV2(t)
 	cfgInvalid := proposalutils.SingleGroupMCMSV2(t)

--- a/deployment/common/changeset/solana/fund_mcm_pdas_test.go
+++ b/deployment/common/changeset/solana/fund_mcm_pdas_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
 
@@ -34,7 +36,7 @@ func setupFundingTestEnv(t *testing.T) cldf.Environment {
 		SolChains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-	chainSelector := env.AllChainSelectorsSolana()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
 
 	config := proposalutils.SingleGroupTimelockConfigV2(t)
 	err := testhelpers.SavePreloadedSolAddresses(env, chainSelector)
@@ -62,7 +64,7 @@ func TestFundMCMSignersChangeset_VerifyPreconditions(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	validEnv := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{SolChains: 1})
 	validEnv.SolChains[chainselectors.SOLANA_DEVNET.Selector] = cldf.SolChain{}
-	validSolChainSelector := validEnv.AllChainSelectorsSolana()[0]
+	validSolChainSelector := validEnv.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
 
 	timelockID := mcmsSolana.ContractAddress(
 		solana.NewWallet().PublicKey(),
@@ -259,7 +261,7 @@ func TestFundMCMSignersChangeset_Apply(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	chainSelector := env.AllChainSelectorsSolana()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
 	solChain := env.SolChains[chainSelector]
 	addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	require.NoError(t, err)

--- a/deployment/common/changeset/solana/transfer_ownership_test.go
+++ b/deployment/common/changeset/solana/transfer_ownership_test.go
@@ -6,8 +6,11 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	accessControllerBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/access_controller"
 	mcmBindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
@@ -31,7 +34,7 @@ func TestTransferToMCMSToTimelockSolana(t *testing.T) {
 	log := logger.TestLogger(t)
 	envConfig := memory.MemoryEnvironmentConfig{Chains: 0, SolChains: 1}
 	env := memory.NewMemoryEnvironment(t, log, zapcore.InfoLevel, envConfig)
-	solanaSelector := env.AllChainSelectorsSolana()[0]
+	solanaSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
 
 	commonchangeset.SetPreloadedSolanaAddresses(t, env, solanaSelector)
 	chainState := deployMCMS(t, env, solanaSelector)

--- a/deployment/common/changeset/state/evm_test.go
+++ b/deployment/common/changeset/state/evm_test.go
@@ -9,10 +9,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	bindings "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -23,7 +26,7 @@ import (
 func TestMCMSWithTimelockState_GenerateMCMSWithTimelockViewV2(t *testing.T) {
 	envConfig := memory.MemoryEnvironmentConfig{Chains: 1}
 	env := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, envConfig)
-	chain := env.Chains[env.AllChainSelectors()[0]]
+	chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 
 	proposerMcm := deployMCMEvm(t, chain, &mcmstypes.Config{Quorum: 1, Signers: []common.Address{
 		common.HexToAddress("0x0000000000000000000000000000000000000001"),

--- a/deployment/common/changeset/state/solana_test.go
+++ b/deployment/common/changeset/state/solana_test.go
@@ -9,8 +9,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
@@ -32,7 +35,7 @@ func TestMCMSWithTimelockState_GenerateMCMSWithTimelockViewSolana(t *testing.T) 
 	t.Parallel()
 	envConfig := memory.MemoryEnvironmentConfig{SolChains: 1}
 	env := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, envConfig)
-	chainSelector := env.AllChainSelectorsSolana()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))[0]
 	chain := env.SolChains[chainSelector]
 	defaultState := func() *state.MCMSWithTimelockStateSolana {
 		addressBook := cldf.NewMemoryAddressBook()

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
@@ -6,11 +6,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -25,7 +28,7 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 		Chains: 1,
 		Nodes:  1,
 	})
-	chain1 := e.AllChainSelectors()[0]
+	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	e, err := Apply(t, e, nil,
 		Configure(
 			cldf.CreateLegacyChangeSet(DeployLinkToken),
@@ -94,7 +97,7 @@ func TestRenounceTimelockDeployerConfigValidate(t *testing.T) {
 		Chains: 1,
 		Nodes:  1,
 	})
-	chain1 := e.AllChainSelectors()[0]
+	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	e, err := Apply(t, e, nil,
 		Configure(
 			cldf.CreateLegacyChangeSet(DeployMCMSWithTimelockV2),
@@ -109,7 +112,7 @@ func TestRenounceTimelockDeployerConfigValidate(t *testing.T) {
 		Chains: 1,
 		Nodes:  1,
 	})
-	chain2 := envWithNoMCMS.AllChainSelectors()[0]
+	chain2 := envWithNoMCMS.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	for _, test := range []struct {
 		name   string
@@ -168,7 +171,7 @@ func TestRenounceTimelockDeployer(t *testing.T) {
 		Chains: 1,
 		Nodes:  1,
 	})
-	chain1 := e.AllChainSelectors()[0]
+	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	e, err := Apply(t, e, nil,
 		Configure(
 			cldf.CreateLegacyChangeSet(DeployMCMSWithTimelockV2),

--- a/deployment/common/proposalutils/propose_test.go
+++ b/deployment/common/proposalutils/propose_test.go
@@ -7,13 +7,18 @@ import (
 	"time"
 
 	solanasdk "github.com/gagliardetto/solana-go"
+
 	"github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -30,8 +35,8 @@ func TestBuildProposalFromBatchesV2(t *testing.T) {
 		Chains:    2,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-	chainSelector := env.AllChainSelectors()[0]
-	chainSelectorSolana := env.AllChainSelectorsSolana()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	chainSelectorSolana := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 	config := proposalutils.SingleGroupMCMSV2(t)
 
 	changeset.SetPreloadedSolanaAddresses(t, env, chainSelectorSolana)

--- a/deployment/common/view/v1_0/link_token_test.go
+++ b/deployment/common/view/v1_0/link_token_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/link_token"
 
@@ -19,7 +22,7 @@ func TestLinkTokenView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.AllChainSelectors()[0]]
+	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	_, tx, lt, err := link_token.DeployLinkToken(chain.DeployerKey, chain.Client)
 	require.NoError(t, err)
 	_, err = chain.Confirm(tx)
@@ -32,7 +35,7 @@ func TestLinkTokenViewZk(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		ZkChains: 1,
 	})
-	chain := e.Chains[e.AllChainSelectors()[0]]
+	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	_, _, lt, err := link_token.DeployLinkTokenZk(nil, chain.ClientZkSyncVM, chain.DeployerKeyZkSyncVM, chain.Client)
 	require.NoError(t, err)
 

--- a/deployment/common/view/v1_0/static_link_token_test.go
+++ b/deployment/common/view/v1_0/static_link_token_test.go
@@ -4,11 +4,16 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -17,7 +22,7 @@ func TestStaticLinkTokenView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.AllChainSelectors()[0]]
+	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	_, tx, lt, err := link_token_interface.DeployLinkToken(chain.DeployerKey, chain.Client)
 	require.NoError(t, err)
 	_, err = chain.Confirm(tx)

--- a/deployment/data-feeds/changeset/accept_ownership_test.go
+++ b/deployment/data-feeds/changeset/accept_ownership_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
@@ -29,7 +32,7 @@ func TestAcceptOwnership(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
 	chain := env.Chains[chainSelector]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,

--- a/deployment/data-feeds/changeset/confirm_aggregator_test.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -30,7 +33,7 @@ func TestConfirmAggregator(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	// without MCMS
 	newEnv, err := commonChangesets.Apply(t, env, nil,

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 
@@ -24,7 +27,7 @@ func TestAggregatorProxy(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	resp, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
@@ -4,10 +4,14 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -22,7 +26,7 @@ func TestBundleAggregatorProxy(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	resp, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/deploy_cache_test.go
+++ b/deployment/data-feeds/changeset/deploy_cache_test.go
@@ -3,8 +3,11 @@ package changeset_test
 import (
 	"testing"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
@@ -24,7 +27,7 @@ func TestDeployCache(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	resp, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/import_to_addressbook_test.go
+++ b/deployment/data-feeds/changeset/import_to_addressbook_test.go
@@ -4,8 +4,11 @@ import (
 	"embed"
 	"testing"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 
@@ -28,7 +31,7 @@ func TestImportToAddressbook(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	resp, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/migrate_feeds_test.go
+++ b/deployment/data-feeds/changeset/migrate_feeds_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -29,7 +32,7 @@ func TestMigrateFeeds(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/new_feed_with_proxy_test.go
+++ b/deployment/data-feeds/changeset/new_feed_with_proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -12,6 +13,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -32,7 +36,7 @@ func TestNewFeedWithProxy(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/propose_aggregator_test.go
+++ b/deployment/data-feeds/changeset/propose_aggregator_test.go
@@ -4,9 +4,13 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -30,7 +34,7 @@ func TestProposeAggregator(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	// without MCMS
 	newEnv, err := commonChangesets.Apply(t, env, nil,

--- a/deployment/data-feeds/changeset/remove_dataid_proxy_mapping_test.go
+++ b/deployment/data-feeds/changeset/remove_dataid_proxy_mapping_test.go
@@ -4,11 +4,15 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -28,7 +32,7 @@ func TestRemoveFeedProxyMapping(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/remove_feed_config_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_config_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
@@ -30,7 +33,7 @@ func TestRemoveFeedConfig(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/remove_feed_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -11,6 +12,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -30,7 +34,7 @@ func TestRemoveFeed(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
@@ -29,7 +32,7 @@ func TestSetBundleFeedConfig(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/set_feed_admin_test.go
+++ b/deployment/data-feeds/changeset/set_feed_admin_test.go
@@ -4,9 +4,13 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -30,7 +34,7 @@ func TestSetCacheAdmin(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/set_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_feed_config_test.go
@@ -4,11 +4,15 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -32,7 +36,7 @@ func TestSetFeedConfig(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/update_data_id_proxy_test.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -29,7 +32,7 @@ func TestUpdateDataIDProxyMap(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/view.go
+++ b/deployment/data-feeds/changeset/view.go
@@ -3,7 +3,11 @@ package changeset
 import (
 	"encoding/json"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	commonview "github.com/smartcontractkit/chainlink/deployment/common/view"
 	dfView "github.com/smartcontractkit/chainlink/deployment/data-feeds/view"
 )
@@ -15,7 +19,7 @@ func ViewDataFeeds(e deployment.Environment) (json.Marshaler, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainView, err := state.View(e.AllChainSelectors(), e)
+	chainView, err := state.View(e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)), e)
 	if err != nil {
 		return nil, err
 	}

--- a/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_set_production_config_test.go
+++ b/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_set_production_config_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/configurator"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -19,7 +22,7 @@ import (
 func TestCallSetProductionConfig(t *testing.T) {
 	e := testutil.NewMemoryEnv(t, true, 0)
 
-	chainSelector := e.AllChainSelectors()[0]
+	chainSelector := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	e, err := commonChangesets.Apply(t, e, nil,
 		commonChangesets.Configure(

--- a/deployment/data-streams/changeset/jobs/helpers_test.go
+++ b/deployment/data-streams/changeset/jobs/helpers_test.go
@@ -12,7 +12,10 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -31,7 +34,7 @@ import (
 
 // sendTestLLOJobs sends some test LLO jobs, which we can then revoke, retrieve, delete, etc.
 func sendTestLLOJobs(t *testing.T, e cldf.Environment, numOracles, numBootstraps int, autoApproveJobs bool) []cldf.ChangesetOutput {
-	chainSel := e.AllChainSelectors()[0]
+	chainSel := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	configurator := "0x4170ed0880ac9a755fd29b2688956bd959f923f4"
 	err := e.ExistingAddresses.Save(chainSel, configurator,
 		cldf.TypeAndVersion{

--- a/deployment/data-streams/changeset/jobs/jd_distribute_llo_jobs_test.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_llo_jobs_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
@@ -34,7 +37,7 @@ func TestDistributeLLOJobSpecs(t *testing.T) {
 	bootstrapNodeNames, oracleNodeNames := collectNodeNames(t, env, 2, 1)
 
 	// pick the first EVM chain selector
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	// insert a Configurator address for the given DON
 	configuratorAddr := "0x4170ed0880ac9a755fd29b2688956bd959f923f4"

--- a/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs_test.go
+++ b/deployment/data-streams/changeset/jobs/jd_distribute_stream_jobs_test.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -63,7 +66,7 @@ func TestDistributeStreamJobSpecs(t *testing.T) {
 	}
 
 	// pick the first EVM chain selector
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	// insert a Configurator address for the given DON
 	configuratorAddr := "0x4170ed0880ac9a755fd29b2688956bd959f923f4"

--- a/deployment/data-streams/changeset/testutil/test_helpers.go
+++ b/deployment/data-streams/changeset/testutil/test_helpers.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	dsCs "github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/mcms"
@@ -70,7 +72,7 @@ func NewMemoryEnv(t *testing.T, deployMCMS bool, optionalNumNodes ...int) cldf.E
 	}
 
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memEnvConf)
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
 
 	if deployMCMS {
 		config := proposalutils.SingleGroupTimelockConfigV2(t)
@@ -118,7 +120,7 @@ func NewMemoryEnvV2(t *testing.T, cfg MemoryEnvConfig) MemoryEnv {
 	}
 
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memEnvConf)
-	chainSelector := env.AllChainSelectors()[0]
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
 	chain := env.Chains[chainSelector]
 
 	// Apply node labels:

--- a/deployment/data-streams/changeset/verification/call_initialize_verifier_test.go
+++ b/deployment/data-streams/changeset/verification/call_initialize_verifier_test.go
@@ -8,9 +8,13 @@ import (
 
 	"github.com/smartcontractkit/chainlink/deployment"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_proxy_v0_5_0"
+
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/testutil"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/types"
@@ -20,7 +24,7 @@ func TestInitializeVerifier(t *testing.T) {
 	t.Parallel()
 	e := testutil.NewMemoryEnv(t, true, 0)
 
-	chainSelector := e.AllChainSelectors()[0]
+	chainSelector := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	e, err := commonChangesets.Apply(t, e, nil,
 		commonChangesets.Configure(
 			DeployVerifierProxyChangeset,

--- a/deployment/data-streams/changeset/verification/call_set_access_controller_test.go
+++ b/deployment/data-streams/changeset/verification/call_set_access_controller_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_proxy_v0_5_0"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -20,7 +23,7 @@ func TestSetAccessController(t *testing.T) {
 
 	e := testEnv.Environment
 	acAddress := common.HexToAddress("0x0000000000000000000000000000000000000123")
-	testChain := e.AllChainSelectors()[0]
+	testChain := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
 
 	e, verifierProxyAddr, _ := DeployVerifierProxyAndVerifier(t, e)
 

--- a/deployment/data-streams/changeset/verification/call_unset_verifier_test.go
+++ b/deployment/data-streams/changeset/verification/call_unset_verifier_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_proxy_v0_5_0"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/verifier_v0_5_0"
+
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/testutil"
 )
@@ -21,7 +25,7 @@ func TestUnsetVerifier(t *testing.T) {
 	e := testEnv.Environment
 	e, verifierProxyAddr, verifierAddr := DeployVerifierProxyAndVerifier(t, e)
 
-	chainSelector := e.AllChainSelectors()[0]
+	chainSelector := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
 	chain := e.Chains[chainSelector]
 
 	verifier, err := verifier_v0_5_0.NewVerifier(verifierAddr, e.Chains[chainSelector].Client)

--- a/deployment/data-streams/changeset/view.go
+++ b/deployment/data-streams/changeset/view.go
@@ -3,7 +3,11 @@ package changeset
 import (
 	"encoding/json"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	dsstate "github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/state"
 	dsView "github.com/smartcontractkit/chainlink/deployment/data-streams/view"
 )
@@ -11,7 +15,7 @@ import (
 var _ deployment.ViewState = ViewDataStreams
 
 func ViewDataStreams(e deployment.Environment) (json.Marshaler, error) {
-	return ViewDataStreamsChain(e, e.AllChainSelectors())
+	return ViewDataStreamsChain(e, e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)))
 }
 
 func ViewDataStreamsChain(e deployment.Environment, chainselectors []uint64) (json.Marshaler, error) {

--- a/deployment/data-streams/utils/txutil/transaction_test.go
+++ b/deployment/data-streams/utils/txutil/transaction_test.go
@@ -8,8 +8,11 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -27,7 +30,7 @@ func TestSignAndExecute_ETHTransfer(t *testing.T) {
 		Chains: 1,
 	})
 
-	testChain := e.AllChainSelectors()[0]
+	testChain := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
 	chain := e.Chains[testChain]
 
 	recipient := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
@@ -69,7 +72,7 @@ func TestSignAndExecute_ContractInteraction(t *testing.T) {
 		Chains: 1,
 	})
 
-	testChain := e.AllChainSelectors()[0]
+	testChain := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
 	chain := e.Chains[testChain]
 
 	e, err := commonchangeset.Apply(t, e, nil,

--- a/deployment/exemplar/changeset/view.go
+++ b/deployment/exemplar/changeset/view.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
@@ -32,7 +35,7 @@ var ViewExemplar deployment.ViewState = func(e deployment.Environment) (json.Mar
 	}
 
 	// Get chain information
-	for _, chainSel := range e.AllChainSelectors() {
+	for _, chainSel := range e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)) {
 		chain := e.Chains[chainSel]
 		chainName := fmt.Sprintf("%s (%d)", chain.Name(), chainSel)
 		view.Chains = append(view.Chains, chainName)

--- a/deployment/keystone/changeset/accept_ownership_test.go
+++ b/deployment/keystone/changeset/accept_ownership_test.go
@@ -6,8 +6,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -27,7 +30,7 @@ func TestAcceptAllOwnership(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	registrySel := env.AllChainSelectors()[0]
+	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	env, err := commonchangeset.Apply(t, env, nil,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(changeset.DeployCapabilityRegistry),

--- a/deployment/keystone/changeset/contracts_test.go
+++ b/deployment/keystone/changeset/contracts_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -122,7 +123,7 @@ func TestGetOwnerTypeAndVersion(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-		chain := env.Chains[env.AllChainSelectors()[0]]
+		chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
 		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -160,7 +161,7 @@ func TestGetOwnerTypeAndVersion(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-		chain := env.Chains[env.AllChainSelectors()[0]]
+		chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
 		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -199,7 +200,7 @@ func TestNewOwnable(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-		chain := env.Chains[env.AllChainSelectors()[0]]
+		chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
 		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -243,7 +244,7 @@ func TestNewOwnable(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-		chain := env.Chains[env.AllChainSelectors()[0]]
+		chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
 		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -286,7 +287,7 @@ func TestNewOwnable(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-		chain := env.Chains[env.AllChainSelectors()[0]]
+		chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
 		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
 		require.NoError(t, err)
 		require.NotNil(t, resp)

--- a/deployment/keystone/changeset/deploy_balance_reader_test.go
+++ b/deployment/keystone/changeset/deploy_balance_reader_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -24,7 +27,7 @@ func TestDeployBalanceReader(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	registrySel := env.AllChainSelectors()[0]
+	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	t.Run("should deploy balancereader", func(t *testing.T) {
 		ab := cldf.NewMemoryAddressBook()
@@ -40,8 +43,8 @@ func TestDeployBalanceReader(t *testing.T) {
 		require.Len(t, addrs, 1)
 
 		// only balancereader on chain 1
-		require.NotEqual(t, registrySel, env.AllChainSelectors()[1])
-		oaddrs, err := resp.AddressBook.AddressesForChain(env.AllChainSelectors()[1])
+		require.NotEqual(t, registrySel, env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
+		oaddrs, err := resp.AddressBook.AddressesForChain(env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
 		require.NoError(t, err)
 		require.Len(t, oaddrs, 1)
 	})

--- a/deployment/keystone/changeset/deploy_consumer_test.go
+++ b/deployment/keystone/changeset/deploy_consumer_test.go
@@ -3,7 +3,10 @@ package changeset_test
 import (
 	"testing"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/stretchr/testify/require"
 
@@ -24,7 +27,7 @@ func TestDeployFeedsConsumer(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	registrySel := env.AllChainSelectors()[0]
+	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	resp, err := changeset.DeployFeedsConsumerV2(env, &changeset.DeployRequestV2{
 		ChainSel:  registrySel,
 		Qualifier: "my-test-feeds-consumer",
@@ -38,7 +41,7 @@ func TestDeployFeedsConsumer(t *testing.T) {
 	require.Len(t, resp.DataStore.Addresses().Filter(datastore.AddressRefByQualifier("my-test-feeds-consumer")), 1, "expected to find 'my-test-feeds-consumer' qualifier")
 
 	// no feeds consumer registry on chain 1
-	require.NotEqual(t, registrySel, env.AllChainSelectors()[1])
-	oaddrs, _ := resp.AddressBook.AddressesForChain(env.AllChainSelectors()[1])
+	require.NotEqual(t, registrySel, env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
+	oaddrs, _ := resp.AddressBook.AddressesForChain(env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
 	require.Empty(t, oaddrs)
 }

--- a/deployment/keystone/changeset/deploy_forwarder_test.go
+++ b/deployment/keystone/changeset/deploy_forwarder_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -33,7 +36,7 @@ func TestDeployForwarder(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	registrySel := env.AllChainSelectors()[0]
+	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	t.Run("should deploy forwarder", func(t *testing.T) {
 		ab := cldf.NewMemoryAddressBook()

--- a/deployment/keystone/changeset/deploy_ocr3_test.go
+++ b/deployment/keystone/changeset/deploy_ocr3_test.go
@@ -6,9 +6,12 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -31,7 +34,7 @@ func TestDeployOCR3(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	registrySel := env.AllChainSelectors()[0]
+	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	resp, err := changeset.DeployOCR3(env, registrySel)
 	require.NoError(t, err)
@@ -42,8 +45,8 @@ func TestDeployOCR3(t *testing.T) {
 	require.Len(t, addrs, 1)
 
 	// nothing on chain 1
-	require.NotEqual(t, registrySel, env.AllChainSelectors()[1])
-	oaddrs, _ := resp.AddressBook.AddressesForChain(env.AllChainSelectors()[1])
+	require.NotEqual(t, registrySel, env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
+	oaddrs, _ := resp.AddressBook.AddressesForChain(env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
 	assert.Empty(t, oaddrs)
 }
 
@@ -93,7 +96,7 @@ func TestConfigureOCR3(t *testing.T) {
 			NumChains:       1,
 		})
 
-		registrySel := te.Env.AllChainSelectors()[0]
+		registrySel := te.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 		existingContracts, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
@@ -158,7 +161,7 @@ func TestConfigureOCR3(t *testing.T) {
 			NumChains:       1,
 		})
 
-		registrySel := te.Env.AllChainSelectors()[0]
+		registrySel := te.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 		existingContracts, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
@@ -198,7 +201,7 @@ func TestConfigureOCR3(t *testing.T) {
 			NumChains:       1,
 		})
 
-		registrySel := te.Env.AllChainSelectors()[0]
+		registrySel := te.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 		existingContracts, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)
@@ -247,7 +250,7 @@ func TestConfigureOCR3(t *testing.T) {
 
 		wfNodes := te.GetP2PIDs("wfDon").Strings()
 
-		registrySel := te.Env.AllChainSelectors()[0]
+		registrySel := te.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 		// Verify after merge there are three original contracts plus one new one
 		addrs, err := te.Env.ExistingAddresses.AddressesForChain(registrySel)
 		require.NoError(t, err)

--- a/deployment/keystone/changeset/deploy_registry_test.go
+++ b/deployment/keystone/changeset/deploy_registry_test.go
@@ -3,7 +3,10 @@ package changeset_test
 import (
 	"testing"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/stretchr/testify/require"
 
@@ -23,7 +26,7 @@ func TestDeployCapabilityRegistry(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	registrySel := env.AllChainSelectors()[0]
+	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	resp, err := changeset.DeployCapabilityRegistryV2(env, &changeset.DeployRequestV2{
 		ChainSel:  registrySel,
 		Qualifier: "my-test-capabilities-registry",
@@ -36,7 +39,7 @@ func TestDeployCapabilityRegistry(t *testing.T) {
 	require.Len(t, addrs, 1)
 	require.Len(t, resp.DataStore.Addresses().Filter(datastore.AddressRefByQualifier("my-test-capabilities-registry")), 1, "expected to find 'my-test-capabilities-registry' qualifier")
 	// no capabilities registry on chain 1
-	require.NotEqual(t, registrySel, env.AllChainSelectors()[1])
-	oaddrs, _ := resp.AddressBook.AddressesForChain(env.AllChainSelectors()[1])
+	require.NotEqual(t, registrySel, env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
+	oaddrs, _ := resp.AddressBook.AddressesForChain(env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
 	require.Empty(t, oaddrs)
 }

--- a/deployment/keystone/changeset/workflowregistry/deploy_test.go
+++ b/deployment/keystone/changeset/workflowregistry/deploy_test.go
@@ -3,12 +3,16 @@ package workflowregistry
 import (
 	"testing"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"go.uber.org/zap/zapcore"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 )
 
@@ -21,7 +25,7 @@ func Test_Deploy(t *testing.T) {
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	registrySel := env.AllChainSelectors()[0]
+	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	resp, err := Deploy(env, registrySel)
 	require.NoError(t, err)
@@ -32,7 +36,7 @@ func Test_Deploy(t *testing.T) {
 	require.Len(t, addrs, 1)
 
 	// assert nothing on chain 1
-	require.NotEqual(t, registrySel, env.AllChainSelectors()[1])
-	oaddrs, _ := resp.AddressBook.AddressesForChain(env.AllChainSelectors()[1])
+	require.NotEqual(t, registrySel, env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
+	oaddrs, _ := resp.AddressBook.AddressesForChain(env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1])
 	assert.Empty(t, oaddrs)
 }

--- a/integration-tests/load/ccip/destination_gun.go
+++ b/integration-tests/load/ccip/destination_gun.go
@@ -28,6 +28,7 @@ import (
 	solstate "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 	soltokens "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -129,7 +130,7 @@ func (m *DestinationGun) Call(_ *wasp.Generator) *wasp.Response {
 
 // MustSourceChain will return a chain selector to send a message from
 func (m *DestinationGun) MustSourceChain() (uint64, error) {
-	otherCS := m.env.AllChainSelectorsExcluding([]uint64{m.chainSelector})
+	otherCS := m.env.BlockChains.ListChainSelectors(cldf_chain.WithChainSelectorsExclusion([]uint64{m.chainSelector}))
 	// todo: uncomment to enable solana as a source chain
 	// otherCS := m.env.AllChainSelectorsAllFamilliesExcluding([]uint64{m.chainSelector})
 	if len(otherCS) == 0 {

--- a/integration-tests/smoke/ccip/ccip_add_chain_test.go
+++ b/integration-tests/smoke/ccip/ccip_add_chain_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
@@ -46,7 +49,10 @@ func Test_AddChain(t *testing.T) {
 
 	allChains := maps.Keys(e.Env.Chains)
 	slices.Sort(allChains)
-	toDeploy := e.Env.AllChainSelectorsExcluding([]uint64{allChains[0]})
+	toDeploy := e.Env.BlockChains.ListChainSelectors(
+		cldf_chain.WithFamily(chain_selectors.FamilyEVM),
+		cldf_chain.WithChainSelectorsExclusion([]uint64{allChains[0]}),
+	)
 	require.Len(t, toDeploy, numChains-1)
 	remainingChain := allChains[0]
 	t.Log("initially deploying chains:", toDeploy, "and afterwards adding chain", remainingChain)

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -11,6 +11,7 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/mcms/types"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -511,7 +512,8 @@ func transferRMNContractToMCMS(t *testing.T, e *testhelpers.DeployedEnv, state s
 	)
 	require.NoError(t, err)
 
-	for _, solChain := range e.Env.AllChainSelectorsSolana() {
+	chainSelectorSolana := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
+	for _, solChain := range chainSelectorSolana {
 		_, _ = testhelpers.TransferOwnershipSolana(t, &e.Env, solChain, true,
 			ccipChangesetSolana.CCIPContractsToTransfer{
 				Router:    true,

--- a/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_home"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -343,11 +346,11 @@ func buildRMNRemoteAddressPerChain(e cldf.Environment, state stateview.CCIPOnCha
 func TestSetRMNRemoteOnRMNProxy(t *testing.T) {
 	t.Parallel()
 	e, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithNoJobsAndContracts())
-	allChains := e.Env.AllChainSelectors()
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))
 	mcmsCfg := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
 	var err error
 	prereqCfgs := make([]changeset.DeployPrerequisiteConfigPerChain, 0)
-	for _, c := range e.Env.AllChainSelectors() {
+	for _, c := range e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)) {
 		mcmsCfg[c] = proposalutils.SingleGroupTimelockConfigV2(t)
 		prereqCfgs = append(prereqCfgs, changeset.DeployPrerequisiteConfigPerChain{
 			ChainSelector: c,

--- a/integration-tests/smoke/ccip/ccip_disable_lane_test.go
+++ b/integration-tests/smoke/ccip/ccip_disable_lane_test.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/stretchr/testify/require"
+
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
@@ -37,7 +40,7 @@ func TestDisableLane(t *testing.T) {
 	testhelpers.AddLanesForAll(t, &tenv, state)
 
 	var (
-		chains                 = e.AllChainSelectors()
+		chains                 = e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))
 		chainA, chainB, chainC = chains[0], chains[1], chains[2]
 		expectedSeqNumExec     = make(map[testhelpers.SourceDestPair][]uint64)
 		startBlocks            = make(map[uint64]*uint64)

--- a/integration-tests/smoke/ccip/ccip_fees_test.go
+++ b/integration-tests/smoke/ccip/ccip_fees_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -172,7 +175,7 @@ func Test_CCIPFees(t *testing.T) {
 	)
 	e := tenv.Env
 
-	allChains := e.AllChainSelectors()
+	allChains := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	require.Len(t, allChains, 2, "need two chains for this test")
 	sourceChain := allChains[0]
 	destChain := allChains[1]

--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
@@ -74,7 +75,7 @@ func TestV1_5_Message_RMNRemote(t *testing.T) {
 	)
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
-	allChains := e.Env.AllChainSelectors()
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))
 	src1, dest := allChains[0], allChains[1]
 	pairs := []testhelpers.SourceDestPair{
 		{SourceChainSelector: src1, DestChainSelector: dest},
@@ -148,7 +149,7 @@ func TestV1_5_Message_RMNRemote(t *testing.T) {
 
 	_, err = cldf.CreateLegacyChangeSet(v1_6.SetRMNRemoteOnRMNProxyChangeset).Apply(e.Env,
 		v1_6.SetRMNRemoteOnRMNProxyConfig{
-			ChainSelectors: e.Env.AllChainSelectors(),
+			ChainSelectors: e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)),
 		})
 	require.NoError(t, err)
 
@@ -200,7 +201,7 @@ func TestV1_5_Message_RMNRemote_Curse(t *testing.T) {
 	)
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
-	allChains := e.Env.AllChainSelectors()
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))
 	src1, dest := allChains[0], allChains[1]
 	pairs := []testhelpers.SourceDestPair{
 		{SourceChainSelector: src1, DestChainSelector: dest},
@@ -276,7 +277,7 @@ func TestV1_5_Message_RMNRemote_Curse(t *testing.T) {
 
 	_, err = cldf.CreateLegacyChangeSet(v1_6.SetRMNRemoteOnRMNProxyChangeset).Apply(e.Env,
 		v1_6.SetRMNRemoteOnRMNProxyConfig{
-			ChainSelectors: e.Env.AllChainSelectors(),
+			ChainSelectors: e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)),
 		})
 	require.NoError(t, err)
 
@@ -297,7 +298,7 @@ func TestV1_5_Message_RMNRemote_Curse(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset).Apply(e.Env, v1_6.RMNCurseConfig{
-		CurseActions: []v1_6.CurseAction{v1_6.CurseChain(e.Env.AllChainSelectors()[0])},
+		CurseActions: []v1_6.CurseAction{v1_6.CurseChain(e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0])},
 		Reason:       "Curse test",
 	})
 	require.NoError(t, err)
@@ -336,7 +337,7 @@ func TestV1_5_Message_RMNRemote_Curse_Uncurse(t *testing.T) {
 	)
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
-	allChains := e.Env.AllChainSelectors()
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))
 	src1, dest := allChains[0], allChains[1]
 	pairs := []testhelpers.SourceDestPair{
 		{SourceChainSelector: src1, DestChainSelector: dest},
@@ -413,7 +414,7 @@ func TestV1_5_Message_RMNRemote_Curse_Uncurse(t *testing.T) {
 
 	_, err = cldf.CreateLegacyChangeSet(v1_6.SetRMNRemoteOnRMNProxyChangeset).Apply(e.Env,
 		v1_6.SetRMNRemoteOnRMNProxyConfig{
-			ChainSelectors: e.Env.AllChainSelectors(),
+			ChainSelectors: e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)),
 		})
 	require.NoError(t, err)
 
@@ -434,7 +435,7 @@ func TestV1_5_Message_RMNRemote_Curse_Uncurse(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset).Apply(e.Env, v1_6.RMNCurseConfig{
-		CurseActions: []v1_6.CurseAction{v1_6.CurseChain(e.Env.AllChainSelectors()[0])},
+		CurseActions: []v1_6.CurseAction{v1_6.CurseChain(e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0])},
 		Reason:       "Curse test",
 	})
 	require.NoError(t, err)
@@ -452,12 +453,12 @@ func TestV1_5_Message_RMNRemote_Curse_Uncurse(t *testing.T) {
 	}()
 
 	_, err = cldf.CreateLegacyChangeSet(v1_6.RMNUncurseChangeset).Apply(e.Env, v1_6.RMNCurseConfig{
-		CurseActions: []v1_6.CurseAction{v1_6.CurseChain(e.Env.AllChainSelectors()[0])},
+		CurseActions: []v1_6.CurseAction{v1_6.CurseChain(e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0])},
 		Reason:       "Uncurse test",
 	})
 	require.NoError(t, err)
 
-	for _, chainSel := range e.Env.AllChainSelectors() {
+	for _, chainSel := range e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)) {
 		subjects, err := state.MustGetEVMChainState(chainSel).RMNRemote.GetCursedSubjects(nil)
 		require.NoError(t, err)
 		require.Empty(t, subjects)
@@ -521,8 +522,11 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	)
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
-	allChainsExcept1337 := e.Env.AllChainSelectorsExcluding([]uint64{chainselectors.GETH_TESTNET.Selector})
-	require.Contains(t, e.Env.AllChainSelectors(), chainselectors.GETH_TESTNET.Selector)
+	allChainsExcept1337 := e.Env.BlockChains.ListChainSelectors(
+		cldf_chain.WithFamily(chainselectors.FamilyEVM),
+		cldf_chain.WithChainSelectorsExclusion([]uint64{chainselectors.GETH_TESTNET.Selector}),
+	)
+	require.Contains(t, e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)), chainselectors.GETH_TESTNET.Selector)
 	require.Len(t, allChainsExcept1337, 2)
 	src1, src2, dest := allChainsExcept1337[0], allChainsExcept1337[1], chainselectors.GETH_TESTNET.Selector
 	pairs := []testhelpers.SourceDestPair{
@@ -601,7 +605,7 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 
 	// now that all 1.5 lanes work transfer ownership of the contracts to MCMS
 	contractsByChain := make(map[uint64][]common.Address)
-	for _, chain := range e.Env.AllChainSelectors() {
+	for _, chain := range e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)) {
 		contractsByChain[chain] = []common.Address{
 			state.MustGetEVMChainState(chain).Router.Address(),
 			state.MustGetEVMChainState(chain).RMNProxy.Address(),
@@ -636,7 +640,7 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	// add 1.6 contracts to the environment and send 1.6 jobs
 	// First we need to deploy Homechain contracts and restart the nodes with updated cap registry
 	// in this test we have already deployed home chain contracts and the nodes are already running with the deployed cap registry.
-	e = testhelpers.AddCCIPContractsToEnvironment(t, e.Env.AllChainSelectors(), tEnv, false)
+	e = testhelpers.AddCCIPContractsToEnvironment(t, e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)), tEnv, false)
 	// Set RMNProxy to point to RMNRemote.
 	// nonce manager should point to 1.5 ramps
 	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
@@ -644,7 +648,7 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 			// as we have already transferred ownership for RMNProxy to MCMS, it needs to be done via MCMS proposal
 			cldf.CreateLegacyChangeSet(v1_6.SetRMNRemoteOnRMNProxyChangeset),
 			v1_6.SetRMNRemoteOnRMNProxyConfig{
-				ChainSelectors: e.Env.AllChainSelectors(),
+				ChainSelectors: e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)),
 				MCMSConfig: &proposalutils.TimelockConfig{
 					MinDelay: 0,
 				},

--- a/integration-tests/smoke/ccip/ccip_reader_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	readermocks "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/contractreader"
 	typepkgmock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
@@ -33,6 +35,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -827,7 +830,7 @@ func TestCCIPReader_GetExpectedNextSequenceNumber(t *testing.T) {
 	state, err := stateview.LoadOnchainState(env.Env)
 	require.NoError(t, err)
 
-	selectors := env.Env.AllChainSelectors()
+	var selectors = env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	destChain, srcChain := selectors[0], selectors[1]
 
 	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &env, state, destChain, srcChain, false)
@@ -1191,7 +1194,7 @@ func Test_GetChainFeePriceUpdates(t *testing.T) {
 	state, err := stateview.LoadOnchainState(env.Env)
 	require.NoError(t, err)
 
-	selectors := env.Env.AllChainSelectors()
+	selectors := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	dest, source1, source2 := selectors[0], selectors[1], selectors[2]
 
 	// Setup: Add lanes and default configs (This sets default prices)
@@ -1296,7 +1299,7 @@ func Test_LinkPriceUSD(t *testing.T) {
 	state, err := stateview.LoadOnchainState(env.Env)
 	require.NoError(t, err)
 
-	selectors := env.Env.AllChainSelectors()
+	selectors := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	chain1, chain2 := selectors[0], selectors[1]
 
 	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &env, state, chain1, chain2, false)
@@ -1331,7 +1334,7 @@ func Test_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 	state, err := stateview.LoadOnchainState(env.Env)
 	require.NoError(t, err)
 
-	selectors := env.Env.AllChainSelectors()
+	selectors := env.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	chain1, chain2 := selectors[0], selectors[1]
 
 	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &env, state, chain1, chain2, false)

--- a/integration-tests/smoke/ccip/ccip_reorg_test.go
+++ b/integration-tests/smoke/ccip/ccip_reorg_test.go
@@ -12,12 +12,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/onsi/gomega"
-	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
@@ -67,7 +69,7 @@ func Test_CCIPReorg_BelowFinality_OnSource(t *testing.T) {
 	)
 
 	// Chain setup
-	allChains := e.Env.AllChainSelectors()
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
 	require.GreaterOrEqual(t, len(allChains), 2)
 	sourceSelector := allChains[0]
 	destSelector := allChains[1]
@@ -125,7 +127,7 @@ func Test_CCIPReorg_BelowFinality_OnDest(t *testing.T) {
 		testhelpers.WithExtraConfigTomls([]string{t.Name() + ".toml"}),
 	)
 
-	allChains := e.Env.AllChainSelectors()
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
 	require.GreaterOrEqual(t, len(allChains), 2)
 	sourceSelector := allChains[0]
 	destSelector := allChains[1]
@@ -172,7 +174,7 @@ func Test_CCIPReorg_BelowFinality_OnDest(t *testing.T) {
 func Test_CCIPReorg_GreaterThanFinality_OnDest(t *testing.T) {
 	e, l, dockerEnv, nonBootstrapP2PIDs, state, _ := setupReorgTest(t, logsToIgnoreOpt)
 
-	allChains := e.Env.AllChainSelectors()
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
 	require.GreaterOrEqual(t, len(allChains), 2)
 	sourceSelector := allChains[0]
 	destSelector := allChains[1]
@@ -237,7 +239,7 @@ func Test_CCIPReorg_GreaterThanFinality_OnDest(t *testing.T) {
 func Test_CCIPReorg_GreaterThanFinality_OnSource(t *testing.T) {
 	e, l, dockerEnv, nonBootstrapP2PIDs, state, _ := setupReorgTest(t, logsToIgnoreOpt)
 
-	allChains := e.Env.AllChainSelectors()
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
 	require.GreaterOrEqual(t, len(allChains), 3)
 	reorgSource := allChains[0]
 	nonReorgSource := allChains[1]

--- a/integration-tests/smoke/ccip/ccip_rmn_test.go
+++ b/integration-tests/smoke/ccip/ccip_rmn_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	ctf_client "github.com/smartcontractkit/chainlink-testing-framework/lib/client"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/logging"
@@ -958,7 +962,7 @@ func configureAndPromoteRMNHome(
 
 func performReorgTest(t *testing.T, e testhelpers.DeployedEnv, l logging.Logger, dockerEnv *testsetups.DeployedLocalDevEnvironment, state stateview.CCIPOnChainState, nonBootstrapP2PIDs []string) (sourceSelector uint64, destSelector uint64) {
 	// Chain setup
-	allChains := e.Env.AllChainSelectors()
+	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))
 	require.GreaterOrEqual(t, len(allChains), 2)
 	sourceSelector = allChains[0]
 	destSelector = allChains[1]


### PR DESCRIPTION
There is a new function in CLDF - ListChainSelectors which supports multiple chain family instead of a new function per chain family. This commit migrates the usage of those legacy functions to the new ListChainSelectors

Context: https://github.com/smartcontractkit/chainlink-deployments-framework/pull/108

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-266

NOTE: The lint errors are expected, bypassing with `allow-lint-issues` label

