### PR TITLE
chore: update chainlink-aptos

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -393,7 +393,7 @@ require (
 	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
-	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 // indirect
+	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250623155929-df514c92ffe1 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1269,8 +1269,8 @@ github.com/smartcontractkit/ccip-owner-contracts v0.1.0 h1:GiBDtlx7539o7AKlDV+9L
 github.com/smartcontractkit/ccip-owner-contracts v0.1.0/go.mod h1:NnT6w4Kj42OFFXhSx99LvJZWPpMjmo4+CpDEWfw61xY=
 github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSbKSBFhYRKqo1C/JmgFs=
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h1:9AytLlQiUzb+2/1xgyKwjSaYmOUBLHfG0QusDGadJuc=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 h1:L9FmhZ050B6piLP9qvNBM5Ao+US1k/CLeGjK+jOrT3k=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=

--- a/deployment/ccip/shared/token_info.go
+++ b/deployment/ccip/shared/token_info.go
@@ -116,6 +116,7 @@ const (
 	BTCUSD   = "BTC / USD"
 	LTCUSD   = "LTC / USD"
 	ARBUSD   = "ARB / USD"
+	APTUSD   = "APT / USD"
 
 	// MockLinkAggregatorDescription is the description of the MockV3Aggregator.sol contract
 	// https://github.com/smartcontractkit/chainlink/blob/a348b98e90527520049c580000a86fb8ceff7fa7/contracts/src/v0.8/tests/MockV3Aggregator.sol#L76-L76

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
-	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6
+	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250623092251-9469184bca40

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1245,8 +1245,8 @@ github.com/smartcontractkit/ccip-owner-contracts v0.1.0 h1:GiBDtlx7539o7AKlDV+9L
 github.com/smartcontractkit/ccip-owner-contracts v0.1.0/go.mod h1:NnT6w4Kj42OFFXhSx99LvJZWPpMjmo4+CpDEWfw61xY=
 github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSbKSBFhYRKqo1C/JmgFs=
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h1:9AytLlQiUzb+2/1xgyKwjSaYmOUBLHfG0QusDGadJuc=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 h1:L9FmhZ050B6piLP9qvNBM5Ao+US1k/CLeGjK+jOrT3k=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.3
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
-	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6
+	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed

--- a/go.sum
+++ b/go.sum
@@ -1063,8 +1063,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSbKSBFhYRKqo1C/JmgFs=
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h1:9AytLlQiUzb+2/1xgyKwjSaYmOUBLHfG0QusDGadJuc=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 h1:L9FmhZ050B6piLP9qvNBM5Ao+US1k/CLeGjK+jOrT3k=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -457,7 +457,7 @@ require (
 	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
-	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 // indirect
+	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250623155929-df514c92ffe1 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1476,8 +1476,8 @@ github.com/smartcontractkit/ccip-owner-contracts v0.1.0 h1:GiBDtlx7539o7AKlDV+9L
 github.com/smartcontractkit/ccip-owner-contracts v0.1.0/go.mod h1:NnT6w4Kj42OFFXhSx99LvJZWPpMjmo4+CpDEWfw61xY=
 github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSbKSBFhYRKqo1C/JmgFs=
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h1:9AytLlQiUzb+2/1xgyKwjSaYmOUBLHfG0QusDGadJuc=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 h1:L9FmhZ050B6piLP9qvNBM5Ao+US1k/CLeGjK+jOrT3k=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -446,7 +446,7 @@ require (
 	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
-	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 // indirect
+	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1458,8 +1458,8 @@ github.com/smartcontractkit/ccip-owner-contracts v0.1.0 h1:GiBDtlx7539o7AKlDV+9L
 github.com/smartcontractkit/ccip-owner-contracts v0.1.0/go.mod h1:NnT6w4Kj42OFFXhSx99LvJZWPpMjmo4+CpDEWfw61xY=
 github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSbKSBFhYRKqo1C/JmgFs=
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h1:9AytLlQiUzb+2/1xgyKwjSaYmOUBLHfG0QusDGadJuc=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 h1:L9FmhZ050B6piLP9qvNBM5Ao+US1k/CLeGjK+jOrT3k=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=

--- a/integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
+++ b/integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
@@ -18,7 +18,6 @@ import (
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
 )
 
-
 // Test_CCIPGasPriceUpdates tests that chain fee price updates are propagated correctly when expiry time is reached.
 func Test_CCIPGasPriceUpdatesWriteFrequency(t *testing.T) {
 	ctx := testhelpers.Context(t)

--- a/integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
+++ b/integration-tests/smoke/ccip/ccip_gas_price_updates_test.go
@@ -18,6 +18,7 @@ import (
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
 )
 
+
 // Test_CCIPGasPriceUpdates tests that chain fee price updates are propagated correctly when expiry time is reached.
 func Test_CCIPGasPriceUpdatesWriteFrequency(t *testing.T) {
 	ctx := testhelpers.Context(t)

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -10,7 +10,7 @@ defaults:
 plugins:
   aptos:
     - moduleURI: "github.com/smartcontractkit/chainlink-aptos"
-      gitRef: "319dff82368776389922d3b921281396599311a1"
+      gitRef: "6b89f926f8640051dce2bccb9b756b87ab7f7572"
       installPath: "github.com/smartcontractkit/chainlink-aptos/cmd/chainlink-aptos"
   cosmos:
     - moduleURI: "github.com/smartcontractkit/chainlink-cosmos"

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -10,7 +10,7 @@ defaults:
 plugins:
   aptos:
     - moduleURI: "github.com/smartcontractkit/chainlink-aptos"
-      gitRef: "9aa8eff952f6a90fc16f36ce4df8c06facf0f054"
+      gitRef: "319dff82368776389922d3b921281396599311a1"
       installPath: "github.com/smartcontractkit/chainlink-aptos/cmd/chainlink-aptos"
   cosmos:
     - moduleURI: "github.com/smartcontractkit/chainlink-cosmos"

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -359,7 +359,7 @@ require (
 	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
-	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 // indirect
+	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1232,8 +1232,8 @@ github.com/smartcontractkit/ccip-owner-contracts v0.1.0 h1:GiBDtlx7539o7AKlDV+9L
 github.com/smartcontractkit/ccip-owner-contracts v0.1.0/go.mod h1:NnT6w4Kj42OFFXhSx99LvJZWPpMjmo4+CpDEWfw61xY=
 github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSbKSBFhYRKqo1C/JmgFs=
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h1:9AytLlQiUzb+2/1xgyKwjSaYmOUBLHfG0QusDGadJuc=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 h1:L9FmhZ050B6piLP9qvNBM5Ao+US1k/CLeGjK+jOrT3k=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -432,7 +432,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chain-selectors v1.0.60 // indirect
-	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 // indirect
+	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1432,8 +1432,8 @@ github.com/smartcontractkit/ccip-owner-contracts v0.1.0 h1:GiBDtlx7539o7AKlDV+9L
 github.com/smartcontractkit/ccip-owner-contracts v0.1.0/go.mod h1:NnT6w4Kj42OFFXhSx99LvJZWPpMjmo4+CpDEWfw61xY=
 github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSbKSBFhYRKqo1C/JmgFs=
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6 h1:9AytLlQiUzb+2/1xgyKwjSaYmOUBLHfG0QusDGadJuc=
-github.com/smartcontractkit/chainlink-aptos v0.0.0-20250618082928-9aa8eff952f6/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864 h1:L9FmhZ050B6piLP9qvNBM5Ao+US1k/CLeGjK+jOrT3k=
+github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620162016-c6fdc20009c6 h1:IZl2vGCnxLm2B3PKf2omAy2We2eQGL7T71GTPiUWutU=


### PR DESCRIPTION
Bumps chainlink-aptos also adds in a helper variable for the apt usd price feed.

Bump includes this fix - https://github.com/smartcontractkit/chainlink-aptos/pull/248