### PR TITLE
[CAPPL-999] Workflow Registry Syncer version switching

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -1003,7 +1003,7 @@ func newCREServices(
 				}
 				wfSyncer, err := syncer.NewWorkflowRegistry(
 					lggr,
-					func(ctx context.Context, bytes []byte) (syncer.ContractReader, error) {
+					func(ctx context.Context, bytes []byte) (commontypes.ContractReader, error) {
 						return wfRegRelayer.NewContractReader(ctx, bytes)
 					},
 					capCfg.WorkflowRegistry().Address(),
@@ -1271,7 +1271,7 @@ func (app *ChainlinkApplication) RunJobV2(
 					common.BigToHash(big.NewInt(42)).Bytes(), // seed
 					evmutils.NewHash().Bytes(),               // sender
 					evmutils.NewHash().Bytes(),               // fee
-					evmutils.NewHash().Bytes()}, // requestID
+					evmutils.NewHash().Bytes()},              // requestID
 					[]byte{}),
 				Topics:      []common.Hash{{}, jb.ExternalIDEncodeBytesToTopic()}, // jobID BYTES
 				TxHash:      evmutils.NewHash(),

--- a/core/services/relay/evm/capabilities/testutils/backend.go
+++ b/core/services/relay/evm/capabilities/testutils/backend.go
@@ -23,6 +23,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 	evmrelaytypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
 )
@@ -36,7 +37,8 @@ type EVMBackendTH struct {
 	Backend   evmtypes.Backend
 	EVMClient evmclient.Client
 
-	ContractsOwner *bind.TransactOpts
+	ContractsOwner    *bind.TransactOpts
+	ContractsOwnerKey ethkey.KeyV2
 
 	HeadTracker logpoller.HeadTracker
 	LogPoller   logpoller.LogPoller
@@ -75,7 +77,8 @@ func NewEVMBackendTH(t *testing.T) *EVMBackendTH {
 		Backend:   backend,
 		EVMClient: client,
 
-		ContractsOwner: contractsOwner,
+		ContractsOwner:    contractsOwner,
+		ContractsOwnerKey: ownerKey,
 	}
 	th.HeadTracker, th.LogPoller = th.SetupCoreServices(t)
 
@@ -104,6 +107,8 @@ func (th *EVMBackendTH) SetupCoreServices(t *testing.T) (logpoller.HeadTracker, 
 	require.NoError(t, lp.Start(testutils.Context(t)))
 	t.Cleanup(func() { ht.Close() })
 	t.Cleanup(func() { lp.Close() })
+	// Sleep 200ms to allow LP to load filters
+	time.Sleep(time.Millisecond * 200)
 	return ht, lp
 }
 

--- a/core/services/relay/evm/capabilities/versioning/contracts.go
+++ b/core/services/relay/evm/capabilities/versioning/contracts.go
@@ -1,0 +1,121 @@
+package versioning
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+
+	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/type_and_version"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
+)
+
+type ContractType string
+
+const (
+	// default version to use when TypeAndVersion is missing.
+	defaultVersion = "1.0.0"
+	ContractName   = "TypeAndVersion"
+	MethodName     = "typeAndVersion"
+)
+
+var (
+	Unknown             ContractType = "Unknown" // contracts which have no TypeAndVersion
+	ErrNoContractReader              = errors.New("no contract reader returned by factory")
+)
+
+type ContractReaderFactory func(context.Context, []byte) (commontypes.ContractReader, error)
+
+func VerifyTypeAndVersion(ctx context.Context, addr string, crFactory ContractReaderFactory, expectedType ContractType) (semver.Version, error) {
+	contractType, version, err := TypeAndVersion(ctx, addr, crFactory)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("failed getting type and version %w", err)
+	}
+	if contractType != expectedType {
+		return semver.Version{}, fmt.Errorf("wrong contract type %s", contractType)
+	}
+	return version, nil
+}
+
+func TypeAndVersion(ctx context.Context, addr string, crFactory ContractReaderFactory) (ContractType, semver.Version, error) {
+	cfg := types.ChainReaderConfig{
+		Contracts: map[string]types.ChainContractReader{
+			ContractName: {
+				ContractABI: type_and_version.ITypeAndVersionABI,
+				Configs: map[string]*types.ChainReaderDefinition{
+					MethodName: {
+						ChainSpecificName: MethodName,
+						ReadType:          types.Method,
+					},
+				},
+			},
+		},
+	}
+	marshalledCfg, err := json.Marshal(cfg)
+	if err != nil {
+		return "", semver.Version{}, err
+	}
+
+	reader, err := crFactory(ctx, marshalledCfg)
+	if err != nil {
+		return "", semver.Version{}, err
+	}
+	if reader == nil {
+		return "", semver.Version{}, ErrNoContractReader
+	}
+
+	bc := commontypes.BoundContract{
+		Name:    ContractName,
+		Address: addr,
+	}
+	err = reader.Bind(ctx, []commontypes.BoundContract{bc})
+	if err != nil {
+		return "", semver.Version{}, err
+	}
+	err = reader.Start(ctx)
+	if err != nil {
+		return "", semver.Version{}, err
+	}
+
+	var typeAndVersion string
+	err = reader.GetLatestValue(ctx, bc.ReadIdentifier(MethodName), primitives.Finalized, map[string]any{}, &typeAndVersion)
+	if err != nil {
+		return "", semver.Version{}, err
+	}
+
+	err = reader.Unbind(ctx, []commontypes.BoundContract{bc})
+	if err != nil {
+		return "", semver.Version{}, err
+	}
+	err = reader.Close()
+	if err != nil {
+		return "", semver.Version{}, err
+	}
+
+	contractType, versionStr, err := ParseTypeAndVersion(typeAndVersion)
+	if err != nil {
+		return "", semver.Version{}, err
+	}
+	v, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return "", semver.Version{}, fmt.Errorf("failed parsing version %s: %w", versionStr, err)
+	}
+	return ContractType(contractType), *v, nil
+}
+
+func ParseTypeAndVersion(tvStr string) (string, string, error) {
+	if tvStr == "" {
+		tvStr = string(Unknown) + " " + defaultVersion
+	}
+	typeAndVersionValues := strings.Split(tvStr, " ")
+
+	if len(typeAndVersionValues) != 2 {
+		return "", "", fmt.Errorf("invalid type and version %s", tvStr)
+	}
+	return typeAndVersionValues[0], typeAndVersionValues[1], nil
+}

--- a/core/services/relay/evm/capabilities/versioning/contracts_test.go
+++ b/core/services/relay/evm/capabilities/versioning/contracts_test.go
@@ -1,0 +1,147 @@
+package versioning_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/balance_reader"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/log_emitter"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/capabilities/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/capabilities/versioning"
+)
+
+func TestContracts_TypeAndVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
+		th := testutils.NewEVMBackendTH(t)
+
+		// Deploy a contract that has typeAndVersion
+		addr, _, _, err := balance_reader.DeployBalanceReader(th.ContractsOwner, th.Backend.Client())
+		th.Backend.Commit()
+		th.Backend.Commit()
+		th.Backend.Commit()
+		require.NoError(t, err)
+
+		contractReaderFactory := func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
+			return th.NewContractReader(ctx, t, bytes)
+		}
+
+		contractType, version, err := versioning.TypeAndVersion(t.Context(), addr.String(), contractReaderFactory)
+		require.NoError(t, err)
+
+		expectedVersion, err := semver.NewVersion("1.0.0")
+		require.NoError(t, err)
+
+		require.Equal(t, versioning.ContractType("BalanceReader"), contractType)
+		require.Equal(t, expectedVersion, &version)
+	})
+
+	t.Run("contract does not have typeAndVersion", func(t *testing.T) {
+		t.Parallel()
+
+		th := testutils.NewEVMBackendTH(t)
+
+		// Deploy a contract that does not have typeAndVersion
+		addr, _, _, err :=
+			log_emitter.DeployLogEmitter(th.ContractsOwner, th.Backend.Client())
+		th.Backend.Commit()
+		require.NoError(t, err)
+
+		contractReaderFactory := func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
+			return th.NewContractReader(ctx, t, bytes)
+		}
+
+		contractType, version, err := versioning.TypeAndVersion(t.Context(), addr.String(), contractReaderFactory)
+		require.NoError(t, err)
+
+		expectedVersion, err := semver.NewVersion("1.0.0")
+		require.NoError(t, err)
+
+		require.Equal(t, versioning.Unknown, contractType)
+		require.Equal(t, expectedVersion, &version)
+	})
+
+	t.Run("errors on empty address", func(t *testing.T) {
+		t.Parallel()
+
+		th := testutils.NewEVMBackendTH(t)
+
+		contractReaderFactory := func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
+			return th.NewContractReader(ctx, t, bytes)
+		}
+
+		_, _, err := versioning.TypeAndVersion(t.Context(), "0x0000000000000000000000000000000000000000", contractReaderFactory)
+		require.ErrorContains(t, err, "internal error: contract does not exist at address: 0x0000000000000000000000000000000000000000")
+	})
+
+	t.Run("errors on invalid contract reader factory", func(t *testing.T) {
+		t.Parallel()
+
+		contractReaderFactory := func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
+			return nil, nil
+		}
+
+		_, _, err := versioning.TypeAndVersion(t.Context(), "", contractReaderFactory)
+		require.ErrorIs(t, versioning.ErrNoContractReader, err)
+	})
+}
+
+func TestContracts_VerifyTypeAndVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("incorrect type", func(t *testing.T) {
+		t.Parallel()
+
+		th := testutils.NewEVMBackendTH(t)
+
+		addr, _, _, err := balance_reader.DeployBalanceReader(th.ContractsOwner, th.Backend.Client())
+		require.NoError(t, err)
+		th.Backend.Commit()
+		th.Backend.Commit()
+		th.Backend.Commit()
+
+		contractReaderFactory := func(ctx context.Context, cfg []byte) (types.ContractReader, error) {
+			return th.NewContractReader(ctx, t, cfg)
+		}
+
+		version, err := versioning.VerifyTypeAndVersion(t.Context(), addr.String(), contractReaderFactory, "SomeType")
+		require.ErrorContains(t, err, "wrong contract type BalanceReader")
+		require.Equal(t, semver.Version{}, version)
+	})
+}
+
+func TestContracts_ParseTypeAndVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid string", func(t *testing.T) {
+		t.Parallel()
+		contractType, version, err := versioning.ParseTypeAndVersion("SomeType 1.2.0")
+		require.NoError(t, err)
+		require.Equal(t, "SomeType", contractType)
+		require.Equal(t, "1.2.0", version)
+	})
+	t.Run("invalid string - too short", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := versioning.ParseTypeAndVersion("v1.2.0")
+		require.ErrorContains(t, err, "invalid type and version v1.2.0")
+	})
+	t.Run("invalid string - too long", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := versioning.ParseTypeAndVersion("SomeType WithMoreWords vv1.2.0")
+		require.ErrorContains(t, err, "invalid type and version SomeType WithMoreWords vv1.2.0")
+	})
+	t.Run("empty string", func(t *testing.T) {
+		t.Parallel()
+		contractType, version, err := versioning.ParseTypeAndVersion("")
+		require.NoError(t, err)
+		require.Equal(t, versioning.Unknown, versioning.ContractType(contractType))
+		require.Equal(t, "1.0.0", version)
+	})
+}

--- a/core/services/workflows/syncer/workflow_registry.go
+++ b/core/services/workflows/syncer/workflow_registry.go
@@ -7,13 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"iter"
 	"maps"
 	"math"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/jonboulle/clockwork"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -28,6 +28,7 @@ import (
 	workflow_registry_wrapper "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v1"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	ghcapabilities "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/capabilities/versioning"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
 	wftypes "github.com/smartcontractkit/chainlink/v2/core/services/workflows/types"
 )
@@ -99,19 +100,6 @@ type Config struct {
 // FetcherFunc is an abstraction for fetching the contents stored at a URL.
 type FetcherFunc func(ctx context.Context, messageID string, req ghcapabilities.Request) ([]byte, error)
 
-// ContractReader is a subset of types.ContractReader defined locally to enable mocking.
-type ContractReader interface {
-	Start(ctx context.Context) error
-	Close() error
-	Bind(context.Context, []types.BoundContract) error
-	QueryKeys(ctx context.Context, keyQueries []types.ContractKeyFilter, limitAndSort query.LimitAndSort) (iter.Seq2[string, types.Sequence], error)
-	GetLatestValueWithHeadData(ctx context.Context, readName string, confidenceLevel primitives.ConfidenceLevel, params any, returnVal any) (head *types.Head, err error)
-}
-
-type ContractReaderFactory interface {
-	NewContractReader(context.Context, []byte) (types.ContractReader, error)
-}
-
 // WorkflowRegistrySyncer is the public interface of the package.
 type WorkflowRegistrySyncer interface {
 	services.Service
@@ -138,8 +126,9 @@ type workflowRegistry struct {
 
 	lggr                    logger.Logger
 	workflowRegistryAddress string
+	workflowRegistryVersion semver.Version
 
-	newContractReaderFn newContractReaderFn
+	contractReaderFn versioning.ContractReaderFactory
 
 	config Config
 
@@ -179,13 +168,11 @@ type donNotifier interface {
 	WaitForDon(ctx context.Context) (capabilities.DON, error)
 }
 
-type newContractReaderFn func(context.Context, []byte) (ContractReader, error)
-
 // NewWorkflowRegistry returns a new workflowRegistry.
 // Only queries for WorkflowRegistryForceUpdateSecretsRequestedV1 events.
 func NewWorkflowRegistry(
 	lggr logger.Logger,
-	newContractReaderFn newContractReaderFn,
+	contractReaderFn versioning.ContractReaderFactory,
 	addr string,
 	config Config,
 	handler evtHandler,
@@ -204,7 +191,7 @@ func NewWorkflowRegistry(
 
 	wr := &workflowRegistry{
 		lggr:                    lggr,
-		newContractReaderFn:     newContractReaderFn,
+		contractReaderFn:        contractReaderFn,
 		workflowRegistryAddress: addr,
 		config:                  config,
 		eventCh:                 make(chan Event),
@@ -249,6 +236,12 @@ func (w *workflowRegistry) Start(_ context.Context) error {
 				return
 			}
 
+			err = w.getContractTypeAndVersion(ctx)
+			if err != nil {
+				w.lggr.Criticalf("unable to get WorkflowRegistry contract version: %s", err)
+				return
+			}
+
 			reader, err := w.newWorkflowRegistryContractReader(ctx)
 			if err != nil {
 				w.lggr.Criticalf("contract reader unavailable : %s", err)
@@ -262,7 +255,6 @@ func (w *workflowRegistry) Start(_ context.Context) error {
 			case SyncStrategyReconciliation:
 				w.syncUsingReconciliationStrategy(ctx, don, reader)
 			}
-
 		}()
 
 		return nil
@@ -290,7 +282,7 @@ func (w *workflowRegistry) Name() string {
 }
 
 // readRegistryEventsLoop polls the contract for events and sends them to the events channel for handling.
-func (w *workflowRegistry) readRegistryEventsLoop(ctx context.Context, eventTypes []WorkflowRegistryEventType, don capabilities.DON, reader ContractReader, lastReadBlockNumber string) {
+func (w *workflowRegistry) readRegistryEventsLoop(ctx context.Context, eventTypes []WorkflowRegistryEventType, don capabilities.DON, reader types.ContractReader, lastReadBlockNumber string) {
 	ticker := w.getTicker()
 
 	var keyQueries = make([]types.ContractKeyFilter, 0, len(eventTypes))
@@ -411,7 +403,7 @@ func (w *workflowRegistry) handleWithMetrics(ctx context.Context, event Event) e
 // syncUsingEventStrategy syncs workflow registry contract state by watching for events on the contract.
 // It first loads the workflow metadata from the contract state as WorkflowRegistered events,
 // and then starts a goroutine with one loop for handling the events.
-func (w *workflowRegistry) syncUsingEventStrategy(ctx context.Context, don capabilities.DON, reader ContractReader) {
+func (w *workflowRegistry) syncUsingEventStrategy(ctx context.Context, don capabilities.DON, reader types.ContractReader) {
 	w.lggr.Debugw("Loading initial workflows for DON", "DON", don.ID)
 
 	workflowMetadata, loadWorkflowsHead, err := w.getWorkflowMetadata(ctx, don, reader)
@@ -646,7 +638,7 @@ func newReconcileReport() *reconcileReport {
 // syncUsingReconciliationStrategy syncs workflow registry contract state by polling the workflow metadata state and comparing to local state.
 // It still watches for ForceUpdateSecretsEvents, which can't be reconciled through workflow metadata state.
 // NOTE: In this mode paused states will be treated as a deleted workflow. Workflows will not be registered as paused.
-func (w *workflowRegistry) syncUsingReconciliationStrategy(ctx context.Context, don capabilities.DON, reader ContractReader) {
+func (w *workflowRegistry) syncUsingReconciliationStrategy(ctx context.Context, don capabilities.DON, reader types.ContractReader) {
 	_, loadWorkflowsHead, err := w.getWorkflowMetadata(ctx, don, reader)
 	if err != nil {
 		w.lggr.Errorw("failed to load workflows head", "err", err)
@@ -736,59 +728,71 @@ type sequenceWithEventType struct {
 	EventType WorkflowRegistryEventType
 }
 
+func (w *workflowRegistry) getContractTypeAndVersion(ctx context.Context) error {
+	version, err := versioning.VerifyTypeAndVersion(ctx, w.workflowRegistryAddress, w.contractReaderFn, versioning.ContractType(WorkflowRegistryContractName))
+	if err != nil {
+		return err
+	}
+	w.workflowRegistryVersion = version
+	return nil
+}
+
 func (w *workflowRegistry) newWorkflowRegistryContractReader(
 	ctx context.Context,
-) (ContractReader, error) {
-	bc := types.BoundContract{
-		Name:    WorkflowRegistryContractName,
-		Address: w.workflowRegistryAddress,
-	}
-
-	contractReaderCfg := evmtypes.ChainReaderConfig{
-		Contracts: map[string]evmtypes.ChainContractReader{
-			WorkflowRegistryContractName: {
-				ContractPollingFilter: evmtypes.ContractPollingFilter{
-					GenericEventNames: []string{
-						string(ForceUpdateSecretsEvent),
-						string(WorkflowActivatedEvent),
-						string(WorkflowDeletedEvent),
-						string(WorkflowPausedEvent),
-						string(WorkflowRegisteredEvent),
-						string(WorkflowUpdatedEvent),
+) (types.ContractReader, error) {
+	var contractReaderCfg evmtypes.ChainReaderConfig
+	switch w.workflowRegistryVersion.Major() {
+	case 1:
+		contractReaderCfg = evmtypes.ChainReaderConfig{
+			Contracts: map[string]evmtypes.ChainContractReader{
+				WorkflowRegistryContractName: {
+					ContractPollingFilter: evmtypes.ContractPollingFilter{
+						GenericEventNames: []string{
+							string(ForceUpdateSecretsEvent),
+							string(WorkflowActivatedEvent),
+							string(WorkflowDeletedEvent),
+							string(WorkflowPausedEvent),
+							string(WorkflowRegisteredEvent),
+							string(WorkflowUpdatedEvent),
+						},
 					},
-				},
-				ContractABI: workflow_registry_wrapper.WorkflowRegistryABI,
-				Configs: map[string]*evmtypes.ChainReaderDefinition{
-					GetWorkflowMetadataListByDONMethodName: {
-						ChainSpecificName: GetWorkflowMetadataListByDONMethodName,
-					},
-					string(ForceUpdateSecretsEvent): {
-						ChainSpecificName: string(ForceUpdateSecretsEvent),
-						ReadType:          evmtypes.Event,
-					},
-					string(WorkflowActivatedEvent): {
-						ChainSpecificName: string(WorkflowActivatedEvent),
-						ReadType:          evmtypes.Event,
-					},
-					string(WorkflowDeletedEvent): {
-						ChainSpecificName: string(WorkflowDeletedEvent),
-						ReadType:          evmtypes.Event,
-					},
-					string(WorkflowPausedEvent): {
-						ChainSpecificName: string(WorkflowPausedEvent),
-						ReadType:          evmtypes.Event,
-					},
-					string(WorkflowRegisteredEvent): {
-						ChainSpecificName: string(WorkflowRegisteredEvent),
-						ReadType:          evmtypes.Event,
-					},
-					string(WorkflowUpdatedEvent): {
-						ChainSpecificName: string(WorkflowUpdatedEvent),
-						ReadType:          evmtypes.Event,
+					ContractABI: workflow_registry_wrapper.WorkflowRegistryABI,
+					Configs: map[string]*evmtypes.ChainReaderDefinition{
+						GetWorkflowMetadataListByDONMethodName: {
+							ChainSpecificName: GetWorkflowMetadataListByDONMethodName,
+						},
+						string(ForceUpdateSecretsEvent): {
+							ChainSpecificName: string(ForceUpdateSecretsEvent),
+							ReadType:          evmtypes.Event,
+						},
+						string(WorkflowActivatedEvent): {
+							ChainSpecificName: string(WorkflowActivatedEvent),
+							ReadType:          evmtypes.Event,
+						},
+						string(WorkflowDeletedEvent): {
+							ChainSpecificName: string(WorkflowDeletedEvent),
+							ReadType:          evmtypes.Event,
+						},
+						string(WorkflowPausedEvent): {
+							ChainSpecificName: string(WorkflowPausedEvent),
+							ReadType:          evmtypes.Event,
+						},
+						string(WorkflowRegisteredEvent): {
+							ChainSpecificName: string(WorkflowRegisteredEvent),
+							ReadType:          evmtypes.Event,
+						},
+						string(WorkflowUpdatedEvent): {
+							ChainSpecificName: string(WorkflowUpdatedEvent),
+							ReadType:          evmtypes.Event,
+						},
 					},
 				},
 			},
-		},
+		}
+	// case 2:
+	// TODO CAPPL-1000
+	default:
+		return nil, errors.New("unsupported version " + w.workflowRegistryVersion.String())
 	}
 
 	marshalledCfg, err := json.Marshal(contractReaderCfg)
@@ -796,9 +800,14 @@ func (w *workflowRegistry) newWorkflowRegistryContractReader(
 		return nil, err
 	}
 
-	reader, err := w.newContractReaderFn(ctx, marshalledCfg)
+	reader, err := w.contractReaderFn(ctx, marshalledCfg)
 	if err != nil {
 		return nil, err
+	}
+
+	bc := types.BoundContract{
+		Name:    WorkflowRegistryContractName,
+		Address: w.workflowRegistryAddress,
 	}
 
 	// bind contract to contract reader
@@ -814,7 +823,7 @@ func (w *workflowRegistry) newWorkflowRegistryContractReader(
 }
 
 // getWorkflowMetadata uses contract reader to query the contract for all workflow metadata using the method GetWorkflowMetadataListByDONMethodName
-func (w *workflowRegistry) getWorkflowMetadata(ctx context.Context, don capabilities.DON, contractReader ContractReader) ([]GetWorkflowMetadata, *types.Head, error) {
+func (w *workflowRegistry) getWorkflowMetadata(ctx context.Context, don capabilities.DON, contractReader types.ContractReader) ([]GetWorkflowMetadata, *types.Head, error) {
 	contractBinding := types.BoundContract{
 		Address: w.workflowRegistryAddress,
 		Name:    WorkflowRegistryContractName,

--- a/core/services/workflows/syncer/workflow_registry_test.go
+++ b/core/services/workflows/syncer/workflow_registry_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -37,7 +38,7 @@ func Test_generateReconciliationEvents(t *testing.T) {
 		er := NewEngineRegistry()
 		wr, err := NewWorkflowRegistry(
 			lggr,
-			func(ctx context.Context, bytes []byte) (ContractReader, error) {
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
 				return nil, nil
 			},
 			"",
@@ -105,7 +106,7 @@ func Test_generateReconciliationEvents(t *testing.T) {
 		require.NoError(t, err)
 		wr, err := NewWorkflowRegistry(
 			lggr,
-			func(ctx context.Context, bytes []byte) (ContractReader, error) {
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
 				return nil, nil
 			},
 			"",
@@ -172,7 +173,7 @@ func Test_generateReconciliationEvents(t *testing.T) {
 		require.NoError(t, err)
 		wr, err := NewWorkflowRegistry(
 			lggr,
-			func(ctx context.Context, bytes []byte) (ContractReader, error) {
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
 				return nil, nil
 			},
 			"",
@@ -214,7 +215,7 @@ func Test_generateReconciliationEvents(t *testing.T) {
 		er := NewEngineRegistry()
 		wr, err := NewWorkflowRegistry(
 			lggr,
-			func(ctx context.Context, bytes []byte) (ContractReader, error) {
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
 				return nil, nil
 			},
 			"",
@@ -286,7 +287,7 @@ func Test_generateReconciliationEvents(t *testing.T) {
 		er := NewEngineRegistry()
 		wr, err := NewWorkflowRegistry(
 			lggr,
-			func(ctx context.Context, bytes []byte) (ContractReader, error) {
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
 				return nil, nil
 			},
 			"",
@@ -341,7 +342,7 @@ func Test_generateReconciliationEvents(t *testing.T) {
 		require.NoError(t, err)
 		wr, err := NewWorkflowRegistry(
 			lggr,
-			func(ctx context.Context, bytes []byte) (ContractReader, error) {
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
 				return nil, nil
 			},
 			"",
@@ -398,7 +399,7 @@ func Test_generateReconciliationEvents(t *testing.T) {
 		er := NewEngineRegistry()
 		wr, err := NewWorkflowRegistry(
 			lggr,
-			func(ctx context.Context, bytes []byte) (ContractReader, error) {
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
 				return nil, nil
 			},
 			"",
@@ -483,7 +484,7 @@ func Test_generateReconciliationEvents(t *testing.T) {
 		er := NewEngineRegistry()
 		wr, err := NewWorkflowRegistry(
 			lggr,
-			func(ctx context.Context, bytes []byte) (ContractReader, error) {
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
 				return nil, nil
 			},
 			"",
@@ -564,7 +565,7 @@ func Test_generateReconciliationEvents(t *testing.T) {
 		er := NewEngineRegistry()
 		wr, err := NewWorkflowRegistry(
 			lggr,
-			func(ctx context.Context, bytes []byte) (ContractReader, error) {
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
 				return nil, nil
 			},
 			"",


### PR DESCRIPTION
### Description
Prepares the Workflow Registry Syncer service for supporting Workflow Registry V2 by loading the contract version when the service `.Start()`s.

Adds:
- Utils for getting a contract version using contract reader
- Switch case that will be used to load the different contract ABI and modify behavior, e.g. no more ForceUpdateSecrets (coming in subsequent PR)

Unrelated:
- Cleans up some unused types.
- Reorders imports in `workflow_syncer_test.go`