### PR TITLE
Bump 2.25.1-ccip to contain fixes from 2.25.0-ccip

### DIFF
--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -359,4 +359,15 @@ runner-test-matrix:
     test_cmd: cd smoke/ccip/ && go test ccip_disable_lane_test.go -timeout 10m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
 
+  - id: smoke/ccip/ccip_topologies_test.go:Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest
+    path: integration-tests/smoke/ccip/ccip_topologies_test.go
+    test_env_type: in-memory
+    runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    triggers:
+      - PR Integration CCIP Tests
+      - Nightly Integration CCIP Tests
+    test_cmd: cd smoke/ccip && go test -run "Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest" -timeout 15m -test.parallel=2 -count=1 -json
+    test_go_project_path: integration-tests
+
   # END: CCIP tests

--- a/core/capabilities/ccip/ccip_integration_tests/usdcreader/usdcreader_test.go
+++ b/core/capabilities/ccip/ccip_integration_tests/usdcreader/usdcreader_test.go
@@ -24,8 +24,6 @@ import (
 
 	sel "github.com/smartcontractkit/chain-selectors"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
-
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
@@ -83,7 +81,7 @@ func Test_USDCReader_MessageHashes(t *testing.T) {
 				SourceMessageTransmitterAddr: ts.contractAddr.String(),
 			},
 		},
-		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
+		map[cciptypes.ChainSelector]contractreader.Extended{
 			ethereumChain: ts.reader,
 		}, mokAddrCodec)
 	require.NoError(t, err)
@@ -283,7 +281,7 @@ func Benchmark_MessageHashes(b *testing.B) {
 						SourceMessageTransmitterAddr: ts.contractAddr.String(),
 					},
 				},
-				map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
+				map[cciptypes.ChainSelector]contractreader.Extended{
 					sourceChain: ts.reader,
 				}, mokAddrCodec)
 			require.NoError(b, err)
@@ -473,13 +471,16 @@ func testSetup(ctx context.Context, t testing.TB, readerChain cciptypes.ChainSel
 		require.NoError(t, db.Close())
 	})
 
+	// Convert to the extended contract reader interface.Add commentMore actions
+	ecr := contractreader.NewExtendedContractReader(
+		(contractreader.ContractReaderFacade)(cr))
 	return &testSetupData{
 		contractAddr: address,
 		contract:     contract,
 		sb:           simulatedBackend,
 		auth:         auth,
 		cl:           cl,
-		reader:       cr,
+		reader:       ecr,
 		orm:          orm,
 		db:           db,
 		lp:           lp,
@@ -492,7 +493,7 @@ type testSetupData struct {
 	sb           *simulated.Backend
 	auth         *bind.TransactOpts
 	cl           client.Client
-	reader       types.ContractReader
+	reader       contractreader.Extended
 	orm          logpoller.ORM
 	db           *sqlx.DB
 	lp           logpoller.LogPoller

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -405,7 +405,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250528121202-292529af39df // indirect
 	github.com/smartcontractkit/freeport v0.1.0 // indirect

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.9.1

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1307,8 +1307,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 h1:iF7WucN9ZxJLbDuyB2co0mGPytFY9NdEBeQHY1+bJnc=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5/go.mod h1:HIpGvF6nKCdtZ30xhdkKWGM9+4Z4CVqJH8ZBL1FTEiY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 h1:2SdcMUYJGmIIXovxUPf2Cc5KiQ9cDZ7QdyvUE+GQdOk=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 h1:8MzS0sEc25WetSuK3o6MgSd96btzC0sHHBHZ0+lNG0M=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.9 h1:2X5TEyJZaBi6KrvfrHuFeC01Rl1A2DL4pQgF5Vzf5z4=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.9/go.mod h1:q99H9vcMJDs6T+zsSI8XJZd6PUkZnyG3iaRbrYNUCTk=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4 h1:+kwLuO9kcq1+ZbRUQjxX1SQmzlL2M6ZP6+L0xQMtmkU=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1273,8 +1273,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86 h1:tXXegjGJJDewy1PJniL0PKb8cQBlLJZ2HboG88eusSw=

--- a/core/services/relay/evm/read/event_test.go
+++ b/core/services/relay/evm/read/event_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/onramp"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 
@@ -28,7 +27,7 @@ func Test_DecodeHardcodedType(t *testing.T) {
 		log, err := generateOfframpLog(fixtLog)
 		require.NoError(t, err)
 
-		var out reader.CommitReportAcceptedEvent
+		var out chainaccessor.CommitReportAcceptedEvent
 		err = decodeHardcodedType(&out, log)
 		require.NoError(t, err)
 
@@ -56,7 +55,7 @@ func Test_DecodeHardcodedType(t *testing.T) {
 		log, err := generateOffRampStateChangeLog(fixtLog)
 		require.NoError(t, err)
 
-		var out reader.ExecutionStateChangedEvent
+		var out chainaccessor.ExecutionStateChangedEvent
 		err = decodeHardcodedType(&out, log)
 		require.NoError(t, err)
 

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86
 	github.com/smartcontractkit/chainlink-deployments-framework v0.9.1

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.11.0
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.7.0
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4
 	github.com/smartcontractkit/freeport v0.1.0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1283,8 +1283,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 h1:iF7WucN9ZxJLbDuyB2co0mGPytFY9NdEBeQHY1+bJnc=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5/go.mod h1:HIpGvF6nKCdtZ30xhdkKWGM9+4Z4CVqJH8ZBL1FTEiY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 h1:2SdcMUYJGmIIXovxUPf2Cc5KiQ9cDZ7QdyvUE+GQdOk=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 h1:8MzS0sEc25WetSuK3o6MgSd96btzC0sHHBHZ0+lNG0M=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1 h1:xDfmixWYefrECJkWpnSDx+WOdnJe/wNADsTZ2B68jcw=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1/go.mod h1:JJlLI8lxMi6nMF+Tl56qHJcAybgNcupQwltnF5Y6Oi0=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4 h1:+kwLuO9kcq1+ZbRUQjxX1SQmzlL2M6ZP6+L0xQMtmkU=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1249,8 +1249,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86 h1:tXXegjGJJDewy1PJniL0PKb8cQBlLJZ2HboG88eusSw=

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610073243-5c425bf3b50f
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/billing/go v0.0.0-20250516160234-c2e27f791437
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.7.0
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250528121202-292529af39df
 	github.com/smartcontractkit/freeport v0.1.0
 	github.com/smartcontractkit/libocr v0.0.0-20250604151357-2fe8c61bbf2e

--- a/go.sum
+++ b/go.sum
@@ -1083,8 +1083,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 h1:iF7WucN9ZxJLbDuyB2co0mGPytFY9NdEBeQHY1+bJnc=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5/go.mod h1:HIpGvF6nKCdtZ30xhdkKWGM9+4Z4CVqJH8ZBL1FTEiY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 h1:2SdcMUYJGmIIXovxUPf2Cc5KiQ9cDZ7QdyvUE+GQdOk=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 h1:8MzS0sEc25WetSuK3o6MgSd96btzC0sHHBHZ0+lNG0M=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250528121202-292529af39df h1:Fu9FHmpkcA0S75bO3heYRkYXpOfxpIv6yI/OQRjOhL8=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250528121202-292529af39df/go.mod h1:EQl7VcrSvpSNOL8qWkc2CV/2cOII5CIkKTeIqzqCWKk=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250528121202-292529af39df h1:36e3ROIZyV/qE8SvFOACXtXfMOMd9vG4+zY2v2ScXkI=

--- a/go.sum
+++ b/go.sum
@@ -1053,8 +1053,8 @@ github.com/smartcontractkit/chain-selectors v1.0.60 h1:X/5CcVB5izIaMrGRdl0hc6sSb
 github.com/smartcontractkit/chain-selectors v1.0.60/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610073243-5c425bf3b50f h1:CixsxQACoR1SgQ/62N2JwfG3f94kIZ0CrYdYI0C4s/0=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610073243-5c425bf3b50f/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86 h1:tXXegjGJJDewy1PJniL0PKb8cQBlLJZ2HboG88eusSw=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86
 	github.com/smartcontractkit/chainlink-deployments-framework v0.9.1

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -468,7 +468,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250528121202-292529af39df // indirect
 	github.com/smartcontractkit/freeport v0.1.0 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1480,8 +1480,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86 h1:tXXegjGJJDewy1PJniL0PKb8cQBlLJZ2HboG88eusSw=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1514,8 +1514,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 h1:iF7WucN9ZxJLbDuyB2co0mGPytFY9NdEBeQHY1+bJnc=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5/go.mod h1:HIpGvF6nKCdtZ30xhdkKWGM9+4Z4CVqJH8ZBL1FTEiY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 h1:2SdcMUYJGmIIXovxUPf2Cc5KiQ9cDZ7QdyvUE+GQdOk=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 h1:8MzS0sEc25WetSuK3o6MgSd96btzC0sHHBHZ0+lNG0M=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1 h1:xDfmixWYefrECJkWpnSDx+WOdnJe/wNADsTZ2B68jcw=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1/go.mod h1:JJlLI8lxMi6nMF+Tl56qHJcAybgNcupQwltnF5Y6Oi0=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5 h1:S5HND0EDtlA+xp2E+mD11DlUTp2wD6uojwixye8ZB/k=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -458,7 +458,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.51.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250528121202-292529af39df // indirect

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86
 	github.com/smartcontractkit/chainlink-deployments-framework v0.9.1

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1496,8 +1496,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 h1:iF7WucN9ZxJLbDuyB2co0mGPytFY9NdEBeQHY1+bJnc=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5/go.mod h1:HIpGvF6nKCdtZ30xhdkKWGM9+4Z4CVqJH8ZBL1FTEiY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 h1:2SdcMUYJGmIIXovxUPf2Cc5KiQ9cDZ7QdyvUE+GQdOk=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 h1:8MzS0sEc25WetSuK3o6MgSd96btzC0sHHBHZ0+lNG0M=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1 h1:xDfmixWYefrECJkWpnSDx+WOdnJe/wNADsTZ2B68jcw=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.1/go.mod h1:JJlLI8lxMi6nMF+Tl56qHJcAybgNcupQwltnF5Y6Oi0=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5 h1:S5HND0EDtlA+xp2E+mD11DlUTp2wD6uojwixye8ZB/k=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1462,8 +1462,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86 h1:tXXegjGJJDewy1PJniL0PKb8cQBlLJZ2HboG88eusSw=

--- a/integration-tests/smoke/ccip/ccip_reader_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_test.go
@@ -1068,7 +1068,10 @@ func TestCCIPReader_DiscoverContracts(t *testing.T) {
 	//--------------------------------Setup done--------------------------------//
 
 	// Call the ccip chain reader with DiscoverContracts for test
-	contractAddresses, err := reader.DiscoverContracts(ctx, []cciptypes.ChainSelector{chainS1, chainD})
+	contractAddresses, err := reader.DiscoverContracts(ctx,
+		[]cciptypes.ChainSelector{chainS1, chainD},
+		[]cciptypes.ChainSelector{chainS1, chainD},
+	)
 	require.NoError(t, err)
 
 	require.Equal(t, contractAddresses[consts.ContractNameOnRamp][chainS1], cciptypes.UnknownAddress(common.LeftPadBytes(onRampS1Addr.Bytes(), 32)))
@@ -1087,7 +1090,9 @@ func TestCCIPReader_DiscoverContracts(t *testing.T) {
 
 	// Since config poller has default refresh interval of 30s, we need to wait for the contract to be discovered
 	require.Eventually(t, func() bool {
-		contractAddresses, err = reader.DiscoverContracts(ctx, []cciptypes.ChainSelector{chainS1, chainD})
+		contractAddresses, err = reader.DiscoverContracts(ctx,
+			[]cciptypes.ChainSelector{chainS1, chainD},
+			[]cciptypes.ChainSelector{chainS1, chainD})
 		if err != nil {
 			return false
 		}
@@ -1102,7 +1107,9 @@ func TestCCIPReader_DiscoverContracts(t *testing.T) {
 	}, tests.WaitTimeout(t), 100*time.Millisecond, "Router and FeeQuoter addresses were not discovered on source chain in time")
 
 	// Final assertions again for completeness:
-	contractAddresses, err = reader.DiscoverContracts(ctx, []cciptypes.ChainSelector{chainS1, chainD})
+	contractAddresses, err = reader.DiscoverContracts(ctx,
+		[]cciptypes.ChainSelector{chainS1, chainD},
+		[]cciptypes.ChainSelector{chainS1, chainD})
 	require.NoError(t, err)
 
 	require.Equal(t, contractAddresses[consts.ContractNameOnRamp][chainS1], cciptypes.UnknownAddress(common.LeftPadBytes(onRampS1Addr.Bytes(), 32)))

--- a/integration-tests/smoke/ccip/ccip_topologies_test.go
+++ b/integration-tests/smoke/ccip/ccip_topologies_test.go
@@ -1,18 +1,13 @@
 package ccip
 
 import (
-	"context"
-	"sync"
+	"sort"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/ccip_home"
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/cciptesthelpertypes"
@@ -22,41 +17,28 @@ import (
 )
 
 func Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest(t *testing.T) {
-	// Setup 3 chains and a single lane between chains that doesn't
-	// include the home chain.
-	// We need at least 7 nodes to set up a suitable role DON.
-	// In this scenario, 7 nodes will support the source chain, and
-	// only 4 nodes will support the destination chain. At least one
-	// node will end up supporting both source and dest in this particular
-	// scenario.
-	// This will help us test the scenario where not all nodes support the destination chain.
-	// There are two parts to the setup:
-	// 1. the chainlink nodes themselves must be configured to support only a subset of the chains
-	// that are spun up in the environment.
-	// 2. the fChain values must be set correctly on CCIPHome according to the determined topology.
-	// When spinning up an environment we don't know the chain IDs / selectors of the chains being
-	// spun up, so we can't have an explicit mapping of chain IDs to fChain values / node indices.
-	ctx := t.Context()
+	// fix the chain ids for the test so we can appropriately set finality depth numbers on the destination chain.
+	chains := []chainsel.Chain{
+		chainsel.TEST_90000001,
+		chainsel.TEST_90000002,
+		chainsel.TEST_90000003,
+	}
+	sort.Slice(chains, func(i, j int) bool { return chains[i].Selector < chains[j].Selector })
+	homeChainSel := chains[0].Selector
+	sourceChainSel := chains[1].Selector
+	destChainSel := chains[2].Selector
 
 	const (
-		// fRoleDON needs to be at least 2, since for a role don of size 4, we can't have
-		// different node/chain committees.
-		fRoleDON = 2
-		nRoleDON = 3*fRoleDON + 1
-
-		// we need at least 3 chains to test the role DON topology.
-		// this is because one chain will be the home chain, which all nodes
-		// must support, and the other two chains will be the source and dest
-		// chains, of which only some nodes will support the dest chain.
-		numChains = 3
-
+		fRoleDON     = 2
+		nRoleDON     = 3*fRoleDON + 1
 		fChainSource = 2
 		fChainDest   = 1
 	)
 
+	// Setup 3 chains and a single lane.
 	e, _, _ := testsetups.NewIntegrationEnvironment(
 		t,
-		testhelpers.WithNumOfChains(numChains),
+		testhelpers.WithNumOfChains(len(chains)),
 		testhelpers.WithNumOfNodes(nRoleDON),
 		testhelpers.WithRoleDONTopology(cciptesthelpertypes.NewRandomTopology(
 			cciptesthelpertypes.RandomTopologyArgs{
@@ -72,89 +54,43 @@ func Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest(t *tes
 	state, err := stateview.LoadOnchainState(e.Env)
 	require.NoError(t, err)
 
-	allChainSelectors := e.Env.BlockChains.ListChainSelectors(chain.WithFamily(chain_selectors.FamilyEVM))
+	allChainSelectors := maps.Keys(e.Env.BlockChains.EVMChains())
 	require.Len(t, allChainSelectors, 3)
-	// filter out the home chain
-	var nonHomeChains []uint64
-	for _, chainSel := range allChainSelectors {
-		if chainSel != e.HomeChainSel {
-			nonHomeChains = append(nonHomeChains, chainSel)
-		}
-	}
-	require.Len(t, nonHomeChains, 2)
 
-	homeChainConfig, err := state.Chains[e.HomeChainSel].CCIPHome.GetChainConfig(&bind.CallOpts{
-		Context: ctx,
-	}, e.HomeChainSel)
-	require.NoError(t, err)
-	require.Equalf(t, homeChainConfig.FChain, uint8(fRoleDON), "home chain fChain must be %d, got %d", fRoleDON, homeChainConfig.FChain)
+	require.Contains(t, allChainSelectors, homeChainSel)
+	require.Contains(t, allChainSelectors, sourceChainSel)
+	require.Contains(t, allChainSelectors, destChainSel)
 
-	// get the fChain values of the chains to determine which will be the source
-	// and which will be the dest.
-	chainConfig0, err := state.Chains[e.HomeChainSel].CCIPHome.GetChainConfig(&bind.CallOpts{
-		Context: ctx,
-	}, nonHomeChains[0])
-	require.NoError(t, err)
-	chainConfig1, err := state.Chains[e.HomeChainSel].CCIPHome.GetChainConfig(&bind.CallOpts{
-		Context: ctx,
-	}, nonHomeChains[1])
-	require.NoError(t, err)
-	// the fChain values must be different, otherwise setup is incorrect.
-	require.NotEqual(t, chainConfig0.FChain, chainConfig1.FChain)
-
-	var sourceChain, destChain uint64
-	var sourceChainConfig, destChainConfig ccip_home.CCIPHomeChainConfig
-	if chainConfig0.FChain == fChainSource {
-		sourceChain = nonHomeChains[0]
-		destChain = nonHomeChains[1]
-		sourceChainConfig = chainConfig0
-		destChainConfig = chainConfig1
-	} else {
-		sourceChain = nonHomeChains[1]
-		destChain = nonHomeChains[0]
-		sourceChainConfig = chainConfig1
-		destChainConfig = chainConfig0
-	}
-
-	t.Logf("home chain: %d, source chain: %d, dest chain: %d", e.HomeChainSel, sourceChain, destChain)
-	t.Logf("source chain is supported by %d readers", len(sourceChainConfig.Readers))
-	t.Logf("dest chain is supported by %d readers", len(destChainConfig.Readers))
-
-	// now we can set up the lane.
-	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &e, state, sourceChain, destChain, false)
+	t.Log("All chain selectors:", allChainSelectors,
+		", home chain selector:", e.HomeChainSel,
+		", feed chain selector:", e.FeedChainSel,
+		", source chain selector:", sourceChainSel,
+		", dest chain selector:", destChainSel,
+	)
+	// connect a single lane, source to dest
+	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(
+		t, &e, state, sourceChainSel, destChainSel, false)
 
 	var (
-		replayed bool
-		nonce    uint64
-		sender   = common.LeftPadBytes(e.Env.BlockChains.EVMChains()[sourceChain].DeployerKey.From.Bytes(), 32)
-		out      mt.TestCaseOutput
-		setup    = mt.NewTestSetupWithDeployedEnv(
+		nonce  uint64
+		sender = common.LeftPadBytes(e.Env.BlockChains.EVMChains()[sourceChainSel].DeployerKey.From.Bytes(), 32)
+		setup  = mt.NewTestSetupWithDeployedEnv(
 			t,
 			e,
 			state,
-			sourceChain,
-			destChain,
+			sourceChainSel,
+			destChainSel,
 			sender,
 			false, // testRouter
 		)
 	)
 
-	monitorCtx, monitorCancel := context.WithCancel(ctx)
-	ms := &monitorState{}
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		monitorReExecutions(monitorCtx, t, state, destChain, ms)
-	}()
-
 	t.Run("data message to eoa", func(t *testing.T) {
-		out = mt.Run(
+		_ = mt.Run(
 			t,
 			mt.TestCase{
 				ValidationType:         mt.ValidationTypeExec,
 				TestSetup:              setup,
-				Replayed:               replayed,
 				Nonce:                  &nonce,
 				Receiver:               common.HexToAddress("0xdead").Bytes(),
 				MsgData:                []byte("hello eoa"),
@@ -167,11 +103,4 @@ func Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest(t *tes
 			},
 		)
 	})
-
-	_ = out
-
-	monitorCancel()
-	wg.Wait()
-	// there should be no re-executions.
-	require.Equal(t, int32(0), ms.reExecutionsObserved.Load())
 }

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -361,7 +361,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -373,7 +373,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250528121202-292529af39df // indirect
 	github.com/smartcontractkit/freeport v0.1.0 // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1236,8 +1236,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86 h1:tXXegjGJJDewy1PJniL0PKb8cQBlLJZ2HboG88eusSw=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1270,8 +1270,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 h1:iF7WucN9ZxJLbDuyB2co0mGPytFY9NdEBeQHY1+bJnc=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5/go.mod h1:HIpGvF6nKCdtZ30xhdkKWGM9+4Z4CVqJH8ZBL1FTEiY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 h1:2SdcMUYJGmIIXovxUPf2Cc5KiQ9cDZ7QdyvUE+GQdOk=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 h1:8MzS0sEc25WetSuK3o6MgSd96btzC0sHHBHZ0+lNG0M=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.9 h1:2X5TEyJZaBi6KrvfrHuFeC01Rl1A2DL4pQgF5Vzf5z4=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.9/go.mod h1:q99H9vcMJDs6T+zsSI8XJZd6PUkZnyG3iaRbrYNUCTk=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4 h1:+kwLuO9kcq1+ZbRUQjxX1SQmzlL2M6ZP6+L0xQMtmkU=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -434,7 +434,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.60 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250522110034-65c54665034a // indirect

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -445,7 +445,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go v0.0.0-20250131130834-15e0d4cde2a6 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 // indirect
-	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250528121202-292529af39df // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1470,8 +1470,8 @@ github.com/smartcontractkit/chainlink-protos/svr v1.1.0 h1:79Z9N9dMbMVRGaLoDPAQ+
 github.com/smartcontractkit/chainlink-protos/svr v1.1.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5 h1:iF7WucN9ZxJLbDuyB2co0mGPytFY9NdEBeQHY1+bJnc=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20250501150903-3e93089d9ad5/go.mod h1:HIpGvF6nKCdtZ30xhdkKWGM9+4Z4CVqJH8ZBL1FTEiY=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15 h1:2SdcMUYJGmIIXovxUPf2Cc5KiQ9cDZ7QdyvUE+GQdOk=
-github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250527212035-5d0564786d15/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0 h1:8MzS0sEc25WetSuK3o6MgSd96btzC0sHHBHZ0+lNG0M=
+github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250625205318-1a395ebc77f0/go.mod h1:Aou/EtRmWMX1igyns+E3lL8luir6dZyJMFm/iQ1a2eA=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.9 h1:2X5TEyJZaBi6KrvfrHuFeC01Rl1A2DL4pQgF5Vzf5z4=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.9/go.mod h1:q99H9vcMJDs6T+zsSI8XJZd6PUkZnyG3iaRbrYNUCTk=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7 h1:ANltXlvv6CbOXieasPD9erc4BewtCHm1tKDPAYvuWLw=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1436,8 +1436,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447 h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250604171518-c6a8d7f44447/go.mod h1:jPS9p770KnuAZLI2EPKQQMo6iiY8YNo/DtjD8Tn7CpI=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a h1:Kmwnke40wlyyVLZWbdOtSRma52lYj9g/cAUE2KQt8DM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250610112507-2a6e86a83c4a/go.mod h1:uhUQUnJA5DkBtJ/0SuBJwD+DuwiK+kRBTyz9IlSY1k0=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d h1:o9kboR/9z6lOCaJCEoLvlkypkVZR+XKSQ6EgziJwxl8=
+github.com/smartcontractkit/chainlink-ccip v0.0.0-20250620114601-01401c69258d/go.mod h1:Yw7X+vtR7A9MBI+q5b0k/H2PlKy6cQOa7vAp4cshz2s=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a h1:BVhdDkwltth3sw9MeFS3ItQlyPat8M4NUwp86QX2j9U=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250603190644-0dcaa6d2cc86 h1:tXXegjGJJDewy1PJniL0PKb8cQBlLJZ2HboG88eusSw=


### PR DESCRIPTION
As PR title says, changes that were added after we made the `2.25.1-ccip` branch from `2.25.0-ccip` 