### PR TITLE
Add validation to prevent MultipleReportsEnabled when EnforceOutOfOrder is false

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1013,6 +1013,7 @@ func AddLaneSolanaChangesets(e *DeployedEnv, solChainSelector, remoteChainSelect
 							DefaultTokenDestGasOverhead: 90000,
 							DestGasOverhead:             90000,
 							ChainFamilySelector:         chainFamilySelector,
+							EnforceOutOfOrder:           true,
 						},
 					},
 				},

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -238,8 +238,7 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 		", source chain selector:", sourceChain,
 		", dest chain selector:", destChain,
 	)
-	// connect a single lane, source to dest
-	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &e, state, sourceChain, destChain, false)
+	testhelpers.AddLaneWithEnforceOutOfOrder(t, &e, state, sourceChain, destChain, false)
 
 	var (
 		// nonce    uint64 // Nonce not used as Solana check is skipped
@@ -371,8 +370,7 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 		", source chain selector:", sourceChain,
 		", dest chain selector:", destChain,
 	)
-	// connect a single lane, source to dest
-	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &e, state, sourceChain, destChain, false)
+	testhelpers.AddLaneWithEnforceOutOfOrder(t, &e, state, sourceChain, destChain, false)
 
 	var (
 		// nonce    uint64 // Nonce not used as Solana check is skipped

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -213,11 +213,13 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 	e, _, _ := testsetups.NewIntegrationEnvironment(t,
 		testhelpers.WithSolChains(1),
 		testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
-			params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(1 * time.Hour)
-			params.ExecuteOffChainConfig.MessageVisibilityInterval = *config.MustNewDuration(1 * time.Hour)
-			params.ExecuteOffChainConfig.MultipleReportsEnabled = true
-			params.ExecuteOffChainConfig.MaxReportMessages = 1
-			params.ExecuteOffChainConfig.MaxSingleChainReports = 1
+			if params.ExecuteOffChainConfig != nil {
+				params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(1 * time.Hour)
+				params.ExecuteOffChainConfig.MessageVisibilityInterval = *config.MustNewDuration(1 * time.Hour)
+				params.ExecuteOffChainConfig.MultipleReportsEnabled = true
+				params.ExecuteOffChainConfig.MaxReportMessages = 1
+				params.ExecuteOffChainConfig.MaxSingleChainReports = 1
+			}
 			return params
 		}),
 	)
@@ -344,11 +346,13 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 	e, _, _ := testsetups.NewIntegrationEnvironment(t,
 		testhelpers.WithSolChains(1),
 		testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
-			params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(1 * time.Hour)
-			params.ExecuteOffChainConfig.MessageVisibilityInterval = *config.MustNewDuration(1 * time.Hour)
-			params.ExecuteOffChainConfig.MultipleReportsEnabled = true
-			params.ExecuteOffChainConfig.MaxReportMessages = 1
-			params.ExecuteOffChainConfig.MaxSingleChainReports = 1
+			if params.ExecuteOffChainConfig != nil {
+				params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(1 * time.Hour)
+				params.ExecuteOffChainConfig.MessageVisibilityInterval = *config.MustNewDuration(1 * time.Hour)
+				params.ExecuteOffChainConfig.MultipleReportsEnabled = true
+				params.ExecuteOffChainConfig.MaxReportMessages = 1
+				params.ExecuteOffChainConfig.MaxSingleChainReports = 1
+			}
 			return params
 		}),
 	)


### PR DESCRIPTION
Adds validation in `validateExecOffchainConfig` to ensure `MultipleReportsEnabled` is only enabled when all destination chains have `EnforceOutOfOrder=true`. 

This prevents configuration issues that can cause bottlenecks and slowness on the plugin side when ordered messages are sent with multi-exec reports enabled.