### PR TITLE
chore migration deployer/environment to use framework chains

### DIFF
--- a/deployment/environment/devenv/chain.go
+++ b/deployment/environment/devenv/chain.go
@@ -12,24 +12,19 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
-	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/gagliardetto/solana-go"
 	solRpc "github.com/gagliardetto/solana-go/rpc"
 	chainselectors "github.com/smartcontractkit/chain-selectors"
+	"golang.org/x/sync/errgroup"
 
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/gagliardetto/solana-go"
-
 	"github.com/smartcontractkit/chainlink/deployment"
 )
 
@@ -138,8 +133,8 @@ func (c *ChainConfig) ToRPCs() []cldf.RPC {
 	return rpcs
 }
 
-func NewChains(logger logger.Logger, configs []ChainConfig) (map[uint64]cldf.Chain, map[uint64]cldf_solana.Chain, error) {
-	evmChains := make(map[uint64]cldf.Chain)
+func NewChains(logger logger.Logger, configs []ChainConfig) (map[uint64]cldf_evm.Chain, map[uint64]cldf_solana.Chain, error) {
+	evmChains := make(map[uint64]cldf_evm.Chain)
 	solChains := make(map[uint64]cldf_solana.Chain)
 	var evmSyncMap sync.Map
 	var solSyncMap sync.Map
@@ -195,7 +190,7 @@ func NewChains(logger logger.Logger, configs []ChainConfig) (map[uint64]cldf.Cha
 					return blockNumber, nil
 				}
 
-				evmSyncMap.Store(chainDetails.ChainSelector, cldf.Chain{
+				evmSyncMap.Store(chainDetails.ChainSelector, cldf_evm.Chain{
 					Selector:    chainDetails.ChainSelector,
 					Client:      ec,
 					DeployerKey: chainCfg.DeployerKey,
@@ -251,7 +246,7 @@ func NewChains(logger logger.Logger, configs []ChainConfig) (map[uint64]cldf.Cha
 	}
 
 	evmSyncMap.Range(func(sel, value interface{}) bool {
-		evmChains[sel.(uint64)] = value.(cldf.Chain)
+		evmChains[sel.(uint64)] = value.(cldf_evm.Chain)
 		return true
 	})
 

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -24,6 +24,7 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -68,7 +69,7 @@ type MemoryEnvironmentConfig struct {
 type NewNodesConfig struct {
 	LogLevel zapcore.Level
 	// EVM chains to be configured. Optional.
-	Chains map[uint64]cldf.Chain
+	Chains map[uint64]cldf_evm.Chain
 	// Solana chains to be configured. Optional.
 	SolChains map[uint64]cldf_solana.Chain
 	// Aptos chains to be configured. Optional.
@@ -81,8 +82,8 @@ type NewNodesConfig struct {
 }
 
 // For placeholders like aptos
-func NewMemoryChain(t *testing.T, selector uint64) cldf.Chain {
-	return cldf.Chain{
+func NewMemoryChain(t *testing.T, selector uint64) cldf_evm.Chain {
+	return cldf_evm.Chain{
 		Selector:    selector,
 		Client:      nil,
 		DeployerKey: &bind.TransactOpts{},
@@ -94,7 +95,7 @@ func NewMemoryChain(t *testing.T, selector uint64) cldf.Chain {
 
 // Needed for environment variables on the node which point to prexisitng addresses.
 // i.e. CapReg.
-func NewMemoryChains(t *testing.T, numChains int, numUsers int) (map[uint64]cldf.Chain, map[uint64][]*bind.TransactOpts) {
+func NewMemoryChains(t *testing.T, numChains int, numUsers int) (map[uint64]cldf_evm.Chain, map[uint64][]*bind.TransactOpts) {
 	mchains := GenerateChains(t, numChains, numUsers)
 	users := make(map[uint64][]*bind.TransactOpts)
 	for id, chain := range mchains {
@@ -114,11 +115,11 @@ func NewMemoryChainsAptos(t *testing.T, numChains int) map[uint64]cldf_aptos.Cha
 	return GenerateChainsAptos(t, numChains)
 }
 
-func NewMemoryChainsZk(t *testing.T, numChains int) map[uint64]cldf.Chain {
+func NewMemoryChainsZk(t *testing.T, numChains int) map[uint64]cldf_evm.Chain {
 	return GenerateChainsZk(t, numChains)
 }
 
-func NewMemoryChainsWithChainIDs(t *testing.T, chainIDs []uint64, numUsers int) (map[uint64]cldf.Chain, map[uint64][]*bind.TransactOpts) {
+func NewMemoryChainsWithChainIDs(t *testing.T, chainIDs []uint64, numUsers int) (map[uint64]cldf_evm.Chain, map[uint64][]*bind.TransactOpts) {
 	mchains := GenerateChainsWithIds(t, chainIDs, numUsers)
 	users := make(map[uint64][]*bind.TransactOpts)
 	for id, chain := range mchains {
@@ -129,14 +130,14 @@ func NewMemoryChainsWithChainIDs(t *testing.T, chainIDs []uint64, numUsers int) 
 	return generateMemoryChain(t, mchains), users
 }
 
-func generateMemoryChain(t *testing.T, inputs map[uint64]EVMChain) map[uint64]cldf.Chain {
-	chains := make(map[uint64]cldf.Chain)
+func generateMemoryChain(t *testing.T, inputs map[uint64]EVMChain) map[uint64]cldf_evm.Chain {
+	chains := make(map[uint64]cldf_evm.Chain)
 	for cid, chain := range inputs {
 		chain := chain
 		chainInfo, err := chainsel.GetChainDetailsByChainIDAndFamily(strconv.FormatUint(cid, 10), chainsel.FamilyEVM)
 		require.NoError(t, err)
 		backend := NewBackend(chain.Backend)
-		chains[chainInfo.ChainSelector] = cldf.Chain{
+		chains[chainInfo.ChainSelector] = cldf_evm.Chain{
 			Selector:    chainInfo.ChainSelector,
 			Client:      backend,
 			DeployerKey: chain.DeployerKey,
@@ -243,7 +244,7 @@ func NewNodes(
 func NewMemoryEnvironmentFromChainsNodes(
 	ctx func() context.Context,
 	lggr logger.Logger,
-	chains map[uint64]cldf.Chain,
+	chains map[uint64]cldf_evm.Chain,
 	solChains map[uint64]cldf_solana.Chain,
 	aptosChains map[uint64]cldf_aptos.Chain,
 	nodes map[string]Node,

--- a/deployment/environment/memory/node.go
+++ b/deployment/environment/memory/node.go
@@ -21,9 +21,9 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/exp/maps"
 
-	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
-
 	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
@@ -39,8 +39,6 @@ import (
 	solrpc "github.com/gagliardetto/solana-go/rpc"
 
 	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
@@ -235,7 +233,7 @@ type NewNodeConfig struct {
 	// Port for the P2P V2 listener.
 	Port int
 	// EVM chains to be configured. Optional.
-	Chains map[uint64]cldf.Chain
+	Chains map[uint64]cldf_evm.Chain
 	// Solana chains to be configured. Optional.
 	Solchains map[uint64]cldf_solana.Chain
 	// Aptos chains to be configured. Optional.
@@ -438,7 +436,7 @@ type Keys struct {
 
 func CreateKeys(t *testing.T,
 	app chainlink.Application,
-	chains map[uint64]cldf.Chain,
+	chains map[uint64]cldf_evm.Chain,
 	solchains map[uint64]cldf_solana.Chain,
 	aptoschains map[uint64]cldf_aptos.Chain,
 ) Keys {

--- a/deployment/environment/memory/zksync_chains.go
+++ b/deployment/environment/memory/zksync_chains.go
@@ -20,13 +20,13 @@ import (
 
 	cs "github.com/smartcontractkit/chain-selectors"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 )
 
-func GenerateChainsZk(t *testing.T, numChains int) map[uint64]cldf.Chain {
-	chains := make(map[uint64]cldf.Chain)
+func GenerateChainsZk(t *testing.T, numChains int) map[uint64]cldf_evm.Chain {
+	chains := make(map[uint64]cldf_evm.Chain)
 
 	for i := 0; i < numChains; i++ {
 		chainID := cs.TEST_90000051.EvmChainID + uint64(i) //nolint:gosec // it shouldn't overflow
@@ -67,7 +67,7 @@ func GenerateChainsZk(t *testing.T, numChains int) map[uint64]cldf.Chain {
 		deployerZk, err := accounts.NewWallet(common.Hex2Bytes(blockchain.AnvilZKSyncRichAccountPks[0]), clientZk, nil)
 		require.NoError(t, err)
 
-		chain := cldf.Chain{
+		chain := cldf_evm.Chain{
 			Selector:    sel,
 			Client:      client,
 			DeployerKey: keyedTransactors[0], // to use to interact with contracts


### PR DESCRIPTION
- Migrate `env.Chains` to `env.BlockChains.EVMChains()`
- Migrate `cldf.Chain` to `cldf_evm.Chain`

