### PR TITLE
Run OCR2 soak on release cuts from within build-publish.yml

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -187,3 +187,10 @@ jobs:
               )
             }}
           docker-image-digest: ${{ steps.docker-outputs.outputs.digest }}
+
+  run-core-soak-on-release:
+    needs: [docker-core]
+    uses: smartcontractkit/chainlink/.github/workflows/on-demand-ocr-soak-test.yml@e5667560098cffc3304ef576dfeead94470c2b45 # 2025-07-22
+    with:
+      chainlink_version: ${{ github.ref_name }}
+      team: CRE


### PR DESCRIPTION
[CRE-585](https://smartcontract-it.atlassian.net/browse/CRE-585)
Runs the OCR2 soak test upon core release cuts. Using the `workflow_dispatch` in this way guarantees that the release image is built and accessible before a test runs.

[CRE-585]: https://smartcontract-it.atlassian.net/browse/CRE-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ