### PR TITLE
Bumping up chainlink-aptos LOOP plugin (#18392)

### DIFF
--- a/integration-tests/smoke/ccip/ccip_aptos_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_aptos_messaging_test.go
@@ -52,7 +52,7 @@ func Test_CCIP_Messaging_EVM2Aptos(t *testing.T) {
 			sourceChain,
 			destChain,
 			sender,
-			false, // testRouter
+			false, // test router
 		)
 	)
 

--- a/plugins/plugins.public.yaml
+++ b/plugins/plugins.public.yaml
@@ -10,7 +10,7 @@ defaults:
 plugins:
   aptos:
     - moduleURI: "github.com/smartcontractkit/chainlink-aptos"
-      gitRef: "9daa693a725301564d4c8e7473ff7fac274e8c85"
+      gitRef: "ceaa9a771745d7f577e5e0e858239e6489ee8b83"
       installPath: "github.com/smartcontractkit/chainlink-aptos/cmd/chainlink-aptos"
   cosmos:
     - moduleURI: "github.com/smartcontractkit/chainlink-cosmos"


### PR DESCRIPTION
* Bumping up chainlink-aptos to bcde3e1ddedd557c8149839750d179a378ebee8c

* Bump chainlink-aptos to ec328536b1607efd6c59ade20037b621b2d1233d

* fix base config field

* Bump chainlink-aptos to ceaa9a771745d7f577e5e0e858239e6489ee8b83

* Change to force integrations tests to run


