### PR TITLE
refactor: remove redundant ApplyChangesets

### DIFF
--- a/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
@@ -243,7 +243,7 @@ func TestDeployAptosChain_Apply(t *testing.T) {
 			},
 		},
 	}
-	env, _, err := commonchangeset.ApplyChangesetsV2(t, env, []commonchangeset.ConfiguredChangeSet{
+	env, _, err := commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(DeployAptosChain{}, ccipConfig),
 	})
 	require.NoError(t, err)

--- a/deployment/ccip/changeset/aptos/cs_set_ocr3_offramp_test.go
+++ b/deployment/ccip/changeset/aptos/cs_set_ocr3_offramp_test.go
@@ -40,7 +40,7 @@ func TestSetOCR3Offramp_Apply(t *testing.T) {
 		CCIPHomeConfigType: globals.ConfigTypeActive, // TODO: investigate why this is not being used, might be a bug
 	}
 
-	env, _, err := commonchangeset.ApplyChangesetsV2(t, env, []commonchangeset.ConfiguredChangeSet{
+	env, _, err := commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(aptoscs.SetOCR3Offramp{}, cfg),
 	})
 	require.NoError(t, err)

--- a/deployment/ccip/changeset/aptos/update_aptos_lanes_test.go
+++ b/deployment/ccip/changeset/aptos/update_aptos_lanes_test.go
@@ -53,7 +53,7 @@ func TestAddAptosLanes_Apply(t *testing.T) {
 	cfg := getMockUpdateConfig(t, emvSelector, emvSelector2, aptosSelector)
 
 	// Apply the changeset
-	env, _, err := commonchangeset.ApplyChangesetsV2(t, env, []commonchangeset.ConfiguredChangeSet{
+	env, _, err := commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(aptoscs.AddAptosLanes{}, cfg),
 	})
 	require.NoError(t, err)

--- a/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana/cs_chain_contracts_test.go
@@ -48,7 +48,7 @@ func deployTokenAndMint(t *testing.T, tenv cldf.Environment, solChain uint64, wa
 	for _, key := range walletPubKeys {
 		mintMap[key] = uint64(1000)
 	}
-	e, err := commonchangeset.Apply(t, tenv, nil,
+	e, err := commonchangeset.Apply(t, tenv,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.DeploySolanaToken),
 			ccipChangesetSolana.DeploySolanaTokenConfig{
@@ -144,7 +144,7 @@ func doTestAddRemoteChain(t *testing.T, mcms bool) {
 			},
 		}
 	}
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.UpdateOnRampsDestsChangeset),
 			v1_6.UpdateOnRampDestsConfig{
@@ -208,7 +208,7 @@ func doTestAddRemoteChain(t *testing.T, mcms bool) {
 
 	// Disable the chain
 
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.DisableRemoteChain),
 			ccipChangesetSolana.DisableRemoteChainConfig{
@@ -268,7 +268,7 @@ func doTestAddRemoteChain(t *testing.T, mcms bool) {
 		}
 	}
 
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.AddRemoteChainToRouter),
 			ccipChangesetSolana.AddRemoteChainToRouterConfig{
@@ -345,7 +345,7 @@ func doTestBilling(t *testing.T, mcms bool) {
 		testPriceUpdater, err = ccipChangesetSolana.FetchTimelockSigner(e, solChain)
 		require.NoError(t, err)
 	}
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.AddBillingTokenChangeset),
 			ccipChangesetSolana.BillingTokenConfig{
@@ -400,7 +400,7 @@ func doTestBilling(t *testing.T, mcms bool) {
 	require.Equal(t, uint32(800), remoteBillingAccount.TokenTransferConfig.MinFeeUsdcents)
 
 	// test update
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.AddBillingTokenChangeset),
 			ccipChangesetSolana.BillingTokenConfig{
@@ -426,7 +426,7 @@ func doTestBilling(t *testing.T, mcms bool) {
 	feeAggregatorPriv, _ := solana.NewRandomPrivateKey()
 	feeAggregator := feeAggregatorPriv.PublicKey()
 
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.AddRemoteChainToRouter),
 			ccipChangesetSolana.AddRemoteChainToRouterConfig{
@@ -534,7 +534,7 @@ func doTestBilling(t *testing.T, mcms bool) {
 	// just send funds to the router manually rather than run e2e
 	billingSignerPDA, _, _ := solState.FindFeeBillingSignerPDA(state.SolChains[solChain].Router)
 	billingSignerATA, _, _ := solTokenUtil.FindAssociatedTokenAddress(solana.TokenProgramID, tokenAddress, billingSignerPDA)
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.MintSolanaToken),
 			ccipChangesetSolana.MintSolanaTokenConfig{
@@ -555,7 +555,7 @@ func doTestBilling(t *testing.T, mcms bool) {
 	feeAggregatorATA, _, _ := solTokenUtil.FindAssociatedTokenAddress(solana.TokenProgramID, tokenAddress, feeAggregator)
 	_, feeAggResult, err := solTokenUtil.TokenBalance(e.GetContext(), e.BlockChains.SolanaChains()[solChain].Client, feeAggregatorATA, cldf_solana.SolDefaultCommitment)
 	require.NoError(t, err)
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.WithdrawBilledFunds),
 			ccipChangesetSolana.WithdrawBilledFundsConfig{
@@ -619,7 +619,7 @@ func doTestTokenAdminRegistry(t *testing.T, mcms bool) {
 	timelockSignerPDA, err := ccipChangesetSolana.FetchTimelockSigner(e, solChain)
 	require.NoError(t, err)
 
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			// register token admin registry for tokenAddress via admin instruction
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.RegisterTokenAdminRegistry),
@@ -680,7 +680,7 @@ func doTestTokenAdminRegistry(t *testing.T, mcms bool) {
 
 	// While we can assign the admin role arbitrarily regardless of mcms, we can only accept it as timelock
 	if mcms {
-		e, err = commonchangeset.Apply(t, e, nil,
+		e, err = commonchangeset.Apply(t, e,
 			commonchangeset.Configure(
 				// accept admin role for tokenAddress
 				cldf.CreateLegacyChangeSet(ccipChangesetSolana.AcceptAdminRoleTokenAdminRegistry),
@@ -698,7 +698,7 @@ func doTestTokenAdminRegistry(t *testing.T, mcms bool) {
 		require.Equal(t, timelockSignerPDA, tokenAdminRegistryAccount.Administrator)
 		require.Equal(t, solana.PublicKey{}, tokenAdminRegistryAccount.PendingAdministrator)
 
-		e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+		e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 			commonchangeset.Configure(
 				// transfer admin role for tokenAddress
 				cldf.CreateLegacyChangeSet(ccipChangesetSolana.TransferAdminRoleTokenAdminRegistry),
@@ -754,7 +754,7 @@ func doTestPoolLookupTable(t *testing.T, e cldf.Environment, mcms bool, tokenMet
 	e, tokenAddress, err := deployTokenAndMint(t, e, solChain, []string{})
 	require.NoError(t, err)
 	pool := solTestTokenPool.LockAndRelease_PoolType
-	e, err = commonchangeset.Apply(t, e, nil,
+	e, err = commonchangeset.Apply(t, e,
 		commonchangeset.Configure(
 			// add token pool lookup table
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.AddTokenPoolLookupTable),
@@ -776,40 +776,36 @@ func doTestPoolLookupTable(t *testing.T, e cldf.Environment, mcms bool, tokenMet
 	require.Equal(t, lookupTablePubKey, lookupTableEntries0[0])
 	require.Equal(t, tokenAddress, lookupTableEntries0[7])
 
-	e, err = commonchangeset.Apply(t, e, nil,
-		commonchangeset.Configure(
-			// register token admin registry for linkToken via owner instruction
-			cldf.CreateLegacyChangeSet(ccipChangesetSolana.RegisterTokenAdminRegistry),
-			ccipChangesetSolana.RegisterTokenAdminRegistryConfig{
-				ChainSelector:           solChain,
-				TokenPubKey:             tokenAddress,
-				TokenAdminRegistryAdmin: newAdmin.String(),
-				RegisterType:            ccipChangesetSolana.ViaGetCcipAdminInstruction,
-				MCMS:                    mcmsConfig,
-			},
-		),
-		commonchangeset.Configure(
-			// accept admin role for tokenAddress
-			cldf.CreateLegacyChangeSet(ccipChangesetSolana.AcceptAdminRoleTokenAdminRegistry),
-			ccipChangesetSolana.AcceptAdminRoleTokenAdminRegistryConfig{
-				ChainSelector: solChain,
-				TokenPubKey:   tokenAddress,
-				MCMS:          mcmsConfig,
-			},
-		),
-		commonchangeset.Configure(
-			// set pool -> this updates tokenAdminRegistryPDA, hence above changeset is required
-			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetPool),
-			ccipChangesetSolana.SetPoolConfig{
-				ChainSelector:   solChain,
-				TokenPubKey:     tokenAddress,
-				PoolType:        &pool,
-				Metadata:        tokenMetadata,
-				WritableIndexes: []uint8{3, 4, 7},
-				MCMS:            mcmsConfig,
-			},
-		),
-	)
+	e, err = commonchangeset.Apply(t, e, commonchangeset.Configure(
+		// register token admin registry for linkToken via owner instruction
+		cldf.CreateLegacyChangeSet(ccipChangesetSolana.RegisterTokenAdminRegistry),
+		ccipChangesetSolana.RegisterTokenAdminRegistryConfig{
+			ChainSelector:           solChain,
+			TokenPubKey:             tokenAddress,
+			TokenAdminRegistryAdmin: newAdmin.String(),
+			RegisterType:            ccipChangesetSolana.ViaGetCcipAdminInstruction,
+			MCMS:                    mcmsConfig,
+		},
+	), commonchangeset.Configure(
+		// accept admin role for tokenAddress
+		cldf.CreateLegacyChangeSet(ccipChangesetSolana.AcceptAdminRoleTokenAdminRegistry),
+		ccipChangesetSolana.AcceptAdminRoleTokenAdminRegistryConfig{
+			ChainSelector: solChain,
+			TokenPubKey:   tokenAddress,
+			MCMS:          mcmsConfig,
+		},
+	), commonchangeset.Configure(
+		// set pool -> this updates tokenAdminRegistryPDA, hence above changeset is required
+		cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetPool),
+		ccipChangesetSolana.SetPoolConfig{
+			ChainSelector:   solChain,
+			TokenPubKey:     tokenAddress,
+			PoolType:        &pool,
+			Metadata:        tokenMetadata,
+			WritableIndexes: []uint8{3, 4, 7},
+			MCMS:            mcmsConfig,
+		},
+	))
 	require.NoError(t, err)
 	tokenAdminRegistry := solCommon.TokenAdminRegistry{}
 	tokenAdminRegistryPDA, _, _ := solState.FindTokenAdminRegistryPDA(tokenAddress, state.SolChains[solChain].Router)
@@ -855,7 +851,7 @@ func TestSetOcr3Active(t *testing.T) {
 			OffRamp:   true,
 		})
 
-	tenv.Env, _, err = commonchangeset.ApplyChangesetsV2(t, tenv.Env, []commonchangeset.ConfiguredChangeSet{
+	tenv.Env, _, err = commonchangeset.ApplyChangesets(t, tenv.Env, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetOCR3ConfigSolana),
 			v1_6.SetOCR3OffRampConfig{
@@ -884,7 +880,7 @@ func TestSetOcr3Candidate(t *testing.T) {
 			OffRamp:   true,
 		})
 
-	tenv.Env, _, err = commonchangeset.ApplyChangesetsV2(t, tenv.Env, []commonchangeset.ConfiguredChangeSet{
+	tenv.Env, _, err = commonchangeset.ApplyChangesets(t, tenv.Env, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetOCR3ConfigSolana),
 			v1_6.SetOCR3OffRampConfig{

--- a/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana/cs_deploy_chain_test.go
@@ -146,7 +146,7 @@ func TestDeployChainContractsChangesetPreload(t *testing.T) {
 	require.NoError(t, err)
 	// empty build config means, if artifacts are not present, resolve the artifact from github based on go.mod version
 	// for a simple local in memory test, they will always be present, because we need them to spin up the in memory chain
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, initialDeployCS(t, e, nil))
+	e, _, err = commonchangeset.ApplyChangesets(t, e, initialDeployCS(t, e, nil))
 	require.NoError(t, err)
 	err = testhelpers.ValidateSolanaState(e, solChainSelectors)
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestUpgrade(t *testing.T) {
 	evmSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 	homeChainSel := evmSelectors[0]
 	solChainSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
-	e, _, err := commonchangeset.ApplyChangesetsV2(t, e, initialDeployCS(t, e,
+	e, _, err := commonchangeset.ApplyChangesets(t, e, initialDeployCS(t, e,
 		&ccipChangesetSolana.BuildSolanaConfig{
 			GitCommitSha:   OldSha,
 			DestinationDir: e.BlockChains.SolanaChains()[solChainSelectors[0]].ProgramsPath,
@@ -222,7 +222,7 @@ func TestUpgrade(t *testing.T) {
 	require.NoError(t, err)
 
 	// deploy the contracts
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		// upgrade authority
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetUpgradeAuthorityChangeset),
@@ -299,7 +299,7 @@ func TestUpgrade(t *testing.T) {
 	require.NoError(t, err)
 	oldOffRampAddress := state.SolChains[solChainSelectors[0]].OffRamp
 	// add a second offramp address
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
 			ccipChangesetSolana.DeployChainContractsConfig{
@@ -362,7 +362,7 @@ func TestIDL(t *testing.T) {
 	skipInCI(t)
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1))
 	solChain := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
-	e, _, err := commonchangeset.ApplyChangesetsV2(t, tenv.Env, []commonchangeset.ConfiguredChangeSet{
+	e, _, err := commonchangeset.ApplyChangesets(t, tenv.Env, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.UploadIDL),
 			ccipChangesetSolana.IDLConfig{
@@ -393,7 +393,7 @@ func TestIDL(t *testing.T) {
 			FeeQuoter: true,
 		})
 
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetAuthorityIDL),
 			ccipChangesetSolana.IDLConfig{
@@ -417,7 +417,7 @@ func TestIDL(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.UpgradeIDL),
 			ccipChangesetSolana.IDLConfig{

--- a/deployment/ccip/changeset/solana/cs_ops_test.go
+++ b/deployment/ccip/changeset/solana/cs_ops_test.go
@@ -58,7 +58,7 @@ func TestGenericOps(t *testing.T) {
 				}
 			}
 
-			e, _, err := commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+			e, _, err := commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetDefaultCodeVersion),
 					ccipChangesetSolana.SetDefaultCodeVersionConfig{

--- a/deployment/ccip/changeset/solana/cs_token_pool_test.go
+++ b/deployment/ccip/changeset/solana/cs_token_pool_test.go
@@ -146,7 +146,7 @@ func doTestTokenPool(t *testing.T, e cldf.Environment, mcms bool, tokenMetadata 
 	for _, testCase := range testCases {
 		typePtr := &testCase.poolType
 		// for _, tokenAddress := range tokenMap {
-		e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+		e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(ccipChangesetSolana.AddTokenPoolAndLookupTable),
 				ccipChangesetSolana.TokenPoolConfig{
@@ -233,7 +233,7 @@ func doTestTokenPool(t *testing.T, e cldf.Environment, mcms bool, tokenMetadata 
 			e.Logger.Debugf("MCMS Configured for token pool %v with token address %v", testCase.poolType, tokenAddress)
 		}
 
-		e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+		e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(ccipChangesetSolana.ConfigureTokenPoolAllowList),
 				ccipChangesetSolana.ConfigureTokenPoolAllowListConfig{
@@ -288,7 +288,7 @@ func doTestTokenPool(t *testing.T, e cldf.Environment, mcms bool, tokenMetadata 
 		require.Equal(t, newOutboundConfig.Enabled, remoteChainConfigAccount.Base.OutboundRateLimit.Cfg.Enabled)
 
 		if testCase.poolType == solTestTokenPool.LockAndRelease_PoolType && tokenAddress == newTokenAddress {
-			e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+			e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(ccipChangesetSolana.LockReleaseLiquidityOps),
 					ccipChangesetSolana.LockReleaseLiquidityOpsConfig{
@@ -355,7 +355,7 @@ func doTestTokenPool(t *testing.T, e cldf.Environment, mcms bool, tokenMetadata 
 				require.NoError(t, err)
 				e.Logger.Debugf("Transferring away from MCMS for token pool %v", testCase.poolType)
 				if testCase.poolType == solTestTokenPool.BurnAndMint_PoolType {
-					e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+					e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 						commonchangeset.Configure(
 							cldf.CreateLegacyChangeSet(ccipChangesetSolana.TransferCCIPToMCMSWithTimelockSolana),
 							ccipChangesetSolana.TransferCCIPToMCMSWithTimelockSolanaConfig{
@@ -376,7 +376,7 @@ func doTestTokenPool(t *testing.T, e cldf.Environment, mcms bool, tokenMetadata 
 					})
 					require.NoError(t, err)
 				} else if testCase.poolType == solTestTokenPool.LockAndRelease_PoolType {
-					e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+					e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 						commonchangeset.Configure(
 							cldf.CreateLegacyChangeSet(ccipChangesetSolana.TransferCCIPToMCMSWithTimelockSolana),
 							ccipChangesetSolana.TransferCCIPToMCMSWithTimelockSolanaConfig{
@@ -398,7 +398,7 @@ func doTestTokenPool(t *testing.T, e cldf.Environment, mcms bool, tokenMetadata 
 					require.NoError(t, err)
 				}
 				e.Logger.Debugf("MCMS Configured for token pool %v with token address %v", testCase.poolType, tokenAddress)
-				e, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+				e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 					// upgrade authority
 					commonchangeset.Configure(
 						cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetUpgradeAuthorityChangeset),
@@ -457,7 +457,7 @@ func TestAddTokenPoolE2EWitMcms(t *testing.T) {
 	require.NoError(t, err)
 	newAdmin := timelockSignerPDA
 
-	_, _, err = commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	_, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.E2ETokenPool),
 			ccipChangesetSolana.E2ETokenPoolConfig{
@@ -567,7 +567,7 @@ func TestPartnerTokenPools(t *testing.T) {
 	e := tenv.Env
 	solChainSelectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
 	metadata := "partner_testing"
-	e, _, err := commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{commonchangeset.Configure(
+	e, _, err := commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{commonchangeset.Configure(
 		cldf.CreateLegacyChangeSet(ccipChangesetSolana.DeployChainContractsChangeset),
 		ccipChangesetSolana.DeployChainContractsConfig{
 			HomeChainSelector: e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0],

--- a/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock_test.go
+++ b/deployment/ccip/changeset/solana/transfer_ccip_to_mcms_with_timelock_test.go
@@ -209,7 +209,7 @@ func prepareEnvironmentForOwnershipTransfer(t *testing.T) (cldf.Environment, sta
 	err = testhelpers.SavePreloadedSolAddresses(e, solChainSelectors[0])
 	require.NoError(t, err)
 	solLinkTokenPrivKey, _ := solana.NewRandomPrivateKey()
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
 			v1_6.DeployHomeChainConfig{
@@ -285,7 +285,7 @@ func prepareEnvironmentForOwnershipTransfer(t *testing.T) (cldf.Environment, sta
 
 	lnr := test_token_pool.LockAndRelease_PoolType
 	bnm := test_token_pool.BurnAndMint_PoolType
-	e, err = commonchangeset.ApplyChangesets(t, e, nil, []commonchangeset.ConfiguredChangeSet{
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(solanachangesets.AddTokenPoolAndLookupTable),
 			solanachangesets.TokenPoolConfig{
@@ -422,7 +422,7 @@ func TestTransferCCIPFromMCMSWithTimelockSolana(t *testing.T) {
 			LockReleaseTokenPools: map[string]map[solana.PublicKey]solana.PublicKey{shared.CLLMetadata: {lockReleasePoolConfigPDA: tokenAddressLockRelease}},
 		})
 	// Transfer ownership back to the deployer
-	e, _, err := commonchangeset.ApplyChangesetsV2(t, e, []commonchangeset.ConfiguredChangeSet{
+	e, _, err := commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.TransferCCIPToMCMSWithTimelockSolana),
 			ccipChangesetSolana.TransferCCIPToMCMSWithTimelockSolanaConfig{

--- a/deployment/ccip/changeset/testhelpers/test_usdc_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_usdc_helpers.go
@@ -124,7 +124,7 @@ func UpdateFeeQuoterForUSDC(
 		DestBytesOverhead: 640,
 		IsEnabled:         true,
 	}
-	_, err := commonchangeset.Apply(t, e, nil,
+	_, err := commonchangeset.Apply(t, e,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.ApplyTokenTransferFeeConfigUpdatesFeeQuoterChangeset),
 			v1_6.ApplyTokenTransferFeeConfigUpdatesConfig{

--- a/deployment/ccip/changeset/testhelpers/v1_5/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/v1_5/test_helpers.go
@@ -37,20 +37,16 @@ import (
 func AddLanes(t *testing.T, e cldf.Environment, state stateview.CCIPOnChainState, pairs []testhelpers.SourceDestPair) cldf.Environment {
 	addLanesCfg, commitOCR2Configs, execOCR2Configs, jobspecs := LaneConfigsForChains(t, e, state, pairs)
 	var err error
-	e, err = commonchangeset.Apply(t, e, nil,
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_5changeset.DeployLanesChangeset),
-			v1_5changeset.DeployLanesConfig{Configs: addLanesCfg},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_5changeset.SetOCR2ConfigForTestChangeset),
-			v1_5changeset.OCR2Config{CommitConfigs: commitOCR2Configs, ExecConfigs: execOCR2Configs},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_5changeset.JobSpecsForLanesChangeset),
-			v1_5changeset.JobSpecsForLanesConfig{Configs: jobspecs},
-		),
-	)
+	e, err = commonchangeset.Apply(t, e, commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_5changeset.DeployLanesChangeset),
+		v1_5changeset.DeployLanesConfig{Configs: addLanesCfg},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_5changeset.SetOCR2ConfigForTestChangeset),
+		v1_5changeset.OCR2Config{CommitConfigs: commitOCR2Configs, ExecConfigs: execOCR2Configs},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_5changeset.JobSpecsForLanesChangeset),
+		v1_5changeset.JobSpecsForLanesConfig{Configs: jobspecs},
+	))
 	require.NoError(t, err)
 	return e
 }

--- a/deployment/ccip/changeset/v1_5/e2e_test.go
+++ b/deployment/ccip/changeset/v1_5/e2e_test.go
@@ -64,7 +64,7 @@ func TestE2ELegacy(t *testing.T) {
 	}
 	e.Env = v1_5.AddLanes(t, e.Env, state, pairs)
 	// permabless the commit stores
-	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+	e.Env, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_5changeset.PermaBlessCommitStoreChangeset),
 			v1_5changeset.PermaBlessCommitStoreConfig{

--- a/deployment/ccip/changeset/v1_5_1/cs_accept_admin_role_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_accept_admin_role_test.go
@@ -21,7 +21,7 @@ import (
 func TestAcceptAdminRoleChangeset_Validations(t *testing.T) {
 	t.Parallel()
 
-	e, selectorA, _, tokens, timelockContracts := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
+	e, selectorA, _, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
 
 	e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
 		selectorA: {
@@ -107,7 +107,7 @@ func TestAcceptAdminRoleChangeset_Validations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Msg, func(t *testing.T) {
-			_, err := commonchangeset.Apply(t, e, timelockContracts,
+			_, err := commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_5_1.AcceptAdminRoleChangeset),
 					test.Config,
@@ -127,7 +127,7 @@ func TestAcceptAdminRoleChangeset_Execution(t *testing.T) {
 		}
 
 		t.Run(msg, func(t *testing.T) {
-			e, selectorA, selectorB, tokens, timelockContracts := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), mcmsConfig != nil)
+			e, selectorA, selectorB, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), mcmsConfig != nil)
 
 			e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
 				selectorA: {
@@ -148,48 +148,45 @@ func TestAcceptAdminRoleChangeset_Execution(t *testing.T) {
 			registryOnA := state.MustGetEVMChainState(selectorA).TokenAdminRegistry
 			registryOnB := state.MustGetEVMChainState(selectorB).TokenAdminRegistry
 
-			e, err = commonchangeset.Apply(t, e, timelockContracts,
-				commonchangeset.Configure(
-					cldf.CreateLegacyChangeSet(v1_5_1.ProposeAdminRoleChangeset),
-					v1_5_1.TokenAdminRegistryChangesetConfig{
-						MCMS: mcmsConfig,
-						Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
-							selectorA: {
-								testhelpers.TestTokenSymbol: {
-									Type:    shared.BurnMintTokenPool,
-									Version: deployment.Version1_5_1,
-								},
+			e, err = commonchangeset.Apply(t, e, commonchangeset.Configure(
+				cldf.CreateLegacyChangeSet(v1_5_1.ProposeAdminRoleChangeset),
+				v1_5_1.TokenAdminRegistryChangesetConfig{
+					MCMS: mcmsConfig,
+					Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
+						selectorA: {
+							testhelpers.TestTokenSymbol: {
+								Type:    shared.BurnMintTokenPool,
+								Version: deployment.Version1_5_1,
 							},
-							selectorB: {
-								testhelpers.TestTokenSymbol: {
-									Type:    shared.BurnMintTokenPool,
-									Version: deployment.Version1_5_1,
-								},
+						},
+						selectorB: {
+							testhelpers.TestTokenSymbol: {
+								Type:    shared.BurnMintTokenPool,
+								Version: deployment.Version1_5_1,
 							},
 						},
 					},
-				),
-				commonchangeset.Configure(
-					cldf.CreateLegacyChangeSet(v1_5_1.AcceptAdminRoleChangeset),
-					v1_5_1.TokenAdminRegistryChangesetConfig{
-						MCMS: mcmsConfig,
-						Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
-							selectorA: {
-								testhelpers.TestTokenSymbol: {
-									Type:    shared.BurnMintTokenPool,
-									Version: deployment.Version1_5_1,
-								},
+				},
+			), commonchangeset.Configure(
+				cldf.CreateLegacyChangeSet(v1_5_1.AcceptAdminRoleChangeset),
+				v1_5_1.TokenAdminRegistryChangesetConfig{
+					MCMS: mcmsConfig,
+					Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
+						selectorA: {
+							testhelpers.TestTokenSymbol: {
+								Type:    shared.BurnMintTokenPool,
+								Version: deployment.Version1_5_1,
 							},
-							selectorB: {
-								testhelpers.TestTokenSymbol: {
-									Type:    shared.BurnMintTokenPool,
-									Version: deployment.Version1_5_1,
-								},
+						},
+						selectorB: {
+							testhelpers.TestTokenSymbol: {
+								Type:    shared.BurnMintTokenPool,
+								Version: deployment.Version1_5_1,
 							},
 						},
 					},
-				),
-			)
+				},
+			))
 			require.NoError(t, err)
 
 			configOnA, err := registryOnA.GetTokenConfig(nil, tokens[selectorA].Address)

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pool_factory_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pool_factory_test.go
@@ -189,7 +189,7 @@ func TestDeployTokenPoolFactoryChangeset(t *testing.T) {
 			state, err := stateview.LoadOnchainState(e)
 			require.NoError(t, err, "failed to load onchain state")
 
-			e, err = commonchangeset.Apply(t, e, nil, commonchangeset.Configure(
+			e, err = commonchangeset.Apply(t, e, commonchangeset.Configure(
 				v1_5_1.DeployTokenPoolFactoryChangeset,
 				test.ConfigFn(selectors, state),
 			))
@@ -211,7 +211,7 @@ func TestDeployTokenPoolFactoryChangeset(t *testing.T) {
 			}
 
 			// IDEMPOTENCY CHECK
-			e, err = commonchangeset.Apply(t, e, nil, commonchangeset.Configure(
+			e, err = commonchangeset.Apply(t, e, commonchangeset.Configure(
 				v1_5_1.DeployTokenPoolFactoryChangeset,
 				v1_5_1.DeployTokenPoolFactoryConfig{
 					Chains: selectors,

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_token_pools_test.go
@@ -102,7 +102,7 @@ func TestValidateDeployTokenPoolContractsConfig(t *testing.T) {
 func TestValidateDeployTokenPoolInput(t *testing.T) {
 	t.Parallel()
 
-	e, selectorA, _, tokens, _ := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
+	e, selectorA, _, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
 	acceptLiquidity := false
 	invalidAddress := utils.RandomAddress()
 
@@ -286,11 +286,11 @@ func TestDeployTokenPoolContracts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Msg, func(t *testing.T) {
-			e, selectorA, _, tokens, timelockContracts := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
+			e, selectorA, _, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
 
 			test.Input.TokenAddress = tokens[selectorA].Address
 
-			e, err := commonchangeset.Apply(t, e, timelockContracts,
+			e, err := commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_5_1.DeployTokenPoolContractsChangeset),
 					v1_5_1.DeployTokenPoolContractsConfig{

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
@@ -259,7 +259,7 @@ func TestDeployUSDCTokenPoolContracts(t *testing.T) {
 				}
 			}
 
-			e, err := commoncs.Apply(t, e, nil,
+			e, err := commoncs.Apply(t, e,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
 					changeset.DeployPrerequisiteConfig{
@@ -280,7 +280,7 @@ func TestDeployUSDCTokenPoolContracts(t *testing.T) {
 			}
 
 			for i := range numRuns {
-				e, err = commoncs.Apply(t, e, nil,
+				e, err = commoncs.Apply(t, e,
 					commonchangeset.Configure(
 						cldf.CreateLegacyChangeSet(v1_5_1.DeployUSDCTokenPoolContractsChangeset),
 						v1_5_1.DeployUSDCTokenPoolContractsConfig{

--- a/deployment/ccip/changeset/v1_5_1/cs_propose_admin_role_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_propose_admin_role_test.go
@@ -23,7 +23,7 @@ import (
 func TestProposeAdminRoleChangeset_Validations(t *testing.T) {
 	t.Parallel()
 
-	e, selectorA, _, tokens, timelockContracts := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
+	e, selectorA, _, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
 
 	e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
 		selectorA: {
@@ -38,36 +38,33 @@ func TestProposeAdminRoleChangeset_Validations(t *testing.T) {
 	}
 
 	// We want an administrator to exist to force failure in the last test
-	e, err := commonchangeset.Apply(t, e, timelockContracts,
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_5_1.ProposeAdminRoleChangeset),
-			v1_5_1.TokenAdminRegistryChangesetConfig{
-				MCMS: mcmsConfig,
-				Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
-					selectorA: {
-						testhelpers.TestTokenSymbol: {
-							Type:    shared.BurnMintTokenPool,
-							Version: deployment.Version1_5_1,
-						},
+	e, err := commonchangeset.Apply(t, e, commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_5_1.ProposeAdminRoleChangeset),
+		v1_5_1.TokenAdminRegistryChangesetConfig{
+			MCMS: mcmsConfig,
+			Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
+				selectorA: {
+					testhelpers.TestTokenSymbol: {
+						Type:    shared.BurnMintTokenPool,
+						Version: deployment.Version1_5_1,
 					},
 				},
 			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_5_1.AcceptAdminRoleChangeset),
-			v1_5_1.TokenAdminRegistryChangesetConfig{
-				MCMS: mcmsConfig,
-				Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
-					selectorA: {
-						testhelpers.TestTokenSymbol: {
-							Type:    shared.BurnMintTokenPool,
-							Version: deployment.Version1_5_1,
-						},
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_5_1.AcceptAdminRoleChangeset),
+		v1_5_1.TokenAdminRegistryChangesetConfig{
+			MCMS: mcmsConfig,
+			Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
+				selectorA: {
+					testhelpers.TestTokenSymbol: {
+						Type:    shared.BurnMintTokenPool,
+						Version: deployment.Version1_5_1,
 					},
 				},
 			},
-		),
-	)
+		},
+	))
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -151,7 +148,7 @@ func TestProposeAdminRoleChangeset_Validations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Msg, func(t *testing.T) {
-			_, err = commonchangeset.Apply(t, e, timelockContracts,
+			_, err = commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_5_1.ProposeAdminRoleChangeset),
 					test.Config,
@@ -171,7 +168,7 @@ func TestProposeAdminRoleChangeset_ExecutionWithoutExternalAdmin(t *testing.T) {
 		}
 
 		t.Run(msg, func(t *testing.T) {
-			e, selectorA, selectorB, tokens, timelockContracts := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), mcmsConfig != nil)
+			e, selectorA, selectorB, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), mcmsConfig != nil)
 
 			e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
 				selectorA: {
@@ -192,7 +189,7 @@ func TestProposeAdminRoleChangeset_ExecutionWithoutExternalAdmin(t *testing.T) {
 			registryOnA := state.Chains[selectorA].TokenAdminRegistry
 			registryOnB := state.Chains[selectorB].TokenAdminRegistry
 
-			e, err = commonchangeset.Apply(t, e, timelockContracts,
+			e, err = commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_5_1.ProposeAdminRoleChangeset),
 					v1_5_1.TokenAdminRegistryChangesetConfig{
@@ -243,7 +240,7 @@ func TestProposeAdminRoleChangeset_ExecutionWithExternalAdmin(t *testing.T) {
 		}
 
 		t.Run(msg, func(t *testing.T) {
-			e, selectorA, selectorB, tokens, timelockContracts := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), mcmsConfig != nil)
+			e, selectorA, selectorB, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), mcmsConfig != nil)
 			externalAdminA := utils.RandomAddress()
 			externalAdminB := utils.RandomAddress()
 
@@ -266,7 +263,7 @@ func TestProposeAdminRoleChangeset_ExecutionWithExternalAdmin(t *testing.T) {
 			registryOnA := state.Chains[selectorA].TokenAdminRegistry
 			registryOnB := state.Chains[selectorB].TokenAdminRegistry
 
-			_, err = commonchangeset.Apply(t, e, timelockContracts,
+			_, err = commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_5_1.ProposeAdminRoleChangeset),
 					v1_5_1.TokenAdminRegistryChangesetConfig{

--- a/deployment/ccip/changeset/v1_5_1/cs_set_pool_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_set_pool_test.go
@@ -21,7 +21,7 @@ import (
 func TestSetPoolChangeset_Validations(t *testing.T) {
 	t.Parallel()
 
-	e, selectorA, _, tokens, timelockContracts := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
+	e, selectorA, _, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
 
 	e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
 		selectorA: {
@@ -107,7 +107,7 @@ func TestSetPoolChangeset_Validations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Msg, func(t *testing.T) {
-			_, err := commonchangeset.Apply(t, e, timelockContracts,
+			_, err := commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_5_1.SetPoolChangeset),
 					test.Config,
@@ -127,7 +127,7 @@ func TestSetPoolChangeset_Execution(t *testing.T) {
 		}
 
 		t.Run(msg, func(t *testing.T) {
-			e, selectorA, selectorB, tokens, timelockContracts := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), mcmsConfig != nil)
+			e, selectorA, selectorB, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), mcmsConfig != nil)
 
 			e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
 				selectorA: {
@@ -148,68 +148,64 @@ func TestSetPoolChangeset_Execution(t *testing.T) {
 			registryOnA := state.Chains[selectorA].TokenAdminRegistry
 			registryOnB := state.Chains[selectorB].TokenAdminRegistry
 
-			_, err = commonchangeset.Apply(t, e, timelockContracts,
-				commonchangeset.Configure(
-					cldf.CreateLegacyChangeSet(v1_5_1.ProposeAdminRoleChangeset),
-					v1_5_1.TokenAdminRegistryChangesetConfig{
-						MCMS: mcmsConfig,
-						Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
-							selectorA: {
-								testhelpers.TestTokenSymbol: {
-									Type:    shared.BurnMintTokenPool,
-									Version: deployment.Version1_5_1,
-								},
+			_, err = commonchangeset.Apply(t, e, commonchangeset.Configure(
+				cldf.CreateLegacyChangeSet(v1_5_1.ProposeAdminRoleChangeset),
+				v1_5_1.TokenAdminRegistryChangesetConfig{
+					MCMS: mcmsConfig,
+					Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
+						selectorA: {
+							testhelpers.TestTokenSymbol: {
+								Type:    shared.BurnMintTokenPool,
+								Version: deployment.Version1_5_1,
 							},
-							selectorB: {
-								testhelpers.TestTokenSymbol: {
-									Type:    shared.BurnMintTokenPool,
-									Version: deployment.Version1_5_1,
-								},
+						},
+						selectorB: {
+							testhelpers.TestTokenSymbol: {
+								Type:    shared.BurnMintTokenPool,
+								Version: deployment.Version1_5_1,
 							},
 						},
 					},
-				),
-				commonchangeset.Configure(
-					cldf.CreateLegacyChangeSet(v1_5_1.AcceptAdminRoleChangeset),
-					v1_5_1.TokenAdminRegistryChangesetConfig{
-						MCMS: mcmsConfig,
-						Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
-							selectorA: {
-								testhelpers.TestTokenSymbol: {
-									Type:    shared.BurnMintTokenPool,
-									Version: deployment.Version1_5_1,
-								},
+				},
+			), commonchangeset.Configure(
+				cldf.CreateLegacyChangeSet(v1_5_1.AcceptAdminRoleChangeset),
+				v1_5_1.TokenAdminRegistryChangesetConfig{
+					MCMS: mcmsConfig,
+					Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
+						selectorA: {
+							testhelpers.TestTokenSymbol: {
+								Type:    shared.BurnMintTokenPool,
+								Version: deployment.Version1_5_1,
 							},
-							selectorB: {
-								testhelpers.TestTokenSymbol: {
-									Type:    shared.BurnMintTokenPool,
-									Version: deployment.Version1_5_1,
-								},
+						},
+						selectorB: {
+							testhelpers.TestTokenSymbol: {
+								Type:    shared.BurnMintTokenPool,
+								Version: deployment.Version1_5_1,
 							},
 						},
 					},
-				),
-				commonchangeset.Configure(
-					cldf.CreateLegacyChangeSet(v1_5_1.SetPoolChangeset),
-					v1_5_1.TokenAdminRegistryChangesetConfig{
-						MCMS: mcmsConfig,
-						Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
-							selectorA: {
-								testhelpers.TestTokenSymbol: {
-									Type:    shared.BurnMintTokenPool,
-									Version: deployment.Version1_5_1,
-								},
+				},
+			), commonchangeset.Configure(
+				cldf.CreateLegacyChangeSet(v1_5_1.SetPoolChangeset),
+				v1_5_1.TokenAdminRegistryChangesetConfig{
+					MCMS: mcmsConfig,
+					Pools: map[uint64]map[shared.TokenSymbol]v1_5_1.TokenPoolInfo{
+						selectorA: {
+							testhelpers.TestTokenSymbol: {
+								Type:    shared.BurnMintTokenPool,
+								Version: deployment.Version1_5_1,
 							},
-							selectorB: {
-								testhelpers.TestTokenSymbol: {
-									Type:    shared.BurnMintTokenPool,
-									Version: deployment.Version1_5_1,
-								},
+						},
+						selectorB: {
+							testhelpers.TestTokenSymbol: {
+								Type:    shared.BurnMintTokenPool,
+								Version: deployment.Version1_5_1,
 							},
 						},
 					},
-				),
-			)
+				},
+			))
 			require.NoError(t, err)
 
 			configOnA, err := registryOnA.GetTokenConfig(nil, tokens[selectorA].Address)

--- a/deployment/ccip/changeset/v1_5_1/cs_sync_usdc_domains_with_chains_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_sync_usdc_domains_with_chains_test.go
@@ -147,7 +147,7 @@ func TestValidateSyncUSDCDomainsWithChainsConfig(t *testing.T) {
 
 			if test.DeployUSDC {
 				var err error
-				e, err = commoncs.Apply(t, e, nil,
+				e, err = commoncs.Apply(t, e,
 					commonchangeset.Configure(
 						cldf.CreateLegacyChangeSet(v1_5_1.ConfigureTokenPoolContractsChangeset),
 						v1_5_1.ConfigureTokenPoolContractsConfig{
@@ -207,21 +207,15 @@ func TestSyncUSDCDomainsWithChainsChangeset(t *testing.T) {
 			state, err := stateview.LoadOnchainState(e)
 			require.NoError(t, err)
 
-			timelockContracts := make(map[uint64]*proposalutils.TimelockExecutionContracts, len(selectors))
 			timelockOwnedContractsByChain := make(map[uint64][]common.Address, 1)
 			for _, selector := range selectors {
-				// Assemble map of addresses required for Timelock scheduling & execution
-				timelockContracts[selector] = &proposalutils.TimelockExecutionContracts{
-					Timelock:  state.Chains[selector].Timelock,
-					CallProxy: state.Chains[selector].CallProxy,
-				}
 				// We would only need the token pool owned by timelock in these tests (if mcms config is provided)
 				timelockOwnedContractsByChain[selector] = []common.Address{state.Chains[selector].USDCTokenPools[deployment.Version1_5_1].Address()}
 			}
 
 			if mcmsConfig != nil {
 				// Transfer ownership of token pools to timelock
-				e, err = commoncs.Apply(t, e, timelockContracts,
+				e, err = commoncs.Apply(t, e,
 					commonchangeset.Configure(
 						cldf.CreateLegacyChangeSet(commoncs.TransferToMCMSWithTimelockV2),
 						commoncs.TransferToMCMSWithTimelockConfig{
@@ -233,7 +227,7 @@ func TestSyncUSDCDomainsWithChainsChangeset(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			e, err = commoncs.Apply(t, e, timelockContracts,
+			e, err = commoncs.Apply(t, e,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_5_1.ConfigureTokenPoolContractsChangeset),
 					v1_5_1.ConfigureTokenPoolContractsConfig{
@@ -260,7 +254,7 @@ func TestSyncUSDCDomainsWithChainsChangeset(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			e, err = commoncs.Apply(t, e, timelockContracts,
+			e, err = commoncs.Apply(t, e,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_5_1.SyncUSDCDomainsWithChainsChangeset),
 					v1_5_1.SyncUSDCDomainsWithChainsConfig{

--- a/deployment/ccip/changeset/v1_6/accept_ownership_test.go
+++ b/deployment/ccip/changeset/v1_6/accept_ownership_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
 func Test_NewAcceptOwnershipChangeset(t *testing.T) {
@@ -21,19 +20,6 @@ func Test_NewAcceptOwnershipChangeset(t *testing.T) {
 	require.NoError(t, err)
 
 	allChains := maps.Keys(e.Env.BlockChains.EVMChains())
-	source := allChains[0]
-	dest := allChains[1]
-
-	timelockContracts := map[uint64]*proposalutils.TimelockExecutionContracts{
-		source: {
-			Timelock:  state.Chains[source].Timelock,
-			CallProxy: state.Chains[source].CallProxy,
-		},
-		dest: {
-			Timelock:  state.Chains[dest].Timelock,
-			CallProxy: state.Chains[dest].CallProxy,
-		},
-	}
 
 	// at this point we have the initial deploys done, now we need to transfer ownership
 	// to the timelock contract
@@ -41,7 +27,7 @@ func Test_NewAcceptOwnershipChangeset(t *testing.T) {
 	require.NoError(t, err)
 
 	// compose the transfer ownership and accept ownership changesets
-	_, err = commonchangeset.Apply(t, e.Env, timelockContracts,
+	_, err = commonchangeset.Apply(t, e.Env,
 		// note this doesn't have proposals.
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),

--- a/deployment/ccip/changeset/v1_6/cs_active_candidate_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_active_candidate_test.go
@@ -47,79 +47,73 @@ func Test_ActiveCandidate(t *testing.T) {
 
 	// Connect source to dest
 	sourceState := state.Chains[source]
-	tenv.Env, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateOnRampsDestsChangeset),
-			v1_6.UpdateOnRampDestsConfig{
-				UpdatesByChain: map[uint64]map[uint64]v1_6.OnRampDestinationUpdate{
-					source: {
-						dest: {
-							IsEnabled:        true,
-							AllowListEnabled: false,
-						},
-					},
-				},
-			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateFeeQuoterPricesChangeset),
-			v1_6.UpdateFeeQuoterPricesConfig{
-				PricesByChain: map[uint64]v1_6.FeeQuoterPriceUpdatePerSource{
-					source: {
-						TokenPrices: map[common.Address]*big.Int{
-							sourceState.LinkToken.Address(): testhelpers.DefaultLinkPrice,
-							sourceState.Weth9.Address():     testhelpers.DefaultWethPrice,
-						},
-						GasPrices: map[uint64]*big.Int{
-							dest: testhelpers.DefaultGasPrice,
-						},
-					},
-				},
-			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateFeeQuoterDestsChangeset),
-			v1_6.UpdateFeeQuoterDestsConfig{
-				UpdatesByChain: map[uint64]map[uint64]fee_quoter.FeeQuoterDestChainConfig{
-					source: {
-						dest: v1_6.DefaultFeeQuoterDestChainConfig(true),
-					},
-				},
-			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateOffRampSourcesChangeset),
-			v1_6.UpdateOffRampSourcesConfig{
-				UpdatesByChain: map[uint64]map[uint64]v1_6.OffRampSourceUpdate{
+	tenv.Env, err = commonchangeset.Apply(t, tenv.Env, commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateOnRampsDestsChangeset),
+		v1_6.UpdateOnRampDestsConfig{
+			UpdatesByChain: map[uint64]map[uint64]v1_6.OnRampDestinationUpdate{
+				source: {
 					dest: {
-						source: {
-							IsEnabled:                 true,
-							IsRMNVerificationDisabled: true,
-						},
+						IsEnabled:        true,
+						AllowListEnabled: false,
 					},
 				},
 			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateRouterRampsChangeset),
-			v1_6.UpdateRouterRampsConfig{
-				UpdatesByChain: map[uint64]v1_6.RouterUpdates{
-					// onRamp update on source chain
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateFeeQuoterPricesChangeset),
+		v1_6.UpdateFeeQuoterPricesConfig{
+			PricesByChain: map[uint64]v1_6.FeeQuoterPriceUpdatePerSource{
+				source: {
+					TokenPrices: map[common.Address]*big.Int{
+						sourceState.LinkToken.Address(): testhelpers.DefaultLinkPrice,
+						sourceState.Weth9.Address():     testhelpers.DefaultWethPrice,
+					},
+					GasPrices: map[uint64]*big.Int{
+						dest: testhelpers.DefaultGasPrice,
+					},
+				},
+			},
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateFeeQuoterDestsChangeset),
+		v1_6.UpdateFeeQuoterDestsConfig{
+			UpdatesByChain: map[uint64]map[uint64]fee_quoter.FeeQuoterDestChainConfig{
+				source: {
+					dest: v1_6.DefaultFeeQuoterDestChainConfig(true),
+				},
+			},
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateOffRampSourcesChangeset),
+		v1_6.UpdateOffRampSourcesConfig{
+			UpdatesByChain: map[uint64]map[uint64]v1_6.OffRampSourceUpdate{
+				dest: {
 					source: {
-						OnRampUpdates: map[uint64]bool{
-							dest: true,
-						},
-					},
-					// offramp update on dest chain
-					dest: {
-						OffRampUpdates: map[uint64]bool{
-							source: true,
-						},
+						IsEnabled:                 true,
+						IsRMNVerificationDisabled: true,
 					},
 				},
 			},
-		),
-	)
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateRouterRampsChangeset),
+		v1_6.UpdateRouterRampsConfig{
+			UpdatesByChain: map[uint64]v1_6.RouterUpdates{
+				// onRamp update on source chain
+				source: {
+					OnRampUpdates: map[uint64]bool{
+						dest: true,
+					},
+				},
+				// offramp update on dest chain
+				dest: {
+					OffRampUpdates: map[uint64]bool{
+						source: true,
+					},
+				},
+			},
+		},
+	))
 	require.NoError(t, err)
 
 	// check that source router has dest enabled
@@ -131,7 +125,7 @@ func Test_ActiveCandidate(t *testing.T) {
 
 	// Transfer ownership so that we can set new candidate configs
 	// and set new config digest on the offramp.
-	_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+	_, err = commonchangeset.Apply(t, tenv.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
 			testhelpers.GenTestTransferOwnershipConfig(tenv, allChains, state, true),
@@ -197,7 +191,7 @@ func Test_ActiveCandidate(t *testing.T) {
 	// Now we can add a candidate config, send another request, and observe behavior.
 	// The candidate config should not be able to execute messages.
 	tokenConfig := shared.NewTestTokenConfig(state.Chains[tenv.FeedChainSel].USDFeeds)
-	_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+	_, err = commonchangeset.Apply(t, tenv.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.SetCandidateChangeset),
 			v1_6.SetCandidateChangesetConfig{

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
@@ -136,15 +136,6 @@ func TestConnectNewChain(t *testing.T) {
 				remoteChainSelectors = append(remoteChainSelectors, selector)
 			}
 
-			timelockContracts := make(map[uint64]*proposalutils.TimelockExecutionContracts, len(selectors))
-			for _, selector := range selectors {
-				// Assemble map of addresses required for Timelock scheduling & execution
-				timelockContracts[selector] = &proposalutils.TimelockExecutionContracts{
-					Timelock:  state.Chains[selector].Timelock,
-					CallProxy: state.Chains[selector].CallProxy,
-				}
-			}
-
 			if test.TransferRemoteChainsToMCMS {
 				// onRamp, offRamp, and router on non-new chains are assumed to be owned by the timelock
 				contractsToTransfer := make(map[uint64][]common.Address, len(remoteChainSelectors))
@@ -155,7 +146,7 @@ func TestConnectNewChain(t *testing.T) {
 						state.Chains[selector].Router.Address(),
 					}
 				}
-				e, err = commonchangeset.Apply(t, e, timelockContracts,
+				e, err = commonchangeset.Apply(t, e,
 					commonchangeset.Configure(
 						cldf.CreateLegacyChangeSet(commoncs.TransferToMCMSWithTimelockV2),
 						commoncs.TransferToMCMSWithTimelockConfig{
@@ -177,7 +168,7 @@ func TestConnectNewChain(t *testing.T) {
 				}
 			}
 
-			e, err = commonchangeset.Apply(t, e, timelockContracts,
+			e, err = commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					v1_6.ConnectNewChainChangeset,
 					v1_6.ConnectNewChainConfig{
@@ -337,15 +328,6 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 			_, err = e.BlockChains.EVMChains()[deployedEnvironment.HomeChainSel].Confirm(tx)
 			require.NoError(t, err, "must confirm chain config removal")
 
-			// Assemble map of addresses required for Timelock scheduling & execution
-			timelockContracts := make(map[uint64]*proposalutils.TimelockExecutionContracts, len(remoteChainSelectors))
-			for _, selector := range remoteChainSelectors {
-				timelockContracts[selector] = &proposalutils.TimelockExecutionContracts{
-					Timelock:  state.Chains[selector].Timelock,
-					CallProxy: state.Chains[selector].CallProxy,
-				}
-			}
-
 			// Transfer remote contracts to MCMS if an MCMS config is supplied
 			if test.MCMS != nil {
 				contractsToTransfer := make(map[uint64][]common.Address, len(remoteChainSelectors))
@@ -369,7 +351,7 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 					contractsToTransfer[deployedEnvironment.HomeChainSel],
 					state.Chains[deployedEnvironment.HomeChainSel].CapabilityRegistry.Address(),
 				)
-				e, err = commonchangeset.Apply(t, e, timelockContracts,
+				e, err = commonchangeset.Apply(t, e,
 					commonchangeset.Configure(
 						cldf.CreateLegacyChangeSet(commoncs.TransferToMCMSWithTimelockV2),
 						commoncs.TransferToMCMSWithTimelockConfig{
@@ -441,7 +423,7 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 			}
 
 			// deploy donIDClaimer
-			e, err = commonchangeset.Apply(t, e, nil,
+			e, err = commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					v1_6.DeployDonIDClaimerChangeset,
 					v1_6.DeployDonIDClaimerConfig{},
@@ -460,7 +442,7 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 			}
 
 			// Apply AddCandidatesForNewChainChangeset
-			e, err = commonchangeset.Apply(t, e, timelockContracts,
+			e, err = commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					v1_6.AddCandidatesForNewChainChangeset,
 					v1_6.AddCandidatesForNewChainConfig{
@@ -507,7 +489,7 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 			}
 
 			// Apply PromoteNewChainForConfigChangeset
-			e, err = commonchangeset.Apply(t, e, timelockContracts,
+			e, err = commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					v1_6.PromoteNewChainForConfigChangeset,
 					v1_6.PromoteNewChainForConfig{
@@ -549,7 +531,7 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 			for _, remoteChain := range remoteChains {
 				remoteConnectionConfigs[remoteChain.Selector] = remoteChain.ConnectionConfig
 			}
-			e, err = commonchangeset.Apply(t, e, timelockContracts,
+			e, err = commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					v1_6.ConnectNewChainChangeset,
 					v1_6.ConnectNewChainConfig{

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts_test.go
@@ -82,7 +82,7 @@ func TestUpdateOnRampsDests(t *testing.T) {
 					MinDelay: 0,
 				}
 			}
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.UpdateOnRampsDestsChangeset),
 					v1_6.UpdateOnRampDestsConfig{
@@ -158,7 +158,7 @@ func TestUpdateOnRampDynamicConfig(t *testing.T) {
 					MinDelay: 0,
 				}
 			}
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.UpdateOnRampDynamicConfigChangeset),
 					v1_6.UpdateOnRampDynamicConfig{
@@ -226,7 +226,7 @@ func TestUpdateOnRampAllowList(t *testing.T) {
 					MinDelay: 0,
 				}
 			}
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.UpdateOnRampAllowListChangeset),
 					v1_6.UpdateOnRampAllowListConfig{
@@ -356,7 +356,7 @@ func TestWithdrawOnRampFeeTokens(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tokenAmount, onRampInitWeth)
 
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.WithdrawOnRampFeeTokensChangeset),
 					v1_6.WithdrawOnRampFeeTokensConfig{
@@ -416,7 +416,7 @@ func TestUpdateOffRampsSources(t *testing.T) {
 					MinDelay: 0,
 				}
 			}
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.UpdateOffRampSourcesChangeset),
 					v1_6.UpdateOffRampSourcesConfig{
@@ -496,7 +496,7 @@ func TestUpdateFQDests(t *testing.T) {
 			fqCfg1 := v1_6.DefaultFeeQuoterDestChainConfig(true)
 			fqCfg2 := v1_6.DefaultFeeQuoterDestChainConfig(true)
 			fqCfg2.DestGasOverhead = 1000
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.UpdateFeeQuoterDestsChangeset),
 					v1_6.UpdateFeeQuoterDestsConfig{
@@ -586,7 +586,7 @@ func TestUpdateRouterRamps(t *testing.T) {
 				}
 			}
 
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.UpdateRouterRampsChangeset),
 					v1_6.UpdateRouterRampsConfig{
@@ -665,7 +665,7 @@ func TestUpdateDynamicConfigOffRampChangeset(t *testing.T) {
 				}
 			}
 			msgInterceptor := utils.RandomAddress()
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.UpdateDynamicConfigOffRampChangeset),
 					v1_6.UpdateDynamicConfigOffRampConfig{
@@ -725,7 +725,7 @@ func TestUpdateNonceManagersCS(t *testing.T) {
 				}
 			}
 
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.UpdateNonceManagersChangeset),
 					v1_6.UpdateNonceManagerConfig{
@@ -787,7 +787,7 @@ func TestUpdateNonceManagersCSApplyPreviousRampsUpdates(t *testing.T) {
 	e = testhelpers.AddCCIPContractsToEnvironment(t, e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM)), tenv, false)
 	// try to apply previous ramps updates without having any previous ramps
 	// it should fail
-	_, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.UpdateNonceManagersChangeset),
 			v1_6.UpdateNonceManagerConfig{
@@ -808,7 +808,7 @@ func TestUpdateNonceManagersCSApplyPreviousRampsUpdates(t *testing.T) {
 	e.Env = v1_5.AddLanes(t, e.Env, state, pairs)
 	// Now apply the nonce manager update
 	// it should fail again as there is no offramp for the source chain
-	_, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.UpdateNonceManagersChangeset),
 			v1_6.UpdateNonceManagerConfig{
@@ -827,7 +827,7 @@ func TestUpdateNonceManagersCSApplyPreviousRampsUpdates(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no previous offramp for source chain")
 	// Now apply the update with AllowEmptyOffRamp and it should pass
-	_, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.UpdateNonceManagersChangeset),
 			v1_6.UpdateNonceManagerConfig{
@@ -884,10 +884,10 @@ func TestSetOCR3ConfigValidations(t *testing.T) {
 			},
 		),
 	}...)
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, nil, apps)
+	e.Env, _, err = commonchangeset.ApplyChangesets(t, e.Env, apps)
 	require.NoError(t, err)
 	// try to apply ocr3config on offRamp without setting the active config on home chain
-	_, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			// Enable the OCR config on the remote chains.
 			cldf.CreateLegacyChangeSet(v1_6.SetOCR3OffRampChangeset),
@@ -921,7 +921,7 @@ func TestSetOCR3ConfigValidations(t *testing.T) {
 	}
 	// now set the chain config with wrong values of FChain
 	// it should fail on addDonAndSetCandidateChangeset
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, nil, []commonchangeset.ConfiguredChangeSet{
+	e.Env, _, err = commonchangeset.ApplyChangesets(t, e.Env, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			// Add the chain configs for the new chains.
 			cldf.CreateLegacyChangeSet(v1_6.UpdateChainConfigChangeset),
@@ -1008,7 +1008,7 @@ func TestApplyFeeTokensUpdatesFeeQuoterChangeset(t *testing.T) {
 				}
 			}
 
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.ApplyFeeTokensUpdatesFeeQuoterChangeset),
 					v1_6.ApplyFeeTokensUpdatesConfig{
@@ -1068,7 +1068,7 @@ func TestApplyPremiumMultiplierWeiPerEthUpdatesFeeQuoterChangeset(t *testing.T) 
 			}
 
 			// try to update PremiumMultiplierWeiPerEth for a token that does not exist
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.ApplyPremiumMultiplierWeiPerEthUpdatesFeeQuoterChangeset),
 					v1_6.PremiumMultiplierWeiPerEthUpdatesConfig{
@@ -1113,7 +1113,7 @@ func TestApplyPremiumMultiplierWeiPerEthUpdatesFeeQuoterChangeset(t *testing.T) 
 			state, err = stateview.LoadOnchainState(tenv.Env)
 			require.NoError(t, err)
 			// now try to apply the changeset for TEST token
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.ApplyPremiumMultiplierWeiPerEthUpdatesFeeQuoterChangeset),
 					v1_6.PremiumMultiplierWeiPerEthUpdatesConfig{
@@ -1204,7 +1204,7 @@ func TestUpdateTokenPriceFeedsFeeQuoterChangeset(t *testing.T) {
 			}
 
 			// try to update price feed for this it will fail as there is no price feed deployed for this token
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.UpdateTokenPriceFeedsFeeQuoterChangeset),
 					v1_6.UpdateTokenPriceFeedsConfig{
@@ -1223,7 +1223,7 @@ func TestUpdateTokenPriceFeedsFeeQuoterChangeset(t *testing.T) {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "price feed for token TEST not found in state for chain")
 			// now try to apply the changeset for link token, there is already a price feed deployed for link token
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.UpdateTokenPriceFeedsFeeQuoterChangeset),
 					v1_6.UpdateTokenPriceFeedsConfig{
@@ -1296,7 +1296,7 @@ func TestApplyTokenTransferFeeConfigUpdatesFeeQuoterChangeset(t *testing.T) {
 				}
 			}
 
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.ApplyTokenTransferFeeConfigUpdatesFeeQuoterChangeset),
 					v1_6.ApplyTokenTransferFeeConfigUpdatesConfig{
@@ -1332,7 +1332,7 @@ func TestApplyTokenTransferFeeConfigUpdatesFeeQuoterChangeset(t *testing.T) {
 			)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "min fee must be less than max fee for token")
-			_, err = commonchangeset.Apply(t, tenv.Env, tenv.TimelockContracts(t),
+			_, err = commonchangeset.Apply(t, tenv.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(v1_6.ApplyTokenTransferFeeConfigUpdatesFeeQuoterChangeset),
 					v1_6.ApplyTokenTransferFeeConfigUpdatesConfig{

--- a/deployment/ccip/changeset/v1_6/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_deploy_chain_test.go
@@ -56,41 +56,35 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 		})
 	}
 
-	e, err = commonchangeset.Apply(t, e, nil,
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
-			v1_6.DeployHomeChainConfig{
-				HomeChainSel:     homeChainSel,
-				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
-				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
-				NodeOperators:    testhelpers.NewTestNodeOperator(e.BlockChains.EVMChains()[homeChainSel].DeployerKey.From),
-				NodeP2PIDsPerNodeOpAdmin: map[string][][32]byte{
-					"NodeOperator": p2pIds,
-				},
+	e, err = commonchangeset.Apply(t, e, commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
+		v1_6.DeployHomeChainConfig{
+			HomeChainSel:     homeChainSel,
+			RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
+			RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
+			NodeOperators:    testhelpers.NewTestNodeOperator(e.BlockChains.EVMChains()[homeChainSel].DeployerKey.From),
+			NodeP2PIDsPerNodeOpAdmin: map[string][][32]byte{
+				"NodeOperator": p2pIds,
 			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(commonchangeset.DeployLinkToken),
-			evmSelectors,
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
-			cfg,
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
-			changeset.DeployPrerequisiteConfig{
-				Configs: prereqCfg,
-			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.DeployChainContractsChangeset),
-			ccipseq.DeployChainContractsConfig{
-				HomeChainSelector:      homeChainSel,
-				ContractParamsPerChain: contractParams,
-			},
-		),
-	)
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(commonchangeset.DeployLinkToken),
+		evmSelectors,
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
+		cfg,
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
+		changeset.DeployPrerequisiteConfig{
+			Configs: prereqCfg,
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.DeployChainContractsChangeset),
+		ccipseq.DeployChainContractsConfig{
+			HomeChainSelector:      homeChainSel,
+			ContractParamsPerChain: contractParams,
+		},
+	))
 	require.NoError(t, err)
 
 	// load onchain state
@@ -126,7 +120,7 @@ func TestDeployChainContractsChangeset(t *testing.T) {
 
 	// try to deploy chain contracts again and it should not deploy any new contracts except feequoter
 	// but should not error
-	e, err = commonchangeset.Apply(t, e, nil, commonchangeset.Configure(
+	e, err = commonchangeset.Apply(t, e, commonchangeset.Configure(
 		cldf.CreateLegacyChangeSet(v1_6.DeployChainContractsChangeset),
 		ccipseq.DeployChainContractsConfig{
 			HomeChainSelector:      homeChainSel,

--- a/deployment/ccip/changeset/v1_6/cs_jobspec_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_jobspec_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
@@ -20,7 +21,7 @@ func TestJobSpecChangeset(t *testing.T) {
 	e := tenv.Env
 	nodes, err := deployment.NodeInfo(e.NodeIDs, e.Offchain)
 	require.NoError(t, err)
-	e, err = commonchangeset.Apply(t, e, nil,
+	e, err = commonchangeset.Apply(t, e,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
 			v1_6.DeployHomeChainConfig{

--- a/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_update_bidirectional_lanes_test.go
@@ -319,15 +319,6 @@ func TestUpdateBidirectiConalLanesChangeset(t *testing.T) {
 
 			selectors := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))
 
-			timelockContracts := make(map[uint64]*proposalutils.TimelockExecutionContracts, len(selectors))
-			for _, selector := range selectors {
-				// Assemble map of addresses required for Timelock scheduling & execution
-				timelockContracts[selector] = &proposalutils.TimelockExecutionContracts{
-					Timelock:  state.Chains[selector].Timelock,
-					CallProxy: state.Chains[selector].CallProxy,
-				}
-			}
-
 			if test.MCMS != nil {
 				contractsToTransfer := make(map[uint64][]common.Address, len(selectors))
 				for _, selector := range selectors {
@@ -342,7 +333,7 @@ func TestUpdateBidirectiConalLanesChangeset(t *testing.T) {
 						state.Chains[selector].NonceManager.Address(),
 					}
 				}
-				e, err = commonchangeset.Apply(t, e, timelockContracts,
+				e, err = commonchangeset.Apply(t, e,
 					commonchangeset.Configure(
 						cldf.CreateLegacyChangeSet(commoncs.TransferToMCMSWithTimelockV2),
 						commoncs.TransferToMCMSWithTimelockConfig{
@@ -370,7 +361,7 @@ func TestUpdateBidirectiConalLanesChangeset(t *testing.T) {
 				}
 			}
 
-			e, err = commonchangeset.Apply(t, e, timelockContracts,
+			e, err = commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
 					v1_6.UpdateBidirectionalLanesChangeset,
 					v1_6.UpdateBidirectionalLanesConfig{
@@ -390,7 +381,7 @@ func TestUpdateBidirectiConalLanesChangeset(t *testing.T) {
 			}
 
 			if test.Disable {
-				e, err = commonchangeset.Apply(t, e, timelockContracts,
+				e, err = commonchangeset.Apply(t, e,
 					commonchangeset.Configure(
 						v1_6.UpdateBidirectionalLanesChangeset,
 						v1_6.UpdateBidirectionalLanesConfig{

--- a/deployment/ccip/shared/deployergroup/deployer_group.go
+++ b/deployment/ccip/shared/deployergroup/deployer_group.go
@@ -482,17 +482,6 @@ func (d *DeployerGroup) enactDeployer() (cldf.ChangesetOutput, error) {
 	return cldf.ChangesetOutput{}, nil
 }
 
-func BuildTimelockPerChain(e cldf.Environment, state stateview.CCIPOnChainState) map[uint64]*proposalutils.TimelockExecutionContracts {
-	timelocksPerChain := make(map[uint64]*proposalutils.TimelockExecutionContracts)
-	for _, chain := range e.BlockChains.EVMChains() {
-		timelocksPerChain[chain.Selector] = &proposalutils.TimelockExecutionContracts{
-			Timelock:  state.MustGetEVMChainState(chain.Selector).Timelock,
-			CallProxy: state.MustGetEVMChainState(chain.Selector).CallProxy,
-		}
-	}
-	return timelocksPerChain
-}
-
 func BuildTimelockAddressPerChain(e cldf.Environment, onchainState stateview.CCIPOnChainState) map[uint64]string {
 	addressPerChain := make(map[uint64]string)
 	for _, chain := range e.BlockChains.EVMChains() {

--- a/deployment/ccip/shared/deployergroup/deployer_group_test.go
+++ b/deployment/ccip/shared/deployergroup/deployer_group_test.go
@@ -239,12 +239,10 @@ func TestDeployerGroupMCMS(t *testing.T) {
 			state, err := stateview.LoadOnchainState(e.Env)
 			require.NoError(t, err)
 
-			timelocksPerChain := deployergroup.BuildTimelockPerChain(e.Env, state)
-
 			contractsByChain := make(map[uint64][]common.Address)
 			contractsByChain[e.HomeChainSel] = []common.Address{state.MustGetEVMChainState(e.HomeChainSel).LinkToken.Address()}
 
-			_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+			_, err = commonchangeset.Apply(t, e.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
 					commonchangeset.TransferToMCMSWithTimelockConfig{
@@ -257,7 +255,7 @@ func TestDeployerGroupMCMS(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+			_, err = commonchangeset.Apply(t, e.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(dummyDeployerGroupGrantMintChangeset),
 					tc.cfg,
@@ -265,7 +263,7 @@ func TestDeployerGroupMCMS(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+			_, err = commonchangeset.Apply(t, e.Env,
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(dummyDeployerGroupMintChangeset),
 					tc.cfg,
@@ -316,14 +314,12 @@ func TestDeployerGroupGenerateMultipleProposals(t *testing.T) {
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
-	timelocksPerChain := deployergroup.BuildTimelockPerChain(e.Env, state)
-
 	contractsByChain := make(map[uint64][]common.Address)
 	for _, chain := range e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 		contractsByChain[chain] = []common.Address{state.MustGetEVMChainState(chain).LinkToken.Address()}
 	}
 
-	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
 			commonchangeset.TransferToMCMSWithTimelockConfig{
@@ -336,7 +332,7 @@ func TestDeployerGroupGenerateMultipleProposals(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(dummyDeployerGroupGrantMintMultiChainChangeset),
 			tc,
@@ -382,14 +378,12 @@ func TestDeployerGroupMultipleProposalsMCMS(t *testing.T) {
 	currentState, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
-	timelocksPerChain := deployergroup.BuildTimelockPerChain(e.Env, currentState)
-
 	contractsByChain := make(map[uint64][]common.Address)
 	for _, chain := range e.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM)) {
 		contractsByChain[chain] = []common.Address{currentState.MustGetEVMChainState(chain).LinkToken.Address()}
 	}
 
-	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
 			commonchangeset.TransferToMCMSWithTimelockConfig{
@@ -402,7 +396,7 @@ func TestDeployerGroupMultipleProposalsMCMS(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(dummyDeployerGroupGrantMintMultiChainChangeset),
 			cfg,
@@ -410,7 +404,7 @@ func TestDeployerGroupMultipleProposalsMCMS(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(dummyDeployerGroupMintMultiDeploymentContextChangeset),
 			cfg,

--- a/deployment/ccip/shared/stateview/state_test.go
+++ b/deployment/ccip/shared/stateview/state_test.go
@@ -198,7 +198,7 @@ func TestEnforceMCMSUsageIfProd(t *testing.T) {
 			}
 
 			if test.DeployMCMS {
-				e, err = commonchangeset.Apply(t, e, nil,
+				e, err = commonchangeset.Apply(t, e,
 					commonchangeset.Configure(cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2), map[uint64]types.MCMSWithTimelockConfigV2{
 						homeChainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
 					}),
@@ -216,12 +216,6 @@ func TestEnforceMCMSUsageIfProd(t *testing.T) {
 				}
 				if len(addrs) > 0 {
 					e, err = commonchangeset.Apply(t, e,
-						map[uint64]*proposalutils.TimelockExecutionContracts{
-							homeChainSelector: &proposalutils.TimelockExecutionContracts{
-								Timelock:  state.Chains[homeChainSelector].Timelock,
-								CallProxy: state.Chains[homeChainSelector].CallProxy,
-							},
-						},
 						commonchangeset.Configure(
 							cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
 							commonchangeset.TransferToMCMSWithTimelockConfig{

--- a/deployment/common/changeset/deploy_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock_test.go
@@ -56,7 +56,7 @@ func TestGrantRoleInTimeLock(t *testing.T) {
 		cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
 		changesetConfig,
 	)
-	updatedEnv, err := commonchangeset.Apply(t, env, nil, configuredChangeset)
+	updatedEnv, err := commonchangeset.Apply(t, env, configuredChangeset)
 	require.NoError(t, err)
 	mcmsState, err := mcmschangesetstate.MaybeLoadMCMSWithTimelockState(updatedEnv, evmSelectors)
 	require.NoError(t, err)
@@ -77,13 +77,13 @@ func TestGrantRoleInTimeLock(t *testing.T) {
 	chain.DeployerKey = evmChains[evmSelectors[0]].Users[0]
 
 	// now deploy MCMS again so that only the proposer is new
-	updatedEnv, err = commonchangeset.Apply(t, updatedEnv, nil, configuredChangeset)
+	updatedEnv, err = commonchangeset.Apply(t, updatedEnv, configuredChangeset)
 	require.NoError(t, err)
 	mcmsState, err = mcmschangesetstate.MaybeLoadMCMSWithTimelockState(updatedEnv, evmSelectors)
 	require.NoError(t, err)
 
 	require.NotEqual(t, existingProposer.Address(), mcmsState[evmSelectors[0]].ProposerMcm.Address())
-	updatedEnv, err = commonchangeset.Apply(t, updatedEnv, nil, commonchangeset.Configure(
+	updatedEnv, err = commonchangeset.Apply(t, updatedEnv, commonchangeset.Configure(
 		commonchangeset.GrantRoleInTimeLock,
 		commonchangeset.GrantRoleInput{
 			ExistingProposerByChain: map[uint64]common.Address{
@@ -178,7 +178,7 @@ func TestDeployMCMSWithTimelockV2WithFewExistingContracts(t *testing.T) {
 	)
 
 	// --- act ---
-	updatedEnv, err := commonchangeset.Apply(t, env, nil, configuredChangeset)
+	updatedEnv, err := commonchangeset.Apply(t, env, configuredChangeset)
 	require.NoError(t, err)
 
 	state, err := mcmschangesetstate.MaybeLoadMCMSWithTimelockState(updatedEnv, evmSelectors)
@@ -321,7 +321,7 @@ func TestDeployMCMSWithTimelockV2(t *testing.T) {
 	commonchangeset.SetPreloadedSolanaAddresses(t, env, solanaSelectors[0])
 
 	// --- act ---
-	updatedEnv, err := commonchangeset.Apply(t, env, nil, configuredChangeset)
+	updatedEnv, err := commonchangeset.Apply(t, env, configuredChangeset)
 	require.NoError(t, err)
 
 	evmState, err := mcmschangesetstate.MaybeLoadMCMSWithTimelockState(updatedEnv, evmSelectors)
@@ -518,14 +518,14 @@ func TestDeployMCMSWithTimelockV2SkipInitSolana(t *testing.T) {
 	)
 	commonchangeset.SetPreloadedSolanaAddresses(t, env, solanaSelectors[0])
 	// --- act ---
-	updatedEnv, err := commonchangeset.Apply(t, env, nil, configuredChangeset)
+	updatedEnv, err := commonchangeset.Apply(t, env, configuredChangeset)
 	require.NoError(t, err)
 
 	solanaState, err := mcmschangesetstate.MaybeLoadMCMSWithTimelockStateSolana(updatedEnv, solanaSelectors)
 	require.NoError(t, err)
 
 	// Call deploy again, seeds and addresses from original state should not change
-	updatedEnvReTriggered, err := commonchangeset.Apply(t, updatedEnv, nil, configuredChangeset)
+	updatedEnvReTriggered, err := commonchangeset.Apply(t, updatedEnv, configuredChangeset)
 	require.NoError(t, err)
 	solanaStateNew, err := mcmschangesetstate.MaybeLoadMCMSWithTimelockStateSolana(updatedEnvReTriggered, solanaSelectors)
 	require.NoError(t, err)

--- a/deployment/common/changeset/example/link_transfer_test.go
+++ b/deployment/common/changeset/example/link_transfer_test.go
@@ -37,23 +37,20 @@ func setupLinkTransferTestEnv(t *testing.T) cldf.Environment {
 	config := proposalutils.SingleGroupMCMSV2(t)
 
 	// Deploy MCMS and Timelock
-	env, err := changeset.Apply(t, env, nil,
-		changeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.DeployLinkToken),
-			[]uint64{chainSelector},
-		),
-		changeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
-			map[uint64]types.MCMSWithTimelockConfigV2{
-				chainSelector: {
-					Canceller:        config,
-					Bypasser:         config,
-					Proposer:         config,
-					TimelockMinDelay: big.NewInt(0),
-				},
+	env, err := changeset.Apply(t, env, changeset.Configure(
+		cldf.CreateLegacyChangeSet(changeset.DeployLinkToken),
+		[]uint64{chainSelector},
+	), changeset.Configure(
+		cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
+		map[uint64]types.MCMSWithTimelockConfigV2{
+			chainSelector: {
+				Canceller:        config,
+				Bypasser:         config,
+				Proposer:         config,
+				TimelockMinDelay: big.NewInt(0),
 			},
-		),
-	)
+		},
+	))
 	require.NoError(t, err)
 	return env
 }
@@ -255,14 +252,8 @@ func TestLinkTransferMCMSV2(t *testing.T) {
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)
 
-	timelocks := map[uint64]*proposalutils.TimelockExecutionContracts{
-		chainSelector: {
-			Timelock:  mcmsState.Timelock,
-			CallProxy: mcmsState.CallProxy,
-		},
-	}
 	// Apply the changeset
-	_, err = changeset.Apply(t, env, timelocks,
+	_, err = changeset.Apply(t, env,
 		// the changeset produces proposals, ApplyChangesets will sign & execute them.
 		// in practice, signing and executing are separated processes.
 		changeset.Configure(

--- a/deployment/common/changeset/example/mint_link_test.go
+++ b/deployment/common/changeset/example/mint_link_test.go
@@ -35,7 +35,7 @@ func TestMintLink(t *testing.T) {
 	linkState, err := changeset.MaybeLoadLinkTokenChainState(chain, addrs)
 	require.NoError(t, err)
 
-	_, err = changeset.Apply(t, env, nil,
+	_, err = changeset.Apply(t, env,
 		changeset.Configure(
 			cldf.CreateLegacyChangeSet(example.AddMintersBurnersLink),
 			&example.AddMintersBurnersLinkConfig{

--- a/deployment/common/changeset/example/solana_transfer_mcm_test.go
+++ b/deployment/common/changeset/example/solana_transfer_mcm_test.go
@@ -48,7 +48,7 @@ func setupFundingTestEnv(t *testing.T) cldf.Environment {
 	require.NoError(t, err)
 
 	// Deploy MCMS and Timelock
-	env, err = changeset.Apply(t, env, nil,
+	env, err = changeset.Apply(t, env,
 		changeset.Configure(
 			cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
 			map[uint64]types.MCMSWithTimelockConfigV2{
@@ -244,7 +244,7 @@ func TestTransferFromTimelockConfig_Apply(t *testing.T) {
 
 	changesetInstance := example.TransferFromTimelock{}
 
-	env, _, err = changeset.ApplyChangesetsV2(t, env, []changeset.ConfiguredChangeSet{
+	env, _, err = changeset.ApplyChangesets(t, env, []changeset.ConfiguredChangeSet{
 		changeset.Configure(changesetInstance, config),
 	})
 	require.NoError(t, err)

--- a/deployment/common/changeset/mcms_firedrill_test.go
+++ b/deployment/common/changeset/mcms_firedrill_test.go
@@ -36,7 +36,7 @@ func setupFiredrillTestEnv(t *testing.T) cldf.Environment {
 	commonchangeset.SetPreloadedSolanaAddresses(t, env, chainSelectorSolana)
 	config := proposalutils.SingleGroupTimelockConfigV2(t)
 	// Deploy MCMS and Timelock
-	env, err := commonchangeset.Apply(t, env, nil,
+	env, err := commonchangeset.Apply(t, env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
 			map[uint64]commontypes.MCMSWithTimelockConfigV2{
@@ -92,7 +92,7 @@ func TestMCMSSignFireDrillChangeset(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			changesetsToApply := tc.changeSets()
-			_, _, err := commonchangeset.ApplyChangesetsV2(t, env, changesetsToApply)
+			_, _, err := commonchangeset.ApplyChangesets(t, env, changesetsToApply)
 			require.NoError(t, err)
 		})
 	}

--- a/deployment/common/changeset/solana/fund_mcm_pdas_test.go
+++ b/deployment/common/changeset/solana/fund_mcm_pdas_test.go
@@ -48,7 +48,7 @@ func setupFundingTestEnv(t *testing.T) cldf.Environment {
 	require.NoError(t, err)
 
 	// Deploy MCMS and Timelock
-	env, err = changeset.Apply(t, env, nil,
+	env, err = changeset.Apply(t, env,
 		changeset.Configure(
 			cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
 			map[uint64]types.MCMSWithTimelockConfigV2{
@@ -254,7 +254,7 @@ func TestFundMCMSignersChangeset_Apply(t *testing.T) {
 
 	changesetInstance := commonSolana.FundMCMSignersChangeset{}
 
-	env, _, err := changeset.ApplyChangesetsV2(t, env, []changeset.ConfiguredChangeSet{
+	env, _, err := changeset.ApplyChangesets(t, env, []changeset.ConfiguredChangeSet{
 		changeset.Configure(changesetInstance, config),
 	})
 	require.NoError(t, err)

--- a/deployment/common/changeset/solana/transfer_ownership_test.go
+++ b/deployment/common/changeset/solana/transfer_ownership_test.go
@@ -52,7 +52,7 @@ func TestTransferToMCMSToTimelockSolana(t *testing.T) {
 	assertOwner(t, env, solanaSelector, chainState, deployer)
 
 	// --- act ---
-	_, _, err := commonchangeset.ApplyChangesetsV2(t, env, []commonchangeset.ConfiguredChangeSet{configuredChangeset})
+	_, _, err := commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{configuredChangeset})
 	require.NoError(t, err)
 
 	// --- assert ---

--- a/deployment/common/changeset/solana/update_delay_timelock_test.go
+++ b/deployment/common/changeset/solana/update_delay_timelock_test.go
@@ -50,7 +50,7 @@ func setupUpdateDelayTestEnv(t *testing.T) cldf.Environment {
 	require.NoError(t, err)
 
 	// Deploy MCMS and Timelock
-	env, err = changeset.Apply(t, env, nil,
+	env, err = changeset.Apply(t, env,
 		changeset.Configure(
 			cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
 			map[uint64]types.MCMSWithTimelockConfigV2{
@@ -186,7 +186,7 @@ func TestUpdateTimelockDelaySolana_Apply(t *testing.T) {
 
 	changesetInstance := commonSolana.UpdateTimelockDelaySolana{}
 
-	env, _, err := changeset.ApplyChangesetsV2(t, env, []changeset.ConfiguredChangeSet{
+	env, _, err := changeset.ApplyChangesets(t, env, []changeset.ConfiguredChangeSet{
 		changeset.Configure(changesetInstance, config),
 	})
 	require.NoError(t, err)

--- a/deployment/common/changeset/test_helpers_test.go
+++ b/deployment/common/changeset/test_helpers_test.go
@@ -33,7 +33,7 @@ func TestChangeSetLegacyFunction_PassingCase(t *testing.T) {
 	)
 	require.False(t, executedCs, "Not expected to have executed the changeset yet")
 	require.False(t, executedValidator, "Not expected to have executed the validator yet")
-	_, err := Apply(t, e, nil, Configure(csv2, 1))
+	_, err := Apply(t, e, Configure(csv2, 1))
 	require.True(t, executedCs, "Validator should have returned nil, allowing changeset execution")
 	require.True(t, executedValidator, "Not expected to have executed the validator yet")
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestChangeSetLegacyFunction_ErrorCase(t *testing.T) {
 	)
 	require.False(t, executedCs, "Not expected to have executed the changeset yet")
 	require.False(t, executedValidator, "Not expected to have executed the validator yet")
-	_, err := Apply(t, e, nil, Configure(csv2, 1))
+	_, err := Apply(t, e, Configure(csv2, 1))
 	require.False(t, executedCs, "Validator should have fired, preventing changeset execution")
 	require.True(t, executedValidator, "Not expected to have executed the validator yet")
 	require.Equal(t, "failed to apply changeset at index 0: you shall not pass", err.Error())
@@ -160,7 +160,7 @@ func TestApplyChangesetsHelpers(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name:                   "ApplyChangesetsV2 validates datastore is merged after apply",
+			name:                   "ApplyChangesets validates datastore is merged after apply",
 			changesets:             changesets,
 			changesetApplyFunction: "V1",
 			validate: func(t *testing.T, e cldf.Environment) {
@@ -192,7 +192,7 @@ func TestApplyChangesetsHelpers(t *testing.T) {
 			switch tt.changesetApplyFunction {
 			case "V2":
 				e := NewNoopEnvironment(t)
-				e, _, err := ApplyChangesetsV2(t, e, tt.changesets)
+				e, _, err := ApplyChangesets(t, e, tt.changesets)
 				if tt.wantError {
 					require.Error(t, err)
 					return
@@ -201,7 +201,7 @@ func TestApplyChangesetsHelpers(t *testing.T) {
 				tt.validate(t, e)
 			case "V1":
 				e := NewNoopEnvironment(t)
-				e, err := ApplyChangesets(t, e, nil, tt.changesets)
+				e, _, err := ApplyChangesets(t, e, tt.changesets)
 				if tt.wantError {
 					require.Error(t, err)
 					return

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock_test.go
@@ -30,18 +30,15 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 	})
 	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 	evmChains := e.BlockChains.EVMChains()
-	e, err := Apply(t, e, nil,
-		Configure(
-			cldf.CreateLegacyChangeSet(DeployLinkToken),
-			[]uint64{chain1},
-		),
-		Configure(
-			cldf.CreateLegacyChangeSet(DeployMCMSWithTimelockV2),
-			map[uint64]types.MCMSWithTimelockConfigV2{
-				chain1: proposalutils.SingleGroupTimelockConfigV2(t),
-			},
-		),
-	)
+	e, err := Apply(t, e, Configure(
+		cldf.CreateLegacyChangeSet(DeployLinkToken),
+		[]uint64{chain1},
+	), Configure(
+		cldf.CreateLegacyChangeSet(DeployMCMSWithTimelockV2),
+		map[uint64]types.MCMSWithTimelockConfigV2{
+			chain1: proposalutils.SingleGroupTimelockConfigV2(t),
+		},
+	))
 	require.NoError(t, err)
 	addrs, err := e.ExistingAddresses.AddressesForChain(chain1)
 	require.NoError(t, err)
@@ -50,9 +47,6 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 	link, err := MaybeLoadLinkTokenChainState(evmChains[chain1], addrs)
 	require.NoError(t, err)
 	e, err = Apply(t, e,
-		map[uint64]*proposalutils.TimelockExecutionContracts{
-			chain1: {Timelock: state.Timelock, CallProxy: state.CallProxy},
-		},
 		Configure(
 			cldf.CreateLegacyChangeSet(TransferToMCMSWithTimelockV2),
 			TransferToMCMSWithTimelockConfig{
@@ -74,7 +68,7 @@ func TestTransferToMCMSWithTimelockV2(t *testing.T) {
 	require.Equal(t, state.Timelock.Address(), o)
 
 	// Try a rollback to the deployer.
-	e, err = Apply(t, e, nil,
+	e, err = Apply(t, e,
 		Configure(
 			cldf.CreateLegacyChangeSet(TransferToDeployer),
 			TransferToDeployerConfig{
@@ -99,7 +93,7 @@ func TestRenounceTimelockDeployerConfigValidate(t *testing.T) {
 		Nodes:  1,
 	})
 	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	e, err := Apply(t, e, nil,
+	e, err := Apply(t, e,
 		Configure(
 			cldf.CreateLegacyChangeSet(DeployMCMSWithTimelockV2),
 			map[uint64]types.MCMSWithTimelockConfigV2{
@@ -173,7 +167,7 @@ func TestRenounceTimelockDeployer(t *testing.T) {
 		Nodes:  1,
 	})
 	chain1 := e.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	e, err := Apply(t, e, nil,
+	e, err := Apply(t, e,
 		Configure(
 			cldf.CreateLegacyChangeSet(DeployMCMSWithTimelockV2),
 			map[uint64]types.MCMSWithTimelockConfigV2{
@@ -199,7 +193,7 @@ func TestRenounceTimelockDeployer(t *testing.T) {
 	require.Equal(t, int64(2), r.Int64())
 
 	// Revoke Deployer
-	e, err = Apply(t, e, nil,
+	e, err = Apply(t, e,
 		Configure(
 			cldf.CreateLegacyChangeSet(RenounceTimelockDeployer),
 			RenounceTimelockDeployerConfig{

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -25,55 +25,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 
-// TimelockExecutionContracts is a helper struct for executing timelock proposals. it contains
-// the timelock and call proxy contracts.
-type TimelockExecutionContracts struct {
-	Timelock  *owner_helpers.RBACTimelock
-	CallProxy *owner_helpers.CallProxy
-}
-
-// NewTimelockExecutionContracts creates a new TimelockExecutionContracts struct.
-// If there are multiple timelocks or call proxy on the chain, an error is returned.
-// Used by CLD'S cli
-func NewTimelockExecutionContracts(env cldf.Environment, chainSelector uint64) (*TimelockExecutionContracts, error) {
-	addrTypeVer, err := env.ExistingAddresses.AddressesForChain(chainSelector)
-	if err != nil {
-		return nil, fmt.Errorf("error getting addresses for chain: %w", err)
-	}
-	var timelock *owner_helpers.RBACTimelock
-	var callProxy *owner_helpers.CallProxy
-	evmChains := env.BlockChains.EVMChains()
-	for addr, tv := range addrTypeVer {
-		if tv.Type == types.RBACTimelock {
-			if timelock != nil {
-				return nil, fmt.Errorf("multiple timelocks found on chain %d", chainSelector)
-			}
-			var err error
-			timelock, err = owner_helpers.NewRBACTimelock(common.HexToAddress(addr), evmChains[chainSelector].Client)
-			if err != nil {
-				return nil, fmt.Errorf("error creating timelock: %w", err)
-			}
-		}
-		if tv.Type == types.CallProxy {
-			if callProxy != nil {
-				return nil, fmt.Errorf("multiple call proxies found on chain %d", chainSelector)
-			}
-			var err error
-			callProxy, err = owner_helpers.NewCallProxy(common.HexToAddress(addr), evmChains[chainSelector].Client)
-			if err != nil {
-				return nil, fmt.Errorf("error creating call proxy: %w", err)
-			}
-		}
-	}
-	if timelock == nil || callProxy == nil {
-		return nil, fmt.Errorf("missing timelock (%T) or call proxy(%T) on chain %d", timelock == nil, callProxy == nil, chainSelector)
-	}
-	return &TimelockExecutionContracts{
-		Timelock:  timelock,
-		CallProxy: callProxy,
-	}, nil
-}
-
 func verboseDebug(lggr logger.Logger, event *owner_helpers.RBACTimelockCallScheduled) {
 	b, err := json.Marshal(event)
 	if err != nil {

--- a/deployment/common/proposalutils/propose_test.go
+++ b/deployment/common/proposalutils/propose_test.go
@@ -40,7 +40,7 @@ func TestBuildProposalFromBatchesV2(t *testing.T) {
 	config := proposalutils.SingleGroupMCMSV2(t)
 
 	changeset.SetPreloadedSolanaAddresses(t, env, chainSelectorSolana)
-	env, err := changeset.Apply(t, env, nil,
+	env, err := changeset.Apply(t, env,
 		changeset.Configure(
 			cldf.CreateLegacyChangeSet(changeset.DeployMCMSWithTimelockV2),
 			map[uint64]commontypes.MCMSWithTimelockConfigV2{

--- a/deployment/data-feeds/changeset/accept_ownership_test.go
+++ b/deployment/data-feeds/changeset/accept_ownership_test.go
@@ -35,7 +35,7 @@ func TestAcceptOwnership(t *testing.T) {
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
 	chain := env.BlockChains.EVMChains()[chainSelector]
 
-	newEnv, err := commonChangesets.Apply(t, env, nil,
+	newEnv, err := commonChangesets.Apply(t, env,
 		commonChangesets.Configure(
 			cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
 			map[uint64]commonTypes.MCMSWithTimelockConfigV2{
@@ -53,7 +53,7 @@ func TestAcceptOwnership(t *testing.T) {
 	_, err = chain.Confirm(tx)
 	require.NoError(t, err)
 
-	_, err = commonChangesets.Apply(t, newEnv, nil,
+	_, err = commonChangesets.Apply(t, newEnv,
 		commonChangesets.Configure(
 			AcceptOwnershipChangeset,
 			types.AcceptOwnershipConfig{

--- a/deployment/data-feeds/changeset/confirm_aggregator_test.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator_test.go
@@ -35,88 +35,72 @@ func TestConfirmAggregator(t *testing.T) {
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	// without MCMS
-	newEnv, err := commonChangesets.Apply(t, env, nil,
-		// Deploy cache and aggregator proxy
-		commonChangesets.Configure(
-			changeset.DeployCacheChangeset,
-			types.DeployConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-				Labels:         []string{"data-feeds"},
-			},
-		),
-		commonChangesets.Configure(
-			changeset.DeployAggregatorProxyChangeset,
-			types.DeployAggregatorProxyConfig{
-				ChainsToDeploy:   []uint64{chainSelector},
-				AccessController: []common.Address{common.HexToAddress("0x")},
-			},
-		),
-	)
+	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
+		changeset.DeployCacheChangeset,
+		types.DeployConfig{
+			ChainsToDeploy: []uint64{chainSelector},
+			Labels:         []string{"data-feeds"},
+		},
+	), commonChangesets.Configure(
+		changeset.DeployAggregatorProxyChangeset,
+		types.DeployAggregatorProxyConfig{
+			ChainsToDeploy:   []uint64{chainSelector},
+			AccessController: []common.Address{common.HexToAddress("0x")},
+		},
+	))
 	require.NoError(t, err)
 
 	proxyAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "AggregatorProxy")
 	require.NoError(t, err)
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		// Propose and confirm new Aggregator
-		commonChangesets.Configure(
-			changeset.ProposeAggregatorChangeset,
-			types.ProposeConfirmAggregatorConfig{
-				ChainSelector:        chainSelector,
-				ProxyAddress:         common.HexToAddress(proxyAddress),
-				NewAggregatorAddress: common.HexToAddress("0x123"),
-			},
-		),
-		commonChangesets.Configure(
-			changeset.ConfirmAggregatorChangeset,
-			types.ProposeConfirmAggregatorConfig{
-				ChainSelector:        chainSelector,
-				ProxyAddress:         common.HexToAddress(proxyAddress),
-				NewAggregatorAddress: common.HexToAddress("0x123"),
-			},
-		),
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-			map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-				chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-			},
-		),
-	)
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.ProposeAggregatorChangeset,
+		types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        chainSelector,
+			ProxyAddress:         common.HexToAddress(proxyAddress),
+			NewAggregatorAddress: common.HexToAddress("0x123"),
+		},
+	), commonChangesets.Configure(
+		changeset.ConfirmAggregatorChangeset,
+		types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        chainSelector,
+			ProxyAddress:         common.HexToAddress(proxyAddress),
+			NewAggregatorAddress: common.HexToAddress("0x123"),
+		},
+	), commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
+		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
+		},
+	))
 	require.NoError(t, err)
 
 	// with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		// propose new Aggregator
-		commonChangesets.Configure(
-			changeset.ProposeAggregatorChangeset,
-			types.ProposeConfirmAggregatorConfig{
-				ChainSelector:        chainSelector,
-				ProxyAddress:         common.HexToAddress(proxyAddress),
-				NewAggregatorAddress: common.HexToAddress("0x124"),
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.ProposeAggregatorChangeset,
+		types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        chainSelector,
+			ProxyAddress:         common.HexToAddress(proxyAddress),
+			NewAggregatorAddress: common.HexToAddress("0x124"),
+		},
+	), commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
+		commonChangesets.TransferToMCMSWithTimelockConfig{
+			ContractsByChain: map[uint64][]common.Address{
+				chainSelector: {common.HexToAddress(proxyAddress)},
 			},
-		),
-		// transfer proxy ownership to timelock
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-			commonChangesets.TransferToMCMSWithTimelockConfig{
-				ContractsByChain: map[uint64][]common.Address{
-					chainSelector: {common.HexToAddress(proxyAddress)},
-				},
-				MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
+			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
+		},
+	), commonChangesets.Configure(
+		changeset.ConfirmAggregatorChangeset,
+		types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        chainSelector,
+			ProxyAddress:         common.HexToAddress(proxyAddress),
+			NewAggregatorAddress: common.HexToAddress("0x124"),
+			McmsConfig: &types.MCMSConfig{
+				MinDelay: 0,
 			},
-		),
-		// confirm from timelock
-		commonChangesets.Configure(
-			changeset.ConfirmAggregatorChangeset,
-			types.ProposeConfirmAggregatorConfig{
-				ChainSelector:        chainSelector,
-				ProxyAddress:         common.HexToAddress(proxyAddress),
-				NewAggregatorAddress: common.HexToAddress("0x124"),
-				McmsConfig: &types.MCMSConfig{
-					MinDelay: 0,
-				},
-			},
-		),
-	)
+		},
+	))
 	require.NoError(t, err)
 }

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
@@ -28,22 +28,19 @@ func TestAggregatorProxy(t *testing.T) {
 
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
-	resp, err := commonChangesets.Apply(t, env, nil,
-		commonChangesets.Configure(
-			DeployCacheChangeset,
-			types.DeployConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-				Labels:         []string{"data-feeds"},
-			},
-		),
-		commonChangesets.Configure(
-			DeployAggregatorProxyChangeset,
-			types.DeployAggregatorProxyConfig{
-				ChainsToDeploy:   []uint64{chainSelector},
-				AccessController: []common.Address{common.HexToAddress("0x")},
-			},
-		),
-	)
+	resp, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
+		DeployCacheChangeset,
+		types.DeployConfig{
+			ChainsToDeploy: []uint64{chainSelector},
+			Labels:         []string{"data-feeds"},
+		},
+	), commonChangesets.Configure(
+		DeployAggregatorProxyChangeset,
+		types.DeployAggregatorProxyConfig{
+			ChainsToDeploy:   []uint64{chainSelector},
+			AccessController: []common.Address{common.HexToAddress("0x")},
+		},
+	))
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
@@ -26,24 +26,21 @@ func TestBundleAggregatorProxy(t *testing.T) {
 
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
-	resp, err := commonChangesets.Apply(t, env, nil,
-		commonChangesets.Configure(
-			DeployCacheChangeset,
-			types.DeployConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-				Labels:         []string{"data-feeds"},
-			},
-		),
-		commonChangesets.Configure(
-			DeployBundleAggregatorProxyChangeset,
-			types.DeployBundleAggregatorProxyConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-				Owners:         map[uint64]common.Address{chainSelector: common.HexToAddress("0x1234")},
-				Labels:         []string{"data-feeds"},
-				CacheLabel:     "data-feeds",
-			},
-		),
-	)
+	resp, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
+		DeployCacheChangeset,
+		types.DeployConfig{
+			ChainsToDeploy: []uint64{chainSelector},
+			Labels:         []string{"data-feeds"},
+		},
+	), commonChangesets.Configure(
+		DeployBundleAggregatorProxyChangeset,
+		types.DeployBundleAggregatorProxyConfig{
+			ChainsToDeploy: []uint64{chainSelector},
+			Owners:         map[uint64]common.Address{chainSelector: common.HexToAddress("0x1234")},
+			Labels:         []string{"data-feeds"},
+			CacheLabel:     "data-feeds",
+		},
+	))
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)

--- a/deployment/data-feeds/changeset/deploy_cache_test.go
+++ b/deployment/data-feeds/changeset/deploy_cache_test.go
@@ -28,7 +28,7 @@ func TestDeployCache(t *testing.T) {
 
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
-	resp, err := commonChangesets.Apply(t, env, nil,
+	resp, err := commonChangesets.Apply(t, env,
 		commonChangesets.Configure(
 			changeset.DeployCacheChangeset,
 			types.DeployConfig{

--- a/deployment/data-feeds/changeset/import_to_addressbook_test.go
+++ b/deployment/data-feeds/changeset/import_to_addressbook_test.go
@@ -32,7 +32,7 @@ func TestImportToAddressbook(t *testing.T) {
 
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
-	resp, err := commonChangesets.Apply(t, env, nil,
+	resp, err := commonChangesets.Apply(t, env,
 		commonChangesets.Configure(
 			changeset.ImportToAddressbookChangeset,
 			types.ImportAddressesConfig{

--- a/deployment/data-feeds/changeset/migrate_feeds_test.go
+++ b/deployment/data-feeds/changeset/migrate_feeds_test.go
@@ -33,7 +33,7 @@ func TestMigrateFeeds(t *testing.T) {
 
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
-	newEnv, err := commonChangesets.Apply(t, env, nil,
+	newEnv, err := commonChangesets.Apply(t, env,
 		commonChangesets.Configure(
 			changeset.DeployCacheChangeset,
 			types.DeployConfig{
@@ -47,33 +47,30 @@ func TestMigrateFeeds(t *testing.T) {
 	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache")
 	require.NoError(t, err)
 
-	resp, err := commonChangesets.Apply(t, newEnv, nil,
-		commonChangesets.Configure(
-			changeset.SetFeedAdminChangeset,
-			types.SetFeedAdminConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
-				IsAdmin:       true,
-			},
-		),
-		commonChangesets.Configure(
-			changeset.MigrateFeedsChangeset,
-			types.MigrationConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				InputFileName: "testdata/migrate_feeds.json",
-				InputFS:       testFS,
-				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					{
-						AllowedSender:        common.HexToAddress("0x22"),
-						AllowedWorkflowOwner: common.HexToAddress("0x33"),
-						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
-					},
+	resp, err := commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.SetFeedAdminChangeset,
+		types.SetFeedAdminConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
+			IsAdmin:       true,
+		},
+	), commonChangesets.Configure(
+		changeset.MigrateFeedsChangeset,
+		types.MigrationConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			InputFileName: "testdata/migrate_feeds.json",
+			InputFS:       testFS,
+			WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
+				{
+					AllowedSender:        common.HexToAddress("0x22"),
+					AllowedWorkflowOwner: common.HexToAddress("0x33"),
+					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
 				},
 			},
-		),
-	)
+		},
+	))
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	addresses, err := resp.ExistingAddresses.AddressesForChain(chainSelector)

--- a/deployment/data-feeds/changeset/propose_aggregator_test.go
+++ b/deployment/data-feeds/changeset/propose_aggregator_test.go
@@ -36,70 +36,58 @@ func TestProposeAggregator(t *testing.T) {
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
 	// without MCMS
-	newEnv, err := commonChangesets.Apply(t, env, nil,
-		// Deploy cache and aggregator proxy
-		commonChangesets.Configure(
-			changeset.DeployCacheChangeset,
-			types.DeployConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-				Labels:         []string{"data-feeds"},
-			},
-		),
-		commonChangesets.Configure(
-			changeset.DeployAggregatorProxyChangeset,
-			types.DeployAggregatorProxyConfig{
-				ChainsToDeploy:   []uint64{chainSelector},
-				AccessController: []common.Address{common.HexToAddress("0x")},
-			},
-		),
-	)
+	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
+		changeset.DeployCacheChangeset,
+		types.DeployConfig{
+			ChainsToDeploy: []uint64{chainSelector},
+			Labels:         []string{"data-feeds"},
+		},
+	), commonChangesets.Configure(
+		changeset.DeployAggregatorProxyChangeset,
+		types.DeployAggregatorProxyConfig{
+			ChainsToDeploy:   []uint64{chainSelector},
+			AccessController: []common.Address{common.HexToAddress("0x")},
+		},
+	))
 	require.NoError(t, err)
 
 	proxyAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "AggregatorProxy")
 	require.NoError(t, err)
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		// Propose a new aggregator
-		commonChangesets.Configure(
-			changeset.ProposeAggregatorChangeset,
-			types.ProposeConfirmAggregatorConfig{
-				ChainSelector:        chainSelector,
-				ProxyAddress:         common.HexToAddress(proxyAddress),
-				NewAggregatorAddress: common.HexToAddress("0x123"),
-			},
-		),
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-			map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-				chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-			},
-		),
-	)
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.ProposeAggregatorChangeset,
+		types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        chainSelector,
+			ProxyAddress:         common.HexToAddress(proxyAddress),
+			NewAggregatorAddress: common.HexToAddress("0x123"),
+		},
+	), commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
+		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
+		},
+	))
 	require.NoError(t, err)
 
 	// with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		// transfer proxy ownership to timelock
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-			commonChangesets.TransferToMCMSWithTimelockConfig{
-				ContractsByChain: map[uint64][]common.Address{
-					chainSelector: {common.HexToAddress(proxyAddress)},
-				},
-				MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
+		commonChangesets.TransferToMCMSWithTimelockConfig{
+			ContractsByChain: map[uint64][]common.Address{
+				chainSelector: {common.HexToAddress(proxyAddress)},
 			},
-		),
-		commonChangesets.Configure(
-			changeset.ProposeAggregatorChangeset,
-			types.ProposeConfirmAggregatorConfig{
-				ChainSelector:        chainSelector,
-				ProxyAddress:         common.HexToAddress(proxyAddress),
-				NewAggregatorAddress: common.HexToAddress("0x123"),
-				McmsConfig: &types.MCMSConfig{
-					MinDelay: 0,
-				},
+			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
+		},
+	), commonChangesets.Configure(
+		changeset.ProposeAggregatorChangeset,
+		types.ProposeConfirmAggregatorConfig{
+			ChainSelector:        chainSelector,
+			ProxyAddress:         common.HexToAddress(proxyAddress),
+			NewAggregatorAddress: common.HexToAddress("0x123"),
+			McmsConfig: &types.MCMSConfig{
+				MinDelay: 0,
 			},
-		),
-	)
+		},
+	))
 	require.NoError(t, err)
 }

--- a/deployment/data-feeds/changeset/remove_feed_config_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_config_test.go
@@ -34,21 +34,18 @@ func TestRemoveFeedConfig(t *testing.T) {
 
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
-	newEnv, err := commonChangesets.Apply(t, env, nil,
-		commonChangesets.Configure(
-			changeset.DeployCacheChangeset,
-			types.DeployConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-				Labels:         []string{"data-feeds"},
-			},
-		),
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-			map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-				chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-			},
-		),
-	)
+	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
+		changeset.DeployCacheChangeset,
+		types.DeployConfig{
+			ChainsToDeploy: []uint64{chainSelector},
+			Labels:         []string{"data-feeds"},
+		},
+	), commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
+		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
+		},
+	))
 	require.NoError(t, err)
 
 	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache")
@@ -57,106 +54,91 @@ func TestRemoveFeedConfig(t *testing.T) {
 	dataid := "0x01bb0467f50003040000000000000000"
 
 	// without MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		// set the feed admin, only admin can perform set/remove operations
-		commonChangesets.Configure(
-			changeset.SetFeedAdminChangeset,
-			types.SetFeedAdminConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
-				IsAdmin:       true,
-			},
-		),
-		// set the feed config
-		commonChangesets.Configure(
-			changeset.SetFeedConfigChangeset,
-			types.SetFeedDecimalConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				DataIDs:       []string{dataid},
-				Descriptions:  []string{"test"},
-				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					{
-						AllowedSender:        common.HexToAddress("0x22"),
-						AllowedWorkflowOwner: common.HexToAddress("0x33"),
-						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
-					},
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.SetFeedAdminChangeset,
+		types.SetFeedAdminConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
+			IsAdmin:       true,
+		},
+	), commonChangesets.Configure(
+		changeset.SetFeedConfigChangeset,
+		types.SetFeedDecimalConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			DataIDs:       []string{dataid},
+			Descriptions:  []string{"test"},
+			WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
+				{
+					AllowedSender:        common.HexToAddress("0x22"),
+					AllowedWorkflowOwner: common.HexToAddress("0x33"),
+					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
 				},
 			},
-		),
-		// remove the feed config
-		commonChangesets.Configure(
-			changeset.RemoveFeedConfigChangeset,
-			types.RemoveFeedConfigCSConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				DataIDs:       []string{dataid},
-			},
-		),
-	)
+		},
+	), commonChangesets.Configure(
+		changeset.RemoveFeedConfigChangeset,
+		types.RemoveFeedConfigCSConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			DataIDs:       []string{dataid},
+		},
+	))
 	require.NoError(t, err)
 
 	// with MCMS
 	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock")
 	require.NoError(t, err)
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		// Set the admin to the timelock
-		commonChangesets.Configure(
-			changeset.SetFeedAdminChangeset,
-			types.SetFeedAdminConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(timeLockAddress),
-				IsAdmin:       true,
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.SetFeedAdminChangeset,
+		types.SetFeedAdminConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			AdminAddress:  common.HexToAddress(timeLockAddress),
+			IsAdmin:       true,
+		},
+	), commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
+		commonChangesets.TransferToMCMSWithTimelockConfig{
+			ContractsByChain: map[uint64][]common.Address{
+				chainSelector: {common.HexToAddress(cacheAddress)},
 			},
-		),
-		// Transfer cache ownership to MCMS
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-			commonChangesets.TransferToMCMSWithTimelockConfig{
-				ContractsByChain: map[uint64][]common.Address{
-					chainSelector: {common.HexToAddress(cacheAddress)},
-				},
-				MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-			},
-		),
-	)
+			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
+		},
+	))
 	require.NoError(t, err)
 
 	// Set and remove the feed config with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		commonChangesets.Configure(
-			changeset.SetFeedConfigChangeset,
-			types.SetFeedDecimalConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				DataIDs:       []string{dataid},
-				Descriptions:  []string{"test2"},
-				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					{
-						AllowedSender:        common.HexToAddress("0x22"),
-						AllowedWorkflowOwner: common.HexToAddress("0x33"),
-						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
-					},
-				},
-				McmsConfig: &types.MCMSConfig{
-					MinDelay: 0,
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.SetFeedConfigChangeset,
+		types.SetFeedDecimalConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			DataIDs:       []string{dataid},
+			Descriptions:  []string{"test2"},
+			WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
+				{
+					AllowedSender:        common.HexToAddress("0x22"),
+					AllowedWorkflowOwner: common.HexToAddress("0x33"),
+					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
 				},
 			},
-		),
-		commonChangesets.Configure(
-			changeset.RemoveFeedConfigChangeset,
-			types.RemoveFeedConfigCSConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				DataIDs:       []string{dataid},
-				McmsConfig: &types.MCMSConfig{
-					MinDelay: 0,
-				},
+			McmsConfig: &types.MCMSConfig{
+				MinDelay: 0,
 			},
-		),
-	)
+		},
+	), commonChangesets.Configure(
+		changeset.RemoveFeedConfigChangeset,
+		types.RemoveFeedConfigCSConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			DataIDs:       []string{dataid},
+			McmsConfig: &types.MCMSConfig{
+				MinDelay: 0,
+			},
+		},
+	))
 	require.NoError(t, err)
 }

--- a/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
@@ -35,21 +35,18 @@ func TestSetBundleFeedConfig(t *testing.T) {
 		cldf_chain.WithFamily(chain_selectors.FamilyEVM),
 	)[0]
 
-	newEnv, err := commonChangesets.Apply(t, env, nil,
-		commonChangesets.Configure(
-			changeset.DeployCacheChangeset,
-			types.DeployConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-				Labels:         []string{"data-feeds"},
-			},
-		),
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-			map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-				chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-			},
-		),
-	)
+	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
+		changeset.DeployCacheChangeset,
+		types.DeployConfig{
+			ChainsToDeploy: []uint64{chainSelector},
+			Labels:         []string{"data-feeds"},
+		},
+	), commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
+		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
+		},
+	))
 	require.NoError(t, err)
 
 	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache") //nolint:staticcheck // TODO: replace with DataStore when ready
@@ -58,66 +55,58 @@ func TestSetBundleFeedConfig(t *testing.T) {
 	dataid := "0x01bb0467f50003040000000000000000"
 
 	// without MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		commonChangesets.Configure(
-			changeset.SetFeedAdminChangeset,
-			types.SetFeedAdminConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
-				IsAdmin:       true,
-			},
-		),
-		commonChangesets.Configure(
-			changeset.SetBundleFeedConfigChangeset,
-			types.SetFeedBundleConfig{
-				ChainSelector:  chainSelector,
-				CacheAddress:   common.HexToAddress(cacheAddress),
-				DataIDs:        []string{dataid},
-				Descriptions:   []string{"test"},
-				DecimalsMatrix: [][]uint8{{18, 8, 6}},
-				WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
-					{
-						AllowedSender:        common.HexToAddress("0x22"),
-						AllowedWorkflowOwner: common.HexToAddress("0x33"),
-						AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
-					},
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.SetFeedAdminChangeset,
+		types.SetFeedAdminConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
+			IsAdmin:       true,
+		},
+	), commonChangesets.Configure(
+		changeset.SetBundleFeedConfigChangeset,
+		types.SetFeedBundleConfig{
+			ChainSelector:  chainSelector,
+			CacheAddress:   common.HexToAddress(cacheAddress),
+			DataIDs:        []string{dataid},
+			Descriptions:   []string{"test"},
+			DecimalsMatrix: [][]uint8{{18, 8, 6}},
+			WorkflowMetadata: []cache.DataFeedsCacheWorkflowMetadata{
+				{
+					AllowedSender:        common.HexToAddress("0x22"),
+					AllowedWorkflowOwner: common.HexToAddress("0x33"),
+					AllowedWorkflowName:  changeset.HashedWorkflowName("test"),
 				},
 			},
-		),
-	)
+		},
+	))
 	require.NoError(t, err)
 
 	// with MCMS
 	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock") //nolint:staticcheck // TODO: replace with DataStore when ready
 	require.NoError(t, err)
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		// Set the admin to the timelock
-		commonChangesets.Configure(
-			changeset.SetFeedAdminChangeset,
-			types.SetFeedAdminConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(timeLockAddress),
-				IsAdmin:       true,
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.SetFeedAdminChangeset,
+		types.SetFeedAdminConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			AdminAddress:  common.HexToAddress(timeLockAddress),
+			IsAdmin:       true,
+		},
+	), commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
+		commonChangesets.TransferToMCMSWithTimelockConfig{
+			ContractsByChain: map[uint64][]common.Address{
+				chainSelector: {common.HexToAddress(cacheAddress)},
 			},
-		),
-		// Transfer cache ownership to MCMS
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-			commonChangesets.TransferToMCMSWithTimelockConfig{
-				ContractsByChain: map[uint64][]common.Address{
-					chainSelector: {common.HexToAddress(cacheAddress)},
-				},
-				MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-			},
-		),
-	)
+			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
+		},
+	))
 	require.NoError(t, err)
 
 	// Set the feed config with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
+	newEnv, err = commonChangesets.Apply(t, newEnv,
 		commonChangesets.Configure(
 			changeset.SetBundleFeedConfigChangeset,
 			types.SetFeedBundleConfig{

--- a/deployment/data-feeds/changeset/set_feed_admin_test.go
+++ b/deployment/data-feeds/changeset/set_feed_admin_test.go
@@ -35,28 +35,25 @@ func TestSetCacheAdmin(t *testing.T) {
 
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
 
-	newEnv, err := commonChangesets.Apply(t, env, nil,
-		commonChangesets.Configure(
-			changeset.DeployCacheChangeset,
-			types.DeployConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-				Labels:         []string{"data-feeds"},
-			},
-		),
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-			map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-				chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-			},
-		),
-	)
+	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
+		changeset.DeployCacheChangeset,
+		types.DeployConfig{
+			ChainsToDeploy: []uint64{chainSelector},
+			Labels:         []string{"data-feeds"},
+		},
+	), commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
+		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
+		},
+	))
 	require.NoError(t, err)
 
 	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache")
 	require.NoError(t, err)
 
 	// without MCMS
-	resp, err := commonChangesets.Apply(t, newEnv, nil,
+	resp, err := commonChangesets.Apply(t, newEnv,
 		commonChangesets.Configure(
 			changeset.SetFeedAdminChangeset,
 			types.SetFeedAdminConfig{
@@ -71,7 +68,7 @@ func TestSetCacheAdmin(t *testing.T) {
 	require.NotNil(t, resp)
 
 	// with MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
+	newEnv, err = commonChangesets.Apply(t, newEnv,
 		commonChangesets.Configure(
 			cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
 			commonChangesets.TransferToMCMSWithTimelockConfig{
@@ -84,7 +81,7 @@ func TestSetCacheAdmin(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	resp, err = commonChangesets.Apply(t, newEnv, nil,
+	resp, err = commonChangesets.Apply(t, newEnv,
 		commonChangesets.Configure(
 			changeset.SetFeedAdminChangeset,
 			types.SetFeedAdminConfig{

--- a/deployment/data-feeds/changeset/update_data_id_proxy_test.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy_test.go
@@ -33,21 +33,18 @@ func TestUpdateDataIDProxyMap(t *testing.T) {
 
 	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chainselectors.FamilyEVM))[0]
 
-	newEnv, err := commonChangesets.Apply(t, env, nil,
-		commonChangesets.Configure(
-			changeset.DeployCacheChangeset,
-			types.DeployConfig{
-				ChainsToDeploy: []uint64{chainSelector},
-				Labels:         []string{"data-feeds"},
-			},
-		),
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
-			map[uint64]commonTypes.MCMSWithTimelockConfigV2{
-				chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
-			},
-		),
-	)
+	newEnv, err := commonChangesets.Apply(t, env, commonChangesets.Configure(
+		changeset.DeployCacheChangeset,
+		types.DeployConfig{
+			ChainsToDeploy: []uint64{chainSelector},
+			Labels:         []string{"data-feeds"},
+		},
+	), commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.DeployMCMSWithTimelockV2),
+		map[uint64]commonTypes.MCMSWithTimelockConfigV2{
+			chainSelector: proposalutils.SingleGroupTimelockConfigV2(t),
+		},
+	))
 	require.NoError(t, err)
 
 	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache")
@@ -56,57 +53,49 @@ func TestUpdateDataIDProxyMap(t *testing.T) {
 	dataID := "0x01bb0467f50003040000000000000000"
 
 	// without MCMS
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		commonChangesets.Configure(
-			changeset.SetFeedAdminChangeset,
-			types.SetFeedAdminConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
-				IsAdmin:       true,
-			},
-		),
-		commonChangesets.Configure(
-			changeset.UpdateDataIDProxyChangeset,
-			types.UpdateDataIDProxyConfig{
-				ChainSelector:  chainSelector,
-				CacheAddress:   common.HexToAddress(cacheAddress),
-				ProxyAddresses: []common.Address{common.HexToAddress("0x11")},
-				DataIDs:        []string{dataID},
-			},
-		),
-	)
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.SetFeedAdminChangeset,
+		types.SetFeedAdminConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			AdminAddress:  common.HexToAddress(env.BlockChains.EVMChains()[chainSelector].DeployerKey.From.Hex()),
+			IsAdmin:       true,
+		},
+	), commonChangesets.Configure(
+		changeset.UpdateDataIDProxyChangeset,
+		types.UpdateDataIDProxyConfig{
+			ChainSelector:  chainSelector,
+			CacheAddress:   common.HexToAddress(cacheAddress),
+			ProxyAddresses: []common.Address{common.HexToAddress("0x11")},
+			DataIDs:        []string{dataID},
+		},
+	))
 	require.NoError(t, err)
 
 	// with MCMS
 	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock")
 	require.NoError(t, err)
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
-		// Set the admin to the timelock
-		commonChangesets.Configure(
-			changeset.SetFeedAdminChangeset,
-			types.SetFeedAdminConfig{
-				ChainSelector: chainSelector,
-				CacheAddress:  common.HexToAddress(cacheAddress),
-				AdminAddress:  common.HexToAddress(timeLockAddress),
-				IsAdmin:       true,
+	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
+		changeset.SetFeedAdminChangeset,
+		types.SetFeedAdminConfig{
+			ChainSelector: chainSelector,
+			CacheAddress:  common.HexToAddress(cacheAddress),
+			AdminAddress:  common.HexToAddress(timeLockAddress),
+			IsAdmin:       true,
+		},
+	), commonChangesets.Configure(
+		cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
+		commonChangesets.TransferToMCMSWithTimelockConfig{
+			ContractsByChain: map[uint64][]common.Address{
+				chainSelector: {common.HexToAddress(cacheAddress)},
 			},
-		),
-		// Transfer cache ownership to MCMS
-		commonChangesets.Configure(
-			cldf.CreateLegacyChangeSet(commonChangesets.TransferToMCMSWithTimelockV2),
-			commonChangesets.TransferToMCMSWithTimelockConfig{
-				ContractsByChain: map[uint64][]common.Address{
-					chainSelector: {common.HexToAddress(cacheAddress)},
-				},
-				MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
-			},
-		),
-	)
+			MCMSConfig: proposalutils.TimelockConfig{MinDelay: 0},
+		},
+	))
 	require.NoError(t, err)
 
-	newEnv, err = commonChangesets.Apply(t, newEnv, nil,
+	newEnv, err = commonChangesets.Apply(t, newEnv,
 		commonChangesets.Configure(
 			changeset.UpdateDataIDProxyChangeset,
 			types.UpdateDataIDProxyConfig{

--- a/deployment/keystone/changeset/accept_ownership_test.go
+++ b/deployment/keystone/changeset/accept_ownership_test.go
@@ -30,42 +30,27 @@ func TestAcceptAllOwnership(t *testing.T) {
 	env := memory.NewMemoryEnvironment(t, lggr, zapcore.DebugLevel, cfg)
 
 	registrySel := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
-	env, err := commonchangeset.Apply(t, env, nil,
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.DeployCapabilityRegistry),
-			registrySel,
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.DeployOCR3),
-			registrySel,
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.DeployForwarder),
-			changeset.DeployForwarderRequest{},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.DeployFeedsConsumer),
-			&changeset.DeployFeedsConsumerRequest{ChainSelector: registrySel},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
-			map[uint64]types.MCMSWithTimelockConfigV2{
-				registrySel: proposalutils.SingleGroupTimelockConfigV2(t),
-			},
-		),
-	)
-	require.NoError(t, err)
-	addrs, err := env.ExistingAddresses.AddressesForChain(registrySel)
-	require.NoError(t, err)
-	timelock, err := commonchangeset.MaybeLoadMCMSWithTimelockChainState(
-		env.BlockChains.EVMChains()[registrySel], addrs,
-	)
+	env, err := commonchangeset.Apply(t, env, commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(changeset.DeployCapabilityRegistry),
+		registrySel,
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(changeset.DeployOCR3),
+		registrySel,
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(changeset.DeployForwarder),
+		changeset.DeployForwarderRequest{},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(changeset.DeployFeedsConsumer),
+		&changeset.DeployFeedsConsumerRequest{ChainSelector: registrySel},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
+		map[uint64]types.MCMSWithTimelockConfigV2{
+			registrySel: proposalutils.SingleGroupTimelockConfigV2(t),
+		},
+	))
 	require.NoError(t, err)
 
 	_, err = commonchangeset.Apply(t, env,
-		map[uint64]*proposalutils.TimelockExecutionContracts{
-			registrySel: {Timelock: timelock.Timelock, CallProxy: timelock.CallProxy},
-		},
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(changeset.AcceptAllOwnershipsProposal),
 			&changeset.AcceptAllOwnershipRequest{

--- a/deployment/keystone/changeset/add_nodes_test.go
+++ b/deployment/keystone/changeset/add_nodes_test.go
@@ -10,8 +10,8 @@ import (
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/test"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -314,15 +314,7 @@ func assertNodesExist(t *testing.T, registry *kcr.CapabilitiesRegistry, nodes ..
 }
 
 func applyProposal(t *testing.T, te test.EnvWrapper, applicable ...commonchangeset.ConfiguredChangeSet) error {
-	// now apply the changeset such that the proposal is signed and execed
-	capReg := te.OwnedCapabilityRegistry()
-	timelockContracts := map[uint64]*proposalutils.TimelockExecutionContracts{
-		te.RegistrySelector: {
-			Timelock:  capReg.McmsContracts.Timelock,
-			CallProxy: capReg.McmsContracts.CallProxy,
-		},
-	}
-	_, err := commonchangeset.ApplyChangesets(t, te.Env, timelockContracts, applicable)
+	_, _, err := commonchangeset.ApplyChangesets(t, te.Env, applicable)
 	return err
 }
 

--- a/deployment/keystone/changeset/deploy_forwarder_test.go
+++ b/deployment/keystone/changeset/deploy_forwarder_test.go
@@ -19,7 +19,6 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/environment/memory"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
@@ -206,19 +205,14 @@ func TestConfigureForwarders(t *testing.T) {
 				require.Len(t, csOut.MCMSTimelockProposals, expectedProposals)
 				require.Nil(t, csOut.AddressBook)
 
-				timelockContracts := make(map[uint64]*proposalutils.TimelockExecutionContracts)
 				x := te.OwnedForwarders()
-				for selector, forwardersByChain := range x {
+				for _, forwardersByChain := range x {
 					require.Len(t, forwardersByChain, 1)
 					f := forwardersByChain[0]
 					require.NotNil(t, f.McmsContracts.Timelock)
 					require.NotNil(t, f.McmsContracts.CallProxy)
-					timelockContracts[selector] = &proposalutils.TimelockExecutionContracts{
-						Timelock:  f.McmsContracts.Timelock,
-						CallProxy: f.McmsContracts.CallProxy,
-					}
 				}
-				_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+				_, err = commonchangeset.Apply(t, te.Env,
 					commonchangeset.Configure(
 						cldf.CreateLegacyChangeSet(changeset.ConfigureForwardContracts),
 						cfg,

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -251,9 +251,7 @@ func initEnv(t *testing.T, nChains int) (registryChainSel uint64, env cldf.Envir
 		),
 	}
 	changes = append(changes, forwarderChangesets...)
-	env, err := commonchangeset.ApplyChangesets(t, env, nil,
-		changes,
-	)
+	env, _, err := commonchangeset.ApplyChangesets(t, env, changes)
 	require.NoError(t, err)
 	require.NotNil(t, env)
 	require.Len(t, env.BlockChains.EVMChains(), nChains)
@@ -381,7 +379,7 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 			t.Logf("Enabling MCMS on chain %d", sel)
 			timelockCfgs[sel] = proposalutils.SingleGroupTimelockConfigV2(t)
 		}
-		env, err = commonchangeset.Apply(t, env, nil,
+		env, err = commonchangeset.Apply(t, env,
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
 				timelockCfgs,
@@ -402,9 +400,6 @@ func setupTestEnv(t *testing.T, c EnvWrapperConfig) EnvWrapper {
 
 			// transfer ownership of all contracts to the MCMS
 			env, err = commonchangeset.Apply(t, env,
-				map[uint64]*proposalutils.TimelockExecutionContracts{
-					sel: {Timelock: mcms.Timelock, CallProxy: mcms.CallProxy},
-				},
 				commonchangeset.Configure(
 					cldf.CreateLegacyChangeSet(changeset.AcceptAllOwnershipsProposal),
 					&changeset.AcceptAllOwnershipRequest{

--- a/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_allowed_dons_test.go
@@ -15,7 +15,6 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/test"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/workflowregistry"
@@ -95,15 +94,7 @@ func Test_UpdateAllowedDons_WithMCMS(t *testing.T) {
 	require.Len(t, out.MCMSTimelockProposals, 1)
 	require.Nil(t, out.AddressBook)
 
-	capReg := te.OwnedCapabilityRegistry()
-	timelockContracts := map[uint64]*proposalutils.TimelockExecutionContracts{
-		te.RegistrySelector: {
-			Timelock:  capReg.McmsContracts.Timelock,
-			CallProxy: capReg.McmsContracts.CallProxy,
-		},
-	}
-
-	_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+	_, err = commonchangeset.Apply(t, te.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(workflowregistry.UpdateAllowedDons),
 			req,

--- a/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
+++ b/deployment/keystone/changeset/workflowregistry/update_authorized_addresses_test.go
@@ -16,7 +16,6 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/test"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/workflowregistry"
@@ -98,15 +97,7 @@ func Test_UpdateAuthorizedAddresses_WithMCMS(t *testing.T) {
 	require.Len(t, out.MCMSTimelockProposals, 1)
 	require.Nil(t, out.AddressBook)
 
-	capReg := te.OwnedCapabilityRegistry()
-	timelockContracts := map[uint64]*proposalutils.TimelockExecutionContracts{
-		te.RegistrySelector: {
-			Timelock:  capReg.McmsContracts.Timelock,
-			CallProxy: capReg.McmsContracts.CallProxy,
-		},
-	}
-
-	_, err = commonchangeset.Apply(t, te.Env, timelockContracts,
+	_, err = commonchangeset.Apply(t, te.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(workflowregistry.UpdateAuthorizedAddresses),
 			req,

--- a/integration-tests/smoke/ccip/ccip_add_chain_test.go
+++ b/integration-tests/smoke/ccip/ccip_add_chain_test.go
@@ -440,23 +440,20 @@ func setupInboundWiring(
 	}
 
 	var err error
-	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateOffRampSourcesChangeset),
-			v1_6.UpdateOffRampSourcesConfig{
-				UpdatesByChain: offRampSourceUpdates(t, newChains, sources, testRouterEnabled),
-				MCMS:           mcmsConfig,
-			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateRouterRampsChangeset),
-			v1_6.UpdateRouterRampsConfig{
-				TestRouter:     testRouterEnabled,
-				UpdatesByChain: routerOffRampUpdates(t, newChains, sources),
-				MCMS:           mcmsConfig,
-			},
-		),
-	)
+	e.Env, err = commonchangeset.Apply(t, e.Env, commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateOffRampSourcesChangeset),
+		v1_6.UpdateOffRampSourcesConfig{
+			UpdatesByChain: offRampSourceUpdates(t, newChains, sources, testRouterEnabled),
+			MCMS:           mcmsConfig,
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateRouterRampsChangeset),
+		v1_6.UpdateRouterRampsConfig{
+			TestRouter:     testRouterEnabled,
+			UpdatesByChain: routerOffRampUpdates(t, newChains, sources),
+			MCMS:           mcmsConfig,
+		},
+	))
 	require.NoError(t, err)
 
 	return e
@@ -481,37 +478,32 @@ func setupOutboundWiring(
 	}
 
 	var err error
-	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateOnRampsDestsChangeset),
-			v1_6.UpdateOnRampDestsConfig{
-				UpdatesByChain: onRampDestUpdates(t, newChains, sources, testRouterEnabled),
-				MCMS:           mcmsConfig,
-			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateFeeQuoterPricesChangeset),
-			v1_6.UpdateFeeQuoterPricesConfig{
-				PricesByChain: feeQuoterPricesByChain(t, newChains, sources),
-				MCMS:          mcmsConfig,
-			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateFeeQuoterDestsChangeset),
-			v1_6.UpdateFeeQuoterDestsConfig{
-				UpdatesByChain: feeQuoterDestUpdates(t, newChains, sources),
-				MCMS:           mcmsConfig,
-			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.UpdateRouterRampsChangeset),
-			v1_6.UpdateRouterRampsConfig{
-				TestRouter:     testRouterEnabled,
-				UpdatesByChain: routerOnRampUpdates(t, newChains, sources),
-				MCMS:           mcmsConfig,
-			},
-		),
-	)
+	e.Env, err = commonchangeset.Apply(t, e.Env, commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateOnRampsDestsChangeset),
+		v1_6.UpdateOnRampDestsConfig{
+			UpdatesByChain: onRampDestUpdates(t, newChains, sources, testRouterEnabled),
+			MCMS:           mcmsConfig,
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateFeeQuoterPricesChangeset),
+		v1_6.UpdateFeeQuoterPricesConfig{
+			PricesByChain: feeQuoterPricesByChain(t, newChains, sources),
+			MCMS:          mcmsConfig,
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateFeeQuoterDestsChangeset),
+		v1_6.UpdateFeeQuoterDestsConfig{
+			UpdatesByChain: feeQuoterDestUpdates(t, newChains, sources),
+			MCMS:           mcmsConfig,
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.UpdateRouterRampsChangeset),
+		v1_6.UpdateRouterRampsConfig{
+			TestRouter:     testRouterEnabled,
+			UpdatesByChain: routerOnRampUpdates(t, newChains, sources),
+			MCMS:           mcmsConfig,
+		},
+	))
 	require.NoError(t, err)
 
 	return e
@@ -525,7 +517,7 @@ func setupChain(t *testing.T, e testhelpers.DeployedEnv, tEnv testhelpers.TestEn
 
 	// Need to update what the RMNProxy is pointing to, otherwise plugin will not work.
 	var err error
-	e.Env, err = commonchangeset.Apply(t, e.Env, e.TimelockContracts(t),
+	e.Env, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.SetRMNRemoteOnRMNProxyChangeset),
 			v1_6.SetRMNRemoteOnRMNProxyConfig{
@@ -796,6 +788,6 @@ func transferToMCMSAndRenounceTimelockDeployer(
 		))
 	}
 	var err error
-	e.Env, err = commonchangeset.ApplyChangesets(t, e.Env, e.TimelockContracts(t), apps)
+	e.Env, _, err = commonchangeset.ApplyChangesets(t, e.Env, apps)
 	require.NoError(t, err)
 }

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -19,7 +19,6 @@ import (
 	ccipChangesetSolana "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/solana"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	commonSolana "github.com/smartcontractkit/chainlink/deployment/common/changeset/solana"
@@ -497,9 +496,8 @@ func transferRMNContractToMCMS(t *testing.T, e *testhelpers.DeployedEnv, state s
 	}
 
 	contractsByChain[e.HomeChainSel] = append(contractsByChain[e.HomeChainSel], state.MustGetEVMChainState(e.HomeChainSel).RMNHome.Address())
-	timelocksPerChain := deployergroup.BuildTimelockPerChain(e.Env, state)
 	// This is required because RMN Contracts is initially owned by the deployer
-	_, err := commonchangeset.Apply(t, e.Env, timelocksPerChain,
+	_, err := commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
 			commonchangeset.TransferToMCMSWithTimelockConfig{
@@ -539,7 +537,7 @@ func transferRMNContractToMCMS(t *testing.T, e *testhelpers.DeployedEnv, state s
 
 	changesetInstance := commonSolana.FundMCMSignersChangeset{}
 
-	_, _, err = commonchangeset.ApplyChangesetsV2(t, e.Env, []commonchangeset.ConfiguredChangeSet{
+	_, _, err = commonchangeset.ApplyChangesets(t, e.Env, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(changesetInstance, config),
 	})
 	require.NoError(t, err)
@@ -569,7 +567,7 @@ func runRmnUncurseMCMSTest(t *testing.T, tc CurseTestCase, action types.Timelock
 
 	transferRMNContractToMCMS(t, &e, state)
 
-	_, _, err = commonchangeset.ApplyChangesetsV2(t, e.Env,
+	_, _, err = commonchangeset.ApplyChangesets(t, e.Env,
 		[]commonchangeset.ConfiguredChangeSet{
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset),
@@ -580,7 +578,7 @@ func runRmnUncurseMCMSTest(t *testing.T, tc CurseTestCase, action types.Timelock
 
 	verifyTestCaseAssertions(t, &e, tc, mapIDToSelector)
 
-	_, _, err = commonchangeset.ApplyChangesetsV2(t, e.Env,
+	_, _, err = commonchangeset.ApplyChangesets(t, e.Env,
 		[]commonchangeset.ConfiguredChangeSet{
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(v1_6.RMNUncurseChangeset),
@@ -707,7 +705,7 @@ func runRmnCurseMCMSTest(t *testing.T, tc CurseTestCase, action types.TimelockAc
 
 	transferRMNContractToMCMS(t, &e, state)
 
-	_, _, err = commonchangeset.ApplyChangesetsV2(t, e.Env,
+	_, _, err = commonchangeset.ApplyChangesets(t, e.Env,
 		[]commonchangeset.ConfiguredChangeSet{
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset),
@@ -780,7 +778,7 @@ var forceOptionTestCases = []ForceOptionTestCase{
 	{
 		name: "RMNCurseForceOptionFalse",
 		applyChangeset: func(env *testhelpers.DeployedEnv, config v1_6.RMNCurseConfig, t *testing.T) deployment.ChangesetOutput {
-			_, _, err := commonchangeset.ApplyChangesetsV2(t, env.Env,
+			_, _, err := commonchangeset.ApplyChangesets(t, env.Env,
 				[]commonchangeset.ConfiguredChangeSet{
 					commonchangeset.Configure(
 						cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset),
@@ -811,7 +809,7 @@ var forceOptionTestCases = []ForceOptionTestCase{
 	{
 		name: "RMNCurseForceOptionTrue",
 		applyChangeset: func(env *testhelpers.DeployedEnv, config v1_6.RMNCurseConfig, t *testing.T) deployment.ChangesetOutput {
-			_, _, err := commonchangeset.ApplyChangesetsV2(t, env.Env,
+			_, _, err := commonchangeset.ApplyChangesets(t, env.Env,
 				[]commonchangeset.ConfiguredChangeSet{
 					commonchangeset.Configure(
 						cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset),

--- a/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_update_rmn_config_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
 	ccipops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/evm/v1_6"
 	ccipseq "github.com/smartcontractkit/chainlink/deployment/ccip/sequence/evm/v1_6"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -201,10 +200,9 @@ func updateRMNConfig(t *testing.T, tc updateRMNConfigTestCase) {
 
 	contractsByChain[e.HomeChainSel] = append(contractsByChain[e.HomeChainSel], state.MustGetEVMChainState(e.HomeChainSel).RMNHome.Address())
 
-	timelocksPerChain := deployergroup.BuildTimelockPerChain(e.Env, state)
 	if tc.useMCMS {
 		// This is required because RMNHome is initially owned by the deployer
-		_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+		_, err = commonchangeset.Apply(t, e.Env,
 			commonchangeset.Configure(
 				cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
 				commonchangeset.TransferToMCMSWithTimelockConfig{
@@ -251,7 +249,7 @@ func updateRMNConfig(t *testing.T, tc updateRMNConfigTestCase) {
 		MCMSConfig: mcmsConfig,
 	}
 
-	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.SetRMNHomeCandidateConfigChangeset),
 			setRMNHomeCandidateConfig,
@@ -277,7 +275,7 @@ func updateRMNConfig(t *testing.T, tc updateRMNConfigTestCase) {
 		MCMSConfig:        mcmsConfig,
 	}
 
-	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.PromoteRMNHomeCandidateConfigChangeset),
 			promoteConfig,
@@ -310,7 +308,7 @@ func updateRMNConfig(t *testing.T, tc updateRMNConfigTestCase) {
 		MCMSConfig:       mcmsConfig,
 	}
 
-	_, err = commonchangeset.Apply(t, e.Env, timelocksPerChain,
+	_, err = commonchangeset.Apply(t, e.Env,
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(v1_6.SetRMNRemoteConfigChangeset),
 			setRemoteConfig,
@@ -358,22 +356,18 @@ func TestSetRMNRemoteOnRMNProxy(t *testing.T) {
 	}
 	// Need to deploy prerequisites first so that we can form the USDC config
 	// no proposals to be made, timelock can be passed as nil here
-	e.Env, err = commonchangeset.Apply(t, e.Env, nil,
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(commonchangeset.DeployLinkToken),
-			allChains,
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
-			changeset.DeployPrerequisiteConfig{
-				Configs: prereqCfgs,
-			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
-			mcmsCfg,
-		),
-	)
+	e.Env, err = commonchangeset.Apply(t, e.Env, commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(commonchangeset.DeployLinkToken),
+		allChains,
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(changeset.DeployPrerequisitesChangeset),
+		changeset.DeployPrerequisiteConfig{
+			Configs: prereqCfgs,
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(commonchangeset.DeployMCMSWithTimelockV2),
+		mcmsCfg,
+	))
 	require.NoError(t, err)
 	contractsByChain := make(map[uint64][]common.Address)
 	state, err := stateview.LoadOnchainState(e.Env)
@@ -383,13 +377,8 @@ func TestSetRMNRemoteOnRMNProxy(t *testing.T) {
 		require.NotNil(t, rmnProxy)
 		contractsByChain[chain] = []common.Address{rmnProxy.Address()}
 	}
-	timelockContractsPerChain := make(map[uint64]*proposalutils.TimelockExecutionContracts)
 	allContractParams := make(map[uint64]ccipseq.ChainContractParams)
 	for _, chain := range allChains {
-		timelockContractsPerChain[chain] = &proposalutils.TimelockExecutionContracts{
-			Timelock:  state.MustGetEVMChainState(chain).Timelock,
-			CallProxy: state.MustGetEVMChainState(chain).CallProxy,
-		}
 		allContractParams[chain] = ccipseq.ChainContractParams{
 			FeeQuoterParams: ccipops.DefaultFeeQuoterParams(),
 			OffRampParams:   ccipops.DefaultOffRampParams(),
@@ -397,46 +386,40 @@ func TestSetRMNRemoteOnRMNProxy(t *testing.T) {
 	}
 	envNodes, err := deployment.NodeInfo(e.Env.NodeIDs, e.Env.Offchain)
 	require.NoError(t, err)
-	e.Env, err = commonchangeset.Apply(t, e.Env, timelockContractsPerChain,
-		// transfer ownership of RMNProxy to timelock
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
-			commonchangeset.TransferToMCMSWithTimelockConfig{
-				ContractsByChain: contractsByChain,
-				MCMSConfig: proposalutils.TimelockConfig{
-					MinDelay: 0 * time.Second,
-				},
+	e.Env, err = commonchangeset.Apply(t, e.Env, commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(commonchangeset.TransferToMCMSWithTimelockV2),
+		commonchangeset.TransferToMCMSWithTimelockConfig{
+			ContractsByChain: contractsByChain,
+			MCMSConfig: proposalutils.TimelockConfig{
+				MinDelay: 0 * time.Second,
 			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
-			v1_6.DeployHomeChainConfig{
-				HomeChainSel:     e.HomeChainSel,
-				RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
-				RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
-				NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.BlockChains.EVMChains()[e.HomeChainSel].DeployerKey.From),
-				NodeP2PIDsPerNodeOpAdmin: map[string][][32]byte{
-					"NodeOperator": envNodes.NonBootstraps().PeerIDs(),
-				},
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.DeployHomeChainChangeset),
+		v1_6.DeployHomeChainConfig{
+			HomeChainSel:     e.HomeChainSel,
+			RMNDynamicConfig: testhelpers.NewTestRMNDynamicConfig(),
+			RMNStaticConfig:  testhelpers.NewTestRMNStaticConfig(),
+			NodeOperators:    testhelpers.NewTestNodeOperator(e.Env.BlockChains.EVMChains()[e.HomeChainSel].DeployerKey.From),
+			NodeP2PIDsPerNodeOpAdmin: map[string][][32]byte{
+				"NodeOperator": envNodes.NonBootstraps().PeerIDs(),
 			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.DeployChainContractsChangeset),
-			ccipseq.DeployChainContractsConfig{
-				HomeChainSelector:      e.HomeChainSel,
-				ContractParamsPerChain: allContractParams,
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.DeployChainContractsChangeset),
+		ccipseq.DeployChainContractsConfig{
+			HomeChainSelector:      e.HomeChainSel,
+			ContractParamsPerChain: allContractParams,
+		},
+	), commonchangeset.Configure(
+		cldf.CreateLegacyChangeSet(v1_6.SetRMNRemoteOnRMNProxyChangeset),
+		v1_6.SetRMNRemoteOnRMNProxyConfig{
+			ChainSelectors: allChains,
+			MCMSConfig: &proposalutils.TimelockConfig{
+				MinDelay: 0,
 			},
-		),
-		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(v1_6.SetRMNRemoteOnRMNProxyChangeset),
-			v1_6.SetRMNRemoteOnRMNProxyConfig{
-				ChainSelectors: allChains,
-				MCMSConfig: &proposalutils.TimelockConfig{
-					MinDelay: 0,
-				},
-			},
-		),
-	)
+		},
+	))
 	require.NoError(t, err)
 	state, err = stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)

--- a/integration-tests/smoke/ccip/ccip_jobspec_test.go
+++ b/integration-tests/smoke/ccip/ccip_jobspec_test.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	commonChangesets "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/view"
@@ -29,7 +30,7 @@ func TestDeleteCCIPJobs(t *testing.T) {
 		}
 	}
 	// run delete JobChangeset
-	_, err = commonChangesets.Apply(t, e.Env, nil,
+	_, err = commonChangesets.Apply(t, e.Env,
 		commonChangesets.Configure(
 			commonChangesets.DeleteJobChangeset,
 			jobIDs,
@@ -65,7 +66,7 @@ func TestRevokeJobs(t *testing.T) {
 		}
 	}
 	// run RevokeJobChangeset
-	_, err = commonChangesets.Apply(t, e.Env, nil,
+	_, err = commonChangesets.Apply(t, e.Env,
 		commonChangesets.Configure(
 			commonChangesets.RevokeJobsChangeset,
 			jobIDs,


### PR DESCRIPTION
With the removal of the legacy MCMS, the 2 methods ApplyChangesets and ApplyChangesetsV2 are now very similar with the exception of the timelock contract field that is no longer used. This commit migrate all usages to a single ApplyChangesets method and clean up all the timelockcontract usage that is no longer used.

what i did
- migrate all usages of `ApplyChangesets` to `ApplyChangesetsV2`
- rename `ApplyChangesetsV2` to `ApplyChangesets` 

**To reviewers, start with `deployment/common/changeset/test_helpers.go` , this will give meaning to everything**

