### PR TITLE
Modify validate of Token Admin Registry to allow override pending admin

### DIFF
--- a/deployment/ccip/changeset/solana/cs_token_admin_registry.go
+++ b/deployment/ccip/changeset/solana/cs_token_admin_registry.go
@@ -72,10 +72,12 @@ func (cfg RegisterTokenAdminRegistryConfig) Validate(e cldf.Environment, chainSt
 	if err != nil {
 		return fmt.Errorf("failed to find token admin registry pda (mint: %s, router: %s): %w", tokenPubKey.String(), routerProgramAddress.String(), err)
 	}
-	var tokenAdminRegistryAccount solCommon.TokenAdminRegistry
-	tokenAdminRegistryPDAErr := chain.GetAccountDataBorshInto(context.Background(), tokenAdminRegistryPDA, &tokenAdminRegistryAccount)
-	if tokenAdminRegistryPDAErr != nil && cfg.Override == false {
-		return fmt.Errorf("token admin registry already exists for (mint: %s, router: %s)", tokenPubKey.String(), routerProgramAddress.String())
+	if !cfg.Override {
+		var tokenAdminRegistryAccount solCommon.TokenAdminRegistry
+		tokenAdminRegistryPDAErr := chain.GetAccountDataBorshInto(context.Background(), tokenAdminRegistryPDA, &tokenAdminRegistryAccount)
+		if tokenAdminRegistryPDAErr != nil {
+			return fmt.Errorf("token admin registry already exists for (mint: %s, router: %s)", tokenPubKey.String(), routerProgramAddress.String())
+		}
 	}
 	return nil
 }

--- a/deployment/ccip/changeset/solana/cs_token_admin_registry.go
+++ b/deployment/ccip/changeset/solana/cs_token_admin_registry.go
@@ -73,7 +73,8 @@ func (cfg RegisterTokenAdminRegistryConfig) Validate(e cldf.Environment, chainSt
 		return fmt.Errorf("failed to find token admin registry pda (mint: %s, router: %s): %w", tokenPubKey.String(), routerProgramAddress.String(), err)
 	}
 	var tokenAdminRegistryAccount solCommon.TokenAdminRegistry
-	if err := chain.GetAccountDataBorshInto(context.Background(), tokenAdminRegistryPDA, &tokenAdminRegistryAccount); err == nil {
+	tokenAdminRegistryPDAErr := chain.GetAccountDataBorshInto(context.Background(), tokenAdminRegistryPDA, &tokenAdminRegistryAccount)
+	if tokenAdminRegistryPDAErr != nil && cfg.Override == false {
 		return fmt.Errorf("token admin registry already exists for (mint: %s, router: %s)", tokenPubKey.String(), routerProgramAddress.String())
 	}
 	return nil

--- a/deployment/ccip/changeset/solana/cs_token_admin_registry.go
+++ b/deployment/ccip/changeset/solana/cs_token_admin_registry.go
@@ -72,10 +72,9 @@ func (cfg RegisterTokenAdminRegistryConfig) Validate(e cldf.Environment, chainSt
 	if err != nil {
 		return fmt.Errorf("failed to find token admin registry pda (mint: %s, router: %s): %w", tokenPubKey.String(), routerProgramAddress.String(), err)
 	}
-	if !cfg.Override {
-		var tokenAdminRegistryAccount solCommon.TokenAdminRegistry
-		tokenAdminRegistryPDAErr := chain.GetAccountDataBorshInto(context.Background(), tokenAdminRegistryPDA, &tokenAdminRegistryAccount)
-		if tokenAdminRegistryPDAErr != nil {
+	var tokenAdminRegistryAccount solCommon.TokenAdminRegistry
+	if err := chain.GetAccountDataBorshInto(context.Background(), tokenAdminRegistryPDA, &tokenAdminRegistryAccount); err == nil {
+		if !cfg.Override {
 			return fmt.Errorf("token admin registry already exists for (mint: %s, router: %s)", tokenPubKey.String(), routerProgramAddress.String())
 		}
 	}

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1933,6 +1933,7 @@ func DeployTransferableTokenSolana(
 						TokenPubKey:             solTokenAddress,
 						TokenAdminRegistryAdmin: solDeployerKey.String(),
 						RegisterType:            ccipChangeSetSolana.ViaGetCcipAdminInstruction,
+						Override:                true,
 					},
 				},
 				AcceptAdminRoleTokenAdminRegistry: []ccipChangeSetSolana.AcceptAdminRoleTokenAdminRegistryConfig{

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -1933,7 +1933,6 @@ func DeployTransferableTokenSolana(
 						TokenPubKey:             solTokenAddress,
 						TokenAdminRegistryAdmin: solDeployerKey.String(),
 						RegisterType:            ccipChangeSetSolana.ViaGetCcipAdminInstruction,
-						Override:                true,
 					},
 				},
 				AcceptAdminRoleTokenAdminRegistry: []ccipChangeSetSolana.AcceptAdminRoleTokenAdminRegistryConfig{


### PR DESCRIPTION
This pull request modifies the `Validate` function in the `cs_token_admin_registry.go` file to improve error handling when checking the existence of a token admin registry.

Error handling improvements:

* [`deployment/ccip/changeset/solana/cs_token_admin_registry.go`](diffhunk://#diff-1a209b5354d79baa9fe283b2f951171e4ca1c0736ae411f07655cda1de9c8613L76-R77): Changed the logic to explicitly capture the error from `GetAccountDataBorshInto` and introduced a condition to prevent overwriting an existing token admin registry unless the `Override` flag is set to `true`.