### PR TITLE
feat(ci): cache cre e2e test deps

### DIFF
--- a/.github/actions/setup-cre-e2e-test-dependencies/action.yml
+++ b/.github/actions/setup-cre-e2e-test-dependencies/action.yml
@@ -1,0 +1,103 @@
+name: Setup CRE E2E Test Dependencies
+description: Setup dependencies for CRE E2E tests with efficient caching
+
+inputs:
+
+  cre-cli-version:
+    description: Version of the CRE CLI to use
+    default: "v0.2.0"
+  capability-version:
+    description: Version of the capability to use
+    default: "v1.0.2-alpha"
+  capability-names:
+    description: Comma-separated list of capability names to use
+    default: "cron"
+
+  # GATI Inputs
+  gati-role-arn:
+    description: ARN of the GATI role to assume for GitHub token
+    required: true
+  gati-lambda-url:
+    description: URL of the GATI Lambda function to get the GitHub token
+    required: true
+  gati-region:
+    description: AWS region for the GATI Lambda function
+    default: "us-west-2"
+
+env:
+  DOWNLOAD_PATH: ${{ github.workspace }}/system-tests/binaries-deps
+  EXPECTED_PATH: ${{ github.workspace }}system-tests/tests/smoke/cre
+
+runs:
+  using: composite
+  steps:
+
+    - name: Setup cache directory and key
+      id: setup-cache-dir-key
+      shell: bash
+      env:
+        CRE_CLI_VERSION: ${{ inputs.cre-cli-version }}
+        CAPABILITY_NAMES: ${{ inputs.capability-names }}
+        CAPABILITY_VERSION: ${{ inputs.capability-version }}
+      run: |
+        mkdir -p ${{ env.DOWNLOAD_PATH }}
+
+        capability_hash=$(echo "${CAPABILITY_NAMES}" | tr ',' '\n' | sort | sha256sum | cut -d ' ' -f 1)
+        cache_key="${CRE_CLI_VERSION}-${CAPABILITY_VERSION}-${capability_hash}"
+        echo "cache-key=${cache_key}" | tee -a "${GITHUB_OUTPUT}"
+
+    - name: Restore Cache CRE CLI
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ steps.setup-cache-dir-key.outputs.cache_key }}
+        path: ${{ env.DOWNLOAD_PATH }}
+
+    - name: Setup GitHub token using GATI
+      if: ${{ cache-restore.outputs.cache-hit != 'true' }}
+      id: setup-gati-token
+      uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
+      with:
+        aws-role-arn: ${{ inputs.gati-role-arn }}
+        aws-lambda-url: ${{ inputs.gati-lambda-url }}
+        aws-region: ${{ inputs.gati-region }}
+        aws-role-duration-seconds: "1800"
+
+    - name: Download test dependencies
+      if: ${{ cache-restore.outputs.cache-hit != 'true' }}
+      shell: bash
+      working-directory: system-tests/tests/smoke/cre/cmd
+      env:
+        GITHUB_API_TOKEN: ${{ steps.setup-gati-token.outputs.access-token }}
+        MAX_RETRIES: 3
+        CRE_CLI_VERSION: ${{ inputs.cre-cli-version }}
+        CAPABILITY_NAMES: ${{ inputs.capability-names }}
+        CAPABILITY_VERSION: ${{ inputs.capability-version }}
+        DOWNLOAD_PATH: ${{ env.DOWNLOAD_PATH }}
+      run: |
+        ./download_cre_ci_deps.sh \
+          ${MAX_RETRIES} \
+          ${CRE_CLI_VERSION} \
+          ${CAPABILITY_NAMES} \
+          ${CAPABILITY_VERSION} \
+          ${DOWNLOAD_PATH}
+
+    - name: Save cache
+      if: ${{ cache-restore.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.setup-cache-dir-key.outputs.cache_key }}
+        path: ${{ env.DOWNLOAD_PATH }}
+
+    - name: Move binaries to expected location
+      shell: bash
+      run: |
+        echo "Moving binaries from ${{ env.DOWNLOAD_PATH }}/ to ${{ env.EXPECTED_PATH }}/"
+
+        echo "Contents of ${{ env.DOWNLOAD_PATH }}/ before moving:"
+        ls -la ${{ env.DOWNLOAD_PATH }}/
+
+        mv ${{ env.DOWNLOAD_PATH }}/* ${{ env.EXPECTED_PATH }}/
+
+        echo "Contents of ${{ env.EXPECTED_PATH }}/ after moving:"
+        ls -la ${{ env.EXPECTED_PATH }}/

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -118,15 +118,6 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
 
-      - name: Setup GitHub token using GATI
-        id: setup-gati-token
-        uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
-        with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
-          aws-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          aws-role-duration-seconds: "1800"
-
       # gotestloghelper gives us pretty test output
       - name: Set Up gotestloghelper
         shell: bash
@@ -135,11 +126,14 @@ jobs:
           github.com/smartcontractkit/chainlink-testing-framework/tools/gotestloghelper@v1.1.1
 
       - name: Download test dependencies
-        shell: bash
-        working-directory: system-tests/tests/smoke/cre/cmd
-        env:
-          GITHUB_API_TOKEN: ${{ steps.setup-gati-token.outputs.access-token }}
-        run: ./download_cre_ci_deps.sh 3
+        uses: smartcontractkit/chainlink/.github/actions/setup-cre-e2e-test-dependencies@feat/cache-cre-e2e-deps # TODO
+        with:
+          cre-cli-version: "v0.2.0"
+          capability-version: "v1.0.2-alpha"
+          capability-names: "cron"
+          gati-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          gati-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+          gati-region: ${{ secrets.AWS_REGION }}
 
       # TODO
       # Add Flakeguard support

--- a/system-tests/tests/smoke/cre/cmd/download_cre_ci_deps.sh
+++ b/system-tests/tests/smoke/cre/cmd/download_cre_ci_deps.sh
@@ -1,14 +1,55 @@
 #!/usr/bin/env bash
 
+# Parse command line arguments
 max_retries=${1:-5} # Default to 5 if not provided
+cre_cli_version=${2:-v0.2.0} # Default to v0.2.0 if not provided
+capability_names=${3:-cron} # Default to cron if not provided
+capability_version=${4:-v1.0.2-alpha} # Default to v1.0.2-alpha if not provided
+output_dir=${5:-../} # Default to ../ if not provided
+
+# Display usage if help is requested
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  echo "Usage: $0 [max_retries] [cre_cli_version] [capability_names] [capability_version] [output_dir]"
+  echo "  max_retries: Maximum number of retry attempts (default: 5)"
+  echo "  cre_cli_version: CRE CLI version to download (default: v0.2.0)"
+  echo "  capability_names: Capability names to download (default: cron)"
+  echo "  capability_version: Capability version to download (default: v1.0.2-alpha)"
+  echo "  output_dir: Directory to save the binaries (default: ../)"
+  echo ""
+  echo "Example: $0 5 v0.2.1 \"cron,automation\" v1.0.3-alpha ./binaries"
+  exit 0
+fi
+
+echo "🔧 Using configuration:"
+echo "  Max retries: $max_retries"
+echo "  CRE CLI version: $cre_cli_version"
+echo "  Capability names: $capability_names"
+echo "  Capability version: $capability_version"
+echo "  Output directory: $output_dir"
+echo ""
+
 count=0
 
+# Build capability-names flags array
+capability_flags=()
+IFS=',' read -ra CAPABILITY_ARRAY <<< "$capability_names"
+for capability in "${CAPABILITY_ARRAY[@]}"; do
+  # Trim whitespace and remove quotes
+  capability="${capability#"${capability%%[![:space:]]*}"}"  # Remove leading whitespace
+  capability="${capability%"${capability##*[![:space:]]}"}"  # Remove trailing whitespace
+  capability="${capability#\"}"  # Remove leading quote
+  capability="${capability%\"}"  # Remove trailing quote
+  if [[ -n "$capability" ]]; then
+    capability_flags+=(--capability-names "$capability")
+  fi
+done
+
 until go run main.go download all \
-  --output-dir ../ \
+  --output-dir "$output_dir" \
   --gh-token-env-var-name GITHUB_API_TOKEN \
-  --cre-cli-version v0.2.0 \
-  --capability-names cron \
-  --capability-version v1.0.2-alpha
+  --cre-cli-version "$cre_cli_version" \
+  "${capability_flags[@]}" \
+  --capability-version "$capability_version"
 do
   ((count++))
   if (( count >= max_retries )); then
@@ -16,7 +57,7 @@ do
     exit 1
   fi
   echo "🔁 Retrying ($count/$max_retries)..." >&2
-  sleep 1
+  sleep 30 # Wait before retrying due to rate limit issues
 done
 
 echo "✅ Download succeeded." >&2


### PR DESCRIPTION
Add support for system tests CRE dependencies caching to reduce interruptions/failures from Github rate-limiting.

### Changes

- Add reusable `setup-cre-e2e-test-dependencies` action to handle downloading and caching of the dependencies
- Modify existing `download_cre_ci_deps.sh` to:
   -  Configurable inputs
   - Increase sleep to 30 seconds between tries

### Testing

TODO

---

DX-1057

