### PR TITLE
[CLD-276]: fix(aptos): migrate to env.BlockChains.AptosChains

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250523142134-2057cda8d221
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.3
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250523142134-2057cda8d221
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.3
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1283,8 +1283,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0 h1:0ZaI9vNyPwVwldYYFWld1XM4SBgGa/MvjlxHu1S1bWI=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0/go.mod h1:bJ/qkKuQWVAUl5S50GlLGp1MMZHaj6C+kgSi0q++biI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1283,8 +1283,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1 h1:7kAx5XXBSYhpvPa3n3yLnwl57+3B7gsZcXmKz2rqStQ=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain.go
@@ -11,6 +11,7 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/operation"
@@ -32,13 +33,14 @@ func (cs DeployAptosChain) VerifyPreconditions(env cldf.Environment, config conf
 	if err != nil {
 		return fmt.Errorf("failed to load existing Aptos onchain state: %w", err)
 	}
+	aptosChains := env.BlockChains.AptosChains()
 	var errs []error
 	for chainSel := range config.ContractParamsPerChain {
 		if err := config.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("invalid config for Aptos chain %d: %w", chainSel, err))
 			continue
 		}
-		if _, ok := env.AptosChains[chainSel]; !ok {
+		if _, ok := aptosChains[chainSel]; !ok {
 			errs = append(errs, fmt.Errorf("aptos chain %d not found in env", chainSel))
 		}
 		chainState, ok := state[chainSel]
@@ -69,10 +71,11 @@ func (cs DeployAptosChain) Apply(env cldf.Environment, config config.DeployAptos
 	seqReports := make([]operations.Report[any, any], 0)
 	proposals := make([]mcms.TimelockProposal, 0)
 
+	aptosChains := env.BlockChains.AptosChains()
 	// Deploy CCIP on each Aptos chain in config
 	for chainSel := range config.ContractParamsPerChain {
 		mcmsOperations := []mcmstypes.BatchOperation{}
-		aptosChain := env.AptosChains[chainSel]
+		aptosChain := aptosChains[chainSel]
 
 		deps := operation.AptosDeps{
 			AB:               ab,

--- a/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
@@ -39,12 +39,8 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 		{
 			name: "success - valid configs",
 			env: cldf.Environment{
-				Name:   "test",
-				Logger: logger.TestLogger(t),
-				AptosChains: map[uint64]cldf.AptosChain{
-					743186221051783445:  {},
-					4457093679053095497: {},
-				},
+				Name:              "test",
+				Logger:            logger.TestLogger(t),
 				ExistingAddresses: cldf.NewMemoryAddressBook(),
 				BlockChains: chain.NewBlockChains(
 					map[uint64]chain.BlockChain{
@@ -69,10 +65,6 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 			env: cldf.Environment{
 				Name:   "test",
 				Logger: logger.TestLogger(t),
-				AptosChains: map[uint64]cldf.AptosChain{
-					743186221051783445:  {},
-					4457093679053095497: {},
-				},
 				ExistingAddresses: getTestAddressBook(
 					t,
 					map[uint64]map[string]cldf.TypeAndVersion{
@@ -103,9 +95,6 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 			env: cldf.Environment{
 				Name:   "test",
 				Logger: logger.TestLogger(t),
-				AptosChains: map[uint64]cldf.AptosChain{
-					4457093679053095497: {},
-				},
 				ExistingAddresses: getTestAddressBook(
 					t,
 					map[uint64]map[string]cldf.TypeAndVersion{
@@ -137,7 +126,6 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 				Name:              "test",
 				Logger:            logger.TestLogger(t),
 				ExistingAddresses: cldf.NewMemoryAddressBook(),
-				AptosChains:       map[uint64]cldf.AptosChain{},
 			},
 			config: config.DeployAptosChainConfig{
 				ContractParamsPerChain: map[uint64]config.ChainContractParams{
@@ -152,9 +140,6 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 			env: cldf.Environment{
 				Name:   "test",
 				Logger: logger.TestLogger(t),
-				AptosChains: map[uint64]cldf.AptosChain{
-					4457093679053095497: {},
-				},
 				ExistingAddresses: getTestAddressBook(
 					t,
 					map[uint64]map[string]cldf.TypeAndVersion{
@@ -180,9 +165,6 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 			env: cldf.Environment{
 				Name:   "test",
 				Logger: logger.TestLogger(t),
-				AptosChains: map[uint64]cldf.AptosChain{
-					4457093679053095497: {},
-				},
 				ExistingAddresses: getTestAddressBook(
 					t,
 					map[uint64]map[string]cldf.TypeAndVersion{
@@ -237,7 +219,7 @@ func TestDeployAptosChain_Apply(t *testing.T) {
 	aptosChainSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyAptos))
 	require.Len(t, aptosChainSelectors, 1, "Expected exactly 1 Aptos chain")
 	chainSelector := aptosChainSelectors[0]
-	t.Log("Deployer: ", env.AptosChains[chainSelector].DeployerSigner)
+	t.Log("Deployer: ", env.BlockChains.AptosChains()[chainSelector].DeployerSigner)
 
 	// Deploy CCIP to Aptos chain
 	mockCCIPParams := GetMockChainContractParams(t, chainSelector)
@@ -275,7 +257,7 @@ func TestDeployAptosChain_Apply(t *testing.T) {
 	require.NotEmpty(t, ccipAddr, "CCIP address should not be empty")
 
 	// Bind CCIP contract
-	offrampBind := ccip_offramp.Bind(ccipAddr, env.AptosChains[chainSelector].Client)
+	offrampBind := ccip_offramp.Bind(ccipAddr, env.BlockChains.AptosChains()[chainSelector].Client)
 	offRampSourceConfig, err := offrampBind.Offramp().GetSourceChainConfig(nil, mockCCIPParams.OffRampParams.SourceChainSelectors[0])
 	require.NoError(t, err)
 	require.True(t, offRampSourceConfig.IsEnabled, "contracts were not initialized correctly")

--- a/deployment/ccip/changeset/aptos/operation/dependencies.go
+++ b/deployment/ccip/changeset/aptos/operation/dependencies.go
@@ -1,12 +1,14 @@
 package operation
 
 import (
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
 
 type AptosDeps struct {
 	AB               *cldf.AddressBookMap
-	AptosChain       cldf.AptosChain
+	AptosChain       cldf_aptos.Chain
 	CCIPOnChainState stateview.CCIPOnChainState
 }

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -393,7 +393,6 @@ func (m *MemoryEnvironment) StartChains(t *testing.T) {
 	env := cldf.Environment{
 		Chains:      m.Chains,
 		SolChains:   m.SolChains,
-		AptosChains: m.AptosChains,
 		BlockChains: cldf_chain.NewBlockChains(blockChains),
 	}
 	homeChainSel, feedSel := allocateCCIPChainSelectors(chains)

--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
 	solanago "github.com/gagliardetto/solana-go"
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
@@ -340,7 +341,7 @@ type MemoryEnvironment struct {
 	TestConfig  *TestConfigs
 	Chains      map[uint64]cldf.Chain
 	SolChains   map[uint64]cldf.SolChain
-	AptosChains map[uint64]cldf.AptosChain
+	AptosChains map[uint64]cldf_aptos.Chain
 }
 
 func (m *MemoryEnvironment) TestConfigs() *TestConfigs {

--- a/deployment/ccip/shared/stateview/aptos/state.go
+++ b/deployment/ccip/shared/stateview/aptos/state.go
@@ -28,7 +28,7 @@ type CCIPChainState struct {
 // LoadOnchainStateAptos loads chain state for Aptos chains from env
 func LoadOnchainStateAptos(env cldf.Environment) (map[uint64]CCIPChainState, error) {
 	aptosChains := make(map[uint64]CCIPChainState)
-	for chainSelector := range env.AptosChains {
+	for chainSelector := range env.BlockChains.AptosChains() {
 		addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 		if err != nil {
 			// Chain not found in address book, initialize empty

--- a/deployment/ccip/shared/stateview/aptos/state.go
+++ b/deployment/ccip/shared/stateview/aptos/state.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aptos-labs/aptos-go-sdk"
 	module_offramp "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_offramp/offramp"
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 
 	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip_offramp"
@@ -70,7 +71,7 @@ func loadAptosChainStateFromAddresses(addresses map[string]cldf.TypeAndVersion) 
 	return chainState, nil
 }
 
-func GetOfframpDynamicConfig(c cldf.AptosChain, ccipAddress aptos.AccountAddress) (module_offramp.DynamicConfig, error) {
+func GetOfframpDynamicConfig(c cldf_aptos.Chain, ccipAddress aptos.AccountAddress) (module_offramp.DynamicConfig, error) {
 	offrampBind := ccip_offramp.Bind(ccipAddress, c.Client)
 	return offrampBind.Offramp().GetDynamicConfig(&bind.CallOpts{})
 }

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -299,7 +299,7 @@ func (c CCIPOnChainState) OffRampPermissionLessExecutionThresholdSeconds(ctx con
 		if !ok {
 			return 0, fmt.Errorf("chain %d does not exist in state", selector)
 		}
-		chain, ok := env.AptosChains[selector]
+		chain, ok := env.BlockChains.AptosChains()[selector]
 		if !ok {
 			return 0, fmt.Errorf("chain %d does not exist in env", selector)
 		}

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -15,7 +15,6 @@ import (
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
@@ -138,16 +137,6 @@ func ApplyChangesets(t *testing.T, e cldf.Environment, timelockContractsPerChain
 			}
 		}
 
-		blockChains := map[uint64]chain.BlockChain{}
-		for selector, ch := range e.Chains {
-			blockChains[selector] = ch
-		}
-		for selector, ch := range e.SolChains {
-			blockChains[selector] = ch
-		}
-		for selector, ch := range e.AptosChains {
-			blockChains[selector] = ch
-		}
 		currentEnv = cldf.Environment{
 			Name:              e.Name,
 			Logger:            e.Logger,
@@ -155,13 +144,12 @@ func ApplyChangesets(t *testing.T, e cldf.Environment, timelockContractsPerChain
 			DataStore:         ds,
 			Chains:            e.Chains,
 			SolChains:         e.SolChains,
-			AptosChains:       e.AptosChains,
 			NodeIDs:           e.NodeIDs,
 			Offchain:          e.Offchain,
 			OCRSecrets:        e.OCRSecrets,
 			GetContext:        e.GetContext,
 			OperationsBundle:  operations.NewBundle(e.GetContext, e.Logger, operations.NewMemoryReporter()), // to ensure that each migration is run in a clean environment
-			BlockChains:       chain.NewBlockChains(blockChains),
+			BlockChains:       e.BlockChains,
 		}
 	}
 	return currentEnv, nil
@@ -214,17 +202,6 @@ func ApplyChangesetsV2(t *testing.T, e cldf.Environment, changesetApplications [
 			// do nothing, as these jobs auto-accept.
 		}
 
-		blockChains := map[uint64]chain.BlockChain{}
-		for selector, ch := range e.Chains {
-			blockChains[selector] = ch
-		}
-		for selector, ch := range e.SolChains {
-			blockChains[selector] = ch
-		}
-		for selector, ch := range e.AptosChains {
-			blockChains[selector] = ch
-		}
-
 		// Updated environment may be required before executing proposals when proposals involve new addresses
 		// Ex. changesets[0] deploys MCMS, changesets[1] generates a proposal with the new MCMS addresses
 		currentEnv = cldf.Environment{
@@ -234,13 +211,12 @@ func ApplyChangesetsV2(t *testing.T, e cldf.Environment, changesetApplications [
 			DataStore:         ds,
 			Chains:            e.Chains,
 			SolChains:         e.SolChains,
-			AptosChains:       e.AptosChains,
 			NodeIDs:           e.NodeIDs,
 			Offchain:          e.Offchain,
 			OCRSecrets:        e.OCRSecrets,
 			GetContext:        e.GetContext,
 			OperationsBundle:  operations.NewBundle(e.GetContext, e.Logger, operations.NewMemoryReporter()), // to ensure that each migration is run in a clean environment
-			BlockChains:       chain.NewBlockChains(blockChains),
+			BlockChains:       e.BlockChains,
 		}
 
 		if out.MCMSTimelockProposals != nil {

--- a/deployment/common/changeset/test_helpers_test.go
+++ b/deployment/common/changeset/test_helpers_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -75,7 +77,7 @@ func NewNoopEnvironment(t *testing.T) cldf.Environment {
 		]().Seal(),
 		map[uint64]cldf.Chain{},
 		map[uint64]cldf.SolChain{},
-		map[uint64]cldf.AptosChain{},
+		map[uint64]cldf_aptos.Chain{},
 		[]string{},
 		nil,
 		t.Context,

--- a/deployment/data-feeds/changeset/import_to_addressbook.go
+++ b/deployment/data-feeds/changeset/import_to_addressbook.go
@@ -40,11 +40,7 @@ func importToAddressbookLogic(env cldf.Environment, c types.ImportToAddressbookC
 }
 
 func importToAddressbookPrecondition(env cldf.Environment, c types.ImportToAddressbookConfig) error {
-	_, evmOK := env.Chains[c.ChainSelector]
-	_, aptosOK := env.AptosChains[c.ChainSelector]
-	_, solOK := env.SolChains[c.ChainSelector]
-
-	if !evmOK && !aptosOK && !solOK {
+	if !env.BlockChains.Exists(c.ChainSelector) {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}
 

--- a/deployment/environment/memory/aptos_chains.go
+++ b/deployment/environment/memory/aptos_chains.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/aptos-labs/aptos-go-sdk/crypto"
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 
 	"github.com/smartcontractkit/freeport"
 
@@ -20,8 +21,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
@@ -55,12 +54,12 @@ func createAptosAccount(t *testing.T, useDefault bool) *aptos.Account {
 	}
 }
 
-func GenerateChainsAptos(t *testing.T, numChains int) map[uint64]cldf.AptosChain {
+func GenerateChainsAptos(t *testing.T, numChains int) map[uint64]cldf_aptos.Chain {
 	testAptosChainSelectors := getTestAptosChainSelectors()
 	if len(testAptosChainSelectors) < numChains {
 		t.Fatalf("not enough test aptos chain selectors available")
 	}
-	chains := make(map[uint64]cldf.AptosChain)
+	chains := make(map[uint64]cldf_aptos.Chain)
 	for i := 0; i < numChains; i++ {
 		selector := testAptosChainSelectors[i]
 		chainID, err := chainsel.GetChainIDFromSelector(selector)
@@ -68,7 +67,7 @@ func GenerateChainsAptos(t *testing.T, numChains int) map[uint64]cldf.AptosChain
 		account := createAptosAccount(t, true)
 
 		url, nodeClient := aptosChain(t, chainID, account.Address)
-		chains[selector] = cldf.AptosChain{
+		chains[selector] = cldf_aptos.Chain{
 			Selector:       selector,
 			Client:         nodeClient,
 			DeployerSigner: account,
@@ -151,7 +150,7 @@ func aptosChain(t *testing.T, chainID string, adminAddress aptos.AccountAddress)
 	return url, client
 }
 
-func createAptosChainConfig(chainID string, chain cldf.AptosChain) chainlink.RawConfig {
+func createAptosChainConfig(chainID string, chain cldf_aptos.Chain) chainlink.RawConfig {
 	chainConfig := chainlink.RawConfig{}
 
 	chainConfig["Enabled"] = true

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -328,7 +328,7 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 		]().Seal(),
 		chains,
 		solChains,
-		aptosChains,
+		nil, // this field will be deleted in future
 		nodeIDs,
 		NewMemoryJobClient(nodes),
 		t.Context,

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+
 	"github.com/smartcontractkit/freeport"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -68,7 +70,7 @@ type NewNodesConfig struct {
 	// Solana chains to be configured. Optional.
 	SolChains map[uint64]cldf.SolChain
 	// Aptos chains to be configured. Optional.
-	AptosChains    map[uint64]cldf.AptosChain
+	AptosChains    map[uint64]cldf_aptos.Chain
 	NumNodes       int
 	NumBootstraps  int
 	RegistryConfig deployment.CapabilityRegistryConfig
@@ -106,7 +108,7 @@ func NewMemoryChainsSol(t *testing.T, numChains int) map[uint64]cldf.SolChain {
 	return generateMemoryChainSol(mchains)
 }
 
-func NewMemoryChainsAptos(t *testing.T, numChains int) map[uint64]cldf.AptosChain {
+func NewMemoryChainsAptos(t *testing.T, numChains int) map[uint64]cldf_aptos.Chain {
 	return GenerateChainsAptos(t, numChains)
 }
 
@@ -241,7 +243,7 @@ func NewMemoryEnvironmentFromChainsNodes(
 	lggr logger.Logger,
 	chains map[uint64]cldf.Chain,
 	solChains map[uint64]cldf.SolChain,
-	aptosChains map[uint64]cldf.AptosChain,
+	aptosChains map[uint64]cldf_aptos.Chain,
 	nodes map[string]Node,
 ) cldf.Environment {
 	var nodeIDs []string
@@ -328,7 +330,7 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 		]().Seal(),
 		chains,
 		solChains,
-		nil, // this field will be deleted in future
+		nil, // this field will be deleted in future since env.BlockChains will now contain all the chains.
 		nodeIDs,
 		NewMemoryJobClient(nodes),
 		t.Context,

--- a/deployment/environment/memory/node.go
+++ b/deployment/environment/memory/node.go
@@ -21,6 +21,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/exp/maps"
 
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -235,7 +237,7 @@ type NewNodeConfig struct {
 	// Solana chains to be configured. Optional.
 	Solchains map[uint64]cldf.SolChain
 	// Aptos chains to be configured. Optional.
-	Aptoschains    map[uint64]cldf.AptosChain
+	Aptoschains    map[uint64]cldf_aptos.Chain
 	LogLevel       zapcore.Level
 	Bootstrap      bool
 	RegistryConfig deployment.CapabilityRegistryConfig
@@ -436,7 +438,7 @@ func CreateKeys(t *testing.T,
 	app chainlink.Application,
 	chains map[uint64]cldf.Chain,
 	solchains map[uint64]cldf.SolChain,
-	aptoschains map[uint64]cldf.AptosChain,
+	aptoschains map[uint64]cldf_aptos.Chain,
 ) Keys {
 	ctx := t.Context()
 	_, err := app.GetKeyStore().P2P().Create(ctx)

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250523142134-2057cda8d221
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250523142134-2057cda8d221
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1259,8 +1259,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1 h1:7kAx5XXBSYhpvPa3n3yLnwl57+3B7gsZcXmKz2rqStQ=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1259,8 +1259,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0 h1:0ZaI9vNyPwVwldYYFWld1XM4SBgGa/MvjlxHu1S1bWI=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0/go.mod h1:bJ/qkKuQWVAUl5S50GlLGp1MMZHaj6C+kgSi0q++biI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250523142134-2057cda8d221
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250523142134-2057cda8d221
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1490,8 +1490,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0 h1:0ZaI9vNyPwVwldYYFWld1XM4SBgGa/MvjlxHu1S1bWI=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0/go.mod h1:bJ/qkKuQWVAUl5S50GlLGp1MMZHaj6C+kgSi0q++biI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1490,8 +1490,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1 h1:7kAx5XXBSYhpvPa3n3yLnwl57+3B7gsZcXmKz2rqStQ=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250523142134-2057cda8d221
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250523142134-2057cda8d221
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1472,8 +1472,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0 h1:0ZaI9vNyPwVwldYYFWld1XM4SBgGa/MvjlxHu1S1bWI=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0/go.mod h1:bJ/qkKuQWVAUl5S50GlLGp1MMZHaj6C+kgSi0q++biI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1472,8 +1472,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1 h1:7kAx5XXBSYhpvPa3n3yLnwl57+3B7gsZcXmKz2rqStQ=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/smartcontractkit/chain-selectors v1.0.59
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.3

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/smartcontractkit/chain-selectors v1.0.59
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.3

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1246,8 +1246,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0 h1:0ZaI9vNyPwVwldYYFWld1XM4SBgGa/MvjlxHu1S1bWI=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0/go.mod h1:bJ/qkKuQWVAUl5S50GlLGp1MMZHaj6C+kgSi0q++biI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1246,8 +1246,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1 h1:7kAx5XXBSYhpvPa3n3yLnwl57+3B7gsZcXmKz2rqStQ=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.3

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250522183927-44d96a7ad0e5
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
-	github.com/smartcontractkit/chainlink-deployments-framework v0.5.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.3

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1446,8 +1446,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1 h1:7kAx5XXBSYhpvPa3n3yLnwl57+3B7gsZcXmKz2rqStQ=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1446,8 +1446,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0 h1:0ZaI9vNyPwVwldYYFWld1XM4SBgGa/MvjlxHu1S1bWI=
-github.com/smartcontractkit/chainlink-deployments-framework v0.5.0/go.mod h1:bJ/qkKuQWVAUl5S50GlLGp1MMZHaj6C+kgSi0q++biI=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004 h1:0APCDAvEwxk6L0M1xb3bqQnSWsDqgXLznfhnwr49pXc=
+github.com/smartcontractkit/chainlink-deployments-framework v0.5.1-0.20250527010109-bbcfc3657004/go.mod h1:OlKntARV8pQV9EU5jyoDv/Fosf7WwFMWKjf3jfzuQnw=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c h1:5QkR2dEPTapo8rwA1VD7205tOaCUHtPso4zTg/wHsdM=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250522161404-27a8f7e1cc6c/go.mod h1:Vg5OKxmLm3TQtyd0fZtWU2UJwALF8uiPEzrtK+ccWL0=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=


### PR DESCRIPTION
Instead of env.AptosChains, we are migrating to env.BlockChains.AptosChains() as part of the newer design refactoring.

Also updated `cldf.AptosChain`  to `cldf_aptos.Chain` as that is the new location

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-276
