### PR TITLE
Fix llo integration test race

### DIFF
--- a/core/services/ocr2/plugins/llo/helpers_test.go
+++ b/core/services/ocr2/plugins/llo/helpers_test.go
@@ -98,9 +98,13 @@ func NewMercuryServer(t *testing.T, csaSigner crypto.Signer, packetsCh chan *pac
 }
 
 func (s *mercuryServer) Transmit(ctx context.Context, req *rpc.TransmitRequest) (*rpc.TransmitResponse, error) {
-	s.packetsCh <- &packet{
+	select {
+	case s.packetsCh <- &packet{
 		req: req,
 		ctx: ctx,
+	}:
+
+	default:
 	}
 
 	return &rpc.TransmitResponse{

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -1492,7 +1492,8 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 			}
 			if finished >= nNodes {
 				for _, node := range nodes {
-					require.NoError(t, node.App.Stop())
+					//nolint:testifylint // need assert to ensure we don't leak nodes
+					assert.NoError(t, node.App.Stop())
 				}
 				defer close(packets)
 				break

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httptest"
 	"sort"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -1466,7 +1465,6 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 		cnts := map[string]int{}
 		// transmitter addr => channel ID => reports
 		m := map[string]map[uint32][]datastreamsllo.Report{}
-		stopOnce := sync.Once{}
 
 		for pckt := range packets {
 			pr, ok := peer.FromContext(pckt.ctx)
@@ -1493,17 +1491,11 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 				}
 			}
 			if finished >= nNodes {
-				stopOnce.Do(func() {
-					// Stop all nodes, close the channel
-					// This helps transmissions have a chance to complete (but
-					// doesn't ensure it; libocr cancels the transmit context
-					// immediately on stop signal)
-					// Loop will exit once all packets are consumed
-					for _, node := range nodes {
-						require.NoError(t, node.App.Stop())
-					}
-					close(packets)
-				})
+				for _, node := range nodes {
+					require.NoError(t, node.App.Stop())
+				}
+				defer close(packets)
+				break
 			}
 		}
 


### PR DESCRIPTION
Defer closing of transmit channel to avoid racing with nodes not stopping fast enough.