### PR TITLE
fix workflow feed duplicate validation

### DIFF
--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
@@ -146,6 +146,9 @@ func proposeWFJobsToJDV2Precondition(env cldf.Environment, c types.ProposeWFJobs
 		return fmt.Errorf("failed to read feed state file %s: %w", feedStatePath, err)
 	}
 
+	feeds := *getFeedsByWorkflow(&feedState.Feeds, c.WorkflowSpecConfig.WorkflowName)
+	feedState.Feeds = feeds
+
 	err = feedState.Validate()
 	if err != nil {
 		return fmt.Errorf("failed to validate feeds: %w", err)

--- a/deployment/data-feeds/view/v1_0/feed_view.go
+++ b/deployment/data-feeds/view/v1_0/feed_view.go
@@ -38,7 +38,7 @@ func (fv *FeedState) Validate() error {
 		return errors.New("at least one feed is required for workflow")
 	}
 
-	// Temporarly removing duplicate checks to allow CHANGE-35
+	// Temporary removing duplicate checks to allow CHANGE-35
 	//streamsIDMap := make(map[string]bool)
 	//feedIDMap := make(map[string]bool)
 	//descriptionMap := make(map[string]bool)

--- a/deployment/data-feeds/view/v1_0/feed_view.go
+++ b/deployment/data-feeds/view/v1_0/feed_view.go
@@ -39,9 +39,9 @@ func (fv *FeedState) Validate() error {
 	}
 
 	// Temporary removing duplicate checks to allow CHANGE-35
-	//streamsIDMap := make(map[string]bool)
-	//feedIDMap := make(map[string]bool)
-	//descriptionMap := make(map[string]bool)
+	// streamsIDMap := make(map[string]bool)
+	// feedIDMap := make(map[string]bool)
+	// descriptionMap := make(map[string]bool)
 
 	for _, f := range fv.Feeds {
 		if f.StreamsID == "" {
@@ -75,20 +75,20 @@ func (fv *FeedState) Validate() error {
 			return fmt.Errorf("invalid feedID %s for feed %s: %w", f.FeedID, f.FeedID, err)
 		}
 
-		//if streamsIDMap[f.StreamsID] {
+		// if streamsIDMap[f.StreamsID] {
 		//	return fmt.Errorf("found duplicate StreamsID %s", f.StreamsID)
-		//}
-		//streamsIDMap[f.StreamsID] = true
+		// }
+		// streamsIDMap[f.StreamsID] = true
 		//
-		//if feedIDMap[f.FeedID] {
+		// if feedIDMap[f.FeedID] {
 		//	return fmt.Errorf("found duplicate FeedID %s", f.FeedID)
-		//}
-		//feedIDMap[f.FeedID] = true
+		// }
+		// feedIDMap[f.FeedID] = true
 		//
-		//if descriptionMap[f.Description] {
+		// if descriptionMap[f.Description] {
 		//	return fmt.Errorf("found duplicate Description %s", f.Description)
-		//}
-		//descriptionMap[f.Description] = true
+		// }
+		// descriptionMap[f.Description] = true
 	}
 
 	return nil

--- a/deployment/data-feeds/view/v1_0/feed_view.go
+++ b/deployment/data-feeds/view/v1_0/feed_view.go
@@ -38,10 +38,9 @@ func (fv *FeedState) Validate() error {
 		return errors.New("at least one feed is required for workflow")
 	}
 
-	// Temporary removing duplicate checks to allow CHANGE-35
-	// streamsIDMap := make(map[string]bool)
-	// feedIDMap := make(map[string]bool)
-	// descriptionMap := make(map[string]bool)
+	streamsIDMap := make(map[string]bool)
+	feedIDMap := make(map[string]bool)
+	descriptionMap := make(map[string]bool)
 
 	for _, f := range fv.Feeds {
 		if f.StreamsID == "" {
@@ -75,20 +74,20 @@ func (fv *FeedState) Validate() error {
 			return fmt.Errorf("invalid feedID %s for feed %s: %w", f.FeedID, f.FeedID, err)
 		}
 
-		// if streamsIDMap[f.StreamsID] {
-		//	return fmt.Errorf("found duplicate StreamsID %s", f.StreamsID)
-		// }
-		// streamsIDMap[f.StreamsID] = true
-		//
-		// if feedIDMap[f.FeedID] {
-		//	return fmt.Errorf("found duplicate FeedID %s", f.FeedID)
-		// }
-		// feedIDMap[f.FeedID] = true
-		//
-		// if descriptionMap[f.Description] {
-		//	return fmt.Errorf("found duplicate Description %s", f.Description)
-		// }
-		// descriptionMap[f.Description] = true
+		if streamsIDMap[f.StreamsID] {
+			return fmt.Errorf("found duplicate StreamsID %s", f.StreamsID)
+		}
+		streamsIDMap[f.StreamsID] = true
+
+		if feedIDMap[f.FeedID] {
+			return fmt.Errorf("found duplicate FeedID %s", f.FeedID)
+		}
+		feedIDMap[f.FeedID] = true
+
+		if descriptionMap[f.Description] {
+			return fmt.Errorf("found duplicate Description %s", f.Description)
+		}
+		descriptionMap[f.Description] = true
 	}
 
 	return nil

--- a/deployment/data-feeds/view/v1_0/feed_view.go
+++ b/deployment/data-feeds/view/v1_0/feed_view.go
@@ -38,9 +38,10 @@ func (fv *FeedState) Validate() error {
 		return errors.New("at least one feed is required for workflow")
 	}
 
-	streamsIDMap := make(map[string]bool)
-	feedIDMap := make(map[string]bool)
-	descriptionMap := make(map[string]bool)
+	// Temporarly removing duplicate checks to allow CHANGE-35
+	//streamsIDMap := make(map[string]bool)
+	//feedIDMap := make(map[string]bool)
+	//descriptionMap := make(map[string]bool)
 
 	for _, f := range fv.Feeds {
 		if f.StreamsID == "" {
@@ -74,20 +75,20 @@ func (fv *FeedState) Validate() error {
 			return fmt.Errorf("invalid feedID %s for feed %s: %w", f.FeedID, f.FeedID, err)
 		}
 
-		if streamsIDMap[f.StreamsID] {
-			return fmt.Errorf("found duplicate StreamsID %s", f.StreamsID)
-		}
-		streamsIDMap[f.StreamsID] = true
-
-		if feedIDMap[f.FeedID] {
-			return fmt.Errorf("found duplicate FeedID %s", f.FeedID)
-		}
-		feedIDMap[f.FeedID] = true
-
-		if descriptionMap[f.Description] {
-			return fmt.Errorf("found duplicate Description %s", f.Description)
-		}
-		descriptionMap[f.Description] = true
+		//if streamsIDMap[f.StreamsID] {
+		//	return fmt.Errorf("found duplicate StreamsID %s", f.StreamsID)
+		//}
+		//streamsIDMap[f.StreamsID] = true
+		//
+		//if feedIDMap[f.FeedID] {
+		//	return fmt.Errorf("found duplicate FeedID %s", f.FeedID)
+		//}
+		//feedIDMap[f.FeedID] = true
+		//
+		//if descriptionMap[f.Description] {
+		//	return fmt.Errorf("found duplicate Description %s", f.Description)
+		//}
+		//descriptionMap[f.Description] = true
 	}
 
 	return nil


### PR DESCRIPTION
Instead of validating all feed mapping json feeds, the validation will be done only for specific workflow feeds