### PR TITLE
Add Channel Definition Opts to LLO capability_trigger report type to enable Stream Multiplication

### DIFF
--- a/.changeset/fast-falcons-add.md
+++ b/.changeset/fast-falcons-add.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Add Channel Definition Opts to LLO capability_trigger report type to enable Stream Multiplication

--- a/.changeset/fast-falcons-add.md
+++ b/.changeset/fast-falcons-add.md
@@ -1,5 +1,5 @@
 ---
-"chainlink": patch
+"chainlink": minor
 ---
 
-Add Channel Definition Opts to LLO capability_trigger report type to enable Stream Multiplication
+#changed Add Channel Definition Opts to LLO capability_trigger report type to enable Stream Multiplication

--- a/core/capabilities/integration_tests/keystone/llo_feed_test.go
+++ b/core/capabilities/integration_tests/keystone/llo_feed_test.go
@@ -97,13 +97,38 @@ func MakeOCRTriggerEvent(lggr logger.Logger, reports *datastreams.LLOStreamsTrig
 
 	// Create simple channel definition to match streams
 	streams := make([]llotypes.Stream, len(reports.Payload))
+	// Create multipliers based on the actual StreamIDs from the payload
+	multipliers := make([]cre.ReportCodecCapabilityTriggerMultiplier, len(reports.Payload))
+	// You can customize the multiplier values based on your needs
+	// Using 10^18 as default, but you can adjust per stream if needed
+	multiplier, err := decimal.NewFromString("1")
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to parse multiplier string: %w", err)
+	}
 	for i, payload := range reports.Payload {
 		streams[i] = llotypes.Stream{
 			StreamID: payload.StreamID,
 		}
+
+		multipliers[i] = cre.ReportCodecCapabilityTriggerMultiplier{
+			Multiplier: multiplier,
+			StreamID:   payload.StreamID,
+		}
+		// Shift the multiplier for each stream to simulate different multipliers
+		multiplier = multiplier.Shift(1)
 	}
+
+	opts, err := (&cre.ReportCodecCapabilityTriggerOpts{
+		Multipliers: multipliers,
+	}).Encode()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to encode opts: %w", err)
+	}
+
 	channelDef := llotypes.ChannelDefinition{
-		Streams: streams,
+		ReportFormat: llotypes.ReportFormatCapabilityTrigger,
+		Opts:         opts,
+		Streams:      streams,
 	}
 
 	// Encode the report to bytes

--- a/core/capabilities/integration_tests/keystone/llo_feed_test.go
+++ b/core/capabilities/integration_tests/keystone/llo_feed_test.go
@@ -99,7 +99,7 @@ func MakeOCRTriggerEvent(lggr logger.Logger, reports *datastreams.LLOStreamsTrig
 	streams := make([]llotypes.Stream, len(reports.Payload))
 	// Create multipliers based on the actual StreamIDs from the payload
 	multipliers := make([]cre.ReportCodecCapabilityTriggerMultiplier, len(reports.Payload))
-	// We currently only use a mutliplier of 1 in this test, as this test uses a value from
+	// We currently only use a multiplier of 1 in this test, as this test uses a value from
 	// the KeystoneFeedsConsumer contract which is already 18 decimals as the source for the StreamValue.
 	// In practice this value will be sourced from an EA + LLO jobspec and will often be non-scaled or up to 18 decimals.
 	// The Opts.Multipliers are used to scale the values post EA + LLO jobspec up to the required 18 decimal values

--- a/core/capabilities/integration_tests/keystone/llo_feed_test.go
+++ b/core/capabilities/integration_tests/keystone/llo_feed_test.go
@@ -99,7 +99,7 @@ func MakeOCRTriggerEvent(lggr logger.Logger, reports *datastreams.LLOStreamsTrig
 	streams := make([]llotypes.Stream, len(reports.Payload))
 	// Create multipliers based on the actual StreamIDs from the payload
 	multipliers := make([]cre.ReportCodecCapabilityTriggerMultiplier, len(reports.Payload))
-	multiplier, err := decimal.NewFromString("1")
+	multiplier, err := decimal.NewFromString("1000000000000000000") // 10^18
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to parse multiplier string: %w", err)
 	}
@@ -112,8 +112,6 @@ func MakeOCRTriggerEvent(lggr logger.Logger, reports *datastreams.LLOStreamsTrig
 			Multiplier: multiplier,
 			StreamID:   payload.StreamID,
 		}
-		// Shift the multiplier for each stream to simulate different multipliers
-		multiplier = multiplier.Shift(1)
 	}
 
 	opts, err := (&cre.ReportCodecCapabilityTriggerOpts{

--- a/core/capabilities/integration_tests/keystone/llo_feed_test.go
+++ b/core/capabilities/integration_tests/keystone/llo_feed_test.go
@@ -99,7 +99,7 @@ func MakeOCRTriggerEvent(lggr logger.Logger, reports *datastreams.LLOStreamsTrig
 	streams := make([]llotypes.Stream, len(reports.Payload))
 	// Create multipliers based on the actual StreamIDs from the payload
 	multipliers := make([]cre.ReportCodecCapabilityTriggerMultiplier, len(reports.Payload))
-	multiplier, err := decimal.NewFromString("1000000000000000000") // 10^18
+	multiplier, err := decimal.NewFromString("1")
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to parse multiplier string: %w", err)
 	}
@@ -123,8 +123,8 @@ func MakeOCRTriggerEvent(lggr logger.Logger, reports *datastreams.LLOStreamsTrig
 
 	channelDef := llotypes.ChannelDefinition{
 		ReportFormat: llotypes.ReportFormatCapabilityTrigger,
-		Opts:         opts,
 		Streams:      streams,
+		Opts:         opts,
 	}
 
 	// Encode the report to bytes

--- a/core/capabilities/integration_tests/keystone/llo_feed_test.go
+++ b/core/capabilities/integration_tests/keystone/llo_feed_test.go
@@ -99,6 +99,11 @@ func MakeOCRTriggerEvent(lggr logger.Logger, reports *datastreams.LLOStreamsTrig
 	streams := make([]llotypes.Stream, len(reports.Payload))
 	// Create multipliers based on the actual StreamIDs from the payload
 	multipliers := make([]cre.ReportCodecCapabilityTriggerMultiplier, len(reports.Payload))
+	// We currently only use a mutliplier of 1 in this test, as this test uses a value from
+	// the KeystoneFeedsConsumer contract which is already 18 decimals as the source for the StreamValue.
+	// In practice this value will be sourced from an EA + LLO jobspec and will often be non-scaled or up to 18 decimals.
+	// The Opts.Multipliers are used to scale the values post EA + LLO jobspec up to the required 18 decimal values
+	// the LLO Asset DON is expected to output to the Capability Trigger at.
 	multiplier, err := decimal.NewFromString("1")
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to parse multiplier string: %w", err)

--- a/core/capabilities/integration_tests/keystone/llo_feed_test.go
+++ b/core/capabilities/integration_tests/keystone/llo_feed_test.go
@@ -99,8 +99,6 @@ func MakeOCRTriggerEvent(lggr logger.Logger, reports *datastreams.LLOStreamsTrig
 	streams := make([]llotypes.Stream, len(reports.Payload))
 	// Create multipliers based on the actual StreamIDs from the payload
 	multipliers := make([]cre.ReportCodecCapabilityTriggerMultiplier, len(reports.Payload))
-	// You can customize the multiplier values based on your needs
-	// Using 10^18 as default, but you can adjust per stream if needed
 	multiplier, err := decimal.NewFromString("1")
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to parse multiplier string: %w", err)

--- a/core/services/llo/cre/report_codec.go
+++ b/core/services/llo/cre/report_codec.go
@@ -45,7 +45,7 @@ type ReportCodecCapabilityTriggerOpts struct {
 
 func (r *ReportCodecCapabilityTriggerOpts) Decode(opts []byte) error {
 	if len(opts) == 0 {
-		return fmt.Errorf("opts cannot be empty for ReportCodecCapabilityTriggerOpts")
+		return errors.New("opts cannot be empty for ReportCodecCapabilityTriggerOpts")
 	}
 	decoder := json.NewDecoder(bytes.NewReader(opts))
 	decoder.DisallowUnknownFields() // Error on unrecognized fields

--- a/core/services/llo/cre/report_codec.go
+++ b/core/services/llo/cre/report_codec.go
@@ -14,6 +14,7 @@ import (
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	datastreamsllo "github.com/smartcontractkit/chainlink-data-streams/llo"
+
 	"google.golang.org/protobuf/proto"
 )
 

--- a/core/services/llo/cre/report_codec.go
+++ b/core/services/llo/cre/report_codec.go
@@ -42,7 +42,7 @@ type ReportCodecCapabilityTriggerOpts struct {
 	//
 	// The total number of streams must be n, where n is the number of
 	// top-level elements in this ReportCodecCapabilityTriggerMultipliers array
-	Multipliers []ReportCodecCapabilityTriggerMultiplier `json:"multipliers,omitempty"`
+	Multipliers []ReportCodecCapabilityTriggerMultiplier `json:"multipliers"`
 }
 
 func (r *ReportCodecCapabilityTriggerOpts) Decode(opts []byte) error {

--- a/core/services/llo/cre/report_codec.go
+++ b/core/services/llo/cre/report_codec.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/shopspring/decimal"
 	commonds "github.com/smartcontractkit/chainlink-common/pkg/capabilities/datastreams"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
@@ -15,6 +13,7 @@ import (
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 	"github.com/smartcontractkit/chainlink-common/pkg/values"
 	datastreamsllo "github.com/smartcontractkit/chainlink-data-streams/llo"
+	"google.golang.org/protobuf/proto"
 )
 
 var _ datastreamsllo.ReportCodec = ReportCodecCapabilityTrigger{}

--- a/core/services/llo/cre/report_codec.go
+++ b/core/services/llo/cre/report_codec.go
@@ -45,7 +45,7 @@ type ReportCodecCapabilityTriggerOpts struct {
 
 func (r *ReportCodecCapabilityTriggerOpts) Decode(opts []byte) error {
 	if len(opts) == 0 {
-		return errors.New("opts cannot be empty for ReportCodecCapabilityTriggerOpts")
+		return nil
 	}
 	decoder := json.NewDecoder(bytes.NewReader(opts))
 	decoder.DisallowUnknownFields() // Error on unrecognized fields
@@ -83,7 +83,11 @@ func (r ReportCodecCapabilityTrigger) Encode(report datastreamsllo.Report, cd ll
 		case nil:
 			// Missing observations are nil
 		case *datastreamsllo.Decimal:
-			multipliedStreamValue := v.Decimal().Mul(opts.Multipliers[i].Multiplier)
+			multipliedStreamValue := v.Decimal()
+
+			if len(opts.Multipliers) != 0 {
+				multipliedStreamValue = multipliedStreamValue.Mul(opts.Multipliers[i].Multiplier)
+			}
 
 			var err error
 			d, err = multipliedStreamValue.MarshalBinary()

--- a/core/services/llo/cre/report_codec.go
+++ b/core/services/llo/cre/report_codec.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/shopspring/decimal"
+
 	commonds "github.com/smartcontractkit/chainlink-common/pkg/capabilities/datastreams"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"

--- a/core/services/llo/cre/report_codec.go
+++ b/core/services/llo/cre/report_codec.go
@@ -81,27 +81,27 @@ func (r ReportCodecCapabilityTrigger) Encode(report datastreamsllo.Report, cd ll
 	payload := make([]*commonds.LLOStreamDecimal, len(report.Values))
 	for i, stream := range report.Values {
 		var d []byte
-		switch stream.(type) {
+		switch v := stream.(type) {
 		case nil:
 			// Missing observations are nil
 		case *datastreamsllo.Decimal:
-			multipliedStreamValue := (stream.(*datastreamsllo.Decimal)).Decimal()
+			multipliedStreamValue := v.Decimal()
 
 			if len(opts.Multipliers) != 0 {
 				if opts.Multipliers[i].StreamID != cd.Streams[i].StreamID {
 					return nil, fmt.Errorf("LLO StreamID %d mismatched with Multiplier StreamID %d", cd.Streams[i].StreamID, opts.Multipliers[i].StreamID)
 				}
 
-				// Mutilpier is optional, if not specified, we use the original value
+				// Multiplier is optional, if not specified, we use the original value
 				if opts.Multipliers[i].Multiplier != nil {
 					if !(opts.Multipliers[i].Multiplier.IsInteger()) {
-						return nil, fmt.Errorf("Multiplier for StreamID %d must be an integer", opts.Multipliers[i].StreamID)
+						return nil, fmt.Errorf("multiplier for StreamID %d must be an integer", opts.Multipliers[i].StreamID)
 					}
 					if opts.Multipliers[i].Multiplier.IsZero() {
-						return nil, fmt.Errorf("Multiplier for StreamID %d can't be zero", opts.Multipliers[i].StreamID)
+						return nil, fmt.Errorf("multiplier for StreamID %d can't be zero", opts.Multipliers[i].StreamID)
 					}
 					if opts.Multipliers[i].Multiplier.IsNegative() {
-						return nil, fmt.Errorf("Multiplier for StreamID %d can't be negative", opts.Multipliers[i].StreamID)
+						return nil, fmt.Errorf("multiplier for StreamID %d can't be negative", opts.Multipliers[i].StreamID)
 					}
 
 					multipliedStreamValue = multipliedStreamValue.Mul(*opts.Multipliers[i].Multiplier)
@@ -149,7 +149,7 @@ func (r ReportCodecCapabilityTrigger) Verify(cd llotypes.ChannelDefinition) erro
 		return fmt.Errorf("invalid Opts, got: %q; %w", cd.Opts, err)
 	}
 	if len(opts.Multipliers) != len(cd.Streams) {
-		return fmt.Errorf("Multipliers length %d != StreamValues length %d", len(opts.Multipliers), len(cd.Streams))
+		return fmt.Errorf("multipliers length %d != StreamValues length %d", len(opts.Multipliers), len(cd.Streams))
 	}
 	return nil
 }

--- a/core/services/llo/cre/report_codec.go
+++ b/core/services/llo/cre/report_codec.go
@@ -28,7 +28,7 @@ func NewReportCodecCapabilityTrigger(lggr logger.Logger, donID uint32) ReportCod
 }
 
 type ReportCodecCapabilityTriggerMultiplier struct {
-	Multiplier *decimal.Decimal  `json:"multiplier"`
+	Multiplier decimal.Decimal   `json:"multiplier"`
 	StreamID   llotypes.StreamID `json:"streamID"`
 }
 
@@ -45,8 +45,7 @@ type ReportCodecCapabilityTriggerOpts struct {
 
 func (r *ReportCodecCapabilityTriggerOpts) Decode(opts []byte) error {
 	if len(opts) == 0 {
-		// special case if opts are unspecified, just use the zero options rather than erroring
-		return nil
+		return fmt.Errorf("opts cannot be empty for ReportCodecCapabilityTriggerOpts")
 	}
 	decoder := json.NewDecoder(bytes.NewReader(opts))
 	decoder.DisallowUnknownFields() // Error on unrecognized fields
@@ -84,28 +83,7 @@ func (r ReportCodecCapabilityTrigger) Encode(report datastreamsllo.Report, cd ll
 		case nil:
 			// Missing observations are nil
 		case *datastreamsllo.Decimal:
-			multipliedStreamValue := v.Decimal()
-
-			if len(opts.Multipliers) != 0 {
-				if opts.Multipliers[i].StreamID != cd.Streams[i].StreamID {
-					return nil, fmt.Errorf("LLO StreamID %d mismatched with Multiplier StreamID %d", cd.Streams[i].StreamID, opts.Multipliers[i].StreamID)
-				}
-
-				// Multiplier is optional, if not specified, we use the original value
-				if opts.Multipliers[i].Multiplier != nil {
-					if !(opts.Multipliers[i].Multiplier.IsInteger()) {
-						return nil, fmt.Errorf("multiplier for StreamID %d must be an integer", opts.Multipliers[i].StreamID)
-					}
-					if opts.Multipliers[i].Multiplier.IsZero() {
-						return nil, fmt.Errorf("multiplier for StreamID %d can't be zero", opts.Multipliers[i].StreamID)
-					}
-					if opts.Multipliers[i].Multiplier.IsNegative() {
-						return nil, fmt.Errorf("multiplier for StreamID %d can't be negative", opts.Multipliers[i].StreamID)
-					}
-
-					multipliedStreamValue = multipliedStreamValue.Mul(*opts.Multipliers[i].Multiplier)
-				}
-			}
+			multipliedStreamValue := v.Decimal().Mul(opts.Multipliers[i].Multiplier)
 
 			var err error
 			d, err = multipliedStreamValue.MarshalBinary()
@@ -149,6 +127,21 @@ func (r ReportCodecCapabilityTrigger) Verify(cd llotypes.ChannelDefinition) erro
 	}
 	if len(opts.Multipliers) != len(cd.Streams) {
 		return fmt.Errorf("multipliers length %d != StreamValues length %d", len(opts.Multipliers), len(cd.Streams))
+	}
+
+	for i, stream := range cd.Streams {
+		if opts.Multipliers[i].StreamID != stream.StreamID {
+			return fmt.Errorf("LLO StreamID %d mismatched with Multiplier StreamID %d", stream.StreamID, opts.Multipliers[i].StreamID)
+		}
+		if !(opts.Multipliers[i].Multiplier.IsInteger()) {
+			return fmt.Errorf("multiplier for StreamID %d must be an integer", opts.Multipliers[i].StreamID)
+		}
+		if opts.Multipliers[i].Multiplier.IsZero() {
+			return fmt.Errorf("multiplier for StreamID %d can't be zero", opts.Multipliers[i].StreamID)
+		}
+		if opts.Multipliers[i].Multiplier.IsNegative() {
+			return fmt.Errorf("multiplier for StreamID %d can't be negative", opts.Multipliers[i].StreamID)
+		}
 	}
 	return nil
 }

--- a/core/services/llo/cre/report_codec.go
+++ b/core/services/llo/cre/report_codec.go
@@ -1,11 +1,14 @@
 package cre
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/shopspring/decimal"
 	commonds "github.com/smartcontractkit/chainlink-common/pkg/capabilities/datastreams"
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -25,6 +28,36 @@ func NewReportCodecCapabilityTrigger(lggr logger.Logger, donID uint32) ReportCod
 	return ReportCodecCapabilityTrigger{lggr, donID}
 }
 
+type ReportCodecCapabilityTriggerMultiplier struct {
+	Multiplier *decimal.Decimal  `json:"multiplier"`
+	StreamID   llotypes.StreamID `json:"streamID"`
+}
+
+// Opts format remains unchanged
+type ReportCodecCapabilityTriggerOpts struct {
+	// EXAMPLE
+	//
+	// [{streamID: 1000000001, "multiplier":"10000"}, ...]
+	//
+	// The total number of streams must be n, where n is the number of
+	// top-level elements in this ReportCodecCapabilityTriggerMultipliers array
+	Multipliers []ReportCodecCapabilityTriggerMultiplier `json:"multipliers,omitempty"`
+}
+
+func (r *ReportCodecCapabilityTriggerOpts) Decode(opts []byte) error {
+	if len(opts) == 0 {
+		// special case if opts are unspecified, just use the zero options rather than erroring
+		return nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(opts))
+	decoder.DisallowUnknownFields() // Error on unrecognized fields
+	return decoder.Decode(r)
+}
+
+func (r *ReportCodecCapabilityTriggerOpts) Encode() ([]byte, error) {
+	return json.Marshal(r)
+}
+
 // Encode a report into a capability trigger report
 // the returned byte slice is the marshaled protobuf of [capabilitiespb.OCRTriggerReport]
 func (r ReportCodecCapabilityTrigger) Encode(report datastreamsllo.Report, cd llotypes.ChannelDefinition) ([]byte, error) {
@@ -36,6 +69,15 @@ func (r ReportCodecCapabilityTrigger) Encode(report datastreamsllo.Report, cd ll
 		// Not supported for now
 		return nil, errors.New("capability trigger encoder does not currently support specimen reports")
 	}
+
+	// NOTE: It seems suboptimal to have to parse the opts on every encode but
+	// not sure how to avoid it. Should be negligible performance hit as long
+	// as Opts is small.
+	opts := ReportCodecCapabilityTriggerOpts{}
+	if err := (&opts).Decode(cd.Opts); err != nil {
+		return nil, fmt.Errorf("failed to decode opts; got: '%s'; %w", cd.Opts, err)
+	}
+
 	payload := make([]*commonds.LLOStreamDecimal, len(report.Values))
 	for i, stream := range report.Values {
 		var d []byte
@@ -43,8 +85,31 @@ func (r ReportCodecCapabilityTrigger) Encode(report datastreamsllo.Report, cd ll
 		case nil:
 			// Missing observations are nil
 		case *datastreamsllo.Decimal:
+			multipliedStreamValue := (stream.(*datastreamsllo.Decimal)).Decimal()
+
+			if len(opts.Multipliers) != 0 {
+				if opts.Multipliers[i].StreamID != cd.Streams[i].StreamID {
+					return nil, fmt.Errorf("LLO StreamID %d mismatched with Multiplier StreamID %d", cd.Streams[i].StreamID, opts.Multipliers[i].StreamID)
+				}
+
+				// Mutilpier is optional, if not specified, we use the original value
+				if opts.Multipliers[i].Multiplier != nil {
+					if !(opts.Multipliers[i].Multiplier.IsInteger()) {
+						return nil, fmt.Errorf("Multiplier for StreamID %d must be an integer", opts.Multipliers[i].StreamID)
+					}
+					if opts.Multipliers[i].Multiplier.IsZero() {
+						return nil, fmt.Errorf("Multiplier for StreamID %d can't be zero", opts.Multipliers[i].StreamID)
+					}
+					if opts.Multipliers[i].Multiplier.IsNegative() {
+						return nil, fmt.Errorf("Multiplier for StreamID %d can't be negative", opts.Multipliers[i].StreamID)
+					}
+
+					multipliedStreamValue = multipliedStreamValue.Mul(*opts.Multipliers[i].Multiplier)
+				}
+			}
+
 			var err error
-			d, err = stream.MarshalBinary()
+			d, err = multipliedStreamValue.MarshalBinary()
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal decimal: %w", err)
 			}
@@ -56,6 +121,7 @@ func (r ReportCodecCapabilityTrigger) Encode(report datastreamsllo.Report, cd ll
 			Decimal:  d,
 		}
 	}
+
 	ste := commonds.LLOStreamsTriggerEvent{
 		Payload:                         payload,
 		ObservationTimestampNanoseconds: report.ObservationTimestampNanoseconds,
@@ -78,8 +144,12 @@ func (r ReportCodecCapabilityTrigger) Encode(report datastreamsllo.Report, cd ll
 }
 
 func (r ReportCodecCapabilityTrigger) Verify(cd llotypes.ChannelDefinition) error {
-	if len(cd.Opts) > 0 {
-		return errors.New("capability trigger does not support channel definitions with options")
+	opts := new(ReportCodecCapabilityTriggerOpts)
+	if err := opts.Decode(cd.Opts); err != nil {
+		return fmt.Errorf("invalid Opts, got: %q; %w", cd.Opts, err)
+	}
+	if len(opts.Multipliers) != len(cd.Streams) {
+		return fmt.Errorf("Multipliers length %d != StreamValues length %d", len(opts.Multipliers), len(cd.Streams))
 	}
 	return nil
 }

--- a/core/services/llo/cre/report_codec_test.go
+++ b/core/services/llo/cre/report_codec_test.go
@@ -79,7 +79,9 @@ func Test_ReportCodec(t *testing.T) {
 		}
 
 		multiplier1, err := decimal.NewFromString("1")
+		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("1000000000000000000") // 10^18
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
@@ -145,7 +147,9 @@ func Test_ReportCodec(t *testing.T) {
 		}
 
 		multiplier1, err := decimal.NewFromString("1")
+		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("1000000000000000000") // 10^18
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
@@ -180,7 +184,9 @@ func Test_ReportCodec(t *testing.T) {
 		}
 
 		multiplier1, err := decimal.NewFromString("123.4567")
+		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("89.01234")
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
@@ -198,7 +204,7 @@ func Test_ReportCodec(t *testing.T) {
 			},
 			Opts: opts,
 		})
-		require.EqualError(t, err, "Multiplier for StreamID 1 must be an integer")
+		require.EqualError(t, err, "multiplier for StreamID 1 must be an integer")
 	})
 	t.Run("Encode: Multiplier is zero FAIL", func(t *testing.T) {
 		donID := uint32(1)
@@ -215,7 +221,9 @@ func Test_ReportCodec(t *testing.T) {
 		}
 
 		multiplier1, err := decimal.NewFromString("0")
+		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("0")
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
@@ -233,7 +241,7 @@ func Test_ReportCodec(t *testing.T) {
 			},
 			Opts: opts,
 		})
-		require.EqualError(t, err, "Multiplier for StreamID 1 can't be zero")
+		require.EqualError(t, err, "multiplier for StreamID 1 can't be zero")
 	})
 	t.Run("Encode: Multiplier is negative FAIL", func(t *testing.T) {
 		donID := uint32(1)
@@ -250,7 +258,9 @@ func Test_ReportCodec(t *testing.T) {
 		}
 
 		multiplier1, err := decimal.NewFromString("-1000000000000000000") // -10^18
+		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("-1")
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
@@ -268,7 +278,7 @@ func Test_ReportCodec(t *testing.T) {
 			},
 			Opts: opts,
 		})
-		require.EqualError(t, err, "Multiplier for StreamID 1 can't be negative")
+		require.EqualError(t, err, "multiplier for StreamID 1 can't be negative")
 	})
 	t.Run("Verify: Multipliers length, StreamValues length mismatch FAIL", func(t *testing.T) {
 		donID := uint32(1)
@@ -278,7 +288,9 @@ func Test_ReportCodec(t *testing.T) {
 		require.NoError(t, err)
 
 		multiplier1, err := decimal.NewFromString("1000000000000000000") // 10^18
+		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("1")
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
@@ -298,6 +310,6 @@ func Test_ReportCodec(t *testing.T) {
 				Opts: opts,
 			},
 		)
-		require.EqualError(t, err, "Multipliers length 3 != StreamValues length 2")
+		require.EqualError(t, err, "multipliers length 3 != StreamValues length 2")
 	})
 }

--- a/core/services/llo/cre/report_codec_test.go
+++ b/core/services/llo/cre/report_codec_test.go
@@ -19,6 +19,51 @@ import (
 )
 
 func Test_ReportCodec(t *testing.T) {
+	t.Run("Encode: Without Opts SUCCESS", func(t *testing.T) {
+		donID := uint32(1)
+		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
+
+		r := datastreamsllo.Report{
+			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
+			SeqNr:                           32,
+			ChannelID:                       llotypes.ChannelID(31),
+			ValidAfterNanoseconds:           28,
+			ObservationTimestampNanoseconds: 34,
+			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36))},
+			Specimen:                        false,
+		}
+		encoded, err := c.Encode(r, llotypes.ChannelDefinition{
+			Streams: []llotypes.Stream{
+				{StreamID: 1},
+				{StreamID: 2},
+			},
+		})
+		require.NoError(t, err)
+
+		var pbuf capabilitiespb.OCRTriggerReport
+		err = proto.Unmarshal(encoded, &pbuf)
+		require.NoError(t, err)
+
+		assert.Equal(t, "streams_1_34", pbuf.EventID)
+		assert.Equal(t, uint64(34), pbuf.Timestamp)
+		require.Len(t, pbuf.Outputs.Fields, 2)
+		assert.Equal(t, &pb.Value_Int64Value{Int64Value: 34}, pbuf.Outputs.Fields["ObservationTimestampNanoseconds"].Value)
+		require.Len(t, pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields, 2)
+
+		require.Len(t, pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[0].Value.(*pb.Value_MapValue).MapValue.Fields, 2)
+		decimalBytes := pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[0].Value.(*pb.Value_MapValue).MapValue.Fields["Decimal"].Value.(*pb.Value_BytesValue).BytesValue
+		d := decimal.Decimal{}
+		require.NoError(t, (&d).UnmarshalBinary(decimalBytes))
+		assert.Equal(t, "35", d.String())
+		assert.Equal(t, int64(1), pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[0].Value.(*pb.Value_MapValue).MapValue.Fields["StreamID"].Value.(*pb.Value_Int64Value).Int64Value)
+
+		require.Len(t, pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[1].Value.(*pb.Value_MapValue).MapValue.Fields, 2)
+		decimalBytes = pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[1].Value.(*pb.Value_MapValue).MapValue.Fields["Decimal"].Value.(*pb.Value_BytesValue).BytesValue
+		d = decimal.Decimal{}
+		require.NoError(t, (&d).UnmarshalBinary(decimalBytes))
+		assert.Equal(t, "36", d.String())
+		assert.Equal(t, int64(2), pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[1].Value.(*pb.Value_MapValue).MapValue.Fields["StreamID"].Value.(*pb.Value_Int64Value).Int64Value)
+	})
 	t.Run("Encode: With Opts SUCCESS", func(t *testing.T) {
 		donID := uint32(1)
 		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
@@ -89,19 +134,32 @@ func Test_ReportCodec(t *testing.T) {
 		assert.Equal(t, "37000000", d.String())
 		assert.Equal(t, int64(3), pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[2].Value.(*pb.Value_MapValue).MapValue.Fields["StreamID"].Value.(*pb.Value_Int64Value).Int64Value)
 	})
-	t.Run("Verify: Without Opts FAIL", func(t *testing.T) {
+	t.Run("Verify: Without Opts SUCCESS", func(t *testing.T) {
 		donID := uint32(1)
 		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
 
-		err := c.Verify(
+		multiplier1, err := decimal.NewFromString("1")
+		require.NoError(t, err)
+		multiplier2, err := decimal.NewFromString("1000000000000000000") // 10^18
+		require.NoError(t, err)
+
+		opts, err := (&ReportCodecCapabilityTriggerOpts{
+			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
+				{Multiplier: multiplier1, StreamID: 1},
+				{Multiplier: multiplier2, StreamID: 2},
+			},
+		}).Encode()
+		require.NoError(t, err)
+		err = c.Verify(
 			llotypes.ChannelDefinition{
 				Streams: []llotypes.Stream{
 					{StreamID: 1},
 					{StreamID: 2},
 				},
+				Opts: opts,
 			},
 		)
-		require.EqualError(t, err, "invalid Opts, got: \"\"; opts cannot be empty for ReportCodecCapabilityTriggerOpts")
+		require.NoError(t, err)
 	})
 	t.Run("Verify: Misaligned Multiplier StreamIDs FAIL", func(t *testing.T) {
 		donID := uint32(1)

--- a/core/services/llo/cre/report_codec_test.go
+++ b/core/services/llo/cre/report_codec_test.go
@@ -19,52 +19,7 @@ import (
 )
 
 func Test_ReportCodec(t *testing.T) {
-	t.Run("Encode: Without Opts SUCCESS", func(t *testing.T) {
-		donID := uint32(1)
-		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
-
-		r := datastreamsllo.Report{
-			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
-			SeqNr:                           32,
-			ChannelID:                       llotypes.ChannelID(31),
-			ValidAfterNanoseconds:           28,
-			ObservationTimestampNanoseconds: 34,
-			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36))},
-			Specimen:                        false,
-		}
-		encoded, err := c.Encode(r, llotypes.ChannelDefinition{
-			Streams: []llotypes.Stream{
-				{StreamID: 1},
-				{StreamID: 2},
-			},
-		})
-		require.NoError(t, err)
-
-		var pbuf capabilitiespb.OCRTriggerReport
-		err = proto.Unmarshal(encoded, &pbuf)
-		require.NoError(t, err)
-
-		assert.Equal(t, "streams_1_34", pbuf.EventID)
-		assert.Equal(t, uint64(34), pbuf.Timestamp)
-		require.Len(t, pbuf.Outputs.Fields, 2)
-		assert.Equal(t, &pb.Value_Int64Value{Int64Value: 34}, pbuf.Outputs.Fields["ObservationTimestampNanoseconds"].Value)
-		require.Len(t, pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields, 2)
-
-		require.Len(t, pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[0].Value.(*pb.Value_MapValue).MapValue.Fields, 2)
-		decimalBytes := pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[0].Value.(*pb.Value_MapValue).MapValue.Fields["Decimal"].Value.(*pb.Value_BytesValue).BytesValue
-		d := decimal.Decimal{}
-		require.NoError(t, (&d).UnmarshalBinary(decimalBytes))
-		assert.Equal(t, "35", d.String())
-		assert.Equal(t, int64(1), pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[0].Value.(*pb.Value_MapValue).MapValue.Fields["StreamID"].Value.(*pb.Value_Int64Value).Int64Value)
-
-		require.Len(t, pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[1].Value.(*pb.Value_MapValue).MapValue.Fields, 2)
-		decimalBytes = pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[1].Value.(*pb.Value_MapValue).MapValue.Fields["Decimal"].Value.(*pb.Value_BytesValue).BytesValue
-		d = decimal.Decimal{}
-		require.NoError(t, (&d).UnmarshalBinary(decimalBytes))
-		assert.Equal(t, "36", d.String())
-		assert.Equal(t, int64(2), pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[1].Value.(*pb.Value_MapValue).MapValue.Fields["StreamID"].Value.(*pb.Value_Int64Value).Int64Value)
-	})
-	t.Run("Encode: with Opts SUCCESS", func(t *testing.T) {
+	t.Run("Encode: With Opts SUCCESS", func(t *testing.T) {
 		donID := uint32(1)
 		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
 
@@ -82,12 +37,14 @@ func Test_ReportCodec(t *testing.T) {
 		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("1000000000000000000") // 10^18
 		require.NoError(t, err)
+		multiplier3, err := decimal.NewFromString("1000000") // 10^6
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
-				{Multiplier: &multiplier1, StreamID: 1},
-				{Multiplier: &multiplier2, StreamID: 2},
-				{StreamID: 3}, // Test that we can omit the multiplier
+				{Multiplier: multiplier1, StreamID: 1},
+				{Multiplier: multiplier2, StreamID: 2},
+				{Multiplier: multiplier3, StreamID: 3},
 			},
 		}).Encode()
 		require.NoError(t, err)
@@ -129,174 +86,163 @@ func Test_ReportCodec(t *testing.T) {
 		decimalBytes = pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[2].Value.(*pb.Value_MapValue).MapValue.Fields["Decimal"].Value.(*pb.Value_BytesValue).BytesValue
 		d = decimal.Decimal{}
 		require.NoError(t, (&d).UnmarshalBinary(decimalBytes))
-		assert.Equal(t, "37", d.String())
+		assert.Equal(t, "37000000", d.String())
 		assert.Equal(t, int64(3), pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[2].Value.(*pb.Value_MapValue).MapValue.Fields["StreamID"].Value.(*pb.Value_Int64Value).Int64Value)
 	})
-	t.Run("Encode: Misaligned Multiplier StreamIDs FAIL", func(t *testing.T) {
+	t.Run("Verify: Without Opts FAIL", func(t *testing.T) {
 		donID := uint32(1)
 		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
 
-		r := datastreamsllo.Report{
-			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
-			SeqNr:                           32,
-			ChannelID:                       llotypes.ChannelID(31),
-			ValidAfterNanoseconds:           28,
-			ObservationTimestampNanoseconds: 34,
-			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36)), llo.ToDecimal(decimal.NewFromInt(37))},
-			Specimen:                        false,
-		}
+		err := c.Verify(
+			llotypes.ChannelDefinition{
+				Streams: []llotypes.Stream{
+					{StreamID: 1},
+					{StreamID: 2},
+				},
+			},
+		)
+		require.EqualError(t, err, "invalid Opts, got: \"\"; opts cannot be empty for ReportCodecCapabilityTriggerOpts")
+	})
+	t.Run("Verify: Misaligned Multiplier StreamIDs FAIL", func(t *testing.T) {
+		donID := uint32(1)
+		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
 
 		multiplier1, err := decimal.NewFromString("1")
 		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("1000000000000000000") // 10^18
 		require.NoError(t, err)
+		multiplier3, err := decimal.NewFromString("1000000") // 10^6
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
-				{Multiplier: &multiplier1, StreamID: 1},
-				{Multiplier: &multiplier2, StreamID: 3},
-				{StreamID: 2}, // Test that we can omit the multiplier
+				{Multiplier: multiplier1, StreamID: 1},
+				{Multiplier: multiplier2, StreamID: 3},
+				{Multiplier: multiplier3, StreamID: 2},
 			},
 		}).Encode()
 		require.NoError(t, err)
-		_, err = c.Encode(r, llotypes.ChannelDefinition{
-			Streams: []llotypes.Stream{
-				{StreamID: 1},
-				{StreamID: 2},
-				{StreamID: 3},
+		err = c.Verify(
+			llotypes.ChannelDefinition{
+				Streams: []llotypes.Stream{
+					{StreamID: 1},
+					{StreamID: 2},
+					{StreamID: 3},
+				},
+				Opts: opts,
 			},
-			Opts: opts,
-		})
+		)
 		require.EqualError(t, err, "LLO StreamID 2 mismatched with Multiplier StreamID 3")
 	})
 	t.Run("Encode: Multiplier isn't an integer FAIL", func(t *testing.T) {
 		donID := uint32(1)
 		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
 
-		r := datastreamsllo.Report{
-			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
-			SeqNr:                           32,
-			ChannelID:                       llotypes.ChannelID(31),
-			ValidAfterNanoseconds:           28,
-			ObservationTimestampNanoseconds: 34,
-			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36)), llo.ToDecimal(decimal.NewFromInt(37))},
-			Specimen:                        false,
-		}
-
 		multiplier1, err := decimal.NewFromString("123.4567")
 		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("89.01234")
 		require.NoError(t, err)
+		multiplier3, err := decimal.NewFromString("1000000") // 10^6
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
-				{Multiplier: &multiplier1, StreamID: 1},
-				{Multiplier: &multiplier2, StreamID: 2},
-				{StreamID: 3}, // Test that we can omit the multiplier
+				{Multiplier: multiplier1, StreamID: 1},
+				{Multiplier: multiplier2, StreamID: 2},
+				{Multiplier: multiplier3, StreamID: 3},
 			},
 		}).Encode()
 		require.NoError(t, err)
-		_, err = c.Encode(r, llotypes.ChannelDefinition{
-			Streams: []llotypes.Stream{
-				{StreamID: 1},
-				{StreamID: 2},
-				{StreamID: 3},
+		err = c.Verify(
+			llotypes.ChannelDefinition{
+				Streams: []llotypes.Stream{
+					{StreamID: 1},
+					{StreamID: 2},
+					{StreamID: 3},
+				},
+				Opts: opts,
 			},
-			Opts: opts,
-		})
+		)
 		require.EqualError(t, err, "multiplier for StreamID 1 must be an integer")
 	})
-	t.Run("Encode: Multiplier is zero FAIL", func(t *testing.T) {
+	t.Run("Verify: Multiplier is zero FAIL", func(t *testing.T) {
 		donID := uint32(1)
 		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
-
-		r := datastreamsllo.Report{
-			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
-			SeqNr:                           32,
-			ChannelID:                       llotypes.ChannelID(31),
-			ValidAfterNanoseconds:           28,
-			ObservationTimestampNanoseconds: 34,
-			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36)), llo.ToDecimal(decimal.NewFromInt(37))},
-			Specimen:                        false,
-		}
 
 		multiplier1, err := decimal.NewFromString("0")
 		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("0")
 		require.NoError(t, err)
+		multiplier3, err := decimal.NewFromString("1000000") // 10^6
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
-				{Multiplier: &multiplier1, StreamID: 1},
-				{Multiplier: &multiplier2, StreamID: 2},
-				{StreamID: 3}, // Test that we can omit the multiplier
+				{Multiplier: multiplier1, StreamID: 1},
+				{Multiplier: multiplier2, StreamID: 2},
+				{Multiplier: multiplier3, StreamID: 3},
 			},
 		}).Encode()
 		require.NoError(t, err)
-		_, err = c.Encode(r, llotypes.ChannelDefinition{
-			Streams: []llotypes.Stream{
-				{StreamID: 1},
-				{StreamID: 2},
-				{StreamID: 3},
+		err = c.Verify(
+			llotypes.ChannelDefinition{
+				Streams: []llotypes.Stream{
+					{StreamID: 1},
+					{StreamID: 2},
+					{StreamID: 3},
+				},
+				Opts: opts,
 			},
-			Opts: opts,
-		})
+		)
 		require.EqualError(t, err, "multiplier for StreamID 1 can't be zero")
 	})
-	t.Run("Encode: Multiplier is negative FAIL", func(t *testing.T) {
+	t.Run("Verify: Multiplier is negative FAIL", func(t *testing.T) {
 		donID := uint32(1)
 		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
-
-		r := datastreamsllo.Report{
-			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
-			SeqNr:                           32,
-			ChannelID:                       llotypes.ChannelID(31),
-			ValidAfterNanoseconds:           28,
-			ObservationTimestampNanoseconds: 34,
-			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36)), llo.ToDecimal(decimal.NewFromInt(37))},
-			Specimen:                        false,
-		}
 
 		multiplier1, err := decimal.NewFromString("-1000000000000000000") // -10^18
 		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("-1")
 		require.NoError(t, err)
+		multiplier3, err := decimal.NewFromString("1000000") // 10^6
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
-				{Multiplier: &multiplier1, StreamID: 1},
-				{Multiplier: &multiplier2, StreamID: 2},
-				{StreamID: 3}, // Test that we can omit the multiplier
+				{Multiplier: multiplier1, StreamID: 1},
+				{Multiplier: multiplier2, StreamID: 2},
+				{Multiplier: multiplier3, StreamID: 3},
 			},
 		}).Encode()
 		require.NoError(t, err)
-		_, err = c.Encode(r, llotypes.ChannelDefinition{
-			Streams: []llotypes.Stream{
-				{StreamID: 1},
-				{StreamID: 2},
-				{StreamID: 3},
+		err = c.Verify(
+			llotypes.ChannelDefinition{
+				Streams: []llotypes.Stream{
+					{StreamID: 1},
+					{StreamID: 2},
+					{StreamID: 3},
+				},
+				Opts: opts,
 			},
-			Opts: opts,
-		})
+		)
 		require.EqualError(t, err, "multiplier for StreamID 1 can't be negative")
 	})
 	t.Run("Verify: Multipliers length, StreamValues length mismatch FAIL", func(t *testing.T) {
 		donID := uint32(1)
 		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
 
-		err := c.Verify(llotypes.ChannelDefinition{})
-		require.NoError(t, err)
-
 		multiplier1, err := decimal.NewFromString("1000000000000000000") // 10^18
 		require.NoError(t, err)
 		multiplier2, err := decimal.NewFromString("1")
 		require.NoError(t, err)
+		multiplier3, err := decimal.NewFromString("1000000") // 10^6
+		require.NoError(t, err)
 
 		opts, err := (&ReportCodecCapabilityTriggerOpts{
 			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
-				{Multiplier: &multiplier1, StreamID: 1},
-				{Multiplier: &multiplier2, StreamID: 2},
-				{StreamID: 3}, // Test that we can omit the multiplier
+				{Multiplier: multiplier1, StreamID: 1},
+				{Multiplier: multiplier2, StreamID: 2},
+				{Multiplier: multiplier3, StreamID: 3},
 			},
 		}).Encode()
 		require.NoError(t, err)

--- a/core/services/llo/cre/report_codec_test.go
+++ b/core/services/llo/cre/report_codec_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func Test_ReportCodec(t *testing.T) {
-	t.Run("Encode", func(t *testing.T) {
+	t.Run("Encode: Without Opts SUCCESS", func(t *testing.T) {
 		donID := uint32(1)
 		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
 
@@ -64,14 +64,240 @@ func Test_ReportCodec(t *testing.T) {
 		assert.Equal(t, "36", d.String())
 		assert.Equal(t, int64(2), pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[1].Value.(*pb.Value_MapValue).MapValue.Fields["StreamID"].Value.(*pb.Value_Int64Value).Int64Value)
 	})
-	t.Run("Verify", func(t *testing.T) {
+	t.Run("Encode: with Opts SUCCESS", func(t *testing.T) {
+		donID := uint32(1)
+		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
+
+		r := datastreamsllo.Report{
+			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
+			SeqNr:                           32,
+			ChannelID:                       llotypes.ChannelID(31),
+			ValidAfterNanoseconds:           28,
+			ObservationTimestampNanoseconds: 34,
+			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36)), llo.ToDecimal(decimal.NewFromInt(37))},
+			Specimen:                        false,
+		}
+
+		multiplier1, err := decimal.NewFromString("1")
+		multiplier2, err := decimal.NewFromString("1000000000000000000") // 10^18
+
+		opts, err := (&ReportCodecCapabilityTriggerOpts{
+			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
+				{Multiplier: &multiplier1, StreamID: 1},
+				{Multiplier: &multiplier2, StreamID: 2},
+				{StreamID: 3}, // Test that we can omit the multiplier
+			},
+		}).Encode()
+		require.NoError(t, err)
+		encoded, err := c.Encode(r, llotypes.ChannelDefinition{
+			Streams: []llotypes.Stream{
+				{StreamID: 1},
+				{StreamID: 2},
+				{StreamID: 3},
+			},
+			Opts: opts,
+		})
+		require.NoError(t, err)
+
+		var pbuf capabilitiespb.OCRTriggerReport
+		err = proto.Unmarshal(encoded, &pbuf)
+		require.NoError(t, err)
+
+		assert.Equal(t, "streams_1_34", pbuf.EventID)
+		assert.Equal(t, uint64(34), pbuf.Timestamp)
+		require.Len(t, pbuf.Outputs.Fields, 2)
+		assert.Equal(t, &pb.Value_Int64Value{Int64Value: 34}, pbuf.Outputs.Fields["ObservationTimestampNanoseconds"].Value)
+		require.Len(t, pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields, 3)
+
+		require.Len(t, pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[0].Value.(*pb.Value_MapValue).MapValue.Fields, 2)
+		decimalBytes := pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[0].Value.(*pb.Value_MapValue).MapValue.Fields["Decimal"].Value.(*pb.Value_BytesValue).BytesValue
+		d := decimal.Decimal{}
+		require.NoError(t, (&d).UnmarshalBinary(decimalBytes))
+		assert.Equal(t, "35", d.String())
+		assert.Equal(t, int64(1), pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[0].Value.(*pb.Value_MapValue).MapValue.Fields["StreamID"].Value.(*pb.Value_Int64Value).Int64Value)
+
+		require.Len(t, pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[1].Value.(*pb.Value_MapValue).MapValue.Fields, 2)
+		decimalBytes = pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[1].Value.(*pb.Value_MapValue).MapValue.Fields["Decimal"].Value.(*pb.Value_BytesValue).BytesValue
+		d = decimal.Decimal{}
+		require.NoError(t, (&d).UnmarshalBinary(decimalBytes))
+		assert.Equal(t, "36000000000000000000", d.String())
+		assert.Equal(t, int64(2), pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[1].Value.(*pb.Value_MapValue).MapValue.Fields["StreamID"].Value.(*pb.Value_Int64Value).Int64Value)
+
+		require.Len(t, pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[2].Value.(*pb.Value_MapValue).MapValue.Fields, 2)
+		decimalBytes = pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[2].Value.(*pb.Value_MapValue).MapValue.Fields["Decimal"].Value.(*pb.Value_BytesValue).BytesValue
+		d = decimal.Decimal{}
+		require.NoError(t, (&d).UnmarshalBinary(decimalBytes))
+		assert.Equal(t, "37", d.String())
+		assert.Equal(t, int64(3), pbuf.Outputs.Fields["Payload"].Value.(*pb.Value_ListValue).ListValue.Fields[2].Value.(*pb.Value_MapValue).MapValue.Fields["StreamID"].Value.(*pb.Value_Int64Value).Int64Value)
+	})
+	t.Run("Encode: Misaligned Multiplier StreamIDs FAIL", func(t *testing.T) {
+		donID := uint32(1)
+		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
+
+		r := datastreamsllo.Report{
+			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
+			SeqNr:                           32,
+			ChannelID:                       llotypes.ChannelID(31),
+			ValidAfterNanoseconds:           28,
+			ObservationTimestampNanoseconds: 34,
+			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36)), llo.ToDecimal(decimal.NewFromInt(37))},
+			Specimen:                        false,
+		}
+
+		multiplier1, err := decimal.NewFromString("1")
+		multiplier2, err := decimal.NewFromString("1000000000000000000") // 10^18
+
+		opts, err := (&ReportCodecCapabilityTriggerOpts{
+			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
+				{Multiplier: &multiplier1, StreamID: 1},
+				{Multiplier: &multiplier2, StreamID: 3},
+				{StreamID: 2}, // Test that we can omit the multiplier
+			},
+		}).Encode()
+		require.NoError(t, err)
+		_, err = c.Encode(r, llotypes.ChannelDefinition{
+			Streams: []llotypes.Stream{
+				{StreamID: 1},
+				{StreamID: 2},
+				{StreamID: 3},
+			},
+			Opts: opts,
+		})
+		require.EqualError(t, err, "LLO StreamID 2 mismatched with Multiplier StreamID 3")
+	})
+	t.Run("Encode: Multiplier isn't an integer FAIL", func(t *testing.T) {
+		donID := uint32(1)
+		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
+
+		r := datastreamsllo.Report{
+			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
+			SeqNr:                           32,
+			ChannelID:                       llotypes.ChannelID(31),
+			ValidAfterNanoseconds:           28,
+			ObservationTimestampNanoseconds: 34,
+			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36)), llo.ToDecimal(decimal.NewFromInt(37))},
+			Specimen:                        false,
+		}
+
+		multiplier1, err := decimal.NewFromString("123.4567")
+		multiplier2, err := decimal.NewFromString("89.01234")
+
+		opts, err := (&ReportCodecCapabilityTriggerOpts{
+			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
+				{Multiplier: &multiplier1, StreamID: 1},
+				{Multiplier: &multiplier2, StreamID: 2},
+				{StreamID: 3}, // Test that we can omit the multiplier
+			},
+		}).Encode()
+		require.NoError(t, err)
+		_, err = c.Encode(r, llotypes.ChannelDefinition{
+			Streams: []llotypes.Stream{
+				{StreamID: 1},
+				{StreamID: 2},
+				{StreamID: 3},
+			},
+			Opts: opts,
+		})
+		require.EqualError(t, err, "Multiplier for StreamID 1 must be an integer")
+	})
+	t.Run("Encode: Multiplier is zero FAIL", func(t *testing.T) {
+		donID := uint32(1)
+		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
+
+		r := datastreamsllo.Report{
+			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
+			SeqNr:                           32,
+			ChannelID:                       llotypes.ChannelID(31),
+			ValidAfterNanoseconds:           28,
+			ObservationTimestampNanoseconds: 34,
+			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36)), llo.ToDecimal(decimal.NewFromInt(37))},
+			Specimen:                        false,
+		}
+
+		multiplier1, err := decimal.NewFromString("0")
+		multiplier2, err := decimal.NewFromString("0")
+
+		opts, err := (&ReportCodecCapabilityTriggerOpts{
+			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
+				{Multiplier: &multiplier1, StreamID: 1},
+				{Multiplier: &multiplier2, StreamID: 2},
+				{StreamID: 3}, // Test that we can omit the multiplier
+			},
+		}).Encode()
+		require.NoError(t, err)
+		_, err = c.Encode(r, llotypes.ChannelDefinition{
+			Streams: []llotypes.Stream{
+				{StreamID: 1},
+				{StreamID: 2},
+				{StreamID: 3},
+			},
+			Opts: opts,
+		})
+		require.EqualError(t, err, "Multiplier for StreamID 1 can't be zero")
+	})
+	t.Run("Encode: Multiplier is negative FAIL", func(t *testing.T) {
+		donID := uint32(1)
+		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
+
+		r := datastreamsllo.Report{
+			ConfigDigest:                    types.ConfigDigest{1, 2, 3},
+			SeqNr:                           32,
+			ChannelID:                       llotypes.ChannelID(31),
+			ValidAfterNanoseconds:           28,
+			ObservationTimestampNanoseconds: 34,
+			Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36)), llo.ToDecimal(decimal.NewFromInt(37))},
+			Specimen:                        false,
+		}
+
+		multiplier1, err := decimal.NewFromString("-1000000000000000000") // -10^18
+		multiplier2, err := decimal.NewFromString("-1")
+
+		opts, err := (&ReportCodecCapabilityTriggerOpts{
+			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
+				{Multiplier: &multiplier1, StreamID: 1},
+				{Multiplier: &multiplier2, StreamID: 2},
+				{StreamID: 3}, // Test that we can omit the multiplier
+			},
+		}).Encode()
+		require.NoError(t, err)
+		_, err = c.Encode(r, llotypes.ChannelDefinition{
+			Streams: []llotypes.Stream{
+				{StreamID: 1},
+				{StreamID: 2},
+				{StreamID: 3},
+			},
+			Opts: opts,
+		})
+		require.EqualError(t, err, "Multiplier for StreamID 1 can't be negative")
+	})
+	t.Run("Verify: Multipliers length, StreamValues length mismatch FAIL", func(t *testing.T) {
 		donID := uint32(1)
 		c := NewReportCodecCapabilityTrigger(logger.Test(t), donID)
 
 		err := c.Verify(llotypes.ChannelDefinition{})
 		require.NoError(t, err)
 
-		err = c.Verify(llotypes.ChannelDefinition{Opts: []byte{1, 2, 3}})
-		require.EqualError(t, err, "capability trigger does not support channel definitions with options")
+		multiplier1, err := decimal.NewFromString("1000000000000000000") // 10^18
+		multiplier2, err := decimal.NewFromString("1")
+
+		opts, err := (&ReportCodecCapabilityTriggerOpts{
+			Multipliers: []ReportCodecCapabilityTriggerMultiplier{
+				{Multiplier: &multiplier1, StreamID: 1},
+				{Multiplier: &multiplier2, StreamID: 2},
+				{StreamID: 3}, // Test that we can omit the multiplier
+			},
+		}).Encode()
+		require.NoError(t, err)
+
+		err = c.Verify(
+			llotypes.ChannelDefinition{
+				Streams: []llotypes.Stream{
+					{StreamID: 1},
+					{StreamID: 3},
+				},
+				Opts: opts,
+			},
+		)
+		require.EqualError(t, err, "Multipliers length 3 != StreamValues length 2")
 	})
 }

--- a/core/services/llo/cre/transmitter_test.go
+++ b/core/services/llo/cre/transmitter_test.go
@@ -89,12 +89,26 @@ func encodeReport(t *testing.T, timestamp uint64) ocr3types.ReportWithInfo[lloty
 		Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36))},
 		Specimen:                        false,
 	}
+
+	multiplier1, err := decimal.NewFromString("1")
+	require.NoError(t, err)
+	multiplier2, err := decimal.NewFromString("1")
+	require.NoError(t, err)
+
+	opts, err := (&ReportCodecCapabilityTriggerOpts{
+		Multipliers: []ReportCodecCapabilityTriggerMultiplier{
+			{Multiplier: multiplier1, StreamID: 1},
+			{Multiplier: multiplier2, StreamID: 2},
+		},
+	}).Encode()
+	require.NoError(t, err)
 	cd := llotypes.ChannelDefinition{
 		ReportFormat: llotypes.ReportFormatCapabilityTrigger,
 		Streams: []llotypes.Stream{
 			{StreamID: 1},
 			{StreamID: 2},
 		},
+		Opts: opts,
 	}
 	rawReport, err := codec.Encode(rep, cd)
 	require.NoError(t, err)

--- a/core/services/llo/cre/transmitter_test.go
+++ b/core/services/llo/cre/transmitter_test.go
@@ -89,26 +89,12 @@ func encodeReport(t *testing.T, timestamp uint64) ocr3types.ReportWithInfo[lloty
 		Values:                          []llo.StreamValue{llo.ToDecimal(decimal.NewFromInt(35)), llo.ToDecimal(decimal.NewFromInt(36))},
 		Specimen:                        false,
 	}
-
-	multiplier1, err := decimal.NewFromString("1")
-	require.NoError(t, err)
-	multiplier2, err := decimal.NewFromString("1")
-	require.NoError(t, err)
-
-	opts, err := (&ReportCodecCapabilityTriggerOpts{
-		Multipliers: []ReportCodecCapabilityTriggerMultiplier{
-			{Multiplier: multiplier1, StreamID: 1},
-			{Multiplier: multiplier2, StreamID: 2},
-		},
-	}).Encode()
-	require.NoError(t, err)
 	cd := llotypes.ChannelDefinition{
 		ReportFormat: llotypes.ReportFormatCapabilityTrigger,
 		Streams: []llotypes.Stream{
 			{StreamID: 1},
 			{StreamID: 2},
 		},
-		Opts: opts,
 	}
 	rawReport, err := codec.Encode(rep, cd)
 	require.NoError(t, err)


### PR DESCRIPTION
`capability_trigger` report type doesn't support an Opts field.

This PR adds a now optional Opts field, where **_all_** of the StreamIDs in the channel must be specified in a Multipliers array, in the correct order to match the order of the Streams array e.g.
```
"opts": {
    "multipliers": [
        {
            "multiplier": "1",
            "streamID": 1000000001,
        },
        {
            "multiplier": "1000000000000000000",
            "streamID": 1000000002,
        },
        {
            "multiplier": "1000000000000000000",
            "streamID": 1000000003,
        },
        {
            "multiplier": "1000000000000000000",
            "streamID": 1000000004,
        },
    ],
}
```
The inner multiplier field is a required variable.

This PR also is related to this PR:
https://github.com/smartcontractkit/chainlink-common/pull/1282

Where the rollout plan for this new direction is defined.