### PR TITLE
Unblock bumping chainlink-common: embed UnimplementedKeystore in mock

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250814153237-9a6c5a35e950
-	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c
+	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6
 	github.com/smartcontractkit/chainlink-data-streams v0.1.2
 	github.com/smartcontractkit/chainlink-deployments-framework v0.25.0
 	github.com/smartcontractkit/chainlink-evm v0.3.2

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1526,8 +1526,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a h1:38dAlTPRUQHZus5dCnBnQyf/V4oYn0p2svWlbPgHDQ4=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c h1:YXFwFoclQBL+B9C3xG07v5GNc31fUcib7hu+MzneFWI=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6 h1:de51Uu/kz/0kbd/b4PD9fAxt8mY4JzRWc02eyvi9daw=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1 h1:ca2z5OXgnbBPQRxpwXwBLJsUA1+cAp5ncfW4Ssvd6eY=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1/go.mod h1:NZv/qKYGFRnkjOYBouajnDfFoZ+WDa6H2KNmSf1dnKc=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/core/services/standardcapabilities/standard_capabilities_test.go
+++ b/core/services/standardcapabilities/standard_capabilities_test.go
@@ -66,7 +66,9 @@ func (k *kvstoreMock) PruneExpiredEntries(ctx context.Context, maxAge time.Durat
 	return 0, nil
 }
 
-type keystoreMock struct{}
+type keystoreMock struct {
+	core.UnimplementedKeystore
+}
 
 func (k *keystoreMock) Accounts(ctx context.Context) (accounts []string, err error) {
 	return nil, nil

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250814153237-9a6c5a35e950
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
-	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c
+	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.25.0
 	github.com/smartcontractkit/chainlink-evm v0.3.2
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250808121824-2c3544aab8f3

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1252,8 +1252,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a h1:38dAlTPRUQHZus5dCnBnQyf/V4oYn0p2svWlbPgHDQ4=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c h1:YXFwFoclQBL+B9C3xG07v5GNc31fUcib7hu+MzneFWI=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6 h1:de51Uu/kz/0kbd/b4PD9fAxt8mY4JzRWc02eyvi9daw=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1 h1:ca2z5OXgnbBPQRxpwXwBLJsUA1+cAp5ncfW4Ssvd6eY=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1/go.mod h1:NZv/qKYGFRnkjOYBouajnDfFoZ+WDa6H2KNmSf1dnKc=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250814153237-9a6c5a35e950
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44
-	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c
+	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6
 	github.com/smartcontractkit/chainlink-data-streams v0.1.2
 	github.com/smartcontractkit/chainlink-evm v0.3.2
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250808121824-2c3544aab8f3

--- a/go.sum
+++ b/go.sum
@@ -1086,8 +1086,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44 h1:S00lus9RPu5JuxKRtGEET+aIUfASahHpTRV5RgPARSI=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c h1:YXFwFoclQBL+B9C3xG07v5GNc31fUcib7hu+MzneFWI=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6 h1:de51Uu/kz/0kbd/b4PD9fAxt8mY4JzRWc02eyvi9daw=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1 h1:ca2z5OXgnbBPQRxpwXwBLJsUA1+cAp5ncfW4Ssvd6eY=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1/go.mod h1:NZv/qKYGFRnkjOYBouajnDfFoZ+WDa6H2KNmSf1dnKc=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250814153237-9a6c5a35e950
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
-	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c
+	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.25.0
 	github.com/smartcontractkit/chainlink-evm v0.3.2
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250808121824-2c3544aab8f3

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1514,8 +1514,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a h1:38dAlTPRUQHZus5dCnBnQyf/V4oYn0p2svWlbPgHDQ4=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c h1:YXFwFoclQBL+B9C3xG07v5GNc31fUcib7hu+MzneFWI=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6 h1:de51Uu/kz/0kbd/b4PD9fAxt8mY4JzRWc02eyvi9daw=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1 h1:ca2z5OXgnbBPQRxpwXwBLJsUA1+cAp5ncfW4Ssvd6eY=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1/go.mod h1:NZv/qKYGFRnkjOYBouajnDfFoZ+WDa6H2KNmSf1dnKc=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250814153237-9a6c5a35e950
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
-	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c
+	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.25.0
 	github.com/smartcontractkit/chainlink-evm v0.3.2
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250808121824-2c3544aab8f3

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1490,8 +1490,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a h1:38dAlTPRUQHZus5dCnBnQyf/V4oYn0p2svWlbPgHDQ4=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c h1:YXFwFoclQBL+B9C3xG07v5GNc31fUcib7hu+MzneFWI=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6 h1:de51Uu/kz/0kbd/b4PD9fAxt8mY4JzRWc02eyvi9daw=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1 h1:ca2z5OXgnbBPQRxpwXwBLJsUA1+cAp5ncfW4Ssvd6eY=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1/go.mod h1:NZv/qKYGFRnkjOYBouajnDfFoZ+WDa6H2KNmSf1dnKc=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/smartcontractkit/chain-selectors v1.0.67
-	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c
+	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6
 	github.com/smartcontractkit/chainlink-deployments-framework v0.25.0
 	github.com/smartcontractkit/chainlink-evm v0.3.2
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250808121824-2c3544aab8f3

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1284,8 +1284,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a h1:38dAlTPRUQHZus5dCnBnQyf/V4oYn0p2svWlbPgHDQ4=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c h1:YXFwFoclQBL+B9C3xG07v5GNc31fUcib7hu+MzneFWI=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6 h1:de51Uu/kz/0kbd/b4PD9fAxt8mY4JzRWc02eyvi9daw=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1 h1:ca2z5OXgnbBPQRxpwXwBLJsUA1+cAp5ncfW4Ssvd6eY=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1/go.mod h1:NZv/qKYGFRnkjOYBouajnDfFoZ+WDa6H2KNmSf1dnKc=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/prometheus/common v0.65.0
 	github.com/rs/zerolog v1.33.0
 	github.com/shopspring/decimal v1.4.0
-	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c
+	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6
 	github.com/smartcontractkit/chainlink-data-streams v0.1.2
 	github.com/smartcontractkit/chainlink-deployments-framework v0.25.0
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250808121824-2c3544aab8f3

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1495,8 +1495,8 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:Ve1xD71bl193YIZQEoJMmBqLGQJdNs29bwbuObwvbhQ=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a h1:38dAlTPRUQHZus5dCnBnQyf/V4oYn0p2svWlbPgHDQ4=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c h1:YXFwFoclQBL+B9C3xG07v5GNc31fUcib7hu+MzneFWI=
-github.com/smartcontractkit/chainlink-common v0.9.1-0.20250819154659-73aa8dc9bf8c/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6 h1:de51Uu/kz/0kbd/b4PD9fAxt8mY4JzRWc02eyvi9daw=
+github.com/smartcontractkit/chainlink-common v0.9.1-0.20250821140651-40de7f5ae3c6/go.mod h1:0OMQFyxibohHOzskRmEz4wr+w0SdAFsU6CjW/VhRf34=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1 h1:ca2z5OXgnbBPQRxpwXwBLJsUA1+cAp5ncfW4Ssvd6eY=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1/go.mod h1:NZv/qKYGFRnkjOYBouajnDfFoZ+WDa6H2KNmSf1dnKc=
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7 h1:9wh1G+WbXwPVqf0cfSRSgwIcaXTQgvYezylEAfwmrbw=


### PR DESCRIPTION
## Summary

Unblocks bumping `chainlink-common` by embedding `UnimplementedKeystore` in the standard-capabilities test mock so it picks up the new `Decrypt` stub method, then bumps `chainlink-common` across all modules.

## Why

`chainlink-common` added a `Decrypt` method to the keystore interface; mocks that didn't embed `UnimplementedKeystore` failed to compile after the bump. (Closed — superseded.)
