### PR TITLE
Bump build-publish workflow to support core soak tests on release.

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -189,8 +189,8 @@ jobs:
           docker-image-digest: ${{ steps.docker-outputs.outputs.digest }}
 
   run-core-soak-on-release:
-    needs: [docker-core]
-    uses: smartcontractkit/chainlink/.github/workflows/on-demand-ocr-soak-test.yml@e5667560098cffc3304ef576dfeead94470c2b45 # 2025-07-22
+    needs: docker-core
+    uses: smartcontractkit/chainlink/.github/workflows/on-demand-ocr-soak-test.yml@e8fa774450995fd45442a2e8e778f3a7eefc7af9 # 2025-08-08
     with:
       chainlink_version: ${{ github.ref_name }}
       team: CRE


### PR DESCRIPTION
[CRE-624](https://smartcontract-it.atlassian.net/browse/CRE-624)

### Requires
- https://github.com/smartcontractkit/chainlink/pull/18884


[CRE-624]: https://smartcontract-it.atlassian.net/browse/CRE-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ