### PR TITLE
[CLD-281]: fix(cldf): remove chain fields on environment struct

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250602150832-c6cd4a526da4
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
-	github.com/smartcontractkit/chainlink-deployments-framework v0.7.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.5
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1283,8 +1283,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0 h1:rUlUd08DHsr2YJfB7reQK4jROAfxK9yy/6r0wZpP8c4=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/deployment/common/changeset/test_helpers_test.go
+++ b/deployment/common/changeset/test_helpers_test.go
@@ -65,7 +65,7 @@ func TestChangeSetLegacyFunction_ErrorCase(t *testing.T) {
 }
 
 func NewNoopEnvironment(t *testing.T) cldf.Environment {
-	return *cldf.NewCLDFEnvironment(
+	return *cldf.NewEnvironment(
 		"noop",
 		logger.TestLogger(t),
 		cldf.NewMemoryAddressBook(),
@@ -73,9 +73,6 @@ func NewNoopEnvironment(t *testing.T) cldf.Environment {
 			datastore.DefaultMetadata,
 			datastore.DefaultMetadata,
 		]().Seal(),
-		nil, // todo remove once fully migrated to CLDF new chain package
-		nil, // todo remove once fully migrated to CLDF new chain package
-		nil, // todo remove once fully migrated to CLDF new chain package
 		[]string{},
 		nil,
 		t.Context,

--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -70,11 +70,11 @@ func DeployHomeChainContracts(ctx context.Context, lggr logger.Logger, envConfig
 	}
 
 	// Fund the deployer
-	solChainSelectors := e.AllChainSelectorsSolana()
+	solChainSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilySolana))
 
 	for _, selector := range solChainSelectors {
-		lggr.Infof("Funding solana deployer account %v", e.SolChains[selector].DeployerKey.PublicKey())
-		err = memory.FundSolanaAccounts(e.GetContext(), []solana.PublicKey{e.SolChains[selector].DeployerKey.PublicKey()}, 10000, e.SolChains[selector].Client)
+		lggr.Infof("Funding solana deployer account %v", e.BlockChains.SolanaChains()[selector].DeployerKey.PublicKey())
+		err = memory.FundSolanaAccounts(e.GetContext(), []solana.PublicKey{e.BlockChains.SolanaChains()[selector].DeployerKey.PublicKey()}, 10000, e.BlockChains.SolanaChains()[selector].Client)
 		if err != nil {
 			return deployment.CapabilityRegistryConfig{}, nil, err
 		}
@@ -337,7 +337,7 @@ func setupChains(lggr logger.Logger, e *cldf.Environment, homeChainSel, feedChai
 
 		buildConfig := ccipChangesetSolana.BuildSolanaConfig{
 			GitCommitSha:   "16aa375",
-			DestinationDir: deployedEnv.Env.SolChains[solChainSelectors[0]].ProgramsPath,
+			DestinationDir: deployedEnv.Env.BlockChains.SolanaChains()[solChainSelectors[0]].ProgramsPath,
 			LocalBuild: ccipChangesetSolana.LocalBuildConfig{
 				BuildLocally: true,
 			},

--- a/deployment/environment/crib/types.go
+++ b/deployment/environment/crib/types.go
@@ -41,7 +41,7 @@ func NewDeployEnvironmentFromCribOutput(lggr logger.Logger, output DeployOutput)
 		blockChains[c.Selector] = c
 	}
 
-	return cldf.NewCLDFEnvironment(
+	return cldf.NewEnvironment(
 		CRIB_ENV_NAME,
 		lggr,
 		output.AddressBook,
@@ -49,9 +49,6 @@ func NewDeployEnvironmentFromCribOutput(lggr logger.Logger, output DeployOutput)
 			datastore.DefaultMetadata,
 			datastore.DefaultMetadata,
 		]().Seal(),
-		chains,
-		solChains, // nil for solana chains, can use memory solana chain example when required
-		nil,       // nil for aptos chains, can use memory solana chain example when required
 		output.NodeIDs,
 		nil, // todo: populate the offchain client using output.DON
 		//nolint:gocritic // intentionally use a lambda to allow dynamic context replacement in Environment Commit 90ee880

--- a/deployment/environment/devenv/environment.go
+++ b/deployment/environment/devenv/environment.go
@@ -60,7 +60,7 @@ func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config Envir
 		blockChains[c.Selector] = c
 	}
 
-	return cldf.NewCLDFEnvironment(
+	return cldf.NewEnvironment(
 		DevEnv,
 		lggr,
 		cldf.NewMemoryAddressBook(),
@@ -68,9 +68,6 @@ func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config Envir
 			datastore.DefaultMetadata,
 			datastore.DefaultMetadata,
 		]().Seal(),
-		nil, // todo: remove this when CLDF migration is complete
-		nil, // todo: remove this when CLDF migration is complete
-		nil, // sending nil for aptos chains right now, we can build this when we need it
 		nodeIDs,
 		offChain,
 		ctx,

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -268,7 +268,7 @@ func NewMemoryEnvironmentFromChainsNodes(
 		blockChains[c.Selector] = c
 	}
 
-	return *cldf.NewCLDFEnvironment(
+	return *cldf.NewEnvironment(
 		Memory,
 		lggr,
 		cldf.NewMemoryAddressBook(),
@@ -276,9 +276,6 @@ func NewMemoryEnvironmentFromChainsNodes(
 			datastore.DefaultMetadata,
 			datastore.DefaultMetadata,
 		]().Seal(),
-		nil,
-		nil,
-		nil,
 		nodeIDs, // Note these have the p2p_ prefix.
 		NewMemoryJobClient(nodes),
 		ctx,
@@ -326,7 +323,7 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 	for _, c := range aptosChains {
 		blockChains[c.Selector] = c
 	}
-	return *cldf.NewCLDFEnvironment(
+	return *cldf.NewEnvironment(
 		Memory,
 		lggr,
 		cldf.NewMemoryAddressBook(),
@@ -334,9 +331,6 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 			datastore.DefaultMetadata,
 			datastore.DefaultMetadata,
 		]().Seal(),
-		nil, // this field will be deleted in future since env.BlockChains will now contain all the chains.
-		nil, // this field will be deleted in future since env.BlockChains will now contain all the chains.
-		nil, // this field will be deleted in future since env.BlockChains will now contain all the chains.
 		nodeIDs,
 		NewMemoryJobClient(nodes),
 		t.Context,

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250602150832-c6cd4a526da4
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
-	github.com/smartcontractkit/chainlink-deployments-framework v0.7.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.11.0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1259,8 +1259,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0 h1:rUlUd08DHsr2YJfB7reQK4jROAfxK9yy/6r0wZpP8c4=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -456,7 +456,7 @@ func setupViewOnlyNodeTest(t *testing.T, registryChainSel uint64, chains map[uin
 		blockChains[sel] = c
 	}
 
-	env := cldf.NewCLDFEnvironment(
+	env := cldf.NewEnvironment(
 		"view only nodes",
 		logger.Test(t),
 		cldf.NewMemoryAddressBook(),
@@ -464,9 +464,6 @@ func setupViewOnlyNodeTest(t *testing.T, registryChainSel uint64, chains map[uin
 			datastore.DefaultMetadata,
 			datastore.DefaultMetadata,
 		]().Seal(),
-		nil,
-		nil,
-		nil,
 		dons.NodeList().IDs(),
 		envtest.NewJDService(dons.NodeList()),
 		t.Context,

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250602150832-c6cd4a526da4
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
-	github.com/smartcontractkit/chainlink-deployments-framework v0.7.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.11.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1490,8 +1490,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0 h1:rUlUd08DHsr2YJfB7reQK4jROAfxK9yy/6r0wZpP8c4=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250602150832-c6cd4a526da4
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
-	github.com/smartcontractkit/chainlink-deployments-framework v0.7.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1472,8 +1472,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0 h1:rUlUd08DHsr2YJfB7reQK4jROAfxK9yy/6r0wZpP8c4=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/smoke/ccip/ccip_topologies_test.go
+++ b/integration-tests/smoke/ccip/ccip_topologies_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/cciptesthelpertypes"
 	mt "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/messagingtest"
@@ -69,7 +72,7 @@ func Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest(t *tes
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
-	allChainSelectors := maps.Keys(e.Env.Chains)
+	allChainSelectors := e.Env.BlockChains.ListChainSelectors(chain.WithFamily(chain_selectors.FamilyEVM))
 	require.Len(t, allChainSelectors, 3)
 	// filter out the home chain
 	var nonHomeChains []uint64
@@ -123,7 +126,7 @@ func Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest(t *tes
 	var (
 		replayed bool
 		nonce    uint64
-		sender   = common.LeftPadBytes(e.Env.Chains[sourceChain].DeployerKey.From.Bytes(), 32)
+		sender   = common.LeftPadBytes(e.Env.BlockChains.EVMChains()[sourceChain].DeployerKey.From.Bytes(), 32)
 		out      mt.TestCaseOutput
 		setup    = mt.NewTestSetupWithDeployedEnv(
 			t,

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/smartcontractkit/chain-selectors v1.0.59
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
-	github.com/smartcontractkit/chainlink-deployments-framework v0.7.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.11.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.5

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1246,8 +1246,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0 h1:rUlUd08DHsr2YJfB7reQK4jROAfxK9yy/6r0wZpP8c4=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
-	github.com/smartcontractkit/chainlink-deployments-framework v0.7.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.11.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.5

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1446,8 +1446,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0 h1:rUlUd08DHsr2YJfB7reQK4jROAfxK9yy/6r0wZpP8c4=
-github.com/smartcontractkit/chainlink-deployments-framework v0.7.0/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
+github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=


### PR DESCRIPTION
There should be no more usage on these deprecated chain fields. All access should be via env.BlockChains.EVMChains() etc.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-281
