### PR TITLE
 CCIP-6264 Perf tuning CR configuration for ExecutionStateChange events

### DIFF
--- a/core/store/migrate/migrations/0269_ccip_logs_exec_state_change_reads.sql
+++ b/core/store/migrate/migrations/0269_ccip_logs_exec_state_change_reads.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+
+CREATE INDEX idx_evm_logs_ccip_exec_state_change_read
+    ON evm.logs (
+                 address,
+                 evm_chain_id,
+                 (topics[2]),
+                 (topics[3]),
+                 block_number,
+                 log_index,
+                 tx_hash
+        )
+    WHERE event_sig = '\x05665fe9ad095383d018353f4cbcba77e84db27dd215081bbf7cdf9ae6fbe48b';
+
+
+-- +goose Down
+DROP INDEX IF EXISTS evm.idx_evm_logs_ccip_exec_state_change_read;
+

--- a/core/store/migrate/migrations/0269_ccip_logs_exec_state_change_reads.sql
+++ b/core/store/migrate/migrations/0269_ccip_logs_exec_state_change_reads.sql
@@ -1,5 +1,24 @@
 -- +goose Up
 
+-- This index is optimized for CCIP use cases related to fetching ExecutionStateChanged events from
+-- the evm.logs table (part of the Execution plugin fetching data from the destination chain).
+--   event ExecutionStateChanged(
+--     uint64 indexed sourceChainSelector,
+--     uint64 indexed sequenceNumber,
+--     bytes32 indexed messageId,
+--     bytes32 messageHash,
+--     Internal.MessageExecutionState state,
+--     bytes returnData,
+--     uint256 gasUsed
+--   );
+--
+-- By making it a partial-index custom to ExecutionStateChanged event, we can reduce the bloat of the index
+-- and improve performance for CCIP use cases. Therefore, it doesn't introduce any perf/space overhead
+-- for products that don't need it.
+--
+-- idx_evm_logs_ccip_exec_state_change_read
+-- This is the main index used for reading ExecutionStateChanged events for sequence number range (topic[2])
+-- and source chain selector (topic[3]).
 CREATE INDEX idx_evm_logs_ccip_exec_state_change_read
     ON evm.logs (
                  address,

--- a/integration-tests/smoke/ccip/ccip_reader_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_test.go
@@ -1484,9 +1484,13 @@ func Benchmark_CCIPReader_ExecutedMessages(b *testing.B) {
 			if chainSelector == chainD {
 				continue
 			}
+			// This enforces variation in seqNum ranges
+			start := cciptypes.SeqNum(i*16) + tt.startSeqNum
+			stop := cciptypes.SeqNum(i*16) + tt.endSeqNum
+
 			filters[chainSelector] = append(
 				filters[chainSelector],
-				cciptypes.NewSeqNumRange(tt.startSeqNum, tt.endSeqNum),
+				cciptypes.NewSeqNumRange(start, stop),
 			)
 		}
 
@@ -1949,7 +1953,7 @@ func testSetup(
 
 	lggr := logger.TestLogger(t)
 	// Change that to DebugLevel to enable SQL logs
-	lggr.SetLogLevel(zapcore.ErrorLevel)
+	lggr.SetLogLevel(zapcore.DebugLevel)
 
 	var dbs sqlutil.DataSource
 	{

--- a/integration-tests/smoke/ccip/ccip_reader_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_test.go
@@ -1431,8 +1431,8 @@ func populateDatabaseForCommitReportAccepted(
 	require.NoError(b, testEnv.orm.InsertBlock(ctx, utils.RandomHash(), int64(offset+numOfReports), timestamp, int64(offset+numOfReports)))
 }
 
-// Benchmark_CCIPReader_ExecutedMessages/ExecutedMessages_Populating_database_with_5_source_chains_and_5_destination_chains,_any-to-any-12         	      52	  25540214 ns/op
-// Benchmark_CCIPReader_ExecutedMessages/ExecutedMessages_Populating_database_with_20_dest_chains_and_40_sources_chains-12                         	     139	   8373795 ns/op
+// Benchmark_CCIPReader_ExecutedMessages/5_source_chains_and_5_destination_chains-12         	      46	  24748651 ns/op
+// Benchmark_CCIPReader_ExecutedMessages/20_dest_chains_and_40_sources_chains-12             	       7	 155096661 ns/op
 func Benchmark_CCIPReader_ExecutedMessages(b *testing.B) {
 	tests := []struct {
 		name                 string
@@ -1447,7 +1447,7 @@ func Benchmark_CCIPReader_ExecutedMessages(b *testing.B) {
 	}{
 		{
 			// Case in which we have 5 chains densely connected generating large volume of logs
-			name:                 "Populating database with 5 source chains and 5 destination chains, any-to-any",
+			name:                 "5 source chains and 5 destination chains",
 			logsInsertedPerChain: 50_000, // 250k logs in total inserted (50k * 5 chains)
 			startSeqNum:          11,
 			endSeqNum:            20,
@@ -1458,7 +1458,7 @@ func Benchmark_CCIPReader_ExecutedMessages(b *testing.B) {
 		},
 		{
 			// Case in which we have multiple a lot of source chains, but only a few destinations are in use
-			name:                 "Populating database with 20 dest chains and 40 sources chains",
+			name:                 "20 dest chains and 40 sources chains",
 			logsInsertedPerChain: 70_000, // 1.4kk logs in total inserted
 			startSeqNum:          101,
 			endSeqNum:            110,
@@ -1494,7 +1494,7 @@ func Benchmark_CCIPReader_ExecutedMessages(b *testing.B) {
 			)
 		}
 
-		b.Run("ExecutedMessages_"+tt.name, func(b *testing.B) {
+		b.Run(tt.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				executedRanges, err := reader.ExecutedMessages(
 					b.Context(),
@@ -1623,7 +1623,15 @@ func populateDatabaseForExecutionStateChanged(
 	require.NoError(b, orm.InsertBlock(ctx, utils.RandomHash(), int64(offset+numOfEvents), time.Now(), int64(offset+numOfEvents)))
 }
 
-func Benchmark_CCIPReader_MessageSentRanges(b *testing.B) {
+// Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_5_source_chains_and_5_destination_chains
+// Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_5_source_chains_and_5_destination_chains-12         	      49	  21842648 ns/op
+// Benchmark_CCIPReader_CCIPMessageSent/LatestMsgSeqNum_5_source_chains_and_5_destination_chains
+// Benchmark_CCIPReader_CCIPMessageSent/LatestMsgSeqNum_5_source_chains_and_5_destination_chains-12            	    2649	    456123 ns/op
+// Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_70_source_chains_and_10_destination_chains
+// Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_70_source_chains_and_10_destination_chains-12       	     114	  12192915 ns/op
+// Benchmark_CCIPReader_CCIPMessageSent/LatestMsgSeqNum_70_source_chains_and_10_destination_chains
+// Benchmark_CCIPReader_CCIPMessageSent/LatestMsgSeqNum_70_source_chains_and_10_destination_chains-12          	    2475	    501386 ns/op
+func Benchmark_CCIPReader_CCIPMessageSent(b *testing.B) {
 	tests := []struct {
 		name                 string
 		logsInsertedPerChain int
@@ -1637,7 +1645,7 @@ func Benchmark_CCIPReader_MessageSentRanges(b *testing.B) {
 	}{
 		{
 			// Case in which we have 5 chains densely connected generating large volume of logs
-			name:                 "Populating database with 5 source chains and 5 destination chains, any-to-any",
+			name:                 "5 source chains and 5 destination chains",
 			logsInsertedPerChain: 50_000, // 250k logs in total inserted (50k * 5 chains)
 			startSeqNum:          5_000,
 			endSeqNum:            5_256,
@@ -1648,7 +1656,7 @@ func Benchmark_CCIPReader_MessageSentRanges(b *testing.B) {
 		},
 		{
 			// Case in which we have multiple a lot of source chains, but only a few destinations are in use
-			name:                 "Populating database with 70 source chains and 10 destination chains",
+			name:                 "70 source chains and 10 destination chains",
 			logsInsertedPerChain: 25_000, // 1.75kk logs in total inserted (25000 * 70 chains)
 			startSeqNum:          2_000,
 			endSeqNum:            2_300,
@@ -1667,7 +1675,7 @@ func Benchmark_CCIPReader_MessageSentRanges(b *testing.B) {
 			tt.destChainsCount,
 		)
 
-		b.Run("MsgsBetweenSeqNums -"+tt.name, func(b *testing.B) {
+		b.Run("MsgsBetweenSeqNums "+tt.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				msgs, err := reader.MsgsBetweenSeqNums(
 					b.Context(),
@@ -1679,7 +1687,7 @@ func Benchmark_CCIPReader_MessageSentRanges(b *testing.B) {
 			}
 		})
 
-		b.Run("LatestMsgSeqNum - "+tt.name, func(b *testing.B) {
+		b.Run("LatestMsgSeqNum "+tt.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				latest, err := reader.LatestMsgSeqNum(
 					b.Context(),
@@ -1953,7 +1961,7 @@ func testSetup(
 
 	lggr := logger.TestLogger(t)
 	// Change that to DebugLevel to enable SQL logs
-	lggr.SetLogLevel(zapcore.DebugLevel)
+	lggr.SetLogLevel(zapcore.ErrorLevel)
 
 	var dbs sqlutil.DataSource
 	{

--- a/integration-tests/smoke/ccip/ccip_reader_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_test.go
@@ -1431,8 +1431,8 @@ func populateDatabaseForCommitReportAccepted(
 	require.NoError(b, testEnv.orm.InsertBlock(ctx, utils.RandomHash(), int64(offset+numOfReports), timestamp, int64(offset+numOfReports)))
 }
 
-// Benchmark_CCIPReader_ExecutedMessages/5_source_chains_and_5_destination_chains-12         	      46	  24748651 ns/op
-// Benchmark_CCIPReader_ExecutedMessages/20_dest_chains_and_40_sources_chains-12             	       7	 155096661 ns/op
+// Benchmark_CCIPReader_ExecutedMessages/5_source_chains_and_5_destination_chains-12         	      49	  24335313 ns/op
+// Benchmark_CCIPReader_ExecutedMessages/20_dest_chains_and_40_sources_chains-12             	     187	   6190834 ns/op
 func Benchmark_CCIPReader_ExecutedMessages(b *testing.B) {
 	tests := []struct {
 		name                 string
@@ -1623,13 +1623,9 @@ func populateDatabaseForExecutionStateChanged(
 	require.NoError(b, orm.InsertBlock(ctx, utils.RandomHash(), int64(offset+numOfEvents), time.Now(), int64(offset+numOfEvents)))
 }
 
-// Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_5_source_chains_and_5_destination_chains
 // Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_5_source_chains_and_5_destination_chains-12         	      49	  21842648 ns/op
-// Benchmark_CCIPReader_CCIPMessageSent/LatestMsgSeqNum_5_source_chains_and_5_destination_chains
 // Benchmark_CCIPReader_CCIPMessageSent/LatestMsgSeqNum_5_source_chains_and_5_destination_chains-12            	    2649	    456123 ns/op
-// Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_70_source_chains_and_10_destination_chains
 // Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_70_source_chains_and_10_destination_chains-12       	     114	  12192915 ns/op
-// Benchmark_CCIPReader_CCIPMessageSent/LatestMsgSeqNum_70_source_chains_and_10_destination_chains
 // Benchmark_CCIPReader_CCIPMessageSent/LatestMsgSeqNum_70_source_chains_and_10_destination_chains-12          	    2475	    501386 ns/op
 func Benchmark_CCIPReader_CCIPMessageSent(b *testing.B) {
 	tests := []struct {

--- a/integration-tests/smoke/ccip/ccip_reader_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_test.go
@@ -1307,9 +1307,6 @@ func Benchmark_CCIPReader_CommitReportsGTETimestamp(b *testing.B) {
 		logsInsertedFirst    int
 		logsInsertedMatching int
 	}{
-		{0, 0},
-		{1, 10},
-		{10, 100},
 		{100, 10_000},
 	}
 
@@ -1623,10 +1620,10 @@ func populateDatabaseForExecutionStateChanged(
 	require.NoError(b, orm.InsertBlock(ctx, utils.RandomHash(), int64(offset+numOfEvents), time.Now(), int64(offset+numOfEvents)))
 }
 
-// Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_5_source_chains_and_5_destination_chains-12         	      49	  21842648 ns/op
 // Benchmark_CCIPReader_CCIPMessageSent/LatestMsgSeqNum_5_source_chains_and_5_destination_chains-12            	    2649	    456123 ns/op
-// Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_70_source_chains_and_10_destination_chains-12       	     114	  12192915 ns/op
 // Benchmark_CCIPReader_CCIPMessageSent/LatestMsgSeqNum_70_source_chains_and_10_destination_chains-12          	    2475	    501386 ns/op
+// Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_5_source_chains_and_5_destination_chains-12         	      49	  21842648 ns/op
+// Benchmark_CCIPReader_CCIPMessageSent/MsgsBetweenSeqNums_70_source_chains_and_10_destination_chains-12       	     114	  12192915 ns/op
 func Benchmark_CCIPReader_CCIPMessageSent(b *testing.B) {
 	tests := []struct {
 		name                 string
@@ -1957,7 +1954,7 @@ func testSetup(
 
 	lggr := logger.TestLogger(t)
 	// Change that to DebugLevel to enable SQL logs
-	lggr.SetLogLevel(zapcore.ErrorLevel)
+	lggr.SetLogLevel(zapcore.DebugLevel)
 
 	var dbs sqlutil.DataSource
 	{


### PR DESCRIPTION
## Description 

Improving the performance of CR queries (database) for fetching ExecutionStateChanged events by the CCIP Execution plugin. Creating a dedicated partial-index to address CCIP use cases when querying these events by sequenceNumber (topics[3]) range and sourceChainSelector (topics[2]). 

```solidity
  event ExecutionStateChanged(
    uint64 indexed sourceChainSelector,
    uint64 indexed sequenceNumber,
    bytes32 indexed messageId,
    bytes32 messageHash,
    Internal.MessageExecutionState state,
    bytes returnData,
    uint256 gasUsed
  );
```

Similar work done for CCIPMessageSent https://github.com/smartcontractkit/chainlink/pull/18100

### Performance boost 

The dedicated index (idx_evm_logs_ccip_exec_state_change_read) provides massive performance improvements by allowing the query planner to:
* Skip bitmap merges
* Use highly selective filters at the index level
* Touch far fewer buffers (454 -> 37)
* Return results ~98% faster (20ms -> 0.5ms)

```sql
explain (analyze, buffers, verbose)
SELECT evm_chain_id,
       log_index,
       block_hash,
       block_number,
       address,
       event_sig,
       topics,
       tx_hash,
       data,
       created_at,
       block_timestamp
FROM evm.logs
WHERE evm_chain_id = 4
  AND (address = '\xa1be7bb68d07C3031964CeB25b6fC0b121902c77' AND
       event_sig = '\x05665fe9ad095383d018353f4cbcba77e84db27dd215081bbf7cdf9ae6fbe48b' AND
       ((topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000000b' AND
         topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000014' AND
         topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000001') OR
        (topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000001b' AND
         topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000024' AND
         topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000002') OR
        (topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000002b' AND
         topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000034' AND
         topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000003') OR
        (topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000003b' AND
         topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000044' AND
         topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000004')) AND
       substring(data from 32 * 1 + 1 for 32) > '\x0000000000000000000000000000000000000000000000000000000000000000' AND
       block_number <= (SELECT greatest(block_number - 10, 0)
                        FROM evm.log_poller_blocks
                        WHERE evm_chain_id = 4
                        ORDER BY block_number DESC
                        LIMIT 1))
ORDER BY block_number ASC, log_index ASC, tx_hash ASC
LIMIT 40;
```

#### Before
```sql
 Limit  (cost=2766.19..2766.23 rows=14 width=521) (actual time=20.575..20.588 rows=40 loops=1)
   Output: logs.evm_chain_id, logs.log_index, logs.block_hash, logs.block_number, logs.address, logs.event_sig, logs.topics, logs.tx_hash, logs.data, logs.created_at, logs.block_timestamp
   Buffers: shared hit=454
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.15..5.51 rows=1 width=16) (actual time=0.018..0.019 rows=1 loops=1)
           Output: (GREATEST((log_poller_blocks.block_number - 10), '0'::bigint)), log_poller_blocks.block_number
           Buffers: shared hit=2
           ->  Index Only Scan using idx_log_poller_blocks_chain_block on evm.log_poller_blocks  (cost=0.15..16.22 rows=3 width=16) (actual time=0.017..0.018 rows=1 loops=1)
                 Output: GREATEST((log_poller_blocks.block_number - 10), '0'::bigint), log_poller_blocks.block_number
                 Index Cond: (log_poller_blocks.evm_chain_id = '4'::numeric)
                 Heap Fetches: 1
                 Buffers: shared hit=2
   ->  Sort  (cost=2760.69..2760.72 rows=14 width=521) (actual time=20.573..20.581 rows=40 loops=1)
         Output: logs.evm_chain_id, logs.log_index, logs.block_hash, logs.block_number, logs.address, logs.event_sig, logs.topics, logs.tx_hash, logs.data, logs.created_at, logs.block_timestamp
         Sort Key: logs.block_number, logs.log_index, logs.tx_hash
         Sort Method: quicksort  Memory: 65kB
         Buffers: shared hit=454
         ->  Bitmap Heap Scan on evm.logs  (cost=2704.83..2760.42 rows=14 width=521) (actual time=20.498..20.553 rows=40 loops=1)
               Output: logs.evm_chain_id, logs.log_index, logs.block_hash, logs.block_number, logs.address, logs.event_sig, logs.topics, logs.tx_hash, logs.data, logs.created_at, logs.block_timestamp
               Recheck Cond: ((logs.evm_chain_id = '4'::numeric) AND (logs.block_number <= $0) AND (((logs.topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000000b'::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000014'::bytea) AND (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000001'::bytea)) OR ((logs.topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000001b'::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000024'::bytea) AND (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000002'::bytea)) OR ((logs.topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000002b'::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000034'::bytea) AND (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000003'::bytea)) OR ((logs.topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000003b'::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000044'::bytea) AND (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000004'::bytea))))
               Filter: ((logs.address = '\xa1be7bb68d07c3031964ceb25b6fc0b121902c77'::bytea) AND (logs.event_sig = '\x05665fe9ad095383d018353f4cbcba77e84db27dd215081bbf7cdf9ae6fbe48b'::bytea) AND (SUBSTRING(logs.data FROM 33 FOR 32) > '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea))
               Heap Blocks: exact=17
               Buffers: shared hit=454
               ->  BitmapAnd  (cost=2704.83..2704.83 rows=14 width=0) (actual time=20.462..20.468 rows=0 loops=1)
                     Buffers: shared hit=437
                     ->  Bitmap Index Scan on idx_logs_chain_block_logindex  (cost=0.00..498.81 rows=16639 width=0) (actual time=6.230..6.231 rows=49990 loops=1)
                           Index Cond: ((logs.evm_chain_id = '4'::numeric) AND (logs.block_number <= $0))
                           Buffers: shared hit=252
                     ->  BitmapOr  (cost=2205.76..2205.76 rows=211 width=0) (actual time=14.073..14.078 rows=0 loops=1)
                           Buffers: shared hit=185
                           ->  BitmapAnd  (cost=552.18..552.18 rows=53 width=0) (actual time=4.533..4.534 rows=0 loops=1)
                                 Buffers: shared hit=46
                                 ->  Bitmap Index Scan on evm_logs_idx_topic_three  (cost=0.00..7.06 rows=264 width=0) (actual time=0.028..
0.028 rows=250 loops=1)
                                       Index Cond: ((logs.topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000000b'
::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000014'::bytea))
                                       Buffers: shared hit=3
                                 ->  Bitmap Index Scan on evm_logs_idx_topic_two  (cost=0.00..544.86 rows=50192 width=0) (actual time=4.500
..4.500 rows=50000 loops=1)
                                       Index Cond: (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000001'::
bytea)
                                       Buffers: shared hit=43
                           ->  BitmapAnd  (cost=557.61..557.61 rows=53 width=0) (actual time=3.175..3.177 rows=0 loops=1)
                                 Buffers: shared hit=46
                                 ->  Bitmap Index Scan on evm_logs_idx_topic_three  (cost=0.00..7.06 rows=264 width=0) (actual time=0.021..
0.021 rows=250 loops=1)
                                       Index Cond: ((logs.topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000001b'
::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000024'::bytea))
                                       Buffers: shared hit=3
                                 ->  Bitmap Index Scan on evm_logs_idx_topic_two  (cost=0.00..550.29 rows=50383 width=0) (actual time=3.151
..3.152 rows=50000 loops=1)
                                       Index Cond: (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000002'::
bytea)
                                       Buffers: shared hit=43
                           ->  BitmapAnd  (cost=549.05..549.05 rows=53 width=0) (actual time=3.257..3.257 rows=0 loops=1)
                                 Buffers: shared hit=46
                                 ->  Bitmap Index Scan on evm_logs_idx_topic_three  (cost=0.00..7.06 rows=264 width=0) (actual time=0.012..
0.012 rows=250 loops=1)
                                       Index Cond: ((logs.topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000002b'
::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000034'::bytea))
                                       Buffers: shared hit=3
                                 ->  Bitmap Index Scan on evm_logs_idx_topic_two  (cost=0.00..541.73 rows=49775 width=0) (actual time=3.242
..3.242 rows=50000 loops=1)
                                       Index Cond: (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000003'::
bytea)
                                       Buffers: shared hit=43
                           ->  BitmapAnd  (cost=546.18..546.18 rows=52 width=0) (actual time=3.098..3.099 rows=0 loops=1)
                                 Buffers: shared hit=47
                                 ->  Bitmap Index Scan on evm_logs_idx_topic_three  (cost=0.00..7.06 rows=264 width=0) (actual time=0.018..
0.018 rows=250 loops=1)
                                       Index Cond: ((logs.topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000003b'
::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000044'::bytea))
                                       Buffers: shared hit=4
                                 ->  Bitmap Index Scan on evm_logs_idx_topic_two  (cost=0.00..538.86 rows=49392 width=0) (actual time=3.078
..3.078 rows=50000 loops=1)
                                       Index Cond: (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000004'::
bytea)
                                       Buffers: shared hit=43
 Planning:
   Buffers: shared hit=34
 Planning Time: 0.623 ms
 Execution Time: 20.872 ms
```

#### After
```sql
 Limit  (cost=80.42..80.46 rows=14 width=521) (actual time=0.304..0.312 rows=40 loops=1)
   Output: logs.evm_chain_id, logs.log_index, logs.block_hash, logs.block_number, logs.address, logs.event_sig, logs.topics, logs.tx_hash,
logs.data, logs.created_at, logs.block_timestamp
   Buffers: shared hit=37
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.15..5.51 rows=1 width=16) (actual time=0.027..0.029 rows=1 loops=1)
           Output: (GREATEST((log_poller_blocks.block_number - 10), '0'::bigint)), log_poller_blocks.block_number
           Buffers: shared hit=2
           ->  Index Only Scan using idx_log_poller_blocks_chain_block on evm.log_poller_blocks  (cost=0.15..16.22 rows=3 width=16) (actual time=0.027..0.027 rows=1 loops=1)
                 Output: GREATEST((log_poller_blocks.block_number - 10), '0'::bigint), log_poller_blocks.block_number
                 Index Cond: (log_poller_blocks.evm_chain_id = '4'::numeric)
                 Heap Fetches: 1
                 Buffers: shared hit=2
   ->  Sort  (cost=74.91..74.95 rows=14 width=521) (actual time=0.302..0.305 rows=40 loops=1)
         Output: logs.evm_chain_id, logs.log_index, logs.block_hash, logs.block_number, logs.address, logs.event_sig, logs.topics, logs.tx_hash, logs.data, logs.created_at, logs.block_timestamp
         Sort Key: logs.block_number, logs.log_index, logs.tx_hash
         Sort Method: quicksort  Memory: 65kB
         Buffers: shared hit=37
         ->  Bitmap Heap Scan on evm.logs  (cost=19.05..74.65 rows=14 width=521) (actual time=0.160..0.267 rows=40 loops=1)
               Output: logs.evm_chain_id, logs.log_index, logs.block_hash, logs.block_number, logs.address, logs.event_sig, logs.topics, logs.tx_hash, logs.data, logs.created_at, logs.block_timestamp
               Recheck Cond: (((logs.address = '\xa1be7bb68d07c3031964ceb25b6fc0b121902c77'::bytea) AND (logs.evm_chain_id = '4'::numeric) AND (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000001'::bytea) AND (logs.topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000000b'::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000014'::bytea) AND (logs.block_number <= $0) AND (logs.event_sig = '\x05665fe9ad095383d018353f4cbcba77e84db27dd215081bbf7cdf9ae6fbe48b'::bytea)) OR ((logs.address = '\xa1be7bb68d07c3031964ceb25b6fc0b121902c77'::bytea) AND (logs.evm_chain_id = '4'::numeric) AND (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000002'::bytea) AND (logs.topics[3] >= '\x000000000000000000000000000000000000000000000000000000000000001b'::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000024'::b
ytea) AND (logs.block_number <= $0) AND (logs.event_sig = '\x05665fe9ad095383d018353f4cbcba77e84db27dd215081bbf7cdf9ae6fbe48b'::bytea)) OR
((logs.address = '\xa1be7bb68d07c3031964ceb25b6fc0b121902c77'::bytea) AND (logs.evm_chain_id = '4'::numeric) AND (logs.topics[2] = '\x00000
00000000000000000000000000000000000000000000000000000000003'::bytea) AND (logs.topics[3] >= '\x00000000000000000000000000000000000000000000
0000000000000000002b'::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000034'::bytea) AND (logs
.block_number <= $0) AND (logs.event_sig = '\x05665fe9ad095383d018353f4cbcba77e84db27dd215081bbf7cdf9ae6fbe48b'::bytea)) OR ((logs.address
= '\xa1be7bb68d07c3031964ceb25b6fc0b121902c77'::bytea) AND (logs.evm_chain_id = '4'::numeric) AND (logs.topics[2] = '\x00000000000000000000
00000000000000000000000000000000000000000004'::bytea) AND (logs.topics[3] >= '\x00000000000000000000000000000000000000000000000000000000000
0003b'::bytea) AND (logs.topics[3] <= '\x0000000000000000000000000000000000000000000000000000000000000044'::bytea) AND (logs.block_number <
= $0) AND (logs.event_sig = '\x05665fe9ad095383d018353f4cbcba77e84db27dd215081bbf7cdf9ae6fbe48b'::bytea)))
               Filter: (SUBSTRING(logs.data FROM 33 FOR 32) > '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea)
               Heap Blocks: exact=17
               Buffers: shared hit=37
               ->  BitmapOr  (cost=19.05..19.05 rows=14 width=0) (actual time=0.144..0.145 rows=0 loops=1)
                     Buffers: shared hit=20
                     ->  Bitmap Index Scan on idx_evm_logs_ccip_exec_state_change_read  (cost=0.00..4.76 rows=4 width=0) (actual time=0.078
..0.078 rows=10 loops=1)
                           Index Cond: ((logs.address = '\xa1be7bb68d07c3031964ceb25b6fc0b121902c77'::bytea) AND (logs.evm_chain_id = '4'::
numeric) AND (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000001'::bytea) AND (logs.topics[3] >= '\x00000
0000000000000000000000000000000000000000000000000000000000b'::bytea) AND (logs.topics[3] <= '\x00000000000000000000000000000000000000000000
00000000000000000014'::bytea) AND (logs.block_number <= $0))
                           Buffers: shared hit=7
                     ->  Bitmap Index Scan on idx_evm_logs_ccip_exec_state_change_read  (cost=0.00..4.76 rows=4 width=0) (actual time=0.023
..0.023 rows=10 loops=1)
                           Index Cond: ((logs.address = '\xa1be7bb68d07c3031964ceb25b6fc0b121902c77'::bytea) AND (logs.evm_chain_id = '4'::
numeric) AND (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000002'::bytea) AND (logs.topics[3] >= '\x00000
0000000000000000000000000000000000000000000000000000000001b'::bytea) AND (logs.topics[3] <= '\x00000000000000000000000000000000000000000000
00000000000000000024'::bytea) AND (logs.block_number <= $0))
                           Buffers: shared hit=5
                     ->  Bitmap Index Scan on idx_evm_logs_ccip_exec_state_change_read  (cost=0.00..4.76 rows=4 width=0) (actual time=0.019
..0.019 rows=10 loops=1)
                           Index Cond: ((logs.address = '\xa1be7bb68d07c3031964ceb25b6fc0b121902c77'::bytea) AND (logs.evm_chain_id = '4'::
numeric) AND (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000003'::bytea) AND (logs.topics[3] >= '\x00000
0000000000000000000000000000000000000000000000000000000002b'::bytea) AND (logs.topics[3] <= '\x00000000000000000000000000000000000000000000
00000000000000000034'::bytea) AND (logs.block_number <= $0))
                           Buffers: shared hit=4
                     ->  Bitmap Index Scan on idx_evm_logs_ccip_exec_state_change_read  (cost=0.00..4.75 rows=3 width=0) (actual time=0.023
..0.023 rows=10 loops=1)
                           Index Cond: ((logs.address = '\xa1be7bb68d07c3031964ceb25b6fc0b121902c77'::bytea) AND (logs.evm_chain_id = '4'::
numeric) AND (logs.topics[2] = '\x0000000000000000000000000000000000000000000000000000000000000004'::bytea) AND (logs.topics[3] >= '\x00000
0000000000000000000000000000000000000000000000000000000003b'::bytea) AND (logs.topics[3] <= '\x00000000000000000000000000000000000000000000
00000000000000000044'::bytea) AND (logs.block_number <= $0))
                           Buffers: shared hit=4
 Planning:
   Buffers: shared hit=34
 Planning Time: 0.944 ms
 Execution Time: 0.417 ms
(41 rows)
```

### Disk space usage

It's around 1.5% of the total size of all indexes created on evm.logs table (checked on staging-testnet)

```sql
                 index_name                  | size_pretty | percent_of_total
---------------------------------------------+-------------+------------------
 evm_logs_idx                                | 620 MB      |            27.87
 evm_logs_by_timestamp                       | 344 MB      |            15.47
 idx_logs_chain_address_event_block_logindex | 311 MB      |            13.98
 idx_logs_chain_block_logindex               | 255 MB      |            11.48
 evm_logs_idx_data_word_five                 | 251 MB      |            11.27
 evm_logs_idx_tx_hash                        | 116 MB      |             5.21
 logs_pkey                                   | 97 MB       |             4.38
 evm_logs_idx_data_word_two                  | 54 MB       |             2.44
 evm_logs_idx_topic_four                     | 31 MB       |             1.41
 idx_evm_logs_ccip_exec_state_change_read    | 28 MB       |             1.25
 evm_logs_idx_data_word_one                  | 27 MB       |             1.21
 evm_logs_idx_data_word_three                | 24 MB       |             1.10
 evm_logs_idx_data_word_four                 | 24 MB       |             1.07
 evm_logs_idx_topic_three                    | 23 MB       |             1.02
 evm_logs_idx_topic_two                      | 19 MB       |             0.83
(15 rows)
```
