### PR TITLE
[CRE-494] Use EVM service instead of the legacy chain interface in GetEVMEffectiveTransmitterID

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -407,6 +407,7 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 	c := clhttptest.NewTestLocalOnlyHTTPClient()
 
 	var evmFactoryConfigFn func(config *chainlink.EVMFactoryConfig)
+	// TODO BCF-2513 Stop injecting ethClient via override, instead use httptest.
 	if cfg.EVMEnabled() {
 		if ethClient == nil {
 			ethClient = evmclient.NewNullClient(evmtest.MustGetDefaultChainID(t, cfg.EVMConfigs()), lggr)

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -67,6 +67,9 @@ func (r *RelayerFactory) NewEVM(config EVMFactoryConfig) (map[types.RelayID]evmr
 	}
 
 	if cmdName := env.EVMPlugin.Cmd.Get(); cmdName != "" {
+		if config.GenEthClient != nil {
+			return nil, fmt.Errorf("GenEthClient override is not supported in the loopp mode")
+		}
 		for _, chain := range config.ChainConfigs {
 			relayID := types.RelayID{Network: relay.NetworkEVM, ChainID: chain.ChainID.String()}
 			// loopp

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -75,7 +75,7 @@ func (r *RelayerFactory) NewEVM(config EVMFactoryConfig) (map[types.RelayID]evmr
 			config.GenHeadTracker,
 			config.GenTxManager,
 			config.GenGasEstimator) {
-			return nil, fmt.Errorf("Gen* overrides are not available in LOOPP Plugin mode: %w", errors.ErrUnsupported)
+			return nil, fmt.Errorf("overrides Gen* are not available in LOOPP Plugin mode: %w", errors.ErrUnsupported)
 		}
 		for _, chain := range config.ChainConfigs {
 			relayID := types.RelayID{Network: relay.NetworkEVM, ChainID: chain.ChainID.String()}

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -75,7 +75,7 @@ func (r *RelayerFactory) NewEVM(config EVMFactoryConfig) (map[types.RelayID]evmr
 			config.GenHeadTracker,
 			config.GenTxManager,
 			config.GenGasEstimator) {
-			return nil, fmt.Errorf("Gen* overrides are not available in LOOP Plugin mode: %w", errors.ErrUnsupported)
+			return nil, fmt.Errorf("Gen* overrides are not available in LOOPP Plugin mode: %w", errors.ErrUnsupported)
 		}
 		for _, chain := range config.ChainConfigs {
 			relayID := types.RelayID{Network: relay.NetworkEVM, ChainID: chain.ChainID.String()}

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -75,7 +75,7 @@ func (r *RelayerFactory) NewEVM(config EVMFactoryConfig) (map[types.RelayID]evmr
 			config.GenHeadTracker,
 			config.GenTxManager,
 			config.GenGasEstimator) {
-			return nil, errors.New("Gen* overrides are not supported in the loopp mode")
+			return nil, fmt.Errorf("Gen* overrides are not available in LOOP Plugin mode: %w", errors.ErrUnsupported)
 		}
 		for _, chain := range config.ChainConfigs {
 			relayID := types.RelayID{Network: relay.NetworkEVM, ChainID: chain.ChainID.String()}

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -67,8 +68,14 @@ func (r *RelayerFactory) NewEVM(config EVMFactoryConfig) (map[types.RelayID]evmr
 	}
 
 	if cmdName := env.EVMPlugin.Cmd.Get(); cmdName != "" {
-		if config.GenEthClient != nil {
-			return nil, errors.New("GenEthClient override is not supported in the loopp mode")
+		if anyNotNil(config.GenChainStore,
+			config.GenEthClient,
+			config.GenLogBroadcaster,
+			config.GenLogPoller,
+			config.GenHeadTracker,
+			config.GenTxManager,
+			config.GenGasEstimator) {
+			return nil, errors.New("Gen* overrides are not supported in the loopp mode")
 		}
 		for _, chain := range config.ChainConfigs {
 			relayID := types.RelayID{Network: relay.NetworkEVM, ChainID: chain.ChainID.String()}
@@ -282,4 +289,13 @@ func (r *RelayerFactory) NewLOOPRelayer(name string, network string, plugin env.
 
 func (r *RelayerFactory) NewTron(ks, ksCSA coretypes.Keystore, chainCfgs RawConfigs) (map[types.RelayID]loop.Relayer, error) {
 	return r.NewLOOPRelayer("Tron", relay.NetworkTron, env.TronPlugin, ks, ksCSA, chainCfgs)
+}
+
+func anyNotNil(vals ...interface{}) bool {
+	for _, v := range vals {
+		if !reflect.ValueOf(v).IsNil() {
+			return true
+		}
+	}
+	return false
 }

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -68,7 +68,7 @@ func (r *RelayerFactory) NewEVM(config EVMFactoryConfig) (map[types.RelayID]evmr
 
 	if cmdName := env.EVMPlugin.Cmd.Get(); cmdName != "" {
 		if config.GenEthClient != nil {
-			return nil, fmt.Errorf("GenEthClient override is not supported in the loopp mode")
+			return nil, errors.New("GenEthClient override is not supported in the loopp mode")
 		}
 		for _, chain := range config.ChainConfigs {
 			relayID := types.RelayID{Network: relay.NetworkEVM, ChainID: chain.ChainID.String()}

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -458,15 +458,15 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) ([]job.Servi
 	if rid.Network == relay.NetworkEVM {
 		lggr = logger.Sugared(lggr.With("evmChainID", rid.ChainID))
 
-		chainService, err2 := d.legacyChains.Get(rid.ChainID)
+		r, err2 := d.Get(rid)
 		if err2 != nil {
-			return nil, fmt.Errorf("ServicesForSpec: could not get EVM chain %s: %w", rid.ChainID, err2)
+			return nil, fmt.Errorf("could not get EVM Relayer for chain ID %s: %w", rid.ChainID, err2)
 		}
-		chain, ok := chainService.(legacyevm.Chain)
-		if !ok {
-			return nil, fmt.Errorf("effective transmitter ID is not available in LOOP Plugin mode: %w", stderrors.ErrUnsupported)
+		evm, err2 := r.EVM()
+		if err2 != nil {
+			return nil, fmt.Errorf("could not get EVMService for chain %s: %w", rid.ChainID, err2)
 		}
-		effectiveTransmitterID, err2 = GetEVMEffectiveTransmitterID(ctx, &jb, chain, lggr)
+		effectiveTransmitterID, err2 = GetEVMEffectiveTransmitterID(ctx, &jb, evm, lggr)
 		if err2 != nil {
 			return nil, fmt.Errorf("ServicesForSpec failed to get evm transmitterID: %w", err2)
 		}
@@ -558,7 +558,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) ([]job.Servi
 	}
 }
 
-func GetEVMEffectiveTransmitterID(ctx context.Context, jb *job.Job, chain legacyevm.Chain, lggr logger.SugaredLogger) (string, error) {
+func GetEVMEffectiveTransmitterID(ctx context.Context, jb *job.Job, evm types.EVMService, lggr logger.SugaredLogger) (string, error) {
 	spec := jb.OCR2OracleSpec
 	if spec.PluginType == types.Mercury || spec.PluginType == types.LLO {
 		return spec.TransmitterID.String, nil
@@ -581,19 +581,14 @@ func GetEVMEffectiveTransmitterID(ctx context.Context, jb *job.Job, chain legacy
 	// In the case of forwarding, the transmitter address is the forwarder contract deployed onchain between EOA and OCR contract.
 	// ForwardingAllowed cannot be set with Mercury, so this should always be false for mercury jobs
 	if jb.ForwardingAllowed {
-		if chain == nil {
-			return "", errors.New("job forwarding requires non-nil chain")
+		if evm == nil {
+			return "", errors.New("job forwarding requires non-nil evm service")
 		}
 
 		var err error
 		var effectiveTransmitterID common.Address
 		// Median forwarders need special handling because of OCR2Aggregator transmitters whitelist.
-		if spec.PluginType == types.Median {
-			effectiveTransmitterID, err = chain.TxManager().GetForwarderForEOAOCR2Feeds(ctx, common.HexToAddress(spec.TransmitterID.String), common.HexToAddress(spec.ContractID))
-		} else {
-			effectiveTransmitterID, err = chain.TxManager().GetForwarderForEOA(ctx, common.HexToAddress(spec.TransmitterID.String))
-		}
-
+		effectiveTransmitterID, err = evm.GetForwarderForEOA(ctx, common.HexToAddress(spec.TransmitterID.String), common.HexToAddress(spec.ContractID), string(spec.PluginType))
 		if err == nil {
 			return effectiveTransmitterID.String(), nil
 		} else if !spec.TransmitterID.Valid {

--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
@@ -451,6 +451,7 @@ func setupNodeCCIP(
 		Config:   config,
 		DS:       db,
 		KeyStore: keyStore,
+		// TODO BCF-2513 Stop injecting ethClient via override, instead use httptest.
 		EVMFactoryConfigFn: func(fc *chainlink.EVMFactoryConfig) {
 			fc.GenEthClient = func(chainID *big.Int) client.Client {
 				if chainID.String() == sourceChainID.String() {

--- a/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/chainlink.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/chainlink.go
@@ -454,6 +454,7 @@ func setupNodeCCIP(
 		Config:   config,
 		DS:       db,
 		KeyStore: keyStore,
+		// TODO BCF-2513 Stop injecting ethClient via override, instead use httptest.
 		EVMFactoryConfigFn: func(fc *chainlink.EVMFactoryConfig) {
 			fc.GenEthClient = func(chainID *big.Int) client.Client {
 				if chainID.String() == sourceChainID.String() {

--- a/deployment/environment/memory/node.go
+++ b/deployment/environment/memory/node.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"context"
-
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -412,6 +411,7 @@ func NewNode(
 		Config:   cfg,
 		DS:       db,
 		KeyStore: master,
+		// TODO BCF-2513 Stop injecting ethClient via override, instead use httptest.
 		EVMFactoryConfigFn: func(fc *chainlink.EVMFactoryConfig) {
 			// Create ChainStores that always sign with 1337
 			fc.GenChainStore = func(ks core.Keystore, i *big.Int) keys.ChainStore {


### PR DESCRIPTION
Also err if the Gen* test injection overrides are used in the loopp mode, since they won't work.