### PR TITLE
chore: bump version for plugins hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.24.0",
+  "version": "2.24.1-plugins-hotfix5",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds version bump to satisfy CI for release/2.24.1-plugins-hotfix5