### PR TITLE
core/services/keystore: remove & block logging from package subtree

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,6 +71,13 @@ linters:
 #              desc: Tron only runs as a LOOPP
             - pkg: github.com/consul/sdk/freeport
               desc: Use github.com/smartcontractkit/freeport instead
+        keystore:
+          list-mode: lax
+          files:
+            - "github.com/smartcontractkit/chainlink/core/services/keystore/**/*.go"
+          deny:
+            - pkg: github.com/smartcontractkit/chainlink-common/pkg/logger
+            - pkg: github.com/smartcontractkit/chainlink/core/logger
     exhaustive:
       default-signifies-exhaustive: true
     gosec:

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -208,7 +208,7 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg chainlink.G
 	}
 
 	ds := sqlutil.WrapDataSource(db, appLggr, sqlutil.TimeoutHook(cfg.Database().DefaultQueryTimeout), sqlutil.MonitorHook(cfg.Database().LogSQL))
-	keyStore := keystore.New(ds, utils.GetScryptParams(cfg), appLggr)
+	keyStore := keystore.New(ds, utils.GetScryptParams(cfg), appLggr.Infof)
 
 	err = keyStoreAuthenticator.Authenticate(ctx, keyStore, cfg.Password())
 	if err != nil {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -423,8 +423,9 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 			}
 		}
 	}
-	keyStore := keystore.NewInMemory(ds, utils.FastScryptParams, lggr)
+	keyStore := keystore.NewInMemory(ds, utils.FastScryptParams, lggr.Infof)
 	require.NoError(t, keyStore.Unlock(ctx, Password))
+	logPubKeys(t, keyStore)
 
 	for _, dep := range flagsAndDeps {
 		switch v := dep.(type) {
@@ -490,6 +491,130 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 	}
 
 	return ta
+}
+
+func logPubKeys(t testing.TB, kr keystore.Master) {
+	ctx := t.Context()
+	csas, err := kr.CSA().GetAll()
+	require.NoError(t, err)
+	csaIDs := make([]string, len(csas))
+	for _, CSAKey := range csas {
+		csaIDs = append(csaIDs, CSAKey.ID())
+	}
+	eths, err := kr.Eth().GetAll(ctx)
+	require.NoError(t, err)
+	ethIDs := make([]string, len(eths))
+	for _, ETHKey := range eths {
+		ethIDs = append(ethIDs, ETHKey.ID())
+	}
+	ocrs, err := kr.OCR().GetAll()
+	require.NoError(t, err)
+	ocrIDs := make([]string, len(ocrs))
+	for _, OCRKey := range ocrs {
+		ocrIDs = append(ocrIDs, OCRKey.ID())
+	}
+	ocr2s, err := kr.OCR2().GetAll()
+	require.NoError(t, err)
+	ocr2IDs := make([]string, len(ocr2s))
+	for _, OCR2Key := range ocr2s {
+		ocr2IDs = append(ocr2IDs, OCR2Key.ID())
+	}
+	p2ps, err := kr.P2P().GetAll()
+	require.NoError(t, err)
+	p2pIDs := make([]string, len(p2ps))
+	for _, P2PKey := range p2ps {
+		p2pIDs = append(p2pIDs, P2PKey.ID())
+	}
+	cosmos, err := kr.Cosmos().GetAll()
+	require.NoError(t, err)
+	cosmosIDs := make([]string, len(cosmos))
+	for _, cosmosKey := range cosmos {
+		cosmosIDs = append(cosmosIDs, cosmosKey.ID())
+	}
+	solanas, err := kr.Solana().GetAll()
+	require.NoError(t, err)
+	solanaIDs := make([]string, len(solanas))
+	for _, solanaKey := range solanas {
+		solanaIDs = append(solanaIDs, solanaKey.ID())
+	}
+	starknets, err := kr.StarkNet().GetAll()
+	require.NoError(t, err)
+	starknetIDs := make([]string, len(starknets))
+	for _, starkkey := range starknets {
+		starknetIDs = append(starknetIDs, starkkey.ID())
+	}
+	aptoses, err := kr.Aptos().GetAll()
+	require.NoError(t, err)
+	aptosIDs := make([]string, len(aptoses))
+	for _, aptosKey := range aptoses {
+		aptosIDs = append(aptosIDs, aptosKey.ID())
+	}
+	trons, err := kr.Tron().GetAll()
+	require.NoError(t, err)
+	tronIDs := make([]string, len(trons))
+	for _, tronKey := range trons {
+		tronIDs = append(tronIDs, tronKey.ID())
+	}
+	tons, err := kr.TON().GetAll()
+	require.NoError(t, err)
+	tonIDs := make([]string, len(tons))
+	for _, tonKey := range tons {
+		tonIDs = append(tonIDs, tonKey.ID())
+	}
+	vrfs, err := kr.VRF().GetAll()
+	require.NoError(t, err)
+	vrfIDs := make([]string, len(vrfs))
+	for _, VRFKey := range vrfs {
+		vrfIDs = append(vrfIDs, VRFKey.ID())
+	}
+	wfs, err := kr.Workflow().GetAll()
+	require.NoError(t, err)
+	workflowIDs := make([]string, len(wfs))
+	i := 0
+	for _, workflowKey := range wfs {
+		workflowIDs[i] = workflowKey.ID()
+		i++
+	}
+	lggr := logger.TestLogger(t)
+	if len(csaIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d CSA keys", len(csaIDs)), "keys", csaIDs)
+	}
+	if len(ethIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d ETH keys", len(ethIDs)), "keys", ethIDs)
+	}
+	if len(ocrIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d OCR keys", len(ocrIDs)), "keys", ocrIDs)
+	}
+	if len(ocr2IDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d OCR2 keys", len(ocr2IDs)), "keys", ocr2IDs)
+	}
+	if len(p2pIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d P2P keys", len(p2pIDs)), "keys", p2pIDs)
+	}
+	if len(cosmosIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d Cosmos keys", len(cosmosIDs)), "keys", cosmosIDs)
+	}
+	if len(solanaIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d Solana keys", len(solanaIDs)), "keys", solanaIDs)
+	}
+	if len(starknetIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d StarkNet keys", len(starknetIDs)), "keys", starknetIDs)
+	}
+	if len(aptosIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d Aptos keys", len(aptosIDs)), "keys", aptosIDs)
+	}
+	if len(tronIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d Tron keys", len(tronIDs)), "keys", tronIDs)
+	}
+	if len(tonIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d TON keys", len(tonIDs)), "keys", tonIDs)
+	}
+	if len(vrfIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d VRF keys", len(vrfIDs)), "keys", vrfIDs)
+	}
+	if len(workflowIDs) > 0 {
+		lggr.Infow(fmt.Sprintf("Unlocked %d Workflow keys", len(workflowIDs)), "keys", workflowIDs)
+	}
 }
 
 func NewEthMocksWithDefaultChain(t testing.TB) (c *clienttest.Client) {
@@ -704,8 +829,9 @@ func (ta *TestApplication) NewAuthenticatingShell(prompter cmd.Prompter) *cmd.Sh
 // NewKeyStore returns a new, unlocked keystore
 func NewKeyStore(t testing.TB, ds sqlutil.DataSource) keystore.Master {
 	ctx := testutils.Context(t)
-	keystore := keystore.NewInMemory(ds, utils.FastScryptParams, logger.TestLogger(t))
+	keystore := keystore.NewInMemory(ds, utils.FastScryptParams, logger.TestLogger(t).Infof)
 	require.NoError(t, keystore.Unlock(ctx, Password))
+	logPubKeys(t, keystore)
 	return keystore
 }
 

--- a/core/scripts/vrfv2/testnet/main.go
+++ b/core/scripts/vrfv2/testnet/main.go
@@ -215,8 +215,7 @@ func main() {
 
 		db := sqlx.MustOpen("postgres", *dbURL)
 		lggr, _ := logger.NewLogger()
-
-		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr)
+		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr.Infof)
 		err = keyStore.Unlock(ctx, *keystorePassword)
 		helpers.PanicErr(err)
 
@@ -307,8 +306,7 @@ func main() {
 
 		db := sqlx.MustOpen("postgres", *dbURL)
 		lggr, _ := logger.NewLogger()
-
-		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr)
+		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr.Infof)
 		err = keyStore.Unlock(ctx, *keystorePassword)
 		helpers.PanicErr(err)
 

--- a/core/scripts/vrfv2plus/testnet/main.go
+++ b/core/scripts/vrfv2plus/testnet/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/smartcontractkit/chainlink/core/scripts/vrfv2plus/testnet/v2plusscripts"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/batch_blockhash_store"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/generated/batch_vrf_coordinator_v2plus"
@@ -43,7 +44,6 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmutils "github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/blockhashstore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/vrf/extraargs"
@@ -196,8 +196,7 @@ func main() {
 
 		db := sqlx.MustOpen("postgres", *dbURL)
 		lggr, _ := logger.NewLogger()
-
-		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr)
+		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr.Infof)
 		err = keyStore.Unlock(ctx, *keystorePassword)
 		helpers.PanicErr(err)
 
@@ -292,8 +291,7 @@ func main() {
 
 		db := sqlx.MustOpen("postgres", *dbURL)
 		lggr, _ := logger.NewLogger()
-
-		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr)
+		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr.Infof)
 		err = keyStore.Unlock(ctx, *keystorePassword)
 		helpers.PanicErr(err)
 

--- a/core/services/keystore/aptos.go
+++ b/core/services/keystore/aptos.go
@@ -138,7 +138,7 @@ func (ks *aptos) EnsureKey(ctx context.Context) error {
 		return err
 	}
 
-	ks.logger.Infof("Created Aptos key with ID %s", key.ID())
+	ks.announce(key)
 
 	return ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/cosmos.go
+++ b/core/services/keystore/cosmos.go
@@ -132,7 +132,7 @@ func (ks *cosmos) EnsureKey(ctx context.Context) error {
 
 	key := cosmoskey.New()
 
-	ks.logger.Infof("Created Cosmos key with ID %s", key.ID())
+	ks.announce(key)
 
 	return ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/csa.go
+++ b/core/services/keystore/csa.go
@@ -181,7 +181,7 @@ func (ks *csa) EnsureKey(ctx context.Context) error {
 		return err
 	}
 
-	ks.logger.Infof("Created CSA key with ID %s", key.ID())
+	ks.announce(key)
 
 	return ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/eth.go
+++ b/core/services/keystore/eth.go
@@ -156,7 +156,7 @@ func (ks *eth) Create(ctx context.Context, chainIDs ...*big.Int) (ethkey.KeyV2, 
 	if err != nil {
 		return ethkey.KeyV2{}, errors.Wrap(err, "unable to add eth key")
 	}
-	ks.logger.Infow("Created EVM key with ID "+key.Address.Hex(), "address", key.Address.Hex(), "evmChainIDs", chainIDs)
+	ks.announce(key)
 	return key, err
 }
 
@@ -183,7 +183,7 @@ func (ks *eth) EnsureKeys(ctx context.Context, chainIDs ...*big.Int) (err error)
 		if err != nil {
 			return fmt.Errorf("failed to add key %s for chain %s: %w", newKey.Address, chainID, err)
 		}
-		ks.logger.Infow("Created EVM key with ID "+newKey.Address.Hex(), "address", newKey.Address.Hex(), "evmChainID", chainID)
+		ks.announce(newKey)
 	}
 
 	return nil

--- a/core/services/keystore/helpers_test.go
+++ b/core/services/keystore/helpers_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -19,7 +19,7 @@ func mustNewEthKey(t *testing.T) *ethkey.KeyV2 {
 }
 
 func ExposedNewMaster(t *testing.T, ds sqlutil.DataSource) *master {
-	return newMaster(ds, utils.FastScryptParams, logger.TestLogger(t))
+	return newMaster(ds, utils.FastScryptParams, logger.Test(t).Infof)
 }
 
 func (m *master) ExportedSave(ctx context.Context) error {

--- a/core/services/keystore/keystore.go
+++ b/core/services/keystore/keystore.go
@@ -1,3 +1,7 @@
+// Package keystore manages private keys.
+// All raw key byte access is limited to internal/ package APIs, so they are not exposed outside of this subtree.
+// Additionally, packages in this subtree may not import the logger packages. Instead, a few select places accept Logf
+// funcs to announce new public keys. No other logging is allowed.
 package keystore
 
 import (

--- a/core/services/keystore/keystoretest.go
+++ b/core/services/keystore/keystoretest.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -51,7 +50,7 @@ func newInMemoryORM(ds sqlutil.DataSource) *memoryORM {
 
 // NewInMemory sets up a keystore which NOOPs attempts to access the `encrypted_key_rings` table. Accessing `evm.key_states`
 // will still hit the DB.
-func NewInMemory(ds sqlutil.DataSource, scryptParams utils.ScryptParams, lggr logger.Logger) *master {
+func NewInMemory(ds sqlutil.DataSource, scryptParams utils.ScryptParams, logf Logf) *master {
 	dbORM := NewORM(ds)
 	memoryORM := newInMemoryORM(ds)
 
@@ -60,7 +59,7 @@ func NewInMemory(ds sqlutil.DataSource, scryptParams utils.ScryptParams, lggr lo
 		keystateORM:  dbORM,
 		scryptParams: scryptParams,
 		lock:         &sync.RWMutex{},
-		logger:       logger.Named(lggr, "KeyStore"),
+		announce:     announcer(logf),
 	}
 
 	return &master{

--- a/core/services/keystore/ocr.go
+++ b/core/services/keystore/ocr.go
@@ -148,7 +148,7 @@ func (ks *ocr) EnsureKey(ctx context.Context) error {
 		return err
 	}
 
-	ks.logger.Infof("Created OCR key with ID %s", key.ID())
+	ks.announce(key)
 
 	return ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/ocr2.go
+++ b/core/services/keystore/ocr2.go
@@ -152,7 +152,7 @@ func (ks ocr2) EnsureKeys(ctx context.Context, enabledChains ...chaintype.ChainT
 			return err
 		}
 
-		ks.logger.Infof("Created OCR2 key with ID %s for chain type %s", created.ID(), chainType)
+		ks.announce(created)
 	}
 
 	return nil

--- a/core/services/keystore/p2p.go
+++ b/core/services/keystore/p2p.go
@@ -144,7 +144,7 @@ func (ks *p2p) EnsureKey(ctx context.Context) error {
 		return err
 	}
 
-	ks.logger.Infof("Created P2P key with ID %s", key.ID())
+	ks.announce(key)
 
 	return ks.safeAddKey(ctx, key)
 }
@@ -162,7 +162,6 @@ func (ks *p2p) GetOrFirst(id p2pkey.PeerID) (p2pkey.KeyV2, error) {
 	if id != (p2pkey.PeerID{}) {
 		return ks.getByID(id)
 	} else if len(ks.keyRing.P2P) == 1 {
-		ks.logger.Warn("No P2P.PeerID set, defaulting to first key in database")
 		for _, key := range ks.keyRing.P2P {
 			return key, nil
 		}

--- a/core/services/keystore/solana.go
+++ b/core/services/keystore/solana.go
@@ -156,7 +156,7 @@ func (ks *solana) EnsureKey(ctx context.Context) error {
 		return err
 	}
 
-	ks.logger.Infof("Created Solana key with ID %s", key.ID())
+	ks.announce(key)
 
 	return ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/starknet.go
+++ b/core/services/keystore/starknet.go
@@ -137,7 +137,7 @@ func (ks *starknet) EnsureKey(ctx context.Context) error {
 		return err
 	}
 
-	ks.logger.Infof("Created StarkNet key with ID %s", key.ID())
+	ks.announce(key)
 
 	return ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/ton.go
+++ b/core/services/keystore/ton.go
@@ -138,7 +138,7 @@ func (ks *ton) EnsureKey(ctx context.Context) error {
 		return err
 	}
 
-	ks.logger.Infof("Created TON key with ID %s", key.ID())
+	ks.announce(key)
 
 	return ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/tron.go
+++ b/core/services/keystore/tron.go
@@ -139,7 +139,7 @@ func (ks *tron) EnsureKey(ctx context.Context) error {
 		return err
 	}
 
-	ks.logger.Infof("Created Tron key with ID %s", key.ID())
+	ks.announce(key)
 
 	return ks.safeAddKey(ctx, key)
 }

--- a/core/services/keystore/workflow.go
+++ b/core/services/keystore/workflow.go
@@ -149,7 +149,7 @@ func (ks *workflow) EnsureKey(ctx context.Context) error {
 		return err
 	}
 
-	ks.logger.Infof("Created Workflow key with ID %s", key.ID())
+	ks.announce(key)
 
 	return ks.safeAddKey(ctx, key)
 }

--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
@@ -446,7 +446,7 @@ func setupNodeCCIP(
 	require.NoError(t, err)
 	csaKeyStore.On("EnsureKey", mock.Anything).Return(nil)
 	csaKeyStore.On("GetAll").Return([]csakey.KeyV2{key}, nil)
-	keyStore := NewKsa(db, lggr, csaKeyStore)
+	keyStore := NewKsa(db, csaKeyStore, lggr.Infof)
 
 	app, err := chainlink.NewApplication(ctx, chainlink.ApplicationOpts{
 		Config:   config,
@@ -1038,9 +1038,9 @@ func (k *ksa) CSA() keystore.CSA {
 	return k.csa
 }
 
-func NewKsa(db *sqlx.DB, lggr logger.Logger, csa keystore.CSA) *ksa {
+func NewKsa(db *sqlx.DB, csa keystore.CSA, logf keystore.Logf) *ksa {
 	return &ksa{
-		Master: keystore.New(db, clutils.FastScryptParams, lggr),
+		Master: keystore.New(db, clutils.FastScryptParams, logf),
 		csa:    csa,
 	}
 }

--- a/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/chainlink.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/testhelpers_1_4_0/chainlink.go
@@ -446,7 +446,7 @@ func setupNodeCCIP(
 	require.NoError(t, err)
 	csaKeyStore.On("EnsureKey", mock.Anything).Return(nil)
 	csaKeyStore.On("GetAll").Return([]csakey.KeyV2{key}, nil)
-	keyStore := NewKsa(db, lggr, csaKeyStore)
+	keyStore := NewKsa(db, csaKeyStore, lggr.Infof)
 	ctx := testutils.Context(t)
 	app, err := chainlink.NewApplication(ctx, chainlink.ApplicationOpts{
 		CREOpts: chainlink.CREOpts{
@@ -1010,9 +1010,9 @@ func (k *ksa) CSA() keystore.CSA {
 	return k.csa
 }
 
-func NewKsa(db *sqlx.DB, lggr logger.Logger, csa keystore.CSA) *ksa {
+func NewKsa(db *sqlx.DB, csa keystore.CSA, logf keystore.Logf) *ksa {
 	return &ksa{
-		Master: keystore.New(db, clutils.FastScryptParams, lggr),
+		Master: keystore.New(db, clutils.FastScryptParams, logf),
 		csa:    csa,
 	}
 }

--- a/core/services/ocr2/plugins/ccip/transmitter/transmitter_test.go
+++ b/core/services/ocr2/plugins/ccip/transmitter/transmitter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
@@ -20,7 +21,6 @@ import (
 	commontxmmocks "github.com/smartcontractkit/chainlink/v2/common/txmgr/types/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
@@ -220,7 +220,7 @@ func Test_Transmitter_With_StatusChecker_CreateEthTransaction(t *testing.T) {
 
 func NewKeyStore(t testing.TB, ds sqlutil.DataSource) keystore.Master {
 	ctx := testutils.Context(t)
-	keystore := keystore.NewInMemory(ds, utils.FastScryptParams, logger.TestLogger(t))
+	keystore := keystore.NewInMemory(ds, utils.FastScryptParams, logger.Test(t).Infof)
 	require.NoError(t, keystore.Unlock(ctx, Password))
 	return keystore
 }

--- a/core/services/ocr2/plugins/generic/pipeline_runner_adapter_test.go
+++ b/core/services/ocr2/plugins/generic/pipeline_runner_adapter_test.go
@@ -44,7 +44,7 @@ func TestAdapter_Integration(t *testing.T) {
 	db, err := pg.NewConnection(ctx, url.String(), cfg.Database().DriverName(), cfg.Database())
 	require.NoError(t, err)
 
-	keystore := keystore.NewInMemory(db, utils.FastScryptParams, logger)
+	keystore := keystore.NewInMemory(db, utils.FastScryptParams, logger.Infof)
 	pipelineORM := pipeline.NewORM(db, logger, cfg.JobPipeline().MaxSuccessfulRuns())
 	bridgesORM := bridges.NewORM(db)
 	jobORM := job.NewORM(db, pipelineORM, bridgesORM, keystore, logger)

--- a/core/services/vrf/delegate_test.go
+++ b/core/services/vrf/delegate_test.go
@@ -81,7 +81,7 @@ func buildVrfUni(t *testing.T, db *sqlx.DB, cfg chainlink.GeneralConfig) vrfUniv
 	// Don't mock db interactions
 	prm := pipeline.NewORM(db, lggr, cfg.JobPipeline().MaxSuccessfulRuns())
 	btORM := bridges.NewORM(db)
-	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr)
+	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr.Infof)
 	_, dbConfig, evmConfig := txmgr.MakeTestConfigs(t)
 	evmKs := keys.NewChainStore(keystore.NewEthSigner(ks.Eth(), ec.ConfiguredChainID()), ec.ConfiguredChainID())
 	txm, err := txmgr.NewTxm(db, evmConfig, evmConfig.GasEstimator(), evmConfig.Transactions(), nil, dbConfig, dbConfig.Listener(), ec, logger.TestLogger(t), nil, evmKs, nil, nil, nil)
@@ -574,7 +574,7 @@ func Test_CheckFromAddressesExist(t *testing.T) {
 		ctx := testutils.Context(t)
 		db := pgtest.NewSqlxDB(t)
 		lggr := logger.TestLogger(t)
-		ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr)
+		ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr.Infof)
 		require.NoError(t, ks.Unlock(ctx, testutils.Password))
 
 		var fromAddresses []string
@@ -602,7 +602,7 @@ func Test_CheckFromAddressesExist(t *testing.T) {
 		ctx := testutils.Context(t)
 		db := pgtest.NewSqlxDB(t)
 		lggr := logger.TestLogger(t)
-		ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr)
+		ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr.Infof)
 		require.NoError(t, ks.Unlock(ctx, testutils.Password))
 
 		var fromAddresses []string

--- a/core/services/vrf/v2/integration_v2_test.go
+++ b/core/services/vrf/v2/integration_v2_test.go
@@ -2104,9 +2104,9 @@ func TestStartingCountsV1(t *testing.T) {
 	cfg, db := heavyweight.FullTestDBNoFixturesV2(t, nil)
 
 	ctx := testutils.Context(t)
-	lggr := logger.TestLogger(t)
 	txStore := txmgr.NewTxStore(db, logger.TestLogger(t))
-	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr)
+	lggr := logger.TestLogger(t)
+	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr.Infof)
 	ec := clienttest.NewClient(t)
 	ec.On("ConfiguredChainID").Return(testutils.SimulatedChainID)
 	ec.On("LatestBlockHeight", mock.Anything).Return(big.NewInt(2), nil).Maybe()

--- a/core/services/vrf/v2/listener_v2_log_listener_test.go
+++ b/core/services/vrf/v2/listener_v2_log_listener_test.go
@@ -120,7 +120,7 @@ func setupVRFLogPollerListenerTH(t *testing.T) *vrfLogPollerListenerTH {
 	backend.Commit()
 
 	// Log Poller Listener
-	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr)
+	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr.Infof)
 	require.NoError(t, ks.Unlock(ctx, "blah"))
 	j, err := vrfcommon.ValidatedVRFSpec(testspecs.GenerateVRFSpec(testspecs.VRFSpecParams{
 		RequestedConfsDelay: 10,

--- a/core/services/vrf/v2/listener_v2_test.go
+++ b/core/services/vrf/v2/listener_v2_test.go
@@ -183,7 +183,7 @@ func testMaybeSubtractReservedLink(t *testing.T, vrfVersion vrfcommon.Version) {
 	ctx := testutils.Context(t)
 	db := pgtest.NewSqlxDB(t)
 	lggr := logger.TestLogger(t)
-	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr)
+	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr.Infof)
 	require.NoError(t, ks.Unlock(ctx, "blah"))
 	chainID := testutils.SimulatedChainID
 	k, err := ks.Eth().Create(testutils.Context(t), chainID)
@@ -263,7 +263,7 @@ func testMaybeSubtractReservedNative(t *testing.T, vrfVersion vrfcommon.Version)
 	ctx := testutils.Context(t)
 	db := pgtest.NewSqlxDB(t)
 	lggr := logger.TestLogger(t)
-	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr)
+	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr.Infof)
 	require.NoError(t, ks.Unlock(ctx, "blah"))
 	chainID := testutils.SimulatedChainID
 	k, err := ks.Eth().Create(testutils.Context(t), chainID)
@@ -340,7 +340,7 @@ func TestMaybeSubtractReservedNativeV2(t *testing.T) {
 	ctx := testutils.Context(t)
 	db := pgtest.NewSqlxDB(t)
 	lggr := logger.TestLogger(t)
-	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr)
+	ks := keystore.NewInMemory(db, utils.FastScryptParams, lggr.Infof)
 	require.NoError(t, ks.Unlock(ctx, "blah"))
 	chainID := testutils.SimulatedChainID
 	subID := new(big.Int).SetUint64(1)

--- a/deployment/environment/memory/node.go
+++ b/deployment/environment/memory/node.go
@@ -389,7 +389,7 @@ func NewNode(
 		}
 	}
 
-	master := keystore.New(db, utils.FastScryptParams, lggr)
+	master := keystore.New(db, utils.FastScryptParams, lggr.Infof)
 	ctx := t.Context()
 	require.NoError(t, master.Unlock(ctx, "password"))
 	require.NoError(t, master.CSA().EnsureKey(ctx))


### PR DESCRIPTION
This PR removes all logging from the keystore, and blocks importing both the common and core logger packages via the linter.