### PR TITLE
CCIP-6116 Enabling detailed OCR telemetry for CCIP OCR instances 

### DIFF
--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -567,6 +567,7 @@ func defaultLocalConfig() ocrtypes.LocalConfig {
 		DatabaseTimeout:                    10 * time.Second,
 		MinOCR2MaxDurationQuery:            1 * time.Second,
 		DevelopmentMode:                    "false",
+		EnableTransmissionTelemetry:        true,
 	}
 }
 

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -566,8 +566,8 @@ func defaultLocalConfig() ocrtypes.LocalConfig {
 		ContractTransmitterTransmitTimeout: 10 * time.Second,
 		DatabaseTimeout:                    10 * time.Second,
 		MinOCR2MaxDurationQuery:            1 * time.Second,
-		DevelopmentMode:                    "false",
 		EnableTransmissionTelemetry:        true,
+		DevelopmentMode:                    "false",
 	}
 }
 

--- a/core/capabilities/ccip/oraclecreator/plugin_test.go
+++ b/core/capabilities/ccip/oraclecreator/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
@@ -123,4 +124,21 @@ func TestPluginOracleCreator_getTransmitterFromPublicConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Sanity-check that these parameters are not accidentally changed without breaking CI
+func Test_defaultLocalConfigProperties(t *testing.T) {
+	lc := defaultLocalConfig()
+
+	require.Equal(t, 30*time.Second, lc.DefaultMaxDurationInitialization)
+	require.Equal(t, 10*time.Second, lc.BlockchainTimeout)
+	require.Equal(t, 10*time.Second, lc.ContractConfigLoadTimeout)
+	require.Equal(t, uint16(1), lc.ContractConfigConfirmations)
+	require.Equal(t, true, lc.SkipContractConfigConfirmations)
+	require.Equal(t, 10*time.Second, lc.ContractConfigTrackerPollInterval)
+	require.Equal(t, 10*time.Second, lc.ContractTransmitterTransmitTimeout)
+	require.Equal(t, 10*time.Second, lc.DatabaseTimeout)
+	require.Equal(t, 1*time.Second, lc.MinOCR2MaxDurationQuery)
+	require.Equal(t, "false", lc.DevelopmentMode)
+	require.Equal(t, true, lc.EnableTransmissionTelemetry)
 }

--- a/core/capabilities/ccip/oraclecreator/plugin_test.go
+++ b/core/capabilities/ccip/oraclecreator/plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
@@ -130,15 +131,15 @@ func TestPluginOracleCreator_getTransmitterFromPublicConfig(t *testing.T) {
 func Test_defaultLocalConfigProperties(t *testing.T) {
 	lc := defaultLocalConfig()
 
-	require.Equal(t, 30*time.Second, lc.DefaultMaxDurationInitialization)
-	require.Equal(t, 10*time.Second, lc.BlockchainTimeout)
-	require.Equal(t, 10*time.Second, lc.ContractConfigLoadTimeout)
-	require.Equal(t, uint16(1), lc.ContractConfigConfirmations)
-	require.Equal(t, true, lc.SkipContractConfigConfirmations)
-	require.Equal(t, 10*time.Second, lc.ContractConfigTrackerPollInterval)
-	require.Equal(t, 10*time.Second, lc.ContractTransmitterTransmitTimeout)
-	require.Equal(t, 10*time.Second, lc.DatabaseTimeout)
-	require.Equal(t, 1*time.Second, lc.MinOCR2MaxDurationQuery)
-	require.Equal(t, "false", lc.DevelopmentMode)
-	require.Equal(t, true, lc.EnableTransmissionTelemetry)
+	assert.Equal(t, 30*time.Second, lc.DefaultMaxDurationInitialization)
+	assert.Equal(t, 10*time.Second, lc.BlockchainTimeout)
+	assert.Equal(t, 10*time.Second, lc.ContractConfigLoadTimeout)
+	assert.Equal(t, uint16(1), lc.ContractConfigConfirmations)
+	assert.True(t, lc.SkipContractConfigConfirmations)
+	assert.Equal(t, 10*time.Second, lc.ContractConfigTrackerPollInterval)
+	assert.Equal(t, 10*time.Second, lc.ContractTransmitterTransmitTimeout)
+	assert.Equal(t, 10*time.Second, lc.DatabaseTimeout)
+	assert.Equal(t, 1*time.Second, lc.MinOCR2MaxDurationQuery)
+	assert.Equal(t, "false", lc.DevelopmentMode)
+	assert.True(t, lc.EnableTransmissionTelemetry)
 }

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -544,8 +544,10 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) ([]job.Servi
 			kvStore)
 
 	case types.CCIPCommit:
+		lc.EnableTransmissionTelemetry = true
 		return d.newServicesCCIPCommit(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc, transmitterID)
 	case types.CCIPExecution:
+		lc.EnableTransmissionTelemetry = true
 		return d.newServicesCCIPExecution(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc, transmitterID)
 
 	case types.VaultPlugin:

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -544,10 +544,8 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) ([]job.Servi
 			kvStore)
 
 	case types.CCIPCommit:
-		lc.EnableTransmissionTelemetry = true
 		return d.newServicesCCIPCommit(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc, transmitterID)
 	case types.CCIPExecution:
-		lc.EnableTransmissionTelemetry = true
 		return d.newServicesCCIPExecution(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc, transmitterID)
 
 	case types.VaultPlugin:
@@ -1712,6 +1710,7 @@ func (d *Delegate) newServicesCCIPCommit(ctx context.Context, lggr logger.Sugare
 		return nil, err
 	}
 
+	lc.EnableTransmissionTelemetry = true
 	oracleArgsNoPlugin := libocr2.OCR2OracleArgs{
 		BinaryNetworkEndpointFactory: d.peerWrapper.Peer2,
 		V2Bootstrappers:              bootstrapPeers,
@@ -1896,6 +1895,7 @@ func (d *Delegate) newServicesCCIPExecution(ctx context.Context, lggr logger.Sug
 		return nil, err
 	}
 
+	lc.EnableTransmissionTelemetry = true
 	oracleArgsNoPlugin2 := libocr2.OCR2OracleArgs{
 		BinaryNetworkEndpointFactory: d.peerWrapper.Peer2,
 		V2Bootstrappers:              bootstrapPeers,


### PR DESCRIPTION
Atlas OTI protos are backward and forward compatible, so according to RTSP this flag can be safely enabled

Atlas protos to be adjusted for testing
https://github.com/smartcontractkit/atlas/blob/c62edb7e5b6d80d543d61922d64022e9e9bde603/ingress/ocr-telemetry/app/protobuf/offchainreporting3_telemetry.proto
https://github.com/smartcontractkit/atlas/blob/0a8e9b5a44c5c015e49a2b58b389e18a52f2e2e1/ingress/ocr-telemetry/app/protobuf/offchainreporting3_messages.proto

To reflect the changes in libocr
https://github.com/smartcontractkit/offchain-reporting/blob/master/lib/offchainreporting2plus/internal/ocr3/serialization/offchainreporting3_telemetry.proto
https://github.com/smartcontractkit/offchain-reporting/blob/master/lib/offchainreporting2plus/internal/ocr3/serialization/offchainreporting3_messages.proto
https://github.com/smartcontractkit/offchain-reporting/blob/master/lib/offchainreporting2plus/internal/ocr2/serialization/offchainreporting2_telemetry.proto
https://github.com/smartcontractkit/offchain-reporting/blob/master/lib/offchainreporting2plus/internal/ocr2/serialization/offchainreporting2_messages.proto
