### PR TITLE
Remove default for CL_MEDIAN_CMD env in Docker (#18722)

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -74,9 +74,10 @@ RUN if [ ${CHAINLINK_USER} != root ]; then useradd --uid 14933 --create-home ${C
 USER ${CHAINLINK_USER}
 
 # Set plugin environment variable configuration.
-ENV CL_MEDIAN_CMD=chainlink-feeds
 ENV CL_SOLANA_CMD=chainlink-solana
 
+ARG CL_MEDIAN_CMD
+ENV CL_MEDIAN_CMD=${CL_MEDIAN_CMD}
 ARG CL_EVM_CMD
 ENV CL_EVM_CMD=${CL_EVM_CMD}
 


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
