### PR TITLE
feat: add tonKey graphql query to support TON in Operator UI

### DIFF
--- a/.changeset/legal-phones-judge.md
+++ b/.changeset/legal-phones-judge.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Add tonKey graphql query to support TON in Operator UI

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -636,6 +636,19 @@ func (r *Resolver) TronKeys(ctx context.Context) (*TronKeysPayloadResolver, erro
 	return NewTronKeysPayload(keys), nil
 }
 
+func (r *Resolver) TONKeys(ctx context.Context) (*TONKeysPayloadResolver, error) {
+	if err := authenticateUser(ctx); err != nil {
+		return nil, err
+	}
+
+	keys, err := r.App.GetKeyStore().TON().GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTONKeysPayload(keys), nil
+}
+
 func (r *Resolver) SQLLogging(ctx context.Context) (*GetSQLLoggingPayloadResolver, error) {
 	if err := authenticateUser(ctx); err != nil {
 		return nil, err

--- a/core/web/resolver/resolver_test.go
+++ b/core/web/resolver/resolver_test.go
@@ -55,6 +55,7 @@ type mocks struct {
 	cosmos               *keystoreMocks.Cosmos
 	starknet             *keystoreMocks.StarkNet
 	tron                 *keystoreMocks.Tron
+	ton                  *keystoreMocks.TON
 	chain                *legacyEvmORMMocks.Chain
 	legacyEVMChains      *legacyEvmORMMocks.LegacyChainContainer
 	relayerChainInterops *chainlinkMocks.FakeRelayerChainInteroperators
@@ -114,6 +115,7 @@ func setupFramework(t *testing.T) *gqlTestFramework {
 		cosmos:               keystoreMocks.NewCosmos(t),
 		starknet:             keystoreMocks.NewStarkNet(t),
 		tron:                 keystoreMocks.NewTron(t),
+		ton:                  keystoreMocks.NewTON(t),
 		chain:                legacyEvmORMMocks.NewChain(t),
 		legacyEVMChains:      legacyEvmORMMocks.NewLegacyChainContainer(t),
 		relayerChainInterops: &chainlinkMocks.FakeRelayerChainInteroperators{},

--- a/core/web/resolver/ton_key.go
+++ b/core/web/resolver/ton_key.go
@@ -1,0 +1,51 @@
+package resolver
+
+import (
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/tonkey"
+)
+
+type TONKeyResolver struct {
+	key tonkey.Key
+}
+
+func NewTONKey(key tonkey.Key) *TONKeyResolver {
+	return &TONKeyResolver{key: key}
+}
+
+func NewTONKeys(keys []tonkey.Key) []*TONKeyResolver {
+	resolvers := make([]*TONKeyResolver, 0, len(keys))
+
+	for _, k := range keys {
+		resolvers = append(resolvers, NewTONKey(k))
+	}
+
+	return resolvers
+}
+
+func (r *TONKeyResolver) ID() graphql.ID {
+	return graphql.ID(r.key.ID())
+}
+
+func (r *TONKeyResolver) AddressBase64() string {
+	return r.key.AddressBase64()
+}
+
+func (r *TONKeyResolver) RawAddress() string {
+	return r.key.RawAddress()
+}
+
+// -- GetTONKeys Query --
+
+type TONKeysPayloadResolver struct {
+	keys []tonkey.Key
+}
+
+func NewTONKeysPayload(keys []tonkey.Key) *TONKeysPayloadResolver {
+	return &TONKeysPayloadResolver{keys: keys}
+}
+
+func (r *TONKeysPayloadResolver) Results() []*TONKeyResolver {
+	return NewTONKeys(r.keys)
+}

--- a/core/web/resolver/ton_key_test.go
+++ b/core/web/resolver/ton_key_test.go
@@ -1,0 +1,78 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
+
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/keystest"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/tonkey"
+)
+
+func TestResolver_TONKeys(t *testing.T) {
+	t.Parallel()
+
+	query := `
+		query GetTONKeys {
+			tonKeys {
+				results {
+					id
+					addressBase64
+					rawAddress
+				}
+			}
+		}`
+	k := tonkey.MustNewInsecure(keystest.NewRandReaderFromSeed(1))
+	result := fmt.Sprintf(`
+	{
+		"tonKeys": {
+			"results": [
+				{
+					"id": "%s",
+					"addressBase64": "%s",
+					"rawAddress": "%s"
+				}
+			]
+		}
+	}`, k.ID(), k.AddressBase64(), k.RawAddress())
+	gError := errors.New("error")
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: query}, "tonKeys"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				f.Mocks.ton.On("GetAll").Return([]tonkey.Key{k}, nil)
+				f.Mocks.keystore.On("TON").Return(f.Mocks.ton)
+				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
+			},
+			query:  query,
+			result: result,
+		},
+		{
+			name:          "no keys returned by GetAll",
+			authenticated: true,
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				f.Mocks.ton.On("GetAll").Return([]tonkey.Key{}, gError)
+				f.Mocks.keystore.On("TON").Return(f.Mocks.ton)
+				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
+			},
+			query:  query,
+			result: `null`,
+			errors: []*gqlerrors.QueryError{
+				{
+					Extensions:    nil,
+					ResolverError: gError,
+					Path:          []interface{}{"tonKeys"},
+					Message:       gError.Error(),
+				},
+			},
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -37,6 +37,7 @@ type Query {
     cosmosKeys: CosmosKeysPayload!
     starknetKeys: StarkNetKeysPayload!
     tronKeys: TronKeysPayload!
+    tonKeys: TONKeysPayload!
     sqlLogging: GetSQLLoggingPayload!
     vrfKey(id: ID!): VRFKeyPayload!
     vrfKeys: VRFKeysPayload!

--- a/core/web/schema/type/ton_key.graphql
+++ b/core/web/schema/type/ton_key.graphql
@@ -1,0 +1,9 @@
+type TONKey {
+	id: ID!
+	addressBase64: String!
+	rawAddress: String!
+}
+
+type TONKeysPayload {
+	results: [TONKey!]!
+}

--- a/deployment/environment/web/sdk/internal/schema.graphql
+++ b/deployment/environment/web/sdk/internal/schema.graphql
@@ -37,6 +37,7 @@ type Query {
     cosmosKeys: CosmosKeysPayload!
     starknetKeys: StarkNetKeysPayload!
     tronKeys: TronKeysPayload!
+    tonKeys: TONKeysPayload!
     sqlLogging: GetSQLLoggingPayload!
     vrfKey(id: ID!): VRFKeyPayload!
     vrfKeys: VRFKeysPayload!


### PR DESCRIPTION
This PR adds tonKeys support to the GraphQL schema in the Core Node. These keys will be used by the Operator UI to retrieve and display a list of TON addresses, allowing users to view and manage their TON keys via the UI.

JIRA: https://smartcontract-it.atlassian.net/browse/NONEVM-1866

<img width="800" src="https://github.com/user-attachments/assets/d970e9da-a46e-456f-8b36-131730acf5ba" />
