### PR TITLE
[chore] Remove high cardinality execution tag

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -792,7 +792,7 @@ func (e *Engine) workerForStepRequest(ctx context.Context, msg stepRequest) {
 			l.Error(fmt.Sprintf("failed to reserve on metering report for %s: %s", stepState.Ref, err))
 		}
 	} else {
-		e.metrics.With(platform.KeyWorkflowID, e.workflow.id, platform.KeyWorkflowExecutionID, msg.state.ExecutionID).IncrementWorkflowMissingMeteringReport(ctx)
+		e.metrics.With(platform.KeyWorkflowID, e.workflow.id).IncrementWorkflowMissingMeteringReport(ctx)
 		// TODO: to be bumped to error if all capabilities must implement metering
 		l.Warnf("no metering report found for %v", msg.state.ExecutionID)
 	}


### PR DESCRIPTION
This is a possible source of a memory leak that I'm tracking down.

As a matter of best practice, high cardinality labels (such as execution ID) should be avoided since they can increase memory utilization of our OTeL backend and significantly increase the cost of storing the metric.