### PR TITLE
Fix/solana smoke tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -139,14 +139,13 @@ jobs:
             (steps.changes.outputs.github_ci_changes == 'true' ||
             steps.changes.outputs.core_changes == 'true') &&
             contains(join(github.event.pull_request.labels.*.name, ' '), 'run-e2e-tests')
+          ) ||
+          (
+            (steps.changes.outputs.github_ci_changes == 'true' ||
+            steps.changes.outputs.core_changes == 'true') &&
+            github.event_name == 'merge_group'
           )
         }}
-      # disable for now in MQ as they take too long to run
-      # (
-      #   (steps.changes.outputs.github_ci_changes == 'true' ||
-      #   steps.changes.outputs.core_changes == 'true') &&
-      #   github.event_name == 'merge_group'
-      # )
       builder-runner-label: ${{ steps.runner-labels.outputs.builder-runner-label }}
       solana-runner-label: ${{ steps.runner-labels.outputs.solana-runner-label }}
       should-use-self-hosted-runners: ${{ steps.label-runs-on-opt-out.outputs.check-label-found == 'false' }}
@@ -1097,13 +1096,12 @@ jobs:
           yarn --cwd ./gauntlet gauntlet
       - name: Generate config overrides
         env:
-          GH_INPUTS_EVM_REF: ${{ inputs.evm-ref }}
-          GH_SHA: ${{ inputs.cl_ref || github.sha }}
+          CL_VERSION: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
         run:
           | # https://github.com/smartcontractkit/chainlink-testing-framework/lib/blob/main/config/README.md
           cat << EOF > config.toml
           [ChainlinkImage]
-          version="test-${{ env.evm-ref || env.GH_SHA }}"
+          version="test-${{ env.CL_VERSION }}"
           [Common]
           user="${{ github.actor }}"
           internal_docker_repo = "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com"
@@ -1118,14 +1116,14 @@ jobs:
         if: needs.changes.outputs.should-run-solana-tests == 'true'
         uses: smartcontractkit/.github/actions/ctf-run-tests@725dd141dd77cc87dad420e9484416fc4ae26be2 # ctf-run-tests@v0.5.0
         env:
-          E2E_TEST_CHAINLINK_IMAGE: test-${{ env.CHAINLINK_IMAGE }}
+          E2E_TEST_CHAINLINK_IMAGE: ${{ env.CHAINLINK_IMAGE }}
           E2E_TEST_SOLANA_SECRET: thisisatestingonlysecret
           CHAINLINK_USER_TEAM: "BIX"
         with:
           test_command_to_run: export ENV_JOB_IMAGE=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ needs.get_solana_sha.outputs.sha }} && make test_smoke
           test_config_override_base64: ${{ env.BASE64_CONFIG_OVERRIDE }}
           cl_repo: ${{ env.CHAINLINK_IMAGE }}
-          cl_image_tag: ${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
+          cl_image_tag: test-${{ inputs.evm-ref || inputs.cl_ref || github.sha }}
           publish_check_name: Solana Smoke Test Results
           go_mod_path: ./integration-tests/go.mod
           cache_key_id: core-solana-e2e-${{ env.MOD_CACHE_VERSION }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -84,7 +84,6 @@ jobs:
     name: Check Paths That Require Tests To Run
     runs-on: ubuntu-latest
     outputs:
-      # Don't run core E2E tests on PR, unless it's tagged with "run-e2e-tests"
       should-run-core-tests: >-
         ${{
           github.event_name == 'workflow_dispatch' ||
@@ -100,14 +99,12 @@ jobs:
             github.event_name == 'merge_group'
           )
         }}
-      # Run CRE tests on PR always, when there are changes to CRE code
-      # but still require the "run-e2e-tests" label to be present for CI changes
       should-run-cre-tests: >-
         ${{
           steps.changes.outputs.cre_changes == 'true' ||
+          steps.changes.outputs.github_ci_changes == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref_type == 'tag' ||
-          (steps.changes.outputs.github_ci_changes == 'true' && contains(join(github.event.pull_request.labels.*.name, ' '), 'run-e2e-tests')) ||
           (
             (steps.changes.outputs.github_ci_changes == 'true' ||
             steps.changes.outputs.cre_changes == 'true') &&
@@ -130,7 +127,6 @@ jobs:
             github.event_name == 'merge_group'
           )
         }}
-      # Don't run Solana E2E tests on PR, unless it's tagged with "run-e2e-tests"
       should-run-solana-tests: >-
         ${{
           github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
### Changes

1. Fixes solana smoke tests by putting the new `test-` prefix in the proper location
2. Re-enables solana smoke tests for merge queues
3. Slightly reorganize the conditionals for running individual jobs



