### PR TITLE
Enable ZK Sync in CRIB

### DIFF
--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -136,7 +136,7 @@ func DeployHomeChainContracts(ctx context.Context, lggr logger.Logger, envConfig
 }
 
 // DeployCCIPAndAddLanes is the actual ccip setup once the nodes are initialized.
-func DeployCCIPAndAddLanes(ctx context.Context, lggr logger.Logger, envConfig devenv.EnvironmentConfig, homeChainSel, feedChainSel uint64, ab cldf.AddressBook, rmnEnabled bool) (DeployCCIPOutput, error) {
+func DeployCCIPAndAddLanes(ctx context.Context, lggr logger.Logger, envConfig devenv.EnvironmentConfig, homeChainSel, feedChainSel uint64, ab cldf.AddressBook, rmnEnabled bool, evmFundingEth uint64) (DeployCCIPOutput, error) {
 	e, don, err := devenv.NewEnvironment(func() context.Context { return ctx }, lggr, envConfig)
 	if err != nil {
 		return DeployCCIPOutput{}, fmt.Errorf("failed to initiate new environment: %w", err)
@@ -181,7 +181,7 @@ func DeployCCIPAndAddLanes(ctx context.Context, lggr logger.Logger, envConfig de
 	// we need to use the nodeinfo from the envConfig here, because multiAddr is not
 	// populated in the environment variable
 	lggr.Infow("distributing funds...")
-	err = distributeTransmitterFunds(lggr, don.PluginNodes(), *e)
+	err = distributeTransmitterFunds(lggr, don.PluginNodes(), *e, evmFundingEth)
 	if err != nil {
 		return DeployCCIPOutput{}, fmt.Errorf("failed to distribute funds to node transmitters: %w", err)
 	}
@@ -197,7 +197,7 @@ func DeployCCIPAndAddLanes(ctx context.Context, lggr logger.Logger, envConfig de
 }
 
 // ConfigureCCIPOCR is a group of changesets used from CRIB to redeploy the chainlink don on an existing setup
-func ConfigureCCIPOCR(ctx context.Context, lggr logger.Logger, envConfig devenv.EnvironmentConfig, homeChainSel, feedChainSel uint64, ab cldf.AddressBook, rmnEnabled bool) (DeployCCIPOutput, error) {
+func ConfigureCCIPOCR(ctx context.Context, lggr logger.Logger, envConfig devenv.EnvironmentConfig, homeChainSel, feedChainSel uint64, ab cldf.AddressBook, rmnEnabled bool, evmFundingEth uint64) (DeployCCIPOutput, error) {
 	e, don, err := devenv.NewEnvironment(func() context.Context { return ctx }, lggr, envConfig)
 	if err != nil {
 		return DeployCCIPOutput{}, fmt.Errorf("failed to initiate new environment: %w", err)
@@ -209,7 +209,7 @@ func ConfigureCCIPOCR(ctx context.Context, lggr logger.Logger, envConfig devenv.
 	if err != nil {
 		return DeployCCIPOutput{}, fmt.Errorf("failed to apply changesets for setting up OCR: %w", err)
 	}
-	err = distributeTransmitterFunds(lggr, don.PluginNodes(), *e)
+	err = distributeTransmitterFunds(lggr, don.PluginNodes(), *e, evmFundingEth)
 	if err != nil {
 		return DeployCCIPOutput{}, err
 	}
@@ -226,7 +226,7 @@ func ConfigureCCIPOCR(ctx context.Context, lggr logger.Logger, envConfig devenv.
 
 // FundCCIPTransmitters is used from CRIB to provide funds to the node transmitters
 // This function sends funds from the deployer key to the chainlink node transmitters
-func FundCCIPTransmitters(ctx context.Context, lggr logger.Logger, envConfig devenv.EnvironmentConfig, ab cldf.AddressBook) (DeployCCIPOutput, error) {
+func FundCCIPTransmitters(ctx context.Context, lggr logger.Logger, envConfig devenv.EnvironmentConfig, ab cldf.AddressBook, evmFundingEth uint64) (DeployCCIPOutput, error) {
 	e, don, err := devenv.NewEnvironment(func() context.Context { return ctx }, lggr, envConfig)
 	if err != nil {
 		return DeployCCIPOutput{}, fmt.Errorf("failed to initiate new environment: %w", err)
@@ -237,7 +237,7 @@ func FundCCIPTransmitters(ctx context.Context, lggr logger.Logger, envConfig dev
 	// we need to use the nodeinfo from the envConfig here, because multiAddr is not
 	// populated in the environment variable
 	lggr.Infow("distributing funds...")
-	err = distributeTransmitterFunds(lggr, don.PluginNodes(), *e)
+	err = distributeTransmitterFunds(lggr, don.PluginNodes(), *e, evmFundingEth)
 	if err != nil {
 		return DeployCCIPOutput{}, err
 	}


### PR DESCRIPTION
- Added ZK configs to `ChainConfig` - this is passed directly into `cldf.Chain`
- Use gas estimations - it will fallback to the old values if failing
- and enable custom amount for node funding

Result of contract deploy without EVM interpreter:
<img width="1291" alt="Screenshot 2025-06-13 at 3 38 04 PM" src="https://github.com/user-attachments/assets/5cdbc912-0d9a-4e32-8787-7c5cd55c7ff1" />

Note that when EVM interpreter is used an [EVM] flag is shown in the explorer:
<img width="1297" alt="Screenshot 2025-06-13 at 3 39 38 PM" src="https://github.com/user-attachments/assets/916cddc2-07a3-4589-9eee-eff5594757a9" />

Result of node funding with 1 ETH:
<img width="565" alt="Screenshot 2025-06-13 at 3 24 55 PM" src="https://github.com/user-attachments/assets/ddb005bb-64b4-4691-a8f5-b5cf99370aa5" />

Usage in CRIB `ccip-v2-scripts/config/config.go`:
```go
	zkDetails, err := chainsel.GetChainDetailsByChainIDAndFamily("300", "evm")
	if err != nil {
		return nil, fmt.Errorf("error getting zk details: %v", err)
	}
	zkSepoliaChain := devenv.ChainConfig{
		ChainID:   "300",
		ChainName: zkDetails.ChainName,
		ChainType: EVM.String(),
		WSRPCs: []devenv.CribRPCs{{
			External: "xxx",
			Internal: "xxx",
		}},
		HTTPRPCs: []devenv.CribRPCs{{
			External: "xxx",
			Internal: "xxx",
		}},
	}
	testKey := "xxx"
	err = zkSepoliaChain.SetDeployerKey(&testKey)
	if err != nil {
		return nil, fmt.Errorf("error setting deployer key: %v", err)
	}

	client, err := ethclient.Dial("xxx")
	if err != nil {
		return nil, fmt.Errorf("error creating eth client: %v", err)
	}
	clientZk := clients.NewClient(client.Client())
	deployerZk, err := accounts.NewWallet(common.Hex2Bytes(testKey), clientZk, nil)
	if err != nil {
		return nil, fmt.Errorf("error creating zk deployer wallet: %v", err)
	}
	zkSepoliaChain.IsZkSyncVM = true
	zkSepoliaChain.ClientZkSyncVM = clientZk
	zkSepoliaChain.DeployerKeyZkSyncVM = deployerZk

	chainConfigs = append(chainConfigs, zkSepoliaChain)
```