### PR TITLE
DX-758: Removing skipped comments

### DIFF
--- a/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane_test.go
+++ b/deployment/ccip/changeset/crossfamily/v1_6/cs_add_evm_solana_lane_test.go
@@ -43,12 +43,6 @@ func TestAddEVMSolanaLaneBidirectional(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			/*if t.Name() == "TestAddEVMSolanaLaneBidirectional/MCMS_enabled" {
-				tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-758")
-			}
-			if t.Name() == "TestAddEVMSolanaLaneBidirectional/MCMS_disabled" {
-				tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/DX-759")
-			}*/
 			t.Parallel()
 			ctx := testcontext.Get(t)
 			tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))


### PR DESCRIPTION
This test was unskipped in this [PR](https://github.com/smartcontractkit/chainlink/pull/17765/files#diff-d33e9e2bcf46b7301bfedbb5293bff7edb0e112359d7529796041884b2c8d727R42) two weeks back. It is running stable so far and I did ran this with several counts in local to ensure there are no flakiness in this test.

In this PR, just removing the comment mentioned in the test.
