### PR TITLE
fix(aptos): ApplyPremiumMultiplierWeiPerEthUpdates on chain deployment

### DIFF
--- a/deployment/ccip/changeset/aptos/config/deploy_aptos_chain.go
+++ b/deployment/ccip/changeset/aptos/config/deploy_aptos_chain.go
@@ -63,8 +63,8 @@ func (f FeeQuoterParams) Validate() error {
 	if f.TokenPriceStalenessThreshold == 0 {
 		return errors.New("TokenPriceStalenessThreshold can't be 0")
 	}
-	if f.PremiumMultiplierWeiPerEthByFeeToken == nil {
-		return errors.New("PremiumMultiplierWeiPerEthByFeeToken is nil, at least one token must be configured")
+	if len(f.PremiumMultiplierWeiPerEthByFeeToken) == 0 {
+		return errors.New("PremiumMultiplierWeiPerEthByFeeToken is nil or empty, at least one token must be configured")
 	}
 	return nil
 }

--- a/deployment/ccip/changeset/aptos/config/deploy_aptos_chain.go
+++ b/deployment/ccip/changeset/aptos/config/deploy_aptos_chain.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
@@ -52,14 +53,18 @@ func (c ChainContractParams) Validate() error {
 }
 
 type FeeQuoterParams struct {
-	MaxFeeJuelsPerMsg            uint64
-	TokenPriceStalenessThreshold uint64
-	FeeTokens                    []aptos.AccountAddress
+	MaxFeeJuelsPerMsg                    uint64
+	TokenPriceStalenessThreshold         uint64
+	FeeTokens                            []aptos.AccountAddress
+	PremiumMultiplierWeiPerEthByFeeToken map[shared.TokenSymbol]uint64
 }
 
 func (f FeeQuoterParams) Validate() error {
 	if f.TokenPriceStalenessThreshold == 0 {
 		return errors.New("TokenPriceStalenessThreshold can't be 0")
+	}
+	if f.PremiumMultiplierWeiPerEthByFeeToken == nil {
+		return errors.New("PremiumMultiplierWeiPerEthByFeeToken is nil, at least one token must be configured")
 	}
 	return nil
 }

--- a/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
@@ -5,16 +5,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aptos-labs/aptos-go-sdk"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip_offramp"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	aptoschain "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
@@ -43,8 +45,8 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 				ExistingAddresses: cldf.NewMemoryAddressBook(),
 				BlockChains: chain.NewBlockChains(
 					map[uint64]chain.BlockChain{
-						743186221051783445:  aptos.Chain{},
-						4457093679053095497: aptos.Chain{},
+						743186221051783445:  aptoschain.Chain{},
+						4457093679053095497: aptoschain.Chain{},
 					}),
 			},
 			config: config.DeployAptosChainConfig{
@@ -77,8 +79,8 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 				),
 				BlockChains: chain.NewBlockChains(
 					map[uint64]chain.BlockChain{
-						743186221051783445:  aptos.Chain{},
-						4457093679053095497: aptos.Chain{},
+						743186221051783445:  aptoschain.Chain{},
+						4457093679053095497: aptoschain.Chain{},
 					}),
 			},
 			config: config.DeployAptosChainConfig{
@@ -107,7 +109,7 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 				),
 				BlockChains: chain.NewBlockChains(
 					map[uint64]chain.BlockChain{
-						4457093679053095497: aptos.Chain{},
+						4457093679053095497: aptoschain.Chain{},
 					}),
 			},
 			config: config.DeployAptosChainConfig{
@@ -147,7 +149,7 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 				),
 				BlockChains: chain.NewBlockChains(
 					map[uint64]chain.BlockChain{
-						4457093679053095497: aptos.Chain{},
+						4457093679053095497: aptoschain.Chain{},
 					}),
 			},
 			config: config.DeployAptosChainConfig{
@@ -174,7 +176,7 @@ func TestDeployAptosChainImp_VerifyPreconditions(t *testing.T) {
 				),
 				BlockChains: chain.NewBlockChains(
 					map[uint64]chain.BlockChain{
-						4457093679053095497: aptos.Chain{},
+						4457093679053095497: aptoschain.Chain{},
 					}),
 			},
 			config: config.DeployAptosChainConfig{
@@ -250,16 +252,29 @@ func TestDeployAptosChain_Apply(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify CCIP deployment state by binding ccip contract and checking if it's deployed
-	state, err := aptosstate.LoadOnchainStateAptos(env)
+	states, err := aptosstate.LoadOnchainStateAptos(env)
 	require.NoError(t, err)
-	require.NotNil(t, state[chainSelector], "No state found for chain")
+	require.NotNil(t, states[chainSelector], "No state found for chain")
+	state := states[chainSelector]
 
-	ccipAddr := state[chainSelector].CCIPAddress
+	ccipAddr := state.CCIPAddress
 	require.NotEmpty(t, ccipAddr, "CCIP address should not be empty")
 
-	// Bind CCIP contract
+	// Bind CCIP offramp contract
 	offrampBind := ccip_offramp.Bind(ccipAddr, env.BlockChains.AptosChains()[chainSelector].Client)
 	offRampSourceConfig, err := offrampBind.Offramp().GetSourceChainConfig(nil, mockCCIPParams.OffRampParams.SourceChainSelectors[0])
 	require.NoError(t, err)
 	require.True(t, offRampSourceConfig.IsEnabled, "contracts were not initialized correctly")
+
+	// Check premium multiplier
+	ccipBind := ccip.Bind(ccipAddr, env.BlockChains.AptosChains()[chainSelector].Client)
+	require.NotEqual(t, state.LinkTokenAddress, aptos.AccountAddress{}, "Link token address should not be empty")
+	mult, err := ccipBind.FeeQuoter().GetPremiumMultiplierWeiPerEth(nil, state.LinkTokenAddress)
+	require.NoError(t, err)
+	require.Equal(t, mult, mockCCIPParams.FeeQuoterParams.PremiumMultiplierWeiPerEthByFeeToken[shared.LinkSymbol])
+
+	aptTokenAdd := mustParseAddress(t, "0xa")
+	mult, err = ccipBind.FeeQuoter().GetPremiumMultiplierWeiPerEth(nil, aptTokenAdd)
+	require.NoError(t, err)
+	require.Equal(t, mult, mockCCIPParams.FeeQuoterParams.PremiumMultiplierWeiPerEthByFeeToken[shared.APTSymbol])
 }

--- a/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain_test.go
@@ -268,13 +268,13 @@ func TestDeployAptosChain_Apply(t *testing.T) {
 
 	// Check premium multiplier
 	ccipBind := ccip.Bind(ccipAddr, env.BlockChains.AptosChains()[chainSelector].Client)
-	require.NotEqual(t, state.LinkTokenAddress, aptos.AccountAddress{}, "Link token address should not be empty")
+	require.NotEqual(t, aptos.AccountAddress{}, state.LinkTokenAddress, "Link token address should not be empty")
 	mult, err := ccipBind.FeeQuoter().GetPremiumMultiplierWeiPerEth(nil, state.LinkTokenAddress)
 	require.NoError(t, err)
-	require.Equal(t, mult, mockCCIPParams.FeeQuoterParams.PremiumMultiplierWeiPerEthByFeeToken[shared.LinkSymbol])
+	require.Equal(t, mockCCIPParams.FeeQuoterParams.PremiumMultiplierWeiPerEthByFeeToken[shared.LinkSymbol], mult)
 
 	aptTokenAdd := mustParseAddress(t, "0xa")
 	mult, err = ccipBind.FeeQuoter().GetPremiumMultiplierWeiPerEth(nil, aptTokenAdd)
 	require.NoError(t, err)
-	require.Equal(t, mult, mockCCIPParams.FeeQuoterParams.PremiumMultiplierWeiPerEthByFeeToken[shared.APTSymbol])
+	require.Equal(t, mockCCIPParams.FeeQuoterParams.PremiumMultiplierWeiPerEthByFeeToken[shared.APTSymbol], mult)
 }

--- a/deployment/ccip/changeset/aptos/operation/ccip.go
+++ b/deployment/ccip/changeset/aptos/operation/ccip.go
@@ -190,7 +190,7 @@ var InitializeCCIPOp = operations.NewOperation(
 	initializeCCIP,
 )
 
-func initializeCCIP(b operations.Bundle, deps AptosDeps, in InitializeCCIPInput) (mcmstypes.BatchOperation, error) {
+func initializeCCIP(b operations.Bundle, deps AptosDeps, in InitializeCCIPInput) ([]mcmstypes.Transaction, error) {
 	var txs []mcmstypes.Transaction
 
 	// Config OnRamp with empty lane configs. We're only able to get router address after deploying the router module
@@ -204,11 +204,11 @@ func initializeCCIP(b operations.Bundle, deps AptosDeps, in InitializeCCIPInput)
 		[]bool{},
 	)
 	if err != nil {
-		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to encode onramp initialize: %w", err)
+		return nil, fmt.Errorf("failed to encode onramp initialize: %w", err)
 	}
 	mcmsTx, err := utils.GenerateMCMSTx(in.CCIPAddress, moduleInfo, function, args)
 	if err != nil {
-		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to generate MCMS operations for OnRamp Initialize: %w", err)
+		return nil, fmt.Errorf("failed to generate MCMS operations for OnRamp Initialize: %w", err)
 	}
 	txs = append(txs, mcmsTx)
 
@@ -223,11 +223,11 @@ func initializeCCIP(b operations.Bundle, deps AptosDeps, in InitializeCCIPInput)
 		in.CCIPConfig.OffRampParams.SourceChainsOnRamp,
 	)
 	if err != nil {
-		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to encode offramp initialize: %w", err)
+		return nil, fmt.Errorf("failed to encode offramp initialize: %w", err)
 	}
 	mcmsTx, err = utils.GenerateMCMSTx(in.CCIPAddress, moduleInfo, function, args)
 	if err != nil {
-		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to generate MCMS operations for OffRamp Initialize: %w", err)
+		return nil, fmt.Errorf("failed to generate MCMS operations for OffRamp Initialize: %w", err)
 	}
 	txs = append(txs, mcmsTx)
 
@@ -242,28 +242,25 @@ func initializeCCIP(b operations.Bundle, deps AptosDeps, in InitializeCCIPInput)
 		in.CCIPConfig.FeeQuoterParams.FeeTokens,
 	)
 	if err != nil {
-		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to encode feequoter initialize: %w", err)
+		return nil, fmt.Errorf("failed to encode feequoter initialize: %w", err)
 	}
 	mcmsTx, err = utils.GenerateMCMSTx(in.CCIPAddress, moduleInfo, function, args)
 	if err != nil {
-		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to generate MCMS operations for FeeQuoter Initialize: %w", err)
+		return nil, fmt.Errorf("failed to generate MCMS operations for FeeQuoter Initialize: %w", err)
 	}
 	txs = append(txs, mcmsTx)
 
 	moduleInfo, function, _, args, err = ccipBind.RMNRemote().Encoder().Initialize(deps.AptosChain.Selector)
 	if err != nil {
-		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to encode rmnremote initialize: %w", err)
+		return nil, fmt.Errorf("failed to encode rmnremote initialize: %w", err)
 	}
 	mcmsTx, err = utils.GenerateMCMSTx(in.CCIPAddress, moduleInfo, function, args)
 	if err != nil {
-		return mcmstypes.BatchOperation{}, fmt.Errorf("failed to generate MCMS operations for RMNRemote Initialize: %w", err)
+		return nil, fmt.Errorf("failed to generate MCMS operations for RMNRemote Initialize: %w", err)
 	}
 	txs = append(txs, mcmsTx)
 
-	return mcmstypes.BatchOperation{
-		ChainSelector: mcmstypes.ChainSelector(deps.AptosChain.Selector),
-		Transactions:  txs,
-	}, nil
+	return txs, nil
 }
 
 // OP: ApplyAllowedOfframpUpdates Operation

--- a/deployment/ccip/changeset/aptos/operation/off_ramp.go
+++ b/deployment/ccip/changeset/aptos/operation/off_ramp.go
@@ -17,8 +17,7 @@ import (
 
 // UpdateOffRampSourcesInput contains configuration for updating OffRamp sources
 type UpdateOffRampSourcesInput struct {
-	MCMSAddress aptos.AccountAddress
-	Updates     map[uint64]v1_6.OffRampSourceUpdate
+	Updates map[uint64]v1_6.OffRampSourceUpdate
 }
 
 // UpdateOffRampSourcesOp operation to update OffRamp source configurations

--- a/deployment/ccip/changeset/aptos/operation/on_ramp.go
+++ b/deployment/ccip/changeset/aptos/operation/on_ramp.go
@@ -15,8 +15,7 @@ import (
 
 // UpdateOnRampDestsInput contains configuration for updating OnRamp destinations
 type UpdateOnRampDestsInput struct {
-	MCMSAddress aptos.AccountAddress
-	Updates     map[uint64]v1_6.OnRampDestinationUpdate
+	Updates map[uint64]v1_6.OnRampDestinationUpdate
 }
 
 // UpdateOnRampDestsOp operation to update OnRamp destination configurations

--- a/deployment/ccip/changeset/aptos/operation/router.go
+++ b/deployment/ccip/changeset/aptos/operation/router.go
@@ -3,7 +3,6 @@ package operation
 import (
 	"fmt"
 
-	"github.com/aptos-labs/aptos-go-sdk"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip_router"
@@ -14,8 +13,7 @@ import (
 
 // UpdateRouterDestInput contains configuration for updating FeeQuoter destination configs
 type UpdateRouterDestInput struct {
-	MCMSAddress aptos.AccountAddress
-	Updates     []aptos_router.OnRampSet
+	Updates []aptos_router.OnRampSet
 }
 
 // UpdateRouterOp...

--- a/deployment/ccip/changeset/aptos/sequence/update_lane.go
+++ b/deployment/ccip/changeset/aptos/sequence/update_lane.go
@@ -129,7 +129,6 @@ func setAptosSourceUpdates(lane config.LaneConfig, updateInputsByAptosChain map[
 
 	// Setting the destination on the on ramp
 	input := updateInputsByAptosChain[source.Selector]
-	input.UpdateOnRampDestsConfig.MCMSAddress = mcmsAddress
 	if input.UpdateOnRampDestsConfig.Updates == nil {
 		input.UpdateOnRampDestsConfig.Updates = make(map[uint64]v1_6.OnRampDestinationUpdate)
 	}
@@ -140,21 +139,18 @@ func setAptosSourceUpdates(lane config.LaneConfig, updateInputsByAptosChain map[
 	}
 
 	// Setting gas prices updates
-	input.UpdateFeeQuoterPricesConfig.MCMSAddress = mcmsAddress
-	if input.UpdateFeeQuoterPricesConfig.Prices.GasPrices == nil {
-		input.UpdateFeeQuoterPricesConfig.Prices.GasPrices = make(map[uint64]*big.Int)
+	if input.UpdateFeeQuoterPricesConfig.GasPrices == nil {
+		input.UpdateFeeQuoterPricesConfig.GasPrices = make(map[uint64]*big.Int)
 	}
-	input.UpdateFeeQuoterPricesConfig.Prices.GasPrices[dest.Selector] = dest.GasPrice
+	input.UpdateFeeQuoterPricesConfig.GasPrices[dest.Selector] = dest.GasPrice
 
 	// Setting the fee quoter destination on the source chain
-	input.UpdateFeeQuoterDestsConfig.MCMSAddress = mcmsAddress
 	if input.UpdateFeeQuoterDestsConfig.Updates == nil {
 		input.UpdateFeeQuoterDestsConfig.Updates = make(map[uint64]aptos_fee_quoter.DestChainConfig)
 	}
 	input.UpdateFeeQuoterDestsConfig.Updates[dest.Selector] = dest.GetConvertedAptosFeeQuoterConfig()
 
 	// Setting Router OnRamp version updates
-	input.UpdateRouterDestConfig.MCMSAddress = mcmsAddress
 	if input.UpdateRouterDestConfig.Updates == nil {
 		input.UpdateRouterDestConfig.Updates = []aptos_router.OnRampSet{}
 	}
@@ -177,7 +173,6 @@ func setAptosDestinationUpdates(lane config.LaneConfig, updateInputsByAptosChain
 
 	// Setting off ramp updates
 	input := updateInputsByAptosChain[dest.Selector]
-	input.UpdateOffRampSourcesConfig.MCMSAddress = mcmsAddress
 	if input.UpdateOffRampSourcesConfig.Updates == nil {
 		input.UpdateOffRampSourcesConfig.Updates = make(map[uint64]v1_6.OffRampSourceUpdate)
 	}

--- a/deployment/ccip/changeset/aptos/test_helpers.go
+++ b/deployment/ccip/changeset/aptos/test_helpers.go
@@ -53,6 +53,7 @@ func GetMockChainContractParams(t *testing.T, chainSelector uint64) config.Chain
 			MaxFeeJuelsPerMsg:            1000000,
 			TokenPriceStalenessThreshold: 1000000,
 			FeeTokens:                    []aptos.AccountAddress{mockParsedLinkAddress},
+			// Using default EVM values for PremiumMultiplierWeiPerEthByFeeToken
 			PremiumMultiplierWeiPerEthByFeeToken: map[shared.TokenSymbol]uint64{
 				shared.APTSymbol:  1_000_000_000_000_000_000,
 				shared.LinkSymbol: 900_000_000_000_000_000,

--- a/deployment/ccip/changeset/aptos/test_helpers.go
+++ b/deployment/ccip/changeset/aptos/test_helpers.go
@@ -11,6 +11,7 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
@@ -52,6 +53,10 @@ func GetMockChainContractParams(t *testing.T, chainSelector uint64) config.Chain
 			MaxFeeJuelsPerMsg:            1000000,
 			TokenPriceStalenessThreshold: 1000000,
 			FeeTokens:                    []aptos.AccountAddress{mockParsedLinkAddress},
+			PremiumMultiplierWeiPerEthByFeeToken: map[shared.TokenSymbol]uint64{
+				shared.APTSymbol:  1_000_000_000_000_000_000,
+				shared.LinkSymbol: 900_000_000_000_000_000,
+			},
 		},
 		OffRampParams: config.OffRampParams{
 			ChainSelector:                    chainSelector,

--- a/deployment/ccip/shared/token_info.go
+++ b/deployment/ccip/shared/token_info.go
@@ -86,6 +86,7 @@ const (
 	CCIPBnMSymbol              TokenSymbol = "CCIP-BnM"
 	CCIPLnMSymbol              TokenSymbol = "CCIP-LnM"
 	CLCCIPLnMSymbol            TokenSymbol = "clCCIP-LnM"
+	APTSymbol                  TokenSymbol = "APT"
 	USDCName                   string      = "USD Coin"
 	LinkDecimals                           = 18
 	WethDecimals                           = 18


### PR DESCRIPTION
# Summary
Applies Premium Multiplier on Aptos chain deployment

# Features
- Adds operation to `ApplyPremiumMultiplierWeiPerEthUpdates`
- Adds configs `PremiumMultiplierWeiPerEthByFeeToken` to fee quoter params
- Changes `initializeCCIP` to return transactions
- Removes unused `MCMSAddress` in lane operations

# Testing
- Unite tests
- Staging tests TBD

# Review Suggestion
- Top down, from chain deployment changeset to the operation

