### PR TITLE
Reducing ccip_reader_duration histogram cardinality

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/observability/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/commit_store.go
@@ -19,7 +19,6 @@ func NewObservedCommitStoreReader(origin ccipdata.CommitStoreReader, chainID int
 		metric: metricDetails{
 			interactionDuration: readerHistogram,
 			resultSetSize:       readerDatasetSize,
-			pluginName:          pluginName,
 			readerName:          "CommitStoreReader",
 			chainId:             chainID,
 		},

--- a/core/services/ocr2/plugins/ccip/internal/observability/metrics.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/metrics.go
@@ -10,22 +10,13 @@ import (
 
 var (
 	latencyBuckets = []float64{
-		float64(10 * time.Millisecond),
-		float64(25 * time.Millisecond),
-		float64(50 * time.Millisecond),
-		float64(75 * time.Millisecond),
+		float64(30 * time.Millisecond),
 		float64(100 * time.Millisecond),
-		float64(200 * time.Millisecond),
 		float64(300 * time.Millisecond),
-		float64(400 * time.Millisecond),
-		float64(500 * time.Millisecond),
-		float64(750 * time.Millisecond),
 		float64(1 * time.Second),
-		float64(2 * time.Second),
 		float64(3 * time.Second),
-		float64(4 * time.Second),
 	}
-	labels          = []string{"evmChainID", "plugin", "reader", "function", "success"}
+	labels          = []string{"evmChainID", "reader", "function"}
 	readerHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "ccip_reader_duration",
 		Help:    "Duration of calls to Reader instance",
@@ -51,10 +42,8 @@ func withObservedInteraction[T any](metric metricDetails, function string, f fun
 	metric.interactionDuration.
 		WithLabelValues(
 			strconv.FormatInt(metric.chainId, 10),
-			metric.pluginName,
 			metric.readerName,
 			function,
-			strconv.FormatBool(err == nil),
 		).
 		Observe(float64(time.Since(contractExecutionStarted)))
 	return value, err
@@ -65,10 +54,8 @@ func withObservedInteractionAndResults[T any](metric metricDetails, function str
 	if err == nil {
 		metric.resultSetSize.WithLabelValues(
 			strconv.FormatInt(metric.chainId, 10),
-			metric.pluginName,
 			metric.readerName,
 			function,
-			strconv.FormatBool(err == nil),
 		).Set(float64(len(results)))
 	}
 	return results, err

--- a/core/services/ocr2/plugins/ccip/internal/observability/metrics.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/metrics.go
@@ -31,7 +31,6 @@ var (
 type metricDetails struct {
 	interactionDuration *prometheus.HistogramVec
 	resultSetSize       *prometheus.GaugeVec
-	pluginName          string
 	readerName          string
 	chainId             int64
 }

--- a/core/services/ocr2/plugins/ccip/internal/observability/metrics_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/metrics_test.go
@@ -21,7 +21,6 @@ func TestProperLabelsArePassed(t *testing.T) {
 
 	details := metricDetails{
 		interactionDuration: histogram,
-		pluginName:          "plugin",
 		readerName:          "reader",
 		chainId:             123,
 	}
@@ -38,9 +37,6 @@ func TestProperLabelsArePassed(t *testing.T) {
 
 	assert.Equal(t, successCounter, counterFromHistogramByLabels(t, histogram, "123", "reader", "successFun"))
 	assert.Equal(t, failedCounter, counterFromHistogramByLabels(t, histogram, "123", "reader", "failedFun"))
-
-	assert.Equal(t, 0, counterFromHistogramByLabels(t, histogram, "123", "reader", "failedFun"))
-	assert.Equal(t, 0, counterFromHistogramByLabels(t, histogram, "123", "reader", "successFun"))
 }
 
 func TestMetricsSendFromContractDirectly(t *testing.T) {

--- a/core/services/ocr2/plugins/ccip/internal/observability/metrics_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/metrics_test.go
@@ -36,11 +36,11 @@ func TestProperLabelsArePassed(t *testing.T) {
 		require.Error(t, err)
 	}
 
-	assert.Equal(t, successCounter, counterFromHistogramByLabels(t, histogram, "123", "plugin", "reader", "successFun", "true"))
-	assert.Equal(t, failedCounter, counterFromHistogramByLabels(t, histogram, "123", "plugin", "reader", "failedFun", "false"))
+	assert.Equal(t, successCounter, counterFromHistogramByLabels(t, histogram, "123", "reader", "successFun"))
+	assert.Equal(t, failedCounter, counterFromHistogramByLabels(t, histogram, "123", "reader", "failedFun"))
 
-	assert.Equal(t, 0, counterFromHistogramByLabels(t, histogram, "123", "plugin", "reader", "failedFun", "true"))
-	assert.Equal(t, 0, counterFromHistogramByLabels(t, histogram, "123", "plugin", "reader", "successFun", "false"))
+	assert.Equal(t, 0, counterFromHistogramByLabels(t, histogram, "123", "reader", "failedFun"))
+	assert.Equal(t, 0, counterFromHistogramByLabels(t, histogram, "123", "reader", "successFun"))
 }
 
 func TestMetricsSendFromContractDirectly(t *testing.T) {
@@ -57,9 +57,9 @@ func TestMetricsSendFromContractDirectly(t *testing.T) {
 		_, _ = observedOfframp.GetTokens(ctx)
 	}
 
-	assert.Equal(t, expectedCounter, counterFromHistogramByLabels(t, observedOfframp.metric.interactionDuration, "420", "plugin", "OffRampReader", "GetTokens", "false"))
-	assert.Equal(t, 0, counterFromHistogramByLabels(t, observedOfframp.metric.interactionDuration, "420", "plugin", "OffRampReader", "GetPoolByDestToken", "false"))
-	assert.Equal(t, 0, counterFromHistogramByLabels(t, observedOfframp.metric.interactionDuration, "420", "plugin", "OffRampReader", "GetPoolByDestToken", "true"))
+	assert.Equal(t, expectedCounter, counterFromHistogramByLabels(t, observedOfframp.metric.interactionDuration, "420", "OffRampReader", "GetTokens"))
+	assert.Equal(t, 0, counterFromHistogramByLabels(t, observedOfframp.metric.interactionDuration, "420", "OffRampReader", "GetPoolByDestToken"))
+	assert.Equal(t, 0, counterFromHistogramByLabels(t, observedOfframp.metric.interactionDuration, "420", "OffRampReader", "GetPoolByDestToken"))
 }
 
 func counterFromHistogramByLabels(t *testing.T, histogramVec *prometheus.HistogramVec, labels ...string) int {

--- a/core/services/ocr2/plugins/ccip/internal/observability/offramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/offramp.go
@@ -19,7 +19,6 @@ func NewObservedOffRampReader(origin ccipdata.OffRampReader, chainID int64, plug
 		metric: metricDetails{
 			interactionDuration: readerHistogram,
 			resultSetSize:       readerDatasetSize,
-			pluginName:          pluginName,
 			readerName:          "OffRampReader",
 			chainId:             chainID,
 		},

--- a/core/services/ocr2/plugins/ccip/internal/observability/onramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/onramp.go
@@ -19,7 +19,6 @@ func NewObservedOnRampReader(origin ccipdata.OnRampReader, chainID int64, plugin
 		metric: metricDetails{
 			interactionDuration: readerHistogram,
 			resultSetSize:       readerDatasetSize,
-			pluginName:          pluginName,
 			readerName:          "OnRampReader",
 			chainId:             chainID,
 		},

--- a/core/services/ocr2/plugins/ccip/internal/observability/onramp_observed_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/onramp_observed_test.go
@@ -135,7 +135,7 @@ func buildCallParams(mc MethodCall) []reflect.Value {
 
 // Build a mock reader and an observed wrapper to be used in the tests.
 func buildReader(t *testing.T) (ObservedOnRampReader, *mocks.OnRampReader) {
-	labels = []string{"evmChainID", "plugin", "reader", "function", "success"}
+	labels = []string{"evmChainID", "reader", "function"}
 	ph := promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "test_histogram",
 	}, labels)

--- a/core/services/ocr2/plugins/ccip/internal/observability/onramp_observed_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/onramp_observed_test.go
@@ -145,7 +145,6 @@ func buildReader(t *testing.T) (ObservedOnRampReader, *mocks.OnRampReader) {
 	metric := metricDetails{
 		interactionDuration: ph,
 		resultSetSize:       pg,
-		pluginName:          "test plugin",
 		readerName:          "test reader",
 		chainId:             1337,
 	}

--- a/core/services/ocr2/plugins/ccip/internal/observability/price_registry.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/price_registry.go
@@ -20,7 +20,6 @@ func NewPriceRegistryReader(origin ccipdata.PriceRegistryReader, chainID int64, 
 		metric: metricDetails{
 			interactionDuration: readerHistogram,
 			resultSetSize:       readerDatasetSize,
-			pluginName:          pluginName,
 			readerName:          "PriceRegistryReader",
 			chainId:             chainID,
 		},


### PR DESCRIPTION
Redcuce `ccip_reader_duration` histogram cardinality
[CCIP-3643](https://smartcontract-it.atlassian.net/browse/CCIP-3643)


[CCIP-3643]: https://smartcontract-it.atlassian.net/browse/CCIP-3643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ