### PR TITLE
solana cctp ops ux

### DIFF
--- a/deployment/ccip/changeset/solana_v0_1_1/cs_chain_contracts_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_chain_contracts_test.go
@@ -319,6 +319,7 @@ func doTestBilling(t *testing.T, mcms bool) {
 	tenv, _ := testhelpers.NewMemoryEnvironment(t, testhelpers.WithSolChains(1), testhelpers.WithCCIPSolanaContractVersion(ccipChangesetSolana.SolanaContractV0_1_1))
 
 	evmChain := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[0]
+	evmChain2 := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilyEVM))[1]
 	solChain := tenv.Env.BlockChains.ListChainSelectors(cldf_chain.WithFamily(chain_selectors.FamilySolana))[0]
 
 	e, tokenAddress, err := deployTokenAndMint(t, tenv.Env, solChain, []string{}, "TEST_TOKEN")
@@ -365,16 +366,25 @@ func doTestBilling(t *testing.T, mcms bool) {
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.AddTokenTransferFeeForRemoteChain),
 			ccipChangesetSolana.TokenTransferFeeForRemoteChainConfig{
-				ChainSelector:       solChain,
-				RemoteChainSelector: evmChain,
-				TokenPubKey:         tokenAddress,
-				Config: solFeeQuoter.TokenTransferFeeConfig{
-					MinFeeUsdcents:    800,
-					MaxFeeUsdcents:    1600,
-					DeciBps:           0,
-					DestGasOverhead:   100,
-					DestBytesOverhead: 100,
-					IsEnabled:         true,
+				ChainSelector: solChain,
+				TokenPubKey:   tokenAddress,
+				RemoteChainConfigs: map[uint64]solFeeQuoter.TokenTransferFeeConfig{
+					evmChain: {
+						MinFeeUsdcents:    800,
+						MaxFeeUsdcents:    1600,
+						DeciBps:           0,
+						DestGasOverhead:   100,
+						DestBytesOverhead: 100,
+						IsEnabled:         true,
+					},
+					evmChain2: {
+						MinFeeUsdcents:    300,
+						MaxFeeUsdcents:    400,
+						DeciBps:           0,
+						DestGasOverhead:   200,
+						DestBytesOverhead: 200,
+						IsEnabled:         true,
+					},
 				},
 				MCMS: mcmsConfig,
 			},

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain.go
@@ -107,8 +107,7 @@ type UpgradeConfig struct {
 	NewTimelockVersion             *semver.Version
 	// Offramp is redeployed with the existing deployer key while the other programs are upgraded in place
 	NewOffRampVersion *semver.Version
-	// SpillAddress and UpgradeAuthority must be set
-	SpillAddress     solana.PublicKey
+	// UpgradeAuthority must be set
 	UpgradeAuthority solana.PublicKey
 	// MCMS config must be set for upgrades and offramp redeploys (to configure the fee quoter after redeploy)
 	MCMS *proposalutils.TimelockConfig
@@ -117,9 +116,6 @@ type UpgradeConfig struct {
 func (cfg UpgradeConfig) Validate(e cldf.Environment, chainSelector uint64) error {
 	if cfg.NewFeeQuoterVersion == nil && cfg.NewRouterVersion == nil && cfg.NewOffRampVersion == nil {
 		return nil
-	}
-	if cfg.SpillAddress.IsZero() {
-		return errors.New("spill address must be set for fee quoter and router upgrades")
 	}
 	if cfg.UpgradeAuthority.IsZero() {
 		return errors.New("upgrade authority must be set for fee quoter and router upgrades")
@@ -950,7 +946,7 @@ func generateUpgradeTxns(
 		&e,
 		programID,
 		bufferProgram,
-		config.UpgradeConfig.SpillAddress,
+		chain.DeployerKey.PublicKey(),
 		config.UpgradeConfig.UpgradeAuthority,
 	)
 	if err != nil {
@@ -959,7 +955,7 @@ func generateUpgradeTxns(
 	closeIxn, err := generateCloseBufferIxn(
 		&e,
 		bufferProgram,
-		config.UpgradeConfig.SpillAddress,
+		chain.DeployerKey.PublicKey(),
 		config.UpgradeConfig.UpgradeAuthority,
 	)
 	if err != nil {
@@ -1099,10 +1095,14 @@ func generateCloseBufferIxn(
 	recipient solana.PublicKey,
 	upgradeAuthority solana.PublicKey,
 ) (solana.Instruction, error) {
+	// Derive the program data address
+	programDataAccount, _, _ := solana.FindProgramAddress([][]byte{bufferAddress.Bytes()}, solana.BPFLoaderUpgradeableProgramID)
+
 	keys := solana.AccountMetaSlice{
 		solana.NewAccountMeta(bufferAddress, true, false),
 		solana.NewAccountMeta(recipient, true, false),
 		solana.NewAccountMeta(upgradeAuthority, false, true),
+		solana.NewAccountMeta(programDataAccount, true, false),
 	}
 
 	instruction := solana.NewInstruction(

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_ops.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_ops.go
@@ -483,7 +483,6 @@ func DeployReceiverForTest(e cldf.Environment, cfg DeployForTestConfig) (cldf.Ch
 		// only support deployer key as upgrade authority. never transfer to timelock
 		_, err := generateUpgradeTxns(e, chain, ab, DeployChainContractsConfig{
 			UpgradeConfig: UpgradeConfig{
-				SpillAddress:     chain.DeployerKey.PublicKey(),
 				UpgradeAuthority: chain.DeployerKey.PublicKey(),
 			},
 		}, cfg.ReceiverVersion, chainState.Receiver, shared.Receiver)


### PR DESCRIPTION
- Allow multiple networks for token fee transfer config
- remove spill address from upgrade config. This will always be the deployer key
- add test for close buffer