### PR TITLE
Fetch keys non evm fix

### DIFF
--- a/deployment/environment/devenv/don.go
+++ b/deployment/environment/devenv/don.go
@@ -239,6 +239,11 @@ func (n *Node) AddLabel(label *ptypes.Label) {
 func (n *Node) CreateCCIPOCRSupportedChains(ctx context.Context, chains []JDChainConfigInput, jd JobDistributor) error {
 	for _, chain := range chains {
 		var account string
+
+		if n.AccountAddr == nil {
+			n.AccountAddr = make(map[string]string)
+		}
+
 		switch chain.ChainType {
 		case "EVM":
 			accountAddr, err := n.gqlClient.FetchAccountAddress(ctx, chain.ChainID)
@@ -247,9 +252,6 @@ func (n *Node) CreateCCIPOCRSupportedChains(ctx context.Context, chains []JDChai
 			}
 			if accountAddr == nil {
 				return fmt.Errorf("no account address found for node %s", n.Name)
-			}
-			if n.AccountAddr == nil {
-				n.AccountAddr = make(map[string]string)
 			}
 			n.AccountAddr[chain.ChainID] = *accountAddr
 			account = *accountAddr
@@ -261,8 +263,6 @@ func (n *Node) CreateCCIPOCRSupportedChains(ctx context.Context, chains []JDChai
 			if len(accounts) == 0 {
 				return fmt.Errorf("failed to fetch account address for node %s and chain %s: %w", n.Name, chain.ChainType, err)
 			}
-
-			n.AccountAddr[chain.ChainID] = accounts[0]
 			n.AccountAddr[chain.ChainID] = accounts[0]
 			account = accounts[0]
 		default:


### PR DESCRIPTION
Fetch keys non evm fix, threw nil pointer exception when called from CLD when only nonevm was passed without account keys.