### PR TITLE
fix: correct TON chain slice initialization and enable CI integration tests

### DIFF
--- a/.github/integration-in-memory-tests.yml
+++ b/.github/integration-in-memory-tests.yml
@@ -475,6 +475,11 @@ runner-test-matrix:
   # TON tests
   - id: smoke/ccip/ccip_ton_messaging_test.go:*
     path: integration-tests/smoke/ccip/ccip_ton_messaging_test.go
+    test_env_type: in-memory
+    runs_on: ubuntu-latest
+    triggers:
+      - PR Integration CCIP Tests
+      - Nightly Integration CCIP Tests
     test_cmd: cd smoke/ccip && go test ccip_ton_messaging_test.go -timeout 20m -test.parallel=1 -count=1 -json
     test_go_project_path: integration-tests
   # END: CCIP tests

--- a/deployment/environment/memory/ton_chains.go
+++ b/deployment/environment/memory/ton_chains.go
@@ -77,7 +77,7 @@ func generateChainsTon(t *testing.T, numChains int) []cldf_chain.BlockChain {
 		t.Fatalf("not enough test ton chain selectors available")
 	}
 
-	chains := make([]cldf_chain.BlockChain, numChains)
+	chains := make([]cldf_chain.BlockChain, 0, numChains)
 	for i := 0; i < numChains; i++ {
 		selector := testTonChainSelectors[i]
 		nodeClient := tonChain(t, selector)


### PR DESCRIPTION
## Problem
`generateChainsTon` was creating a slice with pre-allocated nil elements,([PR](https://github.com/smartcontractkit/chainlink/pull/18363)) causing `append()` to add chains after these nils instead of replacing them.

## Solution
- Fixed slice initialization from `make([]cldf_chain.BlockChain, numChains)` to `make([]cldf_chain.BlockChain, 0, numChains)`
- Added TON integration tests to CI pipeline

## Changes
- Fixed TON chain slice capacity bug
- Enabled `ccip_ton_messaging_test.go` in CI test matrix