### PR TITLE
use correct chainlink_version in CRE tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1102,7 +1102,7 @@ jobs:
           | # https://github.com/smartcontractkit/chainlink-testing-framework/lib/blob/main/config/README.md
           cat << EOF > config.toml
           [ChainlinkImage]
-          version="${{ env.evm-ref || env.GH_SHA }}"
+          version="test-${{ env.evm-ref || env.GH_SHA }}"
           [Common]
           user="${{ github.actor }}"
           internal_docker_repo = "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com"
@@ -1117,7 +1117,7 @@ jobs:
         if: needs.changes.outputs.should-run-solana-tests == 'true'
         uses: smartcontractkit/.github/actions/ctf-run-tests@725dd141dd77cc87dad420e9484416fc4ae26be2 # ctf-run-tests@v0.5.0
         env:
-          E2E_TEST_CHAINLINK_IMAGE: ${{ env.CHAINLINK_IMAGE }}
+          E2E_TEST_CHAINLINK_IMAGE: test-${{ env.CHAINLINK_IMAGE }}
           E2E_TEST_SOLANA_SECRET: thisisatestingonlysecret
           CHAINLINK_USER_TEAM: "BIX"
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -284,7 +284,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
     with:
       workflow_name: Run Core CRE Tests For Merge Queue
-      chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: Merge Queue CRE E2E Core Tests
       upload_cl_node_coverage_artifact: true
@@ -362,7 +362,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
     with:
       workflow_name: Run Core E2E Tests For PR
-      chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: PR E2E Core Tests
       upload_cl_node_coverage_artifact: true
@@ -406,7 +406,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
-      chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: Merge Queue E2E Core Tests
       # Run tests with flakeguard and rerun failed tests once
@@ -452,7 +452,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
     with:
       workflow_name: Run Core E2E Tests For Push
-      chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: Push E2E Core Tests
       # Run tests with flakeguard and rerun failed tests once
@@ -498,7 +498,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
     with:
       workflow_name: Run Core E2E Tests For Workflow Dispatch
-      chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: Workflow Dispatch E2E Core Tests
       # Run tests with flakeguard and rerun failed tests once
@@ -543,7 +543,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
     with:
       workflow_name: Run CCIP E2E Tests For PR
-      chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       test_trigger: PR E2E CCIP Tests
       upload_cl_node_coverage_artifact: true
@@ -590,7 +590,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
-      chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       # Run tests with flakeguard and rerun failed tests once
       extraArgs: ${{ '{"flakeguard_enable":"true","flakeguard_run_count":"1","flakeguard_rerun_failed_count":"1"}' }}
@@ -639,7 +639,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
     with:
       workflow_name: Run CCIP E2E Tests For Push
-      chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       # Run tests with flakeguard and rerun failed tests once
       extraArgs: ${{ '{"flakeguard_enable":"true","flakeguard_run_count":"1","flakeguard_rerun_failed_count":"1"}' }}
@@ -688,7 +688,7 @@ jobs:
     uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
     with:
       workflow_name: Run CCIP E2E Tests For Workflow Dispatch
-      chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       test_path: .github/e2e-tests.yml
       # Run tests with flakeguard and rerun failed tests once
       test_trigger: Workflow Dispatch E2E CCIP Tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -139,13 +139,14 @@ jobs:
             (steps.changes.outputs.github_ci_changes == 'true' ||
             steps.changes.outputs.core_changes == 'true') &&
             contains(join(github.event.pull_request.labels.*.name, ' '), 'run-e2e-tests')
-          ) ||
-          (
-            (steps.changes.outputs.github_ci_changes == 'true' ||
-            steps.changes.outputs.core_changes == 'true') &&
-            github.event_name == 'merge_group'
           )
         }}
+      # disable for now in MQ as they take too long to run
+      # (
+      #   (steps.changes.outputs.github_ci_changes == 'true' ||
+      #   steps.changes.outputs.core_changes == 'true') &&
+      #   github.event_name == 'merge_group'
+      # )
       builder-runner-label: ${{ steps.runner-labels.outputs.builder-runner-label }}
       solana-runner-label: ${{ steps.runner-labels.outputs.solana-runner-label }}
       should-use-self-hosted-runners: ${{ steps.label-runs-on-opt-out.outputs.check-label-found == 'false' }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -93,6 +93,11 @@ jobs:
             (steps.changes.outputs.github_ci_changes == 'true' ||
             steps.changes.outputs.core_changes == 'true') &&
             contains(join(github.event.pull_request.labels.*.name, ' '), 'run-e2e-tests')
+          ) ||
+          (
+            (steps.changes.outputs.github_ci_changes == 'true' ||
+            steps.changes.outputs.core_changes == 'true') &&
+            github.event_name == 'merge_group'
           )
         }}
       # Run CRE tests on PR always, when there are changes to CRE code
@@ -102,7 +107,12 @@ jobs:
           steps.changes.outputs.cre_changes == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref_type == 'tag' ||
-          (steps.changes.outputs.github_ci_changes == 'true' && contains(join(github.event.pull_request.labels.*.name, ' '), 'run-e2e-tests'))
+          (steps.changes.outputs.github_ci_changes == 'true' && contains(join(github.event.pull_request.labels.*.name, ' '), 'run-e2e-tests')) ||
+          (
+            (steps.changes.outputs.github_ci_changes == 'true' ||
+            steps.changes.outputs.cre_changes == 'true') &&
+            github.event_name == 'merge_group'
+          )
         }}
       # Don't run CCIP E2E tests on PR, unless it's tagged with "run-e2e-tests"
       should-run-ccip-tests: >-
@@ -113,6 +123,11 @@ jobs:
             (steps.changes.outputs.github_ci_changes == 'true' ||
             steps.changes.outputs.ccip_changes == 'true') &&
             contains(join(github.event.pull_request.labels.*.name, ' '), 'run-e2e-tests')
+          ) ||
+          (
+            (steps.changes.outputs.github_ci_changes == 'true' ||
+            steps.changes.outputs.ccip_changes == 'true') &&
+            github.event_name == 'merge_group'
           )
         }}
       # Don't run Solana E2E tests on PR, unless it's tagged with "run-e2e-tests"
@@ -124,6 +139,11 @@ jobs:
             (steps.changes.outputs.github_ci_changes == 'true' ||
             steps.changes.outputs.core_changes == 'true') &&
             contains(join(github.event.pull_request.labels.*.name, ' '), 'run-e2e-tests')
+          ) ||
+          (
+            (steps.changes.outputs.github_ci_changes == 'true' ||
+            steps.changes.outputs.core_changes == 'true') &&
+            github.event_name == 'merge_group'
           )
         }}
       builder-runner-label: ${{ steps.runner-labels.outputs.builder-runner-label }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -281,7 +281,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && needs.changes.outputs.should-run-cre-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1e6b821dc36a55e338d6bdbda1320a0db93b729d # 2025-07-04 # 2025-07-04
     with:
       workflow_name: Run Core CRE Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -359,7 +359,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.should-run-core-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1e6b821dc36a55e338d6bdbda1320a0db93b729d # 2025-07-04 # 2025-07-04
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -403,7 +403,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && needs.changes.outputs.should-run-core-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1e6b821dc36a55e338d6bdbda1320a0db93b729d # 2025-07-04 # 2025-07-04
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -449,7 +449,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'push' && needs.changes.outputs.should-run-core-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1e6b821dc36a55e338d6bdbda1320a0db93b729d # 2025-07-04 # 2025-07-04
     with:
       workflow_name: Run Core E2E Tests For Push
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -495,7 +495,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'workflow_dispatch'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1e6b821dc36a55e338d6bdbda1320a0db93b729d # 2025-07-04 # 2025-07-04
     with:
       workflow_name: Run Core E2E Tests For Workflow Dispatch
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -540,7 +540,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.should-run-ccip-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1e6b821dc36a55e338d6bdbda1320a0db93b729d # 2025-07-04 # 2025-07-04
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -587,7 +587,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && needs.changes.outputs.should-run-ccip-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1e6b821dc36a55e338d6bdbda1320a0db93b729d # 2025-07-04 # 2025-07-04
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -636,7 +636,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'push' && needs.changes.outputs.should-run-ccip-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1e6b821dc36a55e338d6bdbda1320a0db93b729d # 2025-07-04 # 2025-07-04
     with:
       workflow_name: Run CCIP E2E Tests For Push
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -685,7 +685,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'workflow_dispatch'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@1e6b821dc36a55e338d6bdbda1320a0db93b729d # 2025-07-04 # 2025-07-04
     with:
       workflow_name: Run CCIP E2E Tests For Workflow Dispatch
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -281,7 +281,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && needs.changes.outputs.should-run-cre-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
     with:
       workflow_name: Run Core CRE Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -359,7 +359,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.should-run-core-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
     with:
       workflow_name: Run Core E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -403,7 +403,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && needs.changes.outputs.should-run-core-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
     with:
       workflow_name: Run Core E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -449,7 +449,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'push' && needs.changes.outputs.should-run-core-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
     with:
       workflow_name: Run Core E2E Tests For Push
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -495,7 +495,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'workflow_dispatch'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
     with:
       workflow_name: Run Core E2E Tests For Workflow Dispatch
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -540,7 +540,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.should-run-ccip-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
     with:
       workflow_name: Run CCIP E2E Tests For PR
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -587,7 +587,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'merge_group' && needs.changes.outputs.should-run-ccip-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
     with:
       workflow_name: Run CCIP E2E Tests For Merge Queue
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -636,7 +636,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'push' && needs.changes.outputs.should-run-ccip-tests == 'true'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
     with:
       workflow_name: Run CCIP E2E Tests For Push
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
@@ -685,7 +685,7 @@ jobs:
       contents: read
     needs: [build-chainlink, changes]
     if: github.event_name == 'workflow_dispatch'
-    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@08494221eaae4aff37a01669818cff24a4f80b4c # 2025-06-20
+    uses: smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@56dd8f85990760253c557386b08702c200ae1953 # 2025-07-04
     with:
       workflow_name: Run CCIP E2E Tests For Workflow Dispatch
       chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -246,7 +246,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.should-run-cre-tests == 'true'
     uses: smartcontractkit/chainlink/.github/workflows/cre-system-tests.yaml@53e6348b792989514a6b7b53745bfcc389f706d9 # 27th June 2025
     with:
-      chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+      chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
       chainlink_image_tag: test-${{ inputs.evm-ref && format('{0}-plugins', inputs.evm-ref) || inputs.cl_ref && format('{0}-plugins', inputs.cl_ref) || format('{0}-plugins', github.sha) }}
     secrets: inherit
 
@@ -307,7 +307,7 @@ jobs:
     if: github.event_name == 'push' && needs.changes.outputs.should-run-cre-tests == 'true'
     uses: smartcontractkit/chainlink/.github/workflows/cre-system-tests.yaml@53e6348b792989514a6b7b53745bfcc389f706d9 # 27th June 2025
     with:
-     chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+     chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
      chainlink_image_tag:  test-${{ inputs.evm-ref && format('{0}-plugins', inputs.evm-ref) || inputs.cl_ref && format('{0}-plugins', inputs.cl_ref) || format('{0}-plugins', github.sha) }}
     secrets:
       inherit
@@ -324,7 +324,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: smartcontractkit/chainlink/.github/workflows/cre-system-tests.yaml@53e6348b792989514a6b7b53745bfcc389f706d9 # 27th June 2025
     with:
-     chainlink_version: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+     chainlink_version: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
      chainlink_image_tag:  test-${{ inputs.evm-ref && format('{0}-plugins', inputs.evm-ref) || inputs.cl_ref && format('{0}-plugins', inputs.cl_ref) || format('{0}-plugins', github.sha) }}
     secrets:
       inherit


### PR DESCRIPTION
we want to run CRE tests in PR always, when there are changes to CRE code. We want to run other tests if there are changes and `run-e2e-tests` label is present.

we want to run all these tests in MQ always, when there are relevant changes.

before merging we need to merge this first https://github.com/smartcontractkit/.github/pull/1133 and use the merge commit as reference for the reusable e2e workflow