### PR TITLE
Enables specifying different contract types and versions for destination pools in fast transfer lane configurations.

### DIFF
--- a/deployment/ccip/changeset/v1_5_1/cs_fast_transfer_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_fast_transfer_token_pools_test.go
@@ -1108,7 +1108,7 @@ func TestFastTransferUpdateLaneConfigChangeset_DestinationPoolTypeAndVersion(t *
 				require.NoError(t, err)
 
 				expectedDestPoolPadded := common.LeftPadBytes(expectedDestPool.Address().Bytes(), 32)
-				require.Equal(t, expectedDestPoolPadded, result.DestinationPool[:])
+				require.Equal(t, expectedDestPoolPadded, result.DestinationPool)
 			}
 		})
 	}

--- a/deployment/ccip/changeset/v1_5_1/cs_fast_transfer_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_fast_transfer_token_pools_test.go
@@ -987,6 +987,7 @@ func TestFastTransferUpdateLaneConfigChangeset_DestinationPoolTypeAndVersion(t *
 	e, selectorA, selectorB, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), false)
 
 	// Deploy different types of pools on different chains
+	externalMinterA, _ := testhelpers.DeployTokenGovernor(t, e, selectorA, tokens[selectorA].Address)
 	externalMinterB, _ := testhelpers.DeployTokenGovernor(t, e, selectorB, tokens[selectorB].Address)
 
 	e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
@@ -994,9 +995,19 @@ func TestFastTransferUpdateLaneConfigChangeset_DestinationPoolTypeAndVersion(t *
 			Type:               shared.HybridWithExternalMinterFastTransferTokenPool,
 			TokenAddress:       tokens[selectorA].Address,
 			LocalTokenDecimals: testhelpers.LocalTokenDecimals,
+			ExternalMinter:     externalMinterA,
 		},
 		selectorB: {
 			Type:               shared.BurnMintWithExternalMinterFastTransferTokenPool,
+			TokenAddress:       tokens[selectorB].Address,
+			LocalTokenDecimals: testhelpers.LocalTokenDecimals,
+			ExternalMinter:     externalMinterB,
+		},
+	}, false)
+
+	e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
+		selectorB: {
+			Type:               shared.HybridWithExternalMinterFastTransferTokenPool,
 			TokenAddress:       tokens[selectorB].Address,
 			LocalTokenDecimals: testhelpers.LocalTokenDecimals,
 			ExternalMinter:     externalMinterB,
@@ -1019,7 +1030,7 @@ func TestFastTransferUpdateLaneConfigChangeset_DestinationPoolTypeAndVersion(t *
 			sourceChain:   selectorA,
 			destChain:     selectorB,
 			sourceType:    shared.HybridWithExternalMinterFastTransferTokenPool,
-			sourceVersion: shared.FastTransferTokenPoolVersion,
+			sourceVersion: shared.HybridWithExternalMinterFastTransferTokenPoolVersion,
 			// No destination type/version specified - should use default
 			expectError: false,
 		},
@@ -1028,19 +1039,19 @@ func TestFastTransferUpdateLaneConfigChangeset_DestinationPoolTypeAndVersion(t *
 			sourceChain:                selectorA,
 			destChain:                  selectorB,
 			sourceType:                 shared.HybridWithExternalMinterFastTransferTokenPool,
-			sourceVersion:              shared.FastTransferTokenPoolVersion,
+			sourceVersion:              shared.HybridWithExternalMinterFastTransferTokenPoolVersion,
 			destinationContractType:    &shared.BurnMintWithExternalMinterFastTransferTokenPool,
 			destinationContractVersion: &shared.BurnMintWithExternalMinterFastTransferTokenPoolVersion,
 			expectError:                false,
 		},
 		{
 			name:                       "Invalid_NonExistentDestinationType",
-			sourceChain:                selectorA,
-			destChain:                  selectorB,
+			sourceChain:                selectorB,
+			destChain:                  selectorA,
 			sourceType:                 shared.HybridWithExternalMinterFastTransferTokenPool,
-			sourceVersion:              shared.FastTransferTokenPoolVersion,
-			destinationContractType:    &shared.HybridWithExternalMinterFastTransferTokenPool, // This type doesn't exist on selectorB
-			destinationContractVersion: &shared.HybridWithExternalMinterFastTransferTokenPoolVersion,
+			sourceVersion:              shared.HybridWithExternalMinterFastTransferTokenPoolVersion,
+			destinationContractType:    &shared.BurnMintWithExternalMinterFastTransferTokenPool, // This type doesn't exist on selectorA
+			destinationContractVersion: &shared.BurnMintWithExternalMinterFastTransferTokenPoolVersion,
 			expectError:                true,
 			expectedErrorMsg:           "destination pool validation failed",
 		},
@@ -1049,10 +1060,10 @@ func TestFastTransferUpdateLaneConfigChangeset_DestinationPoolTypeAndVersion(t *
 			sourceChain:             selectorA,
 			destChain:               99999, // Non-existent chain
 			sourceType:              shared.HybridWithExternalMinterFastTransferTokenPool,
-			sourceVersion:           shared.FastTransferTokenPoolVersion,
+			sourceVersion:           shared.HybridWithExternalMinterFastTransferTokenPoolVersion,
 			destinationContractType: &shared.BurnMintWithExternalMinterFastTransferTokenPool,
 			expectError:             true,
-			expectedErrorMsg:        "destination chain with selector 99999 does not exist in environment",
+			expectedErrorMsg:        "unknown chain selector 99999",
 		},
 	}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_fast_transfer_token_pools_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_fast_transfer_token_pools_test.go
@@ -982,3 +982,215 @@ func TestFastTransferUpdateLaneConfigChangeset_SettlementOverheadGasAndCustomExt
 		})
 	}
 }
+
+func TestFastTransferUpdateLaneConfigChangeset_DestinationPoolTypeAndVersion(t *testing.T) {
+	e, selectorA, selectorB, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), false)
+
+	// Deploy different types of pools on different chains
+	externalMinterB, _ := testhelpers.DeployTokenGovernor(t, e, selectorB, tokens[selectorB].Address)
+
+	e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
+		selectorA: {
+			Type:               shared.HybridWithExternalMinterFastTransferTokenPool,
+			TokenAddress:       tokens[selectorA].Address,
+			LocalTokenDecimals: testhelpers.LocalTokenDecimals,
+		},
+		selectorB: {
+			Type:               shared.BurnMintWithExternalMinterFastTransferTokenPool,
+			TokenAddress:       tokens[selectorB].Address,
+			LocalTokenDecimals: testhelpers.LocalTokenDecimals,
+			ExternalMinter:     externalMinterB,
+		},
+	}, false)
+
+	testCases := []struct {
+		name                       string
+		sourceChain                uint64
+		destChain                  uint64
+		sourceType                 cldf.ContractType
+		sourceVersion              semver.Version
+		destinationContractType    *cldf.ContractType
+		destinationContractVersion *semver.Version
+		expectError                bool
+		expectedErrorMsg           string
+	}{
+		{
+			name:          "Valid_SameTypeAndVersion",
+			sourceChain:   selectorA,
+			destChain:     selectorB,
+			sourceType:    shared.HybridWithExternalMinterFastTransferTokenPool,
+			sourceVersion: shared.FastTransferTokenPoolVersion,
+			// No destination type/version specified - should use default
+			expectError: false,
+		},
+		{
+			name:                       "Valid_DifferentType",
+			sourceChain:                selectorA,
+			destChain:                  selectorB,
+			sourceType:                 shared.HybridWithExternalMinterFastTransferTokenPool,
+			sourceVersion:              shared.FastTransferTokenPoolVersion,
+			destinationContractType:    &shared.BurnMintWithExternalMinterFastTransferTokenPool,
+			destinationContractVersion: &shared.BurnMintWithExternalMinterFastTransferTokenPoolVersion,
+			expectError:                false,
+		},
+		{
+			name:                       "Invalid_NonExistentDestinationType",
+			sourceChain:                selectorA,
+			destChain:                  selectorB,
+			sourceType:                 shared.HybridWithExternalMinterFastTransferTokenPool,
+			sourceVersion:              shared.FastTransferTokenPoolVersion,
+			destinationContractType:    &shared.HybridWithExternalMinterFastTransferTokenPool, // This type doesn't exist on selectorB
+			destinationContractVersion: &shared.HybridWithExternalMinterFastTransferTokenPoolVersion,
+			expectError:                true,
+			expectedErrorMsg:           "destination pool validation failed",
+		},
+		{
+			name:                    "Invalid_NonExistentDestinationChain",
+			sourceChain:             selectorA,
+			destChain:               99999, // Non-existent chain
+			sourceType:              shared.HybridWithExternalMinterFastTransferTokenPool,
+			sourceVersion:           shared.FastTransferTokenPoolVersion,
+			destinationContractType: &shared.BurnMintWithExternalMinterFastTransferTokenPool,
+			expectError:             true,
+			expectedErrorMsg:        "destination chain with selector 99999 does not exist in environment",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			update := v1_5_1.UpdateLaneConfig{
+				FastTransferFillerFeeBps:   100,
+				FastTransferPoolFeeBps:     50,
+				FillAmountMaxRequest:       big.NewInt(1000),
+				FillerAllowlistEnabled:     false,
+				DestinationContractType:    tc.destinationContractType,
+				DestinationContractVersion: tc.destinationContractVersion,
+			}
+
+			config := v1_5_1.FastTransferUpdateLaneConfigConfig{
+				TokenSymbol:     testhelpers.TestTokenSymbol,
+				ContractType:    tc.sourceType,
+				ContractVersion: tc.sourceVersion,
+				Updates: map[uint64]map[uint64]v1_5_1.UpdateLaneConfig{
+					tc.sourceChain: {tc.destChain: update},
+				},
+			}
+
+			_, err := commonchangeset.Apply(t, e, commonchangeset.Configure(v1_5_1.FastTransferUpdateLaneConfigChangeset, config))
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErrorMsg)
+			} else {
+				require.NoError(t, err)
+
+				// Verify the configuration was applied correctly
+				pool, err := bindings.GetFastTransferTokenPoolContract(e, testhelpers.TestTokenSymbol, tc.sourceType, tc.sourceVersion, tc.sourceChain)
+				require.NoError(t, err)
+
+				result, _, err := pool.GetDestChainConfig(nil, tc.destChain)
+				require.NoError(t, err)
+				require.Equal(t, update.FastTransferFillerFeeBps, result.FastTransferFillerFeeBps)
+				require.Equal(t, update.FastTransferPoolFeeBps, result.FastTransferPoolFeeBps)
+				require.Equal(t, update.FillAmountMaxRequest, result.MaxFillAmountPerRequest)
+
+				// Verify the destination pool address is correctly set
+				expectedDestType := tc.sourceType
+				expectedDestVersion := tc.sourceVersion
+				if tc.destinationContractType != nil {
+					expectedDestType = *tc.destinationContractType
+				}
+				if tc.destinationContractVersion != nil {
+					expectedDestVersion = *tc.destinationContractVersion
+				}
+
+				expectedDestPool, err := bindings.GetFastTransferTokenPoolContract(e, testhelpers.TestTokenSymbol, expectedDestType, expectedDestVersion, tc.destChain)
+				require.NoError(t, err)
+
+				expectedDestPoolPadded := common.LeftPadBytes(expectedDestPool.Address().Bytes(), 32)
+				require.Equal(t, expectedDestPoolPadded, result.DestinationPool[:])
+			}
+		})
+	}
+}
+
+func TestFastTransferUpdateLaneConfigChangeset_ValidationErrors_DestinationFields(t *testing.T) {
+	e, selectorA, selectorB, tokens := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), false)
+
+	e = testhelpers.DeployTestTokenPools(t, e, map[uint64]v1_5_1.DeployTokenPoolInput{
+		selectorA: {
+			Type:               shared.BurnMintFastTransferTokenPool,
+			TokenAddress:       tokens[selectorA].Address,
+			LocalTokenDecimals: testhelpers.LocalTokenDecimals,
+		},
+		selectorB: {
+			Type:               shared.BurnMintFastTransferTokenPool,
+			TokenAddress:       tokens[selectorB].Address,
+			LocalTokenDecimals: testhelpers.LocalTokenDecimals,
+		},
+	}, false)
+
+	testCases := []struct {
+		name             string
+		update           v1_5_1.UpdateLaneConfig
+		expectedErrorMsg string
+	}{
+		{
+			name: "Invalid_DestinationPoolType_NonExistent",
+			update: v1_5_1.UpdateLaneConfig{
+				FastTransferFillerFeeBps:   100,
+				FastTransferPoolFeeBps:     50,
+				FillAmountMaxRequest:       big.NewInt(1000),
+				FillerAllowlistEnabled:     false,
+				DestinationContractType:    &shared.BurnMintWithExternalMinterFastTransferTokenPool, // This type doesn't exist on selectorB
+				DestinationContractVersion: &shared.BurnMintWithExternalMinterFastTransferTokenPoolVersion,
+			},
+			expectedErrorMsg: "destination pool validation failed",
+		},
+		{
+			name: "Invalid_DestinationPoolVersion_NonExistent",
+			update: v1_5_1.UpdateLaneConfig{
+				FastTransferFillerFeeBps:   100,
+				FastTransferPoolFeeBps:     50,
+				FillAmountMaxRequest:       big.NewInt(1000),
+				FillerAllowlistEnabled:     false,
+				DestinationContractVersion: func() *semver.Version { v, _ := semver.NewVersion("9.9.9"); return v }(), // Non-existent version
+			},
+			expectedErrorMsg: "destination pool validation failed",
+		},
+		{
+			name: "Valid_OnlyDestinationContractType",
+			update: v1_5_1.UpdateLaneConfig{
+				FastTransferFillerFeeBps: 100,
+				FastTransferPoolFeeBps:   50,
+				FillAmountMaxRequest:     big.NewInt(1000),
+				FillerAllowlistEnabled:   false,
+				DestinationContractType:  &shared.BurnMintFastTransferTokenPool, // Same type as deployed on selectorB
+				// Version will default to root config version
+			},
+			expectedErrorMsg: "", // Should not error
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			config := v1_5_1.FastTransferUpdateLaneConfigConfig{
+				TokenSymbol:     testhelpers.TestTokenSymbol,
+				ContractType:    shared.BurnMintFastTransferTokenPool,
+				ContractVersion: shared.FastTransferTokenPoolVersion,
+				Updates: map[uint64]map[uint64]v1_5_1.UpdateLaneConfig{
+					selectorA: {selectorB: tc.update},
+				},
+			}
+
+			_, err := commonchangeset.Apply(t, e, commonchangeset.Configure(v1_5_1.FastTransferUpdateLaneConfigChangeset, config))
+			if tc.expectedErrorMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErrorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces support for specifying custom contract types and versions for destination pools in the `FastTransferTokenPool` update logic. The changes include updates to the configuration structure, validation logic, and implementation, as well as the addition of comprehensive test cases to ensure correctness.

### Enhancements to Configuration and Validation:

* Added `DestinationContractType` and `DestinationContractVersion` fields to the `UpdateLaneConfig` struct, allowing optional customization of the destination pool's contract type and version.
* Updated the `Validate` method in `FastTransferUpdateLaneConfigConfig` to ensure that destination pools exist and match the specified custom type and version, if provided. This includes validating the existence of the destination chain and its state.

### Implementation Updates:

* Modified the `fastTransferUpdateLaneConfigLogic` function to determine the destination pool's contract type and version based on the new fields, defaulting to the root configuration if unspecified.

### Comprehensive Testing:

* Added a new test suite `TestFastTransferUpdateLaneConfigChangeset_DestinationPoolTypeAndVersion` to verify various scenarios, including valid configurations, non-existent destination types, and non-existent destination chains.
* Introduced `TestFastTransferUpdateLaneConfigChangeset_ValidationErrors_DestinationFields` to specifically test validation error cases for invalid destination pool types and versions.