### PR TITLE
Patch Hyperliquid big blocks usage

### DIFF
--- a/deployment/ccip/changeset/hyperliquid/cs_enable_big_blocks.go
+++ b/deployment/ccip/changeset/hyperliquid/cs_enable_big_blocks.go
@@ -11,22 +11,19 @@ import (
 	"io"
 	"math/big"
 	"net/http"
-	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
-	"github.com/ugorji/go/codec"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 )
 
 var EnableBigBlockChangeset = cldf.CreateChangeSet(enableBigBlocksLogic, enableBigBlocksPreCondition)
@@ -37,21 +34,21 @@ type EnableBigBlocksConfig struct {
 }
 
 // Payload to be sent in the HTTP POST request
-type EnableBigBlocksRequestPayload struct {
-	Action    map[string]interface{} `json:"action"`    // Action details
-	Nonce     int64                  `json:"nonce"`     // Unique nonce for the request
-	Signature ECDSASignature         `json:"signature"` // ECDSA signature of the action
+type enableBigBlocksRequestPayload struct {
+	Action       map[string]interface{} `json:"action"`       // Action details
+	Nonce        int64                  `json:"nonce"`        // Unique nonce for the request
+	Signature    ecdsaSignature         `json:"signature"`    // ECDSA signature of the action
+	VaultAddress *string                `json:"vaultAddress"` // Vault address (null for most cases)
 }
 
-type ECDSASignature struct {
+type ecdsaSignature struct {
 	R string `json:"r"`
 	S string `json:"s"`
-	V byte   `json:"v"`
+	V int    `json:"v"`
 }
 
-type EnableBigBlocksDetailConfig struct {
+type enableBigBlocksDetailConfig struct {
 	URL               string        // RPC URL
-	ChainID           int64         // chain ID
 	VerifyingContract string        // Verifying contract address
 	RequestTimeout    time.Duration // HTTP request timeout
 }
@@ -65,33 +62,14 @@ func enableBigBlocksPreCondition(env cldf.Environment, cfg EnableBigBlocksConfig
 }
 
 func enableBigBlocksLogic(env cldf.Environment, cfg EnableBigBlocksConfig) (cldf.ChangesetOutput, error) {
-	chainIDStr, err := chain_selectors.GetChainIDFromSelector(cfg.ChainSel)
-
 	out := cldf.ChangesetOutput{}
-	if err != nil {
-		return out, fmt.Errorf("invalid chain id: %w", err)
-	}
-
-	if err != nil {
-		return out, fmt.Errorf("invalid private key: %w", err)
-	}
-
-	chainID, err := strconv.ParseUint(chainIDStr, 10, 64)
-	const maxInt64 = int64(^uint64(0) >> 1)
-	if chainID > uint64(maxInt64) {
-		return out, fmt.Errorf("chain ID too large for int64: %d", chainID)
-	}
-
-	if err != nil {
-		return out, fmt.Errorf("error converting string to uint64: %w", err)
-	}
 
 	action := map[string]interface{}{
 		"type":           "evmUserModify",
 		"usingBigBlocks": true,
 	}
 
-	chain, err := FindChainBySelector(env, cfg.ChainSel)
+	chain, err := findChainBySelector(env, cfg.ChainSel)
 
 	if err != nil {
 		return out, fmt.Errorf("error: %w finding chain by selector: %d", err, cfg.ChainSel)
@@ -104,22 +82,22 @@ func enableBigBlocksLogic(env cldf.Environment, cfg EnableBigBlocksConfig) (cldf
 	defaultRequestTimeout := 10 * time.Second
 
 	nonce := time.Now().UnixMilli()
-	config := EnableBigBlocksDetailConfig{
+	config := enableBigBlocksDetailConfig{
 		URL:               cfg.APIURL,
-		ChainID:           int64(chainID),
 		VerifyingContract: defaultVerifyingContract,
 		RequestTimeout:    defaultRequestTimeout,
 	}
 
-	sig, err := SignL1Action(action, nonce, true, config, chain)
+	sig, err := signL1Action(action, nonce, true, config, chain)
 	if err != nil {
 		return out, fmt.Errorf("signing failed: %w", err)
 	}
 
-	err = sendRequest(EnableBigBlocksRequestPayload{
-		Action:    action,
-		Nonce:     nonce,
-		Signature: sig,
+	err = sendRequest(enableBigBlocksRequestPayload{
+		Action:       action,
+		Nonce:        nonce,
+		Signature:    sig,
+		VaultAddress: nil,
 	}, config)
 	if err != nil {
 		return out, fmt.Errorf("send failed: %w", err)
@@ -128,11 +106,11 @@ func enableBigBlocksLogic(env cldf.Environment, cfg EnableBigBlocksConfig) (cldf
 	return out, nil
 }
 
-func SignL1Action(action map[string]interface{}, nonce int64, isMainnet bool, config EnableBigBlocksDetailConfig, chain chain.BlockChain) (ECDSASignature, error) {
+func signL1Action(action map[string]interface{}, nonce int64, isMainnet bool, config enableBigBlocksDetailConfig, chain chain.BlockChain) (ecdsaSignature, error) {
 	// Compute the action hash
-	actionHash, err := ActionHash(action, nil, nonce)
+	actionHash, err := actionHash(action, "", nonce, nil)
 	if err != nil {
-		return ECDSASignature{}, err
+		return ecdsaSignature{}, err
 	}
 
 	// Construct the phantom agent for signing
@@ -142,14 +120,14 @@ func SignL1Action(action map[string]interface{}, nonce int64, isMainnet bool, co
 	}
 	phantomAgent := map[string]interface{}{
 		"source":       source,
-		"connectionId": actionHash,
+		"connectionId": "0x" + hex.EncodeToString(actionHash),
 	}
 
 	// Define the EIP-712 domain
 	domain := apitypes.TypedDataDomain{
 		Name:              "Exchange",
 		Version:           "1",
-		ChainId:           (*math.HexOrDecimal256)(big.NewInt(config.ChainID)),
+		ChainId:           (*math.HexOrDecimal256)(big.NewInt(1337)),
 		VerifyingContract: config.VerifyingContract,
 	}
 
@@ -176,37 +154,45 @@ func SignL1Action(action map[string]interface{}, nonce int64, isMainnet bool, co
 	}
 
 	// Compute the hash of the typed data
-	hash, _, err := apitypes.TypedDataAndHash(typedData)
+	domainSeparator, err := typedData.HashStruct("EIP712Domain", typedData.Domain.Map())
 	if err != nil {
-		return ECDSASignature{}, err
+		return ecdsaSignature{}, err
 	}
+	typedDataHash, err := typedData.HashStruct(typedData.PrimaryType, typedData.Message)
+	if err != nil {
+		return ecdsaSignature{}, err
+	}
+	rawData := []byte{0x19, 0x01}
+	rawData = append(rawData, domainSeparator...)
+	rawData = append(rawData, typedDataHash...)
+	msgHash := crypto.Keccak256Hash(rawData)
 
 	// Sign the hash using the private key
 	// signature, err := crypto.Sign(hash, privateKey)
 	evmChain, ok := chain.(evm.Chain)
 	if !ok {
-		return ECDSASignature{}, errors.New("not an EVM chain")
+		return ecdsaSignature{}, errors.New("not an EVM chain")
 	}
 
-	signature, err := evmChain.SignHash(hash)
+	signature, err := evmChain.SignHash(msgHash.Bytes())
 	if err != nil {
-		return ECDSASignature{}, err
+		return ecdsaSignature{}, err
 	}
 
-	var r, s [32]byte
-	copy(r[:], signature[:32])
-	copy(s[:], signature[32:64])
-	v := signature[64] + 27 // Adjust V to be 27 or 28
+	// Extract r, s, v components
+	r := new(big.Int).SetBytes(signature[:32])
+	s := new(big.Int).SetBytes(signature[32:64])
+	v := int(signature[64]) + 27
 
-	return ECDSASignature{
-		R: hex.EncodeToString(r[:]),
-		S: hex.EncodeToString(s[:]),
+	return ecdsaSignature{
+		R: hexutil.EncodeBig(r),
+		S: hexutil.EncodeBig(s),
 		V: v,
 	}, nil
 }
 
 // sendRequest sends the HTTP POST request with the signed payload
-func sendRequest(payload EnableBigBlocksRequestPayload, config EnableBigBlocksDetailConfig) error {
+func sendRequest(payload enableBigBlocksRequestPayload, config enableBigBlocksDetailConfig) error {
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("error marshaling payload: %w", err)
@@ -238,37 +224,61 @@ func sendRequest(payload EnableBigBlocksRequestPayload, config EnableBigBlocksDe
 }
 
 // ActionHash computes the hash of the action, including the nonce and optional vault address
-func ActionHash(action map[string]interface{}, vaultAddress *string, nonce int64) ([]byte, error) {
+func actionHash(action any, vaultAddress string, nonce int64, expiresAfter *int64) ([]byte, error) {
+	// Pack action using msgpack (like Python's msgpack.packb)
 	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	enc.SetSortMapKeys(true)
 
-	// Encode the action using MessagePack
-	encoder := codec.NewEncoder(&buf, new(codec.MsgpackHandle))
-	if err := encoder.Encode(action); err != nil {
-		return nil, fmt.Errorf("error encoding action: %w", err)
+	err := enc.Encode(action)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal action: %v", err)
 	}
+	data := buf.Bytes()
 
-	// Append the nonce
-	nonceBytes := make([]byte, 8)
+	// Add nonce as 8 bytes big endian
 	if nonce < 0 {
-		return nil, fmt.Errorf("nonce must be non-negative, got %d", nonce)
+		return nil, fmt.Errorf("nonce cannot be negative: %d", nonce)
 	}
+	nonceBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(nonceBytes, uint64(nonce))
-	buf.Write(nonceBytes)
+	data = append(data, nonceBytes...)
 
-	// Append vault address if provided
-	if vaultAddress == nil {
-		buf.WriteByte(0x00)
+	// Add vault address
+	if vaultAddress == "" {
+		data = append(data, 0x00)
 	} else {
-		buf.WriteByte(0x01)
-		addressBytes := hexutil.Bytes(*vaultAddress)
-		buf.Write(addressBytes)
+		data = append(data, 0x01)
+		data = append(data, addressToBytes(vaultAddress)...)
 	}
 
-	// Compute the Keccak-256 hash of the serialized data
-	return crypto.Keccak256(buf.Bytes()), nil
+	// Add expires_after if provided
+	if expiresAfter != nil {
+		if *expiresAfter < 0 {
+			panic(fmt.Sprintf("expiresAfter cannot be negative: %d", *expiresAfter))
+		}
+		data = append(data, 0x00)
+		expiresAfterBytes := make([]byte, 8)
+		binary.BigEndian.PutUint64(expiresAfterBytes, uint64(*expiresAfter))
+		data = append(data, expiresAfterBytes...)
+	}
+
+	// Return keccak256 hash
+	hash := crypto.Keccak256(data)
+	fmt.Printf("go action hash: %s\n", hex.EncodeToString(hash))
+	return hash, nil
 }
 
-func FindChainBySelector(e cldf.Environment, selector uint64) (chain.BlockChain, error) {
+// addressToBytes converts a hex address to bytes
+func addressToBytes(address string) []byte {
+	if strings.HasPrefix(address, "0x") {
+		address = address[2:]
+	}
+	bytes, _ := hex.DecodeString(address)
+	return bytes
+}
+
+func findChainBySelector(e cldf.Environment, selector uint64) (chain.BlockChain, error) {
 	evmChains := e.BlockChains.EVMChains()
 
 	for _, chain := range evmChains {

--- a/deployment/ccip/changeset/hyperliquid/cs_enable_big_blocks.go
+++ b/deployment/ccip/changeset/hyperliquid/cs_enable_big_blocks.go
@@ -232,7 +232,7 @@ func actionHash(action any, vaultAddress string, nonce int64, expiresAfter *int6
 
 	err := enc.Encode(action)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal action: %v", err)
+		return nil, fmt.Errorf("failed to marshal action: %w", err)
 	}
 	data := buf.Bytes()
 
@@ -271,9 +271,7 @@ func actionHash(action any, vaultAddress string, nonce int64, expiresAfter *int6
 
 // addressToBytes converts a hex address to bytes
 func addressToBytes(address string) []byte {
-	if strings.HasPrefix(address, "0x") {
-		address = address[2:]
-	}
+	address = strings.TrimPrefix(address, "0x")
 	bytes, _ := hex.DecodeString(address)
 	return bytes
 }

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
-	github.com/ugorji/go/codec v1.2.12
+	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/xssnick/tonutils-go v1.13.0
 	github.com/zksync-sdk/zksync2-go v1.1.1-0.20250620124214-2c742ee399c6
 	go.uber.org/zap v1.27.0
@@ -415,10 +415,12 @@ require (
 	github.com/tklauser/numcpus v0.10.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
+	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/urfave/cli v1.22.16 // indirect
 	github.com/urfave/cli/v2 v2.27.6 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.14 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1436,6 +1436,10 @@ github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXV
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vektah/gqlparser/v2 v2.5.14 h1:dzLq75BJe03jjQm6n56PdH1oweB8ana42wj7E4jRy70=
 github.com/vektah/gqlparser/v2 v2.5.14/go.mod h1:WQQjFc+I1YIzoPvZBhUQX7waZgg3pMLi0r8KymvAE2w=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/wlynxg/anet v0.0.3/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=


### PR DESCRIPTION
Used https://github.com/LayerZero-Labs/devtools/blob/f9335e044e16557d740f3c46c416a30652b0e750/packages/hyperliquid-composer/src/operations/evmUserModify.ts and https://github.com/sonirico/go-hyperliquid/tree/master as references.

Main fixes:
- actionHash computation
- chainId must be 1337

Tested:
```
Applying ccip migration 0248_enable_big_blocks for environment: mainnet
go action hash: 048715324a88cdb20e1287f5194d6c24be093ce0e1e9c6fb6548c5ac855209ed
Response Status: 200 OK
Response Message: {"status":"ok","response":{"type":"default"}}
```

```
curl -X POST https://rpc.hyperliquid.xyz/evm \
     -H "Content-Type: application/json" \
     -d '{
  "jsonrpc": "2.0",
  "method": "eth_usingBigBlocks",
  "params": [
    "0x269895AC2a2eC6e1Df37F68AcfbBDa53e62b71B1"
  ],
  "id": 1
}'
{"jsonrpc":"2.0","id":1,"result":true}
```