### PR TITLE
Only download Solana artifacts if nodes are spun up

### DIFF
--- a/deployment/environment/memory/solana_chains.go
+++ b/deployment/environment/memory/solana_chains.go
@@ -256,6 +256,11 @@ func FundSolanaAccountsWithLogging(
 func generateChainsSol(t *testing.T, numChains int) []cldf_chain.BlockChain {
 	t.Helper()
 
+	if numChains == 0 {
+		// Avoid downloading Solana program artifacts
+		return nil
+	}
+
 	once.Do(func() {
 		err := DownloadSolanaCCIPProgramArtifacts(t.Context(), programsPath, logger.Test(t), "")
 		require.NoError(t, err)


### PR DESCRIPTION
The once block would always run, causing problems if used in another repo

```

=== CONT  TestDeploy
    logger.go:146: 16:10:42.130849000	INFO	Downloading Solana CCIP program artifacts (tag = solana-artifacts-localtest-5c8cd74b92ed)	{"version": "(devel)@unset"}
    solana_chains.go:109:
        	Error Trace:	/go/pkg/mod/github.com/smartcontractkit/chainlink/deployment@v0.0.0-20250728170612-b2c4e1a4648c/environment/memory/solana_chains.go:109
        	            				/nix/store/rq7irijkj3nhapmjcv9d96xgkisj55x2-go-1.24.4/share/go/src/sync/once.go:78
        	            				/nix/store/rq7irijkj3nhapmjcv9d96xgkisj55x2-go-1.24.4/share/go/src/sync/once.go:69
        	            				/go/pkg/mod/github.com/smartcontractkit/chainlink/deployment@v0.0.0-20250728170612-b2c4e1a4648c/environment/memory/solana_chains.go:107
        	            				/go/pkg/mod/github.com/smartcontractkit/chainlink/deployment@v0.0.0-20250728170612-b2c4e1a4648c/environment/memory/environment.go:77
        	            				/go/pkg/mod/github.com/smartcontractkit/chainlink/deployment@v0.0.0-20250728170612-b2c4e1a4648c/environment/memory/environment.go:171
        	            				/src/chainlink-foo/integration-tests/ops/cs_test.go:35
        	Error:      	Received unexpected error:
        	            	mkdir /go/pkg/mod/github.com/smartcontractkit/chainlink/deployment@v0.0.0-20250728170612-b2c4e1a4648c/ccip/changeset/internal/solana_contracts: permission denied
        	Test:       	TestDeploy
```

