### PR TITLE
feat: add node-auth for workflow storage and billing

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -30,6 +30,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/billing"
 	"github.com/smartcontractkit/chainlink-common/pkg/custmsg"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+	nodeauthjwt "github.com/smartcontractkit/chainlink-common/pkg/nodeauth/jwt"
+	nodeauthjwttypes "github.com/smartcontractkit/chainlink-common/pkg/nodeauth/types"
 	commonservices "github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/settings/limits"
 	"github.com/smartcontractkit/chainlink-common/pkg/storage"
@@ -320,6 +322,12 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 
 	var billingClient metering.BillingClient
 
+	signer, CSAPubKey, p2pID, err := keystore.BuildNodeAuth(ctx, csaKeystore, keyStore.P2P())
+	if err != nil {
+		return nil, fmt.Errorf("failed to build node auth: %w", err)
+	}
+	jwtGenerator := nodeauthjwt.NewNodeJWTGenerator(signer, CSAPubKey, p2pID, nodeauthjwttypes.EnvironmentNameProductionMainnet)
+
 	if opts.BillingClient != nil {
 		billingClient = opts.BillingClient
 	} else if cfg.Billing().URL() != "" {
@@ -328,6 +336,8 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 		if opts.Config.Billing().TLSEnabled() {
 			workflowOpts = append(workflowOpts, billing.WithWorkflowTransportCredentials(credentials.NewClientTLSFromCert(nil, "")))
 		}
+
+		workflowOpts = append(workflowOpts, billing.WithJWTGenerator(jwtGenerator))
 
 		billingClient, err = billing.NewWorkflowClient(globalLogger, opts.Config.Billing().URL(), workflowOpts...)
 		if err != nil {
@@ -344,6 +354,8 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 		if opts.Config.Capabilities().WorkflowRegistry().WorkflowStorage().TLSEnabled() {
 			workflowOpts = append(workflowOpts, storage.WithWorkflowTransportCredentials(credentials.NewClientTLSFromCert(nil, "")))
 		}
+
+		workflowOpts = append(workflowOpts, storage.WithJWTGenerator(jwtGenerator))
 
 		storageClient, err = storage.NewWorkflowClient(globalLogger, opts.Config.Capabilities().WorkflowRegistry().WorkflowStorage().URL(), workflowOpts...)
 		if err != nil {

--- a/core/services/keystore/nodeauth.go
+++ b/core/services/keystore/nodeauth.go
@@ -1,0 +1,47 @@
+package keystore
+
+import (
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+
+	"github.com/smartcontractkit/libocr/ragep2p/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
+)
+
+func BuildNodeAuth(
+	ctx context.Context,
+	keyStoreCSA CSA,
+	keyStoreP2P P2P,
+) (
+	signer *core.Ed25519Signer,
+	csaPubkey ed25519.PublicKey,
+	p2pID types.PeerID,
+	err error,
+) {
+	csaKey, err := GetDefault(ctx, keyStoreCSA)
+	if err != nil {
+		return nil, nil, types.PeerID{}, err
+	}
+
+	p2pKey, err := GetDefault(ctx, keyStoreP2P)
+	if err != nil {
+		return nil, nil, types.PeerID{}, err
+	}
+
+	// Create ed25519 signer from the node's csa private key
+	signFn := func(ctx context.Context, account string, data []byte) (signed []byte, err error) {
+		return csaKey.Sign(rand.Reader, data, crypto.Hash(0))
+	}
+
+	signer, err = core.NewEd25519Signer(hex.EncodeToString(csaKey.PublicKey), signFn)
+	if err != nil {
+		return nil, nil, types.PeerID{}, err
+	}
+	csaPubkey = csaKey.PublicKey
+	p2pID = types.PeerID(p2pKey.PeerID())
+	return
+}


### PR DESCRIPTION
Add integration with nodeauth lib - required for storage, billing service to use JWT tokens sent by the node for authn and authz.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
