### PR TITLE
[CLD-268]: fix: populate new BlockChains field on cldf.env

### DIFF
--- a/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
@@ -11,7 +11,10 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip_offramp"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	aptosstate "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/aptos"
@@ -40,6 +43,11 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 					4457093679053095497: {},
 				},
 				ExistingAddresses: cldf.NewMemoryAddressBook(),
+				BlockChains: chain.NewBlockChains(
+					map[uint64]chain.BlockChain{
+						743186221051783445:  aptos.Chain{},
+						4457093679053095497: aptos.Chain{},
+					}),
 			},
 			config: config.DeployAptosChainConfig{
 				ContractParamsPerChain: map[uint64]config.ChainContractParams{
@@ -73,6 +81,11 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 						},
 					},
 				),
+				BlockChains: chain.NewBlockChains(
+					map[uint64]chain.BlockChain{
+						743186221051783445:  aptos.Chain{},
+						4457093679053095497: aptos.Chain{},
+					}),
 			},
 			config: config.DeployAptosChainConfig{
 				ContractParamsPerChain: map[uint64]config.ChainContractParams{
@@ -101,6 +114,10 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 						},
 					},
 				),
+				BlockChains: chain.NewBlockChains(
+					map[uint64]chain.BlockChain{
+						4457093679053095497: aptos.Chain{},
+					}),
 			},
 			config: config.DeployAptosChainConfig{
 				ContractParamsPerChain: map[uint64]config.ChainContractParams{
@@ -141,6 +158,10 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 						4457093679053095497: {}, // No MCMS address in state
 					},
 				),
+				BlockChains: chain.NewBlockChains(
+					map[uint64]chain.BlockChain{
+						4457093679053095497: aptos.Chain{},
+					}),
 			},
 			config: config.DeployAptosChainConfig{
 				ContractParamsPerChain: map[uint64]config.ChainContractParams{
@@ -167,6 +188,10 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 						},
 					},
 				),
+				BlockChains: chain.NewBlockChains(
+					map[uint64]chain.BlockChain{
+						4457093679053095497: aptos.Chain{},
+					}),
 			},
 			config: config.DeployAptosChainConfig{
 				ContractParamsPerChain: map[uint64]config.ChainContractParams{

--- a/deployment/ccip/changeset/solana/save_existing_test.go
+++ b/deployment/ccip/changeset/solana/save_existing_test.go
@@ -9,6 +9,8 @@ import (
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -66,6 +68,10 @@ func TestSaveExisting(t *testing.T) {
 		SolChains: map[uint64]cldf.SolChain{
 			chainsel.SOLANA_DEVNET.Selector: {},
 		},
+		BlockChains: chain.NewBlockChains(
+			map[uint64]chain.BlockChain{
+				chainsel.SOLANA_DEVNET.Selector: cldf_solana.Chain{},
+			}),
 	}
 	ExistingContracts := commonchangeset.ExistingContractsConfig{
 		ExistingContracts: []commonchangeset.Contract{

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
@@ -374,10 +375,23 @@ func (m *MemoryEnvironment) StartChains(t *testing.T) {
 	m.Chains = chains
 	m.SolChains = memory.NewMemoryChainsSol(t, tc.SolChains)
 	m.AptosChains = memory.NewMemoryChainsAptos(t, tc.AptosChains)
+
+	blockChains := map[uint64]chain.BlockChain{}
+	for selector, ch := range m.Chains {
+		blockChains[selector] = ch
+	}
+	for selector, ch := range m.SolChains {
+		blockChains[selector] = ch
+	}
+	for selector, ch := range m.AptosChains {
+		blockChains[selector] = ch
+	}
+
 	env := cldf.Environment{
 		Chains:      m.Chains,
 		SolChains:   m.SolChains,
 		AptosChains: m.AptosChains,
+		BlockChains: chain.NewBlockChains(blockChains),
 	}
 	homeChainSel, feedSel := allocateCCIPChainSelectors(chains)
 	replayBlocks, err := LatestBlocksByChain(ctx, env)

--- a/deployment/common/changeset/save_existing_test.go
+++ b/deployment/common/changeset/save_existing_test.go
@@ -8,6 +8,8 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -24,6 +26,11 @@ func TestSaveExisting(t *testing.T) {
 			chainsel.TEST_90000001.Selector: {},
 			chainsel.TEST_90000002.Selector: {},
 		},
+		BlockChains: cldf_chain.NewBlockChains(
+			map[uint64]cldf_chain.BlockChain{
+				chainsel.TEST_90000001.Selector: cldf_evm.Chain{},
+				chainsel.TEST_90000002.Selector: cldf_evm.Chain{},
+			}),
 	}
 	ExistingContracts := ExistingContractsConfig{
 		ExistingContracts: []Contract{
@@ -66,6 +73,11 @@ func TestSaveExistingAddressWithLabels(t *testing.T) {
 			chainsel.TEST_90000001.Selector: {},
 			chainsel.TEST_90000002.Selector: {},
 		},
+		BlockChains: cldf_chain.NewBlockChains(
+			map[uint64]cldf_chain.BlockChain{
+				chainsel.TEST_90000001.Selector: cldf_evm.Chain{},
+				chainsel.TEST_90000002.Selector: cldf_evm.Chain{},
+			}),
 	}
 	dummyType1 := cldf.TypeAndVersion{
 		Type:    "dummyType",
@@ -104,6 +116,11 @@ func TestSaveExistingMCMSAddressWithLabels(t *testing.T) {
 			chainsel.TEST_90000001.Selector: {},
 			chainsel.TEST_90000002.Selector: {},
 		},
+		BlockChains: cldf_chain.NewBlockChains(
+			map[uint64]cldf_chain.BlockChain{
+				chainsel.TEST_90000001.Selector: cldf_evm.Chain{},
+				chainsel.TEST_90000002.Selector: cldf_evm.Chain{},
+			}),
 	}
 	mcmsContractTV := cldf.TypeAndVersion{
 		Type:    types.ManyChainMultisig,

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
@@ -133,6 +134,17 @@ func ApplyChangesets(t *testing.T, e cldf.Environment, timelockContractsPerChain
 				}
 			}
 		}
+
+		blockChains := map[uint64]chain.BlockChain{}
+		for selector, ch := range e.Chains {
+			blockChains[selector] = ch
+		}
+		for selector, ch := range e.SolChains {
+			blockChains[selector] = ch
+		}
+		for selector, ch := range e.AptosChains {
+			blockChains[selector] = ch
+		}
 		currentEnv = cldf.Environment{
 			Name:              e.Name,
 			Logger:            e.Logger,
@@ -146,6 +158,7 @@ func ApplyChangesets(t *testing.T, e cldf.Environment, timelockContractsPerChain
 			OCRSecrets:        e.OCRSecrets,
 			GetContext:        e.GetContext,
 			OperationsBundle:  operations.NewBundle(e.GetContext, e.Logger, operations.NewMemoryReporter()), // to ensure that each migration is run in a clean environment
+			BlockChains:       chain.NewBlockChains(blockChains),
 		}
 	}
 	return currentEnv, nil
@@ -198,6 +211,17 @@ func ApplyChangesetsV2(t *testing.T, e cldf.Environment, changesetApplications [
 			// do nothing, as these jobs auto-accept.
 		}
 
+		blockChains := map[uint64]chain.BlockChain{}
+		for selector, ch := range e.Chains {
+			blockChains[selector] = ch
+		}
+		for selector, ch := range e.SolChains {
+			blockChains[selector] = ch
+		}
+		for selector, ch := range e.AptosChains {
+			blockChains[selector] = ch
+		}
+
 		// Updated environment may be required before executing proposals when proposals involve new addresses
 		// Ex. changesets[0] deploys MCMS, changesets[1] generates a proposal with the new MCMS addresses
 		currentEnv = cldf.Environment{
@@ -213,6 +237,7 @@ func ApplyChangesetsV2(t *testing.T, e cldf.Environment, changesetApplications [
 			OCRSecrets:        e.OCRSecrets,
 			GetContext:        e.GetContext,
 			OperationsBundle:  operations.NewBundle(e.GetContext, e.Logger, operations.NewMemoryReporter()), // to ensure that each migration is run in a clean environment
+			BlockChains:       chain.NewBlockChains(blockChains),
 		}
 
 		if out.MCMSTimelockProposals != nil {

--- a/deployment/keystone/changeset/internal/deploy_test.go
+++ b/deployment/keystone/changeset/internal/deploy_test.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,6 +14,9 @@ import (
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -50,6 +52,10 @@ func Test_RegisterNOPS(t *testing.T) {
 					},
 				},
 			}),
+			BlockChains: cldf_chain.NewBlockChains(
+				map[uint64]cldf_chain.BlockChain{
+					chain.Selector: chain,
+				}),
 		}
 		resp, err := internal.RegisterNOPS(context.TODO(), lggr, internal.RegisterNOPSRequest{
 			Env:                   env,
@@ -253,6 +259,10 @@ func Test_RegisterNodes(t *testing.T) {
 							},
 						},
 					}),
+					BlockChains: cldf_chain.NewBlockChains(
+						map[uint64]cldf_chain.BlockChain{
+							chain.Selector: chain,
+						}),
 				}
 				resp, err := internal.RegisterNodes(lggr, &internal.RegisterNodesRequest{
 					Env:                   env,
@@ -314,6 +324,10 @@ func Test_RegisterNodes(t *testing.T) {
 					},
 				},
 			}),
+			BlockChains: cldf_chain.NewBlockChains(
+				map[uint64]cldf_chain.BlockChain{
+					chain.Selector: chain,
+				}),
 		}
 		resp, err := internal.RegisterNodes(lggr, &internal.RegisterNodesRequest{
 			Env:                   env,
@@ -365,6 +379,10 @@ func Test_RegisterNodes(t *testing.T) {
 					},
 				},
 			}),
+			BlockChains: cldf_chain.NewBlockChains(
+				map[uint64]cldf_chain.BlockChain{
+					chain.Selector: chain,
+				}),
 		}
 		resp, err := internal.RegisterNodes(lggr, &internal.RegisterNodesRequest{
 			Env:                   env,
@@ -411,6 +429,10 @@ func Test_RegisterDons(t *testing.T) {
 					},
 				},
 			}),
+			BlockChains: cldf_chain.NewBlockChains(
+				map[uint64]cldf_chain.BlockChain{
+					chain.Selector: chain,
+				}),
 		}
 		resp, err := internal.RegisterDons(lggr, internal.RegisterDonsRequest{
 			Env:                   env,
@@ -507,6 +529,10 @@ func Test_RegisterDons(t *testing.T) {
 					},
 				},
 			}),
+			BlockChains: cldf_chain.NewBlockChains(
+				map[uint64]cldf_chain.BlockChain{
+					setupResp.Chain.Selector: setupResp.Chain,
+				}),
 		}
 		resp, err := internal.RegisterDons(lggr, internal.RegisterDonsRequest{
 			Env:                   env,
@@ -544,6 +570,10 @@ func Test_RegisterDons(t *testing.T) {
 					},
 				},
 			}),
+			BlockChains: cldf_chain.NewBlockChains(
+				map[uint64]cldf_chain.BlockChain{
+					chain.Selector: chain,
+				}),
 		}
 		resp, err := internal.RegisterDons(lggr, internal.RegisterDonsRequest{
 			Env:                   env,

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -193,6 +193,11 @@ func (te EnvWrapper) GetP2PIDs(donName string) P2PIDs {
 func initEnv(t *testing.T, nChains int) (registryChainSel uint64, env cldf.Environment) {
 	chains, _ := memory.NewMemoryChains(t, nChains, 1)
 	registryChainSel = registryChain(t, chains)
+	blockChains := map[uint64]chain.BlockChain{}
+	for selector, ch := range chains {
+		blockChains[selector] = ch
+	}
+
 	// note that all the nodes require TOML configuration of the cap registry address
 	// and writers need forwarder address as TOML config
 	// we choose to use changesets to deploy the initial contracts because that's how it's done in the real world
@@ -203,6 +208,7 @@ func initEnv(t *testing.T, nChains int) (registryChainSel uint64, env cldf.Envir
 		Chains:            chains,
 		ExistingAddresses: cldf.NewMemoryAddressBook(),
 		DataStore:         datastore.NewMemoryDataStore[datastore.DefaultMetadata, datastore.DefaultMetadata]().Seal(),
+		BlockChains:       chain.NewBlockChains(blockChains),
 	}
 
 	forwarderChangesets := make([]commonchangeset.ConfiguredChangeSet, nChains)

--- a/deployment/keystone/changeset/test/registry.go
+++ b/deployment/keystone/changeset/test/registry.go
@@ -19,6 +19,7 @@ import (
 
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -237,6 +238,10 @@ func addNops(t *testing.T, lggr logger.Logger, chain cldf.Chain, registry *capab
 				},
 			},
 		}),
+		BlockChains: cldf_chain.NewBlockChains(
+			map[uint64]cldf_chain.BlockChain{
+				chain.Selector: chain,
+			}),
 	}
 	resp, err := internal.RegisterNOPS(context.TODO(), lggr, internal.RegisterNOPSRequest{
 		Env:                   env,

--- a/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
@@ -11,6 +11,7 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -38,6 +39,10 @@ func TestUpdateAllowedDons(t *testing.T) {
 			chainSel: resp.Chain,
 		},
 		ExistingAddresses: resp.AddressBook,
+		BlockChains: cldf_chain.NewBlockChains(
+			map[uint64]cldf_chain.BlockChain{
+				chainSel: resp.Chain,
+			}),
 	}
 
 	_, err = workflowregistry.UpdateAllowedDons(

--- a/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -39,6 +40,10 @@ func TestUpdateAuthorizedAddresses(t *testing.T) {
 			chainSel: resp.Chain,
 		},
 		ExistingAddresses: resp.AddressBook,
+		BlockChains: cldf_chain.NewBlockChains(
+			map[uint64]cldf_chain.BlockChain{
+				chainSel: resp.Chain,
+			}),
 	}
 
 	addr := "0xc0ffee254729296a45a3885639AC7E10F9d54979"

--- a/system-tests/lib/cre/devenv/devenv.go
+++ b/system-tests/lib/cre/devenv/devenv.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
@@ -141,6 +142,11 @@ func BuildFullCLDEnvironment(lgr logger.Logger, input *types.FullCLDEnvironmentI
 		jd = envs[0].Offchain
 	}
 
+	blockChains := map[uint64]chain.BlockChain{}
+	for selector, ch := range envs[0].Chains {
+		blockChains[selector] = ch
+	}
+
 	// we assume that all DONs run on the same chain and that there's only one chain
 	output := &types.FullCLDEnvironmentOutput{
 		Environment: &cldf.Environment{
@@ -152,6 +158,7 @@ func BuildFullCLDEnvironment(lgr logger.Logger, input *types.FullCLDEnvironmentI
 			OCRSecrets:        envs[0].OCRSecrets,
 			GetContext:        envs[0].GetContext,
 			NodeIDs:           nodeIDs,
+			BlockChains:       chain.NewBlockChains(blockChains),
 		},
 	}
 

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -23,6 +23,7 @@ import (
 
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
@@ -159,6 +160,11 @@ func SetupTestEnvironment(
 		return nil, pkgerrors.Wrap(allChainsErr, "failed to create chains")
 	}
 
+	blockChains := map[uint64]chain.BlockChain{}
+	for selector, ch := range allChains {
+		blockChains[selector] = ch
+	}
+
 	allChainsCLDEnvironment := &cldf.Environment{
 		Logger:            singeFileLogger,
 		Chains:            allChains,
@@ -166,6 +172,7 @@ func SetupTestEnvironment(
 		GetContext: func() context.Context {
 			return ctx
 		},
+		BlockChains: chain.NewBlockChains(blockChains),
 	}
 
 	fmt.Print(libformat.PurpleText("\n[Stage 1/10] Blockchains started in %.2f seconds\n", time.Since(startTime).Seconds()))


### PR DESCRIPTION
As part of the migration to the new BlockChains field on the environment struct in CLDF, this commit popualates the chains into that field, eventually the dedicated chain field (evm, sol and aptos) will be deleted.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-268
