### PR TITLE
CCIP - add chain accessor factories

### DIFF
--- a/core/capabilities/ccip/ccipaptos/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipaptos/chain_accessor_factory.go
@@ -1,0 +1,31 @@
+package ccipaptos
+
+import (
+	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+)
+
+// AptosChainAccessorFactory implements cciptypes.ChainAccessorFactory for Aptos chains.
+type AptosChainAccessorFactory struct{}
+
+// NewChainAccessor creates a new chain accessor to be used for Aptos chains.
+func (f AptosChainAccessorFactory) NewChainAccessor(
+	lggr logger.Logger,
+	_ loop.Relayer,
+	chainSelector ccipocr3.ChainSelector,
+	contractReader types.ContractReader,
+	contractWriter types.ContractWriter,
+	addrCodec ccipocr3.AddressCodec,
+) (ccipocr3.ChainAccessor, error) {
+	return chainaccessor.NewDefaultAccessor(
+		lggr,
+		chainSelector,
+		contractreader.NewExtendedContractReader(contractReader),
+		contractWriter,
+		addrCodec,
+	)
+}

--- a/core/capabilities/ccip/ccipaptos/pluginconfig.go
+++ b/core/capabilities/ccip/ccipaptos/pluginconfig.go
@@ -19,6 +19,7 @@ func initializePluginConfig(lggr logger.Logger, extraDataCodec ccipcommon.ExtraD
 		GasEstimateProvider:        NewGasEstimateProvider(),
 		RMNCrypto:                  nil,
 		ContractTransmitterFactory: ocrimpls.NewAptosContractTransmitterFactory(extraDataCodec),
+		ChainAccessorFactory:       AptosChainAccessorFactory{},
 		ChainRW:                    ChainCWProvider{},
 		ExtraDataCodec:             ExtraDataDecoder{},
 		AddressCodec:               AddressCodec{},

--- a/core/capabilities/ccip/ccipevm/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipevm/chain_accessor_factory.go
@@ -1,0 +1,31 @@
+package ccipevm
+
+import (
+	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+)
+
+// EVMChainAccessorFactory implements cciptypes.ChainAccessorFactory for EVM chains.
+type EVMChainAccessorFactory struct{}
+
+// NewChainAccessor creates a new chain accessor to be used for EVM chains.
+func (f EVMChainAccessorFactory) NewChainAccessor(
+	lggr logger.Logger,
+	_ loop.Relayer,
+	chainSelector ccipocr3.ChainSelector,
+	contractReader types.ContractReader,
+	contractWriter types.ContractWriter,
+	addrCodec ccipocr3.AddressCodec,
+) (ccipocr3.ChainAccessor, error) {
+	return chainaccessor.NewDefaultAccessor(
+		lggr,
+		chainSelector,
+		contractreader.NewExtendedContractReader(contractReader),
+		contractWriter,
+		addrCodec,
+	)
+}

--- a/core/capabilities/ccip/ccipevm/pluginconfig.go
+++ b/core/capabilities/ccip/ccipevm/pluginconfig.go
@@ -21,6 +21,7 @@ func InitializePluginConfig(lggr logger.Logger, extraDataCodec ccipcommon.ExtraD
 		GasEstimateProvider:        NewGasEstimateProvider(extraDataCodec),
 		RMNCrypto:                  NewEVMRMNCrypto(logger.Sugared(lggr).Named(chainsel.FamilyEVM).Named("RMNCrypto")),
 		ContractTransmitterFactory: ocrimpls.NewEVMContractTransmitterFactory(extraDataCodec),
+		ChainAccessorFactory:       EVMChainAccessorFactory{},
 		ChainRW:                    ChainCWProvider{},
 		ExtraDataCodec:             ExtraDataDecoder{},
 		AddressCodec:               AddressCodec{},

--- a/core/capabilities/ccip/ccipsolana/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipsolana/chain_accessor_factory.go
@@ -1,0 +1,31 @@
+package ccipsolana
+
+import (
+	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+)
+
+// SolanaChainAccessorFactory implements cciptypes.ChainAccessorFactory for Solana chains.
+type SolanaChainAccessorFactory struct{}
+
+// NewChainAccessor creates a new chain accessor to be used for Solana chains.
+func (f SolanaChainAccessorFactory) NewChainAccessor(
+	lggr logger.Logger,
+	_ loop.Relayer,
+	chainSelector ccipocr3.ChainSelector,
+	contractReader types.ContractReader,
+	contractWriter types.ContractWriter,
+	addrCodec ccipocr3.AddressCodec,
+) (ccipocr3.ChainAccessor, error) {
+	return chainaccessor.NewDefaultAccessor(
+		lggr,
+		chainSelector,
+		contractreader.NewExtendedContractReader(contractReader),
+		contractWriter,
+		addrCodec,
+	)
+}

--- a/core/capabilities/ccip/ccipsolana/pluginconfig.go
+++ b/core/capabilities/ccip/ccipsolana/pluginconfig.go
@@ -20,6 +20,7 @@ func InitializePluginConfig(lggr logger.Logger, extraDataCodec ccipcommon.ExtraD
 		GasEstimateProvider:        NewGasEstimateProvider(extraDataCodec),
 		RMNCrypto:                  nil,
 		ContractTransmitterFactory: ocrimpls.NewSVMContractTransmitterFactory(extraDataCodec),
+		ChainAccessorFactory:       SolanaChainAccessorFactory{},
 		AddressCodec:               AddressCodec{},
 		ChainRW:                    ChainRWProvider{},
 		ExtraDataCodec:             ExtraDataDecoder{},

--- a/core/capabilities/ccip/ccipton/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipton/chain_accessor_factory.go
@@ -1,0 +1,25 @@
+package ccipton
+
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+)
+
+// TONChainAccessorFactory implements cciptypes.ChainAccessorFactory for TON chains.
+type TONChainAccessorFactory struct{}
+
+// NewChainAccessor creates a new chain accessor to be used for TON chains.
+func (f TONChainAccessorFactory) NewChainAccessor(
+	lggr logger.Logger,
+	relayer loop.Relayer,
+	chainSelector ccipocr3.ChainSelector,
+	_ types.ContractReader,
+	_ types.ContractWriter,
+	addrCodec ccipocr3.AddressCodec,
+) (ccipocr3.ChainAccessor, error) {
+	// TODO(NONEVM-1460): Return TONAccessor from the chainlink-ton repo. This should not be called yet since TON is
+	// not yet supported.
+	return nil, nil
+}

--- a/core/capabilities/ccip/common/chain_accessor_factory.go
+++ b/core/capabilities/ccip/common/chain_accessor_factory.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+)
+
+type ChainAccessorFactory interface {
+	NewChainAccessor(
+		lggr logger.Logger,
+		relayer loop.Relayer,
+		chainSelector ccipocr3.ChainSelector,
+		contractReader types.ContractReader,
+		contractWriter types.ContractWriter,
+		addrCodec ccipocr3.AddressCodec,
+	) (ccipocr3.ChainAccessor, error)
+}

--- a/core/capabilities/ccip/common/mocks/source_chain_extra_data_codec.go
+++ b/core/capabilities/ccip/common/mocks/source_chain_extra_data_codec.go
@@ -3,7 +3,7 @@
 package mocks
 
 import (
-	ccipocr3 "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	ccipocr3 "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/core/capabilities/ccip/common/pluginconfig.go
+++ b/core/capabilities/ccip/common/pluginconfig.go
@@ -18,6 +18,7 @@ type PluginConfig struct {
 	GasEstimateProvider        cciptypes.EstimateProvider
 	RMNCrypto                  cciptypes.RMNCrypto
 	ContractTransmitterFactory cctypes.ContractTransmitterFactory
+	ChainAccessorFactory       ChainAccessorFactory
 	// PriceOnlyCommitFn optional method override for price only commit reports.
 	PriceOnlyCommitFn string
 	ChainRW           ChainRWProvider

--- a/core/capabilities/ccip/oraclecreator/create_test.go
+++ b/core/capabilities/ccip/oraclecreator/create_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
-	ocr3types "github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -20,7 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	ccipreaderpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
-	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
@@ -28,7 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
-	ocrcommon "github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 )
 
 // TestPluginOracleCreatorCreate_InvalidSelector ensures that Create returns an error when an
@@ -101,6 +101,7 @@ func TestCreateFactoryAndTransmitter_PeerWrapperNotStarted(t *testing.T) {
 		1,
 		cfg,
 		types.NewRelayID(chainsel.FamilyEVM, "1"),
+		map[cciptypes.ChainSelector]cciptypes.ChainAccessor{},
 		map[cciptypes.ChainSelector]types.ContractReader{},
 		map[cciptypes.ChainSelector]types.ContractWriter{},
 		/* destChainWriter */ nil,
@@ -134,6 +135,7 @@ func TestCreateFactoryAndTransmitter_NilDestChainWriter(t *testing.T) {
 	// Common arguments for both plugin types
 	donID := uint32(1)
 	relayID := types.NewRelayID(chainsel.FamilyEVM, "1")
+	chainAccessors := map[cciptypes.ChainSelector]cciptypes.ChainAccessor{}
 	contractReaders := map[cciptypes.ChainSelector]types.ContractReader{}
 	chainWriters := map[cciptypes.ChainSelector]types.ContractWriter{}
 	fakeTransmitAccount := ocrtypes.Account("blahblah")
@@ -182,6 +184,7 @@ func TestCreateFactoryAndTransmitter_NilDestChainWriter(t *testing.T) {
 				donID,
 				cfg,
 				relayID,
+				chainAccessors,
 				contractReaders,
 				chainWriters,
 				nil, // Key: destChainWriter is nil

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -23,11 +23,11 @@ import (
 	execocr3 "github.com/smartcontractkit/chainlink-ccip/execute"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	ccipreaderpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
-	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	_ "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipaptos"  // Register Aptos plugin config factories
 	_ "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"    // Register EVM plugin config factories
@@ -185,6 +185,12 @@ func (i *pluginOracleCreator) Create(ctx context.Context, donID uint32, config c
 		return nil, fmt.Errorf("failed to create readers and writers: %w", err)
 	}
 
+	// Create chain accessors
+	chainAccessors, err := i.createChainAccessors(contractReaders, chainWriters, pluginServices)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create chain accessors: %w", err)
+	}
+
 	// build the onchain keyring. it will be the signing key for the destination chain family.
 	keybundle, ok := i.ocrKeyBundles[destChainFamily]
 	if !ok {
@@ -212,7 +218,20 @@ func (i *pluginOracleCreator) Create(ctx context.Context, donID uint32, config c
 
 	// TODO: Extract the correct transmitter address from the destsFromAccount
 	factory, transmitter, err := i.createFactoryAndTransmitter(
-		donID, config, destRelayID, contractReaders, chainWriters, destChainWriter, destFromAccounts, publicConfig, destChainFamily, destChainID, pluginServices.PluginConfig, offrampAddrStr)
+		donID,
+		config,
+		destRelayID,
+		chainAccessors,
+		contractReaders,
+		chainWriters,
+		destChainWriter,
+		destFromAccounts,
+		publicConfig,
+		destChainFamily,
+		destChainID,
+		pluginServices.PluginConfig,
+		offrampAddrStr,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create factory and transmitter: %w", err)
 	}
@@ -269,6 +288,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 	donID uint32,
 	config cctypes.OCR3ConfigWithMeta,
 	destRelayID types.RelayID,
+	chainAccessors map[cciptypes.ChainSelector]cciptypes.ChainAccessor,
 	contractReaders map[cciptypes.ChainSelector]types.ContractReader,
 	chainWriters map[cciptypes.ChainSelector]types.ContractWriter,
 	destChainWriter types.ContractWriter,
@@ -311,6 +331,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 				AddrCodec:         i.addressCodec,
 				HomeChainReader:   i.homeChainReader,
 				HomeChainSelector: i.homeChainSelector,
+				ChainAccessors:    chainAccessors,
 				ContractReaders:   contractReaders,
 				ContractWriters:   chainWriters,
 				RmnPeerClient:     rmnPeerClient,
@@ -368,6 +389,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 				HomeChainReader:  i.homeChainReader,
 				TokenDataEncoder: pluginConfig.TokenDataEncoder,
 				EstimateProvider: pluginConfig.GasEstimateProvider,
+				ChainAccessors:   chainAccessors,
 				ContractReaders:  contractReaders,
 				ContractWriters:  chainWriters,
 			})
@@ -412,6 +434,33 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 		return nil, nil, fmt.Errorf("unsupported Plugin type %d", config.Config.PluginType)
 	}
 	return factory, transmitter, nil
+}
+
+func (i *pluginOracleCreator) createChainAccessors(
+	contractReaders map[cciptypes.ChainSelector]types.ContractReader,
+	chainWriters map[cciptypes.ChainSelector]types.ContractWriter,
+	pluginServices ccipcommon.PluginServices,
+) (map[cciptypes.ChainSelector]cciptypes.ChainAccessor, error) {
+	chainAccessors := make(map[cciptypes.ChainSelector]cciptypes.ChainAccessor)
+	for relayID, relayer := range i.relayers {
+		chainSelector, err := getChainSelectorFromRelayID(relayID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get chain selector from relay ID %s: %w", relayID, err)
+		}
+		chainAccessor, err := pluginServices.PluginConfig.ChainAccessorFactory.NewChainAccessor(
+			i.lggr,
+			relayer,
+			chainSelector,
+			contractReaders[chainSelector],
+			chainWriters[chainSelector],
+			pluginServices.AddrCodec,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create chain accessor for relay ID %s: %w", relayID, err)
+		}
+		chainAccessors[chainSelector] = chainAccessor
+	}
+	return chainAccessors, nil
 }
 
 func (i *pluginOracleCreator) getTransmitterFromPublicConfig(publicConfig ocr3confighelper.PublicConfig) (ocrtypes.Account, error) {
@@ -474,13 +523,13 @@ func (i *pluginOracleCreator) createReadersAndWriters(
 	contractReaders := make(map[cciptypes.ChainSelector]types.ContractReader)
 	chainWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 	for relayID, relayer := range i.relayers {
+		chainSelector, err1 := getChainSelectorFromRelayID(relayID)
+		if err1 != nil {
+			return nil, nil, fmt.Errorf("failed to get chain selector from chain ID %s: %w", relayID.ChainID, err1)
+		}
+
 		chainID := relayID.ChainID
 		relayChainFamily := relayID.Network
-		chainDetails, err1 := chainsel.GetChainDetailsByChainIDAndFamily(chainID, relayChainFamily)
-		chainSelector := cciptypes.ChainSelector(chainDetails.ChainSelector)
-		if err1 != nil {
-			return nil, nil, fmt.Errorf("failed to get chain selector from chain ID %s: %w", chainID, err1)
-		}
 
 		cr, err1 := crcw.GetChainReader(ctx, ccipcommon.ChainReaderProviderOpts{
 			Lggr:          i.lggr,
@@ -533,6 +582,20 @@ func (i *pluginOracleCreator) createReadersAndWriters(
 		chainWriters[chainSelector] = cw
 	}
 	return contractReaders, chainWriters, nil
+}
+
+func getChainSelectorFromRelayID(relayID types.RelayID) (cciptypes.ChainSelector, error) {
+	chainDetails, err1 := chainsel.GetChainDetailsByChainIDAndFamily(relayID.ChainID, relayID.Network)
+	if err1 != nil {
+		return cciptypes.ChainSelector(0), fmt.Errorf(
+			"failed to get chain details for chain ID %s and family %s: %w",
+			relayID.ChainID,
+			relayID.Network,
+			err1,
+		)
+	}
+	chainSelector := cciptypes.ChainSelector(chainDetails.ChainSelector)
+	return chainSelector, nil
 }
 
 func decodeAndValidateOffchainConfig(

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chain-selectors v1.0.62
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469
+	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250709160835-3dbd1ee373a2
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1509,8 +1509,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469 h1:W3GY5pqeFUerM01DgbXdj8pqufd22H4xysP/KMIBmvc=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469/go.mod h1:zPpo78Fv3zQE3WVZFEqRiRNER9QHaCzl+HNeTSaS0kE=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a h1:mfq7rKnoIoY2+wIAuC7EWatfTniiESIR4CMJ9HvNc+s=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a/go.mod h1:daF23OK1A6vg7r4ujvxJJcGBrgCtPM0A2P1a2xHMF6M=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df h1:C/ZIEFifs6vK1nzOVnUgzzAGbyJrQI+AiEyuhheMza0=

--- a/deployment/ccip/changeset/testhelpers/cciptesthelpertypes/mocks/role_don_topology.go
+++ b/deployment/ccip/changeset/testhelpers/cciptesthelpertypes/mocks/role_don_topology.go
@@ -3,7 +3,7 @@
 package mocks
 
 import (
-	ccipocr3 "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	ccipocr3 "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.62
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469
+	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250709160835-3dbd1ee373a2

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1259,8 +1259,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469 h1:W3GY5pqeFUerM01DgbXdj8pqufd22H4xysP/KMIBmvc=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469/go.mod h1:zPpo78Fv3zQE3WVZFEqRiRNER9QHaCzl+HNeTSaS0kE=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a h1:mfq7rKnoIoY2+wIAuC7EWatfTniiESIR4CMJ9HvNc+s=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a/go.mod h1:daF23OK1A6vg7r4ujvxJJcGBrgCtPM0A2P1a2xHMF6M=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df h1:C/ZIEFifs6vK1nzOVnUgzzAGbyJrQI+AiEyuhheMza0=

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.62
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250703172708-3dacb811e668
+	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250709160835-3dbd1ee373a2

--- a/go.sum
+++ b/go.sum
@@ -1084,8 +1084,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250703172708-3dacb811e668 h1:sx6pf5eCKFAMX73jViYixfMJfvRPy3XKQaAJ291WogM=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250703172708-3dacb811e668/go.mod h1:zPpo78Fv3zQE3WVZFEqRiRNER9QHaCzl+HNeTSaS0kE=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a h1:mfq7rKnoIoY2+wIAuC7EWatfTniiESIR4CMJ9HvNc+s=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a/go.mod h1:daF23OK1A6vg7r4ujvxJJcGBrgCtPM0A2P1a2xHMF6M=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df h1:C/ZIEFifs6vK1nzOVnUgzzAGbyJrQI+AiEyuhheMza0=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.62
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a
 	github.com/smartcontractkit/chainlink-automation v0.8.1
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469
+	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df
 	github.com/smartcontractkit/chainlink-deployments-framework v0.17.2

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1523,8 +1523,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469 h1:W3GY5pqeFUerM01DgbXdj8pqufd22H4xysP/KMIBmvc=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469/go.mod h1:zPpo78Fv3zQE3WVZFEqRiRNER9QHaCzl+HNeTSaS0kE=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a h1:mfq7rKnoIoY2+wIAuC7EWatfTniiESIR4CMJ9HvNc+s=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a/go.mod h1:daF23OK1A6vg7r4ujvxJJcGBrgCtPM0A2P1a2xHMF6M=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df h1:C/ZIEFifs6vK1nzOVnUgzzAGbyJrQI+AiEyuhheMza0=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/slack-go/slack v0.15.0
 	github.com/smartcontractkit/chain-selectors v1.0.62
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469
+	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df
 	github.com/smartcontractkit/chainlink-deployments-framework v0.17.2

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1499,8 +1499,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469 h1:W3GY5pqeFUerM01DgbXdj8pqufd22H4xysP/KMIBmvc=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469/go.mod h1:zPpo78Fv3zQE3WVZFEqRiRNER9QHaCzl+HNeTSaS0kE=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a h1:mfq7rKnoIoY2+wIAuC7EWatfTniiESIR4CMJ9HvNc+s=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a/go.mod h1:daF23OK1A6vg7r4ujvxJJcGBrgCtPM0A2P1a2xHMF6M=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df h1:C/ZIEFifs6vK1nzOVnUgzzAGbyJrQI+AiEyuhheMza0=

--- a/integration-tests/smoke/ccip/ccip_reader_test.go
+++ b/integration-tests/smoke/ccip/ccip_reader_test.go
@@ -29,14 +29,15 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm_provider "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider"
+	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 
 	readermocks "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/contractreader"
 	typepkgmock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	ccipreaderpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
-	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/plugintypes"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
@@ -158,6 +159,20 @@ func TestCCIPReader_GetRMNRemoteConfig(t *testing.T) {
 
 	extendedCr := contractreader.NewExtendedContractReader(cr)
 
+	// Create dummy contract writers
+	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
+	chainWriter, err := evm.NewChainWriterService(
+		logger.TestLogger(t),
+		cl,
+		nil,
+		nil,
+		evmtypes.ChainWriterConfig{
+			MaxGasPrice: assets.GWei(1),
+		},
+	)
+	require.NoError(t, err)
+	contractWriters[cciptypes.ChainSelector(ch.ChainSelector)] = chainWriter
+
 	mockAddrCodec := newMockAddressCodec(t)
 	reader := ccipreaderpkg.NewCCIPReaderWithExtendedContractReaders(
 		ctx,
@@ -165,7 +180,7 @@ func TestCCIPReader_GetRMNRemoteConfig(t *testing.T) {
 		map[cciptypes.ChainSelector]contractreader.Extended{
 			cciptypes.ChainSelector(ch.ChainSelector): extendedCr,
 		},
-		nil,
+		contractWriters,
 		cciptypes.ChainSelector(ch.ChainSelector),
 		rmnRemoteAddr.Bytes(),
 		mockAddrCodec,
@@ -287,6 +302,21 @@ func TestCCIPReader_GetOffRampConfigDigest(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	// Create dummy contract writers
+	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
+	chainWriter, err := evm.NewChainWriterService(
+		logger.TestLogger(t),
+		cl,
+		nil,
+		nil,
+		evmtypes.ChainWriterConfig{
+			MaxGasPrice: assets.GWei(1),
+		},
+	)
+	require.NoError(t, err)
+	contractWriters[chainD] = chainWriter
+
 	mokAddrCodec := newMockAddressCodec(t)
 	reader := ccipreaderpkg.NewCCIPReaderWithExtendedContractReaders(
 		ctx,
@@ -294,7 +324,7 @@ func TestCCIPReader_GetOffRampConfigDigest(t *testing.T) {
 		map[cciptypes.ChainSelector]contractreader.Extended{
 			chainD: extendedCr,
 		},
-		nil,
+		contractWriters,
 		chainD,
 		addr.Bytes(),
 		mokAddrCodec,
@@ -850,9 +880,29 @@ func TestCCIPReader_DiscoverContracts(t *testing.T) {
 	contractReaders[chainD] = extendedCrD
 
 	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
+	chainWriter, err := evm.NewChainWriterService(
+		logger.TestLogger(t),
+		clD,
+		nil,
+		nil,
+		evmtypes.ChainWriterConfig{
+			MaxGasPrice: assets.GWei(1),
+		},
+	)
+	require.NoError(t, err)
+	contractWriters[chainS1] = chainWriter
+	contractWriters[chainD] = chainWriter
 
 	mokAddrCodec := newMockAddressCodec(t)
-	reader := ccipreaderpkg.NewCCIPReaderWithExtendedContractReaders(ctx, logger.TestLogger(t), contractReaders, contractWriters, chainD, offRampDestAddr.Bytes(), mokAddrCodec)
+	reader := ccipreaderpkg.NewCCIPReaderWithExtendedContractReaders(
+		ctx,
+		logger.TestLogger(t),
+		contractReaders,
+		contractWriters,
+		chainD,
+		offRampDestAddr.Bytes(),
+		mokAddrCodec,
+	)
 
 	t.Cleanup(func() {
 		assert.NoError(t, crS1.Close())
@@ -1218,11 +1268,12 @@ func testSetupRealContracts(
 	lggr.SetLogLevel(zapcore.ErrorLevel)
 
 	var crs = make(map[cciptypes.ChainSelector]contractreader.Extended)
-	for chain, bindings := range toBindContracts {
-		simClient := env.Env.BlockChains.EVMChains()[uint64(chain)].Client.(*cldf_evm_provider.SimClient)
-		cl := client.NewSimulatedBackendClient(t, simClient.Backend(), big.NewInt(0).SetUint64(uint64(chain)))
+	var contractWriters = make(map[cciptypes.ChainSelector]types.ContractWriter)
+	for chainSelector, bindings := range toBindContracts {
+		simClient := env.Env.BlockChains.EVMChains()[uint64(chainSelector)].Client.(*cldf_evm_provider.SimClient)
+		cl := client.NewSimulatedBackendClient(t, simClient.Backend(), big.NewInt(0).SetUint64(uint64(chainSelector)))
 		headTracker := headstest.NewSimulatedHeadTracker(cl, lpOpts.UseFinalityTag, lpOpts.FinalityDepth)
-		lp := logpoller.NewLogPoller(logpoller.NewORM(big.NewInt(0).SetUint64(uint64(chain)), db, lggr),
+		lp := logpoller.NewLogPoller(logpoller.NewORM(big.NewInt(0).SetUint64(uint64(chainSelector)), db, lggr),
 			cl,
 			lggr,
 			headTracker,
@@ -1231,7 +1282,7 @@ func testSetupRealContracts(
 		require.NoError(t, lp.Start(ctx))
 
 		var cfg evmtypes.ChainReaderConfig
-		if chain == cs(destChain) {
+		if chainSelector == cs(destChain) {
 			cfg = evmconfig.DestReaderConfig
 		} else {
 			cfg = evmconfig.SourceReaderConfig
@@ -1242,10 +1293,22 @@ func testSetupRealContracts(
 		extendedCr2 := contractreader.NewExtendedContractReader(cr)
 		err = extendedCr2.Bind(ctx, bindings)
 		require.NoError(t, err)
-		crs[cciptypes.ChainSelector(chain)] = extendedCr2
+		crs[chainSelector] = extendedCr2
 
 		err = cr.Start(ctx)
 		require.NoError(t, err)
+
+		chainWriter, err := evm.NewChainWriterService(
+			logger.TestLogger(t),
+			cl,
+			nil,
+			nil,
+			evmtypes.ChainWriterConfig{
+				MaxGasPrice: assets.GWei(1),
+			},
+		)
+		require.NoError(t, err)
+		contractWriters[chainSelector] = chainWriter
 
 		t.Cleanup(func() {
 			require.NoError(t, cr.Close())
@@ -1270,9 +1333,17 @@ func testSetupRealContracts(
 	for chain, cr := range crs {
 		contractReaders[chain] = cr
 	}
-	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
+
 	mokAddrCodec := newMockAddressCodec(t)
-	reader := ccipreaderpkg.NewCCIPReaderWithExtendedContractReaders(ctx, lggr, contractReaders, contractWriters, cciptypes.ChainSelector(destChain), nil, mokAddrCodec)
+	reader := ccipreaderpkg.NewCCIPReaderWithExtendedContractReaders(
+		ctx,
+		lggr,
+		contractReaders,
+		contractWriters,
+		cciptypes.ChainSelector(destChain),
+		nil,
+		mokAddrCodec,
+	)
 
 	return reader
 }
@@ -1380,10 +1451,23 @@ func testSetup(
 	require.NoError(t, err)
 
 	contractReaders := map[cciptypes.ChainSelector]contractreader.Extended{params.ReaderChain: extendedCr}
+	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
+	chainWriter, err := evm.NewChainWriterService(
+		logger.TestLogger(t),
+		cl,
+		nil,
+		nil,
+		evmtypes.ChainWriterConfig{
+			MaxGasPrice: assets.GWei(1),
+		},
+	)
+	require.NoError(t, err)
+	contractWriters[params.DestChain] = chainWriter
+	contractWriters[params.ReaderChain] = chainWriter
 	for chain, cr := range otherCrs {
 		contractReaders[chain] = cr
+		contractWriters[chain] = chainWriter
 	}
-	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 
 	mokAddrCodec := newMockAddressCodec(t)
 	reader := ccipreaderpkg.NewCCIPReaderWithExtendedContractReaders(ctx, lggr, contractReaders, contractWriters, params.DestChain, nil, mokAddrCodec)

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -364,7 +364,7 @@ require (
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb v0.0.0-20250709160835-3dbd1ee373a2 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae // indirect

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1253,8 +1253,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469 h1:W3GY5pqeFUerM01DgbXdj8pqufd22H4xysP/KMIBmvc=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469/go.mod h1:zPpo78Fv3zQE3WVZFEqRiRNER9QHaCzl+HNeTSaS0kE=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a h1:mfq7rKnoIoY2+wIAuC7EWatfTniiESIR4CMJ9HvNc+s=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a/go.mod h1:daF23OK1A6vg7r4ujvxJJcGBrgCtPM0A2P1a2xHMF6M=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df h1:C/ZIEFifs6vK1nzOVnUgzzAGbyJrQI+AiEyuhheMza0=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -453,7 +453,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.62 // indirect
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a // indirect
 	github.com/smartcontractkit/chainlink-automation v0.8.1 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469 // indirect
+	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk/v2/pb v0.0.0-20250709160835-3dbd1ee373a2 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1484,8 +1484,8 @@ github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a h
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=
 github.com/smartcontractkit/chainlink-automation v0.8.1/go.mod h1:Iij36PvWZ6blrdC5A/nrQUBuf3MH3JvsBB9sSyc9W08=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469 h1:W3GY5pqeFUerM01DgbXdj8pqufd22H4xysP/KMIBmvc=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250707220619-84bd6c292469/go.mod h1:zPpo78Fv3zQE3WVZFEqRiRNER9QHaCzl+HNeTSaS0kE=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a h1:mfq7rKnoIoY2+wIAuC7EWatfTniiESIR4CMJ9HvNc+s=
+github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250715173602-87c4edfa803a/go.mod h1:daF23OK1A6vg7r4ujvxJJcGBrgCtPM0A2P1a2xHMF6M=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed h1:rjtXQLTCLa/+AmMwMTP5WwJUdPBeBAF3Ivwc1GXetBw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250609091505-5c8cd74b92ed/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250714181736-674a6a44b5df h1:C/ZIEFifs6vK1nzOVnUgzzAGbyJrQI+AiEyuhheMza0=


### PR DESCRIPTION
Corresponding chainlink-ccip PR: https://github.com/smartcontractkit/chainlink-ccip/pull/1083

This PR is effectively a no-op since the chain accessor objects passed into the CCIP plugin factories are not being used or passed down anywhere at the moment