### PR TITLE
Fix CRE workflow benchmark image 

### DIFF
--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -77,6 +77,9 @@ jobs:
           dockerfile: core/chainlink.Dockerfile
           docker-registry-url: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
           docker-repository-name: 'chainlink'
+          docker-additional-build-args: |
+            CL_INSTALL_PRIVATE_PLUGINS=true
+            CL_INSTALL_TESTING_PLUGINS=true
           aws-account-number: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
           aws-role-arn: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -193,7 +196,7 @@ jobs:
         id: create-regression-payload
         run: |
           cd system-tests/tests/load/cre
-          
+
           # Read regression details
           REGRESSION_DETAILS=$(cat logs/regression_details.txt)
           

--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -30,7 +30,7 @@ jobs:
   workflow-don-benchmark:
     runs-on: ubuntu-latest
     environment: "integration"
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -140,19 +140,41 @@ jobs:
           PROMETHEUS_URL: "http://localhost:9090"
         run: |
           cd system-tests/tests/load/cre
-          go test -run TestLoad_Workflow_Streams_MockCapabilities -timeout 15m
+          go test -run TestLoad_Workflow_Streams_MockCapabilities -timeout 20m 2>&1 | tee test_output.log
 
+
+      - name: Parse logs for performance regressions
+        if: always()
+        id: parse-regressions
+        run: |
+          cd system-tests/tests/load/cre
+          # Count the number of regressions - handle exit code properly
+          if grep -c "PERFORMANCE REGRESSION:" test_output.log > /tmp/count.txt; then
+            regression_count=$(cat /tmp/count.txt)
+          else
+            regression_count=0
+          fi
+          echo "regression_count=${regression_count}" >> $GITHUB_OUTPUT
+          if [ $regression_count -gt 0 ]; then
+            echo "::warning::$regression_count performance regressions detected"
+            echo "See the regression_reports artifact for details"
+            # Extract detailed PERFORMANCE REGRESSION lines
+            grep -o "PERFORMANCE REGRESSION.*)" test_output.log | awk '{printf "%s\  ", $0}' > logs/regression_details.txt
+          else
+            echo "No performance regressions detected"
+            mkdir -p logs
+            touch logs/regression_details.txt
+          fi
 
       - name: Upload node logs
-        if: always()
         uses: actions/upload-artifact@v4
         timeout-minutes: 2
         continue-on-error: true
-        with:
-          name: node logs
-          path: |
-            system-tests/tests/load/cre/logs
-          retention-days: 5
+      with:
+        name: node logs
+        path: |
+          system-tests/tests/load/cre/logs
+        retention-days: 5
 
       - name: Upload performance reports
         uses: actions/upload-artifact@v4
@@ -162,9 +184,83 @@ jobs:
           name: performance reports
           path: |
             system-tests/tests/load/cre/performance_reports
-          retention-days: 30
+            retention-days: 30
 
+      - name: Create regression slack payload
+        if: success() && steps.parse-regressions.outputs.regression_count > 0
+        id: create-regression-payload
+        run: |
+          cd system-tests/tests/load/cre
+          
+          # Read regression details
+          REGRESSION_DETAILS=$(cat logs/regression_details.txt)
+          # Create JSON payload with properly escaped details
+          cat > $GITHUB_WORKSPACE/slack_payload.json << EOF
+          {
+            "channel": "C094W1V9A5N",
+            "text": "Performance Regressions Detected",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*:rotating_light: ${{steps.parse-regressions.outputs.regression_count}} Performance Regressions Detected :rotating_light:*"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Performance regression for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>."
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Regression Details:*\\n $REGRESSION_DETAILS"
+                }
+              }
+            ]
+          }
+          EOF
+      - name: Send regression slack notification
+        if: success() && steps.parse-regressions.outputs.regression_count > 0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          errors: "true"
+          method: chat.postMessage
+          token: ${{ secrets.QA_SLACK_API_KEY }}
+          payload-file-path: ${{ github.workspace }}/slack_payload.json
+
+      - name: Send failure slack notification
+        if: failure()
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          errors: "true"
+          method: chat.postMessage
+          token: ${{ secrets.QA_SLACK_API_KEY }}
+          payload: |
+            {
+              "channel": "C094W1V9A5N",
+              "text": "Test failure",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*:rotating_light: Test failure :rotating_light:*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Test failure for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>. ${{ github.event_name != 'pull_request' && 'This commit was already merged to develop.' || 'This is from a pull request.' }}"
+                  }
+                }
+              ]
+            }
       - name: Teardown
         if: always()
         run: |
-          docker rm -f cadvisor prometheus

--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -147,13 +147,16 @@ jobs:
         id: parse-regressions
         run: |
           cd system-tests/tests/load/cre
+          
           # Count the number of regressions - handle exit code properly
           if grep -c "PERFORMANCE REGRESSION:" test_output.log > /tmp/count.txt; then
             regression_count=$(cat /tmp/count.txt)
           else
             regression_count=0
           fi
+          
           echo "regression_count=${regression_count}" >> $GITHUB_OUTPUT
+          
           if [ $regression_count -gt 0 ]; then
             echo "::warning::$regression_count performance regressions detected"
             echo "See the regression_reports artifact for details"
@@ -193,6 +196,7 @@ jobs:
           
           # Read regression details
           REGRESSION_DETAILS=$(cat logs/regression_details.txt)
+          
           # Create JSON payload with properly escaped details
           cat > $GITHUB_WORKSPACE/slack_payload.json << EOF
           {
@@ -223,6 +227,7 @@ jobs:
             ]
           }
           EOF
+
       - name: Send regression slack notification
         if: success() && steps.parse-regressions.outputs.regression_count > 0
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -105,7 +105,7 @@ jobs:
           cat > prometheus.yml<<EOF
           global:
             scrape_interval: 5s
-          
+
           scrape_configs:
             - job_name: 'cadvisor'
               static_configs:
@@ -141,7 +141,6 @@ jobs:
         run: |
           cd system-tests/tests/load/cre
           go test -run TestLoad_Workflow_Streams_MockCapabilities -timeout 20m 2>&1 | tee test_output.log
-
 
       - name: Parse logs for performance regressions
         if: always()

--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -30,7 +30,7 @@ jobs:
   workflow-don-benchmark:
     runs-on: ubuntu-latest
     environment: "integration"
-    timeout-minutes: 25
+    timeout-minutes: 20
     permissions:
       contents: read
       id-token: write
@@ -68,6 +68,21 @@ jobs:
         if:  ${{ github.event_name == 'pull_request' }}
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
+      - name: Build Image
+        if: github.event_name == 'pull_request'
+        id: build-chainlink-image
+        uses: smartcontractkit/.github/actions/ctf-build-image@ctf-build-image/v1
+        with:
+          image-tag: ${{ format('PR-{0}-{1}',github.event.pull_request.number, github.sha ) }}
+          dockerfile: core/chainlink.Dockerfile
+          docker-registry-url: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
+          docker-repository-name: 'chainlink'
+          aws-account-number: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+          aws-role-arn: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          gati-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          gati-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
+
       - name: Set up cAdvisor
         shell: bash
         run: |
@@ -90,7 +105,7 @@ jobs:
           cat > prometheus.yml<<EOF
           global:
             scrape_interval: 5s
-
+          
           scrape_configs:
             - job_name: 'cadvisor'
               static_configs:
@@ -114,7 +129,7 @@ jobs:
           E2E_JD_IMAGE: "${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/job-distributor"
           E2E_JD_VERSION: "0.9.0"
           E2E_TEST_CHAINLINK_IMAGE: "${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink"
-          E2E_TEST_CHAINLINK_VERSION: ${{ github.event_name == 'pull_request' && format('nightly-{0}-plugins-testing', steps.set-date.outputs.date) || inputs.chainlink_image_tag }}
+          E2E_TEST_CHAINLINK_VERSION: ${{ github.event_name == 'pull_request' && format('PR-{0}-{1}',github.event.pull_request.number, github.sha ) || inputs.chainlink_image_tag }}
           # Anvil developer key, not a secret
           PRIVATE_KEY: "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
           CTF_CONFIGS: "workflow-don-benchmark-ci.toml"
@@ -125,35 +140,11 @@ jobs:
           PROMETHEUS_URL: "http://localhost:9090"
         run: |
           cd system-tests/tests/load/cre
-          go test -run TestLoad_Workflow_Streams_MockCapabilities -timeout 20m 2>&1 | tee test_output.log
+          go test -run TestLoad_Workflow_Streams_MockCapabilities -timeout 15m
 
-      - name: Parse logs for performance regressions
-        if: always()
-        id: parse-regressions
-        run: |
-          cd system-tests/tests/load/cre
-
-          # Count the number of regressions - handle exit code properly
-          if grep -c "PERFORMANCE REGRESSION:" test_output.log > /tmp/count.txt; then
-            regression_count=$(cat /tmp/count.txt)
-          else
-            regression_count=0
-          fi
-
-          echo "regression_count=${regression_count}" >> $GITHUB_OUTPUT
-
-          if [ $regression_count -gt 0 ]; then
-            echo "::warning::$regression_count performance regressions detected"
-            echo "See the regression_reports artifact for details"
-            # Extract detailed PERFORMANCE REGRESSION lines
-            grep -o "PERFORMANCE REGRESSION.*)" test_output.log | awk '{printf "%s\  ", $0}' > logs/regression_details.txt
-          else
-            echo "No performance regressions detected"
-            mkdir -p logs
-            touch logs/regression_details.txt
-          fi
 
       - name: Upload node logs
+        if: always()
         uses: actions/upload-artifact@v4
         timeout-minutes: 2
         continue-on-error: true
@@ -172,85 +163,6 @@ jobs:
           path: |
             system-tests/tests/load/cre/performance_reports
           retention-days: 30
-
-
-      - name: Create regression slack payload
-        if: success() && steps.parse-regressions.outputs.regression_count > 0
-        id: create-regression-payload
-        run: |
-          cd system-tests/tests/load/cre
-          
-          # Read regression details
-          REGRESSION_DETAILS=$(cat logs/regression_details.txt)
-
-          # Create JSON payload with properly escaped details
-          cat > $GITHUB_WORKSPACE/slack_payload.json << EOF
-          {
-            "channel": "C094W1V9A5N",
-            "text": "Performance Regressions Detected",
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*:rotating_light: ${{steps.parse-regressions.outputs.regression_count}} Performance Regressions Detected :rotating_light:*"
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Performance regression for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>."
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*Regression Details:*\\n $REGRESSION_DETAILS"
-                }
-              }
-            ]
-          }
-          EOF
-
-      - name: Send regression slack notification
-        if: success() && steps.parse-regressions.outputs.regression_count > 0
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          errors: "true"
-          method: chat.postMessage
-          token: ${{ secrets.QA_SLACK_API_KEY }}
-          payload-file-path: ${{ github.workspace }}/slack_payload.json
-
-      - name: Send failure slack notification
-        if: failure()
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-        with:
-          errors: "true"
-          method: chat.postMessage
-          token: ${{ secrets.QA_SLACK_API_KEY }}
-          payload: |
-            {
-              "channel": "C094W1V9A5N",
-              "text": "Test failure",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*:rotating_light: Test failure :rotating_light:*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Test failure for commit <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> on run ID <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>. ${{ github.event_name != 'pull_request' && 'This commit was already merged to develop.' || 'This is from a pull request.' }}"
-                  }
-                }
-              ]
-            }
 
       - name: Teardown
         if: always()

--- a/.github/workflows/cre-workflow-don-benchmark.yaml
+++ b/.github/workflows/cre-workflow-don-benchmark.yaml
@@ -170,11 +170,11 @@ jobs:
         uses: actions/upload-artifact@v4
         timeout-minutes: 2
         continue-on-error: true
-      with:
-        name: node logs
-        path: |
-          system-tests/tests/load/cre/logs
-        retention-days: 5
+        with:
+          name: node logs
+          path: |
+            system-tests/tests/load/cre/logs
+          retention-days: 5
 
       - name: Upload performance reports
         uses: actions/upload-artifact@v4
@@ -184,7 +184,7 @@ jobs:
           name: performance reports
           path: |
             system-tests/tests/load/cre/performance_reports
-            retention-days: 30
+          retention-days: 30
 
       - name: Create regression slack payload
         if: success() && steps.parse-regressions.outputs.regression_count > 0

--- a/core/services/workflows/cmd/cre/examples/v2/simple_cron_with_secrets/main.go
+++ b/core/services/workflows/cmd/cre/examples/v2/simple_cron_with_secrets/main.go
@@ -5,11 +5,12 @@ package main
 import (
 	"fmt"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/triggers/cron"
-	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
 	"github.com/smartcontractkit/cre-sdk-go/sdk"
 	"github.com/smartcontractkit/cre-sdk-go/sdk/wasm"
 	"gopkg.in/yaml.v3"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb"
+	"github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron"
 )
 
 type runtimeConfig struct {

--- a/system-tests/tests/load/cre/performance_reports/TestLoad_Workflow_Streams_MockCapabilities-baseline.json
+++ b/system-tests/tests/load/cre/performance_reports/TestLoad_Workflow_Streams_MockCapabilities-baseline.json
@@ -1,8 +1,8 @@
 {
  "test_name": "TestLoad_Workflow_Streams_MockCapabilities",
- "commit_or_tag": "5c6a158e51591ca766ef23de064b803976ac70ee20250704112430",
- "test_start_timestamp": "2025-07-04T11:13:15.851644029Z",
- "test_end_timestamp": "2025-07-04T11:23:15.853332894Z",
+ "commit_or_tag": "6da6a95a048e1ac52369b58039f9e43a3076599420250714084034",
+ "test_start_timestamp": "2025-07-14T08:29:04.848382942Z",
+ "test_end_timestamp": "2025-07-14T08:39:04.849249471Z",
  "generator_configs": {
   "Generator": {
    "generator_name": "Generator",
@@ -12,8 +12,8 @@
      "from": 4,
      "duration": 600000000000,
      "type": "plain",
-     "time_start": "2025-07-04T11:13:15.851644029Z",
-     "time_end": "2025-07-04T11:23:15.853332894Z"
+     "time_start": "2025-07-14T08:29:04.848382942Z",
+     "time_end": "2025-07-14T08:39:04.849249471Z"
     }
    ],
    "rate_limit_unit_duration": 60000000000,
@@ -32,26 +32,26 @@
       "from": 4,
       "duration": 600000000000,
       "type": "plain",
-      "time_start": "2025-07-04T11:13:15.851644029Z",
-      "time_end": "2025-07-04T11:23:15.853332894Z"
+      "time_start": "2025-07-14T08:29:04.848382942Z",
+      "time_end": "2025-07-14T08:39:04.849249471Z"
      }
     ],
     "rate_limit_unit_duration": 60000000000,
     "call_timeout": 120000000000
    },
    "queries": [
-    "99th_percentile_latency",
     "max_latency",
     "error_rate",
     "median_latency",
-    "95th_percentile_latency"
+    "95th_percentile_latency",
+    "99th_percentile_latency"
    ],
    "query_results": {
-    "95th_percentile_latency": 120001.33779650001,
-    "99th_percentile_latency": 120004.7764225,
-    "error_rate": 0.14285714285714285,
-    "max_latency": 120006.568738,
-    "median_latency": 52751.922409499995
+    "95th_percentile_latency": 120002.365643,
+    "99th_percentile_latency": 120002.989004,
+    "error_rate": 0.14634146341463414,
+    "max_latency": 120003.055324,
+    "median_latency": 43430.109678
    }
   },
   {
@@ -70,8 +70,8 @@
       {
        "metric": {},
        "value": [
-        1751628195.853,
-        "63.20965969714942"
+        1752482344.849,
+        "63.205949011229556"
        ]
       }
      ],
@@ -82,8 +82,8 @@
       {
        "metric": {},
        "value": [
-        1751628195.853,
-        "0.0000633908"
+        1752482344.849,
+        "0.00008195879999999999"
        ]
       }
      ],
@@ -94,8 +94,8 @@
       {
        "metric": {},
        "value": [
-        1751628195.853,
-        "293915978.3316805"
+        1752482344.849,
+        "301520820.90666676"
        ]
       }
      ],
@@ -106,8 +106,8 @@
       {
        "metric": {},
        "value": [
-        1751628195.853,
-        "380260352"
+        1752482344.849,
+        "398427750.4"
        ]
       }
      ],
@@ -118,8 +118,8 @@
       {
        "metric": {},
        "value": [
-        1751628195.853,
-        "42018130.6"
+        1752482344.849,
+        "37213787.4"
        ]
       }
      ],
@@ -130,8 +130,8 @@
       {
        "metric": {},
        "value": [
-        1751628195.853,
-        "44861770.8"
+        1752482344.849,
+        "40020404.2"
        ]
       }
      ],


### PR DESCRIPTION
This PR modifies the CRE Workflow DON Benchmark GitHub workflow to build and use custom images directly from the PR code instead of using nightly builds.

It also updates the baseline report based on previous runs