### PR TITLE
feat(ci): trunk.io unit test reporting

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -182,6 +182,7 @@ jobs:
           - cmd: go_core_tests
             os: ${{ needs.runner-config.outputs.core-tests-runner }}
             should-run: ${{ needs.filter.outputs.should-run-core-tests }}
+            use-trunk: "true"
 
           - cmd: go_core_tests_integration
             os: ${{ needs.runner-config.outputs.core-tests-integration-runner }}
@@ -201,6 +202,7 @@ jobs:
             should-run: ${{ needs.filter.outputs.should-run-deployment-tests }}
             setup-solana: "true"
             setup-aptos: "true"
+            use-trunk: "true"
 
     name: Core Tests (${{ matrix.type.cmd }})
     # We don't directly merge dependabot PRs, so let's not waste the resources
@@ -280,15 +282,26 @@ jobs:
 
       - name: Run tests
         if: ${{ matrix.type.should-run == 'true' }}
-        timeout-minutes: ${{ github.event_name == 'schedule' && 37 || 22 }} # leave  minute for remaining steps
+        timeout-minutes: ${{ github.event_name == 'schedule' && 37 || 22 }} # leave time for remaining steps
         id: run-tests
         shell: bash
         env:
-          OUTPUT_FILE: ./output.txt
           CL_DATABASE_URL: ${{ env.DB_URL }}
+          OUTPUT_FILE: ./output.txt
+          PRODUCE_JUNIT_XML: ${{ matrix.type.use-trunk }}
         run: |
+          GODEBUG=goindex=0 ./tools/bin/${{ matrix.type.cmd }} ./...
           # See: https://github.com/golang/go/issues/69179
-          ./tools/bin/${{ matrix.type.cmd }} ./...
+
+      - name: Upload Test Results to Trunk.io
+        if: ${{ matrix.type.should-run == 'true' && matrix.type.use-trunk == 'true' && !cancelled() }}
+        uses: trunk-io/analytics-uploader@f2631c653f9675d391e6e68cc877370db927c64c # v2.0.0
+        continue-on-error: true # TODO: Remove this once ready
+        with:
+          junit-paths: "./junit.xml,*/junit.xml"
+          org-slug: chainlink
+          token: ${{ secrets.TRUNK_API_KEY }}
+          previous-step-outcome: ${{ steps.run-tests.outcome }}
 
       - name: Print Races
         id: print-races
@@ -328,6 +341,8 @@ jobs:
             ./race.*
             ./coverage.txt
             ./postgres_logs.txt
+            ./junit.xml
+            ./deployment/junit.xml
           retention-days: 7
 
       - name: Notify Slack on Race Test Failure

--- a/tools/bin/go_core_ccip_deployment_tests
+++ b/tools/bin/go_core_ccip_deployment_tests
@@ -3,55 +3,60 @@ set -o pipefail
 set +e
 
 SCRIPT_PATH=`dirname "$0"`; SCRIPT_PATH=`eval "cd \"$SCRIPT_PATH\" && pwd"`
-OUTPUT_FILE=${OUTPUT_FILE:-"../output.txt"}
-EXTRA_FLAGS=""
+OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
+JUNIT_FILE=${JUNIT_FILE:-"./junit.xml"}
+GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"15m"}
+
+cd deployment || exit 1
+
+echo "Installing gotestsum..."
+go install gotest.tools/gotestsum@v1.12.3
+PATH=$PATH:$(go env GOPATH)/bin
+export PATH
 
 echo "Running go_core_ccip_deployment_tests for event: $GITHUB_EVENT_NAME"
-
-if [[ "$GITHUB_EVENT_NAME" == 'pull_request' || "$GITHUB_EVENT_NAME" == "merge_group" || "$GITHUB_EVENT_NAME" == "push" ]]; then
-  go install gotest.tools/gotestsum@v1.12.3
-  PATH=$PATH:$(go env GOPATH)/bin
-  export PATH
-
-  cd deployment || exit 1
-  gotestsum \
-    --format='standard-quiet' \
-    --rerun-fails-abort-on-data-race \
-    --rerun-fails='3' \
-    --packages='./...' \
-    --jsonfile "$OUTPUT_FILE"
-
-  EXITCODE=${PIPESTATUS[0]}
-else
-  cd ./deployment || exit
-  go mod download
-
-  echo "Test execution results: ---------------------"
-  echo ""
-
-  if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
-    EXTRA_FLAGS="-covermode=atomic -coverpkg=./... -coverprofile=coverage.txt"
-  fi
-
-  go test ./... $EXTRA_FLAGS | tee "$OUTPUT_FILE" | grep -Ev '\[no test files\]|\[no tests to run\]'
-  EXITCODE=${PIPESTATUS[0]}
-
-  # Assert no known sensitive strings present in test logger output
-  printf "\n----------------------------------------------\n\n"
-  echo "Beginning check of output logs for sensitive strings"
-  "$SCRIPT_PATH"/scrub_logs "$OUTPUT_FILE"
-  if [[ $? != 0 ]]; then
-    exit 1
-  fi
+GO_TEST_FLAGS="-timeout=${GO_TEST_TIMEOUT}"
+if [[ "$GITHUB_EVENT_NAME" == 'push' ]]; then
+  GO_TEST_FLAGS="$GO_TEST_FLAGS -count=1"
+elif [[ "$GITHUB_EVENT_NAME" == 'schedule' ]]; then
+  GO_TEST_FLAGS="$GO_TEST_FLAGS -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt"
+elif [[ "$GITHUB_EVENT_NAME" == 'pull_request' || "$GITHUB_EVENT_NAME" == 'merge_group' ]]; then
+  RERUN_FLAGS="--rerun-fails-abort-on-data-race --rerun-fails=3"
 fi
 
-cd ..
+if [[ "$PRODUCE_JUNIT_XML" == "true" ]]; then
+  JUNIT_FLAG="--junitfile=$JUNIT_FILE"
+fi
+
+echo "Using GO_TEST_FLAGS: $GO_TEST_FLAGS"
+echo "Using RERUN_FLAGS: $RERUN_FLAGS"
+echo "Using JUNIT_FLAG: $JUNIT_FLAG"
+
+echo "Test execution results: ---------------------"
+echo ""
+
+gotestsum \
+  --format='standard-quiet' \
+  $RERUN_FLAGS \
+  --packages='./...' \
+  --jsonfile "$OUTPUT_FILE" \
+  "$JUNIT_FLAG" \
+  -- $GO_TEST_FLAGS
+
+EXITCODE=${PIPESTATUS[0]}
+
+# Assert no known sensitive strings present in test logger output
+printf "\n----------------------------------------------\n\n"
+echo "Beginning check of output logs for sensitive strings"
+$SCRIPT_PATH/scrub_logs $OUTPUT_FILE
+if [[ $? != 0 ]]; then
+  exit 1
+fi
+
 echo "Exit code: $EXITCODE"
 if [[ $EXITCODE != 0 ]]; then
   echo "Encountered test failures."
 else
   echo "All tests passed!"
 fi
-
-echo "go_core_ccip_deployment_tests exiting with code $EXITCODE"
 exit $EXITCODE

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -4,41 +4,51 @@ set +e
 
 SCRIPT_PATH=`dirname "$0"`; SCRIPT_PATH=`eval "cd \"$SCRIPT_PATH\" && pwd"`
 OUTPUT_FILE=${OUTPUT_FILE:-"./output.txt"}
-EXTRA_FLAGS="-timeout 16m"
+JUNIT_FILE=${JUNIT_FILE:-"./junit.xml"}
+GO_TEST_TIMEOUT=${GO_TEST_TIMEOUT:-"15m"}
+
+echo "Installing gotestsum..."
+go install gotest.tools/gotestsum@v1.12.3
+PATH=$PATH:$(go env GOPATH)/bin
+export PATH
 
 echo "Running go_core_tests for event: $GITHUB_EVENT_NAME"
+GO_TEST_FLAGS="-timeout=${GO_TEST_TIMEOUT}"
+if [[ "$GITHUB_EVENT_NAME" == 'push' ]]; then
+  GO_TEST_FLAGS="$GO_TEST_FLAGS -count=1"
+elif [[ "$GITHUB_EVENT_NAME" == 'schedule' ]]; then
+  GO_TEST_FLAGS="$GO_TEST_FLAGS -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt"
+elif [[ "$GITHUB_EVENT_NAME" == 'pull_request' || "$GITHUB_EVENT_NAME" == 'merge_group' ]]; then
+  RERUN_FLAGS="--rerun-fails-abort-on-data-race --rerun-fails=3"
+fi
 
-if [[ "$GITHUB_EVENT_NAME" == 'pull_request' || "$GITHUB_EVENT_NAME" == "merge_group" || "$GITHUB_EVENT_NAME" == "push" ]]; then
-  go install gotest.tools/gotestsum@v1.12.3
-  PATH=$PATH:$(go env GOPATH)/bin
-  export PATH
+if [[ "$PRODUCE_JUNIT_XML" == "true" ]]; then
+  JUNIT_FLAG="--junitfile=$JUNIT_FILE"
+fi
 
-  gotestsum \
-    --format='standard-quiet' \
-    --rerun-fails-abort-on-data-race \
-    --rerun-fails='3' \
-    --packages='./...' \
-    --jsonfile "$OUTPUT_FILE"
+echo "Using GO_TEST_FLAGS: $GO_TEST_FLAGS"
+echo "Using RERUN_FLAGS: $RERUN_FLAGS"
+echo "Using JUNIT_FLAG: $JUNIT_FLAG"
 
-  EXITCODE=${PIPESTATUS[0]}
-else
-  if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
-    EXTRA_FLAGS="-covermode=atomic -coverpkg=./... -coverprofile=coverage.txt"
-  fi
+echo "Test execution results: ---------------------"
+echo ""
 
-  echo "Test execution results: ---------------------"
-  echo ""
+gotestsum \
+  --format='standard-quiet' \
+  $RERUN_FLAGS \
+  --packages='./...' \
+  --jsonfile "$OUTPUT_FILE" \
+  "$JUNIT_FLAG" \
+  -- $GO_TEST_FLAGS
 
-  go test $EXTRA_FLAGS $1 | tee "$OUTPUT_FILE" | grep -Ev '\[no test files\]|\[no tests to run\]'
-  EXITCODE=${PIPESTATUS[0]}
+EXITCODE=${PIPESTATUS[0]}
 
-  # Assert no known sensitive strings present in test logger output
-  printf "\n----------------------------------------------\n\n"
-  echo "Beginning check of output logs for sensitive strings"
-  $SCRIPT_PATH/scrub_logs $OUTPUT_FILE
-  if [[ $? != 0 ]]; then
-    exit 1
-  fi
+# Assert no known sensitive strings present in test logger output
+printf "\n----------------------------------------------\n\n"
+echo "Beginning check of output logs for sensitive strings"
+$SCRIPT_PATH/scrub_logs $OUTPUT_FILE
+if [[ $? != 0 ]]; then
+  exit 1
 fi
 
 echo "Exit code: $EXITCODE"
@@ -47,5 +57,4 @@ if [[ $EXITCODE != 0 ]]; then
 else
   echo "All tests passed!"
 fi
-echo "go_core_tests exiting with code $EXITCODE"
 exit $EXITCODE


### PR DESCRIPTION
Add test reporting to unit tests so we can start the data gathering process before a full integration.

### Changes

- Cleanup core and deployment module unit test run scripts
- Enable junit test reports for gotestsum unit test execution
- Upload junit.xml to trunk.io for test tracking

### Notes

I've added a `continue-on-error: true` so any issues during report uploading shouldn't effect the job's outcome.

Once we are ready to fully roll-out the trunk integration we can remove this and add it to the run unit tests step, as the unit tests should pass regardless of the result, and trunk.io integration will report the outcome based on which tests failed (ie. skipping a failure result from quarantined tests).

---

DX-22 / DX-1259
