### PR TITLE
CCIP - wrap readers used for default accessors in observed and extended reader interfaces

### DIFF
--- a/core/capabilities/ccip/ccipaptos/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipaptos/chain_accessor_factory.go
@@ -2,7 +2,6 @@ package ccipaptos
 
 import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 )
@@ -14,10 +13,18 @@ type AptosChainAccessorFactory struct{}
 func (f AptosChainAccessorFactory) NewChainAccessor(
 	params common.ChainAccessorFactoryParams,
 ) (ccipocr3.ChainAccessor, error) {
+	reader, err := common.WrapContractReaderForDefaultAccessor(
+		params.ContractReader,
+		params.ChainSelector,
+		params.Lggr,
+	)
+	if err != nil {
+		return nil, err
+	}
 	return chainaccessor.NewDefaultAccessor(
 		params.Lggr,
 		params.ChainSelector,
-		contractreader.NewExtendedContractReader(params.ContractReader),
+		reader,
 		params.ContractWriter,
 		params.AddrCodec,
 	)

--- a/core/capabilities/ccip/ccipevm/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipevm/chain_accessor_factory.go
@@ -2,7 +2,6 @@ package ccipevm
 
 import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 )
@@ -14,10 +13,18 @@ type EVMChainAccessorFactory struct{}
 func (f EVMChainAccessorFactory) NewChainAccessor(
 	params common.ChainAccessorFactoryParams,
 ) (ccipocr3.ChainAccessor, error) {
+	reader, err := common.WrapContractReaderForDefaultAccessor(
+		params.ContractReader,
+		params.ChainSelector,
+		params.Lggr,
+	)
+	if err != nil {
+		return nil, err
+	}
 	return chainaccessor.NewDefaultAccessor(
 		params.Lggr,
 		params.ChainSelector,
-		contractreader.NewExtendedContractReader(params.ContractReader),
+		reader,
 		params.ContractWriter,
 		params.AddrCodec,
 	)

--- a/core/capabilities/ccip/ccipsolana/chain_accessor_factory.go
+++ b/core/capabilities/ccip/ccipsolana/chain_accessor_factory.go
@@ -2,7 +2,6 @@ package ccipsolana
 
 import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/common"
 )
@@ -14,10 +13,18 @@ type SolanaChainAccessorFactory struct{}
 func (f SolanaChainAccessorFactory) NewChainAccessor(
 	params common.ChainAccessorFactoryParams,
 ) (ccipocr3.ChainAccessor, error) {
+	reader, err := common.WrapContractReaderForDefaultAccessor(
+		params.ContractReader,
+		params.ChainSelector,
+		params.Lggr,
+	)
+	if err != nil {
+		return nil, err
+	}
 	return chainaccessor.NewDefaultAccessor(
 		params.Lggr,
 		params.ChainSelector,
-		contractreader.NewExtendedContractReader(params.ContractReader),
+		reader,
 		params.ContractWriter,
 		params.AddrCodec,
 	)

--- a/core/capabilities/ccip/common/default_accessor_helper.go
+++ b/core/capabilities/ccip/common/default_accessor_helper.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"fmt"
+
+	sel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+)
+
+func WrapContractReaderForDefaultAccessor(
+	contractReader types.ContractReader,
+	chainSelector ccipocr3.ChainSelector,
+	lggr logger.Logger,
+) (contractreader.Extended, error) {
+	chainFamily, err1 := sel.GetSelectorFamily(uint64(chainSelector))
+	if err1 != nil {
+		return nil, fmt.Errorf("failed to get chain family from selector: %w", err1)
+	}
+	chainID, err1 := sel.GetChainIDFromSelector(uint64(chainSelector))
+	if err1 != nil {
+		return nil, fmt.Errorf("failed to get chain id from selector: %w", err1)
+	}
+	reader := contractreader.NewExtendedContractReader(
+		contractreader.NewObserverReader(contractReader, lggr, chainFamily, chainID),
+	)
+	if reader == nil {
+		return nil, fmt.Errorf("failed to create extended contract reader for chain selector %d", chainSelector)
+	}
+	return reader, nil
+}


### PR DESCRIPTION
The contract readers currently used by the `DefaultAccessor` are wrapped in a `NewObserverReader()` and `NewExtendedContractReader()` in the commit and exec plugin factories. Example: https://github.com/smartcontractkit/chainlink-ccip/blob/main/commit/factory.go#L144-L157
 - Extended reader adds finality violation and contract binding management.
 - Observed reader adds metric reporting.

Since the DefaultAccessors are now being constructed with the readers in chainlink core, we need to make sure they're wrapped the same way so we don't lose existing logging and functionality 