### PR TITLE
Use reusable workflow for stale PRs and bump ops limit

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,29 +1,27 @@
+##
 # Workflow is triggered daily midnight UTC
 # A PR with more than 60 days of inactivity will be marked as stale
 # A PR that's stale for more than 7 days will be automatically closed
 # Issues are exempt from auto marking as stale but issues with manually added 'stale' label are eligible for auto closure after 7 days.
 # PRs with `exempt-pr-labels` or assignees are exempt from auto stale marking, it's the responsibility of the assignee to get the PR progressed either with review/merge or closure.
-name: Manage stale Issues and PRs
+##
+name: Manage stale issues and PRs
 
 on:
   schedule:
     - cron: "0 0 * * *" # Will be triggered every day at midnight UTC
-
+permissions: {}
 jobs:
-  stale:
-    runs-on: ubuntu-latest
+  stale-prs:
     permissions:
-      contents: write # only for delete-branch option
+      actions: write
+      contents: write
       issues: write
       pull-requests: write
-
-    steps:
-      - uses: actions/stale@v9
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          exempt-all-pr-assignees: true
-          stale-pr-message: "This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days."
-          days-before-issue-stale: -1 # disables marking issues as stale automatically. Issues can still be marked as stale manually, in which the closure policy applies.
-          delete-branch: true
-          # Comma separated list of labels that exempt issues from being considered stale.
-          exempt-pr-labels: "stale-exempt"
+    uses: smartcontractkit/.github/.github/workflows/reusable-stale-prs-issues.yml@217f5d6f10f04ebd56534dc2f2cd9b485fe45d88 # 2025-06-20
+    with:
+      days-before-pr-stale: 60 # days
+      days-before-pr-close: 7 # days
+      operations-per-run: 200 # max number of API calls to use.
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See [example](https://github.com/smartcontractkit/chainlink/actions/runs/15768403705) of us bumping into the limit.