### PR TITLE
CCIP-6386 Passing chainFamily to OCR3 metrics to avoid clashing across different chains

### DIFF
--- a/.changeset/heavy-carrots-wait.md
+++ b/.changeset/heavy-carrots-wait.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Adding chainFamily to ocr3 prometheus metrics to distinguish between conflicting chainIDs #changed

--- a/core/capabilities/ccip/oraclecreator/create_test.go
+++ b/core/capabilities/ccip/oraclecreator/create_test.go
@@ -97,7 +97,20 @@ func TestCreateFactoryAndTransmitter_PeerWrapperNotStarted(t *testing.T) {
 
 	var cfg cctypes.OCR3ConfigWithMeta // zero value => commit plugin type
 
-	factory, transmitter, err := creator.createFactoryAndTransmitter(1, cfg, types.NewRelayID(chainsel.FamilyEVM, "1"), map[cciptypes.ChainSelector]types.ContractReader{}, map[cciptypes.ChainSelector]types.ContractWriter{}, nil, nil, ocr3confighelper.PublicConfig{}, "1", "", ccipcommon.PluginConfig{}, "")
+	factory, transmitter, err := creator.createFactoryAndTransmitter(
+		1,
+		cfg,
+		types.NewRelayID(chainsel.FamilyEVM, "1"),
+		map[cciptypes.ChainSelector]types.ContractReader{},
+		map[cciptypes.ChainSelector]types.ContractWriter{},
+		/* destChainWriter */ nil,
+		/* destFromAccounts */ nil,
+		ocr3confighelper.PublicConfig{},
+		"evm",
+		"1",
+		ccipcommon.PluginConfig{},
+		"",
+	)
 
 	require.Error(t, err, "expected error when peer wrapper not started")
 	require.Nil(t, factory)
@@ -132,6 +145,7 @@ func TestCreateFactoryAndTransmitter_NilDestChainWriter(t *testing.T) {
 			},
 		},
 	}
+	destChainFamily := "evm"
 	destChainID := "1"
 	pluginCfg := ccipcommon.PluginConfig{
 		// Provide a dummy factory that creates identifiable (or nil) transmitters
@@ -164,7 +178,20 @@ func TestCreateFactoryAndTransmitter_NilDestChainWriter(t *testing.T) {
 				},
 			}
 
-			factory, transmitter, err := creator.createFactoryAndTransmitter(donID, cfg, relayID, contractReaders, chainWriters, nil, nil, publicCfg, destChainID, "", pluginCfg, offrampAddrStr)
+			factory, transmitter, err := creator.createFactoryAndTransmitter(
+				donID,
+				cfg,
+				relayID,
+				contractReaders,
+				chainWriters,
+				nil, // Key: destChainWriter is nil
+				nil, // destFromAccounts can be nil as it's not used before NoOpTransmitter creation
+				publicCfg,
+				destChainFamily,
+				destChainID,
+				pluginCfg,
+				offrampAddrStr,
+			)
 
 			require.NoError(t, err)
 			require.NotNil(t, factory, "factory should not be nil")

--- a/core/capabilities/ccip/oraclecreator/create_test.go
+++ b/core/capabilities/ccip/oraclecreator/create_test.go
@@ -97,19 +97,7 @@ func TestCreateFactoryAndTransmitter_PeerWrapperNotStarted(t *testing.T) {
 
 	var cfg cctypes.OCR3ConfigWithMeta // zero value => commit plugin type
 
-	factory, transmitter, err := creator.createFactoryAndTransmitter(
-		1,
-		cfg,
-		types.NewRelayID(chainsel.FamilyEVM, "1"),
-		map[cciptypes.ChainSelector]types.ContractReader{},
-		map[cciptypes.ChainSelector]types.ContractWriter{},
-		/* destChainWriter */ nil,
-		/* destFromAccounts */ nil,
-		ocr3confighelper.PublicConfig{},
-		"1",
-		ccipcommon.PluginConfig{},
-		"",
-	)
+	factory, transmitter, err := creator.createFactoryAndTransmitter(1, cfg, types.NewRelayID(chainsel.FamilyEVM, "1"), map[cciptypes.ChainSelector]types.ContractReader{}, map[cciptypes.ChainSelector]types.ContractWriter{}, nil, nil, ocr3confighelper.PublicConfig{}, "1", "", ccipcommon.PluginConfig{}, "")
 
 	require.Error(t, err, "expected error when peer wrapper not started")
 	require.Nil(t, factory)
@@ -176,19 +164,7 @@ func TestCreateFactoryAndTransmitter_NilDestChainWriter(t *testing.T) {
 				},
 			}
 
-			factory, transmitter, err := creator.createFactoryAndTransmitter(
-				donID,
-				cfg,
-				relayID,
-				contractReaders,
-				chainWriters,
-				nil, // Key: destChainWriter is nil
-				nil, // destFromAccounts can be nil as it's not used before NoOpTransmitter creation
-				publicCfg,
-				destChainID,
-				pluginCfg,
-				offrampAddrStr,
-			)
+			factory, transmitter, err := creator.createFactoryAndTransmitter(donID, cfg, relayID, contractReaders, chainWriters, nil, nil, publicCfg, destChainID, "", pluginCfg, offrampAddrStr)
 
 			require.NoError(t, err)
 			require.NotNil(t, factory, "factory should not be nil")

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -211,7 +211,7 @@ func (i *pluginOracleCreator) Create(ctx context.Context, donID uint32, config c
 
 	// TODO: Extract the correct transmitter address from the destsFromAccount
 	factory, transmitter, err := i.createFactoryAndTransmitter(
-		donID, config, destRelayID, contractReaders, chainWriters, destChainWriter, destFromAccounts, publicConfig, destChainID, pluginServices.PluginConfig, offrampAddrStr)
+		donID, config, destRelayID, contractReaders, chainWriters, destChainWriter, destFromAccounts, publicConfig, destChainFamily, destChainID, pluginServices.PluginConfig, offrampAddrStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create factory and transmitter: %w", err)
 	}
@@ -273,6 +273,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 	destChainWriter types.ContractWriter,
 	destFromAccounts []string,
 	publicConfig ocr3confighelper.PublicConfig,
+	destChainFamily string,
 	destChainID string,
 	pluginConfig ccipcommon.PluginConfig,
 	offrampAddrStr string,
@@ -313,7 +314,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 				ContractWriters:   chainWriters,
 				RmnPeerClient:     rmnPeerClient,
 				RmnCrypto:         pluginConfig.RMNCrypto})
-		factory = promwrapper.NewReportingPluginFactory(factory, i.lggr, destChainID, "CCIPCommit")
+		factory = promwrapper.NewReportingPluginFactory(factory, i.lggr, destChainFamily, destChainID, "CCIPCommit")
 		if destChainWriter == nil {
 			i.lggr.Infow("no chain writer found for dest chain, creating nil transmitter",
 				"destChainID", destChainID,
@@ -363,7 +364,13 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 				ContractReaders:  contractReaders,
 				ContractWriters:  chainWriters,
 			})
-		factory = promwrapper.NewReportingPluginFactory(factory, i.lggr, destChainID, "CCIPExec")
+		factory = promwrapper.NewReportingPluginFactory(
+			factory,
+			i.lggr,
+			destChainFamily,
+			destChainID,
+			"CCIPExec",
+		)
 
 		if destChainWriter == nil {
 			i.lggr.Infow("no chain writer found for dest chain, creating nil transmitter",

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -314,7 +314,13 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 				ContractWriters:   chainWriters,
 				RmnPeerClient:     rmnPeerClient,
 				RmnCrypto:         pluginConfig.RMNCrypto})
-		factory = promwrapper.NewReportingPluginFactory(factory, i.lggr, destChainFamily, destChainID, "CCIPCommit")
+		factory = promwrapper.NewReportingPluginFactory(
+			factory,
+			i.lggr,
+			destChainFamily,
+			destChainID,
+			"CCIPCommit",
+		)
 		if destChainWriter == nil {
 			i.lggr.Infow("no chain writer found for dest chain, creating nil transmitter",
 				"destChainID", destChainID,

--- a/core/services/llo/delegate.go
+++ b/core/services/llo/delegate.go
@@ -182,6 +182,7 @@ func (d *delegate) Start(ctx context.Context) error {
 						},
 					),
 					lggr,
+					"",
 					d.cfg.ChainID,
 					"llo",
 				),

--- a/core/services/ocr3/promwrapper/factory.go
+++ b/core/services/ocr3/promwrapper/factory.go
@@ -11,23 +11,26 @@ import (
 var _ ocr3types.ReportingPluginFactory[any] = &ReportingPluginFactory[any]{}
 
 type ReportingPluginFactory[RI any] struct {
-	origin  ocr3types.ReportingPluginFactory[RI]
-	lggr    logger.Logger
-	chainID string
-	plugin  string
+	origin      ocr3types.ReportingPluginFactory[RI]
+	lggr        logger.Logger
+	chainFamily string
+	chainID     string
+	plugin      string
 }
 
 func NewReportingPluginFactory[RI any](
 	origin ocr3types.ReportingPluginFactory[RI],
 	lggr logger.Logger,
+	chainFamily string,
 	chainID string,
 	plugin string,
 ) *ReportingPluginFactory[RI] {
 	return &ReportingPluginFactory[RI]{
-		origin:  origin,
-		lggr:    lggr,
-		chainID: chainID,
-		plugin:  plugin,
+		origin:      origin,
+		lggr:        lggr,
+		chainFamily: chainFamily,
+		chainID:     chainID,
+		plugin:      plugin,
 	}
 }
 
@@ -42,6 +45,7 @@ func (r ReportingPluginFactory[RI]) NewReportingPlugin(ctx context.Context, conf
 	)
 	wrapped := newReportingPlugin(
 		plugin,
+		r.chainFamily,
 		r.chainID,
 		r.plugin,
 		config.ConfigDigest.String(),

--- a/core/services/ocr3/promwrapper/factory_test.go
+++ b/core/services/ocr3/promwrapper/factory_test.go
@@ -13,8 +13,20 @@ import (
 )
 
 func Test_WrapperFactory(t *testing.T) {
-	validFactory := NewReportingPluginFactory(fakeFactory[uint]{}, logger.TestLogger(t), "solana", "plugin")
-	failingFactory := NewReportingPluginFactory(fakeFactory[uint]{err: errors.New("error")}, logger.TestLogger(t), "123", "plugin")
+	validFactory := NewReportingPluginFactory(
+		fakeFactory[uint]{},
+		logger.TestLogger(t),
+		"solana",
+		"5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+		"plugin",
+	)
+	failingFactory := NewReportingPluginFactory(
+		fakeFactory[uint]{err: errors.New("error")},
+		logger.TestLogger(t),
+		"evm",
+		"11155111",
+		"plugin",
+	)
 
 	plugin, _, err := validFactory.NewReportingPlugin(t.Context(), ocr3types.ReportingPluginConfig{})
 	require.NoError(t, err)
@@ -22,8 +34,8 @@ func Test_WrapperFactory(t *testing.T) {
 	_, err = plugin.Outcome(t.Context(), ocr3types.OutcomeContext{}, nil, nil)
 	require.NoError(t, err)
 
-	require.Equal(t, 1, counterFromHistogramByLabels(t, promOCR3Durations, "solana", "plugin", "outcome", "true"))
-	require.Equal(t, 0, counterFromHistogramByLabels(t, promOCR3Durations, "solana", "plugin", "outcome", "false"))
+	require.Equal(t, 1, counterFromHistogramByLabels(t, promOCR3Durations, "solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", "plugin", "outcome", "true"))
+	require.Equal(t, 0, counterFromHistogramByLabels(t, promOCR3Durations, "solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", "plugin", "outcome", "false"))
 
 	_, _, err = failingFactory.NewReportingPlugin(t.Context(), ocr3types.ReportingPluginConfig{})
 	require.Error(t, err)

--- a/core/services/ocr3/promwrapper/plugin_test.go
+++ b/core/services/ocr3/promwrapper/plugin_test.go
@@ -42,8 +42,8 @@ func Test_ReportsGeneratedGauge(t *testing.T) {
 	)
 	plugin3 := newReportingPlugin(
 		fakePlugin[string]{err: errors.New("error")},
-		"evm",
-		"43113",
+		"aptos",
+		"1",
 		"empty",
 		"abc",
 		promOCR3ReportsGenerated,
@@ -84,12 +84,12 @@ func Test_ReportsGeneratedGauge(t *testing.T) {
 	require.Equal(t, 1, int(g3))
 
 	g4 := testutil.ToFloat64(promOCR3ReportsGenerated.WithLabelValues(
-		"evm", "43113", "empty", "reports"),
+		"aptos", "1", "empty", "reports"),
 	)
 	require.Equal(t, 0, int(g4))
 
 	pluginHealth := testutil.ToFloat64(promOCR3PluginStatus.WithLabelValues(
-		"evm", "43113", "empty", "abc"),
+		"aptos", "1", "empty", "abc"),
 	)
 	require.Equal(t, 1, int(pluginHealth))
 

--- a/core/services/ocr3/promwrapper/plugin_test.go
+++ b/core/services/ocr3/promwrapper/plugin_test.go
@@ -20,15 +20,36 @@ func Test_ReportsGeneratedGauge(t *testing.T) {
 
 	plugin1 := newReportingPlugin(
 		fakePlugin[uint]{reports: make([]ocr3types.ReportPlus[uint], 2)},
-		"123", "empty", "abc", promOCR3ReportsGenerated, promOCR3Durations, promOCR3Sizes, promOCR3PluginStatus,
+		"evm",
+		"1",
+		"empty",
+		"abc",
+		promOCR3ReportsGenerated,
+		promOCR3Durations,
+		promOCR3Sizes,
+		promOCR3PluginStatus,
 	)
 	plugin2 := newReportingPlugin(
 		fakePlugin[bool]{reports: make([]ocr3types.ReportPlus[bool], 10), observationSize: pluginObservationSize, outcomeSize: pluginOutcomeSize},
-		"solana", "different_plugin", "abc", promOCR3ReportsGenerated, promOCR3Durations, promOCR3Sizes, promOCR3PluginStatus,
+		"solana",
+		"5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+		"different_plugin",
+		"abc",
+		promOCR3ReportsGenerated,
+		promOCR3Durations,
+		promOCR3Sizes,
+		promOCR3PluginStatus,
 	)
 	plugin3 := newReportingPlugin(
 		fakePlugin[string]{err: errors.New("error")},
-		"1234", "empty", "abc", promOCR3ReportsGenerated, promOCR3Durations, promOCR3Sizes, promOCR3PluginStatus,
+		"evm",
+		"43113",
+		"empty",
+		"abc",
+		promOCR3ReportsGenerated,
+		promOCR3Durations,
+		promOCR3Sizes,
+		promOCR3PluginStatus,
 	)
 
 	r1, err := plugin1.Reports(t.Context(), 1, nil)
@@ -47,23 +68,35 @@ func Test_ReportsGeneratedGauge(t *testing.T) {
 	_, err = plugin3.Reports(t.Context(), 1, nil)
 	require.Error(t, err)
 
-	g1 := testutil.ToFloat64(promOCR3ReportsGenerated.WithLabelValues("123", "empty", "reports"))
+	g1 := testutil.ToFloat64(promOCR3ReportsGenerated.WithLabelValues(
+		"evm", "1", "empty", "reports"),
+	)
 	require.Equal(t, 2, int(g1))
 
-	g2 := testutil.ToFloat64(promOCR3ReportsGenerated.WithLabelValues("solana", "different_plugin", "reports"))
+	g2 := testutil.ToFloat64(promOCR3ReportsGenerated.WithLabelValues(
+		"solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", "different_plugin", "reports"),
+	)
 	require.Equal(t, 100, int(g2))
 
-	g3 := testutil.ToFloat64(promOCR3ReportsGenerated.WithLabelValues("solana", "different_plugin", "shouldAccept"))
+	g3 := testutil.ToFloat64(promOCR3ReportsGenerated.WithLabelValues(
+		"solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", "different_plugin", "shouldAccept"),
+	)
 	require.Equal(t, 1, int(g3))
 
-	g4 := testutil.ToFloat64(promOCR3ReportsGenerated.WithLabelValues("1234", "empty", "reports"))
+	g4 := testutil.ToFloat64(promOCR3ReportsGenerated.WithLabelValues(
+		"evm", "43113", "empty", "reports"),
+	)
 	require.Equal(t, 0, int(g4))
 
-	pluginHealth := testutil.ToFloat64(promOCR3PluginStatus.WithLabelValues("123", "empty", "abc"))
+	pluginHealth := testutil.ToFloat64(promOCR3PluginStatus.WithLabelValues(
+		"evm", "43113", "empty", "abc"),
+	)
 	require.Equal(t, 1, int(pluginHealth))
 
 	require.NoError(t, plugin1.Close())
-	pluginHealth = testutil.ToFloat64(promOCR3PluginStatus.WithLabelValues("123", "empty", "abc"))
+	pluginHealth = testutil.ToFloat64(promOCR3PluginStatus.WithLabelValues(
+		"evm", "1", "empty", "abc"),
+	)
 	require.Equal(t, 0, int(pluginHealth))
 
 	iterations := 10
@@ -74,24 +107,28 @@ func Test_ReportsGeneratedGauge(t *testing.T) {
 	_, err1 := plugin2.Observation(t.Context(), ocr3types.OutcomeContext{}, nil)
 	require.NoError(t, err1)
 
-	outcomesLen := testutil.ToFloat64(promOCR3Sizes.WithLabelValues("solana", "different_plugin", "outcome"))
+	outcomesLen := testutil.ToFloat64(promOCR3Sizes.WithLabelValues(
+		"solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", "different_plugin", "outcome"),
+	)
 	require.Equal(t, pluginOutcomeSize*iterations, int(outcomesLen))
-	observationLen := testutil.ToFloat64(promOCR3Sizes.WithLabelValues("solana", "different_plugin", "observation"))
+	observationLen := testutil.ToFloat64(promOCR3Sizes.WithLabelValues(
+		"solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", "different_plugin", "observation"),
+	)
 	require.Equal(t, pluginObservationSize, int(observationLen))
 }
 
 func Test_DurationHistograms(t *testing.T) {
 	plugin1 := newReportingPlugin(
 		fakePlugin[uint]{},
-		"123", "empty", "abc", promOCR3ReportsGenerated, promOCR3Durations, promOCR3Sizes, promOCR3PluginStatus,
+		"evm", "1", "empty", "abc", promOCR3ReportsGenerated, promOCR3Durations, promOCR3Sizes, promOCR3PluginStatus,
 	)
 	plugin2 := newReportingPlugin(
 		fakePlugin[uint]{err: errors.New("error")},
-		"123", "empty", "abc", promOCR3ReportsGenerated, promOCR3Durations, promOCR3Sizes, promOCR3PluginStatus,
+		"evm", "1", "empty", "abc", promOCR3ReportsGenerated, promOCR3Durations, promOCR3Sizes, promOCR3PluginStatus,
 	)
 	plugin3 := newReportingPlugin(
 		fakePlugin[uint]{},
-		"solana", "commit", "abc", promOCR3ReportsGenerated, promOCR3Durations, promOCR3Sizes, promOCR3PluginStatus,
+		"solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", "commit", "abc", promOCR3ReportsGenerated, promOCR3Durations, promOCR3Sizes, promOCR3PluginStatus,
 	)
 
 	for _, p := range []*reportingPlugin[uint]{plugin1, plugin2, plugin3} {
@@ -106,13 +143,13 @@ func Test_DurationHistograms(t *testing.T) {
 		_, _ = p.ShouldTransmitAcceptedReport(t.Context(), 0, ocr3types.ReportWithInfo[uint]{})
 	}
 
-	require.Equal(t, 1, counterFromHistogramByLabels(t, promOCR3Durations, "123", "empty", "query", "true"))
-	require.Equal(t, 1, counterFromHistogramByLabels(t, promOCR3Durations, "123", "empty", "query", "false"))
-	require.Equal(t, 1, counterFromHistogramByLabels(t, promOCR3Durations, "solana", "commit", "query", "true"))
+	require.Equal(t, 1, counterFromHistogramByLabels(t, promOCR3Durations, "evm", "1", "empty", "query", "true"))
+	require.Equal(t, 1, counterFromHistogramByLabels(t, promOCR3Durations, "evm", "1", "empty", "query", "false"))
+	require.Equal(t, 1, counterFromHistogramByLabels(t, promOCR3Durations, "solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", "commit", "query", "true"))
 
-	require.Equal(t, 2, counterFromHistogramByLabels(t, promOCR3Durations, "123", "empty", "observation", "true"))
-	require.Equal(t, 2, counterFromHistogramByLabels(t, promOCR3Durations, "123", "empty", "observation", "false"))
-	require.Equal(t, 2, counterFromHistogramByLabels(t, promOCR3Durations, "solana", "commit", "observation", "true"))
+	require.Equal(t, 2, counterFromHistogramByLabels(t, promOCR3Durations, "evm", "1", "empty", "observation", "true"))
+	require.Equal(t, 2, counterFromHistogramByLabels(t, promOCR3Durations, "evm", "1", "empty", "observation", "false"))
+	require.Equal(t, 2, counterFromHistogramByLabels(t, promOCR3Durations, "solana", "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d", "commit", "observation", "true"))
 }
 
 type fakePlugin[RI any] struct {

--- a/core/services/ocr3/promwrapper/types.go
+++ b/core/services/ocr3/promwrapper/types.go
@@ -40,7 +40,7 @@ var (
 			Name: "ocr3_reporting_plugin_reports_processed",
 			Help: "Tracks number of reports processed/generated within by different OCR3 functions",
 		},
-		[]string{"chainID", "plugin", "function"},
+		[]string{"chainFamily", "chainID", "plugin", "function"},
 	)
 	promOCR3Durations = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -48,20 +48,20 @@ var (
 			Help:    "The amount of time elapsed during the OCR3 plugin's function",
 			Buckets: buckets,
 		},
-		[]string{"chainID", "plugin", "function", "success"},
+		[]string{"chainFamily", "chainID", "plugin", "function", "success"},
 	)
 	promOCR3Sizes = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ocr3_reporting_plugin_data_sizes",
 			Help: "Tracks the size of the data produced by OCR3 plugin in bytes (e.g. reports, observations etc.)",
 		},
-		[]string{"chainID", "plugin", "function"},
+		[]string{"chainFamily", "chainID", "plugin", "function"},
 	)
 	promOCR3PluginStatus = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "ocr3_reporting_plugin_status",
 			Help: "Gauge indicating whether plugin is up and running or not",
 		},
-		[]string{"chainID", "plugin", "configDigest"},
+		[]string{"chainFamily", "chainID", "plugin", "configDigest"},
 	)
 )


### PR DESCRIPTION
Adding chainFamily to metrics exposed by OCR3 promwrapper. That way we will be able to distinguish between chains with clashing IDs (for instance, Aptos Mainnet has the same chainID as Ethereum Mainnet)

We will follow the same labeling strategy as we have in core metrics exposed by different components e.g., https://github.com/smartcontractkit/chainlink-framework/pull/38/files

This change won't increase cardinality as the number of pairs (family, chainID) will be always equal to the number of chains single node is running