### PR TITLE
Remove redundant ccip message hashing log message.

### DIFF
--- a/core/capabilities/ccip/ccipevm/msghasher.go
+++ b/core/capabilities/ccip/ccipevm/msghasher.go
@@ -94,7 +94,6 @@ func (h *MessageHasherV1) Hash(ctx context.Context, msg cciptypes.Message) (ccip
 		"onrampAddress", msg.Header.OnRamp,
 		"sourceChainFamily", sourceChainFamily,
 	)
-	lggr.Debugw("hashing message", "msg", msg)
 
 	var rampTokenAmounts []message_hasher.InternalAny2EVMTokenTransfer
 	for _, rta := range msg.TokenAmounts {

--- a/core/capabilities/ccip/ccipsolana/msghasher.go
+++ b/core/capabilities/ccip/ccipsolana/msghasher.go
@@ -39,8 +39,6 @@ func NewMessageHasherV1(lggr logger.Logger, extraDataCodec common.ExtraDataCodec
 
 // Hash implements the MessageHasher interface.
 func (h *MessageHasherV1) Hash(_ context.Context, msg cciptypes.Message) (cciptypes.Bytes32, error) {
-	h.lggr.Debugw("hashing message", "msg", msg)
-
 	anyToSolanaMessage := ccip_offramp.Any2SVMRampMessage{}
 	anyToSolanaMessage.Header = ccip_offramp.RampMessageHeader{
 		SourceChainSelector: uint64(msg.Header.SourceChainSelector),


### PR DESCRIPTION
The `hashing message` log message is overly verbose. When searching by a random messageID this is nearly 9% of the logs are this message repeating.

It's also almost entirely redundant because the execute plugin logs all msg IDs with a `Hashed message, adding to tree leaves` log.