### PR TITLE
replace multierr with std errors; block via linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,9 +49,8 @@ linters:
               desc: Use github.com/stretchr/testify/mock instead
             - pkg: github.com/test-go/testify/require
               desc: Use github.com/stretchr/testify/require instead
-            # TODO https://smartcontract-it.atlassian.net/browse/BCI-2589
-            #          - pkg: go.uber.org/multierr
-            #            desc: Use the standard library instead, for example https://pkg.go.dev/errors#Join
+            - pkg: go.uber.org/multierr
+              desc: Use the standard library instead, for example https://pkg.go.dev/errors#Join
             - pkg: gopkg.in/guregu/null.v1
               desc: Use gopkg.in/guregu/null.v4 instead
             - pkg: gopkg.in/guregu/null.v2

--- a/core/capabilities/ccip/launcher/launcher.go
+++ b/core/capabilities/ccip/launcher/launcher.go
@@ -2,11 +2,10 @@ package launcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
-
-	"go.uber.org/multierr"
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
@@ -115,7 +114,7 @@ func (l *launcher) Close() error {
 		// shut down all running oracles.
 		var err error
 		for _, ceDep := range l.instances {
-			err = multierr.Append(err, ceDep.CloseAll())
+			err = errors.Join(err, ceDep.CloseAll())
 		}
 
 		return err
@@ -185,8 +184,8 @@ func (l *launcher) tick(ctx context.Context) error {
 // for any updated OCR instances, it will restart them with the new configuration.
 func (l *launcher) processDiff(ctx context.Context, diff diffResult) error {
 	err := l.processRemoved(diff.removed)
-	err = multierr.Append(err, l.processAdded(ctx, diff.added))
-	err = multierr.Append(err, l.processUpdate(ctx, diff.updated))
+	err = errors.Join(err, l.processAdded(ctx, diff.added))
+	err = errors.Join(err, l.processUpdate(ctx, diff.updated))
 
 	return err
 }

--- a/core/cmd/admin_commands.go
+++ b/core/cmd/admin_commands.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	cutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 
@@ -187,7 +186,7 @@ func (s *Shell) ListUsers(_ *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 
@@ -207,7 +206,7 @@ func (s *Shell) CreateUser(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 	var links jsonapi.Links
@@ -246,7 +245,7 @@ func (s *Shell) CreateUser(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := response.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 
@@ -275,7 +274,7 @@ func (s *Shell) ChangeRole(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := response.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 
@@ -295,7 +294,7 @@ func (s *Shell) DeleteUser(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := response.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 
@@ -310,7 +309,7 @@ func (s *Shell) Status(c *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/blocks_commands.go
+++ b/core/cmd/blocks_commands.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	stderrors "errors"
 	"fmt"
 	"net/url"
 	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/web"
 )
@@ -89,7 +89,7 @@ func (s *Shell) ReplayFromBlock(c *cli.Context) (err error) {
 
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -134,7 +134,7 @@ func (s *Shell) FindLCA(c *cli.Context) (err error) {
 
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/bridge_commands.go
+++ b/core/cmd/bridge_commands.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
@@ -97,7 +96,7 @@ func (s *Shell) ShowBridge(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 
@@ -121,7 +120,7 @@ func (s *Shell) CreateBridge(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 
@@ -144,7 +143,7 @@ func (s *Shell) UpdateBridge(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 
@@ -163,7 +162,7 @@ func (s *Shell) RemoveBridge(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/cosmos_transaction_commands.go
+++ b/core/cmd/cosmos_transaction_commands.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/store/models/cosmos"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
@@ -115,7 +114,7 @@ func (s *Shell) CosmosSendNativeToken(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/csa_keys_commands.go
+++ b/core/cmd/csa_keys_commands.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	cutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -114,7 +114,7 @@ func (s *Shell) ListCSAKeys(_ *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -129,7 +129,7 @@ func (s *Shell) CreateCSAKey(_ *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -171,7 +171,7 @@ func (s *Shell) ImportCSAKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -214,7 +214,7 @@ func (s *Shell) ExportCSAKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/eth_keys_commands.go
+++ b/core/cmd/eth_keys_commands.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	cutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
@@ -184,7 +184,7 @@ func (s *Shell) ListETHKeys(_ *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -213,7 +213,7 @@ func (s *Shell) CreateETHKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -238,7 +238,7 @@ func (s *Shell) DeleteETHKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -297,7 +297,7 @@ func (s *Shell) ImportETHKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -339,7 +339,7 @@ func (s *Shell) ExportETHKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -392,7 +392,7 @@ func (s *Shell) UpdateChainEVMKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/evm_transaction_commands.go
+++ b/core/cmd/evm_transaction_commands.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
@@ -123,7 +122,7 @@ func (s *Shell) ShowTransaction(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 
@@ -144,7 +143,7 @@ func (s *Shell) SendEther(c *cli.Context) (err error) {
 
 		value, err = stringutils.ToInt64(c.Args().Get(0))
 		if err != nil {
-			return s.errorOut(multierr.Combine(
+			return s.errorOut(errors.Join(
 				errors.New("while parsing WEI transfer amount"), err))
 		}
 
@@ -152,7 +151,7 @@ func (s *Shell) SendEther(c *cli.Context) (err error) {
 	} else {
 		amount, err = assets.NewEthValueS(c.Args().Get(0))
 		if err != nil {
-			return s.errorOut(multierr.Combine(
+			return s.errorOut(errors.Join(
 				errors.New("while parsing ETH transfer amount"), err))
 		}
 	}
@@ -160,7 +159,7 @@ func (s *Shell) SendEther(c *cli.Context) (err error) {
 	unparsedFromAddress := c.Args().Get(1)
 	fromAddress, err := utils.ParseEthereumAddress(unparsedFromAddress)
 	if err != nil {
-		return s.errorOut(multierr.Combine(
+		return s.errorOut(errors.Join(
 			fmt.Errorf("while parsing withdrawal source address %v",
 				unparsedFromAddress), err))
 	}
@@ -168,7 +167,7 @@ func (s *Shell) SendEther(c *cli.Context) (err error) {
 	unparsedDestinationAddress := c.Args().Get(2)
 	destinationAddress, err := utils.ParseEthereumAddress(unparsedDestinationAddress)
 	if err != nil {
-		return s.errorOut(multierr.Combine(
+		return s.errorOut(errors.Join(
 			fmt.Errorf("while parsing withdrawal destination address %v",
 				unparsedDestinationAddress), err))
 	}
@@ -204,7 +203,7 @@ func (s *Shell) SendEther(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/forwarders_commands.go
+++ b/core/cmd/forwarders_commands.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -12,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/web"
@@ -149,14 +149,14 @@ func (s *Shell) TrackForwarder(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
 	if resp.StatusCode >= 400 {
 		body, rerr := io.ReadAll(resp.Body)
 		if err != nil {
-			err = multierr.Append(err, rerr)
+			err = stderrors.Join(err, rerr)
 			return s.errorOut(err)
 		}
 		fmt.Printf("Response: '%v', Status: %d\n", string(body), resp.StatusCode)

--- a/core/cmd/jobs_commands.go
+++ b/core/cmd/jobs_commands.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"strings"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/web"
@@ -230,7 +230,7 @@ func (s *Shell) ShowJob(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -262,14 +262,14 @@ func (s *Shell) CreateJob(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
 	if resp.StatusCode >= 400 {
 		body, rerr := io.ReadAll(resp.Body)
 		if err != nil {
-			err = multierr.Append(err, rerr)
+			err = stderrors.Join(err, rerr)
 			return s.errorOut(err)
 		}
 		fmt.Printf("Response: '%v', Status: %d\n", string(body), resp.StatusCode)
@@ -309,7 +309,7 @@ func (s *Shell) TriggerPipelineRun(c *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/keys_commands.go
+++ b/core/cmd/keys_commands.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -111,7 +111,7 @@ func (cli *keysClient[K, P, P2]) ListKeys(_ *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -127,7 +127,7 @@ func (cli *keysClient[K, P, P2]) CreateKey(_ *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -158,7 +158,7 @@ func (cli *keysClient[K, P, P2]) DeleteKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -195,7 +195,7 @@ func (cli *keysClient[K, P, P2]) ImportKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -233,7 +233,7 @@ func (cli *keysClient[K, P, P2]) ExportKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/ocr2_keys_commands.go
+++ b/core/cmd/ocr2_keys_commands.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	cutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
@@ -133,7 +133,7 @@ func (s *Shell) ListOCR2KeyBundles(_ *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -155,7 +155,7 @@ func (s *Shell) CreateOCR2KeyBundle(c *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -188,7 +188,7 @@ func (s *Shell) DeleteOCR2KeyBundle(c *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -224,7 +224,7 @@ func (s *Shell) ImportOCR2Key(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -261,7 +261,7 @@ func (s *Shell) ExportOCR2Key(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/ocr_keys_commands.go
+++ b/core/cmd/ocr_keys_commands.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	cutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
@@ -114,7 +114,7 @@ func (s *Shell) ListOCRKeyBundles(_ *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -147,7 +147,7 @@ func (s *Shell) CreateOCRKeyBundle(_ *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -180,7 +180,7 @@ func (s *Shell) DeleteOCRKeyBundle(c *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -216,7 +216,7 @@ func (s *Shell) ImportOCRKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -253,7 +253,7 @@ func (s *Shell) ExportOCRKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/p2p_keys_commands.go
+++ b/core/cmd/p2p_keys_commands.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	cutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -131,7 +131,7 @@ func (s *Shell) ListP2PKeys(_ *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -146,7 +146,7 @@ func (s *Shell) CreateP2PKey(_ *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -176,7 +176,7 @@ func (s *Shell) DeleteP2PKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -212,7 +212,7 @@ func (s *Shell) ImportP2PKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -249,7 +249,7 @@ func (s *Shell) ExportP2PKey(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net"
@@ -29,7 +30,6 @@ import (
 	"github.com/urfave/cli"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
 
@@ -405,7 +405,7 @@ func (n ChainlinkRunner) Run(ctx context.Context, app chainlink.Application) err
 			err = errors.WithStack(server.httpServer.Shutdown(context.Background()))
 		}
 		if server.tlsServer != nil {
-			err = multierr.Combine(err, errors.WithStack(server.tlsServer.Shutdown(context.Background())))
+			err = stderrors.Join(err, errors.WithStack(server.tlsServer.Shutdown(context.Background())))
 		}
 		return err
 	})
@@ -738,7 +738,7 @@ func (d DiskCookieStore) Retrieve() (*http.Cookie, error) {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, multierr.Append(errors.New("unable to retrieve credentials, you must first login through the CLI"), err)
+		return nil, stderrors.Join(errors.New("unable to retrieve credentials, you must first login through the CLI"), err)
 	}
 	header := http.Header{}
 	header.Add("Cookie", string(b))

--- a/core/cmd/solana_transaction_commands.go
+++ b/core/cmd/solana_transaction_commands.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"strconv"
 
 	solanaGo "github.com/gagliardetto/solana-go"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/store/models/solana"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
@@ -72,7 +72,7 @@ func (s *Shell) SolanaSendSol(c *cli.Context) (err error) {
 	unparsedFromAddress := c.Args().Get(1)
 	fromAddress, err := solanaGo.PublicKeyFromBase58(unparsedFromAddress)
 	if err != nil {
-		return s.errorOut(multierr.Combine(
+		return s.errorOut(stderrors.Join(
 			errors.Errorf("while parsing withdrawal source address %v",
 				unparsedFromAddress), err))
 	}
@@ -80,7 +80,7 @@ func (s *Shell) SolanaSendSol(c *cli.Context) (err error) {
 	unparsedDestinationAddress := c.Args().Get(2)
 	destinationAddress, err := solanaGo.PublicKeyFromBase58(unparsedDestinationAddress)
 	if err != nil {
-		return s.errorOut(multierr.Combine(
+		return s.errorOut(stderrors.Join(
 			errors.Errorf("while parsing withdrawal destination address %v",
 				unparsedDestinationAddress), err))
 	}
@@ -111,7 +111,7 @@ func (s *Shell) SolanaSendSol(c *cli.Context) (err error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 

--- a/core/cmd/vrf_keys_commands.go
+++ b/core/cmd/vrf_keys_commands.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/signatures/secp256k1"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -124,7 +124,7 @@ func (s *Shell) CreateVRFKey(_ *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -160,7 +160,7 @@ func (s *Shell) ImportVRFKey(c *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -201,7 +201,7 @@ func (s *Shell) ExportVRFKey(c *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -254,7 +254,7 @@ func (s *Shell) DeleteVRFKey(c *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 
@@ -282,7 +282,7 @@ func (s *Shell) ListVRFKeys(_ *cli.Context) error {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = stderrors.Join(err, cerr)
 		}
 	}()
 

--- a/core/config/docs/docs.go
+++ b/core/config/docs/docs.go
@@ -2,11 +2,10 @@ package docs
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
-
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 )
@@ -251,12 +250,12 @@ func parseTOMLDocs(s string) (items []fmt.Stringer, err error) {
 				kv.name = currentTable.name + "." + kv.name
 			}
 			if len(kv.desc) == 0 {
-				err = multierr.Append(err, fmt.Errorf("%s: missing description", kv.name))
+				err = errors.Join(err, fmt.Errorf("%s: missing description", kv.name))
 			} else if !strings.HasPrefix(kv.desc[0], shortName) {
-				err = multierr.Append(err, fmt.Errorf("%s: description does not begin with %q", kv.name, shortName))
+				err = errors.Join(err, fmt.Errorf("%s: description does not begin with %q", kv.name, shortName))
 			}
 			if !strings.HasSuffix(line, fieldDefault) && !strings.HasSuffix(line, fieldExample) {
-				err = multierr.Append(err, fmt.Errorf(`%s: is not one of %v`, kv.name, []string{fieldDefault, fieldExample}))
+				err = errors.Join(err, fmt.Errorf(`%s: is not one of %v`, kv.name, []string{fieldDefault, fieldExample}))
 			}
 
 			items = append(items, kv)

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
@@ -113,16 +112,16 @@ func (c *Core) SetFrom(f *Core) {
 func (c *Core) ValidateConfig() (err error) {
 	_, verr := parse.HomeDir(*c.RootDir)
 	if verr != nil {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "RootDir", Value: true, Msg: fmt.Sprintf("Failed to expand RootDir. Please use an explicit path: %s", verr)})
+		err = errors.Join(err, configutils.ErrInvalid{Name: "RootDir", Value: true, Msg: fmt.Sprintf("Failed to expand RootDir. Please use an explicit path: %s", verr)})
 	}
 
 	if (*c.OCR.Enabled || *c.OCR2.Enabled) && !*c.P2P.V2.Enabled {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "P2P.V2.Enabled", Value: false, Msg: "P2P required for OCR or OCR2. Please enable P2P or disable OCR/OCR2."})
+		err = errors.Join(err, configutils.ErrInvalid{Name: "P2P.V2.Enabled", Value: false, Msg: "P2P required for OCR or OCR2. Please enable P2P or disable OCR/OCR2."})
 	}
 
 	if *c.Tracing.Enabled && *c.Telemetry.Enabled {
 		if c.Tracing.CollectorTarget == c.Telemetry.Endpoint {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "Tracing.CollectorTarget", Value: *c.Tracing.CollectorTarget, Msg: "Same as Telemetry.Endpoint. Must be different or disabled."})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "Tracing.CollectorTarget", Value: *c.Tracing.CollectorTarget, Msg: "Same as Telemetry.Endpoint. Must be different or disabled."})
 		}
 	}
 
@@ -167,7 +166,7 @@ func (e *EthKeys) validateMerge(f *EthKeys) (err error) {
 		}
 		for _, ethKey := range f.Keys {
 			if _, ok := have[*ethKey.ID]; ok {
-				err = multierr.Append(err, configutils.ErrOverride{Name: fmt.Sprintf("EthKeys: %d", *ethKey.ID)})
+				err = errors.Join(err, configutils.ErrOverride{Name: fmt.Sprintf("EthKeys: %d", *ethKey.ID)})
 			}
 		}
 	}
@@ -177,7 +176,7 @@ func (e *EthKeys) validateMerge(f *EthKeys) (err error) {
 func (e *EthKeys) ValidateConfig() (err error) {
 	for i, ethKey := range e.Keys {
 		if err2 := ethKey.ValidateConfig(); err2 != nil {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: fmt.Sprintf("EthKeys[%d]", i), Value: ethKey, Msg: "invalid EthKey"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: fmt.Sprintf("EthKeys[%d]", i), Value: ethKey, Msg: "invalid EthKey"})
 		}
 	}
 	return err
@@ -224,17 +223,17 @@ func (d *DatabaseSecrets) ValidateConfig() (err error) {
 
 func (d *DatabaseSecrets) validateConfig(buildMode string) (err error) {
 	if d.URL == nil || (*url.URL)(d.URL).String() == "" {
-		err = multierr.Append(err, configutils.ErrEmpty{Name: "URL", Msg: "must be provided and non-empty"})
+		err = errors.Join(err, configutils.ErrEmpty{Name: "URL", Msg: "must be provided and non-empty"})
 	} else if *d.AllowSimplePasswords && buildMode == build.Prod {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "AllowSimplePasswords", Value: true, Msg: "insecure configs are not allowed on secure builds"})
+		err = errors.Join(err, configutils.ErrInvalid{Name: "AllowSimplePasswords", Value: true, Msg: "insecure configs are not allowed on secure builds"})
 	} else if !*d.AllowSimplePasswords {
 		if verr := validateDBURL((url.URL)(*d.URL)); verr != nil {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "URL", Value: "*****", Msg: dbURLPasswordComplexity(verr)})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "URL", Value: "*****", Msg: dbURLPasswordComplexity(verr)})
 		}
 	}
 	if d.BackupURL != nil && !*d.AllowSimplePasswords {
 		if verr := validateDBURL((url.URL)(*d.BackupURL)); verr != nil {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "BackupURL", Value: "*****", Msg: dbURLPasswordComplexity(verr)})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "BackupURL", Value: "*****", Msg: dbURLPasswordComplexity(verr)})
 		}
 	}
 	return err
@@ -260,15 +259,15 @@ func (d *DatabaseSecrets) SetFrom(f *DatabaseSecrets) (err error) {
 
 func (d *DatabaseSecrets) validateMerge(f *DatabaseSecrets) (err error) {
 	if d.AllowSimplePasswords != nil && f.AllowSimplePasswords != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "AllowSimplePasswords"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "AllowSimplePasswords"})
 	}
 
 	if d.BackupURL != nil && f.BackupURL != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "BackupURL"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "BackupURL"})
 	}
 
 	if d.URL != nil && f.URL != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "URL"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "URL"})
 	}
 
 	return err
@@ -299,26 +298,26 @@ func (e *EthKey) SetFrom(f *EthKey) (err error) {
 
 func (e *EthKey) validateMerge(f *EthKey) (err error) {
 	if e.JSON != nil && f.JSON != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "PrivateKey"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "PrivateKey"})
 	}
 	if e.ID != nil && f.ID != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "Selector"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "Selector"})
 	}
 	if e.Password != nil && f.Password != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "Password"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "Password"})
 	}
 	return err
 }
 
 func (e *EthKey) ValidateConfig() (err error) {
 	if (e.JSON != nil) != (e.Password != nil) && (e.Password != nil) != (e.ID != nil) {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "EthKey", Value: e.JSON, Msg: "all fields must be nil or non-nil"})
+		err = errors.Join(err, configutils.ErrInvalid{Name: "EthKey", Value: e.JSON, Msg: "all fields must be nil or non-nil"})
 	}
 	// require valid id
 	if e.ID != nil {
 		_, ok := chain_selectors.ChainByEvmChainID(uint64(*e.ID)) //nolint:gosec // disable G115
 		if !ok {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "ChainSelector", Value: e.ID, Msg: "invalid chain selector"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "ChainSelector", Value: e.ID, Msg: "invalid chain selector"})
 		}
 	}
 	return err
@@ -344,17 +343,17 @@ func (p *P2PKey) SetFrom(f *P2PKey) (err error) {
 }
 func (p *P2PKey) validateMerge(f *P2PKey) (err error) {
 	if p.JSON != nil && f.JSON != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "JSON"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "JSON"})
 	}
 	if p.Password != nil && f.Password != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "Password"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "Password"})
 	}
 	return err
 }
 
 func (p *P2PKey) ValidateConfig() (err error) {
 	if (p.JSON != nil) != (p.Password != nil) {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "P2PKey", Value: p.JSON, Msg: "all fields must be nil or non-nil"})
+		err = errors.Join(err, configutils.ErrInvalid{Name: "P2PKey", Value: p.JSON, Msg: "all fields must be nil or non-nil"})
 	}
 	return err
 }
@@ -382,11 +381,11 @@ func (p *Passwords) SetFrom(f *Passwords) (err error) {
 
 func (p *Passwords) validateMerge(f *Passwords) (err error) {
 	if p.Keystore != nil && f.Keystore != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "Keystore"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "Keystore"})
 	}
 
 	if p.VRF != nil && f.VRF != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "VRF"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "VRF"})
 	}
 
 	return err
@@ -394,7 +393,7 @@ func (p *Passwords) validateMerge(f *Passwords) (err error) {
 
 func (p *Passwords) ValidateConfig() (err error) {
 	if p.Keystore == nil || *p.Keystore == "" {
-		err = multierr.Append(err, configutils.ErrEmpty{Name: "Keystore", Msg: "must be provided and non-empty"})
+		err = errors.Join(err, configutils.ErrEmpty{Name: "Keystore", Msg: "must be provided and non-empty"})
 	}
 	return err
 }
@@ -418,7 +417,7 @@ func (p *PyroscopeSecrets) SetFrom(f *PyroscopeSecrets) (err error) {
 
 func (p *PyroscopeSecrets) validateMerge(f *PyroscopeSecrets) (err error) {
 	if p.AuthToken != nil && f.AuthToken != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "AuthToken"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "AuthToken"})
 	}
 
 	return err
@@ -443,7 +442,7 @@ func (p *PrometheusSecrets) SetFrom(f *PrometheusSecrets) (err error) {
 
 func (p *PrometheusSecrets) validateMerge(f *PrometheusSecrets) (err error) {
 	if p.AuthToken != nil && f.AuthToken != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "AuthToken"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "AuthToken"})
 	}
 
 	return err
@@ -551,7 +550,7 @@ func (l *DatabaseLock) Mode() string {
 
 func (l *DatabaseLock) ValidateConfig() (err error) {
 	if l.LeaseRefreshInterval.Duration() > l.LeaseDuration.Duration()/2 {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "LeaseRefreshInterval", Value: l.LeaseRefreshInterval.String(),
+		err = errors.Join(err, configutils.ErrInvalid{Name: "LeaseRefreshInterval", Value: l.LeaseRefreshInterval.String(),
 			Msg: fmt.Sprintf("must be less than or equal to half of LeaseDuration (%s)", l.LeaseDuration.String())})
 	}
 	return
@@ -807,63 +806,63 @@ func (w *WebServer) ValidateConfig() (err error) {
 	case string(sessions.LDAPAuth):
 		// Assert LDAP fields when AuthMethod set to LDAP
 		if *w.LDAP.BaseDN == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.BaseDN", Msg: "LDAP BaseDN can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "LDAP.BaseDN", Msg: "LDAP BaseDN can not be empty"})
 		}
 		if *w.LDAP.BaseUserAttr == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.BaseUserAttr", Msg: "LDAP BaseUserAttr can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "LDAP.BaseUserAttr", Msg: "LDAP BaseUserAttr can not be empty"})
 		}
 		if *w.LDAP.UsersDN == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.UsersDN", Msg: "LDAP UsersDN can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "LDAP.UsersDN", Msg: "LDAP UsersDN can not be empty"})
 		}
 		if *w.LDAP.GroupsDN == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.GroupsDN", Msg: "LDAP GroupsDN can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "LDAP.GroupsDN", Msg: "LDAP GroupsDN can not be empty"})
 		}
 		if *w.LDAP.AdminUserGroupCN == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.AdminUserGroupCN", Msg: "LDAP AdminUserGroupCN can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "LDAP.AdminUserGroupCN", Msg: "LDAP AdminUserGroupCN can not be empty"})
 		}
 		if *w.LDAP.EditUserGroupCN == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.RunUserGroupCN", Msg: "LDAP ReadUserGroupCN can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "LDAP.RunUserGroupCN", Msg: "LDAP ReadUserGroupCN can not be empty"})
 		}
 		if *w.LDAP.RunUserGroupCN == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.RunUserGroupCN", Msg: "LDAP RunUserGroupCN can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "LDAP.RunUserGroupCN", Msg: "LDAP RunUserGroupCN can not be empty"})
 		}
 		if *w.LDAP.ReadUserGroupCN == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.ReadUserGroupCN", Msg: "LDAP ReadUserGroupCN can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "LDAP.ReadUserGroupCN", Msg: "LDAP ReadUserGroupCN can not be empty"})
 		}
 		return err
 	case string(sessions.OIDCAuth):
 		if w.OIDC.ClientID == nil || *w.OIDC.ClientID == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.ClientID", Msg: "OIDC ClientID can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.ClientID", Msg: "OIDC ClientID can not be empty"})
 		}
 		if w.OIDC.ProviderURL == nil || *w.OIDC.ProviderURL == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.ProviderURL", Msg: "OIDC ProviderURL can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.ProviderURL", Msg: "OIDC ProviderURL can not be empty"})
 		}
 		if w.OIDC.RedirectURL == nil || *w.OIDC.RedirectURL == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.RedirectURL", Msg: "OIDC RedirectURL can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.RedirectURL", Msg: "OIDC RedirectURL can not be empty"})
 		}
 		if w.OIDC.ClaimName == nil || *w.OIDC.ClaimName == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.ClaimName", Msg: "OIDC ClaimName can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.ClaimName", Msg: "OIDC ClaimName can not be empty"})
 		}
 		if w.OIDC.AdminClaim == nil || *w.OIDC.AdminClaim == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.AdminClaim", Msg: "OIDC AdminClaim can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.AdminClaim", Msg: "OIDC AdminClaim can not be empty"})
 		}
 		if w.OIDC.EditClaim == nil || *w.OIDC.EditClaim == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.EditClaim", Msg: "OIDC EditClaim can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.EditClaim", Msg: "OIDC EditClaim can not be empty"})
 		}
 		if w.OIDC.RunClaim == nil || *w.OIDC.RunClaim == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.RunClaim", Msg: "OIDC RunClaim can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.RunClaim", Msg: "OIDC RunClaim can not be empty"})
 		}
 		if w.OIDC.ReadClaim == nil || *w.OIDC.ReadClaim == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.ReadClaim", Msg: "OIDC ReadClaim can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.ReadClaim", Msg: "OIDC ReadClaim can not be empty"})
 		}
 		if w.OIDC.SessionTimeout == commonconfig.MustNewDuration(0) {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.SessionTimeout", Msg: "OIDC SessionTimeout can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.SessionTimeout", Msg: "OIDC SessionTimeout can not be empty"})
 		}
 		if w.OIDC.UserAPITokenEnabled == nil {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.UserAPITokenEnabled", Msg: "OIDC UserAPITokenEnabled can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.UserAPITokenEnabled", Msg: "OIDC UserAPITokenEnabled can not be empty"})
 		}
 		if w.OIDC.UserAPITokenDuration == commonconfig.MustNewDuration(0) {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "OIDC.UserAPITokenDuration", Msg: "OIDC UserAPITokenDuration can not be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "OIDC.UserAPITokenDuration", Msg: "OIDC UserAPITokenDuration can not be empty"})
 		}
 		return err
 	}
@@ -1107,22 +1106,22 @@ func (w *WebServerSecrets) ValidateConfig() (err error) {
 	// Validate LDAP if it has non-zero values
 	if w.LDAP != (WebServerLDAPSecrets{}) {
 		if w.LDAP.ServerAddress == nil || w.LDAP.ServerAddress.URL().String() == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "WebServerLDAPSecrets.ServerAddress", Msg: "WebServerLDAPSecrets ServerAddress cannot be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "WebServerLDAPSecrets.ServerAddress", Msg: "WebServerLDAPSecrets ServerAddress cannot be empty"})
 		}
 
 		if w.LDAP.ReadOnlyUserLogin == nil || *w.LDAP.ReadOnlyUserLogin == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "w.LDAP.bServerLDAPSecrets.ReadOnlyUserLogin", Msg: "WebServerLDAPSecrets ReadOnlyUserLogin cannot be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "w.LDAP.bServerLDAPSecrets.ReadOnlyUserLogin", Msg: "WebServerLDAPSecrets ReadOnlyUserLogin cannot be empty"})
 		}
 
 		if w.LDAP.ReadOnlyUserPass == nil || *w.LDAP.ReadOnlyUserPass == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "w.LDAP.bServerLDAPSecrets.ReadOnlyUserPass", Msg: "WebServerLDAPSecrets ReadOnlyUserPass cannot be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "w.LDAP.bServerLDAPSecrets.ReadOnlyUserPass", Msg: "WebServerLDAPSecrets ReadOnlyUserPass cannot be empty"})
 		}
 	}
 
 	// Validate OIDC if it has non-zero values
 	if w.OIDC != (WebServerOIDCSecrets{}) {
 		if w.OIDC.ClientSecret.String() == "" {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "WebServerOIDCSecrets.ClientSecret", Msg: "WebServerOIDCSecrets ClientSecret cannot be empty"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "WebServerOIDCSecrets.ClientSecret", Msg: "WebServerOIDCSecrets ClientSecret cannot be empty"})
 		}
 	}
 
@@ -1533,17 +1532,17 @@ func (ins *Insecure) validateConfig(buildMode string) (err error) {
 		return
 	}
 	if ins.DevWebServer != nil && *ins.DevWebServer {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "DevWebServer", Value: *ins.DevWebServer, Msg: "insecure configs are not allowed on secure builds"})
+		err = errors.Join(err, configutils.ErrInvalid{Name: "DevWebServer", Value: *ins.DevWebServer, Msg: "insecure configs are not allowed on secure builds"})
 	}
 	// OCRDevelopmentMode is allowed on dev/test builds.
 	if ins.OCRDevelopmentMode != nil && *ins.OCRDevelopmentMode && buildMode == build.Prod {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "OCRDevelopmentMode", Value: *ins.OCRDevelopmentMode, Msg: "insecure configs are not allowed on secure builds"})
+		err = errors.Join(err, configutils.ErrInvalid{Name: "OCRDevelopmentMode", Value: *ins.OCRDevelopmentMode, Msg: "insecure configs are not allowed on secure builds"})
 	}
 	if ins.InfiniteDepthQueries != nil && *ins.InfiniteDepthQueries {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "InfiniteDepthQueries", Value: *ins.InfiniteDepthQueries, Msg: "insecure configs are not allowed on secure builds"})
+		err = errors.Join(err, configutils.ErrInvalid{Name: "InfiniteDepthQueries", Value: *ins.InfiniteDepthQueries, Msg: "insecure configs are not allowed on secure builds"})
 	}
 	if ins.DisableRateLimiting != nil && *ins.DisableRateLimiting {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "DisableRateLimiting", Value: *ins.DisableRateLimiting, Msg: "insecure configs are not allowed on secure builds"})
+		err = errors.Join(err, configutils.ErrInvalid{Name: "DisableRateLimiting", Value: *ins.DisableRateLimiting, Msg: "insecure configs are not allowed on secure builds"})
 	}
 	return err
 }
@@ -1594,7 +1593,7 @@ func (m *MercuryTLS) setFrom(f *MercuryTLS) {
 func (m *MercuryTLS) ValidateConfig() (err error) {
 	if *m.CertFile != "" {
 		if !isValidFilePath(*m.CertFile) {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "CertFile", Value: *m.CertFile, Msg: "must be a valid file path"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "CertFile", Value: *m.CertFile, Msg: "must be a valid file path"})
 		}
 	}
 	return
@@ -1686,7 +1685,7 @@ func (m *MercurySecrets) validateMerge(f *MercurySecrets) (err error) {
 	if m.Credentials != nil && f.Credentials != nil {
 		for k := range f.Credentials {
 			if _, exists := m.Credentials[k]; exists {
-				err = multierr.Append(err, configutils.ErrOverride{Name: fmt.Sprintf("Credentials[\"%s\"]", k)})
+				err = errors.Join(err, configutils.ErrOverride{Name: fmt.Sprintf("Credentials[\"%s\"]", k)})
 			}
 		}
 	}
@@ -1698,19 +1697,19 @@ func (m *MercurySecrets) ValidateConfig() (err error) {
 	urls := make(map[string]struct{}, len(m.Credentials))
 	for name, creds := range m.Credentials {
 		if name == "" {
-			err = multierr.Append(err, configutils.ErrEmpty{Name: "Name", Msg: "must be provided and non-empty"})
+			err = errors.Join(err, configutils.ErrEmpty{Name: "Name", Msg: "must be provided and non-empty"})
 		}
 		if creds.URL == nil || creds.URL.URL() == nil {
-			err = multierr.Append(err, configutils.ErrMissing{Name: "URL", Msg: "must be provided and non-empty"})
+			err = errors.Join(err, configutils.ErrMissing{Name: "URL", Msg: "must be provided and non-empty"})
 			continue
 		}
 		if creds.LegacyURL != nil && creds.LegacyURL.URL() == nil {
-			err = multierr.Append(err, configutils.ErrMissing{Name: "Legacy URL", Msg: "must be a valid URL"})
+			err = errors.Join(err, configutils.ErrMissing{Name: "Legacy URL", Msg: "must be a valid URL"})
 			continue
 		}
 		s := creds.URL.URL().String()
 		if _, exists := urls[s]; exists {
-			err = multierr.Append(err, configutils.NewErrDuplicate("URL", s))
+			err = errors.Join(err, configutils.NewErrDuplicate("URL", s))
 		}
 		urls[s] = struct{}{}
 	}
@@ -1807,10 +1806,10 @@ func (c *CreSecrets) SetFrom(f *CreSecrets) (err error) {
 func (c *CreSecrets) validateMerge(f *CreSecrets) (err error) {
 	if c.Streams != nil && f.Streams != nil {
 		if c.Streams.APIKey != nil && f.Streams.APIKey != nil {
-			err = multierr.Append(err, configutils.ErrOverride{Name: "Streams.APIKey"})
+			err = errors.Join(err, configutils.ErrOverride{Name: "Streams.APIKey"})
 		}
 		if c.Streams.APISecret != nil && f.Streams.APISecret != nil {
-			err = multierr.Append(err, configutils.ErrOverride{Name: "Streams.APISecret"})
+			err = errors.Join(err, configutils.ErrOverride{Name: "Streams.APISecret"})
 		}
 	}
 	return err
@@ -2049,7 +2048,7 @@ func (t *ThresholdKeyShareSecrets) SetFrom(f *ThresholdKeyShareSecrets) (err err
 
 func (t *ThresholdKeyShareSecrets) validateMerge(f *ThresholdKeyShareSecrets) (err error) {
 	if t.ThresholdKeyShare != nil && f.ThresholdKeyShare != nil {
-		err = multierr.Append(err, configutils.ErrOverride{Name: "ThresholdKeyShare"})
+		err = errors.Join(err, configutils.ErrOverride{Name: "ThresholdKeyShare"})
 	}
 
 	return err
@@ -2096,7 +2095,7 @@ func (t *Tracing) ValidateConfig() (err error) {
 
 	if t.SamplingRatio != nil {
 		if *t.SamplingRatio < 0 || *t.SamplingRatio > 1 {
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "SamplingRatio", Value: *t.SamplingRatio, Msg: "must be between 0 and 1"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "SamplingRatio", Value: *t.SamplingRatio, Msg: "must be between 0 and 1"})
 		}
 	}
 
@@ -2105,18 +2104,18 @@ func (t *Tracing) ValidateConfig() (err error) {
 		case "tls":
 			// TLSCertPath must be set
 			if t.TLSCertPath == nil {
-				err = multierr.Append(err, configutils.ErrMissing{Name: "TLSCertPath", Msg: "must be set when Tracing.Mode is tls"})
+				err = errors.Join(err, configutils.ErrMissing{Name: "TLSCertPath", Msg: "must be set when Tracing.Mode is tls"})
 			} else {
 				ok := isValidFilePath(*t.TLSCertPath)
 				if !ok {
-					err = multierr.Append(err, configutils.ErrInvalid{Name: "TLSCertPath", Value: *t.TLSCertPath, Msg: "must be a valid file path"})
+					err = errors.Join(err, configutils.ErrInvalid{Name: "TLSCertPath", Value: *t.TLSCertPath, Msg: "must be a valid file path"})
 				}
 			}
 		case "unencrypted":
 			// no-op
 		default:
 			// Mode must be either "tls" or "unencrypted"
-			err = multierr.Append(err, configutils.ErrInvalid{Name: "Mode", Value: *t.Mode, Msg: "must be either 'tls' or 'unencrypted'"})
+			err = errors.Join(err, configutils.ErrInvalid{Name: "Mode", Value: *t.Mode, Msg: "must be either 'tls' or 'unencrypted'"})
 		}
 	}
 
@@ -2124,12 +2123,12 @@ func (t *Tracing) ValidateConfig() (err error) {
 		switch *t.Mode {
 		case "tls":
 			if !isValidURI(*t.CollectorTarget) {
-				err = multierr.Append(err, configutils.ErrInvalid{Name: "CollectorTarget", Value: *t.CollectorTarget, Msg: "must be a valid URI"})
+				err = errors.Join(err, configutils.ErrInvalid{Name: "CollectorTarget", Value: *t.CollectorTarget, Msg: "must be a valid URI"})
 			}
 		case "unencrypted":
 			// Unencrypted traces can not be sent to external networks
 			if !isValidLocalURI(*t.CollectorTarget) {
-				err = multierr.Append(err, configutils.ErrInvalid{Name: "CollectorTarget", Value: *t.CollectorTarget, Msg: "must be a valid local URI"})
+				err = errors.Join(err, configutils.ErrInvalid{Name: "CollectorTarget", Value: *t.CollectorTarget, Msg: "must be a valid local URI"})
 			}
 		default:
 			// no-op
@@ -2190,16 +2189,16 @@ func (b *Telemetry) ValidateConfig() (err error) {
 		return nil
 	}
 	if b.Endpoint == nil || *b.Endpoint == "" {
-		err = multierr.Append(err, configutils.ErrMissing{Name: "Endpoint", Msg: "must be set when Telemetry is enabled"})
+		err = errors.Join(err, configutils.ErrMissing{Name: "Endpoint", Msg: "must be set when Telemetry is enabled"})
 	}
 	if b.InsecureConnection == nil || !*b.InsecureConnection {
 		// InsecureConnection is set and false
 		if b.CACertFile == nil || *b.CACertFile == "" {
-			err = multierr.Append(err, configutils.ErrMissing{Name: "CACertFile", Msg: "must be set, unless InsecureConnection is used"})
+			err = errors.Join(err, configutils.ErrMissing{Name: "CACertFile", Msg: "must be set, unless InsecureConnection is used"})
 		}
 	}
 	if ratio := b.TraceSampleRatio; ratio != nil && (*ratio < 0 || *ratio > 1) {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "TraceSampleRatio", Value: *ratio, Msg: "must be between 0 and 1"})
+		err = errors.Join(err, configutils.ErrInvalid{Name: "TraceSampleRatio", Value: *ratio, Msg: "must be between 0 and 1"})
 	}
 	return err
 }

--- a/core/services/blockhashstore/feeder.go
+++ b/core/services/blockhashstore/feeder.go
@@ -2,12 +2,12 @@ package blockhashstore
 
 import (
 	"context"
+	stderrors "errors"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
@@ -143,7 +143,7 @@ func (f *Feeder) Run(ctx context.Context) error {
 			f.lggr.Errorw("Failed to check if block is already stored, attempting to store anyway",
 				"err", err,
 				"block", block)
-			errs = multierr.Append(errs, errors.Wrap(err, "checking if stored"))
+			errs = stderrors.Join(errs, errors.Wrap(err, "checking if stored"))
 		} else if stored {
 			// IsStored() can be based on unfinalized blocks. Therefore, f.stored mapping is not updated
 			f.lggr.Infow("Blockhash already stored",
@@ -156,7 +156,7 @@ func (f *Feeder) Run(ctx context.Context) error {
 		err = f.bhs.Store(ctx, block)
 		if err != nil {
 			f.lggr.Errorw("Failed to store block", "err", err, "block", block)
-			errs = multierr.Append(errs, errors.Wrap(err, "storing block"))
+			errs = stderrors.Join(errs, errors.Wrap(err, "storing block"))
 			continue
 		}
 
@@ -214,7 +214,7 @@ func (f *Feeder) runTrusted(
 					"err", err,
 					"block", block)
 				f.errsLock.Lock()
-				errs = multierr.Append(errs, errors.Wrap(err, "checking if stored"))
+				errs = stderrors.Join(errs, errors.Wrap(err, "checking if stored"))
 				f.errsLock.Unlock()
 			} else if stored {
 				f.lggr.Infow("Blockhash already stored",
@@ -248,7 +248,7 @@ func (f *Feeder) runTrusted(
 			f.lggr.Errorw("Failed to get blocks range",
 				"err", err,
 				"blocks", batch)
-			errs = multierr.Append(errs, errors.Wrap(err, "log poller get blocks range"))
+			errs = stderrors.Join(errs, errors.Wrap(err, "log poller get blocks range"))
 			return errs
 		}
 
@@ -283,7 +283,7 @@ func (f *Feeder) runTrusted(
 				"latestBlock", latestBlock,
 				"latestBlockhash", latestBlockhash,
 			)
-			errs = multierr.Append(errs, errors.Wrap(err, "checking if stored"))
+			errs = stderrors.Join(errs, errors.Wrap(err, "checking if stored"))
 			return errs
 		}
 		for i, block := range blocksToStore {

--- a/core/services/blockheaderfeeder/delegate.go
+++ b/core/services/blockheaderfeeder/delegate.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/batch_blockhash_store"
@@ -296,7 +295,7 @@ func (s *service) runFeeder(ctx context.Context) {
 func CheckFromAddressesExist(jb job.Job, enabled []common.Address) (err error) {
 	for _, a := range jb.BlockHeaderFeederSpec.FromAddresses {
 		if !slices.Contains(enabled, a.Address()) {
-			err = multierr.Append(err, fmt.Errorf("address not enabled: %s", a.Hex()))
+			err = stderrors.Join(err, fmt.Errorf("address not enabled: %s", a.Hex()))
 		}
 	}
 	return

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -21,7 +21,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/billing"
@@ -1014,7 +1013,7 @@ func (app *ChainlinkApplication) Start(ctx context.Context) error {
 	for _, service := range app.srvcs {
 		if ctx.Err() != nil {
 			err := errors.Wrap(ctx.Err(), "aborting start")
-			return multierr.Combine(err, ms.Close())
+			return stderrors.Join(err, ms.Close())
 		}
 
 		app.logger.Infow("Starting service...", "name", service.Name())
@@ -1070,7 +1069,7 @@ func (app *ChainlinkApplication) stop() (err error) {
 				return
 			}
 			if lerr := app.closeLogger(); lerr != nil {
-				err = multierr.Append(err, lerr)
+				err = stderrors.Join(err, lerr)
 			}
 		}()
 		app.logger.Info("Gracefully exiting...")
@@ -1079,20 +1078,20 @@ func (app *ChainlinkApplication) stop() (err error) {
 		for i := len(app.srvcs) - 1; i >= 0; i-- {
 			service := app.srvcs[i]
 			app.logger.Debugw("Closing service...", "name", service.Name())
-			err = multierr.Append(err, service.Close())
+			err = stderrors.Join(err, service.Close())
 		}
 
 		app.logger.Debug("Stopping SessionReaper...")
-		err = multierr.Append(err, app.SessionReaper.Stop())
+		err = stderrors.Join(err, app.SessionReaper.Stop())
 		app.logger.Debug("Closing HealthChecker...")
-		err = multierr.Append(err, app.HealthChecker.Close())
+		err = stderrors.Join(err, app.HealthChecker.Close())
 		if app.FeedsService != nil {
 			app.logger.Debug("Closing Feeds Service...")
-			err = multierr.Append(err, app.FeedsService.Close())
+			err = stderrors.Join(err, app.FeedsService.Close())
 		}
 
 		if app.profiler != nil {
-			err = multierr.Append(err, app.profiler.Stop())
+			err = stderrors.Join(err, app.profiler.Stop())
 		}
 
 		app.logger.Debugf("Closed application in %v", time.Since(shutdownStart))

--- a/core/services/chainlink/cfgtest/cfgtest.go
+++ b/core/services/chainlink/cfgtest/cfgtest.go
@@ -2,13 +2,13 @@ package cfgtest
 
 import (
 	"encoding"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 )
@@ -34,7 +34,7 @@ func assertFieldsNotNil(t *testing.T, prefix string, s reflect.Value) (err error
 			}
 			key += tf.Name
 		}
-		err = multierr.Combine(err, assertValNotNil(t, key, f))
+		err = errors.Join(err, assertValNotNil(t, key, f))
 	}
 	return
 }
@@ -50,7 +50,7 @@ func assertValuesNotNil(t *testing.T, prefix string, m reflect.Value) (err error
 	mi := m.MapRange()
 	for mi.Next() {
 		key := prefix + mi.Key().String()
-		err = multierr.Combine(err, assertValNotNil(t, key, mi.Value()))
+		err = errors.Join(err, assertValNotNil(t, key, mi.Value()))
 	}
 	return
 }
@@ -61,7 +61,7 @@ func assertElementsNotNil(t *testing.T, prefix string, s reflect.Value) (err err
 	require.Equal(t, reflect.Slice, s.Kind())
 
 	for i := 0; i < s.Len(); i++ {
-		err = multierr.Combine(err, assertValNotNil(t, prefix, s.Index(i)))
+		err = errors.Join(err, assertValNotNil(t, prefix, s.Index(i)))
 	}
 	return
 }

--- a/core/services/chainlink/config.go
+++ b/core/services/chainlink/config.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 
 	"github.com/imdario/mergo"
-	"go.uber.org/multierr"
 
 	gotoml "github.com/pelletier/go-toml/v2"
 
@@ -120,21 +119,21 @@ func (c RawConfig) parse() (*parsedRawConfig, error) {
 	var err error
 	if v, ok := c["Enabled"]; ok {
 		if _, ok := v.(bool); !ok {
-			err = multierr.Append(err, commonconfig.ErrInvalid{Name: "Enabled", Value: v, Msg: "expected bool"})
+			err = errors.Join(err, commonconfig.ErrInvalid{Name: "Enabled", Value: v, Msg: "expected bool"})
 		}
 	}
 
 	parsedRawConfig := &parsedRawConfig{}
 	chainID, exists := c["ChainID"]
 	if !exists {
-		err = multierr.Append(err, commonconfig.ErrMissing{Name: "ChainID", Msg: "required for all chains"})
+		err = errors.Join(err, commonconfig.ErrMissing{Name: "ChainID", Msg: "required for all chains"})
 	} else {
 		chainIDStr, ok := chainID.(string)
 		switch {
 		case !ok:
-			err = multierr.Append(err, commonconfig.ErrInvalid{Name: "ChainID", Value: chainID, Msg: "expected string"})
+			err = errors.Join(err, commonconfig.ErrInvalid{Name: "ChainID", Value: chainID, Msg: "expected string"})
 		case chainIDStr == "":
-			err = multierr.Append(err, commonconfig.ErrEmpty{Name: "ChainID", Msg: "required for all chains"})
+			err = errors.Join(err, commonconfig.ErrEmpty{Name: "ChainID", Msg: "required for all chains"})
 		default:
 			parsedRawConfig.chainID = chainIDStr
 		}
@@ -145,24 +144,24 @@ func (c RawConfig) parse() (*parsedRawConfig, error) {
 		nodeMaps, ok := nodes.([]any)
 		switch {
 		case !ok:
-			err = multierr.Append(err, commonconfig.ErrInvalid{Name: "Nodes", Value: nodes, Msg: "expected array of node configs"})
+			err = errors.Join(err, commonconfig.ErrInvalid{Name: "Nodes", Value: nodes, Msg: "expected array of node configs"})
 		default:
 			for i, node := range nodeMaps {
 				nodeConfig, ok := node.(map[string]any)
 				if !ok {
-					err = multierr.Append(err, commonconfig.ErrInvalid{Name: fmt.Sprintf("Nodes.%d", i), Value: nodeConfig, Msg: "expected node config map"})
+					err = errors.Join(err, commonconfig.ErrInvalid{Name: fmt.Sprintf("Nodes.%d", i), Value: nodeConfig, Msg: "expected node config map"})
 				} else {
 					parsedRawConfig.nodes = append(parsedRawConfig.nodes, nodeConfig)
 					nodeName, exists := nodeConfig["Name"]
 					if !exists {
-						err = multierr.Append(err, commonconfig.ErrMissing{Name: fmt.Sprintf("Nodes.%d.Name", i), Msg: "required for all nodes"})
+						err = errors.Join(err, commonconfig.ErrMissing{Name: fmt.Sprintf("Nodes.%d.Name", i), Msg: "required for all nodes"})
 					} else {
 						nodeNameStr, ok := nodeName.(string)
 						switch {
 						case !ok:
-							err = multierr.Append(err, commonconfig.ErrInvalid{Name: fmt.Sprintf("Nodes.%d.Name", i), Value: nodeName, Msg: "expected string"})
+							err = errors.Join(err, commonconfig.ErrInvalid{Name: fmt.Sprintf("Nodes.%d.Name", i), Value: nodeName, Msg: "expected string"})
 						case nodeNameStr == "":
-							err = multierr.Append(err, commonconfig.ErrEmpty{Name: fmt.Sprintf("Nodes.%d.Name", i), Msg: "required for all nodes"})
+							err = errors.Join(err, commonconfig.ErrEmpty{Name: fmt.Sprintf("Nodes.%d.Name", i), Msg: "required for all nodes"})
 						default:
 							parsedRawConfig.nodeNames = append(parsedRawConfig.nodeNames, nodeNameStr)
 						}
@@ -179,9 +178,9 @@ func (c RawConfig) parse() (*parsedRawConfig, error) {
 func (c RawConfig) ValidateConfig() error {
 	parsedRawConfig, err := c.parse()
 	if !parsedRawConfig.nodesExist {
-		err = multierr.Append(err, commonconfig.ErrMissing{Name: "Nodes", Msg: "expected at least one node"})
+		err = errors.Join(err, commonconfig.ErrMissing{Name: "Nodes", Msg: "expected at least one node"})
 	} else if len(parsedRawConfig.nodes) == 0 {
-		err = multierr.Append(err, commonconfig.ErrEmpty{Name: "Nodes", Msg: "expected at least one node"})
+		err = errors.Join(err, commonconfig.ErrEmpty{Name: "Nodes", Msg: "expected at least one node"})
 	}
 	return err
 }
@@ -283,7 +282,7 @@ func (c *Config) warnings() (err error) {
 	deprecationErr := c.deprecationWarnings()
 
 	warningErr := c.valueWarnings()
-	err = multierr.Append(deprecationErr, warningErr)
+	err = errors.Join(deprecationErr, warningErr)
 	_, list := commonconfig.MultiErrorList(err)
 	return list
 }
@@ -293,7 +292,7 @@ func (c *Config) valueWarnings() (err error) {
 	if c.Tracing.Enabled != nil && *c.Tracing.Enabled {
 		if c.Tracing.Mode != nil && *c.Tracing.Mode == "unencrypted" {
 			if c.Tracing.TLSCertPath != nil {
-				err = multierr.Append(err, config.ErrInvalid{Name: "Tracing.TLSCertPath", Value: *c.Tracing.TLSCertPath, Msg: "must be empty when Tracing.Mode is 'unencrypted'"})
+				err = errors.Join(err, config.ErrInvalid{Name: "Tracing.TLSCertPath", Value: *c.Tracing.TLSCertPath, Msg: "must be empty when Tracing.Mode is 'unencrypted'"})
 			}
 		}
 	}
@@ -352,7 +351,7 @@ func (c *Config) SetFrom(f *Config) (err error) {
 
 	appendErr := func(e error, name string) {
 		if e != nil {
-			err = multierr.Append(err, commonconfig.NamedMultiErrorList(e, name))
+			err = errors.Join(err, commonconfig.NamedMultiErrorList(e, name))
 		}
 	}
 
@@ -374,43 +373,43 @@ type Secrets struct {
 
 func (s *Secrets) SetFrom(f *Secrets) (err error) {
 	if err2 := s.Database.SetFrom(&f.Database); err2 != nil {
-		err = multierr.Append(err, commonconfig.NamedMultiErrorList(err2, "Database"))
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "Database"))
 	}
 
 	if err2 := s.Password.SetFrom(&f.Password); err2 != nil {
-		err = multierr.Append(err, commonconfig.NamedMultiErrorList(err2, "Password"))
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "Password"))
 	}
 
 	if err2 := s.WebServer.SetFrom(&f.WebServer); err2 != nil {
-		err = multierr.Append(err, commonconfig.NamedMultiErrorList(err2, "WebServer"))
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "WebServer"))
 	}
 
 	if err2 := s.Pyroscope.SetFrom(&f.Pyroscope); err2 != nil {
-		err = multierr.Append(err, commonconfig.NamedMultiErrorList(err2, "Pyroscope"))
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "Pyroscope"))
 	}
 
 	if err2 := s.Prometheus.SetFrom(&f.Prometheus); err2 != nil {
-		err = multierr.Append(err, commonconfig.NamedMultiErrorList(err2, "Prometheus"))
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "Prometheus"))
 	}
 
 	if err2 := s.Mercury.SetFrom(&f.Mercury); err2 != nil {
-		err = multierr.Append(err, commonconfig.NamedMultiErrorList(err2, "Mercury"))
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "Mercury"))
 	}
 
 	if err2 := s.Threshold.SetFrom(&f.Threshold); err2 != nil {
-		err = multierr.Append(err, commonconfig.NamedMultiErrorList(err2, "Threshold"))
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "Threshold"))
 	}
 
 	if err2 := s.EVM.SetFrom(&f.EVM); err2 != nil {
-		err = multierr.Append(err, commonconfig.NamedMultiErrorList(err2, "EthKeys"))
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "EthKeys"))
 	}
 
 	if err2 := s.P2PKey.SetFrom(&f.P2PKey); err2 != nil {
-		err = multierr.Append(err, commonconfig.NamedMultiErrorList(err2, "P2PKey"))
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "P2PKey"))
 	}
 
 	if err2 := s.CRE.SetFrom(&f.CRE); err2 != nil {
-		err = multierr.Append(err, commonconfig.NamedMultiErrorList(err2, "CRE"))
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "CRE"))
 	}
 
 	_, err = commonconfig.MultiErrorList(err)

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -2,6 +2,7 @@ package chainlink
 
 import (
 	_ "embed"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +11,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
@@ -227,7 +227,7 @@ func (g *generalConfig) Validate() error {
 }
 
 func (g *generalConfig) validate(secretsValidationFn func() error) error {
-	err := multierr.Combine(
+	err := stderrors.Join(
 		validateEnv(),
 		g.c.Validate(),
 		secretsValidationFn(),
@@ -263,7 +263,7 @@ func validateEnv() (err error) {
 		k := kv[:i]
 		_, ok := os.LookupEnv(k)
 		if ok {
-			err = multierr.Append(err, fmt.Errorf("environment variable %s must not be set: %w", k, v2.ErrUnsupported))
+			err = stderrors.Join(err, fmt.Errorf("environment variable %s must not be set: %w", k, v2.ErrUnsupported))
 		}
 	}
 	return

--- a/core/services/gateway/gateway.go
+++ b/core/services/gateway/gateway.go
@@ -3,10 +3,9 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
-
-	"go.uber.org/multierr"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jonboulle/clockwork"
@@ -120,10 +119,10 @@ func (g *gateway) Start(ctx context.Context) error {
 func (g *gateway) Close() error {
 	return g.StopOnce("Gateway", func() (err error) {
 		g.lggr.Info("closing gateway")
-		err = multierr.Combine(err, g.httpServer.Close())
-		err = multierr.Combine(err, g.connMgr.Close())
+		err = errors.Join(err, g.httpServer.Close())
+		err = errors.Join(err, g.connMgr.Close())
 		for _, handler := range g.handlers {
-			err = multierr.Combine(err, handler.Close())
+			err = errors.Join(err, handler.Close())
 		}
 		return
 	})

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -10,7 +10,6 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
@@ -333,7 +332,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	}
 	// Send original request to all nodes
 	for _, member := range h.donConfig.Members {
-		err = multierr.Combine(err, don.SendToNode(ctx, member.Address, req))
+		err = errors.Join(err, don.SendToNode(ctx, member.Address, req))
 	}
 	return err
 }

--- a/core/services/gateway/handlers/functions/handler.functions.go
+++ b/core/services/gateway/handlers/functions/handler.functions.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/assets"
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
@@ -412,10 +411,10 @@ func (h *functionsHandler) Close() error {
 	return h.StopOnce("FunctionsHandler", func() (err error) {
 		close(h.chStop)
 		if h.allowlist != nil {
-			err = multierr.Combine(err, h.allowlist.Close())
+			err = errors.Join(err, h.allowlist.Close())
 		}
 		if h.subscriptions != nil {
-			err = multierr.Combine(err, h.subscriptions.Close())
+			err = errors.Join(err, h.subscriptions.Close())
 		}
 		return
 	})

--- a/core/services/gateway/handlers/handler.dummy.go
+++ b/core/services/gateway/handlers/handler.dummy.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"sync"
 
-	"go.uber.org/multierr"
-
 	jsonrpc "github.com/smartcontractkit/chainlink-common/pkg/jsonrpc2"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -62,7 +60,7 @@ func (d *dummyHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Mes
 		Params:  &rawParams,
 	}
 	for _, member := range d.donConfig.Members {
-		err = multierr.Combine(err, don.SendToNode(ctx, member.Address, req))
+		err = errors.Join(err, don.SendToNode(ctx, member.Address, req))
 	}
 	return err
 }

--- a/core/services/headreporter/prometheus_reporter.go
+++ b/core/services/headreporter/prometheus_reporter.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
@@ -83,7 +82,7 @@ func (pr *prometheusReporter) getTxm(evmChainID *big.Int) (txmgr.TxManager, erro
 
 func (pr *prometheusReporter) ReportNewHead(ctx context.Context, head *evmtypes.Head) error {
 	evmChainID := head.EVMChainID.ToInt()
-	return multierr.Combine(
+	return stderrors.Join(
 		errors.Wrap(pr.reportPendingEthTxes(ctx, evmChainID), "reportPendingEthTxes failed"),
 		errors.Wrap(pr.reportMaxUnconfirmedAge(ctx, evmChainID), "reportMaxUnconfirmedAge failed"),
 		errors.Wrap(pr.reportMaxUnconfirmedBlocks(ctx, head), "reportMaxUnconfirmedBlocks failed"),
@@ -163,7 +162,7 @@ SELECT pipeline_run_id FROM pipeline_task_runs WHERE finished_at IS NULL
 		return errors.Wrap(err, "failed to query for pipeline_run_id")
 	}
 	defer func() {
-		err = multierr.Combine(err, rows.Close())
+		err = stderrors.Join(err, rows.Close())
 	}()
 
 	pipelineTaskRunsQueued := 0

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -15,7 +16,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -1494,7 +1494,7 @@ func (o *orm) loadAllJobsTypes(ctx context.Context, jobs []Job) error {
 }
 
 func (o *orm) loadAllJobTypes(ctx context.Context, job *Job) error {
-	return multierr.Combine(
+	return stderrors.Join(
 		o.loadJobPipelineSpec(ctx, job, &job.PipelineSpecID),
 		o.loadJobType(ctx, job, "FluxMonitorSpec", "flux_monitor_specs", job.FluxMonitorSpecID),
 		o.loadJobType(ctx, job, "DirectRequestSpec", "direct_request_specs", job.DirectRequestSpecID),

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
+
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
-	"go.uber.org/multierr"
 
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
@@ -361,7 +361,7 @@ func UnregisterCommitPluginLpFilters(srcProvider commontypes.CCIPCommitProvider,
 	var multiErr error
 	for _, fn := range unregisterFuncs {
 		if err := fn(); err != nil {
-			multiErr = multierr.Append(multiErr, err)
+			multiErr = errors.Join(multiErr, err)
 		}
 	}
 	return multiErr

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	"github.com/Masterminds/semver/v3"
-	"go.uber.org/multierr"
 
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 
@@ -238,7 +237,7 @@ func UnregisterExecPluginLpFilters(srcProvider types.CCIPExecProvider, dstProvid
 	var multiErr error
 	for _, fn := range unregisterFuncs {
 		if err := fn(); err != nil {
-			multiErr = multierr.Append(multiErr, err)
+			multiErr = errors.Join(multiErr, err)
 		}
 	}
 	return multiErr

--- a/core/services/ocr2/plugins/ccip/internal/oraclelib/backfilled_oracle.go
+++ b/core/services/ocr2/plugins/ccip/internal/oraclelib/backfilled_oracle.go
@@ -2,14 +2,13 @@ package oraclelib
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink/v2/core/services"
-
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -56,7 +55,7 @@ func (r *ChainAgnosticBackFilledOracle) run() {
 		s := time.Now()
 		srcReplayErr := r.srcProvider.Start(ctx)
 		errMu.Lock()
-		err = multierr.Combine(err, srcReplayErr)
+		err = errors.Join(err, srcReplayErr)
 		errMu.Unlock()
 		r.lggr.Infow("finished replaying src chain", "time", time.Since(s))
 	}()
@@ -67,7 +66,7 @@ func (r *ChainAgnosticBackFilledOracle) run() {
 		s := time.Now()
 		dstReplayErr := r.dstProvider.Start(ctx)
 		errMu.Lock()
-		err = multierr.Combine(err, dstReplayErr)
+		err = errors.Join(err, dstReplayErr)
 		errMu.Unlock()
 		r.lggr.Infow("finished replaying dst chain", "time", time.Since(s))
 	}()

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
@@ -3,13 +3,13 @@ package pricegetter
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcommon"
 
@@ -238,7 +238,7 @@ func (d *DynamicPriceGetter) performBatchCall(
 		for _, read := range offchainAggregatorRespSlice {
 			val, readErr := read.GetResult()
 			if readErr != nil {
-				respErr = multierr.Append(respErr, fmt.Errorf("error with contract reader readName %v: %w", read.ReadName, readErr))
+				respErr = errors.Join(respErr, fmt.Errorf("error with contract reader readName %v: %w", read.ReadName, readErr))
 				continue
 			}
 			if read.ReadName == DecimalsMethodName {

--- a/core/services/ocr2/plugins/ccip/proxycommitstore.go
+++ b/core/services/ocr2/plugins/ccip/proxycommitstore.go
@@ -7,8 +7,6 @@ import (
 	"math/big"
 	"time"
 
-	"go.uber.org/multierr"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
@@ -131,5 +129,5 @@ func (p *ProviderProxyCommitStoreReader) SetSourceMaxGasPrice(ctx context.Contex
 }
 
 func (p *ProviderProxyCommitStoreReader) Close() error {
-	return multierr.Append(p.srcCommitStoreReader.Close(), p.dstCommitStoreReader.Close())
+	return errors.Join(p.srcCommitStoreReader.Close(), p.dstCommitStoreReader.Close())
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
-	"go.uber.org/multierr"
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v2"
 
@@ -628,7 +627,7 @@ func (r *EvmRegistry) checkUpkeeps(ctx context.Context, keys []ocr2keepers.Upkee
 	for i, req := range checkReqs {
 		if req.Error != nil {
 			r.lggr.Debugf("error encountered for key %s with message '%s' in check", keys[i], req.Error)
-			multierr.AppendInto(&multiErr, req.Error)
+			multiErr = errors.Join(multiErr, req.Error)
 		} else {
 			var err error
 			r.lggr.Debugf("UnpackCheckResult key %s checkResult: %s", string(keys[i]), *checkResults[i])
@@ -699,7 +698,7 @@ func (r *EvmRegistry) simulatePerformUpkeeps(ctx context.Context, checkResults [
 	for i, req := range performReqs {
 		if req.Error != nil {
 			r.lggr.Debugf("error encountered for key %d|%s with message '%s' in simulate perform", checkResults[i].Block, checkResults[i].ID, req.Error)
-			multierr.AppendInto(&multiErr, req.Error)
+			multiErr = errors.Join(multiErr, req.Error)
 		} else {
 			simulatePerformSuccess, err := r.packer.UnpackPerformResult(*performResults[i])
 			if err != nil {
@@ -770,7 +769,7 @@ func (r *EvmRegistry) getUpkeepConfigs(ctx context.Context, ids []*big.Int) ([]a
 	for i, req := range uReqs {
 		if req.Error != nil {
 			r.lggr.Debugf("error encountered for config id %s with message '%s' in get config", ids[i], req.Error)
-			multierr.AppendInto(&multiErr, req.Error)
+			multiErr = errors.Join(multiErr, req.Error)
 		} else {
 			var err error
 			results[i], err = r.packer.UnpackUpkeepResult(ids[i], *uResults[i])

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_test.go
@@ -253,7 +253,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 		registry         Registry
 		packer           encoding.Packer
 		expectsErr       bool
-		wantErr          error
+		wantErrMsg       string
 	}{
 		{
 			name: "an error is returned when fetching indexed logs for IAutomationV21PlusCommonUpkeepUnpaused errors",
@@ -276,7 +276,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 				},
 			},
 			expectsErr: true,
-			wantErr:    errors.New("indexed logs boom"),
+			wantErrMsg: "indexed logs boom",
 		},
 		{
 			name: "an error is returned when fetching indexed logs for IAutomationV21PlusCommonUpkeepTriggerConfigSet errors",
@@ -301,7 +301,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 				},
 			},
 			expectsErr: true,
-			wantErr:    errors.New("indexed logs boom"),
+			wantErrMsg: "indexed logs boom",
 		},
 		{
 			name: "an error is returned when parsing the logs using the registry errors",
@@ -330,7 +330,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 				},
 			},
 			expectsErr: true,
-			wantErr:    errors.New("parse log boom"),
+			wantErrMsg: "parse log boom",
 		},
 		{
 			name: "an error is returned when registering the filter errors",
@@ -383,7 +383,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 				},
 			},
 			expectsErr: true,
-			wantErr:    errors.New("failed to update trigger config for upkeep id 452312848583266388373324160190187140521564213162920931037143039228013182976: failed to register log filter: register filter boom"),
+			wantErrMsg: "failed to update trigger config for upkeep id 452312848583266388373324160190187140521564213162920931037143039228013182976: failed to register log filter: register filter boom",
 		},
 		{
 			name: "log trigger upkeeps are refreshed without error",
@@ -566,7 +566,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 			err := registry.refreshLogTriggerUpkeeps(ctx, tc.ids)
 			if tc.expectsErr {
 				assert.Error(t, err)
-				assert.Equal(t, err.Error(), tc.wantErr.Error())
+				assert.ErrorContains(t, err, tc.wantErrMsg)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/core/services/ocrcommon/discoverer_database.go
+++ b/core/services/ocrcommon/discoverer_database.go
@@ -2,11 +2,11 @@ package ocrcommon
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	ocrnetworking "github.com/smartcontractkit/libocr/networking/types"
 
@@ -72,7 +72,7 @@ func (d *DiscovererDatabase) ReadAnnouncements(ctx context.Context, peerIDs []st
 	if err != nil {
 		return nil, errors.Wrap(err, "DiscovererDatabase failed to ReadAnnouncements")
 	}
-	defer func() { err = multierr.Combine(err, rows.Close()) }()
+	defer func() { err = stderrors.Join(err, rows.Close()) }()
 	results = make(map[string][]byte)
 	for rows.Next() {
 		var peerID string

--- a/core/services/ocrcommon/validate.go
+++ b/core/services/ocrcommon/validate.go
@@ -1,9 +1,10 @@
 package ocrcommon
 
 import (
+	stderrors "errors"
+
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 )
 
 // CloneSet returns a copy of the input map.
@@ -22,12 +23,12 @@ func ValidateExplicitlySetKeys(tree *toml.Tree, expected map[string]struct{}, no
 	// top level keys only
 	for _, k := range tree.Keys() {
 		if _, ok := notExpected[k]; ok {
-			err = multierr.Append(err, errors.Errorf("unrecognised key for %s peer: %s", peerType, k))
+			err = stderrors.Join(err, errors.Errorf("unrecognised key for %s peer: %s", peerType, k))
 		}
 		delete(expected, k)
 	}
 	for missing := range expected {
-		err = multierr.Append(err, errors.Errorf("missing required key %s", missing))
+		err = stderrors.Join(err, errors.Errorf("missing required key %s", missing))
 	}
 	return err
 }

--- a/core/services/pipeline/models.go
+++ b/core/services/pipeline/models.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"database/sql/driver"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -11,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
-	"go.uber.org/multierr"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/jsonserializable"
@@ -243,7 +243,7 @@ func (re RunErrors) ToError() error {
 	for _, e := range re {
 		errs = append(errs, toErr(e))
 	}
-	return multierr.Combine(errs...)
+	return stderrors.Join(errs...)
 }
 
 type ResumeRequest struct {

--- a/core/services/pipeline/models_test.go
+++ b/core/services/pipeline/models_test.go
@@ -78,8 +78,7 @@ func TestRunErrors_ToError(t *testing.T) {
 	runErrors = append(runErrors, null.NewString("bad thing happened", true))
 	runErrors = append(runErrors, null.NewString("pretty bad thing happened", true))
 	runErrors = append(runErrors, null.NewString("", false))
-	expected := errors.New("bad thing happened; pretty bad thing happened")
-	require.Equal(t, expected.Error(), runErrors.ToError().Error())
+	require.ErrorContains(t, runErrors.ToError(), "bad thing happened\npretty bad thing happened")
 }
 
 func TestRun_StringOutputs(t *testing.T) {

--- a/core/services/pipeline/task.base64decode.go
+++ b/core/services/pipeline/task.base64decode.go
@@ -3,9 +3,9 @@ package pipeline
 import (
 	"context"
 	"encoding/base64"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -32,7 +32,7 @@ func (t *Base64DecodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, in
 
 	var input StringParam
 
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err != nil {

--- a/core/services/pipeline/task.base64encode.go
+++ b/core/services/pipeline/task.base64encode.go
@@ -3,9 +3,9 @@ package pipeline
 import (
 	"context"
 	"encoding/base64"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -31,7 +31,7 @@ func (t *Base64EncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, in
 	}
 
 	var stringInput StringParam
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&stringInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil {
@@ -40,7 +40,7 @@ func (t *Base64EncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, in
 	}
 
 	var bytesInput BytesParam
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&bytesInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil {

--- a/core/services/pipeline/task.bridge.go
+++ b/core/services/pipeline/task.bridge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 	"net/url"
 	"path"
@@ -12,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -107,7 +107,7 @@ func (t *BridgeTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inp
 		cacheTTL          Uint64Param
 		reqHeaders        StringSliceParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&name, From(NonemptyString(t.Name))), "name"),
 		errors.Wrap(ResolveParam(&requestData, From(VarExpr(t.RequestData, vars), JSONWithVarExprs(t.RequestData, vars, false), nil)), "requestData"),
 		errors.Wrap(ResolveParam(&includeInputAtKey, From(t.IncludeInputAtKey)), "includeInputAtKey"),

--- a/core/services/pipeline/task.bridge_test.go
+++ b/core/services/pipeline/task.bridge_test.go
@@ -648,9 +648,9 @@ func TestBridgeTask_Variables(t *testing.T) {
 			assert.False(t, runInfo.IsPending)
 			assert.False(t, runInfo.IsRetryable)
 			if test.expectedErrorCause != nil {
-				require.Equal(t, test.expectedErrorCause, errors.Cause(result.Error))
+				require.ErrorIs(t, result.Error, test.expectedErrorCause)
 				if test.expectedErrorContains != "" {
-					require.Contains(t, result.Error.Error(), test.expectedErrorContains)
+					require.ErrorContains(t, result.Error, test.expectedErrorContains)
 				}
 			} else {
 				require.NoError(t, result.Error)

--- a/core/services/pipeline/task.cborparse.go
+++ b/core/services/pipeline/task.cborparse.go
@@ -2,9 +2,9 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -42,7 +42,7 @@ func (t *CBORParseTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 		data BytesParam
 		mode StringParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&data, From(VarExpr(t.Data, vars))), "data"),
 		errors.Wrap(ResolveParam(&mode, From(NonemptyString(t.Mode), "diet")), "mode"),
 	)

--- a/core/services/pipeline/task.conditional.go
+++ b/core/services/pipeline/task.conditional.go
@@ -2,9 +2,9 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -31,7 +31,7 @@ func (t *ConditionalTask) Run(_ context.Context, _ logger.Logger, vars Vars, inp
 	var (
 		boolParam BoolParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&boolParam, From(VarExpr(t.Data, vars), Input(inputs, 0), nil)), "data"),
 	)
 	if err != nil {

--- a/core/services/pipeline/task.divide.go
+++ b/core/services/pipeline/task.divide.go
@@ -2,10 +2,10 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 	"math"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -42,7 +42,7 @@ func (t *DivideTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs [
 		b              DecimalParam
 		maybePrecision MaybeInt32Param
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&a, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 		errors.Wrap(ResolveParam(&b, From(VarExpr(t.Divisor, vars), NonemptyString(t.Divisor))), "divisor"),
 		errors.Wrap(ResolveParam(&maybePrecision, From(VarExpr(t.Precision, vars), t.Precision)), "precision"),

--- a/core/services/pipeline/task.divide_test.go
+++ b/core/services/pipeline/task.divide_test.go
@@ -165,9 +165,9 @@ func TestDivideTask_Unhappy(t *testing.T) {
 			result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), test.vars, test.inputs)
 			assert.False(t, runInfo.IsPending)
 			assert.False(t, runInfo.IsRetryable)
-			require.Equal(t, test.wantErrorCause, errors.Cause(result.Error))
+			require.ErrorIs(t, result.Error, test.wantErrorCause)
 			if test.wantErrorContains != "" {
-				require.Contains(t, result.Error.Error(), test.wantErrorContains)
+				require.ErrorContains(t, result.Error, test.wantErrorContains)
 			}
 		})
 	}

--- a/core/services/pipeline/task.estimategas.go
+++ b/core/services/pipeline/task.estimategas.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -11,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -66,7 +66,7 @@ func (t *EstimateGasLimitTask) Run(ctx context.Context, lggr logger.Logger, vars
 		chainID    StringParam
 		block      StringParam
 	)
-	err := multierr.Combine(
+	err := stderrors.Join(
 		errors.Wrap(ResolveParam(&fromAddr, From(VarExpr(t.From, vars), utils.ZeroAddress)), "from"),
 		errors.Wrap(ResolveParam(&toAddr, From(VarExpr(t.To, vars), NonemptyString(t.To))), "to"),
 		errors.Wrap(ResolveParam(&data, From(VarExpr(t.Data, vars), NonemptyString(t.Data))), "data"),

--- a/core/services/pipeline/task.eth_abi_decode.go
+++ b/core/services/pipeline/task.eth_abi_decode.go
@@ -2,9 +2,9 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -34,7 +34,7 @@ func (t *ETHABIDecodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, in
 		data   BytesParam
 		theABI BytesParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&data, From(VarExpr(t.Data, vars), Input(inputs, 0))), "data"),
 		errors.Wrap(ResolveParam(&theABI, From(NonemptyString(t.ABI))), "abi"),
 	)

--- a/core/services/pipeline/task.eth_abi_decode_log.go
+++ b/core/services/pipeline/task.eth_abi_decode_log.go
@@ -2,10 +2,10 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -37,7 +37,7 @@ func (t *ETHABIDecodeLogTask) Run(_ context.Context, _ logger.Logger, vars Vars,
 		data   BytesParam
 		topics HashSliceParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&data, From(VarExpr(t.Data, vars), nil)), "data"),
 		errors.Wrap(ResolveParam(&topics, From(VarExpr(t.Topics, vars))), "topics"),
 		errors.Wrap(ResolveParam(&theABI, From(NonemptyString(t.ABI))), "abi"),

--- a/core/services/pipeline/task.eth_abi_encode.go
+++ b/core/services/pipeline/task.eth_abi_encode.go
@@ -2,11 +2,11 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -36,7 +36,7 @@ func (t *ETHABIEncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, in
 		inputValues MapParam
 		theABI      BytesParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&inputValues, From(VarExpr(t.Data, vars), JSONWithVarExprs(t.Data, vars, false), nil)), "data"),
 		errors.Wrap(ResolveParam(&theABI, From(NonemptyString(t.ABI))), "abi"),
 	)

--- a/core/services/pipeline/task.eth_abi_encode_2.go
+++ b/core/services/pipeline/task.eth_abi_encode_2.go
@@ -3,11 +3,11 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -37,7 +37,7 @@ func (t *ETHABIEncodeTask2) Run(_ context.Context, _ logger.Logger, vars Vars, i
 		inputValues MapParam
 		theABI      BytesParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&inputValues, From(VarExpr(t.Data, vars), JSONWithVarExprs(t.Data, vars, false), nil)), "data"),
 		errors.Wrap(ResolveParam(&theABI, From(NonemptyString(t.ABI))), "abi"),
 	)

--- a/core/services/pipeline/task.eth_call.go
+++ b/core/services/pipeline/task.eth_call.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"strings"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -83,7 +83,7 @@ func (t *ETHCallTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, in
 		chainID      StringParam
 		block        StringParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&contractAddr, From(VarExpr(t.Contract, vars), NonemptyString(t.Contract))), "contract"),
 		errors.Wrap(ResolveParam(&from, From(VarExpr(t.From, vars), NonemptyString(t.From), utils.ZeroAddress)), "from"),
 		errors.Wrap(ResolveParam(&data, From(VarExpr(t.Data, vars), JSONWithVarExprs(t.Data, vars, false))), "data"),

--- a/core/services/pipeline/task.eth_call_test.go
+++ b/core/services/pipeline/task.eth_call_test.go
@@ -334,7 +334,7 @@ func TestETHCallTask(t *testing.T) {
 			if test.expectedErrorCause != nil || test.expectedErrorContains != "" {
 				require.Nil(t, result.Value)
 				if test.expectedErrorCause != nil {
-					require.Equal(t, test.expectedErrorCause, errors.Cause(result.Error))
+					require.ErrorIs(t, result.Error, test.expectedErrorCause)
 				}
 				if test.expectedErrorContains != "" {
 					require.Contains(t, result.Error.Error(), test.expectedErrorContains)

--- a/core/services/pipeline/task.eth_tx.go
+++ b/core/services/pipeline/task.eth_tx.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -10,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -99,7 +99,7 @@ func (t *ETHTxTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inpu
 		transmitCheckerMap    MapParam
 		failOnRevert          BoolParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&fromAddrs, From(VarExpr(t.From, vars), JSONWithVarExprs(t.From, vars, false), NonemptyString(t.From), nil)), "from"),
 		errors.Wrap(ResolveParam(&toAddr, From(VarExpr(t.To, vars), NonemptyString(t.To))), "to"),
 		errors.Wrap(ResolveParam(&data, From(VarExpr(t.Data, vars), NonemptyString(t.Data))), "data"),

--- a/core/services/pipeline/task.eth_tx_test.go
+++ b/core/services/pipeline/task.eth_tx_test.go
@@ -598,10 +598,10 @@ func TestETHTxTask(t *testing.T) {
 			if test.expectedErrorCause != nil || test.expectedErrorContains != "" {
 				require.Nil(t, result.Value)
 				if test.expectedErrorCause != nil {
-					require.Equal(t, test.expectedErrorCause, errors.Cause(result.Error))
+					require.ErrorIs(t, result.Error, test.expectedErrorCause)
 				}
 				if test.expectedErrorContains != "" {
-					require.Contains(t, result.Error.Error(), test.expectedErrorContains)
+					require.ErrorContains(t, result.Error, test.expectedErrorContains)
 				}
 			} else {
 				require.NoError(t, result.Error)

--- a/core/services/pipeline/task.hexdecode.go
+++ b/core/services/pipeline/task.hexdecode.go
@@ -3,9 +3,9 @@ package pipeline
 import (
 	"context"
 	"encoding/hex"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	commonhex "github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
@@ -33,7 +33,7 @@ func (t *HexDecodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 
 	var input StringParam
 
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err != nil {

--- a/core/services/pipeline/task.hexencode.go
+++ b/core/services/pipeline/task.hexencode.go
@@ -3,10 +3,10 @@ package pipeline
 import (
 	"context"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -39,7 +39,7 @@ func (t *HexEncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 	}
 
 	var stringInput StringParam
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&stringInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil {
@@ -48,7 +48,7 @@ func (t *HexEncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 	}
 
 	var bytesInput BytesParam
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&bytesInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil {
@@ -57,7 +57,7 @@ func (t *HexEncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 	}
 
 	var decimalInput DecimalParam
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&decimalInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil && !decimalInput.Decimal().IsInteger() {
@@ -66,7 +66,7 @@ func (t *HexEncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 	}
 
 	var bigIntInput MaybeBigIntParam
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&bigIntInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil {

--- a/core/services/pipeline/task.http.go
+++ b/core/services/pipeline/task.http.go
@@ -3,12 +3,12 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/multierr"
 
 	clhttp "github.com/smartcontractkit/chainlink-common/pkg/http"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -64,7 +64,7 @@ func (t *HTTPTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, input
 		allowUnrestrictedNetworkAccess BoolParam
 		reqHeaders                     StringSliceParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&method, From(NonemptyString(t.Method), "GET")), "method"),
 		errors.Wrap(ResolveParam(&url, From(VarExpr(t.URL, vars), NonemptyString(t.URL))), "url"),
 		errors.Wrap(ResolveParam(&requestData, From(VarExpr(t.RequestData, vars), JSONWithVarExprs(t.RequestData, vars, false), nil)), "requestData"),

--- a/core/services/pipeline/task.http_test.go
+++ b/core/services/pipeline/task.http_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -188,9 +187,9 @@ func TestHTTPTask_Variables(t *testing.T) {
 			assert.False(t, runInfo.IsPending)
 			assert.False(t, runInfo.IsRetryable)
 			if test.expectedErrorCause != nil {
-				require.Equal(t, test.expectedErrorCause, errors.Cause(result.Error))
+				require.ErrorIs(t, result.Error, test.expectedErrorCause)
 				if test.expectedErrorContains != "" {
-					require.Contains(t, result.Error.Error(), test.expectedErrorContains)
+					require.ErrorContains(t, result.Error, test.expectedErrorContains)
 				}
 			} else {
 				require.NoError(t, result.Error)

--- a/core/services/pipeline/task.jsonparse.go
+++ b/core/services/pipeline/task.jsonparse.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"math/big"
 	"strings"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/jsonserializable"
@@ -51,7 +51,7 @@ func (t *JSONParseTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 		data BytesParam
 		lax  BoolParam
 	)
-	err = multierr.Combine(err,
+	err = stderrors.Join(err,
 		errors.Wrap(ResolveParam(&path, From(VarExpr(t.Path, vars), t.Path)), "path"),
 		errors.Wrap(ResolveParam(&data, From(VarExpr(t.Data, vars), Input(inputs, 0))), "data"),
 		errors.Wrap(ResolveParam(&lax, From(NonemptyString(t.Lax), false)), "lax"),
@@ -112,7 +112,7 @@ func (t *JSONParseTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 
 	decoded, err = jsonserializable.ReinterpretJSONNumbers(decoded)
 	if err != nil {
-		return Result{Error: multierr.Combine(ErrBadInput, err)}, runInfo
+		return Result{Error: stderrors.Join(ErrBadInput, err)}, runInfo
 	}
 
 	return Result{Value: decoded}, runInfo

--- a/core/services/pipeline/task.jsonparse_test.go
+++ b/core/services/pipeline/task.jsonparse_test.go
@@ -404,9 +404,9 @@ func TestJSONParseTask(t *testing.T) {
 			assert.False(t, runInfo.IsRetryable)
 
 			if test.wantErrorCause != nil {
-				require.Equal(t, test.wantErrorCause, errors.Cause(result.Error))
+				require.ErrorIs(t, result.Error, test.wantErrorCause)
 				if test.wantErrorContains != "" {
-					require.Contains(t, result.Error.Error(), test.wantErrorContains)
+					require.ErrorContains(t, result.Error, test.wantErrorContains)
 				}
 
 				require.Nil(t, result.Value)

--- a/core/services/pipeline/task.length.go
+++ b/core/services/pipeline/task.length.go
@@ -2,10 +2,10 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -32,7 +32,7 @@ func (t *LengthTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs [
 
 	var input BytesParam
 
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err != nil {

--- a/core/services/pipeline/task.lessthan.go
+++ b/core/services/pipeline/task.lessthan.go
@@ -2,9 +2,9 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -37,7 +37,7 @@ func (t *LessThanTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs
 		b DecimalParam
 	)
 
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&a, From(VarExpr(t.Left, vars), NonemptyString(t.Left), Input(inputs, 0))), "left"),
 		errors.Wrap(ResolveParam(&b, From(VarExpr(t.Right, vars), NonemptyString(t.Right))), "right"),
 	)

--- a/core/services/pipeline/task.lessthan_test.go
+++ b/core/services/pipeline/task.lessthan_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -133,9 +132,9 @@ func TestLessThanTask_Unhappy(t *testing.T) {
 			result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), test.vars, test.inputs)
 			assert.False(t, runInfo.IsPending)
 			assert.False(t, runInfo.IsRetryable)
-			require.Equal(t, test.wantErrorCause, errors.Cause(result.Error))
+			require.ErrorIs(t, result.Error, test.wantErrorCause)
 			if test.wantErrorContains != "" {
-				require.Contains(t, result.Error.Error(), test.wantErrorContains)
+				require.ErrorContains(t, result.Error, test.wantErrorContains)
 			}
 		})
 	}

--- a/core/services/pipeline/task.lowercase.go
+++ b/core/services/pipeline/task.lowercase.go
@@ -2,10 +2,10 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 	"strings"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -32,7 +32,7 @@ func (t *LowercaseTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 
 	var input StringParam
 
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err != nil {

--- a/core/services/pipeline/task.mean.go
+++ b/core/services/pipeline/task.mean.go
@@ -2,10 +2,10 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -35,7 +35,7 @@ func (t *MeanTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs []R
 		allowedFaults      int
 		faults             int
 	)
-	err := multierr.Combine(
+	err := stderrors.Join(
 		errors.Wrap(ResolveParam(&maybeAllowedFaults, From(t.AllowedFaults)), "allowedFaults"),
 		errors.Wrap(ResolveParam(&maybePrecision, From(VarExpr(t.Precision, vars), t.Precision)), "precision"),
 		errors.Wrap(ResolveParam(&valuesAndErrs, From(VarExpr(t.Values, vars), JSONWithVarExprs(t.Values, vars, true), Inputs(inputs))), "values"),

--- a/core/services/pipeline/task.median.go
+++ b/core/services/pipeline/task.median.go
@@ -2,11 +2,11 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 	"sort"
 
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -38,7 +38,7 @@ func (t *MedianTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs [
 		faults             int
 		lax                BoolParam
 	)
-	err := multierr.Combine(
+	err := stderrors.Join(
 		errors.Wrap(ResolveParam(&maybeAllowedFaults, From(t.AllowedFaults)), "allowedFaults"),
 		errors.Wrap(ResolveParam(&valuesAndErrs, From(VarExpr(t.Values, vars), JSONWithVarExprs(t.Values, vars, true), Inputs(inputs))), "values"),
 		errors.Wrap(ResolveParam(&lax, From(NonemptyString(t.Lax), false)), "lax"),

--- a/core/services/pipeline/task.merge.go
+++ b/core/services/pipeline/task.merge.go
@@ -2,9 +2,9 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -34,7 +34,7 @@ func (t *MergeTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs []
 		lMap MapParam
 		rMap MapParam
 	)
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&lMap, From(VarExpr(t.Left, vars), JSONWithVarExprs(t.Left, vars, false), Input(inputs, 0))), "left-side"),
 		errors.Wrap(ResolveParam(&rMap, From(VarExpr(t.Right, vars), JSONWithVarExprs(t.Right, vars, false))), "right-side"),
 	)

--- a/core/services/pipeline/task.mode.go
+++ b/core/services/pipeline/task.mode.go
@@ -3,12 +3,12 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"math/big"
 
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -38,7 +38,7 @@ func (t *ModeTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs []R
 		allowedFaults      int
 		faults             int
 	)
-	err := multierr.Combine(
+	err := stderrors.Join(
 		errors.Wrap(ResolveParam(&maybeAllowedFaults, From(t.AllowedFaults)), "allowedFaults"),
 		errors.Wrap(ResolveParam(&valuesAndErrs, From(VarExpr(t.Values, vars), JSONWithVarExprs(t.Values, vars, true), Inputs(inputs))), "values"),
 	)

--- a/core/services/pipeline/task.multiply.go
+++ b/core/services/pipeline/task.multiply.go
@@ -2,10 +2,10 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 	"math"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -39,7 +39,7 @@ func (t *MultiplyTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs
 		b DecimalParam
 	)
 
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&a, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 		errors.Wrap(ResolveParam(&b, From(VarExpr(t.Times, vars), NonemptyString(t.Times))), "times"),
 	)

--- a/core/services/pipeline/task.multiply_test.go
+++ b/core/services/pipeline/task.multiply_test.go
@@ -176,9 +176,9 @@ func TestMultiplyTask_Unhappy(t *testing.T) {
 			result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), test.vars, test.inputs)
 			assert.False(t, runInfo.IsPending)
 			assert.False(t, runInfo.IsRetryable)
-			require.Equal(t, test.wantErrorCause, errors.Cause(result.Error))
+			require.ErrorIs(t, result.Error, test.wantErrorCause)
 			if test.wantErrorContains != "" {
-				require.Contains(t, result.Error.Error(), test.wantErrorContains)
+				require.ErrorContains(t, result.Error, test.wantErrorContains)
 			}
 		})
 	}

--- a/core/services/pipeline/task.sum.go
+++ b/core/services/pipeline/task.sum.go
@@ -2,10 +2,10 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -33,7 +33,7 @@ func (t *SumTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs []Re
 		allowedFaults      int
 		faults             int
 	)
-	err := multierr.Combine(
+	err := stderrors.Join(
 		errors.Wrap(ResolveParam(&maybeAllowedFaults, From(t.AllowedFaults)), "allowedFaults"),
 		errors.Wrap(ResolveParam(&valuesAndErrs, From(VarExpr(t.Values, vars), JSONWithVarExprs(t.Values, vars, true), Inputs(inputs))), "values"),
 	)

--- a/core/services/pipeline/task.uppercase.go
+++ b/core/services/pipeline/task.uppercase.go
@@ -2,10 +2,10 @@ package pipeline
 
 import (
 	"context"
+	stderrors "errors"
 	"strings"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -32,7 +32,7 @@ func (t *UppercaseTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 
 	var input StringParam
 
-	err = multierr.Combine(
+	err = stderrors.Join(
 		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err != nil {

--- a/core/services/pipeline/task.vrf.go
+++ b/core/services/pipeline/task.vrf.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -56,7 +56,7 @@ func (t *VRFTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs []Re
 		requestBlockNumber Uint64Param
 		topics             HashSliceParam
 	)
-	err := multierr.Combine(
+	err := stderrors.Join(
 		errors.Wrap(ResolveParam(&pubKey, From(VarExpr(t.PublicKey, vars))), "publicKey"),
 		errors.Wrap(ResolveParam(&requestBlockHash, From(VarExpr(t.RequestBlockHash, vars))), "requestBlockHash"),
 		errors.Wrap(ResolveParam(&requestBlockNumber, From(VarExpr(t.RequestBlockNumber, vars))), "requestBlockNumber"),

--- a/core/services/pipeline/task.vrfv2.go
+++ b/core/services/pipeline/task.vrfv2.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -57,7 +57,7 @@ func (t *VRFTaskV2) Run(_ context.Context, lggr logger.Logger, vars Vars, inputs
 		requestBlockNumber Uint64Param
 		topics             HashSliceParam
 	)
-	err := multierr.Combine(
+	err := stderrors.Join(
 		errors.Wrap(ResolveParam(&pubKey, From(VarExpr(t.PublicKey, vars))), "publicKey"),
 		errors.Wrap(ResolveParam(&requestBlockHash, From(VarExpr(t.RequestBlockHash, vars))), "requestBlockHash"),
 		errors.Wrap(ResolveParam(&requestBlockNumber, From(VarExpr(t.RequestBlockNumber, vars))), "requestBlockNumber"),

--- a/core/services/pipeline/task.vrfv2plus.go
+++ b/core/services/pipeline/task.vrfv2plus.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -60,7 +60,7 @@ func (t *VRFTaskV2Plus) Run(_ context.Context, lggr logger.Logger, vars Vars, in
 		requestBlockNumber Uint64Param
 		topics             HashSliceParam
 	)
-	err := multierr.Combine(
+	err := stderrors.Join(
 		errors.Wrap(ResolveParam(&pubKey, From(VarExpr(t.PublicKey, vars))), "publicKey"),
 		errors.Wrap(ResolveParam(&requestBlockHash, From(VarExpr(t.RequestBlockHash, vars))), "requestBlockHash"),
 		errors.Wrap(ResolveParam(&requestBlockNumber, From(VarExpr(t.RequestBlockNumber, vars))), "requestBlockNumber"),

--- a/core/services/relay/evm/commit_provider.go
+++ b/core/services/relay/evm/commit_provider.go
@@ -2,13 +2,13 @@ package evm
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"math"
 	"math/big"
 
-	"go.uber.org/multierr"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -128,7 +128,7 @@ func (p *SrcCommitProvider) Close() error {
 	var multiErr error
 	for _, fn := range unregisterFuncs {
 		if err := fn(); err != nil {
-			multiErr = multierr.Append(multiErr, err)
+			multiErr = stderrors.Join(multiErr, err)
 		}
 	}
 	return multiErr
@@ -193,7 +193,7 @@ func (p *DstCommitProvider) Close() error {
 	var multiErr error
 	for _, fn := range unregisterFuncs {
 		if err := fn(ctx); err != nil {
-			multiErr = multierr.Append(multiErr, err)
+			multiErr = stderrors.Join(multiErr, err)
 		}
 	}
 

--- a/core/services/relay/evm/dual_contract_transmitter.go
+++ b/core/services/relay/evm/dual_contract_transmitter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
-	errors2 "errors"
+	stderrors "errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -13,7 +13,6 @@ import (
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -141,7 +140,7 @@ func (oc *dualContractTransmitter) Transmit(ctx context.Context, reportCtx ocrty
 
 	err = errors.Wrap(oc.transmitter.CreateSecondaryEthTransaction(ctx, secondaryPayload, txMeta), "failed to send secondary Eth transaction")
 	oc.lggr.Debugw("Created secondary transaction", "error", err)
-	return errors2.Join(transactionErr, err)
+	return stderrors.Join(transactionErr, err)
 }
 
 // LatestConfigDigestAndEpoch retrieves the latest config digest and epoch from the OCR2 contract.
@@ -184,13 +183,13 @@ func (oc *dualContractTransmitter) lockTransmitters(ctx context.Context) error {
 	}
 	err = oc.lockSecondary(ctx)
 	if err != nil {
-		return multierr.Append(err, oc.unlockPrimary(ctx))
+		return stderrors.Join(err, oc.unlockPrimary(ctx))
 	}
 	return nil
 }
 
 func (oc *dualContractTransmitter) unlockTransmitters(ctx context.Context) error {
-	return multierr.Append(oc.unlockPrimary(ctx), oc.unlockSecondary(ctx))
+	return stderrors.Join(oc.unlockPrimary(ctx), oc.unlockSecondary(ctx))
 }
 
 func (oc *dualContractTransmitter) unlockPrimary(ctx context.Context) error {

--- a/core/services/relay/evm/exec_provider.go
+++ b/core/services/relay/evm/exec_provider.go
@@ -2,14 +2,14 @@ package evm
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"math/big"
 	"net/url"
 	"time"
 
-	"go.uber.org/multierr"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -124,7 +124,7 @@ func (s *SrcExecProvider) Close() error {
 	var multiErr error
 	for _, fn := range unregisterFuncs {
 		if err := fn(ctx); err != nil {
-			multiErr = multierr.Append(multiErr, err)
+			multiErr = stderrors.Join(multiErr, err)
 		}
 	}
 	return multiErr
@@ -336,7 +336,7 @@ func (d *DstExecProvider) Close() error {
 	var multiErr error
 	for _, fn := range unregisterFuncs {
 		if err := fn(ctx); err != nil {
-			multiErr = multierr.Append(multiErr, err)
+			multiErr = stderrors.Join(multiErr, err)
 		}
 	}
 

--- a/core/services/relay/evm/relayer_extender.go
+++ b/core/services/relay/evm/relayer_extender.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"go.uber.org/multierr"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
@@ -73,7 +71,7 @@ func NewLegacyChains(
 		opts.Logger.Infow(fmt.Sprintf("Loading chain %s", cid), "evmChainID", cid)
 		chain, err2 := legacyevm.NewTOMLChain(enabled[i], opts, clientsByChainID)
 		if err2 != nil {
-			err = multierr.Combine(err, fmt.Errorf("failed to create chain %s: %w", cid, err2))
+			err = errors.Join(err, fmt.Errorf("failed to create chain %s: %w", cid, err2))
 			continue
 		}
 

--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/theodesp/go-heaps/pairing"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
@@ -288,7 +287,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) ([]job.Servi
 func CheckFromAddressesExist(ctx context.Context, jb job.Job, gethks keystore.Eth) (err error) {
 	for _, a := range jb.VRFSpec.FromAddresses {
 		_, err2 := gethks.Get(ctx, a.Hex())
-		err = multierr.Append(err, err2)
+		err = stderrors.Join(err, err2)
 	}
 	return
 }
@@ -301,7 +300,7 @@ func CheckFromAddressMaxGasPrices(jb job.Job, keySpecificMaxGas keySpecificMaxGa
 	if jb.VRFSpec.GasLanePrice != nil {
 		for _, a := range jb.VRFSpec.FromAddresses {
 			if keySpecific := keySpecificMaxGas(a.Address()); !keySpecific.Equal(jb.VRFSpec.GasLanePrice) {
-				err = multierr.Append(err,
+				err = stderrors.Join(err,
 					fmt.Errorf(
 						"key-specific max gas price of from address %s (%s) does not match gasLanePriceGWei (%s) specified in job spec",
 						a.Hex(), keySpecific.String(), jb.VRFSpec.GasLanePrice.String()))

--- a/core/services/vrf/v2/listener_v2_log_listener.go
+++ b/core/services/vrf/v2/listener_v2_log_listener.go
@@ -3,12 +3,12 @@ package v2
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mathutil"
@@ -295,7 +295,7 @@ func (lsn *listenerV2) getUnfulfilled(logs []logpoller.Log, ll logger.Logger) (u
 			parsed, err2 := lsn.coordinator.ParseRandomWordsFulfilled(l.ToGethLog())
 			if err2 != nil {
 				// should never happen
-				errs = multierr.Append(errs, err2)
+				errs = errors.Join(errs, err2)
 				continue
 			}
 			fulfilled[parsed.RequestID().String()] = parsed
@@ -303,7 +303,7 @@ func (lsn *listenerV2) getUnfulfilled(logs []logpoller.Log, ll logger.Logger) (u
 			parsed, err2 := lsn.coordinator.ParseRandomWordsRequested(l.ToGethLog())
 			if err2 != nil {
 				// should never happen
-				errs = multierr.Append(errs, err2)
+				errs = errors.Join(errs, err2)
 				continue
 			}
 			keyHash := parsed.KeyHash()

--- a/core/services/webhook/validate.go
+++ b/core/services/webhook/validate.go
@@ -2,10 +2,10 @@ package webhook
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
@@ -44,7 +44,7 @@ func ValidatedWebhookSpec(ctx context.Context, tomlString string, externalInitia
 	for _, eiSpec := range tomlSpec.ExternalInitiators {
 		ei, findErr := externalInitiatorManager.FindExternalInitiatorByName(ctx, eiSpec.Name)
 		if findErr != nil {
-			err = multierr.Combine(err, errors.Wrapf(findErr, "unable to find external initiator named %s", eiSpec.Name))
+			err = stderrors.Join(err, errors.Wrapf(findErr, "unable to find external initiator named %s", eiSpec.Name))
 			continue
 		}
 		eiWS := job.ExternalInitiatorWebhookSpec{

--- a/core/services/webhook/validate_test.go
+++ b/core/services/webhook/validate_test.go
@@ -141,7 +141,7 @@ func TestValidatedWebJobSpec(t *testing.T) {
 				eim.On("FindExternalInitiatorByName", mock.Anything, "baz").Return(bridges.ExternalInitiator{}, errors.New("something exploded")).Once()
 			},
 			assertion: func(t *testing.T, s job.Job, err error) {
-				require.EqualError(t, err, "unable to find external initiator named bar: something exploded; unable to find external initiator named baz: something exploded")
+				require.EqualError(t, err, "unable to find external initiator named bar: something exploded\nunable to find external initiator named baz: something exploded")
 			},
 		},
 	}

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/shopspring/decimal"
-	"go.uber.org/multierr"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
@@ -631,13 +630,13 @@ func (s *Reports) End(ctx context.Context, workflowExecutionID string) error {
 	emitErr := report.EmitReceipt(ctx)
 	if emitErr != nil {
 		s.metrics.IncrementWorkflowMissingMeteringReport(ctx)
-		multiErr = multierr.Combine(multiErr, emitErr)
+		multiErr = errors.Join(multiErr, emitErr)
 	}
 
 	sendErr := report.SendReceipt(ctx)
 	if sendErr != nil {
 		s.metrics.IncrementWorkflowMissingMeteringReport(ctx)
-		multiErr = multierr.Combine(multiErr, sendErr)
+		multiErr = errors.Join(multiErr, sendErr)
 	}
 
 	delete(s.reports, workflowExecutionID)

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/hex"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -15,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/robfig/cron/v3"
 	"github.com/tidwall/gjson"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
@@ -487,11 +487,11 @@ var (
 
 func (h ServiceHeader) Validate() (err error) {
 	if !headerNameRegex.MatchString(h.Header) {
-		err = multierr.Append(err, errors.Errorf("invalid header name: %s", h.Header))
+		err = stderrors.Join(err, errors.Errorf("invalid header name: %s", h.Header))
 	}
 
 	if !headerValueRegex.MatchString(h.Value) {
-		err = multierr.Append(err, errors.Errorf("invalid header value: %s", h.Value))
+		err = stderrors.Join(err, errors.Errorf("invalid header value: %s", h.Value))
 	}
 	return
 }

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/kylelemons/godebug/diff"
 	"github.com/lib/pq"
-	"go.uber.org/multierr"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -126,7 +125,7 @@ func dropAndCreateDB(parsed url.URL, force bool) (err error) {
 	}
 	defer func() {
 		if cerr := db.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 	if force {
@@ -212,7 +211,7 @@ func insertFixtures(dbURL url.URL, pathToFixtures string) (err error) {
 	}
 	defer func() {
 		if cerr := db.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
+			err = errors.Join(err, cerr)
 		}
 	}()
 
@@ -261,7 +260,7 @@ func dropDanglingTestDBs(lggr logger.Logger, db *sqlx.DB) (err error) {
 	wg.Wait()
 	close(errCh)
 	for gerr := range errCh {
-		err = multierr.Append(err, gerr)
+		err = errors.Join(err, gerr)
 	}
 	return
 }

--- a/core/utils/files.go
+++ b/core/utils/files.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	stderrors "errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -8,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 )
 
 // FileExists returns true if a file at the passed string exists.
@@ -58,7 +58,7 @@ func WriteFileWithMaxPerms(path string, data []byte, perms os.FileMode) (err err
 	if err != nil {
 		return err
 	}
-	defer func() { err = multierr.Combine(err, f.Close()) }()
+	defer func() { err = stderrors.Join(err, f.Close()) }()
 	err = EnsureFileMaxPerms(f, perms)
 	if err != nil {
 		return
@@ -87,7 +87,7 @@ func EnsureFilepathMaxPerms(filepath string, perms os.FileMode) (err error) {
 	if err != nil {
 		return err
 	}
-	defer func() { err = multierr.Combine(err, dst.Close()) }()
+	defer func() { err = stderrors.Join(err, dst.Close()) }()
 	return EnsureFileMaxPerms(dst, perms)
 }
 

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	stderrors "errors"
 	"io"
 	"math/big"
 	"net/http"
@@ -25,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 )
 
 // ETHKeysController manages account keys
@@ -290,7 +290,7 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 	if abandon {
 		var resetErr error
 		err = chain.TxManager().Reset(address, abandon)
-		err = multierr.Combine(err, resetErr)
+		err = stderrors.Join(err, resetErr)
 		if err != nil {
 			if strings.Contains(err.Error(), "key state not found with address") {
 				jsonAPIError(c, http.StatusNotFound, err)

--- a/core/web/loader/getters.go
+++ b/core/web/loader/getters.go
@@ -2,10 +2,10 @@ package loader
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/graph-gophers/dataloader"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
@@ -104,7 +104,7 @@ func GetJobRunsByIDs(ctx context.Context, ids []int64) ([]pipeline.Run, error) {
 	thunk := ldr.JobRunsByIDLoader.LoadMany(ctx, dataloader.NewKeysFromStrings(strIDs))
 	results, errs := thunk()
 	if errs != nil {
-		merr := multierr.Combine(errs...)
+		merr := stderrors.Join(errs...)
 
 		return nil, errors.Wrap(merr, "errors fetching runs")
 	}

--- a/core/web/sessions_controller.go
+++ b/core/web/sessions_controller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
-	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/logger/audit"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
@@ -61,7 +60,7 @@ func (sc *SessionsController) Create(c *gin.Context) {
 	}
 
 	if err := saveSessionID(session, sid); err != nil {
-		jsonAPIError(c, http.StatusInternalServerError, multierr.Append(errors.New("unable to save session id"), err))
+		jsonAPIError(c, http.StatusInternalServerError, errors.Join(errors.New("unable to save session id"), err))
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.37.0
 	go.opentelemetry.io/otel/trace v1.37.0
 	go.uber.org/atomic v1.11.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.40.0
 	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc
@@ -382,6 +381,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.37.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.13.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
 	golang.org/x/arch v0.11.0 // indirect
 	golang.org/x/net v0.42.0 // indirect

--- a/integration-tests/ccip-tests/contracts/laneconfig/parse_contracts.go
+++ b/integration-tests/ccip-tests/contracts/laneconfig/parse_contracts.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
-	"go.uber.org/multierr"
 )
 
 var (
@@ -60,35 +59,35 @@ func (l *LaneConfig) Validate() error {
 	var laneConfigError error
 
 	if l.ARM == "" || !common.IsHexAddress(l.ARM) {
-		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for arm"))
+		laneConfigError = errors.Join(laneConfigError, errors.New("must set proper address for arm"))
 	}
 
 	if l.FeeToken != "" && !common.IsHexAddress(l.FeeToken) {
-		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for fee_token"))
+		laneConfigError = errors.Join(laneConfigError, errors.New("must set proper address for fee_token"))
 	}
 
 	for _, token := range l.BridgeTokens {
 		if token != "" && !common.IsHexAddress(token) {
-			laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for bridge_tokens"))
+			laneConfigError = errors.Join(laneConfigError, errors.New("must set proper address for bridge_tokens"))
 		}
 	}
 
 	for _, pool := range l.BridgeTokenPools {
 		if pool != "" && !common.IsHexAddress(pool) {
-			laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for bridge_tokens_pools"))
+			laneConfigError = errors.Join(laneConfigError, errors.New("must set proper address for bridge_tokens_pools"))
 		}
 	}
 	if l.Router == "" || !common.IsHexAddress(l.Router) {
-		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for router"))
+		laneConfigError = errors.Join(laneConfigError, errors.New("must set proper address for router"))
 	}
 	if l.PriceRegistry == "" || !common.IsHexAddress(l.PriceRegistry) {
-		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for price_registry"))
+		laneConfigError = errors.Join(laneConfigError, errors.New("must set proper address for price_registry"))
 	}
 	if l.WrappedNative == "" || !common.IsHexAddress(l.WrappedNative) {
-		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for wrapped_native"))
+		laneConfigError = errors.Join(laneConfigError, errors.New("must set proper address for wrapped_native"))
 	}
 	if l.Multicall == "" || !common.IsHexAddress(l.Multicall) {
-		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for multicall"))
+		laneConfigError = errors.Join(laneConfigError, errors.New("must set proper address for multicall"))
 	}
 	return laneConfigError
 }

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -69,7 +69,6 @@ require (
 	github.com/umbracle/ethgo v0.1.3
 	github.com/xssnick/tonutils-go v1.13.0
 	go.uber.org/atomic v1.11.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.40.0
 	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc
@@ -578,6 +577,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.6.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/goleak v1.3.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
 	go4.org/netipx v0.0.0-20230125063823-8449b0a6169f // indirect
 	golang.org/x/arch v0.11.0 // indirect


### PR DESCRIPTION
A bit of leftover work from https://smartcontract-it.atlassian.net/browse/PLEX-211 / https://smartcontract-it.atlassian.net/browse/BCI-2589 to restore the block of `go.uber.org/multierr` and swap over remaining uses.