### PR TITLE
Bump reusable workflow to fix intermittent docker manifest list creation

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -67,7 +67,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@b20336cdc21a6ee08fec353fa16e96786f88096f # 2025-06-17
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-east-1
@@ -98,7 +98,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@b20336cdc21a6ee08fec353fa16e96786f88096f # 2025-06-17
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-east-1

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -67,7 +67,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@a89ebdd9d9cabda77c5f7ea7523af5707afb7786 # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-east-1
@@ -98,7 +98,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@a89ebdd9d9cabda77c5f7ea7523af5707afb7786 # 2025-08-25
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-east-1

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -67,7 +67,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-east-1
@@ -98,7 +98,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-east-1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,7 +65,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -95,7 +95,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -127,7 +127,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -160,7 +160,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -193,7 +193,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -139,7 +139,6 @@ jobs:
         COMMIT_SHA=${{ github.sha }}
         CL_INSTALL_PRIVATE_PLUGINS=true
         CL_INSTALL_TESTING_PLUGINS=true
-      docker-build-cache-disabled: "true"
       docker-manifest-sign: true
       docker-tag-custom-suffix: "-plugins-testing"
       git-sha: ${{ inputs.git-ref || github.sha }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,7 +65,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -95,7 +95,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -127,7 +127,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@4962346cc5ffc9f3840f48639e7b5fa179bcc2cc # 2025-05-28
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -161,7 +161,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -194,7 +194,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@c8bc2e3e0b0ba91253d4cfcba830e31302dd1e4c # June 4, 2025
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@9e7b9ac9ae45d4892fe46ea54c0cc63715301b3f # 2025-08-25
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,7 +65,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@a89ebdd9d9cabda77c5f7ea7523af5707afb7786 # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -95,7 +95,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@a89ebdd9d9cabda77c5f7ea7523af5707afb7786 # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -127,7 +127,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@a89ebdd9d9cabda77c5f7ea7523af5707afb7786 # 2025-08-25
     with:
       aws-ecr-name: chainlink
       aws-region-ecr: us-west-2
@@ -160,7 +160,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@a89ebdd9d9cabda77c5f7ea7523af5707afb7786 # 2025-08-25
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2
@@ -193,7 +193,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@dx-1639/fix-manifest-annotations # 2025-08-25
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@a89ebdd9d9cabda77c5f7ea7523af5707afb7786 # 2025-08-25
     with:
       aws-ecr-name: ccip
       aws-region-ecr: us-west-2


### PR DESCRIPTION
Also adds annotation support on manifest indexes.

Successful run here: https://github.com/smartcontractkit/chainlink/actions/runs/17221388474/job/48857338661?pr=19098