### PR TITLE
Df fix aptos feed config feed id length

### DIFF
--- a/deployment/data-feeds/changeset/aptos/set_feed_config.go
+++ b/deployment/data-feeds/changeset/aptos/set_feed_config.go
@@ -26,6 +26,12 @@ func setFeedConfigLogic(env cldf.Environment, c types.SetRegistryFeedConfig) (cl
 
 	dataIDs, _ := changeset.FeedIDsToBytes(c.DataIDs)
 
+	padding := make([]byte, 16)
+	for i, dataID := range dataIDs {
+		paddedDataID := append(dataID, padding...)
+		dataIDs[i] = paddedDataID
+	}
+
 	var configID []byte
 
 	txOps := &bind.TransactOpts{

--- a/deployment/data-feeds/changeset/aptos/set_feed_config.go
+++ b/deployment/data-feeds/changeset/aptos/set_feed_config.go
@@ -26,12 +26,6 @@ func setFeedConfigLogic(env cldf.Environment, c types.SetRegistryFeedConfig) (cl
 
 	dataIDs, _ := changeset.FeedIDsToBytes(c.DataIDs)
 
-	padding := make([]byte, 16)
-	for i, dataID := range dataIDs {
-		paddedDataID := append(dataID, padding...)
-		dataIDs[i] = paddedDataID
-	}
-
 	var configID []byte
 
 	txOps := &bind.TransactOpts{

--- a/deployment/data-feeds/changeset/utils.go
+++ b/deployment/data-feeds/changeset/utils.go
@@ -39,7 +39,7 @@ func FeedIDsToBytes(feedIDs []string) ([][]byte, error) {
 
 	dataSlices := make([][]byte, len(dataIDs16))
 	for i, v := range dataIDs16 {
-		b := make([]byte, 16)
+		b := make([]byte, 32)
 		copy(b, v[:])
 		dataSlices[i] = b
 	}


### PR DESCRIPTION
Fixed a bug where the tooling calls `set_feeds` function on aptos registry contract with 16 bytes feed ids. 
The aptos tooling now will accept 16 bytes feed ids, but add another 0 value 16 bytes. 