### PR TITLE
Revert "[CRE-670] Temporarily disable Don2Don connection optimization"

### DIFF
--- a/.changeset/cuddly-starfishes-relax.md
+++ b/.changeset/cuddly-starfishes-relax.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-#bugfix Temporarily disable Don2Don connection optimization

--- a/.changeset/cuddly-starfishes-relax.md
+++ b/.changeset/cuddly-starfishes-relax.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#bugfix Temporarily disable Don2Don connection optimization

--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -178,11 +178,8 @@ func (w *launcher) peers(
 		if !candidatePeerDON.DON.IsPublic {
 			continue
 		}
-		filterOut := !isBootstrap && filterDon2Don(w.lggr, belongsToACapabilityDON, belongsToAWorkflowDON, candidatePeerDON)
-		if filterOut {
-			w.lggr.Debugw("candidate DON to filter out from peer list", "donID", candidatePeerDON.ID)
-			// TODO(CRE-670): Not filtering due to extremely noisy RageP2P warn logs. Uncomment when log volume is reduced.
-			// continue
+		if !isBootstrap && filterDon2Don(w.lggr, belongsToACapabilityDON, belongsToAWorkflowDON, candidatePeerDON) {
+			continue
 		}
 		for _, nid := range candidatePeerDON.DON.Members {
 			allPeers[nid] = defaultStreamConfig

--- a/core/capabilities/launcher_test.go
+++ b/core/capabilities/launcher_test.go
@@ -1161,7 +1161,6 @@ func TestLauncher_SucceedsEvenIfDispatcherAlreadyHasReceiver(t *testing.T) {
 }
 
 func TestLauncher_SuccessfullyFilterDon2Don(t *testing.T) {
-	t.Skip("TODO: CRE-670")
 	lggr := logger.Test(t)
 	registry := NewRegistry(lggr)
 	dispatcher := remoteMocks.NewDispatcher(t)


### PR DESCRIPTION
Reverts smartcontractkit/chainlink#18918

This causes unexpected problems, let's keep the optimization.