### PR TITLE
fix(workflows): remove jira comment step

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -100,35 +100,15 @@ jobs:
           ref: a104d316e1d8bf08f7283b90356450c72157e149 # 2025-04-03
           path: ./dot_github
 
-      - name: Update Jira ticket for core
-        id: jira
-        if: ${{ steps.files-changed.outputs.core == 'true' || steps.files-changed.outputs.shared == 'true' }}
-        shell: bash
-        working-directory: ./dot_github
-        run: |
-          echo "COMMIT_MESSAGE=$(git log -1 --pretty=format:'%s')" >> $GITHUB_ENV
-          pnpm install --filter jira-tracing && pnpm --filter jira-tracing issue:update
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JIRA_HOST: ${{ vars.JIRA_HOST }}
-          JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-          GIT_TOP_LEVEL_DIR: ${{ steps.find-git-top-level-dir.outputs.top_level_dir }}
-          CHAINLINK_VERSION: ${{ steps.chainlink-version.outputs.chainlink_version }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
-
       - name: Make a comment
         uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
         if: ${{ steps.files-changed.outputs.core == 'true' || steps.files-changed.outputs.shared == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JIRA_COMMENT: ${{ steps.jira.outputs.jiraComment }}
         with:
           message: |
             I see you updated files related to `core`. Please run `pnpm changeset` in the root directory to add a changeset as well as in the text include at least one of the following tags:
             ${{ env.TAGS }}
-            ${{ env.JIRA_COMMENT }}
           reactions: eyes
           comment_tag: changeset-core
           mode: ${{ steps.files-changed.outputs.core-changeset == 'false' && 'upsert' || 'delete' }}
@@ -146,12 +126,10 @@ jobs:
         if: ${{ steps.files-changed.outputs.core-changeset == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JIRA_COMMENT: ${{ steps.jira.outputs.jiraComment }}
         with:
           message: |
             I see you added a changeset file but it does not contain a tag. Please edit the text include at least one of the following tags:
             ${{ env.TAGS }}
-            ${{ env.JIRA_COMMENT }}
           reactions: eyes
           comment_tag: changeset-core-tags
           mode: ${{ steps.changeset-tags.outputs.has_tags == 'false' && 'upsert' || 'delete' }}


### PR DESCRIPTION
The Jira comment step was failing and seems like it didn't work for some time now. Removing it for now: https://smartcontract-it.atlassian.net/browse/DX-1276
