### PR TITLE
integration-tests/load: linter cleanup

### DIFF
--- a/integration-tests/load/ccip/destination_gun.go
+++ b/integration-tests/load/ccip/destination_gun.go
@@ -5,34 +5,31 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/smartcontractkit/chainlink/deployment/environment/crib"
 	"math/big"
 	mathrand "math/rand"
 	"time"
-
-	selectors "github.com/smartcontractkit/chain-selectors"
-	"go.uber.org/atomic"
-
-	solccip "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/ccip"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
-
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/message_hasher"
-	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
-	soltokens "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gagliardetto/solana-go"
+	"go.uber.org/atomic"
 
+	selectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/message_hasher"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
+	solccip "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/ccip"
+	soltokens "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink-testing-framework/wasp"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	"github.com/smartcontractkit/chainlink/integration-tests/testconfig/ccip"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
 )
 
 type SeqNumRange struct {
@@ -51,8 +48,7 @@ type DestinationGun struct {
 	evmSourceKeys    map[uint64]*bind.TransactOpts
 	solanaSourceKeys map[uint64]*solana.PrivateKey
 	metricPipe       chan messageData
-	laneConfig       *crib.LaneConfiguration // Lane configuration with discovered lanes
-	availableSources []uint64                // Cache of available source chains for this destination
+	availableSources []uint64 // Cache of available source chains for this destination
 }
 
 func NewDestinationGun(

--- a/integration-tests/load/ccip/lane_config_discovery_test.go
+++ b/integration-tests/load/ccip/lane_config_discovery_test.go
@@ -3,16 +3,14 @@ package ccip
 import (
 	"testing"
 
-	"github.com/smartcontractkit/chainlink/deployment/environment/crib"
-
 	"github.com/stretchr/testify/require"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	"github.com/smartcontractkit/chainlink/deployment/environment/crib"
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
 )
 
@@ -45,22 +43,22 @@ func TestLaneDiscovery_AnyToAny(t *testing.T) {
 
 	// Should have n*(n-1) lanes for n chains (any-to-any)
 	expectedLaneCount := len(chains) * (len(chains) - 1)
-	require.Equal(t, expectedLaneCount, len(discoveredLanes),
+	require.Len(t, discoveredLanes, expectedLaneCount,
 		"Should discover %d lanes for %d chains in any-to-any setup", expectedLaneCount, len(chains))
 
 	// Verify all chains are connected
 	connectedChains := laneConfig.GetConnectedChains()
-	require.Equal(t, len(chains), len(connectedChains),
+	require.Len(t, connectedChains, len(chains),
 		"All chains should be connected")
 
 	// Verify each chain can reach every other chain
 	for _, src := range chains {
 		destinations := laneConfig.GetDestinationChainsForSource(src)
-		require.Equal(t, len(chains)-1, len(destinations),
+		require.Len(t, destinations, len(chains)-1,
 			"Each chain should have %d destinations", len(chains)-1)
 
 		sources := laneConfig.GetSourceChainsForDestination(src)
-		require.Equal(t, len(chains)-1, len(sources),
+		require.Len(t, sources, len(chains)-1,
 			"Each chain should have %d sources", len(chains)-1)
 	}
 
@@ -89,12 +87,11 @@ func TestLaneDiscovery_PartialConnectivity(t *testing.T) {
 	chainA, chainB, chainC, chainD := chains[0], chains[1], chains[2], chains[3]
 
 	// Setup partial connectivity: A->B, A->C,  B->C, C->D, D->A (cycle)
-	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &tenv, state, chainA, chainB, false)
-	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &tenv, state, chainA, chainC, false)
-
-	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &tenv, state, chainB, chainC, false)
-	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &tenv, state, chainC, chainD, false)
-	testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &tenv, state, chainD, chainA, false)
+	require.NoError(t, testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &tenv, state, chainA, chainB, false))
+	require.NoError(t, testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &tenv, state, chainA, chainC, false))
+	require.NoError(t, testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &tenv, state, chainB, chainC, false))
+	require.NoError(t, testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &tenv, state, chainC, chainD, false))
+	require.NoError(t, testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig(t, &tenv, state, chainD, chainA, false))
 
 	// Reload state after adding lanes
 	state, err = stateview.LoadOnchainState(e)
@@ -181,7 +178,7 @@ func TestLaneDiscovery_EmptyState(t *testing.T) {
 
 // TestLaneDiscovery_NilConfiguration tests behavior with nil configuration
 func TestLaneDiscovery_NilConfiguration(t *testing.T) {
-	var laneConfig *crib.LaneConfiguration = nil
+	var laneConfig *crib.LaneConfiguration
 
 	// Test GetLanes with nil config
 	lanes, err := laneConfig.GetLanes()

--- a/integration-tests/load/ccip/sol_helpers.go
+++ b/integration-tests/load/ccip/sol_helpers.go
@@ -3,8 +3,6 @@ package ccip
 import (
 	"context"
 	"fmt"
-	solconfig "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
-	soltestutils "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/testutils"
 	"math"
 	"slices"
 	"sync"
@@ -15,18 +13,17 @@ import (
 	solrpc "github.com/gagliardetto/solana-go/rpc"
 	"go.uber.org/atomic"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
+	solconfig "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
+	soltestutils "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/testutils"
 	solccip "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/ccip"
 	solcommon "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	soltokens "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 	ccipconsts "github.com/smartcontractkit/chainlink-ccip/pkg/consts"
-
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
 
 func subscribeSolTransmitEvents(


### PR DESCRIPTION
```xml
<checkstyle version="5.0">
  <file name="/home/runner/_work/chainlink/chainlink/integration-tests/load/ccip/destination_gun.go">
    <error column="1" line="8" message="File is not properly formatted" severity="error" source="goimports"></error>
    <error column="2" line="54" message="field laneConfig is unused" severity="error" source="unused"></error>
  </file>
  <file name="/home/runner/_work/chainlink/chainlink/integration-tests/load/ccip/lane_config_discovery_test.go">
    <error column="56" line="92" message="Error return value of `testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig` is not checked" severity="error" source="errcheck"></error>
    <error column="56" line="93" message="Error return value of `testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig` is not checked" severity="error" source="errcheck"></error>
    <error column="56" line="95" message="Error return value of `testhelpers.AddLaneWithDefaultPricesAndFeeQuoterConfig` is not checked" severity="error" source="errcheck"></error>
    <error column="43" line="184" message="var-declaration: should drop = nil from declaration of var laneConfig; it is the zero value" severity="warning" source="revive"></error>
    <error column="2" line="48" message="len: use require.Len" severity="error" source="testifylint"></error>
    <error column="2" line="53" message="len: use require.Len" severity="error" source="testifylint"></error>
    <error column="3" line="59" message="len: use require.Len" severity="error" source="testifylint"></error>
  </file>
  <file name="/home/runner/_work/chainlink/chainlink/integration-tests/load/ccip/sol_helpers.go">
    <error column="1" line="6" message="File is not properly formatted" severity="error" source="goimports"></error>
  </file>
</checkstyle>
```