### PR TITLE
save workflow spec in datastore

### DIFF
--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	cldf_chain_utils "github.com/smartcontractkit/chainlink-deployments-framework/chain/utils"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
@@ -22,8 +23,7 @@ const (
 	timeoutV2 = 240 * time.Second
 )
 
-type NOPWorkflowMetadata struct {
-}
+type WorkflowMetadata map[string]string
 
 // ProposeWFJobsToJDV2Changeset is a Durable Pipeline compatible changeset that reads a feed state file,
 // creates a workflow job spec from it and proposes it to JD.
@@ -36,7 +36,9 @@ func proposeWFJobsToJDV2Logic(env cldf.Environment, c types.ProposeWFJobsV2Confi
 	chainInfo, _ := cldf_chain_utils.ChainInfo(c.ChainSelector)
 
 	domain := getDomain(c.Domain)
-	feedStatePath := filepath.Join("domains", domain, env.Name, "inputs", "feeds", chainInfo.ChainName+".json")
+
+	root, _ := findWorkspaceRoot()
+	feedStatePath := filepath.Join(root, "domains", domain, env.Name, "inputs", "feeds", chainInfo.ChainName+".json")
 	feedState, _ := readFeedStateFile(feedStatePath)
 
 	// Only get feeds that are part of the workflow
@@ -101,6 +103,38 @@ func proposeWFJobsToJDV2Logic(env cldf.Environment, c types.ProposeWFJobsV2Confi
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to propose workflow job spec: %w", err)
 	}
 
+	// Save workflow spec in the datastore
+	ds := datastore.NewMemoryDataStore()
+
+	// environment metadata is overwritten with every Set(), so we need to read the existing metadata first
+	record, err := env.DataStore.EnvMetadata().Get()
+	if err != nil {
+		env.Logger.Errorf("failed to get env datastore: %s", err)
+	}
+
+	metadata, err := datastore.As[WorkflowMetadata](record.Metadata)
+	if err != nil {
+		env.Logger.Errorf("failed to cast env metadata: %s", err)
+	}
+
+	if metadata == nil {
+		metadata = make(WorkflowMetadata)
+	}
+
+	// upsert the workflow spec in the metadata
+	metadata[workflowSpecConfig.WorkflowName] = workflowSpec
+
+	err = ds.EnvMetadata().Set(
+		datastore.EnvMetadata{
+			Metadata: metadata,
+		},
+	)
+	if err != nil {
+		env.Logger.Errorf("failed to set workflow spec in datastore: %s", err)
+	}
+
+	out.DataStore = ds
+
 	return out, nil
 }
 
@@ -139,7 +173,12 @@ func proposeWFJobsToJDV2Precondition(env cldf.Environment, c types.ProposeWFJobs
 	if err != nil {
 		return fmt.Errorf("failed to get chain info for chain %d: %w", c.ChainSelector, err)
 	}
-	feedStatePath := filepath.Join("domains", domain, env.Name, "inputs", "feeds", chainInfo.ChainName+".json")
+
+	root, err := findWorkspaceRoot()
+	if err != nil {
+		return fmt.Errorf("failed to find workspace root: %w", err)
+	}
+	feedStatePath := filepath.Join(root, "domains", domain, env.Name, "inputs", "feeds", chainInfo.ChainName+".json")
 
 	feedState, err := readFeedStateFile(feedStatePath)
 	if err != nil {

--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
@@ -39,8 +39,7 @@ func proposeWFJobsToJDV2Logic(env cldf.Environment, c types.ProposeWFJobsV2Confi
 
 	domain := getDomain(c.Domain)
 
-	root, _ := findWorkspaceRoot()
-	feedStatePath := filepath.Join(root, "domains", domain, env.Name, "inputs", "feeds", chainInfo.ChainName+".json")
+	feedStatePath := filepath.Join("domains", domain, env.Name, "inputs", "feeds", chainInfo.ChainName+".json")
 	feedState, _ := readFeedStateFile(feedStatePath)
 
 	// Only get feeds that are part of the workflow
@@ -176,11 +175,7 @@ func proposeWFJobsToJDV2Precondition(env cldf.Environment, c types.ProposeWFJobs
 		return fmt.Errorf("failed to get chain info for chain %d: %w", c.ChainSelector, err)
 	}
 
-	root, err := findWorkspaceRoot()
-	if err != nil {
-		return fmt.Errorf("failed to find workspace root: %w", err)
-	}
-	feedStatePath := filepath.Join(root, "domains", domain, env.Name, "inputs", "feeds", chainInfo.ChainName+".json")
+	feedStatePath := filepath.Join("domains", domain, env.Name, "inputs", "feeds", chainInfo.ChainName+".json")
 
 	feedState, err := readFeedStateFile(feedStatePath)
 	if err != nil {

--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
@@ -23,7 +23,9 @@ const (
 	timeoutV2 = 240 * time.Second
 )
 
-type WorkflowMetadata map[string]string
+type WorkflowMetadata struct {
+	Workflows map[string]string
+}
 
 // ProposeWFJobsToJDV2Changeset is a Durable Pipeline compatible changeset that reads a feed state file,
 // creates a workflow job spec from it and proposes it to JD.
@@ -117,12 +119,12 @@ func proposeWFJobsToJDV2Logic(env cldf.Environment, c types.ProposeWFJobsV2Confi
 		env.Logger.Errorf("failed to cast env metadata: %s", err)
 	}
 
-	if metadata == nil {
-		metadata = make(WorkflowMetadata)
+	if metadata.Workflows == nil {
+		metadata.Workflows = make(map[string]string)
 	}
 
 	// upsert the workflow spec in the metadata
-	metadata[workflowSpecConfig.WorkflowName] = workflowSpec
+	metadata.Workflows[workflowSpecConfig.WorkflowName] = workflowSpec
 
 	err = ds.EnvMetadata().Set(
 		datastore.EnvMetadata{

--- a/deployment/data-feeds/changeset/utils.go
+++ b/deployment/data-feeds/changeset/utils.go
@@ -3,11 +3,8 @@ package changeset
 import (
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
-	"os"
-	"path/filepath"
 
 	workflowUtils "github.com/smartcontractkit/chainlink-common/pkg/workflows"
 
@@ -138,29 +135,4 @@ func GetDataFeedsCacheAddress(ab cldf.AddressBook, dataStore datastore.AddressRe
 	}
 
 	return dataFeedsCacheAddress
-}
-
-func findWorkspaceRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	// Walk up directories looking for the root go.mod
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			// Check if this looks like the workspace root by looking for domains/
-			if _, err := os.Stat(filepath.Join(dir, "domains")); err == nil {
-				return dir, nil
-			}
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break // reached root directory
-		}
-		dir = parent
-	}
-
-	return "", errors.New("could not find workspace root (directory with go.mod and domains/)")
 }

--- a/deployment/data-feeds/changeset/utils.go
+++ b/deployment/data-feeds/changeset/utils.go
@@ -3,10 +3,14 @@ package changeset
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
+	"os"
+	"path/filepath"
 
 	workflowUtils "github.com/smartcontractkit/chainlink-common/pkg/workflows"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -134,4 +138,29 @@ func GetDataFeedsCacheAddress(ab cldf.AddressBook, dataStore datastore.AddressRe
 	}
 
 	return dataFeedsCacheAddress
+}
+
+func findWorkspaceRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	// Walk up directories looking for the root go.mod
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			// Check if this looks like the workspace root by looking for domains/
+			if _, err := os.Stat(filepath.Join(dir, "domains")); err == nil {
+				return dir, nil
+			}
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break // reached root directory
+		}
+		dir = parent
+	}
+
+	return "", errors.New("could not find workspace root (directory with go.mod and domains/)")
 }


### PR DESCRIPTION
Saves workflow spec to datastore after workflow jobs are proposed to NOPs. Reads entire state and overwrites it with the newest spec to environment metadata. 