### PR TITLE
Make Validation Errors Descriptive for UpdateChainConfig

### DIFF
--- a/deployment/ccip/changeset/v1_6/cs_ccip_home.go
+++ b/deployment/ccip/changeset/v1_6/cs_ccip_home.go
@@ -1044,10 +1044,10 @@ func (c UpdateChainConfigConfig) Validate(e cldf.Environment) error {
 			return fmt.Errorf("chain to add %d is not supported", add)
 		}
 		if ccfg.FChain == 0 {
-			return errors.New("FChain must be set")
+			return fmt.Errorf("fChain must be set for selector %d", add)
 		}
 		if len(ccfg.Readers) == 0 {
-			return errors.New("Readers must be set")
+			return fmt.Errorf("readers must be set for selector %d", add)
 		}
 		if err := ccfg.EncodableChainConfig.Validate(); err != nil {
 			return fmt.Errorf("invalid chain config for selector %d: %w", add, err)


### PR DESCRIPTION
### What
- Adds chain selector to input validation errors for UpdateChainConfigChangeset

### Why
- This would allow us to know which chain is missing a particular value in the changeset input