### PR TITLE
CCIP-6366 backport tracing disabled

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.66
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.1.0-solana.0.20250801185822-4d19f7e5570f
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1513,8 +1513,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a/go.mod h1:XEtEV52YIISL1Xp2l9XqyXFonKF9WxuGQQJu/lMozl8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44 h1:S00lus9RPu5JuxKRtGEET+aIUfASahHpTRV5RgPARSI=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4 h1:xUgmcXVrt6FQoKhlIt/X9jPmJoLvYUxv+WYC3LYohpU=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254 h1:+Jp8b2OKgu4P3hjWJEo625pKwHEcOBOwuuPo+Z7w9GE=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d h1:86gp4tIXRb6ccSrjcm4gV8iA5wJN6er3rJY9f2UxRLU=

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.0-solana.0.20250801185822-4d19f7e5570f
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1267,8 +1267,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a/go.mod h1:XEtEV52YIISL1Xp2l9XqyXFonKF9WxuGQQJu/lMozl8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44 h1:S00lus9RPu5JuxKRtGEET+aIUfASahHpTRV5RgPARSI=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4 h1:xUgmcXVrt6FQoKhlIt/X9jPmJoLvYUxv+WYC3LYohpU=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254 h1:+Jp8b2OKgu4P3hjWJEo625pKwHEcOBOwuuPo+Z7w9GE=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d h1:86gp4tIXRb6ccSrjcm4gV8iA5wJN6er3rJY9f2UxRLU=

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.1.0-solana.0.20250801185822-4d19f7e5570f
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06

--- a/go.sum
+++ b/go.sum
@@ -1090,8 +1090,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a/go.mod h1:XEtEV52YIISL1Xp2l9XqyXFonKF9WxuGQQJu/lMozl8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44 h1:S00lus9RPu5JuxKRtGEET+aIUfASahHpTRV5RgPARSI=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4 h1:xUgmcXVrt6FQoKhlIt/X9jPmJoLvYUxv+WYC3LYohpU=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254 h1:+Jp8b2OKgu4P3hjWJEo625pKwHEcOBOwuuPo+Z7w9GE=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d h1:86gp4tIXRb6ccSrjcm4gV8iA5wJN6er3rJY9f2UxRLU=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.0-solana.0.20250801185822-4d19f7e5570f
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1490,8 +1490,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a/go.mod h1:XEtEV52YIISL1Xp2l9XqyXFonKF9WxuGQQJu/lMozl8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44 h1:S00lus9RPu5JuxKRtGEET+aIUfASahHpTRV5RgPARSI=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4 h1:xUgmcXVrt6FQoKhlIt/X9jPmJoLvYUxv+WYC3LYohpU=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254 h1:+Jp8b2OKgu4P3hjWJEo625pKwHEcOBOwuuPo+Z7w9GE=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d h1:86gp4tIXRb6ccSrjcm4gV8iA5wJN6er3rJY9f2UxRLU=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.66
 	github.com/smartcontractkit/chainlink-ccip v0.1.0-solana.0.20250801185822-4d19f7e5570f
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.9.6

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1472,8 +1472,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a/go.mod h1:XEtEV52YIISL1Xp2l9XqyXFonKF9WxuGQQJu/lMozl8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44 h1:S00lus9RPu5JuxKRtGEET+aIUfASahHpTRV5RgPARSI=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4 h1:xUgmcXVrt6FQoKhlIt/X9jPmJoLvYUxv+WYC3LYohpU=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254 h1:+Jp8b2OKgu4P3hjWJEo625pKwHEcOBOwuuPo+Z7w9GE=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d h1:86gp4tIXRb6ccSrjcm4gV8iA5wJN6er3rJY9f2UxRLU=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/smartcontractkit/chain-selectors v1.0.66
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1259,8 +1259,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a/go.mod h1:XEtEV52YIISL1Xp2l9XqyXFonKF9WxuGQQJu/lMozl8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44 h1:S00lus9RPu5JuxKRtGEET+aIUfASahHpTRV5RgPARSI=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4 h1:xUgmcXVrt6FQoKhlIt/X9jPmJoLvYUxv+WYC3LYohpU=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254 h1:+Jp8b2OKgu4P3hjWJEo625pKwHEcOBOwuuPo+Z7w9GE=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d h1:86gp4tIXRb6ccSrjcm4gV8iA5wJN6er3rJY9f2UxRLU=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/prometheus/common v0.63.0
 	github.com/rs/zerolog v1.33.0
 	github.com/shopspring/decimal v1.4.0
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1455,8 +1455,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a/go.mod h1:XEtEV52YIISL1Xp2l9XqyXFonKF9WxuGQQJu/lMozl8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44 h1:S00lus9RPu5JuxKRtGEET+aIUfASahHpTRV5RgPARSI=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4 h1:xUgmcXVrt6FQoKhlIt/X9jPmJoLvYUxv+WYC3LYohpU=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250702115140-93959a95eba4/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254 h1:+Jp8b2OKgu4P3hjWJEo625pKwHEcOBOwuuPo+Z7w9GE=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254/go.mod h1:kNOevuC9e+gJXT3+bbJKX0svJal6QCxJVSTrW5e36uM=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d h1:86gp4tIXRb6ccSrjcm4gV8iA5wJN6er3rJY9f2UxRLU=


### PR DESCRIPTION
Bump chainlink-common to backported version https://github.com/smartcontractkit/chainlink-common/pull/1461