### PR TITLE
Deployment: set Aptos tests to run in parallel

### DIFF
--- a/deployment/ccip/changeset/aptos/config/lane_test.go
+++ b/deployment/ccip/changeset/aptos/config/lane_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestToEVMUpdateLanesConfig(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    UpdateAptosLanesConfig
@@ -122,6 +123,7 @@ func TestToEVMUpdateLanesConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := ToEVMUpdateLanesConfig(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/deployment/ccip/changeset/aptos/cs_add_token_pool_test.go
+++ b/deployment/ccip/changeset/aptos/cs_add_token_pool_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestAddTokenPool_Apply(t *testing.T) {
+	t.Parallel()
 	// Setup environment and config with 1 Aptos chain
 	deployedEnvironment, _ := testhelpers.NewMemoryEnvironment(
 		t,

--- a/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		env       cldf.Environment
@@ -192,6 +193,7 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			cs := DeployAptosChain{}
 			err := cs.VerifyPreconditions(tt.env, tt.config)
 			if tt.wantErr {
@@ -206,6 +208,7 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 }
 
 func TestDeployAptosChain_Apply(t *testing.T) {
+	t.Parallel()
 	lggr := logger.TestLogger(t)
 
 	// Setup memory environment with 1 Aptos chain

--- a/deployment/ccip/changeset/aptos/cs_set_ocr3_offramp_test.go
+++ b/deployment/ccip/changeset/aptos/cs_set_ocr3_offramp_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestSetOCR3Offramp_Apply(t *testing.T) {
+	t.Parallel()
 	// Setup environment and config
 	deployedEnvironment, _ := testhelpers.NewMemoryEnvironment(
 		t,

--- a/deployment/ccip/changeset/aptos/operation/ccip.go
+++ b/deployment/ccip/changeset/aptos/operation/ccip.go
@@ -108,7 +108,7 @@ type DeployModulesInput struct {
 var DeployRouterOp = operations.NewOperation(
 	"deploy-router-op",
 	Version1_0_0,
-	"Generates MCMS proposals that deployes Router module on CCIP package",
+	"Generates MCMS proposals that deploys Router module on CCIP package",
 	deployRouter,
 )
 
@@ -133,7 +133,7 @@ func deployRouter(b operations.Bundle, deps AptosDeps, in DeployModulesInput) ([
 var DeployOffRampOp = operations.NewOperation(
 	"deploy-offramp-op",
 	Version1_0_0,
-	"Generates MCMS proposals that deployes OffRamp module on CCIP package",
+	"Generates MCMS proposals that deploys OffRamp module on CCIP package",
 	deployOffRamp,
 )
 
@@ -156,7 +156,7 @@ func deployOffRamp(b operations.Bundle, deps AptosDeps, in DeployModulesInput) (
 var DeployOnRampOp = operations.NewOperation(
 	"deploy-onramp-op",
 	Version1_0_0,
-	"Generates MCMS proposals that deployes OnRamp module on CCIP package",
+	"Generates MCMS proposals that deploys OnRamp module on CCIP package",
 	deployOnRamp,
 )
 

--- a/deployment/ccip/changeset/aptos/update_aptos_lanes_test.go
+++ b/deployment/ccip/changeset/aptos/update_aptos_lanes_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestAddAptosLanes_Apply(t *testing.T) {
+	t.Parallel()
 	// Setup environment and config
 	deployedEnvironment, _ := testhelpers.NewMemoryEnvironment(
 		t,


### PR DESCRIPTION
Run all Aptos tests in `deployment/ccip/changeset/aptos` in parallel to speed up test execution.

Before/after:
```
github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos	518.319s
github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos	318.227s
```