### PR TITLE
TestMetadataRegistry: implement UnimplementedCapReg

### DIFF
--- a/core/capabilities/registry.go
+++ b/core/capabilities/registry.go
@@ -21,7 +21,7 @@ type Registry struct {
 
 	metadataRegistry core.CapabilitiesRegistryMetadata
 	lggr             logger.Logger
-	mu sync.RWMutex
+	mu               sync.RWMutex
 }
 
 func (r *Registry) LocalNode(ctx context.Context) (capabilities.Node, error) {
@@ -71,7 +71,9 @@ func NewRegistry(lggr logger.Logger) *Registry {
 
 // TestMetadataRegistry is a test implementation of the metadataRegistry
 // interface. It is used when ExternalCapabilitiesRegistry is not available.
-type TestMetadataRegistry struct{}
+type TestMetadataRegistry struct {
+	core.UnimplementedCapabilitiesRegistryMetadata
+}
 
 func (t *TestMetadataRegistry) LocalNode(ctx context.Context) (capabilities.Node, error) {
 	peerID := p2ptypes.PeerID{}

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -1553,6 +1553,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 }
 
 func TestIntegration_LLO_transmit_errors(t *testing.T) {
+	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/MERC-7232")
 	t.Parallel()
 
 	// logLevel: the log level to use for the nodes

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -1727,6 +1727,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, serverPubKey
 }
 
 func TestIntegration_LLO_blue_green_lifecycle(t *testing.T) {
+	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/MERC-7232")
 	t.Parallel()
 
 	offchainConfigs := []datastreamsllo.OffchainConfig{

--- a/core/services/ocr2/plugins/llo/integration_test.go
+++ b/core/services/ocr2/plugins/llo/integration_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/smartcontractkit/wsrpc/credentials"
 
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	datastreamsllo "github.com/smartcontractkit/chainlink-data-streams/llo"
 
 	lloevm "github.com/smartcontractkit/chainlink-data-streams/llo/reportcodecs/evm"
@@ -649,6 +650,7 @@ channelDefinitionsContractFromBlock = %d`, serverURL, serverPubKey, donID, confi
 }
 
 func TestIntegration_LLO_multi_formats(t *testing.T) {
+	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/MERC-7232")
 	t.Parallel()
 	offchainConfigs := []datastreamsllo.OffchainConfig{
 		{
@@ -1316,6 +1318,7 @@ dp -> deribit_funding_interval_hours_parse -> deribit_funding_interval_hours_dec
 }
 
 func TestIntegration_LLO_stress_test_V1(t *testing.T) {
+	tests.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/MERC-7232")
 	t.Parallel()
 
 	// logLevel: the log level to use for the nodes


### PR DESCRIPTION
Also skips a flakey LLO test, as per this thread: https://chainlink-core.slack.com/archives/C05JDS9S64S/p1756209641313889