### PR TITLE
Add Df ProposeWFJobsV2 changeset

### DIFF
--- a/deployment/data-feeds/changeset/aptos/deploy_data_feeds.go
+++ b/deployment/data-feeds/changeset/aptos/deploy_data_feeds.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cs "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
@@ -55,7 +56,7 @@ func deployDataFeedsLogic(env cldf.Environment, c types.DeployAptosConfig) (cldf
 			datastore.AddressRef{
 				ChainSelector: chainSelector,
 				Address:       dataFeedsResponse.Address.String(),
-				Type:          "ChainlinkDataFeeds",
+				Type:          cs.DataFeedsCache,
 				Version:       semver.MustParse("1.0.0"),
 				Qualifier:     c.Qualifier,
 				Labels:        datastore.NewLabelSet(c.Labels...),

--- a/deployment/data-feeds/changeset/aptos/deploy_data_feeds_test.go
+++ b/deployment/data-feeds/changeset/aptos/deploy_data_feeds_test.go
@@ -48,12 +48,12 @@ func TestDeployAptosCache(t *testing.T) {
 	addrs, err := resp.DataStore.Addresses().Get(
 		datastore.NewAddressRefKey(
 			chainSelector,
-			"ChainlinkDataFeeds",
+			"DataFeedsCache",
 			semver.MustParse("1.0.0"),
 			"aptos",
 		))
 	require.NoError(t, err)
 	require.NotNil(t, addrs.Address)
-	require.Equal(t, datastore.ContractType("ChainlinkDataFeeds"), addrs.Type)
+	require.Equal(t, datastore.ContractType("DataFeedsCache"), addrs.Type)
 	require.Equal(t, "aptos", addrs.Qualifier)
 }

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy.go
@@ -22,7 +22,7 @@ func deployAggregatorProxyLogic(env cldf.Environment, c types.DeployAggregatorPr
 	for index, chainSelector := range c.ChainsToDeploy {
 		chain := env.BlockChains.EVMChains()[chainSelector]
 
-		dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, chainSelector, nil)
+		dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), chainSelector, nil)
 		if dataFeedsCacheAddress == "" {
 			return cldf.ChangesetOutput{}, fmt.Errorf("DataFeedsCache contract address not found in addressbook for chain %d", chainSelector)
 		}

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy.go
@@ -23,7 +23,7 @@ func deployBundleAggregatorProxyLogic(env cldf.Environment, c types.DeployBundle
 	for _, chainSelector := range c.ChainsToDeploy {
 		chain := env.BlockChains.EVMChains()[chainSelector]
 
-		dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, chainSelector, &c.CacheLabel) //nolint:staticcheck // TODO: replace with DataStore when ready
+		dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), chainSelector, &c.CacheLabel) //nolint:staticcheck // TODO: replace with DataStore when ready
 		if dataFeedsCacheAddress == "" {
 			return cldf.ChangesetOutput{}, fmt.Errorf("DataFeedsCache contract address not found in addressbook for chain %d", chainSelector)
 		}

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy.go
@@ -23,7 +23,7 @@ func deployBundleAggregatorProxyLogic(env cldf.Environment, c types.DeployBundle
 	for _, chainSelector := range c.ChainsToDeploy {
 		chain := env.BlockChains.EVMChains()[chainSelector]
 
-		dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), chainSelector, &c.CacheLabel) //nolint:staticcheck // TODO: replace with DataStore when ready
+		dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), chainSelector, &c.CacheLabel) // TODO: replace with DataStore when ready
 		if dataFeedsCacheAddress == "" {
 			return cldf.ChangesetOutput{}, fmt.Errorf("DataFeedsCache contract address not found in addressbook for chain %d", chainSelector)
 		}
@@ -49,7 +49,7 @@ func deployBundleAggregatorProxyPrecondition(env cldf.Environment, c types.Deplo
 		if !ok {
 			return errors.New("chain not found in environment")
 		}
-		_, err := env.ExistingAddresses.AddressesForChain(chainSelector) //nolint:staticcheck // TODO: replace with DataStore when ready
+		_, err := env.ExistingAddresses.AddressesForChain(chainSelector) // TODO: replace with DataStore when ready
 		if err != nil {
 			return fmt.Errorf("failed to get addessbook for chain %d: %w", chainSelector, err)
 		}

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
@@ -45,7 +45,7 @@ func TestBundleAggregatorProxy(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	addrs, err := resp.ExistingAddresses.AddressesForChain(chainSelector) //nolint:staticcheck // TODO: replace with DataStore when ready
+	addrs, err := resp.ExistingAddresses.AddressesForChain(chainSelector) // TODO: replace with DataStore when ready
 	require.NoError(t, err)
 	require.Len(t, addrs, 2) // BundleAggregatorProxy and DataFeedsCache
 }

--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
@@ -42,7 +42,7 @@ func proposeWFJobsToJDLogic(env cldf.Environment, c types.ProposeWFJobsConfig) (
 	workflowSpecConfig := c.WorkflowSpecConfig
 	workflowState := feedState.Workflows[workflowSpecConfig.WorkflowName]
 
-	//nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+	// Addressbook is deprecated, but we still use it for the time being
 	cacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), c.ChainSelector, &c.CacheLabel)
 
 	// default values
@@ -187,7 +187,7 @@ func proposeWFJobsToJDPrecondition(env cldf.Environment, c types.ProposeWFJobsCo
 		return fmt.Errorf("no workflow found for hash %s in %s", c.WorkflowSpecConfig.WorkflowName, inputFileName)
 	}
 
-	//nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+	// Addressbook is deprecated, but we still use it for the time being
 	cacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), c.ChainSelector, &c.CacheLabel)
 	if cacheAddress == "" {
 		return errors.New("failed to get data feeds cache address")

--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
@@ -105,10 +105,6 @@ func proposeWFJobsToJDV2Logic(env cldf.Environment, c types.ProposeWFJobsV2Confi
 }
 
 func proposeWFJobsToJDV2Precondition(env cldf.Environment, c types.ProposeWFJobsV2Config) error {
-	if c.MigrationName == "" {
-		return errors.New("migration name is required")
-	}
-
 	if c.WorkflowJobName == "" {
 		return errors.New("workflow job name is required")
 	}

--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
@@ -51,7 +51,7 @@ func proposeWFJobsToJDV2Logic(env cldf.Environment, c types.ProposeWFJobsV2Confi
 	workflowSpecConfig := c.WorkflowSpecConfig
 	workflowState := feedState.Workflows[workflowSpecConfig.WorkflowName]
 
-	//nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+	// Addressbook is deprecated, but we still use it for the time being
 	cacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), c.ChainSelector, &c.CacheLabel)
 
 	// default values
@@ -94,7 +94,7 @@ func proposeWFJobsToJDV2Logic(env cldf.Environment, c types.ProposeWFJobsV2Confi
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to create workflow job spec: %w", err)
 	}
 
-	//propose workflow jobs to JD
+	// propose workflow jobs to JD
 	out, err := offchain.ProposeJobs(ctx, env, workflowJobSpec, &workflowSpecConfig.WorkflowName, c.NodeFilter)
 	if err != nil {
 		env.Logger.Debugf("%s", workflowJobSpec)
@@ -156,7 +156,7 @@ func proposeWFJobsToJDV2Precondition(env cldf.Environment, c types.ProposeWFJobs
 		return fmt.Errorf("no workflow found for hash %s in %s", c.WorkflowSpecConfig.WorkflowName, feedStatePath)
 	}
 
-	//nolint:staticcheck // Addressbook is deprecated, but we still use it for the time being
+	// Addressbook is deprecated, but we still use it for the time being
 	cacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), c.ChainSelector, &c.CacheLabel)
 	if cacheAddress == "" {
 		return errors.New("failed to get data feeds cache address")
@@ -198,6 +198,9 @@ func readFeedStateFile(inputFileName string) (*v1_0.FeedState, error) {
 	var feedState *v1_0.FeedState
 
 	err = json.Unmarshal(content, &feedState)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal feed state from %s: %w", inputFileName, err)
+	}
 	return feedState, nil
 }
 

--- a/deployment/data-feeds/changeset/new_feed_with_proxy.go
+++ b/deployment/data-feeds/changeset/new_feed_with_proxy.go
@@ -28,7 +28,7 @@ func newFeedWithProxyLogic(env cldf.Environment, c types.NewFeedWithProxyConfig)
 	chainState := state.Chains[c.ChainSelector]
 	ab := cldf.NewMemoryAddressBook()
 
-	dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, c.ChainSelector, nil)
+	dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), c.ChainSelector, nil)
 	if dataFeedsCacheAddress == "" {
 		return cldf.ChangesetOutput{}, fmt.Errorf("DataFeedsCache contract address not found in addressbook for chain %d", c.ChainSelector)
 	}

--- a/deployment/data-feeds/changeset/set_bundle_feed_config.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config.go
@@ -74,7 +74,7 @@ func setBundleFeedConfigPrecondition(env cldf.Environment, c types.SetFeedBundle
 	}
 
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil { //nolint:staticcheck // TODO: replace with DataStore when ready
+		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil { // TODO: replace with DataStore when ready
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
@@ -49,7 +49,7 @@ func TestSetBundleFeedConfig(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache") //nolint:staticcheck // TODO: replace with DataStore when ready
+	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache") // TODO: replace with DataStore when ready
 	require.NoError(t, err)
 
 	dataid := "0x01bb0467f50003040000000000000000"
@@ -83,7 +83,7 @@ func TestSetBundleFeedConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// with MCMS
-	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock") //nolint:staticcheck // TODO: replace with DataStore when ready
+	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock") // TODO: replace with DataStore when ready
 	require.NoError(t, err)
 
 	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(

--- a/deployment/data-feeds/changeset/state.go
+++ b/deployment/data-feeds/changeset/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+
 	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 	cldf_chain_utils "github.com/smartcontractkit/chainlink-deployments-framework/chain/utils"
 
@@ -36,8 +37,7 @@ import (
 )
 
 var (
-	DataFeedsCache            cldf.ContractType      = "DataFeedsCache"
-	ChainlinkDataFeedsPackage datastore.ContractType = "ChainlinkDataFeeds"
+	DataFeedsCache datastore.ContractType = "DataFeedsCache"
 )
 
 type DataFeedsChainState struct {
@@ -104,10 +104,10 @@ func LoadChainState(logger logger.Logger, chain cldf_evm.Chain, addresses map[st
 	}
 	state.MCMSWithTimelockState = *mcmsWithTimelock
 
-	dfCacheTV := cldf.NewTypeAndVersion(DataFeedsCache, deployment.Version1_0_0)
+	dfCacheTV := cldf.NewTypeAndVersion("DataFeedsCache", deployment.Version1_0_0)
 	dfCacheTV.Labels.Add("data-feeds")
 
-	devPlatformCacheTV := cldf.NewTypeAndVersion(DataFeedsCache, deployment.Version1_0_0)
+	devPlatformCacheTV := cldf.NewTypeAndVersion("DataFeedsCache", deployment.Version1_0_0)
 	devPlatformCacheTV.Labels.Add("dev-platform")
 
 	state.DataFeedsCache = make(map[common.Address]*cache.DataFeedsCache)
@@ -150,7 +150,7 @@ func LoadAptosChainState(logger logger.Logger, chain cldf_aptos.Chain, addresses
 	state.DataFeeds = make(map[aptos.AccountAddress]*modulefeeds.DataFeeds)
 
 	for _, address := range addresses {
-		if address.Type == ChainlinkDataFeedsPackage {
+		if address.Type == DataFeedsCache {
 			feedsAddress := aptos.AccountAddress{}
 			err := feedsAddress.ParseStringRelaxed(address.Address)
 			if err != nil {

--- a/deployment/data-feeds/changeset/types/types.go
+++ b/deployment/data-feeds/changeset/types/types.go
@@ -190,8 +190,7 @@ type ProposeWFJobsConfig struct {
 
 type ProposeWFJobsV2Config struct {
 	ChainSelector      uint64                `json:"chainSelector"`
-	CacheLabel         string                `json:"cacheLabel"`      // Label for the DataFeedsCache contract in AB
-	MigrationName      string                `json:"migrationName"`   // Name of the migration in CLD
+	CacheLabel         string                `json:"cacheLabel"`      // Label for the DataFeedsCache contract in AB, or qualifier in DataStore
 	Domain             string                `json:"domain"`          // default to data-feeds
 	WorkflowJobName    string                `json:"workflowJobName"` // Required
 	WorkflowSpecConfig WorkflowSpecConfig    `json:"workflowSpecConfig"`

--- a/deployment/data-feeds/changeset/types/types.go
+++ b/deployment/data-feeds/changeset/types/types.go
@@ -163,19 +163,19 @@ type NodeConfig struct {
 }
 
 type WorkflowSpecConfig struct {
-	TargetContractEncoderType        string // Required. "data-feeds_decimal", "aptos" or "ccip"
-	ConsensusAggregationMethod       string // Required. "llo_streams" or "data_feeds"
-	WorkflowName                     string // Required
-	ConsensusReportID                string // Required
-	WriteTargetTrigger               string // Required
-	ConsensusRef                     string // Default "data-feeds"
-	ConsensusConfigKeyID             string // Default "evm"
-	ConsensusAllowedPartialStaleness string
-	DeltaStageSec                    *int   // Default 45
-	TargetsSchedule                  string // Default "oneAtATime"
-	TargetProcessor                  string
-	TriggersMaxFrequencyMs           *int // Default 5000
-	CREStepTimeout                   int64
+	TargetContractEncoderType        string `json:"targetContractEncoderType"`  // Required. "data-feeds_decimal", "aptos" or "ccip"
+	ConsensusAggregationMethod       string `json:"consensusAggregationMethod"` // Required. "llo_streams" or "data_feeds"
+	WorkflowName                     string `json:"workflowName"`               // Required
+	ConsensusReportID                string `json:"consensusReportID"`          // Required
+	WriteTargetTrigger               string `json:"writeTargetTrigger"`         // Required
+	ConsensusRef                     string `json:"consensusRef"`               // Default "data-feeds"
+	ConsensusConfigKeyID             string `json:"consensusConfigKeyID"`       // Default "evm"
+	ConsensusAllowedPartialStaleness string `json:"consensusAllowedPartialStaleness"`
+	DeltaStageSec                    *int   `json:"deltaStageSec"`   // Default 45
+	TargetsSchedule                  string `json:"targetsSchedule"` // Default "oneAtATime"
+	TargetProcessor                  string `json:"targetProcessor"`
+	TriggersMaxFrequencyMs           *int   `json:"triggersMaxFrequencyMs"` // Default 5000
+	CREStepTimeout                   int64  `json:"creStepTimeout"`
 }
 
 type ProposeWFJobsConfig struct {
@@ -186,6 +186,16 @@ type ProposeWFJobsConfig struct {
 	WorkflowJobName    string   // Required
 	WorkflowSpecConfig WorkflowSpecConfig
 	NodeFilter         *offchain.NodesFilter // Required. Node filter to select the nodes to send the jobs to.
+}
+
+type ProposeWFJobsV2Config struct {
+	ChainSelector      uint64                `json:"chainSelector"`
+	CacheLabel         string                `json:"cacheLabel"`      // Label for the DataFeedsCache contract in AB
+	MigrationName      string                `json:"migrationName"`   // Name of the migration in CLD
+	Domain             string                `json:"domain"`          // default to data-feeds
+	WorkflowJobName    string                `json:"workflowJobName"` // Required
+	WorkflowSpecConfig WorkflowSpecConfig    `json:"workflowSpecConfig"`
+	NodeFilter         *offchain.NodesFilter `json:"nodeFilter"` // Required. Node filter to select the nodes to send the jobs to.
 }
 
 type ProposeBtJobsConfig struct {

--- a/deployment/data-feeds/changeset/utils.go
+++ b/deployment/data-feeds/changeset/utils.go
@@ -102,9 +102,16 @@ func GetDecimalsFromFeedID(feedID string) (uint8, error) {
 }
 
 func GetDataFeedsCacheAddress(ab cldf.AddressBook, dataStore datastore.AddressRefStore, chainSelector uint64, label *string) string {
+	var qualifier string
+	if label != nil {
+		qualifier = *label
+	} else {
+		qualifier = "data-feeds"
+	}
+
 	// try to find the address in datastore, fallback to addressbook
 	record, err := dataStore.Get(
-		datastore.NewAddressRefKey(chainSelector, DataFeedsCache, &deployment.Version1_0_0, *label),
+		datastore.NewAddressRefKey(chainSelector, DataFeedsCache, &deployment.Version1_0_0, qualifier),
 	)
 	if err == nil {
 		return record.Address
@@ -113,11 +120,7 @@ func GetDataFeedsCacheAddress(ab cldf.AddressBook, dataStore datastore.AddressRe
 	// legacy addressbook
 	dataFeedsCacheAddress := ""
 	cacheTV := cldf.NewTypeAndVersion("DataFeedsCache", deployment.Version1_0_0)
-	if *label != "" {
-		cacheTV.Labels.Add(*label)
-	} else {
-		cacheTV.Labels.Add("data-feeds")
-	}
+	cacheTV.Labels.Add(qualifier)
 
 	address, err := ab.AddressesForChain(chainSelector)
 	if err != nil {

--- a/deployment/data-feeds/changeset/utils.go
+++ b/deployment/data-feeds/changeset/utils.go
@@ -113,7 +113,7 @@ func GetDataFeedsCacheAddress(ab cldf.AddressBook, dataStore datastore.AddressRe
 	// legacy addressbook
 	dataFeedsCacheAddress := ""
 	cacheTV := cldf.NewTypeAndVersion("DataFeedsCache", deployment.Version1_0_0)
-	if &label != nil {
+	if *label != "" {
 		cacheTV.Labels.Add(*label)
 	} else {
 		cacheTV.Labels.Add("data-feeds")

--- a/deployment/data-feeds/offchain/jd.go
+++ b/deployment/data-feeds/offchain/jd.go
@@ -17,12 +17,12 @@ import (
 )
 
 type NodesFilter struct {
-	DONID        uint64 // Required
-	EnvLabel     string
-	ProductLabel string
-	Size         int
-	IsBootstrap  bool
-	NodeIDs      []string // Optional, if other filters are provided
+	DONID        uint64   `json:"donId"` // Required
+	EnvLabel     string   `json:"envLabel"`
+	ProductLabel string   `json:"productLabel"`
+	Size         int      `json:"size"`
+	IsBootstrap  bool     `json:"isBootstrap"`
+	NodeIDs      []string `json:"nodeIds"` // Optional, if other filters are provided
 }
 
 func (f *NodesFilter) filter() *nodeapiv1.ListNodesRequest_Filter {


### PR DESCRIPTION
[DF-21407](https://smartcontract-it.atlassian.net/browse/DF-21407)

[DF-21407]: https://smartcontract-it.atlassian.net/browse/DF-21407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


Added new changeset `ProposeWFJobsV2` which is very similar to `ProposeWFJobs`, but 
- It supports durable pipelines
- It reads feeds json mapping without inputFS
- It reads only selected feeds from feeds json mapping based on workflow name

Changed `GetDataFeedsCacheAddress` function to first try to read the cache address from DataStore and only then searches Addressbook

Increased the ProposeWFJobs timeout from 120 to 240 seconds

