### PR TITLE
Fix simple_cron workflow example

### DIFF
--- a/core/services/workflows/cmd/cre/examples/v2/simple_cron/main.go
+++ b/core/services/workflows/cmd/cre/examples/v2/simple_cron/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/v2"
 )
 
-func RunSimpleCronWorkflow(_ *sdk.WorkflowContext[struct{}]) (sdk.Workflow[struct{}], error) {
+func RunSimpleCronWorkflow(_ *sdk.Environment[struct{}]) (sdk.Workflow[struct{}], error) {
 	cfg := &cron.Config{
 		Schedule: "*/3 * * * * *", // every 3 seconds
 	}
@@ -21,7 +21,7 @@ func RunSimpleCronWorkflow(_ *sdk.WorkflowContext[struct{}]) (sdk.Workflow[struc
 	}, nil
 }
 
-func onTrigger(_ *sdk.WorkflowContext[struct{}], runtime sdk.Runtime, outputs *cron.Payload) (string, error) {
+func onTrigger(_ *sdk.Environment[struct{}], runtime sdk.Runtime, outputs *cron.Payload) (string, error) {
 	return "ping", nil
 }
 


### PR DESCRIPTION
I believe `simple_cron` example of a workflow running in Engine v2 was not working anymore due to parameter change.

Within this PR:
- `RunSimpleCronWorkflow` is changed to now accept `sdk.Environment` instead of `sdk.WorkflowContext`.
- `onTrigger` is also changed to now accept `sdk.Environment` instead of `sdk.WorkflowContext`.