### PR TITLE
fix: migrate usage of evm to BlockChain - dev8

### DIFF
--- a/deployment/exemplar/changeset/view.go
+++ b/deployment/exemplar/changeset/view.go
@@ -36,7 +36,7 @@ var ViewExemplar deployment.ViewState = func(e deployment.Environment) (json.Mar
 
 	// Get chain information
 	for _, chainSel := range e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)) {
-		chain := e.Chains[chainSel]
+		chain := e.BlockChains.EVMChains()[chainSel]
 		chainName := fmt.Sprintf("%s (%d)", chain.Name(), chainSel)
 		view.Chains = append(view.Chains, chainName)
 


### PR DESCRIPTION
## fix: migrate usage of evm to BlockChain - dev8

Breaking down the changes for the migration, there will be more PR with similar changes.

- Migrate `env.Chains` to `env.BlockChains.EVMChains()`
- Migrate `e.Chains` to `e.BlockChains.EVMChains()`
- Migrate `cldf.Chain` to `cldf_evm.Chain`

___
Issue: [CLD-290](https://smartcontract-it.atlassian.net/browse/CLD-290)

[CLD-290]: https://smartcontract-it.atlassian.net/browse/CLD-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ