### PR TITLE
feat: setup-go skip-all-caches

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,6 +4,9 @@ inputs:
   only-modules:
     description: Set to 'true' to only cache modules
     default: "false"
+  skip-all-caches:
+    description: Set to 'true' to only setup go, but do not restore or create any module or build caches.
+    default: "false"
   cache-version:
     description: Set this to cache bust
     default: "1"
@@ -65,7 +68,7 @@ runs:
     # We will only restore the cache by default (by calling actions/cache/restore) and let the
     # `go-mod-cache.yml` workflow handle the creation.
     - uses: actions/cache/restore@v4
-      if: ${{ inputs.restore-module-cache-only == 'true' }}
+      if: ${{ inputs.restore-module-cache-only == 'true' && inputs.skip-all-caches == 'false' }}
       name: Cache Go Modules
       with:
         path: |
@@ -79,7 +82,7 @@ runs:
     # If this is called, then it will create the cache entry upon a cache miss.
     # The cache is created after a cache miss, and after job completes successfully.
     - uses: actions/cache@v4
-      if: ${{ inputs.restore-module-cache-only != 'true' }}
+      if: ${{ inputs.restore-module-cache-only != 'true' && inputs.skip-all-caches == 'false'}}
       name: Cache Go Modules
       with:
         path: |
@@ -124,7 +127,7 @@ runs:
     #     - These "checkpoints" are always being created from scratch, rather than upserted.
     #     - Upserting increases the size of the cache over time, which is fine for PR branches, but not for develop.
     - name: Build Cache Key
-      if: ${{ inputs.only-modules == 'false' }}
+      if: ${{ inputs.only-modules == 'false' && inputs.skip-all-caches == 'false' }}
       id: build-cache-keys
       shell: bash
       env:
@@ -159,8 +162,7 @@ runs:
     #   2. If inputs.restore-build-cache-only == 'true'
     - uses: actions/cache/restore@v4
       name: Cache Go Build Outputs (restore)
-
-      if: ${{ inputs.only-modules == 'false' && (github.event_name == 'merge_group' || inputs.restore-build-cache-only == 'true') }}
+      if: ${{ inputs.only-modules == 'false' && (github.event_name == 'merge_group' || inputs.restore-build-cache-only == 'true') && inputs.skip-all-caches == 'false' }}
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
@@ -174,7 +176,7 @@ runs:
     # A negation of the above actions/cache/restore call.
     # This will create the cache entry upon a cache miss for the primary key.
     - uses: actions/cache@v4
-      if: ${{ inputs.only-modules == 'false' && (github.event_name != 'merge_group' && inputs.restore-build-cache-only == 'false') }}
+      if: ${{ inputs.only-modules == 'false' && (github.event_name != 'merge_group' && inputs.restore-build-cache-only == 'false') && inputs.skip-all-caches == 'false'}}
       id: build-cache
       name: Cache Go Build Outputs
       with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -857,7 +857,7 @@ jobs:
     environment: Integration
     runs-on: ubuntu-latest
     outputs:
-      sha: ${{ steps.getsha.outputs.sha }}
+      sha: ${{ steps.get-sha.outputs.sha }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
@@ -865,12 +865,18 @@ jobs:
           persist-credentials: false
           repository: smartcontractkit/chainlink
           ref: ${{ inputs.cl_ref || github.sha }}
+
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:
           only-modules: "true"
-      - name: Get the sha from go mod
-        id: getshortsha
+          skip-all-caches: "true" # we don't need to restore caches, as we are not building anything here
+
+      - name: Get Solana SHA
+        id: get-sha
+        env:
+          REPOSITORY: smartcontractkit/chainlink-solana
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sol_ver=$(go list -m -json github.com/smartcontractkit/chainlink-solana  | jq -r .Version)
           if [ -z "${sol_ver}" ]; then
@@ -879,26 +885,13 @@ jobs:
           fi
           short_sha="${sol_ver##*-}"
           echo "short sha is: ${short_sha}"
-          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
-      - name: Checkout solana
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          repository: smartcontractkit/chainlink-solana
-          ref: develop
-          fetch-depth: 0
-          path: solanapath
-      - name: Get long sha
-        id: getsha
-        run: |
-          cd solanapath
-          full_sha=$(git rev-parse ${{steps.getshortsha.outputs.short_sha}}^{}) # additional suffix allows handling tagged versions as well
+
+          full_sha=$(gh api repos/smartcontractkit/chainlink-solana/commits/${short_sha} --jq .sha)
           if [ -z "${full_sha}" ]; then
-              echo "Error: could not get the full sha from the short sha using git, look above for error(s)"
+              echo "Error: could not get the full sha from the short sha using gh cli, look above for error(s)"
               exit 1
           fi
-          echo "sha is: ${full_sha}"
-          echo "sha=${full_sha}" >> "$GITHUB_OUTPUT"
+          echo "sha=${full_sha}" | tee -a "$GITHUB_OUTPUT"
 
   get_projectserum_version:
     name: Get ProjectSerum Version


### PR DESCRIPTION
### Changes

- Add parameter `skip-all-caches` to `setup-go` composite action. This allows you to skip restoring of caches, when you simply need a go installation, and are not building anything that the module cache would help with.
- Utilize the `skip-all-caches` parameter in the e2e workflow, where we use go cli to get the short sha of chainlink-solana
	- Don't checkout `chainlink-solana` repo to get the full sha, and use `gh cli` instead


### Testing

After (18s): https://github.com/smartcontractkit/chainlink/actions/runs/15312714601/job/43080652607?pr=17933

Before (29s): https://github.com/smartcontractkit/chainlink/actions/runs/15325903516/job/43120246587

---

DX-916