### PR TITLE
enable running solana in crib with remote deployer

### DIFF
--- a/deployment/environment/crib/ccip_deployer.go
+++ b/deployment/environment/crib/ccip_deployer.go
@@ -384,11 +384,8 @@ func setupChains(lggr logger.Logger, e *cldf.Environment, homeChainSel, feedChai
 		}
 
 		buildConfig := ccipChangesetSolana.BuildSolanaConfig{
-			GitCommitSha:   "c6cd4a526da4",
+			GitCommitSha:   "6aaf88e0848a",
 			DestinationDir: deployedEnv.Env.BlockChains.SolanaChains()[solChainSelectors[0]].ProgramsPath,
-			LocalBuild: ccipChangesetSolana.LocalBuildConfig{
-				BuildLocally: true,
-			},
 		}
 
 		solTestReceiver := commonchangeset.Configure(

--- a/deployment/environment/devenv/chain.go
+++ b/deployment/environment/devenv/chain.go
@@ -233,7 +233,7 @@ func NewChains(logger logger.Logger, configs []ChainConfig) (map[uint64]cldf_evm
 					Selector:    chainDetails.ChainSelector,
 					Client:      sc,
 					DeployerKey: &chainCfg.SolDeployerKey,
-					KeypairPath: fmt.Sprintf("%s/deploy-keypair.json", solArtifactPath),
+					KeypairPath: solArtifactPath + "/deploy-keypair.json",
 					URL:         chainCfg.HTTPRPCs[0].External,
 					WSURL:       chainCfg.WSRPCs[0].External,
 					Confirm: func(instructions []solana.Instruction, opts ...solCommonUtil.TxModifier) error {

--- a/deployment/environment/devenv/chain.go
+++ b/deployment/environment/devenv/chain.go
@@ -233,7 +233,7 @@ func NewChains(logger logger.Logger, configs []ChainConfig) (map[uint64]cldf_evm
 					Selector:    chainDetails.ChainSelector,
 					Client:      sc,
 					DeployerKey: &chainCfg.SolDeployerKey,
-					KeypairPath: solArtifactPath,
+					KeypairPath: fmt.Sprintf("%s/deploy-keypair.json", solArtifactPath),
 					URL:         chainCfg.HTTPRPCs[0].External,
 					WSURL:       chainCfg.WSRPCs[0].External,
 					Confirm: func(instructions []solana.Instruction, opts ...solCommonUtil.TxModifier) error {

--- a/integration-tests/load/ccip/destination_gun.go
+++ b/integration-tests/load/ccip/destination_gun.go
@@ -444,6 +444,7 @@ func (m *DestinationGun) getSolanaMessage(src uint64) (ccip_router.SVM2AnyMessag
 	message := ccip_router.SVM2AnyMessage{
 		Receiver:  common.LeftPadBytes(m.receiver, 32),
 		ExtraArgs: []byte{},
+		FeeToken:  m.state.SolChains[src].LinkToken,
 	}
 
 	switch {


### PR DESCRIPTION
https://github.com/smartcontractkit/crib/pull/613

https://smartcontract-it.atlassian.net/browse/CCIP-5650

Problem:
Remote deployer is unable to deploy ccip on solana. This is because the deployer currently builds all solana contracts in a docker container prior to deployment. Remote deployer would have to run docker-in-docker to accomplish this.

Solution:
Use pre-built artifacts to deploy the Solana contracts. Part of the contract artifact build is generating a keypair that eventually becomes to contracts address. [Sec ticket here](https://smartcontract-it.atlassian.net/servicedesk/customer/portal/4/SECHD-24710?created=true) grants permission to commit this keypair into the repo.