### PR TITLE
DF-21393: Enable Transmission Telemetry for OCR2 Median jobs

### DIFF
--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -1163,6 +1163,7 @@ func (d *Delegate) newServicesMedian(
 		lggr.ErrorIf(d.jobORM.RecordError(ctx, jb.ID, msg), "unable to record error")
 	})
 
+	lc.EnableTransmissionTelemetry = true
 	oracleArgsNoPlugin := libocr2.OCR2OracleArgs{
 		BinaryNetworkEndpointFactory: d.peerWrapper.Peer2,
 		V2Bootstrappers:              bootstrapPeers,


### PR DESCRIPTION
- Set  `EnableTransmissionTelemetry` to true for OCR2 Median jobs, so that Libocr emits the Transmission Telemetry added in https://github.com/smartcontractkit/libocr/commit/dafc48b069ef89660c10f439e45679efefc2fe71
- Expected increase in Telemetry volume is <2% - an upper bound would be 3 telemetry messages per node and generated report.
- https://smartcontract-it.atlassian.net/browse/DF-21393

### Requires
- None

### Supports
- None