### PR TITLE
[CRE-192] Use a standalone CSAKeystore when instantiating relayers.

### DIFF
--- a/core/cmd/shell_test.go
+++ b/core/cmd/shell_test.go
@@ -355,6 +355,7 @@ func TestSetupSolanaRelayer(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	reg := plugins.NewTestLoopRegistry(lggr)
 	ks := &keystore.StarknetLooppSigner{StarkNet: mocks.NewStarkNet(t)}
+	ksCSA := &keystore.CSASigner{CSA: mocks.NewCSA(t)}
 	ds := sqltest.NewNoOpDataSource()
 
 	// config 3 chains but only enable 2 => should only be 2 relayer
@@ -406,7 +407,7 @@ func TestSetupSolanaRelayer(t *testing.T) {
 
 	// not parallel; shared state
 	t.Run("no plugin", func(t *testing.T) {
-		relayers, err := rf.NewSolana(ks, cfg)
+		relayers, err := rf.NewSolana(ks, ksCSA, cfg)
 		require.NoError(t, err)
 		require.NotNil(t, relayers)
 		require.Len(t, relayers, nEnabledChains)
@@ -417,7 +418,7 @@ func TestSetupSolanaRelayer(t *testing.T) {
 	t.Run("plugin", func(t *testing.T) {
 		t.Setenv("CL_SOLANA_CMD", "phony_solana_cmd")
 
-		relayers, err := rf.NewSolana(ks, cfg)
+		relayers, err := rf.NewSolana(ks, ksCSA, cfg)
 		require.NoError(t, err)
 		require.NotNil(t, relayers)
 		require.Len(t, relayers, nEnabledChains)
@@ -449,13 +450,13 @@ func TestSetupSolanaRelayer(t *testing.T) {
 
 	// not parallel; shared state
 	t.Run("no plugin, duplicate chains", func(t *testing.T) {
-		_, err := rf.NewSolana(ks, dupCfg)
+		_, err := rf.NewSolana(ks, ksCSA, dupCfg)
 		require.Error(t, err)
 	})
 
 	t.Run("plugin, duplicate chains", func(t *testing.T) {
 		t.Setenv("CL_SOLANA_CMD", "phony_solana_cmd")
-		_, err := rf.NewSolana(ks, dupCfg)
+		_, err := rf.NewSolana(ks, ksCSA, dupCfg)
 		require.Error(t, err)
 	})
 
@@ -463,7 +464,7 @@ func TestSetupSolanaRelayer(t *testing.T) {
 		t.Setenv("CL_SOLANA_CMD", "phony_solana_cmd")
 		t.Setenv("CL_SOLANA_ENV", "fake_path")
 
-		_, err := rf.NewSolana(ks, chainlink.SolanaFactoryConfig{
+		_, err := rf.NewSolana(ks, ksCSA, chainlink.SolanaFactoryConfig{
 			TOMLConfigs: t2Config.SolanaConfigs(),
 			DS:          ds,
 		})
@@ -484,6 +485,7 @@ func TestSetupStarkNetRelayer(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	reg := plugins.NewTestLoopRegistry(lggr)
 	ks := &keystore.StarknetLooppSigner{StarkNet: mocks.NewStarkNet(t)}
+	ksCSA := &keystore.CSASigner{CSA: mocks.NewCSA(t)}
 	// config 3 chains but only enable 2 => should only be 2 relayer
 	nEnabledChains := 2
 	tConfig := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
@@ -523,7 +525,7 @@ func TestSetupStarkNetRelayer(t *testing.T) {
 	t.Run("plugin-cmd", func(t *testing.T) {
 		t.Setenv("CL_STARKNET_CMD", "phony_starknet_cmd")
 
-		relayers, err := rf.NewStarkNet(ks, tConfig.StarknetConfigs())
+		relayers, err := rf.NewStarkNet(ks, ksCSA, tConfig.StarknetConfigs())
 		require.NoError(t, err)
 		require.NotNil(t, relayers)
 		require.Len(t, relayers, nEnabledChains)
@@ -549,13 +551,13 @@ func TestSetupStarkNetRelayer(t *testing.T) {
 
 	// not parallel; shared state
 	t.Run("no plugin, duplicate chains", func(t *testing.T) {
-		_, err := rf.NewStarkNet(ks, duplicateConfig.StarknetConfigs())
+		_, err := rf.NewStarkNet(ks, ksCSA, duplicateConfig.StarknetConfigs())
 		require.Error(t, err)
 	})
 
 	t.Run("plugin, duplicate chains", func(t *testing.T) {
 		t.Setenv("CL_STARKNET_CMD", "phony_starknet_cmd")
-		_, err := rf.NewStarkNet(ks, duplicateConfig.StarknetConfigs())
+		_, err := rf.NewStarkNet(ks, ksCSA, duplicateConfig.StarknetConfigs())
 		require.Error(t, err)
 	})
 
@@ -563,7 +565,7 @@ func TestSetupStarkNetRelayer(t *testing.T) {
 		t.Setenv("CL_STARKNET_CMD", "phony_starknet_cmd")
 		t.Setenv("CL_STARKNET_ENV", "fake_path")
 
-		_, err := rf.NewStarkNet(ks, t2Config.StarknetConfigs())
+		_, err := rf.NewStarkNet(ks, ksCSA, t2Config.StarknetConfigs())
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to parse env file")
 	})
@@ -571,7 +573,7 @@ func TestSetupStarkNetRelayer(t *testing.T) {
 	t.Run("plugin already registered", func(t *testing.T) {
 		t.Setenv("CL_STARKNET_CMD", "phony_starknet_cmd")
 
-		_, err := rf.NewStarkNet(ks, tConfig.StarknetConfigs())
+		_, err := rf.NewStarkNet(ks, ksCSA, tConfig.StarknetConfigs())
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to create LOOP command")
 	})

--- a/core/cmd/shell_test.go
+++ b/core/cmd/shell_test.go
@@ -475,7 +475,7 @@ func TestSetupSolanaRelayer(t *testing.T) {
 	t.Run("plugin already registered", func(t *testing.T) {
 		t.Setenv("CL_SOLANA_CMD", "phony_solana_cmd")
 
-		_, err := rf.NewSolana(ks, cfg)
+		_, err := rf.NewSolana(ks, ksCSA, cfg)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to create Solana LOOP command")
 	})

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -331,23 +331,23 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 	initOps := []CoreRelayerChainInitFunc{InitDummy(relayerFactory), InitEVM(relayerFactory, evmFactoryCfg)}
 
 	if cfg.CosmosEnabled() {
-		initOps = append(initOps, InitCosmos(relayerFactory, keyStore.Cosmos(), cfg.CosmosConfigs()))
+		initOps = append(initOps, InitCosmos(relayerFactory, keyStore.Cosmos(), keyStore.CSA(), cfg.CosmosConfigs()))
 	}
 	if cfg.SolanaEnabled() {
 		solanaCfg := SolanaFactoryConfig{
 			TOMLConfigs: cfg.SolanaConfigs(),
 			DS:          opts.DS,
 		}
-		initOps = append(initOps, InitSolana(relayerFactory, keyStore.Solana(), solanaCfg))
+		initOps = append(initOps, InitSolana(relayerFactory, keyStore.Solana(), keyStore.CSA(), solanaCfg))
 	}
 	if cfg.StarkNetEnabled() {
-		initOps = append(initOps, InitStarknet(relayerFactory, keyStore.StarkNet(), cfg.StarknetConfigs()))
+		initOps = append(initOps, InitStarknet(relayerFactory, keyStore.StarkNet(), keyStore.CSA(), cfg.StarknetConfigs()))
 	}
 	if cfg.AptosEnabled() {
-		initOps = append(initOps, InitAptos(relayerFactory, keyStore.Aptos(), cfg.AptosConfigs()))
+		initOps = append(initOps, InitAptos(relayerFactory, keyStore.Aptos(), keyStore.CSA(), cfg.AptosConfigs()))
 	}
 	if cfg.TronEnabled() {
-		initOps = append(initOps, InitTron(relayerFactory, keyStore.Tron(), cfg.TronConfigs()))
+		initOps = append(initOps, InitTron(relayerFactory, keyStore.Tron(), keyStore.CSA(), cfg.TronConfigs()))
 	}
 
 	relayChainInterops, err := NewCoreRelayerChainInteroperators(initOps...)

--- a/core/services/chainlink/relayer_chain_interoperators.go
+++ b/core/services/chainlink/relayer_chain_interoperators.go
@@ -136,10 +136,10 @@ func InitEVM(factory RelayerFactory, config EVMFactoryConfig) CoreRelayerChainIn
 }
 
 // InitCosmos is a option for instantiating Cosmos relayers
-func InitCosmos(factory RelayerFactory, ks keystore.Cosmos, chainCfgs RawConfigs) CoreRelayerChainInitFunc {
+func InitCosmos(factory RelayerFactory, ks keystore.Cosmos, csaKS keystore.CSA, chainCfgs RawConfigs) CoreRelayerChainInitFunc {
 	return func(op *CoreRelayerChainInteroperators) (err error) {
 		loopKs := &keystore.CosmosLoopSigner{Cosmos: ks}
-		relayers, err := factory.NewCosmos(loopKs, chainCfgs)
+		relayers, err := factory.NewCosmos(loopKs, &keystore.CSASigner{CSA: csaKS}, chainCfgs)
 		if err != nil {
 			return fmt.Errorf("failed to setup Cosmos relayer: %w", err)
 		}
@@ -153,10 +153,10 @@ func InitCosmos(factory RelayerFactory, ks keystore.Cosmos, chainCfgs RawConfigs
 }
 
 // InitSolana is a option for instantiating Solana relayers
-func InitSolana(factory RelayerFactory, ks keystore.Solana, config SolanaFactoryConfig) CoreRelayerChainInitFunc {
+func InitSolana(factory RelayerFactory, ks keystore.Solana, csaKS keystore.CSA, config SolanaFactoryConfig) CoreRelayerChainInitFunc {
 	return func(op *CoreRelayerChainInteroperators) error {
 		loopKs := &keystore.SolanaLooppSigner{Solana: ks}
-		solRelayers, err := factory.NewSolana(loopKs, config)
+		solRelayers, err := factory.NewSolana(loopKs, &keystore.CSASigner{CSA: csaKS}, config)
 		if err != nil {
 			return fmt.Errorf("failed to setup Solana relayer: %w", err)
 		}
@@ -171,10 +171,10 @@ func InitSolana(factory RelayerFactory, ks keystore.Solana, config SolanaFactory
 }
 
 // InitStarknet is a option for instantiating Starknet relayers
-func InitStarknet(factory RelayerFactory, ks keystore.StarkNet, chainCfgs RawConfigs) CoreRelayerChainInitFunc {
+func InitStarknet(factory RelayerFactory, ks keystore.StarkNet, csaKS keystore.CSA, chainCfgs RawConfigs) CoreRelayerChainInitFunc {
 	return func(op *CoreRelayerChainInteroperators) (err error) {
 		loopKs := &keystore.StarknetLooppSigner{StarkNet: ks}
-		starkRelayers, err := factory.NewStarkNet(loopKs, chainCfgs)
+		starkRelayers, err := factory.NewStarkNet(loopKs, &keystore.CSASigner{CSA: csaKS}, chainCfgs)
 		if err != nil {
 			return fmt.Errorf("failed to setup StarkNet relayer: %w", err)
 		}
@@ -189,10 +189,10 @@ func InitStarknet(factory RelayerFactory, ks keystore.StarkNet, chainCfgs RawCon
 }
 
 // InitAptos is a option for instantiating Aptos relayers
-func InitAptos(factory RelayerFactory, ks keystore.Aptos, chainCfgs RawConfigs) CoreRelayerChainInitFunc {
+func InitAptos(factory RelayerFactory, ks keystore.Aptos, csaKS keystore.CSA, chainCfgs RawConfigs) CoreRelayerChainInitFunc {
 	return func(op *CoreRelayerChainInteroperators) (err error) {
 		loopKs := &keystore.AptosLooppSigner{Aptos: ks}
-		relayers, err := factory.NewAptos(loopKs, chainCfgs)
+		relayers, err := factory.NewAptos(loopKs, &keystore.CSASigner{CSA: csaKS}, chainCfgs)
 		if err != nil {
 			return fmt.Errorf("failed to setup aptos relayer: %w", err)
 		}
@@ -207,10 +207,10 @@ func InitAptos(factory RelayerFactory, ks keystore.Aptos, chainCfgs RawConfigs) 
 }
 
 // InitTron is a option for instantiating Tron relayers
-func InitTron(factory RelayerFactory, ks keystore.Tron, chainCfgs RawConfigs) CoreRelayerChainInitFunc {
+func InitTron(factory RelayerFactory, ks keystore.Tron, csaKS keystore.CSA, chainCfgs RawConfigs) CoreRelayerChainInitFunc {
 	return func(op *CoreRelayerChainInteroperators) error {
 		loopKs := &keystore.TronLOOPSigner{Tron: ks}
-		tronRelayers, err := factory.NewTron(loopKs, chainCfgs)
+		tronRelayers, err := factory.NewTron(loopKs, &keystore.CSASigner{CSA: csaKS}, chainCfgs)
 		if err != nil {
 			return fmt.Errorf("failed to setup Tron relayer: %w", err)
 		}

--- a/core/services/chainlink/relayer_chain_interoperators_test.go
+++ b/core/services/chainlink/relayer_chain_interoperators_test.go
@@ -161,7 +161,7 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 
 		{name: "2 solana chain with 2 node",
 			initFuncs: []chainlink.CoreRelayerChainInitFunc{
-				chainlink.InitSolana(factory, keyStore.Solana(), chainlink.SolanaFactoryConfig{
+				chainlink.InitSolana(factory, keyStore.Solana(), keyStore.CSA(), chainlink.SolanaFactoryConfig{
 					TOMLConfigs: newConfig().SolanaConfigs()}),
 			},
 			expectedSolanaChainCnt: 2,
@@ -174,7 +174,7 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 		},
 
 		{name: "all chains",
-			initFuncs: []chainlink.CoreRelayerChainInitFunc{chainlink.InitSolana(factory, keyStore.Solana(), chainlink.SolanaFactoryConfig{
+			initFuncs: []chainlink.CoreRelayerChainInitFunc{chainlink.InitSolana(factory, keyStore.Solana(), keyStore.CSA(), chainlink.SolanaFactoryConfig{
 				TOMLConfigs: newConfig().SolanaConfigs()}),
 				chainlink.InitEVM(factory, chainlink.EVMFactoryConfig{
 					ChainOpts: legacyevm.ChainOpts{
@@ -189,8 +189,8 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 					EthKeystore: keyStore.Eth(),
 					CSAKeystore: &keystore.CSASigner{CSA: keyStore.CSA()},
 				}),
-				chainlink.InitStarknet(factory, keyStore.StarkNet(), cfg.StarknetConfigs()),
-				chainlink.InitCosmos(factory, keyStore.Cosmos(), cfg.CosmosConfigs()),
+				chainlink.InitStarknet(factory, keyStore.StarkNet(), keyStore.CSA(), cfg.StarknetConfigs()),
+				chainlink.InitCosmos(factory, keyStore.Cosmos(), keyStore.CSA(), cfg.CosmosConfigs()),
 			},
 			expectedEVMChainCnt: 2,
 			expectedEVMNodeCnt:  3,

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -102,7 +102,7 @@ type SolanaFactoryConfig struct {
 	DS sqlutil.DataSource
 }
 
-func (r *RelayerFactory) NewSolana(ks coretypes.Keystore, config SolanaFactoryConfig) (map[types.RelayID]loop.Relayer, error) {
+func (r *RelayerFactory) NewSolana(ks coretypes.Keystore, ksCSA coretypes.Keystore, config SolanaFactoryConfig) (map[types.RelayID]loop.Relayer, error) {
 	chainCfgs, ds := config.TOMLConfigs, config.DS
 	solanaRelayers := make(map[types.RelayID]loop.Relayer)
 	var solLggr = logger.Named(r.Logger, "Solana")
@@ -146,7 +146,7 @@ func (r *RelayerFactory) NewSolana(ks coretypes.Keystore, config SolanaFactoryCo
 				return nil, fmt.Errorf("failed to create Solana LOOP command: %w", err)
 			}
 
-			solanaRelayers[relayID] = loop.NewRelayerService(lggr, r.GRPCOpts, solCmdFn, string(cfgTOML), ks, ks, r.CapabilitiesRegistry)
+			solanaRelayers[relayID] = loop.NewRelayerService(lggr, r.GRPCOpts, solCmdFn, string(cfgTOML), ks, ksCSA, r.CapabilitiesRegistry)
 		} else {
 			// fallback to embedded chain
 			opts := solana.ChainOpts{
@@ -165,8 +165,8 @@ func (r *RelayerFactory) NewSolana(ks coretypes.Keystore, config SolanaFactoryCo
 	return solanaRelayers, nil
 }
 
-func (r *RelayerFactory) NewStarkNet(ks coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
-	return r.NewLOOPRelayer("StarkNet", relay.NetworkStarkNet, env.StarknetPlugin, ks, chainCfgs)
+func (r *RelayerFactory) NewStarkNet(ks coretypes.Keystore, ksCSA coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
+	return r.NewLOOPRelayer("StarkNet", relay.NetworkStarkNet, env.StarknetPlugin, ks, ksCSA, chainCfgs)
 }
 
 type CosmosFactoryConfig struct {
@@ -189,15 +189,15 @@ func (c CosmosFactoryConfig) Validate() error {
 	return err
 }
 
-func (r *RelayerFactory) NewCosmos(ks coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
-	return r.NewLOOPRelayer("Cosmos", relay.NetworkCosmos, env.CosmosPlugin, ks, chainCfgs)
+func (r *RelayerFactory) NewCosmos(ks coretypes.Keystore, ksCSA coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
+	return r.NewLOOPRelayer("Cosmos", relay.NetworkCosmos, env.CosmosPlugin, ks, ksCSA, chainCfgs)
 }
 
-func (r *RelayerFactory) NewAptos(ks coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
-	return r.NewLOOPRelayer("Aptos", relay.NetworkAptos, env.AptosPlugin, ks, chainCfgs)
+func (r *RelayerFactory) NewAptos(ks coretypes.Keystore, ksCSA coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
+	return r.NewLOOPRelayer("Aptos", relay.NetworkAptos, env.AptosPlugin, ks, ksCSA, chainCfgs)
 }
 
-func (r *RelayerFactory) NewLOOPRelayer(name string, network string, plugin env.Plugin, ks coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
+func (r *RelayerFactory) NewLOOPRelayer(name string, network string, plugin env.Plugin, ks coretypes.Keystore, ksCSA coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
 	relayers := make(map[types.RelayID]loop.Relayer)
 	lggr := logger.Named(r.Logger, name)
 
@@ -238,11 +238,11 @@ func (r *RelayerFactory) NewLOOPRelayer(name string, network string, plugin env.
 		}
 		// the relayer service has a delicate keystore dependency. the value that is passed to NewRelayerService must
 		// be compatible with instantiating a starknet transaction manager KeystoreAdapter within the LOOPp executable.
-		relayers[relayID] = loop.NewRelayerService(logger.Named(lggr, relayID.ChainID), r.GRPCOpts, cmdFn, string(cfgTOML), ks, ks, r.CapabilitiesRegistry)
+		relayers[relayID] = loop.NewRelayerService(logger.Named(lggr, relayID.ChainID), r.GRPCOpts, cmdFn, string(cfgTOML), ks, ksCSA, r.CapabilitiesRegistry)
 	}
 	return relayers, nil
 }
 
-func (r *RelayerFactory) NewTron(ks coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
-	return r.NewLOOPRelayer("Tron", relay.NetworkTron, env.TronPlugin, ks, chainCfgs)
+func (r *RelayerFactory) NewTron(ks coretypes.Keystore, ksCSA coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
+	return r.NewLOOPRelayer("Tron", relay.NetworkTron, env.TronPlugin, ks, ksCSA, chainCfgs)
 }


### PR DESCRIPTION
Supports https://github.com/smartcontractkit/chainlink/pull/16578