### PR TITLE
[Fake Capability] HTTP Action

### DIFF
--- a/.changeset/soft-pears-wait.md
+++ b/.changeset/soft-pears-wait.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Add HTTP Action fake for the standalone engine

--- a/core/capabilities/fakes/http_action.go
+++ b/core/capabilities/fakes/http_action.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	customhttp "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/http"
 	httpserver "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/http/server"
@@ -17,20 +16,20 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
-var _ httpserver.ClientCapability = (*DirectHttpAction)(nil)
-var _ services.Service = (*DirectHttpAction)(nil)
-var _ commonCap.ExecutableCapability = (*DirectHttpAction)(nil)
+var _ httpserver.ClientCapability = (*DirectHTTPAction)(nil)
+var _ services.Service = (*DirectHTTPAction)(nil)
+var _ commonCap.ExecutableCapability = (*DirectHTTPAction)(nil)
 
 const HTTPActionID = "http-action@1.0.0"
 const HTTPActionServiceName = "HttpActionService"
 
-var directHttpActionInfo = capabilities.MustNewCapabilityInfo(
+var directHTTPActionInfo = commonCap.MustNewCapabilityInfo(
 	HTTPActionID,
-	capabilities.CapabilityTypeAction,
+	commonCap.CapabilityTypeAction,
 	"An action that makes a direct HTTP request",
 )
 
-type DirectHttpAction struct {
+type DirectHTTPAction struct {
 	commonCap.CapabilityInfo
 	services.Service
 	eng *services.Engine
@@ -38,8 +37,8 @@ type DirectHttpAction struct {
 	lggr logger.Logger
 }
 
-func NewDirectHttpAction(lggr logger.Logger) *DirectHttpAction {
-	fc := &DirectHttpAction{
+func NewDirectHTTPAction(lggr logger.Logger) *DirectHTTPAction {
+	fc := &DirectHTTPAction{
 		lggr: lggr,
 	}
 
@@ -51,7 +50,7 @@ func NewDirectHttpAction(lggr logger.Logger) *DirectHttpAction {
 	return fc
 }
 
-func (fh *DirectHttpAction) SendRequest(ctx context.Context, metadata capabilities.RequestMetadata, input *customhttp.Request) (*customhttp.Response, error) {
+func (fh *DirectHTTPAction) SendRequest(ctx context.Context, metadata capabilities.RequestMetadata, input *customhttp.Request) (*customhttp.Response, error) {
 	fh.eng.Infow("Http Action SendRequest Started", "input", input)
 
 	// Create HTTP client with timeout
@@ -109,7 +108,7 @@ func (fh *DirectHttpAction) SendRequest(ctx context.Context, metadata capabiliti
 		fh.eng.Errorw("Failed to read response body", "error", err)
 		return &customhttp.Response{
 			ErrorMessage: err.Error(),
-			StatusCode:   uint32(resp.StatusCode),
+			StatusCode:   uint32(resp.StatusCode), //nolint:gosec // status code is always in valid range
 		}, err
 	}
 
@@ -122,7 +121,7 @@ func (fh *DirectHttpAction) SendRequest(ctx context.Context, metadata capabiliti
 
 	// Create response
 	response := &customhttp.Response{
-		StatusCode: uint32(resp.StatusCode),
+		StatusCode: uint32(resp.StatusCode), //nolint:gosec // status code is always in valid range
 		Headers:    headers,
 		Body:       respBody,
 	}
@@ -136,36 +135,35 @@ func (fh *DirectHttpAction) SendRequest(ctx context.Context, metadata capabiliti
 	return response, nil
 }
 
-func (fh *DirectHttpAction) Start(ctx context.Context) error {
+func (fh *DirectHTTPAction) Start(ctx context.Context) error {
 	fh.eng.Infow("Http Action Start Started")
 	return nil
 }
 
-func (fh *DirectHttpAction) Close() error {
+func (fh *DirectHTTPAction) Close() error {
 	fh.eng.Infow("Http Action Close Started")
 	return nil
 }
 
-func (fh *DirectHttpAction) Name() string {
+func (fh *DirectHTTPAction) Name() string {
 	return HTTPActionServiceName
 }
 
-func (fh *DirectHttpAction) Description() string {
-	return directHttpActionInfo.Description
+func (fh *DirectHTTPAction) Description() string {
+	return directHTTPActionInfo.Description
 }
 
-func (fh *DirectHttpAction) Ready() error {
+func (fh *DirectHTTPAction) Ready() error {
 	return nil
 }
 
-func (fh *DirectHttpAction) Initialise(ctx context.Context, config string, _ core.TelemetryService,
+func (fh *DirectHTTPAction) Initialise(ctx context.Context, config string, _ core.TelemetryService,
 	_ core.KeyValueStore,
 	_ core.ErrorLog,
 	_ core.PipelineRunnerService,
 	_ core.RelayerSet,
 	_ core.OracleFactory,
 	_ core.GatewayConnector) error {
-
 	// TODO: do validation of config here
 
 	err := fh.Start(ctx)
@@ -176,17 +174,17 @@ func (fh *DirectHttpAction) Initialise(ctx context.Context, config string, _ cor
 	return nil
 }
 
-func (fh *DirectHttpAction) Execute(ctx context.Context, request commonCap.CapabilityRequest) (commonCap.CapabilityResponse, error) {
+func (fh *DirectHTTPAction) Execute(ctx context.Context, request commonCap.CapabilityRequest) (commonCap.CapabilityResponse, error) {
 	fh.eng.Infow("Direct Http Action Execute Started", "request", request)
 	return commonCap.CapabilityResponse{}, nil
 }
 
-func (fh *DirectHttpAction) RegisterToWorkflow(ctx context.Context, request commonCap.RegisterToWorkflowRequest) error {
+func (fh *DirectHTTPAction) RegisterToWorkflow(ctx context.Context, request commonCap.RegisterToWorkflowRequest) error {
 	fh.eng.Infow("Registered to Direct Http Action", "workflowID", request.Metadata.WorkflowID)
 	return nil
 }
 
-func (fh *DirectHttpAction) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
+func (fh *DirectHTTPAction) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
 	fh.eng.Infow("Unregistered from Direct Http Action", "workflowID", request.Metadata.WorkflowID)
 	return nil
 }

--- a/core/capabilities/fakes/http_action.go
+++ b/core/capabilities/fakes/http_action.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shopspring/decimal"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	customhttp "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/http"
@@ -19,20 +17,20 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
-var _ httpserver.ClientCapability = (*FakeHttpAction)(nil)
-var _ services.Service = (*FakeHttpAction)(nil)
-var _ commonCap.ExecutableCapability = (*FakeHttpAction)(nil)
+var _ httpserver.ClientCapability = (*DirectHttpAction)(nil)
+var _ services.Service = (*DirectHttpAction)(nil)
+var _ commonCap.ExecutableCapability = (*DirectHttpAction)(nil)
 
 const HTTPActionID = "http-action@1.0.0"
 const HTTPActionServiceName = "HttpActionService"
 
-var fakeHttpActionInfo = capabilities.MustNewCapabilityInfo(
+var directHttpActionInfo = capabilities.MustNewCapabilityInfo(
 	HTTPActionID,
 	capabilities.CapabilityTypeAction,
-	"An action that uses an HTTP request to run periodically at fixed times, dates, or intervals.",
+	"An action that makes an direct HTTP request",
 )
 
-type FakeHttpAction struct {
+type DirectHttpAction struct {
 	commonCap.CapabilityInfo
 	services.Service
 	eng *services.Engine
@@ -40,32 +38,21 @@ type FakeHttpAction struct {
 	lggr logger.Logger
 }
 
-func NewFakeHttpAction(lggr logger.Logger) *FakeHttpAction {
-	fc := &FakeHttpAction{
+func NewDirectHttpAction(lggr logger.Logger) *DirectHttpAction {
+	fc := &DirectHttpAction{
 		lggr: lggr,
 	}
 
 	fc.Service, fc.eng = services.Config{
-		Name:  "fakeHttpAction",
+		Name:  "directHttpAction",
 		Start: fc.Start,
 		Close: fc.Close,
 	}.NewServiceEngine(lggr)
 	return fc
 }
 
-type ReserveInfo struct {
-	LastUpdated  time.Time       `consensus_aggregation:"median" json:"lastUpdated"`
-	TotalReserve decimal.Decimal `consensus_aggregation:"median" json:"totalReserve"`
-}
-
-type PorResponse struct {
-	DataSignature string `json:"dataSignature"`
-	Ripcord       bool   `json:"ripcord"`
-	Data          string `json:"data"`
-}
-
-func (fh *FakeHttpAction) SendRequest(ctx context.Context, metadata capabilities.RequestMetadata, input *customhttp.Request) (*customhttp.Response, error) {
-	fh.eng.Infow("Fake Http Action SendRequest Started", "input", input)
+func (fh *DirectHttpAction) SendRequest(ctx context.Context, metadata capabilities.RequestMetadata, input *customhttp.Request) (*customhttp.Response, error) {
+	fh.eng.Infow("Http Action SendRequest Started", "input", input)
 
 	// Create HTTP client with timeout
 	timeout := time.Duration(30) * time.Second // default timeout
@@ -149,29 +136,29 @@ func (fh *FakeHttpAction) SendRequest(ctx context.Context, metadata capabilities
 	return response, nil
 }
 
-func (fh *FakeHttpAction) Start(ctx context.Context) error {
-	fh.eng.Infow("Fake Http Action Start Started")
+func (fh *DirectHttpAction) Start(ctx context.Context) error {
+	fh.eng.Infow("Http Action Start Started")
 	return nil
 }
 
-func (fh *FakeHttpAction) Close() error {
-	fh.eng.Infow("Fake Http Action Close Started")
+func (fh *DirectHttpAction) Close() error {
+	fh.eng.Infow("Http Action Close Started")
 	return nil
 }
 
-func (fh *FakeHttpAction) Name() string {
+func (fh *DirectHttpAction) Name() string {
 	return HTTPActionServiceName
 }
 
-func (fh *FakeHttpAction) Description() string {
-	return fakeHttpActionInfo.Description
+func (fh *DirectHttpAction) Description() string {
+	return directHttpActionInfo.Description
 }
 
-func (fh *FakeHttpAction) Ready() error {
+func (fh *DirectHttpAction) Ready() error {
 	return nil
 }
 
-func (fh *FakeHttpAction) Initialise(ctx context.Context, config string, _ core.TelemetryService,
+func (fh *DirectHttpAction) Initialise(ctx context.Context, config string, _ core.TelemetryService,
 	_ core.KeyValueStore,
 	_ core.ErrorLog,
 	_ core.PipelineRunnerService,
@@ -188,17 +175,17 @@ func (fh *FakeHttpAction) Initialise(ctx context.Context, config string, _ core.
 	return nil
 }
 
-func (fh *FakeHttpAction) Execute(ctx context.Context, request commonCap.CapabilityRequest) (commonCap.CapabilityResponse, error) {
-	fh.eng.Infow("Fake Http Action Execute Started", "request", request)
+func (fh *DirectHttpAction) Execute(ctx context.Context, request commonCap.CapabilityRequest) (commonCap.CapabilityResponse, error) {
+	fh.eng.Infow("Direct Http Action Execute Started", "request", request)
 	return commonCap.CapabilityResponse{}, nil
 }
 
-func (fh *FakeHttpAction) RegisterToWorkflow(ctx context.Context, request commonCap.RegisterToWorkflowRequest) error {
-	fh.eng.Infow("Registered to Fake Http Action", "workflowID", request.Metadata.WorkflowID)
+func (fh *DirectHttpAction) RegisterToWorkflow(ctx context.Context, request commonCap.RegisterToWorkflowRequest) error {
+	fh.eng.Infow("Registered to Direct Http Action", "workflowID", request.Metadata.WorkflowID)
 	return nil
 }
 
-func (fh *FakeHttpAction) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
-	fh.eng.Infow("Unregistered from Fake Http Action", "workflowID", request.Metadata.WorkflowID)
+func (fh *DirectHttpAction) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
+	fh.eng.Infow("Unregistered from Direct Http Action", "workflowID", request.Metadata.WorkflowID)
 	return nil
 }

--- a/core/capabilities/fakes/http_action.go
+++ b/core/capabilities/fakes/http_action.go
@@ -1,0 +1,204 @@
+package fakes
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	customhttp "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/http"
+	httpserver "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/http/server"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+var _ httpserver.ClientCapability = (*FakeHttpAction)(nil)
+var _ services.Service = (*FakeHttpAction)(nil)
+var _ commonCap.ExecutableCapability = (*FakeHttpAction)(nil)
+
+const HTTPActionID = "http-action@1.0.0"
+const HTTPActionServiceName = "HttpActionService"
+
+var fakeHttpActionInfo = capabilities.MustNewCapabilityInfo(
+	HTTPActionID,
+	capabilities.CapabilityTypeAction,
+	"An action that uses an HTTP request to run periodically at fixed times, dates, or intervals.",
+)
+
+type FakeHttpAction struct {
+	commonCap.CapabilityInfo
+	services.Service
+	eng *services.Engine
+
+	lggr logger.Logger
+}
+
+func NewFakeHttpAction(lggr logger.Logger) *FakeHttpAction {
+	fc := &FakeHttpAction{
+		lggr: lggr,
+	}
+
+	fc.Service, fc.eng = services.Config{
+		Name:  "fakeHttpAction",
+		Start: fc.Start,
+		Close: fc.Close,
+	}.NewServiceEngine(lggr)
+	return fc
+}
+
+type ReserveInfo struct {
+	LastUpdated  time.Time       `consensus_aggregation:"median" json:"lastUpdated"`
+	TotalReserve decimal.Decimal `consensus_aggregation:"median" json:"totalReserve"`
+}
+
+type PorResponse struct {
+	DataSignature string `json:"dataSignature"`
+	Ripcord       bool   `json:"ripcord"`
+	Data          string `json:"data"`
+}
+
+func (fh *FakeHttpAction) SendRequest(ctx context.Context, metadata capabilities.RequestMetadata, input *customhttp.Request) (*customhttp.Response, error) {
+	fh.eng.Infow("Fake Http Action SendRequest Started", "input", input)
+
+	// Create HTTP client with timeout
+	timeout := time.Duration(30) * time.Second // default timeout
+	if input.GetTimeoutMs() > 0 {
+		timeout = time.Duration(input.GetTimeoutMs()) * time.Millisecond
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	// Determine HTTP method (default to GET if not specified)
+	method := input.GetMethod()
+	if method == "" {
+		method = "GET"
+	}
+	method = strings.ToUpper(method)
+
+	// Create request body
+	var body io.Reader
+	if len(input.GetBody()) > 0 {
+		body = bytes.NewReader(input.GetBody())
+	}
+
+	// Create the HTTP request
+	req, err := http.NewRequestWithContext(ctx, method, input.GetUrl(), body)
+	if err != nil {
+		fh.eng.Errorw("Failed to create HTTP request", "error", err)
+		return &customhttp.Response{
+			ErrorMessage: err.Error(),
+			StatusCode:   0,
+		}, err
+	}
+
+	// Add headers
+	for k, v := range input.GetHeaders() {
+		req.Header.Set(k, v)
+	}
+
+	// Make the HTTP request
+	resp, err := client.Do(req)
+	if err != nil {
+		fh.eng.Errorw("Failed to execute HTTP request", "error", err)
+		return &customhttp.Response{
+			ErrorMessage: err.Error(),
+			StatusCode:   0,
+		}, err
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fh.eng.Errorw("Failed to read response body", "error", err)
+		return &customhttp.Response{
+			ErrorMessage: err.Error(),
+			StatusCode:   uint32(resp.StatusCode),
+		}, err
+	}
+
+	// Convert headers
+	headers := make(map[string]string)
+	for k, v := range resp.Header {
+		// Join multiple header values with comma
+		headers[k] = strings.Join(v, ", ")
+	}
+
+	// Create response
+	response := &customhttp.Response{
+		StatusCode: uint32(resp.StatusCode),
+		Headers:    headers,
+		Body:       respBody,
+	}
+
+	// Add error message if status code indicates an error
+	if resp.StatusCode >= 400 {
+		response.ErrorMessage = resp.Status
+	}
+
+	fh.eng.Debugw("HTTP request completed", "status", resp.StatusCode, "url", input.GetUrl())
+	return response, nil
+}
+
+func (fh *FakeHttpAction) Start(ctx context.Context) error {
+	fh.eng.Infow("Fake Http Action Start Started")
+	return nil
+}
+
+func (fh *FakeHttpAction) Close() error {
+	fh.eng.Infow("Fake Http Action Close Started")
+	return nil
+}
+
+func (fh *FakeHttpAction) Name() string {
+	return HTTPActionServiceName
+}
+
+func (fh *FakeHttpAction) Description() string {
+	return fakeHttpActionInfo.Description
+}
+
+func (fh *FakeHttpAction) Ready() error {
+	return nil
+}
+
+func (fh *FakeHttpAction) Initialise(ctx context.Context, config string, _ core.TelemetryService,
+	_ core.KeyValueStore,
+	_ core.ErrorLog,
+	_ core.PipelineRunnerService,
+	_ core.RelayerSet,
+	_ core.OracleFactory) error {
+
+	// TODO: do validation of config here
+
+	err := fh.Start(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (fh *FakeHttpAction) Execute(ctx context.Context, request commonCap.CapabilityRequest) (commonCap.CapabilityResponse, error) {
+	fh.eng.Infow("Fake Http Action Execute Started", "request", request)
+	return commonCap.CapabilityResponse{}, nil
+}
+
+func (fh *FakeHttpAction) RegisterToWorkflow(ctx context.Context, request commonCap.RegisterToWorkflowRequest) error {
+	fh.eng.Infow("Registered to Fake Http Action", "workflowID", request.Metadata.WorkflowID)
+	return nil
+}
+
+func (fh *FakeHttpAction) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
+	fh.eng.Infow("Unregistered from Fake Http Action", "workflowID", request.Metadata.WorkflowID)
+	return nil
+}

--- a/core/capabilities/fakes/http_action.go
+++ b/core/capabilities/fakes/http_action.go
@@ -50,7 +50,7 @@ func NewDirectHTTPAction(lggr logger.Logger) *DirectHTTPAction {
 	return fc
 }
 
-func (fh *DirectHTTPAction) SendRequest(ctx context.Context, metadata capabilities.RequestMetadata, input *customhttp.Request) (*customhttp.Response, error) {
+func (fh *DirectHTTPAction) SendRequest(ctx context.Context, metadata commonCap.RequestMetadata, input *customhttp.Request) (*customhttp.Response, error) {
 	fh.eng.Infow("Http Action SendRequest Started", "input", input)
 
 	// Create HTTP client with timeout

--- a/core/capabilities/fakes/http_action.go
+++ b/core/capabilities/fakes/http_action.go
@@ -27,7 +27,7 @@ const HTTPActionServiceName = "HttpActionService"
 var directHttpActionInfo = capabilities.MustNewCapabilityInfo(
 	HTTPActionID,
 	capabilities.CapabilityTypeAction,
-	"An action that makes an direct HTTP request",
+	"An action that makes a direct HTTP request",
 )
 
 type DirectHttpAction struct {
@@ -163,7 +163,8 @@ func (fh *DirectHttpAction) Initialise(ctx context.Context, config string, _ cor
 	_ core.ErrorLog,
 	_ core.PipelineRunnerService,
 	_ core.RelayerSet,
-	_ core.OracleFactory) error {
+	_ core.OracleFactory,
+	_ core.GatewayConnector) error {
 
 	// TODO: do validation of config here
 

--- a/core/services/workflows/cmd/cre/utils.go
+++ b/core/services/workflows/cmd/cre/utils.go
@@ -174,7 +174,7 @@ func NewFakeCapabilities(ctx context.Context, lggr logger.Logger, registry *capa
 	}
 	caps = append(caps, streamsTrigger)
 
-	httpAction := fakes.NewDirectHttpAction(lggr)
+	httpAction := fakes.NewDirectHTTPAction(lggr)
 	if err := registry.Add(ctx, httpserver.NewClientServer(httpAction)); err != nil {
 		return nil, err
 	}

--- a/core/services/workflows/cmd/cre/utils.go
+++ b/core/services/workflows/cmd/cre/utils.go
@@ -174,7 +174,7 @@ func NewFakeCapabilities(ctx context.Context, lggr logger.Logger, registry *capa
 	}
 	caps = append(caps, streamsTrigger)
 
-	httpAction := fakes.NewFakeHttpAction(lggr)
+	httpAction := fakes.NewDirectHttpAction(lggr)
 	if err := registry.Add(ctx, httpserver.NewClientServer(httpAction)); err != nil {
 		return nil, err
 	}

--- a/core/services/workflows/cmd/cre/utils.go
+++ b/core/services/workflows/cmd/cre/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/billing"
+	httpserver "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/http/server"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -172,6 +173,12 @@ func NewFakeCapabilities(ctx context.Context, lggr logger.Logger, registry *capa
 		return nil, err
 	}
 	caps = append(caps, streamsTrigger)
+
+	httpAction := fakes.NewFakeHttpAction(lggr)
+	if err := registry.Add(ctx, httpserver.NewClientServer(httpAction)); err != nil {
+		return nil, err
+	}
+	caps = append(caps, httpAction)
 
 	caps = append(caps, newStandardCapabilities(standardCapabilities, lggr, registry)...)
 


### PR DESCRIPTION
This pull request introduces a new fake HTTP action capability (`FakeHttpAction`) and integrates it into the capabilities registry. The changes include the implementation of the `FakeHttpAction` class, updates to the capabilities registry, and modifications to the imports to support the new functionality.

### Implementation of `FakeHttpAction`:

* Added the `FakeHttpAction` class in `core/capabilities/fakes/http_action.go`, which simulates an HTTP-based capability. It includes methods for initialization, request handling (`SendRequest`), lifecycle management (`Start`, `Close`), and integration with workflows. The class uses a service engine for structured logging and lifecycle control.

### Integration into capabilities registry:

* Updated the `NewFakeCapabilities` function in `core/services/workflows/cmd/cre/utils.go` to include the `FakeHttpAction` in the capabilities registry. This ensures the fake HTTP capability is properly registered and available for workflows.

### Import updates:

* Added the `httpserver` package to the imports in `core/services/workflows/cmd/cre/utils.go` to support the `FakeHttpAction` integration.