### PR TITLE
chore: remove dependency on root package in token changesets

### DIFF
--- a/deployment/tokens/changesets/deploy_evm_link_tokens.go
+++ b/deployment/tokens/changesets/deploy_evm_link_tokens.go
@@ -6,7 +6,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/seqs"
 )
 
@@ -62,7 +61,7 @@ func (deployEVMLinkTokens) VerifyPreconditions(
 		return err
 	}
 
-	return deployment.ValidateSelectorsInEnvironment(e, input.ChainSelectors)
+	return validateSelectorsInEnvironment(e.BlockChains, input.ChainSelectors)
 }
 
 // Apply executes the SeqDeployEVMTokens sequence to deploy Link Token contracts to the specified

--- a/deployment/tokens/changesets/deploy_sol_link_tokens.go
+++ b/deployment/tokens/changesets/deploy_sol_link_tokens.go
@@ -6,7 +6,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/seqs"
 )
 
@@ -38,7 +37,7 @@ func (deploySolLinkTokens) VerifyPreconditions(
 		return err
 	}
 
-	return deployment.ValidateSelectorsInEnvironment(e, input.ChainSelectors)
+	return validateSelectorsInEnvironment(e.BlockChains, input.ChainSelectors)
 }
 
 // Apply executes the SeqDeploySolTokens sequence to deploy Link Token contracts to the specified

--- a/deployment/tokens/changesets/validate.go
+++ b/deployment/tokens/changesets/validate.go
@@ -7,6 +7,7 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/tokens/internal/ops"
@@ -79,6 +80,20 @@ func validateChainSelectorsFamily(csels []uint64, fam string) error {
 
 		if cselFam != fam {
 			return fmt.Errorf("chain selector %d is not in the %s family", csel, fam)
+		}
+	}
+
+	return nil
+}
+
+// validateSelectorsInEnvironment checks that all chain selectors are valid and
+// available in the environment's blockchains.
+func validateSelectorsInEnvironment(
+	blockchains cldf_chain.BlockChains, selectors []uint64,
+) error {
+	for _, sel := range selectors {
+		if !blockchains.Exists(sel) {
+			return fmt.Errorf("chain %d not found in environment", sel)
 		}
 	}
 


### PR DESCRIPTION
Removes the last dependency on the root package in the token changesets. This allows the changesets to be used without needing to import the all the dependencies of the root package.
