### PR TITLE
fix typo in deployment/README.md - changsets to changesets

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -10,7 +10,7 @@ and then exposed for use in persistent environments like testnet/mainnet.
 - [View](#view)
 - [Environment](#environment)
 - [Job Distributor](#job-distributor)
-- [Changesets](#changsets)
+- [Changesets](#changesets)
 - [Directory Structure](#directory-structure)
 - [Integration Testing](#integration-testing)
 - [FAQ](#faq)
@@ -50,7 +50,7 @@ The job distributor is a product agnostic in-house service for
 managing jobs and CL nodes. It is required to use if you want to 
 manage your system through chainlink deployments.
 
-## Changsets
+## Changesets
 A [changeset](https://github.com/smartcontractkit/chainlink/blob/develop/deployment/changeset.go#L21) is a 
 Go function which describes a set of changes to be applied to an environment given some configuration:
 ```go


### PR DESCRIPTION
## Description
Fix spelling error in `deployment/README.md` where "changsets" should be "changesets" in both the table of contents and section header.

## Changes
- Fixed typo in table of contents: `- [Changesets](#changsets)` → `- [Changesets](#changesets)`
- Fixed typo in section header: `## Changsets` → `## Changesets`

## Type of Change
- [x] Documentation fix
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
- [x] Verified internal link consistency between TOC and section header
- [x] Confirmed correct spelling of "changesets"

## Checklist
- [x] The change follows the project's coding standards
- [x] Self-review of the change has been performed
- [x] The change improves documentation consistency