### PR TITLE
CRE-738: Allow empty Nodes on config input

### DIFF
--- a/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/register_node.go
+++ b/deployment/cre/capabilities_registry/v2/changeset/operations/contracts/register_node.go
@@ -39,7 +39,10 @@ var RegisterNodes = operations.NewOperation[RegisterNodesInput, RegisterNodesOut
 			return RegisterNodesOutput{}, errors.New("address is not set")
 		}
 		if len(input.Nodes) == 0 {
-			return RegisterNodesOutput{}, errors.New("nodes are not set")
+			// The contract allows to pass an empty array of nodes.
+			return RegisterNodesOutput{
+				Nodes: []*capabilities_registry_v2.CapabilitiesRegistryNodeAdded{},
+			}, nil
 		}
 		if input.ChainSelector == 0 {
 			return RegisterNodesOutput{}, errors.New("chainSelector is not set")


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
This PR helps addressing [CRE-738](https://smartcontract-it.atlassian.net/browse/CRE-738) by allowing an empty Nodes array to be passed as inputs.

The contract itself does not fail if we pass an empty array: https://github.com/smartcontractkit/chainlink-evm/blob/develop/contracts/src/v0.8/workflow/dev/v2/CapabilitiesRegistry.sol#L584

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->

- <https://github.com/smartcontractkit/chainlink-deployments/pull/5402>


[CRE-738]: https://smartcontract-it.atlassian.net/browse/CRE-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ