### PR TITLE
feat: go-mod-cache install plugins,tools

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -96,8 +96,6 @@ runs:
         # The lifetime of go modules is much higher than the build outputs, so we increase cache efficiency
         # here by not having the primary key contain the branch name
         key: ${{ runner.os }}-gomod-${{ inputs.cache-version }}-${{ hashFiles(steps.go-module-path.outputs.path) }}
-        restore-keys: |
-          ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
 
     # BUILD CACHE LOGIC
     # ---

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -26,6 +26,13 @@ inputs:
       Only restore the build cache, don't automatically update/upload it.
     default: "false"
 
+outputs:
+  primary-cache-hit-modules:
+    description: |
+      Set to 'true' if the primary cache for modules was hit.
+      This is useful for debugging cache misses.
+    value: ${{ steps.cache-modules.outputs.cache-hit == 'true' || steps.cache-modules-restore.outputs.cache-hit == 'true' }}
+
 runs:
   using: composite
   steps:
@@ -66,7 +73,8 @@ runs:
     # `go-mod-cache.yml` workflow handle the creation.
     - uses: actions/cache/restore@v4
       if: ${{ inputs.restore-module-cache-only == 'true' }}
-      name: Cache Go Modules
+      name: Cache Go Modules (Restore)
+      id: cache-modules-restore
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gomodcache }}
@@ -80,6 +88,7 @@ runs:
     # The cache is created after a cache miss, and after job completes successfully.
     - uses: actions/cache@v4
       if: ${{ inputs.restore-module-cache-only != 'true' }}
+      id: cache-modules
       name: Cache Go Modules
       with:
         path: |
@@ -159,7 +168,7 @@ runs:
     #   2. If inputs.restore-build-cache-only == 'true'
     - uses: actions/cache/restore@v4
       name: Cache Go Build Outputs (restore)
-
+      id: build-cache-restore
       if: ${{ inputs.only-modules == 'false' && (github.event_name == 'merge_group' || inputs.restore-build-cache-only == 'true') }}
       with:
         path: |

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -50,12 +50,14 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
+        id: setup-go
         uses: ./.github/actions/setup-go
         with:
           only-modules: "true"
           restore-module-cache-only: "false"
 
       - name: Install Dependencies
+        if: ${{ steps.setup-go.outputs.primary-cache-hit-modules != 'true' }}
         shell: bash
         run: |
           echo "::group::go mod download"

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -27,6 +27,8 @@ on:
 
 jobs:
   go-cache:
+    name: Go Cache ${{ matrix.suffix }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -37,8 +39,10 @@ jobs:
           - runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c6id/spot=false/extras=s3-cache
             suffix: "(Self-hosted)"
 
-    name: Go Cache ${{ matrix.suffix }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -67,7 +67,7 @@ jobs:
           make install-plugins-public
           echo "::endgroup::"
 
-          echo "::Install testing tools"
+          echo "::group::Install testing tools"
           go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25
           go install gotest.tools/gotestsum@v1.12.2
-          ::endgroup::"
+          echo "::endgroup::"

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -27,7 +27,17 @@ on:
 
 jobs:
   go-cache:
-    name: Go Cache
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            suffix: "(Github-hosted)"
+
+          - runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c6id/spot=false/extras=s3-cache
+            suffix: "(Self-hosted)"
+
+    name: Go Cache ${{ matrix.suffix }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
@@ -43,26 +53,17 @@ jobs:
 
       - name: Install Dependencies
         shell: bash
-        run:  go mod download
+        run: |
+          echo "::group::go mod download"
+          go mod download
+          echo "::endgroup::"
 
-  go-cache-self-hosted:
-    name: Go Cache
-    runs-on: runs-on=${{ github.run_id }}/cpu=8/ram=16/family=c6id/spot=false/extras=s3-cache
-    steps:
-      # enable runs-on magic cache
-      - uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
+          echo "::group::Install LOOP plugins"
+          make install-loopinstall
+          make install-plugins-public
+          echo "::endgroup::"
 
-      - name: Checkout the repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-        with:
-          only-modules: "true"
-          restore-module-cache-only: "false"
-
-      - name: Install Dependencies
-        shell: bash
-        run:  go mod download
+          echo "::Install testing tools"
+          go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25
+          go install gotest.tools/gotestsum@v1.12.2
+          ::endgroup::"


### PR DESCRIPTION
### Changes

- Collapses `go-cache` and `go-cache-self-hosted` job into matrix job
- Checks if there was a primary cache hit before installing, if there was then the cache will not be saved so installing is a waste of time.
- Now installs `loopinstall`, plugins, and some test tools
- Don't restore from existing cache if creating new entry.
	- The idea here is that if we restore from an older cache when creating a new entry, then we will inflate our module cache unnecessarily. Having it download everything from scratch when creating a new entry, ensures the cache contains only necessary items.

### Motivation

In our tests and builds, we are still pulling modules that we could have cached. So adding those here.

Technically these things are not part of our go.mod, but the cache is keyed with the hash of the go mod. So we could update the new things, but the cache wouldn't be updated. I don't see this as a big deal because then we have a slightly inflated cache, and we have cache misses for the updated things and have to download them (like we are already doing every run).

### Testing

- Before adding the conditional on cache key: https://github.com/smartcontractkit/chainlink/actions/runs/15476519742/job/43573159204?pr=18029 (installs everything fine)
- After checking if primary cache hit: https://github.com/smartcontractkit/chainlink/actions/runs/15476708567/job/43573719323?pr=18029 (skips install)



