### PR TITLE
chore: bump reusable-docker-build-publish workflow ref

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -111,7 +111,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@chore/bump-build-push-docker
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-east-1

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -111,7 +111,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@4962346cc5ffc9f3840f48639e7b5fa179bcc2cc # 2025-05-28
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@chore/bump-build-push-docker
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-east-1
@@ -123,7 +123,7 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_APTOS_CMD=chainlink-aptos
-      docker-build-cache-disabled: "true"
+      docker-cache-behaviour: "disable"
       docker-manifest-sign: true
       docker-registry-url-override: public.ecr.aws/chainlink
       docker-tag-custom-suffix: "-plugins"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -83,7 +83,6 @@ jobs:
       github-ref-name: ${{ github.ref_name }}
       github-ref-type: ${{ github.ref_type}}
       github-workflow-repository: ${{ github.repository }}
-      github-trunk-branch: develop
       github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
       github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:
@@ -117,7 +116,6 @@ jobs:
       github-ref-name: ${{ github.ref_name }}
       github-ref-type: ${{ github.ref_type}}
       github-workflow-repository: ${{ github.repository }}
-      github-trunk-branch: develop
       github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
       github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:
@@ -151,7 +149,6 @@ jobs:
       github-ref-name: ${{ github.ref_name }}
       github-ref-type: ${{ github.ref_type}}
       github-workflow-repository: ${{ github.repository }}
-      github-trunk-branch: develop
       github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
       github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:
@@ -185,7 +182,6 @@ jobs:
       github-ref-name: ${{ github.ref_name }}
       github-ref-type: ${{ github.ref_type}}
       github-workflow-repository: ${{ github.repository }}
-      github-trunk-branch: develop
       github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
       github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,7 +65,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@4962346cc5ffc9f3840f48639e7b5fa179bcc2cc # 2025-05-28
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@chore/bump-build-push-docker
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -76,7 +76,7 @@ jobs:
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
         CL_SOLANA_CMD=chainlink-solana
-      docker-build-cache-disabled: "true"
+      docker-cache-behaviour: "write-on-trunk"
       docker-manifest-sign: true
       git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
@@ -95,7 +95,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@4962346cc5ffc9f3840f48639e7b5fa179bcc2cc # 2025-05-28
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@chore/bump-build-push-docker
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -108,7 +108,7 @@ jobs:
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_APTOS_CMD=chainlink-aptos
         CL_SOLANA_CMD=chainlink-solana
-      docker-build-cache-disabled: "true"
+      docker-cache-behaviour: "write-on-trunk"
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"
       git-sha: ${{ inputs.git-ref || github.sha }}
@@ -130,7 +130,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@4962346cc5ffc9f3840f48639e7b5fa179bcc2cc # 2025-05-28
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@chore/bump-build-push-docker
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -142,7 +142,7 @@ jobs:
         CL_CHAIN_DEFAULTS=/ccip-config
         CL_SOLANA_CMD=
         COMMIT_SHA=${{ github.sha }}
-      docker-build-cache-disabled: "true"
+      docker-cache-behaviour: "write-on-trunk"
       docker-manifest-sign: true
       git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
@@ -161,7 +161,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@4962346cc5ffc9f3840f48639e7b5fa179bcc2cc # 2025-05-28
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@chore/bump-build-push-docker
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -174,7 +174,7 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_APTOS_CMD=chainlink-aptos
-      docker-build-cache-disabled: "true"
+      docker-cache-behaviour: "write-on-trunk"
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"
       git-sha: ${{ inputs.git-ref || github.sha }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -83,6 +83,7 @@ jobs:
       github-ref-name: ${{ github.ref_name }}
       github-ref-type: ${{ github.ref_type}}
       github-workflow-repository: ${{ github.repository }}
+      github-trunk-branch: develop
       github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
       github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:
@@ -116,6 +117,7 @@ jobs:
       github-ref-name: ${{ github.ref_name }}
       github-ref-type: ${{ github.ref_type}}
       github-workflow-repository: ${{ github.repository }}
+      github-trunk-branch: develop
       github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
       github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:
@@ -149,6 +151,7 @@ jobs:
       github-ref-name: ${{ github.ref_name }}
       github-ref-type: ${{ github.ref_type}}
       github-workflow-repository: ${{ github.repository }}
+      github-trunk-branch: develop
       github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
       github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:
@@ -182,6 +185,7 @@ jobs:
       github-ref-name: ${{ github.ref_name }}
       github-ref-type: ${{ github.ref_type}}
       github-workflow-repository: ${{ github.repository }}
+      github-trunk-branch: develop
       github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
       github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
     secrets:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,7 +65,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@chore/bump-build-push-docker
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -76,7 +76,6 @@ jobs:
         CHAINLINK_USER=chainlink
         COMMIT_SHA=${{ github.sha }}
         CL_SOLANA_CMD=chainlink-solana
-      docker-cache-behaviour: "write-on-trunk"
       docker-manifest-sign: true
       git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
@@ -95,7 +94,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@chore/bump-build-push-docker
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -108,7 +107,6 @@ jobs:
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_APTOS_CMD=chainlink-aptos
         CL_SOLANA_CMD=chainlink-solana
-      docker-cache-behaviour: "write-on-trunk"
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"
       git-sha: ${{ inputs.git-ref || github.sha }}
@@ -130,7 +128,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@chore/bump-build-push-docker
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -142,7 +140,6 @@ jobs:
         CL_CHAIN_DEFAULTS=/ccip-config
         CL_SOLANA_CMD=
         COMMIT_SHA=${{ github.sha }}
-      docker-cache-behaviour: "write-on-trunk"
       docker-manifest-sign: true
       git-sha: ${{ inputs.git-ref || github.sha }}
       github-event-name: ${{ github.event_name }}
@@ -161,7 +158,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@chore/bump-build-push-docker
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -174,7 +171,6 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_APTOS_CMD=chainlink-aptos
-      docker-cache-behaviour: "write-on-trunk"
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins"
       git-sha: ${{ inputs.git-ref || github.sha }}


### PR DESCRIPTION
### Changes

Bumps `reusable-docker-build-publish` to:
  - https://github.com/smartcontractkit/.github/pull/1077
  - https://github.com/smartcontractkit/.github/pull/1076

### Context

We previously disabled the cache due to intermittent failures (#17378)
> We were seeing intermittent failures (example) in CI at a ~10-15% rate with cache enabled. GitHub's cache is only 10 GB or so per repo so not a huge loss and build speeds don't seem to be impacted.

This might've been for a few reasons:
1. Concurrent workflow attempting to reuse cache that is being written to.
2. Concurrent workflows both attempting to write to the same cache.

However, the above PR only disabled the usage of the cache during builds, and it was still saving the cache upon every invocation. This should optimize that by, only writing to caches on pushes to 'develop', but allowing for all other events to use the cache.

If this still creates problems, then we can add `docker-cache-behaviour: "disable"` to fully disable cache reads and writes.

### Testing

This PR - https://github.com/smartcontractkit/chainlink/actions/runs/15453071222/job/43566788549?pr=17978