### PR TITLE
Validate writer capabilities names on changeset

### DIFF
--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -20,15 +20,14 @@ import (
 )
 
 const (
-	// See: https://github.com/smartcontractkit/chainlink/blob/3684365e78ef911d7668e724aa782d3b3f3e8801/deployment/keystone/changeset/internal/capability_definitions.go#L15
-	capabilityTypeTarget           = uint8(3)
-	capabilityTypeTargetNamePrefix = "write_"
+	CapabilityTypeTarget           = uint8(3) // See: https://github.com/smartcontractkit/chainlink/blob/3684365e78ef911d7668e724aa782d3b3f3e8801/deployment/keystone/changeset/internal/capability_definitions.go#L15
+	CapabilityTypeTargetNamePrefix = "write_"
 )
 
 var (
 	ErrEmptyWriteCapName         = errors.New("capability labelled name must not be empty")
-	ErrInvalidWriteCapName       = errors.New("capability labelled name must start with " + capabilityTypeTargetNamePrefix)
-	ErrEmptyTrimmedWriteCapName  = errors.New("capability labelled name must not be empty after removing prefix " + capabilityTypeTargetNamePrefix)
+	ErrInvalidWriteCapName       = errors.New("capability labelled name must start with " + CapabilityTypeTargetNamePrefix)
+	ErrEmptyTrimmedWriteCapName  = errors.New("capability labelled name must not be empty after removing prefix " + CapabilityTypeTargetNamePrefix)
 	ErrInvalidWriteCapNameFormat = errors.New("capability labelled name is not a valid chain name or chain ID")
 )
 
@@ -54,22 +53,24 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 	var capNameErr error
 	// Validate write target capabilities labelled name
 	for _, c := range r.Capabilities {
-		if c.CapabilityType != capabilityTypeTarget {
+		if c.CapabilityType != CapabilityTypeTarget {
 			continue
 		}
+		env.Logger.Debugf(c.LabelledName)
 		if c.LabelledName == "" {
 			capNameErr = errors.Join(ErrEmptyWriteCapName, capNameErr)
 			continue
 		}
-		if !strings.HasPrefix(c.LabelledName, capabilityTypeTargetNamePrefix) {
+		if !strings.HasPrefix(c.LabelledName, CapabilityTypeTargetNamePrefix) {
 			capNameErr = errors.Join(ErrInvalidWriteCapName, capNameErr)
 			continue
 		}
-		extracted := strings.TrimPrefix(c.LabelledName, capabilityTypeTargetNamePrefix)
+		extracted := strings.TrimPrefix(c.LabelledName, CapabilityTypeTargetNamePrefix)
 		if extracted == "" {
 			capNameErr = errors.Join(ErrEmptyTrimmedWriteCapName, capNameErr)
 			continue
 		}
+		env.Logger.Debugf("Extracted chain name or ID: %s", extracted)
 		_, err := chainselectors.ChainIdFromName(extracted)
 		if err != nil {
 			// Validate if the extracted value is the chain ID instead, since the labelled name can contain
@@ -84,6 +85,7 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 				}
 			}
 
+			env.Logger.Debugf(err.Error())
 			capNameErr = errors.Join(ErrInvalidWriteCapNameFormat, capNameErr)
 		}
 	}

--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
-	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	"github.com/smartcontractkit/mcms"
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
@@ -75,9 +75,9 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 			// Validate if the extracted value is the chain ID instead, since the labelled name can contain
 			// both the chain ID or the chain name.
 			// See: https://github.com/smartcontractkit/chainlink/blob/3684365e78ef911d7668e724aa782d3b3f3e8801/core/services/relay/evm/write_target.go#L75
-			chainId, chainIdErr := strconv.ParseUint(extracted, 10, 64)
+			chainID, chainIdErr := strconv.ParseUint(extracted, 10, 64)
 			if chainIdErr == nil {
-				_, chainIdErr = chainselectors.NameFromChainId(chainId)
+				_, chainIdErr = chainselectors.NameFromChainId(chainID)
 				if chainIdErr == nil {
 					// If it is a valid chain ID, we don't error and continue
 					continue

--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -70,7 +70,6 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 			capNameErr = errors.Join(ErrEmptyTrimmedWriteCapName, capNameErr)
 			continue
 		}
-		env.Logger.Debugf("Extracted chain name or ID: %s", extracted)
 		_, err := chainselectors.ChainIdFromName(extracted)
 		if err != nil {
 			// Validate if the extracted value is the chain ID instead, since the labelled name can contain
@@ -85,7 +84,6 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 				}
 			}
 
-			env.Logger.Debugf(err.Error())
 			capNameErr = errors.Join(ErrInvalidWriteCapNameFormat, capNameErr)
 		}
 	}

--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -56,7 +56,6 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 		if c.CapabilityType != CapabilityTypeTarget {
 			continue
 		}
-		env.Logger.Debugf(c.LabelledName)
 		if c.LabelledName == "" {
 			capNameErr = errors.Join(ErrEmptyWriteCapName, capNameErr)
 			continue
@@ -75,10 +74,10 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 			// Validate if the extracted value is the chain ID instead, since the labelled name can contain
 			// both the chain ID or the chain name.
 			// See: https://github.com/smartcontractkit/chainlink/blob/3684365e78ef911d7668e724aa782d3b3f3e8801/core/services/relay/evm/write_target.go#L75
-			chainID, chainIdErr := strconv.ParseUint(extracted, 10, 64)
-			if chainIdErr == nil {
-				_, chainIdErr = chainselectors.NameFromChainId(chainID)
-				if chainIdErr == nil {
+			chainID, chainIDErr := strconv.ParseUint(extracted, 10, 64)
+			if chainIDErr == nil {
+				_, chainIDErr = chainselectors.NameFromChainId(chainID)
+				if chainIDErr == nil {
 					// If it is a valid chain ID, we don't error and continue
 					continue
 				}

--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -3,18 +3,26 @@ package changeset
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	"github.com/smartcontractkit/mcms"
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
-
-	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
+)
+
+const (
+	capabilityTypeTarget           = uint8(3)
+	capabilityTypeTargetNamePrefix = "write_"
+	capabilityTypeTargetNameSuffix = "@1.0.0"
 )
 
 // AddCapabilitiesRequest is a request to add capabilities
@@ -34,6 +42,47 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 	}
 	if len(r.Capabilities) == 0 {
 		return errors.New("capabilities must be set")
+	}
+
+	var errs []string
+	// Validate write target capabilities labelled name
+	for _, c := range r.Capabilities {
+		if c.CapabilityType != capabilityTypeTarget {
+			continue
+		}
+		if c.LabelledName == "" {
+			errs = append(errs, "capability label name must be set")
+			continue
+		}
+		if !strings.HasPrefix(c.LabelledName, capabilityTypeTargetNamePrefix) {
+			errs = append(errs, fmt.Sprintf("capability labelled name must start with %s, got %s", capabilityTypeTargetNamePrefix, c.LabelledName))
+			continue
+		}
+		extracted := strings.TrimSuffix(strings.TrimPrefix(c.LabelledName, capabilityTypeTargetNamePrefix), capabilityTypeTargetNameSuffix)
+		if extracted == "" {
+			errs = append(errs, fmt.Sprintf("capability labelled name must not be empty after removing prefix %s and suffix %s, got %s", capabilityTypeTargetNamePrefix, capabilityTypeTargetNameSuffix, c.LabelledName))
+			continue
+		}
+		_, err := chainselectors.ChainIdFromName(extracted)
+		if err != nil {
+			// Validate if the extracted value is the chain ID instead, since the labelled name can contain
+			// both the chain ID or the chain name.
+			// See: https://github.com/smartcontractkit/chainlink/blob/3684365e78ef911d7668e724aa782d3b3f3e8801/core/services/relay/evm/write_target.go#L75
+			chainId, chainIdErr := strconv.ParseUint(extracted, 10, 64)
+			if chainIdErr == nil {
+				_, chainIdErr = chainselectors.NameFromChainId(chainId)
+				if chainIdErr == nil {
+					// If it is a valid chain ID, we don't error and continue
+					continue
+				}
+			}
+
+			errs = append(errs, fmt.Sprintf("capability labelled name %s is a non-existent chain-name/ID", extracted))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("write target capabilities validation errors:\n- %s", strings.Join(errs, "\n- "))
 	}
 
 	if err := shouldUseDatastore(env, r.RegistryRef); err != nil {

--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -22,7 +22,6 @@ import (
 const (
 	capabilityTypeTarget           = uint8(3)
 	capabilityTypeTargetNamePrefix = "write_"
-	capabilityTypeTargetNameSuffix = "@1.0.0"
 )
 
 // AddCapabilitiesRequest is a request to add capabilities
@@ -58,9 +57,9 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 			errs = append(errs, fmt.Sprintf("capability labelled name must start with %s, got %s", capabilityTypeTargetNamePrefix, c.LabelledName))
 			continue
 		}
-		extracted := strings.TrimSuffix(strings.TrimPrefix(c.LabelledName, capabilityTypeTargetNamePrefix), capabilityTypeTargetNameSuffix)
+		extracted := strings.TrimPrefix(c.LabelledName, capabilityTypeTargetNamePrefix)
 		if extracted == "" {
-			errs = append(errs, fmt.Sprintf("capability labelled name must not be empty after removing prefix %s and suffix %s, got %s", capabilityTypeTargetNamePrefix, capabilityTypeTargetNameSuffix, c.LabelledName))
+			errs = append(errs, fmt.Sprintf("capability labelled name must not be empty after removing prefix %s, got %s", capabilityTypeTargetNamePrefix, c.LabelledName))
 			continue
 		}
 		_, err := chainselectors.ChainIdFromName(extracted)

--- a/deployment/keystone/changeset/add_capabilities.go
+++ b/deployment/keystone/changeset/add_capabilities.go
@@ -20,8 +20,16 @@ import (
 )
 
 const (
+	// See: https://github.com/smartcontractkit/chainlink/blob/3684365e78ef911d7668e724aa782d3b3f3e8801/deployment/keystone/changeset/internal/capability_definitions.go#L15
 	capabilityTypeTarget           = uint8(3)
 	capabilityTypeTargetNamePrefix = "write_"
+)
+
+var (
+	ErrEmptyWriteCapName         = errors.New("capability labelled name must not be empty")
+	ErrInvalidWriteCapName       = errors.New("capability labelled name must start with " + capabilityTypeTargetNamePrefix)
+	ErrEmptyTrimmedWriteCapName  = errors.New("capability labelled name must not be empty after removing prefix " + capabilityTypeTargetNamePrefix)
+	ErrInvalidWriteCapNameFormat = errors.New("capability labelled name is not a valid chain name or chain ID")
 )
 
 // AddCapabilitiesRequest is a request to add capabilities
@@ -43,23 +51,23 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 		return errors.New("capabilities must be set")
 	}
 
-	var errs []string
+	var capNameErr error
 	// Validate write target capabilities labelled name
 	for _, c := range r.Capabilities {
 		if c.CapabilityType != capabilityTypeTarget {
 			continue
 		}
 		if c.LabelledName == "" {
-			errs = append(errs, "capability label name must be set")
+			capNameErr = errors.Join(ErrEmptyWriteCapName, capNameErr)
 			continue
 		}
 		if !strings.HasPrefix(c.LabelledName, capabilityTypeTargetNamePrefix) {
-			errs = append(errs, fmt.Sprintf("capability labelled name must start with %s, got %s", capabilityTypeTargetNamePrefix, c.LabelledName))
+			capNameErr = errors.Join(ErrInvalidWriteCapName, capNameErr)
 			continue
 		}
 		extracted := strings.TrimPrefix(c.LabelledName, capabilityTypeTargetNamePrefix)
 		if extracted == "" {
-			errs = append(errs, fmt.Sprintf("capability labelled name must not be empty after removing prefix %s, got %s", capabilityTypeTargetNamePrefix, c.LabelledName))
+			capNameErr = errors.Join(ErrEmptyTrimmedWriteCapName, capNameErr)
 			continue
 		}
 		_, err := chainselectors.ChainIdFromName(extracted)
@@ -76,12 +84,12 @@ func (r *AddCapabilitiesRequest) Validate(env cldf.Environment) error {
 				}
 			}
 
-			errs = append(errs, fmt.Sprintf("capability labelled name %s is a non-existent chain-name/ID", extracted))
+			capNameErr = errors.Join(ErrInvalidWriteCapNameFormat, capNameErr)
 		}
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("write target capabilities validation errors:\n- %s", strings.Join(errs, "\n- "))
+	if capNameErr != nil {
+		return capNameErr
 	}
 
 	if err := shouldUseDatastore(env, r.RegistryRef); err != nil {

--- a/deployment/keystone/changeset/add_capabilities_test.go
+++ b/deployment/keystone/changeset/add_capabilities_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
@@ -103,7 +104,7 @@ func TestAddCapabilitiesRequest_Validate_WriterCapability(t *testing.T) {
 		},
 		// Cannot test this since `chainselectors.ChainIdFromName()` uses the chains from the `.yaml` files,
 		// and the chain name is not set in the `test_selectors.yaml` file.
-		//{
+		// {
 		//	name: "valid request with chain name on capability name",
 		//	req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
 		//		chain := te.Env.BlockChains.EVMChains()[chainselectors.TEST_90000001.Selector]
@@ -114,7 +115,7 @@ func TestAddCapabilitiesRequest_Validate_WriterCapability(t *testing.T) {
 		//		}, nil
 		//	},
 		//	expectError: false,
-		//},
+		// },
 		{
 			name: "empty capability name",
 			req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
@@ -153,7 +154,7 @@ func TestAddCapabilitiesRequest_Validate_WriterCapability(t *testing.T) {
 			req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
 				return &changeset.AddCapabilitiesRequest{
 					RegistryChainSel: te.RegistrySelector,
-					Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: fmt.Sprintf("%stest-cap", changeset.CapabilityTypeTargetNamePrefix), Version: "1.0.0", CapabilityType: 3}},
+					Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: changeset.CapabilityTypeTargetNamePrefix + "test-cap", Version: "1.0.0", CapabilityType: 3}},
 					RegistryRef:      te.CapabilityRegistryAddressRef(),
 				}, nil
 			},
@@ -164,7 +165,7 @@ func TestAddCapabilitiesRequest_Validate_WriterCapability(t *testing.T) {
 			req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
 				return &changeset.AddCapabilitiesRequest{
 					RegistryChainSel: te.RegistrySelector,
-					Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: fmt.Sprintf("%s12345", changeset.CapabilityTypeTargetNamePrefix), Version: "1.0.0", CapabilityType: 3}},
+					Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: changeset.CapabilityTypeTargetNamePrefix + "12345", Version: "1.0.0", CapabilityType: 3}},
 					RegistryRef:      te.CapabilityRegistryAddressRef(),
 				}, nil
 			},

--- a/deployment/keystone/changeset/add_capabilities_test.go
+++ b/deployment/keystone/changeset/add_capabilities_test.go
@@ -1,14 +1,16 @@
 package changeset_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/test"
@@ -74,6 +76,124 @@ func TestAddCapabilities(t *testing.T) {
 
 		assertCapabilitiesExist(t, te.CapabilitiesRegistry(), capabilitiesToAdd...)
 	})
+}
+
+func TestAddCapabilitiesRequest_Validate_WriterCapability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		req           func(wrapper test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error)
+		expectedError error
+	}{
+		{
+			name: "valid request with chain ID on capability name",
+			req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
+				chainID, err := chainselectors.GetChainIDFromSelector(chainselectors.TEST_90000001.Selector)
+				if err != nil {
+					return nil, err
+				}
+				return &changeset.AddCapabilitiesRequest{
+					RegistryChainSel: te.RegistrySelector,
+					Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: fmt.Sprintf("%s%s", changeset.CapabilityTypeTargetNamePrefix, chainID), Version: "1.0.0", CapabilityType: changeset.CapabilityTypeTarget}},
+					RegistryRef:      te.CapabilityRegistryAddressRef(),
+				}, nil
+			},
+			expectedError: nil,
+		},
+		// Cannot test this since `chainselectors.ChainIdFromName()` uses the chains from the `.yaml` files,
+		// and the chain name is not set in the `test_selectors.yaml` file.
+		//{
+		//	name: "valid request with chain name on capability name",
+		//	req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
+		//		chain := te.Env.BlockChains.EVMChains()[chainselectors.TEST_90000001.Selector]
+		//		return &changeset.AddCapabilitiesRequest{
+		//			RegistryChainSel: te.RegistrySelector,
+		//			Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: fmt.Sprintf("%s%s", changeset.CapabilityTypeTargetNamePrefix, chain.Name()), Version: "1.0.0", CapabilityType: changeset.CapabilityTypeTarget}},
+		//			RegistryRef:      te.CapabilityRegistryAddressRef(),
+		//		}, nil
+		//	},
+		//	expectError: false,
+		//},
+		{
+			name: "empty capability name",
+			req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
+				return &changeset.AddCapabilitiesRequest{
+					RegistryChainSel: te.RegistrySelector,
+					Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: "", Version: "1.0.0", CapabilityType: changeset.CapabilityTypeTarget}},
+					RegistryRef:      te.CapabilityRegistryAddressRef(),
+				}, nil
+			},
+			expectedError: changeset.ErrEmptyWriteCapName,
+		},
+		{
+			name: "only has prefix on capability name",
+			req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
+				return &changeset.AddCapabilitiesRequest{
+					RegistryChainSel: te.RegistrySelector,
+					Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: changeset.CapabilityTypeTargetNamePrefix, Version: "1.0.0", CapabilityType: changeset.CapabilityTypeTarget}},
+					RegistryRef:      te.CapabilityRegistryAddressRef(),
+				}, nil
+			},
+			expectedError: changeset.ErrEmptyTrimmedWriteCapName,
+		},
+		{
+			name: "missing prefix on capability name",
+			req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
+				return &changeset.AddCapabilitiesRequest{
+					RegistryChainSel: te.RegistrySelector,
+					Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: "test-cap", Version: "1.0.0", CapabilityType: 3}},
+					RegistryRef:      te.CapabilityRegistryAddressRef(),
+				}, nil
+			},
+			expectedError: changeset.ErrInvalidWriteCapName,
+		},
+		{
+			name: "invalid chain name on capability name",
+			req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
+				return &changeset.AddCapabilitiesRequest{
+					RegistryChainSel: te.RegistrySelector,
+					Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: fmt.Sprintf("%stest-cap", changeset.CapabilityTypeTargetNamePrefix), Version: "1.0.0", CapabilityType: 3}},
+					RegistryRef:      te.CapabilityRegistryAddressRef(),
+				}, nil
+			},
+			expectedError: changeset.ErrInvalidWriteCapNameFormat,
+		},
+		{
+			name: "invalid chain ID on capability name",
+			req: func(te test.EnvWrapper) (*changeset.AddCapabilitiesRequest, error) {
+				return &changeset.AddCapabilitiesRequest{
+					RegistryChainSel: te.RegistrySelector,
+					Capabilities:     []kcr.CapabilitiesRegistryCapability{{LabelledName: fmt.Sprintf("%s12345", changeset.CapabilityTypeTargetNamePrefix), Version: "1.0.0", CapabilityType: 3}},
+					RegistryRef:      te.CapabilityRegistryAddressRef(),
+				}, nil
+			},
+			expectedError: changeset.ErrInvalidWriteCapNameFormat,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			te := test.SetupContractTestEnv(t, test.EnvWrapperConfig{
+				WFDonConfig:     test.DonConfig{Name: "wfDon", N: 4},
+				AssetDonConfig:  test.DonConfig{Name: "assetDon", N: 4},
+				WriterDonConfig: test.DonConfig{Name: "writerDon", N: 4},
+				NumChains:       1,
+				UseMCMS:         true,
+			})
+
+			req, err := tt.req(te)
+			require.NoError(t, err)
+			err = req.Validate(te.Env)
+			if tt.expectedError != nil {
+				assert.ErrorIs(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func assertCapabilitiesExist(t *testing.T, registry *kcr.CapabilitiesRegistry, capabilities ...kcr.CapabilitiesRegistryCapability) {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This PR addresses [CRE-365](https://smartcontract-it.atlassian.net/browse/CRE-365).

We need to make sure that we validate the writer caps names when adding them, since there is a [hard coded assumption](https://github.com/smartcontractkit/chainlink/blob/3684365e78ef911d7668e724aa782d3b3f3e8801/core/services/relay/evm/write_target.go#L75) in the writer target about the pattern.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-365]: https://smartcontract-it.atlassian.net/browse/CRE-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ