### PR TITLE
Use existing proposer for chain in GrantRoleInTimeLock

### DIFF
--- a/deployment/common/changeset/deploy_mcms_with_timelock.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock.go
@@ -162,7 +162,13 @@ func grantRoleLogic(e cldf.Environment, cfg GrantRoleInput) (cldf.ChangesetOutpu
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to create ManyChainMultiSig for existing proposer %s on chain %d: %w",
 					cfg.ExistingProposerByChain[k].Hex(), k, err)
 			}
-			mcmsStateForProposal[k] = *v
+			mcmsStateForProposal[k] = state.MCMSWithTimelockState{
+				CancellerMcm: v.CancellerMcm,
+				BypasserMcm:  v.BypasserMcm,
+				ProposerMcm:  existingProposerMcm,
+				Timelock:     v.Timelock,
+				CallProxy:    v.CallProxy,
+			}
 		}
 	}
 

--- a/deployment/common/changeset/deploy_mcms_with_timelock.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+	"github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"golang.org/x/exp/maps"
 
@@ -148,10 +149,20 @@ func grantRoleLogic(e cldf.Environment, cfg GrantRoleInput) (cldf.ChangesetOutpu
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
-	mcmsStateNoPtr := make(map[uint64]state.MCMSWithTimelockState)
+	mcmsStateForProposal := make(map[uint64]state.MCMSWithTimelockState)
 	for k, v := range mcmsState {
 		if v != nil {
-			mcmsStateNoPtr[k] = *v
+			// Replace the proposer MCM in state with the existing proposer.
+			// This is to ensure that we are using an MCM contract that already has the proposer role.
+			v.ProposerMcm, err = gethwrappers.NewManyChainMultiSig(
+				cfg.ExistingProposerByChain[k],
+				e.BlockChains.EVMChains()[k].Client,
+			)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to create ManyChainMultiSig for existing proposer %s on chain %d: %w",
+					cfg.ExistingProposerByChain[k].Hex(), k, err)
+			}
+			mcmsStateForProposal[k] = *v
 		}
 	}
 
@@ -168,7 +179,7 @@ func grantRoleLogic(e cldf.Environment, cfg GrantRoleInput) (cldf.ChangesetOutpu
 				Timelock:     stateForChain.Timelock,
 				CallProxy:    stateForChain.CallProxy,
 			}, false, gasBoostConfigs[chain])
-		out, err = opsutils.AddEVMCallSequenceToCSOutput(e, out, seqReport, err, mcmsStateNoPtr, cfg.MCMS, fmt.Sprintf("GrantRolesForTimelock on %s", evmChains[chain]))
+		out, err = opsutils.AddEVMCallSequenceToCSOutput(e, out, seqReport, err, mcmsStateForProposal, cfg.MCMS, fmt.Sprintf("GrantRolesForTimelock on %s", evmChains[chain]))
 		if err != nil {
 			return out, fmt.Errorf("failed to grant roles for timelock on chain %d: %w", chain, err)
 		}

--- a/deployment/common/changeset/deploy_mcms_with_timelock.go
+++ b/deployment/common/changeset/deploy_mcms_with_timelock.go
@@ -154,7 +154,7 @@ func grantRoleLogic(e cldf.Environment, cfg GrantRoleInput) (cldf.ChangesetOutpu
 		if v != nil {
 			// Replace the proposer MCM in state with the existing proposer.
 			// This is to ensure that we are using an MCM contract that already has the proposer role.
-			v.ProposerMcm, err = gethwrappers.NewManyChainMultiSig(
+			existingProposerMcm, err := gethwrappers.NewManyChainMultiSig(
 				cfg.ExistingProposerByChain[k],
 				e.BlockChains.EVMChains()[k].Client,
 			)


### PR DESCRIPTION
This change allows us to plug in and use the old proposer addresses specifically for the GrantRoleInTimeLock changeset.
