### PR TITLE
support import keys via toml secrets for solana

### DIFF
--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -476,6 +476,19 @@ func (s *Shell) runNode(c *cli.Context) error {
 		}
 	}
 	if s.Config.SolanaEnabled() {
+		for _, k := range s.Config.ImportedSolKeys().List() {
+			lggr.Debug("Importing sol key")
+			_, err2 := app.GetKeyStore().Solana().Import(rootCtx, []byte(k.JSON()), k.Password())
+			if err2 != nil {
+				if errors.Is(err2, keystore.ErrKeyExists) {
+					lggr.Debugf("Sol key %s already exists for chain %v", k.JSON(), k.ChainDetails())
+					continue
+				}
+				return s.errorOut(errors.Wrap(err2, "error importing sol key"))
+			}
+			lggr.Debugf("Imported sol key %s for chain %v", k.JSON(), k.ChainDetails())
+		}
+
 		err2 := app.GetKeyStore().Solana().EnsureKey(rootCtx)
 		if err2 != nil {
 			return errors.Wrap(err2, "failed to ensure solana key")

--- a/core/config/chain_key_config.go
+++ b/core/config/chain_key_config.go
@@ -2,7 +2,7 @@ package config
 
 import chain_selectors "github.com/smartcontractkit/chain-selectors"
 
-type ImportableEthKey interface {
+type ImportableChainKey interface {
 	// ChainDetails returns the chain details for the key.
 	ChainDetails() chain_selectors.ChainDetails
 	ImportableKey
@@ -16,6 +16,6 @@ type ImportableKey interface {
 	Password() string
 }
 
-type ImportableEthKeyLister interface {
-	List() []ImportableEthKey
+type ImportableChainKeyLister interface {
+	List() []ImportableChainKey
 }

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -228,8 +228,8 @@ func (e *SolKey) ValidateConfig() (err error) {
 	}
 	// require valid id
 	if e.ID != nil {
-		_, err := chain_selectors.SolanaNameFromChainId(*e.ID)
-		if err != nil {
+		_, err2 := chain_selectors.SolanaNameFromChainId(*e.ID)
+		if err2 != nil {
 			err = errors.Join(err, configutils.ErrInvalid{Name: "ChainID", Value: e.ID, Msg: "invalid chain id"})
 		}
 	}

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -139,8 +139,101 @@ type Secrets struct {
 	Mercury    MercurySecrets           `toml:",omitempty"`
 	Threshold  ThresholdKeyShareSecrets `toml:",omitempty"`
 	EVM        EthKeys                  `toml:",omitempty"` // choose EVM as the TOML field name to align with relayer config convention
-	P2PKey     P2PKey                   `toml:",omitempty"`
-	CRE        CreSecrets               `toml:",omitempty"`
+	Solana     SolKeys                  `toml:",omitempty"` // choose Solana as the TOML field name to align with relayer config convention
+
+	P2PKey P2PKey     `toml:",omitempty"`
+	CRE    CreSecrets `toml:",omitempty"`
+}
+
+type SolKeys struct {
+	Keys []*SolKey
+}
+
+type SolKey struct {
+	JSON     *models.Secret
+	ID       *string
+	Password *models.Secret
+}
+
+func (s *SolKeys) SetFrom(f *SolKeys) error {
+	err := s.validateMerge(f)
+	if err != nil {
+		return err
+	}
+	if f == nil || len(f.Keys) == 0 {
+		return nil
+	}
+	s.Keys = make([]*SolKey, len(f.Keys))
+	copy(s.Keys, f.Keys)
+	return nil
+}
+
+func (s *SolKeys) validateMerge(f *SolKeys) (err error) {
+	have := make(map[string]struct{})
+	if s != nil && f != nil {
+		for _, solKey := range s.Keys {
+			have[*solKey.ID] = struct{}{}
+		}
+		for _, solKey := range f.Keys {
+			if _, ok := have[*solKey.ID]; ok {
+				err = errors.Join(err, configutils.ErrOverride{Name: fmt.Sprintf("SolKeys: %s", *solKey.ID)})
+			}
+		}
+	}
+	return err
+}
+
+func (s *SolKeys) ValidateConfig() (err error) {
+	for i, solKey := range s.Keys {
+		if err2 := solKey.ValidateConfig(); err2 != nil {
+			err = errors.Join(err, configutils.ErrInvalid{Name: fmt.Sprintf("SolKeys[%d]", i), Value: solKey, Msg: "invalid SolKey"})
+		}
+	}
+	return err
+}
+
+func (e *SolKey) SetFrom(f *SolKey) (err error) {
+	err = e.validateMerge(f)
+	if err != nil {
+		return err
+	}
+	if v := f.JSON; v != nil {
+		e.JSON = v
+	}
+	if v := f.Password; v != nil {
+		e.Password = v
+	}
+	if v := f.ID; v != nil {
+		e.ID = v
+	}
+	return nil
+}
+
+func (e *SolKey) validateMerge(f *SolKey) (err error) {
+	if e.JSON != nil && f.JSON != nil {
+		err = errors.Join(err, configutils.ErrOverride{Name: "PrivateKey"})
+	}
+	if e.ID != nil && f.ID != nil {
+		err = errors.Join(err, configutils.ErrOverride{Name: "Selector"})
+	}
+	if e.Password != nil && f.Password != nil {
+		err = errors.Join(err, configutils.ErrOverride{Name: "Password"})
+	}
+	return err
+}
+
+func (e *SolKey) ValidateConfig() (err error) {
+	if (e.JSON != nil) != (e.Password != nil) && (e.Password != nil) != (e.ID != nil) {
+		err = errors.Join(err, configutils.ErrInvalid{Name: "SolKey", Value: e.JSON, Msg: "all fields must be nil or non-nil"})
+	}
+	// require valid id
+	if e.ID != nil {
+		_, err := chain_selectors.SolanaNameFromChainId(*e.ID)
+		if err != nil {
+			err = errors.Join(err, configutils.ErrInvalid{Name: "ChainID", Value: e.ID, Msg: "invalid chain id"})
+		}
+	}
+	return err
 }
 
 type EthKeys struct {

--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -176,7 +176,7 @@ func (s *SolKeys) validateMerge(f *SolKeys) (err error) {
 		}
 		for _, solKey := range f.Keys {
 			if _, ok := have[*solKey.ID]; ok {
-				err = errors.Join(err, configutils.ErrOverride{Name: fmt.Sprintf("SolKeys: %s", *solKey.ID)})
+				err = errors.Join(err, configutils.ErrOverride{Name: "SolKeys: " + *solKey.ID})
 			}
 		}
 	}

--- a/core/config/toml/types_test.go
+++ b/core/config/toml/types_test.go
@@ -641,7 +641,7 @@ func TestSolKeys_TOMLSerialization(t *testing.T) {
 		var decoded SolKeys
 		err = toml.NewDecoder(strings.NewReader(buf.String())).Decode(&decoded)
 		require.NoError(t, err)
-		assert.Equal(t, len(solKeys.Keys), len(decoded.Keys))
+		assert.Len(t, solKeys.Keys, len(decoded.Keys))
 		for i, key := range solKeys.Keys {
 			assert.Equal(t, key.JSON.GoString(), decoded.Keys[i].JSON.GoString())
 			assert.Equal(t, key.Password.GoString(), decoded.Keys[i].Password.GoString())

--- a/core/config/toml/types_test.go
+++ b/core/config/toml/types_test.go
@@ -622,6 +622,67 @@ Password = 'something'`
 	})
 }
 
+func TestSolKeys_TOMLSerialization(t *testing.T) {
+	t.Parallel()
+
+	t.Run("encode", func(t *testing.T) {
+		solKeys := SolKeys{
+			Keys: []*SolKey{
+				{JSON: ptr(models.Secret("solkey1")), Password: ptr(models.Secret("pass1")), ID: ptr("devnet")},
+				{JSON: ptr(models.Secret("solkey2")), Password: ptr(models.Secret("pass2")), ID: ptr("mainnet")},
+			},
+		}
+
+		var buf bytes.Buffer
+		enc := toml.NewEncoder(&buf)
+		err := enc.Encode(solKeys)
+		require.NoError(t, err)
+
+		var decoded SolKeys
+		err = toml.NewDecoder(strings.NewReader(buf.String())).Decode(&decoded)
+		require.NoError(t, err)
+		assert.Equal(t, len(solKeys.Keys), len(decoded.Keys))
+		for i, key := range solKeys.Keys {
+			assert.Equal(t, key.JSON.GoString(), decoded.Keys[i].JSON.GoString())
+			assert.Equal(t, key.Password.GoString(), decoded.Keys[i].Password.GoString())
+			assert.Equal(t, *key.ID, *decoded.Keys[i].ID)
+		}
+	})
+
+	t.Run("decode", func(t *testing.T) {
+		var decoded SolKeys
+		btoml := `[[Keys]]
+JSON = '{k:v}'
+ID = "devnet"
+Password = 'secret'`
+		err := toml.Unmarshal([]byte(btoml), &decoded)
+		require.NoError(t, err)
+		assert.Len(t, decoded.Keys, 1)
+		assert.Equal(t, "devnet", *decoded.Keys[0].ID)
+		assert.Equal(t, models.NewSecret("secret"), decoded.Keys[0].Password)
+		assert.Equal(t, models.NewSecret("{k:v}"), decoded.Keys[0].JSON)
+	})
+}
+
+func TestSolKeys_SetFrom(t *testing.T) {
+	t.Parallel()
+
+	solKeysWrapper1 := &SolKeys{}
+	solKeysWrapper2 := SolKeys{
+		Keys: []*SolKey{
+			{
+				JSON:     ptr(models.Secret("solkey1")),
+				Password: ptr(models.Secret("pass1")),
+				ID:       ptr("devnet"),
+			},
+		},
+	}
+
+	err := solKeysWrapper1.SetFrom(&solKeysWrapper2)
+	require.NoError(t, err)
+	assert.Equal(t, solKeysWrapper2, *solKeysWrapper1)
+}
+
 func TestEthKeys_SetFrom(t *testing.T) {
 	ethKeysWrapper1 := &EthKeys{}
 	ethKeysWrapper2 := EthKeys{

--- a/core/services/chainlink/config.go
+++ b/core/services/chainlink/config.go
@@ -408,6 +408,10 @@ func (s *Secrets) SetFrom(f *Secrets) (err error) {
 		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "P2PKey"))
 	}
 
+	if err2 := s.Solana.SetFrom(&f.Solana); err2 != nil {
+		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "Solana"))
+	}
+
 	if err2 := s.CRE.SetFrom(&f.CRE); err2 != nil {
 		err = errors.Join(err, commonconfig.NamedMultiErrorList(err2, "CRE"))
 	}

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -544,9 +544,14 @@ func (g *generalConfig) Threshold() coreconfig.Threshold {
 	return &thresholdConfig{s: g.secrets.Threshold}
 }
 
-func (g *generalConfig) ImportedEthKeys() coreconfig.ImportableEthKeyLister {
+func (g *generalConfig) ImportedEthKeys() coreconfig.ImportableChainKeyLister {
 	return &importedEthKeyConfigs{s: g.secrets.EVM}
 }
+
+func (g *generalConfig) ImportedSolKeys() coreconfig.ImportableChainKeyLister {
+	return &importedSolKeyConfigs{s: g.secrets.Solana}
+}
+
 func (g *generalConfig) ImportedP2PKey() coreconfig.ImportableKey {
 	return &importedP2PKeyConfig{s: g.secrets.P2PKey}
 }

--- a/core/services/chainlink/config_imported_sol_key.go
+++ b/core/services/chainlink/config_imported_sol_key.go
@@ -7,43 +7,43 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/config/toml"
 )
 
-type importedEthKeyConfig struct {
-	s toml.EthKey
+type importedSolKeyConfig struct {
+	s toml.SolKey
 }
 
-func (t *importedEthKeyConfig) JSON() string {
+func (t *importedSolKeyConfig) JSON() string {
 	if t.s.JSON == nil {
 		return ""
 	}
 	return string(*t.s.JSON)
 }
 
-func (t *importedEthKeyConfig) ChainDetails() chain_selectors.ChainDetails {
+func (t *importedSolKeyConfig) ChainDetails() chain_selectors.ChainDetails {
 	if t.s.ID == nil {
 		return chain_selectors.ChainDetails{}
 	}
-	d, ok := chain_selectors.ChainByEvmChainID(uint64(*t.s.ID)) //nolint:gosec // disable G115
+	d, ok := chain_selectors.SolanaChainIdToChainSelector()[*t.s.ID]
 	if !ok {
 		return chain_selectors.ChainDetails{}
 	}
 	return chain_selectors.ChainDetails{
-		ChainSelector: d.Selector,
-		ChainName:     d.Name,
+		ChainSelector: d,
+		ChainName:     "solana",
 	}
 }
 
-func (t *importedEthKeyConfig) Password() string {
+func (t *importedSolKeyConfig) Password() string {
 	if t.s.Password == nil {
 		return ""
 	}
 	return string(*t.s.Password)
 }
 
-type importedEthKeyConfigs struct {
-	s toml.EthKeys
+type importedSolKeyConfigs struct {
+	s toml.SolKeys
 }
 
-func (t *importedEthKeyConfigs) List() []config.ImportableChainKey {
+func (t *importedSolKeyConfigs) List() []config.ImportableChainKey {
 	res := make([]config.ImportableChainKey, len(t.s.Keys))
 
 	if len(t.s.Keys) == 0 {
@@ -51,7 +51,7 @@ func (t *importedEthKeyConfigs) List() []config.ImportableChainKey {
 	}
 
 	for i, v := range t.s.Keys {
-		res[i] = &importedEthKeyConfig{s: *v}
+		res[i] = &importedSolKeyConfig{s: *v}
 	}
 	return res
 }

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -1657,11 +1657,11 @@ func Test_generalConfig_LogConfiguration(t *testing.T) {
 		wantSecrets   string
 		wantWarning   string
 	}{
-		//{name: "empty", wantEffective: emptyEffectiveTOML, wantSecrets: emptyEffectiveSecretsTOML},
+		{name: "empty", wantEffective: emptyEffectiveTOML, wantSecrets: emptyEffectiveSecretsTOML},
 		{name: "full", inputSecrets: secretsFullTOML, inputConfig: fullTOML,
 			wantConfig: fullTOML, wantEffective: fullTOML, wantSecrets: secretsFullRedactedTOML, wantWarning: deprecated},
-		//{name: "multi-chain", inputSecrets: secretsMultiTOML, inputConfig: multiChainTOML,
-		//	wantConfig: multiChainTOML, wantEffective: multiChainEffectiveTOML, wantSecrets: secretsMultiRedactedTOML},
+		{name: "multi-chain", inputSecrets: secretsMultiTOML, inputConfig: multiChainTOML,
+			wantConfig: multiChainTOML, wantEffective: multiChainEffectiveTOML, wantSecrets: secretsMultiRedactedTOML},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -1657,11 +1657,11 @@ func Test_generalConfig_LogConfiguration(t *testing.T) {
 		wantSecrets   string
 		wantWarning   string
 	}{
-		{name: "empty", wantEffective: emptyEffectiveTOML, wantSecrets: emptyEffectiveSecretsTOML},
+		//{name: "empty", wantEffective: emptyEffectiveTOML, wantSecrets: emptyEffectiveSecretsTOML},
 		{name: "full", inputSecrets: secretsFullTOML, inputConfig: fullTOML,
 			wantConfig: fullTOML, wantEffective: fullTOML, wantSecrets: secretsFullRedactedTOML, wantWarning: deprecated},
-		{name: "multi-chain", inputSecrets: secretsMultiTOML, inputConfig: multiChainTOML,
-			wantConfig: multiChainTOML, wantEffective: multiChainEffectiveTOML, wantSecrets: secretsMultiRedactedTOML},
+		//{name: "multi-chain", inputSecrets: secretsMultiTOML, inputConfig: multiChainTOML,
+		//	wantConfig: multiChainTOML, wantEffective: multiChainEffectiveTOML, wantSecrets: secretsMultiRedactedTOML},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/services/chainlink/mocks/general_config.go
+++ b/core/services/chainlink/mocks/general_config.go
@@ -834,19 +834,19 @@ func (_c *GeneralConfig_FluxMonitor_Call) RunAndReturn(run func() config.FluxMon
 }
 
 // ImportedEthKeys provides a mock function with no fields
-func (_m *GeneralConfig) ImportedEthKeys() config.ImportableEthKeyLister {
+func (_m *GeneralConfig) ImportedEthKeys() config.ImportableChainKeyLister {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for ImportedEthKeys")
 	}
 
-	var r0 config.ImportableEthKeyLister
-	if rf, ok := ret.Get(0).(func() config.ImportableEthKeyLister); ok {
+	var r0 config.ImportableChainKeyLister
+	if rf, ok := ret.Get(0).(func() config.ImportableChainKeyLister); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(config.ImportableEthKeyLister)
+			r0 = ret.Get(0).(config.ImportableChainKeyLister)
 		}
 	}
 
@@ -870,12 +870,12 @@ func (_c *GeneralConfig_ImportedEthKeys_Call) Run(run func()) *GeneralConfig_Imp
 	return _c
 }
 
-func (_c *GeneralConfig_ImportedEthKeys_Call) Return(_a0 config.ImportableEthKeyLister) *GeneralConfig_ImportedEthKeys_Call {
+func (_c *GeneralConfig_ImportedEthKeys_Call) Return(_a0 config.ImportableChainKeyLister) *GeneralConfig_ImportedEthKeys_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *GeneralConfig_ImportedEthKeys_Call) RunAndReturn(run func() config.ImportableEthKeyLister) *GeneralConfig_ImportedEthKeys_Call {
+func (_c *GeneralConfig_ImportedEthKeys_Call) RunAndReturn(run func() config.ImportableChainKeyLister) *GeneralConfig_ImportedEthKeys_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -923,6 +923,53 @@ func (_c *GeneralConfig_ImportedP2PKey_Call) Return(_a0 config.ImportableKey) *G
 }
 
 func (_c *GeneralConfig_ImportedP2PKey_Call) RunAndReturn(run func() config.ImportableKey) *GeneralConfig_ImportedP2PKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ImportedSolKeys provides a mock function with no fields
+func (_m *GeneralConfig) ImportedSolKeys() config.ImportableChainKeyLister {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ImportedSolKeys")
+	}
+
+	var r0 config.ImportableChainKeyLister
+	if rf, ok := ret.Get(0).(func() config.ImportableChainKeyLister); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(config.ImportableChainKeyLister)
+		}
+	}
+
+	return r0
+}
+
+// GeneralConfig_ImportedSolKeys_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ImportedSolKeys'
+type GeneralConfig_ImportedSolKeys_Call struct {
+	*mock.Call
+}
+
+// ImportedSolKeys is a helper method to define mock.On call
+func (_e *GeneralConfig_Expecter) ImportedSolKeys() *GeneralConfig_ImportedSolKeys_Call {
+	return &GeneralConfig_ImportedSolKeys_Call{Call: _e.mock.On("ImportedSolKeys")}
+}
+
+func (_c *GeneralConfig_ImportedSolKeys_Call) Run(run func()) *GeneralConfig_ImportedSolKeys_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *GeneralConfig_ImportedSolKeys_Call) Return(_a0 config.ImportableChainKeyLister) *GeneralConfig_ImportedSolKeys_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *GeneralConfig_ImportedSolKeys_Call) RunAndReturn(run func() config.ImportableChainKeyLister) *GeneralConfig_ImportedSolKeys_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/chainlink/testdata/secrets-full-redacted.toml
+++ b/core/services/chainlink/testdata/secrets-full-redacted.toml
@@ -51,6 +51,17 @@ JSON = 'xxxxx'
 ID = 9999
 Password = 'xxxxx'
 
+[Solana]
+[[Solana.Keys]]
+JSON = 'xxxxx'
+ID = 'devnet'
+Password = 'xxxxx'
+
+[[Solana.Keys]]
+JSON = 'xxxxx'
+ID = 'mainnet'
+Password = 'xxxxx'
+
 [P2PKey]
 JSON = 'xxxxx'
 Password = 'xxxxx'

--- a/core/services/chainlink/testdata/secrets-full.toml
+++ b/core/services/chainlink/testdata/secrets-full.toml
@@ -48,6 +48,17 @@ JSON = '{"address":"f21997c29122b22f305ab16f67ae7e629ef717c1","crypto":{"cipher"
 ID = 9999
 Password = ''
 
+[Solana]
+[[Solana.Keys]]
+JSON = '{"address":"f21997c29122b22f305ab16f67ae7e629ef717c1","crypto":{"cipher":"aes-128-ctr","ciphertext":"30305aaa098ea598d52d051e7456b3da8d9c341e7a059465ee4725e5fd791b77","cipherparams":{"iv":"60c25ca87354b54ce8737448856e0e29"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"0b76de520af402f80ec294dafe3c977037cbb4c1a67064156283112067d07498"},"mac":"fa981522b76c95d67a2d5b20aa28a27bce007156ec889b72ef01852d3ff5ff12"},"id":"00000000-0000-0000-0000-000000000000","version":3}'
+ID = 'devnet'
+Password = ''
+
+[[Solana.Keys]]
+JSON = '{"address":"f21997c29122b22f305ab16f67ae7e629ef717c1","crypto":{"cipher":"aes-128-ctr","ciphertext":"30305aaa098ea598d52d051e7456b3da8d9c341e7a059465ee4725e5fd791b77","cipherparams":{"iv":"60c25ca87354b54ce8737448856e0e29"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"0b76de520af402f80ec294dafe3c977037cbb4c1a67064156283112067d07498"},"mac":"fa981522b76c95d67a2d5b20aa28a27bce007156ec889b72ef01852d3ff5ff12"},"id":"00000000-0000-0000-0000-000000000000","version":3}'
+ID = 'mainnet'
+Password = ''
+
 [P2PKey]
 JSON = '{"keyType":"P2P","publicKey":"ca3ddaa1faa0da0290a7ea2af63159de5648b853425be4f3cd59af43634b6652","peerID":"p2p_12D3KooWPRqEAWAEoNLkQKyAsk4ugefGyCquwhrRxQTKi3JRYXEq","crypto":{"cipher":"aes-128-ctr","ciphertext":"463a9e775cc3ae62ba1b9354da2d007221be22ef98b39862466bf7ace16a074cb6ff27be72fb96bd45dd96adcb74a31b35b665c9063e4b7f9077039f76f4fe270f34c9f3","cipherparams":{"iv":"741ba370caa7d34b8b0879e7afd3524f"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"51a575db1450e8c368396a221cb0acfcab3db83f2229fdc4b9065dca286d2069"},"mac":"911b25e421cbd8771e3bc8e434f8fdabf47942f96f71e62db1be65629ec06929"}}'
 Password = ''

--- a/core/services/chainlink/types.go
+++ b/core/services/chainlink/types.go
@@ -26,5 +26,6 @@ type GeneralConfig interface {
 // to be imported into the keystore upon startup.
 type ImportedSecretConfig interface {
 	ImportedP2PKey() coreconfig.ImportableKey
-	ImportedEthKeys() coreconfig.ImportableEthKeyLister
+	ImportedEthKeys() coreconfig.ImportableChainKeyLister
+	ImportedSolKeys() coreconfig.ImportableChainKeyLister
 }

--- a/go.md
+++ b/go.md
@@ -213,7 +213,7 @@ flowchart LR
 	click chainlink-common href "https://github.com/smartcontractkit/chainlink-common"
 	chainlink-common/pkg/chipingress
 	click chainlink-common/pkg/chipingress href "https://github.com/smartcontractkit/chainlink-common"
-	chainlink-common/pkg/monitoring --> chainlink-common
+	chainlink-common/pkg/monitoring
 	click chainlink-common/pkg/monitoring href "https://github.com/smartcontractkit/chainlink-common"
 	chainlink-common/pkg/values
 	click chainlink-common/pkg/values href "https://github.com/smartcontractkit/chainlink-common"
@@ -257,8 +257,6 @@ flowchart LR
 	chainlink-solana --> chainlink-common/pkg/monitoring
 	chainlink-solana --> chainlink-framework/multinode
 	click chainlink-solana href "https://github.com/smartcontractkit/chainlink-solana"
-	chainlink-solana/integration-tests --> chainlink/integration-tests
-	click chainlink-solana/integration-tests href "https://github.com/smartcontractkit/chainlink-solana"
 	chainlink-testing-framework/framework
 	click chainlink-testing-framework/framework href "https://github.com/smartcontractkit/chainlink-testing-framework"
 	chainlink-testing-framework/framework/components/dockercompose --> chainlink-testing-framework/framework
@@ -397,12 +395,6 @@ flowchart LR
 	end
 	click chainlink-protos-repo href "https://github.com/smartcontractkit/chainlink-protos"
 
-	subgraph chainlink-solana-repo[chainlink-solana]
-		 chainlink-solana
-		 chainlink-solana/integration-tests
-	end
-	click chainlink-solana-repo href "https://github.com/smartcontractkit/chainlink-solana"
-
 	subgraph chainlink-testing-framework-repo[chainlink-testing-framework]
 		 chainlink-testing-framework/framework
 		 chainlink-testing-framework/framework/components/dockercompose
@@ -431,5 +423,5 @@ flowchart LR
 	click tdh2-repo href "https://github.com/smartcontractkit/tdh2"
 
 	classDef outline stroke-dasharray:6,fill:none;
-	class chainlink-repo,chainlink-ccip-repo,chainlink-common-repo,chainlink-framework-repo,chainlink-protos-repo,chainlink-solana-repo,chainlink-testing-framework-repo,cre-sdk-go-repo,tdh2-repo outline
+	class chainlink-repo,chainlink-ccip-repo,chainlink-common-repo,chainlink-framework-repo,chainlink-protos-repo,chainlink-testing-framework-repo,cre-sdk-go-repo,tdh2-repo outline
 ```

--- a/go.md
+++ b/go.md
@@ -213,7 +213,7 @@ flowchart LR
 	click chainlink-common href "https://github.com/smartcontractkit/chainlink-common"
 	chainlink-common/pkg/chipingress
 	click chainlink-common/pkg/chipingress href "https://github.com/smartcontractkit/chainlink-common"
-	chainlink-common/pkg/monitoring
+	chainlink-common/pkg/monitoring --> chainlink-common
 	click chainlink-common/pkg/monitoring href "https://github.com/smartcontractkit/chainlink-common"
 	chainlink-common/pkg/values
 	click chainlink-common/pkg/values href "https://github.com/smartcontractkit/chainlink-common"
@@ -257,6 +257,8 @@ flowchart LR
 	chainlink-solana --> chainlink-common/pkg/monitoring
 	chainlink-solana --> chainlink-framework/multinode
 	click chainlink-solana href "https://github.com/smartcontractkit/chainlink-solana"
+	chainlink-solana/integration-tests --> chainlink/integration-tests
+	click chainlink-solana/integration-tests href "https://github.com/smartcontractkit/chainlink-solana"
 	chainlink-testing-framework/framework
 	click chainlink-testing-framework/framework href "https://github.com/smartcontractkit/chainlink-testing-framework"
 	chainlink-testing-framework/framework/components/dockercompose --> chainlink-testing-framework/framework
@@ -395,6 +397,12 @@ flowchart LR
 	end
 	click chainlink-protos-repo href "https://github.com/smartcontractkit/chainlink-protos"
 
+	subgraph chainlink-solana-repo[chainlink-solana]
+		 chainlink-solana
+		 chainlink-solana/integration-tests
+	end
+	click chainlink-solana-repo href "https://github.com/smartcontractkit/chainlink-solana"
+
 	subgraph chainlink-testing-framework-repo[chainlink-testing-framework]
 		 chainlink-testing-framework/framework
 		 chainlink-testing-framework/framework/components/dockercompose
@@ -423,5 +431,5 @@ flowchart LR
 	click tdh2-repo href "https://github.com/smartcontractkit/tdh2"
 
 	classDef outline stroke-dasharray:6,fill:none;
-	class chainlink-repo,chainlink-ccip-repo,chainlink-common-repo,chainlink-framework-repo,chainlink-protos-repo,chainlink-testing-framework-repo,cre-sdk-go-repo,tdh2-repo outline
+	class chainlink-repo,chainlink-ccip-repo,chainlink-common-repo,chainlink-framework-repo,chainlink-protos-repo,chainlink-solana-repo,chainlink-testing-framework-repo,cre-sdk-go-repo,tdh2-repo outline
 ```


### PR DESCRIPTION
Support importing keys via secret files on node start.
This is necessary to onboard solana for cre smoke tests