### PR TITLE
CCIP-6889: Adding token's mint authority check

### DIFF
--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
 	solToken "github.com/gagliardetto/solana-go/programs/token"
-	solRpc "github.com/gagliardetto/solana-go/rpc"
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 
@@ -237,7 +236,7 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 
 		// fetch current token mint authority
 		var tokenMint solToken.Mint
-		err = solCommonUtil.GetAccountDataBorshInto(context.Background(), chain.Client, tokenPubKey, solRpc.CommitmentConfirmed, &tokenMint)
+		err = chain.GetAccountDataBorshInto(context.Background(), tokenPubKey, tokenMint)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get token mint account data: %w", err)
 		}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+	solToken "github.com/gagliardetto/solana-go/programs/token"
+	solRpc "github.com/gagliardetto/solana-go/rpc"
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 
@@ -233,8 +235,16 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 
 		instructions = append(instructions, poolInitI)
 
+		// fetch current token mint authority
+		var tokenMint solToken.Mint
+		err = solCommonUtil.GetAccountDataBorshInto(context.Background(), chain.Client, tokenPubKey, solRpc.CommitmentConfirmed, &tokenMint)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get token mint account data: %w", err)
+		}
+
 		// make pool mint_authority for token
-		if tokenPoolCfg.PoolType == shared.BurnMintTokenPool && tokenPubKey != solana.SolMint {
+		if tokenPoolCfg.PoolType == shared.BurnMintTokenPool && tokenPubKey != solana.SolMint &&
+			tokenMint.MintAuthority != nil && *tokenMint.MintAuthority == chain.DeployerKey.PublicKey() {
 			authI, err := solTokenUtil.SetTokenMintAuthority(
 				tokenprogramID,
 				poolSigner,

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -236,27 +236,32 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 
 		// fetch current token mint authority
 		var tokenMint solToken.Mint
-		err = chain.GetAccountDataBorshInto(context.Background(), tokenPubKey, tokenMint)
+		err = chain.GetAccountDataBorshInto(context.Background(), tokenPubKey, &tokenMint)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get token mint account data: %w", err)
 		}
 
 		// make pool mint_authority for token
-		if tokenPoolCfg.PoolType == shared.BurnMintTokenPool && tokenPubKey != solana.SolMint &&
-			tokenMint.MintAuthority != nil && tokenMint.MintAuthority.String() == chain.DeployerKey.PublicKey().String() {
-			authI, err := solTokenUtil.SetTokenMintAuthority(
-				tokenprogramID,
-				poolSigner,
-				tokenPubKey,
-				chain.DeployerKey.PublicKey(),
-			)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate instructions: %w", err)
+		if tokenPoolCfg.PoolType == shared.BurnMintTokenPool && tokenPubKey != solana.SolMint {
+			if tokenMint.MintAuthority != nil && tokenMint.MintAuthority.String() == chain.DeployerKey.PublicKey().String() {
+				authI, err := solTokenUtil.SetTokenMintAuthority(
+					tokenprogramID,
+					poolSigner,
+					tokenPubKey,
+					chain.DeployerKey.PublicKey(),
+				)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate instructions: %w", err)
+				}
+				instructions = append(instructions, authI)
+				e.Logger.Infow("Setting mint authority", "poolSigner", poolSigner.String())
+			} else {
+				e.Logger.Warnw("Token's mint authority is not with deployer key, skipping setting poolSigner as mint authority",
+					"poolType", tokenPoolCfg.PoolType, "mintAuthority", tokenMint.MintAuthority.String(),
+					"deployer", chain.DeployerKey.PublicKey().String(), "poolSigner", poolSigner.String())
 			}
-			instructions = append(instructions, authI)
-			e.Logger.Infow("Setting mint authority", "poolSigner", poolSigner.String())
 		} else {
-			e.Logger.Warnw("Skipping setting poolSigner as mint authority",
+			e.Logger.Warnw("PoolType is not a BurnMintTokenPool, skipping setting poolSigner as mint authority",
 				"poolType", tokenPoolCfg.PoolType, "mintAuthority", tokenMint.MintAuthority.String(),
 				"deployer", chain.DeployerKey.PublicKey().String(), "poolSigner", poolSigner.String())
 		}

--- a/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_0/cs_token_pool.go
@@ -244,7 +244,7 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 
 		// make pool mint_authority for token
 		if tokenPoolCfg.PoolType == shared.BurnMintTokenPool && tokenPubKey != solana.SolMint &&
-			tokenMint.MintAuthority != nil && *tokenMint.MintAuthority == chain.DeployerKey.PublicKey() {
+			tokenMint.MintAuthority != nil && tokenMint.MintAuthority.String() == chain.DeployerKey.PublicKey().String() {
 			authI, err := solTokenUtil.SetTokenMintAuthority(
 				tokenprogramID,
 				poolSigner,
@@ -256,6 +256,10 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 			}
 			instructions = append(instructions, authI)
 			e.Logger.Infow("Setting mint authority", "poolSigner", poolSigner.String())
+		} else {
+			e.Logger.Warnw("Skipping setting poolSigner as mint authority",
+				"poolType", tokenPoolCfg.PoolType, "mintAuthority", tokenMint.MintAuthority.String(),
+				"deployer", chain.DeployerKey.PublicKey().String(), "poolSigner", poolSigner.String())
 		}
 
 		// confirm instructions

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -292,27 +292,32 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 
 		// fetch current token mint authority
 		var tokenMint solToken.Mint
-		err = chain.GetAccountDataBorshInto(context.Background(), tokenPubKey, tokenMint)
+		err = chain.GetAccountDataBorshInto(context.Background(), tokenPubKey, &tokenMint)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get token mint account data: %w", err)
 		}
 
 		// make pool mint_authority for token
-		if tokenPoolCfg.PoolType == shared.BurnMintTokenPool && tokenPubKey != solana.SolMint &&
-			tokenMint.MintAuthority != nil && tokenMint.MintAuthority.String() == chain.DeployerKey.PublicKey().String() {
-			authI, err := solTokenUtil.SetTokenMintAuthority(
-				tokenprogramID,
-				poolSigner,
-				tokenPubKey,
-				chain.DeployerKey.PublicKey(),
-			)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate instructions: %w", err)
+		if tokenPoolCfg.PoolType == shared.BurnMintTokenPool && tokenPubKey != solana.SolMint {
+			if tokenMint.MintAuthority != nil && tokenMint.MintAuthority.String() == chain.DeployerKey.PublicKey().String() {
+				authI, err := solTokenUtil.SetTokenMintAuthority(
+					tokenprogramID,
+					poolSigner,
+					tokenPubKey,
+					chain.DeployerKey.PublicKey(),
+				)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate instructions: %w", err)
+				}
+				instructions = append(instructions, authI)
+				e.Logger.Infow("Setting mint authority", "poolSigner", poolSigner.String())
+			} else {
+				e.Logger.Warnw("Token's mint authority is not with deployer key, skipping setting poolSigner as mint authority",
+					"poolType", tokenPoolCfg.PoolType, "mintAuthority", tokenMint.MintAuthority.String(),
+					"deployer", chain.DeployerKey.PublicKey().String(), "poolSigner", poolSigner.String())
 			}
-			instructions = append(instructions, authI)
-			e.Logger.Infow("Setting mint authority", "poolSigner", poolSigner.String())
 		} else {
-			e.Logger.Warnw("Skipping setting poolSigner as mint authority",
+			e.Logger.Warnw("PoolType is not a BurnMintTokenPool, skipping setting poolSigner as mint authority",
 				"poolType", tokenPoolCfg.PoolType, "mintAuthority", tokenMint.MintAuthority.String(),
 				"deployer", chain.DeployerKey.PublicKey().String(), "poolSigner", poolSigner.String())
 		}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
 	solToken "github.com/gagliardetto/solana-go/programs/token"
-	solRpc "github.com/gagliardetto/solana-go/rpc"
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 
@@ -293,7 +292,7 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 
 		// fetch current token mint authority
 		var tokenMint solToken.Mint
-		err = solCommonUtil.GetAccountDataBorshInto(context.Background(), chain.Client, tokenPubKey, solRpc.CommitmentConfirmed, &tokenMint)
+		err = chain.GetAccountDataBorshInto(context.Background(), tokenPubKey, tokenMint)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get token mint account data: %w", err)
 		}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_token_pool.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+	solToken "github.com/gagliardetto/solana-go/programs/token"
+	solRpc "github.com/gagliardetto/solana-go/rpc"
 
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 
@@ -289,8 +291,16 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 
 		instructions = append(instructions, poolInitI)
 
+		// fetch current token mint authority
+		var tokenMint solToken.Mint
+		err = solCommonUtil.GetAccountDataBorshInto(context.Background(), chain.Client, tokenPubKey, solRpc.CommitmentConfirmed, &tokenMint)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get token mint account data: %w", err)
+		}
+
 		// make pool mint_authority for token
-		if tokenPoolCfg.PoolType == shared.BurnMintTokenPool && tokenPubKey != solana.SolMint {
+		if tokenPoolCfg.PoolType == shared.BurnMintTokenPool && tokenPubKey != solana.SolMint &&
+			tokenMint.MintAuthority != nil && tokenMint.MintAuthority.String() == chain.DeployerKey.PublicKey().String() {
 			authI, err := solTokenUtil.SetTokenMintAuthority(
 				tokenprogramID,
 				poolSigner,
@@ -302,6 +312,10 @@ func AddTokenPoolAndLookupTable(e cldf.Environment, cfg AddTokenPoolAndLookupTab
 			}
 			instructions = append(instructions, authI)
 			e.Logger.Infow("Setting mint authority", "poolSigner", poolSigner.String())
+		} else {
+			e.Logger.Warnw("Skipping setting poolSigner as mint authority",
+				"poolType", tokenPoolCfg.PoolType, "mintAuthority", tokenMint.MintAuthority.String(),
+				"deployer", chain.DeployerKey.PublicKey().String(), "poolSigner", poolSigner.String())
 		}
 
 		// confirm instructions


### PR DESCRIPTION
Updating the changeset to check if the token's mint authority is with deployer key. if not, skip the set authority instruction even though it is BnM pool.

There are cases where the customer deploys the token and they retain the mint authority and willing to set the authority to pool signer by themselves.
