### PR TITLE
Sync chainlink-solana from go.mod with plugin version

### DIFF
--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -29,7 +29,7 @@ plugins:
 
   solana:
     - moduleURI: "github.com/smartcontractkit/chainlink-solana"
-      gitRef: "v1.1.2-0.20250616223948-ca6f14c333e9"
+      gitRef: "v1.1.2-0.20250611193111-99542a0c5d58"
       installPath: "github.com/smartcontractkit/chainlink-solana/pkg/solana/cmd/chainlink-solana"
 
   starknet:


### PR DESCRIPTION
Fixed via:

```shell
go run ./tools/plugout --update
=== Starting plugin version sync check ===
Checking go.mod path: ./go.mod
Modules to check: github.com/smartcontractkit/chainlink-data-streams, github.com/smartcontractkit/chainlink-feeds, github.com/smartcontractkit/chainlink-solana
Plugin files to check: ./plugins/plugins.public.yaml
Mode: UPDATE (will update plugin gitRef values)
...
Extracting version for github.com/smartcontractkit/chainlink-solana from go.mod...
Version extracted: v1.1.2-0.20250611193111-99542a0c5d58
Extracting version for github.com/smartcontractkit/chainlink-solana from ./plugins/plugins.public.yaml...
  ❌ MISMATCH: github.com/smartcontractkit/chainlink-solana in ./plugins/plugins.public.yaml
    go.mod: v1.1.2-0.20250611193111-99542a0c5d58
    yaml  : v1.1.2-0.20250616223948-ca6f14c333e9
  Updating gitRef for github.com/smartcontractkit/chainlink-solana to v1.1.2-0.20250611193111-99542a0c5d58 in ./plugins/plugins.public.yaml
    ✅ Updated gitRef in ./plugins/plugins.public.yaml
```
    