### PR TITLE
(feat): support updating don composition

### DIFF
--- a/deployment/keystone/changeset/internal/update_don.go
+++ b/deployment/keystone/changeset/internal/update_don.go
@@ -96,7 +96,7 @@ func UpdateDon(_ logger.Logger, req *UpdateDonRequest) (*UpdateDonResponse, erro
 	var don kcr.CapabilitiesRegistryDONInfo
 	var err error
 	if req.DonID != 0 {
-		don, err = registry.GetDON(&bind.CallOpts{}, uint32(req.DonID))
+		don, err = registry.GetDON(&bind.CallOpts{}, uint32(req.DonID)) //nolint:gosec // G115
 		if err != nil {
 			return nil, fmt.Errorf("failed to get DON %d: %w", req.DonID, err)
 		}
@@ -231,9 +231,9 @@ func verboseDonNotFound(donResp []kcr.CapabilitiesRegistryDONInfo, wanted []p2pk
 		Want       []p2pkey.PeerID
 		Got        []p2pkey.PeerID
 	}
-	debugIds := make([]debugDonInfo, len(donResp))
+	debugIDs := make([]debugDonInfo, len(donResp))
 	for i, di := range donResp {
-		debugIds[i] = debugDonInfo{
+		debugIDs[i] = debugDonInfo{
 			OnchainID:  di.Id,
 			P2PIDsHash: SortedHash(di.NodeP2PIds),
 			Want:       wanted,
@@ -241,9 +241,9 @@ func verboseDonNotFound(donResp []kcr.CapabilitiesRegistryDONInfo, wanted []p2pk
 		}
 	}
 	wantedID := SortedHash(PeerIDsToBytes(wanted))
-	b, err2 := json.Marshal(debugIds)
+	b, err2 := json.Marshal(debugIDs)
 	if err2 == nil {
 		return fmt.Errorf("don not found by p2pIDs %s in %s", wantedID, b)
 	}
-	return fmt.Errorf("don not found by p2pIDs %s in %v", wantedID, debugIds)
+	return fmt.Errorf("don not found by p2pIDs %s in %v", wantedID, debugIDs)
 }

--- a/deployment/keystone/changeset/internal/update_don.go
+++ b/deployment/keystone/changeset/internal/update_don.go
@@ -34,8 +34,22 @@ type UpdateDonRequest struct {
 	Chain                cldf_evm.Chain
 	CapabilitiesRegistry *kcr.CapabilitiesRegistry
 
-	P2PIDs            []p2pkey.PeerID    // this is the unique identifier for the don
-	CapabilityConfigs []CapabilityConfig // if Config subfield is nil, a default config is used
+	// P2PIDs are the peer ids that compose the don
+	P2PIDs            []p2pkey.PeerID
+	CapabilityConfigs []CapabilityConfig
+
+	// DonID to update
+	// If omitted, the don will be inferred from the P2P keys
+	// If the update request intended to change the nodes in the don, the DonID must be specified
+	DonID int
+
+	// F is the fault tolerance level
+	// if omitted, the existing value fetched from the registry is used
+	F uint8
+
+	// IsPrivate indicates whether the DON is public or private
+	// If omitted, the existing value fetched from the registry is used
+	IsPrivate bool
 
 	UseMCMS bool
 }
@@ -79,16 +93,24 @@ func UpdateDon(_ logger.Logger, req *UpdateDonRequest) (*UpdateDonResponse, erro
 	}
 
 	registry := req.CapabilitiesRegistry
-	getDonsResp, err := registry.GetDONs(&bind.CallOpts{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get Dons: %w", err)
-	}
+	var don kcr.CapabilitiesRegistryDONInfo
+	var err error
+	if req.DonID != 0 {
+		don, err = registry.GetDON(&bind.CallOpts{}, uint32(req.DonID))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get DON %d: %w", req.DonID, err)
+		}
+	} else {
+		getDonsResp, err := registry.GetDONs(&bind.CallOpts{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get Dons: %w", err)
+		}
 
-	don, err := lookupDonByPeerIDs(getDonsResp, req.P2PIDs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to lookup don by p2pIDs: %w", err)
+		don, err = lookupDonByPeerIDs(getDonsResp, req.P2PIDs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to lookup don by p2pIDs: %w", err)
+		}
 	}
-
 	if don.AcceptsWorkflows {
 		// TODO: CRE-277 ensure forwarders are support the next DON version
 		// https://github.com/smartcontractkit/chainlink/blob/4fc61bb156fe57bfd939b836c02c413ad1209ebb/contracts/src/v0.8/keystone/CapabilitiesRegistry.sol#L812
@@ -105,7 +127,19 @@ func UpdateDon(_ logger.Logger, req *UpdateDonRequest) (*UpdateDonResponse, erro
 	if req.UseMCMS {
 		txOpts = cldf.SimTransactOpts()
 	}
-	tx, err := registry.UpdateDON(txOpts, don.Id, don.NodeP2PIds, cfgs, don.IsPublic, don.F)
+	f := req.F
+	if f == 0 {
+		f = don.F
+	}
+	// this is implement as such to maintain backwards compatibility; the default (omitted) value of a bool is false
+	var isPublic bool
+	if req.IsPrivate {
+		isPublic = false
+	} else {
+		isPublic = don.IsPublic
+	}
+
+	tx, err := registry.UpdateDON(txOpts, don.Id, PeerIDsToBytes(req.P2PIDs), cfgs, isPublic, f)
 	if err != nil {
 		err = cldf.DecodeErr(kcr.CapabilitiesRegistryABI, err)
 		return nil, fmt.Errorf("failed to call UpdateDON: %w", err)

--- a/deployment/keystone/changeset/internal/update_don_test.go
+++ b/deployment/keystone/changeset/internal/update_don_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -166,6 +168,286 @@ func TestUpdateDon(t *testing.T) {
 		assert.Equal(t, want.DonInfo.ConfigCount, got.DonInfo.ConfigCount)
 		assert.Equal(t, sortedP2Pids(want.DonInfo.NodeP2PIds), sortedP2Pids(got.DonInfo.NodeP2PIds))
 		assert.Equal(t, capIds(want.DonInfo.CapabilityConfigurations), capIds(got.DonInfo.CapabilityConfigurations))
+	})
+}
+
+func TestUpdateDon_ChangeComposition(t *testing.T) {
+	var (
+		// Initial nodes (n1-n4)
+		p2p_1     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(100))
+		pubKey_1  = "11114981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e1098e7"
+		admin_1   = common.HexToAddress("0x1111567890123456789012345678901234567890")
+		signing_1 = "11117293a4cc2621b61193135a95928735e4795f"
+		node_1    = newNode(t, minimalNodeCfg{
+			id:            "test node 1",
+			pubKey:        pubKey_1,
+			registryChain: registryChain,
+			p2p:           p2p_1,
+			signingAddr:   signing_1,
+			admin:         admin_1,
+		})
+
+		p2p_2     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(200))
+		pubKey_2  = "22224981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109000"
+		admin_2   = common.HexToAddress("0x2222567890123456789012345678901234567891")
+		signing_2 = "22227293a4cc2621b61193135a95928735e4ffff"
+		node_2    = newNode(t, minimalNodeCfg{
+			id:            "test node 2",
+			pubKey:        pubKey_2,
+			registryChain: registryChain,
+			p2p:           p2p_2,
+			signingAddr:   signing_2,
+			admin:         admin_2,
+		})
+
+		p2p_3     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(300))
+		pubKey_3  = "33334981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109111"
+		admin_3   = common.HexToAddress("0x3333567890123456789012345678901234567892")
+		signing_3 = "33337293a4cc2621b61193135a959287aaaaffff"
+		node_3    = newNode(t, minimalNodeCfg{
+			id:            "test node 3",
+			pubKey:        pubKey_3,
+			registryChain: registryChain,
+			p2p:           p2p_3,
+			signingAddr:   signing_3,
+			admin:         admin_3,
+		})
+
+		p2p_4     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(400))
+		pubKey_4  = "44444981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109222"
+		admin_4   = common.HexToAddress("0x4444567890123456789012345678901234567893")
+		signing_4 = "44447293a4cc2621b61193135a959287aaaaffff"
+		node_4    = newNode(t, minimalNodeCfg{
+			id:            "test node 4",
+			pubKey:        pubKey_4,
+			registryChain: registryChain,
+			p2p:           p2p_4,
+			signingAddr:   signing_4,
+			admin:         admin_4,
+		})
+
+		// Additional node (n5) to be added
+		p2p_5     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(500))
+		pubKey_5  = "55554981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109333"
+		admin_5   = common.HexToAddress("0x5555567890123456789012345678901234567894")
+		signing_5 = "55557293a4cc2621b61193135a959287aaaabbbb"
+		node_5    = newNode(t, minimalNodeCfg{
+			id:            "test node 5",
+			pubKey:        pubKey_5,
+			registryChain: registryChain,
+			p2p:           p2p_5,
+			signingAddr:   signing_5,
+			admin:         admin_5,
+		})
+
+		// Test capability
+		testCap = kcr.CapabilitiesRegistryCapability{
+			LabelledName:   "test",
+			Version:        "1.0.0",
+			CapabilityType: 0,
+		}
+	)
+
+	lggr := logger.Test(t)
+
+	// Setup initial registry with DON containing nodes 1-4
+	cfg := setupUpdateDonTestConfig{
+		dons: []internal.DonInfo{
+			{
+				Name:         "don 1",
+				Nodes:        []deployment.Node{node_1, node_2, node_3, node_4},
+				Capabilities: []internal.DONCapabilityWithConfig{{Capability: testCap, Config: kstest.GetDefaultCapConfig(t, testCap)}},
+			},
+		},
+		nops: []internal.NOP{
+			{
+				Name:  "nop 1",
+				Nodes: []string{node_1.NodeID, node_2.NodeID, node_3.NodeID, node_4.NodeID},
+			},
+		},
+	}
+
+	testCfg := registerTestDon(t, lggr, cfg)
+
+	// Verify initial DON setup
+	initialDon, err := testCfg.CapabilitiesRegistry.GetDON(&bind.CallOpts{}, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), initialDon.Id)
+	require.Len(t, initialDon.NodeP2PIds, 4)
+
+	testCapCfg := kstest.GetDefaultCapConfig(t, testCap)
+	testCapCfgB, err := proto.Marshal(testCapCfg)
+	require.NoError(t, err)
+
+	t.Run("add node to DON composition", func(t *testing.T) {
+
+		caps, err := testCfg.CapabilitiesRegistry.GetCapabilities(nil)
+		require.NoError(t, err)
+		capIds := make([][32]byte, 0, len(caps))
+		for _, c := range caps {
+			capIds = append(capIds, c.HashedId)
+		}
+
+		r, err := internal.AddNodes(lggr, &internal.AddNodesRequest{
+			CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
+			RegistryChain:        testCfg.Chain,
+			NodeParams: map[string]capabilities_registry.CapabilitiesRegistryNodeParams{
+				node_5.NodeID: {
+					NodeOperatorId:      1,
+					P2pId:               node_5.PeerID,
+					Signer:              [32]byte{5: 5},
+					EncryptionPublicKey: [32]byte{5: 5},
+					HashedCapabilityIds: capIds,
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		t.Logf("Added nodes: %v", r.AddedNodes)
+		// Update DON to include all 5 nodes
+		req := &internal.UpdateDonRequest{
+			CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
+			Chain:                testCfg.Chain,
+			DonID:                1,
+			P2PIDs:               []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_4.PeerID(), p2p_5.PeerID()},
+			CapabilityConfigs: []internal.CapabilityConfig{
+				{Capability: testCap, Config: testCapCfgB},
+			},
+		}
+
+		resp, err := internal.UpdateDon(lggr, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		// Verify the DON now has 5 nodes
+		updatedDon, err := testCfg.CapabilitiesRegistry.GetDON(&bind.CallOpts{}, 1)
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), updatedDon.Id)
+		require.Len(t, updatedDon.NodeP2PIds, 5, "DON should now have 5 nodes")
+
+		// Verify the correct P2P IDs are present
+		expectedP2PIDs := []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_4.PeerID(), p2p_5.PeerID()}
+		actualP2PIDs := internal.BytesToPeerIDs(updatedDon.NodeP2PIds)
+
+		require.ElementsMatch(t, expectedP2PIDs, actualP2PIDs, "DON should contain all 5 expected P2P IDs")
+
+		// nested because we need to remove the node we added in the previous test
+		t.Run("remove node from DON composition", func(t *testing.T) {
+			// Update DON to only include nodes 1-4 (removing node 5)
+			req := &internal.UpdateDonRequest{
+				CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
+				Chain:                testCfg.Chain,
+				DonID:                1,
+				P2PIDs:               []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_4.PeerID()},
+				CapabilityConfigs: []internal.CapabilityConfig{
+					{Capability: testCap, Config: testCapCfgB},
+				},
+			}
+
+			resp, err := internal.UpdateDon(lggr, req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			// Verify the DON is back to 4 nodes
+			updatedDon, err := testCfg.CapabilitiesRegistry.GetDON(&bind.CallOpts{}, 1)
+			require.NoError(t, err)
+			require.Equal(t, uint32(1), updatedDon.Id)
+			require.Len(t, updatedDon.NodeP2PIds, 4, "DON should be back to 4 nodes")
+
+			// Verify the correct P2P IDs are present (should match original 4 nodes)
+			expectedP2PIDs := []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_4.PeerID()}
+			actualP2PIDs := internal.BytesToPeerIDs(updatedDon.NodeP2PIds)
+
+			require.ElementsMatch(t, expectedP2PIDs, actualP2PIDs, "DON should contain original 4 P2P IDs")
+
+			// Verify node 5 is not in the DON
+			for _, actualP2PID := range actualP2PIDs {
+				require.NotEqual(t, p2p_5.PeerID(), actualP2PID, "Node 5 should not be in the DON")
+			}
+		})
+
+		// nested we swap the node we just re-added
+		t.Run("replace nodes in DON composition", func(t *testing.T) {
+			// Register another node (node_6) for replacement test
+			p2p_6 := p2pkey.MustNewV2XXXTestingOnly(big.NewInt(600))
+			pubKey_6 := "66664981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109444"
+			admin_6 := common.HexToAddress("0x6666567890123456789012345678901234567895")
+			signing_6 := "66667293a4cc2621b61193135a959287aaaacccc"
+			node_6 := newNode(t, minimalNodeCfg{
+				id:            "test node 6",
+				pubKey:        pubKey_6,
+				registryChain: registryChain,
+				p2p:           p2p_6,
+				signingAddr:   signing_6,
+				admin:         admin_6,
+			})
+
+			// Register node_6 with capabilities
+			caps, err := testCfg.CapabilitiesRegistry.GetCapabilities(nil)
+			require.NoError(t, err)
+			capIds := make([][32]byte, 0, len(caps))
+			for _, c := range caps {
+				capIds = append(capIds, c.HashedId)
+			}
+
+			r, err := internal.AddNodes(lggr, &internal.AddNodesRequest{
+				CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
+				RegistryChain:        testCfg.Chain,
+				NodeParams: map[string]capabilities_registry.CapabilitiesRegistryNodeParams{
+					node_6.NodeID: {
+						NodeOperatorId:      1,
+						P2pId:               node_6.PeerID,
+						Signer:              [32]byte{6: 6},
+						EncryptionPublicKey: [32]byte{6: 6},
+						HashedCapabilityIds: capIds,
+					},
+				},
+			})
+			require.NoError(t, err)
+			lggr.Debugf("Added node 6: %v", r.AddedNodes)
+
+			// Update DON to replace node_4 with node_6 (keeping nodes 1, 2, 3, and adding 6)
+			req := &internal.UpdateDonRequest{
+				CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
+				Chain:                testCfg.Chain,
+				DonID:                1,
+				P2PIDs:               []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_6.PeerID()},
+				CapabilityConfigs: []internal.CapabilityConfig{
+					{Capability: testCap, Config: testCapCfgB},
+				},
+			}
+
+			resp, err := internal.UpdateDon(lggr, req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			// Verify the DON still has 4 nodes but with node_6 instead of node_4
+			updatedDon, err := testCfg.CapabilitiesRegistry.GetDON(&bind.CallOpts{}, 1)
+			require.NoError(t, err)
+			require.Equal(t, uint32(1), updatedDon.Id)
+			require.Len(t, updatedDon.NodeP2PIds, 4, "DON should still have 4 nodes")
+
+			// Verify the correct P2P IDs are present (nodes 1, 2, 3, 6)
+			expectedP2PIDs := []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_6.PeerID()}
+			actualP2PIDs := internal.BytesToPeerIDs(updatedDon.NodeP2PIds)
+
+			require.ElementsMatch(t, expectedP2PIDs, actualP2PIDs, "DON should contain nodes 1, 2, 3, and 6")
+
+			// Verify node_4 is not in the DON anymore
+			for _, actualP2PID := range actualP2PIDs {
+				require.NotEqual(t, p2p_4.PeerID(), actualP2PID, "Node 4 should not be in the DON")
+			}
+
+			// Verify node_6 is in the DON
+			foundNode6 := false
+			for _, actualP2PID := range actualP2PIDs {
+				if actualP2PID == p2p_6.PeerID() {
+					foundNode6 = true
+					break
+				}
+			}
+			require.True(t, foundNode6, "Node 6 should be in the DON")
+		})
 	})
 }
 

--- a/deployment/keystone/changeset/internal/update_don_test.go
+++ b/deployment/keystone/changeset/internal/update_don_test.go
@@ -18,10 +18,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
-
-	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	kscs "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
@@ -37,56 +34,56 @@ var (
 func TestUpdateDon(t *testing.T) {
 	var (
 		// nodes
-		p2p_1     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(100))
-		pubKey_1  = "11114981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e1098e7" // valid csa key
-		admin_1   = common.HexToAddress("0x1111567890123456789012345678901234567890")  // valid eth address
-		signing_1 = "11117293a4cc2621b61193135a95928735e4795f"                         // valid eth address
-		node_1    = newNode(t, minimalNodeCfg{
+		p2p1     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(100))
+		pubKey1  = "11114981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e1098e7" // valid csa key
+		admin1   = common.HexToAddress("0x1111567890123456789012345678901234567890")  // valid eth address
+		signing1 = "11117293a4cc2621b61193135a95928735e4795f"                         // valid eth address
+		node1    = newNode(t, minimalNodeCfg{
 			id:            "test node 1",
-			pubKey:        pubKey_1,
+			pubKey:        pubKey1,
 			registryChain: registryChain,
-			p2p:           p2p_1,
-			signingAddr:   signing_1,
-			admin:         admin_1,
+			p2p:           p2p1,
+			signingAddr:   signing1,
+			admin:         admin1,
 		})
 
-		p2p_2     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(200))
-		pubKey_2  = "22224981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109000" // valid csa key
-		admin_2   = common.HexToAddress("0x2222567890123456789012345678901234567891")  // valid eth address
-		signing_2 = "22227293a4cc2621b61193135a95928735e4ffff"                         // valid eth address
-		node_2    = newNode(t, minimalNodeCfg{
+		p2p2     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(200))
+		pubKey2  = "22224981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109000" // valid csa key
+		admin2   = common.HexToAddress("0x2222567890123456789012345678901234567891")  // valid eth address
+		signing2 = "22227293a4cc2621b61193135a95928735e4ffff"                         // valid eth address
+		node2    = newNode(t, minimalNodeCfg{
 			id:            "test node 2",
-			pubKey:        pubKey_2,
+			pubKey:        pubKey2,
 			registryChain: registryChain,
-			p2p:           p2p_2,
-			signingAddr:   signing_2,
-			admin:         admin_2,
+			p2p:           p2p2,
+			signingAddr:   signing2,
+			admin:         admin2,
 		})
 
-		p2p_3     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(300))
-		pubKey_3  = "33334981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109111" // valid csa key
-		admin_3   = common.HexToAddress("0x3333567890123456789012345678901234567892")  // valid eth address
-		signing_3 = "33337293a4cc2621b61193135a959287aaaaffff"                         // valid eth address
-		node_3    = newNode(t, minimalNodeCfg{
+		p2p3     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(300))
+		pubKey3  = "33334981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109111" // valid csa key
+		admin3   = common.HexToAddress("0x3333567890123456789012345678901234567892")  // valid eth address
+		signing3 = "33337293a4cc2621b61193135a959287aaaaffff"                         // valid eth address
+		node3    = newNode(t, minimalNodeCfg{
 			id:            "test node 3",
-			pubKey:        pubKey_3,
+			pubKey:        pubKey3,
 			registryChain: registryChain,
-			p2p:           p2p_3,
-			signingAddr:   signing_3,
-			admin:         admin_3,
+			p2p:           p2p3,
+			signingAddr:   signing3,
+			admin:         admin3,
 		})
 
-		p2p_4     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(400))
-		pubKey_4  = "44444981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109222" // valid csa key
-		admin_4   = common.HexToAddress("0x4444567890123456789012345678901234567893")  // valid eth address
-		signing_4 = "44447293a4cc2621b61193135a959287aaaaffff"                         // valid eth address
-		node_4    = newNode(t, minimalNodeCfg{
+		p2p4     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(400))
+		pubKey4  = "44444981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109222" // valid csa key
+		admin4   = common.HexToAddress("0x4444567890123456789012345678901234567893")  // valid eth address
+		signing4 = "44447293a4cc2621b61193135a959287aaaaffff"                         // valid eth address
+		node4    = newNode(t, minimalNodeCfg{
 			id:            "test node 4",
-			pubKey:        pubKey_4,
+			pubKey:        pubKey4,
 			registryChain: registryChain,
-			p2p:           p2p_4,
-			signingAddr:   signing_4,
-			admin:         admin_4,
+			p2p:           p2p4,
+			signingAddr:   signing4,
+			admin:         admin4,
 		})
 		// capabilities
 		initialCap = kcr.CapabilitiesRegistryCapability{
@@ -116,14 +113,14 @@ func TestUpdateDon(t *testing.T) {
 			dons: []internal.DonInfo{
 				{
 					Name:         "don 1",
-					Nodes:        []deployment.Node{node_1, node_2, node_3, node_4},
+					Nodes:        []deployment.Node{node1, node2, node3, node4},
 					Capabilities: []internal.DONCapabilityWithConfig{{Capability: initialCap, Config: initialCapCfg}},
 				},
 			},
 			nops: []internal.NOP{
 				{
 					Name:  "nop 1",
-					Nodes: []string{node_1.NodeID, node_2.NodeID, node_3.NodeID, node_4.NodeID},
+					Nodes: []string{node1.NodeID, node2.NodeID, node3.NodeID, node4.NodeID},
 				},
 			},
 		}
@@ -145,7 +142,7 @@ func TestUpdateDon(t *testing.T) {
 		req := &internal.UpdateDonRequest{
 			CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
 			Chain:                testCfg.Chain,
-			P2PIDs:               []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_4.PeerID()},
+			P2PIDs:               []p2pkey.PeerID{p2p1.PeerID(), p2p2.PeerID(), p2p3.PeerID(), p2p4.PeerID()},
 			CapabilityConfigs: []internal.CapabilityConfig{
 				{Capability: initialCap, Config: initialCapCfgB}, {Capability: capToAdd, Config: capToAddCfgB},
 			},
@@ -154,7 +151,7 @@ func TestUpdateDon(t *testing.T) {
 			DonInfo: kcr.CapabilitiesRegistryDONInfo{
 				Id:          1,
 				ConfigCount: 1,
-				NodeP2PIds:  internal.PeerIDsToBytes([]p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_4.PeerID()}),
+				NodeP2PIds:  internal.PeerIDsToBytes([]p2pkey.PeerID{p2p1.PeerID(), p2p2.PeerID(), p2p3.PeerID(), p2p4.PeerID()}),
 				CapabilityConfigurations: []kcr.CapabilitiesRegistryCapabilityConfiguration{
 					{CapabilityId: kstest.MustCapabilityID(t, testCfg.CapabilitiesRegistry, initialCap), Config: initialCapCfgB},
 					{CapabilityId: kstest.MustCapabilityID(t, testCfg.CapabilitiesRegistry, capToAdd), Config: capToAddCfgB},
@@ -167,77 +164,77 @@ func TestUpdateDon(t *testing.T) {
 		assert.Equal(t, want.DonInfo.Id, got.DonInfo.Id)
 		assert.Equal(t, want.DonInfo.ConfigCount, got.DonInfo.ConfigCount)
 		assert.Equal(t, sortedP2Pids(want.DonInfo.NodeP2PIds), sortedP2Pids(got.DonInfo.NodeP2PIds))
-		assert.Equal(t, capIds(want.DonInfo.CapabilityConfigurations), capIds(got.DonInfo.CapabilityConfigurations))
+		assert.Equal(t, capIDs(want.DonInfo.CapabilityConfigurations), capIDs(got.DonInfo.CapabilityConfigurations))
 	})
 }
 
 func TestUpdateDon_ChangeComposition(t *testing.T) {
 	var (
 		// Initial nodes (n1-n4)
-		p2p_1     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(100))
-		pubKey_1  = "11114981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e1098e7"
-		admin_1   = common.HexToAddress("0x1111567890123456789012345678901234567890")
-		signing_1 = "11117293a4cc2621b61193135a95928735e4795f"
-		node_1    = newNode(t, minimalNodeCfg{
+		p2p1     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(100))
+		pubKey1  = "11114981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e1098e7"
+		admin1   = common.HexToAddress("0x1111567890123456789012345678901234567890")
+		signing1 = "11117293a4cc2621b61193135a95928735e4795f"
+		node1    = newNode(t, minimalNodeCfg{
 			id:            "test node 1",
-			pubKey:        pubKey_1,
+			pubKey:        pubKey1,
 			registryChain: registryChain,
-			p2p:           p2p_1,
-			signingAddr:   signing_1,
-			admin:         admin_1,
+			p2p:           p2p1,
+			signingAddr:   signing1,
+			admin:         admin1,
 		})
 
-		p2p_2     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(200))
-		pubKey_2  = "22224981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109000"
-		admin_2   = common.HexToAddress("0x2222567890123456789012345678901234567891")
-		signing_2 = "22227293a4cc2621b61193135a95928735e4ffff"
-		node_2    = newNode(t, minimalNodeCfg{
+		p2p2     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(200))
+		pubKey2  = "22224981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109000"
+		admin2   = common.HexToAddress("0x2222567890123456789012345678901234567891")
+		signing2 = "22227293a4cc2621b61193135a95928735e4ffff"
+		node2    = newNode(t, minimalNodeCfg{
 			id:            "test node 2",
-			pubKey:        pubKey_2,
+			pubKey:        pubKey2,
 			registryChain: registryChain,
-			p2p:           p2p_2,
-			signingAddr:   signing_2,
-			admin:         admin_2,
+			p2p:           p2p2,
+			signingAddr:   signing2,
+			admin:         admin2,
 		})
 
-		p2p_3     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(300))
-		pubKey_3  = "33334981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109111"
-		admin_3   = common.HexToAddress("0x3333567890123456789012345678901234567892")
-		signing_3 = "33337293a4cc2621b61193135a959287aaaaffff"
-		node_3    = newNode(t, minimalNodeCfg{
+		p2p3     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(300))
+		pubKey3  = "33334981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109111"
+		admin3   = common.HexToAddress("0x3333567890123456789012345678901234567892")
+		signing3 = "33337293a4cc2621b61193135a959287aaaaffff"
+		node3    = newNode(t, minimalNodeCfg{
 			id:            "test node 3",
-			pubKey:        pubKey_3,
+			pubKey:        pubKey3,
 			registryChain: registryChain,
-			p2p:           p2p_3,
-			signingAddr:   signing_3,
-			admin:         admin_3,
+			p2p:           p2p3,
+			signingAddr:   signing3,
+			admin:         admin3,
 		})
 
-		p2p_4     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(400))
-		pubKey_4  = "44444981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109222"
-		admin_4   = common.HexToAddress("0x4444567890123456789012345678901234567893")
-		signing_4 = "44447293a4cc2621b61193135a959287aaaaffff"
-		node_4    = newNode(t, minimalNodeCfg{
+		p2p4     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(400))
+		pubKey4  = "44444981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109222"
+		admin4   = common.HexToAddress("0x4444567890123456789012345678901234567893")
+		signing4 = "44447293a4cc2621b61193135a959287aaaaffff"
+		node4    = newNode(t, minimalNodeCfg{
 			id:            "test node 4",
-			pubKey:        pubKey_4,
+			pubKey:        pubKey4,
 			registryChain: registryChain,
-			p2p:           p2p_4,
-			signingAddr:   signing_4,
-			admin:         admin_4,
+			p2p:           p2p4,
+			signingAddr:   signing4,
+			admin:         admin4,
 		})
 
 		// Additional node (n5) to be added
-		p2p_5     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(500))
-		pubKey_5  = "55554981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109333"
-		admin_5   = common.HexToAddress("0x5555567890123456789012345678901234567894")
-		signing_5 = "55557293a4cc2621b61193135a959287aaaabbbb"
-		node_5    = newNode(t, minimalNodeCfg{
+		p2p5     = p2pkey.MustNewV2XXXTestingOnly(big.NewInt(500))
+		pubKey5  = "55554981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109333"
+		admin5   = common.HexToAddress("0x5555567890123456789012345678901234567894")
+		signing5 = "55557293a4cc2621b61193135a959287aaaabbbb"
+		node5    = newNode(t, minimalNodeCfg{
 			id:            "test node 5",
-			pubKey:        pubKey_5,
+			pubKey:        pubKey5,
 			registryChain: registryChain,
-			p2p:           p2p_5,
-			signingAddr:   signing_5,
-			admin:         admin_5,
+			p2p:           p2p5,
+			signingAddr:   signing5,
+			admin:         admin5,
 		})
 
 		// Test capability
@@ -255,14 +252,14 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 		dons: []internal.DonInfo{
 			{
 				Name:         "don 1",
-				Nodes:        []deployment.Node{node_1, node_2, node_3, node_4},
+				Nodes:        []deployment.Node{node1, node2, node3, node4},
 				Capabilities: []internal.DONCapabilityWithConfig{{Capability: testCap, Config: kstest.GetDefaultCapConfig(t, testCap)}},
 			},
 		},
 		nops: []internal.NOP{
 			{
 				Name:  "nop 1",
-				Nodes: []string{node_1.NodeID, node_2.NodeID, node_3.NodeID, node_4.NodeID},
+				Nodes: []string{node1.NodeID, node2.NodeID, node3.NodeID, node4.NodeID},
 			},
 		},
 	}
@@ -280,24 +277,23 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("add node to DON composition", func(t *testing.T) {
-
 		caps, err := testCfg.CapabilitiesRegistry.GetCapabilities(nil)
 		require.NoError(t, err)
-		capIds := make([][32]byte, 0, len(caps))
+		capIDs := make([][32]byte, 0, len(caps))
 		for _, c := range caps {
-			capIds = append(capIds, c.HashedId)
+			capIDs = append(capIDs, c.HashedId)
 		}
 
 		r, err := internal.AddNodes(lggr, &internal.AddNodesRequest{
 			CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
 			RegistryChain:        testCfg.Chain,
-			NodeParams: map[string]capabilities_registry.CapabilitiesRegistryNodeParams{
-				node_5.NodeID: {
+			NodeParams: map[string]kcr.CapabilitiesRegistryNodeParams{
+				node5.NodeID: {
 					NodeOperatorId:      1,
-					P2pId:               node_5.PeerID,
+					P2pId:               node5.PeerID,
 					Signer:              [32]byte{5: 5},
 					EncryptionPublicKey: [32]byte{5: 5},
-					HashedCapabilityIds: capIds,
+					HashedCapabilityIds: capIDs,
 				},
 			},
 		})
@@ -309,7 +305,7 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 			CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
 			Chain:                testCfg.Chain,
 			DonID:                1,
-			P2PIDs:               []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_4.PeerID(), p2p_5.PeerID()},
+			P2PIDs:               []p2pkey.PeerID{p2p1.PeerID(), p2p2.PeerID(), p2p3.PeerID(), p2p4.PeerID(), p2p5.PeerID()},
 			CapabilityConfigs: []internal.CapabilityConfig{
 				{Capability: testCap, Config: testCapCfgB},
 			},
@@ -326,7 +322,7 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 		require.Len(t, updatedDon.NodeP2PIds, 5, "DON should now have 5 nodes")
 
 		// Verify the correct P2P IDs are present
-		expectedP2PIDs := []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_4.PeerID(), p2p_5.PeerID()}
+		expectedP2PIDs := []p2pkey.PeerID{p2p1.PeerID(), p2p2.PeerID(), p2p3.PeerID(), p2p4.PeerID(), p2p5.PeerID()}
 		actualP2PIDs := internal.BytesToPeerIDs(updatedDon.NodeP2PIds)
 
 		require.ElementsMatch(t, expectedP2PIDs, actualP2PIDs, "DON should contain all 5 expected P2P IDs")
@@ -338,7 +334,7 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 				CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
 				Chain:                testCfg.Chain,
 				DonID:                1,
-				P2PIDs:               []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_4.PeerID()},
+				P2PIDs:               []p2pkey.PeerID{p2p1.PeerID(), p2p2.PeerID(), p2p3.PeerID(), p2p4.PeerID()},
 				CapabilityConfigs: []internal.CapabilityConfig{
 					{Capability: testCap, Config: testCapCfgB},
 				},
@@ -355,63 +351,63 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 			require.Len(t, updatedDon.NodeP2PIds, 4, "DON should be back to 4 nodes")
 
 			// Verify the correct P2P IDs are present (should match original 4 nodes)
-			expectedP2PIDs := []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_4.PeerID()}
+			expectedP2PIDs := []p2pkey.PeerID{p2p1.PeerID(), p2p2.PeerID(), p2p3.PeerID(), p2p4.PeerID()}
 			actualP2PIDs := internal.BytesToPeerIDs(updatedDon.NodeP2PIds)
 
 			require.ElementsMatch(t, expectedP2PIDs, actualP2PIDs, "DON should contain original 4 P2P IDs")
 
 			// Verify node 5 is not in the DON
 			for _, actualP2PID := range actualP2PIDs {
-				require.NotEqual(t, p2p_5.PeerID(), actualP2PID, "Node 5 should not be in the DON")
+				require.NotEqual(t, p2p5.PeerID(), actualP2PID, "Node 5 should not be in the DON")
 			}
 		})
 
 		// nested we swap the node we just re-added
 		t.Run("replace nodes in DON composition", func(t *testing.T) {
 			// Register another node (node_6) for replacement test
-			p2p_6 := p2pkey.MustNewV2XXXTestingOnly(big.NewInt(600))
-			pubKey_6 := "66664981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109444"
-			admin_6 := common.HexToAddress("0x6666567890123456789012345678901234567895")
-			signing_6 := "66667293a4cc2621b61193135a959287aaaacccc"
-			node_6 := newNode(t, minimalNodeCfg{
+			p2p6 := p2pkey.MustNewV2XXXTestingOnly(big.NewInt(600))
+			pubKey6 := "66664981a6119ca3f932cdb8c402d71a72d672adae7849f581ecff8b8e109444"
+			admin6 := common.HexToAddress("0x6666567890123456789012345678901234567895")
+			signing6 := "66667293a4cc2621b61193135a959287aaaacccc"
+			node6 := newNode(t, minimalNodeCfg{
 				id:            "test node 6",
-				pubKey:        pubKey_6,
+				pubKey:        pubKey6,
 				registryChain: registryChain,
-				p2p:           p2p_6,
-				signingAddr:   signing_6,
-				admin:         admin_6,
+				p2p:           p2p6,
+				signingAddr:   signing6,
+				admin:         admin6,
 			})
 
 			// Register node_6 with capabilities
 			caps, err := testCfg.CapabilitiesRegistry.GetCapabilities(nil)
 			require.NoError(t, err)
-			capIds := make([][32]byte, 0, len(caps))
+			capIDs := make([][32]byte, 0, len(caps))
 			for _, c := range caps {
-				capIds = append(capIds, c.HashedId)
+				capIDs = append(capIDs, c.HashedId)
 			}
 
 			r, err := internal.AddNodes(lggr, &internal.AddNodesRequest{
 				CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
 				RegistryChain:        testCfg.Chain,
-				NodeParams: map[string]capabilities_registry.CapabilitiesRegistryNodeParams{
-					node_6.NodeID: {
+				NodeParams: map[string]kcr.CapabilitiesRegistryNodeParams{
+					node6.NodeID: {
 						NodeOperatorId:      1,
-						P2pId:               node_6.PeerID,
+						P2pId:               node6.PeerID,
 						Signer:              [32]byte{6: 6},
 						EncryptionPublicKey: [32]byte{6: 6},
-						HashedCapabilityIds: capIds,
+						HashedCapabilityIds: capIDs,
 					},
 				},
 			})
 			require.NoError(t, err)
 			lggr.Debugf("Added node 6: %v", r.AddedNodes)
 
-			// Update DON to replace node_4 with node_6 (keeping nodes 1, 2, 3, and adding 6)
+			// Update DON to replace node4 with node_6 (keeping nodes 1, 2, 3, and adding 6)
 			req := &internal.UpdateDonRequest{
 				CapabilitiesRegistry: testCfg.CapabilitiesRegistry,
 				Chain:                testCfg.Chain,
 				DonID:                1,
-				P2PIDs:               []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_6.PeerID()},
+				P2PIDs:               []p2pkey.PeerID{p2p1.PeerID(), p2p2.PeerID(), p2p3.PeerID(), p2p6.PeerID()},
 				CapabilityConfigs: []internal.CapabilityConfig{
 					{Capability: testCap, Config: testCapCfgB},
 				},
@@ -421,27 +417,27 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 
-			// Verify the DON still has 4 nodes but with node_6 instead of node_4
+			// Verify the DON still has 4 nodes but with node_6 instead of node4
 			updatedDon, err := testCfg.CapabilitiesRegistry.GetDON(&bind.CallOpts{}, 1)
 			require.NoError(t, err)
 			require.Equal(t, uint32(1), updatedDon.Id)
 			require.Len(t, updatedDon.NodeP2PIds, 4, "DON should still have 4 nodes")
 
 			// Verify the correct P2P IDs are present (nodes 1, 2, 3, 6)
-			expectedP2PIDs := []p2pkey.PeerID{p2p_1.PeerID(), p2p_2.PeerID(), p2p_3.PeerID(), p2p_6.PeerID()}
+			expectedP2PIDs := []p2pkey.PeerID{p2p1.PeerID(), p2p2.PeerID(), p2p3.PeerID(), p2p6.PeerID()}
 			actualP2PIDs := internal.BytesToPeerIDs(updatedDon.NodeP2PIds)
 
 			require.ElementsMatch(t, expectedP2PIDs, actualP2PIDs, "DON should contain nodes 1, 2, 3, and 6")
 
-			// Verify node_4 is not in the DON anymore
+			// Verify node4 is not in the DON anymore
 			for _, actualP2PID := range actualP2PIDs {
-				require.NotEqual(t, p2p_4.PeerID(), actualP2PID, "Node 4 should not be in the DON")
+				require.NotEqual(t, p2p4.PeerID(), actualP2PID, "Node 4 should not be in the DON")
 			}
 
 			// Verify node_6 is in the DON
 			foundNode6 := false
 			for _, actualP2PID := range actualP2PIDs {
-				if actualP2PID == p2p_6.PeerID() {
+				if actualP2PID == p2p6.PeerID() {
 					foundNode6 = true
 					break
 				}
@@ -459,7 +455,7 @@ func sortedP2Pids(p2pids [][32]byte) [][32]byte {
 	return p2pids
 }
 
-func capIds(ccs []kcr.CapabilitiesRegistryCapabilityConfiguration) [][32]byte {
+func capIDs(ccs []kcr.CapabilitiesRegistryCapabilityConfiguration) [][32]byte {
 	out := make([][32]byte, len(ccs))
 	for i, cc := range ccs {
 		out[i] = cc.CapabilityId
@@ -486,7 +482,7 @@ func newNode(t *testing.T, cfg minimalNodeCfg) deployment.Node {
 	if err != nil {
 		panic(err)
 	}
-	registryChainDetails, err := chainsel.GetChainDetailsByChainIDAndFamily(strconv.Itoa(int(registryChainID)), chainsel.FamilyEVM)
+	registryChainDetails, err := chainsel.GetChainDetailsByChainIDAndFamily(strconv.Itoa(int(registryChainID)), chainsel.FamilyEVM) //nolint:gosec // G115
 	if err != nil {
 		panic(err)
 	}
@@ -517,11 +513,6 @@ func newNode(t *testing.T, cfg minimalNodeCfg) deployment.Node {
 type setupUpdateDonTestConfig struct {
 	dons []internal.DonInfo
 	nops []internal.NOP
-}
-
-type setupUpdateDonTestResult struct {
-	registry *kcr.CapabilitiesRegistry
-	chain    cldf_evm.Chain
 }
 
 func registerTestDon(t *testing.T, lggr logger.Logger, cfg setupUpdateDonTestConfig) *kstest.SetupTestRegistryResponse {

--- a/deployment/keystone/changeset/update_don.go
+++ b/deployment/keystone/changeset/update_don.go
@@ -19,9 +19,23 @@ var _ cldf.ChangeSet[*UpdateDonRequest] = UpdateDon
 type CapabilityConfig = internal.CapabilityConfig
 
 type UpdateDonRequest struct {
-	RegistryChainSel  uint64
-	P2PIDs            []p2pkey.PeerID    // this is the unique identifier for the don
+	RegistryChainSel uint64
+	// P2PIDs are the peer ids that compose the don
+	P2PIDs            []p2pkey.PeerID
 	CapabilityConfigs []CapabilityConfig // if Config subfield is nil, a default config is used
+
+	// DonID to update
+	// If omitted, the don will be inferred from the P2P keys
+	// If the update request intended to change the nodes in the don, the DonID must be specified
+	DonID int
+
+	// F is the fault tolerance level
+	// if omitted, the existing value fetched from the registry is used
+	F uint8
+
+	// IsPrivate indicates whether the DON is public or private
+	// If omitted, the existing value fetched from the registry is used
+	IsPrivate bool
 
 	// MCMSConfig is optional. If non-nil, the changes will be proposed using MCMS.
 	MCMSConfig *MCMSConfig
@@ -122,5 +136,8 @@ func updateDonRequest(env cldf.Environment, r *UpdateDonRequest) (*internal.Upda
 		P2PIDs:               r.P2PIDs,
 		CapabilityConfigs:    r.CapabilityConfigs,
 		UseMCMS:              r.UseMCMS(),
+		DonID:                r.DonID,
+		F:                    r.F,
+		IsPrivate:            r.IsPrivate,
 	}, nil
 }

--- a/deployment/keystone/changeset/update_don_test.go
+++ b/deployment/keystone/changeset/update_don_test.go
@@ -150,6 +150,220 @@ func TestUpdateDon(t *testing.T) {
 	}
 }
 
+func TestUpdateDon_ChangeComposition(t *testing.T) {
+	t.Parallel()
+
+	// Test capability configurations
+	capACfg, err := proto.Marshal(test.GetDefaultCapConfig(t, capA))
+	require.NoError(t, err)
+
+	type testCase struct {
+		name       string
+		mcmsConfig *changeset.MCMSConfig
+	}
+
+	var mcmsCases = []testCase{
+		{name: "no mcms", mcmsConfig: nil},
+		{name: "with mcms", mcmsConfig: &changeset.MCMSConfig{MinDuration: 0}},
+	}
+
+	for _, mc := range mcmsCases {
+		t.Run(mc.name, func(t *testing.T) {
+			// Setup test environment with initial DON configuration
+			te := test.SetupContractTestEnv(t, test.EnvWrapperConfig{
+				WFDonConfig:     test.DonConfig{Name: "wfDon", N: 4},
+				AssetDonConfig:  test.DonConfig{Name: "assetDon", N: 4},
+				WriterDonConfig: test.DonConfig{Name: "writerDon", N: 4},
+				NumChains:       1,
+				UseMCMS:         mc.mcmsConfig != nil,
+			})
+
+			// Get initial DON info for writerDon
+			initialDons, err := te.CapabilitiesRegistry().GetDONs(nil)
+			require.NoError(t, err)
+
+			var writerDonInfo *kcr.CapabilitiesRegistryDONInfo
+			writerP2PIDs := te.GetP2PIDs("writerDon")
+			for i, don := range initialDons {
+				if internal.SortedHash(internal.PeerIDsToBytes(writerP2PIDs)) == internal.SortedHash(don.NodeP2PIds) {
+					writerDonInfo = &initialDons[i]
+					break
+				}
+			}
+			require.NotNil(t, writerDonInfo, "writerDon not found in registry")
+
+			// Store original DON ID and node count for verification
+			donID := int(writerDonInfo.Id)
+			originalNodeCount := len(writerDonInfo.NodeP2PIds)
+
+			t.Run("add node to DON composition", func(t *testing.T) {
+				// Add one more node from assetDon to writerDon
+				assetP2PIDs := te.GetP2PIDs("assetDon")
+				newP2PIDs := append(writerP2PIDs, assetP2PIDs[0]) // Add first asset node
+
+				cfg := changeset.UpdateDonRequest{
+					RegistryChainSel: te.RegistrySelector,
+					P2PIDs:           newP2PIDs,
+					DonID:            donID, // Explicitly specify DON ID
+					CapabilityConfigs: []changeset.CapabilityConfig{
+						{Capability: capA, Config: capACfg},
+					},
+					MCMSConfig:  mc.mcmsConfig,
+					RegistryRef: te.CapabilityRegistryAddressRef(),
+				}
+
+				csOut, err := changeset.UpdateDon(te.Env, &cfg)
+				require.NoError(t, err)
+
+				if mc.mcmsConfig != nil {
+					require.NotNil(t, csOut.MCMSTimelockProposals)
+					require.Len(t, csOut.MCMSTimelockProposals, 1)
+
+					// Apply the MCMS proposal
+					applyErr := applyProposal(t, te, commonchangeset.Configure(
+						cldf.CreateLegacyChangeSet(changeset.UpdateDon),
+						&cfg,
+					))
+					require.NoError(t, applyErr)
+				}
+
+				// Verify DON now has one additional node
+				updatedDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID))
+				require.NoError(t, err)
+				require.Equal(t, uint32(donID), updatedDon.Id, "DON ID should remain the same")
+				require.Len(t, updatedDon.NodeP2PIds, originalNodeCount+1, "DON should have one additional node")
+
+				// Verify the new P2P ID is present
+				actualP2PIDs := internal.BytesToPeerIDs(updatedDon.NodeP2PIds)
+				require.ElementsMatch(t, newP2PIDs, actualP2PIDs, "DON should contain all expected P2P IDs")
+			})
+
+			t.Run("remove node from DON composition", func(t *testing.T) {
+				// Remove one node from the current composition
+				currentDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID))
+				require.NoError(t, err)
+
+				currentP2PIDs := internal.BytesToPeerIDs(currentDon.NodeP2PIds)
+				// Remove the last node (should be the one we added)
+				reducedP2PIDs := currentP2PIDs[:len(currentP2PIDs)-1]
+
+				cfg := changeset.UpdateDonRequest{
+					RegistryChainSel: te.RegistrySelector,
+					P2PIDs:           reducedP2PIDs,
+					DonID:            donID, // Explicitly specify DON ID
+					CapabilityConfigs: []changeset.CapabilityConfig{
+						{Capability: capA, Config: capACfg},
+					},
+					MCMSConfig:  mc.mcmsConfig,
+					RegistryRef: te.CapabilityRegistryAddressRef(),
+				}
+
+				csOut, err := changeset.UpdateDon(te.Env, &cfg)
+				require.NoError(t, err)
+
+				if mc.mcmsConfig != nil {
+					require.NotNil(t, csOut.MCMSTimelockProposals)
+					require.Len(t, csOut.MCMSTimelockProposals, 1)
+
+					// Apply the MCMS proposal
+					applyErr := applyProposal(t, te, commonchangeset.Configure(
+						cldf.CreateLegacyChangeSet(changeset.UpdateDon),
+						&cfg,
+					))
+					require.NoError(t, applyErr)
+				}
+
+				// Verify DON is back to original node count
+				updatedDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID))
+				require.NoError(t, err)
+				require.Equal(t, uint32(donID), updatedDon.Id, "DON ID should remain the same")
+				require.Len(t, updatedDon.NodeP2PIds, originalNodeCount, "DON should be back to original node count")
+
+				// Verify the correct P2P IDs are present
+				actualP2PIDs := internal.BytesToPeerIDs(updatedDon.NodeP2PIds)
+				require.ElementsMatch(t, reducedP2PIDs, actualP2PIDs, "DON should contain expected P2P IDs")
+			})
+
+			t.Run("replace nodes in DON composition", func(t *testing.T) {
+				// Replace some nodes from writerDon with nodes from assetDon
+				assetP2PIDs := te.GetP2PIDs("assetDon")
+
+				// Keep first 2 nodes from writer, add 2 nodes from asset
+				mixedP2PIDs := append(writerP2PIDs[:2], assetP2PIDs[:2]...)
+
+				cfg := changeset.UpdateDonRequest{
+					RegistryChainSel: te.RegistrySelector,
+					P2PIDs:           mixedP2PIDs,
+					DonID:            donID, // Explicitly specify DON ID
+					CapabilityConfigs: []changeset.CapabilityConfig{
+						{Capability: capA, Config: capACfg},
+					},
+					MCMSConfig:  mc.mcmsConfig,
+					RegistryRef: te.CapabilityRegistryAddressRef(),
+				}
+
+				csOut, err := changeset.UpdateDon(te.Env, &cfg)
+				require.NoError(t, err)
+
+				if mc.mcmsConfig != nil {
+					require.NotNil(t, csOut.MCMSTimelockProposals)
+					require.Len(t, csOut.MCMSTimelockProposals, 1)
+
+					// Apply the MCMS proposal
+					applyErr := applyProposal(t, te, commonchangeset.Configure(
+						cldf.CreateLegacyChangeSet(changeset.UpdateDon),
+						&cfg,
+					))
+					require.NoError(t, applyErr)
+				}
+
+				// Verify DON has the mixed composition
+				updatedDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID))
+				require.NoError(t, err)
+				require.Equal(t, uint32(donID), updatedDon.Id, "DON ID should remain the same")
+				require.Len(t, updatedDon.NodeP2PIds, len(mixedP2PIDs), "DON should have expected node count")
+
+				// Verify the correct P2P IDs are present
+				actualP2PIDs := internal.BytesToPeerIDs(updatedDon.NodeP2PIds)
+				require.ElementsMatch(t, mixedP2PIDs, actualP2PIDs, "DON should contain mixed P2P IDs")
+
+				// Verify capabilities are still configured correctly
+				assertDonContainsCapabilities(t, te.CapabilitiesRegistry(), []kcr.CapabilitiesRegistryCapability{capA}, actualP2PIDs)
+			})
+
+			t.Run("error when DonID not specified and nodes change", func(t *testing.T) {
+				// Try to change composition without specifying DonID
+				assetP2PIDs := te.GetP2PIDs("assetDon")
+				newP2PIDs := append(writerP2PIDs, assetP2PIDs[0])
+
+				cfg := changeset.UpdateDonRequest{
+					RegistryChainSel: te.RegistrySelector,
+					P2PIDs:           newP2PIDs,
+					// DonID intentionally omitted
+					CapabilityConfigs: []changeset.CapabilityConfig{
+						{Capability: capA, Config: capACfg},
+					},
+					MCMSConfig:  mc.mcmsConfig,
+					RegistryRef: te.CapabilityRegistryAddressRef(),
+				}
+
+				// This should either work (if the system can infer the DON) or fail gracefully
+				// The behavior depends on the implementation in update_don.go
+				_, err := changeset.UpdateDon(te.Env, &cfg)
+
+				// If the system requires DonID for composition changes, this should error
+				// If it can infer the DON, it should work
+				// The test documents the current behavior
+				if err != nil {
+					t.Logf("Expected behavior: UpdateDon requires DonID when changing composition: %v", err)
+				} else {
+					t.Log("UpdateDon successfully inferred DON from P2P IDs")
+				}
+			})
+		})
+	}
+}
+
 func assertDonContainsCapabilities(t *testing.T, registry *kcr.CapabilitiesRegistry, want []kcr.CapabilitiesRegistryCapability, p2pIDs []p2pkey.PeerID) {
 	dons, err := registry.GetDONs(nil)
 	require.NoError(t, err)

--- a/deployment/keystone/changeset/update_don_test.go
+++ b/deployment/keystone/changeset/update_don_test.go
@@ -199,7 +199,8 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 			t.Run("add node to DON composition", func(t *testing.T) {
 				// Add one more node from assetDon to writerDon
 				assetP2PIDs := te.GetP2PIDs("assetDon")
-				newP2PIDs := append(writerP2PIDs, assetP2PIDs[0]) // Add first asset node
+				newP2PIDs := writerP2PIDs[:]
+				newP2PIDs = append(newP2PIDs, assetP2PIDs[0]) // Add first asset node
 
 				cfg := changeset.UpdateDonRequest{
 					RegistryChainSel: te.RegistrySelector,
@@ -228,9 +229,9 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 				}
 
 				// Verify DON now has one additional node
-				updatedDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID))
+				updatedDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID)) //nolint:gosec // G115
 				require.NoError(t, err)
-				require.Equal(t, uint32(donID), updatedDon.Id, "DON ID should remain the same")
+				require.Equal(t, uint32(donID), updatedDon.Id, "DON ID should remain the same") //nolint:gosec // G115
 				require.Len(t, updatedDon.NodeP2PIds, originalNodeCount+1, "DON should have one additional node")
 
 				// Verify the new P2P ID is present
@@ -240,7 +241,7 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 
 			t.Run("remove node from DON composition", func(t *testing.T) {
 				// Remove one node from the current composition
-				currentDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID))
+				currentDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID)) //nolint:gosec // G115
 				require.NoError(t, err)
 
 				currentP2PIDs := internal.BytesToPeerIDs(currentDon.NodeP2PIds)
@@ -274,9 +275,9 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 				}
 
 				// Verify DON is back to original node count
-				updatedDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID))
+				updatedDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID)) //nolint:gosec // G115
 				require.NoError(t, err)
-				require.Equal(t, uint32(donID), updatedDon.Id, "DON ID should remain the same")
+				require.Equal(t, uint32(donID), updatedDon.Id, "DON ID should remain the same") //nolint:gosec // G115
 				require.Len(t, updatedDon.NodeP2PIds, originalNodeCount, "DON should be back to original node count")
 
 				// Verify the correct P2P IDs are present
@@ -287,9 +288,9 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 			t.Run("replace nodes in DON composition", func(t *testing.T) {
 				// Replace some nodes from writerDon with nodes from assetDon
 				assetP2PIDs := te.GetP2PIDs("assetDon")
-
+				mixedP2PIDs := writerP2PIDs[:]
 				// Keep first 2 nodes from writer, add 2 nodes from asset
-				mixedP2PIDs := append(writerP2PIDs[:2], assetP2PIDs[:2]...)
+				mixedP2PIDs = append(mixedP2PIDs, assetP2PIDs[:2]...)
 
 				cfg := changeset.UpdateDonRequest{
 					RegistryChainSel: te.RegistrySelector,
@@ -318,9 +319,9 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 				}
 
 				// Verify DON has the mixed composition
-				updatedDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID))
+				updatedDon, err := te.CapabilitiesRegistry().GetDON(nil, uint32(donID)) //nolint:gosec // G115
 				require.NoError(t, err)
-				require.Equal(t, uint32(donID), updatedDon.Id, "DON ID should remain the same")
+				require.Equal(t, uint32(donID), updatedDon.Id, "DON ID should remain the same") //nolint:gosec // G115
 				require.Len(t, updatedDon.NodeP2PIds, len(mixedP2PIDs), "DON should have expected node count")
 
 				// Verify the correct P2P IDs are present
@@ -334,7 +335,8 @@ func TestUpdateDon_ChangeComposition(t *testing.T) {
 			t.Run("error when DonID not specified and nodes change", func(t *testing.T) {
 				// Try to change composition without specifying DonID
 				assetP2PIDs := te.GetP2PIDs("assetDon")
-				newP2PIDs := append(writerP2PIDs, assetP2PIDs[0])
+				newP2PIDs := writerP2PIDs[:]
+				newP2PIDs = append(newP2PIDs, assetP2PIDs[0])
 
 				cfg := changeset.UpdateDonRequest{
 					RegistryChainSel: te.RegistrySelector,


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
[DF-21734](https://smartcontract-it.atlassian.net/browse/DF-21734)

The asset DON needs to swap out nodes. This PR enables that feature in a migration.

Previously we were limited to only changing the capabilities on a don, not the nodes that compose it.

The key change in accepting all the parameters as optional inputs. The rest is all tests.
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->

proven in fork test here
- https://github.com/smartcontractkit/chainlink-deployments/pull/5223


[DF-21734]: https://smartcontract-it.atlassian.net/browse/DF-21734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ