### PR TITLE
Use multiple senders for each message in multi-exec tests

### DIFF
--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -92,6 +92,10 @@ type TestCase struct {
 	ExpectedExecutionState int
 	ExtraAssertions        []func(t *testing.T)
 	NumberOfMessages       int // number of messages to send, use same data and extraArgs
+
+	// If true, use different user address as sender for each message, otherwise use TestSetup.Sender
+	// This can be useful if we want to send multiple messages in parallel especially in evm chains.
+	UserPerMessage bool
 }
 
 type ValidationType int
@@ -207,8 +211,17 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		DestChainSelector:   tc.DestChain,
 	}
 
+	srcChainUsers := tc.DeployedEnv.Users[sourceDest.SourceChainSelector]
+	if tc.UserPerMessage {
+		require.GreaterOrEqual(t, tc.NumberOfMessages, len(srcChainUsers),
+			"UserPerMessage is true but not enough users available for the number of messages to send")
+	}
 	// send all messages first, then validate them
 	for i := 0; i < tc.NumberOfMessages; i++ {
+		var opts []testhelpers.SendReqOpts
+		if tc.UserPerMessage {
+			opts = append(opts, testhelpers.WithSender(srcChainUsers[i]))
+		}
 		msgSentEventLocal := testhelpers.TestSendRequest(
 			tc.T,
 			tc.Env,
@@ -216,7 +229,8 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 			tc.SourceChain,
 			tc.DestChain,
 			tc.TestRouter,
-			msg)
+			msg,
+			opts...)
 
 		_, ok := expectedSeqNumRange[sourceDest]
 		if !ok {

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -210,6 +210,8 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 	ctx := testhelpers.Context(t)
 	e, _, _ := testsetups.NewIntegrationEnvironment(t,
 		testhelpers.WithSolChains(1),
+		// because source is evm, sending multiple messages at once with same sender causes issues.
+		testhelpers.WithNumOfUsersPerChain(numMessages),
 		testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
 			params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(1 * time.Hour)
 			params.ExecuteOffChainConfig.MessageVisibilityInterval = *config.MustNewDuration(1 * time.Hour)
@@ -280,13 +282,6 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 	require.NoError(t, err, "failed to get account info")
 	require.Equal(t, uint8(0), receiverCounterAccount.Value)
 
-	// Ensure Transmitted event filter is registered for the offramp - This is specific for Solana
-	//offRampAddr, err := setup.OnchainState.GetOffRampAddressBytes(setup.DestChain)
-	//require.NoError(t, err)
-	//err = testhelpers.WaitForEventFilterRegistration(t, setup.Env.Offchain, setup.DestChain, "Transmitted", offRampAddr)
-	//require.NoError(t, err)
-
-	numMessages := 5
 	_ = mt.Run(
 		t,
 		mt.TestCase{
@@ -298,6 +293,7 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 			ExtraArgs:              extraArgs,
 			ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
 			NumberOfMessages:       numMessages,
+			UserPerMessage:         true,
 		},
 	)
 

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -206,8 +206,6 @@ func Test_CCIPMessaging_EVM2EVM(t *testing.T) {
 }
 
 func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
-	t.Skip("Skipping for now since this has been flaky")
-
 	// Setup 2 chains (EVM and Solana) and a single lane.
 	ctx := testhelpers.Context(t)
 	e, _, _ := testsetups.NewIntegrationEnvironment(t,
@@ -281,6 +279,12 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 	err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
 	require.NoError(t, err, "failed to get account info")
 	require.Equal(t, uint8(0), receiverCounterAccount.Value)
+
+	// Ensure Transmitted event filter is registered for the offramp - This is specific for Solana
+	offRampAddr, err := setup.OnchainState.GetOffRampAddressBytes(setup.DestChain)
+	require.NoError(t, err)
+	err = testhelpers.WaitForEventFilterRegistration(t, setup.Env.Offchain, setup.DestChain, "Transmitted", offRampAddr)
+	require.NoError(t, err)
 
 	numMessages := 5
 	_ = mt.Run(

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -281,10 +281,10 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 	require.Equal(t, uint8(0), receiverCounterAccount.Value)
 
 	// Ensure Transmitted event filter is registered for the offramp - This is specific for Solana
-	offRampAddr, err := setup.OnchainState.GetOffRampAddressBytes(setup.DestChain)
-	require.NoError(t, err)
-	err = testhelpers.WaitForEventFilterRegistration(t, setup.Env.Offchain, setup.DestChain, "Transmitted", offRampAddr)
-	require.NoError(t, err)
+	//offRampAddr, err := setup.OnchainState.GetOffRampAddressBytes(setup.DestChain)
+	//require.NoError(t, err)
+	//err = testhelpers.WaitForEventFilterRegistration(t, setup.Env.Offchain, setup.DestChain, "Transmitted", offRampAddr)
+	//require.NoError(t, err)
 
 	numMessages := 5
 	_ = mt.Run(


### PR DESCRIPTION
In evm, using the same sender and trying to send multiple messages back to back causes some issues and doesn't work properly. For that reason we're using as many users as messages and sending them back to back instead.