### PR TITLE
bump chainlink-evm to 37a441e4 &config validation for Pharos

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.9.9
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.1
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.3

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1523,8 +1523,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1 h1:8xmWnZxImfNaINbiEFFMbhvVxI/eZ0db16VaSQXfpag=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1/go.mod h1:U4vWLp0dTmYgiN3Y7BXasDfM8NF3ZTIhDo5NjM+7RhQ=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06 h1:M93YcRxtQvqZ0qpZwKJzCqQKDkVtbQnxWu0+gOZHLSE=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4 h1:SDIT8Tx+iZmAgjWk5KXy4hQxteBnMIg0ol4tWXQI7LE=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502 h1:WLgEB8/lIfA1vI+7O4RE/PYitO57TRkKUqVllDIgJD4=

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -1483,7 +1483,7 @@ func TestConfig_Validate(t *testing.T) {
 		- 1: 10 errors:
 			- ChainType: invalid value (Foo): must not be set with this chain id
 			- Nodes: missing: must have at least one node
-			- ChainType: invalid value (Foo): must be one of arbitrum, astar, celo, gnosis, hedera, kroma, mantle, metis, optimismBedrock, sei, scroll, wemix, xlayer, zkevm, zksync, zircuit, tron, rootstock or omitted
+			- ChainType: invalid value (Foo): must be one of arbitrum, astar, celo, gnosis, hedera, kroma, mantle, metis, optimismBedrock, sei, scroll, wemix, xlayer, zkevm, zksync, zircuit, tron, rootstock, pharos or omitted
 			- HeadTracker.HistoryDepth: invalid value (30): must be greater than or equal to FinalizedBlockOffset
 			- GasEstimator.BumpThreshold: invalid value (0): cannot be 0 if auto-purge feature is enabled for Foo
 			- Transactions.AutoPurge.Threshold: missing: needs to be set if auto-purge feature is enabled for Foo
@@ -1496,7 +1496,7 @@ func TestConfig_Validate(t *testing.T) {
 		- 2: 5 errors:
 			- ChainType: invalid value (Arbitrum): only "optimismBedrock" can be used with this chain id
 			- Nodes: missing: must have at least one node
-			- ChainType: invalid value (Arbitrum): must be one of arbitrum, astar, celo, gnosis, hedera, kroma, mantle, metis, optimismBedrock, sei, scroll, wemix, xlayer, zkevm, zksync, zircuit, tron, rootstock or omitted
+			- ChainType: invalid value (Arbitrum): must be one of arbitrum, astar, celo, gnosis, hedera, kroma, mantle, metis, optimismBedrock, sei, scroll, wemix, xlayer, zkevm, zksync, zircuit, tron, rootstock, pharos or omitted
 			- FinalityDepth: invalid value (0): must be greater than or equal to 1
 			- MinIncomingConfirmations: invalid value (0): must be greater than or equal to 1
 		- 3: 3 errors:

--- a/core/services/ocr/contract_tracker.go
+++ b/core/services/ocr/contract_tracker.go
@@ -399,7 +399,7 @@ func (t *OCRContractTracker) LatestBlockHeight(ctx context.Context) (blockheight
 		// care about the block height; we have no way of getting the L1 block
 		// height anyway
 		return 0, nil
-	case "", chaintype.ChainArbitrum, chaintype.ChainAstar, chaintype.ChainCelo, chaintype.ChainGnosis, chaintype.ChainHedera, chaintype.ChainKroma, chaintype.ChainOptimismBedrock, chaintype.ChainSei, chaintype.ChainScroll, chaintype.ChainWeMix, chaintype.ChainXLayer, chaintype.ChainZkEvm, chaintype.ChainZkSync, chaintype.ChainZircuit, chaintype.ChainRootstock:
+	case "", chaintype.ChainArbitrum, chaintype.ChainAstar, chaintype.ChainCelo, chaintype.ChainGnosis, chaintype.ChainHedera, chaintype.ChainKroma, chaintype.ChainOptimismBedrock, chaintype.ChainSei, chaintype.ChainScroll, chaintype.ChainWeMix, chaintype.ChainXLayer, chaintype.ChainZkEvm, chaintype.ChainZkSync, chaintype.ChainZircuit, chaintype.ChainRootstock, chaintype.ChainPharos:
 		// continue
 	}
 	latestBlockHeight := t.getLatestBlockHeight()

--- a/core/services/ocrcommon/block_translator.go
+++ b/core/services/ocrcommon/block_translator.go
@@ -22,7 +22,7 @@ func NewBlockTranslator(cfg Config, client evmclient.Client, lggr logger.Logger)
 	switch cfg.ChainType() {
 	case chaintype.ChainArbitrum:
 		return NewArbitrumBlockTranslator(client, lggr)
-	case "", chaintype.ChainCelo, chaintype.ChainGnosis, chaintype.ChainKroma, chaintype.ChainMetis, chaintype.ChainOptimismBedrock, chaintype.ChainSei, chaintype.ChainScroll, chaintype.ChainWeMix, chaintype.ChainXLayer, chaintype.ChainZkEvm, chaintype.ChainZkSync, chaintype.ChainZircuit, chaintype.ChainRootstock:
+	case "", chaintype.ChainCelo, chaintype.ChainGnosis, chaintype.ChainKroma, chaintype.ChainMetis, chaintype.ChainOptimismBedrock, chaintype.ChainSei, chaintype.ChainScroll, chaintype.ChainWeMix, chaintype.ChainXLayer, chaintype.ChainZkEvm, chaintype.ChainZkSync, chaintype.ChainZircuit, chaintype.ChainRootstock, chaintype.ChainPharos:
 		fallthrough
 	default:
 		return &l1BlockTranslator{}

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0
 	github.com/smartcontractkit/chainlink-protos/orchestrator v0.7.0

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1277,8 +1277,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1 h1:8xmWnZxImfNaINbiEFFMbhvVxI/eZ0db16VaSQXfpag=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1/go.mod h1:U4vWLp0dTmYgiN3Y7BXasDfM8NF3ZTIhDo5NjM+7RhQ=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06 h1:M93YcRxtQvqZ0qpZwKJzCqQKDkVtbQnxWu0+gOZHLSE=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4 h1:SDIT8Tx+iZmAgjWk5KXy4hQxteBnMIg0ol4tWXQI7LE=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502 h1:WLgEB8/lIfA1vI+7O4RE/PYitO57TRkKUqVllDIgJD4=

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250627121608-e7b52913fae2

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e5
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d/go.mod h1:QUEPHdSkH19Or+E1iMGG+rDQ6jpCTIbm//9Osa6MXDE=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae h1:BmqiIDbA9FB/uOCOHi/shgL7P0XmjFxhfRtJHdKPLE4=
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06 h1:M93YcRxtQvqZ0qpZwKJzCqQKDkVtbQnxWu0+gOZHLSE=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4 h1:SDIT8Tx+iZmAgjWk5KXy4hQxteBnMIg0ol4tWXQI7LE=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502 h1:WLgEB8/lIfA1vI+7O4RE/PYitO57TRkKUqVllDIgJD4=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1500,8 +1500,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1 h1:8xmWnZxImfNaINbiEFFMbhvVxI/eZ0db16VaSQXfpag=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1/go.mod h1:U4vWLp0dTmYgiN3Y7BXasDfM8NF3ZTIhDo5NjM+7RhQ=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06 h1:M93YcRxtQvqZ0qpZwKJzCqQKDkVtbQnxWu0+gOZHLSE=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4 h1:SDIT8Tx+iZmAgjWk5KXy4hQxteBnMIg0ol4tWXQI7LE=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502 h1:WLgEB8/lIfA1vI+7O4RE/PYitO57TRkKUqVllDIgJD4=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250707132450-d1f5f0be212a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.9.6
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.52.4

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1482,8 +1482,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1 h1:8xmWnZxImfNaINbiEFFMbhvVxI/eZ0db16VaSQXfpag=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1/go.mod h1:U4vWLp0dTmYgiN3Y7BXasDfM8NF3ZTIhDo5NjM+7RhQ=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06 h1:M93YcRxtQvqZ0qpZwKJzCqQKDkVtbQnxWu0+gOZHLSE=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4 h1:SDIT8Tx+iZmAgjWk5KXy4hQxteBnMIg0ol4tWXQI7LE=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502 h1:WLgEB8/lIfA1vI+7O4RE/PYitO57TRkKUqVllDIgJD4=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250807174108-141496ece254
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.9.9
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.3

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1269,8 +1269,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1 h1:8xmWnZxImfNaINbiEFFMbhvVxI/eZ0db16VaSQXfpag=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1/go.mod h1:U4vWLp0dTmYgiN3Y7BXasDfM8NF3ZTIhDo5NjM+7RhQ=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06 h1:M93YcRxtQvqZ0qpZwKJzCqQKDkVtbQnxWu0+gOZHLSE=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4 h1:SDIT8Tx+iZmAgjWk5KXy4hQxteBnMIg0ol4tWXQI7LE=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502 h1:WLgEB8/lIfA1vI+7O4RE/PYitO57TRkKUqVllDIgJD4=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250626141212-e50b2e7ffe2d
 	github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae
 	github.com/smartcontractkit/chainlink-deployments-framework v0.15.1
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.9.9
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1465,8 +1465,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa
 github.com/smartcontractkit/chainlink-data-streams v0.1.1-0.20250604171706-a98fa6515eae/go.mod h1:2MggrMtbhqr0u4U2pcYa21lvAtvaeSawjxdIy1ytHWE=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1 h1:8xmWnZxImfNaINbiEFFMbhvVxI/eZ0db16VaSQXfpag=
 github.com/smartcontractkit/chainlink-deployments-framework v0.15.1/go.mod h1:U4vWLp0dTmYgiN3Y7BXasDfM8NF3ZTIhDo5NjM+7RhQ=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06 h1:M93YcRxtQvqZ0qpZwKJzCqQKDkVtbQnxWu0+gOZHLSE=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250704141053-c351643e0b06/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4 h1:SDIT8Tx+iZmAgjWk5KXy4hQxteBnMIg0ol4tWXQI7LE=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250820082914-37a441e4e4f4/go.mod h1:LkZDSvFz0vHJZE+nyycmDjxAc6JTfE8haH/XCm52p/g=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135/go.mod h1:NkvE4iQgiT7dMCP6U3xPELHhWhN5Xr6rHC0axRebyMU=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502 h1:WLgEB8/lIfA1vI+7O4RE/PYitO57TRkKUqVllDIgJD4=


### PR DESCRIPTION
For 2.26.1 release
- Bump chainlink-evm to this [commit](https://github.com/smartcontractkit/chainlink-evm/commit/37a441e4e4f49bb5f24da68841440be88cab60ab) ([branch](https://github.com/smartcontractkit/chainlink-evm/commits/2.26.1-cherry-pick/))
      - [Commit](https://github.com/smartcontractkit/chainlink-evm/commit/f190212bab15e84fe49db88f495ad026e6c1d520) in chainlink-evm develop
- from [existing commit](https://github.com/smartcontractkit/chainlink-evm/commit/c351643e0b0608bb8733f8df23a7f44d3ac1f089)