### PR TITLE
Update e2e chain add to skip deployment

### DIFF
--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -182,12 +182,12 @@ func addCandidatesForNewChainPrecondition(e cldf.Environment, c AddCandidatesFor
 	if err := c.prerequisiteConfigForNewChain().Validate(); err != nil {
 		return fmt.Errorf("failed to validate prerequisite config for new chain: %w", err)
 	}
-	
+
 	if !c.SkipDeployments {
-	if err := c.deploymentConfigForNewChain().Validate(); err != nil {
-		return fmt.Errorf("failed to validate deployment config for new chain: %w", err)
+		if err := c.deploymentConfigForNewChain().Validate(); err != nil {
+			return fmt.Errorf("failed to validate deployment config for new chain: %w", err)
+		}
 	}
-}
 	if c.NewChain.RMNRemoteConfig != nil {
 		if err := c.rmnRemoteConfigForNewChain().Validate(e, state); err != nil {
 			return fmt.Errorf("failed to validate RMN remote config for new chain: %w", err)

--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -107,6 +107,9 @@ type AddCandidatesForNewChainConfig struct {
 	// This is a pointer to distinguish between an explicitly set value (including 0) and an unset value (nil).
 	// We can OffSet by 0 as well sync nextDonID with CapReg.
 	DonIDOffSet *uint32 `json:"donIDOffset,omitempty"`
+
+	// SkipDeployments
+	SkipDeployments bool
 }
 
 func (c AddCandidatesForNewChainConfig) prerequisiteConfigForNewChain() changeset.DeployPrerequisiteConfig {
@@ -179,9 +182,12 @@ func addCandidatesForNewChainPrecondition(e cldf.Environment, c AddCandidatesFor
 	if err := c.prerequisiteConfigForNewChain().Validate(); err != nil {
 		return fmt.Errorf("failed to validate prerequisite config for new chain: %w", err)
 	}
+	
+	if !c.SkipDeployments {
 	if err := c.deploymentConfigForNewChain().Validate(); err != nil {
 		return fmt.Errorf("failed to validate deployment config for new chain: %w", err)
 	}
+}
 	if c.NewChain.RMNRemoteConfig != nil {
 		if err := c.rmnRemoteConfigForNewChain().Validate(e, state); err != nil {
 			return fmt.Errorf("failed to validate RMN remote config for new chain: %w", err)
@@ -220,107 +226,109 @@ func addCandidatesForNewChainLogic(e cldf.Environment, c AddCandidatesForNewChai
 	newAddresses := cldf.NewMemoryAddressBook()
 	var allProposals []mcmslib.TimelockProposal
 
-	// Save existing contracts
-	err := runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
-		return commoncs.SaveExistingContractsChangeset(e, c.NewChain.ExistingContracts)
-	}, newAddresses, e.ExistingAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run SaveExistingContractsChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
-	}
-
-	// Deploy the prerequisite contracts to the new chain
-	err = runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
-		return changeset.DeployPrerequisitesChangeset(e, c.prerequisiteConfigForNewChain())
-	}, newAddresses, e.ExistingAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run DeployPrerequisitesChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
-	}
-
-	// Deploy MCMS contracts
-	if c.MCMSDeploymentConfig != nil {
-		err = runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
-			return commoncs.DeployMCMSWithTimelockV2(e, map[uint64]commontypes.MCMSWithTimelockConfigV2{
-				c.NewChain.Selector: *c.MCMSDeploymentConfig,
-			})
+	if !c.SkipDeployments {
+		// Save existing contracts
+		err := runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
+			return commoncs.SaveExistingContractsChangeset(e, c.NewChain.ExistingContracts)
 		}, newAddresses, e.ExistingAddresses)
 		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run DeployMCMSWithTimelockV2 on chain with selector %d: %w", c.NewChain.Selector, err)
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run SaveExistingContractsChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
 		}
-	}
 
-	// Deploy chain contracts to the new chain
-	err = runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
-		return DeployChainContractsChangeset(e, c.deploymentConfigForNewChain())
-	}, newAddresses, e.ExistingAddresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run DeployChainContractsChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
-	}
-
-	// Set RMN remote config & set RMN on proxy on the new chain (if config provided)
-	if c.NewChain.RMNRemoteConfig != nil {
-		_, err = SetRMNRemoteConfigChangeset(e, c.rmnRemoteConfigForNewChain())
+		// Deploy the prerequisite contracts to the new chain
+		err = runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
+			return changeset.DeployPrerequisitesChangeset(e, c.prerequisiteConfigForNewChain())
+		}, newAddresses, e.ExistingAddresses)
 		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run SetRMNRemoteConfigChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run DeployPrerequisitesChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
 		}
-	}
-	// Set the RMN remote on the RMN proxy, using MCMS if RMN proxy is owned by Timelock
-	// RMN proxy will already exist on chains that supported CCIPv1.5.0, in which case RMN proxy will be owned by Timelock
-	state, err := stateview.LoadOnchainState(e)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
-	}
-	owner, err := state.Chains[c.NewChain.Selector].RMNProxy.Owner(&bind.CallOpts{
-		Context: e.GetContext(),
-	})
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get owner of RMN proxy on chain with selector %d: %w", c.NewChain.Selector, err)
-	}
-	var mcmsConfig *proposalutils.TimelockConfig
-	if owner == state.Chains[c.NewChain.Selector].Timelock.Address() {
-		mcmsConfig = c.MCMSConfig
-	}
-	out, err := SetRMNRemoteOnRMNProxyChangeset(e, SetRMNRemoteOnRMNProxyConfig{
-		ChainSelectors: []uint64{c.NewChain.Selector},
-		MCMSConfig:     mcmsConfig,
-	})
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run SetRMNRemoteOnRMNProxyChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
-	}
-	allProposals = append(allProposals, out.MCMSTimelockProposals...)
 
-	// Update the fee quoter destinations on the new chain
-	destChainConfigs := make(map[uint64]fee_quoter.FeeQuoterDestChainConfig, len(c.RemoteChains))
-	for _, remoteChain := range c.RemoteChains {
-		destChainConfigs[remoteChain.Selector] = remoteChain.FeeQuoterDestChainConfig
-	}
-	_, err = UpdateFeeQuoterDestsChangeset(e, UpdateFeeQuoterDestsConfig{
-		UpdatesByChain: map[uint64]map[uint64]fee_quoter.FeeQuoterDestChainConfig{
-			c.NewChain.Selector: destChainConfigs,
-		},
-	})
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run UpdateFeeQuoterDestsChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
-	}
+		// Deploy MCMS contracts
+		if c.MCMSDeploymentConfig != nil {
+			err = runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
+				return commoncs.DeployMCMSWithTimelockV2(e, map[uint64]commontypes.MCMSWithTimelockConfigV2{
+					c.NewChain.Selector: *c.MCMSDeploymentConfig,
+				})
+			}, newAddresses, e.ExistingAddresses)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to run DeployMCMSWithTimelockV2 on chain with selector %d: %w", c.NewChain.Selector, err)
+			}
+		}
 
-	// Update the fee quoter prices on the new chain
-	gasPrices := make(map[uint64]*big.Int, len(c.RemoteChains))
-	for _, remoteChain := range c.RemoteChains {
-		gasPrices[remoteChain.Selector] = remoteChain.GasPrice
-	}
-	_, err = UpdateFeeQuoterPricesChangeset(e, UpdateFeeQuoterPricesConfig{
-		PricesByChain: map[uint64]FeeQuoterPriceUpdatePerSource{
-			c.NewChain.Selector: FeeQuoterPriceUpdatePerSource{
-				TokenPrices: c.NewChain.TokenPrices,
-				GasPrices:   gasPrices,
+		// Deploy chain contracts to the new chain
+		err = runAndSaveAddresses(func() (cldf.ChangesetOutput, error) {
+			return DeployChainContractsChangeset(e, c.deploymentConfigForNewChain())
+		}, newAddresses, e.ExistingAddresses)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run DeployChainContractsChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
+		}
+
+		// Set RMN remote config & set RMN on proxy on the new chain (if config provided)
+		if c.NewChain.RMNRemoteConfig != nil {
+			_, err = SetRMNRemoteConfigChangeset(e, c.rmnRemoteConfigForNewChain())
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to run SetRMNRemoteConfigChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
+			}
+		}
+		// Set the RMN remote on the RMN proxy, using MCMS if RMN proxy is owned by Timelock
+		// RMN proxy will already exist on chains that supported CCIPv1.5.0, in which case RMN proxy will be owned by Timelock
+		state, err := stateview.LoadOnchainState(e)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
+		}
+		owner, err := state.Chains[c.NewChain.Selector].RMNProxy.Owner(&bind.CallOpts{
+			Context: e.GetContext(),
+		})
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get owner of RMN proxy on chain with selector %d: %w", c.NewChain.Selector, err)
+		}
+		var mcmsConfig *proposalutils.TimelockConfig
+		if owner == state.Chains[c.NewChain.Selector].Timelock.Address() {
+			mcmsConfig = c.MCMSConfig
+		}
+		out, err := SetRMNRemoteOnRMNProxyChangeset(e, SetRMNRemoteOnRMNProxyConfig{
+			ChainSelectors: []uint64{c.NewChain.Selector},
+			MCMSConfig:     mcmsConfig,
+		})
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run SetRMNRemoteOnRMNProxyChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
+		}
+		allProposals = append(allProposals, out.MCMSTimelockProposals...)
+
+		// Update the fee quoter destinations on the new chain
+		destChainConfigs := make(map[uint64]fee_quoter.FeeQuoterDestChainConfig, len(c.RemoteChains))
+		for _, remoteChain := range c.RemoteChains {
+			destChainConfigs[remoteChain.Selector] = remoteChain.FeeQuoterDestChainConfig
+		}
+		_, err = UpdateFeeQuoterDestsChangeset(e, UpdateFeeQuoterDestsConfig{
+			UpdatesByChain: map[uint64]map[uint64]fee_quoter.FeeQuoterDestChainConfig{
+				c.NewChain.Selector: destChainConfigs,
 			},
-		},
-	})
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run UpdateFeeQuoterPricesChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
+		})
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run UpdateFeeQuoterDestsChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
+		}
+
+		// Update the fee quoter prices on the new chain
+		gasPrices := make(map[uint64]*big.Int, len(c.RemoteChains))
+		for _, remoteChain := range c.RemoteChains {
+			gasPrices[remoteChain.Selector] = remoteChain.GasPrice
+		}
+		_, err = UpdateFeeQuoterPricesChangeset(e, UpdateFeeQuoterPricesConfig{
+			PricesByChain: map[uint64]FeeQuoterPriceUpdatePerSource{
+				c.NewChain.Selector: FeeQuoterPriceUpdatePerSource{
+					TokenPrices: c.NewChain.TokenPrices,
+					GasPrices:   gasPrices,
+				},
+			},
+		})
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to run UpdateFeeQuoterPricesChangeset on chain with selector %d: %w", c.NewChain.Selector, err)
+		}
 	}
 
 	// Fetch the next DON ID from the capabilities registry
-	state, err = stateview.LoadOnchainState(e)
+	state, err := stateview.LoadOnchainState(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
@@ -344,7 +352,7 @@ func addCandidatesForNewChainLogic(e cldf.Environment, c AddCandidatesForNewChai
 	}
 
 	// Add new chain config to the home chain
-	out, err = UpdateChainConfigChangeset(e, c.updateChainConfig())
+	out, err := UpdateChainConfigChangeset(e, c.updateChainConfig())
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run UpdateChainConfigChangeset on home chain: %w", err)
 	}


### PR DESCRIPTION
# Summary
This PR adds a flag to `AddCandidatesForNewChainChangeset` that enables skipping the deployment part of the changeset and run the HomeChain related logic:
- `UpdateChainConfigChangeset`
- `AddDonAndSetCandidateChangeset`
- `SetCandidateChangeset`

# Features
- Adds new flag to config
- Skips deployment
- Skips validation related to deployment

# Testing
- This changeset was run agains a staging environment generating a proposal

