### PR TITLE
Update Docker build Make targets for integration-tests compatible with private deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ Then you can build the plugins with:
 make install-plugins-private
 ```
 
-### Apple Silicon - ARM64
+### Docker Builds
 
-Native builds on the Apple Silicon should work out of the box, but the Docker image requires more consideration.
+To build the experimental "plugins" Chainlink docker image, you can run this from the root of the repository:
 
-```bash
-$ docker build . -t chainlink-develop:latest -f ./core/chainlink.Dockerfile
+```shell
+# The GITHUB_TOKEN is required to access private repos which are used by some plugins.
+export GITHUB_TOKEN=$(gh auth token) # requires the `gh` cli tool.
+make docker-plugins
 ```
 
 ### Ethereum Execution Client Requirements

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -223,6 +223,7 @@ test_reorg_automation: ## Run the automation reorg tests
 check_github_token:
 	@if [ -z "$(GITHUB_TOKEN)" ]; then \
 		echo "Error: GITHUB_TOKEN environment variable to pull private dependencies. Try to set it via the gh cli: GITHUB_TOKEN=\$$(gh auth token)"; \
+		echo "See: https://github.com/smartcontractkit/chainlink?tab=readme-ov-file#build-plugins"; \
 		exit 1; \
 	fi
 # image: the name for the chainlink image being built, example: image=chainlink

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -17,6 +17,7 @@ ifeq ($(UNAME_S),Darwin)
 		OSFLAG = $(OSX)
 endif
 endif
+comma := ,
 
 install_qa_tools:
 ifeq ($(OSFLAG),$(WINDOWS))
@@ -73,13 +74,16 @@ build_test_image:
 
 #Build a chainlink docker image for local testing and push to k3d registry
 .PHONY: build_push_docker_image
-build_push_docker_image:
-	docker build -f ../core/chainlink.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg CHAINLINK_USER=chainlink -t 127.0.0.1:5000/chainlink:develop ../ ; docker push 127.0.0.1:5000/chainlink:develop
+build_push_docker_image: build_docker_image
+	docker tag $(image):$(tag) 127.0.0.1:5000/chainlink:develop
+	docker push 127.0.0.1:5000/chainlink:develop
 
 #Build a chainlink docker image in plugin mode for local testing and push to k3d registry
 .PHONY: build_push_plugin_docker_image
 build_push_plugin_docker_image:
-	docker build -f ../plugins/chainlink.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg CHAINLINK_USER=chainlink -t 127.0.0.1:5000/chainlink:develop ../ ; docker push 127.0.0.1:5000/chainlink:develop
+	@echo "Run \"make docker-plugins\" from the root to build the chainlink-plugins (experimental) image."
+	@echo "After you run a build, you can push to your local docker registry with something like:"
+	@echo "docker push 127.0.0.1:5000/chainlink:develop"
 
 # Spins up containers needed to collect traces for local testing
 .PHONY: run_tracing
@@ -216,19 +220,26 @@ test_benchmark_automation: ## Run the automation benchmark tests
 test_reorg_automation: ## Run the automation reorg tests
 	go test -timeout 300m -v -run ^TestAutomationReorg$$ ./reorg -count=1 | tee automation_reorg_run_`date +"%Y%m%d-%H%M%S"`.log
 
+.PHONY: check_github_token
+check_github_token:
+	@if [ -z "$(GITHUB_TOKEN)" ]; then \
+		echo "Error: GITHUB_TOKEN environment variable to pull private dependencies. Try to set it via the gh cli: GITHUB_TOKEN=\$$(gh auth token)"; \
+		exit 1; \
+	fi
 # image: the name for the chainlink image being built, example: image=chainlink
 # tag: the tag for the chainlink image being built, example: tag=latest
 # example usage: make build_docker_image image=chainlink tag=latest
 .PHONY: build_docker_image
-build_docker_image:
-	docker build -f ../core/chainlink.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg CHAINLINK_USER=chainlink -t $(image):$(tag) ../
+build_docker_image: check_github_token
+	docker build -f ../core/chainlink.Dockerfile \
+		--build-arg COMMIT_SHA=$(git rev-parse HEAD) \
+		--build-arg CHAINLINK_USER=chainlink \
+		--secret id=GIT_AUTH_TOKEN$(comma)env=GITHUB_TOKEN \
+		-t $(image):$(tag) ../
 
-# image: the name for the chainlink image being built, example: image=chainlink
-# tag: the tag for the chainlink image being built, example: tag=latest
-# example usage: make build_docker_image image=chainlink tag=latest
 .PHONY: build_plugin_docker_image
 build_plugin_docker_image:
-	docker build -f ../plugins/chainlink.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg CHAINLINK_USER=chainlink -t 127.0.0.1:5000/chainlink:develop ../
+	@echo "Run \"make docker-plugins\" from the root to build the chainlink-plugins (experimental) image."
 
 # image: the name for the chainlink image being built, example: image=chainlink
 # tag: the tag for the chainlink image being built, example: tag=latest

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -77,13 +77,6 @@ build_push_docker_image: build_docker_image
 	docker tag $(image):$(tag) 127.0.0.1:5000/chainlink:develop
 	docker push 127.0.0.1:5000/chainlink:develop
 
-#Build a chainlink docker image in plugin mode for local testing and push to k3d registry
-.PHONY: build_push_plugin_docker_image
-build_push_plugin_docker_image:
-	@echo "Run \"make docker-plugins\" from the root to build the chainlink-plugins (experimental) image."
-	@echo "After you run a build, you can push to your local docker registry with something like:"
-	@echo "docker push 127.0.0.1:5000/chainlink:develop"
-
 # Spins up containers needed to collect traces for local testing
 .PHONY: run_tracing
 run_tracing:
@@ -236,10 +229,6 @@ build_docker_image: check_github_token
 		--build-arg CHAINLINK_USER=chainlink \
 		--secret id=GIT_AUTH_TOKEN,env=GITHUB_TOKEN \
 		-t $(image):$(tag) ../
-
-.PHONY: build_plugin_docker_image
-build_plugin_docker_image:
-	@echo "Run \"make docker-plugins\" from the root to build the chainlink-plugins (experimental) image."
 
 # image: the name for the chainlink image being built, example: image=chainlink
 # tag: the tag for the chainlink image being built, example: tag=latest

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -17,7 +17,6 @@ ifeq ($(UNAME_S),Darwin)
 		OSFLAG = $(OSX)
 endif
 endif
-comma := ,
 
 install_qa_tools:
 ifeq ($(OSFLAG),$(WINDOWS))
@@ -234,7 +233,7 @@ build_docker_image: check_github_token
 	docker build -f ../core/chainlink.Dockerfile \
 		--build-arg COMMIT_SHA=$(git rev-parse HEAD) \
 		--build-arg CHAINLINK_USER=chainlink \
-		--secret id=GIT_AUTH_TOKEN$(comma)env=GITHUB_TOKEN \
+		--secret id=GIT_AUTH_TOKEN,env=GITHUB_TOKEN \
 		-t $(image):$(tag) ../
 
 .PHONY: build_plugin_docker_image


### PR DESCRIPTION
Fixes:

```
cd integration-tests && make build_docker_image image=chainlink tag=latest
...
30.54 2025/07/08 09:12:36 Worker 2: Failed to install cron in 1.640575917s: failed to download module github.com/smartcontractkit/capabilities/cron@fed08e9ef44646e515c6ce002867abac53740949: exit status 1
30.54 2025/07/08 09:12:36 Worker 0: Failed to install readcontract in 1.645459917s: failed to download module github.com/smartcontractkit/capabilities/readcontract@fed08e9ef44646e515c6ce002867abac53740949: exit status 1
30.54 2025/07/08 09:12:36 Some plugin installations failed:
30.54 2025/07/08 09:12:36 - readcontract:github.com/smartcontractkit/capabilities/readcontract:github.com/smartcontractkit/capabilities/readcontract: failed to download module github.com/smartcontractkit/capabilities/readcontract@fed08e9ef44646e515c6ce002867abac53740949: exit status 1
30.54 2025/07/08 09:12:36 - cron:github.com/smartcontractkit/capabilities/cron:github.com/smartcontractkit/capabilities/cron: failed to download module github.com/smartcontractkit/capabilities/cron@fed08e9ef44646e515c6ce002867abac53740949: exit status 1
30.54 make: *** [GNUmakefile:80: install-plugins-private] Error 1
```