### PR TITLE
fix: migrate usage of evm to BlockChain - dev11

### DIFF
--- a/integration-tests/smoke/ccip/ccip_add_chain_test.go
+++ b/integration-tests/smoke/ccip/ccip_add_chain_test.go
@@ -47,7 +47,7 @@ func Test_AddChain(t *testing.T) {
 		testhelpers.WithNoJobsAndContracts(),
 	)
 
-	allChains := maps.Keys(e.Env.Chains)
+	allChains := maps.Keys(e.Env.BlockChains.EVMChains())
 	slices.Sort(allChains)
 	toDeploy := e.Env.BlockChains.ListChainSelectors(
 		cldf_chain.WithFamily(chain_selectors.FamilyEVM),
@@ -121,7 +121,7 @@ func Test_AddChain(t *testing.T) {
 					DestChainSelector:   dest,
 				}] = gp.Value
 
-				latesthdr, err := e.Env.Chains[dest].Client.HeaderByNumber(testcontext.Get(t), nil)
+				latesthdr, err := e.Env.BlockChains.EVMChains()[dest].Client.HeaderByNumber(testcontext.Get(t), nil)
 				require.NoError(t, err)
 				block := latesthdr.Number.Uint64()
 				msgSentEvent := testhelpers.TestSendRequest(t, e.Env, state, source, dest, testRouter, router.ClientEVM2AnyMessage{
@@ -166,7 +166,7 @@ func Test_AddChain(t *testing.T) {
 	// 	// for all dests.
 	// 	err := ConfirmGasPriceUpdated(
 	// 		t,
-	// 		e.Env.Chains[sourceDestPair.DestChainSelector],
+	// 		e.Env.BlockChains.EVMChains()[sourceDestPair.DestChainSelector],
 	// 		state.Chains[sourceDestPair.SourceChainSelector].FeeQuoter,
 	// 		*startBlocks[sourceDestPair.DestChainSelector],
 	// 		preUpdateGp,

--- a/integration-tests/smoke/ccip/ccip_batching_test.go
+++ b/integration-tests/smoke/ccip/ccip_batching_test.go
@@ -58,7 +58,7 @@ func newBatchTestSetup(t *testing.T, opts ...testhelpers.TestOps) batchTestSetup
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
-	allChainSelectors := maps.Keys(e.Env.Chains)
+	allChainSelectors := maps.Keys(e.Env.BlockChains.EVMChains())
 	require.Len(t, allChainSelectors, 3, "this test expects 3 chains")
 	sourceChain1 := allChainSelectors[0]
 	sourceChain2 := allChainSelectors[1]
@@ -82,6 +82,7 @@ func Test_CCIPBatching_MaxBatchSizeEVM(t *testing.T) {
 	ctx := testhelpers.Context(t)
 	setup := newBatchTestSetup(t)
 	sourceChain1, sourceChain2, destChain, e, state := setup.sourceChain1, setup.sourceChain2, setup.destChain, setup.e, setup.state
+	evmChains := e.Env.BlockChains.EVMChains()
 
 	var (
 		startSeqNum = map[uint64]ccipocr3.SeqNum{
@@ -90,8 +91,8 @@ func Test_CCIPBatching_MaxBatchSizeEVM(t *testing.T) {
 		}
 		sourceChain = sourceChain1
 		transactors = []*bind.TransactOpts{
-			e.Env.Chains[sourceChain].DeployerKey,
-			e.Env.Chains[sourceChain].Users[0],
+			evmChains[sourceChain].DeployerKey,
+			evmChains[sourceChain].Users[0],
 		}
 		errs = make(chan error, len(transactors))
 	)
@@ -101,7 +102,7 @@ func Test_CCIPBatching_MaxBatchSizeEVM(t *testing.T) {
 			err := sendMessages(
 				ctx,
 				t,
-				e.Env.Chains[sourceChain],
+				evmChains[sourceChain],
 				transactor,
 				state.MustGetEVMChainState(sourceChain).OnRamp,
 				state.MustGetEVMChainState(sourceChain).Router,
@@ -130,7 +131,7 @@ func Test_CCIPBatching_MaxBatchSizeEVM(t *testing.T) {
 	_, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		sourceChain,
-		e.Env.Chains[destChain],
+		evmChains[destChain],
 		state.MustGetEVMChainState(destChain).OffRamp,
 		nil, // startBlock
 		ccipocr3.NewSeqNumRange(
@@ -309,6 +310,7 @@ func ccipBatchingSingleSource(t *testing.T, opts ...testhelpers.TestOps) {
 	ctx := testhelpers.Context(t)
 	setup := newBatchTestSetup(t, opts...)
 	sourceChain1, sourceChain2, destChain, e, state := setup.sourceChain1, setup.sourceChain2, setup.destChain, setup.e, setup.state
+	evmChains := e.Env.BlockChains.EVMChains()
 
 	var (
 		startSeqNum = map[uint64]ccipocr3.SeqNum{
@@ -323,8 +325,8 @@ func ccipBatchingSingleSource(t *testing.T, opts ...testhelpers.TestOps) {
 	err := sendMessages(
 		ctx,
 		t,
-		e.Env.Chains[sourceChain],
-		e.Env.Chains[sourceChain].DeployerKey,
+		evmChains[sourceChain],
+		evmChains[sourceChain].DeployerKey,
 		state.MustGetEVMChainState(sourceChain).OnRamp,
 		state.MustGetEVMChainState(sourceChain).Router,
 		state.MustGetEVMChainState(sourceChain).Multicall3,
@@ -337,7 +339,7 @@ func ccipBatchingSingleSource(t *testing.T, opts ...testhelpers.TestOps) {
 	_, err = testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		sourceChain,
-		e.Env.Chains[destChain],
+		evmChains[destChain],
 		state.MustGetEVMChainState(destChain).OffRamp,
 		nil,
 		ccipocr3.NewSeqNumRange(startSeqNum[sourceChain], startSeqNum[sourceChain]+numMessages-1),
@@ -348,7 +350,7 @@ func ccipBatchingSingleSource(t *testing.T, opts ...testhelpers.TestOps) {
 	states, err := testhelpers.ConfirmExecWithSeqNrs(
 		t,
 		sourceChain,
-		e.Env.Chains[destChain],
+		evmChains[destChain],
 		state.MustGetEVMChainState(destChain).OffRamp,
 		nil,
 		genSeqNrRange(startSeqNum[sourceChain], startSeqNum[sourceChain]+numMessages-1),
@@ -379,7 +381,7 @@ func assertExecAsync(
 	states, err := testhelpers.ConfirmExecWithSeqNrs(
 		t,
 		sourceChainSelector,
-		e.Env.Chains[destChainSelector],
+		e.Env.BlockChains.EVMChains()[destChainSelector],
 		state.MustGetEVMChainState(destChainSelector).OffRamp,
 		nil,
 		seqNums,
@@ -403,7 +405,7 @@ func assertCommitReportsAsync(
 	commitReport, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		sourceChainSelector,
-		e.Env.Chains[destChainSelector],
+		e.Env.BlockChains.EVMChains()[destChainSelector],
 		state.MustGetEVMChainState(destChainSelector).OffRamp,
 		nil,
 		ccipocr3.NewSeqNumRange(startSeqNum, endSeqNum),
@@ -437,8 +439,8 @@ func sendMessagesAsync(
 		err = sendMessages(
 			ctx,
 			t,
-			e.Env.Chains[sourceChainSelector],
-			e.Env.Chains[sourceChainSelector].DeployerKey,
+			e.Env.BlockChains.EVMChains()[sourceChainSelector],
+			e.Env.BlockChains.EVMChains()[sourceChainSelector].DeployerKey,
 			state.MustGetEVMChainState(sourceChainSelector).OnRamp,
 			state.MustGetEVMChainState(sourceChainSelector).Router,
 			state.MustGetEVMChainState(sourceChainSelector).Multicall3,

--- a/integration-tests/smoke/ccip/ccip_batching_test.go
+++ b/integration-tests/smoke/ccip/ccip_batching_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
@@ -462,7 +463,7 @@ func sendMessagesAsync(
 func sendMessages(
 	ctx context.Context,
 	t *testing.T,
-	sourceChain cldf.Chain,
+	sourceChain cldf_evm.Chain,
 	sourceTransactOpts *bind.TransactOpts,
 	sourceOnRamp onramp.OnRampInterface,
 	sourceRouter *router.Router,

--- a/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
@@ -294,9 +294,9 @@ func updateRMNConfig(t *testing.T, tc updateRMNConfigTestCase) {
 	for _, nop := range tc.nops {
 		signers = append(signers, nop.ToRMNRemoteSigner())
 	}
-
-	remoteConfigs := make(map[uint64]ccipops.RMNRemoteConfig, len(e.Env.Chains))
-	for _, chain := range e.Env.Chains {
+	evmChains := e.Env.BlockChains.EVMChains()
+	remoteConfigs := make(map[uint64]ccipops.RMNRemoteConfig, len(evmChains))
+	for _, chain := range evmChains {
 		remoteConfig := ccipops.RMNRemoteConfig{
 			Signers: signers,
 			F:       0,
@@ -414,7 +414,7 @@ func TestSetRMNRemoteOnRMNProxy(t *testing.T) {
 				HomeChainSel:     e.HomeChainSel,
 				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
 				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
-				NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.Chains[e.HomeChainSel].DeployerKey.From),
+				NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.BlockChains.EVMChains()[e.HomeChainSel].DeployerKey.From),
 				NodeP2PIDsPerNodeOpAdmin: map[string][][32]byte{
 					"NodeOperator": envNodes.NonBootstraps().PeerIDs(),
 				},

--- a/integration-tests/smoke/ccip/ccip_fees_test.go
+++ b/integration-tests/smoke/ccip/ccip_fees_test.go
@@ -105,15 +105,14 @@ func setupTokens(
 ) {
 	lggr := logger.TestLogger(t)
 	e := tenv.Env
-	evmChains := e.BlockChains.EVMChains()
 	// Deploy the token to test transferring
 	srcToken, _, dstToken, _, err := testhelpers.DeployTransferableToken(
 		lggr,
-		evmChains,
+		tenv.Env.BlockChains.EVMChains(),
 		src,
 		dest,
-		evmChains[src].DeployerKey,
-		evmChains[dest].DeployerKey,
+		tenv.Env.BlockChains.EVMChains()[src].DeployerKey,
+		tenv.Env.BlockChains.EVMChains()[dest].DeployerKey,
 		state,
 		tenv.Env.ExistingAddresses,
 		"MY_TOKEN",
@@ -121,47 +120,48 @@ func setupTokens(
 	require.NoError(t, err)
 
 	linkToken := state.MustGetEVMChainState(src).LinkToken
+	evmChains := e.BlockChains.EVMChains()
 
 	tx, err := srcToken.Mint(
-		e.Chains[src].DeployerKey,
-		e.Chains[src].DeployerKey.From,
+		evmChains[src].DeployerKey,
+		evmChains[src].DeployerKey.From,
 		transferTokenMintAmount,
 	)
-	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
+	_, err = cldf.ConfirmIfNoError(evmChains[src], tx, err)
 	require.NoError(t, err)
 
 	// Mint a destination token
 	tx, err = dstToken.Mint(
-		e.Chains[dest].DeployerKey,
-		e.Chains[dest].DeployerKey.From,
+		evmChains[dest].DeployerKey,
+		evmChains[dest].DeployerKey.From,
 		transferTokenMintAmount,
 	)
-	_, err = cldf.ConfirmIfNoError(e.Chains[dest], tx, err)
+	_, err = cldf.ConfirmIfNoError(evmChains[dest], tx, err)
 	require.NoError(t, err)
 
 	// Approve the router to spend the tokens and confirm the tx's
 	// To prevent having to approve the router for every transfer, we approve a sufficiently large amount
-	tx, err = srcToken.Approve(e.Chains[src].DeployerKey, state.MustGetEVMChainState(src).Router.Address(), math.MaxBig256)
-	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
+	tx, err = srcToken.Approve(evmChains[src].DeployerKey, state.MustGetEVMChainState(src).Router.Address(), math.MaxBig256)
+	_, err = cldf.ConfirmIfNoError(evmChains[src], tx, err)
 	require.NoError(t, err)
 
-	tx, err = dstToken.Approve(e.Chains[dest].DeployerKey, state.MustGetEVMChainState(dest).Router.Address(), math.MaxBig256)
-	_, err = cldf.ConfirmIfNoError(e.Chains[dest], tx, err)
+	tx, err = dstToken.Approve(evmChains[dest].DeployerKey, state.MustGetEVMChainState(dest).Router.Address(), math.MaxBig256)
+	_, err = cldf.ConfirmIfNoError(evmChains[dest], tx, err)
 	require.NoError(t, err)
 
 	// Grant mint and burn roles to the deployer key for the newly deployed linkToken
 	// Since those roles are not granted automatically
-	tx, err = linkToken.GrantMintAndBurnRoles(e.Chains[src].DeployerKey, e.Chains[src].DeployerKey.From)
-	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
+	tx, err = linkToken.GrantMintAndBurnRoles(evmChains[src].DeployerKey, evmChains[src].DeployerKey.From)
+	_, err = cldf.ConfirmIfNoError(evmChains[src], tx, err)
 	require.NoError(t, err)
 
 	// Mint link token and confirm the tx
 	tx, err = linkToken.Mint(
-		e.Chains[src].DeployerKey,
-		e.Chains[src].DeployerKey.From,
+		evmChains[src].DeployerKey,
+		evmChains[src].DeployerKey.From,
 		feeTokenMintAmount,
 	)
-	_, err = cldf.ConfirmIfNoError(e.Chains[src], tx, err)
+	_, err = cldf.ConfirmIfNoError(evmChains[src], tx, err)
 	require.NoError(t, err)
 
 	return srcToken, dstToken
@@ -247,7 +247,7 @@ func Test_CCIPFees(t *testing.T) {
 	})
 
 	t.Run("Send programmable toke transfer pay with custom fee token", func(t *testing.T) {
-		feeToken := setupNewFeeToken(t, tenv, e.Chains[sourceChain].DeployerKey, sourceChain, state, "FEE", 18)
+		feeToken := setupNewFeeToken(t, tenv, e.BlockChains.EVMChains()[sourceChain].DeployerKey, sourceChain, state, "FEE", 18)
 		feestest.RunFeeTokenTestCase(feestest.NewFeeTokenTestCase(
 			t,
 			e,
@@ -317,7 +317,7 @@ func Test_CCIPFees(t *testing.T) {
 			e,
 			state,
 			&testhelpers.CCIPSendReqConfig{
-				Sender:       e.Chains[sourceChain].DeployerKey,
+				Sender:       e.BlockChains.EVMChains()[sourceChain].DeployerKey,
 				IsTestRouter: true,
 				SourceChain:  sourceChain,
 				DestChain:    destChain,
@@ -382,7 +382,7 @@ func Test_CCIPFees(t *testing.T) {
 	})
 
 	t.Run("Send message pay with custom fee token", func(t *testing.T) {
-		feeToken := setupNewFeeToken(t, tenv, e.Chains[sourceChain].DeployerKey, sourceChain, state, "FEE", 18)
+		feeToken := setupNewFeeToken(t, tenv, e.BlockChains.EVMChains()[sourceChain].DeployerKey, sourceChain, state, "FEE", 18)
 		feestest.RunFeeTokenTestCase(feestest.NewFeeTokenTestCase(
 			t,
 			e,

--- a/integration-tests/smoke/ccip/ccip_fees_test.go
+++ b/integration-tests/smoke/ccip/ccip_fees_test.go
@@ -37,7 +37,7 @@ func setupNewFeeToken(
 	tokenDecimals uint8,
 ) (feeToken *burn_mint_erc677.BurnMintERC677) {
 	lggr := logger.TestLogger(t)
-	chain := tenv.Env.Chains[chainSelector]
+	chain := tenv.Env.BlockChains.EVMChains()[chainSelector]
 	tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
 		deployer,
 		chain.Client,
@@ -105,15 +105,15 @@ func setupTokens(
 ) {
 	lggr := logger.TestLogger(t)
 	e := tenv.Env
-
+	evmChains := e.BlockChains.EVMChains()
 	// Deploy the token to test transferring
 	srcToken, _, dstToken, _, err := testhelpers.DeployTransferableToken(
 		lggr,
-		tenv.Env.Chains,
+		evmChains,
 		src,
 		dest,
-		tenv.Env.Chains[src].DeployerKey,
-		tenv.Env.Chains[dest].DeployerKey,
+		evmChains[src].DeployerKey,
+		evmChains[dest].DeployerKey,
 		state,
 		tenv.Env.ExistingAddresses,
 		"MY_TOKEN",

--- a/integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
+++ b/integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
@@ -36,7 +36,7 @@ func Test_CCIPGasPriceUpdatesWriteFrequency(t *testing.T) {
 	require.NoError(t, err)
 	testhelpers.AddLanesForAll(t, &e, state)
 
-	allChainSelectors := maps.Keys(e.Env.Chains)
+	allChainSelectors := maps.Keys(e.Env.BlockChains.EVMChains())
 	assert.GreaterOrEqual(t, len(allChainSelectors), 2, "test requires at least 2 chains")
 
 	sourceChain1 := allChainSelectors[0]
@@ -142,7 +142,7 @@ func Test_CCIPGasPriceUpdatesDeviation(t *testing.T) {
 	require.NoError(t, err)
 	testhelpers.AddLanesForAll(t, &e, state)
 
-	allChainSelectors := maps.Keys(e.Env.Chains)
+	allChainSelectors := maps.Keys(e.Env.BlockChains.EVMChains())
 	assert.GreaterOrEqual(t, len(allChainSelectors), 2, "test requires at least 2 chains")
 
 	sourceChain1 := allChainSelectors[0]

--- a/integration-tests/smoke/ccip/ccip_message_limitations_test.go
+++ b/integration-tests/smoke/ccip/ccip_message_limitations_test.go
@@ -27,7 +27,7 @@ func Test_CCIPMessageLimitations(t *testing.T) {
 	callOpts := &bind.CallOpts{Context: ctx}
 
 	testEnv, _, _ := testsetups.NewIntegrationEnvironment(t)
-	chains := maps.Keys(testEnv.Env.Chains)
+	chains := maps.Keys(testEnv.Env.BlockChains.EVMChains())
 
 	onChainState, err := stateview.LoadOnchainState(testEnv.Env)
 	require.NoError(t, err)

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -61,7 +61,7 @@ func Test_CCIPMessaging_EVM2EVM(t *testing.T) {
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
-	allChainSelectors := maps.Keys(e.Env.Chains)
+	allChainSelectors := maps.Keys(e.Env.BlockChains.EVMChains())
 	require.Len(t, allChainSelectors, 2)
 	sourceChain := chains[0].Selector
 	destChain := chains[1].Selector
@@ -79,7 +79,7 @@ func Test_CCIPMessaging_EVM2EVM(t *testing.T) {
 	var (
 		replayed bool
 		nonce    uint64
-		sender   = common.LeftPadBytes(e.Env.Chains[sourceChain].DeployerKey.From.Bytes(), 32)
+		sender   = common.LeftPadBytes(e.Env.BlockChains.EVMChains()[sourceChain].DeployerKey.From.Bytes(), 32)
 		out      mt.TestCaseOutput
 		setup    = mt.NewTestSetupWithDeployedEnv(
 			t,
@@ -245,7 +245,7 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 	var (
 		replayed bool
 		// nonce    uint64 // Nonce not used as Solana check is skipped
-		sender = common.LeftPadBytes(e.Env.Chains[sourceChain].DeployerKey.From.Bytes(), 32)
+		sender = common.LeftPadBytes(e.Env.BlockChains.EVMChains()[sourceChain].DeployerKey.From.Bytes(), 32)
 		out    mt.TestCaseOutput
 		setup  = mt.NewTestSetupWithDeployedEnv(
 			t,

--- a/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
+++ b/integration-tests/smoke/ccip/ccip_migration_to_v_1_6_test.go
@@ -110,7 +110,7 @@ func TestV1_5_Message_RMNRemote(t *testing.T) {
 	evmContractParams := make(map[uint64]ccipseq.ChainContractParams)
 	evmChains := []uint64{}
 	for _, chain := range allChains {
-		if _, ok := e.Env.Chains[chain]; ok {
+		if _, ok := e.Env.BlockChains.EVMChains()[chain]; ok {
 			evmChains = append(evmChains, chain)
 		}
 	}
@@ -128,7 +128,7 @@ func TestV1_5_Message_RMNRemote(t *testing.T) {
 				HomeChainSel:     e.HomeChainSel,
 				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
 				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
-				NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.Chains[e.HomeChainSel].DeployerKey.From),
+				NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.BlockChains.EVMChains()[e.HomeChainSel].DeployerKey.From),
 				NodeP2PIDsPerNodeOpAdmin: map[string][][32]byte{
 					testhelpers.TestNodeOperator: envNodes.NonBootstraps().PeerIDs(),
 				},
@@ -169,9 +169,9 @@ func TestV1_5_Message_RMNRemote(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, sentEvent)
-	destChain := e.Env.Chains[dest]
+	destChain := e.Env.BlockChains.EVMChains()[dest]
 	require.NoError(t, err)
-	v1_5testhelpers.WaitForCommit(t, e.Env.Chains[src1], destChain, oldState.MustGetEVMChainState(dest).CommitStore[src1],
+	v1_5testhelpers.WaitForCommit(t, e.Env.BlockChains.EVMChains()[src1], destChain, oldState.MustGetEVMChainState(dest).CommitStore[src1],
 		sentEvent.Message.SequenceNumber)
 }
 
@@ -236,7 +236,7 @@ func TestV1_5_Message_RMNRemote_Curse(t *testing.T) {
 	evmContractParams := make(map[uint64]ccipseq.ChainContractParams)
 	evmChains := []uint64{}
 	for _, chain := range allChains {
-		if _, ok := e.Env.Chains[chain]; ok {
+		if _, ok := e.Env.BlockChains.EVMChains()[chain]; ok {
 			evmChains = append(evmChains, chain)
 		}
 	}
@@ -254,7 +254,7 @@ func TestV1_5_Message_RMNRemote_Curse(t *testing.T) {
 				HomeChainSel:     e.HomeChainSel,
 				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
 				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
-				NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.Chains[e.HomeChainSel].DeployerKey.From),
+				NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.BlockChains.EVMChains()[e.HomeChainSel].DeployerKey.From),
 				NodeP2PIDsPerNodeOpAdmin: map[string][][32]byte{
 					testhelpers.TestNodeOperator: envNodes.NonBootstraps().PeerIDs(),
 				},
@@ -304,9 +304,9 @@ func TestV1_5_Message_RMNRemote_Curse(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, sentEvent)
-	destChain := e.Env.Chains[dest]
+	destChain := e.Env.BlockChains.EVMChains()[dest]
 	require.NoError(t, err)
-	v1_5testhelpers.WaitForNoCommit(t, e.Env.Chains[src1], destChain, oldState.MustGetEVMChainState(dest).CommitStore[src1],
+	v1_5testhelpers.WaitForNoCommit(t, e.Env.BlockChains.EVMChains()[src1], destChain, oldState.MustGetEVMChainState(dest).CommitStore[src1],
 		sentEvent.Message.SequenceNumber)
 }
 
@@ -372,7 +372,7 @@ func TestV1_5_Message_RMNRemote_Curse_Uncurse(t *testing.T) {
 	evmContractParams := make(map[uint64]ccipseq.ChainContractParams)
 	evmChains := []uint64{}
 	for _, chain := range allChains {
-		if _, ok := e.Env.Chains[chain]; ok {
+		if _, ok := e.Env.BlockChains.EVMChains()[chain]; ok {
 			evmChains = append(evmChains, chain)
 		}
 	}
@@ -390,7 +390,7 @@ func TestV1_5_Message_RMNRemote_Curse_Uncurse(t *testing.T) {
 				HomeChainSel:     e.HomeChainSel,
 				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
 				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
-				NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.Chains[e.HomeChainSel].DeployerKey.From),
+				NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.BlockChains.EVMChains()[e.HomeChainSel].DeployerKey.From),
 				NodeP2PIDsPerNodeOpAdmin: map[string][][32]byte{
 					testhelpers.TestNodeOperator: envNodes.NonBootstraps().PeerIDs(),
 				},
@@ -441,13 +441,13 @@ func TestV1_5_Message_RMNRemote_Curse_Uncurse(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, sentEvent)
-	destChain := e.Env.Chains[dest]
-	v1_5testhelpers.WaitForNoCommit(t, e.Env.Chains[src1], destChain, oldState.MustGetEVMChainState(dest).CommitStore[src1],
+	destChain := e.Env.BlockChains.EVMChains()[dest]
+	v1_5testhelpers.WaitForNoCommit(t, e.Env.BlockChains.EVMChains()[src1], destChain, oldState.MustGetEVMChainState(dest).CommitStore[src1],
 		sentEvent.Message.SequenceNumber)
 
 	commitFound := make(chan struct{})
 	go func() {
-		v1_5testhelpers.WaitForCommit(t, e.Env.Chains[src1], destChain, oldState.MustGetEVMChainState(dest).CommitStore[src1],
+		v1_5testhelpers.WaitForCommit(t, e.Env.BlockChains.EVMChains()[src1], destChain, oldState.MustGetEVMChainState(dest).CommitStore[src1],
 			sentEvent.Message.SequenceNumber)
 		commitFound <- struct{}{}
 	}()
@@ -595,12 +595,13 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, sentEvent)
-	destChain := e.Env.Chains[dest]
+	evmChains := e.Env.BlockChains.EVMChains()
+	destChain := evmChains[dest]
 	destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
 	require.NoError(t, err)
-	v1_5testhelpers.WaitForCommit(t, e.Env.Chains[src2], destChain, state.MustGetEVMChainState(dest).CommitStore[src2],
+	v1_5testhelpers.WaitForCommit(t, evmChains[src2], destChain, state.MustGetEVMChainState(dest).CommitStore[src2],
 		sentEvent.Message.SequenceNumber)
-	v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src2], destChain, state.MustGetEVMChainState(dest).EVM2EVMOffRamp[src2],
+	v1_5testhelpers.WaitForExecute(t, evmChains[src2], destChain, state.MustGetEVMChainState(dest).EVM2EVMOffRamp[src2],
 		[]uint64{sentEvent.Message.SequenceNumber}, destStartBlock.Number.Uint64())
 
 	// now that all 1.5 lanes work transfer ownership of the contracts to MCMS
@@ -700,7 +701,7 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	require.GreaterOrEqual(t, len(e.Users[src1]), 2)
 	testhelpers.ReplayLogs(t, e.Env.Offchain, e.ReplayBlocks)
 	startBlocks := make(map[uint64]*uint64)
-	latesthdr, err := e.Env.Chains[dest].Client.HeaderByNumber(testcontext.Get(t), nil)
+	latesthdr, err := e.Env.BlockChains.EVMChains()[dest].Client.HeaderByNumber(testcontext.Get(t), nil)
 	require.NoError(t, err)
 	block := latesthdr.Number.Uint64()
 	startBlocks[dest] = &block
@@ -813,7 +814,8 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, sentEvent)
 
-	v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src2], e.Env.Chains[dest], state.MustGetEVMChainState(dest).EVM2EVMOffRamp[src2],
+	evmChains = e.Env.BlockChains.EVMChains()
+	v1_5testhelpers.WaitForExecute(t, evmChains[src2], evmChains[dest], state.MustGetEVMChainState(dest).EVM2EVMOffRamp[src2],
 		[]uint64{sentEventOnOtherLane.Message.SequenceNumber}, destStartBlock.Number.Uint64())
 
 	// stop the continuous messages in real router
@@ -821,9 +823,9 @@ func TestMigrateFromV1_5ToV1_6(t *testing.T) {
 	wg.Wait()
 	// start validating the messages sent in 1.5 and 1.6
 	for _, msg := range v1_5Msgs {
-		v1_5testhelpers.WaitForCommit(t, e.Env.Chains[src1], destChain, state.MustGetEVMChainState(dest).CommitStore[src1],
+		v1_5testhelpers.WaitForCommit(t, evmChains[src1], destChain, state.MustGetEVMChainState(dest).CommitStore[src1],
 			msg.Message.SequenceNumber)
-		v1_5testhelpers.WaitForExecute(t, e.Env.Chains[src1], destChain, state.MustGetEVMChainState(dest).EVM2EVMOffRamp[src1],
+		v1_5testhelpers.WaitForExecute(t, evmChains[src1], destChain, state.MustGetEVMChainState(dest).EVM2EVMOffRamp[src1],
 			[]uint64{msg.Message.SequenceNumber}, initialBlock)
 		lastNonce = msg.Message.Nonce
 	}
@@ -874,7 +876,7 @@ func sendContinuousMessages(
 			case *evm_2_evm_onramp.EVM2EVMOnRampCCIPSendRequested:
 				v1_5Msgs = append(v1_5Msgs, msg)
 				if initialDestBlock == 0 {
-					destChain := e.Env.Chains[dest]
+					destChain := e.Env.BlockChains.EVMChains()[dest]
 					destStartBlock, err := destChain.Client.HeaderByNumber(context.Background(), nil)
 					if err != nil {
 						t.Errorf("failed to get block header")
@@ -900,7 +902,7 @@ func sendMessageInRealRouter(
 	cfg := &testhelpers.CCIPSendReqConfig{
 		SourceChain:  src,
 		DestChain:    dest,
-		Sender:       e.Env.Chains[src].DeployerKey,
+		Sender:       e.Env.BlockChains.EVMChains()[src].DeployerKey,
 		IsTestRouter: false,
 		Message: router.ClientEVM2AnyMessage{
 			Receiver:     common.LeftPadBytes(state.MustGetEVMChainState(dest).Receiver.Address().Bytes(), 32),
@@ -917,7 +919,7 @@ func sendMessageInRealRouter(
 	if err != nil {
 		t.Errorf("failed to send message: %v", err)
 	}
-	receipt, err := e.Env.Chains[src].Client.TransactionReceipt(context.Background(), tx.Hash())
+	receipt, err := e.Env.BlockChains.EVMChains()[src].Client.TransactionReceipt(context.Background(), tx.Hash())
 	if err != nil {
 		t.Errorf("failed to get transaction receipt: %v", err)
 	}

--- a/integration-tests/smoke/ccip/ccip_ooo_execution_test.go
+++ b/integration-tests/smoke/ccip/ccip_ooo_execution_test.go
@@ -46,10 +46,11 @@ func Test_OutOfOrderExecution(t *testing.T) {
 	state, err := stateview.LoadOnchainState(e)
 	require.NoError(t, err)
 
-	allChainSelectors := maps.Keys(e.Chains)
+	evmChains := e.BlockChains.EVMChains()
+	allChainSelectors := maps.Keys(evmChains)
 	sourceChain, destChain := allChainSelectors[0], allChainSelectors[1]
-	ownerSourceChain := e.Chains[sourceChain].DeployerKey
-	ownerDestChain := e.Chains[destChain].DeployerKey
+	ownerSourceChain := evmChains[sourceChain].DeployerKey
+	ownerDestChain := evmChains[destChain].DeployerKey
 
 	anotherSender, err := pickFirstAvailableUser(tenv, sourceChain, e)
 	require.NoError(t, err)
@@ -69,12 +70,12 @@ func Test_OutOfOrderExecution(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	srcUSDC, destUSDC, err := testhelpers.ConfigureUSDCTokenPools(lggr, e.Chains, sourceChain, destChain, state)
+	srcUSDC, destUSDC, err := testhelpers.ConfigureUSDCTokenPools(lggr, evmChains, sourceChain, destChain, state)
 	require.NoError(t, err)
 
-	err = testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, e.Chains[sourceChain], destChain)
+	err = testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, evmChains[sourceChain], destChain)
 	require.NoError(t, err)
-	err = testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, e.Chains[destChain], sourceChain)
+	err = testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, evmChains[destChain], sourceChain)
 	require.NoError(t, err)
 
 	testhelpers.MintAndAllow(
@@ -111,7 +112,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 	startBlocks := make(map[uint64]*uint64)
 	expectedStatuses := make(map[uint64]int)
 
-	latesthdr, err := e.Chains[destChain].Client.HeaderByNumber(ctx, nil)
+	latesthdr, err := evmChains[destChain].Client.HeaderByNumber(ctx, nil)
 	require.NoError(t, err)
 	block := latesthdr.Number.Uint64()
 	startBlocks[destChain] = &block
@@ -221,7 +222,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 	_, err = testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		sourceChain,
-		e.Chains[destChain],
+		evmChains[destChain],
 		state.MustGetEVMChainState(destChain).OffRamp,
 		startBlocks[destChain],
 		ccipocr3.NewSeqNumRange(
@@ -256,11 +257,11 @@ func Test_OutOfOrderExecution(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint8(testhelpers.EXECUTION_STATE_UNTOUCHED), thirdMsgState)
 
-	testhelpers.WaitForTheTokenBalance(ctx, t, destToken.Address(), firstReceiver, e.Chains[destChain], oneE18)
-	testhelpers.WaitForTheTokenBalance(ctx, t, destUSDC.Address(), secondReceiver, e.Chains[destChain], big.NewInt(0))
-	testhelpers.WaitForTheTokenBalance(ctx, t, destToken.Address(), thirdReceiver, e.Chains[destChain], big.NewInt(0))
-	testhelpers.WaitForTheTokenBalance(ctx, t, destToken.Address(), fourthReceiver, e.Chains[destChain], oneE18)
-	testhelpers.WaitForTheTokenBalance(ctx, t, destToken.Address(), fifthReceiver, e.Chains[destChain], oneE18)
+	testhelpers.WaitForTheTokenBalance(ctx, t, destToken.Address(), firstReceiver, evmChains[destChain], oneE18)
+	testhelpers.WaitForTheTokenBalance(ctx, t, destUSDC.Address(), secondReceiver, evmChains[destChain], big.NewInt(0))
+	testhelpers.WaitForTheTokenBalance(ctx, t, destToken.Address(), thirdReceiver, evmChains[destChain], big.NewInt(0))
+	testhelpers.WaitForTheTokenBalance(ctx, t, destToken.Address(), fourthReceiver, evmChains[destChain], oneE18)
+	testhelpers.WaitForTheTokenBalance(ctx, t, destToken.Address(), fifthReceiver, evmChains[destChain], oneE18)
 }
 
 func pickFirstAvailableUser(
@@ -272,7 +273,7 @@ func pickFirstAvailableUser(
 		if user == nil {
 			continue
 		}
-		if user.From != e.Chains[sourceChain].DeployerKey.From {
+		if user.From != e.BlockChains.EVMChains()[sourceChain].DeployerKey.From {
 			return user, nil
 		}
 	}

--- a/integration-tests/smoke/ccip/ccip_ooo_execution_test.go
+++ b/integration-tests/smoke/ccip/ccip_ooo_execution_test.go
@@ -58,7 +58,7 @@ func Test_OutOfOrderExecution(t *testing.T) {
 
 	srcToken, _, destToken, _, err := testhelpers.DeployTransferableToken(
 		lggr,
-		tenv.Env.Chains,
+		tenv.Env.BlockChains.EVMChains(),
 		sourceChain,
 		destChain,
 		ownerSourceChain,

--- a/integration-tests/smoke/ccip/ccip_reader_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_test.go
@@ -1206,7 +1206,7 @@ func Test_GetChainFeePriceUpdates(t *testing.T) {
 	source1GasPrice := big.NewInt(987654321) // Use a distinct value for source1
 	source2GasPrice := big.NewInt(123456789) // Use a distinct value for source2
 	_, err = feeQuoterDest.UpdatePrices(
-		env.Env.Chains[dest].DeployerKey, fee_quoter.InternalPriceUpdates{
+		env.Env.BlockChains.EVMChains()[dest].DeployerKey, fee_quoter.InternalPriceUpdates{
 			GasPriceUpdates: []fee_quoter.InternalGasPriceUpdate{
 				{
 					DestChainSelector: source1, // Corresponds to sending message *to* source1
@@ -1220,7 +1220,7 @@ func Test_GetChainFeePriceUpdates(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	be := env.Env.Chains[dest].Client.(*memory.Backend)
+	be := env.Env.BlockChains.EVMChains()[dest].Client.(*memory.Backend)
 	be.Commit()
 
 	// Verify the updates took effect on-chain (optional sanity check)
@@ -1839,7 +1839,7 @@ func testSetupRealContracts(
 
 	var crs = make(map[cciptypes.ChainSelector]contractreader.Extended)
 	for chain, bindings := range toBindContracts {
-		be := env.Env.Chains[uint64(chain)].Client.(*memory.Backend)
+		be := env.Env.BlockChains.EVMChains()[uint64(chain)].Client.(*memory.Backend)
 		cl := client.NewSimulatedBackendClient(t, be.Sim, big.NewInt(0).SetUint64(uint64(chain)))
 		headTracker := headstest.NewSimulatedHeadTracker(cl, lpOpts.UseFinalityTag, lpOpts.FinalityDepth)
 		lp := logpoller.NewLogPoller(logpoller.NewORM(big.NewInt(0).SetUint64(uint64(chain)), db, lggr),

--- a/integration-tests/smoke/ccip/ccip_reorg_test.go
+++ b/integration-tests/smoke/ccip/ccip_reorg_test.go
@@ -113,7 +113,7 @@ func Test_CCIPReorg_BelowFinality_OnSource(t *testing.T) {
 	_, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		sourceSelector,
-		e.Env.Chains[destSelector],
+		e.Env.BlockChains.EVMChains()[destSelector],
 		state.MustGetEVMChainState(destSelector).OffRamp,
 		nil, // startBlock
 		ccipocr3.NewSeqNumRange(1, 1),
@@ -126,6 +126,7 @@ func Test_CCIPReorg_BelowFinality_OnDest(t *testing.T) {
 	e, l, dockerEnv, _, state, _ := setupReorgTest(t,
 		testhelpers.WithExtraConfigTomls([]string{t.Name() + ".toml"}),
 	)
+	evmChains := e.Env.BlockChains.EVMChains()
 
 	allChains := e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainsel.FamilyEVM))
 	require.GreaterOrEqual(t, len(allChains), 2)
@@ -145,7 +146,7 @@ func Test_CCIPReorg_BelowFinality_OnDest(t *testing.T) {
 	_, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		sourceSelector,
-		e.Env.Chains[destSelector],
+		evmChains[destSelector],
 		state.MustGetEVMChainState(destSelector).OffRamp,
 		nil, // startBlock
 		ccipocr3.NewSeqNumRange(1, 1),
@@ -162,7 +163,7 @@ func Test_CCIPReorg_BelowFinality_OnDest(t *testing.T) {
 	_, err = testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		sourceSelector,
-		e.Env.Chains[destSelector],
+		evmChains[destSelector],
 		state.MustGetEVMChainState(destSelector).OffRamp,
 		nil, // startBlock
 		ccipocr3.NewSeqNumRange(1, 1),
@@ -197,7 +198,7 @@ func Test_CCIPReorg_GreaterThanFinality_OnDest(t *testing.T) {
 	_, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		sourceSelector,
-		e.Env.Chains[destSelector],
+		e.Env.BlockChains.EVMChains()[destSelector],
 		state.MustGetEVMChainState(destSelector).OffRamp,
 		nil, // startBlock
 		ccipocr3.NewSeqNumRange(1, 1),
@@ -279,7 +280,7 @@ func Test_CCIPReorg_GreaterThanFinality_OnSource(t *testing.T) {
 	_, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		nonReorgSource,
-		e.Env.Chains[destSelector],
+		e.Env.BlockChains.EVMChains()[destSelector],
 		state.MustGetEVMChainState(destSelector).OffRamp,
 		nil, // startBlock
 		ccipocr3.NewSeqNumRange(1, 1),

--- a/integration-tests/smoke/ccip/ccip_rmn_test.go
+++ b/integration-tests/smoke/ccip/ccip_rmn_test.go
@@ -609,8 +609,8 @@ func (tc *rmnTestCase) alterSigners(t *testing.T, signers []rmn_remote.RMNRemote
 }
 
 func (tc *rmnTestCase) populateFields(t *testing.T, envWithRMN testhelpers.DeployedEnv, rmnCluster devenv.RMNCluster) {
-	require.GreaterOrEqual(t, len(envWithRMN.Env.Chains), 2, "test assumes at least two chains")
-	for _, chain := range envWithRMN.Env.Chains {
+	require.GreaterOrEqual(t, len(envWithRMN.Env.BlockChains.EVMChains()), 2, "test assumes at least two chains")
+	for _, chain := range envWithRMN.Env.BlockChains.EVMChains() {
 		tc.pf.chainSelectors = append(tc.pf.chainSelectors, chain.Selector)
 	}
 
@@ -788,7 +788,7 @@ func (tc rmnTestCase) callContractsToCurseChains(ctx context.Context, t *testing
 		remoteSel := tc.pf.chainSelectors[remoteCfg.chainIdx]
 		chState, ok := onChainState.EVMChainState(remoteSel)
 		require.True(t, ok)
-		_, ok = envWithRMN.Env.Chains[remoteSel]
+		_, ok = envWithRMN.Env.BlockChains.EVMChains()[remoteSel]
 		require.True(t, ok)
 
 		cursedSubjects, ok := tc.cursedSubjectsPerChain[remoteCfg.chainIdx]
@@ -823,7 +823,7 @@ func (tc rmnTestCase) callContractsToCurseAndRevokeCurse(ctx context.Context, eg
 		remoteSel := tc.pf.chainSelectors[remoteCfg.chainIdx]
 		chState, ok := onChainState.EVMChainState(remoteSel)
 		require.True(t, ok)
-		_, ok = envWithRMN.Env.Chains[remoteSel]
+		_, ok = envWithRMN.Env.BlockChains.EVMChains()[remoteSel]
 		require.True(t, ok)
 
 		cursedSubjects := tc.revokedCursedSubjectsPerChain[remoteCfg.chainIdx]
@@ -1039,7 +1039,7 @@ func Test_CCIPReorg_BelowFinality_OnSource_WithRMN(t *testing.T) {
 	_, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		sourceSelector,
-		e.Env.Chains[destSelector],
+		e.Env.BlockChains.EVMChains()[destSelector],
 		state.MustGetEVMChainState(destSelector).OffRamp,
 		nil, // startBlock
 		ccipocr3.NewSeqNumRange(1, 1),
@@ -1087,7 +1087,7 @@ func Test_CCIPReorg_BelowFinality_OnSource_WithRMN_Recover(t *testing.T) {
 	_, err = testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 		t,
 		sourceSelector,
-		e.Env.Chains[destSelector],
+		e.Env.BlockChains.EVMChains()[destSelector],
 		state.MustGetEVMChainState(destSelector).OffRamp,
 		nil, // startBlock
 		ccipocr3.NewSeqNumRange(1, 1),
@@ -1136,7 +1136,7 @@ func Test_CCIPReorg_BelowFinality_OnSource_WithRMN_Block(t *testing.T) {
 		_, err := testhelpers.ConfirmCommitWithExpectedSeqNumRange(
 			t,
 			sourceSelector,
-			e.Env.Chains[destSelector],
+			e.Env.BlockChains.EVMChains()[destSelector],
 			state.MustGetEVMChainState(destSelector).OffRamp,
 			nil, // startBlock
 			ccipocr3.NewSeqNumRange(1, 1),

--- a/integration-tests/smoke/ccip/ccip_token_price_updates_test.go
+++ b/integration-tests/smoke/ccip/ccip_token_price_updates_test.go
@@ -43,7 +43,7 @@ func Test_CCIPTokenPriceUpdates(t *testing.T) {
 	require.NoError(t, err)
 	testhelpers.AddLanesForAll(t, &e, state)
 
-	allChainSelectors := maps.Keys(e.Env.Chains)
+	allChainSelectors := maps.Keys(e.Env.BlockChains.EVMChains())
 	assert.GreaterOrEqual(t, len(allChainSelectors), 2, "test requires at least 2 chains")
 
 	sourceChain1 := allChainSelectors[0]
@@ -84,7 +84,7 @@ func Test_CCIPTokenPriceUpdates(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		// manually update token prices by setting values to maxUint64 and 0
-		tx, err := feeQuoter1.UpdatePrices(e.Env.Chains[sourceChain1].DeployerKey, fee_quoter.InternalPriceUpdates{
+		tx, err := feeQuoter1.UpdatePrices(e.Env.BlockChains.EVMChains()[sourceChain1].DeployerKey, fee_quoter.InternalPriceUpdates{
 			TokenPriceUpdates: []fee_quoter.InternalTokenPriceUpdate{
 				{SourceToken: feeTokensChain1[0], UsdPerToken: big.NewInt(0).SetUint64(math.MaxUint64)},
 				{SourceToken: feeTokensChain1[1], UsdPerToken: big.NewInt(0)},
@@ -92,7 +92,7 @@ func Test_CCIPTokenPriceUpdates(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = cldf.ConfirmIfNoError(e.Env.Chains[sourceChain1], tx, err)
+		_, err = cldf.ConfirmIfNoError(e.Env.BlockChains.EVMChains()[sourceChain1], tx, err)
 		require.NoError(t, err)
 		t.Logf("manually editing token prices")
 

--- a/integration-tests/smoke/ccip/ccip_token_transfer_test.go
+++ b/integration-tests/smoke/ccip/ccip_token_transfer_test.go
@@ -66,11 +66,12 @@ func TestTokenTransfer_EVM2EVM(t *testing.T) {
 	selfServeDestTokenPoolDeployer := tenv.Users[destChain][1]
 
 	oneE18 := new(big.Int).SetUint64(1e18)
+	evmChains := tenv.Env.BlockChains.EVMChains()
 
 	// Deploy tokens and pool by CCIP Owner
 	srcToken, _, destToken, _, err := testhelpers.DeployTransferableToken(
 		lggr,
-		tenv.Env.Chains,
+		evmChains,
 		sourceChain,
 		destChain,
 		ownerSourceChain,
@@ -84,7 +85,7 @@ func TestTokenTransfer_EVM2EVM(t *testing.T) {
 	// Deploy Self Serve tokens and pool
 	selfServeSrcToken, _, selfServeDestToken, _, err := testhelpers.DeployTransferableToken(
 		lggr,
-		tenv.Env.Chains,
+		evmChains,
 		sourceChain,
 		destChain,
 		selfServeSrcTokenPoolDeployer,

--- a/integration-tests/smoke/ccip/ccip_token_transfer_test.go
+++ b/integration-tests/smoke/ccip/ccip_token_transfer_test.go
@@ -53,12 +53,13 @@ func TestTokenTransfer_EVM2EVM(t *testing.T) {
 	e := tenv.Env
 	state, err := stateview.LoadOnchainState(e)
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(e.Chains), 2)
+	evmChains := e.BlockChains.EVMChains()
+	require.GreaterOrEqual(t, len(evmChains), 2)
 
-	allChainSelectors := maps.Keys(e.Chains)
+	allChainSelectors := maps.Keys(evmChains)
 	sourceChain, destChain := allChainSelectors[0], allChainSelectors[1]
-	ownerSourceChain := e.Chains[sourceChain].DeployerKey
-	ownerDestChain := e.Chains[destChain].DeployerKey
+	ownerSourceChain := evmChains[sourceChain].DeployerKey
+	ownerDestChain := evmChains[destChain].DeployerKey
 
 	require.GreaterOrEqual(t, len(tenv.Users[sourceChain]), 2)
 	require.GreaterOrEqual(t, len(tenv.Users[destChain]), 2)
@@ -66,12 +67,11 @@ func TestTokenTransfer_EVM2EVM(t *testing.T) {
 	selfServeDestTokenPoolDeployer := tenv.Users[destChain][1]
 
 	oneE18 := new(big.Int).SetUint64(1e18)
-	evmChains := tenv.Env.BlockChains.EVMChains()
 
 	// Deploy tokens and pool by CCIP Owner
 	srcToken, _, destToken, _, err := testhelpers.DeployTransferableToken(
 		lggr,
-		evmChains,
+		tenv.Env.BlockChains.EVMChains(),
 		sourceChain,
 		destChain,
 		ownerSourceChain,
@@ -85,7 +85,7 @@ func TestTokenTransfer_EVM2EVM(t *testing.T) {
 	// Deploy Self Serve tokens and pool
 	selfServeSrcToken, _, selfServeDestToken, _, err := testhelpers.DeployTransferableToken(
 		lggr,
-		evmChains,
+		tenv.Env.BlockChains.EVMChains(),
 		sourceChain,
 		destChain,
 		selfServeSrcTokenPoolDeployer,
@@ -255,12 +255,13 @@ func TestTokenTransfer_EVM2Solana(t *testing.T) {
 	e := tenv.Env
 	state, err := stateview.LoadOnchainState(e)
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(e.Chains), 2)
+	evmChains := e.BlockChains.EVMChains()
+	require.GreaterOrEqual(t, len(evmChains), 2)
 
 	allChainSelectors := e.BlockChains.ListChainSelectors(chain.WithFamily(chain_selectors.FamilyEVM))
 	allSolChainSelectors := e.BlockChains.ListChainSelectors(chain.WithFamily(chain_selectors.FamilySolana))
 	sourceChain, destChain := allChainSelectors[0], allSolChainSelectors[0]
-	ownerSourceChain := e.Chains[sourceChain].DeployerKey
+	ownerSourceChain := evmChains[sourceChain].DeployerKey
 	// ownerDestChain := e.BlockChains.SolanaChains()[destChain].DeployerKey
 
 	require.GreaterOrEqual(t, len(tenv.Users[sourceChain]), 2) // TODO: ???
@@ -389,7 +390,7 @@ func TestTokenTransfer_Solana2EVM(t *testing.T) {
 	e := tenv.Env
 	state, err := stateview.LoadOnchainState(e)
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(e.Chains), 2)
+	require.GreaterOrEqual(t, len(e.BlockChains.EVMChains()), 2)
 
 	allChainSelectors := e.BlockChains.ListChainSelectors(chain.WithFamily(chain_selectors.FamilyEVM))
 	allSolChainSelectors := e.BlockChains.ListChainSelectors(chain.WithFamily(chain_selectors.FamilySolana))

--- a/integration-tests/smoke/ccip/ccip_usdc_test.go
+++ b/integration-tests/smoke/ccip/ccip_usdc_test.go
@@ -44,19 +44,20 @@ func TestUSDCTokenTransfer(t *testing.T) {
 	state, err := stateview.LoadOnchainState(e)
 	require.NoError(t, err)
 
-	allChainSelectors := maps.Keys(e.Chains)
+	evmChains := e.BlockChains.EVMChains()
+	allChainSelectors := maps.Keys(evmChains)
 	chainA := allChainSelectors[0]
 	chainC := allChainSelectors[1]
 	chainB := allChainSelectors[2]
 
-	ownerChainA := e.Chains[chainA].DeployerKey
-	ownerChainC := e.Chains[chainC].DeployerKey
-	ownerChainB := e.Chains[chainB].DeployerKey
+	ownerChainA := evmChains[chainA].DeployerKey
+	ownerChainC := evmChains[chainC].DeployerKey
+	ownerChainB := evmChains[chainB].DeployerKey
 
-	aChainUSDC, cChainUSDC, err := testhelpers.ConfigureUSDCTokenPools(lggr, e.Chains, chainA, chainC, state)
+	aChainUSDC, cChainUSDC, err := testhelpers.ConfigureUSDCTokenPools(lggr, evmChains, chainA, chainC, state)
 	require.NoError(t, err)
 
-	bChainUSDC, _, err := testhelpers.ConfigureUSDCTokenPools(lggr, e.Chains, chainB, chainC, state)
+	bChainUSDC, _, err := testhelpers.ConfigureUSDCTokenPools(lggr, evmChains, chainB, chainC, state)
 	require.NoError(t, err)
 
 	aChainToken, _, cChainToken, _, err := testhelpers.DeployTransferableToken(
@@ -243,19 +244,20 @@ func updateFeeQuoters(
 	chainA, chainB, chainC uint64,
 	aChainUSDC, bChainUSDC, cChainUSDC *burn_mint_erc677.BurnMintERC677,
 ) error {
+	evmChains := e.BlockChains.EVMChains()
 	updateFeeQtrGrp := errgroup.Group{}
 	updateFeeQtrGrp.Go(func() error {
-		return testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, e.Chains[chainA], chainC)
+		return testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, evmChains[chainA], chainC)
 	})
 	updateFeeQtrGrp.Go(func() error {
-		return testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, e.Chains[chainB], chainC)
+		return testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, evmChains[chainB], chainC)
 	})
 	updateFeeQtrGrp.Go(func() error {
-		err1 := testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, e.Chains[chainC], chainA)
+		err1 := testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, evmChains[chainC], chainA)
 		if err1 != nil {
 			return err1
 		}
-		return testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, e.Chains[chainC], chainB)
+		return testhelpers.UpdateFeeQuoterForUSDC(t, e, lggr, evmChains[chainC], chainB)
 	})
 	return updateFeeQtrGrp.Wait()
 }

--- a/integration-tests/smoke/ccip/ccip_usdc_test.go
+++ b/integration-tests/smoke/ccip/ccip_usdc_test.go
@@ -61,7 +61,7 @@ func TestUSDCTokenTransfer(t *testing.T) {
 
 	aChainToken, _, cChainToken, _, err := testhelpers.DeployTransferableToken(
 		lggr,
-		tenv.Env.Chains,
+		tenv.Env.BlockChains.EVMChains(),
 		chainA,
 		chainC,
 		ownerChainA,


### PR DESCRIPTION
## fix: migrate usage of evm to BlockChain - dev11

Breaking down the changes for the migration, there will be more PR with similar changes.

- Migrate `env.Chains` to `env.BlockChains.EVMChains()`
- Migrate `e.Chains` to `e.BlockChains.EVMChains()`
- Migrate `cldf.Chain` to `cldf_evm.Chain`

___
Issue: [CLD-290](https://smartcontract-it.atlassian.net/browse/CLD-290)

[CLD-290]: https://smartcontract-it.atlassian.net/browse/CLD-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ