### PR TITLE
refactor: migrate usage of CLDF Chain in keystone changesets

### DIFF
--- a/deployment/keystone/changeset/accept_ownership_test.go
+++ b/deployment/keystone/changeset/accept_ownership_test.go
@@ -21,12 +21,11 @@ import (
 )
 
 func TestAcceptAllOwnership(t *testing.T) {
-
 	t.Parallel()
+
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
-		Chains: 2,
+		Chains: 1,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
@@ -58,7 +57,9 @@ func TestAcceptAllOwnership(t *testing.T) {
 	require.NoError(t, err)
 	addrs, err := env.ExistingAddresses.AddressesForChain(registrySel)
 	require.NoError(t, err)
-	timelock, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(env.Chains[registrySel], addrs)
+	timelock, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(
+		env.BlockChains.EVMChains()[registrySel], addrs,
+	)
 	require.NoError(t, err)
 
 	_, err = commonchangeset.Apply(t, env,

--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -71,7 +71,7 @@ func AddCapabilities(env cldf.Environment, req *AddCapabilitiesRequest) (cldf.Ch
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to validate request: %w", err)
 	}
-	registryChain, ok := env.Chains[req.RegistryChainSel]
+	registryChain, ok := env.BlockChains.EVMChains()[req.RegistryChainSel]
 	if !ok {
 		return cldf.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}
@@ -81,7 +81,7 @@ func AddCapabilities(env cldf.Environment, req *AddCapabilitiesRequest) (cldf.Ch
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load capability registry: %w", err)
 	}
 	useMCMS := req.MCMSConfig != nil
-	ops, err := internal.AddCapabilities(env.Logger, cr.Contract, env.Chains[req.RegistryChainSel], req.Capabilities, useMCMS)
+	ops, err := internal.AddCapabilities(env.Logger, cr.Contract, env.BlockChains.EVMChains()[req.RegistryChainSel], req.Capabilities, useMCMS)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to add capabilities: %w", err)
 	}

--- a/deployment/keystone/changeset/add_dons.go
+++ b/deployment/keystone/changeset/add_dons.go
@@ -103,7 +103,7 @@ func (r *AddDonsRequest) Validate(e cldf.Environment) error {
 		return fmt.Errorf("invalid registry chain selector %d: selector does not exist", r.RegistryChainSel)
 	}
 
-	_, exists = e.Chains[r.RegistryChainSel]
+	_, exists = e.BlockChains.EVMChains()[r.RegistryChainSel]
 	if !exists {
 		return fmt.Errorf("invalid registry chain selector %d: chain does not exist in environment", r.RegistryChainSel)
 	}
@@ -145,7 +145,7 @@ func AddDons(env cldf.Environment, req *AddDonsRequest) (cldf.ChangesetOutput, e
 		return cldf.ChangesetOutput{}, err
 	}
 	// extract the registry contract and chain from the environment
-	registryChain, ok := env.Chains[req.RegistryChainSel]
+	registryChain, ok := env.BlockChains.EVMChains()[req.RegistryChainSel]
 	if !ok {
 		return cldf.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}

--- a/deployment/keystone/changeset/add_nodes.go
+++ b/deployment/keystone/changeset/add_nodes.go
@@ -220,7 +220,7 @@ func AddNodes(env cldf.Environment, req *AddNodesRequest) (cldf.ChangesetOutput,
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid request: %w", err)
 	}
 
-	capReg, err := loadCapabilityRegistry(env.Chains[req.RegistryChainSel], env, req.RegistryRef)
+	capReg, err := loadCapabilityRegistry(env.BlockChains.EVMChains()[req.RegistryChainSel], env, req.RegistryRef)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load capability registry sets: %w", err)
 	}
@@ -240,7 +240,7 @@ func AddNodes(env cldf.Environment, req *AddNodesRequest) (cldf.ChangesetOutput,
 
 	var (
 		useMCMS       = req.MCMSConfig != nil
-		registryChain = env.Chains[req.RegistryChainSel]
+		registryChain = env.BlockChains.EVMChains()[req.RegistryChainSel]
 	)
 	resp, err := internal.AddNodes(env.Logger, &internal.AddNodesRequest{
 		RegistryChain:        registryChain,

--- a/deployment/keystone/changeset/add_nops.go
+++ b/deployment/keystone/changeset/add_nops.go
@@ -48,7 +48,7 @@ func AddNops(env cldf.Environment, req *AddNopsRequest) (cldf.ChangesetOutput, e
 	for _, nop := range req.Nops {
 		env.Logger.Infow("input NOP", "address", nop.Admin, "name", nop.Name)
 	}
-	registryChain, ok := env.Chains[req.RegistryChainSel]
+	registryChain, ok := env.BlockChains.EVMChains()[req.RegistryChainSel]
 	if !ok {
 		return cldf.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}

--- a/deployment/keystone/changeset/append_node_capabilities.go
+++ b/deployment/keystone/changeset/append_node_capabilities.go
@@ -76,7 +76,7 @@ func (req *AppendNodeCapabilitiesRequest) convert(e cldf.Environment, ref datast
 	if err := req.Validate(e); err != nil {
 		return nil, nil, fmt.Errorf("failed to validate UpdateNodeCapabilitiesRequest: %w", err)
 	}
-	registryChain := e.Chains[req.RegistryChainSel] // exists because of the validation above
+	registryChain := e.BlockChains.EVMChains()[req.RegistryChainSel] // exists because of the validation above
 	cr, err := loadCapabilityRegistry(registryChain, e, ref)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load capability registry: %w", err)

--- a/deployment/keystone/changeset/configure_contracts.go
+++ b/deployment/keystone/changeset/configure_contracts.go
@@ -58,7 +58,7 @@ func ConfigureInitialContracts(lggr logger.Logger, req *kslib.ConfigureContracts
 	}
 	// forwarder on all chains
 	foundForwarder = false
-	for _, c := range req.Env.Chains {
+	for _, c := range req.Env.BlockChains.EVMChains() {
 		addrs, err2 := req.Env.ExistingAddresses.AddressesForChain(c.Selector)
 		if err2 != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("no addresses found for chain %d: %w", c.Selector, err2)

--- a/deployment/keystone/changeset/contracts.go
+++ b/deployment/keystone/changeset/contracts.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -37,7 +38,7 @@ type OwnedContract[T Ownable] struct {
 
 // NewOwnable creates an OwnedContract instance.
 // It checks if the contract is owned by a timelock contract and loads the MCMS state if necessary.
-func NewOwnable[T Ownable](contract T, ab cldf.AddressBook, chain cldf.Chain) (*OwnedContract[T], error) {
+func NewOwnable[T Ownable](contract T, ab cldf.AddressBook, chain cldf_evm.Chain) (*OwnedContract[T], error) {
 	var timelockTV = cldf.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
 
 	// Look for MCMS contracts that might be owned by the contract
@@ -74,7 +75,7 @@ func NewOwnable[T Ownable](contract T, ab cldf.AddressBook, chain cldf.Chain) (*
 
 // NewOwnable creates an OwnedContract instance.
 // It checks if the contract is owned by a timelock contract and loads the MCMS state if necessary.
-func NewOwnableV2[T Ownable](contract T, ab datastore.AddressRefStore, chain cldf.Chain) (*OwnedContract[T], error) {
+func NewOwnableV2[T Ownable](contract T, ab datastore.AddressRefStore, chain cldf_evm.Chain) (*OwnedContract[T], error) {
 	var timelockTV = cldf.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)
 
 	ownerTV, err := GetOwnerTypeAndVersionV2[T](contract, ab, chain)
@@ -120,7 +121,7 @@ func matchLabels(ab datastore.AddressRefStore, tv cldf.TypeAndVersion, chainSele
 }
 
 // GetOwnerTypeAndVersion retrieves the owner type and version of a contract.
-func GetOwnerTypeAndVersion[T Ownable](contract T, ab cldf.AddressBook, chain cldf.Chain) (*cldf.TypeAndVersion, error) {
+func GetOwnerTypeAndVersion[T Ownable](contract T, ab cldf.AddressBook, chain cldf_evm.Chain) (*cldf.TypeAndVersion, error) {
 	// Get the contract owner
 	owner, err := contract.Owner(nil)
 	if err != nil {
@@ -152,7 +153,7 @@ func GetOwnerTypeAndVersion[T Ownable](contract T, ab cldf.AddressBook, chain cl
 }
 
 // GetOwnerTypeAndVersionV2 retrieves the owner type and version of a contract using the datastore instead of the address book.
-func GetOwnerTypeAndVersionV2[T Ownable](contract T, ab datastore.AddressRefStore, chain cldf.Chain) (*cldf.TypeAndVersion, error) {
+func GetOwnerTypeAndVersionV2[T Ownable](contract T, ab datastore.AddressRefStore, chain cldf_evm.Chain) (*cldf.TypeAndVersion, error) {
 	// Get the contract owner
 	owner, err := contract.Owner(nil)
 	if err != nil {
@@ -181,7 +182,7 @@ func GetOwnerTypeAndVersionV2[T Ownable](contract T, ab datastore.AddressRefStor
 // GetOwnableContract retrieves a contract instance of type T from the address book.
 // If `targetAddr` is provided, it will look for that specific address.
 // If not, it will default to looking one contract of type T, and if it doesn't find exactly one, it will error.
-func GetOwnableContract[T Ownable](ab cldf.AddressBook, chain cldf.Chain, targetAddr *string) (*T, error) {
+func GetOwnableContract[T Ownable](ab cldf.AddressBook, chain cldf_evm.Chain, targetAddr *string) (*T, error) {
 	var contractType cldf.ContractType
 	// Determine contract type based on T
 	switch any(*new(T)).(type) {
@@ -241,7 +242,7 @@ func GetOwnableContract[T Ownable](ab cldf.AddressBook, chain cldf.Chain, target
 // GetOwnableContractV2 retrieves a contract instance of type T from the datastore.
 // If `targetAddr` is provided, it will look for that specific address.
 // If not, it will default to looking one contract of type T, and if it doesn't find exactly one, it will error.
-func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf.Chain, targetAddr string) (*T, error) {
+func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf_evm.Chain, targetAddr string) (*T, error) {
 	// Determine contract type based on T
 	switch any(*new(T)).(type) {
 	case *forwarder.KeystoneForwarder:
@@ -269,7 +270,7 @@ func GetOwnableContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf
 }
 
 // createContractInstance is a helper function to create contract instances
-func createContractInstance[T Ownable](addr string, chain cldf.Chain) (*T, error) {
+func createContractInstance[T Ownable](addr string, chain cldf_evm.Chain) (*T, error) {
 	var instance T
 	var err error
 
@@ -298,7 +299,7 @@ func createContractInstance[T Ownable](addr string, chain cldf.Chain) (*T, error
 }
 
 // GetOwnedContract is a helper function that gets a contract and wraps it in OwnedContract
-func GetOwnedContract[T Ownable](addressBook cldf.AddressBook, chain cldf.Chain, addr string) (*OwnedContract[T], error) {
+func GetOwnedContract[T Ownable](addressBook cldf.AddressBook, chain cldf_evm.Chain, addr string) (*OwnedContract[T], error) {
 	contract, err := GetOwnableContract[T](addressBook, chain, &addr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get contract at %s: %w", addr, err)
@@ -312,7 +313,7 @@ func GetOwnedContract[T Ownable](addressBook cldf.AddressBook, chain cldf.Chain,
 	return ownedContract, nil
 }
 
-func GetOwnedContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf.Chain, addr string) (*OwnedContract[T], error) {
+func GetOwnedContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf_evm.Chain, addr string) (*OwnedContract[T], error) {
 	addresses := addrs.Filter(datastore.AddressRefByChainSelector(chain.Selector))
 
 	var foundAddr bool
@@ -339,7 +340,7 @@ func GetOwnedContractV2[T Ownable](addrs datastore.AddressRefStore, chain cldf.C
 }
 
 // loadCapabilityRegistry loads the CapabilitiesRegistry contract from the address book or datastore.
-func loadCapabilityRegistry(registryChain cldf.Chain, env cldf.Environment, ref datastore.AddressRefKey) (*OwnedContract[*capabilities_registry.CapabilitiesRegistry], error) {
+func loadCapabilityRegistry(registryChain cldf_evm.Chain, env cldf.Environment, ref datastore.AddressRefKey) (*OwnedContract[*capabilities_registry.CapabilitiesRegistry], error) {
 	err := shouldUseDatastore(env, ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check registry ref: %w", err)

--- a/deployment/keystone/changeset/contracts_test.go
+++ b/deployment/keystone/changeset/contracts_test.go
@@ -1,6 +1,8 @@
 package changeset_test
 
 import (
+	"maps"
+	"slices"
 	"testing"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -11,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -115,15 +116,16 @@ func TestGetOwnerTypeAndVersion(t *testing.T) {
 
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1, // nodes unused but required in config
-		Chains: 3,
+		Chains: 1,
 	}
 
 	t.Run("finds owner in address book", func(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-		chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
+		evmChains := env.BlockChains.EVMChains()
+		chain := evmChains[slices.Collect(maps.Keys(evmChains))[0]]
+
 		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -161,7 +163,9 @@ func TestGetOwnerTypeAndVersion(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-		chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
+		evmChains := env.BlockChains.EVMChains()
+		chain := evmChains[slices.Collect(maps.Keys(evmChains))[0]]
+
 		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -192,15 +196,16 @@ func TestNewOwnable(t *testing.T) {
 
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1,
-		Chains: 3,
+		Chains: 1,
 	}
 
 	t.Run("creates OwnedContract for non-MCMS owner", func(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-		chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
+		evmChains := env.BlockChains.EVMChains()
+		chain := evmChains[slices.Collect(maps.Keys(evmChains))[0]]
+
 		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -244,7 +249,9 @@ func TestNewOwnable(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-		chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
+		evmChains := env.BlockChains.EVMChains()
+		chain := evmChains[slices.Collect(maps.Keys(evmChains))[0]]
+
 		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -287,7 +294,9 @@ func TestNewOwnable(t *testing.T) {
 		t.Parallel()
 
 		env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
-		chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
+		evmChains := env.BlockChains.EVMChains()
+		chain := evmChains[slices.Collect(maps.Keys(evmChains))[0]]
+
 		resp, err := changeset.DeployCapabilityRegistry(env, chain.Selector)
 		require.NoError(t, err)
 		require.NotNil(t, resp)

--- a/deployment/keystone/changeset/deploy_balance_reader.go
+++ b/deployment/keystone/changeset/deploy_balance_reader.go
@@ -29,7 +29,7 @@ func DeployBalanceReader(env cldf.Environment, cfg DeployBalanceReaderRequest) (
 
 	selectors := cfg.ChainSelectors
 	if len(selectors) == 0 {
-		selectors = slices.Collect(maps.Keys(env.Chains))
+		selectors = slices.Collect(maps.Keys(env.BlockChains.EVMChains()))
 	}
 	for _, sel := range selectors {
 		req := &DeployRequestV2{

--- a/deployment/keystone/changeset/deploy_balance_reader_test.go
+++ b/deployment/keystone/changeset/deploy_balance_reader_test.go
@@ -22,7 +22,6 @@ func TestDeployBalanceReader(t *testing.T) {
 
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1, // nodes unused but required in config
 		Chains: 2,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)

--- a/deployment/keystone/changeset/deploy_forwarder.go
+++ b/deployment/keystone/changeset/deploy_forwarder.go
@@ -31,11 +31,13 @@ func DeployForwarderX(env cldf.Environment, cfg DeployForwarderRequest) (cldf.Ch
 	lggr := env.Logger
 	ab := cldf.NewMemoryAddressBook()
 	selectors := cfg.ChainSelectors
+	evmChains := env.BlockChains.EVMChains()
+
 	if len(selectors) == 0 {
-		selectors = slices.Collect(maps.Keys(env.Chains))
+		selectors = slices.Collect(maps.Keys(evmChains))
 	}
 	for _, sel := range selectors {
-		chain, ok := env.Chains[sel]
+		chain, ok := evmChains[sel]
 		if !ok {
 			return cldf.ChangesetOutput{}, fmt.Errorf("chain with selector %d not found", sel)
 		}
@@ -57,7 +59,7 @@ func DeployForwarder(env cldf.Environment, cfg DeployForwarderRequest) (cldf.Cha
 
 	selectors := cfg.ChainSelectors
 	if len(selectors) == 0 {
-		selectors = slices.Collect(maps.Keys(env.Chains))
+		selectors = slices.Collect(maps.Keys(env.BlockChains.EVMChains()))
 	}
 
 	for _, sel := range selectors {
@@ -139,7 +141,7 @@ func ConfigureForwardContracts(env cldf.Environment, req ConfigureForwardContrac
 			if !ok {
 				return out, fmt.Errorf("expected configured forwarder address for chain selector %d", chainSelector)
 			}
-			fwr, err := GetOwnedContractV2[*forwarder.KeystoneForwarder](env.DataStore.Addresses(), env.Chains[chainSelector], fwrAddr.String())
+			fwr, err := GetOwnedContractV2[*forwarder.KeystoneForwarder](env.DataStore.Addresses(), env.BlockChains.EVMChains()[chainSelector], fwrAddr.String())
 			if err != nil {
 				return out, fmt.Errorf("failed to get forwarder contract for chain selector %d: %w", chainSelector, err)
 			}

--- a/deployment/keystone/changeset/deploy_forwarder_test.go
+++ b/deployment/keystone/changeset/deploy_forwarder_test.go
@@ -31,7 +31,6 @@ func TestDeployForwarder(t *testing.T) {
 
 	lggr := logger.Test(t)
 	cfg := memory.MemoryEnvironmentConfig{
-		Nodes:  1, // nodes unused but required in config
 		Chains: 2,
 	}
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
@@ -87,7 +86,7 @@ func TestConfigureForwarders(t *testing.T) {
 
 		var chainToExclude uint64
 		filteredChains := make(map[uint64]struct{})
-		for chainID := range env.Chains {
+		for chainID := range env.BlockChains.EVMChains() {
 			// we do not really care which chain to exclude, so pick the first one
 			if chainToExclude == 0 {
 				chainToExclude = chainID
@@ -157,7 +156,7 @@ func TestConfigureForwarders(t *testing.T) {
 				// check that forwarder
 				// TODO set up a listener to check that the forwarder is configured
 				forwardersByChain := te.OwnedForwarders()
-				for selector := range te.Env.Chains {
+				for selector := range te.Env.BlockChains.EVMChains() {
 					forwarders, ok := forwardersByChain[selector]
 					require.True(t, ok)
 					require.NotNil(t, forwarders)

--- a/deployment/keystone/changeset/deploy_ocr3.go
+++ b/deployment/keystone/changeset/deploy_ocr3.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	ocr3_capability "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -84,7 +85,7 @@ func ConfigureOCR3Contract(env cldf.Environment, cfg ConfigureOCR3Config) (cldf.
 			return out, errors.New("expected MCMS operation to be non-nil")
 		}
 
-		chain, ok := env.Chains[cfg.ChainSel]
+		chain, ok := env.BlockChains.EVMChains()[cfg.ChainSel]
 		if !ok {
 			return out, fmt.Errorf("chain %d not found in environment", cfg.ChainSel)
 		}

--- a/deployment/keystone/changeset/deploy_registry.go
+++ b/deployment/keystone/changeset/deploy_registry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	kslib "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
@@ -32,12 +33,12 @@ type DeployRequestV2 = struct {
 	Qualifier string
 	Labels    *datastore.LabelSet
 
-	deployFn func(ctx context.Context, chain cldf.Chain, ab cldf.AddressBook) (*kslib.DeployResponse, error)
+	deployFn func(ctx context.Context, chain cldf_evm.Chain, ab cldf.AddressBook) (*kslib.DeployResponse, error)
 }
 
 func deploy(env cldf.Environment, req *DeployRequestV2) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
-	chain, ok := env.Chains[req.ChainSel]
+	chain, ok := env.BlockChains.EVMChains()[req.ChainSel]
 	if !ok {
 		return cldf.ChangesetOutput{}, errors.New("chain not found in environment")
 	}

--- a/deployment/keystone/changeset/internal/append_node_capabilities.go
+++ b/deployment/keystone/changeset/internal/append_node_capabilities.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
@@ -14,7 +14,7 @@ import (
 )
 
 type AppendNodeCapabilitiesRequest struct {
-	Chain                cldf.Chain
+	Chain                cldf_evm.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 
 	P2pToCapabilities map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability

--- a/deployment/keystone/changeset/internal/append_node_capabilities_test.go
+++ b/deployment/keystone/changeset/internal/append_node_capabilities_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
@@ -20,7 +21,7 @@ import (
 func TestAppendNodeCapabilities(t *testing.T) {
 	var (
 		initialp2pToCapabilities = map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability{
-			testPeerID(t, "0x1"): []kcr.CapabilitiesRegistryCapability{
+			testPeerID(t, "0x1"): {
 				{
 					LabelledName:   "test",
 					Version:        "1.0.0",
@@ -29,8 +30,8 @@ func TestAppendNodeCapabilities(t *testing.T) {
 			},
 		}
 		nopToNodes = map[kcr.CapabilitiesRegistryNodeOperator][]*internal.P2PSignerEnc{
-			testNop(t, "testNop"): []*internal.P2PSignerEnc{
-				&internal.P2PSignerEnc{
+			testNop(t, "testNop"): {
+				{
 					Signer:              [32]byte{0: 1},
 					P2PKey:              testPeerID(t, "0x1"),
 					EncryptionPublicKey: [32]byte{7: 7, 13: 13},
@@ -57,7 +58,7 @@ func TestAppendNodeCapabilities(t *testing.T) {
 			args: args{
 				lggr: lggr,
 				req: &internal.AppendNodeCapabilitiesRequest{
-					Chain: cldf.Chain{},
+					Chain: cldf_evm.Chain{},
 				},
 				initialState: &kstest.SetupTestRegistryRequest{},
 			},

--- a/deployment/keystone/changeset/internal/capability_management.go
+++ b/deployment/keystone/changeset/internal/capability_management.go
@@ -10,6 +10,7 @@ import (
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -18,7 +19,7 @@ import (
 // AddCapabilities adds the capabilities to the registry
 //
 // It is idempotent. It deduplicates the input capabilities.
-func AddCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, chain cldf.Chain, capabilities []kcr.CapabilitiesRegistryCapability, useMCMS bool) (*mcmstypes.BatchOperation, error) {
+func AddCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, chain cldf_evm.Chain, capabilities []kcr.CapabilitiesRegistryCapability, useMCMS bool) (*mcmstypes.BatchOperation, error) {
 	if len(capabilities) == 0 {
 		return nil, nil
 	}
@@ -46,7 +47,7 @@ func AddCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, cha
 	return nil, nil
 }
 
-func addCapabilitiesMCMSProposal(registry *kcr.CapabilitiesRegistry, caps []kcr.CapabilitiesRegistryCapability, regChain cldf.Chain) (*mcmstypes.BatchOperation, error) {
+func addCapabilitiesMCMSProposal(registry *kcr.CapabilitiesRegistry, caps []kcr.CapabilitiesRegistryCapability, regChain cldf_evm.Chain) (*mcmstypes.BatchOperation, error) {
 	tx, err := registry.AddCapabilities(cldf.SimTransactOpts(), caps)
 	if err != nil {
 		err = cldf.DecodeErr(kcr.CapabilitiesRegistryABI, err)

--- a/deployment/keystone/changeset/internal/contract_set.go
+++ b/deployment/keystone/changeset/internal/contract_set.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"fmt"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 type deployContractsRequest struct {
-	chain           cldf.Chain
+	chain           cldf_evm.Chain
 	isRegistryChain bool
 	ad              cldf.AddressBook
 }
 
 // DeployCapabilitiesRegistry deploys the CapabilitiesRegistry contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func DeployCapabilitiesRegistry(_ context.Context, chain cldf.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
+func DeployCapabilitiesRegistry(_ context.Context, chain cldf_evm.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
 	capabilitiesRegistryDeployer, err := NewCapabilitiesRegistryDeployer()
 	capabilitiesRegistryResp, err := capabilitiesRegistryDeployer.Deploy(DeployRequest{Chain: chain})
 	if err != nil {
@@ -30,7 +31,7 @@ func DeployCapabilitiesRegistry(_ context.Context, chain cldf.Chain, ab cldf.Add
 
 // DeployOCR3 deploys the OCR3Capability contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func DeployOCR3(_ context.Context, chain cldf.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
+func DeployOCR3(_ context.Context, chain cldf_evm.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
 	ocr3Deployer, err := NewOCR3Deployer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OCR3Deployer: %w", err)
@@ -49,7 +50,7 @@ func DeployOCR3(_ context.Context, chain cldf.Chain, ab cldf.AddressBook) (*Depl
 
 // DeployForwarder deploys the KeystoneForwarder contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func DeployForwarder(ctx context.Context, chain cldf.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
+func DeployForwarder(ctx context.Context, chain cldf_evm.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
 	forwarderDeployer, err := NewKeystoneForwarderDeployer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create KeystoneForwarderDeployer: %w", err)
@@ -67,7 +68,7 @@ func DeployForwarder(ctx context.Context, chain cldf.Chain, ab cldf.AddressBook)
 
 // DeployFeedsConsumer deploys the KeystoneFeedsConsumer contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func DeployFeedsConsumer(_ context.Context, chain cldf.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
+func DeployFeedsConsumer(_ context.Context, chain cldf_evm.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
 	consumerDeploy, err := NewKeystoneFeedsConsumerDeployer()
 	if err != nil {
 		return nil, err
@@ -85,7 +86,7 @@ func DeployFeedsConsumer(_ context.Context, chain cldf.Chain, ab cldf.AddressBoo
 
 // DeployForwarder deploys the BalanceReader contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func DeployBalanceReader(_ context.Context, chain cldf.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
+func DeployBalanceReader(_ context.Context, chain cldf_evm.Chain, ab cldf.AddressBook) (*DeployResponse, error) {
 	balanceReaderDeployer, err := NewBalanceReaderDeployer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BalanceReaderDeployer: %w", err)

--- a/deployment/keystone/changeset/internal/deploy_test.go
+++ b/deployment/keystone/changeset/internal/deploy_test.go
@@ -17,6 +17,7 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -41,7 +42,7 @@ func Test_RegisterNOPS(t *testing.T) {
 		useMCMS = true
 		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]cldf.Chain{
+			Chains: map[uint64]cldf_evm.Chain{
 				chain.Selector: chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -248,7 +249,7 @@ func Test_RegisterNodes(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				env := &cldf.Environment{
 					Logger: lggr,
-					Chains: map[uint64]cldf.Chain{
+					Chains: map[uint64]cldf_evm.Chain{
 						chain.Selector: chain,
 					},
 					ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -313,7 +314,7 @@ func Test_RegisterNodes(t *testing.T) {
 		useMCMS = true
 		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]cldf.Chain{
+			Chains: map[uint64]cldf_evm.Chain{
 				chain.Selector: chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -368,7 +369,7 @@ func Test_RegisterNodes(t *testing.T) {
 		useMCMS = true
 		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]cldf.Chain{
+			Chains: map[uint64]cldf_evm.Chain{
 				chain.Selector: chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -418,7 +419,7 @@ func Test_RegisterDons(t *testing.T) {
 		useMCMS = true
 		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]cldf.Chain{
+			Chains: map[uint64]cldf_evm.Chain{
 				chain.Selector: chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -518,7 +519,7 @@ func Test_RegisterDons(t *testing.T) {
 
 		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]cldf.Chain{
+			Chains: map[uint64]cldf_evm.Chain{
 				setupResp.Chain.Selector: setupResp.Chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -559,7 +560,7 @@ func Test_RegisterDons(t *testing.T) {
 		useMCMS = true
 		env := &cldf.Environment{
 			Logger: lggr,
-			Chains: map[uint64]cldf.Chain{
+			Chains: map[uint64]cldf_evm.Chain{
 				chain.Selector: chain,
 			},
 			ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{

--- a/deployment/keystone/changeset/internal/forwarder_deployer.go
+++ b/deployment/keystone/changeset/internal/forwarder_deployer.go
@@ -91,8 +91,9 @@ type ConfigureForwarderContractsResponse struct {
 // ConfigureForwardContracts configures the forwarder contracts on all chains for the given DONS
 // the address book is required to contain the an address of the deployed forwarder contract for every chain in the environment
 func ConfigureForwardContracts(env *cldf.Environment, req ConfigureForwarderContractsRequest) (*ConfigureForwarderContractsResponse, error) {
+	evmChains := env.BlockChains.EVMChains()
 	contractSetsResp, err := GetContractSets(env.Logger, &GetContractSetsRequest{
-		Chains:      env.Chains,
+		Chains:      evmChains,
 		AddressBook: env.ExistingAddresses,
 	})
 	if err != nil {
@@ -102,7 +103,7 @@ func ConfigureForwardContracts(env *cldf.Environment, req ConfigureForwarderCont
 	opPerChain := make(map[uint64]mcmstypes.BatchOperation)
 	forwarderAddresses := make(map[uint64]common.Address)
 	// configure forwarders on all chains
-	for _, chain := range env.Chains {
+	for _, chain := range evmChains {
 		if _, shouldInclude := req.Chains[chain.Selector]; len(req.Chains) > 0 && !shouldInclude {
 			continue
 		}

--- a/deployment/keystone/changeset/internal/ocr3config.go
+++ b/deployment/keystone/changeset/internal/ocr3config.go
@@ -25,6 +25,7 @@ import (
 
 	kocr3 "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -351,7 +352,7 @@ func GenerateOCR3Config(cfg OracleConfig, nca []NodeKeys, secrets cldf.OCRSecret
 
 type configureOCR3Request struct {
 	cfg        *OracleConfig
-	chain      cldf.Chain
+	chain      cldf_evm.Chain
 	contract   *kocr3.OCR3Capability
 	nodes      []deployment.Node
 	dryRun     bool

--- a/deployment/keystone/changeset/internal/ocr3config_test.go
+++ b/deployment/keystone/changeset/internal/ocr3config_test.go
@@ -16,6 +16,7 @@ import (
 	types3 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/require"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -93,7 +94,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 	r := configureOCR3Request{
 		cfg:   &cfg,
 		nodes: nodes,
-		chain: cldf.Chain{
+		chain: cldf_evm.Chain{
 			Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 		},
 		ocrSecrets: cldf.XXXGenerateTestOCRSecrets(),
@@ -113,7 +114,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 		r := configureOCR3Request{
 			cfg:   &cfg2,
 			nodes: nodes,
-			chain: cldf.Chain{
+			chain: cldf_evm.Chain{
 				Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 			},
 			ocrSecrets: cldf.XXXGenerateTestOCRSecrets(),
@@ -127,7 +128,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 		r := configureOCR3Request{
 			cfg:   &cfg2,
 			nodes: nodes,
-			chain: cldf.Chain{
+			chain: cldf_evm.Chain{
 				Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 			},
 			ocrSecrets: cldf.XXXGenerateTestOCRSecrets(),

--- a/deployment/keystone/changeset/internal/remove_dons.go
+++ b/deployment/keystone/changeset/internal/remove_dons.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -17,7 +18,7 @@ import (
 
 // RemoveDONsRequest holds the parameters for the RemoveDONs operation.
 type RemoveDONsRequest struct {
-	Chain                cldf.Chain
+	Chain                cldf_evm.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 	DONs                 []uint32
 	UseMCMS              bool

--- a/deployment/keystone/changeset/internal/remove_dons_test.go
+++ b/deployment/keystone/changeset/internal/remove_dons_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/data-streams/utils/pointer"
@@ -26,7 +26,7 @@ import (
 func Test_RemoveDONsRequest_validate(t *testing.T) {
 	type fields struct {
 		DONs                 []uint32
-		chain                cldf.Chain
+		chain                cldf_evm.Chain
 		capabilitiesRegistry *kcr.CapabilitiesRegistry
 	}
 	tests := []struct {
@@ -38,7 +38,7 @@ func Test_RemoveDONsRequest_validate(t *testing.T) {
 			name: "missing capabilities registry",
 			fields: fields{
 				DONs:                 []uint32{1},
-				chain:                cldf.Chain{},
+				chain:                cldf_evm.Chain{},
 				capabilitiesRegistry: nil,
 			},
 			wantErr: true,
@@ -47,7 +47,7 @@ func Test_RemoveDONsRequest_validate(t *testing.T) {
 			name: "empty DONs list",
 			fields: fields{
 				DONs:                 []uint32{},
-				chain:                cldf.Chain{},
+				chain:                cldf_evm.Chain{},
 				capabilitiesRegistry: &kcr.CapabilitiesRegistry{},
 			},
 			wantErr: true,
@@ -56,7 +56,7 @@ func Test_RemoveDONsRequest_validate(t *testing.T) {
 			name: "success",
 			fields: fields{
 				DONs:                 []uint32{1},
-				chain:                cldf.Chain{},
+				chain:                cldf_evm.Chain{},
 				capabilitiesRegistry: &kcr.CapabilitiesRegistry{},
 			},
 			wantErr: false,
@@ -143,7 +143,7 @@ func TestRemoveDONs(t *testing.T) {
 		initialCapCfg = kstest.GetDefaultCapConfig(t, initialCap)
 	)
 
-	setupEnv := func(t *testing.T) (cldf.Chain, *kcr.CapabilitiesRegistry, []kcr.CapabilitiesRegistryDONInfo) {
+	setupEnv := func(t *testing.T) (cldf_evm.Chain, *kcr.CapabilitiesRegistry, []kcr.CapabilitiesRegistryDONInfo) {
 		// 1) Set up chain + registry
 		cfg := setupUpdateDonTestConfig{
 			dons: []internal.DonInfo{

--- a/deployment/keystone/changeset/internal/state.go
+++ b/deployment/keystone/changeset/internal/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -20,7 +21,7 @@ import (
 )
 
 type GetContractSetsRequest struct {
-	Chains      map[uint64]cldf.Chain
+	Chains      map[uint64]cldf_evm.Chain
 	AddressBook cldf.AddressBook
 
 	// Labels indicates the label set that a contract must include to be considered as a member
@@ -90,7 +91,7 @@ func GetContractSets(lggr logger.Logger, req *GetContractSetsRequest) (*GetContr
 // loadContractSet loads the MCMS state and then sets the Keystone contract state.
 func loadContractSet(
 	lggr logger.Logger,
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	addresses map[string]cldf.TypeAndVersion,
 ) (*ContractSet, error) {
 	var out ContractSet

--- a/deployment/keystone/changeset/internal/state_test.go
+++ b/deployment/keystone/changeset/internal/state_test.go
@@ -11,6 +11,7 @@ import (
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -54,7 +55,7 @@ func Test_GetContractSet(t *testing.T) {
 					giveAB,
 				)
 				req := &GetContractSetsRequest{
-					Chains: map[uint64]cldf.Chain{
+					Chains: map[uint64]cldf_evm.Chain{
 						chain.Selector: {
 							Selector: chain.Selector,
 						},
@@ -101,7 +102,7 @@ func Test_GetContractSet(t *testing.T) {
 					giveAB,
 				)
 				req := &GetContractSetsRequest{
-					Chains: map[uint64]cldf.Chain{
+					Chains: map[uint64]cldf_evm.Chain{
 						chain.Selector: {
 							Selector: chain.Selector,
 						},

--- a/deployment/keystone/changeset/internal/types.go
+++ b/deployment/keystone/changeset/internal/types.go
@@ -14,6 +14,7 @@ import (
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -41,7 +42,7 @@ type DeployResponse struct {
 }
 
 type DeployRequest struct {
-	Chain cldf.Chain
+	Chain cldf_evm.Chain
 }
 
 type DonNode struct {
@@ -256,7 +257,7 @@ type RegisteredDonConfig struct {
 func NewRegisteredDon(env cldf.Environment, cfg RegisteredDonConfig) (*RegisteredDon, error) {
 	// load the don info from the capabilities registry
 	r, err := GetContractSets(env.Logger, &GetContractSetsRequest{
-		Chains:      env.Chains,
+		Chains:      env.BlockChains.EVMChains(),
 		AddressBook: env.ExistingAddresses,
 	})
 	if err != nil {

--- a/deployment/keystone/changeset/internal/update_don.go
+++ b/deployment/keystone/changeset/internal/update_don.go
@@ -17,6 +17,7 @@ import (
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -30,7 +31,7 @@ type CapabilityConfig struct {
 }
 
 type UpdateDonRequest struct {
-	Chain                cldf.Chain
+	Chain                cldf_evm.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 
 	P2PIDs            []p2pkey.PeerID    // this is the unique identifier for the don

--- a/deployment/keystone/changeset/internal/update_don_test.go
+++ b/deployment/keystone/changeset/internal/update_don_test.go
@@ -19,7 +19,7 @@ import (
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	kscs "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -239,7 +239,7 @@ type setupUpdateDonTestConfig struct {
 
 type setupUpdateDonTestResult struct {
 	registry *kcr.CapabilitiesRegistry
-	chain    cldf.Chain
+	chain    cldf_evm.Chain
 }
 
 func registerTestDon(t *testing.T, lggr logger.Logger, cfg setupUpdateDonTestConfig) *kstest.SetupTestRegistryResponse {

--- a/deployment/keystone/changeset/internal/update_node_capabilities.go
+++ b/deployment/keystone/changeset/internal/update_node_capabilities.go
@@ -7,13 +7,13 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 )
 
 type UpdateNodeCapabilitiesImplRequest struct {
-	Chain                cldf.Chain
+	Chain                cldf_evm.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 	P2pToCapabilities    map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability
 

--- a/deployment/keystone/changeset/internal/update_node_capabilities_test.go
+++ b/deployment/keystone/changeset/internal/update_node_capabilities_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
@@ -55,7 +56,7 @@ func TestUpdateNodeCapabilities(t *testing.T) {
 			args: args{
 				lggr: lggr,
 				req: &internal.UpdateNodeCapabilitiesImplRequest{
-					Chain: cldf.Chain{},
+					Chain: cldf_evm.Chain{},
 				},
 				initialState: &kstest.SetupTestRegistryRequest{},
 			},

--- a/deployment/keystone/changeset/internal/update_nodes.go
+++ b/deployment/keystone/changeset/internal/update_nodes.go
@@ -15,6 +15,7 @@ import (
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -30,7 +31,7 @@ type NodeUpdate struct {
 }
 
 type UpdateNodesRequest struct {
-	Chain                cldf.Chain
+	Chain                cldf_evm.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 
 	P2pToUpdates map[p2pkey.PeerID]NodeUpdate
@@ -146,7 +147,7 @@ func UpdateNodes(lggr logger.Logger, req *UpdateNodesRequest) (*UpdateNodesRespo
 }
 
 // AppendCapabilities appends the capabilities to the existing capabilities of the nodes listed in p2pIds in the registry
-func AppendCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, chain cldf.Chain, p2pIds []p2pkey.PeerID, capabilities []kcr.CapabilitiesRegistryCapability) (map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability, error) {
+func AppendCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, chain cldf_evm.Chain, p2pIDs []p2pkey.PeerID, capabilities []kcr.CapabilitiesRegistryCapability) (map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability, error) {
 	out := make(map[p2pkey.PeerID][]kcr.CapabilitiesRegistryCapability)
 	allCapabilities, err := registry.GetCapabilities(&bind.CallOpts{})
 	if err != nil {
@@ -163,7 +164,7 @@ func AppendCapabilities(lggr logger.Logger, registry *kcr.CapabilitiesRegistry, 
 		}
 	}
 
-	for _, p2pID := range p2pIds {
+	for _, p2pID := range p2pIDs {
 		// read the existing capabilities for the node
 		info, err := registry.GetNode(&bind.CallOpts{}, p2pID)
 		if err != nil {

--- a/deployment/keystone/changeset/internal/update_nodes_test.go
+++ b/deployment/keystone/changeset/internal/update_nodes_test.go
@@ -21,6 +21,7 @@ import (
 
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -33,7 +34,7 @@ func Test_UpdateNodesRequest_validate(t *testing.T) {
 	type fields struct {
 		p2pToUpdates         map[p2pkey.PeerID]internal.NodeUpdate
 		nopToNodes           map[kcr.CapabilitiesRegistryNodeOperator][]*internal.P2PSignerEnc
-		chain                cldf.Chain
+		chain                cldf_evm.Chain
 		capabilitiesRegistry *kcr.CapabilitiesRegistry
 	}
 	tests := []struct {
@@ -46,7 +47,7 @@ func Test_UpdateNodesRequest_validate(t *testing.T) {
 			fields: fields{
 				p2pToUpdates:         map[p2pkey.PeerID]internal.NodeUpdate{},
 				nopToNodes:           nil,
-				chain:                cldf.Chain{},
+				chain:                cldf_evm.Chain{},
 				capabilitiesRegistry: nil,
 			},
 			wantErr: true,
@@ -60,7 +61,7 @@ func Test_UpdateNodesRequest_validate(t *testing.T) {
 					},
 				},
 				nopToNodes:           nil,
-				chain:                cldf.Chain{},
+				chain:                cldf_evm.Chain{},
 				capabilitiesRegistry: nil,
 			},
 			wantErr: true,
@@ -74,7 +75,7 @@ func Test_UpdateNodesRequest_validate(t *testing.T) {
 					},
 				},
 				nopToNodes:           nil,
-				chain:                cldf.Chain{},
+				chain:                cldf_evm.Chain{},
 				capabilitiesRegistry: nil,
 			},
 			wantErr: true,
@@ -692,9 +693,9 @@ func testPeerID(t *testing.T, s string) p2pkey.PeerID {
 	return p2pkey.PeerID(out)
 }
 
-func testChain(t *testing.T) cldf.Chain {
+func testChain(t *testing.T) cldf_evm.Chain {
 	chains, _ := memory.NewMemoryChains(t, 1, 5)
-	var chain cldf.Chain
+	var chain cldf_evm.Chain
 	for _, c := range chains {
 		chain = c
 		break

--- a/deployment/keystone/changeset/remove_dons.go
+++ b/deployment/keystone/changeset/remove_dons.go
@@ -38,7 +38,7 @@ func (r *RemoveDONsRequest) Validate(e cldf.Environment) error {
 		return fmt.Errorf("invalid registry chain selector %d: selector does not exist", r.RegistryChainSel)
 	}
 
-	_, exists = e.Chains[r.RegistryChainSel]
+	_, exists = e.BlockChains.EVMChains()[r.RegistryChainSel]
 	if !exists {
 		return fmt.Errorf("invalid registry chain selector %d: chain does not exist in environment", r.RegistryChainSel)
 	}
@@ -58,7 +58,7 @@ func RemoveDONs(env cldf.Environment, req *RemoveDONsRequest) (cldf.ChangesetOut
 		return cldf.ChangesetOutput{}, err
 	}
 	// extract the registry contract and chain from the environment
-	registryChain, ok := env.Chains[req.RegistryChainSel]
+	registryChain, ok := env.BlockChains.EVMChains()[req.RegistryChainSel]
 	if !ok {
 		return cldf.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}

--- a/deployment/keystone/changeset/state.go
+++ b/deployment/keystone/changeset/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -21,7 +22,7 @@ import (
 )
 
 type GetContractSetsRequest struct {
-	Chains      map[uint64]cldf.Chain
+	Chains      map[uint64]cldf_evm.Chain
 	AddressBook cldf.AddressBook
 
 	// Labels indicates the label set that a contract must include to be considered as a member
@@ -115,7 +116,7 @@ func GetContractSets(lggr logger.Logger, req *GetContractSetsRequest) (*GetContr
 	return resp, nil
 }
 
-func loadContractSet(lggr logger.Logger, chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*ContractSet, error) {
+func loadContractSet(lggr logger.Logger, chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (*ContractSet, error) {
 	var out ContractSet
 	mcmsWithTimelock, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 	if err != nil {

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -128,10 +129,10 @@ func (te EnvWrapper) CapabilityInfos() []kcr.CapabilitiesRegistryCapabilityInfo 
 }
 
 func (te EnvWrapper) OwnedCapabilityRegistry() *changeset.OwnedContract[*kcr.CapabilitiesRegistry] {
-	return loadOneContract[*kcr.CapabilitiesRegistry](te.t, te.Env, te.Env.Chains[te.RegistrySelector], registryQualifier)
+	return loadOneContract[*kcr.CapabilitiesRegistry](te.t, te.Env, te.Env.BlockChains.EVMChains()[te.RegistrySelector], registryQualifier)
 }
 
-func loadOneContract[T changeset.Ownable](t *testing.T, env cldf.Environment, chain cldf.Chain, qualifier string) *changeset.OwnedContract[T] {
+func loadOneContract[T changeset.Ownable](t *testing.T, env cldf.Environment, chain cldf_evm.Chain, qualifier string) *changeset.OwnedContract[T] {
 	t.Helper()
 	addrs := env.DataStore.Addresses().Filter(datastore.AddressRefByQualifier(qualifier))
 	require.Len(t, addrs, 1)
@@ -162,7 +163,7 @@ func (te EnvWrapper) OwnedForwarders() map[uint64][]*changeset.OwnedContract[*fo
 	require.NotEmpty(te.t, addrs)
 	out := make(map[uint64][]*changeset.OwnedContract[*forwarder.KeystoneForwarder])
 	for _, addr := range addrs {
-		c, err := changeset.GetOwnedContractV2[*forwarder.KeystoneForwarder](te.Env.DataStore.Addresses(), te.Env.Chains[addr.ChainSelector], addr.Address)
+		c, err := changeset.GetOwnedContractV2[*forwarder.KeystoneForwarder](te.Env.DataStore.Addresses(), te.Env.BlockChains.EVMChains()[addr.ChainSelector], addr.Address)
 		require.NoError(te.t, err)
 		require.NotNil(te.t, c)
 		out[addr.ChainSelector] = append(out[addr.ChainSelector], c)
@@ -256,7 +257,7 @@ func initEnv(t *testing.T, nChains int) (registryChainSel uint64, env cldf.Envir
 	)
 	require.NoError(t, err)
 	require.NotNil(t, env)
-	require.Len(t, env.Chains, nChains)
+	require.Len(t, env.BlockChains.EVMChains(), nChains)
 	validateInitialChainState(t, env, registryChainSel)
 	return registryChainSel, env
 }
@@ -289,9 +290,9 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 		env  cldf.Environment
 	)
 	if c.useInMemoryNodes {
-		dons, env = setupMemoryNodeTest(t, registryChainSel, envWithContracts.Chains, c)
+		dons, env = setupMemoryNodeTest(t, registryChainSel, envWithContracts.BlockChains.EVMChains(), c)
 	} else {
-		dons, env = setupViewOnlyNodeTest(t, registryChainSel, envWithContracts.Chains, c)
+		dons, env = setupViewOnlyNodeTest(t, registryChainSel, envWithContracts.BlockChains.EVMChains(), c)
 	}
 	err := env.ExistingAddresses.Merge(envWithContracts.ExistingAddresses)
 	require.NoError(t, err)
@@ -354,8 +355,10 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 	require.NoError(t, err)
 	require.Nil(t, csOut.AddressBook, "no new addresses should be created in configure initial contracts")
 
+	evmChains := env.BlockChains.EVMChains()
+
 	// check the registry
-	gotOwnedRegistry := loadOneContract[*kcr.CapabilitiesRegistry](t, env, env.Chains[registryChainSel], registryQualifier)
+	gotOwnedRegistry := loadOneContract[*kcr.CapabilitiesRegistry](t, env, evmChains[registryChainSel], registryQualifier)
 	require.NotNil(t, gotOwnedRegistry)
 	// validate the registry
 	// check the nodes
@@ -375,7 +378,7 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 	if c.UseMCMS {
 		// deploy, configure and xfer ownership of MCMS on all chains
 		timelockCfgs := make(map[uint64]commontypes.MCMSWithTimelockConfigV2)
-		for sel := range env.Chains {
+		for sel := range evmChains {
 			t.Logf("Enabling MCMS on chain %d", sel)
 			timelockCfgs[sel] = proposalutils.SingleGroupTimelockConfigV2(t)
 		}
@@ -389,11 +392,11 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 		// extract the MCMS address using `GetContractSets` instead of `GetContractSetsV2` because the latter
 		// expects contracts to already be owned by MCMS
 		r, err := changeset.GetContractSets(lggr, &changeset.GetContractSetsRequest{
-			Chains:      env.Chains,
+			Chains:      evmChains,
 			AddressBook: env.ExistingAddresses,
 		})
 		require.NoError(t, err)
-		for sel := range env.Chains {
+		for sel := range evmChains {
 			mcms := r.ContractSets[sel].MCMSWithTimelockState
 			require.NotNil(t, mcms, "MCMS not found on chain %d", sel)
 			require.NoError(t, mcms.Validate())
@@ -422,7 +425,7 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 	}
 }
 
-func setupViewOnlyNodeTest(t *testing.T, registryChainSel uint64, chains map[uint64]cldf.Chain, c EnvWrapperConfig) (testDons, cldf.Environment) {
+func setupViewOnlyNodeTest(t *testing.T, registryChainSel uint64, chains map[uint64]cldf_evm.Chain, c EnvWrapperConfig) (testDons, cldf.Environment) {
 	// now that we have the initial contracts deployed, we can configure the nodes with the addresses
 	dons := newViewOnlyDons()
 	for _, donCfg := range []DonConfig{c.WFDonConfig, c.AssetDonConfig, c.WriterDonConfig} {
@@ -475,7 +478,7 @@ func setupViewOnlyNodeTest(t *testing.T, registryChainSel uint64, chains map[uin
 	return dons, *env
 }
 
-func setupMemoryNodeTest(t *testing.T, registryChainSel uint64, chains map[uint64]cldf.Chain, c EnvWrapperConfig) (testDons, cldf.Environment) {
+func setupMemoryNodeTest(t *testing.T, registryChainSel uint64, chains map[uint64]cldf_evm.Chain, c EnvWrapperConfig) (testDons, cldf.Environment) {
 	// now that we have the initial contracts deployed, we can configure the nodes with the addresses
 	// TODO: configure the nodes with the correct override functions
 	lggr := logger.Test(t)
@@ -484,7 +487,7 @@ func setupMemoryNodeTest(t *testing.T, registryChainSel uint64, chains map[uint6
 		Contract:   [20]byte{},
 	}
 
-	wfChains := map[uint64]cldf.Chain{}
+	wfChains := map[uint64]cldf_evm.Chain{}
 	wfChains[registryChainSel] = chains[registryChainSel]
 	wfConf := memory.NewNodesConfig{
 		LogLevel:       zapcore.InfoLevel,
@@ -499,7 +502,7 @@ func setupMemoryNodeTest(t *testing.T, registryChainSel uint64, chains map[uint6
 	wfNodes := memory.NewNodes(t, wfConf)
 	require.Len(t, wfNodes, c.WFDonConfig.N)
 
-	writerChains := map[uint64]cldf.Chain{}
+	writerChains := map[uint64]cldf_evm.Chain{}
 	maps.Copy(writerChains, chains)
 	cwConf := memory.NewNodesConfig{
 		LogLevel:       zapcore.InfoLevel,
@@ -514,7 +517,7 @@ func setupMemoryNodeTest(t *testing.T, registryChainSel uint64, chains map[uint6
 	cwNodes := memory.NewNodes(t, cwConf)
 	require.Len(t, cwNodes, c.WriterDonConfig.N)
 
-	assetChains := map[uint64]cldf.Chain{}
+	assetChains := map[uint64]cldf_evm.Chain{}
 	assetChains[registryChainSel] = chains[registryChainSel]
 	assetCfg := memory.NewNodesConfig{
 		LogLevel:       zapcore.InfoLevel,
@@ -538,7 +541,7 @@ func setupMemoryNodeTest(t *testing.T, registryChainSel uint64, chains map[uint6
 	return dons, env
 }
 
-func registryChain(t *testing.T, chains map[uint64]cldf.Chain) uint64 {
+func registryChain(t *testing.T, chains map[uint64]cldf_evm.Chain) uint64 {
 	var registryChainSel uint64 = math.MaxUint64
 	for sel := range chains {
 		if sel < registryChainSel {
@@ -557,7 +560,7 @@ func validateInitialChainState(t *testing.T, env cldf.Environment, registryChain
 	require.NoError(t, err)
 	require.Len(t, registryChainAddrs, 4) // registry, ocr3, forwarder, workflowRegistry
 	// only forwarder on non-home chain
-	for sel := range env.Chains {
+	for sel := range env.BlockChains.EVMChains() {
 		chainAddrs, err := ad.AddressesForChain(sel)
 		require.NoError(t, err)
 		if sel != registryChainSel {

--- a/deployment/keystone/changeset/test/env_setup_test.go
+++ b/deployment/keystone/changeset/test/env_setup_test.go
@@ -31,7 +31,7 @@ func TestSetupEnv(t *testing.T) {
 					wantAddrCnt += 5 // time lock, call proxy, canceller, bypass, proposer
 				}
 				require.Len(t, addrs, wantAddrCnt)
-				require.Len(t, te.Env.Chains, 3)
+				require.Len(t, te.Env.BlockChains.EVMChains(), 3)
 				require.NotEmpty(t, te.RegistrySelector)
 				require.NotNil(t, te.Env.Offchain)
 				// one forwarder on each chain
@@ -63,7 +63,7 @@ func TestSetupEnv(t *testing.T) {
 			})
 			t.Run(fmt.Sprintf("set up test env using MCMS: %t", useMCMS), func(t *testing.T) {
 				require.NotNil(t, te.Env.ExistingAddresses)
-				require.Len(t, te.Env.Chains, 3)
+				require.Len(t, te.Env.BlockChains.EVMChains(), 3)
 				require.NotEmpty(t, te.RegistrySelector)
 				require.NotNil(t, te.Env.Offchain)
 				r, err := te.Env.Offchain.ListNodes(t.Context(), &node.ListNodesRequest{})

--- a/deployment/keystone/changeset/test/registry.go
+++ b/deployment/keystone/changeset/test/registry.go
@@ -20,6 +20,7 @@ import (
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -48,7 +49,7 @@ type SetupTestRegistryRequest struct {
 
 type SetupTestRegistryResponse struct {
 	CapabilitiesRegistry *capabilities_registry.CapabilitiesRegistry
-	Chain                cldf.Chain
+	Chain                cldf_evm.Chain
 	RegistrySelector     uint64
 	CapabilityCache      *CapabilityCache
 	Nops                 []*capabilities_registry.CapabilitiesRegistryNodeOperatorAdded
@@ -155,7 +156,7 @@ func MustAddCapabilities(
 	t *testing.T,
 	lggr logger.Logger,
 	in map[p2pkey.PeerID][]capabilities_registry.CapabilitiesRegistryCapability,
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	registry *capabilities_registry.CapabilitiesRegistry,
 ) ([]internal.RegisteredCapability, *CapabilityCache) {
 	t.Helper()
@@ -216,7 +217,7 @@ func ToP2PToCapabilities(
 	return out
 }
 
-func deployCapReg(t *testing.T, chain cldf.Chain) *capabilities_registry.CapabilitiesRegistry {
+func deployCapReg(t *testing.T, chain cldf_evm.Chain) *capabilities_registry.CapabilitiesRegistry {
 	capabilitiesRegistryDeployer, err := internal.NewCapabilitiesRegistryDeployer()
 	require.NoError(t, err)
 	_, err = capabilitiesRegistryDeployer.Deploy(internal.DeployRequest{Chain: chain})
@@ -224,10 +225,10 @@ func deployCapReg(t *testing.T, chain cldf.Chain) *capabilities_registry.Capabil
 	return capabilitiesRegistryDeployer.Contract()
 }
 
-func addNops(t *testing.T, lggr logger.Logger, chain cldf.Chain, registry *capabilities_registry.CapabilitiesRegistry, nops []capabilities_registry.CapabilitiesRegistryNodeOperator) *internal.RegisterNOPSResponse {
+func addNops(t *testing.T, lggr logger.Logger, chain cldf_evm.Chain, registry *capabilities_registry.CapabilitiesRegistry, nops []capabilities_registry.CapabilitiesRegistryNodeOperator) *internal.RegisterNOPSResponse {
 	env := &cldf.Environment{
 		Logger: lggr,
-		Chains: map[uint64]cldf.Chain{
+		Chains: map[uint64]cldf_evm.Chain{
 			chain.Selector: chain,
 		},
 		ExistingAddresses: cldf.NewMemoryAddressBookFromMap(map[uint64]map[string]cldf.TypeAndVersion{
@@ -255,7 +256,7 @@ func addNops(t *testing.T, lggr logger.Logger, chain cldf.Chain, registry *capab
 func AddNodes(
 	t *testing.T,
 	lggr logger.Logger,
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	registry *capabilities_registry.CapabilitiesRegistry,
 	nodes []capabilities_registry.CapabilitiesRegistryNodeParams,
 ) {
@@ -271,7 +272,7 @@ func AddNodes(
 func addDons(
 	t *testing.T,
 	_ logger.Logger,
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	registry *capabilities_registry.CapabilitiesRegistry,
 	capCache *CapabilityCache,
 	dons []Don,
@@ -351,7 +352,7 @@ func (cc *CapabilityCache) Get(c capabilities_registry.CapabilitiesRegistryCapab
 // AddCapabilities adds the capabilities to the registry and returns the registered capabilities
 // if the capability is already registered, it will not be re-registered
 // if duplicate capabilities are passed, they will be deduped
-func (cc *CapabilityCache) AddCapabilities(_ logger.Logger, chain cldf.Chain, registry *capabilities_registry.CapabilitiesRegistry, capabilities []capabilities_registry.CapabilitiesRegistryCapability) []internal.RegisteredCapability {
+func (cc *CapabilityCache) AddCapabilities(_ logger.Logger, chain cldf_evm.Chain, registry *capabilities_registry.CapabilitiesRegistry, capabilities []capabilities_registry.CapabilitiesRegistryCapability) []internal.RegisteredCapability {
 	t := cc.t
 	var out []internal.RegisteredCapability
 	// get the registered capabilities & dedup
@@ -400,9 +401,9 @@ func (cc *CapabilityCache) AddCapabilities(_ logger.Logger, chain cldf.Chain, re
 	return out
 }
 
-func testChain(t *testing.T) cldf.Chain {
+func testChain(t *testing.T) cldf_evm.Chain {
 	chains, _ := memory.NewMemoryChains(t, 1, 5)
-	var chain cldf.Chain
+	var chain cldf_evm.Chain
 	for _, c := range chains {
 		chain = c
 		break

--- a/deployment/keystone/changeset/update_don.go
+++ b/deployment/keystone/changeset/update_don.go
@@ -109,13 +109,15 @@ func appendRequest(r *UpdateDonRequest) *AppendNodeCapabilitiesRequest {
 }
 
 func updateDonRequest(env cldf.Environment, r *UpdateDonRequest) (*internal.UpdateDonRequest, error) {
-	capReg, err := loadCapabilityRegistry(env.Chains[r.RegistryChainSel], env, r.RegistryRef)
+	evmChains := env.BlockChains.EVMChains()
+
+	capReg, err := loadCapabilityRegistry(evmChains[r.RegistryChainSel], env, r.RegistryRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load capability registry: %w", err)
 	}
 
 	return &internal.UpdateDonRequest{
-		Chain:                env.Chains[r.RegistryChainSel],
+		Chain:                evmChains[r.RegistryChainSel],
 		CapabilitiesRegistry: capReg.Contract,
 		P2PIDs:               r.P2PIDs,
 		CapabilityConfigs:    r.CapabilityConfigs,

--- a/deployment/keystone/changeset/update_node_capabilities.go
+++ b/deployment/keystone/changeset/update_node_capabilities.go
@@ -76,7 +76,7 @@ func (req *MutateNodeCapabilitiesRequest) Validate(e cldf.Environment) error {
 		return fmt.Errorf("invalid registry chain selector %d: selector does not exist", req.RegistryChainSel)
 	}
 
-	_, exists = e.Chains[req.RegistryChainSel]
+	_, exists = e.BlockChains.EVMChains()[req.RegistryChainSel]
 	if !exists {
 		return fmt.Errorf("invalid registry chain selector %d: chain does not exist in environment", req.RegistryChainSel)
 	}
@@ -94,7 +94,7 @@ func (req *MutateNodeCapabilitiesRequest) updateNodeCapabilitiesImplRequest(e cl
 	if err := req.Validate(e); err != nil {
 		return nil, nil, fmt.Errorf("failed to validate UpdateNodeCapabilitiesRequest: %w", err)
 	}
-	registryChain := e.Chains[req.RegistryChainSel] // exists because of the validation above
+	registryChain := e.BlockChains.EVMChains()[req.RegistryChainSel] // exists because of the validation above
 	capReg, err := loadCapabilityRegistry(registryChain, e, req.RegistryRef)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load capability registry: %w", err)

--- a/deployment/keystone/changeset/update_nodes.go
+++ b/deployment/keystone/changeset/update_nodes.go
@@ -45,7 +45,7 @@ func (r *UpdateNodesRequest) Validate(e cldf.Environment) error {
 		return fmt.Errorf("invalid registry chain selector %d: selector does not exist", r.RegistryChainSel)
 	}
 
-	_, exists = e.Chains[r.RegistryChainSel]
+	_, exists = e.BlockChains.EVMChains()[r.RegistryChainSel]
 	if !exists {
 		return fmt.Errorf("invalid registry chain selector %d: chain does not exist in environment", r.RegistryChainSel)
 	}
@@ -69,7 +69,7 @@ func UpdateNodes(env cldf.Environment, req *UpdateNodesRequest) (cldf.ChangesetO
 		return cldf.ChangesetOutput{}, fmt.Errorf("invalid request: %w", err)
 	}
 	// extract the registry contract and chain from the environment
-	registryChain, ok := env.Chains[req.RegistryChainSel]
+	registryChain, ok := env.BlockChains.EVMChains()[req.RegistryChainSel]
 	if !ok {
 		return cldf.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}

--- a/deployment/keystone/changeset/view.go
+++ b/deployment/keystone/changeset/view.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
@@ -124,7 +125,7 @@ func getContractsPerChain(e deployment.Environment) (contractsPerChain, error) {
 	}
 
 	for _, contractAddress := range contractAddresses {
-		chain, ok := e.Chains[contractAddress.ChainSelector]
+		chain, ok := e.BlockChains.EVMChains()[contractAddress.ChainSelector]
 		if !ok {
 			// the chain might not be present in the environment if it was removed due to RPC instability
 			e.Logger.Warnf("chain with selector %d not found, skipping contract address %s", contractAddress.ChainSelector, contractAddress.Address)

--- a/deployment/keystone/changeset/view_test.go
+++ b/deployment/keystone/changeset/view_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
@@ -240,7 +241,7 @@ func TestKeystoneView(t *testing.T) {
 			}
 			var allDons = []internal.DonCapabilities{wfDonCapabilities}
 			cr, err := changeset.GetOwnedContractV2[*capabilities_registry.CapabilitiesRegistry](
-				env.Env.DataStore.Addresses(), env.Env.Chains[env.RegistrySelector], capabilityRegistryAddr,
+				env.Env.DataStore.Addresses(), env.Env.BlockChains.EVMChains()[env.RegistrySelector], capabilityRegistryAddr,
 			)
 			require.NoError(t, err)
 

--- a/deployment/keystone/changeset/workflowregistry/deploy.go
+++ b/deployment/keystone/changeset/workflowregistry/deploy.go
@@ -15,7 +15,7 @@ var _ cldf.ChangeSet[uint64] = Deploy
 
 func Deploy(env cldf.Environment, registrySelector uint64) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
-	chain, ok := env.Chains[registrySelector]
+	chain, ok := env.BlockChains.EVMChains()[registrySelector]
 	if !ok {
 		return cldf.ChangesetOutput{}, errors.New("chain not found in environment")
 	}
@@ -31,7 +31,7 @@ func Deploy(env cldf.Environment, registrySelector uint64) (cldf.ChangesetOutput
 
 func DeployV2(env cldf.Environment, req *changeset.DeployRequestV2) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
-	chain, ok := env.Chains[req.ChainSel]
+	chain, ok := env.BlockChains.EVMChains()[req.ChainSel]
 	if !ok {
 		return cldf.ChangesetOutput{}, errors.New("chain not found in environment")
 	}

--- a/deployment/keystone/changeset/workflowregistry/setup_test.go
+++ b/deployment/keystone/changeset/workflowregistry/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	workflow_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v1"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -16,7 +17,7 @@ import (
 
 type SetupTestWorkflowRegistryResponse struct {
 	Registry         *workflow_registry.WorkflowRegistry
-	Chain            cldf.Chain
+	Chain            cldf_evm.Chain
 	RegistrySelector uint64
 	AddressBook      cldf.AddressBook
 }
@@ -45,9 +46,9 @@ func SetupTestWorkflowRegistry(t *testing.T, lggr logger.Logger, chainSel uint64
 	}
 }
 
-func testChain(t *testing.T) cldf.Chain {
+func testChain(t *testing.T) cldf_evm.Chain {
 	chains, _ := memory.NewMemoryChains(t, 1, 5)
-	var chain cldf.Chain
+	var chain cldf_evm.Chain
 	for _, c := range chains {
 		chain = c
 		break

--- a/deployment/keystone/changeset/workflowregistry/strategies.go
+++ b/deployment/keystone/changeset/workflowregistry/strategies.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/mcms/sdk"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -21,7 +22,7 @@ type strategy interface {
 }
 
 type simpleTransaction struct {
-	chain cldf.Chain
+	chain cldf_evm.Chain
 }
 
 func (s *simpleTransaction) Apply(callFn func(opts *bind.TransactOpts) (*types.Transaction, error)) (cldf.ChangesetOutput, error) {

--- a/deployment/keystone/changeset/workflowregistry/update_allowed_dons.go
+++ b/deployment/keystone/changeset/workflowregistry/update_allowed_dons.go
@@ -37,8 +37,9 @@ func UpdateAllowedDons(env cldf.Environment, req *UpdateAllowedDonsRequest) (cld
 		return cldf.ChangesetOutput{}, err
 	}
 
+	evmChains := env.BlockChains.EVMChains()
 	resp, err := changeset.GetContractSets(env.Logger, &changeset.GetContractSetsRequest{
-		Chains:      env.Chains,
+		Chains:      evmChains,
 		AddressBook: env.ExistingAddresses,
 	})
 	if err != nil {
@@ -51,7 +52,7 @@ func UpdateAllowedDons(env cldf.Environment, req *UpdateAllowedDonsRequest) (cld
 	}
 	registry := cs.WorkflowRegistry
 
-	chain, ok := env.Chains[req.RegistryChainSel]
+	chain, ok := evmChains[req.RegistryChainSel]
 	if !ok {
 		return cldf.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}

--- a/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
@@ -12,6 +12,7 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -35,7 +36,7 @@ func TestUpdateAllowedDons(t *testing.T) {
 
 	env := cldf.Environment{
 		Logger: lggr,
-		Chains: map[uint64]cldf.Chain{
+		Chains: map[uint64]cldf_evm.Chain{
 			chainSel: resp.Chain,
 		},
 		ExistingAddresses: resp.AddressBook,

--- a/deployment/keystone/changeset/workflowregistry/update_authorized_addresses.go
+++ b/deployment/keystone/changeset/workflowregistry/update_authorized_addresses.go
@@ -36,7 +36,7 @@ func (r *UpdateAuthorizedAddressesRequest) Validate() error {
 
 func getWorkflowRegistry(env cldf.Environment, chainSel uint64) (*workflow_registry.WorkflowRegistry, error) {
 	resp, err := changeset.GetContractSets(env.Logger, &changeset.GetContractSetsRequest{
-		Chains:      env.Chains,
+		Chains:      env.BlockChains.EVMChains(),
 		AddressBook: env.ExistingAddresses,
 	})
 	if err != nil {
@@ -57,8 +57,9 @@ func UpdateAuthorizedAddresses(env cldf.Environment, req *UpdateAuthorizedAddres
 		return cldf.ChangesetOutput{}, err
 	}
 
+	evmChains := env.BlockChains.EVMChains()
 	resp, err := changeset.GetContractSets(env.Logger, &changeset.GetContractSetsRequest{
-		Chains:      env.Chains,
+		Chains:      evmChains,
 		AddressBook: env.ExistingAddresses,
 	})
 	if err != nil {
@@ -71,7 +72,7 @@ func UpdateAuthorizedAddresses(env cldf.Environment, req *UpdateAuthorizedAddres
 	}
 	registry := cs.WorkflowRegistry
 
-	chain, ok := env.Chains[req.RegistryChainSel]
+	chain, ok := evmChains[req.RegistryChainSel]
 	if !ok {
 		return cldf.ChangesetOutput{}, fmt.Errorf("registry chain selector %d does not exist in environment", req.RegistryChainSel)
 	}

--- a/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -36,7 +37,7 @@ func TestUpdateAuthorizedAddresses(t *testing.T) {
 
 	env := cldf.Environment{
 		Logger: lggr,
-		Chains: map[uint64]cldf.Chain{
+		Chains: map[uint64]cldf_evm.Chain{
 			chainSel: resp.Chain,
 		},
 		ExistingAddresses: resp.AddressBook,

--- a/deployment/keystone/changeset/workflowregistry/workflow_registry_deployer.go
+++ b/deployment/keystone/changeset/workflowregistry/workflow_registry_deployer.go
@@ -9,6 +9,7 @@ import (
 
 	workflow_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v1"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -63,7 +64,7 @@ func (c *workflowRegistryDeployer) Deploy(req changeset.DeployRequest) (*changes
 
 // deployWorkflowRegistry deploys the WorkflowRegistry contract to the chain
 // and saves the address in the address book. This mutates the address book.
-func deployWorkflowRegistry(chain cldf.Chain, ab cldf.AddressBook) (*changeset.DeployResponse, error) {
+func deployWorkflowRegistry(chain cldf_evm.Chain, ab cldf.AddressBook) (*changeset.DeployResponse, error) {
 	deployer, err := newWorkflowRegistryDeployer()
 	resp, err := deployer.Deploy(changeset.DeployRequest{Chain: chain})
 	if err != nil {

--- a/deployment/keystone/test/changeset/capability_registry.go
+++ b/deployment/keystone/test/changeset/capability_registry.go
@@ -26,7 +26,8 @@ func HydrateCapabilityRegistry(t *testing.T, v v1_0.CapabilityRegistryView, env 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain selector from chain id: %w", err)
 	}
-	chain, ok := env.Chains[chainSelector]
+	evmChains := env.BlockChains.EVMChains()
+	chain, ok := evmChains[chainSelector]
 	if !ok {
 		return nil, fmt.Errorf("chain with id %d not found", cfg.ChainID)
 	}
@@ -36,7 +37,7 @@ func HydrateCapabilityRegistry(t *testing.T, v v1_0.CapabilityRegistryView, env 
 	}
 
 	resp, err := changeset.GetContractSets(env.Logger, &changeset.GetContractSetsRequest{
-		Chains:      env.Chains,
+		Chains:      evmChains,
 		AddressBook: changesetOutput.AddressBook,
 	})
 	if err != nil {


### PR DESCRIPTION
- Migrate env.Chains to env.BlockChains.EVMChains()
- Migrate cldf.Chain to cldf_evm.Chain
