### PR TITLE
remove solana-tooling alias

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,9 +88,7 @@ core/scripts/gateway @smartcontractkit/dev-services
 /deployment/common @smartcontractkit/devex-tooling
 /deployment/ccip @smartcontractkit/ccip-tooling @smartcontractkit/ccip-offchain @smartcontractkit/core @smartcontractkit/cld-team
 /deployment/ccip/changeset/globals @smartcontractkit/ccip-offchain
-/deployment/ccip/changeset/solana @smartcontractkit/solana-tooling @smartcontractkit/core @smartcontractkit/cld-team
 /deployment/ccip/changeset/ton @smartcontractkit/bix-build @smartcontractkit/core @smartcontractkit/cld-team
-/deployment/ccip/view/solana @smartcontractkit/solana-tooling @smartcontractkit/core @smartcontractkit/cld-team
 /deployment/keystone @smartcontractkit/keystone @smartcontractkit/core @smartcontractkit/cld-team
 /deployment/data-feeds @smartcontractkit/data-feeds-engineers @smartcontractkit/core @smartcontractkit/cld-team
 /deployment/data-streams @smartcontractkit/data-streams-engineers @smartcontractkit/core @smartcontractkit/cld-team


### PR DESCRIPTION
Will use https://github.com/orgs/smartcontractkit/teams/ccip-tooling going forward

### Requires


### Supports

