### PR TITLE
Dry Run Fake EVM Cap WriteReport

### DIFF
--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -160,57 +160,7 @@ func (fc *FakeEVMChain) WriteReport(ctx context.Context, metadata commonCap.Requ
 
 	// If dryRunWrites is enabled, simulate the transaction without broadcasting it
 	if fc.dryRunWrites {
-		fc.eng.Infow("EVM Chain WriteReport Dry-Run Enabled")
-		contractABI, err := abi.JSON(strings.NewReader(MockKeystoneForwarderABI))
-		if err != nil {
-			return nil, err
-		}
-		calldata, err := contractABI.Pack(
-			"report",
-			common.Address(input.Receiver),
-			input.Report.RawReport,
-			input.Report.ReportContext,
-			signatures,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		msg := ethereum.CallMsg{
-			From: auth.From,
-			To:   &fc.mockKeystoneForwarderAddress,
-			Data: calldata,
-		}
-		_, err = fc.gethClient.CallContract(ctx, msg, nil)
-		if err != nil {
-			fc.eng.Infow("EVM Chain WriteReport Dry-Run Reverted", "error", err)
-			receiverStatus := evmcappb.ReceiverContractExecutionStatus_RECEIVER_CONTRACT_EXECUTION_STATUS_REVERTED
-			errMsg := err.Error()
-			response := &evmcappb.WriteReportReply{
-				TxStatus:                        evmcappb.TxStatus_TX_STATUS_REVERTED,
-				ReceiverContractExecutionStatus: &receiverStatus,
-				TransactionFee:                  pb.NewBigIntFromInt(big.NewInt(0)),
-				ErrorMessage:                    &errMsg,
-			}
-			responseAndMetadata := commonCap.ResponseAndMetadata[*evmcappb.WriteReportReply]{
-				Response:         response,
-				ResponseMetadata: commonCap.ResponseMetadata{},
-			}
-			return &responseAndMetadata, nil
-		}
-
-		fc.eng.Infow("EVM Chain WriteReport Dry-Run Successful")
-		receiverStatus := evmcappb.ReceiverContractExecutionStatus_RECEIVER_CONTRACT_EXECUTION_STATUS_SUCCESS
-		response := &evmcappb.WriteReportReply{
-			TxStatus:                        evmcappb.TxStatus_TX_STATUS_SUCCESS,
-			ReceiverContractExecutionStatus: &receiverStatus,
-			TransactionFee:                  pb.NewBigIntFromInt(big.NewInt(0)),
-		}
-		responseAndMetadata := commonCap.ResponseAndMetadata[*evmcappb.WriteReportReply]{
-			Response:         response,
-			ResponseMetadata: commonCap.ResponseMetadata{},
-		}
-		return &responseAndMetadata, nil
+		return fc.dryRunWriteReport(ctx, auth.From, input, signatures)
 	}
 
 	reportTx, err := fc.mockKeystoneForwarder.Report(
@@ -550,4 +500,64 @@ func (fc *FakeEVMChain) Description() string {
 
 func (fc *FakeEVMChain) ChainSelector() uint64 {
 	return fc.chainSelector
+}
+
+// dryRunWriteReport simulates the report transaction using eth_call without broadcasting.
+func (fc *FakeEVMChain) dryRunWriteReport(
+	ctx context.Context,
+	from common.Address,
+	input *evmcappb.WriteReportRequest,
+	signatures [][]byte,
+) (*commonCap.ResponseAndMetadata[*evmcappb.WriteReportReply], error) {
+	fc.eng.Infow("EVM Chain WriteReport Dry-Run Enabled")
+	contractABI, err := abi.JSON(strings.NewReader(MockKeystoneForwarderABI))
+	if err != nil {
+		return nil, err
+	}
+	calldata, err := contractABI.Pack(
+		"report",
+		common.Address(input.Receiver),
+		input.Report.RawReport,
+		input.Report.ReportContext,
+		signatures,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := ethereum.CallMsg{
+		From: from,
+		To:   &fc.mockKeystoneForwarderAddress,
+		Data: calldata,
+	}
+	_, err = fc.gethClient.CallContract(ctx, msg, nil)
+	if err != nil {
+		fc.eng.Infow("EVM Chain WriteReport Dry-Run Reverted", "error", err)
+		receiverStatus := evmcappb.ReceiverContractExecutionStatus_RECEIVER_CONTRACT_EXECUTION_STATUS_REVERTED
+		errMsg := err.Error()
+		response := &evmcappb.WriteReportReply{
+			TxStatus:                        evmcappb.TxStatus_TX_STATUS_REVERTED,
+			ReceiverContractExecutionStatus: &receiverStatus,
+			TransactionFee:                  pb.NewBigIntFromInt(big.NewInt(0)),
+			ErrorMessage:                    &errMsg,
+		}
+		responseAndMetadata := commonCap.ResponseAndMetadata[*evmcappb.WriteReportReply]{
+			Response:         response,
+			ResponseMetadata: commonCap.ResponseMetadata{},
+		}
+		return &responseAndMetadata, nil
+	}
+
+	fc.eng.Infow("EVM Chain WriteReport Dry-Run Successful")
+	receiverStatus := evmcappb.ReceiverContractExecutionStatus_RECEIVER_CONTRACT_EXECUTION_STATUS_SUCCESS
+	response := &evmcappb.WriteReportReply{
+		TxStatus:                        evmcappb.TxStatus_TX_STATUS_SUCCESS,
+		ReceiverContractExecutionStatus: &receiverStatus,
+		TransactionFee:                  pb.NewBigIntFromInt(big.NewInt(0)),
+	}
+	responseAndMetadata := commonCap.ResponseAndMetadata[*evmcappb.WriteReportReply]{
+		Response:         response,
+		ResponseMetadata: commonCap.ResponseMetadata{},
+	}
+	return &responseAndMetadata, nil
 }

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"math/big"
-	"reflect"
 	"strings"
 
 	"github.com/ethereum/go-ethereum"
@@ -35,6 +34,9 @@ type FakeEVMChain struct {
 	mockKeystoneForwarderAddress common.Address
 	chainSelector                uint64
 
+	// if true, WriteReport will simulate the call and not broadcast
+	dryRunWrites bool
+
 	lggr logger.Logger
 
 	// log trigger callback channel
@@ -57,6 +59,7 @@ func NewFakeEvmChain(
 	privateKey *ecdsa.PrivateKey,
 	mockKeystoneForwarderAddress common.Address,
 	chainSelector uint64,
+	dryRunWrites bool,
 ) *FakeEVMChain {
 	mockKeystoneForwarder, err := NewMockKeystoneForwarder(mockKeystoneForwarderAddress, gethClient)
 	if err != nil {
@@ -73,6 +76,7 @@ func NewFakeEvmChain(
 		mockKeystoneForwarderAddress: mockKeystoneForwarderAddress,
 		chainSelector:                chainSelector,
 		callbackCh:                   make(map[string]chan commonCap.TriggerAndId[*evmcappb.Log]),
+		dryRunWrites:                 dryRunWrites,
 	}
 	fc.Service, fc.eng = services.Config{
 		Name:  "FakeEVMChain",
@@ -154,8 +158,8 @@ func (fc *FakeEVMChain) WriteReport(ctx context.Context, metadata commonCap.Requ
 		signatures[i] = sig.Signature
 	}
 
-	// If dryRunWrite is enabled, simulate the transaction without broadcasting it
-	if fc.isDryRunWrite(input) {
+	// If dryRunWrites is enabled, simulate the transaction without broadcasting it
+	if fc.dryRunWrites {
 		fc.eng.Infow("EVM Chain WriteReport Dry-Run Enabled")
 		contractABI, err := abi.JSON(strings.NewReader(MockKeystoneForwarderABI))
 		if err != nil {
@@ -548,20 +552,4 @@ func (fc *FakeEVMChain) ChainSelector() uint64 {
 	return fc.chainSelector
 }
 
-// isDryRunWrite safely checks for an optional DryRunWrite boolean on the request without
-// a hard dependency on a newer proto. Returns false when the method is absent.
-func (fc *FakeEVMChain) isDryRunWrite(input *evmcappb.WriteReportRequest) bool {
-	if input == nil {
-		return false
-	}
-	method := reflect.ValueOf(input).MethodByName("GetDryRunWrite")
-	if method.IsValid() {
-		results := method.Call(nil)
-		if len(results) == 1 {
-			if val, ok := results[0].Interface().(bool); ok {
-				return val
-			}
-		}
-	}
-	return false
-}
+// No public setter needed for dryRunWrites; it is configured via the constructor.

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -551,5 +551,3 @@ func (fc *FakeEVMChain) Description() string {
 func (fc *FakeEVMChain) ChainSelector() uint64 {
 	return fc.chainSelector
 }
-
-// No public setter needed for dryRunWrites; it is configured via the constructor.

--- a/core/capabilities/fakes/evm_chain.go
+++ b/core/capabilities/fakes/evm_chain.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"math/big"
+	"reflect"
+	"strings"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -26,10 +29,11 @@ type FakeEVMChain struct {
 	services.Service
 	eng *services.Engine
 
-	gethClient            *ethclient.Client
-	privateKey            *ecdsa.PrivateKey
-	mockKeystoneForwarder *MockKeystoneForwarder
-	chainSelector         uint64
+	gethClient                   *ethclient.Client
+	privateKey                   *ecdsa.PrivateKey
+	mockKeystoneForwarder        *MockKeystoneForwarder
+	mockKeystoneForwarderAddress common.Address
+	chainSelector                uint64
 
 	lggr logger.Logger
 
@@ -61,13 +65,14 @@ func NewFakeEvmChain(
 	}
 
 	fc := &FakeEVMChain{
-		CapabilityInfo:        evmExecInfo,
-		lggr:                  lggr,
-		gethClient:            gethClient,
-		privateKey:            privateKey,
-		mockKeystoneForwarder: mockKeystoneForwarder,
-		chainSelector:         chainSelector,
-		callbackCh:            make(map[string]chan commonCap.TriggerAndId[*evmcappb.Log]),
+		CapabilityInfo:               evmExecInfo,
+		lggr:                         lggr,
+		gethClient:                   gethClient,
+		privateKey:                   privateKey,
+		mockKeystoneForwarder:        mockKeystoneForwarder,
+		mockKeystoneForwarderAddress: mockKeystoneForwarderAddress,
+		chainSelector:                chainSelector,
+		callbackCh:                   make(map[string]chan commonCap.TriggerAndId[*evmcappb.Log]),
 	}
 	fc.Service, fc.eng = services.Config{
 		Name:  "FakeEVMChain",
@@ -147,6 +152,61 @@ func (fc *FakeEVMChain) WriteReport(ctx context.Context, metadata commonCap.Requ
 	signatures := make([][]byte, len(input.Report.Sigs))
 	for i, sig := range input.Report.Sigs {
 		signatures[i] = sig.Signature
+	}
+
+	// If dryRunWrite is enabled, simulate the transaction without broadcasting it
+	if fc.isDryRunWrite(input) {
+		fc.eng.Infow("EVM Chain WriteReport Dry-Run Enabled")
+		contractABI, err := abi.JSON(strings.NewReader(MockKeystoneForwarderABI))
+		if err != nil {
+			return nil, err
+		}
+		calldata, err := contractABI.Pack(
+			"report",
+			common.Address(input.Receiver),
+			input.Report.RawReport,
+			input.Report.ReportContext,
+			signatures,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		msg := ethereum.CallMsg{
+			From: auth.From,
+			To:   &fc.mockKeystoneForwarderAddress,
+			Data: calldata,
+		}
+		_, err = fc.gethClient.CallContract(ctx, msg, nil)
+		if err != nil {
+			fc.eng.Infow("EVM Chain WriteReport Dry-Run Reverted", "error", err)
+			receiverStatus := evmcappb.ReceiverContractExecutionStatus_RECEIVER_CONTRACT_EXECUTION_STATUS_REVERTED
+			errMsg := err.Error()
+			response := &evmcappb.WriteReportReply{
+				TxStatus:                        evmcappb.TxStatus_TX_STATUS_REVERTED,
+				ReceiverContractExecutionStatus: &receiverStatus,
+				TransactionFee:                  pb.NewBigIntFromInt(big.NewInt(0)),
+				ErrorMessage:                    &errMsg,
+			}
+			responseAndMetadata := commonCap.ResponseAndMetadata[*evmcappb.WriteReportReply]{
+				Response:         response,
+				ResponseMetadata: commonCap.ResponseMetadata{},
+			}
+			return &responseAndMetadata, nil
+		}
+
+		fc.eng.Infow("EVM Chain WriteReport Dry-Run Successful")
+		receiverStatus := evmcappb.ReceiverContractExecutionStatus_RECEIVER_CONTRACT_EXECUTION_STATUS_SUCCESS
+		response := &evmcappb.WriteReportReply{
+			TxStatus:                        evmcappb.TxStatus_TX_STATUS_SUCCESS,
+			ReceiverContractExecutionStatus: &receiverStatus,
+			TransactionFee:                  pb.NewBigIntFromInt(big.NewInt(0)),
+		}
+		responseAndMetadata := commonCap.ResponseAndMetadata[*evmcappb.WriteReportReply]{
+			Response:         response,
+			ResponseMetadata: commonCap.ResponseMetadata{},
+		}
+		return &responseAndMetadata, nil
 	}
 
 	reportTx, err := fc.mockKeystoneForwarder.Report(
@@ -486,4 +546,22 @@ func (fc *FakeEVMChain) Description() string {
 
 func (fc *FakeEVMChain) ChainSelector() uint64 {
 	return fc.chainSelector
+}
+
+// isDryRunWrite safely checks for an optional DryRunWrite boolean on the request without
+// a hard dependency on a newer proto. Returns false when the method is absent.
+func (fc *FakeEVMChain) isDryRunWrite(input *evmcappb.WriteReportRequest) bool {
+	if input == nil {
+		return false
+	}
+	method := reflect.ValueOf(input).MethodByName("GetDryRunWrite")
+	if method.IsValid() {
+		results := method.Call(nil)
+		if len(results) == 1 {
+			if val, ok := results[0].Interface().(bool); ok {
+				return val
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Update Fake EVM Chain to have "dryRun" mode that skips write operations when true, and instead uses `eth_call` to simulate the transaction and return the output to the user