### PR TITLE
feat(deployments): Aptos upgrade packages changeset

### DIFF
--- a/deployment/ccip/changeset/aptos/config/upgrade.go
+++ b/deployment/ccip/changeset/aptos/config/upgrade.go
@@ -1,0 +1,12 @@
+package config
+
+import "github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+
+type UpgradeAptosChainConfig struct {
+	ChainSelector  uint64
+	UpgradeCCIP    bool
+	UpgradeOffRamp bool
+	UpgradeOnRamp  bool
+	UpgradeRouter  bool
+	MCMS           *proposalutils.TimelockConfig
+}

--- a/deployment/ccip/changeset/aptos/cs_upgrade_aptos_ccip.go
+++ b/deployment/ccip/changeset/aptos/cs_upgrade_aptos_ccip.go
@@ -1,0 +1,109 @@
+package aptos
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/types"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/operation"
+	seq "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/sequence"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/utils"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+)
+
+var _ cldf.ChangeSetV2[config.UpgradeAptosChainConfig] = UpgradeAptosChain{}
+
+// DeployAptosChain deploys Aptos chain packages and modules
+type UpgradeAptosChain struct{}
+
+func (cs UpgradeAptosChain) VerifyPreconditions(env cldf.Environment, cfg config.UpgradeAptosChainConfig) error {
+	if !(cfg.UpgradeCCIP || cfg.UpgradeOffRamp || cfg.UpgradeOnRamp || cfg.UpgradeRouter) {
+		return errors.New("no upgrades selected")
+	}
+	state, err := stateview.LoadOnchainState(env)
+	if err != nil {
+		return fmt.Errorf("failed to load Aptos onchain state: %w", err)
+	}
+	var errs []error
+	// Validate supported chain
+	supportedChains := state.SupportedChains()
+	if _, ok := supportedChains[cfg.ChainSelector]; !ok {
+		errs = append(errs, fmt.Errorf("unsupported chain: %d", cfg.ChainSelector))
+	}
+	// Validate MCMS config
+	if cfg.MCMS == nil {
+		errs = append(errs, errors.New("MCMS config is required for AddTokenPool changeset"))
+	}
+	// Check CCIP Package
+	ccipAddress := state.AptosChains[cfg.ChainSelector].CCIPAddress
+	client := env.BlockChains.AptosChains()[cfg.ChainSelector].Client
+	if ccipAddress == (aptos.AccountAddress{}) {
+		return fmt.Errorf("package CCIP is not deployed on Aptos chain %d", cfg.ChainSelector)
+	}
+	// Check OnRamp module
+	hasOnramp, err := utils.IsModuleDeployed(client, ccipAddress, "onramp")
+	if err != nil || !hasOnramp {
+		return fmt.Errorf("onRamp module is not deployed on Aptos chain %d: %w", cfg.ChainSelector, err)
+	}
+	// Check OffRamp module
+	hasOfframp, err := utils.IsModuleDeployed(client, ccipAddress, "offramp")
+	if err != nil || !hasOfframp {
+		return fmt.Errorf("offRamp module is not deployed on Aptos chain %d: %w", cfg.ChainSelector, err)
+	}
+	// Check Router module
+	hasRouter, err := utils.IsModuleDeployed(client, ccipAddress, "router")
+	if err != nil || !hasRouter {
+		return fmt.Errorf("router module is not deployed on Aptos chain %d: %w", cfg.ChainSelector, err)
+	}
+
+	return nil
+}
+
+func (cs UpgradeAptosChain) Apply(env cldf.Environment, cfg config.UpgradeAptosChainConfig) (cldf.ChangesetOutput, error) {
+	timeLockProposals := []mcms.TimelockProposal{}
+	mcmsOperations := []types.BatchOperation{}
+	seqReports := make([]operations.Report[any, any], 0)
+
+	state, err := stateview.LoadOnchainState(env)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load Aptos onchain state: %w", err)
+	}
+
+	deps := operation.AptosDeps{
+		AptosChain:       env.BlockChains.AptosChains()[cfg.ChainSelector],
+		CCIPOnChainState: state,
+	}
+
+	// Execute the sequence
+	upgradeSeqReport, err := operations.ExecuteSequence(env.OperationsBundle, seq.UpgradeCCIPSequence, deps, cfg)
+	if err != nil {
+		return cldf.ChangesetOutput{}, err
+	}
+	seqReports = append(seqReports, upgradeSeqReport.ExecutionReports...)
+	mcmsOperations = append(mcmsOperations, upgradeSeqReport.Output...)
+
+	// Generate MCMS proposals
+	proposal, err := utils.GenerateProposal(
+		env,
+		state.AptosChains[cfg.ChainSelector].MCMSAddress,
+		cfg.ChainSelector,
+		mcmsOperations,
+		"Upgrade chain contracts on Aptos chain",
+		*cfg.MCMS,
+	)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate MCMS proposal for Aptos chain %d: %w", cfg.ChainSelector, err)
+	}
+	timeLockProposals = append(timeLockProposals, *proposal)
+
+	return cldf.ChangesetOutput{
+		MCMSTimelockProposals: timeLockProposals,
+		Reports:               seqReports,
+	}, nil
+}

--- a/deployment/ccip/changeset/aptos/cs_upgrade_aptos_ccip.go
+++ b/deployment/ccip/changeset/aptos/cs_upgrade_aptos_ccip.go
@@ -23,14 +23,14 @@ var _ cldf.ChangeSetV2[config.UpgradeAptosChainConfig] = UpgradeAptosChain{}
 type UpgradeAptosChain struct{}
 
 func (cs UpgradeAptosChain) VerifyPreconditions(env cldf.Environment, cfg config.UpgradeAptosChainConfig) error {
-	if !(cfg.UpgradeCCIP || cfg.UpgradeOffRamp || cfg.UpgradeOnRamp || cfg.UpgradeRouter) {
-		return errors.New("no upgrades selected")
+	var errs []error
+	if !cfg.UpgradeCCIP && !cfg.UpgradeOffRamp && !cfg.UpgradeOnRamp && !cfg.UpgradeRouter {
+		errs = append(errs, errors.New("no upgrades selected"))
 	}
 	state, err := stateview.LoadOnchainState(env)
 	if err != nil {
-		return fmt.Errorf("failed to load Aptos onchain state: %w", err)
+		errs = append(errs, fmt.Errorf("failed to load Aptos onchain state: %w", err))
 	}
-	var errs []error
 	// Validate supported chain
 	supportedChains := state.SupportedChains()
 	if _, ok := supportedChains[cfg.ChainSelector]; !ok {
@@ -44,25 +44,25 @@ func (cs UpgradeAptosChain) VerifyPreconditions(env cldf.Environment, cfg config
 	ccipAddress := state.AptosChains[cfg.ChainSelector].CCIPAddress
 	client := env.BlockChains.AptosChains()[cfg.ChainSelector].Client
 	if ccipAddress == (aptos.AccountAddress{}) {
-		return fmt.Errorf("package CCIP is not deployed on Aptos chain %d", cfg.ChainSelector)
+		errs = append(errs, fmt.Errorf("package CCIP is not deployed on Aptos chain %d", cfg.ChainSelector))
 	}
 	// Check OnRamp module
 	hasOnramp, err := utils.IsModuleDeployed(client, ccipAddress, "onramp")
 	if err != nil || !hasOnramp {
-		return fmt.Errorf("onRamp module is not deployed on Aptos chain %d: %w", cfg.ChainSelector, err)
+		errs = append(errs, fmt.Errorf("onRamp module is not deployed on Aptos chain %d: %w", cfg.ChainSelector, err))
 	}
 	// Check OffRamp module
 	hasOfframp, err := utils.IsModuleDeployed(client, ccipAddress, "offramp")
 	if err != nil || !hasOfframp {
-		return fmt.Errorf("offRamp module is not deployed on Aptos chain %d: %w", cfg.ChainSelector, err)
+		errs = append(errs, fmt.Errorf("offRamp module is not deployed on Aptos chain %d: %w", cfg.ChainSelector, err))
 	}
 	// Check Router module
 	hasRouter, err := utils.IsModuleDeployed(client, ccipAddress, "router")
 	if err != nil || !hasRouter {
-		return fmt.Errorf("router module is not deployed on Aptos chain %d: %w", cfg.ChainSelector, err)
+		errs = append(errs, fmt.Errorf("router module is not deployed on Aptos chain %d: %w", cfg.ChainSelector, err))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (cs UpgradeAptosChain) Apply(env cldf.Environment, cfg config.UpgradeAptosChainConfig) (cldf.ChangesetOutput, error) {

--- a/deployment/ccip/changeset/aptos/cs_upgrade_aptos_ccip_test.go
+++ b/deployment/ccip/changeset/aptos/cs_upgrade_aptos_ccip_test.go
@@ -1,0 +1,54 @@
+package aptos_test
+
+import (
+	"testing"
+	"time"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	aptoscs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+)
+
+func TestUpgradeAptosChain_Apply(t *testing.T) {
+	t.Skip("skipping - no need to run these tests in CI")
+	t.Parallel()
+	// Setup environment with contracts deployed
+	deployedEnvironment, _ := testhelpers.NewMemoryEnvironment(
+		t,
+		testhelpers.WithAptosChains(1),
+	)
+	env := deployedEnvironment.Env
+
+	chainSelector := env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyAptos))[0]
+
+	cfg := config.UpgradeAptosChainConfig{
+		ChainSelector: chainSelector,
+		MCMS: &proposalutils.TimelockConfig{
+			MinDelay:     time.Second,
+			MCMSAction:   mcmstypes.TimelockActionSchedule,
+			OverrideRoot: false,
+		},
+		UpgradeCCIP:    true,
+		UpgradeOffRamp: true,
+		UpgradeOnRamp:  true,
+		UpgradeRouter:  true,
+	}
+
+	// Apply the changeset
+	env, out, err := commonchangeset.ApplyChangesets(t, env, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(aptoscs.UpgradeAptosChain{}, cfg),
+	})
+
+	proposals := out[0].MCMSTimelockProposals
+	require.Len(t, proposals, 1)
+	require.Len(t, proposals[0].Operations, 7)
+	require.NoError(t, err)
+
+}

--- a/deployment/ccip/changeset/aptos/cs_upgrade_aptos_ccip_test.go
+++ b/deployment/ccip/changeset/aptos/cs_upgrade_aptos_ccip_test.go
@@ -50,5 +50,4 @@ func TestUpgradeAptosChain_Apply(t *testing.T) {
 	require.Len(t, proposals, 1)
 	require.Len(t, proposals[0].Operations, 7)
 	require.NoError(t, err)
-
 }

--- a/deployment/ccip/changeset/aptos/operation/ccip.go
+++ b/deployment/ccip/changeset/aptos/operation/ccip.go
@@ -19,7 +19,7 @@ import (
 // OP: DeployCCIPOp deploys the CCIP package on Aptos chain
 type DeployCCIPInput struct {
 	MCMSAddress aptos.AccountAddress
-	IsUpdate    bool
+	IsUpgrade   bool
 }
 
 type DeployCCIPOutput struct {
@@ -37,8 +37,8 @@ var DeployCCIPOp = operations.NewOperation(
 func deployCCIP(b operations.Bundle, deps AptosDeps, in DeployCCIPInput) (DeployCCIPOutput, error) {
 	onChainState := deps.CCIPOnChainState.AptosChains[deps.AptosChain.Selector]
 	// Validate there's no package deployed XOR is update
-	if (onChainState.CCIPAddress == (aptos.AccountAddress{})) == (in.IsUpdate) {
-		if in.IsUpdate {
+	if (onChainState.CCIPAddress == (aptos.AccountAddress{})) == (in.IsUpgrade) {
+		if in.IsUpgrade {
 			b.Logger.Infow("Trying to update a non-deployed package", "addr", onChainState.CCIPAddress.StringLong())
 			return DeployCCIPOutput{}, fmt.Errorf("CCIP package not deployed on Aptos chain %d", deps.AptosChain.Selector)
 		}
@@ -52,7 +52,7 @@ func deployCCIP(b operations.Bundle, deps AptosDeps, in DeployCCIPInput) (Deploy
 	if err != nil {
 		return DeployCCIPOutput{}, fmt.Errorf("failed to compile and create deploy operations: %w", err)
 	}
-	if in.IsUpdate {
+	if in.IsUpgrade {
 		return DeployCCIPOutput{
 			MCMSOperations: operations,
 		}, nil

--- a/deployment/ccip/changeset/aptos/sequence/deploy_ccip.go
+++ b/deployment/ccip/changeset/aptos/sequence/deploy_ccip.go
@@ -48,7 +48,7 @@ func deployCCIPSequence(b operations.Bundle, deps operation.AptosDeps, in Deploy
 	// Generate batch operations to deploy CCIP package
 	deployCCIPInput := operation.DeployCCIPInput{
 		MCMSAddress: in.MCMSAddress,
-		IsUpdate:    false,
+		IsUpgrade:   false,
 	}
 	deployCCIPReport, err := operations.ExecuteOperation(b, operation.DeployCCIPOp, deps, deployCCIPInput)
 	if err != nil {

--- a/deployment/ccip/changeset/aptos/sequence/upgrade_ccip.go
+++ b/deployment/ccip/changeset/aptos/sequence/upgrade_ccip.go
@@ -1,0 +1,73 @@
+package sequence
+
+import (
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/operation"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/utils"
+)
+
+var UpgradeCCIPSequence = operations.NewSequence(
+	"upgrade-aptos-ccip-sequence",
+	operation.Version1_0_0,
+	"Upgrade Aptos CCIP contracts",
+	upgradeCCIPSequence,
+)
+
+func upgradeCCIPSequence(b operations.Bundle, deps operation.AptosDeps, in config.UpgradeAptosChainConfig) ([]mcmstypes.BatchOperation, error) {
+	var mcmsOperations []mcmstypes.BatchOperation
+	mcmsAddress := deps.CCIPOnChainState.AptosChains[deps.AptosChain.Selector].MCMSAddress
+	// Cleanup staging area
+	cleanupReport, err := operations.ExecuteOperation(b, operation.CleanupStagingAreaOp, deps, mcmsAddress)
+	if err != nil {
+		return nil, err
+	}
+	if len(cleanupReport.Output.Transactions) > 0 {
+		mcmsOperations = append(mcmsOperations, cleanupReport.Output)
+	}
+
+	if in.UpgradeCCIP {
+		deployCCIPInput := operation.DeployCCIPInput{
+			MCMSAddress: mcmsAddress,
+			IsUpgrade:   in.UpgradeCCIP,
+		}
+		deployCCIPReport, err := operations.ExecuteOperation(b, operation.DeployCCIPOp, deps, deployCCIPInput)
+		if err != nil {
+			return nil, err
+		}
+		mcmsOperations = append(mcmsOperations, utils.ToBatchOperations(deployCCIPReport.Output.MCMSOperations)...)
+	}
+
+	deployModulesInput := operation.DeployModulesInput{
+		MCMSAddress: mcmsAddress,
+		CCIPAddress: deps.CCIPOnChainState.AptosChains[deps.AptosChain.Selector].CCIPAddress,
+	}
+
+	if in.UpgradeOnRamp {
+		deployOnRampReport, err := operations.ExecuteOperation(b, operation.DeployOnRampOp, deps, deployModulesInput)
+		if err != nil {
+			return nil, err
+		}
+		mcmsOperations = append(mcmsOperations, utils.ToBatchOperations(deployOnRampReport.Output)...)
+	}
+
+	if in.UpgradeOffRamp {
+		deployOffRampReport, err := operations.ExecuteOperation(b, operation.DeployOffRampOp, deps, deployModulesInput)
+		if err != nil {
+			return nil, err
+		}
+		mcmsOperations = append(mcmsOperations, utils.ToBatchOperations(deployOffRampReport.Output)...)
+	}
+
+	if in.UpgradeRouter {
+		deployRouterReport, err := operations.ExecuteOperation(b, operation.DeployRouterOp, deps, deployModulesInput)
+		if err != nil {
+			return nil, err
+		}
+		mcmsOperations = append(mcmsOperations, utils.ToBatchOperations(deployRouterReport.Output)...)
+	}
+
+	return mcmsOperations, nil
+}


### PR DESCRIPTION
# Summary

This pull request introduces a new changeset for upgrading CCIP contracts on the Aptos.

# Features
* Added new configuration struct `UpgradeAptosChainConfig` to support selective upgrades of CCIP, OnRamp, OffRamp, and Router modules
* Implemented the `UpgradeAptosChain` changeset, including precondition verification, MCMS proposal generation, and integration with the upgrade sequence (`cs_upgrade_aptos_ccip.go`).

# Testing
* Added a test for the upgrade changeset to validate proposal creation and operation count, ensuring the upgrade logic works as intended (`cs_upgrade_aptos_ccip_test.go`). Which is skipped to not overload CI.