### PR TITLE
chore: bump chainlink-ccip

### DIFF
--- a/.changeset/yummy-boats-sniff.md
+++ b/.changeset/yummy-boats-sniff.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#updated chainlink-ccip

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1273,8 +1273,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb h1:+X4vCon7EYsTcVtl6uzLRrxn+xQn3PJdCg59flWjhSU=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1249,8 +1249,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb h1:+X4vCon7EYsTcVtl6uzLRrxn+xQn3PJdCg59flWjhSU=

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb h1:+X4vCon7EYsTcVtl6uzLRrxn+xQn3PJdCg59flWjhSU=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1480,8 +1480,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb h1:+X4vCon7EYsTcVtl6uzLRrxn+xQn3PJdCg59flWjhSU=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb
 	github.com/smartcontractkit/chainlink-deployments-framework v0.12.1

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1462,8 +1462,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb h1:+X4vCon7EYsTcVtl6uzLRrxn+xQn3PJdCg59flWjhSU=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -361,7 +361,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1236,8 +1236,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb h1:+X4vCon7EYsTcVtl6uzLRrxn+xQn3PJdCg59flWjhSU=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -434,7 +434,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.60 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1436,8 +1436,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250620150718-13f3ead5fedb h1:+X4vCon7EYsTcVtl6uzLRrxn+xQn3PJdCg59flWjhSU=


### PR DESCRIPTION
Bumps chainlink-ccip to introduce support for correct calculation of `CalculateUsdPerUnitGas` for aptos