### PR TITLE
refactor: use CLDF blockchains for initializing the memory environment

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_environment.go
+++ b/deployment/ccip/changeset/testhelpers/test_environment.go
@@ -451,10 +451,7 @@ func (m *MemoryEnvironment) StartNodes(t *testing.T, crConfig deployment.Capabil
 	tc := m.TestConfig
 	c := memory.NewNodesConfig{
 		LogLevel:       zapcore.InfoLevel,
-		Chains:         m.Chains,
-		SolChains:      m.SolChains,
-		AptosChains:    m.AptosChains,
-		TonChains:      m.TonChains,
+		BlockChains:    m.Env.BlockChains,
 		NumNodes:       tc.Nodes,
 		NumBootstraps:  tc.Bootstraps,
 		RegistryConfig: crConfig,
@@ -470,7 +467,12 @@ func (m *MemoryEnvironment) StartNodes(t *testing.T, crConfig deployment.Capabil
 		})
 	}
 	m.nodes = nodes
-	m.Env = memory.NewMemoryEnvironmentFromChainsNodes(func() context.Context { return ctx }, lggr, m.Chains, m.SolChains, m.AptosChains, m.TonChains, nodes)
+	m.Env = memory.NewMemoryEnvironmentFromChainsNodes(
+		func() context.Context { return ctx },
+		lggr,
+		m.Env.BlockChains,
+		nodes,
+	)
 }
 
 func (m *MemoryEnvironment) DeleteJobs(ctx context.Context, jobIDs map[string][]string) error {

--- a/deployment/environment/memory/job_service_client_test.go
+++ b/deployment/environment/memory/job_service_client_test.go
@@ -22,13 +22,11 @@ import (
 func TestJobClientProposeJob(t *testing.T) {
 	t.Parallel()
 	ctx := testutils.Context(t)
-	chains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsEVM(t, 1, 1))
+	blockchains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsEVM(t, 1, 1))
 	ports := freeport.GetN(t, 1)
 	c := memory.NewNodeConfig{
 		Port:           ports[0],
-		Chains:         chains.EVMChains(),
-		Solchains:      nil,
-		Aptoschains:    nil,
+		BlockChains:    blockchains,
 		LogLevel:       zapcore.DebugLevel,
 		Bootstrap:      false,
 		RegistryConfig: deployment.CapabilityRegistryConfig{},
@@ -125,13 +123,11 @@ func TestJobClientProposeJob(t *testing.T) {
 func TestJobClientJobAPI(t *testing.T) {
 	t.Parallel()
 	ctx := testutils.Context(t)
-	chains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsEVM(t, 1, 1))
+	blockchains := cldf_chain.NewBlockChainsFromSlice(memory.NewMemoryChainsEVM(t, 1, 1))
 	ports := freeport.GetN(t, 1)
 	c := memory.NewNodeConfig{
 		Port:           ports[0],
-		Chains:         chains.EVMChains(),
-		Solchains:      nil,
-		Aptoschains:    nil,
+		BlockChains:    blockchains,
 		LogLevel:       zapcore.DebugLevel,
 		Bootstrap:      false,
 		RegistryConfig: deployment.CapabilityRegistryConfig{},

--- a/deployment/environment/memory/node_test.go
+++ b/deployment/environment/memory/node_test.go
@@ -17,13 +17,11 @@ import (
 )
 
 func TestNode(t *testing.T) {
-	chains := cldf_chain.NewBlockChainsFromSlice(NewMemoryChainsEVM(t, 3, 5))
+	blockchains := cldf_chain.NewBlockChainsFromSlice(NewMemoryChainsEVM(t, 3, 5))
 	ports := freeport.GetN(t, 1)
 	c := NewNodeConfig{
 		Port:           ports[0],
-		Chains:         chains.EVMChains(),
-		Solchains:      nil,
-		Aptoschains:    nil,
+		BlockChains:    blockchains,
 		LogLevel:       zapcore.DebugLevel,
 		Bootstrap:      false,
 		RegistryConfig: deployment.CapabilityRegistryConfig{},
@@ -50,7 +48,7 @@ func TestNode(t *testing.T) {
 			gotChains[i] = k.ChainSelector
 			i++
 		}
-		assert.ElementsMatch(t, slices.Collect(maps.Keys(chains.EVMChains())), gotChains)
+		assert.ElementsMatch(t, slices.Collect(maps.Keys(blockchains.EVMChains())), gotChains)
 	})
 
 	t.Run("JDChainConfigs", func(t *testing.T) {

--- a/deployment/environment/memory/solana_chains.go
+++ b/deployment/environment/memory/solana_chains.go
@@ -27,6 +27,20 @@ import (
 	cldf_solana_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana/provider"
 )
 
+var (
+	// Instead of a relative path, use runtime.Caller or go-bindata
+	programsPath = getProgramsPath()
+)
+
+func getProgramsPath() string {
+	// Get the directory of the current file (environment.go)
+	_, currentFile, _, _ := runtime.Caller(0)
+	// Go up to the root of the deployment package
+	rootDir := filepath.Dir(filepath.Dir(filepath.Dir(currentFile)))
+	// Construct the absolute path
+	return filepath.Join(rootDir, "ccip/changeset/internal", "solana_contracts")
+}
+
 func getTestSolanaChainSelectors() []uint64 {
 	result := []uint64{}
 	for _, x := range chainsel.SolanaALL {
@@ -91,7 +105,7 @@ func generateChainsSol(t *testing.T, numChains int) []cldf_chain.BlockChain {
 	t.Helper()
 
 	once.Do(func() {
-		err := DownloadSolanaCCIPProgramArtifacts(t.Context(), ProgramsPath, logger.Test(t), "")
+		err := DownloadSolanaCCIPProgramArtifacts(t.Context(), programsPath, logger.Test(t), "")
 		require.NoError(t, err)
 	})
 
@@ -108,7 +122,7 @@ func generateChainsSol(t *testing.T, numChains int) []cldf_chain.BlockChain {
 			cldf_solana_provider.CTFChainProviderConfig{
 				Once:                         once,
 				DeployerKeyGen:               cldf_solana_provider.PrivateKeyRandom(),
-				ProgramsPath:                 ProgramsPath,
+				ProgramsPath:                 programsPath,
 				ProgramIDs:                   SolanaProgramIDs,
 				WaitDelayAfterContainerStart: 15 * time.Second, // we have slot errors that force retries if the chain is not given enough time to boot
 			},


### PR DESCRIPTION
Refactor the memory env to take the CLDF Blockchain interface instead of each individual chain family type.

This simplifies the process of adding new chains in the future.