### PR TITLE
feat: codeql advanced improvements

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,7 +88,7 @@ jobs:
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         if: matrix.should-run
-        uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -101,6 +101,6 @@ jobs:
 
       - name: Perform CodeQL Analysis
         if: matrix.should-run
-        uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Build go code manually
         if: matrix.should-run && matrix.language == 'go'
         run: |
-          go build -o ./...
+          go build ./...
 
       - name: Perform CodeQL Analysis
         if: matrix.should-run
@@ -130,6 +130,9 @@ jobs:
     name: Runner Config
     needs: [filter]
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
     env:
       SH_GO_RUNNER: runs-on=${{ github.run_id }}/cpu=32/ram=64/family=c6i/spot=false/extras=s3-cache+tmpfs
       GH_GO_RUNNER: ubuntu24.04-8cores-32GB

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,8 +46,8 @@ jobs:
 
   analyze:
     name: Analyze (${{ matrix.language }})
-    needs: filter
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    needs: [ filter, runner-config ]
+    runs-on: ubuntu-latest
     permissions:
       # required for all workflows
       security-events: write
@@ -61,16 +61,25 @@ jobs:
           - language: actions
             build-mode: none
             should-run: ${{ needs.filter.outputs.should-run-workflow }}
+
           - language: go
-            build-mode: autobuild
+            build-mode: manual
             should-run: ${{ needs.filter.outputs.should-run-go }}
+            runs-on: ${{ needs.runner-config.outputs.go-runner }}
+            is-self-hosted: ${{ needs.runner-config.outputs.go-is-self-hosted }}
+
           - language: javascript-typescript
             build-mode: none
             should-run: ${{ needs.filter.outputs.should-run-js }}
+
           - language: python
             build-mode: none
             should-run: ${{ needs.filter.outputs.should-run-python }}
     steps:
+      - name: Enable S3 Cache for Self-Hosted Runners
+        if: matrix.should-run && matrix.is-self-hosted == 'true'
+        uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -78,8 +87,8 @@ jobs:
         if: matrix.language == 'go' && matrix.should-run == 'true'
         uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          only-modules: "true"
+          restore-build-cache-only: "false"
+          build-cache-version: "codeql"
 
       - name: Touching core/web/assets/index.html
         if: matrix.language == 'go' && matrix.should-run == 'true'
@@ -99,8 +108,64 @@ jobs:
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
 
+      - name: Build go code manually
+        if: matrix.should-run && matrix.language == 'go'
+        run: |
+          go build -o ./...
+
       - name: Perform CodeQL Analysis
         if: matrix.should-run
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"
+
+  # This chooses which runner labels we pass for the matrix jobs above.
+  # General Criteria:
+  # 1. If we are going to 'skip' a test suite, we use the base Github-hosted runner.
+  #   - This is based off `should-run-core-tests`, and `should-run-deployment-tests`
+  # 2. If we are not skipping, we check if the PR has the "runs-on-opt-out" label.
+  #   - If the PR has the label, we use the larger Github-hosted runners.
+  #   - If the PR does not have the label, we use the self-hosted runners.
+  runner-config:
+    name: Runner Config
+    needs: [filter]
+    runs-on: ubuntu-latest
+    env:
+      SH_GO_RUNNER: runs-on=${{ github.run_id }}/cpu=32/ram=64/family=c6i/spot=false/extras=s3-cache+tmpfs
+      GH_GO_RUNNER: ubuntu24.04-8cores-32GB
+      GH_BASE_RUNNER: ubuntu-latest
+    outputs:
+      # go codeql runner
+      go-is-self-hosted: ${{ steps.go-codeql.outputs.go-is-self-hosted }}
+      go-runner: ${{ steps.go-codeql.outputs.go-runner }}
+    steps:
+      - name: Get PR Labels
+        id: pr-labels
+        uses: smartcontractkit/.github/actions/get-pr-labels@get-pr-labels/v1
+        with:
+          check-label: "runs-on-opt-out"
+
+      - name: Select runners for go codeql
+        id: go-codeql
+        shell: bash
+        env:
+          OPT_OUT: ${{ steps.pr-labels.outputs.check-label-found || 'false' }}
+          SHOULD_RUN_GO_CODEQL: ${{ needs.filter.outputs.should-run-go }}
+        run: |
+          if [[ "${SHOULD_RUN_GO_CODEQL}" == "false" ]]; then
+            echo "Go CodeQL will be skipped, using base Github-hosted runner."
+            echo "go-is-self-hosted=false" | tee -a $GITHUB_OUTPUT
+            echo "go-runner=${GH_BASE_RUNNER}" | tee -a $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [[ "$OPT_OUT" == "true" ]]; then
+            echo "Opt-out is true for current run. Using gh-hosted runner for Go codeql."
+            echo "go-is-self-hosted=false" | tee -a $GITHUB_OUTPUT
+            echo "go-runner=${GH_GO_RUNNER}" | tee -a $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Opt-out is false for current run. Using self-hosted runner for Go codeql."
+          echo "go-is-self-hosted=true" | tee -a $GITHUB_OUTPUT
+          echo "go-runner=${SH_GO_RUNNER}" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       should-run-go: ${{ steps.changes.outputs.go-changes == 'true' || steps.changes.outputs.self-changes == 'true' || github.event == 'schedule' }}
       should-run-js: ${{ steps.changes.outputs.js-changes == 'true' || steps.changes.outputs.self-changes == 'true' || github.event == 'schedule' }}
+      should-run-python: ${{ steps.changes.outputs.python-changes == 'true' || steps.changes.outputs.self-changes == 'true' || github.event == 'schedule' }}
       should-run-workflow: ${{ steps.changes.outputs.workflow-changes == 'true' || github.event == 'schedule' }}
     runs-on: ubuntu-latest
     steps:
@@ -37,11 +38,15 @@ jobs:
               - '**/*.ts'
             workflow-changes:
               - '.github/**'
+            python-changes:
+              - '**/requirements.txt'
+              - '**/*.py'
             self-changes:
               - '.github/workflows/codeql.yml'
 
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: filter
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
       # required for all workflows
@@ -62,6 +67,9 @@ jobs:
           - language: javascript-typescript
             build-mode: none
             should-run: ${{ needs.filter.outputs.should-run-js }}
+          - language: python
+            build-mode: none
+            should-run: ${{ needs.filter.outputs.should-run-python }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     needs: [ filter, runner-config ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on || 'ubuntu-latest' }}
     permissions:
       # required for all workflows
       security-events: write


### PR DESCRIPTION
### Changes

- Add python as a language
- Add `needs: filter` to the analyze job matrix
- Add a `runner-config` job to pick runner for go codeql
  - Defaults to using self-hosted runners for go
  - Manual build for go
  - Use build cache for go

### Testing

From 30minutes to 4 minutes: https://github.com/smartcontractkit/chainlink/actions/runs/15450131361/job/43489922579?pr=18009

Note - these are failing because this repository is configured to use CodeQL Default.

### Notes

The repository will have to be configured to use codeql advanced for this to work.
