### PR TITLE
refactor: migrate usage of CLDF Chain in data streams changesets

### DIFF
--- a/deployment/data-streams/changeset/channel-config-store/call_set_channel_definitions.go
+++ b/deployment/data-streams/changeset/channel-config-store/call_set_channel_definitions.go
@@ -85,7 +85,7 @@ func maybeLoadChannelConfigStoreState(e cldf.Environment, chainSel uint64, contr
 	if err := utils.ValidateContract(e, chainSel, contractAddr, types.ChannelConfigStore, deployment.Version1_0_0); err != nil {
 		return nil, err
 	}
-	chain, ok := e.Chains[chainSel]
+	chain, ok := e.BlockChains.EVMChains()[chainSel]
 	if !ok {
 		return nil, fmt.Errorf("chain %d not found", chainSel)
 	}

--- a/deployment/data-streams/changeset/channel-config-store/call_set_channel_definitions_test.go
+++ b/deployment/data-streams/changeset/channel-config-store/call_set_channel_definitions_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/view/v0_5"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink/deployment"
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/changeset/metadata"
@@ -76,12 +75,12 @@ func TestCallSetChannelDefinitions(t *testing.T) {
 		require.Len(t, outputs, 1)
 		output := outputs[0]
 
-		envDatastore, err := ds.FromDefault[metadata.SerializedContractMetadata, ds.DefaultMetadata](output.DataStore.Seal())
+		envDatastore, err := datastore.FromDefault[metadata.SerializedContractMetadata, datastore.DefaultMetadata](output.DataStore.Seal())
 		require.NoError(t, err)
 
 		// Retrieve contract metadata from datastore
 		cm, err := envDatastore.ContractMetadata().Get(
-			ds.NewContractMetadataKey(testutil.TestChain.Selector, channelConfigStoreAddr.String()),
+			datastore.NewContractMetadataKey(testutil.TestChain.Selector, channelConfigStoreAddr.String()),
 		)
 		require.NoError(t, err, "Failed to get contract metadata")
 

--- a/deployment/data-streams/changeset/channel-config-store/deploy_channel_config_store.go
+++ b/deployment/data-streams/changeset/channel-config-store/deploy_channel_config_store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -83,7 +84,7 @@ func deploy(e cldf.Environment, dataStore ds.MutableDataStore[metadata.Serialize
 		return fmt.Errorf("invalid DeployChannelConfigStoreConfig: %w", err)
 	}
 	for _, chainSel := range cc.ChainsToDeploy {
-		chain, ok := e.Chains[chainSel]
+		chain, ok := e.BlockChains.EVMChains()[chainSel]
 		if !ok {
 			return fmt.Errorf("chain not found for chain selector %d", chainSel)
 		}
@@ -119,7 +120,7 @@ func deploy(e cldf.Environment, dataStore ds.MutableDataStore[metadata.Serialize
 
 // channelConfigStoreDeployFn returns a function that deploys a ChannelConfigStore contract.
 func channelConfigStoreDeployFn() changeset.ContractDeployFn[*channel_config_store.ChannelConfigStore] {
-	return func(chain cldf.Chain) *changeset.ContractDeployment[*channel_config_store.ChannelConfigStore] {
+	return func(chain cldf_evm.Chain) *changeset.ContractDeployment[*channel_config_store.ChannelConfigStore] {
 		ccsAddr, ccsTx, ccs, err := channel_config_store.DeployChannelConfigStore(
 			chain.DeployerKey,
 			chain.Client,

--- a/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_promote_staging_config.go
+++ b/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_promote_staging_config.go
@@ -77,7 +77,7 @@ func doPromoteStagingConfig(
 }
 
 func LoadConfigurator(e cldf.Environment, chainSel uint64, contractAddr string) (*configurator.Configurator, error) {
-	chain, ok := e.Chains[chainSel]
+	chain, ok := e.BlockChains.EVMChains()[chainSel]
 	if !ok {
 		return nil, fmt.Errorf("chain %d not found", chainSel)
 	}

--- a/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_promote_staging_config_test.go
+++ b/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_promote_staging_config_test.go
@@ -90,7 +90,7 @@ func TestCallPromoteStagingConfig(t *testing.T) {
 		Addresses: []common.Address{configuratorAddr},
 		Topics:    [][]common.Hash{{configAbi.Events["ProductionConfigSet"].ID}},
 	}
-	prodLogs, err := e.Chains[testutil.TestChain.Selector].Client.FilterLogs(ctx, prodFilterQuery)
+	prodLogs, err := e.BlockChains.EVMChains()[testutil.TestChain.Selector].Client.FilterLogs(ctx, prodFilterQuery)
 	require.NoError(t, err)
 	require.NotEmpty(t, prodLogs)
 
@@ -167,7 +167,7 @@ func TestCallPromoteStagingConfig(t *testing.T) {
 		Addresses: []common.Address{configuratorAddr},
 		Topics:    [][]common.Hash{{configAbi.Events["PromoteStagingConfig"].ID}},
 	}
-	promoLogs, err := e.Chains[testutil.TestChain.Selector].Client.FilterLogs(ctx, promoFilterQuery)
+	promoLogs, err := e.BlockChains.EVMChains()[testutil.TestChain.Selector].Client.FilterLogs(ctx, promoFilterQuery)
 	require.NoError(t, err)
 	require.NotEmpty(t, promoLogs)
 

--- a/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_set_production_config_test.go
+++ b/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_set_production_config_test.go
@@ -93,7 +93,7 @@ func TestCallSetProductionConfig(t *testing.T) {
 		require.Len(t, outputs, 1)
 		output := outputs[0]
 
-		client := e.Chains[testutil.TestChain.Selector].Client
+		client := e.BlockChains.EVMChains()[testutil.TestChain.Selector].Client
 		contract, err := configurator.NewConfigurator(configuratorAddr, client)
 		require.NoError(t, err)
 

--- a/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_set_staging_config_test.go
+++ b/deployment/data-streams/changeset/configurator/v0_5_0/call_configurator_set_staging_config_test.go
@@ -88,7 +88,7 @@ func TestCallSetStagingConfig(t *testing.T) {
 		Addresses: []common.Address{configuratorAddr},
 		Topics:    [][]common.Hash{{configAbi.Events["ProductionConfigSet"].ID}},
 	}
-	prodLogs, err := e.Chains[testutil.TestChain.Selector].Client.FilterLogs(ctx, filterQuery)
+	prodLogs, err := e.BlockChains.EVMChains()[testutil.TestChain.Selector].Client.FilterLogs(ctx, filterQuery)
 	require.NoError(t, err)
 	require.NotEmpty(t, prodLogs)
 
@@ -148,7 +148,7 @@ func TestCallSetStagingConfig(t *testing.T) {
 		require.Len(t, outputs, 1)
 		output := outputs[0]
 
-		client := e.Chains[testutil.TestChain.Selector].Client
+		client := e.BlockChains.EVMChains()[testutil.TestChain.Selector].Client
 		contract, err := configurator.NewConfigurator(configuratorAddr, client)
 		require.NoError(t, err)
 

--- a/deployment/data-streams/changeset/configurator/v0_5_0/deploy_configurator.go
+++ b/deployment/data-streams/changeset/configurator/v0_5_0/deploy_configurator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/llo-feeds/generated/configurator"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -83,7 +84,7 @@ func deployConfiguratorPrecondition(_ cldf.Environment, cc DeployConfiguratorCon
 
 func deploy(e cldf.Environment, dataStore ds.MutableDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata], cc DeployConfiguratorConfig) error {
 	for _, chainSel := range cc.ChainsToDeploy {
-		chain, ok := e.Chains[chainSel]
+		chain, ok := e.BlockChains.EVMChains()[chainSel]
 		if !ok {
 			return fmt.Errorf("chain not found for chain selector %d", chainSel)
 		}
@@ -118,7 +119,7 @@ func deploy(e cldf.Environment, dataStore ds.MutableDataStore[metadata.Serialize
 }
 
 func DeployFn() changeset.ContractDeployFn[*configurator.Configurator] {
-	return func(chain cldf.Chain) *changeset.ContractDeployment[*configurator.Configurator] {
+	return func(chain cldf_evm.Chain) *changeset.ContractDeployment[*configurator.Configurator] {
 		ccsAddr, ccsTx, ccs, err := configurator.DeployConfigurator(
 			chain.DeployerKey,
 			chain.Client,

--- a/deployment/data-streams/changeset/deploy.go
+++ b/deployment/data-streams/changeset/deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/smartcontractkit/mcms"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -27,7 +28,7 @@ type (
 		TransferOwnership(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error)
 	}
 
-	ContractDeployFn[C Contract] func(chain cldf.Chain) *ContractDeployment[C]
+	ContractDeployFn[C Contract] func(chain cldf_evm.Chain) *ContractDeployment[C]
 
 	ContractDeployment[C Contract] struct {
 		Address  common.Address
@@ -52,7 +53,7 @@ type DeploymentOutput[C Contract] struct {
 func DeployContract[C Contract](
 	e cldf.Environment,
 	dataStore ds.MutableDataStore[metadata.SerializedContractMetadata, ds.DefaultMetadata],
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	deployFn ContractDeployFn[C],
 	options *DeployOptions,
 ) (*ContractDeployment[C], error) {

--- a/deployment/data-streams/changeset/fee-manager/call_pay_link_deficit_test.go
+++ b/deployment/data-streams/changeset/fee-manager/call_pay_link_deficit_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	ds "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -33,7 +34,7 @@ func TestPayLinkDeficit(t *testing.T) {
 	require.NoError(t, err)
 
 	e := res.Env
-	chain := e.Chains[testutil.TestChain.Selector]
+	chain := e.BlockChains.EVMChains()[testutil.TestChain.Selector]
 
 	cc := DeployFeeManager{
 		LinkTokenAddress:     res.LinkTokenAddress,
@@ -50,7 +51,7 @@ func TestPayLinkDeficit(t *testing.T) {
 				// This is modeled as a client/server test where the "client" is the PayLinkDeficit changeset
 				// and the "server" is the MockFeeManager. The PayLinkDeficit changeset will call the MockFeeManager using
 				// the real FeeManager interface. The MockFeeManager will then validate the call and return a response.
-				_, err = changeset.DeployContract[*mock_fee_manager_v0_5_0.MockFeeManager](e, dataStore, chain, MockFeeManagerDeployFn(cc), nil)
+				_, err = changeset.DeployContract(e, dataStore, chain, MockFeeManagerDeployFn(cc), nil)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy MockFeeManager: %w", err)
 				}
@@ -118,7 +119,7 @@ func TestPayLinkDeficit(t *testing.T) {
 }
 
 func MockFeeManagerDeployFn(cfg DeployFeeManager) changeset.ContractDeployFn[*mock_fee_manager_v0_5_0.MockFeeManager] {
-	return func(chain cldf.Chain) *changeset.ContractDeployment[*mock_fee_manager_v0_5_0.MockFeeManager] {
+	return func(chain cldf_evm.Chain) *changeset.ContractDeployment[*mock_fee_manager_v0_5_0.MockFeeManager] {
 		ccsAddr, ccsTx, ccs, err := mock_fee_manager_v0_5_0.DeployMockFeeManager(
 			chain.DeployerKey,
 			chain.Client,

--- a/deployment/data-streams/changeset/fee-manager/call_set_native_surcharge_test.go
+++ b/deployment/data-streams/changeset/fee-manager/call_set_native_surcharge_test.go
@@ -20,7 +20,7 @@ func TestSetNativeSurcharge(t *testing.T) {
 	feeManagerAddress := res.FeeManagerAddress
 	e := res.Env
 
-	chain := e.Chains[testutil.TestChain.Selector]
+	chain := e.BlockChains.EVMChains()[testutil.TestChain.Selector]
 	require.NotNil(t, chain)
 
 	e, err = commonChangesets.Apply(t, e, nil,

--- a/deployment/data-streams/changeset/fee-manager/call_update_subscriber_discount_test.go
+++ b/deployment/data-streams/changeset/fee-manager/call_update_subscriber_discount_test.go
@@ -22,7 +22,7 @@ func TestUpdateSubscriberDiscount(t *testing.T) {
 	feeManagerAddress := res.FeeManagerAddress
 	e := res.Env
 
-	chain := e.Chains[testutil.TestChain.Selector]
+	chain := e.BlockChains.EVMChains()[testutil.TestChain.Selector]
 	require.NotNil(t, chain)
 
 	subscriber := common.HexToAddress("0x0fd8b81e3d1143ec7f1ce474827ab93c43523ea2")

--- a/deployment/data-streams/changeset/fee-manager/call_update_subscriber_global_discount_test.go
+++ b/deployment/data-streams/changeset/fee-manager/call_update_subscriber_global_discount_test.go
@@ -21,7 +21,7 @@ func TestUpdateSubscriberGlobalDiscount(t *testing.T) {
 	feeManagerAddress := res.FeeManagerAddress
 	e := res.Env
 
-	chain := e.Chains[testutil.TestChain.Selector]
+	chain := e.BlockChains.EVMChains()[testutil.TestChain.Selector]
 	require.NotNil(t, chain)
 
 	subscriber := common.HexToAddress("0x0fd8b81e3d1143ec7f1ce474827ab93c43523ea2")

--- a/deployment/data-streams/changeset/fee-manager/call_withdraw_test.go
+++ b/deployment/data-streams/changeset/fee-manager/call_withdraw_test.go
@@ -20,7 +20,7 @@ func TestWithdraw(t *testing.T) {
 	feeManagerAddress := res.FeeManagerAddress
 	e := res.Env
 
-	chain := e.Chains[testutil.TestChain.Selector]
+	chain := e.BlockChains.EVMChains()[testutil.TestChain.Selector]
 	require.NotNil(t, chain)
 
 	recipient := common.HexToAddress("0x0fd8b81e3d1143ec7f1ce474827ab93c43523ea2")

--- a/deployment/data-streams/changeset/fee-manager/deploy_fee_manager.go
+++ b/deployment/data-streams/changeset/fee-manager/deploy_fee_manager.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/view/v0_5"
@@ -92,7 +93,7 @@ func deployFeeManager(e cldf.Environment,
 	}
 
 	for chainSel, chainCfg := range cc.ChainsToDeploy {
-		chain, ok := e.Chains[chainSel]
+		chain, ok := e.BlockChains.EVMChains()[chainSel]
 		if !ok {
 			return fmt.Errorf("chain not found for chain selector %d", chainSel)
 		}
@@ -128,7 +129,7 @@ func deployFeeManager(e cldf.Environment,
 
 // FeeManagerDeployFn returns a function that deploys a FeeManager contract.
 func FeeManagerDeployFn(cfg DeployFeeManager) changeset.ContractDeployFn[*fee_manager_v0_5_0.FeeManager] {
-	return func(chain cldf.Chain) *changeset.ContractDeployment[*fee_manager_v0_5_0.FeeManager] {
+	return func(chain cldf_evm.Chain) *changeset.ContractDeployment[*fee_manager_v0_5_0.FeeManager] {
 		ccsAddr, ccsTx, ccs, err := fee_manager_v0_5_0.DeployFeeManager(
 			chain.DeployerKey,
 			chain.Client,

--- a/deployment/data-streams/changeset/fee-manager/deploy_fee_manager_test.go
+++ b/deployment/data-streams/changeset/fee-manager/deploy_fee_manager_test.go
@@ -39,7 +39,7 @@ func TestDeployFeeManager(t *testing.T) {
 	addresses, err := e.ExistingAddresses.AddressesForChain(testutil.TestChain.Selector)
 	require.NoError(t, err)
 
-	chain := e.Chains[testutil.TestChain.Selector]
+	chain := e.BlockChains.EVMChains()[testutil.TestChain.Selector]
 	linkState, err := commonstate.MaybeLoadLinkTokenChainState(chain, addresses)
 	require.NoError(t, err)
 

--- a/deployment/data-streams/changeset/reward-manager/call_set_fee_manager_test.go
+++ b/deployment/data-streams/changeset/reward-manager/call_set_fee_manager_test.go
@@ -24,7 +24,7 @@ func runSetFeeManagerTest(t *testing.T, useMCMS bool) {
 	e := testEnv.Environment
 
 	chainSelector := testutil.TestChain.Selector
-	chain := e.Chains[chainSelector]
+	chain := e.BlockChains.EVMChains()[chainSelector]
 
 	e, rewardManagerAddr := RewardManagerDeploy(t, testEnv)
 

--- a/deployment/data-streams/changeset/reward-manager/call_set_reward_recipients_test.go
+++ b/deployment/data-streams/changeset/reward-manager/call_set_reward_recipients_test.go
@@ -24,7 +24,7 @@ func runSetRewardRecipientsTest(t *testing.T, useMCMS bool) {
 	})
 	chainSelector := testutil.TestChain.Selector
 	e, rewardManagerAddr := RewardManagerDeploy(t, testEnv)
-	chain := e.Chains[chainSelector]
+	chain := e.BlockChains.EVMChains()[chainSelector]
 
 	var poolID [32]byte
 	copy(poolID[:], []byte("poolId"))

--- a/deployment/data-streams/changeset/reward-manager/call_update_reward_recipients_test.go
+++ b/deployment/data-streams/changeset/reward-manager/call_update_reward_recipients_test.go
@@ -19,7 +19,7 @@ func runCallUpdateRewardRecipients(t *testing.T, useMCMS bool) {
 	})
 	e, rewardManagerAddr := RewardManagerDeploy(t, testEnv)
 	chainSelector := testutil.TestChain.Selector
-	chain := e.Chains[chainSelector]
+	chain := e.BlockChains.EVMChains()[chainSelector]
 
 	recipients := []rewardManager.CommonAddressAndWeight{
 		{

--- a/deployment/data-streams/changeset/reward-manager/deploy_reward_manager.go
+++ b/deployment/data-streams/changeset/reward-manager/deploy_reward_manager.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/view/v0_5"
@@ -93,7 +94,7 @@ func deployRewardManager(e cldf.Environment,
 	}
 
 	for chainSel, chainCfg := range cc.ChainsToDeploy {
-		chain, ok := e.Chains[chainSel]
+		chain, ok := e.BlockChains.EVMChains()[chainSel]
 		if !ok {
 			return fmt.Errorf("chain not found for chain selector %d", chainSel)
 		}
@@ -128,7 +129,7 @@ func deployRewardManager(e cldf.Environment,
 }
 
 func RewardManagerDeployFn(linkAddress common.Address) changeset.ContractDeployFn[*rewardManager.RewardManager] {
-	return func(chain cldf.Chain) *changeset.ContractDeployment[*rewardManager.RewardManager] {
+	return func(chain cldf_evm.Chain) *changeset.ContractDeployment[*rewardManager.RewardManager] {
 		ccsAddr, ccsTx, ccs, err := rewardManager.DeployRewardManager(
 			chain.DeployerKey,
 			chain.Client,

--- a/deployment/data-streams/changeset/reward-manager/deploy_reward_manager_test.go
+++ b/deployment/data-streams/changeset/reward-manager/deploy_reward_manager_test.go
@@ -35,7 +35,7 @@ func TestDeployRewardManager(t *testing.T) {
 	addresses, err := e.ExistingAddresses.AddressesForChain(testutil.TestChain.Selector)
 	require.NoError(t, err)
 
-	chain := e.Chains[testutil.TestChain.Selector]
+	chain := e.BlockChains.EVMChains()[testutil.TestChain.Selector]
 	linkState, err := commonState.MaybeLoadLinkTokenChainState(chain, addresses)
 	require.NoError(t, err)
 
@@ -71,7 +71,7 @@ func TestDeployRewardManager(t *testing.T) {
 	require.NotNil(t, record)
 
 	t.Run("VerifyOwnershipTransferred", func(t *testing.T) {
-		chain := e.Chains[testutil.TestChain.Selector]
+		chain := e.BlockChains.EVMChains()[testutil.TestChain.Selector]
 		owner, _, err := commonChangesets.LoadOwnableContract(common.HexToAddress(record.Address), chain.Client)
 		require.NoError(t, err)
 		assert.Equal(t, testEnv.Timelocks[testutil.TestChain.Selector].Timelock.Address(), owner)

--- a/deployment/data-streams/changeset/reward-manager/reward_manager.go
+++ b/deployment/data-streams/changeset/reward-manager/reward_manager.go
@@ -20,7 +20,7 @@ func loadRewardManagerState(
 	chainSel uint64,
 	contractAddr string,
 ) (*rewardManager.RewardManager, error) {
-	chain, ok := e.Chains[chainSel]
+	chain, ok := e.BlockChains.EVMChains()[chainSel]
 	if !ok {
 		return nil, fmt.Errorf("chain %d not found", chainSel)
 	}

--- a/deployment/data-streams/changeset/save_contract_views.go
+++ b/deployment/data-streams/changeset/save_contract_views.go
@@ -54,7 +54,7 @@ func saveViewsLogic(e cldf.Environment, cfg SaveContractViewsConfig) (cldf.Chang
 		if !ok {
 			continue
 		}
-		chain := e.Chains[chainSelector]
+		chain := e.BlockChains.EVMChains()[chainSelector]
 
 		family, err := chain_selectors.GetSelectorFamily(chainSelector)
 		if err != nil {

--- a/deployment/data-streams/changeset/state/evm.go
+++ b/deployment/data-streams/changeset/state/evm.go
@@ -57,7 +57,7 @@ func LoadOnchainState(e cldf.Environment) (DataStreamsOnChainState, error) {
 	if err != nil {
 		return state, fmt.Errorf("failed to convert datastore: %w", err)
 	}
-	for chainSelector, chain := range e.Chains {
+	for chainSelector, chain := range e.BlockChains.EVMChains() {
 		addresses, err := e.ExistingAddresses.AddressesForChain(chainSelector)
 		if err != nil {
 			if !errors.Is(err, cldf.ErrChainNotFound) {

--- a/deployment/data-streams/changeset/testutil/test_helpers.go
+++ b/deployment/data-streams/changeset/testutil/test_helpers.go
@@ -121,7 +121,7 @@ func NewMemoryEnvV2(t *testing.T, cfg MemoryEnvConfig) MemoryEnv {
 
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memEnvConf)
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
-	chain := env.Chains[chainSelector]
+	chain := env.BlockChains.EVMChains()[chainSelector]
 
 	// Apply node labels:
 	resp, err := env.Offchain.ListNodes(t.Context(), &nodev1.ListNodesRequest{})
@@ -230,7 +230,7 @@ func DeployMCMS(
 	addresses, err := e.ExistingAddresses.AddressesForChain(TestChain.Selector)
 	require.NoError(t, err)
 
-	chain := e.Chains[chainSelector]
+	chain := e.BlockChains.EVMChains()[chainSelector]
 
 	mcmsState, err = commonChangesets.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 	require.NoError(t, err)

--- a/deployment/data-streams/changeset/verification/call_initialize_verifier_test.go
+++ b/deployment/data-streams/changeset/verification/call_initialize_verifier_test.go
@@ -75,7 +75,7 @@ func TestInitializeVerifier(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	chain := e.Chains[chainSelector]
+	chain := e.BlockChains.EVMChains()[chainSelector]
 
 	vp, err := verifier_proxy_v0_5_0.NewVerifierProxy(verifierProxyAddr, chain.Client)
 	require.NoError(t, err)

--- a/deployment/data-streams/changeset/verification/call_set_access_controller_test.go
+++ b/deployment/data-streams/changeset/verification/call_set_access_controller_test.go
@@ -43,7 +43,7 @@ func TestSetAccessController(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	client := e.Chains[testChain].Client
+	client := e.BlockChains.EVMChains()[testChain].Client
 	verifierProxy, err := verifier_proxy_v0_5_0.NewVerifierProxy(verifierProxyAddr, client)
 	require.NoError(t, err)
 

--- a/deployment/data-streams/changeset/verification/call_unset_verifier_test.go
+++ b/deployment/data-streams/changeset/verification/call_unset_verifier_test.go
@@ -26,9 +26,9 @@ func TestUnsetVerifier(t *testing.T) {
 	e, verifierProxyAddr, verifierAddr := DeployVerifierProxyAndVerifier(t, e)
 
 	chainSelector := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
-	chain := e.Chains[chainSelector]
+	chain := e.BlockChains.EVMChains()[chainSelector]
 
-	verifier, err := verifier_v0_5_0.NewVerifier(verifierAddr, e.Chains[chainSelector].Client)
+	verifier, err := verifier_v0_5_0.NewVerifier(verifierAddr, chain.Client)
 	require.NoError(t, err)
 	require.NotNil(t, verifier)
 

--- a/deployment/data-streams/changeset/verification/deploy_verifier.go
+++ b/deployment/data-streams/changeset/verification/deploy_verifier.go
@@ -90,7 +90,7 @@ func deployVerifier(e cldf.Environment, dataStore ds.MutableDataStore[metadata.S
 	}
 
 	for chainSel, chainCfg := range cc.ChainsToDeploy {
-		chain, ok := e.Chains[chainSel]
+		chain, ok := e.BlockChains.EVMChains()[chainSel]
 		if !ok {
 			return fmt.Errorf("chain not found for chain selector %d", chainSel)
 		}

--- a/deployment/data-streams/changeset/verification/deploy_verifier_proxy.go
+++ b/deployment/data-streams/changeset/verification/deploy_verifier_proxy.go
@@ -105,7 +105,7 @@ func deploy(e cldf.Environment,
 	}
 
 	for chainSel, chainCfg := range cfg.ChainsToDeploy {
-		chain, ok := e.Chains[chainSel]
+		chain, ok := e.BlockChains.EVMChains()[chainSel]
 		if !ok {
 			return fmt.Errorf("chain not found for chain selector %d", chainSel)
 		}

--- a/deployment/data-streams/changeset/verification/deploy_verifier_proxy_test.go
+++ b/deployment/data-streams/changeset/verification/deploy_verifier_proxy_test.go
@@ -54,7 +54,7 @@ func TestDeployVerifierProxy(t *testing.T) {
 	require.NotNil(t, record)
 
 	t.Run("VerifyOwnershipTransferred", func(t *testing.T) {
-		chain := e.Chains[testutil.TestChain.Selector]
+		chain := e.BlockChains.EVMChains()[testutil.TestChain.Selector]
 		owner, _, err := commonChangesets.LoadOwnableContract(common.HexToAddress(record.Address), chain.Client)
 		require.NoError(t, err)
 		assert.Equal(t, testEnv.Timelocks[testutil.TestChain.Selector].Timelock.Address(), owner)

--- a/deployment/data-streams/changeset/verification/state.go
+++ b/deployment/data-streams/changeset/verification/state.go
@@ -25,7 +25,7 @@ func maybeLoadVerifierProxyState(e cldf.Environment, chainSel uint64, contractAd
 	if err := utils.ValidateContract(e, chainSel, contractAddr, types.VerifierProxy, deployment.Version0_5_0); err != nil {
 		return nil, err
 	}
-	chain, ok := e.Chains[chainSel]
+	chain, ok := e.BlockChains.EVMChains()[chainSel]
 	if !ok {
 		return nil, fmt.Errorf("chain %d not found", chainSel) // This should never happen due to validation
 	}
@@ -39,7 +39,7 @@ func maybeLoadVerifierProxyState(e cldf.Environment, chainSel uint64, contractAd
 	}, nil
 }
 func loadVerifierState(e cldf.Environment, chainSel uint64, contractAddr string) (*verifier_v0_5_0.Verifier, error) {
-	chain, ok := e.Chains[chainSel]
+	chain, ok := e.BlockChains.EVMChains()[chainSel]
 	if !ok {
 		return nil, fmt.Errorf("chain %d not found", chainSel)
 	}

--- a/deployment/data-streams/utils/txutil/transaction.go
+++ b/deployment/data-streams/utils/txutil/transaction.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
@@ -30,7 +31,7 @@ func SignAndExecute(e cldf.Environment, preparedTxs []*PreparedTx) ([]ExecuteTxR
 	var executeTxResults []ExecuteTxResult
 	// To execute the txs in parallel this would need to batch up the txs by chain to avoid nonce issues
 	for _, tx := range preparedTxs {
-		chain, exists := e.Chains[tx.ChainSelector]
+		chain, exists := e.BlockChains.EVMChains()[tx.ChainSelector]
 		if !exists {
 			return executeTxResults, fmt.Errorf("chain not found in env %d", tx.ChainSelector)
 		}
@@ -60,7 +61,7 @@ func SignAndExecute(e cldf.Environment, preparedTxs []*PreparedTx) ([]ExecuteTxR
 }
 
 // reconfigureTx takes the tx `call data` and reconfigures the transaction to use valid nonce, gas price and gas limit
-func reconfigureTx(ctx context.Context, chain cldf.Chain, preparedTx *PreparedTx) (*gethtypes.Transaction, error) {
+func reconfigureTx(ctx context.Context, chain cldf_evm.Chain, preparedTx *PreparedTx) (*gethtypes.Transaction, error) {
 	nonce, err := chain.Client.NonceAt(ctx, chain.DeployerKey.From, nil)
 	if err != nil {
 		return nil, fmt.Errorf("chain %d: failed to get nonce: %w", chain.Selector, err)

--- a/deployment/data-streams/utils/txutil/transaction_test.go
+++ b/deployment/data-streams/utils/txutil/transaction_test.go
@@ -31,7 +31,7 @@ func TestSignAndExecute_ETHTransfer(t *testing.T) {
 	})
 
 	testChain := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
-	chain := e.Chains[testChain]
+	chain := e.BlockChains.EVMChains()[testChain]
 
 	recipient := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
 
@@ -73,7 +73,7 @@ func TestSignAndExecute_ContractInteraction(t *testing.T) {
 	})
 
 	testChain := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
-	chain := e.Chains[testChain]
+	chain := e.BlockChains.EVMChains()[testChain]
 
 	e, err := commonchangeset.Apply(t, e, nil,
 		commonchangeset.Configure(


### PR DESCRIPTION
- Migrate env.Chains to env.BlockChains.EVMChains()
- Migrate cldf.Chain to cldf_evm.Chain

