### PR TITLE
Sync go.mod versions to plugin refs during gomodtidy

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,6 +31,7 @@ gomod: ## Ensure chainlink's go dependencies are installed.
 .PHONY: gomodtidy
 gomodtidy: gomods ## Run go mod tidy on all modules.
 	gomods tidy
+	go run ./tools/plugout --update
 
 .PHONY: tidy
 tidy: gomodtidy ## Tidy all modules and add to git.

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -29,7 +29,7 @@ plugins:
 
   solana:
     - moduleURI: "github.com/smartcontractkit/chainlink-solana"
-      gitRef: "v1.1.2-0.20250616223948-ca6f14c333e9"
+      gitRef: "v1.1.2-0.20250611193111-99542a0c5d58"
       installPath: "github.com/smartcontractkit/chainlink-solana/pkg/solana/cmd/chainlink-solana"
 
   starknet:


### PR DESCRIPTION
We need to make sure that when a module, that also is installed as a plugin with `loopinstall`, is updated in go.mod, that we keep its `plugins/plugins.*.yaml` version in sync with the go.mod ref.