### PR TITLE
feat(aptos): Integrate Aptos on proposalutils

### DIFF
--- a/deployment/ccip/changeset/aptos/cs_add_token_pool.go
+++ b/deployment/ccip/changeset/aptos/cs_add_token_pool.go
@@ -184,7 +184,7 @@ func (cs AddTokenPool) Apply(env cldf.Environment, cfg config.AddTokenPoolConfig
 
 	// Generate Aptos MCMS proposals
 	proposal, err := utils.GenerateProposal(
-		aptosChain.Client,
+		env,
 		state.AptosChains[cfg.ChainSelector].MCMSAddress,
 		cfg.ChainSelector,
 		mcmsOperations,

--- a/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_aptos_chain.go
@@ -165,7 +165,7 @@ func (cs DeployAptosChain) Apply(env cldf.Environment, cfg config.DeployAptosCha
 
 		// Generate MCMS proposals
 		proposal, err := utils.GenerateProposal(
-			aptosChain.Client,
+			env,
 			mcmsSeqReport.Output.MCMSAddress,
 			chainSel,
 			mcmsOperations,

--- a/deployment/ccip/changeset/aptos/cs_deploy_token_faucet.go
+++ b/deployment/ccip/changeset/aptos/cs_deploy_token_faucet.go
@@ -20,8 +20,8 @@ var _ cldf.ChangeSetV2[config.DeployTokenFaucetInput] = DeployTokenFaucet{}
 
 type DeployTokenFaucet struct{}
 
-func (d DeployTokenFaucet) VerifyPreconditions(e cldf.Environment, cfg config.DeployTokenFaucetInput) error {
-	state, err := stateview.LoadOnchainState(e)
+func (d DeployTokenFaucet) VerifyPreconditions(env cldf.Environment, cfg config.DeployTokenFaucetInput) error {
+	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return fmt.Errorf("failed to load Aptos onchain state: %w", err)
 	}
@@ -42,13 +42,13 @@ func (d DeployTokenFaucet) VerifyPreconditions(e cldf.Environment, cfg config.De
 	return errors.Join(errs...)
 }
 
-func (d DeployTokenFaucet) Apply(e cldf.Environment, cfg config.DeployTokenFaucetInput) (cldf.ChangesetOutput, error) {
-	state, err := stateview.LoadOnchainState(e)
+func (d DeployTokenFaucet) Apply(env cldf.Environment, cfg config.DeployTokenFaucetInput) (cldf.ChangesetOutput, error) {
+	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load Aptos onchain state: %w", err)
 	}
 
-	aptosChain := e.BlockChains.AptosChains()[cfg.ChainSelector]
+	aptosChain := env.BlockChains.AptosChains()[cfg.ChainSelector]
 	ab := cldf.NewMemoryAddressBook()
 
 	deps := operation.AptosDeps{
@@ -61,13 +61,13 @@ func (d DeployTokenFaucet) Apply(e cldf.Environment, cfg config.DeployTokenFauce
 		MCMSAddress:         state.AptosChains[cfg.ChainSelector].MCMSAddress,
 		TokenCodeObjAddress: cfg.TokenCodeObjectAddress,
 	}
-	report, err := operations.ExecuteSequence(e.OperationsBundle, seq.DeployTokenFaucetSequence, deps, input)
+	report, err := operations.ExecuteSequence(env.OperationsBundle, seq.DeployTokenFaucetSequence, deps, input)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute DeployTokenFaucetSequence: %w", err)
 	}
 
 	proposal, err := utils.GenerateProposal(
-		aptosChain.Client,
+		env,
 		state.AptosChains[cfg.ChainSelector].MCMSAddress,
 		cfg.ChainSelector,
 		report.Output,

--- a/deployment/ccip/changeset/aptos/cs_mint_token.go
+++ b/deployment/ccip/changeset/aptos/cs_mint_token.go
@@ -20,8 +20,8 @@ var _ cldf.ChangeSetV2[config.MintTokenInput] = MintToken{}
 
 type MintToken struct{}
 
-func (m MintToken) VerifyPreconditions(e cldf.Environment, cfg config.MintTokenInput) error {
-	state, err := stateview.LoadOnchainState(e)
+func (m MintToken) VerifyPreconditions(env cldf.Environment, cfg config.MintTokenInput) error {
+	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return fmt.Errorf("failed to load Aptos onchain state: %w", err)
 	}
@@ -48,13 +48,13 @@ func (m MintToken) VerifyPreconditions(e cldf.Environment, cfg config.MintTokenI
 	return errors.Join(errs...)
 }
 
-func (m MintToken) Apply(e cldf.Environment, cfg config.MintTokenInput) (cldf.ChangesetOutput, error) {
-	state, err := stateview.LoadOnchainState(e)
+func (m MintToken) Apply(env cldf.Environment, cfg config.MintTokenInput) (cldf.ChangesetOutput, error) {
+	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load Aptos onchain state: %w", err)
 	}
 
-	aptosChain := e.BlockChains.AptosChains()[cfg.ChainSelector]
+	aptosChain := env.BlockChains.AptosChains()[cfg.ChainSelector]
 	ab := cldf.NewMemoryAddressBook()
 
 	deps := operation.AptosDeps{
@@ -68,13 +68,13 @@ func (m MintToken) Apply(e cldf.Environment, cfg config.MintTokenInput) (cldf.Ch
 		To:                     cfg.To,
 		Amount:                 cfg.Amount,
 	}
-	report, err := operations.ExecuteOperation(e.OperationsBundle, operation.MintTokensOp, deps, input)
+	report, err := operations.ExecuteOperation(env.OperationsBundle, operation.MintTokensOp, deps, input)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute MintTokensOp: %w", err)
 	}
 
 	proposal, err := utils.GenerateProposal(
-		aptosChain.Client,
+		env,
 		state.AptosChains[cfg.ChainSelector].MCMSAddress,
 		cfg.ChainSelector,
 		[]mcmstypes.BatchOperation{

--- a/deployment/ccip/changeset/aptos/cs_set_ocr3_offramp.go
+++ b/deployment/ccip/changeset/aptos/cs_set_ocr3_offramp.go
@@ -61,7 +61,7 @@ func (cs SetOCR3Offramp) Apply(env cldf.Environment, config v1_6.SetOCR3OffRampC
 
 		// Generate MCMS proposals
 		proposal, err := utils.GenerateProposal(
-			deps.AptosChain.Client,
+			env,
 			state.AptosChains[remoteSelector].MCMSAddress,
 			deps.AptosChain.Selector,
 			[]mcmstypes.BatchOperation{setOCR3SeqReport.Output},

--- a/deployment/ccip/changeset/aptos/cs_update_aptos_lanes.go
+++ b/deployment/ccip/changeset/aptos/cs_update_aptos_lanes.go
@@ -120,7 +120,7 @@ func (cs AddAptosLanes) Apply(env cldf.Environment, cfg config.UpdateAptosLanesC
 
 		// Generate MCMS proposals
 		proposal, err := utils.GenerateProposal(
-			deps.AptosChain.Client,
+			env,
 			state.AptosChains[aptosChainSel].MCMSAddress,
 			deps.AptosChain.Selector,
 			mcmsOperations,

--- a/deployment/ccip/changeset/aptos/utils/mcms.go
+++ b/deployment/ccip/changeset/aptos/utils/mcms.go
@@ -17,19 +17,22 @@ import (
 	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
 	"github.com/smartcontractkit/chainlink-aptos/bindings/compile"
 	mcmsbind "github.com/smartcontractkit/chainlink-aptos/bindings/mcms"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 )
 
 const MCMSProposalVersion = "v1"
 
 func GenerateProposal(
-	client aptos.AptosRpcClient,
+	env cldf.Environment,
 	mcmsAddress aptos.AccountAddress,
 	chainSel uint64,
 	operations []mcmstypes.BatchOperation,
 	description string,
 	mcmsCfg proposalutils.TimelockConfig,
 ) (*mcms.TimelockProposal, error) {
+	client := env.BlockChains.AptosChains()[chainSel].Client
+
 	// Get role from action
 	role, err := roleFromAction(mcmsCfg.MCMSAction)
 	if err != nil {

--- a/deployment/ccip/changeset/aptos/utils/mcms.go
+++ b/deployment/ccip/changeset/aptos/utils/mcms.go
@@ -1,16 +1,13 @@
 package utils
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"strings"
-	"time"
 
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/smartcontractkit/mcms"
+	mcmssdk "github.com/smartcontractkit/mcms/sdk"
 	aptosmcms "github.com/smartcontractkit/mcms/sdk/aptos"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
@@ -31,74 +28,23 @@ func GenerateProposal(
 	description string,
 	mcmsCfg proposalutils.TimelockConfig,
 ) (*mcms.TimelockProposal, error) {
-	client := env.BlockChains.AptosChains()[chainSel].Client
-
 	// Get role from action
-	role, err := roleFromAction(mcmsCfg.MCMSAction)
+	role, err := proposalutils.GetAptosRoleFromAction(mcmsCfg.MCMSAction)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get role from action: %w", err)
 	}
-	jsonRole, _ := json.Marshal(aptosmcms.AdditionalFieldsMetadata{Role: role})
-	var action = mcmsCfg.MCMSAction
-	if action == "" {
-		action = mcmstypes.TimelockActionSchedule
-	}
 	// Create MCMS inspector
-	inspector := aptosmcms.NewInspector(client, role)
-	startingOpCount, err := inspector.GetOpCount(context.Background(), mcmsAddress.StringLong())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get starting op count: %w", err)
-	}
-	opCount := startingOpCount
+	inspector := aptosmcms.NewInspector(env.BlockChains.AptosChains()[chainSel].Client, role)
 
-	// Create proposal builder
-	validUntil := time.Now().Unix() + int64(proposalutils.DefaultValidUntil.Seconds())
-	if validUntil < 0 || validUntil > math.MaxUint32 {
-		return nil, fmt.Errorf("validUntil value out of range for uint32: %d", validUntil)
-	}
-
-	proposalBuilder := mcms.NewTimelockProposalBuilder().
-		SetVersion(MCMSProposalVersion).
-		SetValidUntil(uint32(validUntil)).
-		SetDescription(description).
-		AddTimelockAddress(mcmstypes.ChainSelector(chainSel), mcmsAddress.StringLong()).
-		SetOverridePreviousRoot(mcmsCfg.OverrideRoot).
-		AddChainMetadata(
-			mcmstypes.ChainSelector(chainSel),
-			mcmstypes.ChainMetadata{
-				StartingOpCount:  opCount,
-				MCMAddress:       mcmsAddress.StringLong(),
-				AdditionalFields: jsonRole,
-			},
-		).
-		SetAction(action).
-		SetDelay(mcmstypes.NewDuration(mcmsCfg.MinDelay))
-
-	// Add operations and build
-	for _, op := range operations {
-		proposalBuilder.AddOperation(op)
-	}
-	proposal, err := proposalBuilder.Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to build proposal: %w", err)
-	}
-
-	return proposal, nil
-}
-
-func roleFromAction(action mcmstypes.TimelockAction) (aptosmcms.TimelockRole, error) {
-	switch action {
-	case mcmstypes.TimelockActionSchedule:
-		return aptosmcms.TimelockRoleProposer, nil
-	case mcmstypes.TimelockActionBypass:
-		return aptosmcms.TimelockRoleBypasser, nil
-	case mcmstypes.TimelockActionCancel:
-		return aptosmcms.TimelockRoleCanceller, nil
-	case "":
-		return aptosmcms.TimelockRoleProposer, nil
-	default:
-		return aptosmcms.TimelockRoleProposer, fmt.Errorf("invalid action: %s", action)
-	}
+	return proposalutils.BuildProposalFromBatchesV2(
+		env,
+		map[uint64]string{chainSel: mcmsAddress.StringLong()},
+		map[uint64]string{chainSel: mcmsAddress.StringLong()},
+		map[uint64]mcmssdk.Inspector{chainSel: inspector},
+		operations,
+		description,
+		mcmsCfg,
+	)
 }
 
 // ToBatchOperations converts Operations into BatchOperations with a single transaction each

--- a/deployment/ccip/changeset/testhelpers/test_aptos_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_aptos_helpers.go
@@ -3,10 +3,13 @@ package testhelpers
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 
 	aptoscs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
@@ -51,6 +54,13 @@ func DeployChainContractsToAptosCS(t *testing.T, e DeployedEnv, chainSelector ui
 				Proposer:         proposalutils.SingleGroupMCMSV2(t),
 				Bypasser:         proposalutils.SingleGroupMCMSV2(t),
 				TimelockMinDelay: big.NewInt(1),
+			},
+		},
+		MCMSTimelockConfigPerChain: map[uint64]proposalutils.TimelockConfig{
+			chainSelector: {
+				MinDelay:     time.Duration(1) * time.Second,
+				MCMSAction:   mcmstypes.TimelockActionSchedule,
+				OverrideRoot: false,
 			},
 		},
 	}

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -167,16 +167,24 @@ func McmsTimelockConverters(env cldf.Environment) (map[uint64]mcmssdk.TimelockCo
 	return converters, nil
 }
 
-type InspectorMetadataParams struct {
+type mcmsInspectorOptions struct {
 	AptosRole mcmsaptossdk.TimelockRole
 }
 
-// Deprecated: use McmsInspectorForChainV2 instead. Which supports MetadataParams
-func McmsInspectorForChain(env cldf.Environment, chain uint64) (mcmssdk.Inspector, error) {
-	return McmsInspectorForChainV2(env, chain, InspectorMetadataParams{})
+type MCMSInspectorOption func(*mcmsInspectorOptions)
+
+func WithAptosRole(role mcmsaptossdk.TimelockRole) MCMSInspectorOption {
+	return func(opts *mcmsInspectorOptions) {
+		opts.AptosRole = role
+	}
 }
 
-func McmsInspectorForChainV2(env cldf.Environment, chain uint64, metadataParams InspectorMetadataParams) (mcmssdk.Inspector, error) {
+func McmsInspectorForChain(env cldf.Environment, chain uint64, opts ...MCMSInspectorOption) (mcmssdk.Inspector, error) {
+	var options mcmsInspectorOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	chainFamily, err := mcmstypes.GetChainSelectorFamily(mcmstypes.ChainSelector(chain))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain family for chain %d: %w", chain, err)
@@ -188,10 +196,10 @@ func McmsInspectorForChainV2(env cldf.Environment, chain uint64, metadataParams 
 	case chain_selectors.FamilySolana:
 		return mcmssolanasdk.NewInspector(env.BlockChains.SolanaChains()[chain].Client), nil
 	case chain_selectors.FamilyAptos:
-		if metadataParams.AptosRole.String() == "unknown" {
+		if options.AptosRole.String() == "unknown" {
 			return nil, fmt.Errorf("aptos role not properly set for chain: %d", chain)
 		}
-		inspector := mcmsaptossdk.NewInspector(env.BlockChains.AptosChains()[chain].Client, metadataParams.AptosRole)
+		inspector := mcmsaptossdk.NewInspector(env.BlockChains.AptosChains()[chain].Client, options.AptosRole)
 
 		return inspector, nil
 	default:

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -12,6 +12,7 @@ import (
 	owner_helpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
+	mcmsaptossdk "github.com/smartcontractkit/mcms/sdk/aptos"
 	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
@@ -166,7 +167,7 @@ func McmsTimelockConverters(env cldf.Environment) (map[uint64]mcmssdk.TimelockCo
 	return converters, nil
 }
 
-func McmsInspectorForChain(env cldf.Environment, chain uint64) (mcmssdk.Inspector, error) {
+func McmsInspectorForChain(env cldf.Environment, chain uint64, aptosRole ...mcmsaptossdk.TimelockRole) (mcmssdk.Inspector, error) {
 	chainFamily, err := mcmstypes.GetChainSelectorFamily(mcmstypes.ChainSelector(chain))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain family for chain %d: %w", chain, err)
@@ -177,6 +178,13 @@ func McmsInspectorForChain(env cldf.Environment, chain uint64) (mcmssdk.Inspecto
 		return mcmsevmsdk.NewInspector(env.BlockChains.EVMChains()[chain].Client), nil
 	case chain_selectors.FamilySolana:
 		return mcmssolanasdk.NewInspector(env.BlockChains.SolanaChains()[chain].Client), nil
+	case chain_selectors.FamilyAptos:
+		if len(aptosRole) != 1 {
+			return nil, fmt.Errorf("exactly one Aptos role must be provided for chain: %d", chain)
+		}
+		inspector := mcmsaptossdk.NewInspector(env.BlockChains.AptosChains()[chain].Client, aptosRole[0])
+
+		return inspector, nil
 	default:
 		return nil, fmt.Errorf("unsupported chain family %s", chainFamily)
 	}

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -167,7 +167,16 @@ func McmsTimelockConverters(env cldf.Environment) (map[uint64]mcmssdk.TimelockCo
 	return converters, nil
 }
 
-func McmsInspectorForChain(env cldf.Environment, chain uint64, aptosRole ...mcmsaptossdk.TimelockRole) (mcmssdk.Inspector, error) {
+type InspectorMetadataParams struct {
+	AptosRole mcmsaptossdk.TimelockRole
+}
+
+// Deprecated: use McmsInspectorForChainV2 instead. Which supports MetadataParams
+func McmsInspectorForChain(env cldf.Environment, chain uint64) (mcmssdk.Inspector, error) {
+	return McmsInspectorForChainV2(env, chain, InspectorMetadataParams{})
+}
+
+func McmsInspectorForChainV2(env cldf.Environment, chain uint64, metadataParams InspectorMetadataParams) (mcmssdk.Inspector, error) {
 	chainFamily, err := mcmstypes.GetChainSelectorFamily(mcmstypes.ChainSelector(chain))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain family for chain %d: %w", chain, err)
@@ -179,10 +188,10 @@ func McmsInspectorForChain(env cldf.Environment, chain uint64, aptosRole ...mcms
 	case chain_selectors.FamilySolana:
 		return mcmssolanasdk.NewInspector(env.BlockChains.SolanaChains()[chain].Client), nil
 	case chain_selectors.FamilyAptos:
-		if len(aptosRole) != 1 {
-			return nil, fmt.Errorf("exactly one Aptos role must be provided for chain: %d", chain)
+		if metadataParams.AptosRole.String() == "unknown" {
+			return nil, fmt.Errorf("aptos role not properly set for chain: %d", chain)
 		}
-		inspector := mcmsaptossdk.NewInspector(env.BlockChains.AptosChains()[chain].Client, aptosRole[0])
+		inspector := mcmsaptossdk.NewInspector(env.BlockChains.AptosChains()[chain].Client, metadataParams.AptosRole)
 
 		return inspector, nil
 	default:
@@ -265,8 +274,6 @@ func GetAptosRoleFromAction(action mcmstypes.TimelockAction) (mcmsaptossdk.Timel
 		return mcmsaptossdk.TimelockRoleBypasser, nil
 	case mcmstypes.TimelockActionCancel:
 		return mcmsaptossdk.TimelockRoleCanceller, nil
-	case "":
-		return mcmsaptossdk.TimelockRoleProposer, nil
 	default:
 		return mcmsaptossdk.TimelockRoleProposer, fmt.Errorf("invalid action: %s", action)
 	}

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -282,6 +282,9 @@ func GetAptosRoleFromAction(action mcmstypes.TimelockAction) (mcmsaptossdk.Timel
 		return mcmsaptossdk.TimelockRoleBypasser, nil
 	case mcmstypes.TimelockActionCancel:
 		return mcmsaptossdk.TimelockRoleCanceller, nil
+	case "":
+		// Default case for empty action to avoid breaking changes
+		return mcmsaptossdk.TimelockRoleProposer, nil
 	default:
 		return mcmsaptossdk.TimelockRoleProposer, fmt.Errorf("invalid action: %s", action)
 	}

--- a/deployment/common/proposalutils/mcms_helpers.go
+++ b/deployment/common/proposalutils/mcms_helpers.go
@@ -256,3 +256,18 @@ func BatchOperationForChain(
 		Transactions:  []mcmstypes.Transaction{tx},
 	}, nil
 }
+
+func GetAptosRoleFromAction(action mcmstypes.TimelockAction) (mcmsaptossdk.TimelockRole, error) {
+	switch action {
+	case mcmstypes.TimelockActionSchedule:
+		return mcmsaptossdk.TimelockRoleProposer, nil
+	case mcmstypes.TimelockActionBypass:
+		return mcmsaptossdk.TimelockRoleBypasser, nil
+	case mcmstypes.TimelockActionCancel:
+		return mcmsaptossdk.TimelockRoleCanceller, nil
+	case "":
+		return mcmsaptossdk.TimelockRoleProposer, nil
+	default:
+		return mcmsaptossdk.TimelockRoleProposer, fmt.Errorf("invalid action: %s", action)
+	}
+}

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -168,7 +168,8 @@ func (tc *TimelockConfig) ValidateSolana(e cldf.Environment, chainSelector uint6
 func BuildProposalFromBatchesV2(
 	e cldf.Environment,
 	timelockAddressPerChain map[uint64]string,
-	mcmsAddressPerChain map[uint64]string, inspectorPerChain map[uint64]mcmssdk.Inspector,
+	mcmsAddressPerChain map[uint64]string,
+	inspectorPerChain map[uint64]mcmssdk.Inspector,
 	batches []types.BatchOperation,
 	description string,
 	mcmsCfg TimelockConfig,

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aptos-labs/aptos-go-sdk"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
@@ -298,10 +299,41 @@ func getSolanaState(env cldf.Environment, selector uint64) (*state.MCMSWithTimel
 // AggregateProposals aggregates multiple MCMS proposals into a single proposal by combining their operations, and
 // setting up the proposers and inspectors for each chain. It returns a single MCMS proposal that can be executed
 // and signed.
+//
+// Deprecated: Use extensible AggregateProposalsV2 instead. Which accepts multiple chain families.
 func AggregateProposals(
 	env cldf.Environment,
 	mcmsEVMState map[uint64]state.MCMSWithTimelockState,
 	mcmsSolanaState map[uint64]state.MCMSWithTimelockStateSolana,
+	proposals []mcmslib.TimelockProposal,
+	description string,
+	mcmsConfig *TimelockConfig,
+) (*mcmslib.TimelockProposal, error) {
+	return AggregateProposalsV2(
+		env,
+		TimelockStates{
+			MCMSEVMState:    mcmsEVMState,
+			MCMSSolanaState: mcmsSolanaState,
+		},
+		proposals,
+		description,
+		mcmsConfig,
+	)
+}
+
+type TimelockStates struct {
+	MCMSEVMState    map[uint64]state.MCMSWithTimelockState
+	MCMSSolanaState map[uint64]state.MCMSWithTimelockStateSolana
+	MCMSAptosState  map[uint64]aptos.AccountAddress
+}
+
+// AggregateProposalsV2 aggregates multiple MCMS proposals into a single proposal by combining their operations, and
+// setting up the proposers and inspectors for each chain. It returns a single MCMS proposal that can be executed
+// and signed.
+// It has an extensible signature to allow for future chain families implementations
+func AggregateProposalsV2(
+	env cldf.Environment,
+	mcmsTimelockStates TimelockStates,
 	proposals []mcmslib.TimelockProposal,
 	description string,
 	mcmsConfig *TimelockConfig,
@@ -329,16 +361,27 @@ func AggregateProposals(
 	for _, op := range batches {
 		chainSel := uint64(op.ChainSelector)
 		var err error
-		if _, exists := mcmsEVMState[chainSel]; exists {
-			mcmsContract, err := mcmsConfig.MCMBasedOnAction(mcmsEVMState[chainSel])
+		family, err := chain_selectors.GetSelectorFamily(chainSel)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get family for chain %d: %w", chainSel, err)
+		}
+		switch family {
+		case chain_selectors.FamilyEVM:
+			mcmsEVMState, exists := mcmsTimelockStates.MCMSEVMState[chainSel]
+			if !exists {
+				return nil, fmt.Errorf("missing MCMS state for chain with selector %d", chainSel)
+			}
+			mcmsContract, err := mcmsConfig.MCMBasedOnAction(mcmsEVMState)
 			if err != nil {
 				return &mcmslib.TimelockProposal{}, fmt.Errorf("failed to get MCMS contract for chain with selector %d: %w", chainSel, err)
 			}
-			timelocks[chainSel] = mcmsEVMState[chainSel].Timelock.Address().Hex()
+			timelocks[chainSel] = mcmsEVMState.Timelock.Address().Hex()
 			mcmsPerChain[chainSel] = mcmsContract.Address().Hex()
-		} else if mcmsSolanaState == nil {
-			return nil, fmt.Errorf("missing MCMS state for chain with selector %d", chainSel)
-		} else if solanaState, existsInSolana := mcmsSolanaState[chainSel]; existsInSolana {
+		case chain_selectors.FamilySolana:
+			solanaState, existsInSolana := mcmsTimelockStates.MCMSSolanaState[chainSel]
+			if !existsInSolana {
+				return nil, fmt.Errorf("missing MCMS state for chain with selector %d", chainSel)
+			}
 			timelocks[chainSel] = mcmssolanasdk.ContractAddress(
 				solanaState.TimelockProgram,
 				mcmssolanasdk.PDASeed(solanaState.TimelockSeed),
@@ -348,8 +391,13 @@ func AggregateProposals(
 				return nil, err
 			}
 			mcmsPerChain[chainSel] = mcmsAddr
-		} else {
-			return nil, fmt.Errorf("missing MCMS state for chain with selector %d", chainSel)
+		case chain_selectors.FamilyAptos:
+			aptosMCMSAddress, existsInAptos := mcmsTimelockStates.MCMSAptosState[chainSel]
+			if !existsInAptos {
+				return nil, fmt.Errorf("missing MCMS state for chain with selector %d", chainSel)
+			}
+			timelocks[chainSel] = aptosMCMSAddress.StringLong()
+			mcmsPerChain[chainSel] = aptosMCMSAddress.StringLong()
 		}
 
 		inspectors[chainSel], err = McmsInspectorForChain(env, chainSel)

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -379,6 +379,8 @@ func AggregateProposalsV2(
 	for _, op := range batches {
 		chainSel := uint64(op.ChainSelector)
 		var err error
+		var inspectorParams InspectorMetadataParams
+
 		family, err := chain_selectors.GetSelectorFamily(chainSel)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get family for chain %d: %w", chainSel, err)
@@ -410,15 +412,24 @@ func AggregateProposalsV2(
 			}
 			mcmsPerChain[chainSel] = mcmsAddr
 		case chain_selectors.FamilyAptos:
+			// Set MCMS addresses. Aptos uses the same address for MCMS and Timelock
 			aptosMCMSAddress, existsInAptos := mcmsTimelockStates.MCMSAptosState[chainSel]
 			if !existsInAptos {
 				return nil, fmt.Errorf("missing MCMS state for chain with selector %d", chainSel)
 			}
 			timelocks[chainSel] = aptosMCMSAddress.StringLong()
 			mcmsPerChain[chainSel] = aptosMCMSAddress.StringLong()
+			// Getting inspector parameters for Aptos
+			role, err := GetAptosRoleFromAction(mcmsConfig.MCMSAction)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get role from action: %w", err)
+			}
+			inspectorParams = InspectorMetadataParams{
+				AptosRole: role,
+			}
 		}
 
-		inspectors[chainSel], err = McmsInspectorForChain(env, chainSel)
+		inspectors[chainSel], err = McmsInspectorForChainV2(env, chainSel, inspectorParams)
 		if err != nil {
 			return &mcmslib.TimelockProposal{}, fmt.Errorf("failed to get MCMS inspector for chain with selector %d: %w", chainSel, err)
 		}

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -379,7 +379,7 @@ func AggregateProposalsV2(
 	for _, op := range batches {
 		chainSel := uint64(op.ChainSelector)
 		var err error
-		var inspectorParams InspectorMetadataParams
+		var inspectorOpts []MCMSInspectorOption
 
 		family, err := chain_selectors.GetSelectorFamily(chainSel)
 		if err != nil {
@@ -424,12 +424,10 @@ func AggregateProposalsV2(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get role from action: %w", err)
 			}
-			inspectorParams = InspectorMetadataParams{
-				AptosRole: role,
-			}
+			inspectorOpts = append(inspectorOpts, WithAptosRole(role))
 		}
 
-		inspectors[chainSel], err = McmsInspectorForChainV2(env, chainSel, inspectorParams)
+		inspectors[chainSel], err = McmsInspectorForChain(env, chainSel, inspectorOpts...)
 		if err != nil {
 			return &mcmslib.TimelockProposal{}, fmt.Errorf("failed to get MCMS inspector for chain with selector %d: %w", chainSel, err)
 		}

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -1,6 +1,7 @@
 package proposalutils
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -11,6 +12,7 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcmslib "github.com/smartcontractkit/mcms"
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
+	mcmsaptossdk "github.com/smartcontractkit/mcms/sdk/aptos"
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/smartcontractkit/mcms/types"
 
@@ -273,6 +275,21 @@ func buildProposalMetadataV2(
 				solanaState.BypasserAccessControllerAccount)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create chain metadata: %w", err)
+			}
+		case chain_selectors.FamilyAptos:
+			// Get role from action
+			role, err := GetAptosRoleFromAction(mcmsAction)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get role from action: %w", err)
+			}
+			jsonRole, err := json.Marshal(mcmsaptossdk.AdditionalFieldsMetadata{Role: role})
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal role for chain %d: %w", selector, err)
+			}
+			metaDataPerChain[chainID] = types.ChainMetadata{
+				StartingOpCount:  opCount,
+				MCMAddress:       proposerMcms,
+				AdditionalFields: jsonRole,
 			}
 		}
 	}

--- a/deployment/common/proposalutils/propose.go
+++ b/deployment/common/proposalutils/propose.go
@@ -329,7 +329,7 @@ func AggregateProposals(
 ) (*mcmslib.TimelockProposal, error) {
 	return AggregateProposalsV2(
 		env,
-		TimelockStates{
+		MCMSStates{
 			MCMSEVMState:    mcmsEVMState,
 			MCMSSolanaState: mcmsSolanaState,
 		},
@@ -339,7 +339,7 @@ func AggregateProposals(
 	)
 }
 
-type TimelockStates struct {
+type MCMSStates struct {
 	MCMSEVMState    map[uint64]state.MCMSWithTimelockState
 	MCMSSolanaState map[uint64]state.MCMSWithTimelockStateSolana
 	MCMSAptosState  map[uint64]aptos.AccountAddress
@@ -351,7 +351,7 @@ type TimelockStates struct {
 // It has an extensible signature to allow for future chain families implementations
 func AggregateProposalsV2(
 	env cldf.Environment,
-	mcmsTimelockStates TimelockStates,
+	mcmsTimelockStates MCMSStates,
 	proposals []mcmslib.TimelockProposal,
 	description string,
 	mcmsConfig *TimelockConfig,


### PR DESCRIPTION
# Summary
RMN Curse/Uncurse changeset requires one single proposal to be generated for all chains. To accomplish this `AggregateProposals` need to support Aptos, hence `BuildProposalFromBatchesV2`.

# Features
- Creates a `AggregateProposalsV2` function that has an extensible signature
- Refactors `AggregateProposals` to use `AggregateProposalsV2` implementation
- Deprecates `AggregateProposals` in favor of `AggregateProposalsV2` (usage can be fully removed on a followup PR)
- Integrates Aptos into `BuildProposalFromBatchesV2`
- Refactors Aptos `GenerateProposal` utils to use `BuildProposalFromBatchesV2` under the hood

# Testing
- Aptos changeset tests will test proposal building for Aptos
- EVM changeset tests will test proposal building for EVM
- Some tests, such as `cs_add_evm_solana_lane_test.go` will test `AggregateProposals`

# Review Suggestions
- Review that `AggregateProposalsV2` keeps the same functionality as the old `AggregateProposals`
- Review from AggregateProposal
