### PR TITLE
[COP-1622] Two new 'env workflow' commands

### DIFF
--- a/core/scripts/cre/environment/environment/workflow.go
+++ b/core/scripts/cre/environment/environment/workflow.go
@@ -22,6 +22,12 @@ import (
 const (
 	DefaultArtifactsDir        = "/home/chainlink/workflows"
 	DefaultWorkflowNodePattern = "workflow-node"
+
+	// Might change if deployment sequence changes or if different config file than 'configs/workflow-don.toml' is used
+	DefaultWorkflowRegistryAddress     = "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+	DefaultCapabilitiesRegistryAddress = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+
+	DefaultWorkflowOwnerAddress = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
 )
 
 func workflowCmds() *cobra.Command {
@@ -32,9 +38,11 @@ func workflowCmds() *cobra.Command {
 	}
 
 	workflowCmd.AddCommand(deployAndVerifyExampleWorkflowCmd())
-	workflowCmd.AddCommand(deployWorkflowCmd())
+	workflowCmd.AddCommand(compileDeployWorkflowCmd())
 	workflowCmd.AddCommand(deleteWorkflowCmd())
 	workflowCmd.AddCommand(deleteAllWorkflowsCmd())
+	workflowCmd.AddCommand(compileWorkflowCmd())
+	workflowCmd.AddCommand(deployWorkflowCmd())
 
 	return workflowCmd
 }
@@ -65,7 +73,104 @@ func deleteAllWorkflows(ctx context.Context, rpcURL, workflowRegistryAddress str
 	return nil
 }
 
+func compileWorkflowCmd() *cobra.Command {
+	var (
+		workflowFilePathFlag string
+		workflowNameFlag     string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "compile",
+		Short: "Compiles a workflow",
+		Long:  `Compiles, compresses with Brotli and encodes with base64 a workflow`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, compileErr := compileWorkflow(workflowFilePathFlag, workflowNameFlag)
+			if compileErr != nil {
+				return errors.Wrap(compileErr, "❌ failed to compile workflow")
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&workflowFilePathFlag, "workflow-file-path", "w", "", "Path to the workflow file")
+	cmd.Flags().StringVarP(&workflowNameFlag, "workflow-name", "n", "exampleworkflow", "Workflow name")
+
+	if err := cmd.MarkFlagRequired("workflow-file-path"); err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
 func deployWorkflowCmd() *cobra.Command {
+	var (
+		workflowFilePathFlag            string
+		configFilePathFlag              string
+		secretsFilePathFlag             string
+		containerTargetDirFlag          string
+		containerNamePatternFlag        string
+		workflowNameFlag                string
+		workflowOwnerAddressFlag        string
+		workflowRegistryAddressFlag     string
+		capabilitiesRegistryAddressFlag string
+		deleteWorkflowFileFlag          bool
+		donIDFlag                       uint32
+		chainIDFlag                     uint64
+		rpcURLFlag                      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "deploy",
+		Short: "Deploys a workflow to the environment",
+		Long:  `Deploys a workflow to the environment by copying it to workflow nodes and registering with the workflow registry`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			initDxTracker()
+			var regErr error
+
+			defer func() {
+				metaData := map[string]any{}
+				if regErr != nil {
+					metaData["result"] = "failure"
+					metaData["error"] = oneLineErrorMessage(regErr)
+				} else {
+					metaData["result"] = "success"
+				}
+
+				trackingErr := dxTracker.Track("cre.local.workflow.deploy", metaData)
+				if trackingErr != nil {
+					fmt.Fprintf(os.Stderr, "failed to track workflow deploy: %s\n", trackingErr)
+				}
+			}()
+
+			regErr = deployWorkflow(cmd.Context(), workflowFilePathFlag, workflowNameFlag, workflowOwnerAddressFlag, workflowRegistryAddressFlag, capabilitiesRegistryAddressFlag, containerNamePatternFlag, containerTargetDirFlag, configFilePathFlag, secretsFilePathFlag, rpcURLFlag, donIDFlag, deleteWorkflowFileFlag)
+
+			return regErr
+		},
+	}
+
+	cmd.Flags().StringVarP(&workflowFilePathFlag, "wasm-file-path", "w", "", "Path to the workflow WASM file")
+	cmd.Flags().StringVarP(&configFilePathFlag, "config-file-path", "c", "", "Path to the config file")
+	cmd.Flags().StringVarP(&secretsFilePathFlag, "secrets-file-path", "s", "", "Path to the secrets file")
+	cmd.Flags().StringVarP(&containerTargetDirFlag, "container-target-dir", "t", DefaultArtifactsDir, "Path to the target directory in the Docker container")
+	cmd.Flags().StringVarP(&containerNamePatternFlag, "container-name-pattern", "o", DefaultWorkflowNodePattern, "Pattern to match the container name")
+	cmd.Flags().Uint64VarP(&chainIDFlag, "chain-id", "i", 1337, "Chain ID")
+	cmd.Flags().StringVarP(&rpcURLFlag, "rpc-url", "r", "http://localhost:8545", "RPC URL")
+	cmd.Flags().StringVarP(&workflowOwnerAddressFlag, "workflow-owner-address", "d", DefaultWorkflowOwnerAddress, "Workflow owner address")
+	cmd.Flags().StringVarP(&workflowRegistryAddressFlag, "workflow-registry-address", "a", DefaultWorkflowRegistryAddress, "Workflow registry address")
+	cmd.Flags().StringVarP(&capabilitiesRegistryAddressFlag, "capabilities-registry-address", "b", DefaultCapabilitiesRegistryAddress, "Capabilities registry address")
+	cmd.Flags().Uint32VarP(&donIDFlag, "don-id", "e", 1, "DON ID")
+	cmd.Flags().StringVarP(&workflowNameFlag, "workflow-name", "n", "exampleworkflow", "Workflow name")
+	cmd.Flags().BoolVarP(&deleteWorkflowFileFlag, "delete-workflow-file", "l", false, "Delete the workflow file after deployment")
+
+	if err := cmd.MarkFlagRequired("wasm-file-path"); err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func compileDeployWorkflowCmd() *cobra.Command {
 	var (
 		workflowFilePathFlag            string
 		configFilePathFlag              string
@@ -82,7 +187,7 @@ func deployWorkflowCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "deploy",
+		Use:   "compile-deploy",
 		Short: "Compiles and uploads a workflow to the environment",
 		Long:  `Compiles and uploads a workflow to the environment by copying it to workflow nodes and registering with the workflow registry`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -117,9 +222,9 @@ func deployWorkflowCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&containerNamePatternFlag, "container-name-pattern", "o", DefaultWorkflowNodePattern, "Pattern to match the container name")
 	cmd.Flags().Uint64VarP(&chainIDFlag, "chain-id", "i", 1337, "Chain ID")
 	cmd.Flags().StringVarP(&rpcURLFlag, "rpc-url", "r", "http://localhost:8545", "RPC URL")
-	cmd.Flags().StringVarP(&workflowOwnerAddressFlag, "workflow-owner-address", "d", "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266", "Workflow owner address")
-	cmd.Flags().StringVarP(&workflowRegistryAddressFlag, "workflow-registry-address", "a", "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0", "Workflow registry address")
-	cmd.Flags().StringVarP(&capabilitiesRegistryAddressFlag, "capabilities-registry-address", "b", "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512", "Capabilities registry address")
+	cmd.Flags().StringVarP(&workflowOwnerAddressFlag, "workflow-owner-address", "d", DefaultWorkflowOwnerAddress, "Workflow owner address")
+	cmd.Flags().StringVarP(&workflowRegistryAddressFlag, "workflow-registry-address", "a", DefaultWorkflowRegistryAddress, "Workflow registry address")
+	cmd.Flags().StringVarP(&capabilitiesRegistryAddressFlag, "capabilities-registry-address", "b", DefaultCapabilitiesRegistryAddress, "Capabilities registry address")
 	cmd.Flags().Uint32VarP(&donIDFlag, "don-id", "e", 1, "DON ID")
 	cmd.Flags().StringVarP(&workflowNameFlag, "workflow-name", "n", "exampleworkflow", "Workflow name")
 
@@ -182,8 +287,8 @@ func deleteWorkflowCmd() *cobra.Command {
 
 	cmd.Flags().Uint64VarP(&chainIDFlag, "chain-id", "i", 1337, "Chain ID")
 	cmd.Flags().StringVarP(&rpcURLFlag, "rpc-url", "r", "http://localhost:8545", "RPC URL")
-	cmd.Flags().StringVarP(&workflowOwnerAddressFlag, "workflow-owner-address", "d", "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266", "Workflow owner address")
-	cmd.Flags().StringVarP(&workflowRegistryAddressFlag, "workflow-registry-address", "a", "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0", "Workflow registry address")
+	cmd.Flags().StringVarP(&workflowOwnerAddressFlag, "workflow-owner-address", "d", DefaultWorkflowOwnerAddress, "Workflow owner address")
+	cmd.Flags().StringVarP(&workflowRegistryAddressFlag, "workflow-registry-address", "a", DefaultWorkflowRegistryAddress, "Workflow registry address")
 	cmd.Flags().StringVarP(&workflowNameFlag, "name", "n", "exampleworkflow", "Workflow name")
 
 	return cmd
@@ -233,23 +338,27 @@ func deleteAllWorkflowsCmd() *cobra.Command {
 
 	cmd.Flags().Uint64VarP(&chainIDFlag, "chain-id", "i", 1337, "Chain ID")
 	cmd.Flags().StringVarP(&rpcURLFlag, "rpc-url", "r", "http://localhost:8545", "RPC URL")
-	cmd.Flags().StringVarP(&workflowOwnerAddressFlag, "workflow-owner-address", "d", "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266", "Workflow owner address")
-	cmd.Flags().StringVarP(&workflowRegistryAddressFlag, "workflow-registry-address", "a", "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0", "Workflow registry address")
+	cmd.Flags().StringVarP(&workflowOwnerAddressFlag, "workflow-owner-address", "d", DefaultWorkflowOwnerAddress, "Workflow owner address")
+	cmd.Flags().StringVarP(&workflowRegistryAddressFlag, "workflow-registry-address", "a", DefaultWorkflowRegistryAddress, "Workflow registry address")
 
 	return cmd
 }
 
-func compileCopyAndRegisterWorkflow(ctx context.Context, workflowFilePathFlag, workflowNameFlag, workflowOwnerAddressFlag, workflowRegistryAddressFlag, capabilitiesRegistryAddressFlag, containerNamePatternFlag, containerTargetDirFlag, configFilePathFlag, secretsFilePathFlag, rpcURLFlag string, donIDFlag uint32) error {
+func compileWorkflow(workflowFilePathFlag, workflowNameFlag string) (string, error) {
 	fmt.Printf("\n⚙️ Compiling workflow from %s\n", workflowFilePathFlag)
 
 	compressedWorkflowWasmPath, compileErr := creworkflow.CompileWorkflow(workflowFilePathFlag, workflowNameFlag)
 	if compileErr != nil {
-		return errors.Wrap(compileErr, "❌ failed to compile workflow")
+		return "", errors.Wrap(compileErr, "❌ failed to compile workflow")
 	}
 
-	fmt.Printf("\n✅ Workflow compiled and compressed successfully\n\n")
+	fmt.Printf("\n✅ Workflow saved to %s\n\n", compressedWorkflowWasmPath)
 
-	copyErr := creworkflow.CopyWorkflowToDockerContainers(compressedWorkflowWasmPath, containerNamePatternFlag, containerTargetDirFlag)
+	return compressedWorkflowWasmPath, nil
+}
+
+func deployWorkflow(ctx context.Context, wasmWorkflowFilePathFlag, workflowNameFlag, workflowOwnerAddressFlag, workflowRegistryAddressFlag, capabilitiesRegistryAddressFlag, containerNamePatternFlag, containerTargetDirFlag, configFilePathFlag, secretsFilePathFlag, rpcURLFlag string, donIDFlag uint32, deleteWorkflowFile bool) error {
+	copyErr := creworkflow.CopyWorkflowToDockerContainers(wasmWorkflowFilePathFlag, containerNamePatternFlag, containerTargetDirFlag)
 	if copyErr != nil {
 		return errors.Wrap(copyErr, "❌ failed to copy workflow to Docker container")
 	}
@@ -332,16 +441,27 @@ func compileCopyAndRegisterWorkflow(ctx context.Context, workflowFilePathFlag, w
 
 	fmt.Printf("\n⚙️ Registering workflow '%s' with the workflow registry\n\n", workflowNameFlag)
 
-	registerErr := creworkflow.RegisterWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddressFlag), uint64(donIDFlag), workflowNameFlag, "file://"+compressedWorkflowWasmPath, configPath, secretsPath, &containerTargetDirFlag)
+	registerErr := creworkflow.RegisterWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddressFlag), uint64(donIDFlag), workflowNameFlag, "file://"+wasmWorkflowFilePathFlag, configPath, secretsPath, &containerTargetDirFlag)
 	if registerErr != nil {
 		return errors.Wrapf(registerErr, "❌ failed to register workflow %s", workflowNameFlag)
 	}
 
-	defer func() {
-		_ = os.Remove(compressedWorkflowWasmPath)
-	}()
+	if deleteWorkflowFile {
+		defer func() {
+			_ = os.Remove(wasmWorkflowFilePathFlag)
+		}()
+	}
 
 	fmt.Printf("\n✅ Workflow registered successfully\n\n")
 
 	return nil
+}
+
+func compileCopyAndRegisterWorkflow(ctx context.Context, workflowFilePathFlag, workflowNameFlag, workflowOwnerAddressFlag, workflowRegistryAddressFlag, capabilitiesRegistryAddressFlag, containerNamePatternFlag, containerTargetDirFlag, configFilePathFlag, secretsFilePathFlag, rpcURLFlag string, donIDFlag uint32) error {
+	compressedWorkflowWasmPath, compileErr := compileWorkflow(workflowFilePathFlag, workflowNameFlag)
+	if compileErr != nil {
+		return errors.Wrap(compileErr, "❌ failed to compile workflow")
+	}
+
+	return deployWorkflow(ctx, compressedWorkflowWasmPath, workflowNameFlag, workflowOwnerAddressFlag, workflowRegistryAddressFlag, capabilitiesRegistryAddressFlag, containerNamePatternFlag, containerTargetDirFlag, configFilePathFlag, secretsFilePathFlag, rpcURLFlag, donIDFlag, true)
 }


### PR DESCRIPTION
This pull request refactors and extends the workflow management commands in `core/scripts/cre/environment/environment/workflow.go` to improve usability, modularity, and default configuration management. The main enhancements include splitting compilation and deployment logic, introducing new commands, and centralizing default addresses.

**Command structure improvements:**

* Added two new CLI commands: `compile` (to compile workflows) and `compile-deploy` (to compile and then deploy workflows), separating concerns and increasing flexibility for workflow management. [[1]](diffhunk://#diff-2ad9e8de0f6797c1c34cbfaead651fcb6ab987e030603d0f9acf122b69c39b2cL35-R45) [[2]](diffhunk://#diff-2ad9e8de0f6797c1c34cbfaead651fcb6ab987e030603d0f9acf122b69c39b2cR76-R105) [[3]](diffhunk://#diff-2ad9e8de0f6797c1c34cbfaead651fcb6ab987e030603d0f9acf122b69c39b2cR117-R190)
* Refactored the deployment logic into a dedicated `deployWorkflow` function, and similarly separated compilation into `compileWorkflow`, making the codebase more modular and easier to maintain. [[1]](diffhunk://#diff-2ad9e8de0f6797c1c34cbfaead651fcb6ab987e030603d0f9acf122b69c39b2cL236-R361) [[2]](diffhunk://#diff-2ad9e8de0f6797c1c34cbfaead651fcb6ab987e030603d0f9acf122b69c39b2cL335-R467)

**Default configuration centralization:**

* Centralized default addresses (`DefaultWorkflowRegistryAddress`, `DefaultCapabilitiesRegistryAddress`, `DefaultWorkflowOwnerAddress`) as constants, and updated all command flags to use these defaults, ensuring consistency and simplifying configuration changes. [[1]](diffhunk://#diff-2ad9e8de0f6797c1c34cbfaead651fcb6ab987e030603d0f9acf122b69c39b2cR25-R30) [[2]](diffhunk://#diff-2ad9e8de0f6797c1c34cbfaead651fcb6ab987e030603d0f9acf122b69c39b2cL120-R227) [[3]](diffhunk://#diff-2ad9e8de0f6797c1c34cbfaead651fcb6ab987e030603d0f9acf122b69c39b2cL185-R291) [[4]](diffhunk://#diff-2ad9e8de0f6797c1c34cbfaead651fcb6ab987e030603d0f9acf122b69c39b2cL236-R361)

**Deployment enhancements:**

* Added new flags and improved flag handling for deployment commands (e.g., `delete-workflow-file`), and enhanced error tracking and reporting during workflow deployment.

These changes make the workflow management CLI more user-friendly, maintainable, and consistent across different environments.