### PR TITLE
fix: client timeout discover by cre env

### DIFF
--- a/deployment/environment/devenv/don.go
+++ b/deployment/environment/devenv/don.go
@@ -130,7 +130,7 @@ func NewRegisteredDON(ctx context.Context, nodeInfo []NodeInfo, jd JobDistributo
 		if info.Name == "" {
 			info.Name = fmt.Sprintf("node-%d", i)
 		}
-		node, err := NewNode(info)
+		node, err := NewNodeWithContext(ctx, info)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create node %d: %w", i, err)
 		}
@@ -176,8 +176,13 @@ func NewRegisteredDON(ctx context.Context, nodeInfo []NodeInfo, jd JobDistributo
 	return don, nil
 }
 
+// Deprecated: use NewNodeWithContext
 func NewNode(nodeInfo NodeInfo) (*Node, error) {
-	gqlClient, err := client.New(nodeInfo.CLConfig.URL, client.Credentials{
+	return NewNodeWithContext(context.Background(), nodeInfo)
+}
+
+func NewNodeWithContext(ctx context.Context, nodeInfo NodeInfo) (*Node, error) {
+	gqlClient, err := client.NewWithContext(ctx, nodeInfo.CLConfig.URL, client.Credentials{
 		Email:    nodeInfo.CLConfig.Email,
 		Password: nodeInfo.CLConfig.Password,
 	})


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
Context propagation is shortcut, which causes spurious, flakey errors in the cre local env since the caller can't control it.
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
