### PR TITLE
remove workflow tag validation temporarily

### DIFF
--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -135,9 +135,9 @@ func (c *EngineConfig) Validate() error {
 	if c.WorkflowName == nil {
 		return errors.New("workflowName not set")
 	}
-	if c.WorkflowTag == "" {
-		return errors.New("workflowTag not set")
-	}
+	// if c.WorkflowTag == "" {
+	// 	return errors.New("workflowTag not set")
+	// }
 
 	c.LocalLimits.setDefaultLimits()
 	if c.GlobalLimits == nil {


### PR DESCRIPTION
- remove workflow tag validation temporarily until capability testing framework supports workflow registry v2
- this unblocks progress for integration tests in capabilities repo
