### PR TITLE
[DF] Deployment: Set default deltaStage to 4s

### DIFF
--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs.go
@@ -67,7 +67,7 @@ func proposeWFJobsToJDLogic(env cldf.Environment, c types.ProposeWFJobsConfig) (
 
 	var deltaStageSec int
 	if workflowSpecConfig.DeltaStageSec == nil {
-		deltaStageSec = 45
+		deltaStageSec = 4
 	} else {
 		deltaStageSec = *workflowSpecConfig.DeltaStageSec
 	}

--- a/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
+++ b/deployment/data-feeds/changeset/jd_propose_wf_jobs_v2.go
@@ -274,7 +274,7 @@ func getMaxFrequencyMs(maxFrequencyMs *int) int {
 
 func getDeltaStage(deltaStageSec *int) int {
 	if deltaStageSec == nil {
-		return 45
+		return 4
 	}
 	return *deltaStageSec
 }


### PR DESCRIPTION
Set default `deltaStage` to 4s for Data Feeds Workflows. This is what is currently in use in Testnet and Mainnet. 


<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->
- nothing

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
- nothing