### PR TITLE
[CLD-432]: refactor: update devenv.NewChains to use cldf.blockchains

### DIFF
--- a/deployment/environment/crib/types.go
+++ b/deployment/environment/crib/types.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -28,17 +26,9 @@ type DeployCCIPOutput struct {
 }
 
 func NewDeployEnvironmentFromCribOutput(lggr logger.Logger, output DeployOutput) (*cldf.Environment, error) {
-	chains, solChains, err := devenv.NewChains(lggr, output.Chains)
+	blockChains, err := devenv.NewChains(lggr, output.Chains)
 	if err != nil {
 		return nil, err
-	}
-
-	blockChains := map[uint64]chain.BlockChain{}
-	for _, c := range chains {
-		blockChains[c.Selector] = c
-	}
-	for _, c := range solChains {
-		blockChains[c.Selector] = c
 	}
 
 	return cldf.NewEnvironment(
@@ -51,6 +41,6 @@ func NewDeployEnvironmentFromCribOutput(lggr logger.Logger, output DeployOutput)
 		//nolint:gocritic // intentionally use a lambda to allow dynamic context replacement in Environment Commit 90ee880
 		func() context.Context { return context.Background() },
 		cldf.XXXGenerateTestOCRSecrets(),
-		chain.NewBlockChains(blockChains),
+		blockChains,
 	), nil
 }

--- a/deployment/environment/devenv/chain.go
+++ b/deployment/environment/devenv/chain.go
@@ -21,6 +21,7 @@ import (
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_chain_utils "github.com/smartcontractkit/chainlink-deployments-framework/chain/utils"
 
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
@@ -144,9 +145,7 @@ func (c *ChainConfig) ToRPCs() []cldf.RPC {
 	return rpcs
 }
 
-func NewChains(logger logger.Logger, configs []ChainConfig) (map[uint64]cldf_evm.Chain, map[uint64]cldf_solana.Chain, error) {
-	evmChains := make(map[uint64]cldf_evm.Chain)
-	solChains := make(map[uint64]cldf_solana.Chain)
+func NewChains(logger logger.Logger, configs []ChainConfig) (cldf_chain.BlockChains, error) {
 	var evmSyncMap sync.Map
 	var solSyncMap sync.Map
 
@@ -253,20 +252,22 @@ func NewChains(logger logger.Logger, configs []ChainConfig) (map[uint64]cldf_evm
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, nil, err
+		return cldf_chain.BlockChains{}, err
 	}
 
+	var blockChains []cldf_chain.BlockChain
+
 	evmSyncMap.Range(func(sel, value interface{}) bool {
-		evmChains[sel.(uint64)] = value.(cldf_evm.Chain)
+		blockChains = append(blockChains, value.(cldf_evm.Chain))
 		return true
 	})
 
 	solSyncMap.Range(func(sel, value interface{}) bool {
-		solChains[sel.(uint64)] = value.(cldf_solana.Chain)
+		blockChains = append(blockChains, value.(cldf_solana.Chain))
 		return true
 	})
 
-	return evmChains, solChains, nil
+	return cldf_chain.NewBlockChainsFromSlice(blockChains), nil
 }
 
 func (c *ChainConfig) SetSolDeployerKey(keyString *string) error {

--- a/deployment/environment/devenv/environment.go
+++ b/deployment/environment/devenv/environment.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
-
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
@@ -22,7 +20,7 @@ type EnvironmentConfig struct {
 }
 
 func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config EnvironmentConfig) (*cldf.Environment, *DON, error) {
-	chains, solChains, err := NewChains(lggr, config.Chains)
+	blockChains, err := NewChains(lggr, config.Chains)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create chains: %w", err)
 	}
@@ -52,14 +50,6 @@ func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config Envir
 		nodeIDs = jd.don.NodeIds()
 	}
 
-	blockChains := map[uint64]chain.BlockChain{}
-	for _, c := range chains {
-		blockChains[c.Selector] = c
-	}
-	for _, c := range solChains {
-		blockChains[c.Selector] = c
-	}
-
 	return cldf.NewEnvironment(
 		DevEnv,
 		lggr,
@@ -69,6 +59,6 @@ func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config Envir
 		offChain,
 		ctx,
 		cldf.XXXGenerateTestOCRSecrets(),
-		chain.NewBlockChains(blockChains),
+		blockChains,
 	), jd.don, nil
 }

--- a/integration-tests/testsetups/ccip/test_helpers.go
+++ b/integration-tests/testsetups/ccip/test_helpers.go
@@ -21,7 +21,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/blockchain"
 	ctfconfig "github.com/smartcontractkit/chainlink-testing-framework/lib/config"
 	ctftestenv "github.com/smartcontractkit/chainlink-testing-framework/lib/docker/test_env"
@@ -100,21 +99,16 @@ func (l *DeployedLocalDevEnvironment) StartChains(t *testing.T) {
 	require.NotEmpty(t, homeChainSel, "homeChainSel should not be empty")
 	feedSel := l.devEnvTestCfg.CCIP.GetFeedChainSelector()
 	require.NotEmpty(t, feedSel, "feedSel should not be empty")
-	chains, _, err := devenv.NewChains(lggr, envConfig.Chains)
+	blockChains, err := devenv.NewChains(lggr, envConfig.Chains)
 	require.NoError(t, err)
 	replayBlocks, err := testhelpers.LatestBlocksByChain(ctx, l.DeployedEnv.Env)
 	require.NoError(t, err)
 
-	blockChains := make(map[uint64]chain.BlockChain)
-	for sel, c := range chains {
-		blockChains[sel] = c
-	}
-
-	l.DeployedEnv.Users = users
-	l.DeployedEnv.Env.BlockChains = chain.NewBlockChains(blockChains)
-	l.DeployedEnv.FeedChainSel = feedSel
-	l.DeployedEnv.HomeChainSel = homeChainSel
-	l.DeployedEnv.ReplayBlocks = replayBlocks
+	l.Users = users
+	l.Env.BlockChains = blockChains
+	l.FeedChainSel = feedSel
+	l.HomeChainSel = homeChainSel
+	l.ReplayBlocks = replayBlocks
 }
 
 func (l *DeployedLocalDevEnvironment) StartNodes(t *testing.T, crConfig deployment.CapabilityRegistryConfig) {

--- a/system-tests/lib/cre/devenv/devenv.go
+++ b/system-tests/lib/cre/devenv/devenv.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
 
-	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/seth"
@@ -189,14 +188,9 @@ func BuildFullCLDEnvironment(ctx context.Context, lgr logger.Logger, input *type
 		})
 	}
 
-	allChains, _, allChainsErr := devenv.NewChains(lgr, allChainsConfigs)
+	blockChains, allChainsErr := devenv.NewChains(lgr, allChainsConfigs)
 	if allChainsErr != nil {
 		return nil, errors.Wrap(allChainsErr, "failed to create chains")
-	}
-
-	cldfChains := make([]cldf_chain.BlockChain, 0)
-	for _, c := range allChains {
-		cldfChains = append(cldfChains, c)
 	}
 
 	// we take stateless fields from the first environment, because they are not environment specific
@@ -210,7 +204,7 @@ func BuildFullCLDEnvironment(ctx context.Context, lgr logger.Logger, input *type
 			OCRSecrets:        envs[0].OCRSecrets,
 			GetContext:        envs[0].GetContext,
 			NodeIDs:           nodeIDs,
-			BlockChains:       cldf_chain.NewBlockChainsFromSlice(cldfChains),
+			BlockChains:       blockChains,
 			OperationsBundle:  input.OperationsBundle,
 		},
 	}

--- a/system-tests/lib/cre/environment/blockchains.go
+++ b/system-tests/lib/cre/environment/blockchains.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"maps"
 	"os"
 	"strconv"
 	"strings"
@@ -148,18 +149,13 @@ func StartBlockchains(loggers BlockchainLoggers, input BlockchainsInput) (StartB
 		})
 	}
 
-	allChains, _, err := devenv.NewChains(loggers.singleFile, chainsConfigs)
+	blockChains, err := devenv.NewChains(loggers.singleFile, chainsConfigs)
 	if err != nil {
 		return StartBlockchainsOutput{}, pkgerrors.Wrap(err, "failed to create chains")
 	}
 
-	blockChains := make(map[uint64]chain.BlockChain, len(allChains))
-	for selector, ch := range allChains {
-		blockChains[selector] = ch
-	}
-
 	return StartBlockchainsOutput{
 		BlockChainOutputs: blockchainsOutput,
-		BlockChains:       blockChains,
+		BlockChains:       maps.Collect(blockChains.All()),
 	}, nil
 }


### PR DESCRIPTION
In the `devenv.NewChains` function, it is returning a separate parameter for each chain type, this is not scalable as we add more chains, each new addition will be an api breaking change. We should update this to use the newer blockchains type in CLDF.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-432
