### PR TITLE
fix: migrate usage of evm to BlockChain - dev4

### DIFF
--- a/deployment/common/changeset/deploy_link_token.go
+++ b/deployment/common/changeset/deploy_link_token.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/link_token"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
@@ -47,7 +48,7 @@ func DeployLinkToken(e cldf.Environment, chains []uint64) (cldf.ChangesetOutput,
 			// Deploy EVM LINK token
 			deployFn = func() error {
 				_, err := deployLinkTokenContractEVM(
-					e.Logger, e.Chains[chain], newAddresses,
+					e.Logger, e.BlockChains.EVMChains()[chain], newAddresses,
 				)
 				return err
 			}
@@ -74,12 +75,12 @@ func DeployStaticLinkToken(e cldf.Environment, chains []uint64) (cldf.ChangesetO
 	}
 	newAddresses := cldf.NewMemoryAddressBook()
 	for _, chainSel := range chains {
-		chain, ok := e.Chains[chainSel]
+		chain, ok := e.BlockChains.EVMChains()[chainSel]
 		if !ok {
 			return cldf.ChangesetOutput{}, fmt.Errorf("chain not found in environment: %d", chainSel)
 		}
 		_, err := cldf.DeployContract[*link_token_interface.LinkToken](e.Logger, chain, newAddresses,
-			func(chain cldf.Chain) cldf.ContractDeploy[*link_token_interface.LinkToken] {
+			func(chain cldf_evm.Chain) cldf.ContractDeploy[*link_token_interface.LinkToken] {
 				linkTokenAddr, tx, linkToken, err2 := link_token_interface.DeployLinkToken(
 					chain.DeployerKey,
 					chain.Client,
@@ -102,11 +103,11 @@ func DeployStaticLinkToken(e cldf.Environment, chains []uint64) (cldf.ChangesetO
 
 func deployLinkTokenContractEVM(
 	lggr logger.Logger,
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	ab cldf.AddressBook,
 ) (*cldf.ContractDeploy[*link_token.LinkToken], error) {
 	linkToken, err := cldf.DeployContract[*link_token.LinkToken](lggr, chain, ab,
-		func(chain cldf.Chain) cldf.ContractDeploy[*link_token.LinkToken] {
+		func(chain cldf_evm.Chain) cldf.ContractDeploy[*link_token.LinkToken] {
 			var (
 				linkTokenAddr common.Address
 				tx            *eth_types.Transaction

--- a/deployment/common/changeset/example/add_mint_burners_link.go
+++ b/deployment/common/changeset/example/add_mint_burners_link.go
@@ -19,7 +19,7 @@ var _ cldf.ChangeSet[*AddMintersBurnersLinkConfig] = AddMintersBurnersLink
 
 // AddMintersBurnersLink grants the minter / burner role to the provided addresses.
 func AddMintersBurnersLink(e cldf.Environment, cfg *AddMintersBurnersLinkConfig) (cldf.ChangesetOutput, error) {
-	chain := e.Chains[cfg.ChainSelector]
+	chain := e.BlockChains.EVMChains()[cfg.ChainSelector]
 	addresses, err := e.ExistingAddresses.AddressesForChain(cfg.ChainSelector)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err

--- a/deployment/common/changeset/example/add_mint_burners_link_test.go
+++ b/deployment/common/changeset/example/add_mint_burners_link_test.go
@@ -24,7 +24,7 @@ func TestAddMintersBurnersLink(t *testing.T) {
 	env := setupLinkTransferTestEnv(t)
 
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	chain := env.Chains[chainSelector]
+	chain := env.BlockChains.EVMChains()[chainSelector]
 	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	require.NoError(t, err)
 	require.Len(t, addrs, 6)

--- a/deployment/common/changeset/example/link_transfer_test.go
+++ b/deployment/common/changeset/example/link_transfer_test.go
@@ -61,7 +61,7 @@ func setupLinkTransferTestEnv(t *testing.T) cldf.Environment {
 func TestValidate(t *testing.T) {
 	env := setupLinkTransferTestEnv(t)
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	chain := env.Chains[chainSelector]
+	chain := env.BlockChains.EVMChains()[chainSelector]
 	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	require.NoError(t, err)
 	require.Len(t, addrs, 6)
@@ -232,7 +232,7 @@ func TestLinkTransferMCMSV2(t *testing.T) {
 
 	env := setupLinkTransferTestEnv(t)
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	chain := env.Chains[chainSelector]
+	chain := env.BlockChains.EVMChains()[chainSelector]
 	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	require.NoError(t, err)
 	require.Len(t, addrs, 6)

--- a/deployment/common/changeset/example/mint_link.go
+++ b/deployment/common/changeset/example/mint_link.go
@@ -20,7 +20,7 @@ var _ cldf.ChangeSet[*MintLinkConfig] = MintLink
 
 // MintLink mints LINK to the provided contract.
 func MintLink(e cldf.Environment, cfg *MintLinkConfig) (cldf.ChangesetOutput, error) {
-	chain := e.Chains[cfg.ChainSelector]
+	chain := e.BlockChains.EVMChains()[cfg.ChainSelector]
 	addresses, err := e.ExistingAddresses.AddressesForChain(cfg.ChainSelector)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err

--- a/deployment/common/changeset/example/mint_link_test.go
+++ b/deployment/common/changeset/example/mint_link_test.go
@@ -24,7 +24,7 @@ func TestMintLink(t *testing.T) {
 	env := setupLinkTransferTestEnv(t)
 	ctx := env.GetContext()
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	chain := env.Chains[chainSelector]
+	chain := env.BlockChains.EVMChains()[chainSelector]
 
 	addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 	require.NoError(t, err)

--- a/deployment/common/changeset/example/operations/deploy_and_mint_example.go
+++ b/deployment/common/changeset/example/operations/deploy_and_mint_example.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
@@ -33,7 +34,7 @@ type SqDeployLinkOutput struct {
 
 type EthereumDeps struct {
 	Auth  *bind.TransactOpts
-	Chain cldf.Chain
+	Chain cldf_evm.Chain
 	AB    cldf.AddressBook
 }
 
@@ -45,13 +46,13 @@ func (l DeployAndMintExampleChangeset) VerifyPreconditions(e cldf.Environment, c
 }
 
 func (l DeployAndMintExampleChangeset) Apply(e cldf.Environment, config SqDeployLinkInput) (cldf.ChangesetOutput, error) {
-	auth := e.Chains[config.ChainID].DeployerKey
+	auth := e.BlockChains.EVMChains()[config.ChainID].DeployerKey
 	ab := cldf.NewMemoryAddressBook()
 
 	// build your custom dependencies needed in the sequence/operation
 	deps := EthereumDeps{
 		Auth:  auth,
-		Chain: e.Chains[config.ChainID],
+		Chain: e.BlockChains.EVMChains()[config.ChainID],
 		AB:    ab,
 	}
 

--- a/deployment/common/changeset/example/operations/operation.go
+++ b/deployment/common/changeset/example/operations/operation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/link_token"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -22,7 +23,7 @@ var DeployLinkOp = operations.NewOperation(
 	"Deploy LINK Contract Operation",
 	func(b operations.Bundle, deps EthereumDeps, input operations.EmptyInput) (common.Address, error) {
 		linkToken, err := cldf.DeployContract[*link_token.LinkToken](b.Logger, deps.Chain, deps.AB,
-			func(chain cldf.Chain) cldf.ContractDeploy[*link_token.LinkToken] {
+			func(chain cldf_evm.Chain) cldf.ContractDeploy[*link_token.LinkToken] {
 				linkTokenAddr, tx, linkToken, err2 := link_token.DeployLinkToken(
 					chain.DeployerKey,
 					chain.Client,

--- a/deployment/common/changeset/internal/evm/mcms.go
+++ b/deployment/common/changeset/internal/evm/mcms.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -50,7 +51,7 @@ type MCMSWithTimelockEVMDeploy struct {
 func DeployMCMSWithConfigEVM(
 	contractType cldf.ContractType,
 	lggr logger.Logger,
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	ab cldf.AddressBook,
 	mcmConfig mcmsTypes.Config,
 	options ...DeployMCMSOption,
@@ -61,7 +62,7 @@ func DeployMCMSWithConfigEVM(
 		return nil, err
 	}
 	mcm, err := cldf.DeployContract(lggr, chain, ab,
-		func(chain cldf.Chain) cldf.ContractDeploy[*bindings.ManyChainMultiSig] {
+		func(chain cldf_evm.Chain) cldf.ContractDeploy[*bindings.ManyChainMultiSig] {
 			mcmAddr, tx, mcm, err2 := bindings.DeployManyChainMultiSig(
 				chain.DeployerKey,
 				chain.Client,
@@ -103,7 +104,7 @@ func DeployMCMSWithConfigEVM(
 func DeployMCMSWithTimelockContractsEVM(
 	ctx context.Context,
 	lggr logger.Logger,
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	ab cldf.AddressBook,
 	config commontypes.MCMSWithTimelockConfigV2,
 	state *state.MCMSWithTimelockState,
@@ -157,7 +158,7 @@ func DeployMCMSWithTimelockContractsEVM(
 
 	if timelock == nil {
 		timelockC, err := cldf.DeployContract(lggr, chain, ab,
-			func(chain cldf.Chain) cldf.ContractDeploy[*bindings.RBACTimelock] {
+			func(chain cldf_evm.Chain) cldf.ContractDeploy[*bindings.RBACTimelock] {
 				timelock, tx2, cc, err2 := bindings.DeployRBACTimelock(
 					chain.DeployerKey,
 					chain.Client,
@@ -195,7 +196,7 @@ func DeployMCMSWithTimelockContractsEVM(
 
 	if callProxy == nil {
 		callProxyC, err := cldf.DeployContract(lggr, chain, ab,
-			func(chain cldf.Chain) cldf.ContractDeploy[*bindings.CallProxy] {
+			func(chain cldf_evm.Chain) cldf.ContractDeploy[*bindings.CallProxy] {
 				callProxy, tx2, cc, err2 := bindings.DeployCallProxy(
 					chain.DeployerKey,
 					chain.Client,
@@ -269,7 +270,7 @@ func getAdminAddresses(ctx context.Context, timelock *bindings.RBACTimelock) ([]
 func GrantRolesForTimelock(
 	ctx context.Context,
 	lggr logger.Logger,
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	timelockContracts *proposalutils.MCMSWithTimelockContracts,
 	skipIfDeployerKeyNotAdmin bool, // If true, skip role grants if the deployer key is not an admin.
 ) ([]mcmsTypes.Transaction, error) {
@@ -389,7 +390,7 @@ func GrantRolesForTimelock(
 func grantRoleTx(
 	lggr logger.Logger,
 	timelock *bindings.RBACTimelock,
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	isDeployerKeyAdmin bool,
 	roleID [32]byte,
 	address common.Address,

--- a/deployment/common/changeset/mcms_firedrill.go
+++ b/deployment/common/changeset/mcms_firedrill.go
@@ -24,7 +24,7 @@ type FireDrillConfig struct {
 
 // buildNoOPEVM builds a dummy tx that transfers 0 to the RBACTimelock
 func buildNoOPEVM(e cldf.Environment, selector uint64) (mcmstypes.Transaction, error) {
-	chain, ok := e.Chains[selector]
+	chain, ok := e.BlockChains.EVMChains()[selector]
 	if !ok {
 		return mcmstypes.Transaction{}, nil
 	}
@@ -100,7 +100,7 @@ func MCMSSignFireDrillChangeset(e cldf.Environment, cfg FireDrillConfig) (cldf.C
 			if err != nil {
 				return cldf.ChangesetOutput{}, err
 			}
-			state, err := state.MaybeLoadMCMSWithTimelockChainState(e.Chains[selector], addresses)
+			state, err := state.MaybeLoadMCMSWithTimelockChainState(e.BlockChains.EVMChains()[selector], addresses)
 			if err != nil {
 				return cldf.ChangesetOutput{}, err
 			}

--- a/deployment/common/changeset/save_existing_test.go
+++ b/deployment/common/changeset/save_existing_test.go
@@ -22,7 +22,7 @@ func TestSaveExisting(t *testing.T) {
 		Name:              "dummy",
 		Logger:            logger.TestLogger(t),
 		ExistingAddresses: cldf.NewMemoryAddressBook(),
-		Chains: map[uint64]cldf.Chain{
+		Chains: map[uint64]cldf_evm.Chain{
 			chainsel.TEST_90000001.Selector: {},
 			chainsel.TEST_90000002.Selector: {},
 		},
@@ -69,7 +69,7 @@ func TestSaveExistingAddressWithLabels(t *testing.T) {
 		Name:              "dummy",
 		Logger:            logger.TestLogger(t),
 		ExistingAddresses: cldf.NewMemoryAddressBook(),
-		Chains: map[uint64]cldf.Chain{
+		Chains: map[uint64]cldf_evm.Chain{
 			chainsel.TEST_90000001.Selector: {},
 			chainsel.TEST_90000002.Selector: {},
 		},
@@ -112,7 +112,7 @@ func TestSaveExistingMCMSAddressWithLabels(t *testing.T) {
 		Name:              "dummy",
 		Logger:            logger.TestLogger(t),
 		ExistingAddresses: cldf.NewMemoryAddressBook(),
-		Chains: map[uint64]cldf.Chain{
+		Chains: map[uint64]cldf_evm.Chain{
 			chainsel.TEST_90000001.Selector: {},
 			chainsel.TEST_90000002.Selector: {},
 		},

--- a/deployment/common/changeset/set_config_mcms_test.go
+++ b/deployment/common/changeset/set_config_mcms_test.go
@@ -123,7 +123,7 @@ func TestSetConfigMCMSV2EVM(t *testing.T) {
 
 			env := setupSetConfigTestEnv(t)
 			chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-			chain := env.Chains[chainSelector]
+			chain := env.BlockChains.EVMChains()[chainSelector]
 			addrs, err := env.ExistingAddresses.AddressesForChain(chainSelector)
 			require.NoError(t, err)
 			require.Len(t, addrs, 6)

--- a/deployment/common/changeset/state.go
+++ b/deployment/common/changeset/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/link_token"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -69,7 +70,7 @@ func (state MCMSWithTimelockState) GenerateMCMSWithTimelockView() (v1_0.MCMSWith
 func MaybeLoadMCMSWithTimelockState(env cldf.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
 	result := map[uint64]*MCMSWithTimelockState{}
 	for _, chainSelector := range chainSelectors {
-		chain, ok := env.Chains[chainSelector]
+		chain, ok := env.BlockChains.EVMChains()[chainSelector]
 		if !ok {
 			return nil, fmt.Errorf("chain %d not found", chainSelector)
 		}
@@ -97,7 +98,7 @@ func MaybeLoadMCMSWithTimelockState(env cldf.Environment, chainSelectors []uint6
 // Deprecated: use MaybeLoadMCMSWithTimelockChainState from deployment/common/changeset/state/evm.go instead
 // if you are changing this, please make the similar changes in deployment/common/changeset/state
 func MaybeLoadMCMSWithTimelockChainState(
-	chain cldf.Chain,
+	chain cldf_evm.Chain,
 	addresses map[string]cldf.TypeAndVersion,
 ) (*MCMSWithTimelockState, error) {
 	var (
@@ -206,7 +207,7 @@ func (s LinkTokenState) GenerateLinkView() (v1_0.LinkTokenView, error) {
 func MaybeLoadLinkTokenState(env cldf.Environment, chainSelectors []uint64) (map[uint64]*LinkTokenState, error) {
 	result := map[uint64]*LinkTokenState{}
 	for _, chainSelector := range chainSelectors {
-		chain, ok := env.Chains[chainSelector]
+		chain, ok := env.BlockChains.EVMChains()[chainSelector]
 		if !ok {
 			return nil, fmt.Errorf("chain %d not found", chainSelector)
 		}
@@ -225,7 +226,7 @@ func MaybeLoadLinkTokenState(env cldf.Environment, chainSelectors []uint64) (map
 
 // Deprecated: use MaybeLoadLinkTokenChainState from deployment/common/changeset/state/evm.go instead
 // if you are changing this, please make the similar changes in deployment/common/changeset/state
-func MaybeLoadLinkTokenChainState(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*LinkTokenState, error) {
+func MaybeLoadLinkTokenChainState(chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (*LinkTokenState, error) {
 	state := LinkTokenState{}
 	linkToken := cldf.NewTypeAndVersion(types.LinkToken, deployment.Version1_0_0)
 
@@ -265,7 +266,7 @@ func (s StaticLinkTokenState) GenerateStaticLinkView() (v1_0.StaticLinkTokenView
 
 // Deprecated: use MaybeLoadStaticLinkTokenState from deployment/common/changeset/state/evm.go instead
 // if you are changing this, please make the similar changes in deployment/common/changeset/state
-func MaybeLoadStaticLinkTokenState(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*StaticLinkTokenState, error) {
+func MaybeLoadStaticLinkTokenState(chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (*StaticLinkTokenState, error) {
 	state := StaticLinkTokenState{}
 	staticLinkToken := cldf.NewTypeAndVersion(types.StaticLinkToken, deployment.Version1_0_0)
 

--- a/deployment/common/changeset/state/evm.go
+++ b/deployment/common/changeset/state/evm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/link_token"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -63,7 +64,7 @@ func (state MCMSWithTimelockState) GenerateMCMSWithTimelockView() (view.MCMSWith
 func MaybeLoadMCMSWithTimelockState(env cldf.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
 	result := map[uint64]*MCMSWithTimelockState{}
 	for _, chainSelector := range chainSelectors {
-		chain, ok := env.Chains[chainSelector]
+		chain, ok := env.BlockChains.EVMChains()[chainSelector]
 		if !ok {
 			return nil, fmt.Errorf("chain %d not found", chainSelector)
 		}
@@ -84,7 +85,7 @@ func MaybeLoadMCMSWithTimelockState(env cldf.Environment, chainSelectors []uint6
 func MaybeLoadMCMSWithTimelockStateDataStore(env cldf.Environment, chainSelectors []uint64) (map[uint64]*MCMSWithTimelockState, error) {
 	result := map[uint64]*MCMSWithTimelockState{}
 	for _, chainSelector := range chainSelectors {
-		chain, ok := env.Chains[chainSelector]
+		chain, ok := env.BlockChains.EVMChains()[chainSelector]
 		if !ok {
 			return nil, fmt.Errorf("chain %d not found", chainSelector)
 		}
@@ -127,7 +128,7 @@ func loadAddressesFromDataStore(ds datastore.DataStore[datastore.DefaultMetadata
 // - Found but was unable to load a contract
 // - It only found part of the bundle of contracts
 // - If found more than one instance of a contract (we expect one bundle in the given addresses)
-func MaybeLoadMCMSWithTimelockChainState(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*MCMSWithTimelockState, error) {
+func MaybeLoadMCMSWithTimelockChainState(chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (*MCMSWithTimelockState, error) {
 	state := MCMSWithTimelockState{}
 	var (
 		// We expect one of each contract on the chain.
@@ -227,7 +228,7 @@ func (s LinkTokenState) GenerateLinkView() (view.LinkTokenView, error) {
 func MaybeLoadLinkTokenState(env cldf.Environment, chainSelectors []uint64) (map[uint64]*LinkTokenState, error) {
 	result := map[uint64]*LinkTokenState{}
 	for _, chainSelector := range chainSelectors {
-		chain, ok := env.Chains[chainSelector]
+		chain, ok := env.BlockChains.EVMChains()[chainSelector]
 		if !ok {
 			return nil, fmt.Errorf("chain %d not found", chainSelector)
 		}
@@ -244,7 +245,7 @@ func MaybeLoadLinkTokenState(env cldf.Environment, chainSelectors []uint64) (map
 	return result, nil
 }
 
-func MaybeLoadLinkTokenChainState(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*LinkTokenState, error) {
+func MaybeLoadLinkTokenChainState(chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (*LinkTokenState, error) {
 	state := LinkTokenState{}
 	linkToken := cldf.NewTypeAndVersion(types.LinkToken, deployment.Version1_0_0)
 
@@ -280,7 +281,7 @@ func (s StaticLinkTokenState) GenerateStaticLinkView() (view.StaticLinkTokenView
 	return view.GenerateStaticLinkTokenView(s.StaticLinkToken)
 }
 
-func MaybeLoadStaticLinkTokenState(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*StaticLinkTokenState, error) {
+func MaybeLoadStaticLinkTokenState(chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (*StaticLinkTokenState, error) {
 	state := StaticLinkTokenState{}
 	staticLinkToken := cldf.NewTypeAndVersion(types.StaticLinkToken, deployment.Version1_0_0)
 

--- a/deployment/common/changeset/state/evm_test.go
+++ b/deployment/common/changeset/state/evm_test.go
@@ -16,8 +16,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -26,7 +25,7 @@ import (
 func TestMCMSWithTimelockState_GenerateMCMSWithTimelockViewV2(t *testing.T) {
 	envConfig := memory.MemoryEnvironmentConfig{Chains: 1}
 	env := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, envConfig)
-	chain := env.Chains[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	chain := env.BlockChains.EVMChains()[env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 
 	proposerMcm := deployMCMEvm(t, chain, &mcmstypes.Config{Quorum: 1, Signers: []common.Address{
 		common.HexToAddress("0x0000000000000000000000000000000000000001"),
@@ -139,7 +138,7 @@ func toJSON[T any](t *testing.T, value T) string {
 }
 
 func deployMCMEvm(
-	t *testing.T, chain cldf.Chain, config *mcmstypes.Config,
+	t *testing.T, chain cldf_evm.Chain, config *mcmstypes.Config,
 ) *bindings.ManyChainMultiSig {
 	t.Helper()
 
@@ -159,7 +158,7 @@ func deployMCMEvm(
 }
 
 func deployTimelockEvm(
-	t *testing.T, chain cldf.Chain, minDelay *big.Int, admin common.Address,
+	t *testing.T, chain cldf_evm.Chain, minDelay *big.Int, admin common.Address,
 	proposers, executors, cancellers, bypassers []common.Address,
 ) *bindings.RBACTimelock {
 	t.Helper()
@@ -173,7 +172,7 @@ func deployTimelockEvm(
 }
 
 func deployCallProxyEvm(
-	t *testing.T, chain cldf.Chain, target common.Address,
+	t *testing.T, chain cldf_evm.Chain, target common.Address,
 ) *bindings.CallProxy {
 	t.Helper()
 	_, tx, contract, err := bindings.DeployCallProxy(chain.DeployerKey, chain.Client, target)

--- a/deployment/common/changeset/state_test.go
+++ b/deployment/common/changeset/state_test.go
@@ -8,6 +8,7 @@ import (
 	owner_helpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -20,13 +21,13 @@ import (
 func TestMaybeLoadMCMSWithTimelockChainState(t *testing.T) {
 	type testCase struct {
 		name      string
-		chain     cldf.Chain
+		chain     cldf_evm.Chain
 		addresses map[string]cldf.TypeAndVersion
 		wantState *MCMSWithTimelockState // Expected state
 		wantErr   string
 	}
 
-	defaultChain := cldf.Chain{
+	defaultChain := cldf_evm.Chain{
 		Selector: chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector,
 	}
 	tests := []testCase{

--- a/deployment/common/changeset/test_helpers.go
+++ b/deployment/common/changeset/test_helpers.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
@@ -142,7 +143,7 @@ func ApplyChangesets(t *testing.T, e cldf.Environment, timelockContractsPerChain
 			Logger:            e.Logger,
 			ExistingAddresses: addresses,
 			DataStore:         ds,
-			Chains:            e.Chains,
+			Chains:            e.BlockChains.EVMChains(),
 			NodeIDs:           e.NodeIDs,
 			Offchain:          e.Offchain,
 			OCRSecrets:        e.OCRSecrets,
@@ -208,7 +209,7 @@ func ApplyChangesetsV2(t *testing.T, e cldf.Environment, changesetApplications [
 			Logger:            e.Logger,
 			ExistingAddresses: addresses,
 			DataStore:         ds,
-			Chains:            e.Chains,
+			Chains:            e.BlockChains.EVMChains(),
 			NodeIDs:           e.NodeIDs,
 			Offchain:          e.Offchain,
 			OCRSecrets:        e.OCRSecrets,
@@ -272,7 +273,7 @@ func DeployLinkTokenTest(t *testing.T, memoryConfig memory.MemoryEnvironmentConf
 	require.NoError(t, err)
 	addrs, err := e.ExistingAddresses.AddressesForChain(chain1)
 	require.NoError(t, err)
-	state, err := commonState.MaybeLoadLinkTokenChainState(e.Chains[chain1], addrs)
+	state, err := commonState.MaybeLoadLinkTokenChainState(e.BlockChains.EVMChains()[chain1], addrs)
 	require.NoError(t, err)
 	// View itself already unit tested
 	_, err = state.GenerateLinkView()
@@ -311,7 +312,7 @@ func SetPreloadedSolanaAddresses(t *testing.T, env cldf.Environment, selector ui
 	require.NoError(t, err)
 }
 
-func MustFundAddressWithLink(t *testing.T, e cldf.Environment, chain cldf.Chain, to common.Address, amount int64) {
+func MustFundAddressWithLink(t *testing.T, e cldf.Environment, chain cldf_evm.Chain, to common.Address, amount int64) {
 	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
 	require.NoError(t, err)
 
@@ -341,7 +342,7 @@ func MustFundAddressWithLink(t *testing.T, e cldf.Environment, chain cldf.Chain,
 }
 
 // MaybeGetLinkBalance returns the LINK balance of the given address on the given chain.
-func MaybeGetLinkBalance(t *testing.T, e cldf.Environment, chain cldf.Chain, linkAddr common.Address) *big.Int {
+func MaybeGetLinkBalance(t *testing.T, e cldf.Environment, chain cldf_evm.Chain, linkAddr common.Address) *big.Int {
 	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
 	require.NoError(t, err)
 	linkState, err := commonState.MaybeLoadLinkTokenChainState(chain, addresses)

--- a/deployment/common/changeset/test_helpers_test.go
+++ b/deployment/common/changeset/test_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 
 	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
@@ -77,7 +78,7 @@ func NewNoopEnvironment(t *testing.T) cldf.Environment {
 			datastore.DefaultMetadata,
 			datastore.DefaultMetadata,
 		]().Seal(),
-		map[uint64]cldf.Chain{},
+		map[uint64]cldf_evm.Chain{},
 		map[uint64]cldf_solana.Chain{},
 		map[uint64]cldf_aptos.Chain{},
 		[]string{},

--- a/deployment/common/changeset/token_approve.go
+++ b/deployment/common/changeset/token_approve.go
@@ -11,17 +11,18 @@ import (
 
 // ApproveToken approves the router to spend the given amount of tokens
 func ApproveToken(env cldf.Environment, src uint64, tokenAddress common.Address, routerAddress common.Address, amount *big.Int) error {
-	token, err := erc20.NewERC20(tokenAddress, env.Chains[src].Client)
+	evmChains := env.BlockChains.EVMChains()
+	token, err := erc20.NewERC20(tokenAddress, evmChains[src].Client)
 	if err != nil {
 		return err
 	}
 
-	tx, err := token.Approve(env.Chains[src].DeployerKey, routerAddress, amount)
+	tx, err := token.Approve(evmChains[src].DeployerKey, routerAddress, amount)
 	if err != nil {
 		return err
 	}
 
-	_, err = env.Chains[src].Confirm(tx)
+	_, err = evmChains[src].Confirm(tx)
 	if err != nil {
 		return err
 	}

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock.go
@@ -49,6 +49,7 @@ func LoadOwnableContract(addr common.Address, client bind.ContractBackend) (comm
 }
 
 func (t TransferToMCMSWithTimelockConfig) Validate(e cldf.Environment) error {
+	evmChains := e.BlockChains.EVMChains()
 	for chainSelector, contracts := range t.ContractsByChain {
 		for _, contract := range contracts {
 			// Cannot transfer an unknown address.
@@ -59,11 +60,11 @@ func (t TransferToMCMSWithTimelockConfig) Validate(e cldf.Environment) error {
 				}
 				return fmt.Errorf("contract %s not found in address book", contract)
 			}
-			owner, _, err := LoadOwnableContract(contract, e.Chains[chainSelector].Client)
+			owner, _, err := LoadOwnableContract(contract, evmChains[chainSelector].Client)
 			if err != nil {
 				return fmt.Errorf("failed to load ownable: %w", err)
 			}
-			if owner != e.Chains[chainSelector].DeployerKey.From {
+			if owner != evmChains[chainSelector].DeployerKey.From {
 				return fmt.Errorf("contract %s is not owned by the deployer key", contract)
 			}
 		}
@@ -93,26 +94,27 @@ func TransferToMCMSWithTimelockV2(
 	timelockAddressByChain := make(map[uint64]string)
 	inspectorPerChain := map[uint64]sdk.Inspector{}
 	proposerAddressByChain := make(map[uint64]string)
+	evmChains := e.BlockChains.EVMChains()
 	for chainSelector, contracts := range cfg.ContractsByChain {
 		// Already validated that the timelock/proposer exists.
 		timelockAddr, _ := cldf.SearchAddressBook(e.ExistingAddresses, chainSelector, types.RBACTimelock)
 		proposerAddr, _ := cldf.SearchAddressBook(e.ExistingAddresses, chainSelector, types.ProposerManyChainMultisig)
 		timelockAddressByChain[chainSelector] = timelockAddr
 		proposerAddressByChain[chainSelector] = proposerAddr
-		inspectorPerChain[chainSelector] = evm.NewInspector(e.Chains[chainSelector].Client)
+		inspectorPerChain[chainSelector] = evm.NewInspector(evmChains[chainSelector].Client)
 
 		var ops []mcmstypes.Transaction
 		for _, contract := range contracts {
 			// Just using the ownership interface.
 			// Already validated is ownable.
-			owner, c, _ := LoadOwnableContract(contract, e.Chains[chainSelector].Client)
+			owner, c, _ := LoadOwnableContract(contract, evmChains[chainSelector].Client)
 			if owner.String() == timelockAddr {
 				// Already owned by timelock.
 				e.Logger.Infof("contract %s already owned by timelock", contract)
 				continue
 			}
-			tx, err := c.TransferOwnership(e.Chains[chainSelector].DeployerKey, common.HexToAddress(timelockAddr))
-			_, err = cldf.ConfirmIfNoError(e.Chains[chainSelector], tx, err)
+			tx, err := c.TransferOwnership(evmChains[chainSelector].DeployerKey, common.HexToAddress(timelockAddr))
+			_, err = cldf.ConfirmIfNoError(evmChains[chainSelector], tx, err)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to transfer ownership of contract %T: %w", contract, err)
 			}
@@ -154,15 +156,16 @@ type TransferToDeployerConfig struct {
 // back to the deployer key. It's effectively the rollback function of transferring
 // to the timelock.
 func TransferToDeployer(e cldf.Environment, cfg TransferToDeployerConfig) (cldf.ChangesetOutput, error) {
-	owner, ownable, err := LoadOwnableContract(cfg.ContractAddress, e.Chains[cfg.ChainSel].Client)
+	evmChains := e.BlockChains.EVMChains()
+	owner, ownable, err := LoadOwnableContract(cfg.ContractAddress, evmChains[cfg.ChainSel].Client)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
-	if owner == e.Chains[cfg.ChainSel].DeployerKey.From {
+	if owner == evmChains[cfg.ChainSel].DeployerKey.From {
 		e.Logger.Infof("Contract %s already owned by deployer", cfg.ContractAddress)
 		return cldf.ChangesetOutput{}, nil
 	}
-	tx, err := ownable.TransferOwnership(cldf.SimTransactOpts(), e.Chains[cfg.ChainSel].DeployerKey.From)
+	tx, err := ownable.TransferOwnership(cldf.SimTransactOpts(), evmChains[cfg.ChainSel].DeployerKey.From)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -170,7 +173,7 @@ func TransferToDeployer(e cldf.Environment, cfg TransferToDeployerConfig) (cldf.
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
-	tls, err := MaybeLoadMCMSWithTimelockChainState(e.Chains[cfg.ChainSel], addrs)
+	tls, err := MaybeLoadMCMSWithTimelockChainState(evmChains[cfg.ChainSel], addrs)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
@@ -183,29 +186,29 @@ func TransferToDeployer(e cldf.Environment, cfg TransferToDeployerConfig) (cldf.
 	}
 	var salt [32]byte
 	binary.BigEndian.PutUint32(salt[:], uint32(time.Now().Unix()))
-	tx, err = tls.Timelock.ScheduleBatch(e.Chains[cfg.ChainSel].DeployerKey, calls, [32]byte{}, salt, big.NewInt(0))
-	if _, err = cldf.ConfirmIfNoErrorWithABI(e.Chains[cfg.ChainSel], tx, owner_helpers.RBACTimelockABI, err); err != nil {
+	tx, err = tls.Timelock.ScheduleBatch(evmChains[cfg.ChainSel].DeployerKey, calls, [32]byte{}, salt, big.NewInt(0))
+	if _, err = cldf.ConfirmIfNoErrorWithABI(evmChains[cfg.ChainSel], tx, owner_helpers.RBACTimelockABI, err); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
 	e.Logger.Infof("scheduled transfer ownership batch with tx %s", tx.Hash().Hex())
-	timelockExecutorProxy, err := owner_helpers.NewRBACTimelock(tls.CallProxy.Address(), e.Chains[cfg.ChainSel].Client)
+	timelockExecutorProxy, err := owner_helpers.NewRBACTimelock(tls.CallProxy.Address(), evmChains[cfg.ChainSel].Client)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("error creating timelock executor proxy: %w", err)
 	}
 
 	tx, err = timelockExecutorProxy.ExecuteBatch(
-		e.Chains[cfg.ChainSel].DeployerKey, calls, [32]byte{}, salt)
+		evmChains[cfg.ChainSel].DeployerKey, calls, [32]byte{}, salt)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("error executing batch: %w", err)
 	}
-	if _, err = cldf.ConfirmIfNoErrorWithABI(e.Chains[cfg.ChainSel], tx, owner_helpers.RBACTimelockABI, err); err != nil {
+	if _, err = cldf.ConfirmIfNoErrorWithABI(evmChains[cfg.ChainSel], tx, owner_helpers.RBACTimelockABI, err); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
 
 	e.Logger.Infof("executed transfer ownership to deployer key with tx %s", tx.Hash().Hex())
 
-	tx, err = ownable.AcceptOwnership(e.Chains[cfg.ChainSel].DeployerKey)
-	if _, err = cldf.ConfirmIfNoError(e.Chains[cfg.ChainSel], tx, err); err != nil {
+	tx, err = ownable.AcceptOwnership(evmChains[cfg.ChainSel].DeployerKey)
+	if _, err = cldf.ConfirmIfNoError(evmChains[cfg.ChainSel], tx, err); err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
 	e.Logger.Infof("deployer key accepted ownership tx %s", tx.Hash().Hex())
@@ -223,7 +226,7 @@ func (cfg RenounceTimelockDeployerConfig) Validate(e cldf.Environment) error {
 		return fmt.Errorf("invalid chain selector: %w", err)
 	}
 
-	_, ok := e.Chains[cfg.ChainSel]
+	_, ok := e.BlockChains.EVMChains()[cfg.ChainSel]
 	if !ok {
 		return fmt.Errorf("chain selector: %d not found in environment", cfg.ChainSel)
 	}
@@ -261,7 +264,7 @@ func RenounceTimelockDeployer(e cldf.Environment, cfg RenounceTimelockDeployerCo
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get admin role: %w", err)
 	}
 
-	chain := e.Chains[cfg.ChainSel]
+	chain := e.BlockChains.EVMChains()[cfg.ChainSel]
 	tx, err := tl.RenounceRole(chain.DeployerKey, admin, chain.DeployerKey.From)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to revoke deployer key: %w", err)

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
@@ -26,6 +26,7 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	e := memory.NewMemoryEnvironment(t, lggr, 0, memory.MemoryEnvironmentConfig{
 		Chains: 1,
+		Nodes:  1,
 	})
 	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	evmChains := e.BlockChains.EVMChains()
@@ -169,6 +170,7 @@ func TestRenounceTimelockDeployer(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	e := memory.NewMemoryEnvironment(t, lggr, 0, memory.MemoryEnvironmentConfig{
 		Chains: 1,
+		Nodes:  1,
 	})
 	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	e, err := Apply(t, e, nil,

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
@@ -26,9 +26,9 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	e := memory.NewMemoryEnvironment(t, lggr, 0, memory.MemoryEnvironmentConfig{
 		Chains: 1,
-		Nodes:  1,
 	})
 	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	evmChains := e.BlockChains.EVMChains()
 	e, err := Apply(t, e, nil,
 		Configure(
 			cldf.CreateLegacyChangeSet(DeployLinkToken),
@@ -44,9 +44,9 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 	require.NoError(t, err)
 	addrs, err := e.ExistingAddresses.AddressesForChain(chain1)
 	require.NoError(t, err)
-	state, err := MaybeLoadMCMSWithTimelockChainState(e.Chains[chain1], addrs)
+	state, err := MaybeLoadMCMSWithTimelockChainState(evmChains[chain1], addrs)
 	require.NoError(t, err)
-	link, err := MaybeLoadLinkTokenChainState(e.Chains[chain1], addrs)
+	link, err := MaybeLoadLinkTokenChainState(evmChains[chain1], addrs)
 	require.NoError(t, err)
 	e, err = Apply(t, e,
 		map[uint64]*proposalutils.TimelockExecutionContracts{
@@ -66,7 +66,7 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 	)
 	require.NoError(t, err)
 	// We expect now that the link token is owned by the MCMS timelock.
-	link, err = MaybeLoadLinkTokenChainState(e.Chains[chain1], addrs)
+	link, err = MaybeLoadLinkTokenChainState(evmChains[chain1], addrs)
 	require.NoError(t, err)
 	o, err := link.LinkToken.Owner(nil)
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 
 	o, err = link.LinkToken.Owner(nil)
 	require.NoError(t, err)
-	require.Equal(t, e.Chains[chain1].DeployerKey.From, o)
+	require.Equal(t, evmChains[chain1].DeployerKey.From, o)
 }
 
 func TestRenounceTimelockDeployerConfigValidate(t *testing.T) {
@@ -169,7 +169,6 @@ func TestRenounceTimelockDeployer(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	e := memory.NewMemoryEnvironment(t, lggr, 0, memory.MemoryEnvironmentConfig{
 		Chains: 1,
-		Nodes:  1,
 	})
 	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	e, err := Apply(t, e, nil,
@@ -184,7 +183,7 @@ func TestRenounceTimelockDeployer(t *testing.T) {
 	addrs, err := e.ExistingAddresses.AddressesForChain(chain1)
 	require.NoError(t, err)
 
-	state, err := MaybeLoadMCMSWithTimelockChainState(e.Chains[chain1], addrs)
+	state, err := MaybeLoadMCMSWithTimelockChainState(e.BlockChains.EVMChains()[chain1], addrs)
 	require.NoError(t, err)
 
 	tl := state.Timelock

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -41,13 +42,14 @@ func NewTimelockExecutionContracts(env cldf.Environment, chainSelector uint64) (
 	}
 	var timelock *owner_helpers.RBACTimelock
 	var callProxy *owner_helpers.CallProxy
+	evmChains := env.BlockChains.EVMChains()
 	for addr, tv := range addrTypeVer {
 		if tv.Type == types.RBACTimelock {
 			if timelock != nil {
 				return nil, fmt.Errorf("multiple timelocks found on chain %d", chainSelector)
 			}
 			var err error
-			timelock, err = owner_helpers.NewRBACTimelock(common.HexToAddress(addr), env.Chains[chainSelector].Client)
+			timelock, err = owner_helpers.NewRBACTimelock(common.HexToAddress(addr), evmChains[chainSelector].Client)
 			if err != nil {
 				return nil, fmt.Errorf("error creating timelock: %w", err)
 			}
@@ -57,7 +59,7 @@ func NewTimelockExecutionContracts(env cldf.Environment, chainSelector uint64) (
 				return nil, fmt.Errorf("multiple call proxies found on chain %d", chainSelector)
 			}
 			var err error
-			callProxy, err = owner_helpers.NewCallProxy(common.HexToAddress(addr), env.Chains[chainSelector].Client)
+			callProxy, err = owner_helpers.NewCallProxy(common.HexToAddress(addr), evmChains[chainSelector].Client)
 			if err != nil {
 				return nil, fmt.Errorf("error creating call proxy: %w", err)
 			}
@@ -120,7 +122,7 @@ func (state MCMSWithTimelockContracts) Validate() error {
 // - Found but was unable to load a contract
 // - It only found part of the bundle of contracts
 // - If found more than one instance of a contract (we expect one bundle in the given addresses)
-func MaybeLoadMCMSWithTimelockContracts(chain cldf.Chain, addresses map[string]cldf.TypeAndVersion) (*MCMSWithTimelockContracts, error) {
+func MaybeLoadMCMSWithTimelockContracts(chain cldf_evm.Chain, addresses map[string]cldf.TypeAndVersion) (*MCMSWithTimelockContracts, error) {
 	state := MCMSWithTimelockContracts{}
 	// We expect one of each contract on the chain.
 	timelock := cldf.NewTypeAndVersion(types.RBACTimelock, deployment.Version1_0_0)

--- a/deployment/common/proposalutils/mcms_test_helpers.go
+++ b/deployment/common/proposalutils/mcms_test_helpers.go
@@ -223,7 +223,7 @@ func ExecuteMCMSProposalV2(t *testing.T, env cldf.Environment, proposal *mcmslib
 
 		// no need to confirm transaction on solana as the MCMS sdk confirms it internally
 		if family == chainsel.FamilyEVM {
-			chain := env.Chains[uint64(chainSelector)]
+			chain := evmChains[uint64(chainSelector)]
 			evmTransaction := root.RawData.(*gethtypes.Transaction)
 			t.Logf("[ExecuteMCMSProposalV2] SetRoot EVM tx hash: %s", evmTransaction.Hash().String())
 			_, err = chain.Confirm(evmTransaction)
@@ -254,7 +254,7 @@ func ExecuteMCMSProposalV2(t *testing.T, env cldf.Environment, proposal *mcmslib
 		require.NoError(t, err)
 
 		if family == chainsel.FamilyEVM {
-			chain := env.Chains[uint64(op.ChainSelector)]
+			chain := evmChains[uint64(op.ChainSelector)]
 			evmTransaction := result.RawData.(*gethtypes.Transaction)
 			t.Logf("[ExecuteMCMSProposalV2] Operation %d EVM tx hash: %s", i, evmTransaction.Hash().String())
 			_, err = chain.Confirm(evmTransaction)

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -13,6 +13,7 @@ import (
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/smartcontractkit/mcms/types"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/state"
@@ -88,7 +89,7 @@ func (tc *TimelockConfig) validateCommon() error {
 	return nil
 }
 
-func (tc *TimelockConfig) Validate(chain cldf.Chain, s state.MCMSWithTimelockState) error {
+func (tc *TimelockConfig) Validate(chain cldf_evm.Chain, s state.MCMSWithTimelockState) error {
 	err := tc.validateCommon()
 	if err != nil {
 		return err

--- a/deployment/common/view/v1_0/link_token_test.go
+++ b/deployment/common/view/v1_0/link_token_test.go
@@ -11,7 +11,8 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/link_token"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
@@ -22,7 +23,7 @@ func TestLinkTokenView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	_, tx, lt, err := link_token.DeployLinkToken(chain.DeployerKey, chain.Client)
 	require.NoError(t, err)
 	_, err = chain.Confirm(tx)
@@ -35,14 +36,14 @@ func TestLinkTokenViewZk(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		ZkChains: 1,
 	})
-	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	_, _, lt, err := link_token.DeployLinkTokenZk(nil, chain.ClientZkSyncVM, chain.DeployerKeyZkSyncVM, chain.Client)
 	require.NoError(t, err)
 
 	testLinkTokenViewWithChain(t, chain, lt)
 }
 
-func testLinkTokenViewWithChain(t *testing.T, chain cldf.Chain, lt *link_token.LinkToken) {
+func testLinkTokenViewWithChain(t *testing.T, chain cldf_evm.Chain, lt *link_token.LinkToken) {
 	v, err := GenerateLinkTokenView(lt)
 	require.NoError(t, err)
 

--- a/deployment/common/view/v1_0/static_link_token_test.go
+++ b/deployment/common/view/v1_0/static_link_token_test.go
@@ -22,7 +22,7 @@ func TestStaticLinkTokenView(t *testing.T) {
 	e := memory.NewMemoryEnvironment(t, logger.TestLogger(t), zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 1,
 	})
-	chain := e.Chains[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
+	chain := e.BlockChains.EVMChains()[e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]]
 	_, tx, lt, err := link_token_interface.DeployLinkToken(chain.DeployerKey, chain.Client)
 	require.NoError(t, err)
 	_, err = chain.Confirm(tx)


### PR DESCRIPTION
## fix: migrate usage of evm to BlockChain - dev4

Breaking down the changes for the migration, there will be more PR with similar changes.

- Migrate `env.Chains` to `env.BlockChains.EVMChains()`
- Migrate `e.Chains` to `e.BlockChains.EVMChains()`
- Migrate `cldf.Chain` to `cldf_evm.Chain`

___
Issue: [CLD-290](https://smartcontract-it.atlassian.net/browse/CLD-290)

[CLD-290]: https://smartcontract-it.atlassian.net/browse/CLD-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ