### PR TITLE
Add Tests for Engine Plus Metering

### DIFF
--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -581,16 +581,16 @@ targets:
 			t.Helper()
 			require.NotNil(t, req.Metadata.SpendLimits)
 			require.Len(t, req.Metadata.SpendLimits, 1)
-			assert.Equal(t, req.Metadata.SpendLimits[0], capabilities.SpendLimit{
+			assert.Equal(t, capabilities.SpendLimit{
 				SpendType: capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
 				Limit:     "1000000.000",
-			})
+			}, req.Metadata.SpendLimits[0])
 		})
 		target := withTarget(t, reg, func(t *testing.T, req capabilities.CapabilityRequest) {
 			t.Helper()
 			require.NotNil(t, req.Metadata.SpendLimits)
 			require.Len(t, req.Metadata.SpendLimits, 2)
-			assert.Equal(t, req.Metadata.SpendLimits, []capabilities.SpendLimit{
+			assert.Equal(t, []capabilities.SpendLimit{
 				{
 					SpendType: capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
 					Limit:     "399999.600",
@@ -599,7 +599,7 @@ targets:
 					SpendType: capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_GAS.String()),
 					Limit:     "5999.994",
 				},
-			})
+			}, req.Metadata.SpendLimits)
 		})
 
 		lggr, logs := logger.TestLoggerObserved(t, zapcore.ErrorLevel)

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -560,7 +560,11 @@ targets:
 		require.NoError(t, err)
 
 		assert.Equal(t, store.StatusCompleted, state.Status)
-		assert.Len(t, logs.TakeAll(), 1)
+
+		errLogs := logs.TakeAll()
+
+		require.Len(t, errLogs, 1)
+		assert.Contains(t, errLogs[0].Message, "metering mode")
 
 		mBillingClient.AssertExpectations(t)
 	})
@@ -575,13 +579,27 @@ targets:
 		tr := withTrigger(t, reg)
 		withCompute(t, reg, func(t *testing.T, req capabilities.CapabilityRequest) {
 			t.Helper()
-			assert.NotNil(t, req.Metadata.SpendLimits)
-			assert.Len(t, req.Metadata.SpendLimits, 1)
+			require.NotNil(t, req.Metadata.SpendLimits)
+			require.Len(t, req.Metadata.SpendLimits, 1)
+			assert.Equal(t, req.Metadata.SpendLimits[0], capabilities.SpendLimit{
+				SpendType: capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
+				Limit:     "1000000.000",
+			})
 		})
 		target := withTarget(t, reg, func(t *testing.T, req capabilities.CapabilityRequest) {
 			t.Helper()
-			assert.NotNil(t, req.Metadata.SpendLimits)
-			assert.Len(t, req.Metadata.SpendLimits, 2)
+			require.NotNil(t, req.Metadata.SpendLimits)
+			require.Len(t, req.Metadata.SpendLimits, 2)
+			assert.Equal(t, req.Metadata.SpendLimits, []capabilities.SpendLimit{
+				{
+					SpendType: capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
+					Limit:     "399999.600",
+				},
+				{
+					SpendType: capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_GAS.String()),
+					Limit:     "5999.994",
+				},
+			})
 		})
 
 		lggr, logs := logger.TestLoggerObserved(t, zapcore.ErrorLevel)

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -583,21 +583,32 @@ targets:
 			require.Len(t, req.Metadata.SpendLimits, 1)
 			assert.Equal(t, capabilities.SpendLimit{
 				SpendType: capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
-				Limit:     "1000000.000",
+				// capability limit includes the entire reserve amount; no standard deductions
+				// default worker limit is 100 so each capability call receives 10_000 / 100 units (100)
+				// 100 / 0.0001 = 1_000_000
+				Limit: "1000000.000",
 			}, req.Metadata.SpendLimits[0])
 		})
 		target := withTarget(t, reg, func(t *testing.T, req capabilities.CapabilityRequest) {
 			t.Helper()
 			require.NotNil(t, req.Metadata.SpendLimits)
 			require.Len(t, req.Metadata.SpendLimits, 2)
+
+			// 100 * 0.0001 (0.01) units were deducted for the previous capability
+			// this leaves 9_999.99 units available
+			// again for 100 possible concurrent workers: 9_999.99 / 100 = 99.9999
 			assert.Equal(t, []capabilities.SpendLimit{
 				{
 					SpendType: capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
-					Limit:     "399999.600",
+					// 40% of remaining units divided by 0.0001 is the following
+					// 99.9999 * 0.4 / 0.0001
+					Limit: "399999.600",
 				},
 				{
 					SpendType: capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_GAS.String()),
-					Limit:     "5999.994",
+					// 60% of remaining units divided by 0.01 is the following
+					// 99.9999 * 0.6 / 0.01
+					Limit: "5999.994",
 				},
 			}, req.Metadata.SpendLimits)
 		})

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -376,7 +376,7 @@ targets:
 
 		conf, err := values.WrapMap(vals)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		registry.SetLocalRegistry(&testConfigProvider{
 			configForCapability: func(ctx context.Context, capabilityID string, donID uint32) (registrysyncer.CapabilityConfiguration, error) {
 				cb, err := proto.Marshal(&capabilitiespb.CapabilityConfig{

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -43,6 +44,7 @@ import (
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/events"
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/ratelimiter"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/store"
@@ -341,6 +343,294 @@ func (m *mockTriggerCapability) UnregisterTrigger(ctx context.Context, req capab
 		return errors.New("failed to unregister a non-registered trigger")
 	}
 	return nil
+}
+
+func TestEngine_Metering_ValidBillingClient(t *testing.T) {
+	t.Parallel()
+
+	const meteringSimpleWorkflow = `
+triggers:
+  - id: "simple-trigger@1.0.0"
+    config:
+      data: "test"
+consensus:
+  - id: "simple-capability@1.0.0"
+    ref: "simple_cap"
+    config:
+      data: "test"
+    inputs:
+      observations:
+        - "$(trigger.outputs)"
+targets:
+  - id: "write_polygon-testnet-mumbai@1.0.0"
+    inputs:
+      report: "$(simple_cap.outputs.report)"
+    config:
+      address: "0x3F3554832c636721F1fD1822Ccca0354576741Ef"
+      params: ["$(report)"]
+      abi: "receive(report bytes)"
+`
+
+	setConfig := func(t *testing.T, registry *coreCap.Registry, vals map[string]any) {
+		t.Helper()
+
+		conf, err := values.WrapMap(vals)
+
+		assert.NoError(t, err)
+		registry.SetLocalRegistry(&testConfigProvider{
+			configForCapability: func(ctx context.Context, capabilityID string, donID uint32) (registrysyncer.CapabilityConfiguration, error) {
+				cb, err := proto.Marshal(&capabilitiespb.CapabilityConfig{
+					RestrictedConfig: values.ProtoMap(conf),
+					RestrictedKeys:   []string{metering.RatiosKey},
+				})
+
+				return registrysyncer.CapabilityConfiguration{
+					Config: cb,
+				}, err
+			},
+		})
+	}
+
+	withTrigger := func(t *testing.T, registry *coreCap.Registry) capabilities.TriggerResponse {
+		t.Helper()
+
+		trigger := &mockTriggerCapability{
+			CapabilityInfo: capabilities.MustNewCapabilityInfo(
+				"simple-trigger@1.0.0",
+				capabilities.CapabilityTypeTrigger,
+				"issues a test trigger",
+			),
+			ch:                         make(chan capabilities.TriggerResponse, 10),
+			registerTriggerCallCounter: make(map[string]int),
+		}
+
+		testResp, _ := values.NewMap(map[string]any{
+			"123": decimal.NewFromFloat(1.00),
+			"456": decimal.NewFromFloat(1.25),
+			"789": decimal.NewFromFloat(1.50),
+		})
+
+		response := capabilities.TriggerResponse{
+			Event: capabilities.TriggerEvent{
+				TriggerType: trigger.ID,
+				ID:          fmt.Sprintf("%v:%v", "simple-trigger@1.0.0", time.Now().UTC().Format(time.RFC3339)),
+				Outputs:     testResp,
+			},
+		}
+		trigger.triggerEvent = &response
+
+		require.NoError(t, registry.Add(t.Context(), trigger))
+
+		return response
+	}
+
+	withCompute := func(t *testing.T, registry *coreCap.Registry, assertion func(*testing.T, capabilities.CapabilityRequest)) {
+		t.Helper()
+
+		capability := newMockCapability(
+			capabilities.MustNewCapabilityInfo(
+				"simple-capability@1.0.0",
+				capabilities.CapabilityTypeConsensus,
+				"an ocr3 consensus capability",
+				capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
+			),
+			func(req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+				assertion(t, req)
+
+				obs := req.Inputs.Underlying["observations"]
+				report := obs.(*values.List)
+				rm := map[string]any{
+					"report": report.Underlying[0],
+				}
+
+				rv, err := values.NewMap(rm)
+				if err != nil {
+					return capabilities.CapabilityResponse{}, err
+				}
+
+				return capabilities.CapabilityResponse{
+					Metadata: capabilities.ResponseMetadata{
+						Metering: []capabilities.MeteringNodeDetail{
+							{
+								Peer2PeerID: "local",
+								SpendUnit:   billing.ResourceType_RESOURCE_TYPE_COMPUTE.String(),
+								SpendValue:  "100",
+							},
+						},
+					},
+					Value: rv,
+				}, nil
+			},
+		)
+
+		require.NoError(t, registry.Add(t.Context(), capability))
+	}
+
+	withTarget := func(t *testing.T, registry *coreCap.Registry, assertion func(*testing.T, capabilities.CapabilityRequest)) *mockCapability {
+		t.Helper()
+
+		target := newMockCapability(
+			capabilities.MustNewCapabilityInfo(
+				"write_polygon-testnet-mumbai@1.0.0",
+				capabilities.CapabilityTypeTarget,
+				"a simple write capability",
+				capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
+				capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_GAS.String()),
+			),
+			func(req capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
+				assertion(t, req)
+
+				return capabilities.CapabilityResponse{
+					Value: req.Inputs.Underlying["report"].(*values.Map),
+					Metadata: capabilities.ResponseMetadata{
+						Metering: []capabilities.MeteringNodeDetail{
+							{
+								Peer2PeerID: "local",
+								SpendUnit:   billing.ResourceType_RESOURCE_TYPE_COMPUTE.String(),
+								SpendValue:  "100",
+							},
+							{
+								Peer2PeerID: "local",
+								SpendUnit:   billing.ResourceType_RESOURCE_TYPE_GAS.String(),
+								SpendValue:  "1000",
+							},
+						},
+					},
+				}, nil
+			},
+		)
+
+		require.NoError(t, registry.Add(t.Context(), target))
+
+		return target
+	}
+
+	t.Run("incorrect ratios config switches to metering mode", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		reg := coreCap.NewRegistry(logger.NullLogger)
+		mBillingClient := new(mocks.BillingClient)
+
+		tr := withTrigger(t, reg)
+		withCompute(t, reg, func(t *testing.T, req capabilities.CapabilityRequest) {
+			t.Helper()
+			assert.NotNil(t, req.Metadata.SpendLimits)
+			assert.Len(t, req.Metadata.SpendLimits, 1)
+		})
+		target := withTarget(t, reg, func(t *testing.T, req capabilities.CapabilityRequest) {
+			t.Helper()
+			assert.NotNil(t, req.Metadata.SpendLimits)
+			assert.Empty(t, req.Metadata.SpendLimits)
+		})
+
+		lggr, logs := logger.TestLoggerObserved(t, zapcore.ErrorLevel)
+		eng, testHooks := newTestEngineWithYAMLSpec(
+			t,
+			reg,
+			meteringSimpleWorkflow,
+			func(cfg *Config) {
+				cfg.BillingClient = mBillingClient
+				cfg.Lggr = lggr
+			},
+		)
+
+		mBillingClient.EXPECT().
+			ReserveCredits(mock.Anything, mock.MatchedBy(func(req *billing.ReserveCreditsRequest) bool {
+				return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
+			})).
+			Return(&billing.ReserveCreditsResponse{Success: true, Entries: []*billing.RateCardEntry{
+				{ResourceType: billing.ResourceType_RESOURCE_TYPE_COMPUTE, MeasurementUnit: billing.MeasurementUnit_MEASUREMENT_UNIT_MILLISECONDS, UnitsPerCredit: "0.0001"},
+				{ResourceType: billing.ResourceType_RESOURCE_TYPE_GAS, MeasurementUnit: billing.MeasurementUnit_MEASUREMENT_UNIT_COST, UnitsPerCredit: "0.01"},
+			}, Credits: 10_000}, nil)
+
+		mBillingClient.EXPECT().
+			SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
+				return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
+			})).
+			Return(&emptypb.Empty{}, nil)
+
+		servicetest.Run(t, eng)
+
+		eid := getExecutionID(t, eng, testHooks)
+		resp := <-target.response
+		assert.Equal(t, tr.Event.Outputs, resp.Value)
+
+		state, err := eng.executionsStore.Get(ctx, eid)
+		require.NoError(t, err)
+
+		assert.Equal(t, store.StatusCompleted, state.Status)
+		assert.Len(t, logs.TakeAll(), 1)
+
+		mBillingClient.AssertExpectations(t)
+	})
+
+	t.Run("correct ratios config produces spending limits", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		reg := coreCap.NewRegistry(logger.NullLogger)
+		mBillingClient := new(mocks.BillingClient)
+
+		tr := withTrigger(t, reg)
+		withCompute(t, reg, func(t *testing.T, req capabilities.CapabilityRequest) {
+			t.Helper()
+			assert.NotNil(t, req.Metadata.SpendLimits)
+			assert.Len(t, req.Metadata.SpendLimits, 1)
+		})
+		target := withTarget(t, reg, func(t *testing.T, req capabilities.CapabilityRequest) {
+			t.Helper()
+			assert.NotNil(t, req.Metadata.SpendLimits)
+			assert.Len(t, req.Metadata.SpendLimits, 2)
+		})
+
+		lggr, logs := logger.TestLoggerObserved(t, zapcore.ErrorLevel)
+		eng, testHooks := newTestEngineWithYAMLSpec(
+			t,
+			reg,
+			meteringSimpleWorkflow,
+			func(cfg *Config) {
+				cfg.BillingClient = mBillingClient
+				cfg.Lggr = lggr
+			},
+		)
+
+		setConfig(t, reg, map[string]any{
+			metering.RatiosKey: map[string]any{
+				billing.ResourceType_RESOURCE_TYPE_COMPUTE.String(): "0.4",
+				billing.ResourceType_RESOURCE_TYPE_GAS.String():     "0.6",
+			},
+		})
+
+		mBillingClient.EXPECT().
+			ReserveCredits(mock.Anything, mock.MatchedBy(func(req *billing.ReserveCreditsRequest) bool {
+				return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
+			})).
+			Return(&billing.ReserveCreditsResponse{Success: true, Entries: []*billing.RateCardEntry{
+				{ResourceType: billing.ResourceType_RESOURCE_TYPE_COMPUTE, MeasurementUnit: billing.MeasurementUnit_MEASUREMENT_UNIT_MILLISECONDS, UnitsPerCredit: "0.0001"},
+				{ResourceType: billing.ResourceType_RESOURCE_TYPE_GAS, MeasurementUnit: billing.MeasurementUnit_MEASUREMENT_UNIT_COST, UnitsPerCredit: "0.01"},
+			}, Credits: 10_000}, nil)
+
+		mBillingClient.EXPECT().
+			SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
+				return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
+			})).
+			Return(&emptypb.Empty{}, nil)
+
+		servicetest.Run(t, eng)
+
+		eid := getExecutionID(t, eng, testHooks)
+		resp := <-target.response
+		assert.Equal(t, tr.Event.Outputs, resp.Value)
+
+		state, err := eng.executionsStore.Get(ctx, eid)
+		require.NoError(t, err)
+
+		assert.Equal(t, store.StatusCompleted, state.Status)
+		assert.Empty(t, logs)
+
+		mBillingClient.AssertExpectations(t)
+	})
 }
 
 func TestEngineWithHardcodedWorkflow(t *testing.T) {

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -228,6 +228,9 @@ func (r *Report) CreditToSpendingLimits(
 	config *values.Map,
 	amount decimal.Decimal,
 ) []capabilities.SpendLimit {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if r.meteringMode {
 		return []capabilities.SpendLimit{}
 	}
@@ -451,6 +454,7 @@ func (r *Report) EmitReceipt(ctx context.Context) error {
 
 func (r *Report) switchToMeteringMode(err error) {
 	r.lggr.Errorf("switching to metering mode: %s", err)
+
 	r.meteringMode = true
 	r.ready = true
 }

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -187,7 +187,7 @@ func (r *Report) ConvertToBalance(fromUnit string, amount decimal.Decimal) (deci
 	bal, err := r.balance.ConvertToBalance(fromUnit, amount)
 	if err != nil {
 		// Fail open, continue optimistically
-		r.switchToMeteringMode(err)
+		r.switchToMeteringMode(fmt.Errorf("failed to convert to balance [%s]: %w", fromUnit, err))
 	}
 
 	return bal, nil
@@ -265,7 +265,7 @@ func (r *Report) CreditToSpendingLimits(
 		// use rate card to convert capSpendLimit to native units
 		spendLimit, err := r.balance.ConvertFromBalance(string(spendType), amount.Mul(ratio))
 		if err != nil {
-			r.switchToMeteringMode(err)
+			r.switchToMeteringMode(fmt.Errorf("attempted to create spending limits [%s]: %w", spendType, err))
 
 			return []capabilities.SpendLimit{}
 		}
@@ -361,7 +361,7 @@ func (r *Report) Settle(ref string, spendsByNode []capabilities.MeteringNodeDeta
 		aggregateSpend := medianSpend(deciVals)
 		bal, err := r.balance.ConvertToBalance(unit, aggregateSpend)
 		if err != nil {
-			r.switchToMeteringMode(err)
+			r.switchToMeteringMode(fmt.Errorf("attempted to Settle [%s]: %w", unit, err))
 		}
 
 		spentCredits = spentCredits.Add(bal)

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -580,14 +580,29 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 				},
 			}, nil).Once()
 
-		// verify that spend limits is set and has a length of zero
+		// verify that spend limits is set and has a length of two
 		capability.EXPECT().
 			Execute(matches.AnyContext, mock.Anything).
 			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
 				assert.NotNil(t, req.Metadata.SpendLimits)
 				assert.Len(t, req.Metadata.SpendLimits, 2)
 			}).
-			Return(capabilities.CapabilityResponse{}, nil).Once()
+			Return(capabilities.CapabilityResponse{
+				Metadata: capabilities.ResponseMetadata{
+					Metering: []capabilities.MeteringNodeDetail{
+						{
+							Peer2PeerID: "local",
+							SpendUnit:   billing.ResourceType_RESOURCE_TYPE_COMPUTE.String(),
+							SpendValue:  "100",
+						},
+						{
+							Peer2PeerID: "local",
+							SpendUnit:   billing.ResourceType_RESOURCE_TYPE_GAS.String(),
+							SpendValue:  "1000",
+						},
+					},
+				},
+			}, nil).Once()
 
 		// Mock workflow execution that calls the metered capability
 		module.EXPECT().
@@ -651,14 +666,24 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 				},
 			}, nil).Once()
 
-		// verify that spend limits is set and has a length of zero
+		// verify that spend limits is set and has a length of one
 		capability.EXPECT().
 			Execute(matches.AnyContext, mock.Anything).
 			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
 				assert.NotNil(t, req.Metadata.SpendLimits)
 				assert.Len(t, req.Metadata.SpendLimits, 1)
 			}).
-			Return(capabilities.CapabilityResponse{}, nil).Once()
+			Return(capabilities.CapabilityResponse{
+				Metadata: capabilities.ResponseMetadata{
+					Metering: []capabilities.MeteringNodeDetail{
+						{
+							Peer2PeerID: "local",
+							SpendUnit:   billing.ResourceType_RESOURCE_TYPE_COMPUTE.String(),
+							SpendValue:  "100",
+						},
+					},
+				},
+			}, nil).Once()
 
 		// Mock workflow execution that calls the metered capability
 		module.EXPECT().
@@ -696,6 +721,101 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 
 		logged := logs.TakeAll()
 		require.Empty(t, logged)
+	})
+
+	t.Run("billing type and capability settle spend type mismatch", func(t *testing.T) {
+		// Setup a metered capability
+		capability := capmocks.NewExecutableCapability(t)
+
+		capreg.EXPECT().
+			GetExecutable(matches.AnyContext, "metered-capability-2").
+			Return(capability, nil).Once()
+
+		ratios, _ := values.NewMap(map[string]any{
+			metering.RatiosKey: map[string]string{
+				billing.ResourceType_RESOURCE_TYPE_COMPUTE.String(): "0.4",
+				billing.ResourceType_RESOURCE_TYPE_GAS.String():     "0.6",
+			},
+		})
+
+		capreg.EXPECT().
+			ConfigForCapability(mock.Anything, mock.Anything, mock.Anything).
+			Return(capabilities.CapabilityConfiguration{RestrictedConfig: ratios}, nil).Once()
+
+		// return some spend types in the Info call
+		capability.EXPECT().
+			Info(matches.AnyContext).
+			Return(capabilities.CapabilityInfo{
+				DON: &capabilities.DON{
+					ID: 42,
+				},
+				SpendTypes: []capabilities.CapabilitySpendType{
+					capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
+					capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_GAS.String()),
+				},
+			}, nil).Once()
+
+		// verify that spend limits is set and has a length of two
+		capability.EXPECT().
+			Execute(matches.AnyContext, mock.Anything).
+			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
+				assert.NotNil(t, req.Metadata.SpendLimits)
+				assert.Len(t, req.Metadata.SpendLimits, 2)
+			}).
+			Return(capabilities.CapabilityResponse{
+				Metadata: capabilities.ResponseMetadata{
+					Metering: []capabilities.MeteringNodeDetail{
+						{
+							Peer2PeerID: "local",
+							// SpendUnit does not match units from billing or ratios
+							SpendUnit:  "COMPUTE",
+							SpendValue: "100",
+						},
+						{
+							Peer2PeerID: "local",
+							SpendUnit:   billing.ResourceType_RESOURCE_TYPE_GAS.String(),
+							SpendValue:  "1000",
+						},
+					},
+				},
+			}, nil).Once()
+
+		// Mock workflow execution that calls the metered capability
+		module.EXPECT().
+			Execute(matches.AnyContext, mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, request *sdkpb.ExecuteRequest, executor host.ExecutionHelper) {
+				// Simulate calling the slow capability from within the workflow
+				_, errCap := executor.CallCapability(ctx, &sdkpb.CapabilityRequest{
+					Id:         "metered-capability-2",
+					Method:     "execute",
+					CallbackId: 1,
+					Payload:    nil,
+				})
+
+				require.NoError(t, errCap)
+			}).Return(nil, nil).Once()
+
+		// Trigger the execution
+		mockTriggerEvent := capabilities.TriggerEvent{
+			TriggerType: "basic-trigger@1.0.0",
+			ID:          "metering_capability_test_2",
+			Payload:     nil,
+		}
+
+		eventCh <- capabilities.TriggerResponse{
+			Event: mockTriggerEvent,
+		}
+
+		// Wait for execution to finish with error status
+		executionID := <-executionFinishedCh
+		wantExecID, err := types.GenerateExecutionID(cfg.WorkflowID, mockTriggerEvent.ID)
+
+		require.NoError(t, err)
+		require.Equal(t, wantExecID, executionID)
+		capability.AssertExpectations(t)
+
+		logged := logs.TakeAll()
+		require.Len(t, logged, 1)
 	})
 
 	require.NoError(t, engine.Close())

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -11,15 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basicaction"
-	basicactionmock "github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basicaction/mock"
-	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger"
-	basictriggermock "github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger/mock"
-	"github.com/smartcontractkit/cre-sdk-go/sdk/testutils/registry"
-	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -37,9 +33,17 @@ import (
 	modulemocks "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host/mocks"
 	billing "github.com/smartcontractkit/chainlink-protos/billing/go"
 	"github.com/smartcontractkit/chainlink-protos/workflows/go/events"
+	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basicaction"
+	basicactionmock "github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basicaction/mock"
+	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger"
+	basictriggermock "github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger/mock"
+	"github.com/smartcontractkit/cre-sdk-go/sdk/testutils/registry"
+	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
 	capmocks "github.com/smartcontractkit/chainlink/v2/core/capabilities/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/wasmtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering"
 	metmocks "github.com/smartcontractkit/chainlink/v2/core/services/workflows/metering/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncerlimiter"
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/types"
@@ -419,7 +423,285 @@ func TestEngine_ExecutionTimeout(t *testing.T) {
 	require.NoError(t, engine.Close())
 }
 
-// TODO [https://smartcontract-it.atlassian.net/browse/CRE-532]: this test produces a error from the metering package because the spending types and ratios are not set.
+func TestEngine_Metering_ValidBillingClient(t *testing.T) {
+	t.Parallel()
+
+	module := modulemocks.NewModuleV2(t)
+	module.EXPECT().Start()
+	module.EXPECT().Close()
+	capreg := regmocks.NewCapabilitiesRegistry(t)
+	capreg.EXPECT().LocalNode(matches.AnyContext).Return(newNode(t), nil)
+
+	// all tests in this section assume that the billing client returns valid rate cards
+	billingClient := setupMockBillingClient(t)
+
+	initDoneCh := make(chan error)
+	subscribedToTriggersCh := make(chan []string, 1)
+	executionFinishedCh := make(chan string)
+
+	var logs *observer.ObservedLogs
+
+	cfg := defaultTestConfig(t)
+	cfg.Lggr, logs = logger.TestLoggerObserved(t, zapcore.ErrorLevel)
+	cfg.Module = module
+	cfg.CapRegistry = capreg
+	cfg.BillingClient = billingClient
+	cfg.LocalLimits.CapabilityCallTimeoutMs = 50
+	cfg.Hooks = v2.LifecycleHooks{
+		OnInitialized: func(err error) {
+			initDoneCh <- err
+		},
+		OnSubscribedToTriggers: func(triggerIDs []string) {
+			subscribedToTriggersCh <- triggerIDs
+		},
+		OnExecutionFinished: func(executionID string, status string) {
+			executionFinishedCh <- executionID
+		},
+	}
+
+	engine, err := v2.NewEngine(cfg)
+	require.NoError(t, err)
+
+	// Setup trigger registration
+	trigger := capmocks.NewTriggerCapability(t)
+	eventCh := make(chan capabilities.TriggerResponse)
+
+	module.EXPECT().Execute(matches.AnyContext, mock.Anything, mock.Anything).Return(newTriggerSubs(1), nil).Once()
+	capreg.EXPECT().GetTrigger(matches.AnyContext, "id_0").Return(trigger, nil).Once()
+	trigger.EXPECT().RegisterTrigger(matches.AnyContext, mock.Anything).Return(eventCh, nil).Once()
+	trigger.EXPECT().UnregisterTrigger(matches.AnyContext, mock.Anything).Return(nil).Once()
+
+	require.NoError(t, engine.Start(t.Context()))
+	require.NoError(t, <-initDoneCh)
+	require.Equal(t, []string{"id_0"}, <-subscribedToTriggersCh)
+
+	t.Run("incorrect ratios config switches to metering mode", func(t *testing.T) {
+		// Setup a metered capability
+		cap := capmocks.NewExecutableCapability(t)
+
+		capreg.EXPECT().
+			GetExecutable(matches.AnyContext, "metered-capability-1").
+			Return(cap, nil).Once()
+
+		capreg.EXPECT().
+			ConfigForCapability(mock.Anything, mock.Anything, mock.Anything).
+			Return(capabilities.CapabilityConfiguration{}, nil).Once()
+
+		// return some spend types in the Info call
+		cap.EXPECT().
+			Info(matches.AnyContext).
+			Return(capabilities.CapabilityInfo{
+				DON: &capabilities.DON{
+					ID: 42,
+				},
+				SpendTypes: []capabilities.CapabilitySpendType{
+					capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
+					capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_GAS.String()),
+				},
+			}, nil).Once()
+
+		// verify that spend limits is set and has a length of zero
+		cap.EXPECT().
+			Execute(matches.AnyContext, mock.Anything).
+			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
+				assert.NotNil(t, req.Metadata.SpendLimits)
+				assert.Empty(t, req.Metadata.SpendLimits, 0)
+			}).
+			Return(capabilities.CapabilityResponse{}, nil).Once()
+
+		// Mock workflow execution that calls the metered capability
+		module.EXPECT().
+			Execute(matches.AnyContext, mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, request *sdkpb.ExecuteRequest, executor host.ExecutionHelper) {
+				// Simulate calling the slow capability from within the workflow
+				_, errCap := executor.CallCapability(ctx, &sdkpb.CapabilityRequest{
+					Id:         "metered-capability-1",
+					Method:     "execute",
+					CallbackId: 1,
+					Payload:    nil,
+				})
+
+				require.NoError(t, errCap)
+			}).Return(nil, nil).Once()
+
+		// Trigger the execution
+		mockTriggerEvent := capabilities.TriggerEvent{
+			TriggerType: "basic-trigger@1.0.0",
+			ID:          "metering_capability_test_1",
+			Payload:     nil,
+		}
+
+		eventCh <- capabilities.TriggerResponse{
+			Event: mockTriggerEvent,
+		}
+
+		// Wait for execution to finish with error status
+		executionID := <-executionFinishedCh
+		wantExecID, err := types.GenerateExecutionID(cfg.WorkflowID, mockTriggerEvent.ID)
+
+		require.NoError(t, err)
+		require.Equal(t, wantExecID, executionID)
+		cap.AssertExpectations(t)
+
+		logged := logs.TakeAll()
+		require.Len(t, logged, 1)
+		assert.Contains(t, logged[0].Message, "switching to metering mode")
+	})
+
+	t.Run("correct ratios config produces spending limits", func(t *testing.T) {
+
+		// Setup a metered capability
+		cap := capmocks.NewExecutableCapability(t)
+
+		capreg.EXPECT().
+			GetExecutable(matches.AnyContext, "metered-capability-2").
+			Return(cap, nil).Once()
+
+		ratios, _ := values.NewMap(map[string]any{
+			metering.RatiosKey: map[string]string{
+				billing.ResourceType_RESOURCE_TYPE_COMPUTE.String(): "0.4",
+				billing.ResourceType_RESOURCE_TYPE_GAS.String():     "0.6",
+			},
+		})
+
+		capreg.EXPECT().
+			ConfigForCapability(mock.Anything, mock.Anything, mock.Anything).
+			Return(capabilities.CapabilityConfiguration{RestrictedConfig: ratios}, nil).Once()
+
+		// return some spend types in the Info call
+		cap.EXPECT().
+			Info(matches.AnyContext).
+			Return(capabilities.CapabilityInfo{
+				DON: &capabilities.DON{
+					ID: 42,
+				},
+				SpendTypes: []capabilities.CapabilitySpendType{
+					capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
+					capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_GAS.String()),
+				},
+			}, nil).Once()
+
+		// verify that spend limits is set and has a length of zero
+		cap.EXPECT().
+			Execute(matches.AnyContext, mock.Anything).
+			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
+				assert.NotNil(t, req.Metadata.SpendLimits)
+				assert.Len(t, req.Metadata.SpendLimits, 2)
+			}).
+			Return(capabilities.CapabilityResponse{}, nil).Once()
+
+		// Mock workflow execution that calls the metered capability
+		module.EXPECT().
+			Execute(matches.AnyContext, mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, request *sdkpb.ExecuteRequest, executor host.ExecutionHelper) {
+				// Simulate calling the slow capability from within the workflow
+				_, errCap := executor.CallCapability(ctx, &sdkpb.CapabilityRequest{
+					Id:         "metered-capability-2",
+					Method:     "execute",
+					CallbackId: 1,
+					Payload:    nil,
+				})
+
+				require.NoError(t, errCap)
+			}).Return(nil, nil).Once()
+
+		// Trigger the execution
+		mockTriggerEvent := capabilities.TriggerEvent{
+			TriggerType: "basic-trigger@1.0.0",
+			ID:          "metering_capability_test_2",
+			Payload:     nil,
+		}
+
+		eventCh <- capabilities.TriggerResponse{
+			Event: mockTriggerEvent,
+		}
+
+		// Wait for execution to finish with error status
+		executionID := <-executionFinishedCh
+		wantExecID, err := types.GenerateExecutionID(cfg.WorkflowID, mockTriggerEvent.ID)
+
+		require.NoError(t, err)
+		require.Equal(t, wantExecID, executionID)
+		cap.AssertExpectations(t)
+
+		logged := logs.TakeAll()
+		require.Empty(t, logged)
+	})
+
+	t.Run("single spend type and no ratios config produces spending limit with no error", func(t *testing.T) {
+		// Setup a metered capability
+		cap := capmocks.NewExecutableCapability(t)
+
+		capreg.EXPECT().
+			GetExecutable(matches.AnyContext, "metered-capability-3").
+			Return(cap, nil).Once()
+
+		capreg.EXPECT().
+			ConfigForCapability(mock.Anything, mock.Anything, mock.Anything).
+			Return(capabilities.CapabilityConfiguration{}, nil).Once()
+
+		// return some spend types in the Info call
+		cap.EXPECT().
+			Info(matches.AnyContext).
+			Return(capabilities.CapabilityInfo{
+				DON: &capabilities.DON{
+					ID: 42,
+				},
+				SpendTypes: []capabilities.CapabilitySpendType{
+					capabilities.CapabilitySpendType(billing.ResourceType_RESOURCE_TYPE_COMPUTE.String()),
+				},
+			}, nil).Once()
+
+		// verify that spend limits is set and has a length of zero
+		cap.EXPECT().
+			Execute(matches.AnyContext, mock.Anything).
+			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
+				assert.NotNil(t, req.Metadata.SpendLimits)
+				assert.Len(t, req.Metadata.SpendLimits, 1)
+			}).
+			Return(capabilities.CapabilityResponse{}, nil).Once()
+
+		// Mock workflow execution that calls the metered capability
+		module.EXPECT().
+			Execute(matches.AnyContext, mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, request *sdkpb.ExecuteRequest, executor host.ExecutionHelper) {
+				// Simulate calling the slow capability from within the workflow
+				_, errCap := executor.CallCapability(ctx, &sdkpb.CapabilityRequest{
+					Id:         "metered-capability-3",
+					Method:     "execute",
+					CallbackId: 1,
+					Payload:    nil,
+				})
+
+				require.NoError(t, errCap)
+			}).Return(nil, nil).Once()
+
+		// Trigger the execution
+		mockTriggerEvent := capabilities.TriggerEvent{
+			TriggerType: "basic-trigger@1.0.0",
+			ID:          "metering_capability_test_3",
+			Payload:     nil,
+		}
+
+		eventCh <- capabilities.TriggerResponse{
+			Event: mockTriggerEvent,
+		}
+
+		// Wait for execution to finish with error status
+		executionID := <-executionFinishedCh
+		wantExecID, err := types.GenerateExecutionID(cfg.WorkflowID, mockTriggerEvent.ID)
+
+		require.NoError(t, err)
+		require.Equal(t, wantExecID, executionID)
+		cap.AssertExpectations(t)
+
+		logged := logs.TakeAll()
+		require.Empty(t, logged)
+	})
+
+	require.NoError(t, engine.Close())
+}
+
 func TestEngine_CapabilityCallTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -878,11 +1160,27 @@ func TestSecretsFetcher_Integration(t *testing.T) {
 // setupMockBillingClient creates a mock billing client with default expectations.
 func setupMockBillingClient(t *testing.T) *metmocks.BillingClient {
 	billingClient := metmocks.NewBillingClient(t)
+
 	billingClient.EXPECT().
 		ReserveCredits(mock.Anything, mock.MatchedBy(func(req *billing.ReserveCreditsRequest) bool {
 			return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""
 		})).
-		Return(&billing.ReserveCreditsResponse{Success: true, Entries: []*billing.RateCardEntry{{ResourceType: billing.ResourceType_RESOURCE_TYPE_COMPUTE, MeasurementUnit: billing.MeasurementUnit_MEASUREMENT_UNIT_MILLISECONDS, UnitsPerCredit: "0.0001"}}, Credits: 10000}, nil).Maybe()
+		Return(&billing.ReserveCreditsResponse{
+			Success: true,
+			Entries: []*billing.RateCardEntry{
+				{
+					ResourceType:    billing.ResourceType_RESOURCE_TYPE_COMPUTE,
+					MeasurementUnit: billing.MeasurementUnit_MEASUREMENT_UNIT_MILLISECONDS,
+					UnitsPerCredit:  "0.0001",
+				},
+				{
+					ResourceType:    billing.ResourceType_RESOURCE_TYPE_GAS,
+					MeasurementUnit: billing.MeasurementUnit_MEASUREMENT_UNIT_COST,
+					UnitsPerCredit:  "0.01",
+				},
+			},
+			Credits: 10000,
+		}, nil).Maybe()
 	billingClient.EXPECT().
 		SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
 			return req != nil && req.WorkflowId != "" && req.WorkflowExecutionId != ""

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -477,18 +477,18 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 
 	t.Run("incorrect ratios config switches to metering mode", func(t *testing.T) {
 		// Setup a metered capability
-		cap := capmocks.NewExecutableCapability(t)
+		capability := capmocks.NewExecutableCapability(t)
 
 		capreg.EXPECT().
 			GetExecutable(matches.AnyContext, "metered-capability-1").
-			Return(cap, nil).Once()
+			Return(capability, nil).Once()
 
 		capreg.EXPECT().
 			ConfigForCapability(mock.Anything, mock.Anything, mock.Anything).
 			Return(capabilities.CapabilityConfiguration{}, nil).Once()
 
 		// return some spend types in the Info call
-		cap.EXPECT().
+		capability.EXPECT().
 			Info(matches.AnyContext).
 			Return(capabilities.CapabilityInfo{
 				DON: &capabilities.DON{
@@ -501,7 +501,7 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 			}, nil).Once()
 
 		// verify that spend limits is set and has a length of zero
-		cap.EXPECT().
+		capability.EXPECT().
 			Execute(matches.AnyContext, mock.Anything).
 			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
 				assert.NotNil(t, req.Metadata.SpendLimits)
@@ -541,7 +541,7 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, wantExecID, executionID)
-		cap.AssertExpectations(t)
+		capability.AssertExpectations(t)
 
 		logged := logs.TakeAll()
 		require.Len(t, logged, 1)
@@ -549,13 +549,12 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 	})
 
 	t.Run("correct ratios config produces spending limits", func(t *testing.T) {
-
 		// Setup a metered capability
-		cap := capmocks.NewExecutableCapability(t)
+		capability := capmocks.NewExecutableCapability(t)
 
 		capreg.EXPECT().
 			GetExecutable(matches.AnyContext, "metered-capability-2").
-			Return(cap, nil).Once()
+			Return(capability, nil).Once()
 
 		ratios, _ := values.NewMap(map[string]any{
 			metering.RatiosKey: map[string]string{
@@ -569,7 +568,7 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 			Return(capabilities.CapabilityConfiguration{RestrictedConfig: ratios}, nil).Once()
 
 		// return some spend types in the Info call
-		cap.EXPECT().
+		capability.EXPECT().
 			Info(matches.AnyContext).
 			Return(capabilities.CapabilityInfo{
 				DON: &capabilities.DON{
@@ -582,7 +581,7 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 			}, nil).Once()
 
 		// verify that spend limits is set and has a length of zero
-		cap.EXPECT().
+		capability.EXPECT().
 			Execute(matches.AnyContext, mock.Anything).
 			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
 				assert.NotNil(t, req.Metadata.SpendLimits)
@@ -622,7 +621,7 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, wantExecID, executionID)
-		cap.AssertExpectations(t)
+		capability.AssertExpectations(t)
 
 		logged := logs.TakeAll()
 		require.Empty(t, logged)
@@ -630,18 +629,18 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 
 	t.Run("single spend type and no ratios config produces spending limit with no error", func(t *testing.T) {
 		// Setup a metered capability
-		cap := capmocks.NewExecutableCapability(t)
+		capability := capmocks.NewExecutableCapability(t)
 
 		capreg.EXPECT().
 			GetExecutable(matches.AnyContext, "metered-capability-3").
-			Return(cap, nil).Once()
+			Return(capability, nil).Once()
 
 		capreg.EXPECT().
 			ConfigForCapability(mock.Anything, mock.Anything, mock.Anything).
 			Return(capabilities.CapabilityConfiguration{}, nil).Once()
 
 		// return some spend types in the Info call
-		cap.EXPECT().
+		capability.EXPECT().
 			Info(matches.AnyContext).
 			Return(capabilities.CapabilityInfo{
 				DON: &capabilities.DON{
@@ -653,7 +652,7 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 			}, nil).Once()
 
 		// verify that spend limits is set and has a length of zero
-		cap.EXPECT().
+		capability.EXPECT().
 			Execute(matches.AnyContext, mock.Anything).
 			Run(func(_ context.Context, req capabilities.CapabilityRequest) {
 				assert.NotNil(t, req.Metadata.SpendLimits)
@@ -693,7 +692,7 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, wantExecID, executionID)
-		cap.AssertExpectations(t)
+		capability.AssertExpectations(t)
 
 		logged := logs.TakeAll()
 		require.Empty(t, logged)

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -33,13 +33,6 @@ import (
 	modulemocks "github.com/smartcontractkit/chainlink-common/pkg/workflows/wasm/host/mocks"
 	billing "github.com/smartcontractkit/chainlink-protos/billing/go"
 	"github.com/smartcontractkit/chainlink-protos/workflows/go/events"
-	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basicaction"
-	basicactionmock "github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basicaction/mock"
-	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger"
-	basictriggermock "github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger/mock"
-	"github.com/smartcontractkit/cre-sdk-go/sdk/testutils/registry"
-	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
-
 	capmocks "github.com/smartcontractkit/chainlink/v2/core/capabilities/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/wasmtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -49,6 +42,13 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/workflows/types"
 	v2 "github.com/smartcontractkit/chainlink/v2/core/services/workflows/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/matches"
+
+	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basicaction"
+	basicactionmock "github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basicaction/mock"
+	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger"
+	basictriggermock "github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger/mock"
+	"github.com/smartcontractkit/cre-sdk-go/sdk/testutils/registry"
+	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
 )
 
 func TestEngine_Init(t *testing.T) {

--- a/core/services/workflows/v2/engine_test.go
+++ b/core/services/workflows/v2/engine_test.go
@@ -816,6 +816,7 @@ func TestEngine_Metering_ValidBillingClient(t *testing.T) {
 
 		logged := logs.TakeAll()
 		require.Len(t, logged, 1)
+		assert.Contains(t, logged[0].Message, "metering mode")
 	})
 
 	require.NoError(t, engine.Close())


### PR DESCRIPTION
This commit adds 3 unit tests that verify basic happy path and error states for correctly and incorrectly configured metering.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
--> 
[CRE-532](https://smartcontract-it.atlassian.net/browse/CRE-532)

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->
- https://github.com/smartcontractkit/chainlink/pull/18310

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[CRE-532]: https://smartcontract-it.atlassian.net/browse/CRE-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ