### PR TITLE
fix: migrate usage of evm to BlockChain - dev10

### DIFF
--- a/integration-tests/load/ccip/destination_gun.go
+++ b/integration-tests/load/ccip/destination_gun.go
@@ -185,7 +185,7 @@ func (m *DestinationGun) sendEVMMessage(src uint64) error {
 		return err
 	}
 
-	_, err = m.env.Chains[src].Confirm(tx)
+	_, err = m.env.BlockChains.EVMChains()[src].Confirm(tx)
 	if err != nil {
 		m.l.Errorw("could not confirm tx on source", "tx", tx, "err", cldf.MaybeDataErr(err))
 		return err

--- a/integration-tests/load/ccip/helpers.go
+++ b/integration-tests/load/ccip/helpers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
 
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -486,7 +487,8 @@ func fundAdditionalKeys(lggr logger.Logger, e cldf.Environment, destChains []uin
 	deployerMap := make(map[uint64][]*bind.TransactOpts)
 	addressMap := make(map[uint64][]common.Address)
 	numAccounts := len(destChains)
-	for chain := range e.Chains {
+	evmChains := e.BlockChains.EVMChains()
+	for chain := range evmChains {
 		deployerMap[chain] = make([]*bind.TransactOpts, 0, numAccounts)
 		addressMap[chain] = make([]common.Address, 0, numAccounts)
 		for range numAccounts {
@@ -516,7 +518,7 @@ func fundAdditionalKeys(lggr logger.Logger, e cldf.Environment, destChains []uin
 	for sel, addresses := range addressMap {
 		sel, addresses := sel, addresses
 		g.Go(func() error {
-			return crib.SendFundsToAccounts(e.GetContext(), lggr, e.Chains[sel], addresses, fundingAmount, sel)
+			return crib.SendFundsToAccounts(e.GetContext(), lggr, evmChains[sel], addresses, fundingAmount, sel)
 		})
 	}
 
@@ -526,7 +528,7 @@ func fundAdditionalKeys(lggr logger.Logger, e cldf.Environment, destChains []uin
 	return deployerMap, nil
 }
 func reclaimFunds(lggr logger.Logger, e cldf.Environment, addressesByChain map[uint64][]*bind.TransactOpts, returnAddress common.Address) error {
-	removeFundsFromAccounts := func(ctx context.Context, lggr logger.Logger, chain cldf.Chain, addresses []*bind.TransactOpts, returnAddress common.Address, sel uint64) error {
+	removeFundsFromAccounts := func(ctx context.Context, lggr logger.Logger, chain cldf_evm.Chain, addresses []*bind.TransactOpts, returnAddress common.Address, sel uint64) error {
 		for _, deployer := range addresses {
 			balance, err := chain.Client.BalanceAt(ctx, deployer.From, nil)
 			if err != nil {
@@ -586,7 +588,7 @@ func reclaimFunds(lggr logger.Logger, e cldf.Environment, addressesByChain map[u
 	for sel, addresses := range addressesByChain {
 		sel, addresses := sel, addresses
 		g.Go(func() error {
-			return removeFundsFromAccounts(e.GetContext(), lggr, e.Chains[sel], addresses, returnAddress, sel)
+			return removeFundsFromAccounts(e.GetContext(), lggr, e.BlockChains.EVMChains()[sel], addresses, returnAddress, sel)
 		})
 	}
 

--- a/integration-tests/testconfig/ccip/load.go
+++ b/integration-tests/testconfig/ccip/load.go
@@ -55,7 +55,7 @@ func (l *LoadConfig) Validate(t *testing.T, e *cldf.Environment) {
 	require.Equal(t, 100, agg, "Sum of MessageDetails Ratios must be 100")
 
 	require.GreaterOrEqual(t, *l.NumDestinationChains, 1, "NumDestinationChains must be greater than or equal to 1")
-	require.GreaterOrEqual(t, len(e.Chains), *l.NumDestinationChains, "NumDestinationChains must be less than or equal to the number of chains in the environment")
+	require.GreaterOrEqual(t, len(e.BlockChains.EVMChains()), *l.NumDestinationChains, "NumDestinationChains must be less than or equal to the number of chains in the environment")
 }
 
 func (l *LoadConfig) GetLoadDuration() time.Duration {


### PR DESCRIPTION
## fix: migrate usage of evm to BlockChain - dev10

Breaking down the changes for the migration, there will be more PR with similar changes.

- Migrate `env.Chains` to `env.BlockChains.EVMChains()`
- Migrate `e.Chains` to `e.BlockChains.EVMChains()`
- Migrate `cldf.Chain` to `cldf_evm.Chain`

___
Issue: [CLD-290](https://smartcontract-it.atlassian.net/browse/CLD-290)

[CLD-290]: https://smartcontract-it.atlassian.net/browse/CLD-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ