### PR TITLE
Engine V2 Logging improvements

### DIFF
--- a/core/services/workflows/cmd/cre/examples/v2/simple_cron/main.go
+++ b/core/services/workflows/cmd/cre/examples/v2/simple_cron/main.go
@@ -21,8 +21,9 @@ func RunSimpleCronWorkflow(_ *sdk.Environment[struct{}]) (sdk.Workflow[struct{}]
 	}, nil
 }
 
-func onTrigger(_ *sdk.Environment[struct{}], runtime sdk.Runtime, outputs *cron.Payload) (string, error) {
-	return "ping", nil
+func onTrigger(env *sdk.Environment[struct{}], runtime sdk.Runtime, outputs *cron.Payload) (string, error) {
+	env.Logger.Info("inside onTrigger handler")
+	return "success!", nil
 }
 
 func main() {

--- a/core/services/workflows/cmd/cre/examples/v2/simple_cron_with_config/main.go
+++ b/core/services/workflows/cmd/cre/examples/v2/simple_cron_with_config/main.go
@@ -29,7 +29,8 @@ func RunSimpleCronWorkflow(env *sdk.Environment[*runtimeConfig]) (sdk.Workflow[*
 }
 
 func onTrigger(env *sdk.Environment[*runtimeConfig], runtime sdk.Runtime, outputs *cron.Payload) (string, error) {
-	return fmt.Sprintf("ping (Schedule: %s)", env.Config.Schedule), nil
+	env.Logger.Info("inside onTrigger handler")
+	return fmt.Sprintf("success (Schedule: %s)", env.Config.Schedule), nil
 }
 
 func main() {

--- a/core/services/workflows/cmd/cre/utils.go
+++ b/core/services/workflows/cmd/cre/utils.go
@@ -155,6 +155,8 @@ func NewStandaloneEngine(
 
 		BillingClient: billingClient,
 		Hooks:         lifecycleHooks,
+
+		DebugMode: true,
 	}
 
 	return v2.NewEngine(cfg)

--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -40,6 +40,9 @@ type EngineConfig struct {
 
 	Hooks         LifecycleHooks
 	BillingClient metering.BillingClient
+
+	// includes additional logging of events internal to user workflows
+	DebugMode bool
 }
 
 const (


### PR DESCRIPTION
1. Log user messages when debug mode is enabled
2. Use e.lggr (which includes Beholder logger) consistently across Engine
