### PR TITLE
[CRE-701] SharedPeer for Don2Don based on PeerGroupFactory

### DIFF
--- a/.changeset/many-glasses-relax.md
+++ b/.changeset/many-glasses-relax.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#added SharedPeer for Don2Don based on PeerGroupFactory

--- a/core/services/p2p/metrics.go
+++ b/core/services/p2p/metrics.go
@@ -1,0 +1,44 @@
+package p2p
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+)
+
+type SharedPeerMetrics struct {
+	// Measure current number of PeerGroups. On non-bootstrap nodes, the number of discovery groups
+	// should be at least equal to number of remote DONs this node is expected to connect with.
+	// The number of messaging groups should be equal to number of remote nodes this node is expected to connect with.
+	discoveryGroups metric.Int64Gauge
+	messagingGroups metric.Int64Gauge
+
+	// Failure count and latency of a peer group update call.
+	groupUpdateFailureCounter metric.Int64Counter
+	groupUpdateDurationMs     metric.Int64Histogram
+}
+
+func initSharedPeerMetrics() (m *SharedPeerMetrics, err error) {
+	m = &SharedPeerMetrics{}
+	m.discoveryGroups, err = beholder.GetMeter().Int64Gauge("platform_don2don_discovery_groups")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register platform_don2don_discovery_groups gauge: %w", err)
+	}
+	m.messagingGroups, err = beholder.GetMeter().Int64Gauge("platform_don2don_messaging_groups")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register platform_don2don_messaging_groups gauge: %w", err)
+	}
+	m.groupUpdateFailureCounter, err = beholder.GetMeter().Int64Counter("platform_don2don_group_update_failure_total")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register platform_don2don_group_update_failure_total counter: %w", err)
+	}
+	m.groupUpdateDurationMs, err = beholder.GetMeter().Int64Histogram(
+		"platform_don2don_group_update_duration_ms",
+		metric.WithUnit("ms"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to register platform_don2don_group_update_duration_ms histogram: %w", err)
+	}
+	return m, nil
+}

--- a/core/services/p2p/shared_peer.go
+++ b/core/services/p2p/shared_peer.go
@@ -1,0 +1,394 @@
+package p2p
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	ocrcommontypes "github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/networking"
+	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+)
+
+// Don2DonSharedPeer is a wrapper around PeerGroupFactory created by SingletonPeerWrapper.
+// It manages peer groups and their streams for Don2Don traffic.
+//
+// Don2DonSharedPeer creates two types of PeerGroups:
+//   - Discovery Groups - each consisting of all peers from exactly two DONs.
+//     Those groups are used for peer discovery and won’t have any Streams created within them.
+//   - Messaging Groups (“pairs”) - each consisting of exactly two peers - the current peer
+//     and one remote peer. Each of those groups will always have exactly one Stream
+//     created within them, which will be used to exchange Don2Don messages.
+//
+// Thread-safety: after calling Start(), Send() can be called concurrently from multiple goroutines,
+// UpdateConnectionsByDONs() can be called concurrently with Send() but only from a single goroutine.
+type don2DonSharedPeer struct {
+	services.Service
+	srvcEng              *services.Engine
+	singletonPeerWrapper *ocrcommon.SingletonPeerWrapper
+	bootstrappers        []ocrcommontypes.BootstrapperLocator
+	lggr                 logger.Logger
+
+	// fields derived from config and dependencies
+	pgFactory   networking.PeerGroupFactory
+	myID        ragetypes.PeerID
+	isBootstrap bool
+
+	recvCh          chan p2ptypes.Message
+	discoveryGroups map[string]networking.PeerGroup // keyed by donPairHash()
+	remotePeers     map[ragetypes.PeerID]*remotePeer
+	mu              sync.RWMutex // protects discoveryGroups and remotePeers
+
+	metrics *SharedPeerMetrics
+}
+
+var _ p2ptypes.SharedPeer = &don2DonSharedPeer{}
+
+const (
+	// TODO(CRE-755): replace these with don2don values when available in libocr
+	streamNamePrefix = "ccip-rmn/"
+	digestPrefix     = ocr2types.ConfigDigestPrefixCCIPMultiRoleRMNCombo
+)
+
+type remotePeer struct {
+	// A PeerGroup with exactly two members, connecting our peer with a single remote peer.
+	peerPairGroup networking.PeerGroup
+	// Stream managed by the PeerGroup.
+	stream networking.Stream
+}
+
+func NewDon2DonSharedPeer(singletonPeerWrapper *ocrcommon.SingletonPeerWrapper, bootstrappers []ocrcommontypes.BootstrapperLocator, lggr logger.Logger) *don2DonSharedPeer {
+	sp := &don2DonSharedPeer{
+		singletonPeerWrapper: singletonPeerWrapper,
+		bootstrappers:        bootstrappers,
+		recvCh:               make(chan p2ptypes.Message, defaultRecvChSize),
+		discoveryGroups:      make(map[string]networking.PeerGroup),
+		remotePeers:          make(map[ragetypes.PeerID]*remotePeer),
+		lggr:                 lggr.Named("Don2DonSharedPeer"),
+	}
+	sp.Service, sp.srvcEng = services.Config{
+		Name:  "Don2DonSharedPeer",
+		Start: sp.start,
+		Close: sp.close,
+	}.NewServiceEngine(sp.lggr)
+	return sp
+}
+
+func (sp *don2DonSharedPeer) start(ctx context.Context) error {
+	sp.lggr.Info("Starting Don2DonSharedPeer ...")
+	sp.pgFactory = sp.singletonPeerWrapper.PeerGroupFactory
+	if sp.pgFactory == nil {
+		return errors.New("PeerGroupFactory is not set in SingletonPeerWrapper. It's possible that SingletonPeerWrapper was not started before Don2DonSharedPeer or somehow failed to initialize")
+	}
+	sp.myID = ragetypes.PeerID(sp.singletonPeerWrapper.PeerID)
+	if (sp.myID == ragetypes.PeerID{}) {
+		return errors.New("PeerID is not set in SingletonPeerWrapper. Was it started before Don2DonSharedPeer?")
+	}
+	myIDStr := sp.myID.String()
+	for _, bootstrapper := range sp.bootstrappers {
+		if bootstrapper.PeerID == myIDStr {
+			sp.isBootstrap = true
+			break
+		}
+	}
+	metrics, err := initSharedPeerMetrics()
+	if err != nil {
+		return fmt.Errorf("failed to init Don2DonSharedPeer metrics: %w", err)
+	}
+	sp.metrics = metrics
+	sp.lggr.Infow("Started Don2DonSharedPeer", "peerId", myIDStr, "isBootstrap", sp.isBootstrap)
+	return nil
+}
+
+func (sp *don2DonSharedPeer) close() error {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.lggr.Info("Closing Don2DonSharedPeer ...")
+	for name, group := range sp.discoveryGroups {
+		if group.Close() != nil {
+			sp.lggr.Errorw("failed to close discovery group", "name", name)
+		}
+	}
+	sp.discoveryGroups = make(map[string]networking.PeerGroup)
+	for pid, peer := range sp.remotePeers {
+		if peer.peerPairGroup.Close() != nil {
+			sp.lggr.Errorw("failed to close messaging group peer", "remotePeerID", pid.String())
+		}
+	}
+	sp.remotePeers = make(map[ragetypes.PeerID]*remotePeer)
+	close(sp.recvCh)
+	sp.lggr.Info("Closed Don2DonSharedPeer")
+	return nil
+}
+
+func (sp *don2DonSharedPeer) ID() ragetypes.PeerID {
+	return sp.myID
+}
+
+func (sp *don2DonSharedPeer) IsBootstrap() bool {
+	return sp.isBootstrap
+}
+
+func (sp *don2DonSharedPeer) Send(peerID ragetypes.PeerID, msg []byte) error {
+	sp.mu.RLock()
+	rp, ok := sp.remotePeers[peerID]
+	sp.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("no stream to remote peer id: %s, from local peer id: %s", peerID.String(), sp.myID.String())
+	}
+	rp.stream.SendMessage(msg)
+	return nil
+}
+
+func (sp *don2DonSharedPeer) Receive() <-chan p2ptypes.Message {
+	return sp.recvCh
+}
+
+func (sp *don2DonSharedPeer) UpdateConnections(peers map[ragetypes.PeerID]p2ptypes.StreamConfig) error {
+	return errors.New("UpdateConnections is not supported, use UpdateConnectionsByDON instead")
+}
+
+func (sp *don2DonSharedPeer) UpdateConnectionsByDONs(ctx context.Context, donPairs []p2ptypes.DonPair, streamConfig p2ptypes.StreamConfig) error {
+	sp.lggr.Infow("UpdateConnectionsByDONs", "numDonPairs", len(donPairs))
+	startTs := time.Now().UnixMilli()
+
+	desiredDONPairsIDs := make(map[string]struct{})
+	for _, dp := range donPairs {
+		pairID := pairID(dp[0], dp[1])
+		desiredDONPairsIDs[pairID] = struct{}{}
+	}
+	desiredRemotePeers := make(map[ragetypes.PeerID]struct{})
+	for _, dp := range donPairs {
+		if slices.Contains(dp[0].Members, sp.myID) {
+			for _, pid := range dp[1].Members {
+				desiredRemotePeers[pid] = struct{}{}
+			}
+		}
+		if slices.Contains(dp[1].Members, sp.myID) {
+			for _, pid := range dp[0].Members {
+				desiredRemotePeers[pid] = struct{}{}
+			}
+		}
+	}
+	delete(desiredRemotePeers, sp.myID) // don't accidentally create a stream to ourselves
+
+	// Most of the time, there are no changes to peer groups and we can short-circuit.
+	// If changes are needed, let's perform updates under a write lock.
+	// A large change is expected only once, on startup, when all groups are created.
+	if !sp.stateEqual(desiredDONPairsIDs, desiredRemotePeers) {
+		err := sp.updateConnections(donPairs, desiredDONPairsIDs, desiredRemotePeers, streamConfig)
+		if err != nil {
+			sp.metrics.groupUpdateFailureCounter.Add(ctx, 1)
+			return fmt.Errorf("failed to update connections by DONs: %w", err)
+		}
+	}
+
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+	sp.metrics.discoveryGroups.Record(ctx, int64(len(sp.discoveryGroups)))
+	sp.metrics.messagingGroups.Record(ctx, int64(len(sp.remotePeers)))
+	sp.metrics.groupUpdateDurationMs.Record(ctx, time.Now().UnixMilli()-startTs)
+	sp.lggr.Info("UpdateConnectionsByDONs done")
+	return nil
+}
+
+// Return true if current state is equal to desider state.
+func (sp *don2DonSharedPeer) stateEqual(desiredDONPairsIDs map[string]struct{}, desiredRemotePeers map[ragetypes.PeerID]struct{}) bool {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+	if len(sp.discoveryGroups) != len(desiredDONPairsIDs) || len(sp.remotePeers) != len(desiredRemotePeers) {
+		return false
+	}
+	for donPairID := range desiredDONPairsIDs {
+		if _, ok := sp.discoveryGroups[donPairID]; !ok {
+			return false
+		}
+	}
+	for pid := range desiredRemotePeers {
+		if _, ok := sp.remotePeers[pid]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (sp *don2DonSharedPeer) updateConnections(donPairs []p2ptypes.DonPair, desiredDONPairsIDs map[string]struct{}, desiredRemotePeers map[ragetypes.PeerID]struct{}, streamConfig p2ptypes.StreamConfig) error {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	// Phase 1 - create discovery groups. Those groups consist of peers from exactly two DONs.
+	for _, dp := range donPairs {
+		pairID := pairID(dp[0], dp[1])
+		if _, ok := sp.discoveryGroups[pairID]; ok {
+			continue // group already exists, no need to recreate it
+		}
+		peerSet := make(map[string]struct{})
+		for _, pid := range dp[0].Members {
+			peerSet[pid.String()] = struct{}{}
+		}
+		for _, pid := range dp[1].Members {
+			peerSet[pid.String()] = struct{}{}
+		}
+		peers := make([]string, 0, len(peerSet))
+		for pidStr := range peerSet {
+			peers = append(peers, pidStr) // no duplicate peers
+		}
+
+		if _, ok := sp.discoveryGroups[pairID]; !ok {
+			digest := donPairDigest(dp[0].ID, dp[1].ID)
+			peerGroup, err := sp.pgFactory.NewPeerGroup(digest, peers, sp.bootstrappers)
+			if err != nil {
+				sp.lggr.Errorw("failed to create discovery group", "digest", digest, "err", err)
+				return fmt.Errorf("failed to create discovery group: %w", err)
+			}
+			sp.lggr.Infow("Created discovery group", "donPairId", pairID, "don1", dp[0].ID, "don2", dp[1].ID, "numPeers", len(peers))
+			sp.discoveryGroups[pairID] = peerGroup
+		}
+	}
+
+	// Remove obsolete groups
+	for donPairID := range sp.discoveryGroups {
+		if _, ok := desiredDONPairsIDs[donPairID]; !ok {
+			peerGroup := sp.discoveryGroups[donPairID]
+			err := peerGroup.Close()
+			if err != nil {
+				sp.lggr.Errorw("failed to close discovery group", "donPairId", donPairID, "err", err)
+			}
+			delete(sp.discoveryGroups, donPairID)
+			sp.lggr.Infow("Closed discovery group", "donPairId", donPairID)
+		}
+	}
+
+	// Phase 2 - create messaging groups for Don2Don streams. Each group consists of exactly two Peers.
+	if !sp.isBootstrap {
+		for remotePID := range desiredRemotePeers {
+			if _, exists := sp.remotePeers[remotePID]; exists {
+				continue // stream to this peer already exists
+			}
+			// Create a group with only our peer and the remote peer
+			peers := []string{sp.myID.String(), remotePID.String()}
+			digest := nodePairDigest(sp.myID, remotePID)
+			peerGroup, err := sp.pgFactory.NewPeerGroup(digest, peers, sp.bootstrappers)
+			if err != nil {
+				sp.lggr.Errorw("failed to create remote peer group", "digest", digest, "err", err)
+				return fmt.Errorf("failed to create remote peer group: %w", err)
+			}
+			idStr1, idStr2 := peerIDStrings(sp.myID, remotePID)
+			cfg := networking.NewStreamArgs1{
+				StreamName:         streamNamePrefix + idStr1 + "-" + idStr2,
+				OutgoingBufferSize: streamConfig.OutgoingMessageBufferSize,
+				IncomingBufferSize: streamConfig.IncomingMessageBufferSize,
+				MaxMessageLength:   streamConfig.MaxMessageLenBytes,
+				MessagesLimit:      streamConfig.MessageRateLimiter,
+				BytesLimit:         streamConfig.BytesRateLimiter,
+			}
+			stream, err := peerGroup.NewStream(remotePID.String(), cfg)
+			if err != nil {
+				sp.lggr.Errorw("failed to create stream for remote peer", "peerID", remotePID, "err", err)
+				peerGroup.Close()
+				return fmt.Errorf("failed to create stream for remote peer: %w", err)
+			}
+			sp.remotePeers[remotePID] = &remotePeer{
+				peerPairGroup: peerGroup,
+				stream:        stream,
+			}
+			sp.srvcEng.Go(func(srvcCtx context.Context) {
+				sp.recvLoopSingle(srvcCtx, remotePID, stream.ReceiveMessages())
+			})
+			sp.lggr.Infow("Created stream to remote peer", "remotePeerID", remotePID)
+		}
+
+		// Remove obsolete remote peers
+		for pid := range sp.remotePeers {
+			if _, ok := desiredRemotePeers[pid]; !ok {
+				rp := sp.remotePeers[pid]
+				if rp.peerPairGroup != nil {
+					rp.peerPairGroup.Close() // closes the stream
+				}
+				delete(sp.remotePeers, pid)
+				sp.lggr.Infow("Closed stream to remote peer", "remotePeerID", pid)
+			}
+		}
+	}
+	return nil
+}
+
+func (sp *don2DonSharedPeer) recvLoopSingle(ctx context.Context, pid ragetypes.PeerID, ch <-chan []byte) {
+	sp.lggr.Infow("starting recvLoopSingle", "peerID", pid)
+	for {
+		select {
+		case <-ctx.Done():
+			sp.lggr.Infow("stopped - exiting recvLoopSingle", "peerID", pid)
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				sp.lggr.Infow("channel closed - exiting recvLoopSingle", "peerID", pid)
+				return
+			}
+			sp.recvCh <- p2ptypes.Message{Sender: pid, Payload: msg}
+		}
+	}
+}
+
+// Create a unique ID based of both DON IDs and all sorted DON members to uniquely represent a DON pair
+func pairID(donA, donB capabilities.DON) string {
+	if donA.ID > donB.ID {
+		donA, donB = donB, donA
+	}
+	memberIDsA := make([]string, 0, len(donA.Members))
+	for _, pid := range donA.Members {
+		memberIDsA = append(memberIDsA, pid.String())
+	}
+	slices.Sort(memberIDsA)
+	hashPeersA := sha256.Sum256([]byte(strings.Join(memberIDsA, ",")))
+	memberIDsB := make([]string, 0, len(donB.Members))
+	for _, pid := range donB.Members {
+		memberIDsB = append(memberIDsB, pid.String())
+	}
+	slices.Sort(memberIDsB)
+	hashPeersB := sha256.Sum256([]byte(strings.Join(memberIDsB, ",")))
+	return fmt.Sprintf("%d-%d-%s-%s", donA.ID, donB.ID, hex.EncodeToString(hashPeersA[:]), hex.EncodeToString(hashPeersB[:]))
+}
+
+func donPairDigest(donID1, donID2 uint32) ocr2types.ConfigDigest {
+	// Create a digest based on sorted DON IDs
+	if donID1 > donID2 {
+		donID1, donID2 = donID2, donID1
+	}
+	var digest ocr2types.ConfigDigest
+	binary.BigEndian.PutUint16(digest[:], uint16(digestPrefix))
+	binary.BigEndian.PutUint32(digest[2:], donID1)
+	binary.BigEndian.PutUint32(digest[6:], donID2)
+	return digest
+}
+
+func nodePairDigest(peerID1, peerID2 ragetypes.PeerID) ocr2types.ConfigDigest {
+	id1Str, id2Str := peerIDStrings(peerID1, peerID2)
+	var digest ocr2types.ConfigDigest
+	binary.BigEndian.PutUint16(digest[:], uint16(digestPrefix))
+	combinedHash := sha256.Sum256(([]byte(id1Str + id2Str)))
+	copy(digest[2:], combinedHash[:30])
+	return digest
+}
+
+func peerIDStrings(peerID1, peerID2 ragetypes.PeerID) (string, string) {
+	id1Str := peerID1.String()
+	id2Str := peerID2.String()
+	if id1Str > id2Str {
+		id1Str, id2Str = id2Str, id1Str
+	}
+	return id1Str, id2Str
+}

--- a/core/services/p2p/shared_peer_test.go
+++ b/core/services/p2p/shared_peer_test.go
@@ -1,0 +1,163 @@
+package p2p_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/freeport"
+	"github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/networking"
+	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
+	"github.com/smartcontractkit/chainlink/v2/core/services/p2p"
+	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+)
+
+func TestDon2DonSharedPeer_WithRealSingletonPeerWrapper(t *testing.T) {
+	db := pgtest.NewSqlxDB(t)
+	keyStore := cltest.NewKeyStore(t, db)
+	k, err := keyStore.P2P().Create(testutils.Context(t))
+	require.NoError(t, err)
+
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.P2P.V2.Enabled = ptr(true)
+		c.P2P.V2.ListenAddresses = &[]string{fmt.Sprintf("127.0.0.1:%d", freeport.GetOne(t))}
+		c.P2P.PeerID = ptr(k.PeerID())
+	})
+	pw := ocrcommon.NewSingletonPeerWrapper(keyStore, cfg.P2P(), cfg.OCR(), db, logger.TestLogger(t))
+
+	require.NoError(t, pw.Start(t.Context()))
+	defer pw.Close()
+
+	require.Equal(t, k.PeerID(), pw.PeerID)
+	sp := p2p.NewDon2DonSharedPeer(pw, nil, logger.TestLogger(t))
+	require.NoError(t, sp.Start(t.Context()))
+
+	_, peerID2 := newKeyPair(t)
+	_, peerID3 := newKeyPair(t)
+	donPairs := []p2ptypes.DonPair{{
+		{ID: 1, Members: []ragetypes.PeerID{ragetypes.PeerID(k.PeerID()), peerID2}},
+		{ID: 2, Members: []ragetypes.PeerID{peerID2, peerID3}},
+	}}
+	require.NoError(t, sp.UpdateConnectionsByDONs(t.Context(), donPairs, p2ptypes.StreamConfig{}))
+	require.NoError(t, sp.Close())
+}
+
+func TestDon2DonSharedPeer_UpdateConnectionsByDONs(t *testing.T) {
+	pw := ocrcommon.NewSingletonPeerWrapper(nil, nil, nil, nil, logger.TestLogger(t)) // nils are ok, we won't Start() it
+	_, myPeerID := newKeyPair(t)
+	_, peerID2 := newKeyPair(t)
+	_, peerID3 := newKeyPair(t)
+	_, peerID4 := newKeyPair(t)
+	mockPGFactory := mockPeerGroupFactory{}
+	pw.PeerGroupFactory = &mockPGFactory
+	pw.PeerID = p2pkey.PeerID(myPeerID)
+
+	sp := p2p.NewDon2DonSharedPeer(pw, nil, logger.TestLogger(t))
+	require.NoError(t, sp.Start(t.Context()))
+
+	donPairs := []p2ptypes.DonPair{{
+		{ID: 1, Members: []ragetypes.PeerID{myPeerID, peerID2}},
+		{ID: 2, Members: []ragetypes.PeerID{peerID2, peerID3}},
+	}}
+	// Adding a new DON pair
+	require.NoError(t, sp.UpdateConnectionsByDONs(t.Context(), donPairs, p2ptypes.StreamConfig{}))
+	require.Equal(t, 1, mockPGFactory.newDonGroupCounter)
+	require.Equal(t, 2, mockPGFactory.newNodeGroupCounter) // myPeer is connected to peers 2 and 3
+	require.Equal(t, 0, mockPGFactory.closedGroupCounter)
+	require.Equal(t, 2, mockPGFactory.newStreamCounter)
+
+	// No changes expected when updating the same group
+	require.NoError(t, sp.UpdateConnectionsByDONs(t.Context(), donPairs, p2ptypes.StreamConfig{}))
+	require.Equal(t, 1, mockPGFactory.newDonGroupCounter)
+	require.Equal(t, 2, mockPGFactory.newNodeGroupCounter)
+	require.Equal(t, 0, mockPGFactory.closedGroupCounter)
+	require.Equal(t, 2, mockPGFactory.newStreamCounter)
+
+	// Expect a change when DON membership changes
+	donPairs[0][1].Members[1] = peerID4
+	require.NoError(t, sp.UpdateConnectionsByDONs(t.Context(), donPairs, p2ptypes.StreamConfig{}))
+	require.Equal(t, 2, mockPGFactory.newDonGroupCounter)  // update of existing group
+	require.Equal(t, 3, mockPGFactory.newNodeGroupCounter) // one new connection to peer 4
+	require.Equal(t, 2, mockPGFactory.closedGroupCounter)  // close old DON group + peer 2 group
+	require.Equal(t, 3, mockPGFactory.newStreamCounter)    // one new connection to peer 4
+
+	// Expect a change when a new DON pair is added
+	donPairs = append(donPairs, [2]capabilities.DON{
+		{ID: 3, Members: []ragetypes.PeerID{myPeerID, peerID3}},
+		{ID: 2, Members: []ragetypes.PeerID{peerID2, peerID3}},
+	})
+	require.NoError(t, sp.UpdateConnectionsByDONs(t.Context(), donPairs, p2ptypes.StreamConfig{}))
+	require.Equal(t, 3, mockPGFactory.newDonGroupCounter)
+	require.Equal(t, 4, mockPGFactory.newNodeGroupCounter) // re-create connection to peer 2
+	require.Equal(t, 2, mockPGFactory.closedGroupCounter)
+	require.Equal(t, 4, mockPGFactory.newStreamCounter) // re-create connection to peer 2
+
+	require.NoError(t, sp.Close())
+	require.Equal(t, 2+2+3, mockPGFactory.closedGroupCounter) // closed 2 DON groups and 3 node groups
+}
+
+type mockPeerGroupFactory struct {
+	newDonGroupCounter  int // large - more than 2 members
+	newNodeGroupCounter int // small - 2 members
+	closedGroupCounter  int
+	newStreamCounter    int
+}
+
+func (m *mockPeerGroupFactory) NewPeerGroup(
+	configDigest ocr2types.ConfigDigest,
+	peerIDs []string,
+	bootstrappers []commontypes.BootstrapperLocator,
+) (networking.PeerGroup, error) {
+	if len(peerIDs) > 2 {
+		m.newDonGroupCounter++
+	} else {
+		m.newNodeGroupCounter++
+	}
+	return &mockPeerGroup{groupFactory: m}, nil
+}
+
+type mockPeerGroup struct {
+	groupFactory *mockPeerGroupFactory
+}
+
+func (m *mockPeerGroup) NewStream(remotePeerID string, newStreamArgs networking.NewStreamArgs) (networking.Stream, error) {
+	m.groupFactory.newStreamCounter++
+	return &mockStream{msgCh: make(chan []byte)}, nil
+}
+
+func (m *mockPeerGroup) Close() error {
+	m.groupFactory.closedGroupCounter++
+	return nil
+}
+
+type mockStream struct {
+	msgCh chan []byte
+}
+
+func (m *mockStream) SendMessage(data []byte) {
+	m.msgCh <- data
+}
+
+func (m *mockStream) ReceiveMessages() <-chan []byte {
+	return m.msgCh
+}
+
+func (m *mockStream) Close() error {
+	close(m.msgCh)
+	return nil
+}
+
+func ptr[T any](t T) *T { return &t }

--- a/core/services/p2p/types/types.go
+++ b/core/services/p2p/types/types.go
@@ -1,9 +1,12 @@
 package types
 
 import (
+	"context"
+
 	"github.com/smartcontractkit/libocr/ragep2p"
 	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 )
 
@@ -18,6 +21,12 @@ type Peer interface {
 	Send(peerID PeerID, msg []byte) error
 	Receive() <-chan Message
 	IsBootstrap() bool
+}
+
+type DonPair [2]capabilities.DON
+type SharedPeer interface {
+	Peer
+	UpdateConnectionsByDONs(ctx context.Context, donPairs []DonPair, streamConfig StreamConfig) error
 }
 
 type PeerWrapper interface {


### PR DESCRIPTION
Introduce a wrapper around PeerGroupFactory from SingletonPeerWrapper. It manages peer groups and their streams for Don2Don traffic.

SharePeer creates and maintains two types of Peer Groups:
- "discovery" groups, consisting of peers from two DONs that are expected to communicate
- "messaging" groups, consisting of exactly two peers that are expected to communicate