### PR TITLE
Fix Web Auth Check Typo

### DIFF
--- a/core/web/auth/auth.go
+++ b/core/web/auth/auth.go
@@ -85,7 +85,7 @@ func AuthenticateByToken(c *gin.Context, authr Authenticator) error {
 		return auth.ErrorAuthFailed
 	}
 
-	if token.AccessKey == "" {
+	if token.Secret == "" {
 		return auth.ErrorAuthFailed
 	}
 


### PR DESCRIPTION
One liner typo fix in `core/web/auth/auth.go`. `token.AccessKey == ""` is checked twice.