### PR TITLE
Relocate the `OCR3 Job` struct into core

### DIFF
--- a/deployment/keystone/changeset/ocr3_job.go
+++ b/deployment/keystone/changeset/ocr3_job.go
@@ -108,7 +108,7 @@ func BuildOCR3JobConfigSpecs(
 		return nil, fmt.Errorf("failed to get chain ID from selector: %w", err)
 	}
 
-	extJobID, err := externalJobID(donName, evmChainSel)
+	extJobID, err := ExternalJobID(donName, evmChainSel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get external job ID: %w", err)
 	}
@@ -164,7 +164,7 @@ func BuildOCR3JobConfigSpecs(
 }
 
 // NOTE: consider adding contract address to the hash
-func externalJobID(donName string, evmChainSel uint64) (string, error) {
+func ExternalJobID(donName string, evmChainSel uint64) (string, error) {
 	in := []byte(donName + "-ocr3-capability-job-spec")
 	b := make([]byte, 8)
 	binary.BigEndian.PutUint64(b, evmChainSel)

--- a/deployment/keystone/changeset/ocr3_job.go
+++ b/deployment/keystone/changeset/ocr3_job.go
@@ -1,0 +1,185 @@
+package changeset
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"embed"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"text/template"
+
+	"github.com/google/uuid"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+	"github.com/smartcontractkit/chainlink/deployment"
+)
+
+type OCR3JobConfig struct {
+	JobName              string
+	ChainID              string
+	P2PID                string
+	OCR2EVMKeyBundleID   string
+	TransmitterID        string
+	OCR2AptosKeyBundleID string
+	ContractID           string // contract ID of the ocr3 contract
+	P2Pv2Bootstrappers   []string
+	ExternalJobID        string
+}
+
+func (c OCR3JobConfig) Validate() error {
+	if c.JobName == "" {
+		return errors.New("JobName is empty")
+	}
+	if c.ChainID == "" {
+		return errors.New("ChainID is empty")
+	}
+	if c.P2PID == "" {
+		return errors.New("P2PID is empty")
+	}
+	if c.OCR2EVMKeyBundleID == "" && c.OCR2AptosKeyBundleID == "" {
+		return errors.New("OCR2EVMKeyBundleID and OCR2AptosKeyBundleID are empty, one must be set")
+	}
+	if c.TransmitterID == "" {
+		return errors.New("TransmitterID is empty")
+	}
+	if c.ContractID == "" {
+		return errors.New("ContractID is empty")
+	}
+	if len(c.P2Pv2Bootstrappers) == 0 {
+		return errors.New("P2Pv2Bootstrappers is empty")
+	}
+
+	return nil
+}
+
+//go:embed *tmpl
+var tmplFS embed.FS
+
+func ResolveOCR3Job(cfg OCR3JobConfig) (string, error) {
+	t, err := template.New("s").ParseFS(tmplFS, "ocr3_spec.tmpl")
+	if err != nil {
+		return "", fmt.Errorf("failed to parse ocr3_spec.tmpl: %w", err)
+	}
+
+	b := &bytes.Buffer{}
+	err = t.ExecuteTemplate(b, "ocr3_spec.tmpl", cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return b.String(), nil
+}
+
+type OCR3JobConfigSpec struct {
+	NodeID  string
+	JobName string
+	Spec    string
+}
+
+func BuildOCR3JobConfigSpecs(
+	client deployment.NodeChainConfigsLister,
+	lggr logger.Logger,
+	contractID string,
+	evmChainSel, aptosChainSel uint64,
+	nodes []*nodev1.Node,
+	btURLs []string,
+	donName string,
+) ([]OCR3JobConfigSpec, error) {
+	nodesLen := len(nodes)
+	if nodesLen == 0 {
+		return nil, errors.New("no nodes to build OCR3 job configs")
+	}
+	nodeIDs := make([]string, 0, nodesLen)
+	nodesByID := make(map[string]*nodev1.Node)
+	for _, node := range nodes {
+		nodesByID[node.Id] = node
+		nodeIDs = append(nodeIDs, node.Id)
+	}
+	nodeInfos, err := deployment.NodeInfo(nodeIDs, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node info: %w", err)
+	}
+
+	chainID, err := chainsel.GetChainIDFromSelector(evmChainSel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chain ID from selector: %w", err)
+	}
+
+	extJobID, err := externalJobID(donName, evmChainSel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get external job ID: %w", err)
+	}
+
+	jobConfigByNode := make(map[string]*OCR3JobConfig)
+	for _, node := range nodeInfos {
+		if node.IsBootstrap {
+			lggr.Infow("Skipping bootstrap node", "nodeID", node.NodeID, "chainSelector", evmChainSel)
+			continue
+		}
+		evmConfig, ok := node.OCRConfigForChainSelector(evmChainSel)
+		if !ok {
+			return nil, fmt.Errorf("no evm ocr2 config for node %s", node.NodeID)
+		}
+		aptosConfig, ok := node.OCRConfigForChainSelector(aptosChainSel)
+		if !ok {
+			return nil, fmt.Errorf("no aptos ocr2 config for node %s", node.NodeID)
+		}
+
+		jobConfig := &OCR3JobConfig{
+			JobName:              "OCR3 Multichain Capability (" + node.Name + ")",
+			ChainID:              chainID,
+			P2PID:                node.PeerID.String(),
+			OCR2EVMKeyBundleID:   evmConfig.KeyBundleID,
+			OCR2AptosKeyBundleID: aptosConfig.KeyBundleID,
+			ContractID:           contractID,
+			TransmitterID:        string(evmConfig.TransmitAccount),
+			P2Pv2Bootstrappers:   btURLs,
+			ExternalJobID:        extJobID,
+		}
+
+		err1 := jobConfig.Validate()
+		if err1 != nil {
+			return nil, fmt.Errorf("failed to validate ocr3 job config: %w", err1)
+		}
+		jobConfigByNode[node.NodeID] = jobConfig
+	}
+
+	specs := make([]OCR3JobConfigSpec, 0)
+	for nodeID, jobConfig := range jobConfigByNode {
+		spec, err1 := ResolveOCR3Job(*jobConfig)
+		if err1 != nil {
+			return nil, fmt.Errorf("failed to resolve ocr3 job: %w", err)
+		}
+		specs = append(specs, OCR3JobConfigSpec{
+			Spec:    spec,
+			NodeID:  nodeID,
+			JobName: jobConfig.JobName,
+		})
+	}
+
+	return specs, nil
+}
+
+// NOTE: consider adding contract address to the hash
+func externalJobID(donName string, evmChainSel uint64) (string, error) {
+	in := []byte(donName + "-ocr3-capability-job-spec")
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, evmChainSel)
+	in = append(in, b...)
+	sha256Hash := sha256.New()
+	sha256Hash.Write(in)
+	in = sha256Hash.Sum(nil)[:16]
+	// tag as valid UUID v4 https://github.com/google/uuid/blob/0f11ee6918f41a04c201eceeadf612a377bc7fbc/version4.go#L53-L54
+	in[6] = (in[6] & 0x0f) | 0x40 // Version 4
+	in[8] = (in[8] & 0x3f) | 0x80 // Variant is 10
+
+	id, err := uuid.FromBytes(in)
+	if err != nil {
+		return "", err
+	}
+
+	return id.String(), nil
+}

--- a/deployment/keystone/changeset/ocr3_job_test.go
+++ b/deployment/keystone/changeset/ocr3_job_test.go
@@ -1,0 +1,85 @@
+package changeset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveOCR3Job(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		cfg OCR3JobConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "basic",
+			args: args{
+				cfg: OCR3JobConfig{
+					JobName:              "OCR3 MultiChain Capability",
+					ChainID:              "11155111",
+					OCR2EVMKeyBundleID:   "0x123",
+					TransmitterID:        "0x456",
+					OCR2AptosKeyBundleID: "0x789",
+					ContractID:           "0x5Cf6c5D188Ed72428aEC2E53afA5149F7B50f38D",
+					P2Pv2Bootstrappers: []string{
+						"12D3KooWB78smeNRVYBVsZVQUXTZ9jemuW7Y7yvwSMov56NZW2z1@cl-keystone-one-bt-0:5001",
+						"12D3KooWBeFB8CGj1Pqph86ugvp7JCSuN88ffx1gtAS9857x9hoE@cl-keystone-one-bt-2:5001",
+						"12D3KooWDjdJ2kMS5CDZe41orMhpnFEZ2Ht13WY37ecWZRYjAVvi@cl-keystone-one-bt-3:5001",
+						"12D3KooWPBeMpPvDNmBdAjab7aLCEafZs5Q4EHcp4CAqZSLzScUL@cl-keystone-one-bt-1:5001",
+					},
+					ExternalJobID: "f1ac5211-ab79-4c31-ba1c-0997b72db466",
+				},
+			},
+			want: `type = "offchainreporting2"
+schemaVersion = 1
+name = "OCR3 MultiChain Capability"
+externalJobID = "f1ac5211-ab79-4c31-ba1c-0997b72db466"
+contractID = "0x5Cf6c5D188Ed72428aEC2E53afA5149F7B50f38D"
+ocrKeyBundleID = "0x123"
+p2pv2Bootstrappers = [
+  "12D3KooWB78smeNRVYBVsZVQUXTZ9jemuW7Y7yvwSMov56NZW2z1@cl-keystone-one-bt-0:5001",
+  "12D3KooWBeFB8CGj1Pqph86ugvp7JCSuN88ffx1gtAS9857x9hoE@cl-keystone-one-bt-2:5001",
+  "12D3KooWDjdJ2kMS5CDZe41orMhpnFEZ2Ht13WY37ecWZRYjAVvi@cl-keystone-one-bt-3:5001",
+  "12D3KooWPBeMpPvDNmBdAjab7aLCEafZs5Q4EHcp4CAqZSLzScUL@cl-keystone-one-bt-1:5001",
+]
+relay = "evm"
+pluginType = "plugin"
+transmitterID = "0x456"
+
+[relayConfig]
+chainID = "11155111"
+
+[pluginConfig]
+command = "chainlink-ocr3-capability"
+ocrVersion = 3
+pluginName = "ocr-capability"
+providerType = "ocr3-capability"
+telemetryType = "plugin"
+
+[onchainSigningStrategy]
+strategyName = 'multi-chain'
+[onchainSigningStrategy.config]
+evm = "0x123"
+aptos = "0x789"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ResolveOCR3Job(tt.args.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveOCR3Job() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/deployment/keystone/changeset/ocr3_spec.tmpl
+++ b/deployment/keystone/changeset/ocr3_spec.tmpl
@@ -1,0 +1,28 @@
+type = "offchainreporting2"
+schemaVersion = 1
+name = "{{ .JobName }}"
+externalJobID = "{{ .ExternalJobID }}"
+contractID = "{{ .ContractID }}"
+ocrKeyBundleID = "{{ .OCR2EVMKeyBundleID }}"
+p2pv2Bootstrappers = [
+{{ range .P2Pv2Bootstrappers }}  "{{ . }}",
+{{ end }}]
+relay = "evm"
+pluginType = "plugin"
+transmitterID = "{{ .TransmitterID }}"
+
+[relayConfig]
+chainID = "{{ .ChainID }}"
+
+[pluginConfig]
+command = "chainlink-ocr3-capability"
+ocrVersion = 3
+pluginName = "ocr-capability"
+providerType = "ocr3-capability"
+telemetryType = "plugin"
+
+[onchainSigningStrategy]
+strategyName = 'multi-chain'
+[onchainSigningStrategy.config]
+evm = "{{ .OCR2EVMKeyBundleID }}"
+aptos = "{{ .OCR2AptosKeyBundleID }}"


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This PR addresses [CRE-412](https://smartcontract-it.atlassian.net/browse/CRE-412).

We want to relocate [this definition](https://github.com/smartcontractkit/chainlink-deployments/blob/main/domains/keystone/internal/jobs/ocr3_job.go) into `core` so we are able to reuse it on `cld` and `system-tests`.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->

- <https://github.com/smartcontractkit/chainlink-deployments/pull/3470>

[CRE-412]: https://smartcontract-it.atlassian.net/browse/CRE-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ