### PR TITLE
fix(core): Potentially unsafe quoting

### DIFF
--- a/core/services/s4/envelope.go
+++ b/core/services/s4/envelope.go
@@ -59,19 +59,25 @@ func (e Envelope) GetSignerAddress(signature []byte) (address common.Address, er
 }
 
 func (e Envelope) ToJson() ([]byte, error) {
-	address, err := json.Marshal(e.Address)
-	if err != nil {
-		return nil, err
-	}
 	nonNilPayload := e.Payload
 	if nonNilPayload == nil {
 		// prevent unwanted "null" values in JSON representation
 		nonNilPayload = []byte{}
 	}
-	payload, err := json.Marshal(nonNilPayload)
-	if err != nil {
-		return nil, err
+	// Create a struct with the same fields and order as required
+	type envelopeJSON struct {
+		Address    []byte `json:"address"`
+		SlotID     uint   `json:"slotid"`
+		Payload    []byte `json:"payload"`
+		Version    uint64 `json:"version"`
+		Expiration int64  `json:"expiration"`
 	}
-	js := fmt.Sprintf(`{"address":%s,"slotid":%d,"payload":%s,"version":%d,"expiration":%d}`, address, e.SlotID, payload, e.Version, e.Expiration)
-	return []byte(js), nil
+	obj := envelopeJSON{
+		Address:    e.Address,
+		SlotID:     e.SlotID,
+		Payload:    nonNilPayload,
+		Version:    e.Version,
+		Expiration: e.Expiration,
+	}
+	return json.Marshal(obj)
 }


### PR DESCRIPTION

fix the problem, we should avoid manually constructing the JSON string with `fmt.Sprintf`. Instead, we should define a struct that matches the desired JSON structure and use `json.Marshal` to serialize the entire struct. This ensures that all fields are properly escaped and encoded, and eliminates the risk of injection or malformed JSON due to improper quoting. The fix involves:

- Defining a local struct (or reusing `Envelope` if the field order and nil handling are acceptable) that matches the required JSON structure.
- Ensuring that the `Payload` field is set to an empty byte slice if it is `nil`, to avoid unwanted `"null"` values.
- Using `json.Marshal` to serialize the struct, rather than assembling the JSON string manually.
- Removing the manual use of `json.Marshal` for individual fields and the `fmt.Sprintf` call.

All changes are within the `ToJson()` method in `core/services/s4/envelope.go`.