### PR TITLE
chore: use the stdlib instead of 3rd party libraries errors

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -263,14 +263,12 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-envparse v0.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-metrics v0.5.4 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -733,8 +733,6 @@ github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026/go.mod h1:5Scbynm8dF1
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -754,8 +752,6 @@ github.com/hashicorp/go-metrics v0.5.4 h1:8mmPiIJkTPPEbAiV97IxdAGNdRdaWwVap1BU6e
 github.com/hashicorp/go-metrics v0.5.4/go.mod h1:CG5yz4NZ/AI/aQt9Ucm/vdBnbh7fvmv4lxZ350i+QQI=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.6.3 h1:xgHB+ZUSYeuJi96WtxEjzi23uh7YQpznjGh0U0UUrwg=
 github.com/hashicorp/go-plugin v1.6.3/go.mod h1:MRobyh+Wc/nYy1V4KAXUiYfzxoYhs7V1mlH1Z7iY2h0=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=

--- a/deployment/.golangci.yml
+++ b/deployment/.golangci.yml
@@ -49,6 +49,8 @@ linters:
               desc: Use github.com/stretchr/testify/require instead
             - pkg: go.uber.org/multierr
               desc: Use the standard library instead, for example https://pkg.go.dev/errors#Join
+            - pkg: "github.com/hashicorp/go-multierror"
+              desc: Use the standard library instead, for example https://pkg.go.dev/errors#Join
             - pkg: gopkg.in/guregu/null.v1
               desc: Use gopkg.in/guregu/null.v4 instead
             - pkg: gopkg.in/guregu/null.v2
@@ -61,6 +63,8 @@ linters:
               desc: Use github.com/smartcontractkit/chainlink-evm instead
             - pkg: github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal
               desc: Use github.com/smartcontractkit/mcms instead
+            - pkg: github.com/pkg/errors
+              desc: Use the standard library instead
     exhaustive:
       default-signifies-exhaustive: true
     gosec:

--- a/deployment/ccip/changeset/cs_prerequisites.go
+++ b/deployment/ccip/changeset/cs_prerequisites.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
@@ -50,7 +49,7 @@ var (
 func DeployPrerequisitesChangeset(env cldf.Environment, cfg DeployPrerequisiteConfig) (cldf.ChangesetOutput, error) {
 	err := cfg.Validate()
 	if err != nil {
-		return cldf.ChangesetOutput{}, errors.Wrapf(cldf.ErrInvalidConfig, "%v", err)
+		return cldf.ChangesetOutput{}, fmt.Errorf("%w: %w", err, cldf.ErrInvalidConfig)
 	}
 	ab := cldf.NewMemoryAddressBook()
 	err = deployPrerequisiteChainContracts(env, ab, cfg)

--- a/deployment/ccip/changeset/v1_5/cs_ocr2_config.go
+++ b/deployment/ccip/changeset/v1_5/cs_ocr2_config.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/pkg/errors"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -57,8 +56,8 @@ func (c *CommitOCR2ConfigParams) PopulateOffChainAndOnChainCfg(priceReg common.A
 		c.PriceReportingDisabled,
 	).Encode()
 	if err != nil {
-		return errors.Wrapf(err, "failed to encode offchain config for source chain %d and destination chain %d",
-			c.SourceChainSelector, c.DestinationChainSelector)
+		return fmt.Errorf("failed to encode offchain config for source chain %d and destination chain %d: %w",
+			c.SourceChainSelector, c.DestinationChainSelector, err)
 	}
 	c.OCR2ConfigParams.OnchainConfig, err = abihelpers.EncodeAbiStruct(testhelpers.NewCommitOnchainConfig(priceReg))
 	if err != nil {
@@ -317,10 +316,10 @@ func deriveOCR2Config(
 	for _, transmitter := range transmitters {
 		bytes, err := hexutil.Decode(string(transmitter))
 		if err != nil {
-			return FinalOCR2Config{}, errors.Wrap(err, fmt.Sprintf("given address is not valid %s", transmitter))
+			return FinalOCR2Config{}, fmt.Errorf("given address is not valid %s: %w", transmitter, err)
 		}
 		if len(bytes) != 20 {
-			return FinalOCR2Config{}, errors.Errorf("address is not 20 bytes %s", transmitter)
+			return FinalOCR2Config{}, fmt.Errorf("address is not 20 bytes %s", transmitter)
 		}
 		transmittersAddresses = append(transmittersAddresses, common.BytesToAddress(bytes))
 	}

--- a/deployment/ccip/changeset/v1_6/cs_home_chain.go
+++ b/deployment/ccip/changeset/v1_6/cs_home_chain.go
@@ -3,13 +3,13 @@ package v1_6
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 	mcmslib "github.com/smartcontractkit/mcms"
 	mcmssdk "github.com/smartcontractkit/mcms/sdk"
 	mcmsevmsdk "github.com/smartcontractkit/mcms/sdk/evm"
@@ -66,7 +66,7 @@ var (
 func DeployHomeChainChangeset(env cldf.Environment, cfg DeployHomeChainConfig) (cldf.ChangesetOutput, error) {
 	err := cfg.Validate()
 	if err != nil {
-		return cldf.ChangesetOutput{}, errors.Wrapf(cldf.ErrInvalidConfig, "%v", err)
+		return cldf.ChangesetOutput{}, fmt.Errorf("%w: %w", err, cldf.ErrInvalidConfig)
 	}
 	ab := cldf.NewMemoryAddressBook()
 	// Note we also deploy the cap reg.
@@ -441,7 +441,7 @@ func addNodes(
 		for _, p2pID := range p2pIDs {
 			// if any p2pIDs are empty throw error
 			if p2pID == ([32]byte{}) {
-				return errors.Wrapf(errors.New("empty p2pID"), "p2pID: %x selector: %d", p2pID, chain.Selector)
+				return fmt.Errorf("p2pID: %x selector: %d: %w", p2pID, chain.Selector, errors.New("empty p2pID"))
 			}
 			nodeParam := capabilities_registry.CapabilitiesRegistryNodeParams{
 				NodeOperatorId:      nopID,

--- a/deployment/ccip/shared/stateview/evm/state.go
+++ b/deployment/ccip/shared/stateview/evm/state.go
@@ -2,12 +2,12 @@ package evm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/burn_mint_erc677_helper"
@@ -649,7 +649,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			routerView, err := v1_2.GenerateRouterView(c.Router, false)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate router view for router %s", c.Router.Address().String())
+				return fmt.Errorf("failed to generate router view for router %s: %w", c.Router.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -663,7 +663,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			testRouterView, err := v1_2.GenerateRouterView(c.TestRouter, true)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate router view for test router %s", c.TestRouter.Address().String())
+				return fmt.Errorf("failed to generate test router view for test router %s: %w", c.TestRouter.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -678,7 +678,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				"tokenAdminRegistry", c.TokenAdminRegistry.Address().Hex(), "chain", chain)
 			taView, err := v1_5.GenerateTokenAdminRegistryView(c.TokenAdminRegistry)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate token admin registry view for token admin registry %s", c.TokenAdminRegistry.Address().String())
+				return fmt.Errorf("failed to generate token admin registry view for token admin registry %s: %w", c.TokenAdminRegistry.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -691,7 +691,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			tpfView, err := v1_5_1.GenerateTokenPoolFactoryView(c.TokenPoolFactory)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate token pool factory view for token pool factory %s", c.TokenPoolFactory.Address().String())
+				return fmt.Errorf("failed to generate token pool factory view for token pool factory %s: %w", c.TokenPoolFactory.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -705,7 +705,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			grp.Go(func() error {
 				tokenPoolView, err := v1_5_1.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return errors.Wrapf(err, "failed to generate burn mint token pool view for %s", tokenPool.Address().String())
+					return fmt.Errorf("failed to generate burn mint token pool view for %s: %w", tokenPool.Address().String(), err)
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
@@ -720,7 +720,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			grp.Go(func() error {
 				tokenPoolView, err := v1_5_1.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return errors.Wrapf(err, "failed to generate burn mint token pool view for %s", tokenPool.Address().String())
+					return fmt.Errorf("failed to generate burn mint token pool view for %s: %w", tokenPool.Address().String(), err)
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
@@ -735,7 +735,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			grp.Go(func() error {
 				tokenPoolView, err := v1_5_1.GenerateTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return errors.Wrapf(err, "failed to generate burn mint token pool view for %s", tokenPool.Address().String())
+					return fmt.Errorf("failed to generate burn mint token pool view for %s: %w", tokenPool.Address().String(), err)
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), v1_5_1.PoolView{
 					TokenPoolView: tokenPoolView,
@@ -750,7 +750,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			grp.Go(func() error {
 				tokenPoolView, err := v1_5_1.GenerateLockReleaseTokenPoolView(tokenPool, c.usdFeedOrDefault(tokenSymbol))
 				if err != nil {
-					return errors.Wrapf(err, "failed to generate lock release token pool view for %s", tokenPool.Address().String())
+					return fmt.Errorf("failed to generate lock release token pool view for %s: %w", tokenPool.Address().String(), err)
 				}
 				chainView.UpdateTokenPool(tokenSymbol.String(), tokenPool.Address().Hex(), tokenPoolView)
 				lggr.Infow("generated lock release token pool view", "tokenPool", tokenPool.Address().Hex(), "chain", chain)
@@ -762,7 +762,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			tokenPoolView, err := v1_5_1.GenerateUSDCTokenPoolView(pool)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate USDC token pool view for %s", pool.Address().String())
+				return fmt.Errorf("failed to generate USDC token pool view for %s: %w", pool.Address().String(), err)
 			}
 			chainView.UpdateTokenPool(string(shared.USDCSymbol), pool.Address().Hex(), tokenPoolView)
 			lggr.Infow("generated USDC token pool view", "tokenPool", pool.Address().Hex(), "chain", chain)
@@ -773,7 +773,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			nmView, err := v1_6.GenerateNonceManagerView(c.NonceManager)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate nonce manager view for nonce manager %s", c.NonceManager.Address().String())
+				return fmt.Errorf("failed to generate nonce manager view for nonce manager %s: %w", c.NonceManager.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -786,7 +786,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			rmnView, err := v1_6.GenerateRMNRemoteView(c.RMNRemote)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate rmn remote view for rmn remote %s", c.RMNRemote.Address().String())
+				return fmt.Errorf("failed to generate rmn remote view for rmn remote %s: %w", c.RMNRemote.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -800,7 +800,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			rmnHomeView, err := v1_6.GenerateRMNHomeView(c.RMNHome)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate rmn home view for rmn home %s", c.RMNHome.Address().String())
+				return fmt.Errorf("failed to generate rmn home view for rmn home %s: %w", c.RMNHome.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -823,7 +823,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 			}
 			fqView, err := v1_6.GenerateFeeQuoterView(c.FeeQuoter, c.Router, c.TestRouter, tokens)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate fee quoter view for fee quoter %s", c.FeeQuoter.Address().String())
+				return fmt.Errorf("failed to generate fee quoter view for fee quoter %s: %w", c.FeeQuoter.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -842,7 +842,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				c.TokenAdminRegistry,
 			)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate on ramp view for on ramp %s", c.OnRamp.Address().String())
+				return fmt.Errorf("failed to generate on ramp view for on ramp %s: %w", c.OnRamp.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -860,7 +860,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 				c.TestRouter,
 			)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate off ramp view for off ramp %s", c.OffRamp.Address().String())
+				return fmt.Errorf("failed to generate off ramp view for off ramp %s: %w", c.OffRamp.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -874,7 +874,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			rmnProxyView, err := v1_0.GenerateRMNProxyView(c.RMNProxy)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate rmn proxy view for rmn proxy %s", c.RMNProxy.Address().String())
+				return fmt.Errorf("failed to generate rmn proxy view for rmn proxy %s: %w", c.RMNProxy.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -887,7 +887,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			chView, err := v1_6.GenerateCCIPHomeView(c.CapabilityRegistry, c.CCIPHome)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate CCIP home view for CCIP home %s", c.CCIPHome.Address())
+				return fmt.Errorf("failed to generate CCIP home view for CCIP home %s: %w", c.CCIPHome.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -900,7 +900,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			capRegView, err := v1_1.GenerateCapabilityRegistryView(c.CapabilityRegistry)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate capability registry view for capability registry %s", c.CapabilityRegistry.Address().String())
+				return fmt.Errorf("failed to generate capability registry view for capability registry %s: %w", c.CapabilityRegistry.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -913,7 +913,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			mcmsView, err := c.MCMSWithTimelockState.GenerateMCMSWithTimelockView()
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate MCMS with timelock view for MCMS with timelock %s", c.MCMSWithTimelockState.Timelock.Address().String())
+				return fmt.Errorf("failed to generate MCMS with timelock view for MCMS with timelock %s: %w", c.MCMSWithTimelockState.Timelock.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -926,7 +926,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			linkTokenView, err := c.GenerateLinkView()
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate link token view for link token %s", c.LinkToken.Address().String())
+				return fmt.Errorf("failed to generate link token view for link token %s: %w", c.LinkToken.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -957,7 +957,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			registryModuleView, err := shared2.GetRegistryModuleView(registryModule, c.TokenAdminRegistry.Address())
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate registry module view for registry module %s", registryModule.Address().Hex())
+				return fmt.Errorf("failed to generate registry module view for registry module %s: %w", registryModule.Address().Hex(), err)
 			}
 			chainView.UpdateRegistryModuleView(registryModule.Address().Hex(), registryModuleView)
 			lggr.Infow("generated registry module view", "registryModule", registryModule.Address().Hex(), "chain", chain)
@@ -969,7 +969,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			registryModuleView, err := shared2.GetRegistryModuleView(registryModule, c.TokenAdminRegistry.Address())
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate registry module view for registry module %s", registryModule.Address().Hex())
+				return fmt.Errorf("failed to generate registry module view for registry module %s: %w", registryModule.Address().Hex(), err)
 			}
 			chainView.UpdateRegistryModuleView(registryModule.Address().Hex(), registryModuleView)
 			lggr.Infow("generated registry module view", "registryModule", registryModule.Address().Hex(), "chain", chain)
@@ -981,7 +981,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			priceRegistryView, err := v1_2.GeneratePriceRegistryView(c.PriceRegistry)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate price registry view for price registry %s", c.PriceRegistry.Address().String())
+				return fmt.Errorf("failed to generate price registry view for price registry %s: %w", c.PriceRegistry.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()
@@ -995,7 +995,7 @@ func (c CCIPChainState) GenerateView(lggr logger.Logger, chain string) (view.Cha
 		grp.Go(func() error {
 			rmnView, err := v1_5.GenerateRMNView(c.RMN)
 			if err != nil {
-				return errors.Wrapf(err, "failed to generate rmn view for rmn %s", c.RMN.Address().String())
+				return fmt.Errorf("failed to generate rmn view for rmn %s: %w", c.RMN.Address().String(), err)
 			}
 			chainView.UpdateMu.Lock()
 			defer chainView.UpdateMu.Unlock()

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -2,7 +2,7 @@ package stateview
 
 import (
 	"context"
-	std_errors "errors"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -53,7 +53,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/view"
@@ -483,7 +482,7 @@ func (c CCIPOnChainState) ValidateOwnershipOfChain(e cldf.Environment, chainSel 
 	close(errs)
 	var multiErr error
 	for err := range errs {
-		multiErr = std_errors.Join(multiErr, err)
+		multiErr = errors.Join(multiErr, err)
 	}
 	if multiErr != nil {
 		return multiErr
@@ -1198,7 +1197,7 @@ func LoadOnchainStateSolana(e cldf.Environment) (CCIPOnChainState, error) {
 		addresses, err := e.ExistingAddresses.AddressesForChain(chainSelector)
 		if err != nil {
 			// Chain not found in address book, initialize empty
-			if !std_errors.Is(err, cldf.ErrChainNotFound) {
+			if !errors.Is(err, cldf.ErrChainNotFound) {
 				return state, err
 			}
 			addresses = make(map[string]cldf.TypeAndVersion)

--- a/deployment/common/changeset/deploy_link_token.go
+++ b/deployment/common/changeset/deploy_link_token.go
@@ -7,25 +7,18 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	eth_types "github.com/ethereum/go-ethereum/core/types"
 	"github.com/gagliardetto/solana-go"
-	"golang.org/x/sync/errgroup"
-
-	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
 	chainsel "github.com/smartcontractkit/chain-selectors"
-
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/link_token"
-
-	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"golang.org/x/sync/errgroup"
 
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	solTokenUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
-
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/link_token_interface"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/link_token"
 	"github.com/smartcontractkit/chainlink/deployment"
-
 	"github.com/smartcontractkit/chainlink/deployment/common/types"
 )
 

--- a/deployment/common/changeset/save_existing.go
+++ b/deployment/common/changeset/save_existing.go
@@ -1,15 +1,14 @@
 package changeset
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	"github.com/mr-tron/base58"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 var (
@@ -70,7 +69,7 @@ func (cfg ExistingContractsConfig) Validate() error {
 func SaveExistingContractsChangeset(env cldf.Environment, cfg ExistingContractsConfig) (cldf.ChangesetOutput, error) {
 	err := cfg.Validate()
 	if err != nil {
-		return cldf.ChangesetOutput{}, errors.Wrapf(cldf.ErrInvalidConfig, "%v", err)
+		return cldf.ChangesetOutput{}, fmt.Errorf("%w: %w", err, cldf.ErrInvalidConfig)
 	}
 	ab := cldf.NewMemoryAddressBook()
 	for _, ec := range cfg.ExistingContracts {

--- a/deployment/data-feeds/changeset/state.go
+++ b/deployment/data-feeds/changeset/state.go
@@ -2,6 +2,7 @@ package changeset
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 
 	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
@@ -222,7 +222,7 @@ func (c DataFeedsChainState) GenerateView() (view.ChainView, error) {
 		for _, cacheContract := range c.DataFeedsCache {
 			cacheView, err := v1_0.GenerateDataFeedsCacheView(cacheContract)
 			if err != nil {
-				return chainView, errors.Wrapf(err, "failed to generate cache view %s", cacheContract.Address().String())
+				return chainView, fmt.Errorf("failed to generate cache view %s: %w", cacheContract.Address().String(), err)
 			}
 			chainView.DataFeedsCache[cacheContract.Address().Hex()] = cacheView
 		}
@@ -231,7 +231,7 @@ func (c DataFeedsChainState) GenerateView() (view.ChainView, error) {
 		for _, proxyContract := range c.AggregatorProxy {
 			proxyView, err := v1_0.GenerateAggregatorProxyView(proxyContract)
 			if err != nil {
-				return chainView, errors.Wrapf(err, "failed to generate proxy view %s", proxyContract.Address().String())
+				return chainView, fmt.Errorf("failed to generate proxy view %s: %w", proxyContract.Address().String(), err)
 			}
 			chainView.AggregatorProxy[proxyContract.Address().Hex()] = proxyView
 		}

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/hashicorp/go-multierror"
 	"google.golang.org/grpc"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
@@ -122,16 +121,17 @@ func (n Nodes) BootstrapLocators() []string {
 
 // P2PIDsPresentInJD - For a given p2pIDs, check if the nodes are present in JD.
 func (n Nodes) P2PIDsPresentInJD(p2pIDs [][32]byte) error {
-	var allErrs error
+	var err error
 	for _, p2pID := range p2pIDs {
 		p2pIDString := "p2p_" + libocrtypes.PeerID(p2pID).String()
 		if !slices.ContainsFunc(n, func(n Node) bool {
 			return p2pIDString == n.PeerID.String()
 		}) {
-			allErrs = multierror.Append(allErrs, fmt.Errorf("node with p2pID %s not found in JD", p2pIDString))
+			err = errors.Join(err, fmt.Errorf("node with p2pID %s not found in JD", p2pIDString))
 		}
 	}
-	return allErrs
+
+	return err
 }
 
 func isValidMultiAddr(s string) bool {

--- a/deployment/environment/devenv/rmn.go
+++ b/deployment/environment/devenv/rmn.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	tc "github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/exec"
@@ -268,7 +267,7 @@ func (proxy *RageProxy) Start(t *testing.T, lggr zerolog.Logger, networks []stri
 	_, reader, err := container.Exec(context.Background(), []string{
 		"cat", ProxyKeyStore}, exec.Multiplexed())
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to cat keystore")
+		return nil, fmt.Errorf("unable to cat keystore: %w", err)
 	}
 	b, err := io.ReadAll(reader)
 	if err != nil {
@@ -276,7 +275,7 @@ func (proxy *RageProxy) Start(t *testing.T, lggr zerolog.Logger, networks []stri
 	}
 	peerID, err := extractPeerID(b)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to extract peerID %s", string(b))
+		return nil, fmt.Errorf("unable to extract peerID: %w", err)
 	}
 	proxy.PeerID = peerID
 	proxy.Container = container
@@ -397,7 +396,7 @@ func (rmn *AFN2Proxy) Start(t *testing.T, lggr zerolog.Logger, reuse bool, netwo
 	_, reader, err := container.Exec(context.Background(), []string{
 		"cat", RMNKeyStore}, exec.Multiplexed())
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to cat keystore")
+		return nil, fmt.Errorf("unable to cat keystore: %w", err)
 	}
 	b, err := io.ReadAll(reader)
 	if err != nil {
@@ -405,7 +404,7 @@ func (rmn *AFN2Proxy) Start(t *testing.T, lggr zerolog.Logger, reuse bool, netwo
 	}
 	onchainPubKey, offchainPubKey, err := extractKeys(b)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to extract peerID %s", string(b))
+		return nil, fmt.Errorf("unable to extract peerID %s: %w", string(b), err)
 	}
 	rmn.OffchainPublicKey = offchainPubKey
 	rmn.EVMOnchainPublicKey = onchainPubKey

--- a/deployment/evm_kmsclient.go
+++ b/deployment/evm_kmsclient.go
@@ -6,12 +6,12 @@ import (
 	"crypto/ecdsa"
 	"encoding/asn1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -23,11 +23,9 @@ require (
 	github.com/go-resty/resty/v2 v2.16.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mr-tron/base58 v1.2.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pelletier/go-toml/v2 v2.2.3
-	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
@@ -51,7 +49,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/zksync-sdk/zksync2-go v1.1.1-0.20250620124214-2c742ee399c6
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
 	golang.org/x/mod v0.24.0
@@ -252,7 +249,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-envparse v0.1.0 // indirect
@@ -353,6 +349,7 @@ require (
 	github.com/pion/stun/v2 v2.0.0 // indirect
 	github.com/pion/transport/v2 v2.2.10 // indirect
 	github.com/pion/transport/v3 v3.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/pressly/goose/v3 v3.21.1 // indirect
@@ -452,6 +449,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
 	golang.org/x/arch v0.11.0 // indirect
 	golang.org/x/crypto v0.38.0 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -721,8 +721,6 @@ github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026/go.mod h1:5Scbynm8dF1
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -742,8 +740,6 @@ github.com/hashicorp/go-metrics v0.5.4 h1:8mmPiIJkTPPEbAiV97IxdAGNdRdaWwVap1BU6e
 github.com/hashicorp/go-metrics v0.5.4/go.mod h1:CG5yz4NZ/AI/aQt9Ucm/vdBnbh7fvmv4lxZ350i+QQI=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.6.3 h1:xgHB+ZUSYeuJi96WtxEjzi23uh7YQpznjGh0U0UUrwg=
 github.com/hashicorp/go-plugin v1.6.3/go.mod h1:MRobyh+Wc/nYy1V4KAXUiYfzxoYhs7V1mlH1Z7iY2h0=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=

--- a/deployment/helpers.go
+++ b/deployment/helpers.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,11 +11,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
@@ -57,7 +55,7 @@ func parseError(txError error) (string, error) {
 	}
 
 	if callErr.Data == "" && strings.Contains(callErr.Message, "missing trie node") {
-		return "", errors.Errorf("please use an archive node")
+		return "", errors.New("please use an archive node")
 	}
 
 	return callErr.Data, nil
@@ -92,7 +90,7 @@ func AddressListContainsEmptyAddress(addresses []common.Address) bool {
 	return false
 }
 
-func MigrateAddressBook(addrBook deployment.AddressBook) (datastore.MutableDataStore, error) {
+func MigrateAddressBook(addrBook cldf.AddressBook) (datastore.MutableDataStore, error) {
 	addrs, err := addrBook.Addresses()
 	if err != nil {
 		return nil, err

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -231,14 +231,12 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-envparse v0.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-metrics v0.5.4 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -708,8 +708,6 @@ github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026/go.mod h1:5Scbynm8dF1
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -729,8 +727,6 @@ github.com/hashicorp/go-metrics v0.5.4 h1:8mmPiIJkTPPEbAiV97IxdAGNdRdaWwVap1BU6e
 github.com/hashicorp/go-metrics v0.5.4/go.mod h1:CG5yz4NZ/AI/aQt9Ucm/vdBnbh7fvmv4lxZ350i+QQI=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.6.3 h1:xgHB+ZUSYeuJi96WtxEjzi23uh7YQpznjGh0U0UUrwg=
 github.com/hashicorp/go-plugin v1.6.3/go.mod h1:MRobyh+Wc/nYy1V4KAXUiYfzxoYhs7V1mlH1Z7iY2h0=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=


### PR DESCRIPTION
This change updates the `deployment` package to use the standard library's `errors` package instead of the `pkg/errors` package, and also removes the 2 multi error libraries in favour of `errors.Join`.

The linter has also been updated to enforce this change going forward.

