### PR TITLE
Update pinned SHA for on-demand-ocr-soak-test workflow to b424e29

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -190,7 +190,7 @@ jobs:
 
   run-core-soak-on-release:
     needs: [docker-core]
-    uses: smartcontractkit/chainlink/.github/workflows/on-demand-ocr-soak-test.yml@b424e29a479e4f80f5c02216ff2f4bc3ca534eac # 2025-07-22
+    uses: smartcontractkit/chainlink/.github/workflows/on-demand-ocr-soak-test.yml@b424e29a479e4f80f5c02216ff2f4bc3ca534eac # 2025-08-06
     with:
       chainlink_version: ${{ github.ref_name }}
       team: CRE

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -190,7 +190,7 @@ jobs:
 
   run-core-soak-on-release:
     needs: [docker-core]
-    uses: smartcontractkit/chainlink/.github/workflows/on-demand-ocr-soak-test.yml@e5667560098cffc3304ef576dfeead94470c2b45 # 2025-07-22
+    uses: smartcontractkit/chainlink/.github/workflows/on-demand-ocr-soak-test.yml@b424e29a479e4f80f5c02216ff2f4bc3ca534eac # 2025-07-22
     with:
       chainlink_version: ${{ github.ref_name }}
       team: CRE


### PR DESCRIPTION
This PR updates the pinned SHA for the on-demand-ocr-soak-test.yml reusable workflow in build-publish.yml.

The currently pinned SHA (e566756...) references a version that depends on a now-deleted job (wait-for-workflows), causing the release build to fail:
https://github.com/smartcontractkit/chainlink/actions/runs/16783653322

The new SHA (b424e29...) includes the fix merged in #18851.

This should unblock the release/2.27.0 pipeline.