### PR TITLE
Removed redundant Solana E2E test

### DIFF
--- a/integration-tests/smoke/ccip/ccip_token_transfer_test.go
+++ b/integration-tests/smoke/ccip/ccip_token_transfer_test.go
@@ -318,25 +318,6 @@ func TestTokenTransfer_EVM2Solana(t *testing.T) {
 			ExtraArgs:      extraArgs,
 			ExpectedStatus: testhelpers.EXECUTION_STATE_SUCCESS,
 		},
-		{
-			Name:        "Send token to contract with large data payload",
-			SourceChain: sourceChain,
-			DestChain:   destChain,
-			Data:        make([]byte, 1233), // set large payload that cannot fit in single transaction but does not overflow memory allocation
-			Tokens: []router.ClientEVMTokenAmount{
-				{
-					Token:  srcToken.Address(),
-					Amount: oneE9,
-				},
-			},
-			TokenReceiver: tokenReceiver.Bytes(),
-			ExpectedTokenBalances: []testhelpers.ExpectedBalance{
-				// due to the differences in decimals, 1e9 on EVM results to 1 on SVM
-				{Token: destToken.Bytes(), Amount: big.NewInt(1)},
-			},
-			ExtraArgs:      extraArgs,
-			ExpectedStatus: testhelpers.EXECUTION_STATE_SUCCESS,
-		},
 		// {
 		// 	Name:        "Send N tokens to contract",
 		// 	SourceChain: destChain,


### PR DESCRIPTION
A redundant E2E test was removed for Solana token transfer. A large payload test for buffering is more relevant to messaging where a similar test already exists