### PR TITLE
Add a fail hook to engine

### DIFF
--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -100,6 +100,7 @@ type LifecycleHooks struct {
 	OnInitialized          func(err error)
 	OnSubscribedToTriggers func(triggerIDs []string)
 	OnExecutionFinished    func(executionID string, status string)
+	OnExecutionError       func(msg string)
 	OnResultReceived       func(*sdkpb.ExecutionResult)
 	OnRateLimited          func(executionID string)
 }
@@ -213,6 +214,9 @@ func (h *LifecycleHooks) setDefaultHooks() {
 	}
 	if h.OnResultReceived == nil {
 		h.OnResultReceived = func(res *sdkpb.ExecutionResult) {}
+	}
+	if h.OnExecutionError == nil {
+		h.OnExecutionError = func(msg string) {}
 	}
 	if h.OnExecutionFinished == nil {
 		h.OnExecutionFinished = func(executionID string, status string) {}

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -437,6 +437,7 @@ func (e *Engine) startExecution(ctx context.Context, wrappedTriggerEvent enqueue
 		executionLogger.Errorw("Workflow execution failed", "err", err, "status", executionStatus, "durationMs", executionDuration.Milliseconds())
 		_ = events.EmitExecutionFinishedEvent(ctx, e.loggerLabels, executionStatus, executionID)
 		e.cfg.Hooks.OnExecutionFinished(executionID, executionStatus)
+		e.cfg.Hooks.OnExecutionError(err.Error())
 		return
 	}
 


### PR DESCRIPTION
This PR adds a hook to allow cleaner logging of errors from the engine

[PR 1/2: Add lifecycle hook to core](https://github.com/smartcontractkit/chainlink/pull/18893)
[PR 2/2: Clean output from simulator](https://github.com/smartcontractkit/dev-platform/pull/568)