### PR TITLE
Replace BurnMintERC677 with BurnMintERC20

### DIFF
--- a/core/scripts/ccip/revert-reason/handler/reason.go
+++ b/core/scripts/ccip/revert-reason/handler/reason.go
@@ -33,7 +33,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/onramp"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc20"
 )
 
@@ -145,7 +145,7 @@ func getAllABIs() []string {
 		lock_release_token_pool_1_4_0.LockReleaseTokenPoolABI,
 		burn_mint_token_pool_1_2_0.BurnMintTokenPoolABI,
 		usdc_token_pool_1_4_0.USDCTokenPoolABI,
-		burn_mint_erc677.BurnMintERC677ABI,
+		burn_mint_erc20.BurnMintERC20ABI,
 		erc20.ERC20ABI,
 		lock_release_token_pool.LockReleaseTokenPoolABI,
 		burn_mint_token_pool.BurnMintTokenPoolABI,

--- a/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/ccip_contracts_1_4_0.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/ccip_contracts_1_4_0.go
@@ -599,7 +599,7 @@ func (c *CCIPContracts) SetupLockAndMintTokenPool(
 	wrappedTokenName,
 	wrappedTokenSymbol string) (common.Address, *burn_mint_erc20.BurnMintERC20, error) {
 	// Deploy dest token & pool
-	destTokenAddress, _, _, err := burn_mint_erc20.DeployBurnMintERC20(c.Dest.User, c.Dest.Chain, wrappedTokenName, wrappedTokenSymbol, 18, big.NewInt(0))
+	destTokenAddress, _, _, err := burn_mint_erc20.DeployBurnMintERC20(c.Dest.User, c.Dest.Chain, wrappedTokenName, wrappedTokenSymbol, 18, big.NewInt(0), big.NewInt(0))
 	if err != nil {
 		return [20]byte{}, nil, err
 	}

--- a/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/ccip_contracts_1_4_0.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/ccip_contracts_1_4_0.go
@@ -42,7 +42,7 @@ import (
 	lock_release_token_pool_1_4_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_4_0/lock_release_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/mock_rmn_contract"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/weth9"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
@@ -597,15 +597,15 @@ func (c *CCIPContracts) SetupOnchainConfig(t *testing.T, commitOnchainConfig, co
 func (c *CCIPContracts) SetupLockAndMintTokenPool(
 	sourceTokenAddress common.Address,
 	wrappedTokenName,
-	wrappedTokenSymbol string) (common.Address, *burn_mint_erc677.BurnMintERC677, error) {
+	wrappedTokenSymbol string) (common.Address, *burn_mint_erc20.BurnMintERC20, error) {
 	// Deploy dest token & pool
-	destTokenAddress, _, _, err := burn_mint_erc677.DeployBurnMintERC677(c.Dest.User, c.Dest.Chain, wrappedTokenName, wrappedTokenSymbol, 18, big.NewInt(0))
+	destTokenAddress, _, _, err := burn_mint_erc20.DeployBurnMintERC20(c.Dest.User, c.Dest.Chain, wrappedTokenName, wrappedTokenSymbol, 18, big.NewInt(0))
 	if err != nil {
 		return [20]byte{}, nil, err
 	}
 	c.Dest.Chain.Commit()
 
-	destToken, err := burn_mint_erc677.NewBurnMintERC677(destTokenAddress, c.Dest.Chain)
+	destToken, err := burn_mint_erc20.NewBurnMintERC20(destTokenAddress, c.Dest.Chain)
 	if err != nil {
 		return [20]byte{}, nil, err
 	}

--- a/deployment/ccip/changeset/cs_prerequisites.go
+++ b/deployment/ccip/changeset/cs_prerequisites.go
@@ -26,7 +26,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/rmn_contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/usdc_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/registry_module_owner_custom"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/multicall3"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/weth9"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/weth9_zksync"
@@ -755,22 +755,22 @@ func deployUSDC(
 	rmnProxy common.Address,
 	router common.Address,
 ) (
-	*burn_mint_erc677.BurnMintERC677,
+	*burn_mint_erc20.BurnMintERC20,
 	*usdc_token_pool.USDCTokenPool,
 	*mock_usdc_token_messenger.MockE2EUSDCTokenMessenger,
 	*mock_usdc_token_transmitter.MockE2EUSDCTransmitter,
 	error,
 ) {
 	token, err := cldf.DeployContract(lggr, chain, addresses,
-		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
+		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
 			var (
 				tokenAddress  common.Address
 				tx            *types.Transaction
-				tokenContract *burn_mint_erc677.BurnMintERC677
+				tokenContract *burn_mint_erc20.BurnMintERC20
 				err2          error
 			)
 			if chain.IsZkSyncVM {
-				tokenAddress, _, tokenContract, err2 = burn_mint_erc677.DeployBurnMintERC677Zk(
+				tokenAddress, _, tokenContract, err2 = burn_mint_erc20.DeployBurnMintERC20Zk(
 					nil,
 					chain.ClientZkSyncVM,
 					chain.DeployerKeyZkSyncVM,
@@ -781,7 +781,7 @@ func deployUSDC(
 					big.NewInt(0),
 				)
 			} else {
-				tokenAddress, tx, tokenContract, err2 = burn_mint_erc677.DeployBurnMintERC677(
+				tokenAddress, tx, tokenContract, err2 = burn_mint_erc20.DeployBurnMintERC20(
 					chain.DeployerKey,
 					chain.Client,
 					shared.USDCName,
@@ -790,7 +790,7 @@ func deployUSDC(
 					big.NewInt(0),
 				)
 			}
-			return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+			return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 				Address:  tokenAddress,
 				Contract: tokenContract,
 				Tx:       tx,

--- a/deployment/ccip/changeset/cs_prerequisites.go
+++ b/deployment/ccip/changeset/cs_prerequisites.go
@@ -779,6 +779,7 @@ func deployUSDC(
 					string(shared.USDCSymbol),
 					shared.UsdcDecimals,
 					big.NewInt(0),
+					big.NewInt(0),
 				)
 			} else {
 				tokenAddress, tx, tokenContract, err2 = burn_mint_erc20.DeployBurnMintERC20(
@@ -787,6 +788,7 @@ func deployUSDC(
 					shared.USDCName,
 					string(shared.USDCSymbol),
 					shared.UsdcDecimals,
+					big.NewInt(0),
 					big.NewInt(0),
 				)
 			}

--- a/deployment/ccip/changeset/solana/cs_token_pool_test.go
+++ b/deployment/ccip/changeset/solana/cs_token_pool_test.go
@@ -62,6 +62,7 @@ func deployEVMTokenPool(t *testing.T, e cldf.Environment, evmChain uint64) (cldf
 				string(testhelpers.TestTokenSymbol),
 				testhelpers.LocalTokenDecimals,
 				big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+				big.NewInt(0),
 			)
 			return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 				Address:  tokenAddress,

--- a/deployment/ccip/changeset/solana/cs_token_pool_test.go
+++ b/deployment/ccip/changeset/solana/cs_token_pool_test.go
@@ -17,7 +17,7 @@ import (
 	solTestTokenPool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/test_token_pool"
 	solTokenUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
@@ -54,8 +54,8 @@ func TestAddTokenPoolWithMcms(t *testing.T) {
 func deployEVMTokenPool(t *testing.T, e cldf.Environment, evmChain uint64) (cldf.Environment, common.Address, error) {
 	addressBook := cldf.NewMemoryAddressBook()
 	evmToken, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[evmChain], addressBook,
-		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
-			tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
+			tokenAddress, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 				e.BlockChains.EVMChains()[evmChain].DeployerKey,
 				e.BlockChains.EVMChains()[evmChain].Client,
 				string(testhelpers.TestTokenSymbol),
@@ -63,7 +63,7 @@ func deployEVMTokenPool(t *testing.T, e cldf.Environment, evmChain uint64) (cldf
 				testhelpers.LocalTokenDecimals,
 				big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 			)
-			return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+			return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 				Address:  tokenAddress,
 				Contract: token,
 				Tv:       cldf.NewTypeAndVersion(shared.BurnMintToken, deployment.Version1_0_0),

--- a/deployment/ccip/changeset/testhelpers/feestest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/feestest/helpers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/weth9"
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
@@ -29,7 +29,7 @@ func NewFeeTokenTestCase(
 	src, dst uint64,
 	feeToken common.Address,
 	tokenAmounts []router.ClientEVMTokenAmount,
-	srcToken, dstToken *burn_mint_erc677.BurnMintERC677,
+	srcToken, dstToken *burn_mint_erc20.BurnMintERC20,
 	receiver []byte,
 	data []byte,
 	assertTokenBalance, assertExecution bool,
@@ -54,7 +54,7 @@ type FeeTokenTestCase struct {
 	t                  *testing.T
 	src, dst           uint64
 	env                cldf.Environment
-	srcToken, dstToken *burn_mint_erc677.BurnMintERC677
+	srcToken, dstToken *burn_mint_erc20.BurnMintERC20
 	tokenAmounts       []router.ClientEVMTokenAmount
 	feeToken           common.Address
 	receiver           []byte
@@ -88,7 +88,7 @@ func RunFeeTokenTestCase(tc FeeTokenTestCase) {
 	}
 
 	// if fee token is not native then approve the router to spend the fee token from the sender.
-	var feeTokenWrapper *burn_mint_erc677.BurnMintERC677
+	var feeTokenWrapper *burn_mint_erc20.BurnMintERC20
 	if tc.feeToken != common.HexToAddress("0x0") {
 		if tc.feeToken == state.Chains[tc.src].Weth9.Address() {
 			// Deposit some ETH into the WETH contract
@@ -108,7 +108,7 @@ func RunFeeTokenTestCase(tc FeeTokenTestCase) {
 		}
 
 		var err error
-		feeTokenWrapper, err = burn_mint_erc677.NewBurnMintERC677(tc.feeToken, srcChain.Client)
+		feeTokenWrapper, err = burn_mint_erc20.NewBurnMintERC20(tc.feeToken, srcChain.Client)
 		require.NoError(tc.t, err)
 
 		bal, err := feeTokenWrapper.BalanceOf(&bind.CallOpts{

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1761,7 +1761,7 @@ func deployTransferTokenOneEnd(
 			}
 		})
 	if err != nil {
-		lggr.Errorw("Failed to deploy Token ERC677", "err", err)
+		lggr.Errorw("Failed to deploy Token ERC20", "err", err)
 		return nil, nil, err
 	}
 

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -84,7 +84,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/mock_ethusd_aggregator_wrapper"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/aggregator_v3_interface"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/mock_v3_aggregator_contract"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
@@ -1335,7 +1335,7 @@ func DeployTransferableToken(
 	state stateview.CCIPOnChainState,
 	addresses cldf.AddressBook,
 	token string,
-) (*burn_mint_erc677.BurnMintERC677, *burn_mint_token_pool.BurnMintTokenPool, *burn_mint_erc677.BurnMintERC677, *burn_mint_token_pool.BurnMintTokenPool, error) {
+) (*burn_mint_erc20.BurnMintERC20, *burn_mint_token_pool.BurnMintTokenPool, *burn_mint_erc20.BurnMintERC20, *burn_mint_token_pool.BurnMintTokenPool, error) {
 	// Deploy token and pools
 	srcToken, srcPool, dstToken, dstPool, err := deployTokenPoolsInParallel(lggr, chains, src, dst, srcActor, dstActor, state, addresses, token)
 	if err != nil {
@@ -1378,7 +1378,7 @@ func DeployTransferableTokenSolana(
 	evmChainSel, solChainSel uint64,
 	evmDeployer *bind.TransactOpts,
 	evmTokenName string,
-) (*burn_mint_erc677.BurnMintERC677,
+) (*burn_mint_erc20.BurnMintERC20,
 	*burn_mint_token_pool.BurnMintTokenPool, solana.PublicKey, error) {
 	selectorFamily, err := chainsel.GetSelectorFamily(evmChainSel)
 	if err != nil {
@@ -1545,17 +1545,17 @@ func deployTokenPoolsInParallel(
 	addresses cldf.AddressBook,
 	token string,
 ) (
-	*burn_mint_erc677.BurnMintERC677,
+	*burn_mint_erc20.BurnMintERC20,
 	*burn_mint_token_pool.BurnMintTokenPool,
-	*burn_mint_erc677.BurnMintERC677,
+	*burn_mint_erc20.BurnMintERC20,
 	*burn_mint_token_pool.BurnMintTokenPool,
 	error,
 ) {
 	deployGrp := errgroup.Group{}
 	// Deploy token and pools
-	var srcToken *burn_mint_erc677.BurnMintERC677
+	var srcToken *burn_mint_erc20.BurnMintERC20
 	var srcPool *burn_mint_token_pool.BurnMintTokenPool
-	var dstToken *burn_mint_erc677.BurnMintERC677
+	var dstToken *burn_mint_erc20.BurnMintERC20
 	var dstPool *burn_mint_token_pool.BurnMintTokenPool
 
 	deployGrp.Go(func() error {
@@ -1585,7 +1585,7 @@ func deployTokenPoolsInParallel(
 	return srcToken, srcPool, dstToken, dstPool, nil
 }
 
-func grantMintBurnPermissions(lggr logger.Logger, chain cldf_evm.Chain, token *burn_mint_erc677.BurnMintERC677, actor *bind.TransactOpts, address common.Address) error {
+func grantMintBurnPermissions(lggr logger.Logger, chain cldf_evm.Chain, token *burn_mint_erc20.BurnMintERC20, actor *bind.TransactOpts, address common.Address) error {
 	lggr.Infow("Granting burn/mint permissions", "token", token.Address(), "address", address)
 	tx, err := token.GrantMintAndBurnRoles(actor, address)
 	if err != nil {
@@ -1725,7 +1725,7 @@ func deployTransferTokenOneEnd(
 	deployer *bind.TransactOpts,
 	addressBook cldf.AddressBook,
 	tokenSymbol string,
-) (*burn_mint_erc677.BurnMintERC677, *burn_mint_token_pool.BurnMintTokenPool, error) {
+) (*burn_mint_erc20.BurnMintERC20, *burn_mint_token_pool.BurnMintTokenPool, error) {
 	var rmnAddress, routerAddress string
 	chainAddresses, err := addressBook.AddressesForChain(chain.Selector)
 	if err != nil {
@@ -1746,8 +1746,8 @@ func deployTransferTokenOneEnd(
 	tokenDecimals := uint8(18)
 
 	tokenContract, err := cldf.DeployContract(lggr, chain, addressBook,
-		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
-			tokenAddress, tx, token, err2 := burn_mint_erc677.DeployBurnMintERC677(
+		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
+			tokenAddress, tx, token, err2 := burn_mint_erc20.DeployBurnMintERC20(
 				deployer,
 				chain.Client,
 				tokenSymbol,
@@ -1755,7 +1755,7 @@ func deployTransferTokenOneEnd(
 				tokenDecimals,
 				big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 			)
-			return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+			return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 				Address: tokenAddress, Contract: token, Tx: tx, Tv: cldf.NewTypeAndVersion(shared.BurnMintToken, deployment.Version1_0_0), Err: err2,
 			}
 		})
@@ -1799,14 +1799,14 @@ func deployTransferTokenOneEnd(
 type MintTokenInfo struct {
 	auth   *bind.TransactOpts
 	sender *bind.TransactOpts
-	tokens []*burn_mint_erc677.BurnMintERC677
+	tokens []*burn_mint_erc20.BurnMintERC20
 }
 
-func NewMintTokenInfo(auth *bind.TransactOpts, tokens ...*burn_mint_erc677.BurnMintERC677) MintTokenInfo {
+func NewMintTokenInfo(auth *bind.TransactOpts, tokens ...*burn_mint_erc20.BurnMintERC20) MintTokenInfo {
 	return MintTokenInfo{auth: auth, tokens: tokens}
 }
 
-func NewMintTokenWithCustomSender(auth *bind.TransactOpts, sender *bind.TransactOpts, tokens ...*burn_mint_erc677.BurnMintERC677) MintTokenInfo {
+func NewMintTokenWithCustomSender(auth *bind.TransactOpts, sender *bind.TransactOpts, tokens ...*burn_mint_erc20.BurnMintERC20) MintTokenInfo {
 	return MintTokenInfo{auth: auth, sender: sender, tokens: tokens}
 }
 
@@ -2142,7 +2142,7 @@ func WaitForTheTokenBalance(
 	chain cldf_evm.Chain,
 	expected *big.Int,
 ) {
-	tokenContract, err := burn_mint_erc677.NewBurnMintERC677(token, chain.Client)
+	tokenContract, err := burn_mint_erc20.NewBurnMintERC20(token, chain.Client)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1754,6 +1754,7 @@ func deployTransferTokenOneEnd(
 				tokenSymbol,
 				tokenDecimals,
 				big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+				big.NewInt(0),
 			)
 			return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 				Address: tokenAddress, Contract: token, Tx: tx, Tv: cldf.NewTypeAndVersion(shared.BurnMintToken, deployment.Version1_0_0), Err: err2,

--- a/deployment/ccip/changeset/testhelpers/test_token_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_token_helpers.go
@@ -101,6 +101,7 @@ func SetupTwoChainEnvironmentWithTokens(
 					string(TestTokenSymbol),
 					LocalTokenDecimals,
 					big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+					big.NewInt(0),
 				)
 				return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 					Address:  tokenAddress,

--- a/deployment/ccip/changeset/testhelpers/test_token_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_token_helpers.go
@@ -16,7 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -70,7 +70,7 @@ func SetupTwoChainEnvironmentWithTokens(
 	t *testing.T,
 	lggr logger.Logger,
 	transferToTimelock bool,
-) (env cldf.Environment, sel1 uint64, sel2 uint64, ercmap map[uint64]*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]) {
+) (env cldf.Environment, sel1 uint64, sel2 uint64, ercmap map[uint64]*cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]) {
 	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
 		Chains: 2,
 	})
@@ -90,11 +90,11 @@ func SetupTwoChainEnvironmentWithTokens(
 	}
 
 	// Deploy one burn-mint token per chain to use in the tests
-	tokens := make(map[uint64]*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677])
+	tokens := make(map[uint64]*cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20])
 	for _, selector := range selectors {
 		token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], addressBook,
-			func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
-				tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+			func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
+				tokenAddress, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 					e.BlockChains.EVMChains()[selector].DeployerKey,
 					e.BlockChains.EVMChains()[selector].Client,
 					string(TestTokenSymbol),
@@ -102,7 +102,7 @@ func SetupTwoChainEnvironmentWithTokens(
 					LocalTokenDecimals,
 					big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 				)
-				return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+				return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 					Address:  tokenAddress,
 					Contract: token,
 					Tv:       cldf.NewTypeAndVersion(shared.BurnMintToken, deployment.Version1_0_0),

--- a/deployment/ccip/changeset/testhelpers/test_usdc_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_usdc_helpers.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/usdc_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -29,7 +29,7 @@ func ConfigureUSDCTokenPools(
 	chains map[uint64]cldf_evm.Chain,
 	src, dst uint64,
 	state stateview.CCIPOnChainState,
-) (*burn_mint_erc677.BurnMintERC677, *burn_mint_erc677.BurnMintERC677, error) {
+) (*burn_mint_erc20.BurnMintERC20, *burn_mint_erc20.BurnMintERC20, error) {
 	srcToken := state.MustGetEVMChainState(src).BurnMintTokens677[shared.USDCSymbol]
 	dstToken := state.MustGetEVMChainState(dst).BurnMintTokens677[shared.USDCSymbol]
 	srcPool := state.MustGetEVMChainState(src).USDCTokenPools[deployment.Version1_5_1]
@@ -39,9 +39,9 @@ func ConfigureUSDCTokenPools(
 		sourceChain cldf_evm.Chain
 		dstChainSel uint64
 		state       evm.CCIPChainState
-		srcToken    *burn_mint_erc677.BurnMintERC677
+		srcToken    *burn_mint_erc20.BurnMintERC20
 		srcPool     *usdc_token_pool.USDCTokenPool
-		dstToken    *burn_mint_erc677.BurnMintERC677
+		dstToken    *burn_mint_erc20.BurnMintERC20
 		dstPool     *usdc_token_pool.USDCTokenPool
 	}{
 		{
@@ -79,9 +79,9 @@ func configureSingleChain(
 	sourceChain cldf_evm.Chain,
 	dstChainSel uint64,
 	state evm.CCIPChainState,
-	srcToken *burn_mint_erc677.BurnMintERC677,
+	srcToken *burn_mint_erc20.BurnMintERC20,
 	srcPool *usdc_token_pool.USDCTokenPool,
-	dstToken *burn_mint_erc677.BurnMintERC677,
+	dstToken *burn_mint_erc20.BurnMintERC20,
 	dstPool *usdc_token_pool.USDCTokenPool,
 ) func() error {
 	return func() error {

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc677_helper"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc20_helper"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc677"
 
@@ -451,8 +451,8 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 		switch cfg.Type {
 		case shared.BurnMintToken:
 			token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], ab,
-				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
-					tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
+					tokenAddress, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 						e.BlockChains.EVMChains()[selector].DeployerKey,
 						e.BlockChains.EVMChains()[selector].Client,
 						cfg.TokenName,
@@ -460,7 +460,7 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 						cfg.TokenDecimals,
 						cfg.MaxSupply,
 					)
-					return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+					return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 						Address:  tokenAddress,
 						Contract: token,
 						Tv:       cldf.NewTypeAndVersion(shared.BurnMintToken, deployment.Version1_0_0),
@@ -470,7 +470,7 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 				},
 			)
 			if err != nil {
-				return nil, ab, fmt.Errorf("failed to deploy BurnMintERC677 token "+
+				return nil, ab, fmt.Errorf("failed to deploy BurnMintERC20 token "+
 					"%s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 			if err := addMinterAndMintTokenERC677(e, selector, token.Contract, e.BlockChains.EVMChains()[selector].DeployerKey.From,
@@ -536,14 +536,14 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 			tokenAddresses[selector] = token.Address
 		case shared.ERC677TokenHelper:
 			token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], ab,
-				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677_helper.BurnMintERC677Helper] {
-					tokenAddress, tx, token, err := burn_mint_erc677_helper.DeployBurnMintERC677Helper(
+				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20_helper.BurnMintERC20Helper] {
+					tokenAddress, tx, token, err := burn_mint_erc20_helper.DeployBurnMintERC20Helper(
 						e.BlockChains.EVMChains()[selector].DeployerKey,
 						e.BlockChains.EVMChains()[selector].Client,
 						cfg.TokenName,
 						string(cfg.TokenSymbol),
 					)
-					return cldf.ContractDeploy[*burn_mint_erc677_helper.BurnMintERC677Helper]{
+					return cldf.ContractDeploy[*burn_mint_erc20_helper.BurnMintERC20Helper]{
 						Address:  tokenAddress,
 						Contract: token,
 						Tv:       cldf.NewTypeAndVersion(shared.ERC677TokenHelper, deployment.Version1_0_0),
@@ -586,7 +586,7 @@ func grantAccessToPool(
 	tpAddress common.Address,
 	tokenAddress common.Address,
 ) error {
-	token, err := burn_mint_erc677.NewBurnMintERC677(tokenAddress, chain.Client)
+	token, err := burn_mint_erc20.NewBurnMintERC20(tokenAddress, chain.Client)
 	if err != nil {
 		return fmt.Errorf("failed to connect address %s with erc677 bindings: %w", tokenAddress, err)
 	}
@@ -609,20 +609,20 @@ func grantAccessToPool(
 }
 
 // addMinterAndMintTokenERC677 adds the minter role to the recipient and mints the specified amount of tokens to the recipient's address.
-func addMinterAndMintTokenERC677(env cldf.Environment, selector uint64, token *burn_mint_erc677.BurnMintERC677, recipient common.Address, amount *big.Int) error {
+func addMinterAndMintTokenERC677(env cldf.Environment, selector uint64, token *burn_mint_erc20.BurnMintERC20, recipient common.Address, amount *big.Int) error {
 	return addMinterAndMintTokenHelper(env, selector, token, recipient, amount)
 }
 
 // addMinterAndMintTokenERC677Helper adds the minter role to the recipient and mints the specified amount of tokens to the recipient's address.
-func addMinterAndMintTokenERC677Helper(env cldf.Environment, selector uint64, token *burn_mint_erc677_helper.BurnMintERC677Helper, recipient common.Address, amount *big.Int) error {
-	baseToken, err := burn_mint_erc677.NewBurnMintERC677(token.Address(), env.BlockChains.EVMChains()[selector].Client)
+func addMinterAndMintTokenERC677Helper(env cldf.Environment, selector uint64, token *burn_mint_erc20_helper.BurnMintERC20Helper, recipient common.Address, amount *big.Int) error {
+	baseToken, err := burn_mint_erc20.NewBurnMintERC20(token.Address(), env.BlockChains.EVMChains()[selector].Client)
 	if err != nil {
 		return fmt.Errorf("failed to cast helper to base token: %w", err)
 	}
 	return addMinterAndMintTokenHelper(env, selector, baseToken, recipient, amount)
 }
 
-func addMinterAndMintTokenHelper(env cldf.Environment, selector uint64, token *burn_mint_erc677.BurnMintERC677, recipient common.Address, amount *big.Int) error {
+func addMinterAndMintTokenHelper(env cldf.Environment, selector uint64, token *burn_mint_erc20.BurnMintERC20, recipient common.Address, amount *big.Int) error {
 	deployerKey := env.BlockChains.EVMChains()[selector].DeployerKey
 	ctx := env.GetContext()
 	// check if owner is the deployer key

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -459,6 +459,7 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 						string(cfg.TokenSymbol),
 						cfg.TokenDecimals,
 						cfg.MaxSupply,
+						big.NewInt(0),
 					)
 					return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 						Address:  tokenAddress,

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc20_helper"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc677_helper"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc677"
@@ -474,14 +474,14 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 				return nil, ab, fmt.Errorf("failed to deploy BurnMintERC20 token "+
 					"%s on chain %d: %w", cfg.TokenName, selector, err)
 			}
-			if err := addMinterAndMintTokenERC677(e, selector, token.Contract, e.BlockChains.EVMChains()[selector].DeployerKey.From,
+			if err := addMinterAndMintTokenERC20(e, selector, token.Contract, e.BlockChains.EVMChains()[selector].DeployerKey.From,
 				new(big.Int).Mul(big.NewInt(1_000), big.NewInt(1_000_000_000))); err != nil {
 				return nil, ab, fmt.Errorf("failed to add minter and mint token "+
 					"%s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 			if len(cfg.MintTokenForRecipients) > 0 {
 				for recipient, amount := range cfg.MintTokenForRecipients {
-					if err := addMinterAndMintTokenERC677(e, selector, token.Contract, recipient,
+					if err := addMinterAndMintTokenERC20(e, selector, token.Contract, recipient,
 						amount); err != nil {
 						return nil, ab, fmt.Errorf("failed to add minter and mint "+
 							"token %s on chain %d: %w", cfg.TokenName, selector, err)
@@ -513,38 +513,16 @@ func deployTokens(e cldf.Environment, tokenDeployCfg map[uint64]DeployTokenConfi
 				return nil, ab, fmt.Errorf("failed to deploy ERC20 token %s on chain %d: %w", cfg.TokenName, selector, err)
 			}
 			tokenAddresses[selector] = token.Address
-		case shared.ERC677Token:
-			token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], ab,
-				func(chain cldf_evm.Chain) cldf.ContractDeploy[*erc677.ERC677] {
-					tokenAddress, tx, token, err := erc677.DeployERC677(
-						e.BlockChains.EVMChains()[selector].DeployerKey,
-						e.BlockChains.EVMChains()[selector].Client,
-						cfg.TokenName,
-						string(cfg.TokenSymbol),
-					)
-					return cldf.ContractDeploy[*erc677.ERC677]{
-						Address:  tokenAddress,
-						Contract: token,
-						Tv:       cldf.NewTypeAndVersion(shared.ERC677Token, deployment.Version1_0_0),
-						Tx:       tx,
-						Err:      err,
-					}
-				},
-			)
-			if err != nil {
-				return nil, ab, fmt.Errorf("failed to deploy ERC677 token %s on chain %d: %w", cfg.TokenName, selector, err)
-			}
-			tokenAddresses[selector] = token.Address
 		case shared.ERC677TokenHelper:
 			token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], ab,
-				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20_helper.BurnMintERC20Helper] {
-					tokenAddress, tx, token, err := burn_mint_erc20_helper.DeployBurnMintERC20Helper(
+				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677_helper.BurnMintERC677Helper] {
+					tokenAddress, tx, token, err := burn_mint_erc677_helper.DeployBurnMintERC677Helper(
 						e.BlockChains.EVMChains()[selector].DeployerKey,
 						e.BlockChains.EVMChains()[selector].Client,
 						cfg.TokenName,
 						string(cfg.TokenSymbol),
 					)
-					return cldf.ContractDeploy[*burn_mint_erc20_helper.BurnMintERC20Helper]{
+					return cldf.ContractDeploy[*burn_mint_erc677_helper.BurnMintERC677Helper]{
 						Address:  tokenAddress,
 						Contract: token,
 						Tv:       cldf.NewTypeAndVersion(shared.ERC677TokenHelper, deployment.Version1_0_0),
@@ -609,13 +587,13 @@ func grantAccessToPool(
 	return nil
 }
 
-// addMinterAndMintTokenERC677 adds the minter role to the recipient and mints the specified amount of tokens to the recipient's address.
-func addMinterAndMintTokenERC677(env cldf.Environment, selector uint64, token *burn_mint_erc20.BurnMintERC20, recipient common.Address, amount *big.Int) error {
+// addMinterAndMintTokenERC20 adds the minter role to the recipient and mints the specified amount of tokens to the recipient's address.
+func addMinterAndMintTokenERC20(env cldf.Environment, selector uint64, token *burn_mint_erc20.BurnMintERC20, recipient common.Address, amount *big.Int) error {
 	return addMinterAndMintTokenHelper(env, selector, token, recipient, amount)
 }
 
 // addMinterAndMintTokenERC677Helper adds the minter role to the recipient and mints the specified amount of tokens to the recipient's address.
-func addMinterAndMintTokenERC677Helper(env cldf.Environment, selector uint64, token *burn_mint_erc20_helper.BurnMintERC20Helper, recipient common.Address, amount *big.Int) error {
+func addMinterAndMintTokenERC677Helper(env cldf.Environment, selector uint64, token *burn_mint_erc677_helper.BurnMintERC677Helper, recipient common.Address, amount *big.Int) error {
 	baseToken, err := burn_mint_erc20.NewBurnMintERC20(token.Address(), env.BlockChains.EVMChains()[selector].Client)
 	if err != nil {
 		return fmt.Errorf("failed to cast helper to base token: %w", err)

--- a/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_add_token_e2e_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -84,7 +84,7 @@ func TestAddTokenE2E(t *testing.T) {
 				err                  error
 			)
 
-			tokens := make(map[uint64]*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677])
+			tokens := make(map[uint64]*cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20])
 			if test.withMCMS {
 				mcmsConfig = &proposalutils.TimelockConfig{
 					MinDelay:   0,
@@ -200,7 +200,7 @@ func TestAddTokenE2E(t *testing.T) {
 				for chain, chainState := range state.Chains {
 					token, ok := chainState.BurnMintTokens677[testhelpers.TestTokenSymbol]
 					require.True(t, ok)
-					tokens[chain] = &cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+					tokens[chain] = &cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 						Address:  token.Address(),
 						Contract: token,
 					}

--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools_test.go
@@ -748,6 +748,7 @@ func TestValidateConfigureTokenPoolContractsForSolana(t *testing.T) {
 					string(testhelpers.TestTokenSymbol),
 					testhelpers.LocalTokenDecimals,
 					big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+					big.NewInt(0),
 				)
 				return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 					Address:  tokenAddress,

--- a/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_configure_token_pools_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
 	solTestTokenPool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/test_token_pool"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -58,7 +58,7 @@ func validateMemberOfTokenPoolPair(
 	state stateview.CCIPOnChainState,
 	tokenPool *token_pool.TokenPool,
 	expectedRemotePools []common.Address,
-	tokens map[uint64]*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677],
+	tokens map[uint64]*cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20],
 	tokenSymbol shared.TokenSymbol,
 	chainSelector uint64,
 	rate *big.Int,
@@ -740,8 +740,8 @@ func TestValidateConfigureTokenPoolContractsForSolana(t *testing.T) {
 	///////////////////////////
 	for _, selector := range evmSelectors {
 		token, err := cldf.DeployContract(e.Logger, e.BlockChains.EVMChains()[selector], addressBook,
-			func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
-				tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+			func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
+				tokenAddress, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 					e.BlockChains.EVMChains()[selector].DeployerKey,
 					e.BlockChains.EVMChains()[selector].Client,
 					string(testhelpers.TestTokenSymbol),
@@ -749,7 +749,7 @@ func TestValidateConfigureTokenPoolContractsForSolana(t *testing.T) {
 					testhelpers.LocalTokenDecimals,
 					big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 				)
-				return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+				return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 					Address:  tokenAddress,
 					Contract: token,
 					Tv:       cldf.NewTypeAndVersion(shared.BurnMintToken, deployment.Version1_0_0),

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
@@ -44,6 +44,7 @@ func deployUSDCPrerequisites(
 				"USDC",
 				6,
 				big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+				big.NewInt(0),
 			)
 			return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 				Address:  tokenAddress,
@@ -159,6 +160,7 @@ func TestValidateDeployUSDCTokenPoolInput(t *testing.T) {
 				"NOTUSDC",
 				6,
 				big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+				big.NewInt(0),
 			)
 			return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 				Address:  tokenAddress,

--- a/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_deploy_usdc_token_pools_test.go
@@ -16,7 +16,7 @@ import (
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -34,10 +34,10 @@ func deployUSDCPrerequisites(
 	logger logger.Logger,
 	chain cldf_evm.Chain,
 	addressBook cldf.AddressBook,
-) (*cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677], *cldf.ContractDeploy[*mock_usdc_token_messenger.MockE2EUSDCTokenMessenger]) {
+) (*cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20], *cldf.ContractDeploy[*mock_usdc_token_messenger.MockE2EUSDCTokenMessenger]) {
 	usdcToken, err := cldf.DeployContract(logger, chain, addressBook,
-		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
-			tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
+			tokenAddress, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 				chain.DeployerKey,
 				chain.Client,
 				"USDC",
@@ -45,7 +45,7 @@ func deployUSDCPrerequisites(
 				6,
 				big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 			)
-			return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+			return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 				Address:  tokenAddress,
 				Contract: token,
 				Tv:       cldf.NewTypeAndVersion(shared.USDCTokenPool, deployment.Version1_5_1),
@@ -151,8 +151,8 @@ func TestValidateDeployUSDCTokenPoolInput(t *testing.T) {
 	usdcToken, tokenMessenger := deployUSDCPrerequisites(t, lggr, chain, addressBook)
 
 	nonUsdcToken, err := cldf.DeployContract(e.Logger, chain, addressBook,
-		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
-			tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+		func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
+			tokenAddress, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 				chain.DeployerKey,
 				chain.Client,
 				"NOTUSDC",
@@ -160,7 +160,7 @@ func TestValidateDeployUSDCTokenPoolInput(t *testing.T) {
 				6,
 				big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 			)
-			return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+			return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 				Address:  tokenAddress,
 				Contract: token,
 				Tv:       cldf.NewTypeAndVersion(shared.USDCTokenPool, deployment.Version1_5_1),

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/rmn_contract"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -1061,8 +1061,8 @@ func TestApplyFeeTokensUpdatesFeeQuoterChangeset(t *testing.T) {
 			ab := cldf.NewMemoryAddressBook()
 			for _, selector := range allChains {
 				_, err := cldf.DeployContract(tenv.Env.Logger, tenv.Env.BlockChains.EVMChains()[selector], ab,
-					func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
-						tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+					func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
+						tokenAddress, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 							tenv.Env.BlockChains.EVMChains()[selector].DeployerKey,
 							tenv.Env.BlockChains.EVMChains()[selector].Client,
 							string(testhelpers.TestTokenSymbol),
@@ -1070,7 +1070,7 @@ func TestApplyFeeTokensUpdatesFeeQuoterChangeset(t *testing.T) {
 							testhelpers.LocalTokenDecimals,
 							big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 						)
-						return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+						return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 							Address:  tokenAddress,
 							Contract: token,
 							Tv:       cldf.NewTypeAndVersion(shared.BurnMintToken, deployment.Version1_0_0),
@@ -1180,8 +1180,8 @@ func TestApplyPremiumMultiplierWeiPerEthUpdatesFeeQuoterChangeset(t *testing.T) 
 			ab := cldf.NewMemoryAddressBook()
 			for _, selector := range allChains {
 				_, err := cldf.DeployContract(tenv.Env.Logger, tenv.Env.BlockChains.EVMChains()[selector], ab,
-					func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
-						tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+					func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
+						tokenAddress, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 							tenv.Env.BlockChains.EVMChains()[selector].DeployerKey,
 							tenv.Env.BlockChains.EVMChains()[selector].Client,
 							string(testhelpers.TestTokenSymbol),
@@ -1189,7 +1189,7 @@ func TestApplyPremiumMultiplierWeiPerEthUpdatesFeeQuoterChangeset(t *testing.T) 
 							testhelpers.LocalTokenDecimals,
 							big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 						)
-						return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+						return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 							Address:  tokenAddress,
 							Contract: token,
 							Tv:       cldf.NewTypeAndVersion(shared.BurnMintToken, deployment.Version1_0_0),
@@ -1259,8 +1259,8 @@ func TestUpdateTokenPriceFeedsFeeQuoterChangeset(t *testing.T) {
 			// deploy a new token
 			ab := cldf.NewMemoryAddressBook()
 			_, err := cldf.DeployContract(tenv.Env.Logger, tenv.Env.BlockChains.EVMChains()[source], ab,
-				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677] {
-					tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+				func(chain cldf_evm.Chain) cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20] {
+					tokenAddress, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 						tenv.Env.BlockChains.EVMChains()[source].DeployerKey,
 						tenv.Env.BlockChains.EVMChains()[source].Client,
 						string(testhelpers.TestTokenSymbol),
@@ -1268,7 +1268,7 @@ func TestUpdateTokenPriceFeedsFeeQuoterChangeset(t *testing.T) {
 						testhelpers.LocalTokenDecimals,
 						big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 					)
-					return cldf.ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
+					return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 						Address:  tokenAddress,
 						Contract: token,
 						Tv:       cldf.NewTypeAndVersion(shared.BurnMintToken, deployment.Version1_0_0),

--- a/deployment/ccip/changeset/v1_6/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/v1_6/cs_chain_contracts_test.go
@@ -1069,6 +1069,7 @@ func TestApplyFeeTokensUpdatesFeeQuoterChangeset(t *testing.T) {
 							string(testhelpers.TestTokenSymbol),
 							testhelpers.LocalTokenDecimals,
 							big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+							big.NewInt(0),
 						)
 						return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 							Address:  tokenAddress,
@@ -1188,6 +1189,7 @@ func TestApplyPremiumMultiplierWeiPerEthUpdatesFeeQuoterChangeset(t *testing.T) 
 							string(testhelpers.TestTokenSymbol),
 							testhelpers.LocalTokenDecimals,
 							big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+							big.NewInt(0),
 						)
 						return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 							Address:  tokenAddress,
@@ -1267,6 +1269,7 @@ func TestUpdateTokenPriceFeedsFeeQuoterChangeset(t *testing.T) {
 						string(testhelpers.TestTokenSymbol),
 						testhelpers.LocalTokenDecimals,
 						big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+						big.NewInt(0),
 					)
 					return cldf.ContractDeploy[*burn_mint_erc20.BurnMintERC20]{
 						Address:  tokenAddress,

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc677_helper"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc20_helper"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/don_id_claimer"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/factory_burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/fast_transfer_token_pool"
@@ -45,7 +45,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/aggregator_v3_interface"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc677"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/multicall3"
@@ -95,8 +95,8 @@ type CCIPChainState struct {
 	ERC20Tokens                                      map[shared.TokenSymbol]*erc20.ERC20
 	FactoryBurnMintERC20Token                        *factory_burn_mint_erc20.FactoryBurnMintERC20
 	ERC677Tokens                                     map[shared.TokenSymbol]*erc677.ERC677
-	BurnMintTokens677                                map[shared.TokenSymbol]*burn_mint_erc677.BurnMintERC677
-	BurnMintTokens677Helper                          map[shared.TokenSymbol]*burn_mint_erc677_helper.BurnMintERC677Helper
+	BurnMintTokens677                                map[shared.TokenSymbol]*burn_mint_erc20.BurnMintERC20
+	BurnMintTokens677Helper                          map[shared.TokenSymbol]*burn_mint_erc20_helper.BurnMintERC20Helper
 	BurnMintTokenPools                               map[shared.TokenSymbol]map[semver.Version]*burn_mint_token_pool.BurnMintTokenPool
 	BurnMintFastTransferTokenPools                   map[shared.TokenSymbol]map[semver.Version]*fast_transfer_token_pool.BurnMintFastTransferTokenPool
 	BurnMintWithExternalMinterFastTransferTokenPools map[shared.TokenSymbol]map[semver.Version]*burn_mint_with_external_minter_fast_transfer_token_pool.BurnMintWithExternalMinterFastTransferTokenPool

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc20_helper"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc677_helper"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/don_id_claimer"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/factory_burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/fast_transfer_token_pool"
@@ -96,7 +96,7 @@ type CCIPChainState struct {
 	FactoryBurnMintERC20Token                        *factory_burn_mint_erc20.FactoryBurnMintERC20
 	ERC677Tokens                                     map[shared.TokenSymbol]*erc677.ERC677
 	BurnMintTokens677                                map[shared.TokenSymbol]*burn_mint_erc20.BurnMintERC20
-	BurnMintTokens677Helper                          map[shared.TokenSymbol]*burn_mint_erc20_helper.BurnMintERC20Helper
+	BurnMintTokens677Helper                          map[shared.TokenSymbol]*burn_mint_erc677_helper.BurnMintERC677Helper
 	BurnMintTokenPools                               map[shared.TokenSymbol]map[semver.Version]*burn_mint_token_pool.BurnMintTokenPool
 	BurnMintFastTransferTokenPools                   map[shared.TokenSymbol]map[semver.Version]*fast_transfer_token_pool.BurnMintFastTransferTokenPool
 	BurnMintWithExternalMinterFastTransferTokenPools map[shared.TokenSymbol]map[semver.Version]*burn_mint_with_external_minter_fast_transfer_token_pool.BurnMintWithExternalMinterFastTransferTokenPool

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -67,7 +67,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc677_helper"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc20_helper"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/don_id_claimer"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/fast_transfer_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/maybe_revert_message_receiver"
@@ -84,7 +84,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/aggregator_v3_interface"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/multicall3"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/weth9"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/bindings/burn_mint_with_external_minter_fast_transfer_token_pool"
@@ -869,14 +869,14 @@ func LoadChainState(ctx context.Context, chain cldf_evm.Chain, addresses map[str
 			state.FeeQuoter = fq
 			state.ABIByAddress[address] = fee_quoter.FeeQuoterABI
 		case cldf.NewTypeAndVersion(ccipshared.USDCToken, deployment.Version1_0_0).String():
-			ut, err := burn_mint_erc677.NewBurnMintERC677(common.HexToAddress(address), chain.Client)
+			ut, err := burn_mint_erc20.NewBurnMintERC20(common.HexToAddress(address), chain.Client)
 			if err != nil {
 				return state, err
 			}
-			state.BurnMintTokens677 = map[ccipshared.TokenSymbol]*burn_mint_erc677.BurnMintERC677{
+			state.BurnMintTokens677 = map[ccipshared.TokenSymbol]*burn_mint_erc20.BurnMintERC20{
 				ccipshared.USDCSymbol: ut,
 			}
-			state.ABIByAddress[address] = burn_mint_erc677.BurnMintERC677ABI
+			state.ABIByAddress[address] = burn_mint_erc20.BurnMintERC20ABI
 		case cldf.NewTypeAndVersion(ccipshared.USDCTokenPool, deployment.Version1_5_1).String():
 			utp, err := usdc_token_pool.NewUSDCTokenPool(common.HexToAddress(address), chain.Client)
 			if err != nil {
@@ -1007,19 +1007,19 @@ func LoadChainState(ctx context.Context, chain cldf_evm.Chain, addresses map[str
 			state.LockReleaseTokenPools = helpers.AddValueToNestedMap(state.LockReleaseTokenPools, metadata.Symbol, metadata.Version, pool)
 			state.ABIByAddress[address] = lock_release_token_pool.LockReleaseTokenPoolABI
 		case cldf.NewTypeAndVersion(ccipshared.BurnMintToken, deployment.Version1_0_0).String():
-			tok, err := burn_mint_erc677.NewBurnMintERC677(common.HexToAddress(address), chain.Client)
+			tok, err := burn_mint_erc20.NewBurnMintERC20(common.HexToAddress(address), chain.Client)
 			if err != nil {
 				return state, err
 			}
 			if state.BurnMintTokens677 == nil {
-				state.BurnMintTokens677 = make(map[ccipshared.TokenSymbol]*burn_mint_erc677.BurnMintERC677)
+				state.BurnMintTokens677 = make(map[ccipshared.TokenSymbol]*burn_mint_erc20.BurnMintERC20)
 			}
 			symbol, err := tok.Symbol(nil)
 			if err != nil {
 				return state, fmt.Errorf("failed to get token symbol of token at %s: %w", address, err)
 			}
 			state.BurnMintTokens677[ccipshared.TokenSymbol(symbol)] = tok
-			state.ABIByAddress[address] = burn_mint_erc677.BurnMintERC677ABI
+			state.ABIByAddress[address] = burn_mint_erc20.BurnMintERC20ABI
 		case cldf.NewTypeAndVersion(ccipshared.ERC20Token, deployment.Version1_0_0).String():
 			tok, err := erc20.NewERC20(common.HexToAddress(address), chain.Client)
 			if err != nil {
@@ -1133,20 +1133,20 @@ func LoadChainState(ctx context.Context, chain cldf_evm.Chain, addresses map[str
 			state.DonIDClaimer = donIDClaimer
 			state.ABIByAddress[address] = don_id_claimer.DonIDClaimerABI
 		case cldf.NewTypeAndVersion(ccipshared.ERC677TokenHelper, deployment.Version1_0_0).String():
-			ERC677HelperToken, err := burn_mint_erc677_helper.NewBurnMintERC677Helper(common.HexToAddress(address), chain.Client)
+			ERC677HelperToken, err := burn_mint_erc20_helper.NewBurnMintERC20Helper(common.HexToAddress(address), chain.Client)
 			if err != nil {
 				return state, err
 			}
 
 			if state.BurnMintTokens677Helper == nil {
-				state.BurnMintTokens677Helper = make(map[ccipshared.TokenSymbol]*burn_mint_erc677_helper.BurnMintERC677Helper)
+				state.BurnMintTokens677Helper = make(map[ccipshared.TokenSymbol]*burn_mint_erc20_helper.BurnMintERC20Helper)
 			}
 			symbol, err := ERC677HelperToken.Symbol(nil)
 			if err != nil {
 				return state, fmt.Errorf("failed to get token symbol of token at %s: %w", address, err)
 			}
 			state.BurnMintTokens677Helper[ccipshared.TokenSymbol(symbol)] = ERC677HelperToken
-			state.ABIByAddress[address] = burn_mint_erc677_helper.BurnMintERC677HelperABI
+			state.ABIByAddress[address] = burn_mint_erc20_helper.BurnMintERC20HelperABI
 		default:
 			// ManyChainMultiSig 1.0.0 can have any of these labels, it can have either 1,2 or 3 of these -
 			// bypasser, proposer and canceller

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -38,18 +38,16 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/factory_burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/log_message_data_receiver"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/mock_usdc_token_messenger"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/mock_usdc_token_transmitter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/token_pool_factory"
 	price_registry_1_2_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/price_registry"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/rmn_contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/burn_mint_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/burn_with_from_mint_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/lock_release_token_pool"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc20"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc677"
-
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/mock_usdc_token_messenger"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/mock_usdc_token_transmitter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/usdc_token_pool"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc20"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -67,7 +65,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc20_helper"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc677_helper"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/don_id_claimer"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/fast_transfer_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/maybe_revert_message_receiver"
@@ -1041,20 +1039,6 @@ func LoadChainState(ctx context.Context, chain cldf_evm.Chain, addresses map[str
 			}
 			state.FactoryBurnMintERC20Token = tok
 			state.ABIByAddress[address] = factory_burn_mint_erc20.FactoryBurnMintERC20ABI
-		case cldf.NewTypeAndVersion(ccipshared.ERC677Token, deployment.Version1_0_0).String():
-			tok, err := erc677.NewERC677(common.HexToAddress(address), chain.Client)
-			if err != nil {
-				return state, err
-			}
-			if state.ERC677Tokens == nil {
-				state.ERC677Tokens = make(map[ccipshared.TokenSymbol]*erc677.ERC677)
-			}
-			symbol, err := tok.Symbol(nil)
-			if err != nil {
-				return state, fmt.Errorf("failed to get token symbol of token at %s: %w", address, err)
-			}
-			state.ERC677Tokens[ccipshared.TokenSymbol(symbol)] = tok
-			state.ABIByAddress[address] = erc677.ERC677ABI
 		// legacy addresses below
 		case cldf.NewTypeAndVersion(ccipshared.OnRamp, deployment.Version1_5_0).String():
 			onRampC, err := evm_2_evm_onramp.NewEVM2EVMOnRamp(common.HexToAddress(address), chain.Client)
@@ -1133,20 +1117,20 @@ func LoadChainState(ctx context.Context, chain cldf_evm.Chain, addresses map[str
 			state.DonIDClaimer = donIDClaimer
 			state.ABIByAddress[address] = don_id_claimer.DonIDClaimerABI
 		case cldf.NewTypeAndVersion(ccipshared.ERC677TokenHelper, deployment.Version1_0_0).String():
-			ERC677HelperToken, err := burn_mint_erc20_helper.NewBurnMintERC20Helper(common.HexToAddress(address), chain.Client)
+			ERC677HelperToken, err := burn_mint_erc677_helper.NewBurnMintERC677Helper(common.HexToAddress(address), chain.Client)
 			if err != nil {
 				return state, err
 			}
 
 			if state.BurnMintTokens677Helper == nil {
-				state.BurnMintTokens677Helper = make(map[ccipshared.TokenSymbol]*burn_mint_erc20_helper.BurnMintERC20Helper)
+				state.BurnMintTokens677Helper = make(map[ccipshared.TokenSymbol]*burn_mint_erc677_helper.BurnMintERC677Helper)
 			}
 			symbol, err := ERC677HelperToken.Symbol(nil)
 			if err != nil {
 				return state, fmt.Errorf("failed to get token symbol of token at %s: %w", address, err)
 			}
 			state.BurnMintTokens677Helper[ccipshared.TokenSymbol(symbol)] = ERC677HelperToken
-			state.ABIByAddress[address] = burn_mint_erc20_helper.BurnMintERC20HelperABI
+			state.ABIByAddress[address] = burn_mint_erc677_helper.BurnMintERC677HelperABI
 		default:
 			// ManyChainMultiSig 1.0.0 can have any of these labels, it can have either 1,2 or 3 of these -
 			// bypasser, proposer and canceller

--- a/deployment/ccip/shared/token_pools.go
+++ b/deployment/ccip/shared/token_pools.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc20"
@@ -24,7 +25,6 @@ var BurnMintWithExternalMinterFastTransferTokenPoolVersion = deployment.Version1
 var TokenTypes = map[cldf.ContractType]struct{}{
 	BurnMintToken:     {},
 	ERC20Token:        {},
-	ERC677Token:       {},
 	ERC677TokenHelper: {},
 }
 

--- a/deployment/ccip/shared/types.go
+++ b/deployment/ccip/shared/types.go
@@ -40,7 +40,6 @@ var (
 	BurnMintToken                                   deployment.ContractType = "BurnMintToken"
 	FactoryBurnMintERC20Token                       deployment.ContractType = "FactoryBurnMintERC20Token"
 	ERC20Token                                      deployment.ContractType = "ERC20Token"
-	ERC677Token                                     deployment.ContractType = "ERC677Token"
 	ERC677TokenHelper                               deployment.ContractType = "ERC677TokenHelper"
 	BurnMintTokenPool                               deployment.ContractType = "BurnMintTokenPool"
 	BurnWithFromMintTokenPool                       deployment.ContractType = "BurnWithFromMintTokenPool"

--- a/deployment/common/changeset/internal/seqs/seq_transfer_to_mcms_timelock.go
+++ b/deployment/common/changeset/internal/seqs/seq_transfer_to_mcms_timelock.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/ops"
 	mcms_shared "github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/shared"
 )
@@ -101,7 +101,7 @@ var SeqTransferToMCMSWithTimelockV2 = operations.NewSequence(
 // TODO: convert this to an OP
 func LoadOwnableContract(addr common.Address, client bind.ContractBackend) (common.Address, mcms_shared.Ownable, error) {
 	// Just using the ownership interface from here.
-	c, err := burn_mint_erc677.NewBurnMintERC677(addr, client)
+	c, err := burn_mint_erc20.NewBurnMintERC20(addr, client)
 	if err != nil {
 		return common.Address{}, nil, fmt.Errorf("failed to create contract: %w", err)
 	}

--- a/deployment/common/changeset/transfer_to_mcms_with_timelock.go
+++ b/deployment/common/changeset/transfer_to_mcms_with_timelock.go
@@ -17,7 +17,7 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink/deployment/common/changeset/internal/seqs"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
@@ -38,7 +38,7 @@ type Ownable interface {
 
 func LoadOwnableContract(addr common.Address, client bind.ContractBackend) (common.Address, Ownable, error) {
 	// Just using the ownership interface from here.
-	c, err := burn_mint_erc677.NewBurnMintERC677(addr, client)
+	c, err := burn_mint_erc20.NewBurnMintERC20(addr, client)
 	if err != nil {
 		return common.Address{}, nil, fmt.Errorf("failed to create contract: %w", err)
 	}

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -58,7 +58,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/ccipexec"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/testhelpers"
@@ -902,7 +902,7 @@ func (ccipModule *CCIPCommon) DeployContracts(
 			if len(tokenDeployerFns) != noOfTokens {
 				if ccipModule.IsUSDCDeployment() && i == 0 {
 					// if it's USDC deployment, we deploy the burn mint token 677 with decimal 6 and cast it to ERC20Token
-					usdcToken, err := ccipModule.tokenDeployer.DeployBurnMintERC677(new(big.Int).Mul(big.NewInt(1e6), big.NewInt(1e18)))
+					usdcToken, err := ccipModule.tokenDeployer.DeployBurnMintERC20(new(big.Int).Mul(big.NewInt(1e6), big.NewInt(1e18)))
 					if err != nil {
 						return fmt.Errorf("deploying bridge usdc token contract shouldn't fail %w", err)
 					}
@@ -946,7 +946,7 @@ func (ccipModule *CCIPCommon) DeployContracts(
 					}
 				} else if ccipModule.IsLBTCDeployment() && i == 0 {
 					// if it's LBTC deployment, we deploy the burn mint token 677 with decimal 8 and cast it to ERC20Token
-					lbtcToken, err := ccipModule.tokenDeployer.DeployCustomBurnMintERC677Token("Lombard LBTC", "LBTC", uint8(8), new(big.Int).Mul(big.NewInt(1e6), big.NewInt(1e18)))
+					lbtcToken, err := ccipModule.tokenDeployer.DeployCustomBurnMintERC20Token("Lombard LBTC", "LBTC", uint8(8), new(big.Int).Mul(big.NewInt(1e6), big.NewInt(1e18)))
 					if err != nil {
 						return fmt.Errorf("deploying bridge lbtc token contract shouldn't fail %w", err)
 					}
@@ -1037,7 +1037,7 @@ func (ccipModule *CCIPCommon) DeployContracts(
 				if err != nil {
 					return errors.Wrapf(err, "deploying mock lbtc bridge token pool shouldn't fail")
 				}
-				lbtcInstance, err := burn_mint_erc677.NewBurnMintERC677(token.ContractAddress, ccipModule.ChainClient.Backend())
+				lbtcInstance, err := burn_mint_erc20.NewBurnMintERC20(token.ContractAddress, ccipModule.ChainClient.Backend())
 				if err != nil {
 					return errors.Wrapf(err, "failed to get dest usdc token instance")
 				}

--- a/integration-tests/ccip-tests/contracts/contract_deployer.go
+++ b/integration-tests/ccip-tests/contracts/contract_deployer.go
@@ -216,8 +216,8 @@ func (e *CCIPContractsDeployer) DeployBurnMintERC20(ownerMintingAmount *big.Int)
 		return burn_mint_erc20.DeployBurnMintERC20(
 			auth,
 			wrappers.MustNewWrappedContractBackend(e.evmClient, nil),
-			"Test Token ERC677",
-			"TERC677",
+			"Test Token ERC20",
+			"TERC20",
 			6,
 			new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9)),
 			big.NewInt(0),

--- a/integration-tests/ccip-tests/contracts/contract_deployer.go
+++ b/integration-tests/ccip-tests/contracts/contract_deployer.go
@@ -49,7 +49,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/lock_release_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/usdc_token_pool"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/mock_v3_aggregator_contract"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/type_and_version"
@@ -207,13 +207,13 @@ func (e *CCIPContractsDeployer) DeployLinkTokenContract() (*LinkToken, error) {
 	}, err
 }
 
-// DeployBurnMintERC677 deploys a BurnMintERC677 contract, mints given amount ( if provided) to the owner address and returns the ERC20Token wrapper instance
-func (e *CCIPContractsDeployer) DeployBurnMintERC677(ownerMintingAmount *big.Int) (*ERC677Token, error) {
+// DeployBurnMintERC20 deploys a BurnMintERC20 contract, mints given amount ( if provided) to the owner address and returns the ERC20Token wrapper instance
+func (e *CCIPContractsDeployer) DeployBurnMintERC20(ownerMintingAmount *big.Int) (*ERC677Token, error) {
 	address, _, instance, err := e.evmClient.DeployContract("Burn Mint ERC 677", func(
 		auth *bind.TransactOpts,
 		_ bind.ContractBackend,
 	) (common.Address, *types.Transaction, interface{}, error) {
-		return burn_mint_erc677.DeployBurnMintERC677(auth, wrappers.MustNewWrappedContractBackend(e.evmClient, nil), "Test Token ERC677", "TERC677", 6, new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9)))
+		return burn_mint_erc20.DeployBurnMintERC20(auth, wrappers.MustNewWrappedContractBackend(e.evmClient, nil), "Test Token ERC677", "TERC677", 6, new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9)))
 	})
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (e *CCIPContractsDeployer) DeployBurnMintERC677(ownerMintingAmount *big.Int
 		client:          e.evmClient,
 		logger:          e.logger,
 		ContractAddress: *address,
-		instance:        instance.(*burn_mint_erc677.BurnMintERC677),
+		instance:        instance.(*burn_mint_erc20.BurnMintERC20),
 		OwnerAddress:    common.HexToAddress(e.evmClient.GetDefaultWallet().Address()),
 		OwnerWallet:     e.evmClient.GetDefaultWallet(),
 	}
@@ -245,12 +245,12 @@ func (e *CCIPContractsDeployer) DeployBurnMintERC677(ownerMintingAmount *big.Int
 	return token, err
 }
 
-func (e *CCIPContractsDeployer) DeployCustomBurnMintERC677Token(name, symbol string, decimals uint8, ownerMintingAmount *big.Int) (*ERC677Token, error) {
+func (e *CCIPContractsDeployer) DeployCustomBurnMintERC20Token(name, symbol string, decimals uint8, ownerMintingAmount *big.Int) (*ERC677Token, error) {
 	address, _, instance, err := e.evmClient.DeployContract("Burn Mint ERC 677", func(
 		auth *bind.TransactOpts,
 		_ bind.ContractBackend,
 	) (common.Address, *types.Transaction, interface{}, error) {
-		return burn_mint_erc677.DeployBurnMintERC677(auth, wrappers.MustNewWrappedContractBackend(e.evmClient, nil), name, symbol, decimals, new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9)))
+		return burn_mint_erc20.DeployBurnMintERC20(auth, wrappers.MustNewWrappedContractBackend(e.evmClient, nil), name, symbol, decimals, new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9)))
 	})
 	if err != nil {
 		return nil, err
@@ -260,7 +260,7 @@ func (e *CCIPContractsDeployer) DeployCustomBurnMintERC677Token(name, symbol str
 		client:          e.evmClient,
 		logger:          e.logger,
 		ContractAddress: *address,
-		instance:        instance.(*burn_mint_erc677.BurnMintERC677),
+		instance:        instance.(*burn_mint_erc20.BurnMintERC20),
 		OwnerAddress:    common.HexToAddress(e.evmClient.GetDefaultWallet().Address()),
 		OwnerWallet:     e.evmClient.GetDefaultWallet(),
 	}

--- a/integration-tests/ccip-tests/contracts/contract_deployer.go
+++ b/integration-tests/ccip-tests/contracts/contract_deployer.go
@@ -208,18 +208,26 @@ func (e *CCIPContractsDeployer) DeployLinkTokenContract() (*LinkToken, error) {
 }
 
 // DeployBurnMintERC20 deploys a BurnMintERC20 contract, mints given amount ( if provided) to the owner address and returns the ERC20Token wrapper instance
-func (e *CCIPContractsDeployer) DeployBurnMintERC20(ownerMintingAmount *big.Int) (*ERC677Token, error) {
+func (e *CCIPContractsDeployer) DeployBurnMintERC20(ownerMintingAmount *big.Int) (*burn_mint_erc20., error) {
 	address, _, instance, err := e.evmClient.DeployContract("Burn Mint ERC 677", func(
 		auth *bind.TransactOpts,
 		_ bind.ContractBackend,
 	) (common.Address, *types.Transaction, interface{}, error) {
-		return burn_mint_erc20.DeployBurnMintERC20(auth, wrappers.MustNewWrappedContractBackend(e.evmClient, nil), "Test Token ERC677", "TERC677", 6, new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9)))
+		return burn_mint_erc20.DeployBurnMintERC20(
+			auth,
+			wrappers.MustNewWrappedContractBackend(e.evmClient, nil),
+			"Test Token ERC677",
+			"TERC677",
+			6,
+			new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9)),
+			big.NewInt(0),
+			)
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	token := &ERC677Token{
+	token := &ERC20Token{
 		client:          e.evmClient,
 		logger:          e.logger,
 		ContractAddress: *address,
@@ -245,18 +253,18 @@ func (e *CCIPContractsDeployer) DeployBurnMintERC20(ownerMintingAmount *big.Int)
 	return token, err
 }
 
-func (e *CCIPContractsDeployer) DeployCustomBurnMintERC20Token(name, symbol string, decimals uint8, ownerMintingAmount *big.Int) (*ERC677Token, error) {
+func (e *CCIPContractsDeployer) DeployCustomBurnMintERC20Token(name, symbol string, decimals uint8, ownerMintingAmount *big.Int) (*ERC20Token, error) {
 	address, _, instance, err := e.evmClient.DeployContract("Burn Mint ERC 677", func(
 		auth *bind.TransactOpts,
 		_ bind.ContractBackend,
 	) (common.Address, *types.Transaction, interface{}, error) {
-		return burn_mint_erc20.DeployBurnMintERC20(auth, wrappers.MustNewWrappedContractBackend(e.evmClient, nil), name, symbol, decimals, new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9)))
+		return burn_mint_erc20.DeployBurnMintERC20(auth, wrappers.MustNewWrappedContractBackend(e.evmClient, nil), name, symbol, decimals, new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9)), big.NewInt(0)
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	token := &ERC677Token{
+	token := &ERC20Token{
 		client:          e.evmClient,
 		logger:          e.logger,
 		ContractAddress: *address,

--- a/integration-tests/ccip-tests/contracts/contract_models.go
+++ b/integration-tests/ccip-tests/contracts/contract_models.go
@@ -186,7 +186,7 @@ type TokenTransmitter struct {
 	ContractAddress common.Address
 }
 
-type ERC677Token struct {
+type ERC20Token struct {
 	client          blockchain.EVMClient
 	logger          *zerolog.Logger
 	instance        *burn_mint_erc20.BurnMintERC20
@@ -195,7 +195,7 @@ type ERC677Token struct {
 	OwnerWallet     *blockchain.EthereumWallet
 }
 
-func (token *ERC677Token) GrantMintAndBurn(burnAndMinter common.Address) error {
+func (token *ERC20Token) GrantMintAndBurn(burnAndMinter common.Address) error {
 	opts, err := token.client.TransactionOpts(token.OwnerWallet)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction opts: %w", err)
@@ -212,7 +212,7 @@ func (token *ERC677Token) GrantMintAndBurn(burnAndMinter common.Address) error {
 	return token.client.ProcessTransaction(tx)
 }
 
-func (token *ERC677Token) GrantMintRole(minter common.Address) error {
+func (token *ERC20Token) GrantMintRole(minter common.Address) error {
 	opts, err := token.client.TransactionOpts(token.OwnerWallet)
 	if err != nil {
 		return err
@@ -229,7 +229,7 @@ func (token *ERC677Token) GrantMintRole(minter common.Address) error {
 	return token.client.ProcessTransaction(tx)
 }
 
-func (token *ERC677Token) Mint(to common.Address, amount *big.Int) error {
+func (token *ERC20Token) Mint(to common.Address, amount *big.Int) error {
 	opts, err := token.client.TransactionOpts(token.OwnerWallet)
 	if err != nil {
 		return err

--- a/integration-tests/ccip-tests/contracts/contract_models.go
+++ b/integration-tests/ccip-tests/contracts/contract_models.go
@@ -46,7 +46,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/usdc_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/mock_v3_aggregator_contract"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
@@ -189,7 +189,7 @@ type TokenTransmitter struct {
 type ERC677Token struct {
 	client          blockchain.EVMClient
 	logger          *zerolog.Logger
-	instance        *burn_mint_erc677.BurnMintERC677
+	instance        *burn_mint_erc20.BurnMintERC20
 	ContractAddress common.Address
 	OwnerAddress    common.Address
 	OwnerWallet     *blockchain.EthereumWallet
@@ -721,7 +721,7 @@ func (pool *TokenPool) MintUSDCToUSDCPool() error {
 	if err != nil {
 		return fmt.Errorf("failed to get dest usdc token: %w", err)
 	}
-	usdcInstance, err := burn_mint_erc677.NewBurnMintERC677(usdcToken, pool.client.Backend())
+	usdcInstance, err := burn_mint_erc20.NewBurnMintERC20(usdcToken, pool.client.Backend())
 	if err != nil {
 		return fmt.Errorf("failed to get dest usdc token instance: %w", err)
 	}

--- a/integration-tests/smoke/ccip/ccip_fast_transfer_test.go
+++ b/integration-tests/smoke/ccip/ccip_fast_transfer_test.go
@@ -309,6 +309,7 @@ func deployTokenAndGrantAllRoles(t *testing.T, chain evmChain.Chain, tokenSymbol
 		tokenSymbol,
 		tokenDecimals,
 		big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+		big.NewInt(0),
 	)
 	require.NoError(t, err)
 	_, err = chain.Confirm(tx)

--- a/integration-tests/smoke/ccip/ccip_fast_transfer_test.go
+++ b/integration-tests/smoke/ccip/ccip_fast_transfer_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/bindings"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/link_token"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/blockchain"
@@ -302,7 +302,7 @@ func deployTokenAndGrantAllRoles(t *testing.T, chain evmChain.Chain, tokenSymbol
 		return token
 	}
 
-	_, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+	_, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 		chain.DeployerKey,
 		chain.Client,
 		tokenSymbol,
@@ -484,13 +484,13 @@ func configureBurnMintTokenPool(t *testing.T, e cldf.Environment, sourceChainSel
 		},
 	}
 
-	sourceToken, err := burn_mint_erc677.NewBurnMintERC677(sourceTokenAddress, sourceChain.Client)
+	sourceToken, err := burn_mint_erc20.NewBurnMintERC20(sourceTokenAddress, sourceChain.Client)
 	require.NoError(t, err)
-	destToken, err := burn_mint_erc677.NewBurnMintERC677(destinationTokenAddress, destChain.Client)
+	destToken, err := burn_mint_erc20.NewBurnMintERC20(destinationTokenAddress, destChain.Client)
 	require.NoError(t, err)
 
 	postSetupAction := func(sourceTokenPool common.Address, destinationTokenPool common.Address) {
-		sourceTokenInstance, err := burn_mint_erc677.NewBurnMintERC677(sourceTokenAddress, sourceChain.Client)
+		sourceTokenInstance, err := burn_mint_erc20.NewBurnMintERC20(sourceTokenAddress, sourceChain.Client)
 		require.NoError(t, err)
 		tx, err := sourceTokenInstance.GrantBurnRole(sourceChain.DeployerKey, sourceTokenPool)
 		require.NoError(t, err)

--- a/integration-tests/smoke/ccip/ccip_fees_test.go
+++ b/integration-tests/smoke/ccip/ccip_fees_test.go
@@ -45,6 +45,7 @@ func setupNewFeeToken(
 		tokenSymbol,
 		tokenDecimals,
 		big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
+		big.NewInt(0),
 	)
 	_, err = cldf.ConfirmIfNoError(chain, tx, err)
 	require.NoError(t, err)

--- a/integration-tests/smoke/ccip/ccip_fees_test.go
+++ b/integration-tests/smoke/ccip/ccip_fees_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
@@ -35,10 +35,10 @@ func setupNewFeeToken(
 	state stateview.CCIPOnChainState,
 	tokenSymbol string,
 	tokenDecimals uint8,
-) (feeToken *burn_mint_erc677.BurnMintERC677) {
+) (feeToken *burn_mint_erc20.BurnMintERC20) {
 	lggr := logger.TestLogger(t)
 	chain := tenv.Env.BlockChains.EVMChains()[chainSelector]
-	tokenAddress, tx, token, err := burn_mint_erc677.DeployBurnMintERC677(
+	tokenAddress, tx, token, err := burn_mint_erc20.DeployBurnMintERC20(
 		deployer,
 		chain.Client,
 		tokenSymbol,
@@ -100,8 +100,8 @@ func setupTokens(
 	transferTokenMintAmount,
 	feeTokenMintAmount *big.Int,
 ) (
-	srcToken *burn_mint_erc677.BurnMintERC677,
-	dstToken *burn_mint_erc677.BurnMintERC677,
+	srcToken *burn_mint_erc20.BurnMintERC20,
+	dstToken *burn_mint_erc20.BurnMintERC20,
 ) {
 	lggr := logger.TestLogger(t)
 	e := tenv.Env

--- a/integration-tests/smoke/ccip/ccip_usdc_test.go
+++ b/integration-tests/smoke/ccip/ccip_usdc_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc677"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -238,7 +238,7 @@ func updateFeeQuoters(
 	e cldf.Environment,
 	state stateview.CCIPOnChainState,
 	chainA, chainB, chainC uint64,
-	aChainUSDC, bChainUSDC, cChainUSDC *burn_mint_erc677.BurnMintERC677,
+	aChainUSDC, bChainUSDC, cChainUSDC *burn_mint_erc20.BurnMintERC20,
 ) error {
 	evmChains := e.BlockChains.EVMChains()
 	updateFeeQtrGrp := errgroup.Group{}


### PR DESCRIPTION
Replaces the old BurnMintERC677 in tests/changesets with the newer BurnMintERC20. This allows for the removal of the wrappers for BurnMintERC677 and ERC677 in this [PR](https://github.com/smartcontractkit/chainlink-evm/pull/120).

Note that BurnMintERC677Helper is still available, which is imported through chainlink-ccip. 