### PR TITLE
fix: migrate usage of evm to BlockChain - dev3

### DIFF
--- a/deployment/ccip/operation/evm/v1_2/ops_router.go
+++ b/deployment/ccip/operation/evm/v1_2/ops_router.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -28,9 +29,9 @@ var (
 			ab := deps.AddressBook
 			chain := deps.Chain
 
-			deployFn := func(chain cldf.Chain, tv cldf.TypeAndVersion) (cldf.ContractDeploy[*router.Router], error) {
+			deployFn := func(chain cldf_evm.Chain, tv cldf.TypeAndVersion) (cldf.ContractDeploy[*router.Router], error) {
 				r, err := cldf.DeployContract(b.Logger, chain, ab,
-					func(chain cldf.Chain) cldf.ContractDeploy[*router.Router] {
+					func(chain cldf_evm.Chain) cldf.ContractDeploy[*router.Router] {
 						routerAddr, tx2, routerC, err2 := router.DeployRouter(
 							chain.DeployerKey,
 							chain.Client,

--- a/deployment/ccip/operation/evm/v1_6/ops_fee_quoter.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_fee_quoter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -39,7 +40,7 @@ var (
 			ab := deps.AddressBook
 			contractParams := input.Params
 			feeQ, err := cldf.DeployContract(b.Logger, chain, ab,
-				func(chain cldf.Chain) cldf.ContractDeploy[*fee_quoter.FeeQuoter] {
+				func(chain cldf_evm.Chain) cldf.ContractDeploy[*fee_quoter.FeeQuoter] {
 					prAddr, tx2, pr, err2 := fee_quoter.DeployFeeQuoter(
 						chain.DeployerKey,
 						chain.Client,
@@ -86,7 +87,7 @@ var (
 			if err != nil {
 				return opsutil.OpOutput{}, err
 			}
-			chain := deps.Env.Chains[input.ChainSelector]
+			chain := deps.Env.BlockChains.EVMChains()[input.ChainSelector]
 			chainState := state.MustGetEVMChainState(input.ChainSelector)
 			deployerGroup := deployergroup.NewDeployerGroup(e, state, input.MCMS).
 				WithDeploymentContext("set FeeQuoter authorized caller on %s" + chain.String())
@@ -122,7 +123,7 @@ func (i FeeQApplyAuthorizedCallerOpInput) Validate(env cldf.Environment, state s
 	if err != nil {
 		return err
 	}
-	chain := env.Chains[i.ChainSelector]
+	chain := env.BlockChains.EVMChains()[i.ChainSelector]
 	if state.MustGetEVMChainState(i.ChainSelector).FeeQuoter == nil {
 		return fmt.Errorf("FeeQuoter not found for chain %s", chain.String())
 	}

--- a/deployment/ccip/operation/evm/v1_6/ops_nonce_manager.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_nonce_manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/nonce_manager"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -29,7 +30,7 @@ var (
 			ab := deps.AddressBook
 			chain := deps.Chain
 			nonceManager, err := cldf.DeployContract(b.Logger, chain, ab,
-				func(chain cldf.Chain) cldf.ContractDeploy[*nonce_manager.NonceManager] {
+				func(chain cldf_evm.Chain) cldf.ContractDeploy[*nonce_manager.NonceManager] {
 					nonceManagerAddr, tx2, nonceManager, err2 := nonce_manager.DeployNonceManager(
 						chain.DeployerKey,
 						chain.Client,
@@ -57,7 +58,7 @@ var (
 			if err != nil {
 				return opsutil.OpOutput{}, err
 			}
-			chain := deps.Env.Chains[input.ChainSelector]
+			chain := deps.Env.BlockChains.EVMChains()[input.ChainSelector]
 			chainState := state.MustGetEVMChainState(input.ChainSelector)
 			deployerGroup := deployergroup.NewDeployerGroup(e, state, input.MCMS).
 				WithDeploymentContext("set NonceManager authorized caller on " + chain.String())
@@ -93,7 +94,7 @@ func (n NonceManagerUpdateAuthorizedCallerInput) Validate(env cldf.Environment, 
 	if err != nil {
 		return err
 	}
-	chain := env.Chains[n.ChainSelector]
+	chain := env.BlockChains.EVMChains()[n.ChainSelector]
 	if state.MustGetEVMChainState(n.ChainSelector).NonceManager == nil {
 		return fmt.Errorf("NonceManager not found for chain %s", chain.String())
 	}

--- a/deployment/ccip/operation/evm/v1_6/ops_offramp.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_offramp.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -25,7 +26,7 @@ var (
 			ab := deps.AddressBook
 			chain := deps.Chain
 			offRamp, err := cldf.DeployContract(b.Logger, chain, ab,
-				func(chain cldf.Chain) cldf.ContractDeploy[*offramp.OffRamp] {
+				func(chain cldf_evm.Chain) cldf.ContractDeploy[*offramp.OffRamp] {
 					offRampAddr, tx2, offRamp, err2 := offramp.DeployOffRamp(
 						chain.DeployerKey,
 						chain.Client,

--- a/deployment/ccip/operation/evm/v1_6/ops_onramp.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_onramp.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -22,7 +23,7 @@ var (
 			ab := deps.AddressBook
 			chain := deps.Chain
 			onRamp, err := cldf.DeployContract(b.Logger, chain, ab,
-				func(chain cldf.Chain) cldf.ContractDeploy[*onramp.OnRamp] {
+				func(chain cldf_evm.Chain) cldf.ContractDeploy[*onramp.OnRamp] {
 					onRampAddr, tx2, onRamp, err2 := onramp.DeployOnRamp(
 						chain.DeployerKey,
 						chain.Client,

--- a/deployment/ccip/operation/evm/v1_6/ops_rmnremote.go
+++ b/deployment/ccip/operation/evm/v1_6/ops_rmnremote.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -43,7 +44,7 @@ var (
 			ab := deps.AddressBook
 			chain := deps.Chain
 			contract, err := cldf.DeployContract(b.Logger, chain, ab,
-				func(chain cldf.Chain) cldf.ContractDeploy[*rmn_remote.RMNRemote] {
+				func(chain cldf_evm.Chain) cldf.ContractDeploy[*rmn_remote.RMNRemote] {
 					rmnRemoteAddr, tx, rmnRemote, err2 := rmn_remote.DeployRMNRemote(
 						chain.DeployerKey,
 						chain.Client,
@@ -69,7 +70,7 @@ var (
 			state := deps.CurrentState
 			b.Logger.Infow("Setting RMNRemoteConfig based on ActiveDigest from RMNHome", "chain", input.ChainSelector)
 			e := deps.Env
-			chain := deps.Env.Chains[input.ChainSelector]
+			chain := deps.Env.BlockChains.EVMChains()[input.ChainSelector]
 			homeChainSel, err := state.HomeChainSelector()
 			if err != nil {
 				return opsutil.OpOutput{}, err

--- a/deployment/ccip/sequence/evm/v1_6/seq_deploy_chain.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_deploy_chain.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	ccipopsv1_2 "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_2"
@@ -77,7 +78,7 @@ var (
 				chainSelector := chainSelector
 				contractParams := contractParams
 				grp.Go(func() error {
-					chain, ok := e.Chains[chainSelector]
+					chain, ok := e.BlockChains.EVMChains()[chainSelector]
 					if !ok {
 						return fmt.Errorf("chain %d not found in env", chainSelector)
 					}
@@ -384,7 +385,7 @@ var (
 		})
 )
 
-func isRMNRemoteInitialSetUpCompleted(e cldf.Environment, rmnHome *rmn_home.RMNHome, rmnRemoteContract *rmn_remote.RMNRemote, chain cldf.Chain) (bool, error) {
+func isRMNRemoteInitialSetUpCompleted(e cldf.Environment, rmnHome *rmn_home.RMNHome, rmnRemoteContract *rmn_remote.RMNRemote, chain cldf_evm.Chain) (bool, error) {
 	activeDigest, err := rmnHome.GetActiveDigest(&bind.CallOpts{})
 	if err != nil {
 		e.Logger.Errorw("Failed to get active digest", "chain", chain.String(), "err", err)

--- a/deployment/ccip/sequence/evm/v1_6/seq_rmn.go
+++ b/deployment/ccip/sequence/evm/v1_6/seq_rmn.go
@@ -73,7 +73,7 @@ func (c SetRMNRemoteConfig) Validate(env cldf.Environment, state stateview.CCIPO
 		if err != nil {
 			return err
 		}
-		chain := env.Chains[chainSelector]
+		chain := env.BlockChains.EVMChains()[chainSelector]
 		if state.MustGetEVMChainState(chainSelector).RMNRemote == nil {
 			return fmt.Errorf("RMNRemote not found for chain %s", chain.String())
 		}

--- a/deployment/ccip/shared/opsutil/types.go
+++ b/deployment/ccip/shared/opsutil/types.go
@@ -3,6 +3,7 @@ package opsutil
 import (
 	"github.com/smartcontractkit/mcms"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -18,7 +19,7 @@ type ConfigureDependencies struct {
 // DeployContractDependencies is used on operations which need to deploy contracts or operations which can be used without
 // the deployer group
 type DeployContractDependencies struct {
-	Chain       cldf.Chain
+	Chain       cldf_evm.Chain
 	AddressBook cldf.AddressBook
 }
 

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -328,9 +328,9 @@ func (c CCIPChainState) ValidateOnRamp(
 				c.OnRamp.Address().Hex(), c.FeeAggregator.Hex(), dynamicCfg.FeeAggregator.Hex())
 		}
 	} else {
-		if dynamicCfg.FeeAggregator != e.Chains[selector].DeployerKey.From {
+		if dynamicCfg.FeeAggregator != e.BlockChains.EVMChains()[selector].DeployerKey.From {
 			return fmt.Errorf("onRamp %s feeAggregator mismatch in dynamic config: expected deployer key %s, got %s",
-				c.OnRamp.Address().Hex(), e.Chains[selector].DeployerKey.From.Hex(), dynamicCfg.FeeAggregator.Hex())
+				c.OnRamp.Address().Hex(), e.BlockChains.EVMChains()[selector].DeployerKey.From.Hex(), dynamicCfg.FeeAggregator.Hex())
 		}
 	}
 

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -494,7 +494,7 @@ func (c CCIPOnChainState) View(e *cldf.Environment, chains []uint64) (map[string
 			if err != nil {
 				return err
 			}
-			chainInfo, err := cldf_evm.ChainInfo(chainSelector)
+			chainInfo, err := cldf.ChainInfo(chainSelector)
 			if err != nil {
 				return err
 			}

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -430,7 +430,7 @@ func (c CCIPOnChainState) EnforceMCMSUsageIfProd(ctx context.Context, mcmsConfig
 // If mcmsConfig is nil, the expected owner of each contract is the chain's deployer key.
 // If provided, the expected owner is the Timelock contract.
 func (c CCIPOnChainState) ValidateOwnershipOfChain(e cldf.Environment, chainSel uint64, mcmsConfig *proposalutils.TimelockConfig) error {
-	chain, ok := e.Chains[chainSel]
+	chain, ok := e.BlockChains.EVMChains()[chainSel]
 	if !ok {
 		return fmt.Errorf("chain with selector %d not found in the environment", chainSel)
 	}
@@ -494,7 +494,7 @@ func (c CCIPOnChainState) View(e *cldf.Environment, chains []uint64) (map[string
 			if err != nil {
 				return err
 			}
-			chainInfo, err := cldf.ChainInfo(chainSelector)
+			chainInfo, err := cldf_evm.ChainInfo(chainSelector)
 			if err != nil {
 				return err
 			}
@@ -681,7 +681,7 @@ func LoadOnchainState(e cldf.Environment) (CCIPOnChainState, error) {
 		AptosChains: aptosChains,
 		evmMu:       &sync.RWMutex{},
 	}
-	for chainSelector, chain := range e.Chains {
+	for chainSelector, chain := range e.BlockChains.EVMChains() {
 		addresses, err := e.ExistingAddresses.AddressesForChain(chainSelector)
 		if err != nil {
 			if !errors.Is(err, cldf.ErrChainNotFound) {
@@ -700,7 +700,7 @@ func LoadOnchainState(e cldf.Environment) (CCIPOnChainState, error) {
 }
 
 // LoadChainState Loads all state for a chain into state
-func LoadChainState(ctx context.Context, chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (evm.CCIPChainState, error) {
+func LoadChainState(ctx context.Context, chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (evm.CCIPChainState, error) {
 	var state evm.CCIPChainState
 	mcmsWithTimelock, err := commonstate.MaybeLoadMCMSWithTimelockChainState(chain, addresses)
 	if err != nil {
@@ -1119,7 +1119,7 @@ func ValidateChain(env cldf.Environment, state CCIPOnChainState, chainSel uint64
 	if err != nil {
 		return fmt.Errorf("is not valid chain selector %d: %w", chainSel, err)
 	}
-	chain, ok := env.Chains[chainSel]
+	chain, ok := env.BlockChains.EVMChains()[chainSel]
 	if !ok {
 		return fmt.Errorf("chain with selector %d does not exist in environment", chainSel)
 	}

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -16,6 +16,7 @@ import (
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/burn_from_mint_token_pool"

--- a/deployment/ccip/shared/stateview/state_test.go
+++ b/deployment/ccip/shared/stateview/state_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
@@ -166,10 +167,10 @@ func TestEnforceMCMSUsageIfProd(t *testing.T) {
 				Chains: 1,
 			})
 			homeChainSelector := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-
+			evmChains := e.BlockChains.EVMChains()
 			if test.DeployCCIPHome {
-				_, err = cldf.DeployContract(e.Logger, e.Chains[homeChainSelector], e.ExistingAddresses,
-					func(chain cldf.Chain) cldf.ContractDeploy[*ccip_home.CCIPHome] {
+				_, err = cldf.DeployContract(e.Logger, evmChains[homeChainSelector], e.ExistingAddresses,
+					func(chain cldf_evm.Chain) cldf.ContractDeploy[*ccip_home.CCIPHome] {
 						address, tx2, contract, err2 := ccip_home.DeployCCIPHome(
 							chain.DeployerKey,
 							chain.Client,
@@ -183,8 +184,8 @@ func TestEnforceMCMSUsageIfProd(t *testing.T) {
 			}
 
 			if test.DeployCapReg {
-				_, err = cldf.DeployContract(e.Logger, e.Chains[homeChainSelector], e.ExistingAddresses,
-					func(chain cldf.Chain) cldf.ContractDeploy[*capabilities_registry.CapabilitiesRegistry] {
+				_, err = cldf.DeployContract(e.Logger, evmChains[homeChainSelector], e.ExistingAddresses,
+					func(chain cldf_evm.Chain) cldf.ContractDeploy[*capabilities_registry.CapabilitiesRegistry] {
 						address, tx2, contract, err2 := capabilities_registry.DeployCapabilitiesRegistry(
 							chain.DeployerKey,
 							chain.Client,

--- a/deployment/ccip/view/v1_2/price_registry_test.go
+++ b/deployment/ccip/view/v1_2/price_registry_test.go
@@ -25,7 +25,7 @@ func TestGeneratePriceRegistryView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	f1, f2 := common.HexToAddress("0x1"), common.HexToAddress("0x2")
 	_, tx, c, err := price_registry_1_2_0.DeployPriceRegistry(
 		chain.DeployerKey, chain.Client, []common.Address{chain.DeployerKey.From}, []common.Address{f1, f2}, uint32(10))

--- a/deployment/ccip/view/v1_5/offramp_test.go
+++ b/deployment/ccip/view/v1_5/offramp_test.go
@@ -27,7 +27,7 @@ func TestOffRampView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
+	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
 	_, tx, c, err := commit_store.DeployCommitStore(
 		chain.DeployerKey, chain.Client, commit_store.CommitStoreStaticConfig{
 			ChainSelector:       chainsel.TEST_90000002.Selector,

--- a/deployment/ccip/view/v1_5/onramp_test.go
+++ b/deployment/ccip/view/v1_5/onramp_test.go
@@ -26,7 +26,7 @@ func TestOnRampView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	_, tx, c, err := evm_2_evm_onramp.DeployEVM2EVMOnRamp(
 		chain.DeployerKey, chain.Client,
 		evm_2_evm_onramp.EVM2EVMOnRampStaticConfig{

--- a/deployment/ccip/view/v1_5/rmn_test.go
+++ b/deployment/ccip/view/v1_5/rmn_test.go
@@ -23,7 +23,7 @@ func TestGenerateRMNView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	cfg := rmn_contract.RMNConfig{
 		Voters: []rmn_contract.RMNVoter{
 			{

--- a/deployment/ccip/view/v1_6/ccip_home_test.go
+++ b/deployment/ccip/view/v1_6/ccip_home_test.go
@@ -24,7 +24,7 @@ func TestCCIPHomeView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	_, tx, cr, err := capabilities_registry.DeployCapabilitiesRegistry(
 		chain.DeployerKey, chain.Client)
 	require.NoError(t, err)

--- a/deployment/ccip/view/v1_6/rmnremote_test.go
+++ b/deployment/ccip/view/v1_6/rmnremote_test.go
@@ -24,7 +24,7 @@ func Test_RMNRemote_Curse_View(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
+	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0]]
 	_, tx, remote, err := rmn_remote.DeployRMNRemote(chain.DeployerKey, chain.Client, e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))[0], common.Address{})
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)


### PR DESCRIPTION
## fix: migrate usage of evm to BlockChain - dev3

Breaking down the changes for the migration, there will be more PR with similar changes.

- Migrate `env.Chains` to `env.BlockChains.EVMChains()`
- Migrate `e.Chains` to `e.BlockChains.EVMChains()`
- Migrate `cldf.Chain` to `cldf_evm.Chain`

___
Issue: [CLD-290](https://smartcontract-it.atlassian.net/browse/CLD-290)

[CLD-290]: https://smartcontract-it.atlassian.net/browse/CLD-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ