### PR TITLE
[CRE-768] better validation of capability flags

### DIFF
--- a/system-tests/lib/cre/environment/config/config.go
+++ b/system-tests/lib/cre/environment/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake"
@@ -35,14 +36,14 @@ func (c Config) Validate(envDependencies cre.CLIEnvironmentDependencies) error {
 
 	for _, nodeSet := range c.NodeSets {
 		for _, capability := range nodeSet.Capabilities {
-			if !slices.Contains(envDependencies.SupportedCapabilityFlags(), capability) {
-				return errors.New("unknown capability: " + capability + ". Make sure you have added it to the capabilityFlagsProvider")
+			if !slices.Contains(envDependencies.GlobalCapabilityFlags(), capability) {
+				return errors.New("unknown global capability: " + capability + ". Valid ones are: " + strings.Join(envDependencies.GlobalCapabilityFlags(), ", ") + ". If it is a new capability make sure you have added it to the capabilityFlagsProvider. If it's chain-specific add it under [nodesets.chain_capabilities] TOML table.")
 			}
 		}
 
 		for capability := range nodeSet.ChainCapabilities {
-			if !slices.Contains(envDependencies.SupportedCapabilityFlags(), capability) {
-				return errors.New("unknown capability: " + capability + ". Make sure you have added it to the capabilityFlagsProvider")
+			if !slices.Contains(envDependencies.ChainSpecificCapabilityFlags(), capability) {
+				return errors.New("unknown chain-specific capability: " + capability + ". Valid ones are: " + strings.Join(envDependencies.ChainSpecificCapabilityFlags(), ", ") + ". If it is a new capability make sure you have added it to the capabilityFlagsProvider. If it's a global capability add it under 'capabilities' TOML key.")
 			}
 		}
 	}

--- a/system-tests/lib/cre/flags/provider.go
+++ b/system-tests/lib/cre/flags/provider.go
@@ -3,20 +3,17 @@ package flags
 import "github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 
 type DefaultCapbilityFlagsProvider struct {
-	supportedCapabilities []cre.CapabilityFlag
+	globalCapabilities        []cre.CapabilityFlag
+	chainSpecificCapabilities []cre.CapabilityFlag
 }
 
 func NewDefaultCapabilityFlagsProvider() *DefaultCapbilityFlagsProvider {
 	return &DefaultCapbilityFlagsProvider{
-		supportedCapabilities: []cre.CapabilityFlag{
+		globalCapabilities: []cre.CapabilityFlag{
 			cre.ConsensusCapability,
 			cre.ConsensusCapabilityV2,
 			cre.CronCapability,
-			cre.EVMCapability,
 			cre.CustomComputeCapability,
-			cre.WriteEVMCapability,
-			cre.ReadContractCapability,
-			cre.LogTriggerCapability,
 			cre.WebAPITargetCapability,
 			cre.WebAPITriggerCapability,
 			cre.MockCapability,
@@ -25,9 +22,23 @@ func NewDefaultCapabilityFlagsProvider() *DefaultCapbilityFlagsProvider {
 			cre.HTTPActionCapability,
 			cre.WriteSolanaCapability,
 		},
+		chainSpecificCapabilities: []cre.CapabilityFlag{
+			cre.EVMCapability,
+			cre.WriteEVMCapability,
+			cre.ReadContractCapability,
+			cre.LogTriggerCapability,
+		},
 	}
 }
 
 func (p *DefaultCapbilityFlagsProvider) SupportedCapabilityFlags() []cre.CapabilityFlag {
-	return p.supportedCapabilities
+	return append(p.globalCapabilities, p.chainSpecificCapabilities...)
+}
+
+func (p *DefaultCapbilityFlagsProvider) GlobalCapabilityFlags() []cre.CapabilityFlag {
+	return p.globalCapabilities
+}
+
+func (p *DefaultCapbilityFlagsProvider) ChainSpecificCapabilityFlags() []cre.CapabilityFlag {
+	return p.chainSpecificCapabilities
 }

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -102,6 +102,8 @@ func NewContractVersionsProvider(overrides map[string]string) *contractVersionsP
 
 type CapabilityFlagsProvider interface {
 	SupportedCapabilityFlags() []CapabilityFlag
+	GlobalCapabilityFlags() []CapabilityFlag
+	ChainSpecificCapabilityFlags() []CapabilityFlag
 }
 
 func NewEnvironmentDependencies(cfp CapabilityFlagsProvider, cvp ContractVersionsProvider) *envionmentDependencies {
@@ -122,6 +124,14 @@ func (e *envionmentDependencies) GetContractVersions() map[string]string {
 
 func (e *envionmentDependencies) SupportedCapabilityFlags() []CapabilityFlag {
 	return e.flagsProvider.SupportedCapabilityFlags()
+}
+
+func (e *envionmentDependencies) GlobalCapabilityFlags() []CapabilityFlag {
+	return e.flagsProvider.GlobalCapabilityFlags()
+}
+
+func (e *envionmentDependencies) ChainSpecificCapabilityFlags() []CapabilityFlag {
+	return e.flagsProvider.ChainSpecificCapabilityFlags()
 }
 
 type NodeType = string


### PR DESCRIPTION
This pull request refactors how capability flags are managed and validated in the environment configuration for system tests. The main improvement is the clear separation between global and chain-specific capability flags, which enhances validation accuracy and error messaging. The changes also update relevant interfaces and providers to support this distinction.

**Capability Flag Management Improvements:**

* Split supported capabilities into `globalCapabilities` and `chainSpecificCapabilities` in `DefaultCapbilityFlagsProvider`, and added new methods to retrieve them separately (`GlobalCapabilityFlags`, `ChainSpecificCapabilityFlags`) (`system-tests/lib/cre/flags/provider.go`) [[1]](diffhunk://#diff-d8ce6b4d30b04e40d743395addff5544fae733ce4918b2cb1560ba4e70209760L6-L19) [[2]](diffhunk://#diff-d8ce6b4d30b04e40d743395addff5544fae733ce4918b2cb1560ba4e70209760R25-R43).
* Updated the `CapabilityFlagsProvider` interface and `envionmentDependencies` to include methods for fetching global and chain-specific capabilities (`system-tests/lib/cre/types.go`) [[1]](diffhunk://#diff-a0ccf4ab647f9ac666c82f0bf073d26dea9595c58b5f78ffd965531ce608c18eR105-R106) [[2]](diffhunk://#diff-a0ccf4ab647f9ac666c82f0bf073d26dea9595c58b5f78ffd965531ce608c18eR129-R136).

**Validation and Error Handling:**

* Modified the `Config.Validate` method to use the new global and chain-specific capability lists for validation, and improved error messages to specify valid options and guidance for adding new capabilities (`system-tests/lib/cre/environment/config/config.go`).
* Added the `strings` package import to support improved error messages in validation (`system-tests/lib/cre/environment/config/config.go`).