### PR TITLE
Metering steps not included in metering report when in metering mode

### DIFF
--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -3089,4 +3089,76 @@ targets:
 		// This is expected behavior since no metering report exists
 		mBillingClient.AssertNotCalled(t, "SubmitWorkflowReceipt")
 	})
+
+	t.Run("includes step data when billing client errors", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		reg := coreCap.NewRegistry(logger.NullLogger)
+		mBillingClient := new(mocks.BillingClient)
+		errBillingClient := errors.New("billing client error")
+
+		expectedRegistryAddress := "0xe3188aFCc8FA3aE39Ea38d73DBBf90A6AD529128"
+		expectedChainID := uint64(11155111) // Sepolia chain ID
+		expectedChainSelector, err := chainselectors.SelectorFromChainId(expectedChainID)
+		require.NoError(t, err)
+
+		mBillingClient.EXPECT().GetWorkflowExecutionRates(mock.Anything, mock.Anything).
+			Return(nil, errBillingClient)
+
+		// Verify that ReserveCredits is called with the correct workflow registry information
+		// Sepolia chain ID 11155111 converts to the expected chainSelector
+		mBillingClient.EXPECT().
+			ReserveCredits(mock.Anything, mock.MatchedBy(func(req *billing.ReserveCreditsRequest) bool {
+				if req == nil {
+					return false
+				}
+				// Check that the workflow registry fields are set correctly
+				return req.WorkflowRegistryAddress == expectedRegistryAddress &&
+					req.WorkflowRegistryChainSelector == expectedChainSelector // Sepolia selector
+			})).
+			Return(nil, errBillingClient)
+
+		// Verify that SubmitWorkflowReceipt is called with the correct workflow registry information
+		mBillingClient.EXPECT().
+			SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
+				if req == nil {
+					return false
+				}
+
+				return len(req.Metering.Steps) == 1 && req.Metering.Message == errBillingClient.Error() &&
+					req.WorkflowRegistryAddress == expectedRegistryAddress &&
+					req.WorkflowRegistryChainSelector == expectedChainSelector // Sepolia selector
+			})).
+			Return(nil, errBillingClient)
+
+		tr := withTrigger(t, reg)
+		target := withTarget(t, reg)
+		lggr, logs := logger.TestLoggerObserved(t, zapcore.ErrorLevel)
+		eng, testHooks := newTestEngineWithYAMLSpec(
+			t,
+			reg,
+			testWorkflow,
+			func(cfg *Config) {
+				cfg.BillingClient = mBillingClient
+				cfg.WorkflowRegistryAddress = expectedRegistryAddress
+				cfg.WorkflowRegistryChainID = "11155111"
+				cfg.Lggr = lggr
+			},
+		)
+
+		servicetest.Run(t, eng)
+
+		eid := getExecutionID(t, eng, testHooks)
+		resp := <-target.response
+		assert.Equal(t, tr.Event.Outputs, resp.Value)
+
+		state, err := eng.executionsStore.Get(ctx, eid)
+		require.NoError(t, err)
+		assert.Equal(t, store.StatusCompleted, state.Status)
+
+		// expected errors include a switch to metering mode due to billing client error and a failure to end
+		// a report due to billing client error.
+		assert.Len(t, logs.All(), 2)
+	})
 }

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -3006,6 +3006,8 @@ targets:
 		state, err := eng.executionsStore.Get(ctx, eid)
 		require.NoError(t, err)
 		assert.Equal(t, store.StatusCompleted, state.Status)
+
+		mBillingClient.AssertExpectations(t)
 	})
 
 	t.Run("handles empty workflow registry information", func(t *testing.T) {
@@ -3076,18 +3078,16 @@ targets:
 
 		// Verify that warnings were logged about the empty chain selector
 		warnLogs := logs.TakeAll()
-		require.Len(t, warnLogs, 3) // Error about chain selector parsing, warning about no metering report, error about failed to end metering report
+		require.GreaterOrEqual(t, len(warnLogs), 1) // Error about chain selector parsing
 		chainSelectorWarnings := 0
 		for _, log := range warnLogs {
-			if strings.Contains(log.Message, "failed to parse workflow registry chain selector") {
+			if strings.Contains(log.Message, "failed to parse registry chain id") {
 				chainSelectorWarnings++
 			}
 		}
 		assert.GreaterOrEqual(t, chainSelectorWarnings, 0) // May or may not have chain selector warnings
 
-		// When chain selector is empty, metering fails to initialize, so SubmitWorkflowReceipt is not called
-		// This is expected behavior since no metering report exists
-		mBillingClient.AssertNotCalled(t, "SubmitWorkflowReceipt")
+		mBillingClient.AssertExpectations(t)
 	})
 
 	t.Run("includes step data when billing client errors", func(t *testing.T) {
@@ -3126,7 +3126,7 @@ targets:
 					return false
 				}
 
-				return len(req.Metering.Steps) == 1 && req.Metering.Message == errBillingClient.Error() &&
+				return len(req.Metering.Steps) == 1 && strings.Contains(req.Metering.Message, errBillingClient.Error()) &&
 					req.WorkflowRegistryAddress == expectedRegistryAddress &&
 					req.WorkflowRegistryChainSelector == expectedChainSelector // Sepolia selector
 			})).
@@ -3160,5 +3160,7 @@ targets:
 		// expected errors include a switch to metering mode due to billing client error and a failure to end
 		// a report due to billing client error.
 		assert.Len(t, logs.All(), 2)
+
+		mBillingClient.AssertExpectations(t)
 	})
 }

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -3119,6 +3119,50 @@ targets:
 			})).
 			Return(nil, errBillingClient)
 
+		expectedSteps := map[string]*eventspb.MeteringReportStep{
+			"write_polygon-testnet-mumbai@1.0.0": {
+				Nodes: []*eventspb.MeteringReportNodeDetail{
+					{
+						Peer_2PeerId: "12D3KooW9pNAk8aiBuGVQtWRdbkLmo5qVL3e2h5UxbN2Nz9ttwiw",
+						SpendUnit:    "RESOURCE_TYPE_COMPUTE",
+						SpendValue:   "100",
+					},
+				},
+			},
+		}
+
+		stepCompare := func(expected, compared map[string]*eventspb.MeteringReportStep) bool {
+			if len(expected) != len(compared) {
+				return false
+			}
+
+			for key, step := range expected {
+				comparedStep, exists := compared[key]
+				if !exists {
+					return false
+				}
+
+				expectedNodes := step.GetNodes()
+				comparedNodes := comparedStep.GetNodes()
+
+				if len(expectedNodes) != len(comparedNodes) {
+					return false
+				}
+
+				for idx, node := range expectedNodes {
+					comparedNode := comparedNodes[idx]
+
+					if comparedNode.GetPeer_2PeerId() != node.GetPeer_2PeerId() ||
+						comparedNode.GetSpendUnit() != node.GetSpendUnit() ||
+						comparedNode.GetSpendValue() != node.GetSpendValue() {
+						return false
+					}
+				}
+			}
+
+			return true
+		}
+
 		// Verify that SubmitWorkflowReceipt is called with the correct workflow registry information
 		mBillingClient.EXPECT().
 			SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
@@ -3126,7 +3170,7 @@ targets:
 					return false
 				}
 
-				return len(req.Metering.Steps) == 1 && strings.Contains(req.Metering.Message, errBillingClient.Error()) &&
+				return stepCompare(expectedSteps, req.Metering.Steps) && strings.Contains(req.Metering.Message, errBillingClient.Error()) &&
 					req.WorkflowRegistryAddress == expectedRegistryAddress &&
 					req.WorkflowRegistryChainSelector == expectedChainSelector // Sepolia selector
 			})).

--- a/core/services/workflows/metering/balance_store.go
+++ b/core/services/workflows/metering/balance_store.go
@@ -94,6 +94,15 @@ func (bs *balanceStore) ConvertFromBalance(toResourceType string, amount decimal
 	return bs.convertFromBalance(toResourceType, amount)
 }
 
+// Set sets the current balance to the provided amount and resets spend.
+func (bs *balanceStore) Set(amount decimal.Decimal) {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+
+	bs.balance = amount
+	bs.spent = decimal.Zero
+}
+
 // Get returns the current credit balance
 func (bs *balanceStore) Get() decimal.Decimal {
 	bs.mu.RLock()

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -106,6 +106,7 @@ type Report struct {
 	meteringModeErr error
 	steps           map[string]ReportStep
 	rateCard        map[string]decimal.Decimal
+	stepRefLookup   []string
 
 	// WorkflowRegistryAddress is the address of the workflow registry contract
 	workflowRegistryAddress string
@@ -433,11 +434,11 @@ func (r *Report) FormatReport() *protoEvents.MeteringReport {
 		protoReport.Message = r.meteringModeErr.Error()
 	}
 
-	stepRefLookup := []string{}
+	r.stepRefLookup = []string{}
 
 	for ref, step := range r.steps {
 		nodeDetails := []*protoEvents.MeteringReportNodeDetail{}
-		stepRefLookup = append(stepRefLookup, ref+":"+step.CapabilityID)
+		r.stepRefLookup = append(r.stepRefLookup, ref+":"+step.CapabilityID)
 
 		for unit, details := range step.Spends {
 			for _, detail := range details {
@@ -453,8 +454,6 @@ func (r *Report) FormatReport() *protoEvents.MeteringReport {
 			Nodes: nodeDetails,
 		}
 	}
-
-	r.lggr.Debug("Step references:", "steps", strings.Join(stepRefLookup, ","))
 
 	return protoReport
 }
@@ -499,9 +498,11 @@ func (r *Report) EmitReceipt(ctx context.Context) error {
 		return ErrNoReserve
 	}
 
-	r.lggr.Debug("Emitting metering report", "report", r.FormatReport())
+	rpt := r.FormatReport()
 
-	return wfEvents.EmitMeteringReport(ctx, r.labels, r.FormatReport())
+	r.lggr.Debug("Emitting metering report", "report", rpt, "stepRefs", strings.Join(r.stepRefLookup, ","))
+
+	return wfEvents.EmitMeteringReport(ctx, r.labels, rpt)
 }
 
 // creditToSpendingLimits returns a slice of spend limits where the amount is applied to the spend types from the

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -71,6 +71,8 @@ type ProtoDetail struct {
 }
 
 type ReportStep struct {
+	// The ID of the capability being used in this step
+	CapabilityID string
 	// The maximum amount of universal credits that should be used in this step
 	Deduction decimal.Decimal
 	// The actual resource spend that each node used for this step
@@ -251,12 +253,13 @@ type DeductOpt func(string, *Report) ([]capabilities.SpendLimit, error)
 // ByResource returns a DeductOpt that earmarks a specified amount of local universal credit balance for a given spend
 // type.
 func ByResource(
-	spendType string,
+	spendType, capabilityID string,
 	amount decimal.Decimal,
 ) func(string, *Report) ([]capabilities.SpendLimit, error) {
 	return func(ref string, r *Report) ([]capabilities.SpendLimit, error) {
 		step := ReportStep{
-			Deduction: decimal.Zero,
+			CapabilityID: capabilityID,
+			Deduction:    decimal.Zero,
 		}
 
 		defer func() {
@@ -290,7 +293,8 @@ func ByDerivedAvailability(
 ) func(string, *Report) ([]capabilities.SpendLimit, error) {
 	return func(ref string, r *Report) ([]capabilities.SpendLimit, error) {
 		step := ReportStep{
-			Deduction: decimal.Zero,
+			CapabilityID: info.ID,
+			Deduction:    decimal.Zero,
 		}
 
 		defer func() {
@@ -429,8 +433,11 @@ func (r *Report) FormatReport() *protoEvents.MeteringReport {
 		protoReport.Message = r.meteringModeErr.Error()
 	}
 
+	stepRefLookup := []string{}
+
 	for ref, step := range r.steps {
 		nodeDetails := []*protoEvents.MeteringReportNodeDetail{}
+		stepRefLookup = append(stepRefLookup, ref+":"+step.CapabilityID)
 
 		for unit, details := range step.Spends {
 			for _, detail := range details {
@@ -446,6 +453,8 @@ func (r *Report) FormatReport() *protoEvents.MeteringReport {
 			Nodes: nodeDetails,
 		}
 	}
+
+	r.lggr.Debug("Step references:", "steps", strings.Join(stepRefLookup, ","))
 
 	return protoReport
 }

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -49,6 +49,7 @@ var (
 	ErrRatiosAndTypesNoMatch = errors.New("spending types and ratios do not match")
 	ErrInvalidRatios         = errors.New("invalid spending type ratios")
 	ErrDeductOptionRequired  = errors.New("deduct option required")
+	ErrEmptyRateCard         = errors.New("empty rate card")
 )
 
 type BillingClient interface {
@@ -92,8 +93,8 @@ type Report struct {
 	metrics *monitoring.WorkflowsMetricLabeler
 
 	// internal state
-	mu    sync.RWMutex
-	ready bool
+	mu       sync.RWMutex
+	reserved bool
 
 	// meteringMode turns off double spend checks.
 	// In meteringMode, no accounting wrt universal credits is required;
@@ -119,14 +120,15 @@ func NewReport(ctx context.Context, labels map[string]string, lggr logger.Logger
 		}
 	}
 
-	report := Report{
+	report := &Report{
 		labels:                  labels,
 		lggr:                    logger.Sugared(lggr).Named("Metering").With(platform.KeyWorkflowExecutionID, labels[platform.KeyWorkflowExecutionID]),
 		metrics:                 metrics,
 		workflowRegistryAddress: workflowRegistryAddress,
+		rateCard:                make(map[string]decimal.Decimal),
 
-		ready: false,
-		steps: make(map[string]ReportStep),
+		reserved: false,
+		steps:    make(map[string]ReportStep),
 	}
 
 	// for safety in evaluating the client interface.
@@ -137,26 +139,18 @@ func NewReport(ctx context.Context, labels map[string]string, lggr logger.Logger
 	}
 
 	if client == nil {
-		report.meteringMode = true
-
-		lggr.Errorf("switching to metering mode: %s", ErrNoBillingClient)
+		report.switchToMeteringMode(ErrNoBillingClient)
 	}
 
 	chainID, err := strconv.ParseUint(workflowRegistryChainID, 10, 64)
 	if err != nil {
-		report.meteringMode = true
-
-		lggr.Errorf("switching to metering mode: failed to parse registry chain id: %s", err)
+		report.switchToMeteringMode(fmt.Errorf("failed to parse registry chain id: %w", err))
 	}
 
 	report.workflowRegistryChainSelector, err = chainselectors.SelectorFromChainId(chainID)
 	if err != nil {
-		report.meteringMode = true
-
-		lggr.Errorf("switching to metering mode: failed to get selector for chain id: %s", err)
+		report.switchToMeteringMode(fmt.Errorf("failed to get selector for chain id: %w", err))
 	}
-
-	report.rateCard = make(map[string]decimal.Decimal)
 
 	if client != nil {
 		report.client = client
@@ -169,24 +163,32 @@ func NewReport(ctx context.Context, labels map[string]string, lggr logger.Logger
 			ChainSelector:           report.workflowRegistryChainSelector,
 		})
 		if err != nil {
-			lggr.Error(err)
+			report.switchToMeteringMode(err)
 		}
 
 		report.rateCard, err = toRateCard(resp)
 		if err != nil {
-			lggr.Errorf("switching to metering mode: %s", err)
-
-			report.meteringMode = true
+			report.switchToMeteringMode(err)
 		}
 	}
 
-	if len(report.rateCard) == 0 && !report.meteringMode {
-		lggr.Error("switching to metering mode: empty rate card")
-
-		report.meteringMode = true
+	if len(report.rateCard) == 0 {
+		report.switchToMeteringMode(ErrEmptyRateCard)
 	}
 
-	return &report, nil
+	report.balance, err = NewBalanceStore(decimal.Zero, report.rateCard)
+	if err != nil {
+		report.switchToMeteringMode(fmt.Errorf("failed to create balance store: %w", err))
+
+		// we can recover with an empty rate card and in metering mode
+		report.balance, err = NewBalanceStore(decimal.Zero, map[string]decimal.Decimal{})
+		if err != nil {
+			// this should never happen, but if it does, we cannot proceed
+			return nil, err
+		}
+	}
+
+	return report, nil
 }
 
 // Reserve calls the billing service for the initial credit balance that can be used in an execution.
@@ -195,10 +197,11 @@ func (r *Report) Reserve(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// to avoid nil pointers, the balance store should be initialized with a zero value
-	r.balance, _ = NewBalanceStore(decimal.Zero, r.rateCard)
+	// always indicate that reserve was called.
+	r.reserved = true
 
-	if r.client == nil {
+	// no need to move forward here if already in metering mode
+	if r.client == nil || r.meteringMode {
 		r.switchToMeteringMode(ErrNoBillingClient)
 
 		return nil
@@ -238,25 +241,7 @@ func (r *Report) Reserve(ctx context.Context) error {
 		return nil
 	}
 
-	r.ready = true
-
-	// once credits are available, the balance store can be initialized again with the actual initial balance
-	r.balance, err = NewBalanceStore(credits, r.rateCard)
-	if err != nil {
-		r.lggr.Error("switching to metering mode: failed to create balance store: %s", err)
-		r.meteringMode = true
-
-		// we can recover with an empty rate card and in metering mode
-		r.balance, err = NewBalanceStore(decimal.Zero, map[string]decimal.Decimal{})
-		if err != nil {
-			// this should never happen, but if it does, we cannot proceed
-			r.lggr.Error("failed to create empty balance store with no rates: %s", err)
-
-			return err
-		}
-	}
-
-	return nil
+	return r.balance.Add(credits)
 }
 
 // DeductOpt changes both the functional behavior of the Deduct method. We chose to do DeductOpt because the standard deduction
@@ -271,16 +256,21 @@ func ByResource(
 	amount decimal.Decimal,
 ) func(string, *Report) ([]capabilities.SpendLimit, error) {
 	return func(ref string, r *Report) ([]capabilities.SpendLimit, error) {
+		step := ReportStep{
+			Deduction: decimal.Zero,
+		}
+
+		defer func() {
+			r.steps[ref] = step
+		}()
+
 		bal, err := r.balance.ConvertToBalance(spendType, amount)
 		if err != nil {
 			// Fail open, continue optimistically
 			r.switchToMeteringMode(fmt.Errorf("failed to convert to balance [%s]: %w", spendType, err))
 		}
 
-		r.steps[ref] = ReportStep{
-			Deduction: bal,
-			Spends:    nil,
-		}
+		step.Deduction = bal
 
 		// if in metering mode, exit early without modifying local balance
 		if r.meteringMode {
@@ -300,6 +290,14 @@ func ByDerivedAvailability(
 	config *values.Map,
 ) func(string, *Report) ([]capabilities.SpendLimit, error) {
 	return func(ref string, r *Report) ([]capabilities.SpendLimit, error) {
+		step := ReportStep{
+			Deduction: decimal.Zero,
+		}
+
+		defer func() {
+			r.steps[ref] = step
+		}()
+
 		limit, err := r.getMaxSpendForInvocation(userSpendLimit, openConcurrentCallSlots)
 		if err != nil {
 			return nil, err
@@ -309,10 +307,7 @@ func ByDerivedAvailability(
 			return []capabilities.SpendLimit{}, nil
 		}
 
-		r.steps[ref] = ReportStep{
-			Deduction: limit.Decimal,
-			Spends:    nil,
-		}
+		step.Deduction = limit.Decimal
 
 		// if in metering mode, exit early without modifying local balance
 		if r.meteringMode {
@@ -330,12 +325,12 @@ func (r *Report) Deduct(ref string, opt DeductOpt) ([]capabilities.SpendLimit, e
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if opt == nil {
-		return nil, ErrDeductOptionRequired
+	if !r.reserved {
+		return nil, ErrNoReserve
 	}
 
-	if !r.ready {
-		return nil, ErrNoReserve
+	if opt == nil {
+		return nil, ErrDeductOptionRequired
 	}
 
 	if _, ok := r.steps[ref]; ok {
@@ -353,7 +348,7 @@ func (r *Report) Settle(ref string, spendsByNode []capabilities.MeteringNodeDeta
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if !r.ready {
+	if !r.reserved {
 		return ErrNoReserve
 	}
 
@@ -457,7 +452,7 @@ func (r *Report) FormatReport() *protoEvents.MeteringReport {
 }
 
 func (r *Report) SendReceipt(ctx context.Context) error {
-	if !r.ready {
+	if !r.reserved {
 		return ErrNoReserve
 	}
 
@@ -492,7 +487,7 @@ func (r *Report) SendReceipt(ctx context.Context) error {
 }
 
 func (r *Report) EmitReceipt(ctx context.Context) error {
-	if !r.ready {
+	if !r.reserved {
 		return ErrNoReserve
 	}
 
@@ -579,7 +574,7 @@ func (r *Report) getMaxSpendForInvocation(
 		return nullCapSpendLimit, ErrNoOpenCalls
 	}
 
-	if !r.ready {
+	if !r.reserved {
 		return nullCapSpendLimit, ErrNoReserve
 	}
 
@@ -598,11 +593,18 @@ func (r *Report) getMaxSpendForInvocation(
 }
 
 func (r *Report) switchToMeteringMode(err error) {
+	// add to the reported errors to indicate all errors encountered during metering
+	r.meteringModeErr = errors.Join(r.meteringModeErr, err)
+
+	if r.meteringMode {
+		return
+	}
+
+	// only log a single metering mode switch error. this error should indicate the first metering related error
+	// encountered
 	r.lggr.Errorf("switching to metering mode: %s", err)
 
 	r.meteringMode = true
-	r.meteringModeErr = err
-	r.ready = true
 }
 
 func toRateCard(resp *billing.GetWorkflowExecutionRatesResponse) (map[string]decimal.Decimal, error) {

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -200,8 +200,7 @@ func (r *Report) Reserve(ctx context.Context) error {
 	// always indicate that reserve was called.
 	r.reserved = true
 
-	// no need to move forward here if already in metering mode
-	if r.client == nil || r.meteringMode {
+	if r.client == nil {
 		r.switchToMeteringMode(ErrNoBillingClient)
 
 		return nil

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -490,6 +490,8 @@ func (r *Report) EmitReceipt(ctx context.Context) error {
 		return ErrNoReserve
 	}
 
+	r.lggr.Debug("Emitting metering report", "report", r.FormatReport())
+
 	return wfEvents.EmitMeteringReport(ctx, r.labels, r.FormatReport())
 }
 

--- a/core/services/workflows/metering/metering.go
+++ b/core/services/workflows/metering/metering.go
@@ -243,7 +243,9 @@ func (r *Report) Reserve(ctx context.Context) error {
 		return nil
 	}
 
-	return r.balance.Add(credits)
+	r.balance.Set(credits)
+
+	return nil
 }
 
 // DeductOpt changes both the functional behavior of the Deduct method. We chose to do DeductOpt because the standard deduction

--- a/core/services/workflows/metering/metering_test.go
+++ b/core/services/workflows/metering/metering_test.go
@@ -994,7 +994,20 @@ func Test_Report_SendReceipt(t *testing.T) {
 
 		billingClient.EXPECT().ReserveCredits(mock.Anything, mock.Anything).
 			Return(&successReserveResponse, nil)
-		billingClient.EXPECT().SubmitWorkflowReceipt(mock.Anything, mock.Anything).Return(nil, someErr)
+		billingClient.EXPECT().SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
+			if req == nil {
+				return false
+			}
+			// Assert on key fields that should be present in a valid receipt
+			return req.WorkflowId == "workflowId" &&
+				req.WorkflowExecutionId == "workflowExecutionId" &&
+				req.CreditsConsumed == "0" &&
+				req.WorkflowOwner == "accountId" &&
+				req.WorkflowRegistryAddress == "0x123" &&
+				req.WorkflowRegistryChainSelector == 16015286601757825753 &&
+				req.Metering != nil &&
+				req.Metering.Metadata != nil
+		})).Return(nil, someErr)
 
 		require.NoError(t, report.Reserve(t.Context()))
 		require.ErrorIs(t, report.SendReceipt(t.Context()), someErr)
@@ -1005,24 +1018,88 @@ func Test_Report_SendReceipt(t *testing.T) {
 		t.Parallel()
 
 		billingClient := mocks.NewBillingClient(t)
+		billingClient.EXPECT().ReserveCredits(mock.Anything, mock.Anything).
+		Return(&successReserveResponse, nil)
 		billingClient.EXPECT().GetWorkflowExecutionRates(mock.Anything, mock.Anything).
 			Return(&billing.GetWorkflowExecutionRatesResponse{}, nil)
-		report := newTestReport(t, logger.Nop(), billingClient)
 
+		// errors on nil response
+		billingClient.EXPECT().SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
+			if req == nil {
+				return false
+			}
+			// Assert on key fields that should be present in a valid receipt
+			return req.WorkflowId == "workflowId" &&
+				req.WorkflowExecutionId == "workflowExecutionId" &&
+				req.CreditsConsumed == "0" &&
+				req.WorkflowOwner == "accountId" &&
+				req.WorkflowRegistryAddress == "0x123" &&
+				req.WorkflowRegistryChainSelector == 16015286601757825753 &&
+				req.Metering != nil &&
+				req.Metering.Metadata != nil &&
+				req.Metering.MeteringMode == true &&
+				req.Metering.Message == "empty rate card"
+		})).Return(nil, nil)
+		report := newTestReport(t, logger.Nop(), billingClient)
+		require.NoError(t, report.Reserve(t.Context()))
+		require.ErrorIs(t, report.SendReceipt(t.Context()), ErrReceiptFailed)
+		billingClient.AssertExpectations(t)
+	})
+
+	t.Run("happy path with deductions", func(t *testing.T) {
+		t.Parallel()
+
+		billingClient := mocks.NewBillingClient(t)
+		billingClient.EXPECT().GetWorkflowExecutionRates(mock.Anything, mock.Anything).
+			Return(&billing.GetWorkflowExecutionRatesResponse{
+				RateCards: successRates,
+			}, nil)
 		billingClient.EXPECT().ReserveCredits(mock.Anything, mock.Anything).
-			Return(&successReserveResponse, nil)
+			Return(&successReserveResponseWithRates, nil)
+
+		report := newTestReport(t, logger.Nop(), billingClient)
 
 		require.NoError(t, report.Reserve(t.Context()))
 
-		// errors on nil response
-		billingClient.EXPECT().SubmitWorkflowReceipt(mock.Anything, mock.Anything).Return(nil, nil)
-		require.ErrorIs(t, report.SendReceipt(t.Context()), ErrReceiptFailed)
+		// Deduct and Settle a few times to consume credits
+		// Each deduction of 2 units of compute consumes 1 credit (rate: 2 units per credit)
+		_, err := report.Deduct("step1", ByResource(testUnitA, "", decimal.NewFromInt(2)))
+		require.NoError(t, err)
+		require.NoError(t, report.Settle("step1", []capabilities.MeteringNodeDetail{
+			{Peer2PeerID: "node1", SpendUnit: testUnitA, SpendValue: "2"},
+		}))
 
-		// errors on unsuccessful response
-		billingClient.EXPECT().SubmitWorkflowReceipt(mock.Anything, mock.Anything).
-			Return(&emptypb.Empty{}, nil)
-		require.ErrorIs(t, report.SendReceipt(t.Context()), ErrReceiptFailed)
+		_, err = report.Deduct("step2", ByResource(testUnitA, "", decimal.NewFromInt(4)))
+		require.NoError(t, err)
+		require.NoError(t, report.Settle("step2", []capabilities.MeteringNodeDetail{
+			{Peer2PeerID: "node2", SpendUnit: testUnitA, SpendValue: "4"},
+		}))
 
+		_, err = report.Deduct("step3", ByResource(testUnitA, "", decimal.NewFromInt(2)))
+		require.NoError(t, err)
+		require.NoError(t, report.Settle("step3", []capabilities.MeteringNodeDetail{
+			{Peer2PeerID: "node3", SpendUnit: testUnitA, SpendValue: "2"},
+		}))
+
+		// Total deducted: 2 + 4 + 2 = 8 units of compute = 16 credits consumed
+		billingClient.EXPECT().SubmitWorkflowReceipt(mock.Anything, mock.MatchedBy(func(req *billing.SubmitWorkflowReceiptRequest) bool {
+			if req == nil {
+				return false
+			}
+
+			return req.WorkflowId == "workflowId" &&
+				req.WorkflowExecutionId == "workflowExecutionId" &&
+				req.CreditsConsumed == "16" &&
+				req.WorkflowOwner == "accountId" &&
+				req.WorkflowRegistryAddress == "0x123" &&
+				req.WorkflowRegistryChainSelector == 16015286601757825753 &&
+				req.Metering != nil &&
+				req.Metering.Metadata != nil &&
+				req.Metering.MeteringMode == false &&
+				req.Metering.Message == ""
+		})).Return(&emptypb.Empty{}, nil)
+
+		require.NoError(t, report.SendReceipt(t.Context()))
 		billingClient.AssertExpectations(t)
 	})
 }
@@ -1033,17 +1110,19 @@ func Test_Report_EmitReceipt(t *testing.T) {
 		beholderTester := beholdertest.NewObserver(t)
 		billingClient := mocks.NewBillingClient(t)
 
+		billingClient.EXPECT().ReserveCredits(mock.Anything, mock.Anything).
+			Return(&successReserveResponseWithRates, nil)
 		billingClient.EXPECT().GetWorkflowExecutionRates(mock.Anything, mock.Anything).
 			Return(&billing.GetWorkflowExecutionRatesResponse{
 				OrganizationId:     "",
 				RateCards:          successRates,
 				GasTokensPerCredit: map[uint64]string{},
 			}, nil)
+		billingClient.EXPECT().SubmitWorkflowReceipt(mock.Anything, mock.Anything).
+			Return(&emptypb.Empty{}, nil)
 
 		report := newTestReport(t, logger.Nop(), billingClient)
 
-		billingClient.EXPECT().ReserveCredits(mock.Anything, mock.Anything).
-			Return(&successReserveResponseWithRates, nil)
 		require.NoError(t, report.Reserve(t.Context()))
 
 		require.NoError(t, report.EmitReceipt(t.Context()))
@@ -1062,6 +1141,9 @@ func Test_Report_EmitReceipt(t *testing.T) {
 				assert.Equal(t, testAccountID, report.Metadata.WorkflowOwner)
 			}
 		}
+
+		require.NoError(t, report.SendReceipt(t.Context()))
+		billingClient.AssertExpectations(t)
 	})
 
 	t.Run("sends receipt with report data when billing service errors", func(t *testing.T) {
@@ -1072,10 +1154,12 @@ func Test_Report_EmitReceipt(t *testing.T) {
 		billingClient := mocks.NewBillingClient(t)
 		billingClient.EXPECT().GetWorkflowExecutionRates(mock.Anything, mock.Anything).
 			Return(nil, errBillingFailure)
-		report := newTestReport(t, logger.Nop(), billingClient)
-
 		billingClient.EXPECT().ReserveCredits(mock.Anything, mock.Anything).
 			Return(nil, errBillingFailure)
+		billingClient.EXPECT().SubmitWorkflowReceipt(mock.Anything, mock.Anything).
+			Return(&emptypb.Empty{}, nil)
+
+		report := newTestReport(t, logger.Nop(), billingClient)
 		require.NoError(t, report.Reserve(t.Context()))
 
 		expected := map[string]*eventspb.MeteringReportStep{}
@@ -1100,6 +1184,7 @@ func Test_Report_EmitReceipt(t *testing.T) {
 		}
 
 		assert.Equal(t, expected, report.FormatReport().Steps)
+		report.SendReceipt(t.Context())
 		billingClient.AssertExpectations(t)
 	})
 

--- a/core/services/workflows/metering/metering_test.go
+++ b/core/services/workflows/metering/metering_test.go
@@ -178,7 +178,7 @@ func Test_Report_MeteringMode(t *testing.T) {
 			require.NoError(t, report.Reserve(t.Context()))
 
 			balanceBefore := report.balance.balance
-			_, err := report.Deduct("ref1", ByResource(testUnitA, two))
+			_, err := report.Deduct("ref1", ByResource(testUnitA, "", two))
 
 			require.NoError(t, err)
 			_, err = report.Deduct("ref2", ByDerivedAvailability(decimal.NewNullDecimal(decimal.Zero), 1, capabilities.CapabilityInfo{}, nil))
@@ -330,7 +330,7 @@ func Test_Report_MeteringMode(t *testing.T) {
 
 		balanceBefore := report.balance.balance
 
-		_, err := report.Deduct("ref1", ByResource(testUnitA, two))
+		_, err := report.Deduct("ref1", ByResource(testUnitA, "", two))
 		require.NoError(t, err)
 
 		steps := []capabilities.MeteringNodeDetail{
@@ -466,7 +466,7 @@ func Test_Report_Deduct(t *testing.T) {
 		billingClient.EXPECT().GetWorkflowExecutionRates(mock.Anything, mock.Anything).
 			Return(&billing.GetWorkflowExecutionRatesResponse{}, nil)
 		report := newTestReport(t, logger.Nop(), billingClient)
-		_, err := report.Deduct("ref1", ByResource(testUnitA, one))
+		_, err := report.Deduct("ref1", ByResource(testUnitA, "", one))
 
 		require.ErrorIs(t, err, ErrNoReserve)
 	})
@@ -483,10 +483,10 @@ func Test_Report_Deduct(t *testing.T) {
 			Return(&successReserveResponseWithMultiRates, nil)
 		require.NoError(t, report.Reserve(t.Context()))
 
-		_, err := report.Deduct("ref1", ByResource(testUnitA, two))
+		_, err := report.Deduct("ref1", ByResource(testUnitA, "", two))
 		require.NoError(t, err)
 
-		_, err = report.Deduct("ref1", ByResource(testUnitA, one))
+		_, err = report.Deduct("ref1", ByResource(testUnitA, "", one))
 		require.ErrorIs(t, err, ErrStepDeductExists)
 
 		billingClient.AssertExpectations(t)
@@ -507,7 +507,7 @@ func Test_Report_Deduct(t *testing.T) {
 			Return(&successReserveResponseWithRates, nil)
 		require.NoError(t, report.Reserve(t.Context()))
 
-		_, err := report.Deduct("ref1", ByResource(testUnitA, deductValue))
+		_, err := report.Deduct("ref1", ByResource(testUnitA, "", deductValue))
 		require.ErrorIs(t, err, ErrInsufficientBalance)
 
 		billingClient.AssertExpectations(t)
@@ -787,7 +787,7 @@ func Test_Report_Settle(t *testing.T) {
 			{Peer2PeerID: "abc", SpendUnit: testUnitA, SpendValue: "1"},
 		}
 
-		_, err := report.Deduct("ref1", ByResource(testUnitA, decimal.NewFromInt(2)))
+		_, err := report.Deduct("ref1", ByResource(testUnitA, "", decimal.NewFromInt(2)))
 		require.NoError(t, err)
 		require.NoError(t, report.Settle("ref1", steps))
 		require.ErrorIs(t, report.Settle("ref1", steps), ErrStepSpendExists)
@@ -814,7 +814,7 @@ func Test_Report_Settle(t *testing.T) {
 			{Peer2PeerID: "abc", SpendUnit: testUnitA, SpendValue: "1"},
 		}
 
-		_, err := report.Deduct("ref1", ByResource(testUnitA, decimal.NewFromInt(2)))
+		_, err := report.Deduct("ref1", ByResource(testUnitA, "", decimal.NewFromInt(2)))
 		require.NoError(t, err)
 
 		require.NoError(t, report.Settle("ref1", steps))
@@ -841,7 +841,7 @@ func Test_Report_Settle(t *testing.T) {
 			{Peer2PeerID: "xyz", SpendUnit: testUnitA, SpendValue: "2"},
 		}
 
-		_, err := report.Deduct("ref1", ByResource(testUnitA, decimal.NewFromInt(1)))
+		_, err := report.Deduct("ref1", ByResource(testUnitA, "", decimal.NewFromInt(1)))
 		require.NoError(t, err)
 
 		require.NoError(t, report.Settle("ref1", steps))
@@ -939,7 +939,7 @@ func Test_Report_FormatReport(t *testing.T) {
 		for i := range numSteps {
 			stepRef := strconv.Itoa(i)
 
-			_, err := report.Deduct(stepRef, ByResource(testUnitA, decimal.NewFromInt(1)))
+			_, err := report.Deduct(stepRef, ByResource(testUnitA, "", decimal.NewFromInt(1)))
 			require.NoError(t, err)
 
 			require.NoError(t, report.Settle(stepRef, []capabilities.MeteringNodeDetail{
@@ -1083,7 +1083,7 @@ func Test_Report_EmitReceipt(t *testing.T) {
 		for i := range numSteps {
 			stepRef := strconv.Itoa(i)
 
-			_, err := report.Deduct(stepRef, ByResource(testUnitA, decimal.NewFromInt(1)))
+			_, err := report.Deduct(stepRef, ByResource(testUnitA, "", decimal.NewFromInt(1)))
 			require.NoError(t, err)
 
 			require.NoError(t, report.Settle(stepRef, []capabilities.MeteringNodeDetail{
@@ -1148,7 +1148,7 @@ func Test_MeterReports(t *testing.T) {
 
 		require.NoError(t, r.Reserve(t.Context()))
 
-		_, err = r.Deduct(capabilityCall1, ByResource(testUnitA, decimal.NewFromInt(1)))
+		_, err = r.Deduct(capabilityCall1, ByResource(testUnitA, "", decimal.NewFromInt(1)))
 		require.NoError(t, err)
 
 		require.NoError(t, r.Settle(capabilityCall1, []capabilities.MeteringNodeDetail{
@@ -1182,7 +1182,7 @@ func Test_MeterReports(t *testing.T) {
 
 		require.NoError(t, r.Reserve(t.Context()))
 
-		_, err = r.Deduct(capabilityCall1, ByResource(testUnitA, decimal.NewFromInt(1)))
+		_, err = r.Deduct(capabilityCall1, ByResource(testUnitA, "", decimal.NewFromInt(1)))
 		require.NoError(t, err)
 
 		require.NoError(t, r.Settle(capabilityCall1, []capabilities.MeteringNodeDetail{

--- a/core/services/workflows/metering/metering_test.go
+++ b/core/services/workflows/metering/metering_test.go
@@ -1019,7 +1019,7 @@ func Test_Report_SendReceipt(t *testing.T) {
 
 		billingClient := mocks.NewBillingClient(t)
 		billingClient.EXPECT().ReserveCredits(mock.Anything, mock.Anything).
-		Return(&successReserveResponse, nil)
+			Return(&successReserveResponse, nil)
 		billingClient.EXPECT().GetWorkflowExecutionRates(mock.Anything, mock.Anything).
 			Return(&billing.GetWorkflowExecutionRatesResponse{}, nil)
 
@@ -1037,7 +1037,7 @@ func Test_Report_SendReceipt(t *testing.T) {
 				req.WorkflowRegistryChainSelector == 16015286601757825753 &&
 				req.Metering != nil &&
 				req.Metering.Metadata != nil &&
-				req.Metering.MeteringMode == true &&
+				req.Metering.MeteringMode &&
 				req.Metering.Message == "empty rate card"
 		})).Return(nil, nil)
 		report := newTestReport(t, logger.Nop(), billingClient)
@@ -1095,7 +1095,7 @@ func Test_Report_SendReceipt(t *testing.T) {
 				req.WorkflowRegistryChainSelector == 16015286601757825753 &&
 				req.Metering != nil &&
 				req.Metering.Metadata != nil &&
-				req.Metering.MeteringMode == false &&
+				!req.Metering.MeteringMode &&
 				req.Metering.Message == ""
 		})).Return(&emptypb.Empty{}, nil)
 
@@ -1184,7 +1184,7 @@ func Test_Report_EmitReceipt(t *testing.T) {
 		}
 
 		assert.Equal(t, expected, report.FormatReport().Steps)
-		report.SendReceipt(t.Context())
+		require.NoError(t, report.SendReceipt(t.Context()))
 		billingClient.AssertExpectations(t)
 	})
 

--- a/core/services/workflows/metering/metering_test.go
+++ b/core/services/workflows/metering/metering_test.go
@@ -1064,6 +1064,45 @@ func Test_Report_EmitReceipt(t *testing.T) {
 		}
 	})
 
+	t.Run("sends receipt with report data when billing service errors", func(t *testing.T) {
+		t.Parallel()
+
+		numSteps := 100
+		errBillingFailure := errors.New("billing service failed")
+		billingClient := mocks.NewBillingClient(t)
+		billingClient.EXPECT().GetWorkflowExecutionRates(mock.Anything, mock.Anything).
+			Return(nil, errBillingFailure)
+		report := newTestReport(t, logger.Nop(), billingClient)
+
+		billingClient.EXPECT().ReserveCredits(mock.Anything, mock.Anything).
+			Return(nil, errBillingFailure)
+		require.NoError(t, report.Reserve(t.Context()))
+
+		expected := map[string]*eventspb.MeteringReportStep{}
+
+		for i := range numSteps {
+			stepRef := strconv.Itoa(i)
+
+			_, err := report.Deduct(stepRef, ByResource(testUnitA, decimal.NewFromInt(1)))
+			require.NoError(t, err)
+
+			require.NoError(t, report.Settle(stepRef, []capabilities.MeteringNodeDetail{
+				{Peer2PeerID: "xyz", SpendUnit: "a", SpendValue: "42"},
+			}))
+
+			expected[stepRef] = &eventspb.MeteringReportStep{Nodes: []*eventspb.MeteringReportNodeDetail{
+				{
+					Peer_2PeerId: "xyz",
+					SpendUnit:    "a",
+					SpendValue:   "42",
+				},
+			}}
+		}
+
+		assert.Equal(t, expected, report.FormatReport().Steps)
+		billingClient.AssertExpectations(t)
+	})
+
 	t.Run("returns an error if not initialized", func(t *testing.T) {
 		t.Parallel()
 

--- a/core/services/workflows/v2/engine.go
+++ b/core/services/workflows/v2/engine.go
@@ -566,7 +566,7 @@ func (e *Engine) deductStandardBalances(ctx context.Context, meteringReport *met
 
 	if _, err := meteringReport.Deduct(
 		computeUnit,
-		metering.ByResource(computeUnit, compMs),
+		metering.ByResource(computeUnit, "v2-standard-deduction-compute", compMs),
 	); err != nil {
 		e.lggr.Errorw("could not deduct balance for capability request", "capReq", "standard-deduction-compute", "err", err)
 	}


### PR DESCRIPTION
A set of cases came up for incomplete metering report data specifically for when a billing client was missing. Some of these cases included messages of Settle being called before Deduct. The solution was to ensure the `Report.ready` property was set in cases where `Reserve` was called with or without errors.

The ready state was being set in when metering mode was turned on, but since some metering mode cases were introduced before `Reserve` _could_ be called, it made more sense to set the ready state for all cases of `Reserve` and change the property name for more clarity.

Additionally, all cases where metering mode could be turned on use the helper function. The helper function was updated to log metering mode details only once in an effort to not clutter the logs, but to capture all encountered errors in the metering report.

[CRE-724](https://smartcontract-it.atlassian.net/browse/CRE-724)

### Requires

### Supports


[CRE-724]: https://smartcontract-it.atlassian.net/browse/CRE-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ