### PR TITLE
Runnable example NoDAG workflow with node mode and consensus

### DIFF
--- a/core/capabilities/fakes/consensus.go
+++ b/core/capabilities/fakes/consensus.go
@@ -57,7 +57,7 @@ type fakeConsensus struct {
 }
 
 type capIface interface {
-	commonCap.ConsensusCapability
+	commonCap.ExecutableCapability
 	services.Service
 }
 
@@ -204,7 +204,7 @@ func (fc *fakeConsensus) RegisterToWorkflow(ctx context.Context, request commonC
 }
 
 func (fc *fakeConsensus) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
-	fc.eng.Infow("Unegistering from Fake Consensus", "workflowID", request.Metadata.WorkflowID)
+	fc.eng.Infow("Unregistering from Fake Consensus", "workflowID", request.Metadata.WorkflowID)
 	return fc.cap.UnregisterFromWorkflow(ctx, request)
 }
 

--- a/core/capabilities/fakes/consensus_nodag.go
+++ b/core/capabilities/fakes/consensus_nodag.go
@@ -1,0 +1,80 @@
+package fakes
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/protobuf/types/known/anypb"
+
+	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
+)
+
+type fakeConsensusNoDAG struct {
+	services.Service
+	eng *services.Engine
+}
+
+var _ services.Service = (*fakeConsensus)(nil)
+var _ commonCap.ExecutableCapability = (*fakeConsensusNoDAG)(nil)
+
+const consensusNoDAGCapID = "consensus@1.0.0"
+
+func NewFakeConsensusNoDAG(lggr logger.Logger) (*fakeConsensusNoDAG, error) {
+	fc := &fakeConsensusNoDAG{}
+	fc.Service, fc.eng = services.Config{
+		Name:  "fakeConsensusNoDAG",
+		Start: fc.start,
+		Close: fc.close,
+	}.NewServiceEngine(lggr)
+	return fc, nil
+}
+
+func (fc *fakeConsensusNoDAG) start(ctx context.Context) error {
+	return nil
+}
+
+func (fc *fakeConsensusNoDAG) close() error {
+	return nil
+}
+
+// NOTE: This fake capability currently bounces back the request payload, ignoring everything else.
+// When the real NoDAG consensus OCR plugin is ready, it should be used here, similarly to how the V1 fake works.
+func (fc *fakeConsensusNoDAG) Execute(ctx context.Context, request commonCap.CapabilityRequest) (commonCap.CapabilityResponse, error) {
+	resp := commonCap.CapabilityResponse{}
+	inputs := &pb.SimpleConsensusInputs{}
+	err := request.Payload.UnmarshalTo(inputs)
+	if err != nil {
+		return resp, fmt.Errorf("failed to unmarshal SimpleConsensusInputs err=%w, payload=%v", err, request.Payload)
+	}
+	fc.eng.Infow("Executing Fake Consensus NoDAG", "inputs", inputs)
+	anyProto, err := anypb.New(inputs.GetValue())
+	if err != nil {
+		return resp, fmt.Errorf("failed to marshal SimpleConsensusInputs value err=%w, value=%v", err, inputs.GetValue())
+	}
+	resp.Metadata = commonCap.ResponseMetadata{}
+	resp.Payload = anyProto
+	return resp, nil
+}
+
+func (fc *fakeConsensusNoDAG) RegisterToWorkflow(ctx context.Context, request commonCap.RegisterToWorkflowRequest) error {
+	fc.eng.Infow("Registering to Fake Consensus NoDAG", "workflowID", request.Metadata.WorkflowID)
+	return nil
+}
+
+func (fc *fakeConsensusNoDAG) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
+	fc.eng.Infow("Unregistering from Fake Consensus NoDAG", "workflowID", request.Metadata.WorkflowID)
+	return nil
+}
+
+func (fc *fakeConsensusNoDAG) Info(ctx context.Context) (commonCap.CapabilityInfo, error) {
+	return commonCap.CapabilityInfo{
+		ID:             consensusNoDAGCapID,
+		CapabilityType: commonCap.CapabilityTypeConsensus,
+		Description:    "Fake OCR Consensus NoDAG",
+		DON:            &commonCap.DON{},
+		IsLocal:        true,
+	}, nil
+}

--- a/core/capabilities/fakes/consensus_nodag.go
+++ b/core/capabilities/fakes/consensus_nodag.go
@@ -2,14 +2,14 @@ package fakes
 
 import (
 	"context"
-	"fmt"
 
-	"google.golang.org/protobuf/types/known/anypb"
-
-	commonCap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	consensusserver "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/consensus/server"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
+	valpb "github.com/smartcontractkit/chainlink-common/pkg/values/pb"
+	sdkpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
 )
 
 type fakeConsensusNoDAG struct {
@@ -18,18 +18,16 @@ type fakeConsensusNoDAG struct {
 }
 
 var _ services.Service = (*fakeConsensus)(nil)
-var _ commonCap.ExecutableCapability = (*fakeConsensusNoDAG)(nil)
+var _ consensusserver.ConsensusCapability = (*fakeConsensusNoDAG)(nil)
 
-const consensusNoDAGCapID = "consensus@1.0.0"
-
-func NewFakeConsensusNoDAG(lggr logger.Logger) (*fakeConsensusNoDAG, error) {
+func NewFakeConsensusNoDAG(lggr logger.Logger) *fakeConsensusNoDAG {
 	fc := &fakeConsensusNoDAG{}
 	fc.Service, fc.eng = services.Config{
 		Name:  "fakeConsensusNoDAG",
 		Start: fc.start,
 		Close: fc.close,
 	}.NewServiceEngine(lggr)
-	return fc, nil
+	return fc
 }
 
 func (fc *fakeConsensusNoDAG) start(ctx context.Context) error {
@@ -42,39 +40,24 @@ func (fc *fakeConsensusNoDAG) close() error {
 
 // NOTE: This fake capability currently bounces back the request payload, ignoring everything else.
 // When the real NoDAG consensus OCR plugin is ready, it should be used here, similarly to how the V1 fake works.
-func (fc *fakeConsensusNoDAG) Execute(ctx context.Context, request commonCap.CapabilityRequest) (commonCap.CapabilityResponse, error) {
-	resp := commonCap.CapabilityResponse{}
-	inputs := &pb.SimpleConsensusInputs{}
-	err := request.Payload.UnmarshalTo(inputs)
-	if err != nil {
-		return resp, fmt.Errorf("failed to unmarshal SimpleConsensusInputs err=%w, payload=%v", err, request.Payload)
-	}
-	fc.eng.Infow("Executing Fake Consensus NoDAG", "inputs", inputs)
-	anyProto, err := anypb.New(inputs.GetValue())
-	if err != nil {
-		return resp, fmt.Errorf("failed to marshal SimpleConsensusInputs value err=%w, value=%v", err, inputs.GetValue())
-	}
-	resp.Metadata = commonCap.ResponseMetadata{}
-	resp.Payload = anyProto
-	return resp, nil
+func (fc *fakeConsensusNoDAG) Simple(ctx context.Context, metadata capabilities.RequestMetadata, input *sdkpb.SimpleConsensusInputs) (*valpb.Value, error) {
+	fc.eng.Infow("Executing Fake Consensus NoDAG", "input", input)
+	return input.GetValue(), nil
 }
 
-func (fc *fakeConsensusNoDAG) RegisterToWorkflow(ctx context.Context, request commonCap.RegisterToWorkflowRequest) error {
-	fc.eng.Infow("Registering to Fake Consensus NoDAG", "workflowID", request.Metadata.WorkflowID)
+func (fc *fakeConsensusNoDAG) Description() string {
+	return "Fake OCR Consensus NoDAG"
+}
+
+func (fc *fakeConsensusNoDAG) Initialise(
+	_ context.Context,
+	_ string,
+	_ core.TelemetryService,
+	_ core.KeyValueStore,
+	_ core.ErrorLog,
+	_ core.PipelineRunnerService,
+	_ core.RelayerSet,
+	_ core.OracleFactory,
+	_ core.GatewayConnector) error {
 	return nil
-}
-
-func (fc *fakeConsensusNoDAG) UnregisterFromWorkflow(ctx context.Context, request commonCap.UnregisterFromWorkflowRequest) error {
-	fc.eng.Infow("Unregistering from Fake Consensus NoDAG", "workflowID", request.Metadata.WorkflowID)
-	return nil
-}
-
-func (fc *fakeConsensusNoDAG) Info(ctx context.Context) (commonCap.CapabilityInfo, error) {
-	return commonCap.CapabilityInfo{
-		ID:             consensusNoDAGCapID,
-		CapabilityType: commonCap.CapabilityTypeConsensus,
-		Description:    "Fake OCR Consensus NoDAG",
-		DON:            &commonCap.DON{},
-		IsLocal:        true,
-	}, nil
 }

--- a/core/capabilities/fakes/write_chain.go
+++ b/core/capabilities/fakes/write_chain.go
@@ -16,7 +16,7 @@ type fakeWriteChain struct {
 }
 
 var _ services.Service = (*fakeWriteChain)(nil)
-var _ commonCap.TargetCapability = (*fakeWriteChain)(nil)
+var _ commonCap.ExecutableCapability = (*fakeWriteChain)(nil)
 
 func (wc *fakeWriteChain) Info(ctx context.Context) (commonCap.CapabilityInfo, error) {
 	return commonCap.CapabilityInfo{

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1283,8 +1283,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d h1:BS3gBU0+8C8HzLFNczE1ZI2E8pDYaXXlgAlBE0w7p0w=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1283,8 +1283,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1 h1:HSPdcYsWkRQq4H5VpzdVDDSkViowVx8VTm3g6ql2nDk=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/core/services/workflows/cmd/cre/examples/compile_test.go
+++ b/core/services/workflows/cmd/cre/examples/compile_test.go
@@ -1,4 +1,4 @@
-package v2
+package examples
 
 import (
 	"path/filepath"
@@ -9,12 +9,14 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/wasmtest"
 )
 
-const pathPrefix = "core/services/workflows/cmd/cre/examples/v2"
+const pathPrefix = "core/services/workflows/cmd/cre/examples"
 
 func Test_AllExampleWorkflowsCompileToWASM(t *testing.T) {
 	paths := []string{
-		"simple_cron",
-		"simple_cron_with_config",
+		"legacy/data_feeds",
+		"v2/http_read",
+		"v2/simple_cron",
+		"v2/simple_cron_with_config",
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {

--- a/core/services/workflows/cmd/cre/examples/v2/simple_cron_with_config/main.go
+++ b/core/services/workflows/cmd/cre/examples/v2/simple_cron_with_config/main.go
@@ -21,7 +21,7 @@ func RunSimpleCronWorkflow(env *sdk.Environment[*runtimeConfig]) (sdk.Workflow[*
 	}
 
 	return sdk.Workflow[*runtimeConfig]{
-		sdk.On(
+		sdk.Handler(
 			cron.Trigger(cfg),
 			onTrigger,
 		),

--- a/core/services/workflows/cmd/cre/utils.go
+++ b/core/services/workflows/cmd/cre/utils.go
@@ -193,6 +193,15 @@ func NewFakeCapabilities(ctx context.Context, lggr logger.Logger, registry *capa
 	}
 	caps = append(caps, fakeConsensus)
 
+	fakeConsensusNoDAG, err := fakes.NewFakeConsensusNoDAG(lggr)
+	if err != nil {
+		return nil, err
+	}
+	if err := registry.Add(ctx, fakeConsensusNoDAG); err != nil {
+		return nil, err
+	}
+	caps = append(caps, fakeConsensusNoDAG)
+
 	writers := []string{"write_aptos-testnet@1.0.0"}
 	for _, writer := range writers {
 		writeCap := fakes.NewFakeWriteChain(lggr, writer)

--- a/core/services/workflows/cmd/cre/utils.go
+++ b/core/services/workflows/cmd/cre/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/billing"
 	httpserver "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/actions/http/server"
+	consensusserver "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/consensus/server"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -193,11 +194,8 @@ func NewFakeCapabilities(ctx context.Context, lggr logger.Logger, registry *capa
 	}
 	caps = append(caps, fakeConsensus)
 
-	fakeConsensusNoDAG, err := fakes.NewFakeConsensusNoDAG(lggr)
-	if err != nil {
-		return nil, err
-	}
-	if err := registry.Add(ctx, fakeConsensusNoDAG); err != nil {
+	fakeConsensusNoDAG := fakes.NewFakeConsensusNoDAG(lggr)
+	if err := registry.Add(ctx, consensusserver.NewConsensusServer(fakeConsensusNoDAG)); err != nil {
 		return nil, err
 	}
 	caps = append(caps, fakeConsensusNoDAG)

--- a/core/services/workflows/test/wasm/v2/cmd/with_config/main.go
+++ b/core/services/workflows/test/wasm/v2/cmd/with_config/main.go
@@ -17,7 +17,7 @@ type runtimeConfig struct {
 func CreateWorkflow(env *sdk.Environment[*runtimeConfig]) (sdk.Workflow[*runtimeConfig], error) {
 	runnerCfg := env.Config
 	return sdk.Workflow[*runtimeConfig]{
-		sdk.On(
+		sdk.Handler(
 			basictrigger.Trigger(&basictrigger.Config{
 				Name:   runnerCfg.Name,
 				Number: runnerCfg.Number,

--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
+	sdkpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"

--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/jonboulle/clockwork"
-	sdkpb "github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -473,7 +473,9 @@ func (e *Engine) deductStandardBalances(meteringReport *metering.Report) {
 
 // separate call for each workflow execution
 func (e *Engine) emitUserLogs(ctx context.Context, userLogChan chan *protoevents.LogLine, executionID string) {
+	e.lggr.Debugw("Listening for user logs ...")
 	count := 0
+	defer func() { e.lggr.Debugw("Listening for user logs done.", "processedLogLines", count) }()
 	for {
 		select {
 		case <-ctx.Done():

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250625151958-31b61ac8e1d9

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250624090157-6b89f926f864
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250625151958-31b61ac8e1d9

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1259,8 +1259,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d h1:BS3gBU0+8C8HzLFNczE1ZI2E8pDYaXXlgAlBE0w7p0w=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1259,8 +1259,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1 h1:HSPdcYsWkRQq4H5VpzdVDDSkViowVx8VTm3g6ql2nDk=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250625151958-31b61ac8e1d9

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250625151958-31b61ac8e1d9

--- a/go.sum
+++ b/go.sum
@@ -1084,8 +1084,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1 h1:HSPdcYsWkRQq4H5VpzdVDDSkViowVx8VTm3g6ql2nDk=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/go.sum
+++ b/go.sum
@@ -1084,8 +1084,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d h1:BS3gBU0+8C8HzLFNczE1ZI2E8pDYaXXlgAlBE0w7p0w=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250625151958-31b61ac8e1d9
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250625151958-31b61ac8e1d9
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1484,8 +1484,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d h1:BS3gBU0+8C8HzLFNczE1ZI2E8pDYaXXlgAlBE0w7p0w=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1484,8 +1484,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1 h1:HSPdcYsWkRQq4H5VpzdVDDSkViowVx8VTm3g6ql2nDk=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250625151958-31b61ac8e1d9
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.9.0

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250625151958-31b61ac8e1d9
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.9.0

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1466,8 +1466,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1 h1:HSPdcYsWkRQq4H5VpzdVDDSkViowVx8VTm3g6ql2nDk=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1466,8 +1466,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d h1:BS3gBU0+8C8HzLFNczE1ZI2E8pDYaXXlgAlBE0w7p0w=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/smartcontractkit/chain-selectors v1.0.60
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250625151958-31b61ac8e1d9

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/smartcontractkit/chain-selectors v1.0.60
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250625151958-31b61ac8e1d9

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1246,8 +1246,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1 h1:HSPdcYsWkRQq4H5VpzdVDDSkViowVx8VTm3g6ql2nDk=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1246,8 +1246,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d h1:BS3gBU0+8C8HzLFNczE1ZI2E8pDYaXXlgAlBE0w7p0w=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/shopspring/decimal v1.4.0
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/shopspring/decimal v1.4.0
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.14.0

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1440,8 +1440,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1 h1:HSPdcYsWkRQq4H5VpzdVDDSkViowVx8VTm3g6ql2nDk=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250624193310-7566a2b110f1/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1440,8 +1440,8 @@ github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804 h1
 github.com/smartcontractkit/chainlink-ccip v0.0.0-20250624142741-45c8e9237804/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad h1:nhjdTvWHl7Lz3C/eGWzUqBgtCCAAB4tEIHB8TkQI0Ag=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250625170538-5613187324ad/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d h1:BS3gBU0+8C8HzLFNczE1ZI2E8pDYaXXlgAlBE0w7p0w=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250626141212-e50b2e7ffe2d/go.mod h1:plVu/MNDcoGbX++P0Dhv8gTtpafG98HqG6BfNj+dfE0=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250624161023-93f383781b0a h1:AVYA3UTkn2wjdpkTRhtXH0XgVBE25tXmfqxmEZhE+4s=


### PR DESCRIPTION
1. Add a NoDAG version of the fake consensus capability. Trivial implementation for now.
2. Add an example workflow that uses HTTP action in Node mode and consensus.
3. Bump common dep to latest.