### PR TITLE
feat(deployment): Integrate Aptos to curse/uncurse CS

### DIFF
--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -244,6 +244,17 @@ runner-test-matrix:
     test_cmd: go test smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go -run "^TestRMNCurse$" -timeout 20m -test.parallel=4 -count=1 -json
     test_go_project_path: integration-tests
 
+  - id: smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go:TestRMNCurseUncurseAptos
+    path: integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+    test_env_type: in-memory
+    runs_on: ubuntu-latest
+    runs_on_self_hosted: runs-on/cpu=8/ram=32/family=m6i/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    triggers:
+      - PR Integration CCIP Tests
+      - Nightly Integration CCIP Tests
+    test_cmd: go test smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go -run "^TestRMNCurseUncurseAptos$" -timeout 20m -test.parallel=4 -count=1 -json
+    test_go_project_path: integration-tests
+
   - id: smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go:TestRMNCurseMCMS
     path: integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
     test_env_type: in-memory

--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -254,6 +254,7 @@ runner-test-matrix:
       - Nightly Integration CCIP Tests
     test_cmd: go test smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go -run "^TestRMNCurseUncurseAptos$" -timeout 20m -test.parallel=4 -count=1 -json
     test_go_project_path: integration-tests
+    aptos_cli_version: 7.2.0
 
   - id: smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go:TestRMNCurseMCMS
     path: integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -187,7 +187,6 @@ jobs:
             os: ${{ needs.runner-config.outputs.core-tests-integration-runner }}
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
             setup-solana: "true"
-            setup-aptos: "true"
 
           - cmd: go_core_fuzz
             os: ${{ needs.runner-config.outputs.core-fuzz-tests-runner }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -187,6 +187,7 @@ jobs:
             os: ${{ needs.runner-config.outputs.core-tests-integration-runner }}
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
             setup-solana: "true"
+            setup-aptos: "true"
 
           - cmd: go_core_fuzz
             os: ${{ needs.runner-config.outputs.core-fuzz-tests-runner }}

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -73,10 +73,6 @@ func (c RMNCurseConfig) Validate(e cldf.Environment) error {
 		return err
 	}
 
-	if err != nil {
-		return fmt.Errorf("failed to load onchain state: %w", err)
-	}
-
 	if len(c.CurseActions) == 0 {
 		return errors.New("curse actions are required")
 	}
@@ -946,18 +942,50 @@ func (c EvmCursableChain) Uncurse(deployerGroup *deployergroup.DeployerGroup, su
 }
 
 type AptosCursableChain struct {
-	selector uint64
-	env      cldf.Environment
-	chain    aptosstateview.CCIPChainState
-	MCMSOp   mcmstypes.BatchOperation
+	selector            uint64
+	env                 cldf.Environment
+	chain               aptosstateview.CCIPChainState
+	MCMSOp              mcmstypes.BatchOperation
+	cursedSubjectsCache map[globals.Subject]struct{}
 }
 
 func (c AptosCursableChain) IsSubjectCursed(subject globals.Subject) (bool, error) {
-	chain := c.env.BlockChains.AptosChains()[c.selector]
-	ccipBind := aptosCCIP.Bind(c.chain.CCIPAddress, chain.Client)
-	return ccipBind.RMNRemote().IsCursed(nil, subject[:])
+	err := c.cacheCurses()
+	if err != nil {
+		return false, fmt.Errorf("failed to cache curses for chain %d: %w", c.selector, err)
+	}
+	_, cursed := c.cursedSubjectsCache[subject]
+	return cursed, nil
 }
 
+func (c *AptosCursableChain) IsCursed(subject globals.Subject) (bool, error) {
+	err := c.cacheCurses()
+	if err != nil {
+		return false, fmt.Errorf("failed to cache curses for chain %d: %w", c.selector, err)
+	}
+	if _, isGloballyCursed := c.cursedSubjectsCache[globals.GlobalCurseSubject()]; isGloballyCursed {
+		return true, nil
+	}
+	_, isCursed := c.cursedSubjectsCache[subject]
+	return isCursed, nil
+}
+
+func (c *AptosCursableChain) cacheCurses() error {
+	if c.cursedSubjectsCache != nil {
+		return nil
+	}
+	c.cursedSubjectsCache = make(map[globals.Subject]struct{})
+	chain := c.env.BlockChains.AptosChains()[c.selector]
+	ccipBind := aptosCCIP.Bind(c.chain.CCIPAddress, chain.Client)
+	cursedSubjects, err := ccipBind.RMNRemote().GetCursedSubjects(nil)
+	if err != nil {
+		return fmt.Errorf("failed to get cursed subjects for chain %d: %w", c.selector, err)
+	}
+	for _, subj := range cursedSubjects {
+		c.cursedSubjectsCache[globals.Subject(subj)] = struct{}{}
+	}
+	return nil
+}
 func (c *AptosCursableChain) Curse(deployerGroup *deployergroup.DeployerGroup, subjects []globals.Subject) error {
 	err := assertEndianness(subjects, chain_selectors.FamilyAptos)
 	if err != nil {
@@ -1098,7 +1126,7 @@ func assertEndianness(subjects []globals.Subject, family string) error {
 				return fmt.Errorf("endianness incorrect for Solana curse subject: %s", subject)
 			}
 		default:
-			// EVM uses big endian to encode the subject so we expect the first 8 bytes to be 0
+			// EVM and Aptos uses big endian to encode the subject so we expect the first 8 bytes to be 0
 			if !bytes.Equal(subject[:8], []byte{0, 0, 0, 0, 0, 0, 0, 0}) {
 				return fmt.Errorf("endianness incorrect for curse subject: %s", subject)
 			}

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -375,7 +375,8 @@ func RMNCurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.ChangesetOu
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	deployerGroup := deployergroup.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("proposal to curse RMNs: " + cfg.Reason)
+	description := "proposal to curse RMNs: " + cfg.Reason
+	deployerGroup := deployergroup.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext(description)
 
 	// Generate curse actions
 	var curseActions []RMNCurseAction
@@ -440,9 +441,8 @@ func RMNCurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.ChangesetOu
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to check family for chain %d: %w", selector, err)
 			}
 			if family == chain_selectors.FamilyAptos {
-				aptosChain := e.BlockChains.AptosChains()[selector]
 				proposal, err := aptosUtils.GenerateProposal(
-					aptosChain.Client,
+					e,
 					state.AptosChains[selector].MCMSAddress,
 					selector,
 					[]mcmstypes.BatchOperation{chain.(*AptosCursableChain).MCMSOp},
@@ -464,10 +464,30 @@ func RMNCurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.ChangesetOu
 	if len(aptosProposals) == 0 {
 		return partialOut, nil
 	}
+	// TODO: can't have Aptos curse/uncurse without MCMS, validate this
 	if len(partialOut.MCMSTimelockProposals) != 1 && cfg.MCMS != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("expected exactly one MCMS proposal, got %d", len(partialOut.MCMSTimelockProposals))
 	}
-	proposalutils.AggregateProposals()
+	proposals := partialOut.MCMSTimelockProposals
+	proposals = append(proposals, aptosProposals...)
+	aggProposal, err := proposalutils.AggregateProposalsV2(
+		e,
+		proposalutils.MCMSStates{
+			MCMSEVMState:    state.EVMMCMSStateByChain(),
+			MCMSSolanaState: state.SolanaMCMSStateByChain(e),
+			MCMSAptosState:  state.AptosMCMSStateByChain(),
+		},
+		proposals,
+		description,
+		cfg.MCMS,
+	)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to aggregate MCMS proposals: %w", err)
+	}
+	return cldf.ChangesetOutput{
+		MCMSTimelockProposals:      []mcms.TimelockProposal{*aggProposal},
+		DescribedTimelockProposals: []string{}, // TODO: figure this out
+	}, nil
 }
 
 // RMNUncurseChangeset creates a new changeset for uncursing chains or lanes on RMNRemote contracts.

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -435,7 +435,7 @@ func RMNCurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.ChangesetOu
 			}
 			e.Logger.Infof("Cursed chain %d with subjects %v", selector, notAlreadyCursedSubjects)
 
-			// Aptos have no deployerGroup implementation, collecting MCMS operations separately
+			// Aptos has no deployerGroup implementation, collecting MCMS operations separately
 			family, err := chain_selectors.GetSelectorFamily(selector)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to check family for chain %d: %w", selector, err)
@@ -517,7 +517,8 @@ func RMNUncurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.Changeset
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	deployerGroup := deployergroup.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext("proposal to uncurse RMNs: " + cfg.Reason)
+	description := "proposal to curse RMNs: " + cfg.Reason
+	deployerGroup := deployergroup.NewDeployerGroup(e, state, cfg.MCMS).WithDeploymentContext(description)
 
 	// Generate curse actions
 	var curseActions []RMNCurseAction
@@ -540,6 +541,7 @@ func RMNUncurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.Changeset
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get cursable chains: %w", err)
 	}
+	var aptosProposals []mcms.TimelockProposal
 	for selector, chain := range cursableChains {
 		if curseSubjects, ok := grouped[selector]; ok {
 			// Only keep the subject that are actually cursed
@@ -567,10 +569,60 @@ func RMNUncurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.Changeset
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to uncurse chain %d: %w", selector, err)
 			}
 			e.Logger.Infof("Uncursed chain %d with subjects %v", selector, actuallyCursedSubjects)
+
+			// Aptos has no deployerGroup implementation, collecting MCMS operations separately
+			family, err := chain_selectors.GetSelectorFamily(selector)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to check family for chain %d: %w", selector, err)
+			}
+			if family == chain_selectors.FamilyAptos {
+				proposal, err := aptosUtils.GenerateProposal(
+					e,
+					state.AptosChains[selector].MCMSAddress,
+					selector,
+					[]mcmstypes.BatchOperation{chain.(*AptosCursableChain).MCMSOp},
+					cfg.Reason,
+					*cfg.MCMS,
+				)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate MCMS proposal for Aptos chain %d: %w", selector, err)
+				}
+				aptosProposals = append(aptosProposals, *proposal)
+			}
 		}
 	}
 
-	return deployerGroup.Enact()
+	partialOut, err := deployerGroup.Enact()
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to enact deployer group: %w", err)
+	}
+	if len(aptosProposals) == 0 {
+		return partialOut, nil
+	}
+	// TODO: can't have Aptos curse/uncurse without MCMS, validate this
+	if len(partialOut.MCMSTimelockProposals) != 1 && cfg.MCMS != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("expected exactly one MCMS proposal, got %d", len(partialOut.MCMSTimelockProposals))
+	}
+	proposals := partialOut.MCMSTimelockProposals
+	proposals = append(proposals, aptosProposals...)
+	aggProposal, err := proposalutils.AggregateProposalsV2(
+		e,
+		proposalutils.MCMSStates{
+			MCMSEVMState:    state.EVMMCMSStateByChain(),
+			MCMSSolanaState: state.SolanaMCMSStateByChain(e),
+			MCMSAptosState:  state.AptosMCMSStateByChain(),
+		},
+		proposals,
+		description,
+		cfg.MCMS,
+	)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to aggregate MCMS proposals: %w", err)
+	}
+	return cldf.ChangesetOutput{
+		MCMSTimelockProposals:      []mcms.TimelockProposal{*aggProposal},
+		DescribedTimelockProposals: []string{}, // TODO: figure this out
+	}, nil
 }
 
 type CursableChain interface {
@@ -922,6 +974,9 @@ func (c *AptosCursableChain) Curse(deployerGroup *deployergroup.DeployerGroup, s
 		CCIPAddress: c.chain.CCIPAddress,
 	}
 	report, err := operations.ExecuteOperation(c.env.OperationsBundle, aptos_ops.CurseMultipleOp, chain, in)
+	if err != nil {
+		return fmt.Errorf("failed to execute curse operation on Aptos chain %d: %w", c.selector, err)
+	}
 	c.MCMSOp = mcmstypes.BatchOperation{
 		ChainSelector: mcmstypes.ChainSelector(c.selector),
 		Transactions:  []mcmstypes.Transaction{report.Output},
@@ -946,6 +1001,9 @@ func (c *AptosCursableChain) Uncurse(deployerGroup *deployergroup.DeployerGroup,
 		CCIPAddress: c.chain.CCIPAddress,
 	}
 	report, err := operations.ExecuteOperation(c.env.OperationsBundle, aptos_ops.UncurseMultipleOp, chain, in)
+	if err != nil {
+		return fmt.Errorf("failed to execute curse operation on Aptos chain %d: %w", c.selector, err)
+	}
 	c.MCMSOp = mcmstypes.BatchOperation{
 		ChainSelector: mcmstypes.ChainSelector(c.selector),
 		Transactions:  []mcmstypes.Transaction{report.Output},

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -1076,10 +1076,13 @@ func GetCursableChains(env cldf.Environment) (map[uint64]CursableChain, error) {
 }
 
 func GetAllCursableChainsSelector(env cldf.Environment) []uint64 {
+	// This function has to list family by family to guarantee order for tests
 	selectors := make([]uint64, 0)
 	selectors = append(selectors, env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))...)
 	solSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))
 	selectors = append(selectors, solSelectors...)
+	aptosSelectors := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyAptos))
+	selectors = append(selectors, aptosSelectors...)
 	return selectors
 }
 

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -155,7 +155,7 @@ func (c RMNCurseConfig) Validate(e cldf.Environment) error {
 					return fmt.Errorf("chain %s not found in onchain state", targetChain.String())
 				}
 
-				if c.MCMS != nil {
+				if c.MCMS == nil {
 					return errors.New("mcms configs are required for aptos chains")
 				}
 			}

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -89,9 +89,14 @@ func (c RMNCurseConfig) Validate(e cldf.Environment) error {
 		globals.GlobalCurseSubject(): {},
 	}
 
+	validAptosSubjects := map[globals.Subject]struct{}{
+		globals.GlobalCurseSubject(): {},
+	}
+
 	for _, selector := range GetAllCursableChainsSelector(e) {
 		validEVMSubjects[globals.FamilyAwareSelectorToSubject(selector, chain_selectors.FamilyEVM)] = struct{}{}
 		validSolanaSubjects[globals.FamilyAwareSelectorToSubject(selector, chain_selectors.FamilySolana)] = struct{}{}
+		validAptosSubjects[globals.FamilyAwareSelectorToSubject(selector, chain_selectors.FamilyAptos)] = struct{}{}
 	}
 
 	for _, curseAction := range c.CurseActions {
@@ -138,6 +143,20 @@ func (c RMNCurseConfig) Validate(e cldf.Environment) error {
 				}
 				if err := solanastateview.ValidateOwnershipSolana(&e, targetChain, c.MCMS != nil, targetChainState.RMNRemote, shared.RMNRemote, solana.PublicKey{}); err != nil {
 					return fmt.Errorf("chain %s: %w", targetChain.String(), err)
+				}
+			case chain_selectors.FamilyAptos:
+				if _, ok := validAptosSubjects[action.SubjectToCurse]; !ok {
+					return fmt.Errorf("invalid subject %x", action.SubjectToCurse)
+				}
+
+				targetChain := e.BlockChains.AptosChains()[action.ChainSelector]
+				_, ok := state.AptosChains[action.ChainSelector]
+				if !ok {
+					return fmt.Errorf("chain %s not found in onchain state", targetChain.String())
+				}
+
+				if c.MCMS != nil {
+					return errors.New("mcms configs are required for aptos chains")
 				}
 			}
 		}
@@ -460,7 +479,7 @@ func RMNCurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.ChangesetOu
 	if len(aptosProposals) == 0 {
 		return partialOut, nil
 	}
-	// TODO: can't have Aptos curse/uncurse without MCMS, validate this
+	// can't have Aptos curse/uncurse without MCMS
 	if len(partialOut.MCMSTimelockProposals) != 1 && cfg.MCMS != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("expected exactly one MCMS proposal, got %d", len(partialOut.MCMSTimelockProposals))
 	}
@@ -481,8 +500,7 @@ func RMNCurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.ChangesetOu
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to aggregate MCMS proposals: %w", err)
 	}
 	return cldf.ChangesetOutput{
-		MCMSTimelockProposals:      []mcms.TimelockProposal{*aggProposal},
-		DescribedTimelockProposals: []string{}, // TODO: figure this out
+		MCMSTimelockProposals: []mcms.TimelockProposal{*aggProposal},
 	}, nil
 }
 
@@ -595,7 +613,7 @@ func RMNUncurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.Changeset
 	if len(aptosProposals) == 0 {
 		return partialOut, nil
 	}
-	// TODO: can't have Aptos curse/uncurse without MCMS, validate this
+	// can't have Aptos curse/uncurse without MCMS
 	if len(partialOut.MCMSTimelockProposals) != 1 && cfg.MCMS != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("expected exactly one MCMS proposal, got %d", len(partialOut.MCMSTimelockProposals))
 	}
@@ -616,8 +634,7 @@ func RMNUncurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.Changeset
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to aggregate MCMS proposals: %w", err)
 	}
 	return cldf.ChangesetOutput{
-		MCMSTimelockProposals:      []mcms.TimelockProposal{*aggProposal},
-		DescribedTimelockProposals: []string{}, // TODO: figure this out
+		MCMSTimelockProposals: []mcms.TimelockProposal{*aggProposal},
 	}, nil
 }
 

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -7,25 +7,30 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/mcms"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
+	aptosCCIP "github.com/smartcontractkit/chainlink-aptos/bindings/ccip"
+	aptosOffRamp "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_offramp"
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
 	solRmnRemote "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/rmn_remote"
-	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
-
+	solState "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	aptosUtils "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/utils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
+	aptos_ops "github.com/smartcontractkit/chainlink/deployment/ccip/operation/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/deployergroup"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	aptosstateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/evm"
 	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
 	commoncs "github.com/smartcontractkit/chainlink/deployment/common/changeset"
@@ -400,6 +405,7 @@ func RMNCurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.ChangesetOu
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get cursable chains: %w", err)
 	}
+	var aptosProposals []mcms.TimelockProposal
 	for selector, chain := range cursableChains {
 		if curseSubjects, ok := grouped[selector]; ok {
 			// Only curse the subjects that are not actually cursed
@@ -427,10 +433,41 @@ func RMNCurseChangeset(e cldf.Environment, cfg RMNCurseConfig) (cldf.ChangesetOu
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to curse chain %d: %w", selector, err)
 			}
 			e.Logger.Infof("Cursed chain %d with subjects %v", selector, notAlreadyCursedSubjects)
+
+			// Aptos have no deployerGroup implementation, collecting MCMS operations separately
+			family, err := chain_selectors.GetSelectorFamily(selector)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to check family for chain %d: %w", selector, err)
+			}
+			if family == chain_selectors.FamilyAptos {
+				aptosChain := e.BlockChains.AptosChains()[selector]
+				proposal, err := aptosUtils.GenerateProposal(
+					aptosChain.Client,
+					state.AptosChains[selector].MCMSAddress,
+					selector,
+					[]mcmstypes.BatchOperation{chain.(*AptosCursableChain).MCMSOp},
+					cfg.Reason,
+					*cfg.MCMS,
+				)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate MCMS proposal for Aptos chain %d: %w", selector, err)
+				}
+				aptosProposals = append(aptosProposals, *proposal)
+			}
 		}
 	}
 
-	return deployerGroup.Enact()
+	partialOut, err := deployerGroup.Enact()
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to enact deployer group: %w", err)
+	}
+	if len(aptosProposals) == 0 {
+		return partialOut, nil
+	}
+	if len(partialOut.MCMSTimelockProposals) != 1 && cfg.MCMS != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("expected exactly one MCMS proposal, got %d", len(partialOut.MCMSTimelockProposals))
+	}
+	proposalutils.AggregateProposals()
 }
 
 // RMNUncurseChangeset creates a new changeset for uncursing chains or lanes on RMNRemote contracts.
@@ -836,6 +873,86 @@ func (c EvmCursableChain) Uncurse(deployerGroup *deployergroup.DeployerGroup, su
 	return nil
 }
 
+type AptosCursableChain struct {
+	selector uint64
+	env      cldf.Environment
+	chain    aptosstateview.CCIPChainState
+	MCMSOp   mcmstypes.BatchOperation
+}
+
+func (c AptosCursableChain) IsSubjectCursed(subject globals.Subject) (bool, error) {
+	chain := c.env.BlockChains.AptosChains()[c.selector]
+	ccipBind := aptosCCIP.Bind(c.chain.CCIPAddress, chain.Client)
+	return ccipBind.RMNRemote().IsCursed(nil, subject[:])
+}
+
+func (c *AptosCursableChain) Curse(deployerGroup *deployergroup.DeployerGroup, subjects []globals.Subject) error {
+	err := assertEndianness(subjects, chain_selectors.FamilyAptos)
+	if err != nil {
+		return fmt.Errorf("failed to assert subject endianness: %w", err)
+	}
+
+	chain := c.env.BlockChains.AptosChains()[c.selector]
+	subjectBytes := make([][]byte, len(subjects))
+	for i, subject := range subjects {
+		subjectBytes[i] = subject[:]
+	}
+	in := aptos_ops.CurseMultipleInput{
+		Subjects:    subjectBytes,
+		CCIPAddress: c.chain.CCIPAddress,
+	}
+	report, err := operations.ExecuteOperation(c.env.OperationsBundle, aptos_ops.CurseMultipleOp, chain, in)
+	c.MCMSOp = mcmstypes.BatchOperation{
+		ChainSelector: mcmstypes.ChainSelector(c.selector),
+		Transactions:  []mcmstypes.Transaction{report.Output},
+	}
+
+	return nil
+}
+
+func (c *AptosCursableChain) Uncurse(deployerGroup *deployergroup.DeployerGroup, subjects []globals.Subject) error {
+	err := assertEndianness(subjects, chain_selectors.FamilyAptos)
+	if err != nil {
+		return fmt.Errorf("failed to assert subject endianness: %w", err)
+	}
+
+	chain := c.env.BlockChains.AptosChains()[c.selector]
+	subjectBytes := make([][]byte, len(subjects))
+	for i, subject := range subjects {
+		subjectBytes[i] = subject[:]
+	}
+	in := aptos_ops.UncurseMultipleInput{
+		Subjects:    subjectBytes,
+		CCIPAddress: c.chain.CCIPAddress,
+	}
+	report, err := operations.ExecuteOperation(c.env.OperationsBundle, aptos_ops.UncurseMultipleOp, chain, in)
+	c.MCMSOp = mcmstypes.BatchOperation{
+		ChainSelector: mcmstypes.ChainSelector(c.selector),
+		Transactions:  []mcmstypes.Transaction{report.Output},
+	}
+
+	return nil
+}
+
+func (c AptosCursableChain) IsCursable() (bool, error) {
+	return c.chain.CCIPAddress != aptos.AccountAddress{}, nil
+}
+
+func (c AptosCursableChain) IsConnectedToSourceChain(selector uint64) (bool, error) {
+	chain := c.env.BlockChains.AptosChains()[c.selector]
+	offRampBind := aptosOffRamp.Bind(c.chain.CCIPAddress, chain.Client)
+	cfg, err := offRampBind.Offramp().GetSourceChainConfig(nil, selector)
+	if err != nil {
+		return false, fmt.Errorf("failed to GetSourceChainConfig for %d: %w", selector, err)
+	}
+
+	return cfg.IsEnabled, nil
+}
+
+func (c AptosCursableChain) Name() string {
+	return c.env.BlockChains.AptosChains()[c.selector].Name()
+}
+
 func GetCursableChains(env cldf.Environment) (map[uint64]CursableChain, error) {
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
@@ -852,6 +969,14 @@ func GetCursableChains(env cldf.Environment) (map[uint64]CursableChain, error) {
 
 	for selector, chain := range state.SolChains {
 		cursableChains[selector] = SolanaCursableChain{
+			selector: selector,
+			chain:    chain,
+			env:      env,
+		}
+	}
+
+	for selector, chain := range state.AptosChains {
+		cursableChains[selector] = &AptosCursableChain{
 			selector: selector,
 			chain:    chain,
 			env:      env,

--- a/deployment/ccip/operation/aptos/rmn.go
+++ b/deployment/ccip/operation/aptos/rmn.go
@@ -1,0 +1,80 @@
+package aptos
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/aptos-labs/aptos-go-sdk"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/ccip"
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/utils"
+)
+
+// CurseMultipleInput is the input for cursing multiple subjects
+type CurseMultipleInput struct {
+	CCIPAddress aptos.AccountAddress
+	Subjects    [][]byte
+}
+
+// OP: CurseMultipleOp generates MCMS transaction to curse multiple subjects
+var CurseMultipleOp = operations.NewOperation(
+	"curse-multiple-op",
+	semver.MustParse("1.0.0"),
+	"Generates MCMS transaction to curse multiple subjects on RMN Remote",
+	curseMultiple,
+)
+
+func curseMultiple(b operations.Bundle, aptosChain cldf_aptos.Chain, in CurseMultipleInput) (mcmstypes.Transaction, error) {
+	// Bind CCIP Package
+	ccipBind := ccip.Bind(in.CCIPAddress, aptosChain.Client)
+
+	// Encode curse multiple operation
+	moduleInfo, function, _, args, err := ccipBind.RMNRemote().Encoder().CurseMultiple(in.Subjects)
+	if err != nil {
+		return mcmstypes.Transaction{}, fmt.Errorf("failed to encode CurseMultiple: %w", err)
+	}
+
+	// Generate MCMS transaction
+	tx, err := utils.GenerateMCMSTx(in.CCIPAddress, moduleInfo, function, args)
+	if err != nil {
+		return mcmstypes.Transaction{}, fmt.Errorf("failed to generate MCMS transaction: %w", err)
+	}
+
+	return tx, nil
+}
+
+// UncurseMultipleInput is the input for uncursing multiple subjects
+type UncurseMultipleInput struct {
+	CCIPAddress aptos.AccountAddress
+	Subjects    [][]byte
+}
+
+// OP: UncurseMultipleOp generates MCMS transaction to uncurse multiple subjects
+var UncurseMultipleOp = operations.NewOperation(
+	"uncurse-multiple-op",
+	semver.MustParse("1.0.0"),
+	"Generates MCMS transaction to uncurse multiple subjects on RMN Remote",
+	uncurseMultiple,
+)
+
+func uncurseMultiple(b operations.Bundle, aptosChain cldf_aptos.Chain, in UncurseMultipleInput) (mcmstypes.Transaction, error) {
+	// Bind CCIP Package
+	ccipBind := ccip.Bind(in.CCIPAddress, aptosChain.Client)
+
+	// Encode uncurse multiple operation
+	moduleInfo, function, _, args, err := ccipBind.RMNRemote().Encoder().UncurseMultiple(in.Subjects)
+	if err != nil {
+		return mcmstypes.Transaction{}, fmt.Errorf("failed to encode UncurseMultiple: %w", err)
+	}
+
+	// Generate MCMS transaction
+	tx, err := utils.GenerateMCMSTx(in.CCIPAddress, moduleInfo, function, args)
+	if err != nil {
+		return mcmstypes.Transaction{}, fmt.Errorf("failed to generate MCMS transaction: %w", err)
+	}
+
+	return tx, nil
+}

--- a/deployment/ccip/shared/stateview/state.go
+++ b/deployment/ccip/shared/stateview/state.go
@@ -266,6 +266,14 @@ func (c CCIPOnChainState) SolanaMCMSStateByChain(e cldf.Environment) map[uint64]
 	return mcmsStateByChain
 }
 
+func (c CCIPOnChainState) AptosMCMSStateByChain() map[uint64]aptos.AccountAddress {
+	mcmsByChain := make(map[uint64]aptos.AccountAddress)
+	for chainSelector, state := range c.AptosChains {
+		mcmsByChain[chainSelector] = state.MCMSAddress
+	}
+	return mcmsByChain
+}
+
 func (c CCIPOnChainState) OffRampPermissionLessExecutionThresholdSeconds(ctx context.Context, env cldf.Environment, selector uint64) (uint32, error) {
 	family, err := chain_selectors.GetSelectorFamily(selector)
 	if err != nil {

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -1,6 +1,7 @@
 package ccip
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -26,10 +27,9 @@ import (
 )
 
 const (
-	Evm1   = iota // 0
-	Evm2          // 1
-	Sol1          // 2
-	Aptos1        // 3
+	Evm1 = iota // 0
+	Evm2        // 1
+	Sol1        // 2
 )
 
 type curseAssertion struct {
@@ -495,7 +495,8 @@ func TestRMNCurseOneConnectedLanesSolana(t *testing.T) {
 // TestRMNCurseUncurseAptos runs separately because setting up Aptos chain is slow
 // and can't be done on every test run.
 func TestRMNCurseUncurseAptos(t *testing.T) {
-	testCases := []CurseTestCase{
+	Aptos1 := uint64(2)
+	tcs := []CurseTestCase{
 		{
 			name: "curse global Aptos and EVM1",
 			curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
@@ -506,20 +507,13 @@ func TestRMNCurseUncurseAptos(t *testing.T) {
 			},
 			curseAssertions: []curseAssertion{
 				{chainID: Evm1, globalCurse: true, cursed: true},
-				{chainID: Sol1, globalCurse: true, cursed: false},
 				{chainID: Aptos1, globalCurse: true, cursed: true},
 				{chainID: Evm1, subject: Evm2, cursed: true},
-				{chainID: Evm1, subject: Sol1, cursed: true},
 				{chainID: Evm1, subject: Aptos1, cursed: true},
 				{chainID: Evm2, subject: Evm1, cursed: true},
-				{chainID: Evm2, subject: Sol1, cursed: false},
 				{chainID: Evm2, subject: Aptos1, cursed: true},
-				{chainID: Sol1, subject: Evm1, cursed: true},
-				{chainID: Sol1, subject: Evm2, cursed: false},
-				{chainID: Sol1, subject: Aptos1, cursed: true},
 				{chainID: Aptos1, subject: Evm1, cursed: true},
 				{chainID: Aptos1, subject: Evm2, cursed: true},
-				{chainID: Aptos1, subject: Sol1, cursed: true},
 			},
 		},
 		{
@@ -541,14 +535,13 @@ func TestRMNCurseUncurseAptos(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			e, _ := testhelpers.NewMemoryEnvironment(
 				t,
 				testhelpers.WithNumOfChains(2),
-				testhelpers.WithSolChains(1),
 				testhelpers.WithAptosChains(1),
 			)
 
@@ -593,6 +586,7 @@ func TestRMNCurseUncurseAptos(t *testing.T) {
 			require.NoError(t, err)
 
 			verifyNoActiveCurseOnAllChains(t, &e)
+			fmt.Println("finished test case:", tc.name)
 		})
 	}
 }

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	Evm1 = uint64(0)
-	Evm2 = uint64(1)
-	Sol1 = uint64(2)
+	Evm1   = iota // 0
+	Evm2          // 1
+	Sol1          // 2
+	Aptos1        // 3
 )
 
 type curseAssertion struct {
@@ -482,6 +483,85 @@ func TestRMNCurseOneConnectedLanesSolana(t *testing.T) {
 			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	}, mapIDToSelector)
+}
+
+func TestRMNCurseUncurseAptos(t *testing.T) {
+	e, _ := testhelpers.NewMemoryEnvironment(
+		t,
+		testhelpers.WithNumOfChains(2),
+		testhelpers.WithSolChains(1),
+		// testhelpers.WithAptosChains(1),
+	)
+
+	mapIDToSelector := func(id uint64) uint64 {
+		return v1_6.GetAllCursableChainsSelector(e.Env)[id]
+	}
+
+	config := v1_6.RMNCurseConfig{
+		CurseActions: []v1_6.CurseAction{
+			v1_6.CurseChain(mapIDToSelector(Evm1)),
+			v1_6.CurseChain(mapIDToSelector(Sol1)),
+			// v1_6.CurseChain(mapIDToSelector(Aptos1)),
+		},
+		Reason:                   "test curse",
+		IncludeNotConnectedLanes: true,
+		MCMS: &proposalutils.TimelockConfig{
+			MinDelay:   1 * time.Second,
+			MCMSAction: types.TimelockActionSchedule,
+		},
+	}
+
+	// tc := CurseTestCase{
+	// 	curseAssertions: []curseAssertion{
+	// 		{chainID: Evm1, globalCurse: true, cursed: true},
+	// 		{chainID: Aptos1, globalCurse: true, cursed: true},
+	// 		{chainID: Evm1, subject: Evm2, cursed: true},
+	// 		{chainID: Evm1, subject: Sol1, cursed: true},
+	// 		{chainID: Evm2, subject: Evm1, cursed: false},
+	// 		{chainID: Evm2, subject: Sol1, cursed: false},
+	// 		{chainID: Sol1, subject: Evm1, cursed: true},
+	// 		{chainID: Sol1, subject: Evm2, cursed: false},
+	// 	},
+	// }
+
+	_, err := ccipChangesetSolana.AddRemoteChainToOffRamp(e.Env, ccipChangesetSolana.AddRemoteChainToOffRampConfig{
+		ChainSelector: mapIDToSelector(Sol1),
+		UpdatesByChain: map[uint64]*ccipChangesetSolana.OffRampConfig{
+			mapIDToSelector(Evm1): {
+				EnabledAsSource: true,
+				IsUpdate:        false,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	verifyNoActiveCurseOnAllChains(t, &e)
+
+	state, err := stateview.LoadOnchainState(e.Env)
+	require.NoError(t, err)
+	transferRMNContractToMCMS(t, &e, state)
+
+	_, _, err = commonchangeset.ApplyChangesets(t, e.Env,
+		[]commonchangeset.ConfiguredChangeSet{
+			commonchangeset.Configure(
+				cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset),
+				config,
+			)},
+	)
+	require.NoError(t, err)
+
+	// verifyTestCaseAssertions(t, &e, tc, mapIDToSelector)
+
+	_, _, err = commonchangeset.ApplyChangesets(t, e.Env,
+		[]commonchangeset.ConfiguredChangeSet{
+			commonchangeset.Configure(
+				cldf.CreateLegacyChangeSet(v1_6.RMNUncurseChangeset),
+				config,
+			)},
+	)
+	require.NoError(t, err)
+
+	verifyNoActiveCurseOnAllChains(t, &e)
 }
 
 func runRmnUncurseTest(t *testing.T, tc CurseTestCase) {

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -180,7 +180,14 @@ var testCases = []CurseTestCase{
 				v1_6.CurseChain(mapIDToSelector(Sol1)),
 			}
 		},
-		curseAssertions: []curseAssertion{},
+		curseAssertions: []curseAssertion{
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Sol1, globalCurse: true, cursed: true},
+			{chainID: Evm1, subject: Evm2, cursed: true},
+			{chainID: Evm1, subject: Sol1, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: true},
+			{chainID: Evm2, subject: Sol1, cursed: true},
+		},
 	},
 }
 
@@ -485,83 +492,109 @@ func TestRMNCurseOneConnectedLanesSolana(t *testing.T) {
 	}, mapIDToSelector)
 }
 
+// TestRMNCurseUncurseAptos runs separately because setting up Aptos chain is slow
+// and can't be done on every test run.
 func TestRMNCurseUncurseAptos(t *testing.T) {
-	e, _ := testhelpers.NewMemoryEnvironment(
-		t,
-		testhelpers.WithNumOfChains(2),
-		testhelpers.WithSolChains(1),
-		// testhelpers.WithAptosChains(1),
-	)
-
-	mapIDToSelector := func(id uint64) uint64 {
-		return v1_6.GetAllCursableChainsSelector(e.Env)[id]
-	}
-
-	config := v1_6.RMNCurseConfig{
-		CurseActions: []v1_6.CurseAction{
-			v1_6.CurseChain(mapIDToSelector(Evm1)),
-			v1_6.CurseChain(mapIDToSelector(Sol1)),
-			// v1_6.CurseChain(mapIDToSelector(Aptos1)),
-		},
-		Reason:                   "test curse",
-		IncludeNotConnectedLanes: true,
-		MCMS: &proposalutils.TimelockConfig{
-			MinDelay:   1 * time.Second,
-			MCMSAction: types.TimelockActionSchedule,
-		},
-	}
-
-	// tc := CurseTestCase{
-	// 	curseAssertions: []curseAssertion{
-	// 		{chainID: Evm1, globalCurse: true, cursed: true},
-	// 		{chainID: Aptos1, globalCurse: true, cursed: true},
-	// 		{chainID: Evm1, subject: Evm2, cursed: true},
-	// 		{chainID: Evm1, subject: Sol1, cursed: true},
-	// 		{chainID: Evm2, subject: Evm1, cursed: false},
-	// 		{chainID: Evm2, subject: Sol1, cursed: false},
-	// 		{chainID: Sol1, subject: Evm1, cursed: true},
-	// 		{chainID: Sol1, subject: Evm2, cursed: false},
-	// 	},
-	// }
-
-	_, err := ccipChangesetSolana.AddRemoteChainToOffRamp(e.Env, ccipChangesetSolana.AddRemoteChainToOffRampConfig{
-		ChainSelector: mapIDToSelector(Sol1),
-		UpdatesByChain: map[uint64]*ccipChangesetSolana.OffRampConfig{
-			mapIDToSelector(Evm1): {
-				EnabledAsSource: true,
-				IsUpdate:        false,
+	testCases := []CurseTestCase{
+		{
+			name: "curse global Aptos and EVM1",
+			curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+				return []v1_6.CurseAction{
+					v1_6.CurseChain(mapIDToSelector(Evm1)),
+					v1_6.CurseChain(mapIDToSelector(Aptos1)),
+				}
+			},
+			curseAssertions: []curseAssertion{
+				{chainID: Evm1, globalCurse: true, cursed: true},
+				{chainID: Sol1, globalCurse: true, cursed: false},
+				{chainID: Aptos1, globalCurse: true, cursed: true},
+				{chainID: Evm1, subject: Evm2, cursed: true},
+				{chainID: Evm1, subject: Sol1, cursed: true},
+				{chainID: Evm1, subject: Aptos1, cursed: true},
+				{chainID: Evm2, subject: Evm1, cursed: true},
+				{chainID: Evm2, subject: Sol1, cursed: false},
+				{chainID: Evm2, subject: Aptos1, cursed: true},
+				{chainID: Sol1, subject: Evm1, cursed: true},
+				{chainID: Sol1, subject: Evm2, cursed: false},
+				{chainID: Sol1, subject: Aptos1, cursed: true},
+				{chainID: Aptos1, subject: Evm1, cursed: true},
+				{chainID: Aptos1, subject: Evm2, cursed: true},
+				{chainID: Aptos1, subject: Sol1, cursed: true},
 			},
 		},
-	})
-	require.NoError(t, err)
+		{
+			name: "Curse Aptos <> EVM1",
+			curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+				return []v1_6.CurseAction{
+					v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Aptos1)),
+				}
+			},
+			curseAssertions: []curseAssertion{
+				{chainID: Evm1, globalCurse: true, cursed: false},
+				{chainID: Aptos1, globalCurse: true, cursed: false},
+				{chainID: Evm1, subject: Evm2, cursed: false},
+				{chainID: Evm1, subject: Aptos1, cursed: true},
+				{chainID: Evm2, subject: Aptos1, cursed: false},
+				{chainID: Aptos1, subject: Evm1, cursed: true},
+				{chainID: Aptos1, subject: Evm2, cursed: false},
+			},
+		},
+	}
 
-	verifyNoActiveCurseOnAllChains(t, &e)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	state, err := stateview.LoadOnchainState(e.Env)
-	require.NoError(t, err)
-	transferRMNContractToMCMS(t, &e, state)
+			e, _ := testhelpers.NewMemoryEnvironment(
+				t,
+				testhelpers.WithNumOfChains(2),
+				testhelpers.WithSolChains(1),
+				testhelpers.WithAptosChains(1),
+			)
 
-	_, _, err = commonchangeset.ApplyChangesets(t, e.Env,
-		[]commonchangeset.ConfiguredChangeSet{
-			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset),
-				config,
-			)},
-	)
-	require.NoError(t, err)
+			mapIDToSelector := func(id uint64) uint64 {
+				return v1_6.GetAllCursableChainsSelector(e.Env)[id]
+			}
 
-	// verifyTestCaseAssertions(t, &e, tc, mapIDToSelector)
+			config := v1_6.RMNCurseConfig{
+				CurseActions:             tc.curseActionsBuilder(mapIDToSelector),
+				Reason:                   "test curse",
+				IncludeNotConnectedLanes: true,
+				MCMS: &proposalutils.TimelockConfig{
+					MinDelay:   1 * time.Second,
+					MCMSAction: types.TimelockActionSchedule,
+				},
+			}
 
-	_, _, err = commonchangeset.ApplyChangesets(t, e.Env,
-		[]commonchangeset.ConfiguredChangeSet{
-			commonchangeset.Configure(
-				cldf.CreateLegacyChangeSet(v1_6.RMNUncurseChangeset),
-				config,
-			)},
-	)
-	require.NoError(t, err)
+			verifyNoActiveCurseOnAllChains(t, &e)
 
-	verifyNoActiveCurseOnAllChains(t, &e)
+			state, err := stateview.LoadOnchainState(e.Env)
+			require.NoError(t, err)
+			transferRMNContractToMCMS(t, &e, state)
+
+			_, _, err = commonchangeset.ApplyChangesets(t, e.Env,
+				[]commonchangeset.ConfiguredChangeSet{
+					commonchangeset.Configure(
+						cldf.CreateLegacyChangeSet(v1_6.RMNCurseChangeset),
+						config,
+					)},
+			)
+			require.NoError(t, err)
+
+			verifyTestCaseAssertions(t, &e, tc, mapIDToSelector)
+
+			_, _, err = commonchangeset.ApplyChangesets(t, e.Env,
+				[]commonchangeset.ConfiguredChangeSet{
+					commonchangeset.Configure(
+						cldf.CreateLegacyChangeSet(v1_6.RMNUncurseChangeset),
+						config,
+					)},
+			)
+			require.NoError(t, err)
+
+			verifyNoActiveCurseOnAllChains(t, &e)
+		})
+	}
 }
 
 func runRmnUncurseTest(t *testing.T, tc CurseTestCase) {

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -1,7 +1,6 @@
 package ccip
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -586,7 +585,6 @@ func TestRMNCurseUncurseAptos(t *testing.T) {
 			require.NoError(t, err)
 
 			verifyNoActiveCurseOnAllChains(t, &e)
-			fmt.Println("finished test case:", tc.name)
 		})
 	}
 }


### PR DESCRIPTION
# Summary
Add Aptos support on curse/uncurse changesets. We don't have DeployerGroup support for Aptos, it uses OperationsAPI. `AptosCursableChain` implementing `CursableChain` and runs operations to curse/uncurse returning MCMS operations that are then added to the final proposal.

# Features
- `AptosCursableChain` implementing `CursableChain` interface
- Proposal aggregation to output Aptos in the same Proposal as EVM and Solana
- Validation for Aptos

# Testing
- Smoke tests on `integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go`
There's a separate test for Aptos since initializing an env with Aptos chain for all the current `CurseTestCase` would increase CI time. 

