### PR TITLE
handle workflow tag for V1 workflow registrations

### DIFF
--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -498,6 +498,7 @@ func (h *eventHandler) createWorkflowSpec(ctx context.Context, payload WorkflowR
 		Status:        status,
 		WorkflowOwner: owner,
 		WorkflowName:  payload.WorkflowName,
+		WorkflowTag:   "", // V1 workflows don't have tags, so set empty string
 		SpecType:      job.WASMFile,
 		BinaryURL:     payload.BinaryURL,
 		ConfigURL:     payload.ConfigURL,
@@ -532,19 +533,19 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, o
 		}
 
 		cfg := workflows.Config{
-			Lggr:           h.lggr,
-			Workflow:       *sdkSpec,
-			WorkflowID:     workflowID,
-			WorkflowOwner:  owner, // this gets hex encoded in the engine.
-			WorkflowName:   name,
-			Registry:       h.capRegistry,
-			Store:          h.workflowStore,
-			Config:         config,
-			Binary:         binary,
-			SecretsFetcher: h.workflowArtifactsStore.SecretsFor,
-			RateLimiter:    h.ratelimiter,
-			WorkflowLimits: h.workflowLimits,
-			BillingClient:  h.billingClient,
+			Lggr:                    h.lggr,
+			Workflow:                *sdkSpec,
+			WorkflowID:              workflowID,
+			WorkflowOwner:           owner, // this gets hex encoded in the engine.
+			WorkflowName:            name,
+			Registry:                h.capRegistry,
+			Store:                   h.workflowStore,
+			Config:                  config,
+			Binary:                  binary,
+			SecretsFetcher:          h.workflowArtifactsStore.SecretsFor,
+			RateLimiter:             h.ratelimiter,
+			WorkflowLimits:          h.workflowLimits,
+			BillingClient:           h.billingClient,
 			WorkflowRegistryAddress: h.workflowRegistryAddress,
 			WorkflowRegistryChainID: h.workflowRegistryChainSelector,
 		}
@@ -563,6 +564,7 @@ func (h *eventHandler) engineFactoryFn(ctx context.Context, workflowID string, o
 		WorkflowID:            workflowID,
 		WorkflowOwner:         owner,
 		WorkflowName:          name,
+		WorkflowTag:           "", // V1 workflows don't have tags, so set empty string
 		WorkflowEncryptionKey: h.workflowEncryptionKey,
 
 		LocalLimits:          v2.EngineLimits{}, // all defaults

--- a/core/services/workflows/syncer/handler.go
+++ b/core/services/workflows/syncer/handler.go
@@ -498,7 +498,6 @@ func (h *eventHandler) createWorkflowSpec(ctx context.Context, payload WorkflowR
 		Status:        status,
 		WorkflowOwner: owner,
 		WorkflowName:  payload.WorkflowName,
-		WorkflowTag:   "", // V1 workflows don't have tags, so set empty string
 		SpecType:      job.WASMFile,
 		BinaryURL:     payload.BinaryURL,
 		ConfigURL:     payload.ConfigURL,

--- a/core/services/workflows/v2/config.go
+++ b/core/services/workflows/v2/config.go
@@ -136,9 +136,6 @@ func (c *EngineConfig) Validate() error {
 	if c.WorkflowName == nil {
 		return errors.New("workflowName not set")
 	}
-	if c.WorkflowTag == "" {
-		return errors.New("workflowTag not set")
-	}
 
 	c.LocalLimits.setDefaultLimits()
 	if c.GlobalLimits == nil {

--- a/core/services/workflows/v2/config_test.go
+++ b/core/services/workflows/v2/config_test.go
@@ -51,6 +51,12 @@ func TestEngineConfig_Validate(t *testing.T) {
 		require.NotEqual(t, 0, cfg.LocalLimits.TriggerEventQueueSize)
 		require.NotNil(t, cfg.Hooks.OnInitialized)
 	})
+
+	t.Run("empty workflow tag is allowed", func(t *testing.T) {
+		cfg.Module = modulemocks.NewModuleV2(t)
+		cfg.WorkflowTag = "" // V1 workflows don't have tags
+		require.NoError(t, cfg.Validate())
+	})
 }
 
 func defaultTestConfig(t *testing.T) *v2.EngineConfig {


### PR DESCRIPTION
- either DAG and NoDAG can be registered on V1 workflow registry. When NoDAG workflow is registered, set workflowTag to an empty string. 