### PR TITLE
update cosign version

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -253,7 +253,7 @@ runs:
       name: Install cosign
       uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
       with:
-        cosign-release: "v2.4.0"
+        cosign-release: "v2.5.2"
 
     # This automatically signs the image with the correct OIDC provider from Github
     - if: inputs.sign-images == 'true'


### PR DESCRIPTION
This bumps cosign to v2.5.2 to address signature failures when signing public ECR images.
Previous versions were incompatible with recent Sigstore behavior.