### PR TITLE
CCIP - bump version to move CCIPReader types

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1273,8 +1273,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f h1:hwfLPlxifnkvJgO9UIMGVmyK1iot4UiJseT0QO0RA9A=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1273,8 +1273,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1273,8 +1273,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/core/services/relay/evm/read/event.go
+++ b/core/services/relay/evm/read/event.go
@@ -820,7 +820,7 @@ const executionStateChangedEvent = ccipconsts.EventNameExecutionStateChanged
 
 func isTypeHardcoded(t any) bool {
 	switch t.(type) {
-	case *reader.CommitReportAcceptedEvent:
+	case *chainaccessor.CommitReportAcceptedEvent:
 		return true
 	case *chainaccessor.SendRequestedEvent:
 		return true
@@ -833,7 +833,7 @@ func isTypeHardcoded(t any) bool {
 
 func decodeHardcodedType(out any, log *logpoller.Log) error {
 	switch out := out.(type) {
-	case *reader.CommitReportAcceptedEvent:
+	case *chainaccessor.CommitReportAcceptedEvent:
 		var internalEvent offramp.OffRampCommitReportAccepted
 		err := unpackLog(&internalEvent, commitReportAcceptedEvent, log, offrampABI)
 		if err != nil {
@@ -950,13 +950,13 @@ func convertOnRampCCIPMessage(m onramp.InternalEVM2AnyRampMessage) ccipocr3.Mess
 	return out
 }
 
-func populateCommitReportAcceptFromEvent(out *reader.CommitReportAcceptedEvent, internalEvent offramp.OffRampCommitReportAccepted) {
+func populateCommitReportAcceptFromEvent(out *chainaccessor.CommitReportAcceptedEvent, internalEvent offramp.OffRampCommitReportAccepted) {
 	out.BlessedMerkleRoots = convertRoots(internalEvent.BlessedMerkleRoots)
 	out.UnblessedMerkleRoots = convertRoots(internalEvent.UnblessedMerkleRoots)
 
 	for _, update := range internalEvent.PriceUpdates.TokenPriceUpdates {
 		out.PriceUpdates.TokenPriceUpdates = append(out.PriceUpdates.TokenPriceUpdates,
-			reader.TokenPriceUpdate{
+			chainaccessor.TokenPriceUpdate{
 				SourceToken: update.SourceToken.Bytes(),
 				UsdPerToken: update.UsdPerToken,
 			},
@@ -965,14 +965,14 @@ func populateCommitReportAcceptFromEvent(out *reader.CommitReportAcceptedEvent, 
 
 	for _, update := range internalEvent.PriceUpdates.GasPriceUpdates {
 		out.PriceUpdates.GasPriceUpdates = append(out.PriceUpdates.GasPriceUpdates,
-			reader.GasPriceUpdate(update),
+			chainaccessor.GasPriceUpdate(update),
 		)
 	}
 
 }
 
-func convertRoots(r []offramp.InternalMerkleRoot) []reader.MerkleRoot {
-	res := make([]reader.MerkleRoot, 0, len(r))
+func convertRoots(r []offramp.InternalMerkleRoot) []chainaccessor.MerkleRoot {
+	res := make([]chainaccessor.MerkleRoot, 0, len(r))
 	for _, root := range r {
 		res = append(res, convertRoot(root))
 	}
@@ -980,8 +980,8 @@ func convertRoots(r []offramp.InternalMerkleRoot) []reader.MerkleRoot {
 	return res
 }
 
-func convertRoot(r offramp.InternalMerkleRoot) reader.MerkleRoot {
-	return reader.MerkleRoot{
+func convertRoot(r offramp.InternalMerkleRoot) chainaccessor.MerkleRoot {
+	return chainaccessor.MerkleRoot{
 		SourceChainSelector: r.SourceChainSelector,
 		OnRampAddress:       r.OnRampAddress,
 		MinSeqNr:            r.MinSeqNr,

--- a/core/services/relay/evm/read/event_test.go
+++ b/core/services/relay/evm/read/event_test.go
@@ -28,7 +28,7 @@ func Test_DecodeHardcodedType(t *testing.T) {
 		log, err := generateOfframpLog(fixtLog)
 		require.NoError(t, err)
 
-		var out reader.CommitReportAcceptedEvent
+		var out chainaccessor.CommitReportAcceptedEvent
 		err = decodeHardcodedType(&out, log)
 		require.NoError(t, err)
 

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1249,8 +1249,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1249,8 +1249,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f h1:hwfLPlxifnkvJgO9UIMGVmyK1iot4UiJseT0QO0RA9A=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1249,8 +1249,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae

--- a/go.sum
+++ b/go.sum
@@ -1051,8 +1051,8 @@ github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSb
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f h1:hwfLPlxifnkvJgO9UIMGVmyK1iot4UiJseT0QO0RA9A=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/go.sum
+++ b/go.sum
@@ -1051,8 +1051,8 @@ github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSb
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/go.sum
+++ b/go.sum
@@ -1051,8 +1051,8 @@ github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSb
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1480,8 +1480,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1480,8 +1480,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f h1:hwfLPlxifnkvJgO9UIMGVmyK1iot4UiJseT0QO0RA9A=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1480,8 +1480,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1462,8 +1462,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1462,8 +1462,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1462,8 +1462,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f h1:hwfLPlxifnkvJgO9UIMGVmyK1iot4UiJseT0QO0RA9A=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -361,7 +361,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -361,7 +361,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -361,7 +361,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1236,8 +1236,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1236,8 +1236,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1236,8 +1236,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f h1:hwfLPlxifnkvJgO9UIMGVmyK1iot4UiJseT0QO0RA9A=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -434,7 +434,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.60 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a // indirect

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -434,7 +434,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.60 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a // indirect

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -434,7 +434,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.60 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1436,8 +1436,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f h1:hwfLPlxifnkvJgO9UIMGVmyK1iot4UiJseT0QO0RA9A=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612205233-2103b4b0449f/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1436,8 +1436,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1436,8 +1436,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22 h1:kVdRUCDHU6Kc2QHY0xy7VhoyfSpIz7lQIiYmnYrPWyw=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250611010854-f55e26361b22/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681 h1:n6GoLjtuHu1pmwz0d/dvgULRpsigO0BMSIk+0FDg93I=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250612181834-1f198952d681/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250610171147-67d52ef3a683 h1:yEzoBjaIlvHDu/gWF1XXmWDO+w5U8YqLdnh9oYFpOIw=


### PR DESCRIPTION
Relevant chainlink-ccip PR: https://github.com/smartcontractkit/chainlink-ccip/pull/1000