### PR TITLE
Fix GetChainWriter Bug

### DIFF
--- a/.changeset/fluffy-kids-ask.md
+++ b/.changeset/fluffy-kids-ask.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#added a transmitter array length check to GetChainWriter

--- a/core/capabilities/ccip/ccipaptos/crcwconfig.go
+++ b/core/capabilities/ccip/ccipaptos/crcwconfig.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	aptosloop "github.com/smartcontractkit/chainlink-aptos/relayer/chainreader/loop"
+	"github.com/smartcontractkit/chainlink-aptos/relayer/chainwriter"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	aptosconfig "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/configs/aptos"
@@ -38,7 +39,16 @@ func (g ChainCWProvider) GetChainReader(ctx context.Context, params ccipcommon.C
 // GetChainWriter returns a new ContractWriter for Aptos chains.
 func (g ChainCWProvider) GetChainWriter(ctx context.Context, params ccipcommon.ChainWriterProviderOpts) (types.ContractWriter, error) {
 	transmitter := params.Transmitters[types.NewRelayID(params.ChainFamily, params.ChainID)]
-	cfg, err := aptosconfig.GetChainWriterConfig(transmitter[0])
+
+	var cfg chainwriter.ChainWriterConfig
+	var err error
+
+	if len(transmitter) > 0 {
+		cfg, err = aptosconfig.GetChainWriterConfig(transmitter[0])
+	} else {
+		return nil, fmt.Errorf("there must be at least one transmitter for Aptos chain: %s", params.ChainID)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Aptos chain writer config: %w", err)
 	}

--- a/core/capabilities/ccip/ccipaptos/crcwconfig.go
+++ b/core/capabilities/ccip/ccipaptos/crcwconfig.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	aptosloop "github.com/smartcontractkit/chainlink-aptos/relayer/chainreader/loop"
-	"github.com/smartcontractkit/chainlink-aptos/relayer/chainwriter"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	aptosconfig "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/configs/aptos"
@@ -40,14 +39,11 @@ func (g ChainCWProvider) GetChainReader(ctx context.Context, params ccipcommon.C
 func (g ChainCWProvider) GetChainWriter(ctx context.Context, params ccipcommon.ChainWriterProviderOpts) (types.ContractWriter, error) {
 	transmitter := params.Transmitters[types.NewRelayID(params.ChainFamily, params.ChainID)]
 
-	var cfg chainwriter.ChainWriterConfig
-	var err error
-
-	if len(transmitter) > 0 {
-		cfg, err = aptosconfig.GetChainWriterConfig(transmitter[0])
-	} else {
+	if len(transmitter) == 0 {
 		return nil, fmt.Errorf("there must be at least one transmitter for Aptos chain: %s", params.ChainID)
 	}
+
+	cfg, err := aptosconfig.GetChainWriterConfig(transmitter[0])
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Aptos chain writer config: %w", err)

--- a/core/capabilities/ccip/ccipevm/crcwconfig.go
+++ b/core/capabilities/ccip/ccipevm/crcwconfig.go
@@ -56,10 +56,13 @@ func (g ChainCWProvider) GetChainReader(ctx context.Context, params ccipcommon.C
 func (g ChainCWProvider) GetChainWriter(ctx context.Context, params ccipcommon.ChainWriterProviderOpts) (types.ContractWriter, error) {
 	var fromAddress common.Address
 	transmitter, ok := params.Transmitters[types.NewRelayID(params.ChainFamily, params.ChainID)]
-	if ok && len(transmitter) > 0 {
-		fromAddress = common.HexToAddress(transmitter[0])
-	} else {
+
+	if len(transmitter) == 0 {
 		return nil, fmt.Errorf("there must be at least one transmitter for EVM chain: %s", params.ChainID)
+	}
+
+	if ok {
+		fromAddress = common.HexToAddress(transmitter[0])
 	}
 
 	evmConfig, err := evmconfig.ChainWriterConfigRaw(

--- a/core/capabilities/ccip/ccipevm/crcwconfig.go
+++ b/core/capabilities/ccip/ccipevm/crcwconfig.go
@@ -56,8 +56,10 @@ func (g ChainCWProvider) GetChainReader(ctx context.Context, params ccipcommon.C
 func (g ChainCWProvider) GetChainWriter(ctx context.Context, params ccipcommon.ChainWriterProviderOpts) (types.ContractWriter, error) {
 	var fromAddress common.Address
 	transmitter, ok := params.Transmitters[types.NewRelayID(params.ChainFamily, params.ChainID)]
-	if ok {
+	if ok && len(transmitter) > 0 {
 		fromAddress = common.HexToAddress(transmitter[0])
+	} else {
+		return nil, fmt.Errorf("there must be at least one transmitter for EVM chain: %s", params.ChainID)
 	}
 
 	evmConfig, err := evmconfig.ChainWriterConfigRaw(

--- a/core/capabilities/ccip/ccipsolana/crcwconfig.go
+++ b/core/capabilities/ccip/ccipsolana/crcwconfig.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gagliardetto/solana-go"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana/chainwriter"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	solanaconfig "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/configs/solana"
@@ -20,8 +19,6 @@ type ChainRWProvider struct{}
 // GetChainWriter ChainRWProvider returns a new ContractWriter for Solana chains.
 func (g ChainRWProvider) GetChainWriter(ctx context.Context, params ccipcommon.ChainWriterProviderOpts) (types.ContractWriter, error) {
 	var offrampProgramAddress solana.PublicKey
-	var solConfig chainwriter.ChainWriterConfig
-	var err error
 	// NOTE: this function can still be called with EVM inputs, and PublicKeyFromBytes will panic on addresses with len=20
 	// technically we only need the writer to do fee estimation so this doesn't matter and we can use a zero address
 	if len(params.OfframpProgramAddress) == solana.PublicKeyLength {
@@ -30,11 +27,11 @@ func (g ChainRWProvider) GetChainWriter(ctx context.Context, params ccipcommon.C
 
 	transmitter := params.Transmitters[types.NewRelayID(params.ChainFamily, params.ChainID)]
 
-	if len(transmitter) > 0 {
-		solConfig, err = solanaconfig.GetSolanaChainWriterConfig(offrampProgramAddress.String(), transmitter[0])
-	} else {
+	if len(transmitter) == 0 {
 		return nil, fmt.Errorf("there must be at least one transmitter for Solana chain: %s", params.ChainID)
 	}
+
+	solConfig, err := solanaconfig.GetSolanaChainWriterConfig(offrampProgramAddress.String(), transmitter[0])
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Solana chain writer config: %w", err)

--- a/core/capabilities/ccip/ccipsolana/crcwconfig.go
+++ b/core/capabilities/ccip/ccipsolana/crcwconfig.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/chainwriter"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	solanaconfig "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/configs/solana"
@@ -17,16 +18,24 @@ import (
 type ChainRWProvider struct{}
 
 // GetChainWriter ChainRWProvider returns a new ContractWriter for Solana chains.
-func (g ChainRWProvider) GetChainWriter(ctx context.Context, pararms ccipcommon.ChainWriterProviderOpts) (types.ContractWriter, error) {
+func (g ChainRWProvider) GetChainWriter(ctx context.Context, params ccipcommon.ChainWriterProviderOpts) (types.ContractWriter, error) {
 	var offrampProgramAddress solana.PublicKey
+	var solConfig chainwriter.ChainWriterConfig
+	var err error
 	// NOTE: this function can still be called with EVM inputs, and PublicKeyFromBytes will panic on addresses with len=20
 	// technically we only need the writer to do fee estimation so this doesn't matter and we can use a zero address
-	if len(pararms.OfframpProgramAddress) == solana.PublicKeyLength {
-		offrampProgramAddress = solana.PublicKeyFromBytes(pararms.OfframpProgramAddress)
+	if len(params.OfframpProgramAddress) == solana.PublicKeyLength {
+		offrampProgramAddress = solana.PublicKeyFromBytes(params.OfframpProgramAddress)
 	}
 
-	transmitter := pararms.Transmitters[types.NewRelayID(pararms.ChainFamily, pararms.ChainID)]
-	solConfig, err := solanaconfig.GetSolanaChainWriterConfig(offrampProgramAddress.String(), transmitter[0])
+	transmitter := params.Transmitters[types.NewRelayID(params.ChainFamily, params.ChainID)]
+
+	if len(transmitter) > 0 {
+		solConfig, err = solanaconfig.GetSolanaChainWriterConfig(offrampProgramAddress.String(), transmitter[0])
+	} else {
+		return nil, fmt.Errorf("there must be at least one transmitter for Solana chain: %s", params.ChainID)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Solana chain writer config: %w", err)
 	}
@@ -35,9 +44,9 @@ func (g ChainRWProvider) GetChainWriter(ctx context.Context, pararms ccipcommon.
 		return nil, fmt.Errorf("failed to marshal Solana chain writer config: %w", err)
 	}
 
-	cw, err := pararms.Relayer.NewContractWriter(ctx, chainWriterConfig)
+	cw, err := params.Relayer.NewContractWriter(ctx, chainWriterConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create chain writer for chain %s: %w", pararms.ChainID, err)
+		return nil, fmt.Errorf("failed to create chain writer for chain %s: %w", params.ChainID, err)
 	}
 
 	return cw, nil


### PR DESCRIPTION
### What
- Add transmitter array length check to GetChainWriter function

### Why
- This aims to fix a bug causing the core node to crash when trying to run for chains that either do not have a transmitter address or have a disabled transmitter address
