### PR TITLE
Bump chainlink-evm version and remove GasEstimator from ChainOpts

### DIFF
--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -86,7 +86,6 @@ func NewChainOpts(t testing.TB, testopts TestChainOpts) (logger.Logger, keystore
 		ListenerConfig: testopts.ListenerConfig,
 		FeatureConfig:  testopts.FeatureConfig,
 		MailMon:        testopts.MailMon,
-		GasEstimator:   testopts.GasEstimator,
 		DS:             testopts.DB,
 	}
 	opts.GenEthClient = func(*big.Int) evmclient.Client {

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
 	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.5
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.0

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1285,8 +1285,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019 h1:OwjwGNLZZ5JlVQ+2Ysn8hgsfm+LGeN2byMT8V49RW54=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a h1:1CrY+turGOYaSEs4efA4zJprX0G2Uk+0dcDO1eCsHhk=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
 	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.11.0
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.7.0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1261,8 +1261,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019 h1:OwjwGNLZZ5JlVQ+2Ysn8hgsfm+LGeN2byMT8V49RW54=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a h1:1CrY+turGOYaSEs4efA4zJprX0G2Uk+0dcDO1eCsHhk=

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a

--- a/go.sum
+++ b/go.sum
@@ -1063,8 +1063,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049 h1:7HwYt8rDz1ehTcB28oNipdTZUtV17F2sfkLTLtMJC4c=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019 h1:OwjwGNLZZ5JlVQ+2Ysn8hgsfm+LGeN2byMT8V49RW54=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a h1:1CrY+turGOYaSEs4efA4zJprX0G2Uk+0dcDO1eCsHhk=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
 	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.11.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1492,8 +1492,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019 h1:OwjwGNLZZ5JlVQ+2Ysn8hgsfm+LGeN2byMT8V49RW54=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a h1:1CrY+turGOYaSEs4efA4zJprX0G2Uk+0dcDO1eCsHhk=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
 	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1474,8 +1474,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019 h1:OwjwGNLZZ5JlVQ+2Ysn8hgsfm+LGeN2byMT8V49RW54=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a h1:1CrY+turGOYaSEs4efA4zJprX0G2Uk+0dcDO1eCsHhk=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.59
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
 	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.11.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.5
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1248,8 +1248,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019 h1:OwjwGNLZZ5JlVQ+2Ysn8hgsfm+LGeN2byMT8V49RW54=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a h1:1CrY+turGOYaSEs4efA4zJprX0G2Uk+0dcDO1eCsHhk=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250528133621-89eb1ce3d76f
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049
 	github.com/smartcontractkit/chainlink-deployments-framework v0.8.2
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.11.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.5
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1448,8 +1448,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250417193446-eeb0a7d1e049/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2 h1:Q59tT2oiQI8TxI9+QLksIwXj51DoNwIWpdZO1FYefDM=
 github.com/smartcontractkit/chainlink-deployments-framework v0.8.2/go.mod h1:HGXUv2r4mPmQ1H35Lx2gB16B2e+tY7G3n9wCye0pnRU=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df h1:5QfOt0EQPqIGDcZfEMeb+5Y0A7w4+7e1rAlGkEDQs8U=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250602025034-8c2185e683df/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019 h1:OwjwGNLZZ5JlVQ+2Ysn8hgsfm+LGeN2byMT8V49RW54=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250602121001-1a3c233e4019/go.mod h1:E0HKGl6U66jLcQaELbH6xu3C7cXOvzcR0mVSzk+VhxY=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a h1:1CrY+turGOYaSEs4efA4zJprX0G2Uk+0dcDO1eCsHhk=


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
