### PR TITLE
[DX-1125] update nightly workflows with proper triggers

### DIFF
--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Track local env startup success rate
         # track only scheduled runs to exclude failures in PRs or manual runs
-        if: always() && github.event_name == 'workflow_call'
+        if: always() && github.event_name == 'schedule'
         shell: bash
         env:
           START_CLI_OUTCOME: ${{ steps.start-cli.outcome }}
@@ -164,7 +164,7 @@ jobs:
 
       - name: Track local env startup duration
         # track only scheduled runs to exclude failures in PRs or manual runs
-        if: github.event_name == 'workflow_call'
+        if: always() && github.event_name == 'schedule'
         shell: bash
         env:
           GETDX_SECRET_KEY: ${{ secrets.GETDX_SECRET_KEY }}

--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-cre-workflow-don-benchmark'))
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'workflow_call' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-cre-workflow-don-benchmark'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
why?
because the `github.event_name` is inherited from caller workflow ifs need to be changed to handle `schedule` instead of `workflow_call`