### PR TITLE
refactor: Load Aptos Chains using framework providers

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -383,7 +383,10 @@ func (m *MemoryEnvironment) StartChains(t *testing.T) {
 
 	m.Chains = chains
 	m.SolChains = memory.NewMemoryChainsSol(t, tc.SolChains)
-	m.AptosChains = memory.NewMemoryChainsAptos(t, tc.AptosChains)
+	aptosChains := memory.NewMemoryChainsAptos(t, tc.AptosChains)
+	// if we have Aptos chains, we need to set the Aptos chain selectors on the wrapper
+	// environment, so we have to convert it back to the concrete type. This needs to be refactored
+	m.AptosChains = cldf_chain.NewBlockChainsFromSlice(aptosChains).AptosChains()
 
 	blockChains := map[uint64]cldf_chain.BlockChain{}
 	for selector, ch := range m.Chains {
@@ -392,8 +395,8 @@ func (m *MemoryEnvironment) StartChains(t *testing.T) {
 	for selector, ch := range m.SolChains {
 		blockChains[selector] = ch
 	}
-	for selector, ch := range m.AptosChains {
-		blockChains[selector] = ch
+	for _, ch := range aptosChains {
+		blockChains[ch.ChainSelector()] = ch
 	}
 
 	env := cldf.Environment{

--- a/deployment/environment/memory/aptos_chains.go
+++ b/deployment/environment/memory/aptos_chains.go
@@ -1,27 +1,14 @@
 package memory
 
 import (
-	"crypto/ed25519"
-	"encoding/hex"
-	"fmt"
-	"strings"
 	"testing"
-	"time"
-
-	"github.com/aptos-labs/aptos-go-sdk"
-	"github.com/aptos-labs/aptos-go-sdk/crypto"
-	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
-
-	"github.com/smartcontractkit/freeport"
-
-	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-testing-framework/framework"
-	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
-
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	cldf_aptos_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos/provider"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
@@ -30,123 +17,32 @@ func getTestAptosChainSelectors() []uint64 {
 	return []uint64{chainsel.APTOS_LOCALNET.Selector}
 }
 
-func createAptosAccount(t *testing.T, useDefault bool) *aptos.Account {
-	if useDefault {
-		addressStr := blockchain.DefaultAptosAccount
-		var defaultAddress aptos.AccountAddress
-		err := defaultAddress.ParseStringRelaxed(addressStr)
-		require.NoError(t, err)
+func generateChainsAptos(t *testing.T, numChains int) []cldf_chain.BlockChain {
+	t.Helper()
 
-		privateKeyStr := blockchain.DefaultAptosPrivateKey
-		privateKeyBytes, err := hex.DecodeString(strings.TrimPrefix(privateKeyStr, "0x"))
-		require.NoError(t, err)
-		privateKey := ed25519.NewKeyFromSeed(privateKeyBytes)
-
-		t.Logf("Using default Aptos account: %s %+v", addressStr, privateKeyBytes)
-
-		account, err := aptos.NewAccountFromSigner(&crypto.Ed25519PrivateKey{Inner: privateKey}, defaultAddress)
-		require.NoError(t, err)
-		return account
-	} else {
-		account, err := aptos.NewEd25519SingleSenderAccount()
-		require.NoError(t, err)
-		return account
-	}
-}
-
-func GenerateChainsAptos(t *testing.T, numChains int) map[uint64]cldf_aptos.Chain {
 	testAptosChainSelectors := getTestAptosChainSelectors()
 	if len(testAptosChainSelectors) < numChains {
 		t.Fatalf("not enough test aptos chain selectors available")
 	}
-	chains := make(map[uint64]cldf_aptos.Chain)
-	for i := 0; i < numChains; i++ {
+
+	chains := make([]cldf_chain.BlockChain, 0, numChains)
+	for i := range numChains {
 		selector := testAptosChainSelectors[i]
-		chainID, err := chainsel.GetChainIDFromSelector(selector)
-		require.NoError(t, err)
-		account := createAptosAccount(t, true)
 
-		url, nodeClient := aptosChain(t, chainID, account.Address)
-		chains[selector] = cldf_aptos.Chain{
-			Selector:       selector,
-			Client:         nodeClient,
-			DeployerSigner: account,
-			URL:            url,
-			Confirm: func(txHash string, opts ...any) error {
-				userTx, err := nodeClient.WaitForTransaction(txHash, opts...)
-				if err != nil {
-					return err
-				}
-				if !userTx.Success {
-					return fmt.Errorf("transaction failed: %s", userTx.VmStatus)
-				}
-				return nil
+		c, err := cldf_aptos_provider.NewCTFChainProvider(t, selector,
+			cldf_aptos_provider.CTFChainProviderConfig{
+				Once:              once,
+				DeployerSignerGen: cldf_aptos_provider.AccountGenCTFDefault(),
 			},
-		}
-	}
-	t.Logf("Created %d Aptos chains: %+v", len(chains), chains)
-	return chains
-}
-
-func aptosChain(t *testing.T, chainID string, adminAddress aptos.AccountAddress) (string, *aptos.NodeClient) {
-	t.Helper()
-
-	// initialize the docker network used by CTF
-	err := framework.DefaultNetwork(once)
-	require.NoError(t, err)
-
-	maxRetries := 10
-	var url string
-	var containerName string
-	for i := 0; i < maxRetries; i++ {
-		// reserve all the ports we need explicitly to avoid port conflicts in other tests
-		ports := freeport.GetN(t, 2)
-
-		bcInput := &blockchain.Input{
-			Image:       "", // filled out by defaultAptos function
-			Type:        "aptos",
-			ChainID:     chainID,
-			PublicKey:   adminAddress.String(),
-			CustomPorts: []string{fmt.Sprintf("%d:8080", ports[0]), fmt.Sprintf("%d:8081", ports[1])},
-		}
-		output, err := blockchain.NewBlockchainNetwork(bcInput)
-		if err != nil {
-			t.Logf("Error creating Aptos network: %v", err)
-			freeport.Return(ports)
-			time.Sleep(time.Second)
-			maxRetries -= 1
-			continue
-		}
+		).Initialize()
 		require.NoError(t, err)
-		containerName = output.ContainerName
-		testcontainers.CleanupContainer(t, output.Container)
-		url = output.Nodes[0].ExternalHTTPUrl + "/v1"
-		break
+
+		chains = append(chains, c)
 	}
 
-	client, err := aptos.NewNodeClient(url, 0)
-	require.NoError(t, err)
+	t.Logf("Created %d Aptos chains", len(chains))
 
-	var ready bool
-	for i := 0; i < 30; i++ {
-		time.Sleep(time.Second)
-		_, err := client.GetChainId()
-		if err != nil {
-			t.Logf("API server not ready yet (attempt %d): %+v\n", i+1, err)
-			continue
-		}
-		ready = true
-		break
-	}
-	require.True(t, ready, "Aptos network not ready")
-
-	dc, err := framework.NewDockerClient()
-	require.NoError(t, err)
-	// incase we didn't use the default account above
-	_, err = dc.ExecContainer(containerName, []string{"aptos", "account", "fund-with-faucet", "--account", adminAddress.String(), "--amount", "100000000000"})
-	require.NoError(t, err)
-
-	return url, client
+	return chains
 }
 
 func createAptosChainConfig(chainID string, chain cldf_aptos.Chain) chainlink.RawConfig {

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -12,28 +12,21 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/gagliardetto/solana-go"
+	solRpc "github.com/gagliardetto/solana-go/rpc"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/freeport"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
-	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
-
-	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
-
-	"github.com/smartcontractkit/freeport"
-
-	chainsel "github.com/smartcontractkit/chain-selectors"
-
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
-	"github.com/smartcontractkit/chainlink/deployment"
-
-	solRpc "github.com/gagliardetto/solana-go/rpc"
-
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/deployment"
 )
 
 const (
@@ -111,8 +104,8 @@ func NewMemoryChainsSol(t *testing.T, numChains int) map[uint64]cldf_solana.Chai
 	return generateMemoryChainSol(mchains)
 }
 
-func NewMemoryChainsAptos(t *testing.T, numChains int) map[uint64]cldf_aptos.Chain {
-	return GenerateChainsAptos(t, numChains)
+func NewMemoryChainsAptos(t *testing.T, numChains int) []cldf_chain.BlockChain {
+	return generateChainsAptos(t, numChains)
 }
 
 func NewMemoryChainsZk(t *testing.T, numChains int) map[uint64]cldf_evm.Chain {
@@ -257,7 +250,7 @@ func NewMemoryEnvironmentFromChainsNodes(
 		nodeIDs = append(nodeIDs, id)
 	}
 
-	blockChains := map[uint64]chain.BlockChain{}
+	blockChains := map[uint64]cldf_chain.BlockChain{}
 	for _, c := range chains {
 		blockChains[c.Selector] = c
 	}
@@ -280,7 +273,7 @@ func NewMemoryEnvironmentFromChainsNodes(
 		NewMemoryJobClient(nodes),
 		ctx,
 		cldf.XXXGenerateTestOCRSecrets(),
-		chain.NewBlockChains(blockChains),
+		cldf_chain.NewBlockChains(blockChains),
 	)
 }
 
@@ -293,11 +286,17 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 	for chainSel, chain := range zkChains {
 		chains[chainSel] = chain
 	}
+
+	// Convert aptos chains to concrete type to pass to the NewNodesConfig.
+	// This is a temporary workaround until we have a better way to handle bringing up configuring
+	// the memory nodes.
+	concreteAptosChains := cldf_chain.NewBlockChainsFromSlice(aptosChains).AptosChains()
+
 	c := NewNodesConfig{
 		LogLevel:       logLevel,
 		Chains:         chains,
 		SolChains:      solChains,
-		AptosChains:    aptosChains,
+		AptosChains:    concreteAptosChains,
 		NumNodes:       config.Nodes,
 		NumBootstraps:  config.Bootstraps,
 		RegistryConfig: config.RegistryConfig,
@@ -313,7 +312,7 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 		nodeIDs = append(nodeIDs, id)
 	}
 
-	blockChains := map[uint64]chain.BlockChain{}
+	blockChains := map[uint64]cldf_chain.BlockChain{}
 	for _, c := range chains {
 		blockChains[c.Selector] = c
 	}
@@ -321,7 +320,7 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 		blockChains[c.Selector] = c
 	}
 	for _, c := range aptosChains {
-		blockChains[c.Selector] = c
+		blockChains[c.ChainSelector()] = c
 	}
 	return *cldf.NewEnvironment(
 		Memory,
@@ -335,6 +334,6 @@ func NewMemoryEnvironment(t *testing.T, lggr logger.Logger, logLevel zapcore.Lev
 		NewMemoryJobClient(nodes),
 		t.Context,
 		cldf.XXXGenerateTestOCRSecrets(),
-		chain.NewBlockChains(blockChains),
+		cldf_chain.NewBlockChains(blockChains),
 	)
 }


### PR DESCRIPTION
The framework now offers a way to load Aptos chains using chain providers. This replaces the current implementation with the one provided by the framework, simplifying the code and improving maintainability.
