### PR TITLE
fix(ci): CRE download retries sleep 30s

### DIFF
--- a/system-tests/tests/smoke/cre/cmd/download_cre_ci_deps.sh
+++ b/system-tests/tests/smoke/cre/cmd/download_cre_ci_deps.sh
@@ -16,7 +16,7 @@ do
     exit 1
   fi
   echo "🔁 Retrying ($count/$max_retries)..." >&2
-  sleep 1
+  sleep 30
 done
 
 echo "✅ Download succeeded." >&2


### PR DESCRIPTION
### Changes

- Increase sleep to 30s in cre download retry script

### Motivation

We are seeing what I believe to be 403s from rate-limits. I believe the 30 second retry provides better success rates.

Tested in #18596.

