### PR TITLE
fix/Added workflowName padding to match report metadata

### DIFF
--- a/core/services/relay/evm/write_target.go
+++ b/core/services/relay/evm/write_target.go
@@ -210,6 +210,12 @@ func evaluate(rawRequest capabilities.CapabilityRequest) (receiver string, err e
 		return "", fmt.Errorf("WorkflowOwner in the report does not match WorkflowOwner in the request metadata. Report WorkflowOwner: %+v, request WorkflowOwner: %+v", reportMetadata.WorkflowOwner, rawRequest.Metadata.WorkflowOwner)
 	}
 
+	// pad workflow name to match the report which is padded to 20 characters
+	if len(rawRequest.Metadata.WorkflowName) < 20 {
+		suffix := strings.Repeat("0", 20-len(rawRequest.Metadata.WorkflowName))
+		rawRequest.Metadata.WorkflowName += suffix
+	}
+
 	if !strings.EqualFold(reportMetadata.WorkflowName, rawRequest.Metadata.WorkflowName) {
 		return "", fmt.Errorf("WorkflowName in the report does not match WorkflowName in the request metadata. Report WorkflowName: %+v, request WorkflowName: %+v", reportMetadata.WorkflowName, rawRequest.Metadata.WorkflowName)
 	}

--- a/core/services/relay/evm/write_target_test.go
+++ b/core/services/relay/evm/write_target_test.go
@@ -175,7 +175,7 @@ func TestEvmWrite(t *testing.T) {
 		DONID:            1,
 		DONConfigVersion: 1,
 		WorkflowID:       "1234567890123456789012345678901234567890123456789012345678901234",
-		WorkflowName:     "12345678901234567890",
+		WorkflowName:     "123456789",
 		WorkflowOwner:    "1234567890123456789012345678901234567890",
 		ReportID:         hex.EncodeToString(reportID[:]),
 	}


### PR DESCRIPTION
The report metadata is padded [here](https://github.com/smartcontractkit/chainlink-common/blob/a5a42ee8701be96574c4c416f6c2e2e3993558f4/pkg/capabilities/consensus/ocr3/types/aggregator.go#L46) so before this fix if a workflow name was < 20 bytes is would lead to a mismatch error. 

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
