### PR TITLE
core/services/workflows: use common logger

### DIFF
--- a/core/services/workflows/cmd/cre/utils.go
+++ b/core/services/workflows/cmd/cre/utils.go
@@ -123,7 +123,7 @@ func NewStandaloneEngine(
 		BillingClient: billingClient,
 	}
 
-	return v2.NewEngine(ctx, cfg)
+	return v2.NewEngine(cfg)
 }
 
 // TODO support fetching secrets (from a local file)

--- a/core/services/workflows/internal/retry.go
+++ b/core/services/workflows/internal/retry.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // RunWithRetries is a helper function that retries a function until it succeeds.

--- a/core/services/workflows/metering/balance_store.go
+++ b/core/services/workflows/metering/balance_store.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/shopspring/decimal"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 var (

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -9,8 +9,8 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-protos/workflows/go/events"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 type ReportStepRef string
@@ -94,7 +94,7 @@ type Report struct {
 }
 
 func NewReport(lggr logger.Logger) *Report {
-	logger := lggr.Named("Metering")
+	logger := logger.Named(lggr, "Metering")
 	balanceStore := NewBalanceStore(0, map[string]decimal.Decimal{}, logger)
 	return &Report{
 		balance:  balanceStore,

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -2,9 +2,8 @@ package syncer
 
 import (
 	"context"
-	"errors"
-
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
@@ -534,7 +533,7 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, o
 		GlobalLimits:         h.workflowLimits,
 		ExecutionRateLimiter: h.ratelimiter,
 	}
-	return v2.NewEngine(ctx, cfg)
+	return v2.NewEngine(cfg)
 }
 
 // workflowUpdatedEvent handles the WorkflowUpdatedEvent event type by first finding the

--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -12,7 +12,7 @@ import (
 	wasmpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/v2/pb"
 	billing "github.com/smartcontractkit/chainlink-protos/billing/go"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/ratelimiter"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/store"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncerlimiter"

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 
 	sdkpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
@@ -60,7 +61,7 @@ type enqueuedTriggerEvent struct {
 	event        capabilities.TriggerResponse
 }
 
-func NewEngine(ctx context.Context, cfg *EngineConfig) (*Engine, error) {
+func NewEngine(cfg *EngineConfig) (*Engine, error) {
 	err := cfg.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
@@ -77,7 +78,7 @@ func NewEngine(ctx context.Context, cfg *EngineConfig) (*Engine, error) {
 		Name:  "WorkflowEngineV2",
 		Start: engine.start,
 		Close: engine.close,
-	}.NewServiceEngine(cfg.Lggr.Named("WorkflowEngine").With("workflowID", cfg.WorkflowID))
+	}.NewServiceEngine(logger.Sugared(cfg.Lggr).Named("WorkflowEngine").With("workflowID", cfg.WorkflowID))
 	return engine, nil
 }
 

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -50,7 +50,7 @@ func TestEngine_Init(t *testing.T) {
 		},
 	}
 
-	engine, err := v2.NewEngine(t.Context(), cfg)
+	engine, err := v2.NewEngine(cfg)
 	require.NoError(t, err)
 
 	module.EXPECT().Start().Once()
@@ -93,14 +93,14 @@ func TestEngine_Start_RateLimited(t *testing.T) {
 	var engine1, engine2, engine3, engine4 *v2.Engine
 
 	t.Run("engine 1 inits successfully", func(t *testing.T) {
-		engine1, err = v2.NewEngine(t.Context(), cfg)
+		engine1, err = v2.NewEngine(cfg)
 		require.NoError(t, err)
 		require.NoError(t, engine1.Start(t.Context()))
 		require.NoError(t, <-initDoneCh)
 	})
 
 	t.Run("engine 2 gets rate-limited by per-owner limit", func(t *testing.T) {
-		engine2, err = v2.NewEngine(t.Context(), cfg)
+		engine2, err = v2.NewEngine(cfg)
 		require.NoError(t, err)
 		require.NoError(t, engine2.Start(t.Context()))
 		initErr := <-initDoneCh
@@ -109,7 +109,7 @@ func TestEngine_Start_RateLimited(t *testing.T) {
 
 	t.Run("engine 3 inits successfully", func(t *testing.T) {
 		cfg.WorkflowOwner = testWorkflowOwnerB
-		engine3, err = v2.NewEngine(t.Context(), cfg)
+		engine3, err = v2.NewEngine(cfg)
 		require.NoError(t, err)
 		require.NoError(t, engine3.Start(t.Context()))
 		require.NoError(t, <-initDoneCh)
@@ -117,7 +117,7 @@ func TestEngine_Start_RateLimited(t *testing.T) {
 
 	t.Run("engine 4 gets rate-limited by global limit", func(t *testing.T) {
 		cfg.WorkflowOwner = testWorkflowOwnerC
-		engine4, err = v2.NewEngine(t.Context(), cfg)
+		engine4, err = v2.NewEngine(cfg)
 		require.NoError(t, err)
 		require.NoError(t, engine4.Start(t.Context()))
 		initErr := <-initDoneCh
@@ -156,7 +156,7 @@ func TestEngine_TriggerSubscriptions(t *testing.T) {
 
 	t.Run("too many triggers", func(t *testing.T) {
 		cfg.LocalLimits.MaxTriggerSubscriptions = 1
-		engine, err := v2.NewEngine(t.Context(), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(2), nil).Once()
 		require.NoError(t, engine.Start(t.Context()))
@@ -166,7 +166,7 @@ func TestEngine_TriggerSubscriptions(t *testing.T) {
 	})
 
 	t.Run("trigger capability not found in the registry", func(t *testing.T) {
-		engine, err := v2.NewEngine(t.Context(), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(2), nil).Once()
 		capreg.EXPECT().GetTrigger(matches.AnyContext, "id_0").Return(nil, errors.New("not found")).Once()
@@ -176,7 +176,7 @@ func TestEngine_TriggerSubscriptions(t *testing.T) {
 	})
 
 	t.Run("successful trigger registration", func(t *testing.T) {
-		engine, err := v2.NewEngine(t.Context(), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(2), nil).Once()
 		trigger0, trigger1 := capmocks.NewTriggerCapability(t), capmocks.NewTriggerCapability(t)
@@ -194,7 +194,7 @@ func TestEngine_TriggerSubscriptions(t *testing.T) {
 	})
 
 	t.Run("failed trigger registration and rollback", func(t *testing.T) {
-		engine, err := v2.NewEngine(t.Context(), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(2), nil).Once()
 		trigger0, trigger1 := capmocks.NewTriggerCapability(t), capmocks.NewTriggerCapability(t)
@@ -256,7 +256,7 @@ func TestEngine_Execution(t *testing.T) {
 	}
 
 	t.Run("successful execution with no capability calls", func(t *testing.T) {
-		engine, err := v2.NewEngine(t.Context(), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(1), nil).Once()
 		trigger := capmocks.NewTriggerCapability(t)
@@ -345,7 +345,7 @@ func TestEngine_MockCapabilityRegistry_NoDAGBinary(t *testing.T) {
 
 	t.Run("OK happy path", func(t *testing.T) {
 		wantResponse := "Hello, world!"
-		engine, err := v2.NewEngine(t.Context(), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 
 		capreg.EXPECT().


### PR DESCRIPTION
Replace legacy core logger use with common.