### PR TITLE
chore: bump flakeguard ref

### DIFF
--- a/.github/workflows/flakeguard.yml
+++ b/.github/workflows/flakeguard.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Install flakeguard
         if: ${{ inputs.runAllTests == false }}
         shell: bash
-        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25 # flakguard@0.1.0
+        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@9687993689805382c40dd48250a07efd155a09b9 # june 11, 2025
 
       - name: Find new or updated test packages
         if: ${{ inputs.runAllTests == false && env.RUN_CUSTOM_TEST_PACKAGES == '' }}
@@ -330,7 +330,7 @@ jobs:
       - name: Install flakeguard and gotestsum
         shell: bash
         run: |
-          go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25 # flakguard@0.1.0
+          go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@9687993689805382c40dd48250a07efd155a09b9 # june 11, 2025
           go install gotest.tools/gotestsum@v1.12.2 # needed for flakeguard output formatting
 
       - name: Run tests with flakeguard
@@ -441,7 +441,7 @@ jobs:
 
       - name: Install flakeguard
         shell: bash
-        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25 # flakguard@0.1.0
+        run: go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@9687993689805382c40dd48250a07efd155a09b9 # june 11, 2025
 
       - name: Aggregate Flakeguard Results
         id: results

--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -70,6 +70,6 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Install testing tools"
-          go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25
+          go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@9687993689805382c40dd48250a07efd155a09b9 # june 11, 2025
           go install gotest.tools/gotestsum@v1.12.2
           echo "::endgroup::"

--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -8,7 +8,7 @@ EXTRA_FLAGS=""
 
 if [[ -n "$USE_FLAKEGUARD" ]]; then
   # Install flakeguard
-  go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25
+  go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@9687993689805382c40dd48250a07efd155a09b9 # june 11, 2025
   # Install gotestsum to parse JSON test outputs from flakeguard to console outputs
   go install gotest.tools/gotestsum@v1.12.2
 

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -9,7 +9,7 @@ EXTRA_FLAGS="-timeout 16m"
 
 if [[ -n "$USE_FLAKEGUARD" ]]; then
   # Install flakeguard
-  go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@bc66d27e3325a1fecedc0fc932d13d3e54ff6f25
+  go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@9687993689805382c40dd48250a07efd155a09b9 # june 11, 2025
   # Install gotestsum to parse JSON test outputs from flakeguard to console outputs
   go install gotest.tools/gotestsum@v1.12.2
   # Make sure bins are in PATH


### PR DESCRIPTION
Bump all refs of flakeguard to https://github.com/smartcontractkit/chainlink-testing-framework/commit/9687993689805382c40dd48250a07efd155a09b9, which fixes bugs during panic edge cases.


