### PR TITLE
deprecate logger.Logger; swap out for common

### DIFF
--- a/core/capabilities/ccip/ccipevm/pluginconfig.go
+++ b/core/capabilities/ccip/ccipevm/pluginconfig.go
@@ -2,9 +2,11 @@ package ccipevm
 
 import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ocrimpls"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 const defaultCommitGasLimit = 500_000
@@ -14,10 +16,10 @@ func InitializePluginConfig(lggr logger.Logger, extraDataCodec ccipcommon.ExtraD
 	return ccipcommon.PluginConfig{
 		CommitPluginCodec:          NewCommitPluginCodecV1(),
 		ExecutePluginCodec:         NewExecutePluginCodecV1(extraDataCodec),
-		MessageHasher:              NewMessageHasherV1(lggr.Named(chainsel.FamilyEVM).Named("MessageHasherV1"), extraDataCodec),
+		MessageHasher:              NewMessageHasherV1(logger.Sugared(lggr).Named(chainsel.FamilyEVM).Named("MessageHasherV1"), extraDataCodec),
 		TokenDataEncoder:           NewEVMTokenDataEncoder(),
 		GasEstimateProvider:        NewGasEstimateProvider(extraDataCodec),
-		RMNCrypto:                  NewEVMRMNCrypto(lggr.Named(chainsel.FamilyEVM).Named("RMNCrypto")),
+		RMNCrypto:                  NewEVMRMNCrypto(logger.Sugared(lggr).Named(chainsel.FamilyEVM).Named("RMNCrypto")),
 		ContractTransmitterFactory: ocrimpls.NewEVMContractTransmitterFactory(extraDataCodec),
 		ChainRW:                    ChainCWProvider{},
 		ExtraDataCodec:             ExtraDataDecoder{},

--- a/core/capabilities/ccip/ccipsolana/pluginconfig.go
+++ b/core/capabilities/ccip/ccipsolana/pluginconfig.go
@@ -4,10 +4,10 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ocrimpls"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // InitializePluginConfig returns a pluginConfig for Solana chains.
@@ -15,7 +15,7 @@ func InitializePluginConfig(lggr logger.Logger, extraDataCodec ccipcommon.ExtraD
 	return ccipcommon.PluginConfig{
 		CommitPluginCodec:          NewCommitPluginCodecV1(),
 		ExecutePluginCodec:         NewExecutePluginCodecV1(extraDataCodec),
-		MessageHasher:              NewMessageHasherV1(lggr.Named(chainsel.FamilySolana).Named("MessageHasherV1"), extraDataCodec),
+		MessageHasher:              NewMessageHasherV1(logger.Sugared(lggr).Named(chainsel.FamilySolana).Named("MessageHasherV1"), extraDataCodec),
 		TokenDataEncoder:           NewSolanaTokenDataEncoder(),
 		GasEstimateProvider:        NewGasEstimateProvider(extraDataCodec),
 		RMNCrypto:                  nil,

--- a/core/capabilities/ccip/common/crcwconfig.go
+++ b/core/capabilities/ccip/common/crcwconfig.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // ChainReaderProviderOpts is a struct that contains the parameters for GetChainReader.

--- a/core/capabilities/ccip/common/pluginconfig.go
+++ b/core/capabilities/ccip/common/pluginconfig.go
@@ -5,8 +5,8 @@ import (
 	"maps"
 
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // PluginConfig holds the configuration for a plugin.

--- a/core/capabilities/ccip/delegate.go
+++ b/core/capabilities/ccip/delegate.go
@@ -13,6 +13,7 @@ import (
 
 	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -33,7 +34,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/oraclecreator"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
@@ -196,7 +196,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 
 	hcr := ccipreaderpkg.NewObservedHomeChainReader(
 		homeChainContractReader,
-		d.lggr.Named("HomeChainReader"),
+		logger.Named(d.lggr, "HomeChainReader"),
 		ccipreaderpkg.HomeChainPollingInterval,
 		ccipConfigBinding,
 		d.capabilityConfig.ExternalRegistry().ChainID(),

--- a/core/capabilities/ccip/launcher/launcher.go
+++ b/core/capabilities/ccip/launcher/launcher.go
@@ -6,24 +6,20 @@ import (
 	"sync"
 	"time"
 
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-
-	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
-
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	"github.com/smartcontractkit/chainlink/v2/core/services/job"
-	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
-	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
-
 	"go.uber.org/multierr"
 
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
 	ccipreader "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
-
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+
+	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
 )
 
 var (

--- a/core/capabilities/ccip/launcher/launcher_test.go
+++ b/core/capabilities/ccip/launcher/launcher_test.go
@@ -4,17 +4,18 @@ import (
 	"math/big"
 	"testing"
 
-	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
 	ccipreaderpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
 )
@@ -36,7 +37,7 @@ func Test_createDON(t *testing.T) {
 		{
 			"not a member of the DON and not a bootstrap node",
 			args{
-				logger.TestLogger(t),
+				logger.Test(t),
 				p2pID1,
 				mocks.NewHomeChainReader(t),
 				mocks.NewOracleCreator(t),
@@ -77,7 +78,7 @@ func Test_createDON(t *testing.T) {
 		{
 			"not a member of the DON but a running a bootstrap oracle creator",
 			args{
-				logger.TestLogger(t),
+				logger.Test(t),
 				ragep2ptypes.PeerID(p2pkey.MustNewV2XXXTestingOnly(big.NewInt(1)).PeerID()),
 				mocks.NewHomeChainReader(t),
 				mocks.NewOracleCreator(t),
@@ -119,7 +120,7 @@ func Test_createDON(t *testing.T) {
 		{
 			"success",
 			args{
-				logger.TestLogger(t),
+				logger.Test(t),
 				p2pID1,
 				mocks.NewHomeChainReader(t),
 				mocks.NewOracleCreator(t),
@@ -166,7 +167,7 @@ func Test_createDON(t *testing.T) {
 		{
 			"if a don is created with active and candidate configs, all should be created",
 			args{
-				logger.TestLogger(t),
+				logger.Test(t),
 				p2pID1,
 				mocks.NewHomeChainReader(t),
 				mocks.NewOracleCreator(t),
@@ -265,7 +266,7 @@ func Test_updateDON(t *testing.T) {
 		{
 			name: "should start new plugins",
 			args: args{
-				logger.TestLogger(t),
+				logger.Test(t),
 				p2pID3,
 				mocks.NewHomeChainReader(t),
 				mocks.NewOracleCreator(t),
@@ -318,7 +319,7 @@ func Test_updateDON(t *testing.T) {
 		{
 			name: "should return no plugins if config is empty",
 			args: args{
-				logger.TestLogger(t),
+				logger.Test(t),
 				p2pID3,
 				mocks.NewHomeChainReader(t),
 				mocks.NewOracleCreator(t),
@@ -354,7 +355,7 @@ func Test_updateDON(t *testing.T) {
 		{
 			name: "should maintain existing plugins",
 			args: args{
-				logger.TestLogger(t),
+				logger.Test(t),
 				p2pID3,
 				mocks.NewHomeChainReader(t),
 				mocks.NewOracleCreator(t),
@@ -419,7 +420,7 @@ func Test_updateDON(t *testing.T) {
 		{
 			name: "should start brand new plugins if all are new",
 			args: args{
-				logger.TestLogger(t),
+				logger.Test(t),
 				p2pID3,
 				mocks.NewHomeChainReader(t),
 				mocks.NewOracleCreator(t),
@@ -568,7 +569,7 @@ func Test_launcher_processDiff(t *testing.T) {
 		{
 			"don added success",
 			fields{
-				lggr:  logger.TestLogger(t),
+				lggr:  logger.Test(t),
 				p2pID: p2pID1,
 				homeChainReader: newMock(t, func(t *testing.T) *mocks.HomeChainReader {
 					return mocks.NewHomeChainReader(t)
@@ -633,7 +634,7 @@ func Test_launcher_processDiff(t *testing.T) {
 		{
 			"don updated new candidate instance success",
 			fields{
-				lggr:  logger.TestLogger(t),
+				lggr:  logger.Test(t),
 				p2pID: p2pID1,
 				homeChainReader: newMock(t, func(t *testing.T) *mocks.HomeChainReader {
 					return mocks.NewHomeChainReader(t)

--- a/core/capabilities/ccip/ocrimpls/contract_transmitter.go
+++ b/core/capabilities/ccip/ocrimpls/contract_transmitter.go
@@ -12,11 +12,11 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 )
 
 // ToCalldataFunc is a function that takes in the OCR3 report and signature data and processes them.

--- a/core/capabilities/ccip/ocrimpls/evm_contract_transmitter_factory.go
+++ b/core/capabilities/ccip/ocrimpls/evm_contract_transmitter_factory.go
@@ -5,10 +5,10 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // EVMCommitCallArgs defines the calldata structure for an EVM commit transaction.

--- a/core/capabilities/ccip/ocrimpls/keyring.go
+++ b/core/capabilities/ccip/ocrimpls/keyring.go
@@ -2,10 +2,12 @@ package ocrimpls
 
 import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 )
 
@@ -28,7 +30,7 @@ type ocr3Keyring[RI any] struct {
 func NewOnchainKeyring[RI any](keyring OCR3SignerVerifierExtra, lggr logger.Logger) *ocr3Keyring[RI] {
 	return &ocr3Keyring[RI]{
 		core: keyring,
-		lggr: lggr.Named("OCR3Keyring"),
+		lggr: logger.Named(lggr, "OCR3Keyring"),
 	}
 }
 

--- a/core/capabilities/ccip/ocrimpls/no_op_transmitter.go
+++ b/core/capabilities/ccip/ocrimpls/no_op_transmitter.go
@@ -7,7 +7,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 var _ ocr3types.ContractTransmitter[[]byte] = (*noOpTransmitter)(nil)
@@ -18,7 +18,7 @@ const errMsg = "no-op transmitter %s called, it shouldn't be! Check the CCIPHome
 // role DONs where the node that is participating cannot transmit to the destination chain.
 func NewNoOpTransmitter(lggr logger.Logger, myP2PID string, fakeTransmitAccount types.Account) *noOpTransmitter {
 	return &noOpTransmitter{
-		lggr:                lggr,
+		lggr:                logger.Sugared(lggr),
 		myP2PID:             myP2PID,
 		fakeTransmitAccount: fakeTransmitAccount,
 	}
@@ -28,7 +28,7 @@ func NewNoOpTransmitter(lggr logger.Logger, myP2PID string, fakeTransmitAccount 
 // that does nothing. It is intended to be used in role DONs where the
 // node that is participating cannot transmit to the destination chain.
 type noOpTransmitter struct {
-	lggr    logger.Logger
+	lggr    logger.SugaredLogger
 	myP2PID string
 	// fakeTransmitAccount is a transmit account that we return from the FromAccount() method.
 	// it should be equal to the account that is returned for this oracle from the configTracker.PublicConfig() method.

--- a/core/capabilities/ccip/ocrimpls/svm_contract_transmitter_factory.go
+++ b/core/capabilities/ccip/ocrimpls/svm_contract_transmitter_factory.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 )

--- a/core/capabilities/ccip/oraclecreator/bootstrap.go
+++ b/core/capabilities/ccip/oraclecreator/bootstrap.go
@@ -13,10 +13,10 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 
-	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/smartcontractkit/libocr/networking"
 	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
@@ -26,17 +26,16 @@ import (
 	libocr3 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 
+	"github.com/smartcontractkit/chainlink-ccip/pkg/peergroup"
 	ccipreaderpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-
-	"github.com/smartcontractkit/chainlink-ccip/pkg/peergroup"
 
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ocrimpls"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/synchronization"
@@ -175,7 +174,7 @@ func (i *bootstrapOracleCreator) Create(ctx context.Context, _ uint32, config cc
 	}
 
 	pgd := newPeerGroupDialer(
-		i.lggr.Named("PeerGroupDialer"),
+		logger.Named(i.lggr, "PeerGroupDialer"),
 		i.peerWrapper.PeerGroupFactory,
 		rmnHomeReader,
 		i.bootstrapperLocators,
@@ -190,7 +189,7 @@ func (i *bootstrapOracleCreator) Create(ctx context.Context, _ uint32, config cc
 		Database:              i.db,
 		LocalConfig:           defaultLocalConfig(),
 		Logger: ocrcommon.NewOCRWrapper(
-			i.lggr.
+			logger.Sugared(i.lggr).
 				Named("CCIPBootstrap").
 				Named(destRelayID.String()).
 				Named(config.Config.ChainSelector.String()).
@@ -399,7 +398,7 @@ func calculateSyncActions(
 func (d *peerGroupDialer) sync() {
 	activeRmnHomeDigest, candidateRmnHomeDigest := d.rmnHomeReader.GetAllConfigDigests()
 
-	lggr := commonlogger.With(
+	lggr := logger.With(
 		d.lggr,
 		"method", "sync",
 		"activeRmnHomeDigest", activeRmnHomeDigest.String(),
@@ -418,7 +417,7 @@ func (d *peerGroupDialer) sync() {
 
 	// Handle each action
 	for _, action := range actions {
-		actionLggr := commonlogger.With(lggr,
+		actionLggr := logger.With(lggr,
 			"action", action.actionType,
 			"endpointConfigDigest", action.endpointConfigDigest,
 			"rmnHomeConfigDigest", action.rmnHomeConfigDigest)
@@ -440,7 +439,7 @@ func (d *peerGroupDialer) sync() {
 
 // Helper function to close specific peer group
 func (d *peerGroupDialer) closePeerGroup(endpointConfigDigest cciptypes.Bytes32) {
-	lggr := d.lggr.With("genericEndpointConfigDigest", endpointConfigDigest.String())
+	lggr := logger.With(d.lggr, "genericEndpointConfigDigest", endpointConfigDigest.String())
 
 	for i, digest := range d.activeEndpointConfigDigests {
 		if digest == endpointConfigDigest {
@@ -468,7 +467,7 @@ func (d *peerGroupDialer) createPeerGroup(
 		return fmt.Errorf("get RMN nodes info: %w", err)
 	}
 
-	lggr := d.lggr.With(
+	lggr := logger.With(d.lggr,
 		"genericEndpointConfigDigest", endpointConfigDigest.String(),
 		"rmnHomeConfigDigest", rmnHomeConfigDigest.String(),
 	)

--- a/core/capabilities/ccip/oraclecreator/create_test.go
+++ b/core/capabilities/ccip/oraclecreator/create_test.go
@@ -6,30 +6,28 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
-	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
-	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	"github.com/smartcontractkit/chainlink/v2/core/services/job"
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
+	ocr3types "github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	ccipreaderpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
-
-	"github.com/stretchr/testify/require"
-
-	ocr3types "github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-
+	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types/mocks"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 	ocrcommon "github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 )
 
@@ -39,7 +37,7 @@ import (
 func TestPluginOracleCreatorCreate_InvalidSelector(t *testing.T) {
 	t.Parallel()
 
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 
 	// Minimal creator with empty/nil dependencies – these will not be hit as the
 	// selector validation fails first.
@@ -87,12 +85,12 @@ func TestPluginOracleCreatorCreate_InvalidSelector(t *testing.T) {
 func TestCreateFactoryAndTransmitter_PeerWrapperNotStarted(t *testing.T) {
 	t.Parallel()
 
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 
 	p2pk := p2pkey.MustNewV2XXXTestingOnly(big.NewInt(1))
 
 	creator := &pluginOracleCreator{
-		lggr:        lggr,
+		lggr:        logger.Sugared(lggr),
 		peerWrapper: &ocrcommon.SingletonPeerWrapper{}, // unstarted but non-nil to prevent panic
 		p2pID:       p2pk,
 	}
@@ -124,11 +122,11 @@ func TestCreateFactoryAndTransmitter_PeerWrapperNotStarted(t *testing.T) {
 func TestCreateFactoryAndTransmitter_NilDestChainWriter(t *testing.T) {
 	t.Parallel()
 
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	p2pk := p2pkey.MustNewV2XXXTestingOnly(big.NewInt(1))
 
 	creator := &pluginOracleCreator{
-		lggr:  lggr,
+		lggr:  logger.Sugared(lggr),
 		p2pID: p2pk,
 	}
 

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
+
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/libocr/commontypes"
 	libocr3 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-
-	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 
 	commitocr3 "github.com/smartcontractkit/chainlink-ccip/commit"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
@@ -26,13 +25,15 @@ import (
 	ccipreaderpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+
 	_ "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"    // Register EVM plugin config factories
 	_ "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipsolana" // Register Solana plugin config factories
+	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ocrimpls"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -60,7 +61,7 @@ type pluginOracleCreator struct {
 	isNewlyCreatedJob     bool
 	pluginConfig          job.JSONConfig
 	db                    ocr3types.Database
-	lggr                  logger.Logger
+	lggr                  logger.SugaredLogger
 	monitoringEndpointGen telemetry.MonitoringEndpointGenerator
 	bootstrapperLocators  []commontypes.BootstrapperLocator
 	homeChainReader       ccipreaderpkg.HomeChain
@@ -98,7 +99,7 @@ func NewPluginOracleCreator(
 		isNewlyCreatedJob:     isNewlyCreatedJob,
 		pluginConfig:          pluginConfig,
 		db:                    db,
-		lggr:                  lggr,
+		lggr:                  logger.Sugared(lggr),
 		monitoringEndpointGen: monitoringEndpointGen,
 		bootstrapperLocators:  bootstrapperLocators,
 		homeChainReader:       homeChainReader,

--- a/core/capabilities/ccip/types/contract_transmitter_factory.go
+++ b/core/capabilities/ccip/types/contract_transmitter_factory.go
@@ -4,9 +4,8 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
-
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // ContractTransmitterFactory creates commit/execute transmitters for a specific chain family.

--- a/core/capabilities/ccip/types/mocks/contract_transmitter_factory.go
+++ b/core/capabilities/ccip/types/mocks/contract_transmitter_factory.go
@@ -3,7 +3,7 @@
 package mocks
 
 import (
-	logger "github.com/smartcontractkit/chainlink/v2/core/logger"
+	logger "github.com/smartcontractkit/chainlink-common/pkg/logger"
 	mock "github.com/stretchr/testify/mock"
 
 	ocr3types "github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"

--- a/core/capabilities/compute/compute_test.go
+++ b/core/capabilities/compute/compute_test.go
@@ -9,26 +9,23 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/metering"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/wasmtest"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	"github.com/smartcontractkit/chainlink/v2/core/utils/matches"
-
 	cappkg "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/metering"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 
-	corecapabilities "github.com/smartcontractkit/chainlink/v2/core/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/webapi"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/wasmtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
 	gcmocks "github.com/smartcontractkit/chainlink/v2/core/services/gateway/connector/mocks"
 	ghcapabilities "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/common"
+	"github.com/smartcontractkit/chainlink/v2/core/utils/matches"
 )
 
 const (
@@ -54,7 +51,7 @@ var defaultConfig = Config{
 }
 
 type testHarness struct {
-	registry         *corecapabilities.Registry
+	registry         *capabilities.Registry
 	connector        *gcmocks.GatewayConnector
 	log              logger.Logger
 	config           Config
@@ -63,7 +60,7 @@ type testHarness struct {
 }
 
 func setup(t *testing.T, config Config) testHarness {
-	log := logger.TestLogger(t)
+	log := logger.Test(t)
 	registry := capabilities.NewRegistry(log)
 	connector := gcmocks.NewGatewayConnector(t)
 	idGeneratorFn := func() string { return validRequestUUID }

--- a/core/capabilities/fakes/consensus.go
+++ b/core/capabilities/fakes/consensus.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -15,9 +15,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/requests"
 	pbtypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // This capability simulates consensus by running the OCR plugin on a single node, without libOCR.

--- a/core/capabilities/fakes/streams_trigger.go
+++ b/core/capabilities/fakes/streams_trigger.go
@@ -17,10 +17,11 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/datastreams"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/triggers"
 	commonStreams "github.com/smartcontractkit/chainlink-common/pkg/capabilities/triggers/streams"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	v3 "github.com/smartcontractkit/chainlink-common/pkg/types/mercury/v3"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/streams"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/v3/reportcodec"

--- a/core/capabilities/fakes/write_chain.go
+++ b/core/capabilities/fakes/write_chain.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 type fakeWriteChain struct {

--- a/core/capabilities/gateway_connector/service_wrapper.go
+++ b/core/capabilities/gateway_connector/service_wrapper.go
@@ -6,10 +6,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jonboulle/clockwork"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	gwcommon "github.com/smartcontractkit/chainlink/v2/core/services/gateway/common"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/connector"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/network"
@@ -56,7 +56,7 @@ func NewGatewayConnectorServiceWrapper(config config.GatewayConnector, keystore 
 		config:   config,
 		keystore: keystore,
 		clock:    clock,
-		lggr:     lggr.Named("GatewayConnectorServiceWrapper"),
+		lggr:     logger.Named(lggr, "GatewayConnectorServiceWrapper"),
 	}
 }
 

--- a/core/capabilities/integration_tests/keystone/llo_feed_test.go
+++ b/core/capabilities/integration_tests/keystone/llo_feed_test.go
@@ -10,17 +10,17 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	ocrTypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/datastreams"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 	datastreamsllo "github.com/smartcontractkit/chainlink-data-streams/llo"
 	feeds_consumer "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/feeds_consumer_1_0_0"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/integration_tests/framework"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/cre"
 )
@@ -28,8 +28,7 @@ import (
 func Test_runLLOWorkflow(t *testing.T) {
 	ctx := t.Context()
 
-	lggr := logger.TestLogger(t)
-	lggr.SetLogLevel(zapcore.InfoLevel)
+	lggr := logger.Test(t)
 
 	// setup the trigger sink that will receive the trigger event in the llo-specific format, per v2.0.0
 	triggerSink := framework.NewTriggerSink(t, "streams-trigger:don_16nodes", "2.0.0") // note the label {"don": "16nodes"} to ensure that we can support labelled capabilities; it must match the llo wf spec in [workflow.go]. the label nor the value are important for this test

--- a/core/capabilities/integration_tests/keystone/setup.go
+++ b/core/capabilities/integration_tests/keystone/setup.go
@@ -11,18 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
+	ocrTypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/datastreams"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	v3 "github.com/smartcontractkit/chainlink-common/pkg/types/mercury/v3"
 	feeds_consumer "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/feeds_consumer_1_0_0"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/integration_tests/framework"
-
-	ocrTypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury/v3/reportcodec"
 )
@@ -32,7 +30,7 @@ var (
 	workflowOwnerID = "0100000000000000000000000000000000000001"
 )
 
-func setupKeystoneDons(ctx context.Context, t *testing.T, lggr logger.SugaredLogger,
+func setupKeystoneDons(ctx context.Context, t *testing.T, lggr logger.Logger,
 	workflowDonInfo framework.DonConfiguration,
 	triggerDonInfo framework.DonConfiguration,
 	targetDonInfo framework.DonConfiguration,
@@ -57,7 +55,7 @@ func setupKeystoneDons(ctx context.Context, t *testing.T, lggr logger.SugaredLog
 	return workflowDon, consumer
 }
 
-func createKeystoneTriggerDon(ctx context.Context, t *testing.T, lggr logger.SugaredLogger, triggerDonInfo framework.DonConfiguration,
+func createKeystoneTriggerDon(ctx context.Context, t *testing.T, lggr logger.Logger, triggerDonInfo framework.DonConfiguration,
 	donContext framework.DonContext, trigger framework.TriggerFactory) *framework.DON {
 	triggerDon := framework.NewDON(ctx, t, lggr, triggerDonInfo,
 		[]commoncap.DON{}, donContext, false, 1*time.Second)
@@ -67,7 +65,7 @@ func createKeystoneTriggerDon(ctx context.Context, t *testing.T, lggr logger.Sug
 	return triggerDon
 }
 
-func createKeystoneWriteTargetDon(ctx context.Context, t *testing.T, lggr logger.SugaredLogger, targetDonInfo framework.DonConfiguration, donContext framework.DonContext, forwarderAddr common.Address) *framework.DON {
+func createKeystoneWriteTargetDon(ctx context.Context, t *testing.T, lggr logger.Logger, targetDonInfo framework.DonConfiguration, donContext framework.DonContext, forwarderAddr common.Address) *framework.DON {
 	writeTargetDon := framework.NewDON(ctx, t, lggr, targetDonInfo,
 		[]commoncap.DON{}, donContext, false, 1*time.Second)
 	_, err := writeTargetDon.AddPublishedEthereumWriteTargetNonStandardCapability(forwarderAddr)
@@ -76,7 +74,7 @@ func createKeystoneWriteTargetDon(ctx context.Context, t *testing.T, lggr logger
 	return writeTargetDon
 }
 
-func createKeystoneWorkflowDon(ctx context.Context, t *testing.T, lggr logger.SugaredLogger, workflowDonInfo framework.DonConfiguration,
+func createKeystoneWorkflowDon(ctx context.Context, t *testing.T, lggr logger.Logger, workflowDonInfo framework.DonConfiguration,
 	triggerDonInfo framework.DonConfiguration, targetDonInfo framework.DonConfiguration, donContext framework.DonContext) *framework.DON {
 	workflowDon := framework.NewDON(ctx, t, lggr, workflowDonInfo,
 		[]commoncap.DON{triggerDonInfo.DON, targetDonInfo.DON},
@@ -126,7 +124,7 @@ func RawReportContext(reportCtx ocrTypes.ReportContext) []byte {
 }
 
 func newReport(t *testing.T, feedID [32]byte, price *big.Int, timestamp int64) []byte {
-	v3Codec := reportcodec.NewReportCodec(feedID, logger.TestLogger(t))
+	v3Codec := reportcodec.NewReportCodec(feedID, logger.Test(t))
 	raw, err := v3Codec.BuildReport(t.Context(), v3.ReportFields{
 		BenchmarkPrice: price,
 

--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/smartcontractkit/libocr/ragep2p"
 	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
@@ -18,14 +18,15 @@ import (
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/registry"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/triggers"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable"
 	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/streams"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
 )
@@ -109,7 +110,7 @@ func NewLauncher(
 	workflowDonNotifier donNotifier,
 ) *launcher {
 	return &launcher{
-		lggr:                lggr.Named("CapabilitiesLauncher"),
+		lggr:                logger.Named(lggr, "CapabilitiesLauncher"),
 		peerWrapper:         peerWrapper,
 		dispatcher:          dispatcher,
 		registry:            registry,

--- a/core/capabilities/remote/dispatcher.go
+++ b/core/capabilities/remote/dispatcher.go
@@ -12,12 +12,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/common"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
@@ -67,7 +67,7 @@ func NewDispatcher(cfg config.Dispatcher, peerWrapper p2ptypes.PeerWrapper, sign
 		rateLimiter: rl,
 		receivers:   make(map[key]*receiver),
 		stopCh:      make(services.StopChan),
-		lggr:        lggr.Named("Dispatcher"),
+		lggr:        logger.Named(lggr, "Dispatcher"),
 	}, nil
 }
 

--- a/core/capabilities/remote/executable/client.go
+++ b/core/capabilities/remote/executable/client.go
@@ -9,11 +9,12 @@ import (
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable/request"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // client is a shim for remote executable capabilities.
@@ -51,7 +52,7 @@ var (
 func NewClient(remoteCapabilityInfo commoncap.CapabilityInfo, localDonInfo commoncap.DON, dispatcher types.Dispatcher,
 	requestTimeout time.Duration, lggr logger.Logger) *client {
 	return &client{
-		lggr:                     lggr.Named("ExecutableCapabilityClient"),
+		lggr:                     logger.Named(lggr, "ExecutableCapabilityClient"),
 		remoteCapabilityInfo:     remoteCapabilityInfo,
 		localDONInfo:             localDonInfo,
 		dispatcher:               dispatcher,

--- a/core/capabilities/remote/executable/request/client_request.go
+++ b/core/capabilities/remote/executable/request/client_request.go
@@ -10,19 +10,20 @@ import (
 	"sync"
 	"time"
 
-	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 	"google.golang.org/protobuf/proto"
+
+	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-protos/workflows/go/events"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/transmission"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/validation"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
 
@@ -75,7 +76,7 @@ func NewClientExecuteRequest(ctx context.Context, lggr logger.Logger, req common
 		return nil, fmt.Errorf("failed to extract transmission config from request: %w", err)
 	}
 
-	lggr = lggr.With("requestId", requestID, "capabilityID", remoteCapabilityInfo.ID)
+	lggr = logger.With(lggr, "requestId", requestID, "capabilityID", remoteCapabilityInfo.ID)
 	return newClientRequest(ctx, lggr, requestID, remoteCapabilityInfo, localDonInfo, dispatcher, requestTimeout, tc, types.MethodExecute, rawRequest, workflowExecutionID, req.Metadata.ReferenceID)
 }
 
@@ -302,7 +303,7 @@ func (c *ClientRequest) OnMessage(_ context.Context, msg *types.MessageBody) err
 			return fmt.Errorf("failed to get message hash: %w", err)
 		}
 
-		lggr := c.lggr.With("responseID", hex.EncodeToString(responseID[:]), "requiredCount", c.requiredIdenticalResponses, "peer", sender)
+		lggr := logger.With(c.lggr, "responseID", hex.EncodeToString(responseID[:]), "requiredCount", c.requiredIdenticalResponses, "peer", sender)
 
 		nodeReports, exists := c.meteringResponses[responseID]
 		if !exists {

--- a/core/capabilities/remote/executable/request/server_request.go
+++ b/core/capabilities/remote/executable/request/server_request.go
@@ -16,9 +16,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
 
@@ -137,7 +138,7 @@ func NewServerRequest(capability capabilities.ExecutableCapability, method strin
 	capabilityPeerID p2ptypes.PeerID,
 	callingDon capabilities.DON, requestID string,
 	dispatcher types.Dispatcher, requestTimeout time.Duration, lggr logger.Logger) (*ServerRequest, error) {
-	lggr = lggr.Named("ServerRequest").With("requestID", requestID, "capabilityID", capabilityID)
+	lggr = logger.Sugared(lggr).Named("ServerRequest").With("requestID", requestID, "capabilityID", capabilityID)
 
 	m, err := newSrMetrics(capabilityID, callingDon.ID)
 	if err != nil {
@@ -331,7 +332,7 @@ func executeCapabilityRequest(ctx context.Context, lggr logger.Logger, capabilit
 		return nil, errors.New("failed to unmarshal capability request")
 	}
 
-	lggr = lggr.With("metadata", capabilityRequest.Metadata)
+	lggr = logger.With(lggr, "metadata", capabilityRequest.Metadata)
 
 	lggr.Debugw("executing capability")
 	capResponse, err := capability.Execute(ctx, capabilityRequest)

--- a/core/capabilities/remote/executable/server.go
+++ b/core/capabilities/remote/executable/server.go
@@ -11,14 +11,14 @@ import (
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable/request"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/validation"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
-
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // server manages all external users of a local executable capability.
@@ -82,7 +82,7 @@ func NewServer(remoteExecutableConfig *commoncap.RemoteExecutableConfig, peerID 
 		messageIDToRequestIDsCount: map[string]map[string]int{},
 		requestTimeout:             requestTimeout,
 
-		lggr:   lggr.Named("ExecutableCapabilityServer"),
+		lggr:   logger.Named(lggr, "ExecutableCapabilityServer"),
 		stopCh: make(services.StopChan),
 
 		parallelExecutor: newParallelExecutor(maxParallelRequests),

--- a/core/capabilities/remote/trigger_publisher.go
+++ b/core/capabilities/remote/trigger_publisher.go
@@ -9,12 +9,13 @@ import (
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/validation"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
 
@@ -92,7 +93,7 @@ func NewTriggerPublisher(config *commoncap.RemoteTriggerConfig, underlying commo
 		batchingQueue:   make(map[[32]byte]*batchedResponse),
 		batchingEnabled: config.MaxBatchSize > 1 && config.BatchCollectionPeriod >= minAllowedBatchCollectionPeriod,
 		stopCh:          make(services.StopChan),
-		lggr:            lggr.Named("TriggerPublisher"),
+		lggr:            logger.Named(lggr, "TriggerPublisher"),
 	}
 }
 

--- a/core/capabilities/remote/trigger_subscriber.go
+++ b/core/capabilities/remote/trigger_subscriber.go
@@ -8,11 +8,12 @@ import (
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
 
@@ -89,7 +90,7 @@ func NewTriggerSubscriber(config *commoncap.RemoteTriggerConfig, capInfo commonc
 		messageCache:        messagecache.NewMessageCache[triggerEventKey, p2ptypes.PeerID](),
 		registeredWorkflows: make(map[string]*subRegState),
 		stopCh:              make(services.StopChan),
-		lggr:                lggr.Named("TriggerSubscriber"),
+		lggr:                logger.Named(lggr, "TriggerSubscriber"),
 	}
 }
 

--- a/core/capabilities/targets/write_target_test.go
+++ b/core/capabilities/targets/write_target_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
@@ -19,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/targets"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/targets/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 type testHarness struct {
@@ -36,7 +36,7 @@ type testHarness struct {
 }
 
 func setup(t *testing.T) testHarness {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 
 	cw := mocks.NewContractWriter(t)
 	cr := mocks.NewContractValueGetter(t)

--- a/core/capabilities/transmission/local_target_capability.go
+++ b/core/capabilities/transmission/local_target_capability.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // LocalTargetCapability handles the transmission protocol required for a target capability that exists in the same don as

--- a/core/capabilities/webapi/trigger/trigger.go
+++ b/core/capabilities/webapi/trigger/trigger.go
@@ -11,12 +11,12 @@ import (
 	ethCommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/webapi/webapicap"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/connector"
 	ghcapabilities "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
@@ -66,7 +66,7 @@ func NewTrigger(config string, registry core.CapabilitiesRegistry, connector con
 		connector:           connector,
 		registeredWorkflows: map[string]webapiTrigger{},
 		registry:            registry,
-		lggr:                lggr.Named("WorkflowConnectorHandler"),
+		lggr:                logger.Named(lggr, "WorkflowConnectorHandler"),
 	}
 
 	return handler, nil

--- a/core/cmd/shell_remote.go
+++ b/core/cmd/shell_remote.go
@@ -20,8 +20,9 @@ import (
 	"github.com/urfave/cli"
 	"go.uber.org/multierr"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/sessions"
 	"github.com/smartcontractkit/chainlink/v2/core/static"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -71,6 +71,7 @@ var _ common.Logger = (Logger)(nil)
 //   - Trace: Only included if compiled with the trace tag. For example: go test -tags trace ...
 //
 // Node Operator Docs: https://docs.chain.link/docs/configuration-variables/#log_level
+// Deprecated: use [common.Logger] & [common.SugaredLogger]
 type Logger interface {
 	// With creates a new Logger with the given arguments
 	With(args ...interface{}) Logger

--- a/core/scripts/ccip/shared/helpers.go
+++ b/core/scripts/ccip/shared/helpers.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	evmclient "github.com/smartcontractkit/chainlink-evm/pkg/client"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 const RetryTiming = 5 * time.Second

--- a/core/scripts/gateway/connector/run_connector.go
+++ b/core/scripts/gateway/connector/run_connector.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/pelletier/go-toml/v2"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/common"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/connector"
@@ -67,7 +67,11 @@ func main() {
 	}
 
 	sampleKey, _ := crypto.HexToECDSA("cd47d3fafdbd652dd2b66c6104fa79b372c13cb01f4a4fbfc36107cce913ac1d")
-	lggr, _ := logger.NewLogger()
+	lggr, err := logger.New()
+	if err != nil {
+		fmt.Println("error creating logger:", err)
+		return
+	}
 	client := &client{privateKey: sampleKey, lggr: lggr}
 	// client acts as a signer here
 	connector, _ := connector.NewGatewayConnector(&cfg, client, clockwork.NewRealClock(), lggr)

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -20,7 +21,6 @@ import (
 
 	coreconfig "github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/config/env"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/retirement"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
@@ -59,7 +59,7 @@ type EVMFactoryConfig struct {
 func (r *RelayerFactory) NewEVM(config EVMFactoryConfig) (map[types.RelayID]evmrelay.LOOPRelayAdapter, error) {
 	// TODO impl EVM loop. For now always 'fallback' to an adapter and embedded chain
 	relayers := make(map[types.RelayID]evmrelay.LOOPRelayAdapter)
-	lggr := r.Logger.Named("EVM")
+	lggr := logger.Named(r.Logger, "EVM")
 
 	legacyChains, err := evmrelay.NewLegacyChains(lggr, config.EthKeystore, config.ChainOpts)
 	if err != nil {
@@ -84,7 +84,7 @@ func (r *RelayerFactory) NewEVM(config EVMFactoryConfig) (map[types.RelayID]evmr
 			HTTPClient:            r.HTTPClient,
 			RetirementReportCache: r.RetirementReportCache,
 		}
-		relayer, err2 := evmrelay.NewRelayer(lggr.Named(relayID.ChainID), chain, relayerOpts)
+		relayer, err2 := evmrelay.NewRelayer(logger.Named(lggr, relayID.ChainID), chain, relayerOpts)
 		if err2 != nil {
 			err = errors.Join(err, err2)
 			continue
@@ -105,7 +105,7 @@ type SolanaFactoryConfig struct {
 func (r *RelayerFactory) NewSolana(ks coretypes.Keystore, config SolanaFactoryConfig) (map[types.RelayID]loop.Relayer, error) {
 	chainCfgs, ds := config.TOMLConfigs, config.DS
 	solanaRelayers := make(map[types.RelayID]loop.Relayer)
-	var solLggr = r.Logger.Named("Solana")
+	var solLggr = logger.Named(r.Logger, "Solana")
 
 	unique := make(map[string]struct{})
 	// create one relayer per chain id
@@ -123,7 +123,7 @@ func (r *RelayerFactory) NewSolana(ks coretypes.Keystore, config SolanaFactoryCo
 			continue
 		}
 
-		lggr := solLggr.Named(relayID.ChainID)
+		lggr := logger.Named(solLggr, relayID.ChainID)
 
 		if cmdName := env.SolanaPlugin.Cmd.Get(); cmdName != "" {
 			// setup the solana relayer to be a LOOP
@@ -199,7 +199,7 @@ func (r *RelayerFactory) NewAptos(ks coretypes.Keystore, chainCfgs RawConfigs) (
 
 func (r *RelayerFactory) NewLOOPRelayer(name string, network string, plugin env.Plugin, ks coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
 	relayers := make(map[types.RelayID]loop.Relayer)
-	lggr := r.Logger.Named(name)
+	lggr := logger.Named(r.Logger, name)
 
 	cmdName := cmp.Or(plugin.Cmd.Get(), plugin.CmdDefault)
 	if cmdName == "" {
@@ -238,7 +238,7 @@ func (r *RelayerFactory) NewLOOPRelayer(name string, network string, plugin env.
 		}
 		// the relayer service has a delicate keystore dependency. the value that is passed to NewRelayerService must
 		// be compatible with instantiating a starknet transaction manager KeystoreAdapter within the LOOPp executable.
-		relayers[relayID] = loop.NewRelayerService(lggr.Named(relayID.ChainID), r.GRPCOpts, cmdFn, string(cfgTOML), ks, r.CapabilitiesRegistry)
+		relayers[relayID] = loop.NewRelayerService(logger.Named(lggr, relayID.ChainID), r.GRPCOpts, cmdFn, string(cfgTOML), ks, r.CapabilitiesRegistry)
 	}
 	return relayers, nil
 }

--- a/core/services/gateway/connector/connector.go
+++ b/core/services/gateway/connector/connector.go
@@ -11,10 +11,10 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/jonboulle/clockwork"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	commonhex "github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/network"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -122,7 +122,7 @@ func NewGatewayConnector(config *ConnectorConfig, signer Signer, clock clockwork
 		signer:      signer,
 		handlers:    make(map[string]GatewayConnectorHandler),
 		shutdownCh:  make(chan struct{}),
-		lggr:        lggr.Named("GatewayConnector"),
+		lggr:        logger.Named(lggr, "GatewayConnector"),
 	}
 	gateways := make(map[string]*gatewayState)
 	urlToId := make(map[string]string)
@@ -138,7 +138,7 @@ func NewGatewayConnector(config *ConnectorConfig, signer Signer, clock clockwork
 		if err != nil {
 			return nil, err
 		}
-		l := lggr.With("URL", parsedURL)
+		l := logger.With(lggr, "URL", parsedURL)
 		gateway := &gatewayState{
 			conn:     network.NewWSConnectionWrapper(l),
 			config:   gw,

--- a/core/services/gateway/network/wsclient.go
+++ b/core/services/gateway/network/wsclient.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 type WebSocketClient interface {
@@ -33,7 +33,7 @@ func NewWebSocketClient(config WebSocketClientConfig, initiator ConnectionInitia
 	client := &webSocketClient{
 		initiator: initiator,
 		dialer:    dialer,
-		lggr:      lggr.Named("WebSocketClient"),
+		lggr:      logger.Named(lggr, "WebSocketClient"),
 	}
 	return client
 }

--- a/core/services/gateway/network/wsconnection.go
+++ b/core/services/gateway/network/wsconnection.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"sync/atomic"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/services"
-
 	"github.com/gorilla/websocket"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 )
 
@@ -77,7 +77,7 @@ var (
 
 func NewWSConnectionWrapper(lggr logger.Logger) WSConnectionWrapper {
 	cw := &wsConnectionWrapper{
-		lggr:       lggr.Named("WSConnectionWrapper"),
+		lggr:       logger.Named(lggr, "WSConnectionWrapper"),
 		writeCh:    make(chan writeItem),
 		readCh:     make(chan ReadItem),
 		shutdownCh: make(chan struct{}),

--- a/core/services/keystore/keystoretest.go
+++ b/core/services/keystore/keystoretest.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
@@ -52,7 +52,7 @@ func newInMemoryORM(ds sqlutil.DataSource) *memoryORM {
 // NewInMemory sets up a keystore which NOOPs attempts to access the `encrypted_key_rings` table. Accessing `evm.key_states`
 // will still hit the DB.
 func NewInMemory(ds sqlutil.DataSource, scryptParams utils.ScryptParams, lggr logger.Logger) *master {
-	dbORM := NewORM(ds, lggr)
+	dbORM := NewORM(ds)
 	memoryORM := newInMemoryORM(ds)
 
 	km := &keyManager{
@@ -60,7 +60,7 @@ func NewInMemory(ds sqlutil.DataSource, scryptParams utils.ScryptParams, lggr lo
 		keystateORM:  dbORM,
 		scryptParams: scryptParams,
 		lock:         &sync.RWMutex{},
-		logger:       lggr.Named("KeyStore"),
+		logger:       logger.Named(lggr, "KeyStore"),
 	}
 
 	return &master{

--- a/core/services/keystore/master.go
+++ b/core/services/keystore/master.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/aptoskey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/cosmoskey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/csakey"
@@ -76,13 +76,13 @@ func New(ds sqlutil.DataSource, scryptParams utils.ScryptParams, lggr logger.Log
 }
 
 func newMaster(ds sqlutil.DataSource, scryptParams utils.ScryptParams, lggr logger.Logger) *master {
-	orm := NewORM(ds, lggr)
+	orm := NewORM(ds)
 	km := &keyManager{
 		orm:          orm,
 		keystateORM:  orm,
 		scryptParams: scryptParams,
 		lock:         &sync.RWMutex{},
-		logger:       lggr.Named("KeyStore"),
+		logger:       logger.Named(lggr, "KeyStore"),
 	}
 
 	return &master{

--- a/core/services/keystore/models.go
+++ b/core/services/keystore/models.go
@@ -10,7 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/aptoskey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/cosmoskey"
@@ -259,7 +260,7 @@ func (kr *keyRing) raw() (rawKeys rawKeyRing) {
 }
 
 func (kr *keyRing) logPubKeys(lggr logger.Logger) {
-	lggr = lggr.Named("KeyRing")
+	lggr = logger.Named(lggr, "KeyRing")
 	var csaIDs []string
 	for _, CSAKey := range kr.CSA {
 		csaIDs = append(csaIDs, CSAKey.ID())

--- a/core/services/keystore/orm.go
+++ b/core/services/keystore/orm.go
@@ -7,21 +7,17 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 )
 
-func NewORM(ds sqlutil.DataSource, lggr logger.Logger) ksORM {
-	namedLogger := lggr.Named("KeystoreORM")
+func NewORM(ds sqlutil.DataSource) ksORM {
 	return ksORM{
-		ds:   ds,
-		lggr: namedLogger,
+		ds: ds,
 	}
 }
 
 type ksORM struct {
-	ds   sqlutil.DataSource
-	lggr logger.Logger
+	ds sqlutil.DataSource
 }
 
 func (orm ksORM) isEmpty(ctx context.Context) (bool, error) {

--- a/core/services/ocr2/database.go
+++ b/core/services/ocr2/database.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
+
 	ocrcommon "github.com/smartcontractkit/libocr/commontypes"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 type db struct {

--- a/core/services/relay/dummy/config_provider.go
+++ b/core/services/relay/dummy/config_provider.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
-
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
@@ -63,7 +63,7 @@ type configProvider struct {
 }
 
 func NewConfigProvider(lggr logger.Logger, cfg RelayConfig) (types.ConfigProvider, error) {
-	cp := &configProvider{lggr: lggr.Named("DummyConfigProvider").Named(cfg.ConfigTracker.ConfigDigest.String())}
+	cp := &configProvider{lggr: logger.Sugared(lggr).Named("DummyConfigProvider").Named(cfg.ConfigTracker.ConfigDigest.String())}
 
 	{
 		contractConfig, err := cfg.ConfigTracker.ToContractConfig()

--- a/core/services/relay/dummy/config_tracker.go
+++ b/core/services/relay/dummy/config_tracker.go
@@ -5,7 +5,7 @@ import (
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 type configTracker struct {
@@ -21,7 +21,7 @@ func NewContractConfigTracker(lggr logger.Logger, cfg ConfigTrackerCfg) (ocrtype
 	if err != nil {
 		return nil, err
 	}
-	return &configTracker{lggr.Named("DummyConfigTracker"), contractConfig, cfg.ChangedInBlock, cfg.BlockHeight}, nil
+	return &configTracker{logger.Named(lggr, "DummyConfigTracker"), contractConfig, cfg.ChangedInBlock, cfg.BlockHeight}, nil
 }
 
 // Notify may optionally emit notification events when the contract's

--- a/core/services/relay/dummy/llo_provider.go
+++ b/core/services/relay/dummy/llo_provider.go
@@ -6,11 +6,11 @@ import (
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	relaytypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 var _ commontypes.LLOProvider = (*lloProvider)(nil)
@@ -40,7 +40,7 @@ func NewLLOProvider(
 	return &lloProvider{
 		cp,
 		transmitter,
-		lggr.Named("LLOProvider"),
+		logger.Named(lggr, "LLOProvider"),
 		channelDefinitionCache,
 		shouldRetireCache,
 		services.MultiStart{},

--- a/core/services/relay/dummy/relayer.go
+++ b/core/services/relay/dummy/relayer.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"math/big"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/bm"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/channeldefinitions"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/retirement"

--- a/core/services/streams/pipeline.go
+++ b/core/services/streams/pipeline.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 )
@@ -85,7 +86,7 @@ func newMultiStreamPipeline(lggr logger.Logger, jb job.Job, runner Runner, rrs R
 	}
 
 	return &multiStreamPipeline{
-		lggr.Named("MultiStreamPipeline").With("spec.ID", spec.ID, "jobID", spec.JobID, "jobName", spec.JobName, "jobType", spec.JobType),
+		logger.Sugared(lggr).Named("MultiStreamPipeline").With("spec.ID", spec.ID, "jobID", spec.JobID, "jobName", spec.JobName, "jobType", spec.JobType),
 		spec,
 		runner,
 		rrs,

--- a/core/services/streams/stream_test.go
+++ b/core/services/streams/stream_test.go
@@ -10,9 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 )
@@ -56,7 +57,7 @@ func (m *MockTask) TaskMinBackoff() time.Duration      { return 0 }
 func (m *MockTask) TaskMaxBackoff() time.Duration      { return 0 }
 
 func Test_Stream(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	runner := &mockRunner{}
 	ctx := testutils.Context(t)
 

--- a/core/services/vrf/v2/listener_v2.go
+++ b/core/services/vrf/v2/listener_v2.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/theodesp/go-heaps/pairing"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
@@ -28,7 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"

--- a/core/services/vrf/v2/listener_v2_log_listener.go
+++ b/core/services/vrf/v2/listener_v2_log_listener.go
@@ -10,10 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/multierr"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mathutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/vrf/vrfcommon"
 )
 

--- a/core/services/vrf/v2/listener_v2_log_listener_test.go
+++ b/core/services/vrf/v2/listener_v2_log_listener_test.go
@@ -19,8 +19,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
-
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/vrf_coordinator_v2"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/log_emitter"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/vrf_log_emitter"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
@@ -28,13 +31,9 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/vrf_coordinator_v2"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/log_emitter"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/vrf_log_emitter"
 	evmmocks "github.com/smartcontractkit/chainlink/v2/common/chains/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/vrf/vrfcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/testdata/testspecs"
@@ -73,7 +72,7 @@ func setupVRFLogPollerListenerTH(t *testing.T) *vrfLogPollerListenerTH {
 
 	ctx := testutils.Context(t)
 
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	chainID := testutils.NewRandomEVMChainID()
 	db := pgtest.NewSqlxDB(t)
 
@@ -796,7 +795,7 @@ func TestUpdateLastProcessedBlock_UnfulfilledNFulfilledVRFReqs(t *testing.T) {
 
 func SetupGetUnfulfilledTH(t *testing.T) (*listenerV2, *ubig.Big) {
 	chainID := ubig.New(big.NewInt(12345))
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	j, err := vrfcommon.ValidatedVRFSpec(testspecs.GenerateVRFSpec(testspecs.VRFSpecParams{
 		RequestedConfsDelay: 10,
 		EVMChainID:          chainID.String(),

--- a/core/services/vrf/v2/listener_v2_log_processor.go
+++ b/core/services/vrf/v2/listener_v2_log_processor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/vrf_coordinator_v2"
@@ -28,7 +29,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 	txmgrtypes "github.com/smartcontractkit/chainlink-framework/chains/txmgr/types"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/vrf/vrfcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -1065,7 +1065,7 @@ func (lsn *listenerV2) runPipelines(
 		wg.Add(1)
 		go func(i int, req pendingRequest) {
 			defer wg.Done()
-			ll := l.With("reqID", req.req.RequestID().String())
+			ll := logger.With(l, "reqID", req.req.RequestID().String())
 			results[i] = lsn.simulateFulfillment(ctx, maxGasPriceWei, req, ll)
 		}(i, req)
 	}
@@ -1167,7 +1167,7 @@ func (lsn *listenerV2) simulateFulfillment(
 						// canceled sub and active requests.
 						// since this would be an extraordinary situation,
 						// we can log loudly here.
-						lg.Criticalw("failed to generate VRF proof", "err", trr.Result.Error)
+						logger.Sugared(lg).Criticalw("failed to generate VRF proof", "err", trr.Result.Error)
 						break
 					}
 

--- a/core/services/vrf/v2/listener_v2_types.go
+++ b/core/services/vrf/v2/listener_v2_types.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	heaps "github.com/theodesp/go-heaps"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/vrf/vrfcommon"
 )
@@ -212,7 +212,7 @@ func (lsn *listenerV2) processBatch(
 		float64(lsn.job.VRFSpec.BatchFulfillmentGasMultiplier),
 	)
 
-	ll := l.With("numRequestsInBatch", len(batch.reqIDs),
+	ll := logger.With(l, "numRequestsInBatch", len(batch.reqIDs),
 		"requestIDs", batch.reqIDs,
 		"batchSumGasLimit", batch.totalGasLimit,
 		"fromAddress", fromAddress,

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
@@ -5,31 +5,28 @@ import (
 	"math/big"
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/mock_usdc_token_messenger"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/mock_usdc_token_transmitter"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
-
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func deployUSDCPrerequisites(
@@ -93,7 +90,7 @@ func deployUSDCPrerequisites(
 func TestValidateDeployUSDCTokenPoolContractsConfig(t *testing.T) {
 	t.Parallel()
 
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 2,
 	})
@@ -143,7 +140,7 @@ func TestValidateDeployUSDCTokenPoolContractsConfig(t *testing.T) {
 func TestValidateDeployUSDCTokenPoolInput(t *testing.T) {
 	t.Parallel()
 
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 2,
 	})
@@ -245,7 +242,7 @@ func TestDeployUSDCTokenPoolContracts(t *testing.T) {
 
 	for _, numRuns := range []int{1, 2} {
 		t.Run(fmt.Sprintf("Run deployment %d time(s)", numRuns), func(t *testing.T) {
-			lggr := logger.TestLogger(t)
+			lggr := logger.Test(t)
 			e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 				Chains: 2,
 			})

--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -14,41 +14,36 @@ import (
 	xerrgroup "golang.org/x/sync/errgroup"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 
+	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_home"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 
+	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
+	ccipChangesetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 	ccipseq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_6"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
-	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
-	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
-
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
-
-	mcmstypes "github.com/smartcontractkit/mcms/types"
-
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_home"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
-
-	"github.com/smartcontractkit/chainlink/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
-	ccipChangesetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	commontypes "github.com/smartcontractkit/chainlink/deployment/common/types"
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
-	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 )
 
 // DeployHomeChainContracts deploys the home chain contracts so that the chainlink nodes can use the CR address in Capabilities.ExternalRegistry

--- a/deployment/environment/memory/node.go
+++ b/deployment/environment/memory/node.go
@@ -348,7 +348,6 @@ func NewNode(
 
 	// Set logging.
 	lggr := logger.NewSingleFileLogger(t)
-	lggr.SetLogLevel(nodecfg.LogLevel)
 
 	// Create clients for the core node backed by sim.
 	clients := make(map[uint64]client.Client)

--- a/integration-tests/smoke/ccip/ccip_usdc_test.go
+++ b/integration-tests/smoke/ccip/ccip_usdc_test.go
@@ -5,22 +5,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
-
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
-
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 /*
@@ -32,7 +28,7 @@ import (
 * 	chainB (USDC)
  */
 func TestUSDCTokenTransfer(t *testing.T) {
-	lggr := logger.TestLogger(t)
+	lggr := logger.Test(t)
 	ctx := t.Context()
 	tenv, _, _ := testsetups.NewIntegrationEnvironment(t,
 		testhelpers.WithNumOfUsersPerChain(3),

--- a/system-tests/lib/cre/devenv/devenv.go
+++ b/system-tests/lib/cre/devenv/devenv.go
@@ -11,12 +11,11 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
-
 	"github.com/smartcontractkit/chainlink-testing-framework/seth"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 	libnode "github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/node"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/types"
 )

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
@@ -30,17 +31,15 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
-	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
-	workflow_registry_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/workflowregistry"
-	cldlogger "github.com/smartcontractkit/chainlink/deployment/logger"
-
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/clclient"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/jd"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/postgres"
 	ctfconfig "github.com/smartcontractkit/chainlink-testing-framework/lib/config"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
+	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
+	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
+	workflow_registry_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/workflowregistry"
 
 	ns "github.com/smartcontractkit/chainlink-testing-framework/framework/components/simple_node_set"
 	"github.com/smartcontractkit/chainlink-testing-framework/seth"
@@ -94,7 +93,7 @@ type SetupInput struct {
 func SetupTestEnvironment(
 	ctx context.Context,
 	testLogger zerolog.Logger,
-	singeFileLogger *cldlogger.SingleFileLogger,
+	singeFileLogger logger.Logger,
 	input SetupInput,
 ) (*SetupOutput, error) {
 	topologyErr := libdon.ValidateTopology(input.CapabilitiesAwareNodeSets, input.InfraInput)
@@ -814,7 +813,7 @@ func (c *ConcurrentNonceMap) Increment(chainID uint64) uint64 {
 const NumberOfTrackedWorkflowRegistryEvents = 6
 
 // waitForAllNodesToHaveExpectedFiltersRegistered manually checks if all WorkflowRegistry filters used by the LogPoller are registered for all nodes. We want to see if this will help with the flakiness.
-func waitForAllNodesToHaveExpectedFiltersRegistered(singeFileLogger *cldlogger.SingleFileLogger, testLogger zerolog.Logger, homeChainID uint64, donTopology cretypes.DonTopology, nodeSetInput []*cretypes.CapabilitiesAwareNodeSet) error {
+func waitForAllNodesToHaveExpectedFiltersRegistered(singeFileLogger logger.Logger, testLogger zerolog.Logger, homeChainID uint64, donTopology cretypes.DonTopology, nodeSetInput []*cretypes.CapabilitiesAwareNodeSet) error {
 	for donIdx, don := range donTopology.DonsWithMetadata {
 		if !flags.HasFlag(don.Flags, cretypes.WorkflowDON) {
 			continue
@@ -877,7 +876,7 @@ func waitForAllNodesToHaveExpectedFiltersRegistered(singeFileLogger *cldlogger.S
 	return nil
 }
 
-func NewORM(logger *cldlogger.SingleFileLogger, chainID *big.Int, nodeIndex, externalPort int) (logpoller.ORM, *sqlx.DB, error) {
+func NewORM(logger logger.Logger, chainID *big.Int, nodeIndex, externalPort int) (logpoller.ORM, *sqlx.DB, error) {
 	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", "127.0.0.1", externalPort, postgres.User, postgres.Password, fmt.Sprintf("db_%d", nodeIndex))
 	db, err := sqlx.Open("postgres", dsn)
 	if err != nil {
@@ -888,7 +887,7 @@ func NewORM(logger *cldlogger.SingleFileLogger, chainID *big.Int, nodeIndex, ext
 	return logpoller.NewORM(chainID, db, logger), db, nil
 }
 
-func getAllFilters(ctx context.Context, logger *cldlogger.SingleFileLogger, chainID *big.Int, nodeIndex, externalPort int) (map[string]logpoller.Filter, error) {
+func getAllFilters(ctx context.Context, logger logger.Logger, chainID *big.Int, nodeIndex, externalPort int) (map[string]logpoller.Filter, error) {
 	orm, db, err := NewORM(logger, chainID, nodeIndex, externalPort)
 	if err != nil {
 		return nil, err

--- a/system-tests/tests/load/cre/workflow_don_load_test.go
+++ b/system-tests/tests/load/cre/workflow_don_load_test.go
@@ -21,12 +21,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/shopspring/decimal"
-	ocrTypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/require"
+
+	ocrTypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/datastreams"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	datastreamsllo "github.com/smartcontractkit/chainlink-data-streams/llo"
@@ -47,7 +49,6 @@ import (
 	keystonetypes "github.com/smartcontractkit/chainlink/system-tests/lib/cre/types"
 	libtypes "github.com/smartcontractkit/chainlink/system-tests/lib/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/targets"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/cre"
@@ -621,7 +622,7 @@ func (s *StreamsGun) precomputeReports() {
 		}
 	}
 
-	event, eventID, err := createFeedReport(logger.NullLogger, price, uint64(timestamp.UnixNano()), feeds, s.keyBundles) //nolint:gosec // G115 don't care in test code
+	event, eventID, err := createFeedReport(logger.Nop(), price, uint64(timestamp.UnixNano()), feeds, s.keyBundles) //nolint:gosec // G115 don't care in test code
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Following #17952, swap more uses