### PR TITLE
chore: workflow fixes from runs-on update

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -165,11 +165,9 @@ runs:
         path: |
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
         key: ${{ steps.build-cache-keys.outputs.primary-key }}
-        # Include `secondary-key` twice due to a bug in runs-on S3 cache solution. Will remove once patched.
         restore-keys: |
           ${{ steps.build-cache-keys.outputs.secondary-key }}
           ${{ steps.build-cache-keys.outputs.develop-key }}
-          ${{ steps.build-cache-keys.outputs.secondary-key }}
 
     # 4. Upsert/Create the build cache
     # ---
@@ -183,8 +181,6 @@ runs:
         path: |
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
         key: ${{ steps.build-cache-keys.outputs.primary-key }}
-        # Include `secondary-key` twice due to a bug in runs-on S3 cache solution. Will remove once patched.
         restore-keys: |
           ${{ steps.build-cache-keys.outputs.secondary-key }}
           ${{ steps.build-cache-keys.outputs.develop-key }}
-          ${{ steps.build-cache-keys.outputs.secondary-key }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -215,35 +215,6 @@ jobs:
         if: ${{ matrix.type.is-self-hosted == 'true' }}
         uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
 
-      - name: Setup self-hosted directory mounts
-        # For self-hosted runners - the volume mounted to / is too small to handle everything stored in
-        # /home/runner. So we mount certain directories to the larger volume.
-        if: ${{ matrix.type.is-self-hosted == 'true' }}
-        run: |
-          if [ ! -d "/home/runner/_work" ]; then
-            echo "::warning::/home/runner/_work does not exist, skipping mount."
-            exit 0
-          fi
-
-          # Define the directories to mount as tuples of source:destination
-          DIRS=(
-            "/home/runner/_work/runner-go:/home/runner/go"
-            "/home/runner/_work/runner-cache:/home/runner/.cache"
-          )
-
-          # Process each directory pair
-          for DIR_PAIR in "${DIRS[@]}"; do
-            SRC_DIR=$(echo $DIR_PAIR | cut -d':' -f1)
-            DEST_DIR=$(echo $DIR_PAIR | cut -d':' -f2)
-
-            sudo mkdir -m 755 "$SRC_DIR"
-            sudo chown -R $(id -u):$(id -g) "$SRC_DIR"
-
-            mkdir -p "$DEST_DIR"
-            sudo mount --bind "$SRC_DIR" "$DEST_DIR"
-            echo "Successfully mounted $SRC_DIR to $DEST_DIR"
-          done
-
       - name: Checkout the repo
         if: ${{ matrix.type.should-run == 'true' }}
         uses: actions/checkout@v4

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -47,38 +47,10 @@ jobs:
 
   go-cache-self-hosted:
     name: Go Cache
-    runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=16+32/family=c6id+m6id+m6idn/spot=false/extras=s3-cache
+    runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c6id/spot=false/extras=s3-cache
     steps:
       # enable runs-on magic cache
       - uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
-
-      - name: Setup self-hosted directory mounts
-        # For self-hosted runners - the volume mounted to / is too small to handle everything stored in
-        # /home/runner. So we mount certain directories to the larger volume.
-        run: |
-          if [ ! -d "/home/runner/_work" ]; then
-            echo "::warning::/home/runner/_work does not exist, skipping mount."
-            exit 0
-          fi
-
-          # Define the directories to mount as tuples of source:destination
-          DIRS=(
-            "/home/runner/_work/runner-go:/home/runner/go"
-            "/home/runner/_work/runner-cache:/home/runner/.cache"
-          )
-
-          # Process each directory pair
-          for DIR_PAIR in "${DIRS[@]}"; do
-            SRC_DIR=$(echo $DIR_PAIR | cut -d':' -f1)
-            DEST_DIR=$(echo $DIR_PAIR | cut -d':' -f2)
-
-            sudo mkdir -m 755 "$SRC_DIR"
-            sudo chown -R $(id -u):$(id -g) "$SRC_DIR"
-
-            mkdir -p "$DEST_DIR"
-            sudo mount --bind "$SRC_DIR" "$DEST_DIR"
-            echo "Successfully mounted $SRC_DIR to $DEST_DIR"
-          done
 
       - name: Checkout the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
### Changes

- Remove the custom disk mounts used for self-hosted runners
- Remove duplicate secondary cache key

### Motivation

[runs-on v2.8.2](https://github.com/runs-on/runs-on/releases/tag/v2.8.2) offers better mounting of ec2 instance storage. So these are no longer necessary.

The cache restore bug was fixed.

---

DX-743