### PR TITLE
fix for ccip load tests

### DIFF
--- a/integration-tests/ccip-tests/Makefile
+++ b/integration-tests/ccip-tests/Makefile
@@ -27,7 +27,7 @@ test_load_ccip: set_config
 	source ./testconfig/override/.env && \
 	DATABASE_URL=postgresql://postgres:node@localhost:5432/chainlink_test?sslmode=disable	\
     ENV_JOB_IMAGE=$(testimage)  \
-    TEST_SUITE=ccip-tests/load \
+    TEST_SUITE=ccip-load \
     TEST_ARGS="-test.timeout 900h" \
     DETACH_RUNNER=true \
     RR_MEM=45Gi \

--- a/integration-tests/test.Dockerfile
+++ b/integration-tests/test.Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 # Get the SHA of the current commit and save it to sha.txt
 RUN git rev-parse HEAD > /go/testdir/sha.txt
 
-ARG SUITES=chaos soak benchmark ccip-tests/load
+ARG SUITES=chaos soak benchmark ccip-load
 
 RUN /go/testdir/integration-tests/scripts/buildTests "${SUITES}"
 


### PR DESCRIPTION
This fixes:

`/go/testdir/integration-tests/scripts/entrypoint: line 27: ./ccip-tests/load.test: No such file or directory`



