### PR TITLE
fix: run docker-build on push events

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,6 +28,7 @@ jobs:
       should-run: >-
         ${{
           steps.pr-labels.outputs.check-label-found == 'true' ||
+          github.event_name == 'push' ||
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch'
         }}


### PR DESCRIPTION
### Changes

- Run `docker-build` on `push` events


