### PR TITLE
fix(workflows/v2): pass empty config in capability executor

### DIFF
--- a/.changeset/purple-coins-pump.md
+++ b/.changeset/purple-coins-pump.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+set empty map directly on cap request for config #internal #bugfix

--- a/core/services/workflows/v2/capability_executor.go
+++ b/core/services/workflows/v2/capability_executor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	sdkpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 	protoevents "github.com/smartcontractkit/chainlink-protos/workflows/go/events"
@@ -49,6 +50,7 @@ func (c *ExecutionHelper) CallCapability(ctx context.Context, request *sdkpb.Cap
 		Metadata: capabilities.RequestMetadata{
 			WorkflowExecutionID: c.WorkflowExecutionID,
 		},
+		Config: values.EmptyMap(),
 	}
 
 	meterReport, ok := c.meterReports.Get(c.WorkflowExecutionID)


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

the SDK creates a capability request via the engine without passing config, this fix explicitly places an empty map for the config


### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
