### PR TITLE
Temporarily remove soak test job from release workflow to unblock 2.27.0

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -187,10 +187,3 @@ jobs:
               )
             }}
           docker-image-digest: ${{ steps.docker-outputs.outputs.digest }}
-
-  run-core-soak-on-release:
-    needs: [docker-core]
-    uses: smartcontractkit/chainlink/.github/workflows/on-demand-ocr-soak-test.yml@b424e29a479e4f80f5c02216ff2f4bc3ca534eac # 2025-08-06
-    with:
-      chainlink_version: ${{ github.ref_name }}
-      team: CRE


### PR DESCRIPTION
This PR removes the run-core-soak-on-release job from .github/workflows/build-publish.yml.

That job was calling the on-demand-ocr-soak-test.yml reusable workflow, which is currently broken due to missing dependencies and permission issues. Even after updating the SHA to the latest version, the workflow still fails at runtime:
https://github.com/smartcontractkit/chainlink/actions/runs/16784144624

Since the original author of the breaking change (@chudilka1 ) is out, we’re removing the job to unblock the release/2.27.0 build. A follow-up ticket will be created to restore the soak test job once the underlying issue is fixed.

cc @chainchad 