### PR TITLE
[bugfix] Do not filter out any don2don peers on bootstrap nodes

### DIFF
--- a/.changeset/clever-mayflies-share.md
+++ b/.changeset/clever-mayflies-share.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix Do not filter out any don2don peers on bootstrap nodes

--- a/core/capabilities/integration_tests/framework/peer.go
+++ b/core/capabilities/integration_tests/framework/peer.go
@@ -163,6 +163,10 @@ func (t p2pPeer) Receive() <-chan p2ptypes.Message {
 	return nil
 }
 
+func (t p2pPeer) IsBootstrap() bool {
+	return false
+}
+
 func NewPeerID(donName string, nodeOrdinal int) string {
 	privKeyString := fmt.Sprintf("privatekey:%s:%d", donName, nodeOrdinal)
 	privKey := sha256.Sum256([]byte(privKeyString))

--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -168,6 +168,7 @@ func filterDon2Don(
 func (w *launcher) peers(
 	belongsToACapabilityDON bool,
 	belongsToAWorkflowDON bool,
+	isBootstrap bool,
 	localRegistry *registrysyncer.LocalRegistry,
 ) map[ragetypes.PeerID]p2ptypes.StreamConfig {
 	allPeers := make(map[ragetypes.PeerID]p2ptypes.StreamConfig)
@@ -176,7 +177,7 @@ func (w *launcher) peers(
 		if !candidatePeerDON.DON.IsPublic {
 			continue
 		}
-		if filterDon2Don(w.lggr, belongsToACapabilityDON, belongsToAWorkflowDON, candidatePeerDON) {
+		if !isBootstrap && filterDon2Don(w.lggr, belongsToACapabilityDON, belongsToAWorkflowDON, candidatePeerDON) {
 			continue
 		}
 		for _, nid := range candidatePeerDON.DON.Members {
@@ -317,8 +318,9 @@ func (w *launcher) Launch(ctx context.Context, localRegistry *registrysyncer.Loc
 	}
 
 	// Lastly, we identify peers to connect to, based on their DONs functions
-	myPeers := w.peers(belongsToACapabilityDON, belongsToAWorkflowDON, localRegistry)
-	err := w.peerWrapper.GetPeer().UpdateConnections(myPeers)
+	peer := w.peerWrapper.GetPeer()
+	myPeers := w.peers(belongsToACapabilityDON, belongsToAWorkflowDON, peer.IsBootstrap(), localRegistry)
+	err := peer.UpdateConnections(myPeers)
 	if err != nil {
 		return fmt.Errorf("failed to update peer connections: %w", err)
 	}

--- a/core/services/p2p/peer.go
+++ b/core/services/p2p/peer.go
@@ -242,3 +242,7 @@ func (p *peer) HealthReport() map[string]error {
 func (p *peer) Name() string {
 	return p.lggr.Name()
 }
+
+func (p *peer) IsBootstrap() bool {
+	return p.isBootstrap
+}

--- a/core/services/p2p/types/mocks/peer.go
+++ b/core/services/p2p/types/mocks/peer.go
@@ -163,6 +163,51 @@ func (_c *Peer_ID_Call) RunAndReturn(run func() ragep2ptypes.PeerID) *Peer_ID_Ca
 	return _c
 }
 
+// IsBootstrap provides a mock function with no fields
+func (_m *Peer) IsBootstrap() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsBootstrap")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// Peer_IsBootstrap_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsBootstrap'
+type Peer_IsBootstrap_Call struct {
+	*mock.Call
+}
+
+// IsBootstrap is a helper method to define mock.On call
+func (_e *Peer_Expecter) IsBootstrap() *Peer_IsBootstrap_Call {
+	return &Peer_IsBootstrap_Call{Call: _e.mock.On("IsBootstrap")}
+}
+
+func (_c *Peer_IsBootstrap_Call) Run(run func()) *Peer_IsBootstrap_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Peer_IsBootstrap_Call) Return(_a0 bool) *Peer_IsBootstrap_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Peer_IsBootstrap_Call) RunAndReturn(run func() bool) *Peer_IsBootstrap_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Name provides a mock function with no fields
 func (_m *Peer) Name() string {
 	ret := _m.Called()

--- a/core/services/p2p/types/types.go
+++ b/core/services/p2p/types/types.go
@@ -17,6 +17,7 @@ type Peer interface {
 	UpdateConnections(peers map[PeerID]StreamConfig) error
 	Send(peerID PeerID, msg []byte) error
 	Receive() <-chan Message
+	IsBootstrap() bool
 }
 
 type PeerWrapper interface {


### PR DESCRIPTION
Bootstrap nodes need to always add the full list of peers to their RageP2P groups.
