### PR TITLE
Update Solana token transfer E2E test to transfer larger amount

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -2310,7 +2310,7 @@ func MintAndAllow(
 	tokenMap map[uint64][]MintTokenInfo,
 ) {
 	configurePoolGrp := errgroup.Group{}
-	tenCoins := new(big.Int).Mul(big.NewInt(1e18), big.NewInt(10))
+	tenCoins := new(big.Int).Mul(big.NewInt(1e18), big.NewInt(100))
 
 	for chain, mintTokenInfos := range tokenMap {
 		mintTokenInfos := mintTokenInfos

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -2310,7 +2310,7 @@ func MintAndAllow(
 	tokenMap map[uint64][]MintTokenInfo,
 ) {
 	configurePoolGrp := errgroup.Group{}
-	tenCoins := new(big.Int).Mul(big.NewInt(1e18), big.NewInt(100))
+	allowance := new(big.Int).Mul(big.NewInt(1e18), big.NewInt(100))
 
 	for chain, mintTokenInfos := range tokenMap {
 		mintTokenInfos := mintTokenInfos
@@ -2326,13 +2326,13 @@ func MintAndAllow(
 					tx, err := token.Mint(
 						mintTokenInfo.auth,
 						sender.From,
-						new(big.Int).Mul(tenCoins, big.NewInt(10)),
+						new(big.Int).Mul(allowance, big.NewInt(10)),
 					)
 					require.NoError(t, err)
 					_, err = e.BlockChains.EVMChains()[chain].Confirm(tx)
 					require.NoError(t, err)
 
-					tx, err = token.Approve(sender, state.MustGetEVMChainState(chain).Router.Address(), tenCoins)
+					tx, err = token.Approve(sender, state.MustGetEVMChainState(chain).Router.Address(), allowance)
 					require.NoError(t, err)
 					_, err = e.BlockChains.EVMChains()[chain].Confirm(tx)
 					require.NoError(t, err)

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -2485,7 +2485,7 @@ func TransferMultiple(
 				// Approve router to spend tokens
 				if tt.RouterAddress != (common.Address{}) {
 					for _, ta := range tt.Tokens {
-						err := commoncs.ApproveToken(env, tt.SourceChain, ta.Token, tt.RouterAddress, new(big.Int).Mul(ta.Amount, big.NewInt(10)))
+						err := commoncs.ApproveToken(env, tt.SourceChain, ta.Token, tt.RouterAddress, new(big.Int).Mul(ta.Amount, big.NewInt(1000)))
 						require.NoError(t, err)
 					}
 				}

--- a/deployment/ccip/changeset/testhelpers/test_helpers.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers.go
@@ -2485,7 +2485,7 @@ func TransferMultiple(
 				// Approve router to spend tokens
 				if tt.RouterAddress != (common.Address{}) {
 					for _, ta := range tt.Tokens {
-						err := commoncs.ApproveToken(env, tt.SourceChain, ta.Token, tt.RouterAddress, new(big.Int).Mul(ta.Amount, big.NewInt(1000)))
+						err := commoncs.ApproveToken(env, tt.SourceChain, ta.Token, tt.RouterAddress, new(big.Int).Mul(ta.Amount, big.NewInt(10)))
 						require.NoError(t, err)
 					}
 				}

--- a/integration-tests/smoke/ccip/ccip_token_transfer_test.go
+++ b/integration-tests/smoke/ccip/ccip_token_transfer_test.go
@@ -259,6 +259,7 @@ func TestTokenTransfer_EVM2Solana(t *testing.T) {
 	require.GreaterOrEqual(t, len(tenv.Users[sourceChain]), 2) // TODO: ???
 
 	oneE9 := new(big.Int).SetUint64(1e9)
+	oneE18 := new(big.Int).SetUint64(1e18)
 
 	// Deploy tokens and pool by CCIP Owner
 	srcToken, _, destToken, err := testhelpers.DeployTransferableTokenSolana(
@@ -307,13 +308,13 @@ func TestTokenTransfer_EVM2Solana(t *testing.T) {
 			Tokens: []router.ClientEVMTokenAmount{
 				{
 					Token:  srcToken.Address(),
-					Amount: oneE9,
+					Amount: new(big.Int).Mul(big.NewInt(20), oneE18),
 				},
 			},
 			TokenReceiver: tokenReceiver.Bytes(),
 			ExpectedTokenBalances: []testhelpers.ExpectedBalance{
-				// due to the differences in decimals, 1e9 on EVM results to 1 on SVM
-				{Token: destToken.Bytes(), Amount: big.NewInt(1)},
+				// due to the differences in decimals, 20e18 on EVM results to 20e9 on SVM
+				{Token: destToken.Bytes(), Amount: new(big.Int).Mul(big.NewInt(20), oneE9)},
 			},
 			ExtraArgs:      extraArgs,
 			ExpectedStatus: testhelpers.EXECUTION_STATE_SUCCESS,


### PR DESCRIPTION
Transfer larger amount (specifically greater than uint64 max) to cover CCIP message hashing conversion for Solana