### PR TITLE
integration-tests/load/ocr: defer parrot upgrade with nolint comment

### DIFF
--- a/integration-tests/load/ocr/vu.go
+++ b/integration-tests/load/ocr/vu.go
@@ -32,7 +32,7 @@ type VU struct {
 	lta           common.Address
 	bootstrapNode *nodeclient.ChainlinkK8sClient
 	workerNodes   []*nodeclient.ChainlinkK8sClient
-	msClient      *client2.MockserverClient
+	msClient      *client2.MockserverClient // nolint:staticcheck //SA1019 no need to upgrade
 	l             zerolog.Logger
 	ocrInstances  []contracts.OffchainAggregator
 	config        ocr.OffChainAggregatorsConfig
@@ -47,7 +47,7 @@ func NewVU(
 	lta common.Address,
 	bootstrapNode *nodeclient.ChainlinkK8sClient,
 	workerNodes []*nodeclient.ChainlinkK8sClient,
-	msClient *client2.MockserverClient,
+	msClient *client2.MockserverClient, // nolint:staticcheck //SA1019 no need to upgrade
 ) *VU {
 	return &VU{
 		VUControl:     wasp.NewVUControl(),


### PR DESCRIPTION
```xml
<file name="/home/runner/_work/chainlink/chainlink/integration-tests/load/ocr/vu.go">
    <error column="17" line="35" message="SA1019: client2.MockserverClient is deprecated: Use Parrot instead " severity="error" source="staticcheck"></error>
    <error column="12" line="50" message="SA1019: client2.MockserverClient is deprecated: Use Parrot instead " severity="error" source="staticcheck"></error>
  </file>
```