### PR TITLE
[CAPPL-938] Create CRE plugins image

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -133,6 +133,39 @@ jobs:
       AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
+  build-sign-publish-chainlink-cre:
+    needs: [checks]
+    if: needs.checks.outputs.git-tag-type == 'core'
+    permissions:
+      contents: read
+      id-token: write
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
+    with:
+      aws-ecr-name: chainlink
+      aws-region-ecr: us-east-1
+      aws-region-gati: us-west-2
+      dockerfile: core/chainlink.cre.Dockerfile
+      docker-build-context: .
+      docker-build-args: |
+        CHAINLINK_USER=chainlink
+        COMMIT_SHA=${{ github.sha }}
+        CL_INSTALL_PRIVATE_PLUGINS=true
+        CL_APTOS_CMD=chainlink-aptos
+      docker-cache-behaviour: "disable"
+      docker-manifest-sign: true
+      docker-registry-url-override: public.ecr.aws/chainlink
+      docker-tag-custom-suffix: "-cre"
+      git-sha: ${{ github.sha }}
+      github-event-name: ${{ github.event_name }}
+      github-ref-name: ${{ github.ref_name }}
+      github-ref-type: ${{ github.ref_type}}
+      github-workflow-repository: ${{ github.repository }}
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
+      AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_SDLC_BUILD_PUBLISH_ARN }}
+      AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+      AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+
   # Notify Slack channel for new git tags.
   slack-notify:
     if: github.ref_type == 'tag'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -122,6 +122,39 @@ jobs:
       AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
       AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
+  docker-cre:
+    needs: [init]
+    if: ${{ needs.init.outputs.should-run == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
+    with:
+      aws-ecr-name: chainlink
+      aws-region-ecr: us-west-2
+      aws-region-gati: us-west-2
+      dockerfile: core/chainlink.cre.Dockerfile
+      docker-build-context: .
+      docker-build-args: |
+        CHAINLINK_USER=chainlink
+        COMMIT_SHA=${{ github.sha }}
+        CL_INSTALL_PRIVATE_PLUGINS=true
+        CL_APTOS_CMD=chainlink-aptos
+      docker-manifest-sign: true
+      docker-tag-custom-suffix: "-cre"
+      git-sha: ${{ inputs.git-ref || github.sha }}
+      github-event-name: ${{ github.event_name }}
+      github-ref-name: ${{ github.ref_name }}
+      github-ref-type: ${{ github.ref_type}}
+      github-workflow-repository: ${{ github.repository }}
+      github-runner-arm64: ${{ needs.init.outputs.runner-arm64 }}
+      github-runner-amd64: ${{ needs.init.outputs.runner-amd64 }}
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_SDLC }}
+      AWS_ROLE_PUBLISH_ARN: ${{ secrets.AWS_OIDC_IAM_ROLE_BUILD_PUBLISH_DEVELOP_PR }}
+      AWS_ROLE_GATI_ARN: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+      AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+
   docker-core-plugins-testing:
     needs: [init]
     if: ${{ needs.init.outputs.should-run == 'true' }}

--- a/core/chainlink.cre.Dockerfile
+++ b/core/chainlink.cre.Dockerfile
@@ -1,0 +1,98 @@
+##
+# Build image: Chainlink binary with plugins.
+##
+FROM golang:1.24-bullseye AS buildgo
+RUN go version
+RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /chainlink
+
+COPY GNUmakefile package.json ./
+COPY tools/bin/ldflags ./tools/bin/
+
+ADD go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+COPY . .
+
+# Install Delve for debugging with cache mounts
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go install github.com/go-delve/delve/cmd/dlv@v1.24.2
+
+# Flag to control installation of private plugins (default: false).
+ARG CL_INSTALL_PRIVATE_PLUGINS=false
+# Flag to control installation of testing plugins (default: false).
+ARG CL_INSTALL_TESTING_PLUGINS=false
+# Flags for Go Delve debugger
+ARG GO_GCFLAGS
+# Env vars needed for chainlink build
+ARG COMMIT_SHA
+
+ENV CL_LOOPINSTALL_OUTPUT_DIR=/tmp/loopinstall-output
+RUN --mount=type=secret,id=GIT_AUTH_TOKEN \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    ./plugins/scripts/setup_git_auth.sh && \
+    mkdir -p /gobins && mkdir -p "${CL_LOOPINSTALL_OUTPUT_DIR}" && \
+    GOBIN=/go/bin make install-loopinstall && \
+    GOBIN=/gobins CL_LOOPINSTALL_OUTPUT_DIR=${CL_LOOPINSTALL_OUTPUT_DIR} make install-cre-plugins-local install-cre-plugins-public && \
+    if [ "${CL_INSTALL_PRIVATE_PLUGINS}" = "true" ]; then \
+        GOBIN=/gobins CL_LOOPINSTALL_OUTPUT_DIR=${CL_LOOPINSTALL_OUTPUT_DIR} make install-cre-plugins-private; \
+    fi && \
+    if [ "${CL_INSTALL_TESTING_PLUGINS}" = "true" ]; then \
+        GOBIN=/gobins CL_LOOPINSTALL_OUTPUT_DIR=${CL_LOOPINSTALL_OUTPUT_DIR} make install-cre-plugins-testing; \
+    fi
+
+# Copy any shared libraries.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    mkdir -p /tmp/lib && \
+    ./plugins/scripts/copy_loopinstall_libs.sh \
+    "$CL_LOOPINSTALL_OUTPUT_DIR" \
+    /tmp/lib
+
+# Build chainlink.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOBIN=/gobins make GO_GCFLAGS="${GO_GCFLAGS}" install-chainlink
+
+##
+# Final Image
+##
+FROM ubuntu:24.04
+
+ARG CHAINLINK_USER=root
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y ca-certificates gnupg lsb-release curl && rm -rf /var/lib/apt/lists/*
+
+# Install Postgres for CLI tools, needed specifically for DB backups
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |tee /etc/apt/sources.list.d/pgdg.list \
+  && apt-get update && apt-get install -y postgresql-client-16 \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN if [ ${CHAINLINK_USER} != root ]; then useradd --uid 14933 --create-home ${CHAINLINK_USER}; fi
+USER ${CHAINLINK_USER}
+
+# Copy Delve debugger from build stage.
+COPY --from=buildgo /go/bin/dlv /usr/local/bin/dlv
+
+# Set plugin environment variable configuration.
+ARG CL_APTOS_CMD
+ENV CL_APTOS_CMD=${CL_APTOS_CMD}
+
+# Copy the binaries from the build stage (plugins + chainlink).
+COPY --from=buildgo /gobins/ /usr/local/bin/
+# Copy shared libraries from the build stage.
+COPY --from=buildgo /tmp/lib /usr/lib/
+
+WORKDIR /home/${CHAINLINK_USER}
+
+# Explicitly set the cache dir. Needed so both root and non-root user has an explicit location.
+ENV XDG_CACHE_HOME=/home/${CHAINLINK_USER}/.cache
+RUN mkdir -p ${XDG_CACHE_HOME}
+
+EXPOSE 6688
+ENTRYPOINT ["chainlink"]
+HEALTHCHECK CMD curl -f http://localhost:6688/health || exit 1
+CMD ["local", "node"]

--- a/core/cre-plugins.private.yaml
+++ b/core/cre-plugins.private.yaml
@@ -1,0 +1,29 @@
+# This file defines private plugins to be installed via `loopinstall`.
+
+# Common plugin configuration
+defaults:
+  # The `-s` flag is added to strip debug information from the binary to reduce
+  # the binary size for releases.
+  # See: `go tool link -help`
+  goflags: "-ldflags=-s"
+
+plugins:
+  cron:
+    - moduleURI: "github.com/smartcontractkit/capabilities/cron"
+      gitRef: "1b414f8954d071345255fa0ffb3c374b13f18a0d"
+      installPath: "github.com/smartcontractkit/capabilities/cron"
+  kvstore:
+    - enabled: false
+      moduleURI: "github.com/smartcontractkit/capabilities/kvstore"
+      gitRef: "1b414f8954d071345255fa0ffb3c374b13f18a0d"
+      installPath: "github.com/smartcontractkit/capabilities/kvstore"
+  readcontract:
+    - moduleURI: "github.com/smartcontractkit/capabilities/readcontract"
+      gitRef: "1b414f8954d071345255fa0ffb3c374b13f18a0d"
+      installPath: "github.com/smartcontractkit/capabilities/readcontract"
+  workflowevent:
+    - enabled: false
+      moduleURI: "github.com/smartcontractkit/capabilities/workflowevent"
+      gitRef: "1b414f8954d071345255fa0ffb3c374b13f18a0d"
+      installPath: "github.com/smartcontractkit/capabilities/workflowevent"
+

--- a/core/cre-plugins.public.yaml
+++ b/core/cre-plugins.public.yaml
@@ -1,0 +1,43 @@
+# This file defines public plugins to be installed via `loopinstall`.
+
+# Common plugin configuration
+defaults:
+  # The `-s` flag is added to strip debug information from the binary to reduce
+  # the binary size for releases.
+  # See: `go tool link -help`
+  goflags: "-ldflags=-s"
+
+plugins:
+  aptos:
+    - moduleURI: "github.com/smartcontractkit/chainlink-aptos"
+      gitRef: "547303093feb4adcbb2ef1c822b0760d0235c732"
+      installPath: "github.com/smartcontractkit/chainlink-aptos/cmd/chainlink-aptos"
+  cosmos:
+    - moduleURI: "github.com/smartcontractkit/chainlink-cosmos"
+      # Git reference - can be a tag, branch, or commit hash
+      # If not specified, uses the latest version.
+      gitRef: "f740e9ae54e79762991bdaf8ad6b50363261c056" # 2025-02-07
+      installPath: "github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/cmd/chainlink-cosmos"
+      # These will be copied into /usr/lib in the container.
+      libs:
+        - /go/pkg/mod/github.com/!cosm!wasm/wasmvm@v*/internal/api/libwasmvm.*.so
+
+  feeds:
+    - moduleURI: "github.com/smartcontractkit/chainlink-feeds"
+      gitRef: "v0.1.2-0.20250227211209-7cd000095135"
+      installPath: "github.com/smartcontractkit/chainlink-feeds/cmd/chainlink-feeds"
+
+  solana:
+    - moduleURI: "github.com/smartcontractkit/chainlink-solana"
+      gitRef: "v1.1.2-0.20250611193111-99542a0c5d58"
+      installPath: "github.com/smartcontractkit/chainlink-solana/pkg/solana/cmd/chainlink-solana"
+
+  starknet:
+    - moduleURI: "github.com/smartcontractkit/chainlink-starknet/relayer"
+      gitRef: "7e854bab99ef4a9cdbaa8dc2cac1fdf059238682" # 2025-05-15
+      installPath: "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/cmd/chainlink-starknet"
+
+  streams:
+    - moduleURI: "github.com/smartcontractkit/chainlink-data-streams"
+      gitRef: "v0.1.1-0.20250604171706-a98fa6515eae"
+      installPath: "github.com/smartcontractkit/chainlink-data-streams/mercury/cmd/chainlink-mercury"

--- a/core/cre-plugins.testing.yaml
+++ b/core/cre-plugins.testing.yaml
@@ -1,0 +1,17 @@
+# This file defines testing plugins to be installed via `loopinstall`.
+# This file should only include testing plugins that are not meant to be released to the public. Relayer and other plugins that make it into the final release should not be added here. They should be tested within their own repo's CI pipelines.
+
+# Common plugin configuration
+defaults:
+  # The `-s` flag is added to strip debug information from the binary to reduce
+  # the binary size for releases.
+  # See: `go tool link -help`
+  goflags: "-ldflags=-s"
+
+plugins:
+  mock:
+    - enabled: true
+      moduleURI: "github.com/smartcontractkit/capabilities/mock"
+      gitRef: "6eeb6eb0ca6751db8ceabcbe8461df8748f17361"
+      installPath: "github.com/smartcontractkit/capabilities/mock"
+


### PR DESCRIPTION
Create a CRE-specific dockerfile, with plugins.yaml. This divorces CRE image builds from the existing plugins build, allowing the CRE team to maintain our own build and protect against backwards incompatible changes being made to the plugins build.