### PR TITLE
fix(deployments): Rmn curse uncurse changeset

### DIFF
--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -520,7 +520,10 @@ type CursableChain interface {
 	Name() string
 	IsConnectedToSourceChain(selector uint64) (bool, error)
 	IsCursable() (bool, error)
+	// IsCursed has the default RMN behavior.
+	// Returns true if subject is cursed or chain is globally cursed. False otherwise.
 	IsCursed(subject globals.Subject) (bool, error)
+	// IsSubjectCursed checks if that specific subject is cursed.
 	IsSubjectCursed(subject globals.Subject) (bool, error)
 	Curse(deployerGroup *deployergroup.DeployerGroup, subjects []globals.Subject) error
 	Uncurse(deployerGroup *deployergroup.DeployerGroup, subjects []globals.Subject) error
@@ -561,7 +564,7 @@ func (c SolanaCursableChain) IsSubjectCursed(subject globals.Subject) (bool, err
 	}
 }
 
-// getIsCursed checks if a subject is cursed on the Solana chain.
+// getIsCursed checks if a subject is cursed on the Solana chain. And returns the curseType if it is cursed.
 func (c SolanaCursableChain) getIsCursed(subject globals.Subject) (isCursed bool, curseType int64, err error) {
 	chain := c.env.BlockChains.SolanaChains()[c.selector]
 	curseSubject := solRmnRemote.CurseSubject{

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -526,10 +526,9 @@ type CursableChain interface {
 }
 
 type SolanaCursableChain struct {
-	selector       uint64
-	env            cldf.Environment
-	chain          solanastateview.CCIPChainState
-	cursedSubjects *[]globals.Subject
+	selector uint64
+	env      cldf.Environment
+	chain    solanastateview.CCIPChainState
 }
 
 func (c SolanaCursableChain) IsSubjectCursed(subject globals.Subject) (bool, error) {
@@ -710,9 +709,10 @@ func (c SolanaCursableChain) Name() string {
 }
 
 type EvmCursableChain struct {
-	selector uint64
-	env      cldf.Environment
-	chain    evm.CCIPChainState
+	selector            uint64
+	env                 cldf.Environment
+	chain               evm.CCIPChainState
+	cursedSubjectsCache map[globals.Subject]struct{}
 }
 
 func (c EvmCursableChain) Name() string {
@@ -732,10 +732,17 @@ func (c EvmCursableChain) IsConnectedToSourceChain(sourceSelector uint64) (bool,
 }
 
 func (c EvmCursableChain) IsSubjectCursed(subject globals.Subject) (bool, error) {
-	cursed, err := c.chain.RMNRemote.IsCursed(nil, subject)
-	if err != nil {
-		return false, fmt.Errorf("failed to check if chain %d is cursed: %w", c.selector, err)
+	if c.cursedSubjectsCache == nil {
+		c.cursedSubjectsCache = make(map[globals.Subject]struct{})
+		cursedSubjects, err := c.chain.RMNRemote.GetCursedSubjects(nil)
+		if err != nil {
+			return false, fmt.Errorf("failed to get cursed subjects for chain %d: %w", c.selector, err)
+		}
+		for _, subj := range cursedSubjects {
+			c.cursedSubjectsCache[subj] = struct{}{}
+		}
 	}
+	_, cursed := c.cursedSubjectsCache[subject]
 	return cursed, nil
 }
 

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -585,46 +585,45 @@ func (c SolanaCursableChain) getIsCursed(subject globals.Subject) (isCursed bool
 	}
 	errCode, err := parseSolanaErrorCode(txErr)
 	if err != nil {
-		c.env.Logger.Errorf("failed to parse solana error code: %w", err)
-		return false, 0, fmt.Errorf("failed to VerifyNotCursed: %w", txErr)
+		return false, 0, fmt.Errorf("failed to parse solana error code: %w", err)
 	}
 	return true, errCode, nil
 }
 
 func parseSolanaErrorCode(err error) (int64, error) {
-	rpcErr, ok := err.(*jsonrpc.RPCError)
-	if !ok {
-		return 0, fmt.Errorf("not a jsonrpc.RPCError")
+	var rpcErr *jsonrpc.RPCError
+	if !errors.As(err, &rpcErr) {
+		return 0, fmt.Errorf("not a jsonrpc.RPCError: %w", err)
 	}
 
 	data, ok := rpcErr.Data.(map[string]interface{})
 	if !ok {
-		return 0, fmt.Errorf("invalid data format")
+		return 0, fmt.Errorf("invalid data format: %w", err)
 	}
 
 	errData, ok := data["err"].(map[string]interface{})
 	if !ok {
-		return 0, fmt.Errorf("no err field found")
+		return 0, fmt.Errorf("no err field found: %w", err)
 	}
 
 	instrErr, ok := errData["InstructionError"].([]interface{})
 	if !ok || len(instrErr) < 2 {
-		return 0, fmt.Errorf("invalid InstructionError format")
+		return 0, fmt.Errorf("invalid InstructionError format: %w", err)
 	}
 
 	customErr, ok := instrErr[1].(map[string]interface{})
 	if !ok {
-		return 0, fmt.Errorf("invalid custom error format")
+		return 0, fmt.Errorf("invalid custom error format: %w", err)
 	}
 
 	custom, ok := customErr["Custom"].(json.Number)
 	if !ok {
-		return 0, fmt.Errorf("no Custom field found")
+		return 0, fmt.Errorf("no Custom field found: %w", err)
 	}
 
 	errorCode, err := custom.Int64()
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse custom error number: %v", err)
+		return 0, fmt.Errorf("failed to parse custom error number: %w", err)
 	}
 
 	return errorCode, nil
@@ -757,7 +756,10 @@ func (c EvmCursableChain) IsConnectedToSourceChain(sourceSelector uint64) (bool,
 }
 
 func (c *EvmCursableChain) IsCursed(subject globals.Subject) (bool, error) {
-	c.cacheCurses()
+	err := c.cacheCurses()
+	if err != nil {
+		return false, fmt.Errorf("failed to cache curses for chain %d: %w", c.selector, err)
+	}
 	if _, isGloballyCursed := c.cursedSubjectsCache[globals.GlobalCurseSubject()]; isGloballyCursed {
 		return true, nil
 	}
@@ -766,7 +768,10 @@ func (c *EvmCursableChain) IsCursed(subject globals.Subject) (bool, error) {
 }
 
 func (c *EvmCursableChain) IsSubjectCursed(subject globals.Subject) (bool, error) {
-	c.cacheCurses()
+	err := c.cacheCurses()
+	if err != nil {
+		return false, fmt.Errorf("failed to cache curses for chain %d: %w", c.selector, err)
+	}
 	_, cursed := c.cursedSubjectsCache[subject]
 	return cursed, nil
 }

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -3,12 +3,15 @@ package v1_6
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	solOffRamp "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_offramp"
@@ -523,9 +526,10 @@ type CursableChain interface {
 }
 
 type SolanaCursableChain struct {
-	selector uint64
-	env      cldf.Environment
-	chain    solanastateview.CCIPChainState
+	selector       uint64
+	env            cldf.Environment
+	chain          solanastateview.CCIPChainState
+	cursedSubjects *[]globals.Subject
 }
 
 func (c SolanaCursableChain) IsSubjectCursed(subject globals.Subject) (bool, error) {
@@ -544,13 +548,62 @@ func (c SolanaCursableChain) IsSubjectCursed(subject globals.Subject) (bool, err
 	if err != nil {
 		return false, fmt.Errorf("failed to generate instructions: %w", err)
 	}
-	_, err = solCommonUtil.SendAndConfirmWithLookupTables(context.Background(), chain.Client, []solana.Instruction{ix}, *chain.DeployerKey, rpc.CommitmentConfirmed, nil)
+	_, txErr := solCommonUtil.SendAndConfirmWithLookupTables(context.Background(), chain.Client, []solana.Instruction{ix}, *chain.DeployerKey, rpc.CommitmentConfirmed, nil)
+	if txErr == nil {
+		return false, nil
+	}
+	errCode, err := parseSolanaErrorCode(txErr)
 	if err != nil {
-		c.env.Logger.Infof("Curse already exists for chain %d and curse subject %v", c.selector, curseSubject)
+		c.env.Logger.Errorf("failed to parse solana error code: %w", err)
+		return false, fmt.Errorf("failed to VerifyNotCursed: %w", txErr)
+	}
+	switch errCode {
+	case 9006: // Globally cursed
+		return false, nil
+	case 9005: // Subject cursed
 		return true, nil
+	default:
+		return false, fmt.Errorf("failed to VerifyNotCursed: %w", txErr)
+	}
+}
+
+func parseSolanaErrorCode(err error) (int64, error) {
+	rpcErr, ok := err.(*jsonrpc.RPCError)
+	if !ok {
+		return 0, fmt.Errorf("not a jsonrpc.RPCError")
 	}
 
-	return false, nil
+	data, ok := rpcErr.Data.(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("invalid data format")
+	}
+
+	errData, ok := data["err"].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("no err field found")
+	}
+
+	instrErr, ok := errData["InstructionError"].([]interface{})
+	if !ok || len(instrErr) < 2 {
+		return 0, fmt.Errorf("invalid InstructionError format")
+	}
+
+	customErr, ok := instrErr[1].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("invalid custom error format")
+	}
+
+	custom, ok := customErr["Custom"].(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("no Custom field found")
+	}
+
+	errorCode, err := custom.Int64()
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse custom error number: %v", err)
+	}
+
+	return errorCode, nil
 }
 
 func (c SolanaCursableChain) Curse(deployerGroup *deployergroup.DeployerGroup, subjects []globals.Subject) error {

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -558,6 +558,9 @@ func (c SolanaCursableChain) IsSubjectCursed(subject globals.Subject) (bool, err
 	}
 	switch errCode {
 	case 9006: // Globally cursed
+		if subject == globals.GlobalCurseSubject() {
+			return true, nil
+		}
 		return false, nil
 	case 9005: // Subject cursed
 		return true, nil

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -520,6 +520,7 @@ type CursableChain interface {
 	Name() string
 	IsConnectedToSourceChain(selector uint64) (bool, error)
 	IsCursable() (bool, error)
+	IsCursed(subject globals.Subject) (bool, error)
 	IsSubjectCursed(subject globals.Subject) (bool, error)
 	Curse(deployerGroup *deployergroup.DeployerGroup, subjects []globals.Subject) error
 	Uncurse(deployerGroup *deployergroup.DeployerGroup, subjects []globals.Subject) error
@@ -531,7 +532,37 @@ type SolanaCursableChain struct {
 	chain    solanastateview.CCIPChainState
 }
 
+func (c SolanaCursableChain) IsCursed(subject globals.Subject) (bool, error) {
+	isCursed, _, err := c.getIsCursed(subject)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if subject %x is cursed on chain %d: %w", subject, c.selector, err)
+	}
+	return isCursed, nil
+}
+
 func (c SolanaCursableChain) IsSubjectCursed(subject globals.Subject) (bool, error) {
+	isCursed, curseType, err := c.getIsCursed(subject)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if subject %x is cursed on chain %d: %w", subject, c.selector, err)
+	}
+	if !isCursed {
+		return false, nil
+	}
+	switch curseType {
+	case 9006: // Globally cursed
+		if subject == globals.GlobalCurseSubject() {
+			return true, nil
+		}
+		return false, nil
+	case 9005: // Subject cursed
+		return true, nil
+	default:
+		return false, fmt.Errorf("unknown curseType %d: %w", curseType, err)
+	}
+}
+
+// getIsCursed checks if a subject is cursed on the Solana chain.
+func (c SolanaCursableChain) getIsCursed(subject globals.Subject) (isCursed bool, curseType int64, err error) {
 	chain := c.env.BlockChains.SolanaChains()[c.selector]
 	curseSubject := solRmnRemote.CurseSubject{
 		Value: subject,
@@ -545,28 +576,19 @@ func (c SolanaCursableChain) IsSubjectCursed(subject globals.Subject) (bool, err
 		rmnRemoteConfigPDA,
 	).ValidateAndBuild()
 	if err != nil {
-		return false, fmt.Errorf("failed to generate instructions: %w", err)
+		return false, 0, fmt.Errorf("failed to generate instructions: %w", err)
 	}
 	_, txErr := solCommonUtil.SendAndConfirmWithLookupTables(context.Background(), chain.Client, []solana.Instruction{ix}, *chain.DeployerKey, rpc.CommitmentConfirmed, nil)
 	if txErr == nil {
-		return false, nil
+		// If no error return then it's not cursed
+		return false, 0, nil
 	}
 	errCode, err := parseSolanaErrorCode(txErr)
 	if err != nil {
 		c.env.Logger.Errorf("failed to parse solana error code: %w", err)
-		return false, fmt.Errorf("failed to VerifyNotCursed: %w", txErr)
+		return false, 0, fmt.Errorf("failed to VerifyNotCursed: %w", txErr)
 	}
-	switch errCode {
-	case 9006: // Globally cursed
-		if subject == globals.GlobalCurseSubject() {
-			return true, nil
-		}
-		return false, nil
-	case 9005: // Subject cursed
-		return true, nil
-	default:
-		return false, fmt.Errorf("failed to VerifyNotCursed: %w", txErr)
-	}
+	return true, errCode, nil
 }
 
 func parseSolanaErrorCode(err error) (int64, error) {
@@ -734,19 +756,34 @@ func (c EvmCursableChain) IsConnectedToSourceChain(sourceSelector uint64) (bool,
 	return true, nil
 }
 
-func (c EvmCursableChain) IsSubjectCursed(subject globals.Subject) (bool, error) {
-	if c.cursedSubjectsCache == nil {
-		c.cursedSubjectsCache = make(map[globals.Subject]struct{})
-		cursedSubjects, err := c.chain.RMNRemote.GetCursedSubjects(nil)
-		if err != nil {
-			return false, fmt.Errorf("failed to get cursed subjects for chain %d: %w", c.selector, err)
-		}
-		for _, subj := range cursedSubjects {
-			c.cursedSubjectsCache[subj] = struct{}{}
-		}
+func (c *EvmCursableChain) IsCursed(subject globals.Subject) (bool, error) {
+	c.cacheCurses()
+	if _, isGloballyCursed := c.cursedSubjectsCache[globals.GlobalCurseSubject()]; isGloballyCursed {
+		return true, nil
 	}
+	_, isCursed := c.cursedSubjectsCache[subject]
+	return isCursed, nil
+}
+
+func (c *EvmCursableChain) IsSubjectCursed(subject globals.Subject) (bool, error) {
+	c.cacheCurses()
 	_, cursed := c.cursedSubjectsCache[subject]
 	return cursed, nil
+}
+
+func (c *EvmCursableChain) cacheCurses() error {
+	if c.cursedSubjectsCache != nil {
+		return nil
+	}
+	c.cursedSubjectsCache = make(map[globals.Subject]struct{})
+	cursedSubjects, err := c.chain.RMNRemote.GetCursedSubjects(nil)
+	if err != nil {
+		return fmt.Errorf("failed to get cursed subjects for chain %d: %w", c.selector, err)
+	}
+	for _, subj := range cursedSubjects {
+		c.cursedSubjectsCache[subj] = struct{}{}
+	}
+	return nil
 }
 
 func (c EvmCursableChain) IsCursable() (bool, error) {
@@ -796,7 +833,7 @@ func GetCursableChains(env cldf.Environment) (map[uint64]CursableChain, error) {
 	}
 	cursableChains := make(map[uint64]CursableChain)
 	for selector := range state.Chains {
-		cursableChains[selector] = EvmCursableChain{
+		cursableChains[selector] = &EvmCursableChain{
 			selector: selector,
 			chain:    state.Chains[selector], // Access chain state directly
 			env:      env,

--- a/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
+++ b/deployment/ccip/changeset/v1_6/cs_rmn_curse_uncurse.go
@@ -551,6 +551,8 @@ func (c SolanaCursableChain) IsSubjectCursed(subject globals.Subject) (bool, err
 	if !isCursed {
 		return false, nil
 	}
+	// Curse types are returned as errors.
+	// ref: https://github.com/smartcontractkit/chainlink-ccip/blob/1d85eec090976eaa0a3063d89f4fccc5e29323fa/chains/solana/contracts/target/idl/rmn_remote.json#L478
 	switch curseType {
 	case 9006: // Globally cursed
 		if subject == globals.GlobalCurseSubject() {

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -181,7 +181,7 @@ var testCases = []CurseTestCase{
 	},
 
 	{
-		name: "two chain",
+		name: "two chain globally",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
 			return []v1_6.CurseAction{
 				v1_6.CurseChain(mapIDToSelector(Evm1)),

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -61,7 +61,6 @@ var testCases = []CurseTestCase{
 			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	},
-
 	{
 		name: "solana lane",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
@@ -76,7 +75,6 @@ var testCases = []CurseTestCase{
 			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	},
-
 	{
 		name: "lane duplicate",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
@@ -93,7 +91,6 @@ var testCases = []CurseTestCase{
 			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	},
-
 	{
 		name: "chain",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
@@ -107,7 +104,6 @@ var testCases = []CurseTestCase{
 			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	},
-
 	{
 		name: "solana chain",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
@@ -123,7 +119,6 @@ var testCases = []CurseTestCase{
 			{chainID: Sol1, subject: Evm2, cursed: true},
 		},
 	},
-
 	{
 		name: "chain duplicate",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
@@ -137,7 +132,6 @@ var testCases = []CurseTestCase{
 			{chainID: Sol1, subject: Evm2, cursed: false},
 		},
 	},
-
 	{
 		name: "solana chain duplicate",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
@@ -153,7 +147,6 @@ var testCases = []CurseTestCase{
 			{chainID: Sol1, subject: Evm2, cursed: true},
 		},
 	},
-
 	{
 		name: "chain and lanes",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
@@ -167,7 +160,6 @@ var testCases = []CurseTestCase{
 			{chainID: Sol1, subject: Evm2, cursed: true},
 		},
 	},
-
 	{
 		name: "all chain",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
@@ -179,7 +171,6 @@ var testCases = []CurseTestCase{
 			{chainID: Sol1, globalCurse: true, cursed: true},
 		},
 	},
-
 	{
 		name: "two chain globally",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
@@ -768,7 +759,7 @@ func verifyTestCaseAssertions(t *testing.T, e *testhelpers.DeployedEnv, tc Curse
 			cursedSubject = globals.GlobalCurseSubject()
 		}
 
-		isCursed, err := cursableChains[mapIDToSelector(assertion.chainID)].IsSubjectCursed(cursedSubject)
+		isCursed, err := cursableChains[mapIDToSelector(assertion.chainID)].IsCursed(cursedSubject)
 		require.NoError(t, err)
 		require.Equal(t, assertion.cursed, isCursed, "chain %d subject %d", assertion.chainID, assertion.subject)
 	}
@@ -783,7 +774,7 @@ func verifyNoActiveCurseOnAllChains(t *testing.T, e *testhelpers.DeployedEnv) {
 			family, err := chain_selectors.GetSelectorFamily(chainSelector)
 			require.NoError(t, err)
 
-			isCursed, err := chain.IsSubjectCursed(globals.FamilyAwareSelectorToSubject(selector, family))
+			isCursed, err := chain.IsCursed(globals.FamilyAwareSelectorToSubject(selector, family))
 			require.NoError(t, err)
 			require.False(t, isCursed, "chain %d subject %d", chainSelector, globals.FamilyAwareSelectorToSubject(selector, family))
 		}

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -48,6 +48,139 @@ type mapIDToSelectorFunc func(uint64) uint64
 
 var testCases = []CurseTestCase{
 	{
+		name: "lane",
+		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Evm2))}
+		},
+		curseAssertions: []curseAssertion{
+			{chainID: Evm1, subject: Evm2, cursed: true},
+			{chainID: Evm1, subject: Sol1, cursed: false},
+			{chainID: Evm2, subject: Evm1, cursed: true},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: false},
+			{chainID: Sol1, subject: Evm2, cursed: false},
+		},
+	},
+
+	{
+		name: "solana lane",
+		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1))}
+		},
+		curseAssertions: []curseAssertion{
+			{chainID: Evm1, subject: Evm2, cursed: false},
+			{chainID: Evm1, subject: Sol1, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: false},
+		},
+	},
+
+	{
+		name: "lane duplicate",
+		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+			return []v1_6.CurseAction{
+				v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1)),
+				v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1))}
+		},
+		curseAssertions: []curseAssertion{
+			{chainID: Evm1, subject: Evm2, cursed: false},
+			{chainID: Evm1, subject: Sol1, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: false},
+		},
+	},
+
+	{
+		name: "chain",
+		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1))}
+		},
+		curseAssertions: []curseAssertion{
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: true},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: false},
+		},
+	},
+
+	{
+		name: "solana chain",
+		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Sol1))}
+		},
+		curseAssertions: []curseAssertion{
+			{chainID: Sol1, globalCurse: true, cursed: true},
+			{chainID: Evm1, subject: Evm2, cursed: false},
+			{chainID: Evm1, subject: Sol1, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: true},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: true},
+		},
+	},
+
+	{
+		name: "chain duplicate",
+		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1)), v1_6.CurseChain(mapIDToSelector(Evm1))}
+		},
+		curseAssertions: []curseAssertion{
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: true},
+			{chainID: Evm2, subject: Sol1, cursed: false},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: false},
+		},
+	},
+
+	{
+		name: "solana chain duplicate",
+		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Sol1)), v1_6.CurseChain(mapIDToSelector(Sol1))}
+		},
+		curseAssertions: []curseAssertion{
+			{chainID: Sol1, globalCurse: true, cursed: true},
+			{chainID: Evm1, subject: Evm2, cursed: false},
+			{chainID: Evm1, subject: Sol1, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: false},
+			{chainID: Evm2, subject: Sol1, cursed: true},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: true},
+		},
+	},
+
+	{
+		name: "chain and lanes",
+		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1)), v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm2), mapIDToSelector(Sol1))}
+		},
+		curseAssertions: []curseAssertion{
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm2, subject: Evm1, cursed: true},
+			{chainID: Evm2, subject: Sol1, cursed: true},
+			{chainID: Sol1, subject: Evm1, cursed: true},
+			{chainID: Sol1, subject: Evm2, cursed: true},
+		},
+	},
+
+	{
+		name: "all chain",
+		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+			return []v1_6.CurseAction{v1_6.CurseGloballyAllChains()}
+		},
+		curseAssertions: []curseAssertion{
+			{chainID: Evm1, globalCurse: true, cursed: true},
+			{chainID: Evm2, globalCurse: true, cursed: true},
+			{chainID: Sol1, globalCurse: true, cursed: true},
+		},
+	},
+
+	{
 		name: "two chain",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
 			return []v1_6.CurseAction{
@@ -57,138 +190,6 @@ var testCases = []CurseTestCase{
 		},
 		curseAssertions: []curseAssertion{},
 	},
-	//	{
-	//		name: "lane",
-	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-	//			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Evm2))}
-	//		},
-	//		curseAssertions: []curseAssertion{
-	//			{chainID: Evm1, subject: Evm2, cursed: true},
-	//			{chainID: Evm1, subject: Sol1, cursed: false},
-	//			{chainID: Evm2, subject: Evm1, cursed: true},
-	//			{chainID: Evm2, subject: Sol1, cursed: false},
-	//			{chainID: Sol1, subject: Evm1, cursed: false},
-	//			{chainID: Sol1, subject: Evm2, cursed: false},
-	//		},
-	//	},
-	//
-	//	{
-	//		name: "solana lane",
-	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-	//			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1))}
-	//		},
-	//		curseAssertions: []curseAssertion{
-	//			{chainID: Evm1, subject: Evm2, cursed: false},
-	//			{chainID: Evm1, subject: Sol1, cursed: true},
-	//			{chainID: Evm2, subject: Evm1, cursed: false},
-	//			{chainID: Evm2, subject: Sol1, cursed: false},
-	//			{chainID: Sol1, subject: Evm1, cursed: true},
-	//			{chainID: Sol1, subject: Evm2, cursed: false},
-	//		},
-	//	},
-	//
-	//	{
-	//		name: "lane duplicate",
-	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-	//			return []v1_6.CurseAction{
-	//				v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1)),
-	//				v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1))}
-	//		},
-	//		curseAssertions: []curseAssertion{
-	//			{chainID: Evm1, subject: Evm2, cursed: false},
-	//			{chainID: Evm1, subject: Sol1, cursed: true},
-	//			{chainID: Evm2, subject: Evm1, cursed: false},
-	//			{chainID: Evm2, subject: Sol1, cursed: false},
-	//			{chainID: Sol1, subject: Evm1, cursed: true},
-	//			{chainID: Sol1, subject: Evm2, cursed: false},
-	//		},
-	//	},
-	//
-	//	{
-	//		name: "chain",
-	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-	//			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1))}
-	//		},
-	//		curseAssertions: []curseAssertion{
-	//			{chainID: Evm1, globalCurse: true, cursed: true},
-	//			{chainID: Evm2, subject: Evm1, cursed: true},
-	//			{chainID: Evm2, subject: Sol1, cursed: false},
-	//			{chainID: Sol1, subject: Evm1, cursed: true},
-	//			{chainID: Sol1, subject: Evm2, cursed: false},
-	//		},
-	//	},
-	//
-	//	{
-	//		name: "solana chain",
-	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-	//			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Sol1))}
-	//		},
-	//		curseAssertions: []curseAssertion{
-	//			{chainID: Sol1, globalCurse: true, cursed: true},
-	//			{chainID: Evm1, subject: Evm2, cursed: false},
-	//			{chainID: Evm1, subject: Sol1, cursed: true},
-	//			{chainID: Evm2, subject: Evm1, cursed: false},
-	//			{chainID: Evm2, subject: Sol1, cursed: true},
-	//			{chainID: Sol1, subject: Evm1, cursed: true},
-	//			{chainID: Sol1, subject: Evm2, cursed: true},
-	//		},
-	//	},
-	//
-	//	{
-	//		name: "chain duplicate",
-	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-	//			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1)), v1_6.CurseChain(mapIDToSelector(Evm1))}
-	//		},
-	//		curseAssertions: []curseAssertion{
-	//			{chainID: Evm1, globalCurse: true, cursed: true},
-	//			{chainID: Evm2, subject: Evm1, cursed: true},
-	//			{chainID: Evm2, subject: Sol1, cursed: false},
-	//			{chainID: Sol1, subject: Evm1, cursed: true},
-	//			{chainID: Sol1, subject: Evm2, cursed: false},
-	//		},
-	//	},
-	//
-	//	{
-	//		name: "solana chain duplicate",
-	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-	//			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Sol1)), v1_6.CurseChain(mapIDToSelector(Sol1))}
-	//		},
-	//		curseAssertions: []curseAssertion{
-	//			{chainID: Sol1, globalCurse: true, cursed: true},
-	//			{chainID: Evm1, subject: Evm2, cursed: false},
-	//			{chainID: Evm1, subject: Sol1, cursed: true},
-	//			{chainID: Evm2, subject: Evm1, cursed: false},
-	//			{chainID: Evm2, subject: Sol1, cursed: true},
-	//			{chainID: Sol1, subject: Evm1, cursed: true},
-	//			{chainID: Sol1, subject: Evm2, cursed: true},
-	//		},
-	//	},
-	//
-	//	{
-	//		name: "chain and lanes",
-	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-	//			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1)), v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm2), mapIDToSelector(Sol1))}
-	//		},
-	//		curseAssertions: []curseAssertion{
-	//			{chainID: Evm1, globalCurse: true, cursed: true},
-	//			{chainID: Evm2, subject: Evm1, cursed: true},
-	//			{chainID: Evm2, subject: Sol1, cursed: true},
-	//			{chainID: Sol1, subject: Evm1, cursed: true},
-	//			{chainID: Sol1, subject: Evm2, cursed: true},
-	//		},
-	//	},
-	//
-	//	{
-	//		name: "all chain",
-	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-	//			return []v1_6.CurseAction{v1_6.CurseGloballyAllChains()}
-	//		},
-	//		curseAssertions: []curseAssertion{
-	//			{chainID: Evm1, globalCurse: true, cursed: true},
-	//			{chainID: Evm2, globalCurse: true, cursed: true},
-	//			{chainID: Sol1, globalCurse: true, cursed: true},
-	//		},
-	//	},
 }
 
 func TestRMNCurse(t *testing.T) {

--- a/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
+++ b/integration-tests/smoke/ccip/ccip_cs_rmn_curse_uncurse_test.go
@@ -48,129 +48,147 @@ type mapIDToSelectorFunc func(uint64) uint64
 
 var testCases = []CurseTestCase{
 	{
-		name: "lane",
-		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Evm2))}
-		},
-		curseAssertions: []curseAssertion{
-			{chainID: Evm1, subject: Evm2, cursed: true},
-			{chainID: Evm1, subject: Sol1, cursed: false},
-			{chainID: Evm2, subject: Evm1, cursed: true},
-			{chainID: Evm2, subject: Sol1, cursed: false},
-			{chainID: Sol1, subject: Evm1, cursed: false},
-			{chainID: Sol1, subject: Evm2, cursed: false},
-		},
-	},
-	{
-		name: "solana lane",
-		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1))}
-		},
-		curseAssertions: []curseAssertion{
-			{chainID: Evm1, subject: Evm2, cursed: false},
-			{chainID: Evm1, subject: Sol1, cursed: true},
-			{chainID: Evm2, subject: Evm1, cursed: false},
-			{chainID: Evm2, subject: Sol1, cursed: false},
-			{chainID: Sol1, subject: Evm1, cursed: true},
-			{chainID: Sol1, subject: Evm2, cursed: false},
-		},
-	},
-	{
-		name: "lane duplicate",
+		name: "two chain",
 		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
 			return []v1_6.CurseAction{
-				v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1)),
-				v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1))}
+				v1_6.CurseChain(mapIDToSelector(Evm1)),
+				v1_6.CurseChain(mapIDToSelector(Sol1)),
+			}
 		},
-		curseAssertions: []curseAssertion{
-			{chainID: Evm1, subject: Evm2, cursed: false},
-			{chainID: Evm1, subject: Sol1, cursed: true},
-			{chainID: Evm2, subject: Evm1, cursed: false},
-			{chainID: Evm2, subject: Sol1, cursed: false},
-			{chainID: Sol1, subject: Evm1, cursed: true},
-			{chainID: Sol1, subject: Evm2, cursed: false},
-		},
+		curseAssertions: []curseAssertion{},
 	},
-	{
-		name: "chain",
-		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1))}
-		},
-		curseAssertions: []curseAssertion{
-			{chainID: Evm1, globalCurse: true, cursed: true},
-			{chainID: Evm2, subject: Evm1, cursed: true},
-			{chainID: Evm2, subject: Sol1, cursed: false},
-			{chainID: Sol1, subject: Evm1, cursed: true},
-			{chainID: Sol1, subject: Evm2, cursed: false},
-		},
-	},
-	{
-		name: "solana chain",
-		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Sol1))}
-		},
-		curseAssertions: []curseAssertion{
-			{chainID: Sol1, globalCurse: true, cursed: true},
-			{chainID: Evm1, subject: Evm2, cursed: false},
-			{chainID: Evm1, subject: Sol1, cursed: true},
-			{chainID: Evm2, subject: Evm1, cursed: false},
-			{chainID: Evm2, subject: Sol1, cursed: true},
-			{chainID: Sol1, subject: Evm1, cursed: true},
-			{chainID: Sol1, subject: Evm2, cursed: true},
-		},
-	},
-	{
-		name: "chain duplicate",
-		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1)), v1_6.CurseChain(mapIDToSelector(Evm1))}
-		},
-		curseAssertions: []curseAssertion{
-			{chainID: Evm1, globalCurse: true, cursed: true},
-			{chainID: Evm2, subject: Evm1, cursed: true},
-			{chainID: Evm2, subject: Sol1, cursed: false},
-			{chainID: Sol1, subject: Evm1, cursed: true},
-			{chainID: Sol1, subject: Evm2, cursed: false},
-		},
-	},
-	{
-		name: "solana chain duplicate",
-		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Sol1)), v1_6.CurseChain(mapIDToSelector(Sol1))}
-		},
-		curseAssertions: []curseAssertion{
-			{chainID: Sol1, globalCurse: true, cursed: true},
-			{chainID: Evm1, subject: Evm2, cursed: false},
-			{chainID: Evm1, subject: Sol1, cursed: true},
-			{chainID: Evm2, subject: Evm1, cursed: false},
-			{chainID: Evm2, subject: Sol1, cursed: true},
-			{chainID: Sol1, subject: Evm1, cursed: true},
-			{chainID: Sol1, subject: Evm2, cursed: true},
-		},
-	},
-	{
-		name: "chain and lanes",
-		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1)), v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm2), mapIDToSelector(Sol1))}
-		},
-		curseAssertions: []curseAssertion{
-			{chainID: Evm1, globalCurse: true, cursed: true},
-			{chainID: Evm2, subject: Evm1, cursed: true},
-			{chainID: Evm2, subject: Sol1, cursed: true},
-			{chainID: Sol1, subject: Evm1, cursed: true},
-			{chainID: Sol1, subject: Evm2, cursed: true},
-		},
-	},
-	{
-		name: "all chain",
-		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
-			return []v1_6.CurseAction{v1_6.CurseGloballyAllChains()}
-		},
-		curseAssertions: []curseAssertion{
-			{chainID: Evm1, globalCurse: true, cursed: true},
-			{chainID: Evm2, globalCurse: true, cursed: true},
-			{chainID: Sol1, globalCurse: true, cursed: true},
-		},
-	},
+	//	{
+	//		name: "lane",
+	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+	//			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Evm2))}
+	//		},
+	//		curseAssertions: []curseAssertion{
+	//			{chainID: Evm1, subject: Evm2, cursed: true},
+	//			{chainID: Evm1, subject: Sol1, cursed: false},
+	//			{chainID: Evm2, subject: Evm1, cursed: true},
+	//			{chainID: Evm2, subject: Sol1, cursed: false},
+	//			{chainID: Sol1, subject: Evm1, cursed: false},
+	//			{chainID: Sol1, subject: Evm2, cursed: false},
+	//		},
+	//	},
+	//
+	//	{
+	//		name: "solana lane",
+	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+	//			return []v1_6.CurseAction{v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1))}
+	//		},
+	//		curseAssertions: []curseAssertion{
+	//			{chainID: Evm1, subject: Evm2, cursed: false},
+	//			{chainID: Evm1, subject: Sol1, cursed: true},
+	//			{chainID: Evm2, subject: Evm1, cursed: false},
+	//			{chainID: Evm2, subject: Sol1, cursed: false},
+	//			{chainID: Sol1, subject: Evm1, cursed: true},
+	//			{chainID: Sol1, subject: Evm2, cursed: false},
+	//		},
+	//	},
+	//
+	//	{
+	//		name: "lane duplicate",
+	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+	//			return []v1_6.CurseAction{
+	//				v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1)),
+	//				v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm1), mapIDToSelector(Sol1))}
+	//		},
+	//		curseAssertions: []curseAssertion{
+	//			{chainID: Evm1, subject: Evm2, cursed: false},
+	//			{chainID: Evm1, subject: Sol1, cursed: true},
+	//			{chainID: Evm2, subject: Evm1, cursed: false},
+	//			{chainID: Evm2, subject: Sol1, cursed: false},
+	//			{chainID: Sol1, subject: Evm1, cursed: true},
+	//			{chainID: Sol1, subject: Evm2, cursed: false},
+	//		},
+	//	},
+	//
+	//	{
+	//		name: "chain",
+	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+	//			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1))}
+	//		},
+	//		curseAssertions: []curseAssertion{
+	//			{chainID: Evm1, globalCurse: true, cursed: true},
+	//			{chainID: Evm2, subject: Evm1, cursed: true},
+	//			{chainID: Evm2, subject: Sol1, cursed: false},
+	//			{chainID: Sol1, subject: Evm1, cursed: true},
+	//			{chainID: Sol1, subject: Evm2, cursed: false},
+	//		},
+	//	},
+	//
+	//	{
+	//		name: "solana chain",
+	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+	//			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Sol1))}
+	//		},
+	//		curseAssertions: []curseAssertion{
+	//			{chainID: Sol1, globalCurse: true, cursed: true},
+	//			{chainID: Evm1, subject: Evm2, cursed: false},
+	//			{chainID: Evm1, subject: Sol1, cursed: true},
+	//			{chainID: Evm2, subject: Evm1, cursed: false},
+	//			{chainID: Evm2, subject: Sol1, cursed: true},
+	//			{chainID: Sol1, subject: Evm1, cursed: true},
+	//			{chainID: Sol1, subject: Evm2, cursed: true},
+	//		},
+	//	},
+	//
+	//	{
+	//		name: "chain duplicate",
+	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+	//			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1)), v1_6.CurseChain(mapIDToSelector(Evm1))}
+	//		},
+	//		curseAssertions: []curseAssertion{
+	//			{chainID: Evm1, globalCurse: true, cursed: true},
+	//			{chainID: Evm2, subject: Evm1, cursed: true},
+	//			{chainID: Evm2, subject: Sol1, cursed: false},
+	//			{chainID: Sol1, subject: Evm1, cursed: true},
+	//			{chainID: Sol1, subject: Evm2, cursed: false},
+	//		},
+	//	},
+	//
+	//	{
+	//		name: "solana chain duplicate",
+	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+	//			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Sol1)), v1_6.CurseChain(mapIDToSelector(Sol1))}
+	//		},
+	//		curseAssertions: []curseAssertion{
+	//			{chainID: Sol1, globalCurse: true, cursed: true},
+	//			{chainID: Evm1, subject: Evm2, cursed: false},
+	//			{chainID: Evm1, subject: Sol1, cursed: true},
+	//			{chainID: Evm2, subject: Evm1, cursed: false},
+	//			{chainID: Evm2, subject: Sol1, cursed: true},
+	//			{chainID: Sol1, subject: Evm1, cursed: true},
+	//			{chainID: Sol1, subject: Evm2, cursed: true},
+	//		},
+	//	},
+	//
+	//	{
+	//		name: "chain and lanes",
+	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+	//			return []v1_6.CurseAction{v1_6.CurseChain(mapIDToSelector(Evm1)), v1_6.CurseLaneBidirectionally(mapIDToSelector(Evm2), mapIDToSelector(Sol1))}
+	//		},
+	//		curseAssertions: []curseAssertion{
+	//			{chainID: Evm1, globalCurse: true, cursed: true},
+	//			{chainID: Evm2, subject: Evm1, cursed: true},
+	//			{chainID: Evm2, subject: Sol1, cursed: true},
+	//			{chainID: Sol1, subject: Evm1, cursed: true},
+	//			{chainID: Sol1, subject: Evm2, cursed: true},
+	//		},
+	//	},
+	//
+	//	{
+	//		name: "all chain",
+	//		curseActionsBuilder: func(mapIDToSelector mapIDToSelectorFunc) []v1_6.CurseAction {
+	//			return []v1_6.CurseAction{v1_6.CurseGloballyAllChains()}
+	//		},
+	//		curseAssertions: []curseAssertion{
+	//			{chainID: Evm1, globalCurse: true, cursed: true},
+	//			{chainID: Evm2, globalCurse: true, cursed: true},
+	//			{chainID: Sol1, globalCurse: true, cursed: true},
+	//		},
+	//	},
 }
 
 func TestRMNCurse(t *testing.T) {


### PR DESCRIPTION
# Summary
When cursing more than one chain, but not all (e.g., the `two chain globally` test case), the corresponding uncurse changeset would fail. This occurred because a global curse in the chain would cause the old `IsSubjectCursed` function implementation to return `true` for any subject. This is the expected logic for RMN behavior, but wasn't accounted for in the CS's logic.

This happened because `RMNRemote.IsCursed` does not distinguish between global and subject-level curses on EVM, and for Solana we were not distinguishing the response. As a result, more subjects than necessary were passed to the uncurse call, which then reverted on every chain family -- since attempting to uncurse an already-uncursed subject causes a revert.

This PR addresses the issue by fixing `IsSubjectCursed` implementations for both EVM and Solana:  
- Separates `IsSubjectCursed` from `IsCursed`
  - `IsSubjectCursed` checks if that specific subject is already cursed to avoid duplicating curses (used on CS logic)
  - `IsCursed` mimics the call to `RMN.IsCursed` which will return `true` if subject or global curse is active (used on tests to assert RMN behavior)
- EVM: Now caches all cursed subjects and checks against the cache, avoiding redundant RPC calls and incorrect evaluations.
- Solana: Adds error code parsing to differentiate between global and subject-specific curses based on the error returned by `VerifyNotCursed`. ([Reference](https://github.com/smartcontractkit/chainlink-ccip/blob/1d85eec090976eaa0a3063d89f4fccc5e29323fa/chains/solana/contracts/target/idl/rmn_remote.json#L484))

# Features
- Separated `IsSubjectCursed` from `IsCursed`;
- Fix `IsSubjectCursed` for Solana and EVM;
- Cache cursed subjects for EVM instead of multiple RPC calls.

# Testing
- Added a new test case for the bug
