### PR TITLE
expose nodes

### DIFF
--- a/core/capabilities/integration_tests/framework/don.go
+++ b/core/capabilities/integration_tests/framework/don.go
@@ -198,6 +198,10 @@ func NewDON(ctx context.Context, t *testing.T, lggr logger.Logger, donConfig Don
 	return don
 }
 
+func (d *DON) GetAllNodes() []*capabilityNode {
+	return d.nodes
+}
+
 // Initialise must be called after all capabilities have been added to the DONs and before Start is called
 func (d *DON) Initialise() {
 	id := d.capabilitiesRegistry.setupDON(d.config, d.publishedCapabilities)


### PR DESCRIPTION
Need to expose the nodes so that from the test context I can reach the DB initialization prameters, so that later on I can perform queries to it (DB names are being randomly generated)

### Supports
https://github.com/smartcontractkit/capabilities/pull/182
