### PR TITLE
core/services/modsec: add job, boilerplate

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -64,6 +64,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keeper"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/llo/retirement"
+	"github.com/smartcontractkit/chainlink/v2/core/services/modsec"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrbootstrap"
@@ -637,6 +638,14 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 			telemetryManager,
 			cfg.Capabilities(),
 			cfg.EVMConfigs(),
+		)
+		delegates[job.Modsec] = modsec.NewDelegate(
+			cfg,
+			globalLogger,
+			opts.KeyStore,
+			opts.DS,
+			cfg.EVMConfigs(),
+			legacyEVMChains,
 		)
 	} else {
 		globalLogger.Debug("Off-chain reporting v2 disabled")

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -514,6 +514,14 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 				pipelineRunner,
 				cfg.JobPipeline(),
 			),
+			job.Modsec: modsec.NewDelegate(
+				cfg,
+				globalLogger,
+				opts.KeyStore,
+				opts.DS,
+				cfg.EVMConfigs(),
+				legacyEVMChains,
+			),
 		}
 		webhookJobRunner = delegates[job.Webhook].(*webhook.Delegate).WebhookJobRunner()
 	)
@@ -638,14 +646,6 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 			telemetryManager,
 			cfg.Capabilities(),
 			cfg.EVMConfigs(),
-		)
-		delegates[job.Modsec] = modsec.NewDelegate(
-			cfg,
-			globalLogger,
-			opts.KeyStore,
-			opts.DS,
-			cfg.EVMConfigs(),
-			legacyEVMChains,
 		)
 	} else {
 		globalLogger.Debug("Off-chain reporting v2 disabled")

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -36,6 +36,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocrkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
+	"github.com/smartcontractkit/chainlink/v2/core/services/modsec"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr"
 	ocr2 "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/validate"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrbootstrap"
@@ -1394,6 +1395,8 @@ func (s *service) generateJob(ctx context.Context, spec string) (*job.Job, error
 		js, err = workflows.ValidatedWorkflowJobSpec(ctx, spec)
 	case job.CCIP:
 		js, err = ccip.ValidatedCCIPSpec(spec)
+	case job.Modsec:
+		js, err = modsec.ValidatedModsecSpec(spec)
 	case job.Stream:
 		js, err = streams.ValidatedStreamSpec(spec)
 	case job.Gateway:

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -41,6 +41,7 @@ const (
 	Bootstrap               Type = (Type)(pipeline.BootstrapJobType)
 	Cron                    Type = (Type)(pipeline.CronJobType)
 	CCIP                    Type = (Type)(pipeline.CCIPJobType)
+	Modsec                  Type = (Type)(pipeline.ModsecJobType)
 	DirectRequest           Type = (Type)(pipeline.DirectRequestJobType)
 	FluxMonitor             Type = (Type)(pipeline.FluxMonitorJobType)
 	Gateway                 Type = (Type)(pipeline.GatewayJobType)
@@ -82,6 +83,7 @@ var (
 		Bootstrap:               false,
 		Cron:                    true,
 		CCIP:                    false,
+		Modsec:                  false,
 		DirectRequest:           true,
 		FluxMonitor:             true,
 		Gateway:                 false,
@@ -102,6 +104,7 @@ var (
 		Bootstrap:               false,
 		Cron:                    true,
 		CCIP:                    false,
+		Modsec:                  false,
 		DirectRequest:           true,
 		FluxMonitor:             false,
 		Gateway:                 false,
@@ -122,6 +125,7 @@ var (
 		Bootstrap:               1,
 		Cron:                    1,
 		CCIP:                    1,
+		Modsec:                  1,
 		DirectRequest:           1,
 		FluxMonitor:             1,
 		Gateway:                 1,
@@ -184,6 +188,8 @@ type Job struct {
 	CCIPSpecID                    *int32
 	CCIPSpec                      *CCIPSpec
 	CCIPBootstrapSpecID           *int32
+	ModsecSpecID                  *int32
+	ModsecSpec                    *ModsecSpec
 	JobSpecErrors                 []SpecError
 	Type                          Type          `toml:"type"`
 	SchemaVersion                 uint32        `toml:"schemaVersion"`
@@ -1113,4 +1119,32 @@ type CCIPSpec struct {
 	// PluginConfig contains plugin-specific config, like token price pipelines
 	// and RMN network info for offchain blessing.
 	PluginConfig JSONConfig `toml:"pluginConfig"`
+}
+
+type ModsecSpec struct {
+	ID        int32
+	CreatedAt time.Time `toml:"-"`
+	UpdatedAt time.Time `toml:"-"`
+
+	// SourceChainID is the chain ID of the source chain.
+	SourceChainID string `toml:"sourceChainID" db:"source_chain_id"`
+
+	// SourceChainFamily is the family of the source chain.
+	SourceChainFamily string `toml:"sourceChainFamily" db:"source_chain_family"`
+
+	// DestChainID is the chain ID of the destination chain.
+	DestChainID string `toml:"destChainID" db:"dest_chain_id"`
+
+	// DestChainFamily is the family of the destination chain.
+	DestChainFamily string `toml:"destChainFamily" db:"dest_chain_family"`
+
+	// OnRampAddress is the address of the Commit OnRamp contract.
+	OnRampAddress string `toml:"onRampAddress" db:"on_ramp_address"`
+
+	// CCIPMessageSentEventSig is the event signature of the CCIPMessageSent event, emitted on the
+	// source chain onramp contract.
+	CCIPMessageSentEventSig string `toml:"ccipMessageSentEventSig" db:"ccip_message_sent_event_sig"`
+
+	// OffRampAddress is the address of the OffRamp contract.
+	OffRampAddress string `toml:"offRampAddress" db:"off_ramp_address"`
 }

--- a/core/services/modsec/delegate.go
+++ b/core/services/modsec/delegate.go
@@ -1,0 +1,196 @@
+package modsec
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
+	"github.com/smartcontractkit/chainlink/v2/core/config"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
+	"github.com/smartcontractkit/chainlink/v2/core/services/modsec/modsecrelayer"
+	"github.com/smartcontractkit/chainlink/v2/core/services/modsec/modsecverifier"
+)
+
+type Config interface {
+	Feature() config.Feature
+}
+
+type RelayGetter interface {
+	Get(types.RelayID) (loop.Relayer, error)
+	GetIDToRelayerMap() map[types.RelayID]loop.Relayer
+}
+
+type Keystore[K keystore.Key] interface {
+	GetAll() ([]K, error)
+}
+
+type Delegate struct {
+	cfg          Config
+	lggr         logger.Logger
+	keystore     keystore.Master
+	ds           sqlutil.DataSource
+	evmConfigs   toml.EVMConfigs
+	legacyChains legacyevm.LegacyChainContainer
+
+	isNewlyCreatedJob bool
+}
+
+func NewDelegate(
+	cfg Config,
+	lggr logger.Logger,
+	keystore keystore.Master,
+	ds sqlutil.DataSource,
+	evmConfigs toml.EVMConfigs,
+	legacyChains legacyevm.LegacyChainContainer,
+) *Delegate {
+	return &Delegate{
+		cfg:          cfg,
+		lggr:         lggr,
+		keystore:     keystore,
+		ds:           ds,
+		evmConfigs:   evmConfigs,
+		legacyChains: legacyChains,
+	}
+}
+
+func (d *Delegate) JobType() job.Type {
+	return job.Modsec
+}
+
+func (d *Delegate) BeforeJobCreated(job.Job) {
+	// This is only called first time the job is created
+	d.isNewlyCreatedJob = true
+}
+
+func validate(spec *job.ModsecSpec) error {
+	sourceChainID := spec.SourceChainID
+	sourceChainFamily := spec.SourceChainFamily
+
+	if sourceChainID == "" || sourceChainFamily == "" {
+		return fmt.Errorf("source chain id (%s) or family (%s) is empty", sourceChainID, sourceChainFamily)
+	}
+
+	if sourceChainFamily != string(chaintype.EVM) {
+		return fmt.Errorf("source chain family (%s) is not an EVM chain", sourceChainFamily)
+	}
+
+	destChainID := spec.DestChainID
+	destChainFamily := spec.DestChainFamily
+
+	if destChainID == "" || destChainFamily == "" {
+		return fmt.Errorf("dest chain id (%s) or family (%s) is empty", destChainID, destChainFamily)
+	}
+
+	if destChainFamily != string(chaintype.EVM) {
+		return fmt.Errorf("dest chain family (%s) is not an EVM chain", destChainFamily)
+	}
+
+	if sourceChainID == destChainID {
+		return fmt.Errorf("source chain id (%s) and dest chain id (%s) are the same", sourceChainID, destChainID)
+	}
+
+	if spec.OnRampAddress == "" {
+		return fmt.Errorf("on ramp address is empty")
+	}
+
+	if !common.IsHexAddress(spec.OnRampAddress) {
+		return fmt.Errorf("on ramp address (%s) is not a valid address", spec.OnRampAddress)
+	}
+
+	if spec.OffRampAddress == "" {
+		return fmt.Errorf("off ramp address is empty")
+	}
+
+	if !common.IsHexAddress(spec.OffRampAddress) {
+		return fmt.Errorf("off ramp address (%s) is not a valid address", spec.OffRampAddress)
+	}
+
+	if spec.CCIPMessageSentEventSig == "" {
+		return fmt.Errorf("ccip message sent event sig is empty")
+	}
+
+	if len(common.FromHex(spec.CCIPMessageSentEventSig)) != 32 {
+		return fmt.Errorf("ccip message sent event sig is not 32 bytes")
+	}
+
+	return nil
+}
+
+func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services []job.ServiceCtx, err error) {
+	if spec.ModsecSpec == nil {
+		return nil, errors.New("modsec spec is nil")
+	}
+
+	marshalledJob, err := json.MarshalIndent(spec.ModsecSpec, "", " ")
+	if err != nil {
+		return nil, err
+	}
+	d.lggr.Debugw("Creating services for modsec job spec", "job", string(marshalledJob))
+
+	if !d.cfg.Feature().LogPoller() {
+		return nil, errors.New("log poller must be enabled to run modsec")
+	}
+
+	if err = validate(spec.ModsecSpec); err != nil {
+		return nil, err
+	}
+
+	sourceChain, err := d.legacyChains.Get(spec.ModsecSpec.SourceChainID)
+	if err != nil {
+		return nil, err
+	}
+
+	legacySourceChain, ok := sourceChain.(legacyevm.Chain)
+	if !ok {
+		return nil, fmt.Errorf("source chain (%s) is not an EVM chain", spec.ModsecSpec.SourceChainID)
+	}
+
+	destChain, err := d.legacyChains.Get(spec.ModsecSpec.DestChainID)
+	if err != nil {
+		return nil, err
+	}
+
+	legacyDestChain, ok := destChain.(legacyevm.Chain)
+	if !ok {
+		return nil, fmt.Errorf("dest chain (%s) is not an EVM chain", spec.ModsecSpec.DestChainID)
+	}
+
+	verifier := modsecverifier.NewVerifier(
+		d.lggr,
+		legacySourceChain.LogPoller(),
+		spec.ModsecSpec.CCIPMessageSentEventSig,
+		spec.ModsecSpec.OnRampAddress,
+	)
+
+	relayer := modsecrelayer.NewRelayer(
+		d.lggr,
+		legacyDestChain.LogPoller(),
+		legacyDestChain.TxManager(),
+		spec.ModsecSpec.CCIPMessageSentEventSig,
+		spec.ModsecSpec.OnRampAddress,
+		spec.ModsecSpec.OffRampAddress,
+	)
+
+	services = append(services, verifier, relayer)
+
+	return services, nil
+}
+
+func (d *Delegate) AfterJobCreated(spec job.Job) {}
+
+func (d *Delegate) BeforeJobDeleted(spec job.Job) {}
+
+func (d *Delegate) OnDeleteJob(ctx context.Context, spec job.Job) error {
+	// TODO: shut down needed services?
+	return nil
+}

--- a/core/services/modsec/delegate_test.go
+++ b/core/services/modsec/delegate_test.go
@@ -1,0 +1,199 @@
+package modsec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
+)
+
+func validSpec() *job.ModsecSpec {
+	return &job.ModsecSpec{
+		SourceChainID:           "1338",
+		SourceChainFamily:       string(chaintype.EVM),
+		DestChainID:             "1337",
+		DestChainFamily:         string(chaintype.EVM),
+		OnRampAddress:           "0x1234567890123456789012345678901234567890",
+		OffRampAddress:          "0x0987654321098765432109876543210987654321",
+		CCIPMessageSentEventSig: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		modifier    func(*job.ModsecSpec)
+		expectedErr string
+	}{
+		{
+			name:        "valid spec",
+			modifier:    func(spec *job.ModsecSpec) {},
+			expectedErr: "",
+		},
+		{
+			name: "empty source chain id",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.SourceChainID = ""
+			},
+			expectedErr: "source chain id () or family (evm) is empty",
+		},
+		{
+			name: "empty source chain family",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.SourceChainFamily = ""
+			},
+			expectedErr: "source chain id (1338) or family () is empty",
+		},
+		{
+			name: "empty dest chain id",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.DestChainID = ""
+			},
+			expectedErr: "dest chain id () or family (evm) is empty",
+		},
+		{
+			name: "empty dest chain family",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.DestChainFamily = ""
+			},
+			expectedErr: "dest chain id (1337) or family () is empty",
+		},
+		{
+			name: "source and dest chain same",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.DestChainID = "1338"
+			},
+			expectedErr: "source chain id (1338) and dest chain id (1338) are the same",
+		},
+		{
+			name: "empty onramp address",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.OnRampAddress = ""
+			},
+			expectedErr: "on ramp address is empty",
+		},
+		{
+			name: "invalid onramp address",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.OnRampAddress = "not-an-address"
+			},
+			expectedErr: "on ramp address (not-an-address) is not a valid address",
+		},
+		{
+			name: "empty offramp address",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.OffRampAddress = ""
+			},
+			expectedErr: "off ramp address is empty",
+		},
+		{
+			name: "invalid offramp address",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.OffRampAddress = "not-an-address"
+			},
+			expectedErr: "off ramp address (not-an-address) is not a valid address",
+		},
+		{
+			name: "empty ccip message sent event sig",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.CCIPMessageSentEventSig = ""
+			},
+			expectedErr: "ccip message sent event sig is empty",
+		},
+		{
+			name: "invalid ccip message sent event sig",
+			modifier: func(spec *job.ModsecSpec) {
+				spec.CCIPMessageSentEventSig = "0x1234"
+			},
+			expectedErr: "ccip message sent event sig is not 32 bytes",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := validSpec()
+			tc.modifier(spec)
+			err := validate(spec)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestValidatedModsecSpec(t *testing.T) {
+	t.Parallel()
+
+	validToml := `
+		type = "modsec"
+		schemaVersion = 1
+		sourceChainID = "1338"
+		sourceChainFamily = "evm"
+		destChainID = "1337"
+		destChainFamily = "evm"
+		onRampAddress = "0x1234567890123456789012345678901234567890"
+		offRampAddress = "0x0987654321098765432109876543210987654321"
+		ccipMessageSentEventSig = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+	`
+
+	testCases := []struct {
+		name        string
+		toml        string
+		expectedErr string
+	}{
+		{
+			name:        "valid spec",
+			toml:        validToml,
+			expectedErr: "",
+		},
+		{
+			name:        "invalid toml",
+			toml:        "invalid-toml",
+			expectedErr: "toml error on load",
+		},
+		{
+			name: "unmarshal error on job",
+			toml: `
+				type = "modsec"
+				schemaVersion = "not-a-number"
+			`,
+			expectedErr: "toml unmarshal error on job",
+		},
+		{
+			name: "wrong job type",
+			toml: `
+				type = "not-modsec"
+				schemaVersion = 1
+			`,
+			expectedErr: "the only supported type is currently 'modsec', got not-modsec",
+		},
+		{
+			name: "validation error",
+			toml: `
+				type = "modsec"
+				schemaVersion = 1
+				sourceChainID = ""
+			`,
+			expectedErr: "source chain id () or family () is empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ValidatedModsecSpec(tc.toml)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+			}
+		})
+	}
+}

--- a/core/services/modsec/e2e_test.go
+++ b/core/services/modsec/e2e_test.go
@@ -1,0 +1,325 @@
+package modsec_test
+
+import (
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
+	"github.com/ethereum/go-ethereum/params"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_0_0/rmn_proxy_contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/mock_rmn_contract"
+	"github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/weth9"
+	"github.com/smartcontractkit/chainlink-evm/pkg/client"
+	v2toml "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
+	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
+	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	configv2 "github.com/smartcontractkit/chainlink/v2/core/config/toml"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/logger/audit"
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
+	"github.com/smartcontractkit/chainlink/v2/core/services/llo/retirement"
+	"github.com/smartcontractkit/chainlink/v2/core/services/modsec"
+	"github.com/smartcontractkit/chainlink/v2/core/testdata/testspecs"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
+	"github.com/smartcontractkit/chainlink/v2/core/utils/testutils/heavyweight"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	// Always 1337 for the simulated chain
+	simChainID = big.NewInt(1337)
+	// prefundAmount is the amount of Ether to pre-fund the deployer account with.
+	prefundAmountEth = big.NewInt(1_000_000)
+	// prefundAmountWei is the prefund amount in wei.
+	prefundAmountWei = prefundAmountEth.Mul(prefundAmountEth, big.NewInt(params.Ether))
+)
+
+// evmTestChainSelectors returns the selectors for the test EVM chains. We arbitrarily
+// start this from the EVM test selector TEST_90000001 and limit the number of chains you can load
+// to 10. This avoid conflicts with other selectors.
+var evmTestChainSelectors = []uint64{
+	chain_selectors.TEST_90000001.Selector,
+	chain_selectors.TEST_90000002.Selector,
+	chain_selectors.TEST_90000003.Selector,
+	chain_selectors.TEST_90000004.Selector,
+	chain_selectors.TEST_90000005.Selector,
+	chain_selectors.TEST_90000006.Selector,
+	chain_selectors.TEST_90000007.Selector,
+	chain_selectors.TEST_90000008.Selector,
+	chain_selectors.TEST_90000009.Selector,
+	chain_selectors.TEST_90000010.Selector,
+}
+
+// startAutoMine triggers the simulated backend to create a new block at intervals defined by
+// `blockTime`. After the test is done, it stops the mining goroutine.
+func startAutoMine(t *testing.T, backend *simulated.Backend, blockTime time.Duration) {
+	t.Helper()
+
+	ctx := t.Context() // Available since Go 1.20
+	ticker := time.NewTicker(blockTime)
+	go func() {
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				backend.Commit()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// GenerateChainsEVM generates a number of simulated EVM chains for testing purposes.
+func generateChainsEVM(t *testing.T, numChains int, numUsers int, blockTime time.Duration) []EVMChain {
+	if numChains > len(evmTestChainSelectors) {
+		require.Failf(t, "not enough test EVM chain selectors available", "max is %d",
+			len(evmTestChainSelectors),
+		)
+	}
+
+	chains := make([]EVMChain, 0, numChains)
+	for i := range numChains {
+		selector := evmTestChainSelectors[i]
+		evmChainID, err := chain_selectors.ChainIdFromSelector(selector)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Generate a deployer account
+		adminKey, err := crypto.GenerateKey()
+		require.NoError(t, err, "failed to generate deployer key")
+
+		adminTransactor, err := bind.NewKeyedTransactorWithChainID(adminKey, simChainID)
+		require.NoError(t, err)
+
+		// Prefund the admin account
+		genesis := types.GenesisAlloc{
+			adminTransactor.From: {Balance: prefundAmountWei},
+		}
+
+		additionalTransactors := make([]*bind.TransactOpts, 0, numUsers)
+		for i := 0; i < numUsers; i++ {
+			userKey, err := crypto.GenerateKey()
+			require.NoError(t, err, "failed to generate user key")
+			userTransactor, err := bind.NewKeyedTransactorWithChainID(userKey, simChainID)
+			require.NoError(t, err)
+			additionalTransactors = append(additionalTransactors, userTransactor)
+
+			genesis[userTransactor.From] = types.Account{Balance: prefundAmountWei}
+		}
+
+		// Initialize the simulated backend with the genesis state
+		backend := simulated.NewBackend(genesis, simulated.WithBlockGasLimit(50000000))
+		backend.Commit() // Commit the genesis block
+
+		// Start mining blocks if a block time is configured
+		if blockTime > 0 {
+			startAutoMine(t, backend, blockTime)
+		}
+
+		chains = append(chains, EVMChain{
+			EVMChainID:  new(big.Int).SetUint64(evmChainID),
+			Backend:     backend,
+			DeployerKey: adminTransactor,
+			Users:       additionalTransactors,
+		})
+	}
+
+	return chains
+}
+
+type EVMChain struct {
+	EVMChainID  *big.Int
+	Backend     *simulated.Backend
+	DeployerKey *bind.TransactOpts
+	Users       []*bind.TransactOpts
+}
+
+func setupApp(t *testing.T) (chainlink.Application, ccipDeployments) {
+	evmChains := generateChainsEVM(t, 2, 1, 500*time.Millisecond)
+	source, dest := evmChains[0], evmChains[1]
+	deployments := deployContracts(t, source, dest)
+
+	cfg, db := heavyweight.FullTestDBNoFixturesV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.Insecure.OCRDevelopmentMode = ptr(true) // Disables ocr spec validation so we can have fast polling for the test.
+
+		c.Feature.LogPoller = ptr(true)
+
+		c.Log.Level = ptr(configv2.LogLevel(zapcore.DebugLevel))
+
+		var evmConfigs v2toml.EVMConfigs
+		for _, chain := range evmChains {
+			evmConfigs = append(evmConfigs, createConfigV2Chain(chain.EVMChainID.Uint64()))
+		}
+		c.EVM = evmConfigs
+	})
+
+	// Create clients for the core node backed by sim.
+	clients := make(map[uint64]client.Client)
+	for _, chain := range evmChains {
+		if chain.Backend != nil {
+			clients[chain.EVMChainID.Uint64()] = client.NewSimulatedBackendClient(t, chain.Backend, chain.EVMChainID)
+		}
+	}
+
+	// Set logging.
+	lggr := logger.TestLogger(t)
+
+	master := keystore.New(db, utils.FastScryptParams, lggr)
+	ctx := t.Context()
+	require.NoError(t, master.Unlock(ctx, "password"))
+	require.NoError(t, master.CSA().EnsureKey(ctx))
+	require.NoError(t, master.Workflow().EnsureKey(ctx))
+
+	// OCR signing key for evm chains
+	require.NoError(t, master.OCR2().EnsureKeys(ctx, chaintype.EVM))
+
+	// transmitter key for each chain
+	for _, chain := range evmChains {
+		require.NoError(t, master.Eth().EnsureKeys(ctx, chain.EVMChainID))
+	}
+
+	app, err := chainlink.NewApplication(ctx, chainlink.ApplicationOpts{
+		Config:   cfg,
+		DS:       db,
+		KeyStore: master,
+		// TODO BCF-2513 Stop injecting ethClient via override, instead use httptest.
+		EVMFactoryConfigFn: func(fc *chainlink.EVMFactoryConfig) {
+			// Create ChainStores that always sign with 1337
+			fc.GenChainStore = func(ks core.Keystore, i *big.Int) keys.ChainStore {
+				return keys.NewChainStore(ks, big.NewInt(1337))
+			}
+			fc.GenEthClient = func(i *big.Int) client.Client {
+				ethClient, ok := clients[i.Uint64()]
+				if !ok {
+					return client.NewNullClient(i, lggr)
+				}
+				return ethClient
+			}
+		},
+		Logger:                   lggr,
+		ExternalInitiatorManager: nil,
+		CloseLogger:              lggr.Sync,
+		UnrestrictedHTTPClient:   &http.Client{},
+		RestrictedHTTPClient:     &http.Client{},
+		AuditLogger:              audit.NoopLogger,
+		RetirementReportCache:    retirement.NewRetirementReportCache(lggr, db),
+	})
+	require.NoError(t, err)
+
+	return app, deployments
+}
+
+func createConfigV2Chain(chainID uint64) *v2toml.EVMConfig {
+	chainIDBig := evmutils.NewI(int64(chainID))
+	chain := v2toml.Defaults(chainIDBig)
+	chain.GasEstimator.LimitDefault = ptr(uint64(5e6))
+	chain.LogPollInterval = config.MustNewDuration(500 * time.Millisecond)
+	chain.Transactions.ForwardersEnabled = ptr(false)
+	chain.FinalityDepth = ptr(uint32(2))
+	return &v2toml.EVMConfig{
+		ChainID: chainIDBig,
+		Enabled: ptr(true),
+		Chain:   chain,
+		Nodes:   v2toml.EVMNodes{&v2toml.Node{}},
+	}
+}
+
+type ccipChainDeployment struct {
+	evmChainID   *big.Int
+	routerAddr   common.Address
+	mockRMNAddr  common.Address
+	armProxyAddr common.Address
+	wethAddr     common.Address
+}
+
+type ccipDeployments struct {
+	source ccipChainDeployment
+	dest   ccipChainDeployment
+}
+
+func deploySingleChain(t *testing.T, chain EVMChain) ccipChainDeployment {
+	// deploy wrapped native
+	wethAddr, _, _, err := weth9.DeployWETH9(chain.DeployerKey, chain.Backend.Client())
+	require.NoError(t, err)
+	chain.Backend.Commit()
+
+	// deploy mock arm
+	mockRMNAddr, _, _, err := mock_rmn_contract.DeployMockRMNContract(chain.DeployerKey, chain.Backend.Client())
+	require.NoError(t, err)
+	chain.Backend.Commit()
+
+	// deploy arm proxy
+	armProxyAddr, _, _, err := rmn_proxy_contract.DeployRMNProxy(chain.DeployerKey, chain.Backend.Client(), mockRMNAddr)
+	require.NoError(t, err)
+	chain.Backend.Commit()
+
+	// deploy router
+	routerAddr, _, _, err := router.DeployRouter(chain.DeployerKey, chain.Backend.Client(), wethAddr, armProxyAddr)
+	require.NoError(t, err)
+	chain.Backend.Commit()
+
+	return ccipChainDeployment{
+		evmChainID:   chain.EVMChainID,
+		routerAddr:   routerAddr,
+		mockRMNAddr:  mockRMNAddr,
+		armProxyAddr: armProxyAddr,
+		wethAddr:     wethAddr,
+	}
+}
+
+func deployContracts(t *testing.T, source, dest EVMChain) ccipDeployments {
+	sourceChain := deploySingleChain(t, source)
+	destChain := deploySingleChain(t, dest)
+
+	return ccipDeployments{
+		source: sourceChain,
+		dest:   destChain,
+	}
+}
+
+func sendMessage(t *testing.T, sourceDeployment, destDeployment ccipChainDeployment) {
+	// TODO: implement
+}
+
+func TestModsec_E2E(t *testing.T) {
+	app, deployments := setupApp(t)
+
+	require.NoError(t, app.Start(t.Context()))
+	t.Cleanup(func() {
+		require.NoError(t, app.Stop())
+	})
+
+	jb, err := modsec.ValidatedModsecSpec(testspecs.GenerateModsecSpec(
+		testspecs.ModsecSpecParams{
+			Name:                    "modsec-test-e2e",
+			SourceChainID:           deployments.source.evmChainID.String(),
+			DestinationChainID:      deployments.dest.evmChainID.String(),
+			SourceChainFamily:       string(chaintype.EVM),
+			DestinationChainFamily:  string(chaintype.EVM),
+			OnRampAddress:           deployments.source.routerAddr.Hex(),
+			OffRampAddress:          deployments.dest.routerAddr.Hex(),
+			CCIPMessageSentEventSig: common.HexToHash("0x1").String(),
+		},
+	).Toml())
+	require.NoError(t, err)
+
+	require.NoError(t, app.AddJobV2(t.Context(), &jb))
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/core/services/modsec/modsecrelayer/relayer.go
+++ b/core/services/modsec/modsecrelayer/relayer.go
@@ -1,0 +1,71 @@
+package modsecrelayer
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+)
+
+// relayer is a service that monitors the source chain for CCIPMessageSent events,
+// observes attestations for them on offchain storage, and executes them on the destination chain.
+type relayer struct {
+	lggr           logger.Logger
+	lp             logpoller.LogPoller
+	txm            txmgr.TxManager
+	wg             sync.WaitGroup
+	runCtx         context.Context
+	runCtxCancel   context.CancelFunc
+	eventSig       string
+	onRampAddress  string
+	offRampAddress string
+}
+
+var _ job.ServiceCtx = &relayer{}
+
+func NewRelayer(lggr logger.Logger, lp logpoller.LogPoller, txm txmgr.TxManager, eventSig string, onRampAddress string, offRampAddress string) *relayer {
+	return &relayer{
+		lggr:           lggr,
+		lp:             lp,
+		txm:            txm,
+		eventSig:       eventSig,
+		onRampAddress:  onRampAddress,
+		offRampAddress: offRampAddress,
+	}
+}
+
+func (r *relayer) run(ctx context.Context) error {
+	ticker := time.NewTicker(time.Second * 1)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			r.lggr.Info("relaying modsec")
+		}
+	}
+}
+
+// Close implements job.ServiceCtx.
+func (r *relayer) Close() error {
+	r.runCtxCancel()
+	r.wg.Wait()
+	return nil
+}
+
+// Start implements job.ServiceCtx.
+func (r *relayer) Start(context.Context) error {
+	r.wg.Add(1)
+	r.runCtx, r.runCtxCancel = context.WithCancel(context.Background())
+	go func() {
+		defer r.wg.Done()
+		r.run(r.runCtx)
+	}()
+	return nil
+}

--- a/core/services/modsec/modsecverifier/verifier.go
+++ b/core/services/modsec/modsecverifier/verifier.go
@@ -1,0 +1,67 @@
+package modsecverifier
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+)
+
+var _ job.ServiceCtx = &verifier{}
+
+// verifier is a service that monitors the source chain for CCIPMessageSent events
+// and pushes attestations to them to offchain storage.
+type verifier struct {
+	lggr          logger.Logger
+	lp            logpoller.LogPoller
+	wg            sync.WaitGroup
+	runCtx        context.Context
+	runCtxCancel  context.CancelFunc
+	eventSig      string
+	onRampAddress string
+}
+
+func NewVerifier(lggr logger.Logger, lp logpoller.LogPoller, eventSig string, onRampAddress string) *verifier {
+	return &verifier{
+		lggr:          lggr,
+		lp:            lp,
+		eventSig:      eventSig,
+		onRampAddress: onRampAddress,
+	}
+}
+
+func (v *verifier) run(ctx context.Context) error {
+	ticker := time.NewTicker(time.Second * 1)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			// TODO: implement logic
+			v.lggr.Info("verifying modsec")
+		}
+	}
+}
+
+// Close implements job.ServiceCtx.
+func (v *verifier) Close() error {
+	v.runCtxCancel()
+	v.wg.Wait()
+	return nil
+}
+
+// Start implements job.ServiceCtx.
+func (v *verifier) Start(context.Context) error {
+	v.wg.Add(1)
+	v.runCtx, v.runCtxCancel = context.WithCancel(context.Background())
+	go func() {
+		defer v.wg.Done()
+		v.run(v.runCtx)
+	}()
+	return nil
+}

--- a/core/services/modsec/validated.go
+++ b/core/services/modsec/validated.go
@@ -1,0 +1,38 @@
+package modsec
+
+import (
+	"fmt"
+
+	"github.com/pelletier/go-toml"
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+)
+
+func ValidatedModsecSpec(tomlString string) (jb job.Job, err error) {
+	var spec job.ModsecSpec
+	tree, err := toml.Load(tomlString)
+	if err != nil {
+		return job.Job{}, fmt.Errorf("toml error on load: %w", err)
+	}
+
+	err = tree.Unmarshal(&spec)
+	if err != nil {
+		return job.Job{}, fmt.Errorf("toml unmarshal error on spec: %w", err)
+	}
+
+	err = tree.Unmarshal(&jb)
+	if err != nil {
+		return job.Job{}, fmt.Errorf("toml unmarshal error on job: %w", err)
+	}
+
+	jb.ModsecSpec = &spec
+
+	if jb.Type != job.Modsec {
+		return job.Job{}, fmt.Errorf("the only supported type is currently 'modsec', got %s", jb.Type)
+	}
+
+	if err = validate(jb.ModsecSpec); err != nil {
+		return job.Job{}, err
+	}
+
+	return jb, nil
+}

--- a/core/services/pipeline/common.go
+++ b/core/services/pipeline/common.go
@@ -31,6 +31,7 @@ const (
 	BootstrapJobType               string = "bootstrap"
 	CronJobType                    string = "cron"
 	CCIPJobType                    string = "ccip"
+	ModsecJobType                  string = "modsec"
 	DirectRequestJobType           string = "directrequest"
 	FluxMonitorJobType             string = "fluxmonitor"
 	GatewayJobType                 string = "gateway"

--- a/core/store/migrate/migrations/0275_modsec.sql
+++ b/core/store/migrate/migrations/0275_modsec.sql
@@ -1,0 +1,102 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- The modsec_specs table will hold the Modsec job specs.
+CREATE TABLE modsec_specs(
+    id BIGSERIAL PRIMARY KEY,
+
+    -- The source chain ID.
+    source_chain_id TEXT NOT NULL,
+
+    -- The source chain family.
+    source_chain_family TEXT NOT NULL,
+
+    -- The destination chain ID.
+    dest_chain_id TEXT NOT NULL,
+
+    -- The destination chain family.
+    dest_chain_family TEXT NOT NULL,
+
+    -- The onramp address.
+    on_ramp_address TEXT NOT NULL,
+
+    -- The ccip message sent event signature.
+    ccip_message_sent_event_sig TEXT NOT NULL,
+
+    -- The offramp address.
+    off_ramp_address TEXT NOT NULL,
+
+    -- The created at timestamp.
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+    -- The updated at timestamp.
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- Add the modsec_spec_id column to the jobs table
+-- and update the chk_specs constraint to include modsec_spec_id
+ALTER TABLE jobs
+    ADD COLUMN modsec_spec_id INT REFERENCES modsec_specs (id),
+DROP CONSTRAINT chk_specs,
+    ADD CONSTRAINT chk_specs CHECK (
+        num_nonnulls(
+            ocr_oracle_spec_id, ocr2_oracle_spec_id,
+            direct_request_spec_id, flux_monitor_spec_id,
+            keeper_spec_id, cron_spec_id, webhook_spec_id,
+            vrf_spec_id, blockhash_store_spec_id,
+            block_header_feeder_spec_id, bootstrap_spec_id,
+            gateway_spec_id,
+            legacy_gas_station_server_spec_id,
+            legacy_gas_station_sidecar_spec_id,
+            eal_spec_id,
+            workflow_spec_id,
+            standard_capabilities_spec_id,
+            ccip_spec_id,
+            ccip_bootstrap_spec_id,
+            modsec_spec_id,
+            CASE "type"
+                WHEN 'stream'
+                THEN 1
+                ELSE NULL
+            END -- 'stream' type lacks a spec but should not cause validation to fail
+        ) = 1
+    );
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Remove the modsec_spec_id column from the jobs table
+-- and update the chk_specs constraint to remove modsec_spec_id
+ALTER TABLE jobs
+    DROP CONSTRAINT chk_specs,
+    ADD CONSTRAINT chk_specs CHECK (
+        num_nonnulls(
+            ocr_oracle_spec_id, ocr2_oracle_spec_id,
+            direct_request_spec_id, flux_monitor_spec_id,
+            keeper_spec_id, cron_spec_id, webhook_spec_id,
+            vrf_spec_id, blockhash_store_spec_id,
+            block_header_feeder_spec_id, bootstrap_spec_id,
+            gateway_spec_id,
+            legacy_gas_station_server_spec_id,
+            legacy_gas_station_sidecar_spec_id,
+            eal_spec_id,
+            workflow_spec_id,
+            standard_capabilities_spec_id,
+            ccip_spec_id,
+            ccip_bootstrap_spec_id,
+            CASE "type"
+                WHEN 'stream'
+                THEN 1
+                ELSE NULL
+            END -- 'stream' type lacks a spec but should not cause validation to fail
+        ) = 1
+    );
+
+ALTER TABLE jobs
+    DROP COLUMN modsec_spec_id;
+
+DROP TABLE modsec_specs;
+
+-- +goose StatementEnd

--- a/core/testdata/testspecs/v2_specs.go
+++ b/core/testdata/testspecs/v2_specs.go
@@ -319,6 +319,85 @@ observationSource = """%s"""
 	}
 }
 
+type ModsecSpecParams struct {
+	JobID                   string
+	Name                    string
+	SourceChainID           string
+	SourceChainFamily       string
+	DestinationChainID      string
+	DestinationChainFamily  string
+	OnRampAddress           string
+	CCIPMessageSentEventSig string
+	OffRampAddress          string
+}
+
+type ModsecSpec struct {
+	ModsecSpecParams
+	toml string
+}
+
+func (ms ModsecSpec) Toml() string {
+	return ms.toml
+}
+
+func GenerateModsecSpec(params ModsecSpecParams) ModsecSpec {
+	jobID := params.JobID
+	if jobID == "" {
+		jobID = uuid.New().String()
+	}
+	name := params.Name
+	if name == "" {
+		name = "modsec-primary"
+	}
+	sourceChainID := params.SourceChainID
+	if sourceChainID == "" {
+		sourceChainID = "1"
+	}
+	sourceChainFamily := params.SourceChainFamily
+	if sourceChainFamily == "" {
+		sourceChainFamily = "evm"
+	}
+	destinationChainID := params.DestinationChainID
+	if destinationChainID == "" {
+		destinationChainID = "2"
+	}
+	destinationChainFamily := params.DestinationChainFamily
+	if destinationChainFamily == "" {
+		destinationChainFamily = "evm"
+	}
+	onRampAddress := params.OnRampAddress
+	if onRampAddress == "" {
+		onRampAddress = "0x1234567890123456789012345678901234567890"
+	}
+	ccipMessageSentEventSig := params.CCIPMessageSentEventSig
+	if ccipMessageSentEventSig == "" {
+		ccipMessageSentEventSig = "0x1234567890123456789012345678901234567890"
+	}
+	offRampAddress := params.OffRampAddress
+	if offRampAddress == "" {
+		offRampAddress = "0x1234567890123456789012345678901234567890"
+	}
+
+	template := `
+type = "modsec"
+schemaVersion = 1
+externalJobID = "%s"
+name = "%s"
+sourceChainID = "%s"
+sourceChainFamily = "%s"
+destChainID = "%s"
+destChainFamily = "%s"
+onRampAddress = "%s"
+ccipMessageSentEventSig = "%s"
+offRampAddress = "%s"
+`
+
+	return ModsecSpec{
+		ModsecSpecParams: params,
+		toml:             fmt.Sprintf(template, jobID, name, sourceChainID, sourceChainFamily, destinationChainID, destinationChainFamily, onRampAddress, ccipMessageSentEventSig, offRampAddress),
+	}
+}
+
 type VRFSpecParams struct {
 	JobID                         string
 	Name                          string

--- a/core/web/jobs_controller.go
+++ b/core/web/jobs_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keeper"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/modsec"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/validate"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrbootstrap"
@@ -261,6 +262,8 @@ func (jc *JobsController) validateJobSpec(ctx context.Context, tomlString string
 		jb, err = standardcapabilities.ValidatedStandardCapabilitiesSpec(tomlString)
 	case job.CCIP:
 		jb, err = ccip.ValidatedCCIPSpec(tomlString)
+	case job.Modsec:
+		jb, err = modsec.ValidatedModsecSpec(tomlString)
 	default:
 		return jb, http.StatusUnprocessableEntity, errors.Errorf("unknown job type: %s", jobType)
 	}

--- a/core/web/presenters/job.go
+++ b/core/web/presenters/job.go
@@ -492,6 +492,32 @@ func NewCCIPSpec(spec *job.CCIPSpec) *CCIPSpec {
 	}
 }
 
+type ModsecSpec struct {
+	CreatedAt               time.Time `json:"createdAt"`
+	UpdatedAt               time.Time `json:"updatedAt"`
+	SourceChainID           string    `json:"sourceChainID"`
+	SourceChainFamily       string    `json:"sourceChainFamily"`
+	DestChainID             string    `json:"destChainID"`
+	DestChainFamily         string    `json:"destChainFamily"`
+	OnRampAddress           string    `json:"onRampAddress"`
+	OffRampAddress          string    `json:"offRampAddress"`
+	CCIPMessageSentEventSig string    `json:"ccipMessageSentEventSig"`
+}
+
+func NewModsecSpec(spec *job.ModsecSpec) *ModsecSpec {
+	return &ModsecSpec{
+		CreatedAt:               spec.CreatedAt,
+		UpdatedAt:               spec.UpdatedAt,
+		SourceChainID:           spec.SourceChainID,
+		SourceChainFamily:       spec.SourceChainFamily,
+		DestChainID:             spec.DestChainID,
+		DestChainFamily:         spec.DestChainFamily,
+		OnRampAddress:           spec.OnRampAddress,
+		OffRampAddress:          spec.OffRampAddress,
+		CCIPMessageSentEventSig: spec.CCIPMessageSentEventSig,
+	}
+}
+
 // JobError represents errors on the job
 type JobError struct {
 	ID          int64     `json:"id"`
@@ -537,6 +563,7 @@ type JobResource struct {
 	WorkflowSpec             *WorkflowSpec             `json:"workflowSpec"`
 	StandardCapabilitiesSpec *StandardCapabilitiesSpec `json:"standardCapabilitiesSpec"`
 	CCIPSpec                 *CCIPSpec                 `json:"ccipSpec"`
+	ModsecSpec               *ModsecSpec               `json:"modsecSpec"`
 	PipelineSpec             PipelineSpec              `json:"pipelineSpec"`
 	Errors                   []JobError                `json:"errors"`
 }
@@ -589,6 +616,8 @@ func NewJobResource(j job.Job) *JobResource {
 		resource.StandardCapabilitiesSpec = NewStandardCapabilitiesSpec(j.StandardCapabilitiesSpec)
 	case job.CCIP:
 		resource.CCIPSpec = NewCCIPSpec(j.CCIPSpec)
+	case job.Modsec:
+		resource.ModsecSpec = NewModsecSpec(j.ModsecSpec)
 	case job.LegacyGasStationServer, job.LegacyGasStationSidecar:
 		// unsupported
 	}

--- a/core/web/presenters/job_test.go
+++ b/core/web/presenters/job_test.go
@@ -1004,6 +1004,80 @@ func TestJob(t *testing.T) {
 			}`,
 		},
 		{
+			name: "modsec spec",
+			job: job.Job{
+				ID: 1,
+				ModsecSpec: &job.ModsecSpec{
+					ID:                      1,
+					CreatedAt:               timestamp,
+					UpdatedAt:               timestamp,
+					SourceChainID:           "1338",
+					SourceChainFamily:       "evm",
+					DestChainID:             "1337",
+					DestChainFamily:         "evm",
+					OnRampAddress:           "0x1234567890123456789012345678901234567890",
+					OffRampAddress:          "0x0987654321098765432109876543210987654321",
+					CCIPMessageSentEventSig: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+				},
+				PipelineSpec: &pipeline.Spec{
+					ID:           1,
+					DotDagSource: "",
+				},
+				ExternalJobID: uuid.MustParse("0eec7e1d-d0d2-476c-a1a8-72dfb6633f46"),
+				Type:          job.Modsec,
+				SchemaVersion: 1,
+				Name:          null.StringFrom("modsec test"),
+			},
+			want: `
+			{
+				"data": {
+					"type": "jobs",
+					"id": "1",
+					"attributes": {
+						"name": "modsec test",
+						"type": "modsec",
+						"schemaVersion": 1,
+						"maxTaskDuration": "0s",
+						"externalJobID": "0eec7e1d-d0d2-476c-a1a8-72dfb6633f46",
+						"directRequestSpec": null,
+						"fluxMonitorSpec": null,
+						"gasLimit": null,
+						"forwardingAllowed": false,
+						"cronSpec": null,
+						"offChainReportingOracleSpec": null,
+						"offChainReporting2OracleSpec": null,
+						"keeperSpec": null,
+						"vrfSpec": null,
+						"webhookSpec": null,
+						"workflowSpec": null,
+						"blockhashStoreSpec": null,
+						"blockHeaderFeederSpec": null,
+						"bootstrapSpec": null,
+						"gatewaySpec": null,
+						"standardCapabilitiesSpec": null,
+						"ccipSpec": null,
+						"modsecSpec": {
+							"sourceChainID": "1338",
+							"sourceChainFamily": "evm",
+							"destChainID": "1337",
+							"destChainFamily": "evm",
+							"onRampAddress": "0x1234567890123456789012345678901234567890",
+							"offRampAddress": "0x0987654321098765432109876543210987654321",
+							"ccipMessageSentEventSig": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+							"createdAt": "2000-01-01T00:00:00Z",
+							"updatedAt": "2000-01-01T00:00:00Z"
+						},
+						"pipelineSpec": {
+							"id": 1,
+							"jobID": 0,
+							"dotDagSource": ""
+						},
+						"errors": []
+					}
+				}
+			}`,
+		},
+		{
 			name: "ccip spec",
 			job: job.Job{
 				ID: 1,

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -35,6 +35,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocrkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/vrfkey"
+	"github.com/smartcontractkit/chainlink/v2/core/services/modsec"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/validate"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrbootstrap"
@@ -1114,6 +1115,8 @@ func (r *Resolver) CreateJob(ctx context.Context, args struct {
 		jb, err = streams.ValidatedStreamSpec(args.Input.TOML)
 	case job.CCIP:
 		jb, err = ccip.ValidatedCCIPSpec(args.Input.TOML)
+	case job.Modsec:
+		jb, err = modsec.ValidatedModsecSpec(args.Input.TOML)
 	default:
 		return NewCreateJobPayload(r.App, nil, map[string]string{
 			"Job Type": fmt.Sprintf("unknown job type: %s", jbt),

--- a/core/web/resolver/spec.go
+++ b/core/web/resolver/spec.go
@@ -1086,6 +1086,46 @@ func (r *StreamSpecResolver) StreamID() *string {
 	return r.streamID
 }
 
+type ModsecSpecResolver struct {
+	spec job.ModsecSpec
+}
+
+func (r *ModsecSpecResolver) CreatedAt() graphql.Time {
+	return graphql.Time{Time: r.spec.CreatedAt}
+}
+
+func (r *ModsecSpecResolver) ID() graphql.ID {
+	return graphql.ID(stringutils.FromInt32(r.spec.ID))
+}
+
+func (r *ModsecSpecResolver) SourceChainID() string {
+	return r.spec.SourceChainID
+}
+
+func (r *ModsecSpecResolver) SourceChainFamily() string {
+	return r.spec.SourceChainFamily
+}
+
+func (r *ModsecSpecResolver) DestChainID() string {
+	return r.spec.DestChainID
+}
+
+func (r *ModsecSpecResolver) DestChainFamily() string {
+	return r.spec.DestChainFamily
+}
+
+func (r *ModsecSpecResolver) OnRampAddress() string {
+	return r.spec.OnRampAddress
+}
+
+func (r *ModsecSpecResolver) OffRampAddress() string {
+	return r.spec.OffRampAddress
+}
+
+func (r *ModsecSpecResolver) CCIPMessageSentEventSig() string {
+	return r.spec.CCIPMessageSentEventSig
+}
+
 type CCIPSpecResolver struct {
 	spec job.CCIPSpec
 }


### PR DESCRIPTION
This PR adds basic boilerplate, once an E2E test is added that:

* Creates a source and dest chain
* Creates a chainlink node
* Creates the modsec job on the CL node

We can merge it as a step 0.
