### PR TITLE
[CRE-703] Move signing logic outside of Peer object

### DIFF
--- a/core/capabilities/remote/dispatcher.go
+++ b/core/capabilities/remote/dispatcher.go
@@ -77,6 +77,10 @@ func (d *dispatcher) Start(ctx context.Context) error {
 	if d.peer == nil {
 		return errors.New("peer is not initialized")
 	}
+	err := d.signer.Initialize()
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize signer")
+	}
 	d.wg.Add(1)
 	go func() {
 		defer d.wg.Done()

--- a/core/capabilities/remote/dispatcher_test.go
+++ b/core/capabilities/remote/dispatcher_test.go
@@ -84,6 +84,7 @@ func TestDispatcher_CleanStartClose(t *testing.T) {
 	wrapper := mocks.NewPeerWrapper(t)
 	wrapper.On("GetPeer").Return(peer)
 	signer := mocks.NewSigner(t)
+	signer.EXPECT().Initialize().Return(nil)
 	registry := commonMocks.NewCapabilitiesRegistry(t)
 
 	dispatcher, err := remote.NewDispatcher(testConfig{
@@ -114,7 +115,8 @@ func TestDispatcher_Receive(t *testing.T) {
 	wrapper := mocks.NewPeerWrapper(t)
 	wrapper.On("GetPeer").Return(peer)
 	signer := mocks.NewSigner(t)
-	signer.On("Sign", mock.Anything).Return(nil, errors.New("not implemented"))
+	signer.EXPECT().Initialize().Return(nil)
+	signer.EXPECT().Sign(mock.Anything).Return(nil, errors.New("not implemented"))
 	registry := commonMocks.NewCapabilitiesRegistry(t)
 
 	dispatcher, err := remote.NewDispatcher(testConfig{
@@ -172,7 +174,8 @@ func TestDispatcher_RespondWithError(t *testing.T) {
 	wrapper := mocks.NewPeerWrapper(t)
 	wrapper.On("GetPeer").Return(peer)
 	signer := mocks.NewSigner(t)
-	signer.On("Sign", mock.Anything).Return([]byte{}, nil)
+	signer.EXPECT().Initialize().Return(nil)
+	signer.EXPECT().Sign(mock.Anything).Return([]byte{1, 2, 3}, nil)
 	registry := commonMocks.NewCapabilitiesRegistry(t)
 
 	dispatcher, err := remote.NewDispatcher(testConfig{

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -77,8 +77,9 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrbootstrap"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
+	externalp2p "github.com/smartcontractkit/chainlink/v2/core/services/p2p"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
-	externalp2p "github.com/smartcontractkit/chainlink/v2/core/services/p2p/wrapper"
+	p2pwrapper "github.com/smartcontractkit/chainlink/v2/core/services/p2p/wrapper"
 	"github.com/smartcontractkit/chainlink/v2/core/services/periodicbackup"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	registrysyncerV1 "github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer"
@@ -927,9 +928,8 @@ func newCREServices(
 	if capCfg.Peering().Enabled() {
 		var dispatcher remotetypes.Dispatcher
 		if opts.CapabilitiesDispatcher == nil {
-			externalPeer := externalp2p.NewExternalPeerWrapper(keyStore.P2P(), capCfg.Peering(), ds, globalLogger)
-			signer := externalPeer
-			externalPeerWrapper = externalPeer
+			externalPeerWrapper = p2pwrapper.NewExternalPeerWrapper(keyStore.P2P(), capCfg.Peering(), ds, globalLogger)
+			signer := externalp2p.NewSigner(keyStore.P2P(), capCfg.Peering().PeerID())
 			remoteDispatcher, err := remote.NewDispatcher(capCfg.Dispatcher(), externalPeerWrapper, signer, opts.CapabilitiesRegistry, globalLogger)
 			if err != nil {
 				return nil, fmt.Errorf("could not create dispatcher: %w", err)

--- a/core/services/p2p/signer.go
+++ b/core/services/p2p/signer.go
@@ -1,0 +1,45 @@
+package p2p
+
+import (
+	"crypto"
+	"crypto/rand"
+	"errors"
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
+	"github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
+)
+
+type signer struct {
+	keystoreP2P keystore.P2P
+	peerID      p2pkey.PeerID
+	privateKey  crypto.Signer
+}
+
+var _ types.Signer = &signer{}
+
+// We can't access the Keystore until it is started and unlocked. The owner of the
+// Signer object needs to call Initialize() when Keystore is ready and before calling Sign().
+func NewSigner(keystoreP2P keystore.P2P, peerID p2pkey.PeerID) *signer {
+	return &signer{
+		keystoreP2P: keystoreP2P,
+		peerID:      peerID,
+	}
+}
+
+func (s *signer) Initialize() error {
+	key, err := s.keystoreP2P.GetOrFirst(s.peerID)
+	if err != nil {
+		return fmt.Errorf("failed to get P2P key from keystore: %w", err)
+	}
+	s.privateKey = key
+	return nil
+}
+
+func (s *signer) Sign(msg []byte) ([]byte, error) {
+	if s.privateKey == nil {
+		return nil, errors.New("private key not set")
+	}
+	return s.privateKey.Sign(rand.Reader, msg, crypto.Hash(0))
+}

--- a/core/services/p2p/signer_test.go
+++ b/core/services/p2p/signer_test.go
@@ -1,0 +1,28 @@
+package p2p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
+	ksmocks "github.com/smartcontractkit/chainlink/v2/core/services/keystore/mocks"
+)
+
+func TestSigner_InitializeAndSign(t *testing.T) {
+	keystoreP2P := ksmocks.NewP2P(t)
+	key, err := p2pkey.NewV2()
+	require.NoError(t, err)
+	keystoreP2P.On("GetOrFirst", mock.Anything).Return(key, nil)
+	s := NewSigner(keystoreP2P, p2pkey.PeerID{}) // peerID unset gets the default one
+
+	_, err = s.Sign([]byte("msg"))
+	require.Error(t, err)
+	require.Equal(t, "private key not set", err.Error())
+
+	require.NoError(t, s.Initialize())
+	sig, err := s.Sign([]byte("msg"))
+	require.NoError(t, err)
+	require.NotNil(t, sig)
+}

--- a/core/services/p2p/types/mocks/signer.go
+++ b/core/services/p2p/types/mocks/signer.go
@@ -17,6 +17,51 @@ func (_m *Signer) EXPECT() *Signer_Expecter {
 	return &Signer_Expecter{mock: &_m.Mock}
 }
 
+// Initialize provides a mock function with no fields
+func (_m *Signer) Initialize() error {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Initialize")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Signer_Initialize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Initialize'
+type Signer_Initialize_Call struct {
+	*mock.Call
+}
+
+// Initialize is a helper method to define mock.On call
+func (_e *Signer_Expecter) Initialize() *Signer_Initialize_Call {
+	return &Signer_Initialize_Call{Call: _e.mock.On("Initialize")}
+}
+
+func (_c *Signer_Initialize_Call) Run(run func()) *Signer_Initialize_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Signer_Initialize_Call) Return(_a0 error) *Signer_Initialize_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Signer_Initialize_Call) RunAndReturn(run func() error) *Signer_Initialize_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Sign provides a mock function with given fields: data
 func (_m *Signer) Sign(data []byte) ([]byte, error) {
 	ret := _m.Called(data)

--- a/core/services/p2p/types/types.go
+++ b/core/services/p2p/types/types.go
@@ -26,6 +26,7 @@ type PeerWrapper interface {
 }
 
 type Signer interface {
+	Initialize() error
 	Sign(data []byte) ([]byte, error)
 }
 

--- a/core/services/p2p/wrapper/wrapper.go
+++ b/core/services/p2p/wrapper/wrapper.go
@@ -3,8 +3,6 @@ package wrapper
 import (
 	"context"
 	"crypto"
-	"crypto/rand"
-	"errors"
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,7 +30,6 @@ type peerWrapper struct {
 }
 
 var _ types.PeerWrapper = &peerWrapper{}
-var _ types.Signer = &peerWrapper{}
 
 func NewExternalPeerWrapper(keystoreP2P keystore.P2P, p2pConfig config.P2P, ds sqlutil.DataSource, lggr logger.Logger) *peerWrapper {
 	return &peerWrapper{
@@ -129,11 +126,4 @@ func (e *peerWrapper) HealthReport() map[string]error {
 
 func (e *peerWrapper) Name() string {
 	return e.lggr.Name()
-}
-
-func (e *peerWrapper) Sign(msg []byte) ([]byte, error) {
-	if e.privateKey == nil {
-		return nil, errors.New("private key not set")
-	}
-	return e.privateKey.Sign(rand.Reader, msg, crypto.Hash(0))
 }


### PR DESCRIPTION
Move it into an independent Signer object so it can be reuse with either current or new Peer.