### PR TITLE
Fix compilation of workflows on any machine.

### DIFF
--- a/system-tests/lib/cre/workflow/compile.go
+++ b/system-tests/lib/cre/workflow/compile.go
@@ -34,7 +34,7 @@ func CompileWorkflow(workflowFilePath, workflowName string) (string, error) {
 	buffer := bytes.Buffer{}
 	compileCmd := exec.Command("go", "build", "-o", workflowWasmPath, filepath.Base(workflowFilePath)) // #nosec G204 -- we control the value of the cmd so the lint/sec error is a false positive
 	compileCmd.Dir = filepath.Dir(workflowFilePath)
-	compileCmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm")
+	compileCmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=wasip1", "GOARCH=wasm")
 	compileCmd.Stdout = &buffer
 	compileCmd.Stderr = &buffer
 	if err := compileCmd.Run(); err != nil {


### PR DESCRIPTION
[CRE-681](https://smartcontract-it.atlassian.net/browse/CRE-681)
To compile a workflow with no errors, sometimes it is necessary to run the command with "CGO_ENABLED=0".


[CRE-681]: https://smartcontract-it.atlassian.net/browse/CRE-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ