### PR TITLE
Add keystore service to standardcapabilities delegate

### DIFF
--- a/core/capabilities/fakes/standard_capabilities_mocks.go
+++ b/core/capabilities/fakes/standard_capabilities_mocks.go
@@ -22,6 +22,15 @@ func (k *KVStoreMock) Get(ctx context.Context, key string) ([]byte, error) {
 	return nil, nil
 }
 
+type KeystoreMock struct{}
+
+func (k *KeystoreMock) Accounts(ctx context.Context) (accounts []string, err error) {
+	return nil, nil
+}
+func (k *KeystoreMock) Sign(ctx context.Context, account string, data []byte) (signed []byte, err error) {
+	return nil, nil
+}
+
 type ErrorLogMock struct{}
 
 func (e *ErrorLogMock) SaveError(ctx context.Context, msg string) error {

--- a/core/services/standardcapabilities/delegate.go
+++ b/core/services/standardcapabilities/delegate.go
@@ -2,6 +2,7 @@ package standardcapabilities
 
 import (
 	"context"
+	"crypto"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -111,6 +112,18 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 	log := d.logger.Named("StandardCapabilities").Named(spec.StandardCapabilitiesSpec.GetID())
 
 	kvStore := job.NewKVStore(spec.ID, d.ds)
+
+	var accountIds []string
+	var signers []crypto.Signer
+	key, err := d.ks.P2P().GetOrFirst(d.peerWrapper.PeerID)
+	if err != nil {
+		log.Warnw("Failed to get P2P key", "error", err, "peerID", d.peerWrapper.PeerID)
+	} else {
+		accountIds = append(accountIds, "P2P_SIGNER")
+		signers = append(signers, key)
+	}
+	keystore := core.NewMultiAccountSigner(accountIds, signers)
+
 	telemetryService := generic.NewTelemetryAdapter(d.monitoringEndpointGen)
 	errorLog := &ErrorLog{jobID: spec.ID, recordError: d.jobORM.RecordError}
 	pr := generic.NewPipelineRunnerAdapter(log, spec, d.pipelineRunner)
@@ -283,7 +296,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 	}
 
 	standardCapability := NewStandardCapabilities(log, spec.StandardCapabilitiesSpec, d.cfg, telemetryService, kvStore, d.registry, errorLog,
-		pr, relayerSet, oracleFactory)
+		pr, relayerSet, oracleFactory, keystore)
 
 	return []job.ServiceCtx{standardCapability}, nil
 }

--- a/core/services/standardcapabilities/standard_capabilities.go
+++ b/core/services/standardcapabilities/standard_capabilities.go
@@ -31,6 +31,7 @@ type StandardCapabilities struct {
 	errorLog             core.ErrorLog
 	pipelineRunner       core.PipelineRunnerService
 	relayerSet           core.RelayerSet
+	keystore             core.Keystore
 	oracleFactory        core.OracleFactory
 
 	capabilitiesLoop *loop.StandardCapabilitiesService
@@ -52,6 +53,7 @@ func NewStandardCapabilities(
 	pipelineRunner core.PipelineRunnerService,
 	relayerSet core.RelayerSet,
 	oracleFactory core.OracleFactory,
+	keystore core.Keystore,
 ) *StandardCapabilities {
 	return &StandardCapabilities{
 		log:                  log,
@@ -64,6 +66,7 @@ func NewStandardCapabilities(
 		pipelineRunner:       pipelineRunner,
 		relayerSet:           relayerSet,
 		oracleFactory:        oracleFactory,
+		keystore:             keystore,
 		stopChan:             make(chan struct{}),
 		readyChan:            make(chan struct{}),
 	}
@@ -105,7 +108,7 @@ func (s *StandardCapabilities) Start(ctx context.Context) error {
 			}
 
 			if err = s.capabilitiesLoop.Service.Initialise(cctx, s.spec.Config, s.telemetryService, s.store, s.CapabilitiesRegistry, s.errorLog,
-				s.pipelineRunner, s.relayerSet, s.oracleFactory); err != nil {
+				s.pipelineRunner, s.relayerSet, s.oracleFactory, s.keystore); err != nil {
 				s.log.Errorf("error initialising standard capabilities service: %v", err)
 				return
 			}

--- a/core/services/standardcapabilities/standard_capabilities_test.go
+++ b/core/services/standardcapabilities/standard_capabilities_test.go
@@ -36,7 +36,7 @@ func TestStandardCapabilityStart(t *testing.T) {
 				Network:            "evm",
 			}}
 
-		standardCapability := NewStandardCapabilities(lggr, spec, pluginRegistrar, &telemetryServiceMock{}, &kvstoreMock{}, registry, &errorLogMock{}, &pipelineRunnerServiceMock{}, &relayerSetMock{}, &oracleFactoryMock{})
+		standardCapability := NewStandardCapabilities(lggr, spec, pluginRegistrar, &telemetryServiceMock{}, &kvstoreMock{}, registry, &errorLogMock{}, &pipelineRunnerServiceMock{}, &relayerSetMock{}, &oracleFactoryMock{}, &keystoreMock{})
 		standardCapability.startTimeout = 1 * time.Second
 		err := standardCapability.Start(ctx)
 		require.NoError(t, err)
@@ -57,6 +57,15 @@ func (k *kvstoreMock) Store(ctx context.Context, key string, val []byte) error {
 	return nil
 }
 func (k *kvstoreMock) Get(ctx context.Context, key string) ([]byte, error) {
+	return nil, nil
+}
+
+type keystoreMock struct{}
+
+func (k *keystoreMock) Accounts(ctx context.Context) (accounts []string, err error) {
+	return nil, nil
+}
+func (k *keystoreMock) Sign(ctx context.Context, account string, data []byte) (signed []byte, err error) {
 	return nil, nil
 }
 

--- a/core/services/workflows/cmd/cre/utils.go
+++ b/core/services/workflows/cmd/cre/utils.go
@@ -232,7 +232,7 @@ func newStandardCapabilities(
 		loop := standardcapabilities.NewStandardCapabilities(lggr, spec,
 			pluginRegistrar, &fakes.TelemetryServiceMock{}, &fakes.KVStoreMock{},
 			registry, &fakes.ErrorLogMock{}, &fakes.PipelineRunnerServiceMock{},
-			&fakes.RelayerSetMock{}, &fakes.OracleFactoryMock{})
+			&fakes.RelayerSetMock{}, &fakes.OracleFactoryMock{}, &fakes.KeystoreMock{})
 
 		service := &standaloneLoopWrapper{
 			StandardCapabilities: loop,


### PR DESCRIPTION
- Adds a multi-account signer to every standardcapabilities job.
- Signer should use the P2P key if available, otherwise it will contain an empty list of signers.
- Requires: https://github.com/smartcontractkit/chainlink-common/pull/1269