### PR TITLE
Refactor Solana extra data decoder 

### DIFF
--- a/core/capabilities/ccip/ccipevm/msghasher.go
+++ b/core/capabilities/ccip/ccipevm/msghasher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	ag_binary "github.com/gagliardetto/binary"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/message_hasher"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
@@ -278,14 +277,8 @@ func parseExtraArgsMap(input map[string]any) (*big.Int, error) {
 			if val, ok := fieldValue.(*big.Int); ok {
 				outputGas = val
 				return outputGas, nil
-			} else {
-				// when source chain is svm, the gas limit is an ag_binary.Uint128 struct instead of *big.Int
-				if val, ok := fieldValue.(ag_binary.Uint128); ok {
-					outputGas = val.BigInt()
-					return outputGas, nil
-				}
-				return nil, fmt.Errorf("unexpected type for gas limit: %T", fieldValue)
 			}
+			return nil, fmt.Errorf("unexpected type for gas limit: %T", fieldValue)
 		default:
 			// no error here, as we only need the keys to gasLimit, other keys can be skipped without like AllowOutOfOrderExecution	etc.
 		}

--- a/core/capabilities/ccip/ccipsolana/extradatacodec.go
+++ b/core/capabilities/ccip/ccipsolana/extradatacodec.go
@@ -70,7 +70,11 @@ func (d ExtraDataDecoder) DecodeExtraArgsToMap(extraArgs cciptypes.Bytes) (map[s
 		fieldValue := val.Field(i).Interface()
 		if field.Name == evmGasLimitKey {
 			// convert SVM Borsh specific type uint128 to *big.Int for EVM gas limit
-			gl := fieldValue.(agbinary.Uint128)
+			gl, ok := fieldValue.(agbinary.Uint128)
+			if !ok {
+				return nil, fmt.Errorf("expected field %s to be of type agbinary.Uint128, got %T", field.Name, fieldValue)
+			}
+
 			fieldValue = gl.BigInt()
 		}
 		outputMap[field.Name] = fieldValue

--- a/core/capabilities/ccip/ccipsolana/extradatacodec.go
+++ b/core/capabilities/ccip/ccipsolana/extradatacodec.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	svmDestExecDataKey = "destGasAmount"
+	evmGasLimitKey     = "GasLimit"
 )
 
 var (
@@ -67,6 +68,11 @@ func (d ExtraDataDecoder) DecodeExtraArgsToMap(extraArgs cciptypes.Bytes) (map[s
 	for i := 0; i < val.NumField(); i++ {
 		field := typ.Field(i)
 		fieldValue := val.Field(i).Interface()
+		if field.Name == evmGasLimitKey {
+			// convert SVM Borsh specific type uint128 to *big.Int for EVM gas limit
+			gl := fieldValue.(agbinary.Uint128)
+			fieldValue = gl.BigInt()
+		}
 		outputMap[field.Name] = fieldValue
 	}
 

--- a/core/capabilities/ccip/ccipsolana/extradatacodec_test.go
+++ b/core/capabilities/ccip/ccipsolana/extradatacodec_test.go
@@ -81,7 +81,7 @@ func Test_decodeExtraArgs(t *testing.T) {
 
 		gasLimit, exist := output["GasLimit"]
 		require.True(t, exist)
-		require.Equal(t, agbinary.Uint128{Lo: 5000, Hi: 0}, gasLimit)
+		require.Equal(t, agbinary.Uint128{Lo: 5000, Hi: 0}.BigInt(), gasLimit)
 
 		ooe, exist := output["AllowOutOfOrderExecution"]
 		require.True(t, exist)


### PR DESCRIPTION
Update Solana extra data codec to return bigInt() instead of uint128 for the gaslimit . Therefore we don't need Solana specific logic in Non-SVM parseExtraArgsMap(). Slack discussion [link](https://chainlink-core.slack.com/archives/C087SC7K40Y/p1751552456149189)