### PR TITLE
PLEX-1711 enable evm multi don

### DIFF
--- a/system-tests/lib/cre/capabilities/evm/evm.go
+++ b/system-tests/lib/cre/capabilities/evm/evm.go
@@ -63,7 +63,7 @@ func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]k
 			return nil, errors.Wrapf(selectorErr, "failed to get selector from chainID: %d", chainID)
 		}
 
-		faultyNodes := uint32((nodeSetInput.Nodes - 1) / 3)
+		faultyNodes := uint32((nodeSetInput.Nodes - 1) / 3) //nolint:gosec // disable G115
 		capabilities = append(capabilities, keystone_changeset.DONCapabilityWithConfig{
 			Capability: kcr.CapabilitiesRegistryCapability{
 				LabelledName:   "evm" + ":ChainSelector:" + strconv.FormatUint(selector, 10),

--- a/system-tests/lib/cre/capabilities/evm/evm.go
+++ b/system-tests/lib/cre/capabilities/evm/evm.go
@@ -80,7 +80,7 @@ func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]k
 					},
 				},
 			},
-		}
+		})
 	}
 
 	return capabilities, nil

--- a/system-tests/lib/cre/capabilities/evm/evm.go
+++ b/system-tests/lib/cre/capabilities/evm/evm.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"strconv"
 	"text/template"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	chainselectors "github.com/smartcontractkit/chain-selectors"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 
@@ -28,6 +30,8 @@ import (
 
 const flag = cre.EVMCapability
 const configTemplate = `'{"chainId":{{.ChainID}},"network":"{{.NetworkFamily}}","logTriggerPollInterval":{{.LogTriggerPollInterval}}, "creForwarderAddress":"{{.CreForwarderAddress}}","receiverGasMinimum":{{.ReceiverGasMinimum}},"nodeAddress":"{{.NodeAddress}}"}'`
+const registrationRefresh = 20 * time.Second
+const registrationExpiry = 60 * time.Second
 
 func New() (*capabilities.Capability, error) {
 	return capabilities.New(
@@ -59,15 +63,23 @@ func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]k
 			return nil, errors.Wrapf(selectorErr, "failed to get selector from chainID: %d", chainID)
 		}
 
+		faultyNodes := uint32((nodeSetInput.Nodes - 1) / 3)
 		capabilities = append(capabilities, keystone_changeset.DONCapabilityWithConfig{
 			Capability: kcr.CapabilitiesRegistryCapability{
 				LabelledName:   "evm" + ":ChainSelector:" + strconv.FormatUint(selector, 10),
 				Version:        "1.0.0",
-				CapabilityType: 3, // TARGET
-				ResponseType:   1, // OBSERVATION_IDENTICAL
+				CapabilityType: 0, // TRIGGER
 			},
-			Config: &capabilitiespb.CapabilityConfig{},
-		})
+			Config: &capabilitiespb.CapabilityConfig{
+				RemoteConfig: &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
+					RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
+						// needed for message_cache.go#Ready(), without these events from the capability will never be accepted
+						RegistrationRefresh:     durationpb.New(registrationRefresh),
+						RegistrationExpiry:      durationpb.New(registrationExpiry),
+						MinResponsesToAggregate: faultyNodes + 1,
+					},
+				},
+			},
 	}
 
 	return capabilities, nil

--- a/system-tests/lib/cre/capabilities/evm/evm.go
+++ b/system-tests/lib/cre/capabilities/evm/evm.go
@@ -63,7 +63,10 @@ func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]k
 			return nil, errors.Wrapf(selectorErr, "failed to get selector from chainID: %d", chainID)
 		}
 
-		faultyNodes := uint32((nodeSetInput.Nodes - 1) / 3) //nolint:gosec // disable G115
+		faultyNodes, faultyErr := nodeSetInput.MaxFaultyNodes()
+		if faultyErr != nil {
+			return nil, errors.Wrap(faultyErr, "failed to get faulty nodes")
+		}
 		capabilities = append(capabilities, keystone_changeset.DONCapabilityWithConfig{
 			Capability: kcr.CapabilitiesRegistryCapability{
 				LabelledName:   "evm" + ":ChainSelector:" + strconv.FormatUint(selector, 10),

--- a/system-tests/lib/cre/capabilities/evm/evm.go
+++ b/system-tests/lib/cre/capabilities/evm/evm.go
@@ -80,6 +80,7 @@ func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]k
 					},
 				},
 			},
+		}
 	}
 
 	return capabilities, nil

--- a/system-tests/lib/cre/capabilities/evm/evm.go
+++ b/system-tests/lib/cre/capabilities/evm/evm.go
@@ -62,7 +62,6 @@ func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]k
 		if selectorErr != nil {
 			return nil, errors.Wrapf(selectorErr, "failed to get selector from chainID: %d", chainID)
 		}
-
 		faultyNodes, faultyErr := nodeSetInput.MaxFaultyNodes()
 		if faultyErr != nil {
 			return nil, errors.Wrap(faultyErr, "failed to get faulty nodes")

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -694,6 +694,19 @@ func (c *CapabilitiesAwareNodeSet) ValidateChainCapabilities(bcInput []blockchai
 	return nil
 }
 
+// MaxFaultyNodes returns the maximum number of faulty (Byzantine) nodes
+// that a network of `n` total nodes can tolerate while still maintaining
+// consensus safety under the standard BFT assumption (n >= 3f + 1).
+//
+// For example, with 4 nodes, at most 1 can be faulty.
+// With 7 nodes, at most 2 can be faulty.
+func (c *CapabilitiesAwareNodeSet) MaxFaultyNodes() (uint32, error) {
+	if c.Nodes <= 0 {
+		return 0, fmt.Errorf("total nodes must be greater than 0, got %d", c.Nodes)
+	}
+	return uint32((c.Nodes - 1) / 3), nil //nolint:gosec // disable G115
+}
+
 type GenerateKeysInput struct {
 	GenerateEVMKeysForChainIDs []int
 	GenerateSolKeysForChainIDs []string


### PR DESCRIPTION
Jira: https://smartcontract-it.atlassian.net/browse/PLEX-1711

Current EVM capability works for both actions and triggers in a single DON setup (everything running inside of the workflow DON).

The current change allows to deploy the EVM Capability in the `capabilities` don, making the lookup for the trigger ID work in a remote context (this change shouldn't impact local CRE in single DON setup). Actions, in a multi don setup, won't work with this change, but that's fine for the time being, as that will be sorted out once https://github.com/smartcontractkit/chainlink/pull/19102 is working.

### Relates
- https://github.com/smartcontractkit/chainlink/pull/19102
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
