### PR TITLE
feat: add finalization checker for monitoring block synchronization across multiple RPCs

### DIFF
--- a/core/scripts/ccip/finalization_checker.go
+++ b/core/scripts/ccip/finalization_checker.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"time"
 )
@@ -56,7 +57,7 @@ func getFinalizedBlockNumber(url string) (uint64, error) {
 		"id":      1,
 	}
 	b, _ := json.Marshal(payload)
-	//nolint:nosec G107 - URL is from trusted configuration
+	//nolint:gosec // G107 - URL is from trusted configuration
 	resp, err := http.Post(url, "application/json", bytes.NewReader(b))
 	if err != nil {
 		return 0, err
@@ -96,7 +97,7 @@ func main() {
 
 	for {
 		blockNumbers := make([]uint64, len(endpoints))
-		minBlock, maxBlock := uint64(0), uint64(0)
+		minBlock, maxBlock := uint64(math.MaxUint64), uint64(0)
 		hasValidData := false
 
 		for i, ep := range endpoints {

--- a/core/scripts/ccip/finalization_checker.go
+++ b/core/scripts/ccip/finalization_checker.go
@@ -31,22 +31,10 @@ type BlockResponse struct {
 }
 
 // MODIFY HERE THE ENDPOINTS YOU WANT TO TEST
-// var endpoints = []Endpoint{
-// 	{"LinkPool", "https://rpcs.cldev.sh/base/sepolia/linkpool1"},
-// 	{"Chainstack", "https://rpcs.cldev.sh/base/sepolia/chainstack1"},
-// 	{"SimplyVC", "https://rpcs.cldev.sh/base/sepolia/simplyvc1"},
-// }
-
-// var endpoints = []Endpoint{
-// 	{"Chainstack", "https://rpcs.cldev.sh/base/mainnet/chainstack1"},
-// 	{"LinkPool", "https://rpcs.cldev.sh/base/mainnet/linkpool1"},
-// 	{"SimplyVC", "https://rpcs.cldev.sh/base/mainnet/simplyvc1"},
-// }
-
 var endpoints = []Endpoint{
-	{"SimplyVC", "https://rpcs.cldev.sh/optimism/sepolia/simplyvc1"},
-	{"LinkPool", "https://rpcs.cldev.sh/optimism/sepolia/linkpool1"},
-	{"Chainstack", "https://rpcs.cldev.sh/optimism/sepolia/chainstack1"},
+	{"LinkPool", "https://rpc1"},
+	{"Chainstack", "https://rpc2"},
+	{"SimplyVC", "https://rpc3"},
 }
 
 func getFinalizedBlockNumber(url string) (uint64, error) {

--- a/core/scripts/ccip/finalization_checker.go
+++ b/core/scripts/ccip/finalization_checker.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -57,8 +58,18 @@ func getFinalizedBlockNumber(url string) (uint64, error) {
 		"id":      1,
 	}
 	b, _ := json.Marshal(payload)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
 	//nolint:gosec // G107 - URL is from trusted configuration
-	resp, err := http.Post(url, "application/json", bytes.NewReader(b))
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return 0, err
 	}
@@ -95,6 +106,10 @@ func main() {
 	// Track last block number for each endpoint
 	lastBlockNumbers := make(map[string]uint64)
 
+	// Track last time we printed full status
+	lastStatusPrint := time.Now()
+	statusInterval := 120 * time.Second
+
 	for {
 		blockNumbers := make([]uint64, len(endpoints))
 		minBlock, maxBlock := uint64(math.MaxUint64), uint64(0)
@@ -128,6 +143,22 @@ func main() {
 			fmt.Printf("[%s] All endpoints failed, retrying...\n", time.Now().Format(time.RFC3339))
 			time.Sleep(time.Duration(*interval) * time.Second)
 			continue
+		}
+
+		// Print full status every 90 seconds
+		if time.Since(lastStatusPrint) >= statusInterval {
+			fmt.Printf("\n[%s] === PERIODIC STATUS CHECK ===\n", time.Now().Format(time.RFC3339))
+			fmt.Println("Current finalized blocks:")
+			for i, ep := range endpoints {
+				if blockNumbers[i] > 0 {
+					fmt.Printf("  %s: %d\n", ep.Name, blockNumbers[i])
+				} else {
+					fmt.Printf("  %s: ERROR\n", ep.Name)
+				}
+			}
+			fmt.Printf("Block difference: %d (min: %d, max: %d)\n", maxBlock-minBlock, minBlock, maxBlock)
+			fmt.Println("================================")
+			lastStatusPrint = time.Now()
 		}
 
 		currentDiff := maxBlock - minBlock

--- a/core/scripts/ccip/finalization_checker.go
+++ b/core/scripts/ccip/finalization_checker.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -56,15 +56,17 @@ func getFinalizedBlockNumber(url string) (uint64, error) {
 		"id":      1,
 	}
 	b, _ := json.Marshal(payload)
+	//nolint //nosec G107 - URL is from trusted configuration
 	resp, err := http.Post(url, "application/json", bytes.NewReader(b))
 	if err != nil {
 		return 0, err
 	}
 	defer resp.Body.Close()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	var br BlockResponse
-	if err := json.Unmarshal(body, &br); err != nil {
+	err = json.Unmarshal(body, &br)
+	if err != nil {
 		return 0, err
 	}
 	if br.Result == nil || br.Result.Number == "" {
@@ -73,7 +75,7 @@ func getFinalizedBlockNumber(url string) (uint64, error) {
 	var blockNum uint64
 	_, err = fmt.Sscanf(br.Result.Number, "0x%x", &blockNum)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse block number: %v", err)
+		return 0, fmt.Errorf("failed to parse block number: %w", err)
 	}
 	return blockNum, nil
 }
@@ -91,7 +93,7 @@ func main() {
 
 	for {
 		blockNumbers := make([]uint64, len(endpoints))
-		min, max := uint64(^uint64(0)), uint64(0)
+		minBlock, maxBlock := uint64(^uint64(0)), uint64(0)
 		hasValidData := false
 
 		for i, ep := range endpoints {
@@ -102,11 +104,11 @@ func main() {
 			}
 			blockNumbers[i] = num
 			hasValidData = true
-			if num < min {
-				min = num
+			if num < minBlock {
+				minBlock = num
 			}
-			if num > max {
-				max = num
+			if num > maxBlock {
+				maxBlock = num
 			}
 		}
 
@@ -116,7 +118,7 @@ func main() {
 			continue
 		}
 
-		currentDiff := max - min
+		currentDiff := maxBlock - minBlock
 		currentSynced := currentDiff == 0
 		now := time.Now()
 

--- a/core/scripts/ccip/finalization_checker.go
+++ b/core/scripts/ccip/finalization_checker.go
@@ -35,17 +35,17 @@ type BlockResponse struct {
 // 	{"SimplyVC", "https://rpcs.cldev.sh/base/sepolia/simplyvc1"},
 // }
 
-// var endpoints = []Endpoint{
-// 	{"Chainstack", "https://rpcs.cldev.sh/base/mainnet/chainstack1"},
-// 	{"LinkPool", "https://rpcs.cldev.sh/base/mainnet/linkpool1"},
-// 	{"SimplyVC", "https://rpcs.cldev.sh/base/mainnet/simplyvc1"},
-// }
-
 var endpoints = []Endpoint{
-	{"SimplyVC", "https://rpcs.cldev.sh/optimism/sepolia/simplyvc1"},
-	{"LinkPool", "https://rpcs.cldev.sh/optimism/sepolia/linkpool1"},
-	{"Chainstack", "https://rpcs.cldev.sh/optimism/sepolia/chainstack1"},
+	{"Chainstack", "https://rpcs.cldev.sh/base/mainnet/chainstack1"},
+	{"LinkPool", "https://rpcs.cldev.sh/base/mainnet/linkpool1"},
+	{"SimplyVC", "https://rpcs.cldev.sh/base/mainnet/simplyvc1"},
 }
+
+// var endpoints = []Endpoint{
+// 	{"SimplyVC", "https://rpcs.cldev.sh/optimism/sepolia/simplyvc1"},
+// 	{"LinkPool", "https://rpcs.cldev.sh/optimism/sepolia/linkpool1"},
+// 	{"Chainstack", "https://rpcs.cldev.sh/optimism/sepolia/chainstack1"},
+// }
 
 func getFinalizedBlockNumber(url string) (uint64, error) {
 	// JSON-RPC request
@@ -56,7 +56,7 @@ func getFinalizedBlockNumber(url string) (uint64, error) {
 		"id":      1,
 	}
 	b, _ := json.Marshal(payload)
-	//nolint //nosec G107 - URL is from trusted configuration
+	//nolint:nosec G107 - URL is from trusted configuration
 	resp, err := http.Post(url, "application/json", bytes.NewReader(b))
 	if err != nil {
 		return 0, err
@@ -91,9 +91,12 @@ func main() {
 	var timestamps []time.Time
 	var states []string
 
+	// Track last block number for each endpoint
+	lastBlockNumbers := make(map[string]uint64)
+
 	for {
 		blockNumbers := make([]uint64, len(endpoints))
-		minBlock, maxBlock := uint64(^uint64(0)), uint64(0)
+		minBlock, maxBlock := uint64(0), uint64(0)
 		hasValidData := false
 
 		for i, ep := range endpoints {
@@ -104,6 +107,14 @@ func main() {
 			}
 			blockNumbers[i] = num
 			hasValidData = true
+
+			// Check if block number changed for this endpoint
+			if lastBlock, exists := lastBlockNumbers[ep.Name]; !exists || lastBlock != num {
+				fmt.Printf("[%s] %s block changed: %d -> %d\n",
+					time.Now().Format(time.RFC3339), ep.Name, lastBlock, num)
+				lastBlockNumbers[ep.Name] = num
+			}
+
 			if num < minBlock {
 				minBlock = num
 			}

--- a/core/scripts/ccip/finalization_checker.go
+++ b/core/scripts/ccip/finalization_checker.go
@@ -37,17 +37,17 @@ type BlockResponse struct {
 // 	{"SimplyVC", "https://rpcs.cldev.sh/base/sepolia/simplyvc1"},
 // }
 
-var endpoints = []Endpoint{
-	{"Chainstack", "https://rpcs.cldev.sh/base/mainnet/chainstack1"},
-	{"LinkPool", "https://rpcs.cldev.sh/base/mainnet/linkpool1"},
-	{"SimplyVC", "https://rpcs.cldev.sh/base/mainnet/simplyvc1"},
-}
-
 // var endpoints = []Endpoint{
-// 	{"SimplyVC", "https://rpcs.cldev.sh/optimism/sepolia/simplyvc1"},
-// 	{"LinkPool", "https://rpcs.cldev.sh/optimism/sepolia/linkpool1"},
-// 	{"Chainstack", "https://rpcs.cldev.sh/optimism/sepolia/chainstack1"},
+// 	{"Chainstack", "https://rpcs.cldev.sh/base/mainnet/chainstack1"},
+// 	{"LinkPool", "https://rpcs.cldev.sh/base/mainnet/linkpool1"},
+// 	{"SimplyVC", "https://rpcs.cldev.sh/base/mainnet/simplyvc1"},
 // }
+
+var endpoints = []Endpoint{
+	{"SimplyVC", "https://rpcs.cldev.sh/optimism/sepolia/simplyvc1"},
+	{"LinkPool", "https://rpcs.cldev.sh/optimism/sepolia/linkpool1"},
+	{"Chainstack", "https://rpcs.cldev.sh/optimism/sepolia/chainstack1"},
+}
 
 func getFinalizedBlockNumber(url string) (uint64, error) {
 	// JSON-RPC request
@@ -68,7 +68,6 @@ func getFinalizedBlockNumber(url string) (uint64, error) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	//nolint:gosec // G107 - URL is from trusted configuration
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return 0, err

--- a/core/scripts/ccip/finalization_checker.go
+++ b/core/scripts/ccip/finalization_checker.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// Endpoint represents an RPC endpoint with a name and URL
+type Endpoint struct {
+	Name string
+	URL  string
+}
+
+// BlockResponse is the structure for eth_getBlockByNumber response
+// Only need the 'number' field
+// The 'result' can be null if the node is not synced
+// So we use a pointer
+
+type Block struct {
+	Number string `json:"number"`
+}
+type BlockResponse struct {
+	Result *Block `json:"result"`
+}
+
+// MODIFY HERE THE ENDPOINTS YOU WANT TO TEST
+// var endpoints = []Endpoint{
+// 	{"LinkPool", "https://rpcs.cldev.sh/base/sepolia/linkpool1"},
+// 	{"Chainstack", "https://rpcs.cldev.sh/base/sepolia/chainstack1"},
+// 	{"SimplyVC", "https://rpcs.cldev.sh/base/sepolia/simplyvc1"},
+// }
+
+// var endpoints = []Endpoint{
+// 	{"Chainstack", "https://rpcs.cldev.sh/base/mainnet/chainstack1"},
+// 	{"LinkPool", "https://rpcs.cldev.sh/base/mainnet/linkpool1"},
+// 	{"SimplyVC", "https://rpcs.cldev.sh/base/mainnet/simplyvc1"},
+// }
+
+var endpoints = []Endpoint{
+	{"SimplyVC", "https://rpcs.cldev.sh/optimism/sepolia/simplyvc1"},
+	{"LinkPool", "https://rpcs.cldev.sh/optimism/sepolia/linkpool1"},
+	{"Chainstack", "https://rpcs.cldev.sh/optimism/sepolia/chainstack1"},
+}
+
+func getFinalizedBlockNumber(url string) (uint64, error) {
+	// JSON-RPC request
+	payload := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "eth_getBlockByNumber",
+		"params":  []interface{}{"finalized", false},
+		"id":      1,
+	}
+	b, _ := json.Marshal(payload)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	var br BlockResponse
+	if err := json.Unmarshal(body, &br); err != nil {
+		return 0, err
+	}
+	if br.Result == nil || br.Result.Number == "" {
+		return 0, fmt.Errorf("no block number in response: %s", string(body))
+	}
+	var blockNum uint64
+	_, err = fmt.Sscanf(br.Result.Number, "0x%x", &blockNum)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse block number: %v", err)
+	}
+	return blockNum, nil
+}
+
+func main() {
+	interval := flag.Int("interval", 10, "Polling interval in seconds")
+	flag.Parse()
+
+	fmt.Printf("Monitoring finalized blocks every %d seconds. Press Ctrl+C to stop.\n", *interval)
+	fmt.Println("Waiting for state changes (synchronized <-> unsynchronized)...")
+
+	var lastSynced *bool // nil = unknown, true = synced (diff=0), false = not synced (diff>0)
+	var timestamps []time.Time
+	var states []string
+
+	for {
+		blockNumbers := make([]uint64, len(endpoints))
+		min, max := uint64(^uint64(0)), uint64(0)
+		hasValidData := false
+
+		for i, ep := range endpoints {
+			num, err := getFinalizedBlockNumber(ep.URL)
+			if err != nil {
+				blockNumbers[i] = 0
+				continue
+			}
+			blockNumbers[i] = num
+			hasValidData = true
+			if num < min {
+				min = num
+			}
+			if num > max {
+				max = num
+			}
+		}
+
+		if !hasValidData {
+			fmt.Printf("[%s] All endpoints failed, retrying...\n", time.Now().Format(time.RFC3339))
+			time.Sleep(time.Duration(*interval) * time.Second)
+			continue
+		}
+
+		currentDiff := max - min
+		currentSynced := currentDiff == 0
+		now := time.Now()
+
+		// Check if state changed
+		if lastSynced == nil || *lastSynced != currentSynced {
+			stateStr := "UNSYNCHRONIZED"
+			if currentSynced {
+				stateStr = "SYNCHRONIZED"
+			}
+
+			fmt.Printf("\n[%s] STATE CHANGE: %s (block difference: %d)\n",
+				now.Format(time.RFC3339), stateStr, currentDiff)
+
+			// Print current block numbers for context
+			fmt.Println("Current finalized blocks:")
+			for i, ep := range endpoints {
+				if blockNumbers[i] > 0 {
+					fmt.Printf("  %s: %d\n", ep.Name, blockNumbers[i])
+				}
+			}
+
+			// Store timestamp and state
+			timestamps = append(timestamps, now)
+			states = append(states, stateStr)
+
+			// Print summary of recorded events
+			fmt.Printf("\nRecorded events (%d total):\n", len(timestamps))
+			for i, ts := range timestamps {
+				fmt.Printf("  %d. [%s] %s\n", i+1, ts.Format(time.RFC3339), states[i])
+			}
+
+			lastSynced = &currentSynced
+		}
+
+		time.Sleep(time.Duration(*interval) * time.Second)
+	}
+}


### PR DESCRIPTION
This new script allows monitoring of finalized blocks from specified RPC endpoints, reporting state changes between synchronized and unsynchronized states for finalized blocks. It includes functionality for polling at configurable intervals and logging the results for analysis.

