### PR TITLE
Add OCR2 CaptureTransmissionTelemetry config flag

### DIFF
--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -360,6 +360,8 @@ DatabaseTimeout = '10s' # Default
 KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000' # Example
 # CaptureEATelemetry toggles collecting extra information from External Adaptares
 CaptureEATelemetry = false # Default
+# CaptureTransmissionTelemetry toggles collecting telemetry on transmissions from OCR. 
+CaptureTransmissionTelemetry = true # Default
 # CaptureAutomationCustomTelemetry toggles collecting automation specific telemetry
 CaptureAutomationCustomTelemetry = true # Default
 # AllowNoBootstrappers enables single-node consensus without bootstrapper nodes (i.e. f=0, n=1)

--- a/core/config/ocr2_config.go
+++ b/core/config/ocr2_config.go
@@ -18,6 +18,7 @@ type OCR2 interface {
 	// OCR2 config, cannot override in jobs
 	TraceLogging() bool
 	CaptureEATelemetry() bool
+	CaptureTransmissionTelemetry() bool
 	DefaultTransactionQueueDepth() uint32
 	SimulateTransactions() bool
 	CaptureAutomationCustomTelemetry() bool

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -1077,6 +1077,7 @@ type OCR2 struct {
 	DatabaseTimeout                    *commonconfig.Duration
 	KeyBundleID                        *models.Sha256Hash
 	CaptureEATelemetry                 *bool
+	CaptureTransmissionTelemetry       *bool
 	CaptureAutomationCustomTelemetry   *bool
 	AllowNoBootstrappers               *bool
 	DefaultTransactionQueueDepth       *uint32
@@ -1111,6 +1112,9 @@ func (o *OCR2) setFrom(f *OCR2) {
 	}
 	if v := f.CaptureEATelemetry; v != nil {
 		o.CaptureEATelemetry = v
+	}
+	if v := f.CaptureTransmissionTelemetry; v != nil {
+		o.CaptureTransmissionTelemetry = v
 	}
 	if v := f.CaptureAutomationCustomTelemetry; v != nil {
 		o.CaptureAutomationCustomTelemetry = v

--- a/core/services/chainlink/config_ocr2.go
+++ b/core/services/chainlink/config_ocr2.go
@@ -57,6 +57,10 @@ func (o *ocr2Config) CaptureEATelemetry() bool {
 	return *o.c.CaptureEATelemetry
 }
 
+func (o *ocr2Config) CaptureTransmissionTelemetry() bool {
+	return *o.c.CaptureTransmissionTelemetry
+}
+
 func (o *ocr2Config) CaptureAutomationCustomTelemetry() bool {
 	return *o.c.CaptureAutomationCustomTelemetry
 }

--- a/core/services/chainlink/config_ocr2_test.go
+++ b/core/services/chainlink/config_ocr2_test.go
@@ -38,6 +38,7 @@ func TestOCR2Config(t *testing.T) {
 	require.False(t, ocr2Cfg.TraceLogging())
 	require.Equal(t, uint32(1), ocr2Cfg.DefaultTransactionQueueDepth())
 	require.False(t, ocr2Cfg.CaptureEATelemetry())
+	require.True(t, ocr2Cfg.CaptureTransmissionTelemetry())
 	require.True(t, ocr2Cfg.CaptureAutomationCustomTelemetry())
 	require.True(t, ocr2Cfg.AllowNoBootstrappers())
 

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -417,6 +417,7 @@ func TestConfig_Marshal(t *testing.T) {
 		DatabaseTimeout:                    commoncfg.MustNewDuration(8 * time.Second),
 		KeyBundleID:                        ptr(models.MustSha256HashFromHex("7a5f66bbe6594259325bf2b4f5b1a9c9")),
 		CaptureEATelemetry:                 ptr(false),
+		CaptureTransmissionTelemetry:       ptr(true),
 		CaptureAutomationCustomTelemetry:   ptr(true),
 		AllowNoBootstrappers:               ptr(true),
 		DefaultTransactionQueueDepth:       ptr[uint32](1),
@@ -1023,6 +1024,7 @@ ContractTransmitterTransmitTimeout = '1m0s'
 DatabaseTimeout = '8s'
 KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000'
 CaptureEATelemetry = false
+CaptureTransmissionTelemetry = true
 CaptureAutomationCustomTelemetry = true
 AllowNoBootstrappers = true
 DefaultTransactionQueueDepth = 1

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -145,6 +145,7 @@ ContractTransmitterTransmitTimeout = '1m0s'
 DatabaseTimeout = '8s'
 KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000'
 CaptureEATelemetry = false
+CaptureTransmissionTelemetry = true
 CaptureAutomationCustomTelemetry = true
 AllowNoBootstrappers = true
 DefaultTransactionQueueDepth = 1

--- a/core/services/feeds/config.go
+++ b/core/services/feeds/config.go
@@ -38,4 +38,5 @@ type OCR2Config interface {
 	DefaultTransactionQueueDepth() uint32
 	SimulateTransactions() bool
 	TraceLogging() bool
+	CaptureTransmissionTelemetry() bool
 }

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -183,6 +183,7 @@ type ocr2Config interface {
 	TraceLogging() bool
 	CaptureAutomationCustomTelemetry() bool
 	AllowNoBootstrappers() bool
+	CaptureTransmissionTelemetry() bool
 }
 
 type insecureConfig interface {

--- a/core/services/ocr2/validate/config.go
+++ b/core/services/ocr2/validate/config.go
@@ -22,6 +22,7 @@ type OCR2Config interface {
 	DefaultTransactionQueueDepth() uint32
 	SimulateTransactions() bool
 	TraceLogging() bool
+	CaptureTransmissionTelemetry() bool
 }
 
 type InsecureConfig interface {
@@ -52,6 +53,7 @@ func ToLocalConfig(ocr2Config OCR2Config, insConf InsecureConfig, spec job.OCR2O
 		ContractConfigTrackerPollInterval:  ccTrackerPollInterval,
 		ContractTransmitterTransmitTimeout: ocr2Config.ContractTransmitterTransmitTimeout(),
 		DatabaseTimeout:                    ocr2Config.DatabaseTimeout(),
+		EnableTransmissionTelemetry:        ocr2Config.CaptureTransmissionTelemetry(),
 	}
 	if spec.Relay == relay.NetworkSolana && env.MedianPlugin.Cmd.Get() != "" {
 		// Work around for Solana Feeds configured with zero values to support LOOP Plugins.

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -145,6 +145,7 @@ ContractTransmitterTransmitTimeout = '1m0s'
 DatabaseTimeout = '8s'
 KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000'
 CaptureEATelemetry = false
+CaptureTransmissionTelemetry = true
 CaptureAutomationCustomTelemetry = true
 AllowNoBootstrappers = true
 DefaultTransactionQueueDepth = 1

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -909,6 +909,7 @@ ContractTransmitterTransmitTimeout = '10s' # Default
 DatabaseTimeout = '10s' # Default
 KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000' # Example
 CaptureEATelemetry = false # Default
+CaptureTransmissionTelemetry = true # Default
 CaptureAutomationCustomTelemetry = true # Default
 AllowNoBootstrappers = false # Default
 DefaultTransactionQueueDepth = 1 # Default
@@ -1004,6 +1005,12 @@ KeyBundleID is a sha256 hexadecimal hash identifier.
 CaptureEATelemetry = false # Default
 ```
 CaptureEATelemetry toggles collecting extra information from External Adaptares
+
+### CaptureTransmissionTelemetry
+```toml
+CaptureTransmissionTelemetry = true # Default
+```
+CaptureTransmissionTelemetry toggles collecting telemetry on transmissions from OCR.
 
 ### CaptureAutomationCustomTelemetry
 ```toml


### PR DESCRIPTION
- Add OCR2 `CaptureTransmissionTelemetry` config flag
- `CaptureTransmissionTelemetry` is used to gate the emission of telemetry relating to OCR Transmission - TransmissionScheduleComputed, TransmissionShouldAcceptFinalizedReportComputed, TransmissionShouldTransmitAcceptedReportComputed
- Defaults to true. Expected increase in Telemetry volume is <2% - an upper bound would be 3 telemetry messages per node and generated report.

[DF-21393](https://smartcontract-it.atlassian.net/browse/DF-21393)

### Requires
- None

### Supports
- None


[DF-21393]: https://smartcontract-it.atlassian.net/browse/DF-21393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ