### PR TITLE
fix: add push trigger for codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
         if: matrix.language == 'go'
         uses: ./.github/actions/setup-go
         with:
-          restore-build-cache-only: "false"
+          restore-build-cache-only: ${{ github.event_name != 'push' }}
           build-cache-version: "codeql"
 
       - name: Touching core/web/assets/index.html

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,10 @@
 name: "CodeQL Advanced"
 
 on:
+  push:
+    branches:
+      - develop
+      - release/*
   merge_group:
   pull_request:
   schedule:


### PR DESCRIPTION
### Changes

- Add on push trigger for CodeQL
- Restore build cache for PRs only

### Motivation

CodeQL complaining: https://github.com/smartcontractkit/chainlink/actions/runs/15476047874

```
Analyze (go)
1 issue was detected with this workflow: Please specify an on.push hook to analyze and see code scanning alerts from the default branch on the Security tab.

Analyze (go)
Unable to validate code scanning workflow: MissingPushHook
```