### PR TITLE
[COP-1673] do not delete secrets after creation, only after workflow has been re…

### DIFF
--- a/core/scripts/cre/environment/environment/workflow.go
+++ b/core/scripts/cre/environment/environment/workflow.go
@@ -298,6 +298,10 @@ func compileCopyAndRegisterWorkflow(ctx context.Context, workflowFilePathFlag, w
 			return errors.Wrap(secretsErr, "failed to prepare secrets")
 		}
 
+		defer func() {
+			_ = os.Remove(secretPathAbs)
+		}()
+
 		fmt.Printf("\n✅ Encrypted workflow secrets file prepared\n\n")
 
 		fmt.Printf("\n⚙️ Copying encrypted secrets file to Docker container\n")

--- a/system-tests/lib/cre/workflow/secrets.go
+++ b/system-tests/lib/cre/workflow/secrets.go
@@ -42,9 +42,6 @@ func PrepareSecrets(sethClient *seth.Client, donID uint32, capabilitiesRegistryA
 	}
 
 	defer encryptedSecretsFile.Close()
-	defer func() {
-		_ = os.Remove(encryptedSecretsFilePath)
-	}()
 
 	encoder := json.NewEncoder(encryptedSecretsFile)
 	if encoderErr := encoder.Encode(encryptSecrets); encoderErr != nil {


### PR DESCRIPTION
This pull request updates the handling of temporary encrypted secrets files in the workflow preparation process. The main change is to move the responsibility for deleting the temporary secrets file from the secrets preparation function to the workflow compilation function, ensuring the file is available for subsequent steps before being cleaned up.

**Temporary secrets file management:**

* Removed the deferred deletion of the temporary encrypted secrets file from `PrepareSecrets` in `system-tests/lib/cre/workflow/secrets.go`, so the file is no longer deleted immediately after preparation.
* Added a deferred cleanup in `compileCopyAndRegisterWorkflow` in `core/scripts/cre/environment/environment/workflow.go` to delete the temporary encrypted secrets file after it has been used, ensuring proper cleanup at the appropriate stage.