### PR TITLE
CCIP - add chain accessor factories

### DIFF
--- a/core/capabilities/ccip/ccipaptos/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipaptos/chain_accessor_factory.go
@@ -1,0 +1,24 @@
+package ccipaptos
+
+import (
+	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+)
+
+// AptosChainAccessorFactory implements cciptypes.ChainAccessorFactory for Aptos chains.
+type AptosChainAccessorFactory struct{}
+
+// NewChainAccessor creates a new chain accessor to be used for Aptos chains.
+func (f AptosChainAccessorFactory) NewChainAccessor(
+	params common.ChainAccessorFactoryParams,
+) (ccipocr3.ChainAccessor, error) {
+	return chainaccessor.NewDefaultAccessor(
+		params.Lggr,
+		params.ChainSelector,
+		contractreader.NewExtendedContractReader(params.ContractReader),
+		params.ContractWriter,
+		params.AddrCodec,
+	)
+}

--- a/core/capabilities/ccip/ccipaptos/pluginconfig.go
+++ b/core/capabilities/ccip/ccipaptos/pluginconfig.go
@@ -19,6 +19,7 @@ func initializePluginConfig(lggr logger.Logger, extraDataCodec ccipcommon.ExtraD
 		GasEstimateProvider:        NewGasEstimateProvider(),
 		RMNCrypto:                  nil,
 		ContractTransmitterFactory: ocrimpls.NewAptosContractTransmitterFactory(extraDataCodec),
+		ChainAccessorFactory:       AptosChainAccessorFactory{},
 		ChainRW:                    ChainCWProvider{},
 		ExtraDataCodec:             ExtraDataDecoder{},
 		AddressCodec:               AddressCodec{},

--- a/core/capabilities/ccip/ccipevm/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipevm/chain_accessor_factory.go
@@ -1,0 +1,24 @@
+package ccipevm
+
+import (
+	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+)
+
+// EVMChainAccessorFactory implements cciptypes.ChainAccessorFactory for EVM chains.
+type EVMChainAccessorFactory struct{}
+
+// NewChainAccessor creates a new chain accessor to be used for EVM chains.
+func (f EVMChainAccessorFactory) NewChainAccessor(
+	params common.ChainAccessorFactoryParams,
+) (ccipocr3.ChainAccessor, error) {
+	return chainaccessor.NewDefaultAccessor(
+		params.Lggr,
+		params.ChainSelector,
+		contractreader.NewExtendedContractReader(params.ContractReader),
+		params.ContractWriter,
+		params.AddrCodec,
+	)
+}

--- a/core/capabilities/ccip/ccipevm/pluginconfig.go
+++ b/core/capabilities/ccip/ccipevm/pluginconfig.go
@@ -21,6 +21,7 @@ func InitializePluginConfig(lggr logger.Logger, extraDataCodec ccipcommon.ExtraD
 		GasEstimateProvider:        NewGasEstimateProvider(extraDataCodec),
 		RMNCrypto:                  NewEVMRMNCrypto(logger.Sugared(lggr).Named(chainsel.FamilyEVM).Named("RMNCrypto")),
 		ContractTransmitterFactory: ocrimpls.NewEVMContractTransmitterFactory(extraDataCodec),
+		ChainAccessorFactory:       EVMChainAccessorFactory{},
 		ChainRW:                    ChainCWProvider{},
 		ExtraDataCodec:             ExtraDataDecoder{},
 		AddressCodec:               AddressCodec{},

--- a/core/capabilities/ccip/ccipsolana/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipsolana/chain_accessor_factory.go
@@ -1,0 +1,24 @@
+package ccipsolana
+
+import (
+	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+)
+
+// SolanaChainAccessorFactory implements cciptypes.ChainAccessorFactory for Solana chains.
+type SolanaChainAccessorFactory struct{}
+
+// NewChainAccessor creates a new chain accessor to be used for Solana chains.
+func (f SolanaChainAccessorFactory) NewChainAccessor(
+	params common.ChainAccessorFactoryParams,
+) (ccipocr3.ChainAccessor, error) {
+	return chainaccessor.NewDefaultAccessor(
+		params.Lggr,
+		params.ChainSelector,
+		contractreader.NewExtendedContractReader(params.ContractReader),
+		params.ContractWriter,
+		params.AddrCodec,
+	)
+}

--- a/core/capabilities/ccip/ccipsolana/pluginconfig.go
+++ b/core/capabilities/ccip/ccipsolana/pluginconfig.go
@@ -20,6 +20,7 @@ func InitializePluginConfig(lggr logger.Logger, extraDataCodec ccipcommon.ExtraD
 		GasEstimateProvider:        NewGasEstimateProvider(extraDataCodec),
 		RMNCrypto:                  nil,
 		ContractTransmitterFactory: ocrimpls.NewSVMContractTransmitterFactory(extraDataCodec),
+		ChainAccessorFactory:       SolanaChainAccessorFactory{},
 		AddressCodec:               AddressCodec{},
 		ChainRW:                    ChainRWProvider{},
 		ExtraDataCodec:             ExtraDataDecoder{},

--- a/core/capabilities/ccip/ccipton/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipton/chain_accessor_factory.go
@@ -1,0 +1,16 @@
+package ccipton
+
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
+)
+
+// TONChainAccessorFactory implements cciptypes.ChainAccessorFactory for TON chains.
+type TONChainAccessorFactory struct{}
+
+// NewChainAccessor creates a new chain accessor to be used for TON chains.
+func (f TONChainAccessorFactory) NewChainAccessor(_ common.ChainAccessorFactoryParams) (ccipocr3.ChainAccessor, error) {
+	// TODO(NONEVM-1460): Return TONAccessor from the chainlink-ton repo. This should not be called yet since TON is
+	// not yet supported.
+	return nil, nil
+}

--- a/core/capabilities/ccip/ccipton/pluginconfig.go
+++ b/core/capabilities/ccip/ccipton/pluginconfig.go
@@ -3,9 +3,17 @@ package ccipton
 import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipnoop"
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 )
+
+// InitializePluginConfig returns a pluginConfig for TON chains.
+func InitializePluginConfig(lggr logger.Logger, extraDataCodec ccipcommon.ExtraDataCodec) ccipcommon.PluginConfig {
+	return ccipcommon.PluginConfig{
+		ChainAccessorFactory: TONChainAccessorFactory{},
+	}
+}
 
 // TON plugin is a noop implementation for now.
 // This registers TON with a noop plugin via init() when this package is imported.

--- a/core/capabilities/ccip/common/chain_accessor_factory.go
+++ b/core/capabilities/ccip/common/chain_accessor_factory.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+)
+
+type ChainAccessorFactoryParams struct {
+	Lggr           logger.Logger
+	Relayer        loop.Relayer
+	ChainSelector  ccipocr3.ChainSelector
+	ContractReader types.ContractReader
+	ContractWriter types.ContractWriter
+	AddrCodec      ccipocr3.AddressCodec
+}
+
+type ChainAccessorFactory interface {
+	NewChainAccessor(ChainAccessorFactoryParams) (ccipocr3.ChainAccessor, error)
+}

--- a/core/capabilities/ccip/common/pluginconfig.go
+++ b/core/capabilities/ccip/common/pluginconfig.go
@@ -18,6 +18,7 @@ type PluginConfig struct {
 	GasEstimateProvider        cciptypes.EstimateProvider
 	RMNCrypto                  cciptypes.RMNCrypto
 	ContractTransmitterFactory cctypes.ContractTransmitterFactory
+	ChainAccessorFactory       ChainAccessorFactory
 	// PriceOnlyCommitFn optional method override for price only commit reports.
 	PriceOnlyCommitFn string
 	ChainRW           ChainRWProvider

--- a/core/capabilities/ccip/oraclecreator/create_test.go
+++ b/core/capabilities/ccip/oraclecreator/create_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3confighelper"
-	ocr3types "github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -20,7 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	ccipreaderpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
-	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	ccipcommon "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 	cctypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/types"
@@ -28,7 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
-	ocrcommon "github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 )
 
 // TestPluginOracleCreatorCreate_InvalidSelector ensures that Create returns an error when an
@@ -101,6 +101,7 @@ func TestCreateFactoryAndTransmitter_PeerWrapperNotStarted(t *testing.T) {
 		1,
 		cfg,
 		types.NewRelayID(chainsel.FamilyEVM, "1"),
+		map[cciptypes.ChainSelector]cciptypes.ChainAccessor{},
 		map[cciptypes.ChainSelector]types.ContractReader{},
 		map[cciptypes.ChainSelector]types.ContractWriter{},
 		/* destChainWriter */ nil,
@@ -134,6 +135,7 @@ func TestCreateFactoryAndTransmitter_NilDestChainWriter(t *testing.T) {
 	// Common arguments for both plugin types
 	donID := uint32(1)
 	relayID := types.NewRelayID(chainsel.FamilyEVM, "1")
+	chainAccessors := map[cciptypes.ChainSelector]cciptypes.ChainAccessor{}
 	contractReaders := map[cciptypes.ChainSelector]types.ContractReader{}
 	chainWriters := map[cciptypes.ChainSelector]types.ContractWriter{}
 	fakeTransmitAccount := ocrtypes.Account("blahblah")
@@ -182,6 +184,7 @@ func TestCreateFactoryAndTransmitter_NilDestChainWriter(t *testing.T) {
 				donID,
 				cfg,
 				relayID,
+				chainAccessors,
 				contractReaders,
 				chainWriters,
 				nil, // Key: destChainWriter is nil

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -23,11 +23,11 @@ import (
 	execocr3 "github.com/smartcontractkit/chainlink-ccip/execute"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	ccipreaderpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
-	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	_ "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipaptos"  // Register Aptos plugin config factories
 	_ "github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"    // Register EVM plugin config factories
@@ -185,6 +185,12 @@ func (i *pluginOracleCreator) Create(ctx context.Context, donID uint32, config c
 		return nil, fmt.Errorf("failed to create readers and writers: %w", err)
 	}
 
+	// Create chain accessors
+	chainAccessors, err := i.createChainAccessors(contractReaders, chainWriters, pluginServices)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create chain accessors: %w", err)
+	}
+
 	// build the onchain keyring. it will be the signing key for the destination chain family.
 	keybundle, ok := i.ocrKeyBundles[destChainFamily]
 	if !ok {
@@ -212,7 +218,20 @@ func (i *pluginOracleCreator) Create(ctx context.Context, donID uint32, config c
 
 	// TODO: Extract the correct transmitter address from the destsFromAccount
 	factory, transmitter, err := i.createFactoryAndTransmitter(
-		donID, config, destRelayID, contractReaders, chainWriters, destChainWriter, destFromAccounts, publicConfig, destChainFamily, destChainID, pluginServices.PluginConfig, offrampAddrStr)
+		donID,
+		config,
+		destRelayID,
+		chainAccessors,
+		contractReaders,
+		chainWriters,
+		destChainWriter,
+		destFromAccounts,
+		publicConfig,
+		destChainFamily,
+		destChainID,
+		pluginServices.PluginConfig,
+		offrampAddrStr,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create factory and transmitter: %w", err)
 	}
@@ -269,6 +288,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 	donID uint32,
 	config cctypes.OCR3ConfigWithMeta,
 	destRelayID types.RelayID,
+	chainAccessors map[cciptypes.ChainSelector]cciptypes.ChainAccessor,
 	contractReaders map[cciptypes.ChainSelector]types.ContractReader,
 	chainWriters map[cciptypes.ChainSelector]types.ContractWriter,
 	destChainWriter types.ContractWriter,
@@ -311,6 +331,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 				AddrCodec:         i.addressCodec,
 				HomeChainReader:   i.homeChainReader,
 				HomeChainSelector: i.homeChainSelector,
+				ChainAccessors:    chainAccessors,
 				ContractReaders:   contractReaders,
 				ContractWriters:   chainWriters,
 				RmnPeerClient:     rmnPeerClient,
@@ -368,6 +389,7 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 				HomeChainReader:  i.homeChainReader,
 				TokenDataEncoder: pluginConfig.TokenDataEncoder,
 				EstimateProvider: pluginConfig.GasEstimateProvider,
+				ChainAccessors:   chainAccessors,
 				ContractReaders:  contractReaders,
 				ContractWriters:  chainWriters,
 			})
@@ -412,6 +434,36 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 		return nil, nil, fmt.Errorf("unsupported Plugin type %d", config.Config.PluginType)
 	}
 	return factory, transmitter, nil
+}
+
+func (i *pluginOracleCreator) createChainAccessors(
+	contractReaders map[cciptypes.ChainSelector]types.ContractReader,
+	chainWriters map[cciptypes.ChainSelector]types.ContractWriter,
+	pluginServices ccipcommon.PluginServices,
+) (map[cciptypes.ChainSelector]cciptypes.ChainAccessor, error) {
+	chainAccessors := make(map[cciptypes.ChainSelector]cciptypes.ChainAccessor)
+	for relayID, relayer := range i.relayers {
+		chainDetails, err := chainsel.GetChainDetailsByChainIDAndFamily(relayID.ChainID, relayID.Network)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get chain selector from relay ID %s and family %s: %w", relayID.ChainID, relayID.Network, err)
+		}
+		chainSelector := cciptypes.ChainSelector(chainDetails.ChainSelector)
+		chainAccessor, err := pluginServices.PluginConfig.ChainAccessorFactory.NewChainAccessor(
+			ccipcommon.ChainAccessorFactoryParams{
+				Lggr:           i.lggr,
+				Relayer:        relayer,
+				ChainSelector:  chainSelector,
+				ContractReader: contractReaders[chainSelector],
+				ContractWriter: chainWriters[chainSelector],
+				AddrCodec:      pluginServices.AddrCodec,
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create chain accessor for relay ID %s: %w", relayID, err)
+		}
+		chainAccessors[chainSelector] = chainAccessor
+	}
+	return chainAccessors, nil
 }
 
 func (i *pluginOracleCreator) getTransmitterFromPublicConfig(publicConfig ocr3confighelper.PublicConfig) (ocrtypes.Account, error) {


### PR DESCRIPTION
This PR:
- Creates the `ChainAccessorFactory` interface and implements it for EVM, Solana, and Aptos using the `DefaultAccessor` defined in chainlink-ccip: https://github.com/smartcontractkit/chainlink-ccip/blob/main/pkg/chainaccessor/default_accessor.go
- It creates an empty/no-op accessor factory for TON 
- It initializes these accessors and passes them into the CCIP commit and exec plugin factories, though they are currently not being used