### PR TITLE
[CAPPL-737] Engine V2 timeouts

### DIFF
--- a/core/services/workflows/cmd/cre/utils.go
+++ b/core/services/workflows/cmd/cre/utils.go
@@ -153,7 +153,7 @@ func NewStandaloneEngine(
 		Hooks:         lifecycleHooks,
 	}
 
-	return v2.NewEngine(ctx, cfg)
+	return v2.NewEngine(cfg)
 }
 
 // TODO support fetching secrets (from a local file)

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -549,7 +549,7 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, o
 		BeholderEmitter: h.emitter,
 		BillingClient:   h.billingClient,
 	}
-	return v2.NewEngine(ctx, cfg)
+	return v2.NewEngine(cfg)
 }
 
 // workflowUpdatedEvent handles the WorkflowUpdatedEvent event type by first finding the

--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -44,8 +44,10 @@ type EngineConfig struct {
 const (
 	defaultModuleExecuteMaxResponseSizeBytes   = 100000
 	defaultTriggerSubscriptionRequestTimeoutMs = 500
+	defaultTriggerAllRegistrationsTimeoutMs    = 1000
 	defaultMaxTriggerSubscriptions             = 10
 	defaultTriggerEventQueueSize               = 1000
+	defaultTriggerEventMaxAgeMs                = 1000 * 60 * 10 // 10 minutes
 
 	defaultMaxConcurrentWorkflowExecutions         = 100
 	defaultMaxConcurrentCapabilityCallsPerWorkflow = 10
@@ -59,8 +61,10 @@ const (
 type EngineLimits struct {
 	ModuleExecuteMaxResponseSizeBytes   uint32
 	TriggerSubscriptionRequestTimeoutMs uint32
+	TriggerAllRegistrationsTimeoutMs    uint32
 	MaxTriggerSubscriptions             uint16
 	TriggerEventQueueSize               uint16
+	TriggerEventMaxAgeMs                uint32
 
 	MaxConcurrentWorkflowExecutions         uint16
 	MaxConcurrentCapabilityCallsPerWorkflow uint16
@@ -74,13 +78,9 @@ type EngineLimits struct {
 type LifecycleHooks struct {
 	OnInitialized          func(err error)
 	OnSubscribedToTriggers func(triggerIDs []string)
-	OnExecutionFinished    func(executionID string)
-
-	// TODO(CAPPL-736): handle execution result.
-	// OnResultReceived exposes the execution result for now.  By default, if
-	// unspecified, it is a no-op and the result is logged.
-	OnResultReceived func(*wasmpb.ExecutionResult)
-	OnRateLimited    func(executionID string)
+	OnExecutionFinished    func(executionID string, status string)
+	OnResultReceived       func(*wasmpb.ExecutionResult)
+	OnRateLimited          func(executionID string)
 }
 
 func (c *EngineConfig) Validate() error {
@@ -138,11 +138,17 @@ func (l *EngineLimits) setDefaultLimits() {
 	if l.TriggerSubscriptionRequestTimeoutMs == 0 {
 		l.TriggerSubscriptionRequestTimeoutMs = defaultTriggerSubscriptionRequestTimeoutMs
 	}
+	if l.TriggerAllRegistrationsTimeoutMs == 0 {
+		l.TriggerAllRegistrationsTimeoutMs = defaultTriggerAllRegistrationsTimeoutMs
+	}
 	if l.MaxTriggerSubscriptions == 0 {
 		l.MaxTriggerSubscriptions = defaultMaxTriggerSubscriptions
 	}
 	if l.TriggerEventQueueSize == 0 {
 		l.TriggerEventQueueSize = defaultTriggerEventQueueSize
+	}
+	if l.TriggerEventMaxAgeMs == 0 {
+		l.TriggerEventMaxAgeMs = defaultTriggerEventMaxAgeMs
 	}
 	if l.MaxConcurrentWorkflowExecutions == 0 {
 		l.MaxConcurrentWorkflowExecutions = defaultMaxConcurrentWorkflowExecutions
@@ -176,7 +182,7 @@ func (h *LifecycleHooks) setDefaultHooks() {
 		h.OnResultReceived = func(res *wasmpb.ExecutionResult) {}
 	}
 	if h.OnExecutionFinished == nil {
-		h.OnExecutionFinished = func(executionID string) {}
+		h.OnExecutionFinished = func(executionID string, status string) {}
 	}
 	if h.OnRateLimited == nil {
 		h.OnRateLimited = func(executionID string) {}

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -63,7 +63,7 @@ type enqueuedTriggerEvent struct {
 	event        capabilities.TriggerResponse
 }
 
-func NewEngine(ctx context.Context, cfg *EngineConfig) (*Engine, error) {
+func NewEngine(cfg *EngineConfig) (*Engine, error) {
 	err := cfg.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
@@ -72,6 +72,10 @@ func NewEngine(ctx context.Context, cfg *EngineConfig) (*Engine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize monitoring resources: %w", err)
 	}
+
+	// LocalNode() is expected to be non-blocking at this stage (i.e. the registry is already synced)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
 	localNode, err := cfg.CapRegistry.LocalNode(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get local node state: %w", err)
@@ -161,8 +165,8 @@ func (e *Engine) init(ctx context.Context) {
 
 func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 	// call into the workflow to get trigger subscriptions
-	subCtx, cancel := context.WithTimeout(ctx, time.Millisecond*time.Duration(e.cfg.LocalLimits.TriggerSubscriptionRequestTimeoutMs))
-	defer cancel()
+	subCtx, subCancel := context.WithTimeout(ctx, time.Millisecond*time.Duration(e.cfg.LocalLimits.TriggerSubscriptionRequestTimeoutMs))
+	defer subCancel()
 	result, err := e.cfg.Module.Execute(subCtx, &wasmpb.ExecuteRequest{
 		Request:         &wasmpb.ExecuteRequest_Subscribe{},
 		MaxResponseSize: uint64(e.cfg.LocalLimits.ModuleExecuteMaxResponseSizeBytes),
@@ -193,6 +197,8 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 	}
 
 	// register to all triggers
+	regCtx, regCancel := context.WithTimeout(ctx, time.Millisecond*time.Duration(e.cfg.LocalLimits.TriggerAllRegistrationsTimeoutMs))
+	defer regCancel()
 	e.triggersRegMu.Lock()
 	defer e.triggersRegMu.Unlock()
 	eventChans := make([]<-chan capabilities.TriggerResponse, len(subs.Subscriptions))
@@ -200,9 +206,8 @@ func (e *Engine) runTriggerSubscriptionPhase(ctx context.Context) error {
 	for i, sub := range subs.Subscriptions {
 		triggerCap := triggers[i]
 		registrationID := fmt.Sprintf("trigger_reg_%s_%d", e.cfg.WorkflowID, i)
-		// TODO(CAPPL-737): run with a timeout
 		e.lggr.Debugw("Registering trigger", "triggerID", sub.Id, "method", sub.Method)
-		triggerEventCh, err := triggerCap.RegisterTrigger(ctx, capabilities.TriggerRegistrationRequest{
+		triggerEventCh, err := triggerCap.RegisterTrigger(regCtx, capabilities.TriggerRegistrationRequest{
 			TriggerID: registrationID,
 			Metadata: capabilities.RequestMetadata{
 				WorkflowID:               e.cfg.WorkflowID,
@@ -272,7 +277,11 @@ func (e *Engine) handleAllTriggerEvents(ctx context.Context) {
 			if !isOpen {
 				return
 			}
-			// TODO(CAPPL-737): check if expired
+			eventAge := queueHead.timestamp.Sub(e.cfg.Clock.Now())
+			if eventAge > time.Duration(e.cfg.LocalLimits.TriggerEventMaxAgeMs)*time.Millisecond {
+				e.lggr.Warnw("Trigger event is too old, skipping execution", "triggerID", queueHead.triggerCapID, "eventID", queueHead.event.Event.ID, "eventAgeMs", eventAge.Milliseconds())
+				continue
+			}
 			select {
 			case e.executionsSemaphore <- struct{}{}: // block if too many concurrent workflow executions
 				e.srvcEng.Go(func(srvcCtx context.Context) {
@@ -296,16 +305,6 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	}
 
 	// TODO(CAPPL-911): add rate-limiting
-
-	subCtx, cancel := context.WithTimeout(ctx, time.Millisecond*time.Duration(e.cfg.LocalLimits.WorkflowExecutionTimeoutMs))
-	defer cancel()
-	executionLogger := logger.With(e.lggr, "executionID", executionID, "triggerID", wrappedTriggerEvent.triggerCapID, "triggerIndex", wrappedTriggerEvent.triggerIndex)
-
-	tid, err := safe.IntToUint64(wrappedTriggerEvent.triggerIndex)
-	if err != nil {
-		executionLogger.Errorw("Failed to convert trigger index to uint64", "err", err)
-		return
-	}
 
 	meteringReport, meteringErr := e.meterReports.Start(ctx, executionID)
 	if meteringErr != nil {
@@ -336,11 +335,22 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		}
 	}
 
-	startTime := time.Now()
+	execCtx, execCancel := context.WithTimeout(ctx, time.Millisecond*time.Duration(e.cfg.LocalLimits.WorkflowExecutionTimeoutMs))
+	defer execCancel()
+	executionLogger := logger.With(e.lggr, "executionID", executionID, "triggerID", wrappedTriggerEvent.triggerCapID, "triggerIndex", wrappedTriggerEvent.triggerIndex)
+
+	tid, err := safe.IntToUint64(wrappedTriggerEvent.triggerIndex)
+	if err != nil {
+		executionLogger.Errorw("Failed to convert trigger index to uint64", "err", err)
+		return
+	}
+
+	startTime := e.cfg.Clock.Now()
 	executionLogger.Infow("Workflow execution starting ...")
 	_ = events.EmitExecutionStartedEvent(ctx, e.loggerLabels, triggerEvent.ID, executionID)
+	var executionStatus string // store.StatusStarted
 
-	result, err := e.cfg.Module.Execute(subCtx, &wasmpb.ExecuteRequest{
+	result, err := e.cfg.Module.Execute(execCtx, &wasmpb.ExecuteRequest{
 		Request: &wasmpb.ExecuteRequest_Trigger{
 			Trigger: &sdkpb.Trigger{
 				Id:      tid,
@@ -351,11 +361,16 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		Config:          e.cfg.WorkflowConfig,
 	}, &ExecutionHelper{Engine: e, WorkflowExecutionID: executionID})
 
-	endTime := time.Now()
-	executionMS := strconv.Itoa(int(endTime.Sub(startTime).Milliseconds()))
+	endTime := e.cfg.Clock.Now()
+	executionDuration := endTime.Sub(startTime)
 
 	if isMetering {
-		mrErr := meteringReport.Settle(metering.ComputeResourceDimension, []capabilities.MeteringNodeDetail{{Peer2PeerID: e.localNode.PeerID.String(), SpendUnit: metering.ComputeResourceDimension, SpendValue: executionMS}})
+		mrErr := meteringReport.Settle(metering.ComputeResourceDimension,
+			[]capabilities.MeteringNodeDetail{{
+				Peer2PeerID: e.localNode.PeerID.String(),
+				SpendUnit:   metering.ComputeResourceDimension,
+				SpendValue:  strconv.Itoa(int(executionDuration.Milliseconds())),
+			}})
 		if mrErr != nil {
 			e.cfg.Lggr.Errorw("could not set metering for compute", "err", mrErr)
 		}
@@ -366,21 +381,21 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 	}
 
 	if err != nil {
-		status := store.StatusErrored
+		executionStatus = store.StatusErrored
 		if errors.Is(err, context.DeadlineExceeded) {
-			status = store.StatusTimeout
+			executionStatus = store.StatusTimeout
 		}
-		executionLogger.Errorw("Workflow execution failed", "err", err, "status", status)
-		_ = events.EmitExecutionFinishedEvent(ctx, e.loggerLabels, status, executionID)
+		executionLogger.Errorw("Workflow execution failed", "err", err, "status", executionStatus, "durationMs", executionDuration.Milliseconds())
+		_ = events.EmitExecutionFinishedEvent(ctx, e.loggerLabels, executionStatus, executionID)
+		e.cfg.Hooks.OnExecutionFinished(executionID, executionStatus)
 		return
 	}
-	// TODO(CAPPL-737): measure and report execution time
-
-	executionLogger.Infow("Workflow execution finished successfully")
-	_ = events.EmitExecutionFinishedEvent(ctx, e.loggerLabels, store.StatusCompleted, executionID)
+	executionStatus = store.StatusCompleted
+	executionLogger.Infow("Workflow execution finished successfully", "durationMs", executionDuration.Milliseconds())
+	_ = events.EmitExecutionFinishedEvent(ctx, e.loggerLabels, executionStatus, executionID)
 
 	e.cfg.Hooks.OnResultReceived(result)
-	e.cfg.Hooks.OnExecutionFinished(executionID)
+	e.cfg.Hooks.OnExecutionFinished(executionID, executionStatus)
 }
 
 func (e *Engine) close() error {

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -33,7 +34,6 @@ import (
 	wasmpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/v2/pb"
 	billing "github.com/smartcontractkit/chainlink-protos/billing/go"
 	capmocks "github.com/smartcontractkit/chainlink/v2/core/capabilities/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/wasmtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering"
@@ -62,7 +62,7 @@ func TestEngine_Init(t *testing.T) {
 		},
 	}
 
-	engine, err := v2.NewEngine(testutils.Context(t), cfg)
+	engine, err := v2.NewEngine(cfg)
 	require.NoError(t, err)
 
 	module.EXPECT().Start().Once()
@@ -104,14 +104,14 @@ func TestEngine_Start_RateLimited(t *testing.T) {
 	var engine1, engine2, engine3, engine4 *v2.Engine
 
 	t.Run("engine 1 inits successfully", func(t *testing.T) {
-		engine1, err = v2.NewEngine(testutils.Context(t), cfg)
+		engine1, err = v2.NewEngine(cfg)
 		require.NoError(t, err)
 		require.NoError(t, engine1.Start(t.Context()))
 		require.NoError(t, <-initDoneCh)
 	})
 
 	t.Run("engine 2 gets rate-limited by per-owner limit", func(t *testing.T) {
-		engine2, err = v2.NewEngine(testutils.Context(t), cfg)
+		engine2, err = v2.NewEngine(cfg)
 		require.NoError(t, err)
 		require.NoError(t, engine2.Start(t.Context()))
 		initErr := <-initDoneCh
@@ -120,7 +120,7 @@ func TestEngine_Start_RateLimited(t *testing.T) {
 
 	t.Run("engine 3 inits successfully", func(t *testing.T) {
 		cfg.WorkflowOwner = testWorkflowOwnerB
-		engine3, err = v2.NewEngine(testutils.Context(t), cfg)
+		engine3, err = v2.NewEngine(cfg)
 		require.NoError(t, err)
 		require.NoError(t, engine3.Start(t.Context()))
 		require.NoError(t, <-initDoneCh)
@@ -128,7 +128,7 @@ func TestEngine_Start_RateLimited(t *testing.T) {
 
 	t.Run("engine 4 gets rate-limited by global limit", func(t *testing.T) {
 		cfg.WorkflowOwner = testWorkflowOwnerC
-		engine4, err = v2.NewEngine(testutils.Context(t), cfg)
+		engine4, err = v2.NewEngine(cfg)
 		require.NoError(t, err)
 		require.NoError(t, engine4.Start(t.Context()))
 		initErr := <-initDoneCh
@@ -167,7 +167,7 @@ func TestEngine_TriggerSubscriptions(t *testing.T) {
 
 	t.Run("too many triggers", func(t *testing.T) {
 		cfg.LocalLimits.MaxTriggerSubscriptions = 1
-		engine, err := v2.NewEngine(testutils.Context(t), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(2), nil).Once()
 		require.NoError(t, engine.Start(t.Context()))
@@ -177,7 +177,7 @@ func TestEngine_TriggerSubscriptions(t *testing.T) {
 	})
 
 	t.Run("trigger capability not found in the registry", func(t *testing.T) {
-		engine, err := v2.NewEngine(testutils.Context(t), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(2), nil).Once()
 		capreg.EXPECT().GetTrigger(matches.AnyContext, "id_0").Return(nil, errors.New("not found")).Once()
@@ -187,7 +187,7 @@ func TestEngine_TriggerSubscriptions(t *testing.T) {
 	})
 
 	t.Run("successful trigger registration", func(t *testing.T) {
-		engine, err := v2.NewEngine(testutils.Context(t), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(2), nil).Once()
 		trigger0, trigger1 := capmocks.NewTriggerCapability(t), capmocks.NewTriggerCapability(t)
@@ -205,7 +205,7 @@ func TestEngine_TriggerSubscriptions(t *testing.T) {
 	})
 
 	t.Run("failed trigger registration and rollback", func(t *testing.T) {
-		engine, err := v2.NewEngine(testutils.Context(t), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(2), nil).Once()
 		trigger0, trigger1 := capmocks.NewTriggerCapability(t), capmocks.NewTriggerCapability(t)
@@ -244,17 +244,7 @@ func TestEngine_Execution(t *testing.T) {
 	module.EXPECT().Close()
 	capreg := regmocks.NewCapabilitiesRegistry(t)
 	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil)
-	billingClient := metmocks.NewBillingClient(t)
-	billingClient.EXPECT().
-		ReserveCredits(mock.Anything, mock.MatchedBy(func(req *billing.ReserveCreditsRequest) bool {
-			return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
-		})).
-		Return(&billing.ReserveCreditsResponse{Success: true, Rates: []*billing.ResourceUnitRate{{ResourceUnit: metering.ComputeResourceDimension, ConversionRate: "0.0001"}}, Credits: 10000}, nil)
-	billingClient.EXPECT().
-		SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
-			return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
-		})).
-		Return(&billing.SubmitWorkflowReceiptResponse{Success: true}, nil)
+	billingClient := setupMockBillingClient(t)
 
 	initDoneCh := make(chan error)
 	subscribedToTriggersCh := make(chan []string, 1)
@@ -271,7 +261,7 @@ func TestEngine_Execution(t *testing.T) {
 		OnSubscribedToTriggers: func(triggerIDs []string) {
 			subscribedToTriggersCh <- triggerIDs
 		},
-		OnExecutionFinished: func(executionID string) {
+		OnExecutionFinished: func(executionID string, _ string) {
 			executionFinishedCh <- executionID
 		},
 	}
@@ -279,11 +269,11 @@ func TestEngine_Execution(t *testing.T) {
 	cfg.BeholderEmitter = custmsg.NewLabeler()
 
 	t.Run("successful execution with no capability calls", func(t *testing.T) {
-		engine, err := v2.NewEngine(testutils.Context(t), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 		module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(1), nil).Once()
 		trigger := capmocks.NewTriggerCapability(t)
-		capreg.EXPECT().GetTrigger(matches.AnyContext, "id_0").Return(trigger, nil).Once()
+		capreg.EXPECT().GetTrigger(matches.AnyContext, "id_0").Return(trigger, nil)
 		eventCh := make(chan capabilities.TriggerResponse)
 		trigger.EXPECT().RegisterTrigger(matches.AnyContext, mock.Anything).Return(eventCh, nil).Once()
 		trigger.EXPECT().UnregisterTrigger(matches.AnyContext, mock.Anything).Return(nil).Once()
@@ -335,6 +325,198 @@ func TestEngine_Execution(t *testing.T) {
 	})
 }
 
+func TestEngine_ExecutionTimeout(t *testing.T) {
+	t.Parallel()
+
+	module := modulemocks.NewModuleV2(t)
+	module.EXPECT().Start()
+	module.EXPECT().Close()
+	capreg := regmocks.NewCapabilitiesRegistry(t)
+	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil)
+	billingClient := setupMockBillingClient(t)
+
+	initDoneCh := make(chan error)
+	subscribedToTriggersCh := make(chan []string, 1)
+	executionFinishedCh := make(chan string)
+
+	cfg := defaultTestConfig(t)
+	cfg.Module = module
+	cfg.CapRegistry = capreg
+	cfg.BillingClient = billingClient
+	// Set a very short execution timeout (100ms)
+	cfg.LocalLimits.WorkflowExecutionTimeoutMs = 100
+	cfg.Hooks = v2.LifecycleHooks{
+		OnInitialized: func(err error) {
+			initDoneCh <- err
+		},
+		OnSubscribedToTriggers: func(triggerIDs []string) {
+			subscribedToTriggersCh <- triggerIDs
+		},
+		OnExecutionFinished: func(executionID string, status string) {
+			// Verify the execution status is timeout
+			require.Equal(t, "timeout", status)
+			executionFinishedCh <- executionID
+		},
+	}
+
+	engine, err := v2.NewEngine(cfg)
+	require.NoError(t, err)
+
+	// Setup trigger registration
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(1), nil).Once()
+	trigger := capmocks.NewTriggerCapability(t)
+	capreg.EXPECT().GetTrigger(matches.AnyContext, "id_0").Return(trigger, nil).Once()
+	eventCh := make(chan capabilities.TriggerResponse)
+	trigger.EXPECT().RegisterTrigger(matches.AnyContext, mock.Anything).Return(eventCh, nil).Once()
+	trigger.EXPECT().UnregisterTrigger(matches.AnyContext, mock.Anything).Return(nil).Once()
+
+	// Mock a long-running execution that will exceed the timeout
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).
+		Run(func(ctx context.Context, request *wasmpb.ExecuteRequest, executor host.ExecutionHelper) {
+			// Simulate work that takes longer than the 100ms timeout
+			select {
+			case <-time.After(200 * time.Millisecond):
+				// This should not complete due to context timeout
+			case <-ctx.Done():
+				// Context should be canceled due to timeout
+				require.Error(t, ctx.Err())
+				require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+			}
+		}).
+		Return(nil, context.DeadlineExceeded).
+		Once()
+
+	// Start the engine and wait for initialization and trigger subscription
+	require.NoError(t, engine.Start(t.Context()))
+	require.NoError(t, <-initDoneCh)
+	require.Equal(t, []string{"id_0"}, <-subscribedToTriggersCh)
+
+	// Trigger the execution
+	mockTriggerEvent := capabilities.TriggerEvent{
+		TriggerType: "basic-trigger@1.0.0",
+		ID:          "timeout_test_event",
+		Payload:     nil,
+	}
+
+	eventCh <- capabilities.TriggerResponse{
+		Event: mockTriggerEvent,
+	}
+
+	// Wait for execution to finish with timeout status
+	executionID := <-executionFinishedCh
+	wantExecID, err := types.GenerateExecutionID(cfg.WorkflowID, mockTriggerEvent.ID)
+	require.NoError(t, err)
+	require.Equal(t, wantExecID, executionID)
+
+	require.NoError(t, engine.Close())
+}
+
+func TestEngine_CapabilityCallTimeout(t *testing.T) {
+	t.Parallel()
+
+	module := modulemocks.NewModuleV2(t)
+	module.EXPECT().Start()
+	module.EXPECT().Close()
+	capreg := regmocks.NewCapabilitiesRegistry(t)
+	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil)
+	billingClient := setupMockBillingClient(t)
+
+	initDoneCh := make(chan error)
+	subscribedToTriggersCh := make(chan []string, 1)
+	executionFinishedCh := make(chan string)
+
+	cfg := defaultTestConfig(t)
+	cfg.Module = module
+	cfg.CapRegistry = capreg
+	cfg.BillingClient = billingClient
+	// Set a very short capability call timeout (50ms)
+	cfg.LocalLimits.CapabilityCallTimeoutMs = 50
+	cfg.Hooks = v2.LifecycleHooks{
+		OnInitialized: func(err error) {
+			initDoneCh <- err
+		},
+		OnSubscribedToTriggers: func(triggerIDs []string) {
+			subscribedToTriggersCh <- triggerIDs
+		},
+		OnExecutionFinished: func(executionID string, status string) {
+			// Verify the execution status is errored due to capability timeout
+			require.Equal(t, "errored", status)
+			executionFinishedCh <- executionID
+		},
+	}
+
+	engine, err := v2.NewEngine(cfg)
+	require.NoError(t, err)
+
+	// Setup trigger registration
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(1), nil).Once()
+	trigger := capmocks.NewTriggerCapability(t)
+	capreg.EXPECT().GetTrigger(matches.AnyContext, "id_0").Return(trigger, nil).Once()
+	eventCh := make(chan capabilities.TriggerResponse)
+	trigger.EXPECT().RegisterTrigger(matches.AnyContext, mock.Anything).Return(eventCh, nil).Once()
+	trigger.EXPECT().UnregisterTrigger(matches.AnyContext, mock.Anything).Return(nil).Once()
+
+	// Setup a slow capability that will timeout
+	slowCapability := capmocks.NewExecutableCapability(t)
+	capreg.EXPECT().GetExecutable(matches.AnyContext, "slow-capability").Return(slowCapability, nil).Once()
+
+	// Mock capability that takes longer than the 50ms timeout
+	slowCapability.EXPECT().Execute(matches.AnyContext, mock.Anything).
+		Run(func(ctx context.Context, req capabilities.CapabilityRequest) {
+			// Simulate work that takes longer than the 50ms timeout
+			select {
+			case <-time.After(100 * time.Millisecond):
+				// This should not complete due to context timeout
+			case <-ctx.Done():
+				// Context should be canceled due to timeout
+				require.Error(t, ctx.Err())
+				require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+			}
+		}).
+		Return(capabilities.CapabilityResponse{}, context.DeadlineExceeded).
+		Once()
+
+	require.NoError(t, engine.Start(t.Context()))
+	require.NoError(t, <-initDoneCh)
+	require.Equal(t, []string{"id_0"}, <-subscribedToTriggersCh)
+
+	// Mock workflow execution that calls the slow capability
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).
+		Run(func(ctx context.Context, request *wasmpb.ExecuteRequest, executor host.ExecutionHelper) {
+			// Simulate calling the slow capability from within the workflow
+			_, errCap := executor.CallCapability(ctx, &sdkpb.CapabilityRequest{
+				Id:         "slow-capability",
+				Method:     "execute",
+				CallbackId: 1,
+				Payload:    nil,
+			})
+			// Verify that the capability call returns a timeout error
+			require.Error(t, errCap)
+			require.Contains(t, errCap.Error(), "failed to execute capability")
+		}).
+		Return(nil, errors.New("capability timeout error")).
+		Once()
+
+	// Trigger the execution
+	mockTriggerEvent := capabilities.TriggerEvent{
+		TriggerType: "basic-trigger@1.0.0",
+		ID:          "timeout_capability_test",
+		Payload:     nil,
+	}
+
+	eventCh <- capabilities.TriggerResponse{
+		Event: mockTriggerEvent,
+	}
+
+	// Wait for execution to finish with error status
+	executionID := <-executionFinishedCh
+	wantExecID, err := types.GenerateExecutionID(cfg.WorkflowID, mockTriggerEvent.ID)
+	require.NoError(t, err)
+	require.Equal(t, wantExecID, executionID)
+
+	require.NoError(t, engine.Close())
+}
+
 func TestEngine_MockCapabilityRegistry_NoDAGBinary(t *testing.T) {
 	cmd := "core/services/workflows/test/wasm/v2/cmd"
 	log := logger.TestLogger(t)
@@ -346,19 +528,9 @@ func TestEngine_MockCapabilityRegistry_NoDAGBinary(t *testing.T) {
 	require.NoError(t, err)
 
 	capreg := regmocks.NewCapabilitiesRegistry(t)
-	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil).Once()
+	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil)
 
-	billingClient := metmocks.NewBillingClient(t)
-	billingClient.EXPECT().
-		ReserveCredits(mock.Anything, mock.MatchedBy(func(req *billing.ReserveCreditsRequest) bool {
-			return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
-		})).
-		Return(&billing.ReserveCreditsResponse{Success: true, Rates: []*billing.ResourceUnitRate{{ResourceUnit: metering.ComputeResourceDimension, ConversionRate: "0.0001"}}, Credits: 10000}, nil)
-	billingClient.EXPECT().
-		SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
-			return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
-		})).
-		Return(&billing.SubmitWorkflowReceiptResponse{Success: true}, nil)
+	billingClient := setupMockBillingClient(t)
 
 	cfg := defaultTestConfig(t)
 	cfg.Module = module
@@ -376,7 +548,7 @@ func TestEngine_MockCapabilityRegistry_NoDAGBinary(t *testing.T) {
 		OnSubscribedToTriggers: func(triggerIDs []string) {
 			subscribedToTriggersCh <- triggerIDs
 		},
-		OnExecutionFinished: func(executionID string) {
+		OnExecutionFinished: func(executionID string, _ string) {
 			executionFinishedCh <- executionID
 		},
 		OnResultReceived: func(er *wasmpb.ExecutionResult) {
@@ -394,7 +566,7 @@ func TestEngine_MockCapabilityRegistry_NoDAGBinary(t *testing.T) {
 
 	t.Run("OK happy path", func(t *testing.T) {
 		wantResponse := "Hello, world!"
-		engine, err := v2.NewEngine(testutils.Context(t), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 
 		capreg.EXPECT().
@@ -454,19 +626,9 @@ func TestEngine_Config_MockCapabilityRegistry_NoDAGBinary(t *testing.T) {
 	require.NoError(t, err)
 
 	capreg := regmocks.NewCapabilitiesRegistry(t)
-	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil).Once()
+	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil)
 
-	billingClient := metmocks.NewBillingClient(t)
-	billingClient.EXPECT().
-		ReserveCredits(mock.Anything, mock.MatchedBy(func(req *billing.ReserveCreditsRequest) bool {
-			return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
-		})).
-		Return(&billing.ReserveCreditsResponse{Success: true, Rates: []*billing.ResourceUnitRate{{ResourceUnit: metering.ComputeResourceDimension, ConversionRate: "0.0001"}}, Credits: 10000}, nil)
-	billingClient.EXPECT().
-		SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
-			return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
-		})).
-		Return(&billing.SubmitWorkflowReceiptResponse{Success: true}, nil)
+	billingClient := setupMockBillingClient(t)
 
 	cfg := defaultTestConfig(t)
 	cfg.WorkflowConfig = config
@@ -485,7 +647,7 @@ func TestEngine_Config_MockCapabilityRegistry_NoDAGBinary(t *testing.T) {
 		OnSubscribedToTriggers: func(triggerIDs []string) {
 			subscribedToTriggersCh <- triggerIDs
 		},
-		OnExecutionFinished: func(executionID string) {
+		OnExecutionFinished: func(executionID string, _ string) {
 			executionFinishedCh <- executionID
 		},
 		OnResultReceived: func(er *wasmpb.ExecutionResult) {
@@ -505,7 +667,7 @@ func TestEngine_Config_MockCapabilityRegistry_NoDAGBinary(t *testing.T) {
 	}
 
 	t.Run("OK received expected config", func(t *testing.T) {
-		engine, err := v2.NewEngine(testutils.Context(t), cfg)
+		engine, err := v2.NewEngine(cfg)
 		require.NoError(t, err)
 
 		capreg.EXPECT().
@@ -542,6 +704,22 @@ func TestEngine_Config_MockCapabilityRegistry_NoDAGBinary(t *testing.T) {
 		require.Equal(t, execID, <-executionFinishedCh)
 		require.NoError(t, engine.Close())
 	})
+}
+
+// setupMockBillingClient creates a mock billing client with default expectations.
+func setupMockBillingClient(t *testing.T) *metmocks.BillingClient {
+	billingClient := metmocks.NewBillingClient(t)
+	billingClient.EXPECT().
+		ReserveCredits(mock.Anything, mock.MatchedBy(func(req *billing.ReserveCreditsRequest) bool {
+			return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
+		})).
+		Return(&billing.ReserveCreditsResponse{Success: true, Rates: []*billing.ResourceUnitRate{{ResourceUnit: metering.ComputeResourceDimension, ConversionRate: "0.0001"}}, Credits: 10000}, nil).Maybe()
+	billingClient.EXPECT().
+		SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
+			return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
+		})).
+		Return(&billing.SubmitWorkflowReceiptResponse{Success: true}, nil).Maybe()
+	return billingClient
 }
 
 // setupExpectedCalls mocks single call to trigger and two calls to the basic action


### PR DESCRIPTION
1. Add timeouts for workflow execution, capability calls and expired trigger events.
2. Add an extra helper in tests to reduce code duplication.