### PR TITLE
ccip - role don - fix transmitter validation

### DIFF
--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -206,9 +206,6 @@ func (i *pluginOracleCreator) Create(ctx context.Context, donID uint32, config c
 			"destChainID", destChainID,
 			"destChainSelector", config.Config.ChainSelector)
 	}
-	if len(destFromAccounts) == 0 {
-		return nil, fmt.Errorf("transmitter array is empty for dest relay ID %s", destRelayID)
-	}
 
 	// TODO: Extract the correct transmitter address from the destsFromAccount
 	factory, transmitter, err := i.createFactoryAndTransmitter(
@@ -340,6 +337,9 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 				transmitAccount,
 			)
 		} else {
+			if len(destFromAccounts) == 0 {
+				return nil, nil, fmt.Errorf("transmitter array is empty for dest relay ID %s", destRelayID)
+			}
 			transmitter = pluginConfig.ContractTransmitterFactory.NewCommitTransmitter(
 				i.lggr.
 					Named("CCIPCommitTransmitter").
@@ -398,6 +398,9 @@ func (i *pluginOracleCreator) createFactoryAndTransmitter(
 				transmitAccount,
 			)
 		} else {
+			if len(destFromAccounts) == 0 {
+				return nil, nil, fmt.Errorf("transmitter array is empty for dest relay ID %s", destRelayID)
+			}
 			transmitter = pluginConfig.ContractTransmitterFactory.NewExecTransmitter(
 				i.lggr.
 					Named("CCIPExecTransmitter").


### PR DESCRIPTION
The validation that was recently added prevents oracles to boot when they are not transmitters / they don't support the destination chain.

This PR fixes this issue by moving the validation only in the paths that it is required.