### PR TITLE
[DX-1316] do not run local CRE test for arm64

### DIFF
--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -77,11 +77,12 @@ jobs:
             echo "deps_download_seconds=$total_seconds" >> $GITHUB_OUTPUT
           fi
 
-      - name: Delete incompatible static archive
+      - name: Delete vendored static librdkafka (.a) to avoid arch mismatch
         if: ${{ contains(matrix.runner, 'arm') }}
         run: |
           # delete incompatible static archive, otherwise Go will still try to use it, even with correct CGO_ENABLED=1 and CGO_LDFLAGS=-lrdkafka flags
-          rm -f $(go list -f '{{.Dir}}' -m github.com/confluentinc/confluent-kafka-go)/kafka/librdkafka_vendor/librdkafka_glibc_linux.a
+          rm -f "$(go list -f '{{.Dir}}' github.com/confluentinc/confluent-kafka-go/kafka)/librdkafka_vendor/librdkafka_glibc_linux.a"
+          test ! -f "$(go list -f '{{.Dir}}' github.com/confluentinc/confluent-kafka-go/kafka)/librdkafka_vendor/librdkafka_glibc_linux.a" && echo "✅ File removed"
 
       # We need to login to ECR to allow the test to pull the Job Distributor and Chainlink images
       - name: Configure AWS Credentials
@@ -229,7 +230,3 @@ jobs:
                 }
               ]
             }
-
-
-
-

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -58,9 +58,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y librdkafka-dev
 
-          # delete incompatible static archive, otherwise Go will still try to use it, even with correct CGO_ENABLED=1 and CGO_LDFLAGS=-lrdkafka flags
-          rm -f $(go list -f '{{.Dir}}' -m github.com/confluentinc/confluent-kafka-go)/kafka/librdkafka_vendor/librdkafka_glibc_linux.a
-
       - name: Download Go dependencies
         id: go-deps
         working-directory: core/scripts/cre/environment
@@ -79,6 +76,12 @@ jobs:
             total_seconds=$(echo "$minutes * 60 + $seconds" | bc)
             echo "deps_download_seconds=$total_seconds" >> $GITHUB_OUTPUT
           fi
+
+      - name: Delete incompatible static archive
+        if: ${{ contains(matrix.runner, 'arm') }}
+        run: |
+          # delete incompatible static archive, otherwise Go will still try to use it, even with correct CGO_ENABLED=1 and CGO_LDFLAGS=-lrdkafka flags
+          rm -f $(go list -f '{{.Dir}}' -m github.com/confluentinc/confluent-kafka-go)/kafka/librdkafka_vendor/librdkafka_glibc_linux.a
 
       # We need to login to ECR to allow the test to pull the Job Distributor and Chainlink images
       - name: Configure AWS Credentials

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -30,7 +30,11 @@ jobs:
   test-cli:
     strategy:
       matrix:
-        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        runner: [
+          ubuntu-latest,
+          # can't work due to arch mismatch of kafka librdkafka .a file bundled with the package
+          # ubuntu-24.04-arm,
+          ]
     runs-on: ${{ matrix.runner }}
     environment: "integration"
     timeout-minutes: 30
@@ -77,6 +81,7 @@ jobs:
             echo "deps_download_seconds=$total_seconds" >> $GITHUB_OUTPUT
           fi
 
+      # this doesn't work, we cannot delete the file, because it's read-only
       - name: Delete vendored static librdkafka (.a) to avoid arch mismatch
         if: ${{ contains(matrix.runner, 'arm') }}
         run: |

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -58,6 +58,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y librdkafka-dev
 
+          # delete incompatible static archive, otherwise Go will still try to use it, even with correct CGO_ENABLED=1 and CGO_LDFLAGS=-lrdkafka flags
+          rm -f $(go list -f '{{.Dir}}' -m github.com/confluentinc/confluent-kafka-go)/kafka/librdkafka_vendor/librdkafka_glibc_linux.a
+
       - name: Download Go dependencies
         id: go-deps
         working-directory: core/scripts/cre/environment

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -136,6 +136,12 @@ jobs:
           E2E_TEST_CHAINLINK_VERSION: ${{ github.event_name == 'pull_request' && format('nightly-{0}-plugins', steps.set-date.outputs.date) || inputs.chainlink_image_tag }}
           DISABLE_DX_TRACKING: "true"
         run: |
+          if [[ "${{ contains(matrix.runner, 'arm') }}" == "true" ]]; then
+            echo "Setting CGO_ENABLED=1 and CGO_LDFLAGS=-lrdkafka for arm runners"
+            export CGO_ENABLED=1
+            export CGO_LDFLAGS="-lrdkafka"
+          fi
+
           { time go run main.go env start; } 2> >(tee /tmp/time_output >&2)
 
           # Convert time to total seconds

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -81,8 +81,12 @@ jobs:
         if: ${{ contains(matrix.runner, 'arm') }}
         run: |
           # delete incompatible static archive, otherwise Go will still try to use it, even with correct CGO_ENABLED=1 and CGO_LDFLAGS=-lrdkafka flags
-          rm -f "$(go list -f '{{.Dir}}' github.com/confluentinc/confluent-kafka-go/kafka)/librdkafka_vendor/librdkafka_glibc_linux.a"
-          test ! -f "$(go list -f '{{.Dir}}' github.com/confluentinc/confluent-kafka-go/kafka)/librdkafka_vendor/librdkafka_glibc_linux.a" && echo "✅ File removed"
+          find "$(go env GOMODCACHE)/github.com/confluentinc/confluent-kafka-go@v1.9.2" -name librdkafka_glibc_linux.a -delete
+          if find "$(go env GOMODCACHE)/github.com/confluentinc/confluent-kafka-go@v1.9.2" -name librdkafka_glibc_linux.a | grep .; then
+            echo "❌ vendored .a still exists"; exit 1
+          else
+            echo "✅ vendored .a is gone"
+          fi
 
       # We need to login to ECR to allow the test to pull the Job Distributor and Chainlink images
       - name: Configure AWS Credentials

--- a/.github/workflows/cre-local-env-tests.yaml
+++ b/.github/workflows/cre-local-env-tests.yaml
@@ -27,15 +27,6 @@ on:
     types: [labeled, synchronize]
 
 jobs:
-  log-workflow-trigger:
-    name: Log Workflow Trigger
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Log Workflow Trigger
-        run: |
-          echo "Workflow Trigger: ${{ github.event_name }}"
-
   test-cli:
     strategy:
       matrix:
@@ -59,6 +50,13 @@ jobs:
         with:
           go-version-file: core/scripts/go.mod
           cache: true
+
+      - name: Install librdkafka
+        if: ${{ contains(matrix.runner, 'arm') }}
+        run: |
+          # install librdkafka-dev for arm runners to avoid using static librdkafka_glibc_linux.a, which is compiled for x86_64
+          sudo apt-get update
+          sudo apt-get install -y librdkafka-dev
 
       - name: Download Go dependencies
         id: go-deps
@@ -200,7 +198,7 @@ jobs:
           token: ${{ secrets.QA_SLACK_API_KEY }}
           payload: |
             {
-              "channel": "C0364FG2CN9",
+              "channel": "C0948PT3X38",
               "text": "Local CRE environment failed to start",
               "blocks": [
                 {


### PR DESCRIPTION
original isse:
```
/usr/bin/ld.gold: error: /home/runner/go/pkg/mod/github.com/confluentinc/confluent-kafka-go@v1.9.2/kafka/librdkafka_vendor/librdkafka_glibc_linux.a(rdkafka_error.o): incompatible target
/usr/bin/ld.gold: error: /home/runner/go/pkg/mod/github.com/confluentinc/confluent-kafka-go@v1.9.2/kafka/librdkafka_vendor/librdkafka_glibc_linux.a(rdkafka_mock.o): incompatible target
/usr/bin/ld.gold: error: /home/runner/go/pkg/mod/github.com/confluentinc/confluent-kafka-go@v1.9.2/kafka/librdkafka_vendor/librdkafka_glibc_linux.a(rdkafka_txnmgr.o): incompatible target
/usr/bin/ld.gold: error: /home/runner/go/pkg/mod/github.com/confluentinc/confluent-kafka-go@v1.9.2/kafka/librdkafka_vendor/librdkafka_glibc_linux.a(rdkafka_aux.o): incompatible target
```

Example: https://github.com/smartcontractkit/chainlink/actions/runs/16065107034/job/45338363943

Why?
since it is running on `linux/arm64` it is trying to use incorrect `librdkafka` static archive that was compiled for `linux/x86_64` and since there's no way we can remove it or modify it I had to disable that runner for now.

Successful run: https://github.com/smartcontractkit/chainlink/actions/runs/16071636609

extra change: notify about failures in a different channel