### PR TITLE
refactor: migration usage of CLDF Chain in data feeds changesets

### DIFF
--- a/deployment/data-feeds/changeset/accept_ownership.go
+++ b/deployment/data-feeds/changeset/accept_ownership.go
@@ -18,7 +18,7 @@ import (
 var AcceptOwnershipChangeset = cldf.CreateChangeSet(acceptOwnershipLogic, acceptOwnershipPrecondition)
 
 func acceptOwnershipLogic(env cldf.Environment, c types.AcceptOwnershipConfig) (cldf.ChangesetOutput, error) {
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 
 	var mcmsProposals []ProposalData
 	for _, contractAddress := range c.ContractAddresses {
@@ -47,7 +47,7 @@ func acceptOwnershipLogic(env cldf.Environment, c types.AcceptOwnershipConfig) (
 }
 
 func acceptOwnershipPrecondition(env cldf.Environment, c types.AcceptOwnershipConfig) error {
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/accept_ownership_test.go
+++ b/deployment/data-feeds/changeset/accept_ownership_test.go
@@ -25,15 +25,15 @@ import (
 
 func TestAcceptOwnership(t *testing.T) {
 	t.Parallel()
+
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
-	chain := env.Chains[chainSelector]
+	chain := env.BlockChains.EVMChains()[chainSelector]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/confirm_aggregator.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator.go
@@ -17,7 +17,7 @@ import (
 var ConfirmAggregatorChangeset = cldf.CreateChangeSet(confirmAggregatorLogic, confirmAggregatorPrecondition)
 
 func confirmAggregatorLogic(env cldf.Environment, c types.ProposeConfirmAggregatorConfig) (cldf.ChangesetOutput, error) {
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 
 	aggregatorProxy, err := proxy.NewAggregatorProxy(c.ProxyAddress, chain.Client)
 	if err != nil {
@@ -56,7 +56,7 @@ func confirmAggregatorLogic(env cldf.Environment, c types.ProposeConfirmAggregat
 }
 
 func confirmAggregatorPrecondition(env cldf.Environment, c types.ProposeConfirmAggregatorConfig) error {
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/confirm_aggregator_test.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator_test.go
@@ -28,7 +28,6 @@ func TestConfirmAggregator(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)

--- a/deployment/data-feeds/changeset/deploy.go
+++ b/deployment/data-feeds/changeset/deploy.go
@@ -10,12 +10,13 @@ import (
 	bundleproxy "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/bundle_aggregator_proxy"
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
-func DeployCache(chain cldf.Chain, labels []string) (*types.DeployCacheResponse, error) {
+func DeployCache(chain cldf_evm.Chain, labels []string) (*types.DeployCacheResponse, error) {
 	cacheAddr, tx, cacheContract, err := cache.DeployDataFeedsCache(chain.DeployerKey, chain.Client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy DataFeedsCache: %w", err)
@@ -49,7 +50,7 @@ func DeployCache(chain cldf.Chain, labels []string) (*types.DeployCacheResponse,
 	return resp, nil
 }
 
-func DeployAggregatorProxy(chain cldf.Chain, aggregator common.Address, accessController common.Address, labels []string) (*types.DeployProxyResponse, error) {
+func DeployAggregatorProxy(chain cldf_evm.Chain, aggregator common.Address, accessController common.Address, labels []string) (*types.DeployProxyResponse, error) {
 	proxyAddr, tx, proxyContract, err := proxy.DeployAggregatorProxy(chain.DeployerKey, chain.Client, aggregator, accessController)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy AggregatorProxy: %w", err)
@@ -80,7 +81,7 @@ func DeployAggregatorProxy(chain cldf.Chain, aggregator common.Address, accessCo
 	return resp, nil
 }
 
-func DeployBundleAggregatorProxy(chain cldf.Chain, aggregator common.Address, owner common.Address, labels []string) (*types.DeployBundleAggregatorProxyResponse, error) {
+func DeployBundleAggregatorProxy(chain cldf_evm.Chain, aggregator common.Address, owner common.Address, labels []string) (*types.DeployBundleAggregatorProxyResponse, error) {
 	proxyAddr, tx, proxyContract, err := bundleproxy.DeployBundleAggregatorProxy(chain.DeployerKey, chain.Client, aggregator, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy BundleAggregatorProxy: %w", err)

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy.go
@@ -20,7 +20,7 @@ func deployAggregatorProxyLogic(env cldf.Environment, c types.DeployAggregatorPr
 	ab := cldf.NewMemoryAddressBook()
 
 	for index, chainSelector := range c.ChainsToDeploy {
-		chain := env.Chains[chainSelector]
+		chain := env.BlockChains.EVMChains()[chainSelector]
 
 		dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, chainSelector, nil)
 		if dataFeedsCacheAddress == "" {
@@ -48,7 +48,7 @@ func deployAggregatorProxyPrecondition(env cldf.Environment, c types.DeployAggre
 	}
 
 	for _, chainSelector := range c.ChainsToDeploy {
-		_, ok := env.Chains[chainSelector]
+		_, ok := env.BlockChains.EVMChains()[chainSelector]
 		if !ok {
 			return errors.New("chain not found in environment")
 		}

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
@@ -22,8 +22,7 @@ func TestAggregatorProxy(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
-		Chains: 2,
+		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy.go
@@ -21,7 +21,7 @@ func deployBundleAggregatorProxyLogic(env cldf.Environment, c types.DeployBundle
 	ab := cldf.NewMemoryAddressBook()
 
 	for _, chainSelector := range c.ChainsToDeploy {
-		chain := env.Chains[chainSelector]
+		chain := env.BlockChains.EVMChains()[chainSelector]
 
 		dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, chainSelector, &c.CacheLabel) //nolint:staticcheck // TODO: replace with DataStore when ready
 		if dataFeedsCacheAddress == "" {
@@ -45,7 +45,7 @@ func deployBundleAggregatorProxyLogic(env cldf.Environment, c types.DeployBundle
 
 func deployBundleAggregatorProxyPrecondition(env cldf.Environment, c types.DeployBundleAggregatorProxyConfig) error {
 	for _, chainSelector := range c.ChainsToDeploy {
-		_, ok := env.Chains[chainSelector]
+		_, ok := env.BlockChains.EVMChains()[chainSelector]
 		if !ok {
 			return errors.New("chain not found in environment")
 		}

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
@@ -8,9 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
@@ -21,7 +20,6 @@ func TestBundleAggregatorProxy(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 2,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)

--- a/deployment/data-feeds/changeset/deploy_cache.go
+++ b/deployment/data-feeds/changeset/deploy_cache.go
@@ -17,7 +17,7 @@ func deployCacheLogic(env cldf.Environment, c types.DeployConfig) (cldf.Changese
 	lggr := env.Logger
 	ab := cldf.NewMemoryAddressBook()
 	for _, chainSelector := range c.ChainsToDeploy {
-		chain := env.Chains[chainSelector]
+		chain := env.BlockChains.EVMChains()[chainSelector]
 		cacheResponse, err := DeployCache(chain, c.Labels)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy DataFeedsCache: %w", err)
@@ -35,7 +35,7 @@ func deployCacheLogic(env cldf.Environment, c types.DeployConfig) (cldf.Changese
 
 func deployCachePrecondition(env cldf.Environment, c types.DeployConfig) error {
 	for _, chainSelector := range c.ChainsToDeploy {
-		_, ok := env.Chains[chainSelector]
+		_, ok := env.BlockChains.EVMChains()[chainSelector]
 		if !ok {
 			return errors.New("chain not found in environment")
 		}

--- a/deployment/data-feeds/changeset/deploy_cache_test.go
+++ b/deployment/data-feeds/changeset/deploy_cache_test.go
@@ -22,7 +22,6 @@ func TestDeployCache(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 2,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)

--- a/deployment/data-feeds/changeset/import_to_addressbook_test.go
+++ b/deployment/data-feeds/changeset/import_to_addressbook_test.go
@@ -26,7 +26,6 @@ func TestImportToAddressbook(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)

--- a/deployment/data-feeds/changeset/jd_propose_bt_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_bt_jobs.go
@@ -36,7 +36,7 @@ func proposeBtJobsToJDPrecondition(env cldf.Environment, c types.ProposeBtJobsCo
 		return errors.New("node labels are required")
 	}
 
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/migrate_feeds.go
+++ b/deployment/data-feeds/changeset/migrate_feeds.go
@@ -26,7 +26,7 @@ type MigrationSchema struct {
 
 func migrateFeedsLogic(env cldf.Environment, c types.MigrationConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
 	contract := chainState.DataFeedsCache[c.CacheAddress]
 	ab := cldf.NewMemoryAddressBook()
@@ -70,7 +70,7 @@ func migrateFeedsLogic(env cldf.Environment, c types.MigrationConfig) (cldf.Chan
 }
 
 func migrateFeedsPrecondition(env cldf.Environment, c types.MigrationConfig) error {
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/migrate_feeds_test.go
+++ b/deployment/data-feeds/changeset/migrate_feeds_test.go
@@ -27,7 +27,6 @@ func TestMigrateFeeds(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -54,7 +53,7 @@ func TestMigrateFeeds(t *testing.T) {
 			types.SetFeedAdminConfig{
 				ChainSelector: chainSelector,
 				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.Chains[chainSelector].DeployerKey.From.Hex()),
+				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
 				IsAdmin:       true,
 			},
 		),
@@ -66,7 +65,7 @@ func TestMigrateFeeds(t *testing.T) {
 				InputFileName: "testdata/migrate_feeds.json",
 				InputFS:       testFS,
 				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					cache.DataFeedsCacheWorkflowMetadata{
+					{
 						AllowedSender:        common.HexToAddress("0x22"),
 						AllowedWorkflowOwner: common.HexToAddress("0x33"),
 						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),

--- a/deployment/data-feeds/changeset/new_feed_with_proxy.go
+++ b/deployment/data-feeds/changeset/new_feed_with_proxy.go
@@ -23,7 +23,7 @@ import (
 var NewFeedWithProxyChangeset = cldf.CreateChangeSet(newFeedWithProxyLogic, newFeedWithProxyPrecondition)
 
 func newFeedWithProxyLogic(env cldf.Environment, c types.NewFeedWithProxyConfig) (cldf.ChangesetOutput, error) {
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 	state, _ := LoadOnchainState(env)
 	chainState := state.Chains[c.ChainSelector]
 	ab := cldf.NewMemoryAddressBook()
@@ -140,7 +140,7 @@ func newFeedWithProxyPrecondition(env cldf.Environment, c types.NewFeedWithProxy
 		return fmt.Errorf("failed to convert feed ids to bytes16: %w", err)
 	}
 
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/new_feed_with_proxy_test.go
+++ b/deployment/data-feeds/changeset/new_feed_with_proxy_test.go
@@ -31,7 +31,6 @@ func TestNewFeedWithProxy(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -97,7 +96,7 @@ func TestNewFeedWithProxy(t *testing.T) {
 				DataIDs:          []string{dataid, dataid2},
 				Descriptions:     []string{"feed1", "feed2"},
 				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					cache.DataFeedsCacheWorkflowMetadata{
+					{
 						AllowedSender:        common.HexToAddress("0x22"),
 						AllowedWorkflowOwner: common.HexToAddress("0x33"),
 						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),

--- a/deployment/data-feeds/changeset/proposal.go
+++ b/deployment/data-feeds/changeset/proposal.go
@@ -32,7 +32,7 @@ func BuildMultiChainProposals(env cldf.Environment, description string, proposal
 	var batches []mcmstypes.BatchOperation
 
 	for chainSelector, proposalData := range proposalConfig {
-		chain := env.Chains[chainSelector]
+		chain := env.BlockChains.EVMChains()[chainSelector]
 		chainState := state.Chains[chainSelector]
 
 		inspectorPerChain[chainSelector] = evm.NewInspector(chain.Client)

--- a/deployment/data-feeds/changeset/propose_aggregator.go
+++ b/deployment/data-feeds/changeset/propose_aggregator.go
@@ -17,7 +17,7 @@ import (
 var ProposeAggregatorChangeset = cldf.CreateChangeSet(proposeAggregatorLogic, proposeAggregatorPrecondition)
 
 func proposeAggregatorLogic(env cldf.Environment, c types.ProposeConfirmAggregatorConfig) (cldf.ChangesetOutput, error) {
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 
 	aggregatorProxy, err := proxy.NewAggregatorProxy(c.ProxyAddress, chain.Client)
 	if err != nil {
@@ -55,7 +55,7 @@ func proposeAggregatorLogic(env cldf.Environment, c types.ProposeConfirmAggregat
 }
 
 func proposeAggregatorPrecondition(env cldf.Environment, c types.ProposeConfirmAggregatorConfig) error {
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/propose_aggregator_test.go
+++ b/deployment/data-feeds/changeset/propose_aggregator_test.go
@@ -29,7 +29,6 @@ func TestProposeAggregator(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)

--- a/deployment/data-feeds/changeset/remove_dataid_proxy_mapping.go
+++ b/deployment/data-feeds/changeset/remove_dataid_proxy_mapping.go
@@ -17,7 +17,7 @@ var RemoveFeedProxyMappingChangeset = cldf.CreateChangeSet(removeFeedProxyMappin
 
 func removeFeedProxyMappingLogic(env cldf.Environment, c types.RemoveFeedProxyConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
 	contract := chainState.DataFeedsCache[c.CacheAddress]
 
@@ -53,7 +53,7 @@ func removeFeedProxyMappingLogic(env cldf.Environment, c types.RemoveFeedProxyCo
 }
 
 func removeFeedFeedProxyMappingPrecondition(env cldf.Environment, c types.RemoveFeedProxyConfig) error {
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/remove_dataid_proxy_mapping_test.go
+++ b/deployment/data-feeds/changeset/remove_dataid_proxy_mapping_test.go
@@ -27,7 +27,6 @@ func TestRemoveFeedProxyMapping(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -64,7 +63,7 @@ func TestRemoveFeedProxyMapping(t *testing.T) {
 			types.SetFeedAdminConfig{
 				ChainSelector: chainSelector,
 				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.Chains[chainSelector].DeployerKey.From.Hex()),
+				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
 				IsAdmin:       true,
 			},
 		),

--- a/deployment/data-feeds/changeset/remove_feed.go
+++ b/deployment/data-feeds/changeset/remove_feed.go
@@ -17,7 +17,7 @@ var RemoveFeedChangeset = cldf.CreateChangeSet(removeFeedLogic, removeFeedPrecon
 
 func removeFeedLogic(env cldf.Environment, c types.RemoveFeedConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
 	contract := chainState.DataFeedsCache[c.CacheAddress]
 
@@ -73,7 +73,7 @@ func removeFeedLogic(env cldf.Environment, c types.RemoveFeedConfig) (cldf.Chang
 }
 
 func removeFeedPrecondition(env cldf.Environment, c types.RemoveFeedConfig) error {
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/remove_feed_config.go
+++ b/deployment/data-feeds/changeset/remove_feed_config.go
@@ -17,7 +17,7 @@ var RemoveFeedConfigChangeset = cldf.CreateChangeSet(removeFeedConfigLogic, remo
 
 func removeFeedConfigLogic(env cldf.Environment, c types.RemoveFeedConfigCSConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
 	contract := chainState.DataFeedsCache[c.CacheAddress]
 

--- a/deployment/data-feeds/changeset/remove_feed_config_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_config_test.go
@@ -28,7 +28,6 @@ func TestRemoveFeedConfig(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -65,7 +64,7 @@ func TestRemoveFeedConfig(t *testing.T) {
 			types.SetFeedAdminConfig{
 				ChainSelector: chainSelector,
 				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.Chains[chainSelector].DeployerKey.From.Hex()),
+				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
 				IsAdmin:       true,
 			},
 		),
@@ -78,7 +77,7 @@ func TestRemoveFeedConfig(t *testing.T) {
 				DataIDs:       []string{dataid},
 				Descriptions:  []string{"test"},
 				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					cache.DataFeedsCacheWorkflowMetadata{
+					{
 						AllowedSender:        common.HexToAddress("0x22"),
 						AllowedWorkflowOwner: common.HexToAddress("0x33"),
 						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
@@ -136,7 +135,7 @@ func TestRemoveFeedConfig(t *testing.T) {
 				DataIDs:       []string{dataid},
 				Descriptions:  []string{"test2"},
 				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					cache.DataFeedsCacheWorkflowMetadata{
+					{
 						AllowedSender:        common.HexToAddress("0x22"),
 						AllowedWorkflowOwner: common.HexToAddress("0x33"),
 						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),

--- a/deployment/data-feeds/changeset/remove_feed_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_test.go
@@ -29,7 +29,6 @@ func TestRemoveFeed(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -66,7 +65,7 @@ func TestRemoveFeed(t *testing.T) {
 			types.SetFeedAdminConfig{
 				ChainSelector: chainSelector,
 				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.Chains[chainSelector].DeployerKey.From.Hex()),
+				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
 				IsAdmin:       true,
 			},
 		),
@@ -79,7 +78,7 @@ func TestRemoveFeed(t *testing.T) {
 				DataIDs:       []string{dataid},
 				Descriptions:  []string{"test"},
 				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					cache.DataFeedsCacheWorkflowMetadata{
+					{
 						AllowedSender:        common.HexToAddress("0x22"),
 						AllowedWorkflowOwner: common.HexToAddress("0x33"),
 						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
@@ -138,7 +137,7 @@ func TestRemoveFeed(t *testing.T) {
 				DataIDs:       []string{dataid},
 				Descriptions:  []string{"test2"},
 				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					cache.DataFeedsCacheWorkflowMetadata{
+					{
 						AllowedSender:        common.HexToAddress("0x22"),
 						AllowedWorkflowOwner: common.HexToAddress("0x33"),
 						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),

--- a/deployment/data-feeds/changeset/set_bundle_feed_config.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config.go
@@ -17,7 +17,7 @@ var SetBundleFeedConfigChangeset = cldf.CreateChangeSet(setBundleFeedConfigLogic
 
 func setBundleFeedConfigLogic(env cldf.Environment, c types.SetFeedBundleConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
 	contract := chainState.DataFeedsCache[c.CacheAddress]
 
@@ -57,7 +57,7 @@ func setBundleFeedConfigLogic(env cldf.Environment, c types.SetFeedBundleConfig)
 }
 
 func setBundleFeedConfigPrecondition(env cldf.Environment, c types.SetFeedBundleConfig) error {
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
@@ -27,12 +27,13 @@ func TestSetBundleFeedConfig(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
-	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	chainSelector := env.BlockChains.ListChainSelectors(
+		cldf_chain.WithFamily(chain_selectors.FamilyEVM),
+	)[0]
 
 	newEnv, err := commonChangesets.Apply(t, env, nil,
 		commonChangesets.Configure(
@@ -63,7 +64,7 @@ func TestSetBundleFeedConfig(t *testing.T) {
 			types.SetFeedAdminConfig{
 				ChainSelector: chainSelector,
 				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.Chains[chainSelector].DeployerKey.From.Hex()),
+				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
 				IsAdmin:       true,
 			},
 		),
@@ -76,7 +77,7 @@ func TestSetBundleFeedConfig(t *testing.T) {
 				Descriptions:   []string{"test"},
 				DecimalsMatrix: [][]uint8{{18, 8, 6}},
 				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					cache.DataFeedsCacheWorkflowMetadata{
+					{
 						AllowedSender:        common.HexToAddress("0x22"),
 						AllowedWorkflowOwner: common.HexToAddress("0x33"),
 						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
@@ -126,7 +127,7 @@ func TestSetBundleFeedConfig(t *testing.T) {
 				Descriptions:   []string{"test2"},
 				DecimalsMatrix: [][]uint8{{18, 8, 6}},
 				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					cache.DataFeedsCacheWorkflowMetadata{
+					{
 						AllowedSender:        common.HexToAddress("0x22"),
 						AllowedWorkflowOwner: common.HexToAddress("0x33"),
 						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),

--- a/deployment/data-feeds/changeset/set_feed_admin.go
+++ b/deployment/data-feeds/changeset/set_feed_admin.go
@@ -16,7 +16,7 @@ var SetFeedAdminChangeset = cldf.CreateChangeSet(setFeedAdminLogic, setFeedAdmin
 
 func setFeedAdminLogic(env cldf.Environment, c types.SetFeedAdminConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
 	contract := chainState.DataFeedsCache[c.CacheAddress]
 
@@ -52,7 +52,7 @@ func setFeedAdminLogic(env cldf.Environment, c types.SetFeedAdminConfig) (cldf.C
 }
 
 func setFeedAdminPrecondition(env cldf.Environment, c types.SetFeedAdminConfig) error {
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/set_feed_admin_test.go
+++ b/deployment/data-feeds/changeset/set_feed_admin_test.go
@@ -29,7 +29,6 @@ func TestSetCacheAdmin(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)

--- a/deployment/data-feeds/changeset/set_feed_config.go
+++ b/deployment/data-feeds/changeset/set_feed_config.go
@@ -17,7 +17,7 @@ var SetFeedConfigChangeset = cldf.CreateChangeSet(setFeedConfigLogic, setFeedCon
 
 func setFeedConfigLogic(env cldf.Environment, c types.SetFeedDecimalConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
 	contract := chainState.DataFeedsCache[c.CacheAddress]
 
@@ -57,7 +57,7 @@ func setFeedConfigLogic(env cldf.Environment, c types.SetFeedDecimalConfig) (cld
 }
 
 func setFeedConfigPrecondition(env cldf.Environment, c types.SetFeedDecimalConfig) error {
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/set_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_feed_config_test.go
@@ -31,7 +31,6 @@ func TestSetFeedConfig(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -67,7 +66,7 @@ func TestSetFeedConfig(t *testing.T) {
 			types.SetFeedAdminConfig{
 				ChainSelector: chainSelector,
 				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.Chains[chainSelector].DeployerKey.From.Hex()),
+				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
 				IsAdmin:       true,
 			},
 		),
@@ -79,7 +78,7 @@ func TestSetFeedConfig(t *testing.T) {
 				DataIDs:       []string{dataid},
 				Descriptions:  []string{"test"},
 				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					cache.DataFeedsCacheWorkflowMetadata{
+					{
 						AllowedSender:        common.HexToAddress("0x22"),
 						AllowedWorkflowOwner: common.HexToAddress("0x33"),
 						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
@@ -128,7 +127,7 @@ func TestSetFeedConfig(t *testing.T) {
 				DataIDs:       []string{dataid},
 				Descriptions:  []string{"test2"},
 				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					cache.DataFeedsCacheWorkflowMetadata{
+					{
 						AllowedSender:        common.HexToAddress("0x22"),
 						AllowedWorkflowOwner: common.HexToAddress("0x33"),
 						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),

--- a/deployment/data-feeds/changeset/state.go
+++ b/deployment/data-feeds/changeset/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -66,7 +67,7 @@ func LoadOnchainState(e cldf.Environment) (DataFeedsOnChainState, error) {
 }
 
 // LoadChainState Loads all state for a chain into state
-func LoadChainState(logger logger.Logger, chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*DataFeedsChainState, error) {
+func LoadChainState(logger logger.Logger, chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (*DataFeedsChainState, error) {
 	var state DataFeedsChainState
 
 	mcmsWithTimelock, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)

--- a/deployment/data-feeds/changeset/update_data_id_proxy.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy.go
@@ -17,7 +17,7 @@ var UpdateDataIDProxyChangeset = cldf.CreateChangeSet(updateDataIDProxyLogic, up
 
 func updateDataIDProxyLogic(env cldf.Environment, c types.UpdateDataIDProxyConfig) (cldf.ChangesetOutput, error) {
 	state, _ := LoadOnchainState(env)
-	chain := env.Chains[c.ChainSelector]
+	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
 	contract := chainState.DataFeedsCache[c.CacheAddress]
 
@@ -54,7 +54,7 @@ func updateDataIDProxyLogic(env cldf.Environment, c types.UpdateDataIDProxyConfi
 }
 
 func updateDataIDProxyPrecondition(env cldf.Environment, c types.UpdateDataIDProxyConfig) error {
-	_, ok := env.Chains[c.ChainSelector]
+	_, ok := env.BlockChains.EVMChains()[c.ChainSelector]
 	if !ok {
 		return fmt.Errorf("chain not found in env %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/update_data_id_proxy_test.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy_test.go
@@ -27,7 +27,6 @@ func TestUpdateDataIDProxyMap(t *testing.T) {
 	t.Parallel()
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
 		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -63,7 +62,7 @@ func TestUpdateDataIDProxyMap(t *testing.T) {
 			types.SetFeedAdminConfig{
 				ChainSelector: chainSelector,
 				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.Chains[chainSelector].DeployerKey.From.Hex()),
+				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
 				IsAdmin:       true,
 			},
 		),


### PR DESCRIPTION
* Migrate env.Chains to env.BlockChains.EVMChains()
* Migrate cldf.Chain to cldf_evm.Chain
* Remove node boot in tests that do not require it
