### PR TITLE
delete only undeleted jobs

### DIFF
--- a/deployment/data-feeds/changeset/jd_delete_jobs.go
+++ b/deployment/data-feeds/changeset/jd_delete_jobs.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	deleteJobTimeout = 120 * time.Second
+	deleteJobTimeout = 5 * time.Minute
 )
 
 // DeleteJobsJDChangeset is a changeset that deletes jobs from JD either using job ids or workflow name

--- a/deployment/data-feeds/offchain/jd.go
+++ b/deployment/data-feeds/offchain/jd.go
@@ -167,9 +167,13 @@ func DeleteJobs(ctx context.Context, env cldf.Environment, jobIDs []string, work
 			return
 		}
 		for _, job := range listJobResponse.Jobs {
-			jobIDs = append(jobIDs, job.Id)
+			if job.DeletedAt == nil {
+				jobIDs = append(jobIDs, job.Id)
+			}
 		}
 	}
+
+	env.Logger.Debugf("Jobs to delete %s", jobIDs)
 
 	for _, jobID := range jobIDs {
 		env.Logger.Debugf("Deleting job %s", jobID)


### PR DESCRIPTION
Increased deleteJobTimeout from 2 to 5 minutes
Fixed a bug to only delete undeleted jobs. 