### PR TITLE
[CAPPL-936] Add Standalone Engine runner & test

### DIFF
--- a/core/capabilities/fakes/http_action.go
+++ b/core/capabilities/fakes/http_action.go
@@ -44,8 +44,8 @@ func NewDirectHTTPAction(lggr logger.Logger) *DirectHTTPAction {
 
 	fc.Service, fc.eng = services.Config{
 		Name:  "directHttpAction",
-		Start: fc.Start,
-		Close: fc.Close,
+		Start: fc.start,
+		Close: fc.close,
 	}.NewServiceEngine(lggr)
 	return fc
 }
@@ -135,26 +135,18 @@ func (fh *DirectHTTPAction) SendRequest(ctx context.Context, metadata commonCap.
 	return response, nil
 }
 
-func (fh *DirectHTTPAction) Start(ctx context.Context) error {
+func (fh *DirectHTTPAction) start(ctx context.Context) error {
 	fh.eng.Infow("Http Action Start Started")
 	return nil
 }
 
-func (fh *DirectHTTPAction) Close() error {
+func (fh *DirectHTTPAction) close() error {
 	fh.eng.Infow("Http Action Close Started")
 	return nil
 }
 
-func (fh *DirectHTTPAction) Name() string {
-	return HTTPActionServiceName
-}
-
 func (fh *DirectHTTPAction) Description() string {
 	return directHTTPActionInfo.Description
-}
-
-func (fh *DirectHTTPAction) Ready() error {
-	return nil
 }
 
 func (fh *DirectHTTPAction) Initialise(ctx context.Context, config string, _ core.TelemetryService,

--- a/core/services/workflows/cmd/cre/billing.go
+++ b/core/services/workflows/cmd/cre/billing.go
@@ -98,6 +98,15 @@ func setupBeholder(lggr logger.Logger) error {
 	return nil
 }
 
+func cleanupBeholder() error {
+	client := beholder.GetClient()
+	if client != nil {
+		return client.Close()
+	}
+
+	return nil
+}
+
 type lggrWriter struct {
 	lggr logger.Logger
 }

--- a/core/services/workflows/cmd/cre/examples/compile_test.go
+++ b/core/services/workflows/cmd/cre/examples/compile_test.go
@@ -17,6 +17,7 @@ func Test_AllExampleWorkflowsCompileToWASM(t *testing.T) {
 		"v2/http_read",
 		"v2/simple_cron",
 		"v2/simple_cron_with_config",
+		"v2/empty",
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {

--- a/core/services/workflows/cmd/cre/examples/v2/empty/main.go
+++ b/core/services/workflows/cmd/cre/examples/v2/empty/main.go
@@ -1,0 +1,16 @@
+//go:build wasip1
+
+package main
+
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/v2"
+)
+
+func RunEmptyWorkflow(_ *sdk.Environment[struct{}]) (sdk.Workflow[struct{}], error) {
+	return sdk.Workflow[struct{}]{}, nil
+}
+
+func main() {
+	wasm.NewRunner(func(_ []byte) (struct{}, error) { return struct{}{}, nil }).Run(RunEmptyWorkflow)
+}

--- a/core/services/workflows/cmd/cre/main.go
+++ b/core/services/workflows/cmd/cre/main.go
@@ -10,25 +10,25 @@ import (
 
 	"go.uber.org/zap/zapcore"
 
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	v2 "github.com/smartcontractkit/chainlink/v2/core/services/workflows/v2"
 )
 
 func main() {
 	var (
-		wasmPath          string
-		configPath        string
-		debugMode         bool
-		billingClientAddr string
-		enableBeholder    bool
+		wasmPath                   string
+		configPath                 string
+		debugMode                  bool
+		enableBeholder             bool
+		enableBilling              bool
+		enableStandardCapabilities bool
 	)
 
 	flag.StringVar(&wasmPath, "wasm", "", "Path to the WASM binary file")
 	flag.StringVar(&configPath, "config", "", "Path to the Config file")
 	flag.BoolVar(&debugMode, "debug", false, "Enable debug-level logging")
-	flag.StringVar(&billingClientAddr, "billing-client-address", "", "Billing client address; Leave empty to run a local client that prints to the standard log.")
 	flag.BoolVar(&enableBeholder, "beholder", false, "Enable printing beholder messages to standard log")
+	flag.BoolVar(&enableBilling, "billing", false, "Enable to run a faked billing service that prints to the standard log.")
+	flag.BoolVar(&enableStandardCapabilities, "standardCapabilities", true, "Enable to use the latest production standard capability binaries for capabilities. The binaries must be available in local GOBIN.")
 	flag.Parse()
 
 	if wasmPath == "" {
@@ -63,81 +63,11 @@ func main() {
 	logCfg := logger.Config{LogLevel: logLevel}
 	lggr, _ := logCfg.New()
 
-	run(ctx, lggr, binary, config, billingClientAddr, enableBeholder)
-}
-
-// run instantiates the engine, starts it and blocks until the context is canceled.
-func run(
-	ctx context.Context,
-	lggr logger.Logger,
-	binary, config []byte,
-	billingClientAddr string,
-	enableBeholder bool,
-) {
-	lggr.Infof("executing engine in process: %d", os.Getpid())
-
-	// Create the registry and fake capabilities
-	registry := capabilities.NewRegistry(lggr)
-	registry.SetLocalRegistry(&capabilities.TestMetadataRegistry{})
-	capabilities, err := NewFakeCapabilities(ctx, lggr, registry)
-	if err != nil {
-		fmt.Printf("Failed to create capabilities: %v\n", err)
-		os.Exit(1)
-	}
-
-	if enableBeholder {
-		_ = setupBeholder(lggr.Named("Fake_Stdlog_Beholder"))
-	}
-
-	if billingClientAddr != "" {
-		bs := NewBillingService(lggr.Named("Fake_Billing_Client"))
-		err = bs.Start(ctx)
-		if err != nil {
-			fmt.Printf("Failed to start billing service: %v\n", err)
-			os.Exit(1)
-		}
-
-		defer func(bs *BillingService) {
-			cerr := bs.close()
-			if cerr != nil {
-				fmt.Printf("Failed to close billing service: %v\n", cerr)
-			}
-		}(bs)
-	}
-
-	for _, cap := range capabilities {
-		if err2 := cap.Start(ctx); err2 != nil {
-			fmt.Printf("Failed to start capability: %v\n", err2)
-			os.Exit(1)
-		}
-
-		// await the capability to be initialized if using a loop plugin
-		if standardcap, ok := cap.(*standaloneLoopWrapper); ok {
-			if err = standardcap.Await(ctx); err != nil {
-				fmt.Printf("Failed to await capability: %v\n", err)
-				os.Exit(1)
-			}
-		}
-	}
-
-	engine, err := NewStandaloneEngine(ctx, lggr, registry, binary, config, billingClientAddr, v2.LifecycleHooks{})
-	if err != nil {
-		fmt.Printf("Failed to create engine: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = engine.Start(ctx)
-	if err != nil {
-		fmt.Printf("Failed to start engine: %v\n", err)
-		os.Exit(1)
-	}
-
-	<-ctx.Done()
-
-	lggr.Info("Shutting down the Engine")
-	_ = engine.Close()
-	for _, cap := range capabilities {
-		lggr.Infow("Shutting down capability", "id", cap.Name())
-		_ = cap.Close()
-	}
+	runner := NewRunner(nil)
+	runner.run(ctx, binary, config, RunnerConfig{
+		enableBilling:              enableBilling,
+		enableBeholder:             enableBeholder,
+		enableStandardCapabilities: enableStandardCapabilities,
+		lggr:                       lggr,
+	})
 }

--- a/core/services/workflows/cmd/cre/runner.go
+++ b/core/services/workflows/cmd/cre/runner.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	v2 "github.com/smartcontractkit/chainlink/v2/core/services/workflows/v2"
+)
+
+type Runner struct {
+	hooks RunnerHooks
+}
+
+type RunnerConfig struct {
+	enableBeholder             bool
+	enableBilling              bool
+	enableStandardCapabilities bool
+	lggr                       logger.Logger
+}
+
+type RunnerHooks struct {
+	Initialize func(context.Context, RunnerConfig) (*capabilities.Registry, []services.Service)
+	BeforeRun  func(context.Context, RunnerConfig, *capabilities.Registry, []services.Service)
+	AfterRun   func(context.Context, RunnerConfig, *capabilities.Registry, []services.Service)
+	Cleanup    func(context.Context, RunnerConfig, *capabilities.Registry, []services.Service)
+	Finally    func(context.Context, RunnerConfig, *capabilities.Registry, []services.Service)
+}
+
+var emptyHook = func(context.Context, RunnerConfig, *capabilities.Registry, []services.Service) {}
+
+var defaultInitialize = func(ctx context.Context, cfg RunnerConfig) (*capabilities.Registry, []services.Service) {
+	registry := capabilities.NewRegistry(cfg.lggr)
+	registry.SetLocalRegistry(&capabilities.TestMetadataRegistry{})
+
+	srvcs := []services.Service{}
+
+	if cfg.enableBilling {
+		bs := NewBillingService(cfg.lggr.Named("Fake_Billing_Client"))
+		err := bs.Start(ctx)
+		if err != nil {
+			fmt.Printf("Failed to start billing service: %v\n", err)
+			os.Exit(1)
+		}
+
+		srvcs = append(srvcs, bs)
+	}
+
+	var caps []services.Service
+	var err error
+
+	if cfg.enableStandardCapabilities {
+		caps, err = NewCapabilities(ctx, cfg.lggr, registry)
+	} else {
+		caps, err = NewFakeCapabilities(ctx, cfg.lggr, registry)
+	}
+	if err != nil {
+		fmt.Printf("Failed to create capabilities: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, cap := range caps {
+		err = cap.Start(ctx)
+		if err != nil {
+			fmt.Printf("Failed to start capability: %v\n", err)
+			os.Exit(1)
+		}
+
+		// await the capability to be initialized if using a loop plugin
+		if standardcap, ok := cap.(*standaloneLoopWrapper); ok {
+			err = standardcap.Await(ctx)
+			if err != nil {
+				fmt.Printf("Failed to await capability: %v\n", err)
+				os.Exit(1)
+			}
+		}
+
+		srvcs = append(srvcs, cap)
+	}
+
+	if cfg.enableBeholder {
+		_ = setupBeholder(cfg.lggr.Named("Fake_Stdlog_Beholder"))
+	}
+
+	return registry, srvcs
+}
+
+var defaultCleanup = func(ctx context.Context, cfg RunnerConfig, registry *capabilities.Registry, services []services.Service) {
+	for _, service := range services {
+		cfg.lggr.Infow("Shutting down", "id", service.Name())
+		_ = service.Close()
+	}
+
+	_ = cleanupBeholder()
+}
+
+func DefaultHooks() *RunnerHooks {
+	return &RunnerHooks{
+		Initialize: defaultInitialize,
+		BeforeRun:  emptyHook,
+		AfterRun:   emptyHook,
+		Cleanup:    defaultCleanup,
+		Finally:    emptyHook,
+	}
+}
+
+func NewRunner(hooks *RunnerHooks) *Runner {
+	if hooks == nil {
+		hooks = DefaultHooks()
+	}
+
+	return &Runner{
+		hooks: *hooks,
+	}
+}
+
+// run instantiates the engine, starts it and blocks until the context is canceled.
+func (r *Runner) run(
+	ctx context.Context,
+	binary, config []byte,
+	cfg RunnerConfig,
+) {
+	cfg.lggr.Infof("executing engine in process: %d", os.Getpid())
+
+	registry, services := r.hooks.Initialize(ctx, cfg)
+
+	billingAddress := ""
+	if cfg.enableBilling {
+		billingAddress = "localhost:4319"
+	}
+
+	engine, err := NewStandaloneEngine(ctx, cfg.lggr, registry, binary, config, billingAddress, v2.LifecycleHooks{})
+	if err != nil {
+		fmt.Printf("Failed to create engine: %v\n", err)
+		os.Exit(1)
+	}
+
+	services = append(services, engine)
+
+	r.hooks.BeforeRun(ctx, cfg, registry, services)
+
+	err = engine.Start(ctx)
+	if err != nil {
+		fmt.Printf("Failed to start engine: %v\n", err)
+		os.Exit(1)
+	}
+
+	<-ctx.Done()
+
+	r.hooks.AfterRun(ctx, cfg, registry, services)
+
+	r.hooks.Cleanup(ctx, cfg, registry, services)
+
+	r.hooks.Finally(ctx, cfg, registry, services)
+}

--- a/core/services/workflows/cmd/cre/runner_test.go
+++ b/core/services/workflows/cmd/cre/runner_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/wasmtest"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunner(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path with an empty workflow", func(t *testing.T) {
+		t.Parallel()
+
+		duration := 5 * time.Second
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(duration))
+		defer cancel()
+
+		hooks := DefaultHooks()
+		hooks.Finally = func(ctx context.Context, cfg RunnerConfig, registry *capabilities.Registry, svcs []services.Service) {
+			for _, service := range svcs {
+				require.ErrorContains(t, service.Ready(), "Stopped")
+			}
+		}
+
+		binary := wasmtest.CreateTestBinary(filepath.Join("core/services/workflows/cmd/cre/examples/v2", "empty"), false, t)
+
+		runner := NewRunner(hooks)
+		runner.run(ctx, binary, []byte{}, RunnerConfig{
+			enableBeholder:             false,
+			enableBilling:              true,
+			enableStandardCapabilities: false,
+			lggr:                       logger.TestLogger(t),
+		})
+	})
+}

--- a/core/services/workflows/cmd/cre/runner_test.go
+++ b/core/services/workflows/cmd/cre/runner_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/wasmtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRunner(t *testing.T) {


### PR DESCRIPTION
## Description
Refactors Standalone Engine commands to use a `runner` with hooks, which allows more control and higher testing ability.

Additionally:
- Adds a unit test using an empty workflow to protect the standalone engine from regressions.
- Amends fake HTTP action overwriting default service methods
- Ensures beholder client is cleaned up
- Puts using standard capabilities on an configurable arg (still default behavior)