### PR TITLE
[CLD-487]: refactor: use jd client import from cldf_offchain package

### DIFF
--- a/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
@@ -43,6 +43,7 @@ import (
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 
 	aptoscs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
@@ -169,7 +170,7 @@ func SleepAndReplay(t *testing.T, env cldf.Environment, duration time.Duration, 
 
 // ReplayLogs replays logs for the given blocks using the provided offchain client.
 // By default, it will assert on errors. Use WithAssertOnError(false) to change this behavior.
-func ReplayLogs(t *testing.T, oc cldf.OffchainClient, replayBlocks map[uint64]uint64, opts ...ReplayLogsOption) {
+func ReplayLogs(t *testing.T, oc cldf_offchain.Client, replayBlocks map[uint64]uint64, opts ...ReplayLogsOption) {
 	options := &replayLogsOptions{
 		assertOnError: true,
 	}
@@ -198,7 +199,7 @@ func ReplayLogs(t *testing.T, oc cldf.OffchainClient, replayBlocks map[uint64]ui
 	}
 }
 
-func WaitForEventFilterRegistration(t *testing.T, oc cldf.OffchainClient, chainSel uint64, eventName string, address []byte) error {
+func WaitForEventFilterRegistration(t *testing.T, oc cldf_offchain.Client, chainSel uint64, eventName string, address []byte) error {
 	family, err := chainsel.GetSelectorFamily(chainSel)
 	if err != nil {
 		return err
@@ -238,7 +239,7 @@ func WaitForEventFilterRegistration(t *testing.T, oc cldf.OffchainClient, chainS
 	return nil
 }
 
-func isLogFilterRegistered(t *testing.T, oc cldf.OffchainClient, chainSel uint64, eventName string, address []byte) (bool, error) {
+func isLogFilterRegistered(t *testing.T, oc cldf_offchain.Client, chainSel uint64, eventName string, address []byte) (bool, error) {
 	var registered bool
 	var err error
 	switch oc := oc.(type) {
@@ -250,7 +251,7 @@ func isLogFilterRegistered(t *testing.T, oc cldf.OffchainClient, chainSel uint64
 	return registered, err
 }
 
-func WaitForEventFilterRegistrationOnLane(t *testing.T, onchainState stateview.CCIPOnChainState, onchainClient cldf.OffchainClient, sourceChainSel, destChainSel uint64) {
+func WaitForEventFilterRegistrationOnLane(t *testing.T, onchainState stateview.CCIPOnChainState, onchainClient cldf_offchain.Client, sourceChainSel, destChainSel uint64) {
 	onRampAddr, err := onchainState.GetOnRampAddressBytes(sourceChainSel)
 	require.NoError(t, err)
 	// Ensure CCIPMessageSent event filter is registered

--- a/deployment/common/view/nops.go
+++ b/deployment/common/view/nops.go
@@ -12,7 +12,8 @@ import (
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+
 	"github.com/smartcontractkit/chainlink/deployment"
 )
 
@@ -52,7 +53,7 @@ type OCRKeyView struct {
 }
 
 // GenerateNopsView generates a view of nodes with their details
-func GenerateNopsView(lggr logger.Logger, nodeIDs []string, oc cldf.OffchainClient) (map[string]NopView, error) {
+func GenerateNopsView(lggr logger.Logger, nodeIDs []string, oc cldf_offchain.Client) (map[string]NopView, error) {
 	nv := make(map[string]NopView)
 	nodes, err := deployment.NodeInfo(nodeIDs, oc)
 	if errors.Is(err, deployment.ErrMissingNodeMetadata) {
@@ -127,7 +128,7 @@ func GenerateNopsView(lggr logger.Logger, nodeIDs []string, oc cldf.OffchainClie
 	return nv, nil
 }
 
-func approvedJobspecs(ctx context.Context, lggr logger.Logger, nodeIDs []string, oc cldf.OffchainClient) (nodeJobsView map[string]map[string]JobView, verr error) {
+func approvedJobspecs(ctx context.Context, lggr logger.Logger, nodeIDs []string, oc cldf_offchain.Client) (nodeJobsView map[string]map[string]JobView, verr error) {
 	nodeJobsView = make(map[string]map[string]JobView)
 
 	jobs, err := oc.ListJobs(ctx, &jobv1.ListJobsRequest{

--- a/deployment/environment/devenv/jd.go
+++ b/deployment/environment/devenv/jd.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd"
 
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
@@ -30,7 +30,7 @@ type JobDistributor struct {
 }
 
 // NewJDClient creates a new Job Distributor client with the provided configuration.
-func NewJDClient(ctx context.Context, cfg JDConfig) (deployment.OffchainClient, error) {
+func NewJDClient(ctx context.Context, cfg JDConfig) (cldf_offchain.Client, error) {
 	jdConfig := jd.JDConfig{
 		GRPC:  cfg.GRPC,
 		WSRPC: cfg.WSRPC,

--- a/deployment/environment/memory/offchain_client.go
+++ b/deployment/environment/memory/offchain_client.go
@@ -11,11 +11,12 @@ import (
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/test"
 )
 
-var _ deployment.OffchainClient = &JobClient{}
+var _ cldf_offchain.Client = &JobClient{}
 
 type JobClient struct {
 	RegisteredNodes map[string]Node

--- a/deployment/keystone/changeset/internal/deploy.go
+++ b/deployment/keystone/changeset/internal/deploy.go
@@ -27,6 +27,7 @@ import (
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 
@@ -125,7 +126,7 @@ type DonInfo struct {
 	Capabilities []DONCapabilityWithConfig // every capability is hosted on each node
 }
 
-func DonInfos(dons []DonCapabilities, jd cldf.OffchainClient) ([]DonInfo, error) {
+func DonInfos(dons []DonCapabilities, jd cldf_offchain.Client) ([]DonInfo, error) {
 	var donInfos []DonInfo
 	for _, don := range dons {
 		var nodeIDs []string

--- a/integration-tests/smoke/ccip/ccip_token_price_updates_test.go
+++ b/integration-tests/smoke/ccip/ccip_token_price_updates_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/cciptesthelpertypes"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/fee_quoter"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6"
@@ -142,7 +144,7 @@ func Test_CCIPTokenPriceUpdates(t *testing.T) {
 	}, tests.WaitTimeout(t), 500*time.Millisecond)
 }
 
-func disableOracles(ctx context.Context, t *testing.T, client cldf.OffchainClient) []string {
+func disableOracles(ctx context.Context, t *testing.T, client cldf_offchain.Client) []string {
 	var disabledOracleIDs []string
 	listNodesResp, err := client.ListNodes(ctx, &node.ListNodesRequest{})
 	require.NoError(t, err)
@@ -160,7 +162,7 @@ func disableOracles(ctx context.Context, t *testing.T, client cldf.OffchainClien
 	return disabledOracleIDs
 }
 
-func enableOracles(ctx context.Context, t *testing.T, client cldf.OffchainClient, oracleIDs []string) {
+func enableOracles(ctx context.Context, t *testing.T, client cldf_offchain.Client, oracleIDs []string) {
 	for _, n := range oracleIDs {
 		_, err := client.EnableNode(ctx, &node.EnableNodeRequest{Id: n})
 		require.NoError(t, err)

--- a/system-tests/lib/cre/devenv/devenv.go
+++ b/system-tests/lib/cre/devenv/devenv.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/seth"
 
@@ -141,7 +142,7 @@ func BuildFullCLDEnvironment(ctx context.Context, lgr logger.Logger, input *cre.
 		}
 	}
 
-	var jd cldf.OffchainClient
+	var jd cldf_offchain.Client
 
 	if len(input.NodeSetOutput) > 0 {
 		// We create a new instance of JD client using `allNodesInfo` instead of `nodeInfo` to ensure that it can interact with all nodes.

--- a/system-tests/lib/cre/don/jobs/jobs.go
+++ b/system-tests/lib/cre/don/jobs/jobs.go
@@ -10,13 +10,14 @@ import (
 	"go.uber.org/ratelimit"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 )
 
-func Create(ctx context.Context, offChainClient deployment.OffchainClient, don *devenv.DON, flags []string, jobSpecs cre.DonJobs) error {
+func Create(ctx context.Context, offChainClient cldf_offchain.Client, don *devenv.DON, flags []string, jobSpecs cre.DonJobs) error {
 	if len(jobSpecs) == 0 {
 		return nil
 	}

--- a/system-tests/lib/cre/don/jobs/vault/vault.go
+++ b/system-tests/lib/cre/don/jobs/vault/vault.go
@@ -12,8 +12,9 @@ import (
 	"golang.org/x/crypto/nacl/box"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/jobs"
@@ -70,7 +71,7 @@ func dkgKeys(n, t int) (string, []*tdh2easy.PrivateShare, error) {
 	return pks, shares, nil
 }
 
-func GenerateJobSpecs(offchainClient deployment.OffchainClient, donTopology *cre.DonTopology, ds datastore.DataStore, chainID uint64) (cre.DonsToJobSpecs, error) {
+func GenerateJobSpecs(offchainClient cldf_offchain.Client, donTopology *cre.DonTopology, ds datastore.DataStore, chainID uint64) (cre.DonsToJobSpecs, error) {
 	if donTopology == nil {
 		return nil, errors.New("topology is nil")
 	}
@@ -162,7 +163,7 @@ func GenerateJobSpecs(offchainClient deployment.OffchainClient, donTopology *cre
 	return donToJobSpecs, nil
 }
 
-func encryptPrivateShare(offchain deployment.OffchainClient, nodeID string, sk *tdh2easy.PrivateShare) (string, error) {
+func encryptPrivateShare(offchain cldf_offchain.Client, nodeID string, sk *tdh2easy.PrivateShare) (string, error) {
 	nodeResp, err := offchain.GetNode(context.Background(), &nodev1.GetNodeRequest{
 		Id: nodeID,
 	})

--- a/system-tests/lib/cre/environment/env_artifact.go
+++ b/system-tests/lib/cre/environment/env_artifact.go
@@ -10,6 +10,7 @@ import (
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/jd"
 
@@ -86,7 +87,7 @@ func DumpArtifact(
 	addressBook cldf_deployment.AddressBook,
 	jdOutput jd.Output,
 	donTopology cre.DonTopology,
-	offchainClient cldf_deployment.OffchainClient,
+	offchainClient cldf_offchain.Client,
 	capabilityFactoryFns []cre.DONCapabilityWithConfigFactoryFn,
 ) (string, error) {
 	artifact, err := GenerateArtifact(datastore, addressBook, jdOutput, donTopology, offchainClient, capabilityFactoryFns)
@@ -107,7 +108,7 @@ func GenerateArtifact(
 	addressBook cldf_deployment.AddressBook,
 	jdOutput jd.Output,
 	donTopology cre.DonTopology,
-	offchainClient cldf_deployment.OffchainClient,
+	offchainClient cldf_offchain.Client,
 	capabilityFactoryFns []cre.DONCapabilityWithConfigFactoryFn,
 ) (*EnvArtifact, error) {
 	var err error


### PR DESCRIPTION
Instead of referencing the offchain client in CLDF deployment package due to the original lift and shift move, we now should reference the new location in cldf offchain package

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-487
