### PR TITLE
Remove wait for workflow action from on-demand-ocr-soak-test workflow

### DIFF
--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -1,10 +1,5 @@
 name: On Demand OCR Soak Test
 on:
-  push:
-    tags:
-      # Run on release tags
-      - 'v*'
-
   workflow_dispatch:
     inputs:
       testToRun:
@@ -47,35 +42,6 @@ on:
         default: U01A2B2C3D4
 
 jobs:
-  # When running on a tag, wait for the image to be published to a registry
-  wait-for-workflows:
-    name: Wait for Release Image Build
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          ref: ${{ github.ref_name || github.sha }}
-
-      - name: Wait for Image Build
-        uses: smartcontractkit/.github/actions/wait-for-workflows@wait-for-workflows/1.0.0
-        with:
-          max-timeout: '900'
-          polling-interval: '30'
-          exclude-workflow-names: |
-            Automation Nightly Tests
-            Client Compatibility Tests
-            Integration In-Memory Tests
-            Integration Tests
-          exclude-workflow-ids: ''
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          DEBUG: 'true'
-  
   # Based on the `inputs.chainlink_version` define whether to:
   # - use a private or public ECR registry
   # - skip image build if public ECR registry is used


### PR DESCRIPTION
[CRE-585](https://smartcontract-it.atlassian.net/browse/CRE-585)
The soak-test workflow did not run on release tags. The corresponding logic is removed in favor of dispatching the soak test workflow in the build-publish.yml file, which runs on release tags.

### Supports
- https://github.com/smartcontractkit/chainlink/pull/18704


[CRE-585]: https://smartcontract-it.atlassian.net/browse/CRE-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ