### PR TITLE
CCIP-6100 Add validation to prevent MultipleReportsEnabled when EnforceOutOfOrder is false

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1197,7 +1197,9 @@ func AddLaneWithEnforceOutOfOrder(t *testing.T, e *DeployedEnv, state stateview.
 	gasPrices := map[uint64]*big.Int{
 		to: DefaultGasPrice,
 	}
-	fromFamily, _ := chainsel.GetSelectorFamily(from)
+	fromFamily, err := chainsel.GetSelectorFamily(from)
+	require.NoError(t, err)
+
 	tokenPrices := map[common.Address]*big.Int{}
 	if fromFamily == chainsel.FamilyEVM {
 		stateChainFrom := state.MustGetEVMChainState(from)

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1193,6 +1193,32 @@ func AddLaneWithDefaultPricesAndFeeQuoterConfig(t *testing.T, e *DeployedEnv, st
 	)
 }
 
+func AddLaneWithEnforceOutOfOrder(t *testing.T, e *DeployedEnv, state stateview.CCIPOnChainState, from, to uint64, isTestRouter bool) {
+	gasPrices := map[uint64]*big.Int{
+		to: DefaultGasPrice,
+	}
+	fromFamily, _ := chainsel.GetSelectorFamily(from)
+	tokenPrices := map[common.Address]*big.Int{}
+	if fromFamily == chainsel.FamilyEVM {
+		stateChainFrom := state.MustGetEVMChainState(from)
+		tokenPrices = map[common.Address]*big.Int{
+			stateChainFrom.LinkToken.Address(): DefaultLinkPrice,
+			stateChainFrom.Weth9.Address():     DefaultWethPrice,
+		}
+	}
+	fqCfg := v1_6.DefaultFeeQuoterDestChainConfig(true, to)
+	fqCfg.EnforceOutOfOrder = true
+	AddLane(
+		t,
+		e,
+		from, to,
+		isTestRouter,
+		gasPrices,
+		tokenPrices,
+		fqCfg,
+	)
+}
+
 // AddLanesForAll adds densely connected lanes for all chains in the environment so that each chain
 // is connected to every other chain except itself.
 func AddLanesForAll(t *testing.T, e *DeployedEnv, state stateview.CCIPOnChainState) {

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -204,11 +204,11 @@ func addCandidatesForNewChainPrecondition(e cldf.Environment, c AddCandidatesFor
 		return fmt.Errorf("deployerKey %v is not authorized deployer on donIDClaimer. ", txOpts.From.String())
 	}
 
-	// If MultipleReportsEnabled is false, then EnforceOutOfOrder must be true for all remote chains.
-	if !c.NewChain.ExecOCRParams.ExecuteOffChainConfig.MultipleReportsEnabled {
+	// If MultipleReportsEnabled is true, then EnforceOutOfOrder must also be true for all remote chains.
+	if c.NewChain.ExecOCRParams.ExecuteOffChainConfig.MultipleReportsEnabled {
 		for _, remoteChain := range c.RemoteChains {
 			if !remoteChain.FeeQuoterDestChainConfig.EnforceOutOfOrder {
-				return errors.New("EnforceOutOfOrder must be set to true in the FeeQuoterDestChainConfig")
+				return errors.New("EnforceOutOfOrder must be true when MultipleReportsEnabled is true")
 			}
 		}
 	}

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -208,7 +208,7 @@ func addCandidatesForNewChainPrecondition(e cldf.Environment, c AddCandidatesFor
 	if !c.NewChain.ExecOCRParams.ExecuteOffChainConfig.MultipleReportsEnabled {
 		for _, remoteChain := range c.RemoteChains {
 			if !remoteChain.FeeQuoterDestChainConfig.EnforceOutOfOrder {
-				return fmt.Errorf("EnforceOutOfOrder must be set to true in the FeeQuoterDestChainConfig")
+				return errors.New("EnforceOutOfOrder must be set to true in the FeeQuoterDestChainConfig")
 			}
 		}
 	}

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -204,6 +204,15 @@ func addCandidatesForNewChainPrecondition(e cldf.Environment, c AddCandidatesFor
 		return fmt.Errorf("deployerKey %v is not authorized deployer on donIDClaimer. ", txOpts.From.String())
 	}
 
+	// If MultipleReportsEnabled is false, then EnforceOutOfOrder must be true for all remote chains.
+	if !c.NewChain.ExecOCRParams.ExecuteOffChainConfig.MultipleReportsEnabled {
+		for _, remoteChain := range c.RemoteChains {
+			if !remoteChain.FeeQuoterDestChainConfig.EnforceOutOfOrder {
+				return fmt.Errorf("EnforceOutOfOrder must be set to true in the FeeQuoterDestChainConfig")
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
@@ -242,6 +242,7 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 		Msg         string
 		MCMS        *proposalutils.TimelockConfig
 		DonIDOffSet *uint32
+		ErrStr      string
 	}
 
 	offset := uint32(0)
@@ -265,6 +266,10 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 		{
 			Msg:         "Remote chains with donID offset (Sync with capReg reg after wrong donIDClaim)",
 			DonIDOffSet: &offset,
+		},
+		{
+			Msg:    "fail when multiple reports are disabled and enforce out of order is disabled",
+			ErrStr: "EnforceOutOfOrder must be set to true in the FeeQuoterDestChainConfig",
 		},
 	}
 
@@ -422,6 +427,11 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 				// RMNRemoteConfig:   &v1_6.RMNRemoteConfig{...}, // TODO: Enable?
 			}
 
+			if test.ErrStr != "" {
+				newChain.ExecOCRParams.ExecuteOffChainConfig.MultipleReportsEnabled = false
+				remoteChains[0].FeeQuoterDestChainConfig.EnforceOutOfOrder = false
+			}
+
 			// deploy donIDClaimer
 			e, err = commonchangeset.Apply(t, e,
 				commonchangeset.Configure(
@@ -456,6 +466,10 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 					},
 				),
 			)
+			if test.ErrStr != "" {
+				require.ErrorContains(t, err, test.ErrStr)
+				return
+			}
 			require.NoError(t, err, "must apply AddCandidatesForNewChainChangeset")
 			state, err = stateview.LoadOnchainState(e)
 			require.NoError(t, err, "must load onchain state")

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e_test.go
@@ -268,8 +268,8 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 			DonIDOffSet: &offset,
 		},
 		{
-			Msg:    "fail when multiple reports are disabled and enforce out of order is disabled",
-			ErrStr: "EnforceOutOfOrder must be set to true in the FeeQuoterDestChainConfig",
+			Msg:    "fail when multiple reports are enabled and enforce out of order is disabled",
+			ErrStr: "EnforceOutOfOrder must be true when MultipleReportsEnabled is true",
 		},
 	}
 
@@ -428,7 +428,7 @@ func TestAddAndPromoteCandidatesForNewChain(t *testing.T) {
 			}
 
 			if test.ErrStr != "" {
-				newChain.ExecOCRParams.ExecuteOffChainConfig.MultipleReportsEnabled = false
+				newChain.ExecOCRParams.ExecuteOffChainConfig.MultipleReportsEnabled = true
 				remoteChains[0].FeeQuoterDestChainConfig.EnforceOutOfOrder = false
 			}
 

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	mcmslib "github.com/smartcontractkit/mcms"
 
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
@@ -22,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
+	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -958,6 +961,23 @@ func (cfg UpdateFeeQuoterDestsConfig) Validate(e cldf.Environment) error {
 			if destination == sc.ChainSelector {
 				return errors.New("source and destination chain cannot be the same")
 			}
+
+			homeChainSelector, err := state.HomeChainSelector()
+			if err != nil {
+				return fmt.Errorf("failed to get home chain selector: %w", err)
+			}
+			execConfigs, err := GetAllActiveExecConfigs(e, homeChainSelector, destination)
+			if err != nil {
+				return fmt.Errorf("failed to get exec configs for destination chain %d: %w", destination, err)
+			}
+
+			for _, execOffchainCfg := range execConfigs {
+				if execOffchainCfg.MultipleReportsEnabled {
+					if !updates[destination].EnforceOutOfOrder {
+						return errors.New("EnforceOutOfOrder must be true when MultipleReportsEnabled is true")
+					}
+				}
+			}
 		}
 	}
 	return nil
@@ -1006,6 +1026,85 @@ func UpdateFeeQuoterDestsChangeset(e cldf.Environment, cfg UpdateFeeQuoterDestsC
 		cfg.ToSequenceInput(s),
 	)
 	return opsutil.AddEVMCallSequenceToCSOutput(e, s, output, report, err, cfg.MCMS, "Call ApplyDestChainConfigUpdates on FeeQuoters")
+}
+
+func GetAllActiveExecConfigs(e cldf.Environment, homeChainSelector uint64, destChainSelector uint64) ([]*pluginconfig.ExecuteOffchainConfig, error) {
+	state, err := stateview.LoadOnchainState(e)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	homeChainState, ok := state.Chains[homeChainSelector]
+	if !ok {
+		return nil, fmt.Errorf("home chain %d not found in state", homeChainSelector)
+	}
+
+	var executeOffchainConfigs []*pluginconfig.ExecuteOffchainConfig
+
+	if homeChainState.CCIPHome == nil {
+		return nil, errors.New("no CCIPHome contract found in the state for home chain")
+	}
+	if homeChainState.CapabilityRegistry == nil {
+		return nil, errors.New("no CapabilityRegistry contract found in the state for home chain")
+	}
+
+	// get capReg from CCIPHome to ensure they match
+	capRegAddr, err := homeChainState.CCIPHome.GetCapabilityRegistry(&bind.CallOpts{
+		Context: e.GetContext(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get capability registry from CCIPHome contract: %w", err)
+	}
+	if capRegAddr != homeChainState.CapabilityRegistry.Address() {
+		return nil, fmt.Errorf("capability registry mismatch: expected %s, got %s", capRegAddr.Hex(), homeChainState.CapabilityRegistry.Address().Hex())
+	}
+
+	ccipDons, err := shared.GetCCIPDonsFromCapRegistry(e.GetContext(), homeChainState.CapabilityRegistry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CCIP Dons from capability registry: %w", err)
+	}
+
+	if len(ccipDons) == 0 {
+		return executeOffchainConfigs, nil
+	}
+
+	for _, don := range ccipDons {
+		execConfigs, err := homeChainState.CCIPHome.GetAllConfigs(&bind.CallOpts{Context: e.GetContext()}, don.Id, uint8(cctypes.PluginTypeCCIPExec))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get exec config for DON %d: %w", don.Id, err)
+		}
+
+		// We only care about active configs. It's possible for a DON to not have an active config.
+		// An empty config will have version 0.
+		if execConfigs.ActiveConfig.Version != 0 {
+			if execConfigs.ActiveConfig.Config.ChainSelector == destChainSelector {
+				signers := make([]ocrtypes.OnchainPublicKey, 0)
+				transmitters := make([]ocrtypes.Account, 0)
+				for _, node := range execConfigs.ActiveConfig.Config.Nodes {
+					signers = append(signers, node.SignerKey)
+					transmitters = append(transmitters, ocrtypes.Account(node.TransmitterKey))
+				}
+				publicConfig, err := ocr3confighelper.PublicConfigFromContractConfig(false, ocrtypes.ContractConfig{
+					Signers:               signers,
+					Transmitters:          transmitters,
+					F:                     execConfigs.ActiveConfig.Config.FRoleDON,
+					OnchainConfig:         []byte{}, // empty OnChainConfig
+					OffchainConfigVersion: execConfigs.ActiveConfig.Config.OffchainConfigVersion,
+					OffchainConfig:        execConfigs.ActiveConfig.Config.OffchainConfig,
+				})
+				if err != nil {
+					return nil, err
+				}
+				execOffchainCfg, err := pluginconfig.DecodeExecuteOffchainConfig(publicConfig.ReportingPluginConfig)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode execute offchain config for don %d: %w", don.Id, err)
+				}
+				executeOffchainConfigs = append(executeOffchainConfigs, &execOffchainCfg)
+			}
+		}
+	}
+
+	return executeOffchainConfigs, nil
 }
 
 type OffRampSourceUpdate struct {

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -456,9 +456,10 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 		accountsFailure[2] = solana.SystemProgramID
 
 		extraArgsFailure, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
-			AccountIsWritableBitmap: solccip.GenerateBitMapForIndexes(writableIndexes),
-			Accounts:                accountsFailure,
-			ComputeUnits:            80_000,
+			AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes(writableIndexes),
+			Accounts:                 accountsFailure,
+			ComputeUnits:             80_000,
+			AllowOutOfOrderExecution: true,
 		})
 		require.NoError(t, err, "failed to serialize extra args for failing message")
 
@@ -485,9 +486,10 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 		}
 
 		extraArgsSuccess, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
-			AccountIsWritableBitmap: solccip.GenerateBitMapForIndexes([]int{0, 1}), // Mark relevant accounts as writable
-			Accounts:                accountsSuccess,
-			ComputeUnits:            80_000,
+			AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}), // Mark relevant accounts as writable
+			Accounts:                 accountsSuccess,
+			ComputeUnits:             80_000,
+			AllowOutOfOrderExecution: true,
 		})
 		require.NoError(t, err, "failed to serialize extra args for successful message")
 

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -372,7 +372,7 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 		", dest chain selector:", destChain,
 	)
 	// connect a single lane, source to dest
-	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &e, state, sourceChain, destChain, false)
+	testhelpers.AddLaneWithEnforceOutOfOrder(t, &e, state, sourceChain, destChain, false)
 
 	var (
 		// nonce    uint64 // Nonce not used as Solana check is skipped


### PR DESCRIPTION
Adds validation in validateExecOffchainConfig to ensure MultipleReportsEnabled is only enabled when all destination chains have EnforceOutOfOrder=true.