### PR TITLE
fix broken link in core/README.md - correct anchor to #build-ch…

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -21,7 +21,7 @@ for interacting with Ethereum contracts.
 
 ## Installation
 
-See the [root README](../README.md#install)
+See the [root README](../README.md#build-chainlink)
 for instructions on how to build the full Chainlink node.
 
 ## Directory Structure


### PR DESCRIPTION
## Description
Fix broken internal link in `core/README.md` that points to non-existent anchor `#install` in the root README.

## Changes
- Updated link from `../README.md#install` to `../README.md#build-chainlink`
- The correct section in root README is "Build Chainlink", not "install"

## Type of Change
- [x] Documentation fix
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
- [x] Verified the target anchor `#build-chainlink` exists in root README.md
- [x] Confirmed the link now works correctly

## Checklist
- [x] The change follows the project's coding standards
- [x] Self-review of the change has been performed
- [x] The change improves documentation navigation