### PR TITLE
fix: s3 cache for self-hosted runners

### DIFF
--- a/.github/workflows/go-mod-cache.yml
+++ b/.github/workflows/go-mod-cache.yml
@@ -44,6 +44,11 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      - name: Enable S3 Cache for Self-Hosted Runners
+        # these env vars are set (and exposed) when it is a self-hosted runner with extras=s3-cache
+        if: ${{ env.RUNS_ON_INSTANCE_ID != '' && env.ACTIONS_CACHE_URL != '' }}
+        uses: runs-on/action@66d4449b717b5462159659523d1241051ff470b9 # v1
+
       - name: Checkout the repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Changes

Properly sets up magic cache for the self-hosted runners.
