### PR TITLE
feat: fix chainid collisions across families

### DIFF
--- a/.changeset/crazy-paths-report.md
+++ b/.changeset/crazy-paths-report.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#fixed chainid collisions across families

--- a/.changeset/crazy-paths-report.md
+++ b/.changeset/crazy-paths-report.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-#fixed chainid collisions across families
+#bugfix chainid collisions across families

--- a/core/capabilities/ccip/ccipevm/crcwconfig.go
+++ b/core/capabilities/ccip/ccipevm/crcwconfig.go
@@ -18,7 +18,7 @@ type ChainCWProvider struct{}
 // GetChainReader returns a new ContractReader for EVM chains.
 func (g ChainCWProvider) GetChainReader(ctx context.Context, params ccipcommon.ChainReaderProviderOpts) (types.ContractReader, error) {
 	var chainReaderConfig evmrelaytypes.ChainReaderConfig
-	if params.ChainID == params.DestChainID {
+	if params.ChainID == params.DestChainID && params.ChainFamily == params.DestChainFamily {
 		chainReaderConfig = evmconfig.DestReaderConfig
 	} else {
 		chainReaderConfig = evmconfig.SourceReaderConfig

--- a/core/capabilities/ccip/ccipsolana/crcwconfig.go
+++ b/core/capabilities/ccip/ccipsolana/crcwconfig.go
@@ -47,7 +47,7 @@ func (g ChainRWProvider) GetChainWriter(ctx context.Context, pararms ccipcommon.
 func (g ChainRWProvider) GetChainReader(ctx context.Context, params ccipcommon.ChainReaderProviderOpts) (types.ContractReader, error) {
 	var err error
 	var cfg config.ContractReader
-	if params.ChainID == params.DestChainID {
+	if params.ChainID == params.DestChainID && params.ChainFamily == params.DestChainFamily {
 		cfg, err = solanaconfig.DestContractReaderConfig()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get Solana dest contract reader config: %w", err)

--- a/core/capabilities/ccip/common/crcwconfig.go
+++ b/core/capabilities/ccip/common/crcwconfig.go
@@ -12,14 +12,15 @@ import (
 
 // ChainReaderProviderOpts is a struct that contains the parameters for GetChainReader.
 type ChainReaderProviderOpts struct {
-	Lggr          logger.Logger
-	Relayer       loop.Relayer
-	ChainID       string
-	DestChainID   string
-	HomeChainID   string
-	Ofc           OffChainConfig
-	ChainSelector cciptypes.ChainSelector
-	ChainFamily   string
+	Lggr            logger.Logger
+	Relayer         loop.Relayer
+	ChainID         string
+	DestChainID     string
+	HomeChainID     string
+	Ofc             OffChainConfig
+	ChainSelector   cciptypes.ChainSelector
+	ChainFamily     string
+	DestChainFamily string
 }
 
 // ChainWriterProviderOpts is a struct that contains the parameters for GetChainWriter.

--- a/core/capabilities/ccip/common/crcwconfig.go
+++ b/core/capabilities/ccip/common/crcwconfig.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 )
 
 // ChainReaderProviderOpts is a struct that contains the parameters for GetChainReader.

--- a/core/capabilities/ccip/oraclecreator/plugin.go
+++ b/core/capabilities/ccip/oraclecreator/plugin.go
@@ -541,14 +541,15 @@ func (i *pluginOracleCreator) createReadersAndWriters(
 		}
 
 		cr, err1 := crcw.GetChainReader(ctx, ccipcommon.ChainReaderProviderOpts{
-			Lggr:          i.lggr,
-			Relayer:       relayer,
-			ChainID:       chainID,
-			DestChainID:   destChainID,
-			HomeChainID:   homeChainID,
-			Ofc:           ofc,
-			ChainSelector: chainSelector,
-			ChainFamily:   relayChainFamily,
+			Lggr:            i.lggr,
+			Relayer:         relayer,
+			ChainID:         chainID,
+			DestChainID:     destChainID,
+			HomeChainID:     homeChainID,
+			Ofc:             ofc,
+			ChainSelector:   chainSelector,
+			ChainFamily:     relayChainFamily,
+			DestChainFamily: destChainFamily,
 		})
 		if err1 != nil {
 			return nil, nil, nil, err1


### PR DESCRIPTION
This PR adds a fix to allow CR instances to have undefined behaviour when chainid collisions happen across families (As is the case for aptos and evm)

Tested via E2E tests in CI runs, to replicate you need a custom version of chain-selectors. for simplicity of this PR i've left out. the test will be added in a follow PR

- [Broken Test](https://github.com/smartcontractkit/chainlink/actions/runs/17105367160/job/48512932272?pr=19024)
- [Fix Applied](https://github.com/smartcontractkit/chainlink/actions/runs/17105427510/job/48513175968?pr=19037)