### PR TITLE
remove depracated addressbook from DF changesets

### DIFF
--- a/deployment/data-feeds/changeset/accept_ownership.go
+++ b/deployment/data-feeds/changeset/accept_ownership.go
@@ -56,5 +56,5 @@ func acceptOwnershipPrecondition(env cldf.Environment, c types.AcceptOwnershipCo
 		return errors.New("mcms config is required")
 	}
 
-	return ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector)
+	return ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector)
 }

--- a/deployment/data-feeds/changeset/accept_ownership_test.go
+++ b/deployment/data-feeds/changeset/accept_ownership_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
@@ -45,8 +47,9 @@ func TestAcceptOwnership(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock")
-	require.NoError(t, err)
+	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	require.Len(t, records, 1)
+	timeLockAddress := records[0].Address
 
 	cache, _ := DeployCache(chain, []string{})
 	tx, _ := cache.Contract.TransferOwnership(chain.DeployerKey, common.HexToAddress(timeLockAddress))

--- a/deployment/data-feeds/changeset/aptos/deploy_data_feeds.go
+++ b/deployment/data-feeds/changeset/aptos/deploy_data_feeds.go
@@ -19,7 +19,6 @@ var DeployDataFeedsChangeset = cldf.CreateChangeSet(deployDataFeedsLogic, deploy
 
 func deployDataFeedsLogic(env cldf.Environment, c types.DeployAptosConfig) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
-	ab := cldf.NewMemoryAddressBook()
 	dataStore := datastore.NewMemoryDataStore()
 
 	for _, chainSelector := range c.ChainsToDeploy {
@@ -47,11 +46,6 @@ func deployDataFeedsLogic(env cldf.Environment, c types.DeployAptosConfig) (cldf
 		}
 		lggr.Infof("Deployed %s chain selector %d addr %s", dataFeedsResponse.Tv.String(), chain.Selector, dataFeedsResponse.Address.String())
 
-		err = ab.Save(chain.Selector, dataFeedsResponse.Address.String(), dataFeedsResponse.Tv)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save ChainlinkDataFeeds: %w", err)
-		}
-
 		if err = dataStore.Addresses().Add(
 			datastore.AddressRef{
 				ChainSelector: chainSelector,
@@ -66,7 +60,7 @@ func deployDataFeedsLogic(env cldf.Environment, c types.DeployAptosConfig) (cldf
 		}
 	}
 
-	return cldf.ChangesetOutput{AddressBook: ab, DataStore: dataStore}, nil
+	return cldf.ChangesetOutput{DataStore: dataStore}, nil
 }
 
 func deployDataFeedsPrecondition(env cldf.Environment, c types.DeployAptosConfig) error {

--- a/deployment/data-feeds/changeset/confirm_aggregator.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator.go
@@ -62,7 +62,7 @@ func confirmAggregatorPrecondition(env cldf.Environment, c types.ProposeConfirmA
 	}
 
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil {
+		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil {
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/confirm_aggregator_test.go
+++ b/deployment/data-feeds/changeset/confirm_aggregator_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
@@ -50,8 +52,9 @@ func TestConfirmAggregator(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	proxyAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "AggregatorProxy")
-	require.NoError(t, err)
+	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("AggregatorProxy"))
+	require.Len(t, records, 1)
+	proxyAddress := records[0].Address
 
 	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
 		changeset.ProposeAggregatorChangeset,

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy.go
@@ -20,6 +20,7 @@ var DeployAggregatorProxyChangeset = cldf.CreateChangeSet(deployAggregatorProxyL
 func deployAggregatorProxyLogic(env cldf.Environment, c types.DeployAggregatorProxyConfig) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
 	ds := datastore.NewMemoryDataStore()
+	ab := cldf.NewMemoryAddressBook()
 
 	for index, chainSelector := range c.ChainsToDeploy {
 		chain := env.BlockChains.EVMChains()[chainSelector]
@@ -48,8 +49,12 @@ func deployAggregatorProxyLogic(env cldf.Environment, c types.DeployAggregatorPr
 		); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save address ref in datastore: %w", err)
 		}
+		err = ab.Save(chain.Selector, proxyResponse.Address.String(), proxyResponse.Tv)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save DataFeedsCache: %w", err)
+		}
 	}
-	return cldf.ChangesetOutput{DataStore: ds}, nil
+	return cldf.ChangesetOutput{DataStore: ds, AddressBook: ab}, nil
 }
 
 func deployAggregatorProxyPrecondition(env cldf.Environment, c types.DeployAggregatorProxyConfig) error {

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy.go
@@ -6,18 +6,20 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
 // DeployAggregatorProxyChangeset deploys an AggregatorProxy contract on the given chains. It uses the address of DataFeedsCache contract
-// from addressbook to set it in the AggregatorProxy constructor. Returns a new addressbook with deploy AggregatorProxy contract addresses.
+// from DataStore to set it in the AggregatorProxy constructor. Returns a new DataStore with deployed AggregatorProxy contract addresses.
 var DeployAggregatorProxyChangeset = cldf.CreateChangeSet(deployAggregatorProxyLogic, deployAggregatorProxyPrecondition)
 
 func deployAggregatorProxyLogic(env cldf.Environment, c types.DeployAggregatorProxyConfig) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
-	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	for index, chainSelector := range c.ChainsToDeploy {
 		chain := env.BlockChains.EVMChains()[chainSelector]
@@ -34,12 +36,20 @@ func deployAggregatorProxyLogic(env cldf.Environment, c types.DeployAggregatorPr
 
 		lggr.Infof("Deployed %s chain selector %d addr %s", proxyResponse.Tv.String(), chain.Selector, proxyResponse.Address.String())
 
-		err = ab.Save(chain.Selector, proxyResponse.Address.String(), proxyResponse.Tv)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save AggregatorProxy: %w", err)
+		if err = ds.Addresses().Add(
+			datastore.AddressRef{
+				ChainSelector: chainSelector,
+				Address:       proxyResponse.Address.String(),
+				Type:          datastore.ContractType(proxyResponse.Tv.Type),
+				Version:       &proxyResponse.Tv.Version,
+				Qualifier:     c.Qualifier,
+				Labels:        datastore.NewLabelSet(c.Labels...),
+			},
+		); err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save address ref in datastore: %w", err)
 		}
 	}
-	return cldf.ChangesetOutput{AddressBook: ab}, nil
+	return cldf.ChangesetOutput{DataStore: ds}, nil
 }
 
 func deployAggregatorProxyPrecondition(env cldf.Environment, c types.DeployAggregatorProxyConfig) error {
@@ -51,10 +61,6 @@ func deployAggregatorProxyPrecondition(env cldf.Environment, c types.DeployAggre
 		_, ok := env.BlockChains.EVMChains()[chainSelector]
 		if !ok {
 			return errors.New("chain not found in environment")
-		}
-		_, err := env.ExistingAddresses.AddressesForChain(chainSelector)
-		if err != nil {
-			return fmt.Errorf("failed to get addessbook for chain %d: %w", chainSelector, err)
 		}
 	}
 

--- a/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_aggregator_proxy_test.go
@@ -45,7 +45,7 @@ func TestAggregatorProxy(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	addrs, err := resp.ExistingAddresses.AddressesForChain(chainSelector)
+	addrs, err := resp.DataStore.Addresses().Fetch()
 	require.NoError(t, err)
 	require.Len(t, addrs, 2) // AggregatorProxy and DataFeedsCache
 }

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy.go
@@ -6,24 +6,26 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
 // DeployBundleAggregatorProxyChangeset deploys a BundleAggregatorProxy contract on the given chains. It uses the address of DataFeedsCache contract
-// from addressbook to set it in the BundleAggregatorProxy constructor. It uses the provided owner address to set it in the BundleAggregatorProxy constructor.
-// Returns a new addressbook with deploy BundleAggregatorProxy contract addresses.
+// from DataStore to set it in the BundleAggregatorProxy constructor. It uses the provided owner address to set it in the BundleAggregatorProxy constructor.
+// Returns a new DataStore with deployed BundleAggregatorProxy contract addresses.
 var DeployBundleAggregatorProxyChangeset = cldf.CreateChangeSet(deployBundleAggregatorProxyLogic, deployBundleAggregatorProxyPrecondition)
 
 func deployBundleAggregatorProxyLogic(env cldf.Environment, c types.DeployBundleAggregatorProxyConfig) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
-	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	for _, chainSelector := range c.ChainsToDeploy {
 		chain := env.BlockChains.EVMChains()[chainSelector]
 
-		dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), chainSelector, &c.CacheLabel) // TODO: replace with DataStore when ready
+		dataFeedsCacheAddress := GetDataFeedsCacheAddress(env.ExistingAddresses, env.DataStore.Addresses(), chainSelector, &c.CacheLabel)
 		if dataFeedsCacheAddress == "" {
 			return cldf.ChangesetOutput{}, fmt.Errorf("DataFeedsCache contract address not found in addressbook for chain %d", chainSelector)
 		}
@@ -35,12 +37,20 @@ func deployBundleAggregatorProxyLogic(env cldf.Environment, c types.DeployBundle
 
 		lggr.Infof("Deployed %s chain selector %d addr %s", bundleProxyResponse.Tv.String(), chain.Selector, bundleProxyResponse.Address.String())
 
-		err = ab.Save(chain.Selector, bundleProxyResponse.Address.String(), bundleProxyResponse.Tv)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save BundleAggregatorProxy: %w", err)
+		if err = ds.Addresses().Add(
+			datastore.AddressRef{
+				ChainSelector: chainSelector,
+				Address:       bundleProxyResponse.Address.String(),
+				Type:          datastore.ContractType(bundleProxyResponse.Tv.Type),
+				Version:       &bundleProxyResponse.Tv.Version,
+				Qualifier:     c.Qualifier,
+				Labels:        datastore.NewLabelSet(c.Labels...),
+			},
+		); err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save address ref in datastore: %w", err)
 		}
 	}
-	return cldf.ChangesetOutput{AddressBook: ab}, nil
+	return cldf.ChangesetOutput{DataStore: ds}, nil
 }
 
 func deployBundleAggregatorProxyPrecondition(env cldf.Environment, c types.DeployBundleAggregatorProxyConfig) error {
@@ -48,10 +58,6 @@ func deployBundleAggregatorProxyPrecondition(env cldf.Environment, c types.Deplo
 		_, ok := env.BlockChains.EVMChains()[chainSelector]
 		if !ok {
 			return errors.New("chain not found in environment")
-		}
-		_, err := env.ExistingAddresses.AddressesForChain(chainSelector) // TODO: replace with DataStore when ready
-		if err != nil {
-			return fmt.Errorf("failed to get addessbook for chain %d: %w", chainSelector, err)
 		}
 		if !common.IsHexAddress(c.Owners[chainSelector].String()) {
 			return fmt.Errorf("owner %s is not a valid address for chain %d", c.Owners[chainSelector].String(), chainSelector)

--- a/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
+++ b/deployment/data-feeds/changeset/deploy_bundle_aggregator_proxy_test.go
@@ -45,7 +45,7 @@ func TestBundleAggregatorProxy(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	addrs, err := resp.ExistingAddresses.AddressesForChain(chainSelector) // TODO: replace with DataStore when ready
+	addrs, err := resp.DataStore.Addresses().Fetch()
 	require.NoError(t, err)
 	require.Len(t, addrs, 2) // BundleAggregatorProxy and DataFeedsCache
 }

--- a/deployment/data-feeds/changeset/deploy_cache.go
+++ b/deployment/data-feeds/changeset/deploy_cache.go
@@ -4,18 +4,20 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
 )
 
 // DeployCacheChangeset deploys the DataFeedsCache contract to the specified chains
-// Returns a new addressbook with deployed DataFeedsCache contracts
+// Returns a new DataStore with deployed DataFeedsCache contracts
 var DeployCacheChangeset = cldf.CreateChangeSet(deployCacheLogic, deployCachePrecondition)
 
 func deployCacheLogic(env cldf.Environment, c types.DeployConfig) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
-	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
+
 	for _, chainSelector := range c.ChainsToDeploy {
 		chain := env.BlockChains.EVMChains()[chainSelector]
 		cacheResponse, err := DeployCache(chain, c.Labels)
@@ -24,13 +26,21 @@ func deployCacheLogic(env cldf.Environment, c types.DeployConfig) (cldf.Changese
 		}
 		lggr.Infof("Deployed %s chain selector %d addr %s", cacheResponse.Tv.String(), chain.Selector, cacheResponse.Address.String())
 
-		err = ab.Save(chain.Selector, cacheResponse.Address.String(), cacheResponse.Tv)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save DataFeedsCache: %w", err)
+		if err = ds.Addresses().Add(
+			datastore.AddressRef{
+				ChainSelector: chainSelector,
+				Address:       cacheResponse.Address.String(),
+				Type:          datastore.ContractType(cacheResponse.Tv.Type),
+				Version:       &cacheResponse.Tv.Version,
+				Qualifier:     c.Qualifier,
+				Labels:        datastore.NewLabelSet(c.Labels...),
+			},
+		); err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save address ref in datastore: %w", err)
 		}
 	}
 
-	return cldf.ChangesetOutput{AddressBook: ab}, nil
+	return cldf.ChangesetOutput{DataStore: ds}, nil
 }
 
 func deployCachePrecondition(env cldf.Environment, c types.DeployConfig) error {

--- a/deployment/data-feeds/changeset/deploy_cache.go
+++ b/deployment/data-feeds/changeset/deploy_cache.go
@@ -17,6 +17,7 @@ var DeployCacheChangeset = cldf.CreateChangeSet(deployCacheLogic, deployCachePre
 func deployCacheLogic(env cldf.Environment, c types.DeployConfig) (cldf.ChangesetOutput, error) {
 	lggr := env.Logger
 	ds := datastore.NewMemoryDataStore()
+	ab := cldf.NewMemoryAddressBook()
 
 	for _, chainSelector := range c.ChainsToDeploy {
 		chain := env.BlockChains.EVMChains()[chainSelector]
@@ -38,9 +39,13 @@ func deployCacheLogic(env cldf.Environment, c types.DeployConfig) (cldf.Changese
 		); err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save address ref in datastore: %w", err)
 		}
+		err = ab.Save(chain.Selector, cacheResponse.Address.String(), cacheResponse.Tv)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save DataFeedsCache: %w", err)
+		}
 	}
 
-	return cldf.ChangesetOutput{DataStore: ds}, nil
+	return cldf.ChangesetOutput{DataStore: ds, AddressBook: ab}, nil
 }
 
 func deployCachePrecondition(env cldf.Environment, c types.DeployConfig) error {

--- a/deployment/data-feeds/changeset/deploy_cache_test.go
+++ b/deployment/data-feeds/changeset/deploy_cache_test.go
@@ -39,7 +39,7 @@ func TestDeployCache(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	addrs, err := resp.ExistingAddresses.AddressesForChain(chainSelector)
+	addrs, err := resp.DataStore.Addresses().Fetch()
 	require.NoError(t, err)
 	require.Len(t, addrs, 1)
 }

--- a/deployment/data-feeds/changeset/migrate_feeds.go
+++ b/deployment/data-feeds/changeset/migrate_feeds.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset/types"
@@ -14,7 +16,7 @@ import (
 // MigrateFeedsChangeset Migrates feeds to DataFeedsCache contract.
 // 1. It reads the existing Aggregator Proxy contract addresses from the input file and saves them to the address book.
 // 2. It reads the data ids and descriptions from the input file and sets the feed config on the DataFeedsCache contract.
-// Returns a new addressbook with the deployed AggregatorProxy addresses.
+// Returns a new datastore with the deployed AggregatorProxy addresses.
 var MigrateFeedsChangeset = cldf.CreateChangeSet(migrateFeedsLogic, migrateFeedsPrecondition)
 
 type MigrationSchema struct {
@@ -29,7 +31,7 @@ func migrateFeedsLogic(env cldf.Environment, c types.MigrationConfig) (cldf.Chan
 	chain := env.BlockChains.EVMChains()[c.ChainSelector]
 	chainState := state.Chains[c.ChainSelector]
 	contract := chainState.DataFeedsCache[c.CacheAddress]
-	ab := cldf.NewMemoryAddressBook()
+	ds := datastore.NewMemoryDataStore()
 
 	proxies, _ := LoadJSON[[]*MigrationSchema](c.InputFileName, c.InputFS)
 
@@ -42,13 +44,16 @@ func migrateFeedsLogic(env cldf.Environment, c types.MigrationConfig) (cldf.Chan
 		descriptions[i] = proxy.Description
 
 		proxy.TypeAndVersion.AddLabel(proxy.Description)
-		err := ab.Save(
-			c.ChainSelector,
-			proxy.Address,
-			proxy.TypeAndVersion,
-		)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save address %s: %w", proxy.Address, err)
+		if err := ds.Addresses().Add(
+			datastore.AddressRef{
+				ChainSelector: c.ChainSelector,
+				Address:       proxy.Address,
+				Type:          datastore.ContractType(proxy.TypeAndVersion.Type),
+				Version:       &proxy.TypeAndVersion.Version,
+				Qualifier:     proxy.Description,
+			},
+		); err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to save address ref in datastore: %w", err)
 		}
 	}
 
@@ -66,7 +71,7 @@ func migrateFeedsLogic(env cldf.Environment, c types.MigrationConfig) (cldf.Chan
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to confirm transaction: %s, %w", tx.Hash().String(), err)
 	}
 
-	return cldf.ChangesetOutput{AddressBook: ab}, nil
+	return cldf.ChangesetOutput{DataStore: ds}, nil
 }
 
 func migrateFeedsPrecondition(env cldf.Environment, c types.MigrationConfig) error {

--- a/deployment/data-feeds/changeset/propose_aggregator.go
+++ b/deployment/data-feeds/changeset/propose_aggregator.go
@@ -61,7 +61,7 @@ func proposeAggregatorPrecondition(env cldf.Environment, c types.ProposeConfirmA
 	}
 
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil {
+		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil {
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/propose_aggregator_test.go
+++ b/deployment/data-feeds/changeset/propose_aggregator_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -51,8 +53,9 @@ func TestProposeAggregator(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	proxyAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "AggregatorProxy")
-	require.NoError(t, err)
+	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("AggregatorProxy"))
+	require.Len(t, records, 1)
+	proxyAddress := records[0].Address
 
 	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
 		changeset.ProposeAggregatorChangeset,

--- a/deployment/data-feeds/changeset/remove_dataid_proxy_mapping.go
+++ b/deployment/data-feeds/changeset/remove_dataid_proxy_mapping.go
@@ -62,7 +62,7 @@ func removeFeedFeedProxyMappingPrecondition(env cldf.Environment, c types.Remove
 		return errors.New("proxy addresses must not be empty")
 	}
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil {
+		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil {
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/remove_dataid_proxy_mapping_test.go
+++ b/deployment/data-feeds/changeset/remove_dataid_proxy_mapping_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -47,8 +49,9 @@ func TestRemoveFeedProxyMapping(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache")
-	require.NoError(t, err)
+	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	require.Len(t, records, 1)
+	cacheAddress := records[0].Address
 
 	dataid := "0x01bb0467f50003040000000000000000"
 
@@ -80,8 +83,9 @@ func TestRemoveFeedProxyMapping(t *testing.T) {
 	require.NoError(t, err)
 
 	// with MCMS
-	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock")
-	require.NoError(t, err)
+	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	require.Len(t, records, 1)
+	timeLockAddress := records[0].Address
 
 	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
 		changeset.SetFeedAdminChangeset,

--- a/deployment/data-feeds/changeset/remove_feed.go
+++ b/deployment/data-feeds/changeset/remove_feed.go
@@ -90,7 +90,7 @@ func removeFeedPrecondition(env cldf.Environment, c types.RemoveFeedConfig) erro
 	}
 
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil {
+		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil {
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/remove_feed_config.go
+++ b/deployment/data-feeds/changeset/remove_feed_config.go
@@ -62,7 +62,7 @@ func removeFeedConfigPrecondition(env cldf.Environment, c types.RemoveFeedConfig
 		return fmt.Errorf("failed to convert feed ids to bytes16: %w", err)
 	}
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil {
+		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil {
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/remove_feed_config_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_config_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cache "github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
@@ -48,8 +50,9 @@ func TestRemoveFeedConfig(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache")
-	require.NoError(t, err)
+	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	require.Len(t, records, 1)
+	cacheAddress := records[0].Address
 
 	dataid := "0x01bb0467f50003040000000000000000"
 
@@ -88,8 +91,9 @@ func TestRemoveFeedConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// with MCMS
-	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock")
-	require.NoError(t, err)
+	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	require.Len(t, records, 1)
+	timeLockAddress := records[0].Address
 
 	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
 		changeset.SetFeedAdminChangeset,

--- a/deployment/data-feeds/changeset/remove_feed_test.go
+++ b/deployment/data-feeds/changeset/remove_feed_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -49,8 +51,9 @@ func TestRemoveFeed(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache")
-	require.NoError(t, err)
+	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	require.Len(t, records, 1)
+	cacheAddress := records[0].Address
 
 	dataid := "0x01bb0467f50003040000000000000000"
 
@@ -90,8 +93,9 @@ func TestRemoveFeed(t *testing.T) {
 	require.NoError(t, err)
 
 	// with MCMS
-	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock")
-	require.NoError(t, err)
+	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	require.Len(t, records, 1)
+	timeLockAddress := records[0].Address
 
 	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
 		changeset.SetFeedAdminChangeset,

--- a/deployment/data-feeds/changeset/set_bundle_feed_config.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config.go
@@ -74,7 +74,7 @@ func setBundleFeedConfigPrecondition(env cldf.Environment, c types.SetFeedBundle
 	}
 
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil { // TODO: replace with DataStore when ready
+		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil { // TODO: replace with DataStore when ready
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/set_bundle_feed_config.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config.go
@@ -74,7 +74,7 @@ func setBundleFeedConfigPrecondition(env cldf.Environment, c types.SetFeedBundle
 	}
 
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil { // TODO: replace with DataStore when ready
+		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil {
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_bundle_feed_config_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -49,8 +51,9 @@ func TestSetBundleFeedConfig(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache") // TODO: replace with DataStore when ready
-	require.NoError(t, err)
+	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	require.Len(t, records, 1)
+	cacheAddress := records[0].Address
 
 	dataid := "0x01bb0467f50003040000000000000000"
 
@@ -83,8 +86,9 @@ func TestSetBundleFeedConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// with MCMS
-	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock") // TODO: replace with DataStore when ready
-	require.NoError(t, err)
+	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	require.Len(t, records, 1)
+	timeLockAddress := records[0].Address
 
 	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
 		changeset.SetFeedAdminChangeset,

--- a/deployment/data-feeds/changeset/set_feed_admin.go
+++ b/deployment/data-feeds/changeset/set_feed_admin.go
@@ -58,7 +58,7 @@ func setFeedAdminPrecondition(env cldf.Environment, c types.SetFeedAdminConfig) 
 	}
 
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil {
+		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil {
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/set_feed_admin_test.go
+++ b/deployment/data-feeds/changeset/set_feed_admin_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -49,8 +51,9 @@ func TestSetCacheAdmin(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache")
-	require.NoError(t, err)
+	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	require.Len(t, records, 1)
+	cacheAddress := records[0].Address
 
 	// without MCMS
 	resp, err := commonChangesets.Apply(t, newEnv,

--- a/deployment/data-feeds/changeset/set_feed_config.go
+++ b/deployment/data-feeds/changeset/set_feed_config.go
@@ -74,7 +74,7 @@ func setFeedConfigPrecondition(env cldf.Environment, c types.SetFeedDecimalConfi
 	}
 
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil {
+		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil {
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/set_feed_config_test.go
+++ b/deployment/data-feeds/changeset/set_feed_config_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -51,8 +53,9 @@ func TestSetFeedConfig(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache")
-	require.NoError(t, err)
+	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	require.Len(t, records, 1)
+	cacheAddress := records[0].Address
 
 	dataid := "0x01bb0467f50003040000000000000000"
 
@@ -84,8 +87,9 @@ func TestSetFeedConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// with MCMS
-	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock")
-	require.NoError(t, err)
+	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	require.Len(t, records, 1)
+	timeLockAddress := records[0].Address
 
 	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
 		changeset.SetFeedAdminChangeset,

--- a/deployment/data-feeds/changeset/types/types.go
+++ b/deployment/data-feeds/changeset/types/types.go
@@ -34,12 +34,14 @@ type DeployCacheResponse struct {
 type DeployConfig struct {
 	ChainsToDeploy []uint64 // Chain Selectors
 	Labels         []string // Labels for the cache, applies to all chains
+	Qualifier      string   // Qualifier for the contract, applies to all chains
 }
 
 type DeployAggregatorProxyConfig struct {
 	ChainsToDeploy   []uint64         // Chain Selectors
 	AccessController []common.Address // AccessController addresses per chain
-	Labels           []string         // Labels for the cache, applies to all chains
+	Labels           []string         // Labels for the contract, applies to all chains
+	Qualifier        string           // Qualifier for the contract, applies to all chains
 }
 
 type DeployBundleAggregatorProxyConfig struct {
@@ -47,6 +49,7 @@ type DeployBundleAggregatorProxyConfig struct {
 	Owners         map[uint64]common.Address
 	Labels         []string // Labels for the BundleAggregatorProxy, applies to all chains
 	CacheLabel     string   // Label to find the DataFeedsCache contract address in addressbook
+	Qualifier      string   // Qualifier for the contract, applies to all chains
 }
 
 type DeployBundleAggregatorProxyResponse struct {
@@ -151,6 +154,7 @@ type NewFeedWithProxyConfig struct {
 	ChainSelector    uint64
 	AccessController common.Address
 	Labels           []string // labels for AggregatorProxy
+	Qualifiers       []string // Qualifiers for AggregatorProxy
 	DataIDs          []string
 	Descriptions     []string
 	WorkflowMetadata []cache.DataFeedsCacheWorkflowMetadata

--- a/deployment/data-feeds/changeset/update_data_id_proxy.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy.go
@@ -71,7 +71,7 @@ func updateDataIDProxyPrecondition(env cldf.Environment, c types.UpdateDataIDPro
 	}
 
 	if c.McmsConfig != nil {
-		if err := ValidateMCMSAddresses(env.ExistingAddresses, c.ChainSelector); err != nil {
+		if err := ValidateMCMSAddresses(env.DataStore.Addresses(), c.ChainSelector); err != nil {
 			return err
 		}
 	}

--- a/deployment/data-feeds/changeset/update_data_id_proxy_test.go
+++ b/deployment/data-feeds/changeset/update_data_id_proxy_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -47,8 +49,9 @@ func TestUpdateDataIDProxyMap(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	cacheAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "DataFeedsCache")
-	require.NoError(t, err)
+	records := newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("DataFeedsCache"))
+	require.Len(t, records, 1)
+	cacheAddress := records[0].Address
 
 	dataID := "0x01bb0467f50003040000000000000000"
 
@@ -73,8 +76,9 @@ func TestUpdateDataIDProxyMap(t *testing.T) {
 	require.NoError(t, err)
 
 	// with MCMS
-	timeLockAddress, err := cldf.SearchAddressBook(newEnv.ExistingAddresses, chainSelector, "RBACTimelock")
-	require.NoError(t, err)
+	records = newEnv.DataStore.Addresses().Filter(datastore.AddressRefByType("RBACTimelock"))
+	require.Len(t, records, 1)
+	timeLockAddress := records[0].Address
 
 	newEnv, err = commonChangesets.Apply(t, newEnv, commonChangesets.Configure(
 		changeset.SetFeedAdminChangeset,

--- a/deployment/data-feeds/changeset/validation.go
+++ b/deployment/data-feeds/changeset/validation.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/ethereum/go-ethereum/common"
 
@@ -35,13 +37,17 @@ func ValidateCacheForChain(env cldf.Environment, chainSelector uint64, cacheAddr
 	return nil
 }
 
-func ValidateMCMSAddresses(ab cldf.AddressBook, chainSelector uint64) error {
-	if _, err := cldf.SearchAddressBook(ab, chainSelector, commonTypes.RBACTimelock); err != nil {
-		return fmt.Errorf("timelock not present on the chain %w", err)
+func ValidateMCMSAddresses(addressStore datastore.AddressRefStore, chainSelector uint64) error {
+	records := addressStore.Filter(datastore.AddressRefByType(datastore.ContractType(commonTypes.RBACTimelock)))
+	if len(records) == 0 {
+		return fmt.Errorf("timelock not present on the chain %d", chainSelector)
 	}
-	if _, err := cldf.SearchAddressBook(ab, chainSelector, commonTypes.ProposerManyChainMultisig); err != nil {
-		return fmt.Errorf("mcms proposer not present on the chain %w", err)
+
+	records = addressStore.Filter(datastore.AddressRefByType(datastore.ContractType(commonTypes.ProposerManyChainMultisig)))
+	if len(records) == 0 {
+		return fmt.Errorf("mcms proposer not present on the chain %d", chainSelector)
 	}
+
 	return nil
 }
 

--- a/system-tests/tests/smoke/cre/capabilities_test.go
+++ b/system-tests/tests/smoke/cre/capabilities_test.go
@@ -141,6 +141,7 @@ func executePoRTest(t *testing.T, in *environment.Config, envArtifact environmen
 
 		mergeErr := fullCldEnvOutput.Environment.ExistingAddresses.Merge(dfOutput.AddressBook) //nolint:staticcheck // won't migrate now
 		require.NoError(t, mergeErr, "failed to merge address book")
+		fullCldEnvOutput.Environment.DataStore = dfOutput.DataStore.Seal()
 
 		workflowName := "por-workflow-" + bcOutput.BlockchainOutput.ChainID + "-" + uuid.New().String()[0:4]
 


### PR DESCRIPTION
[DF-21667](https://smartcontract-it.atlassian.net/browse/DF-21667)
Changes in this PR

1. Removed the feature to write to addressbook in changesets, instead now all the changesets write to DataStore.
      a. Only DataFeedsCache and AggregatorProxy deployment changesets write to both Addressbook and DataStore. This is due some common MCMS changesets still relying on Addressbook
3. Modified the unit test to use DataStore for assertions

For read operations we still use Addressbook as a fallback option if the address is not in DataStore. 
All the current addresses are migrated from addressbook to DataStore in CLD

[DF-21667]: https://smartcontract-it.atlassian.net/browse/DF-21667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ