### PR TITLE
Add changeset to close account

### DIFF
--- a/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain_test.go
@@ -425,11 +425,14 @@ func TestIDL(t *testing.T) {
 
 	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetAuthorityIDLByDeployerKey),
+			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetAuthorityIDL),
 			ccipChangesetSolana.IDLConfig{
 				ChainSelector: solChain,
 				Router:        true,
 				FeeQuoter:     true,
+				BurnMintTokenPoolMetadata: []string{
+					shared.CLLMetadata,
+				},
 			},
 		),
 		commonchangeset.Configure(
@@ -439,6 +442,9 @@ func TestIDL(t *testing.T) {
 				GitCommitSha:  "",
 				Router:        true,
 				FeeQuoter:     true,
+				BurnMintTokenPoolMetadata: []string{
+					shared.CLLMetadata,
+				},
 				MCMS: &proposalutils.TimelockConfig{
 					MinDelay: 1 * time.Second,
 				},
@@ -455,9 +461,6 @@ func TestIDL(t *testing.T) {
 				GitCommitSha:  "",
 				OffRamp:       true,
 				RMNRemote:     true,
-				BurnMintTokenPoolMetadata: []string{
-					shared.CLLMetadata,
-				},
 				LockReleaseTokenPoolMetadata: []string{
 					shared.CLLMetadata,
 				},
@@ -465,6 +468,78 @@ func TestIDL(t *testing.T) {
 				AccessController: true,
 				Timelock:         true,
 				MCM:              true,
+			},
+		),
+	})
+	require.NoError(t, err)
+
+	// Test transfering ownership of the IDL back to the deployer key and then close and recreate the PDA
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetAuthorityIDLByMCMs),
+			ccipChangesetSolana.IDLConfig{
+				ChainSelector: solChain,
+				BurnMintTokenPoolMetadata: []string{
+					shared.CLLMetadata,
+				},
+				MCMS: &proposalutils.TimelockConfig{
+					MinDelay: 1 * time.Second,
+				},
+			},
+		),
+	})
+	require.NoError(t, err)
+
+	// close idl account
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			cldf.CreateLegacyChangeSet(ccipChangesetSolana.CloseIDLs),
+			ccipChangesetSolana.IDLConfig{
+				ChainSelector: solChain,
+				BurnMintTokenPoolMetadata: []string{
+					shared.CLLMetadata,
+				},
+			},
+		),
+	})
+	require.NoError(t, err)
+
+	// deploy idl
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			cldf.CreateLegacyChangeSet(ccipChangesetSolana.UploadIDL),
+			ccipChangesetSolana.IDLConfig{
+				ChainSelector: solChain,
+				GitCommitSha:  "ee587a6c0562",
+				BurnMintTokenPoolMetadata: []string{
+					shared.CLLMetadata,
+				},
+			},
+		),
+	})
+	require.NoError(t, err)
+
+	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
+		commonchangeset.Configure(
+			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetAuthorityIDL),
+			ccipChangesetSolana.IDLConfig{
+				ChainSelector: solChain,
+				BurnMintTokenPoolMetadata: []string{
+					shared.CLLMetadata,
+				},
+			},
+		),
+		commonchangeset.Configure(
+			cldf.CreateLegacyChangeSet(ccipChangesetSolana.UpgradeIDL),
+			ccipChangesetSolana.IDLConfig{
+				ChainSelector: solChain,
+				GitCommitSha:  "ee587a6c0562",
+				BurnMintTokenPoolMetadata: []string{
+					shared.CLLMetadata,
+				},
+				MCMS: &proposalutils.TimelockConfig{
+					MinDelay: 1 * time.Second,
+				},
 			},
 		),
 	})

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain_test.go
@@ -473,7 +473,7 @@ func TestIDL(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Test transfering ownership of the IDL back to the deployer key and then close and recreate the PDA
+	// Test transferring ownership of the IDL back to the deployer key and then close and recreate the PDA
 	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
 			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetAuthorityIDLByMCMs),

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain_test.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_deploy_chain_test.go
@@ -425,7 +425,7 @@ func TestIDL(t *testing.T) {
 
 	e, _, err = commonchangeset.ApplyChangesets(t, e, []commonchangeset.ConfiguredChangeSet{
 		commonchangeset.Configure(
-			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetAuthorityIDL),
+			cldf.CreateLegacyChangeSet(ccipChangesetSolana.SetAuthorityIDLByDeployerKey),
 			ccipChangesetSolana.IDLConfig{
 				ChainSelector: solChain,
 				Router:        true,

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
 	"os"
 	"path/filepath"
 	"strings"
+
+	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/pelletier/go-toml"

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -40,8 +40,8 @@ var _ cldf.ChangeSet[IDLConfig] = UpgradeIDL
 // Discriminator to invoke IDL operations
 const IdlIxTag uint64 = 0x0a69e9a778bcf440
 
-//Number ids of the operations:
-//pub enum IdlInstruction {
+// Number ids of the operations:
+// pub enum IdlInstruction {
 //
 //	0 Create { data_len: u64 }, // One time initializer for creating the program's idl account.
 //
@@ -56,7 +56,7 @@ const IdlIxTag uint64 = 0x0a69e9a778bcf440
 //	5 Close, // Closes the IDL pda Account
 //
 //	6 Resize { data_len: u64 }, // Increases account size for accounts that need over 10kb.
-//}
+// }
 
 // IDL
 type IDLConfig struct {
@@ -223,18 +223,6 @@ func setIdlAuthority(e cldf.Environment, newAuthority, programsPath, programID, 
 	return nil
 }
 
-// Close IDL account for a program
-func runCloseIDLAccount(e cldf.Environment, programsPath, programID, programName string) error {
-	e.Logger.Infow("Closing IDL Account", "programName", programName)
-	args := []string{"idl", "close", programID}
-	e.Logger.Info(args)
-	_, err := runCommand("anchor", args, programsPath)
-	if err != nil {
-		return fmt.Errorf("error closing idl account: %w", err)
-	}
-	return nil
-}
-
 // get IDL address for a program
 func getIDLAddress(e cldf.Environment, programID solana.PublicKey) (solana.PublicKey, error) {
 	base, _, _ := solana.FindProgramAddress([][]byte{}, programID)
@@ -356,7 +344,7 @@ func closeIDLAccountIx(e cldf.Environment, programID, authority, spillAddress so
 	return *instruction, nil
 }
 
-// generate upgrade IDL ix for a program via timelock
+// generate close IDL PDA ix for a program via timelock
 func removeIDLIx(e cldf.Environment, programID, programName string, spillAddress solana.PublicKey, c IDLConfig) (*mcmsTypes.Transaction, error) {
 	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
 	if err != nil {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -15,8 +15,7 @@ import (
 	"github.com/smartcontractkit/mcms"
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
 
-	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
-
+	cldfsolana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink/deployment"
@@ -37,21 +36,15 @@ var _ cldf.ChangeSet[IDLConfig] = SetAuthorityIDL
 // use this changeset to upgrade the IDL of a program via timelock
 var _ cldf.ChangeSet[IDLConfig] = UpgradeIDL
 
-// Discriminator to invoke IDL operations
-const IdlIxTag uint64 = 0x0a69e9a778bcf440
+// use this changeset to set the authority for the IDL of a program (timelock) via timelock
+var _ cldf.ChangeSet[IDLConfig] = SetAuthorityIDLByMCMs
 
-// Number ids of the operations:
-const (
-	IdlInstructionCreate       int = iota // One time initializer for creating the program's idl account.
-	IdlInstructionCreateBuffer            // Creates a new IDL account buffer. Can be called several times.
-	IdlInstructionWrite                   // Appends the given data to the end of the idl account buffer.
-	IdlInstructionSetBuffer               // Sets a new data buffer for the IdlAccount.
-	IdlInstructionSetAuthority            // Sets a new authority on the IdlAccount.
-	IdlInstructionClose                   // Closes the IDL pda Account
-	IdlInstructionResize                  // Increases account size for accounts that need over 10kb.
-)
+// changeset to upgrade idl for a program via timelock
+var _ cldf.ChangeSet[IDLConfig] = UpgradeIDL
 
-// IDL
+// use this changeset to close the IDL account for a program via timelock
+var _ cldf.ChangeSet[IDLConfig] = CloseIDLs
+
 type IDLConfig struct {
 	ChainSelector                uint64
 	GitCommitSha                 string                        // this will be used to download the correct artifacts (idls) -> best if same as what was used to deploy the programs
@@ -66,6 +59,245 @@ type IDLConfig struct {
 	LockReleaseTokenPoolMetadata []string                      // metadata for the lock release token pool (keyed my client identifier (metadata))
 	MCMS                         *proposalutils.TimelockConfig // timelock config for mcms
 	CCTPTokenPool                bool
+}
+
+func (c IDLConfig) Validate(e cldf.Environment) error {
+	if err := cldf.IsValidChainSelector(c.ChainSelector); err != nil {
+		return fmt.Errorf("invalid chain selector: %d - %w", c.ChainSelector, err)
+	}
+	family, _ := chainsel.GetSelectorFamily(c.ChainSelector)
+	if family != chainsel.FamilySolana {
+		return fmt.Errorf("chain %d is not a solana chain", c.ChainSelector)
+	}
+	existingState, err := stateview.LoadOnchainState(e)
+	if err != nil {
+		return fmt.Errorf("failed to load existing onchain state: %w", err)
+	}
+	if _, exists := existingState.SupportedChains()[c.ChainSelector]; !exists {
+		return fmt.Errorf("chain %d not supported", c.ChainSelector)
+	}
+	chainState := existingState.SolChains[c.ChainSelector]
+	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
+	if c.Router && chainState.Router.IsZero() {
+		return fmt.Errorf("router not deployed for chain %d, cannot upload idl", c.ChainSelector)
+	}
+	if c.FeeQuoter && chainState.FeeQuoter.IsZero() {
+		return fmt.Errorf("feeQuoter not deployed for chain %d, cannot upload idl", c.ChainSelector)
+	}
+	if c.OffRamp && chainState.OffRamp.IsZero() {
+		return fmt.Errorf("offRamp not deployed for chain %d, cannot upload idl", c.ChainSelector)
+	}
+	if c.RMNRemote && chainState.RMNRemote.IsZero() {
+		return fmt.Errorf("rmnRemote not deployed for chain %d, cannot upload idl", c.ChainSelector)
+	}
+	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
+		bnmTokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
+		if bnmTokenPool.IsZero() {
+			return fmt.Errorf("burnMintTokenPool not deployed for chain %d, cannot upload idl", c.ChainSelector)
+		}
+	}
+	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
+		lrTokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
+		if lrTokenPool.IsZero() {
+			return fmt.Errorf("lockReleaseTokenPool not deployed for chain %d, cannot upload idl", c.ChainSelector)
+		}
+	}
+	addresses, err := e.ExistingAddresses.AddressesForChain(c.ChainSelector)
+	if err != nil {
+		return fmt.Errorf("failed to get existing addresses: %w", err)
+	}
+	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(e.BlockChains.SolanaChains()[c.ChainSelector], addresses)
+	if err != nil {
+		return fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
+	}
+	if c.MCM && mcmState.McmProgram.IsZero() {
+		return fmt.Errorf("mcm program not deployed for chain %d, cannot upload idl", c.ChainSelector)
+	}
+	if c.Timelock && mcmState.TimelockProgram.IsZero() {
+		return fmt.Errorf("timelock program not deployed for chain %d, cannot upload idl", c.ChainSelector)
+	}
+	if c.AccessController && mcmState.AccessControllerProgram.IsZero() {
+		return fmt.Errorf("access controller program not deployed for chain %d, cannot upload idl", c.ChainSelector)
+	}
+
+	return repoSetup(e, chain, c.GitCommitSha)
+}
+
+// ANCHOR CLI OPERATIONS
+
+// changeset to upload idl for a program
+func UploadIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
+	if err := c.Validate(e); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
+	}
+	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
+	state, _ := stateview.LoadOnchainState(e)
+	chainState := state.SolChains[c.ChainSelector]
+
+	// start uploading
+	if c.Router {
+		err := idlInit(e, chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.FeeQuoter {
+		err := idlInit(e, chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, nil
+		}
+	}
+	if c.OffRamp {
+		err := idlInit(e, chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, nil
+		}
+	}
+	if c.RMNRemote {
+		err := idlInit(e, chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, nil
+		}
+	}
+	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
+		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
+		err := idlInit(e, chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, nil
+		}
+	}
+	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
+		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
+		err := idlInit(e, chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, nil
+		}
+	}
+	if c.CCTPTokenPool {
+		err := idlInit(e, chain.ProgramsPath, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, nil
+		}
+	}
+	addresses, err := e.ExistingAddresses.AddressesForChain(c.ChainSelector)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
+	}
+	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(e.BlockChains.SolanaChains()[c.ChainSelector], addresses)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
+	}
+	if c.MCM {
+		err := idlInit(e, chain.ProgramsPath, mcmState.McmProgram.String(), deployment.McmProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, nil
+		}
+	}
+	if c.Timelock {
+		err := idlInit(e, chain.ProgramsPath, mcmState.TimelockProgram.String(), deployment.TimelockProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, nil
+		}
+	}
+	if c.AccessController {
+		err := idlInit(e, chain.ProgramsPath, mcmState.AccessControllerProgram.String(), deployment.AccessControllerProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, nil
+		}
+	}
+
+	return cldf.ChangesetOutput{}, nil
+}
+
+// changeset to set idl authority for a program to timelock
+func SetAuthorityIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
+	if err := c.Validate(e); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
+	}
+	state, _ := stateview.LoadOnchainState(e)
+	chainState := state.SolChains[c.ChainSelector]
+	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
+
+	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("error loading timelockSignerPDA: %w", err)
+	}
+
+	// set idl authority
+	if c.Router {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.FeeQuoter {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.OffRamp {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.RMNRemote {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
+		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
+		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.CCTPTokenPool {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+
+	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
+	}
+	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
+	}
+
+	if c.AccessController {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String(), "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.Timelock {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String(), "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.MCM {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String(), "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+
+	return cldf.ChangesetOutput{}, nil
 }
 
 // parse anchor version from running anchor --version
@@ -110,7 +342,7 @@ func writeAnchorToml(e cldf.Environment, filename, anchorVersion, cluster, walle
 }
 
 // resolve artifacts based on sha and write anchor.toml file to simulate anchor workspace
-func repoSetup(e cldf.Environment, chain cldf_solana.Chain, gitCommitSha string) error {
+func repoSetup(e cldf.Environment, chain cldfsolana.Chain, gitCommitSha string) error {
 	e.Logger.Debug("Downloading Solana CCIP program artifacts...")
 	err := memory.DownloadSolanaCCIPProgramArtifacts(e.GetContext(), chain.ProgramsPath, e.Logger, gitCommitSha)
 	if err != nil {
@@ -199,53 +431,6 @@ func idlInit(e cldf.Environment, programsPath, programID, programName string) er
 	return nil
 }
 
-func setAuthorityIdlInstruction(e cldf.Environment, programID, authority, newAuthority solana.PublicKey) (solana.GenericInstruction, error) {
-	accounts, instruction, err2 := getAccountsForSetAuthorityIdlInstruction(e, programID, authority)
-	if err2 != nil {
-		return instruction, err2
-	}
-	return buildIdlInstruction(programID, accounts, IdlInstructionSetAuthority, newAuthority.Bytes())
-}
-
-func getAccountsForSetAuthorityIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
-	idlAddress, err := getIDLAddress(e, programID)
-	if err != nil {
-		return nil, solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
-	}
-	accounts := solana.AccountMetaSlice{
-		solana.NewAccountMeta(idlAddress, true, false), // IDL account
-		solana.NewAccountMeta(authority, false, true),
-	}
-	return accounts, solana.GenericInstruction{}, nil
-}
-
-// generate close IDL PDA ix for a program via timelock
-func setAuthorityIDLIx(e cldf.Environment, programID, programName string, newAuthority solana.PublicKey, c IDLConfig) (*mcmsTypes.Transaction, error) {
-	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
-	if err != nil {
-		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
-	}
-	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
-	if c.MCMS != nil {
-		authority = timelockSignerPDA
-	}
-	instruction, err := setAuthorityIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), authority, newAuthority)
-	if err != nil {
-		return nil, fmt.Errorf("error setting authority IDL ix: %w", err)
-	}
-	if c.MCMS != nil {
-		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
-		if err != nil {
-			return nil, fmt.Errorf("failed to set authority IDL transaction: %w", err)
-		}
-		return upgradeTx, nil
-	}
-	if err := e.BlockChains.SolanaChains()[c.ChainSelector].Confirm([]solana.Instruction{&instruction}); err != nil {
-		return nil, fmt.Errorf("failed to confirm instructions: %w", err)
-	}
-	return nil, nil
-}
-
 // get IDL address for a program
 func getIDLAddress(e cldf.Environment, programID solana.PublicKey) (solana.PublicKey, error) {
 	base, _, _ := solana.FindProgramAddress([][]byte{}, programID)
@@ -290,41 +475,6 @@ func writeBuffer(e cldf.Environment, programsPath, programID, programName string
 	return bufferAddress, nil
 }
 
-// generate set buffer ix using solana-go sdk
-func setBufferIdlInstruction(e cldf.Environment, programID, buffer, authority solana.PublicKey) (solana.GenericInstruction, error) {
-	accounts, instruction, err2 := getAccountsForCreateBufferIdlInstruction(e, programID, buffer, authority)
-	if err2 != nil {
-		return instruction, err2
-	}
-	return buildIdlInstruction(programID, accounts, IdlInstructionSetBuffer, []byte{})
-}
-
-func getAccountsForCreateBufferIdlInstruction(e cldf.Environment, programID solana.PublicKey, buffer solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
-	idlAddress, err := getIDLAddress(e, programID)
-	if err != nil {
-		return nil, solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
-	}
-	accounts := solana.AccountMetaSlice{
-		solana.NewAccountMeta(buffer, true, false),
-		solana.NewAccountMeta(idlAddress, true, false),
-		solana.NewAccountMeta(authority, false, true),
-	}
-	return accounts, solana.GenericInstruction{}, nil
-}
-
-func buildIdlInstruction(programID solana.PublicKey, accountsForIx solana.AccountMetaSlice, idlInstruction int, params []byte) (solana.GenericInstruction, error) {
-	data := binary.LittleEndian.AppendUint64([]byte{}, IdlIxTag) // 4-byte Extend instruction identifier
-	data = append(data, byte(idlInstruction))                    // Append the numeric ID of the operation
-	data = append(data, params...)                               // Append any additional parameters
-
-	instruction := solana.NewInstruction(
-		programID,
-		accountsForIx,
-		data,
-	)
-	return *instruction, nil
-}
-
 func setAuthorityIDLByCLI(e cldf.Environment, newAuthority, programsPath, programID, programName, bufferAccount string) error {
 	e.Logger.Infow("Setting IDL authority", "programName", programName, "newAuthority", newAuthority)
 	args := []string{"idl", "set-authority", "-n", newAuthority, "-p", programID}
@@ -340,232 +490,21 @@ func setAuthorityIDLByCLI(e cldf.Environment, newAuthority, programsPath, progra
 	return nil
 }
 
-// generate upgrade IDL ix for a program via timelock
-func upgradeIDLIx(e cldf.Environment, programsPath, programID, programName string, c IDLConfig) (*mcmsTypes.Transaction, error) {
-	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
-	if err != nil {
-		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
-	}
-	buffer, err := writeBuffer(e, programsPath, programID, programName)
-	if err != nil {
-		return nil, fmt.Errorf("error writing buffer: %w", err)
-	}
-	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
-	if c.MCMS != nil {
-		authority = timelockSignerPDA
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), programsPath, programID, programName, buffer.String())
-		if err != nil {
-			return nil, fmt.Errorf("error setting buffer authority: %w", err)
-		}
-	}
-	instruction, err := setBufferIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), buffer, authority)
-	if err != nil {
-		return nil, fmt.Errorf("error generating set buffer ix: %w", err)
-	}
-	if c.MCMS != nil {
-		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create upgrade transaction: %w", err)
-		}
-		return upgradeTx, nil
-	}
-	if err := e.BlockChains.SolanaChains()[c.ChainSelector].Confirm([]solana.Instruction{&instruction}); err != nil {
-		return nil, fmt.Errorf("failed to confirm instructions: %w", err)
-	}
-	return nil, nil
-}
+// SOLANA INSTRUCTIONS
 
-// generate set buffer ix using solana-go sdk
-func closeIdlInstruction(e cldf.Environment, programID, authority, spillAddress solana.PublicKey) (solana.GenericInstruction, error) {
-	accounts, err := getAccountsForCloseIdlInstruction(e, programID, authority, spillAddress)
-	if err != nil {
-		return solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
-	}
-	return buildIdlInstruction(programID, accounts, IdlInstructionClose, []byte{})
-}
+// Discriminator to invoke IDL operations
+const IdlIxTag uint64 = 0x0a69e9a778bcf440
 
-func getAccountsForCloseIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey, spillAddress solana.PublicKey) (solana.AccountMetaSlice, error) {
-	idlAddress, err := getIDLAddress(e, programID)
-	accounts := solana.AccountMetaSlice{
-		solana.NewAccountMeta(idlAddress, true, false), // IDL account
-		solana.NewAccountMeta(authority, false, true),
-		solana.NewAccountMeta(spillAddress, true, false), // sol destination for close funds
-	}
-	return accounts, err
-}
-
-// generate close IDL PDA ix for a program via timelock
-func removeIDLIx(e cldf.Environment, programID, programName string, spillAddress solana.PublicKey, c IDLConfig) (*mcmsTypes.Transaction, error) {
-	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
-	if err != nil {
-		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
-	}
-	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
-	if c.MCMS != nil {
-		authority = timelockSignerPDA
-	}
-	instruction, err := closeIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), authority, spillAddress)
-	if err != nil {
-		return nil, fmt.Errorf("error closing IDL account ix: %w", err)
-	}
-	if c.MCMS != nil {
-		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create close IDL transaction: %w", err)
-		}
-		return upgradeTx, nil
-	}
-	if err := e.BlockChains.SolanaChains()[c.ChainSelector].Confirm([]solana.Instruction{&instruction}); err != nil {
-		return nil, fmt.Errorf("failed to confirm instructions: %w", err)
-	}
-	return nil, nil
-}
-
-func (c IDLConfig) Validate(e cldf.Environment) error {
-	if err := cldf.IsValidChainSelector(c.ChainSelector); err != nil {
-		return fmt.Errorf("invalid chain selector: %d - %w", c.ChainSelector, err)
-	}
-	family, _ := chainsel.GetSelectorFamily(c.ChainSelector)
-	if family != chainsel.FamilySolana {
-		return fmt.Errorf("chain %d is not a solana chain", c.ChainSelector)
-	}
-	existingState, err := stateview.LoadOnchainState(e)
-	if err != nil {
-		return fmt.Errorf("failed to load existing onchain state: %w", err)
-	}
-	if _, exists := existingState.SupportedChains()[c.ChainSelector]; !exists {
-		return fmt.Errorf("chain %d not supported", c.ChainSelector)
-	}
-	chainState := existingState.SolChains[c.ChainSelector]
-	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
-	if c.Router && chainState.Router.IsZero() {
-		return fmt.Errorf("router not deployed for chain %d, cannot upload idl", c.ChainSelector)
-	}
-	if c.FeeQuoter && chainState.FeeQuoter.IsZero() {
-		return fmt.Errorf("feeQuoter not deployed for chain %d, cannot upload idl", c.ChainSelector)
-	}
-	if c.OffRamp && chainState.OffRamp.IsZero() {
-		return fmt.Errorf("offRamp not deployed for chain %d, cannot upload idl", c.ChainSelector)
-	}
-	if c.RMNRemote && chainState.RMNRemote.IsZero() {
-		return fmt.Errorf("rmnRemote not deployed for chain %d, cannot upload idl", c.ChainSelector)
-	}
-	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
-		bnmTokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		if bnmTokenPool.IsZero() {
-			return fmt.Errorf("burnMintTokenPool not deployed for chain %d, cannot upload idl", c.ChainSelector)
-		}
-	}
-	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
-		lrTokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		if lrTokenPool.IsZero() {
-			return fmt.Errorf("lockReleaseTokenPool not deployed for chain %d, cannot upload idl", c.ChainSelector)
-		}
-	}
-	addresses, err := e.ExistingAddresses.AddressesForChain(c.ChainSelector)
-	if err != nil {
-		return fmt.Errorf("failed to get existing addresses: %w", err)
-	}
-	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(e.BlockChains.SolanaChains()[c.ChainSelector], addresses)
-	if err != nil {
-		return fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
-	}
-	if c.MCM && mcmState.McmProgram.IsZero() {
-		return fmt.Errorf("mcm program not deployed for chain %d, cannot upload idl", c.ChainSelector)
-	}
-	if c.Timelock && mcmState.TimelockProgram.IsZero() {
-		return fmt.Errorf("timelock program not deployed for chain %d, cannot upload idl", c.ChainSelector)
-	}
-	if c.AccessController && mcmState.AccessControllerProgram.IsZero() {
-		return fmt.Errorf("access controller program not deployed for chain %d, cannot upload idl", c.ChainSelector)
-	}
-
-	return repoSetup(e, chain, c.GitCommitSha)
-}
-
-// changeset to upload idl for a program
-func UploadIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
-	if err := c.Validate(e); err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
-	}
-	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
-	state, _ := stateview.LoadOnchainState(e)
-	chainState := state.SolChains[c.ChainSelector]
-
-	// start uploading
-	if c.Router {
-		err := idlInit(e, chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.FeeQuoter {
-		err := idlInit(e, chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, nil
-		}
-	}
-	if c.OffRamp {
-		err := idlInit(e, chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, nil
-		}
-	}
-	if c.RMNRemote {
-		err := idlInit(e, chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, nil
-		}
-	}
-	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
-		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		err := idlInit(e, chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, nil
-		}
-	}
-	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
-		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		err := idlInit(e, chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, nil
-		}
-	}
-	if c.CCTPTokenPool {
-		err := idlInit(e, chain.ProgramsPath, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, nil
-		}
-	}
-	addresses, err := e.ExistingAddresses.AddressesForChain(c.ChainSelector)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
-	}
-	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(e.BlockChains.SolanaChains()[c.ChainSelector], addresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
-	}
-	if c.MCM {
-		err := idlInit(e, chain.ProgramsPath, mcmState.McmProgram.String(), deployment.McmProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, nil
-		}
-	}
-	if c.Timelock {
-		err := idlInit(e, chain.ProgramsPath, mcmState.TimelockProgram.String(), deployment.TimelockProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, nil
-		}
-	}
-	if c.AccessController {
-		err := idlInit(e, chain.ProgramsPath, mcmState.AccessControllerProgram.String(), deployment.AccessControllerProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, nil
-		}
-	}
-
-	return cldf.ChangesetOutput{}, nil
-}
+// Number ids of the operations:
+const (
+	IdlInstructionCreate       int = iota // One time initializer for creating the program's idl account.
+	IdlInstructionCreateBuffer            // Creates a new IDL account buffer. Can be called several times.
+	IdlInstructionWrite                   // Appends the given data to the end of the idl account buffer.
+	IdlInstructionSetBuffer               // Sets a new data buffer for the IdlAccount.
+	IdlInstructionSetAuthority            // Sets a new authority on the IdlAccount.
+	IdlInstructionClose                   // Closes the IDL pda Account
+	IdlInstructionResize                  // Increases account size for accounts that need over 10kb.
+)
 
 // changeset to set idl authority for a program to timelock
 func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
@@ -692,97 +631,6 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 		return cldf.ChangesetOutput{
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 		}, nil
-	}
-
-	return cldf.ChangesetOutput{}, nil
-}
-
-// changeset to set idl authority for a program to timelock
-func SetAuthorityIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
-	if err := c.Validate(e); err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
-	}
-	state, _ := stateview.LoadOnchainState(e)
-	chainState := state.SolChains[c.ChainSelector]
-	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
-
-	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("error loading timelockSignerPDA: %w", err)
-	}
-
-	// set idl authority
-	if c.Router {
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName, "")
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.FeeQuoter {
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, "")
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.OffRamp {
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName, "")
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.RMNRemote {
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, "")
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
-		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, "")
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
-		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, "")
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.CCTPTokenPool {
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName, "")
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-
-	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
-	}
-	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
-	}
-
-	if c.AccessController {
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String(), "")
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.Timelock {
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String(), "")
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.MCM {
-		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String(), "")
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
 	}
 
 	return cldf.ChangesetOutput{}, nil
@@ -1050,4 +898,168 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	}
 
 	return cldf.ChangesetOutput{}, nil
+}
+
+// Build instruction to interact with Anchor IDL using the list of ids above for each message
+func buildIdlInstruction(programID solana.PublicKey, accountsForIx solana.AccountMetaSlice, idlInstruction int, params []byte) (solana.GenericInstruction, error) {
+	data := binary.LittleEndian.AppendUint64([]byte{}, IdlIxTag) // 8-byte Extend instruction identifier
+	data = append(data, byte(idlInstruction))                    // Append the numeric ID of the operation
+	data = append(data, params...)                               // Append any additional parameters
+
+	instruction := solana.NewInstruction(
+		programID,
+		accountsForIx,
+		data,
+	)
+	return *instruction, nil
+}
+
+func setAuthorityIdlInstruction(e cldf.Environment, programID, authority, newAuthority solana.PublicKey) (solana.GenericInstruction, error) {
+	accounts, instruction, err2 := getAccountsForSetAuthorityIdlInstruction(e, programID, authority)
+	if err2 != nil {
+		return instruction, err2
+	}
+	return buildIdlInstruction(programID, accounts, IdlInstructionSetAuthority, newAuthority.Bytes())
+}
+
+func getAccountsForSetAuthorityIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
+	idlAddress, err := getIDLAddress(e, programID)
+	if err != nil {
+		return nil, solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
+	}
+	accounts := solana.AccountMetaSlice{
+		solana.NewAccountMeta(idlAddress, true, false), // IDL account
+		solana.NewAccountMeta(authority, false, true),
+	}
+	return accounts, solana.GenericInstruction{}, nil
+}
+
+// Set Authority IDL
+func setAuthorityIDLIx(e cldf.Environment, programID, programName string, newAuthority solana.PublicKey, c IDLConfig) (*mcmsTypes.Transaction, error) {
+	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
+	}
+	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
+	if c.MCMS != nil {
+		authority = timelockSignerPDA
+	}
+	instruction, err := setAuthorityIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), authority, newAuthority)
+	if err != nil {
+		return nil, fmt.Errorf("error setting authority IDL ix: %w", err)
+	}
+	if c.MCMS != nil {
+		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
+		if err != nil {
+			return nil, fmt.Errorf("failed to set authority IDL transaction: %w", err)
+		}
+		return upgradeTx, nil
+	}
+	if err := e.BlockChains.SolanaChains()[c.ChainSelector].Confirm([]solana.Instruction{&instruction}); err != nil {
+		return nil, fmt.Errorf("failed to confirm instructions: %w", err)
+	}
+	return nil, nil
+}
+
+// generate set buffer ix using solana-go sdk
+func setBufferIdlInstruction(e cldf.Environment, programID, buffer, authority solana.PublicKey) (solana.GenericInstruction, error) {
+	accounts, instruction, err2 := getAccountsForCreateBufferIdlInstruction(e, programID, buffer, authority)
+	if err2 != nil {
+		return instruction, err2
+	}
+	return buildIdlInstruction(programID, accounts, IdlInstructionSetBuffer, []byte{})
+}
+
+func getAccountsForCreateBufferIdlInstruction(e cldf.Environment, programID solana.PublicKey, buffer solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
+	idlAddress, err := getIDLAddress(e, programID)
+	if err != nil {
+		return nil, solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
+	}
+	accounts := solana.AccountMetaSlice{
+		solana.NewAccountMeta(buffer, true, false),
+		solana.NewAccountMeta(idlAddress, true, false),
+		solana.NewAccountMeta(authority, false, true),
+	}
+	return accounts, solana.GenericInstruction{}, nil
+}
+
+// generate upgrade IDL ix for a program via timelock
+func upgradeIDLIx(e cldf.Environment, programsPath, programID, programName string, c IDLConfig) (*mcmsTypes.Transaction, error) {
+	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
+	}
+	buffer, err := writeBuffer(e, programsPath, programID, programName)
+	if err != nil {
+		return nil, fmt.Errorf("error writing buffer: %w", err)
+	}
+	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
+	if c.MCMS != nil {
+		authority = timelockSignerPDA
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), programsPath, programID, programName, buffer.String())
+		if err != nil {
+			return nil, fmt.Errorf("error setting buffer authority: %w", err)
+		}
+	}
+	instruction, err := setBufferIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), buffer, authority)
+	if err != nil {
+		return nil, fmt.Errorf("error generating set buffer ix: %w", err)
+	}
+	if c.MCMS != nil {
+		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create upgrade transaction: %w", err)
+		}
+		return upgradeTx, nil
+	}
+	if err := e.BlockChains.SolanaChains()[c.ChainSelector].Confirm([]solana.Instruction{&instruction}); err != nil {
+		return nil, fmt.Errorf("failed to confirm instructions: %w", err)
+	}
+	return nil, nil
+}
+
+// generate set buffer ix using solana-go sdk
+func closeIdlInstruction(e cldf.Environment, programID, authority, spillAddress solana.PublicKey) (solana.GenericInstruction, error) {
+	accounts, err := getAccountsForCloseIdlInstruction(e, programID, authority, spillAddress)
+	if err != nil {
+		return solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
+	}
+	return buildIdlInstruction(programID, accounts, IdlInstructionClose, []byte{})
+}
+
+func getAccountsForCloseIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey, spillAddress solana.PublicKey) (solana.AccountMetaSlice, error) {
+	idlAddress, err := getIDLAddress(e, programID)
+	accounts := solana.AccountMetaSlice{
+		solana.NewAccountMeta(idlAddress, true, false), // IDL account
+		solana.NewAccountMeta(authority, false, true),
+		solana.NewAccountMeta(spillAddress, true, false), // sol destination for close funds
+	}
+	return accounts, err
+}
+
+// generate close IDL PDA ix for a program via timelock
+func removeIDLIx(e cldf.Environment, programID, programName string, spillAddress solana.PublicKey, c IDLConfig) (*mcmsTypes.Transaction, error) {
+	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
+	}
+	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
+	if c.MCMS != nil {
+		authority = timelockSignerPDA
+	}
+	instruction, err := closeIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), authority, spillAddress)
+	if err != nil {
+		return nil, fmt.Errorf("error closing IDL account ix: %w", err)
+	}
+	if c.MCMS != nil {
+		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create close IDL transaction: %w", err)
+		}
+		return upgradeTx, nil
+	}
+	if err := e.BlockChains.SolanaChains()[c.ChainSelector].Confirm([]solana.Instruction{&instruction}); err != nil {
+		return nil, fmt.Errorf("failed to confirm instructions: %w", err)
+	}
+	return nil, nil
 }

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -519,7 +519,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 	mcmsTxs := make([]mcmsTypes.Transaction, 0)
 	newAuthority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
 	if c.Router {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.Router.String(), deployment.RouterProgramName, newAuthority, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.Router, deployment.RouterProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -528,7 +528,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 		}
 	}
 	if c.FeeQuoter {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, newAuthority, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.FeeQuoter, deployment.FeeQuoterProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -537,7 +537,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 		}
 	}
 	if c.OffRamp {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.OffRamp.String(), deployment.OffRampProgramName, newAuthority, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.OffRamp, deployment.OffRampProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -546,7 +546,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 		}
 	}
 	if c.RMNRemote {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, newAuthority, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.RMNRemote, deployment.RMNRemoteProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -556,7 +556,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 	}
 	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, newAuthority, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool, deployment.BurnMintTokenPoolProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -566,7 +566,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 	}
 	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, newAuthority, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool, deployment.LockReleaseTokenPoolProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -575,7 +575,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 		}
 	}
 	if c.CCTPTokenPool {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName, newAuthority, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.CCTPTokenPool, deployment.CCTPTokenPoolProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -594,7 +594,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 	}
 
 	if c.AccessController {
-		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String(), newAuthority, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.AccessControllerProgram, types.AccessControllerProgram.String(), newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -603,7 +603,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 		}
 	}
 	if c.Timelock {
-		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String(), newAuthority, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.TimelockProgram, types.RBACTimelockProgram.String(), newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -612,7 +612,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 		}
 	}
 	if c.MCM {
-		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String(), newAuthority, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.McmProgram, types.ManyChainMultisigProgram.String(), newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -778,11 +778,10 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
 	state, _ := stateview.LoadOnchainState(e)
 	chainState := state.SolChains[c.ChainSelector]
-	spillAddress := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
 
 	mcmsTxs := make([]mcmsTypes.Transaction, 0)
 	if c.Router {
-		upgradeTx, err := removeIDLIx(e, chainState.Router.String(), deployment.RouterProgramName, spillAddress, c)
+		upgradeTx, err := closeIdlInstruction(e, chainState.Router, deployment.RouterProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -791,7 +790,7 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 		}
 	}
 	if c.FeeQuoter {
-		upgradeTx, err := removeIDLIx(e, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, spillAddress, c)
+		upgradeTx, err := closeIdlInstruction(e, chainState.FeeQuoter, deployment.FeeQuoterProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -800,7 +799,7 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 		}
 	}
 	if c.OffRamp {
-		upgradeTx, err := removeIDLIx(e, chainState.OffRamp.String(), deployment.OffRampProgramName, spillAddress, c)
+		upgradeTx, err := closeIdlInstruction(e, chainState.OffRamp, deployment.OffRampProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -809,7 +808,7 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 		}
 	}
 	if c.RMNRemote {
-		upgradeTx, err := removeIDLIx(e, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, spillAddress, c)
+		upgradeTx, err := closeIdlInstruction(e, chainState.RMNRemote, deployment.RMNRemoteProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -819,7 +818,7 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	}
 	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		upgradeTx, err := removeIDLIx(e, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, spillAddress, c)
+		upgradeTx, err := closeIdlInstruction(e, tokenPool, deployment.BurnMintTokenPoolProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -829,7 +828,7 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	}
 	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		upgradeTx, err := removeIDLIx(e, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, spillAddress, c)
+		upgradeTx, err := closeIdlInstruction(e, tokenPool, deployment.LockReleaseTokenPoolProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -839,7 +838,7 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	}
 	if c.CCTPTokenPool {
 		tokenPool := chainState.GetActiveTokenPool(shared.CCTPTokenPool, shared.CLLMetadata)
-		upgradeTx, err := removeIDLIx(e, tokenPool.String(), deployment.CCTPTokenPoolProgramName, spillAddress, c)
+		upgradeTx, err := closeIdlInstruction(e, tokenPool, deployment.CCTPTokenPoolProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -858,7 +857,7 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	}
 
 	if c.AccessController {
-		upgradeTx, err := removeIDLIx(e, mcmState.AccessControllerProgram.String(), deployment.AccessControllerProgramName, spillAddress, c)
+		upgradeTx, err := closeIdlInstruction(e, mcmState.AccessControllerProgram, deployment.AccessControllerProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -867,7 +866,7 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 		}
 	}
 	if c.Timelock {
-		upgradeTx, err := removeIDLIx(e, mcmState.TimelockProgram.String(), deployment.TimelockProgramName, spillAddress, c)
+		upgradeTx, err := closeIdlInstruction(e, mcmState.TimelockProgram, deployment.TimelockProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -876,7 +875,7 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 		}
 	}
 	if c.MCM {
-		upgradeTx, err := removeIDLIx(e, mcmState.McmProgram.String(), deployment.McmProgramName, spillAddress, c)
+		upgradeTx, err := closeIdlInstruction(e, mcmState.McmProgram, deployment.McmProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -914,44 +913,23 @@ func buildIdlInstruction(programID solana.PublicKey, accountsForIx solana.Accoun
 	return *instruction, nil
 }
 
-func setAuthorityIdlInstruction(e cldf.Environment, programID, authority, newAuthority solana.PublicKey) (solana.GenericInstruction, error) {
-	accounts, instruction, err2 := getAccountsForSetAuthorityIdlInstruction(e, programID, authority)
-	if err2 != nil {
-		return instruction, err2
-	}
-	return buildIdlInstruction(programID, accounts, IdlInstructionSetAuthority, newAuthority.Bytes())
-}
-
-func getAccountsForSetAuthorityIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
-	idlAddress, err := getIDLAddress(e, programID)
-	if err != nil {
-		return nil, solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
-	}
-	accounts := solana.AccountMetaSlice{
-		solana.NewAccountMeta(idlAddress, true, false), // IDL account
-		solana.NewAccountMeta(authority, false, true),
-	}
-	return accounts, solana.GenericInstruction{}, nil
-}
-
-// Set Authority IDL
-func setAuthorityIDLIx(e cldf.Environment, programID, programName string, newAuthority solana.PublicKey, c IDLConfig) (*mcmsTypes.Transaction, error) {
+func calculateAuthority(e cldf.Environment, c IDLConfig) (solana.PublicKey, error) {
 	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
 	if err != nil {
-		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
+		return solana.PublicKey{}, fmt.Errorf("error loading timelockSignerPDA: %w", err)
 	}
 	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
 	if c.MCMS != nil {
 		authority = timelockSignerPDA
 	}
-	instruction, err := setAuthorityIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), authority, newAuthority)
-	if err != nil {
-		return nil, fmt.Errorf("error setting authority IDL ix: %w", err)
-	}
+	return authority, err
+}
+
+func buildTxWithCorrectSigner(e cldf.Environment, programID string, programName string, c IDLConfig, instruction solana.GenericInstruction) (*mcmsTypes.Transaction, error) {
 	if c.MCMS != nil {
 		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
 		if err != nil {
-			return nil, fmt.Errorf("failed to set authority IDL transaction: %w", err)
+			return nil, fmt.Errorf("failed to create close IDL transaction: %w", err)
 		}
 		return upgradeTx, nil
 	}
@@ -963,22 +941,22 @@ func setAuthorityIDLIx(e cldf.Environment, programID, programName string, newAut
 
 // generate set buffer ix using solana-go sdk
 func setBufferIdlInstruction(e cldf.Environment, programID, buffer, authority solana.PublicKey) (solana.GenericInstruction, error) {
-	accounts, instruction, err2 := getAccountsForCreateBufferIdlInstruction(e, programID, buffer, authority)
+	accounts, instruction, err2 := getAccountsFoSetBufferIdlInstruction(e, programID, buffer, authority)
 	if err2 != nil {
 		return instruction, err2
 	}
 	return buildIdlInstruction(programID, accounts, IdlInstructionSetBuffer, []byte{})
 }
 
-func getAccountsForCreateBufferIdlInstruction(e cldf.Environment, programID solana.PublicKey, buffer solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
+func getAccountsFoSetBufferIdlInstruction(e cldf.Environment, programID solana.PublicKey, buffer solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
 	idlAddress, err := getIDLAddress(e, programID)
 	if err != nil {
 		return nil, solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
 	}
 	accounts := solana.AccountMetaSlice{
-		solana.NewAccountMeta(buffer, true, false),
-		solana.NewAccountMeta(idlAddress, true, false),
-		solana.NewAccountMeta(authority, false, true),
+		solana.Meta(buffer).WRITE(),
+		solana.Meta(idlAddress).WRITE(),
+		solana.Meta(authority).SIGNER(),
 	}
 	return accounts, solana.GenericInstruction{}, nil
 }
@@ -1018,48 +996,63 @@ func upgradeIDLIx(e cldf.Environment, programsPath, programID, programName strin
 	return nil, nil
 }
 
-// generate set buffer ix using solana-go sdk
-func closeIdlInstruction(e cldf.Environment, programID, authority, spillAddress solana.PublicKey) (solana.GenericInstruction, error) {
+// generate close IDL ix for a program (via timelock or via prod deployer)
+func closeIdlInstruction(e cldf.Environment, programID solana.PublicKey, programName string, c IDLConfig) (*mcmsTypes.Transaction, error) {
+	authority, err := calculateAuthority(e, c)
+	if err != nil {
+		return nil, err
+	}
+	// The spill Address should always be the deployer key, even if using timelock to close the account
+	// since the deployer key is the one that pays for the account rent
+	// and is therefore the one that should receive the remaining lamports
+	// in the account when it is closed.
+	spillAddress := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
 	accounts, err := getAccountsForCloseIdlInstruction(e, programID, authority, spillAddress)
 	if err != nil {
-		return solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
+		return nil, fmt.Errorf("error getting accounts for close idl instruction %s: %w", programID.String(), err)
 	}
-	return buildIdlInstruction(programID, accounts, IdlInstructionClose, []byte{})
+	instruction, err := buildIdlInstruction(programID, accounts, IdlInstructionClose, []byte{})
+	if err != nil {
+		return nil, fmt.Errorf("error closing IDL account ix: %w", err)
+	}
+	return buildTxWithCorrectSigner(e, programID.String(), programName, c, instruction)
 }
 
 func getAccountsForCloseIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey, spillAddress solana.PublicKey) (solana.AccountMetaSlice, error) {
 	idlAddress, err := getIDLAddress(e, programID)
 	accounts := solana.AccountMetaSlice{
-		solana.NewAccountMeta(idlAddress, true, false), // IDL account
-		solana.NewAccountMeta(authority, false, true),
-		solana.NewAccountMeta(spillAddress, true, false), // sol destination for close funds
+		solana.Meta(idlAddress).WRITE(),
+		solana.Meta(authority).SIGNER(),
+		solana.Meta(spillAddress).WRITE(), // SOL destination to close funds
 	}
 	return accounts, err
 }
 
-// generate close IDL PDA ix for a program via timelock
-func removeIDLIx(e cldf.Environment, programID, programName string, spillAddress solana.PublicKey, c IDLConfig) (*mcmsTypes.Transaction, error) {
-	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
+// Set Authority IDL
+func setAuthorityIDLIx(e cldf.Environment, programID solana.PublicKey, programName string, newAuthority solana.PublicKey, c IDLConfig) (*mcmsTypes.Transaction, error) {
+	authority, err := calculateAuthority(e, c)
 	if err != nil {
-		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
+		return nil, err
 	}
-	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
-	if c.MCMS != nil {
-		authority = timelockSignerPDA
-	}
-	instruction, err := closeIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), authority, spillAddress)
+	accounts, err := getAccountsForSetAuthorityIdlInstruction(e, programID, authority)
 	if err != nil {
-		return nil, fmt.Errorf("error closing IDL account ix: %w", err)
+		return nil, err
 	}
-	if c.MCMS != nil {
-		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create close IDL transaction: %w", err)
-		}
-		return upgradeTx, nil
+	instruction, err := buildIdlInstruction(programID, accounts, IdlInstructionSetAuthority, newAuthority.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("error setting authority IDL ix: %w", err)
 	}
-	if err := e.BlockChains.SolanaChains()[c.ChainSelector].Confirm([]solana.Instruction{&instruction}); err != nil {
-		return nil, fmt.Errorf("failed to confirm instructions: %w", err)
+	return buildTxWithCorrectSigner(e, programID.String(), programName, c, instruction)
+}
+
+func getAccountsForSetAuthorityIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, error) {
+	idlAddress, err := getIDLAddress(e, programID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
 	}
-	return nil, nil
+	accounts := solana.AccountMetaSlice{
+		solana.Meta(idlAddress).WRITE(),
+		solana.Meta(authority).SIGNER(),
+	}
+	return accounts, nil
 }

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -683,6 +683,18 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 		}
 	}
 
+	if len(mcmsTxs) > 0 {
+		proposal, err := BuildProposalsForTxns(
+			e, c.ChainSelector, "proposal to upgrade CCIP contracts", c.MCMS.MinDelay, mcmsTxs)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
+		}
+
+		return cldf.ChangesetOutput{
+			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
+		}, nil
+	}
+
 	return cldf.ChangesetOutput{}, nil
 }
 

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -205,7 +205,7 @@ func setIdlAuthority(e cldf.Environment, newAuthority, programsPath, programID, 
 
 // changeset to close idl account for a program - this is needed when the idl increased so much in size that it no longer fits in the account
 // and the idl account can not be resized when it already contains data, so you need to close the account and reinitialize it
-func CloseIDLAccount(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
+func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
 	}
@@ -217,25 +217,25 @@ func CloseIDLAccount(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, err
 
 	// CCIP Core Programs
 	if c.Router {
-		err := closeIDLAccount(e, chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName)
+		err := runCloseIDLAccount(e, chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
 	}
 	if c.FeeQuoter {
-		err := closeIDLAccount(e, chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName)
+		err := runCloseIDLAccount(e, chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
 	}
 	if c.OffRamp {
-		err := closeIDLAccount(e, chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName)
+		err := runCloseIDLAccount(e, chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
 	}
 	if c.RMNRemote {
-		err := closeIDLAccount(e, chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName)
+		err := runCloseIDLAccount(e, chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -244,20 +244,20 @@ func CloseIDLAccount(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, err
 	// Token Pools
 	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		err := closeIDLAccount(e, chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName)
+		err := runCloseIDLAccount(e, chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
 	}
 	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		err := closeIDLAccount(e, chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName)
+		err := runCloseIDLAccount(e, chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
 	}
 	if c.CCTPTokenPool {
-		err := closeIDLAccount(e, chain.ProgramsPath, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName)
+		err := runCloseIDLAccount(e, chain.ProgramsPath, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -274,19 +274,19 @@ func CloseIDLAccount(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, err
 	}
 
 	if c.AccessController {
-		err = closeIDLAccount(e, chain.ProgramsPath, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String())
+		err = runCloseIDLAccount(e, chain.ProgramsPath, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String())
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
 	}
 	if c.Timelock {
-		err = closeIDLAccount(e, chain.ProgramsPath, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String())
+		err = runCloseIDLAccount(e, chain.ProgramsPath, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String())
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
 	}
 	if c.MCM {
-		err = closeIDLAccount(e, chain.ProgramsPath, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String())
+		err = runCloseIDLAccount(e, chain.ProgramsPath, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String())
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -296,7 +296,7 @@ func CloseIDLAccount(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, err
 }
 
 // Close IDL account for a program
-func closeIDLAccount(e cldf.Environment, programsPath, programID, programName string) error {
+func runCloseIDLAccount(e cldf.Environment, programsPath, programID, programName string) error {
 	e.Logger.Infow("Closing IDL Account", "programName", programName)
 	args := []string{"idl", "close", programID}
 	e.Logger.Info(args)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -838,7 +838,7 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
 	}
 	if c.SpillAddress.IsZero() {
-		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config, spill address must be set")
+		return cldf.ChangesetOutput{}, errors.New("error validating idl config, spill address must be set")
 	}
 	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
 	state, _ := stateview.LoadOnchainState(e)

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	solanastateview "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/solana"
 	"os"
 	"path/filepath"
 	"strings"
@@ -495,7 +496,7 @@ func setAuthorityIDLByCLI(e cldf.Environment, newAuthority, programsPath, progra
 // Discriminator to invoke IDL operations
 const IdlIxTag uint64 = 0x0a69e9a778bcf440
 
-// Number ids of the operations:
+// Number ids of the operations: copied from https://github.com/solana-foundation/anchor/blob/v0.29.0/lang/src/idl.rs#L36
 const (
 	IdlInstructionCreate       int = iota // One time initializer for creating the program's idl account.
 	IdlInstructionCreateBuffer            // Creates a new IDL account buffer. Can be called several times.
@@ -515,104 +516,16 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 	chainState := state.SolChains[c.ChainSelector]
 	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
 
-	// set idl authority
 	mcmsTxs := make([]mcmsTypes.Transaction, 0)
 	newAuthority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
-	if c.Router {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.Router, deployment.RouterProgramName, newAuthority, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-		if setAuthorityTx != nil {
-			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
-		}
-	}
-	if c.FeeQuoter {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.FeeQuoter, deployment.FeeQuoterProgramName, newAuthority, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-		if setAuthorityTx != nil {
-			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
-		}
-	}
-	if c.OffRamp {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.OffRamp, deployment.OffRampProgramName, newAuthority, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-		if setAuthorityTx != nil {
-			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
-		}
-	}
-	if c.RMNRemote {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.RMNRemote, deployment.RMNRemoteProgramName, newAuthority, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-		if setAuthorityTx != nil {
-			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
-		}
-	}
-	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
-		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool, deployment.BurnMintTokenPoolProgramName, newAuthority, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-		if setAuthorityTx != nil {
-			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
-		}
-	}
-	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
-		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool, deployment.LockReleaseTokenPoolProgramName, newAuthority, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-		if setAuthorityTx != nil {
-			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
-		}
-	}
-	if c.CCTPTokenPool {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.CCTPTokenPool, deployment.CCTPTokenPoolProgramName, newAuthority, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-		if setAuthorityTx != nil {
-			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
-		}
-	}
 
-	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
+	programs, err := getAffectedPrograms(e, c, chainState, chain)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
-	}
-	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
+		return cldf.ChangesetOutput{}, err
 	}
 
-	if c.AccessController {
-		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.AccessControllerProgram, types.AccessControllerProgram.String(), newAuthority, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-		if setAuthorityTx != nil {
-			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
-		}
-	}
-	if c.Timelock {
-		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.TimelockProgram, types.RBACTimelockProgram.String(), newAuthority, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-		if setAuthorityTx != nil {
-			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
-		}
-	}
-	if c.MCM {
-		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.McmProgram, types.ManyChainMultisigProgram.String(), newAuthority, c)
+	for programID, programName := range programs {
+		setAuthorityTx, err := setAuthorityIDLIx(e, programID, programName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -621,19 +534,7 @@ func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutpu
 		}
 	}
 
-	if len(mcmsTxs) > 0 {
-		proposal, err := BuildProposalsForTxns(
-			e, c.ChainSelector, "proposal to upgrade CCIP contracts", c.MCMS.MinDelay, mcmsTxs)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
-		}
-
-		return cldf.ChangesetOutput{
-			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
-		}, nil
-	}
-
-	return cldf.ChangesetOutput{}, nil
+	return generateProposalIfMCMS(e, c, mcmsTxs)
 }
 
 // changeset to upgrade idl for a program via timelock
@@ -650,102 +551,14 @@ func UpgradeIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	chainState := state.SolChains[c.ChainSelector]
 
 	mcmsTxs := make([]mcmsTypes.Transaction, 0)
-	if c.Router {
-		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
-	}
-	if c.FeeQuoter {
-		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
-	}
-	if c.OffRamp {
-		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
-	}
-	if c.RMNRemote {
-		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
-	}
-	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
-		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
-	}
-	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
-		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
-	}
-	if c.CCTPTokenPool {
-		tokenPool := chainState.GetActiveTokenPool(shared.CCTPTokenPool, shared.CLLMetadata)
-		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, tokenPool.String(), deployment.CCTPTokenPoolProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
-	}
 
-	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
+	programs, err := getAffectedPrograms(e, c, chainState, chain)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
-	}
-	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
+		return cldf.ChangesetOutput{}, err
 	}
 
-	if c.AccessController {
-		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, mcmState.AccessControllerProgram.String(), deployment.AccessControllerProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
-	}
-	if c.Timelock {
-		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, mcmState.TimelockProgram.String(), deployment.TimelockProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
-	}
-	if c.MCM {
-		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, mcmState.McmProgram.String(), deployment.McmProgramName, c)
+	for programID, programName := range programs {
+		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, programID.String(), programName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}
@@ -754,19 +567,7 @@ func UpgradeIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 		}
 	}
 
-	if len(mcmsTxs) > 0 {
-		proposal, err := BuildProposalsForTxns(
-			e, c.ChainSelector, "proposal to upgrade CCIP contracts", c.MCMS.MinDelay, mcmsTxs)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
-		}
-
-		return cldf.ChangesetOutput{
-			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
-		}, nil
-	}
-
-	return cldf.ChangesetOutput{}, nil
+	return generateProposalIfMCMS(e, c, mcmsTxs)
 }
 
 // changeset to close idl account for a program - this is needed when the idl increased so much in size that it no longer fits in the account
@@ -780,110 +581,72 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	chainState := state.SolChains[c.ChainSelector]
 
 	mcmsTxs := make([]mcmsTypes.Transaction, 0)
-	if c.Router {
-		upgradeTx, err := closeIdlInstruction(e, chainState.Router, deployment.RouterProgramName, c)
+
+	programs, err := getAffectedPrograms(e, c, chainState, chain)
+	if err != nil {
+		return cldf.ChangesetOutput{}, err
+	}
+
+	for programID, programName := range programs {
+		closeIdlIx, err := closeIdlInstruction(e, programID, programName, c)
 		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating close IDL tx: %w", err)
 		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		if closeIdlIx != nil {
+			mcmsTxs = append(mcmsTxs, *closeIdlIx)
 		}
+	}
+
+	return generateProposalIfMCMS(e, c, mcmsTxs)
+}
+
+func getAffectedPrograms(e cldf.Environment, c IDLConfig, chainState solanastateview.CCIPChainState, chain cldfsolana.Chain) (map[solana.PublicKey]string, error) {
+	programs := make(map[solana.PublicKey]string)
+	if c.Router {
+		programs[chainState.Router] = deployment.RouterProgramName
 	}
 	if c.FeeQuoter {
-		upgradeTx, err := closeIdlInstruction(e, chainState.FeeQuoter, deployment.FeeQuoterProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
+		programs[chainState.FeeQuoter] = deployment.FeeQuoterProgramName
 	}
 	if c.OffRamp {
-		upgradeTx, err := closeIdlInstruction(e, chainState.OffRamp, deployment.OffRampProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
+		programs[chainState.OffRamp] = deployment.OffRampProgramName
 	}
 	if c.RMNRemote {
-		upgradeTx, err := closeIdlInstruction(e, chainState.RMNRemote, deployment.RMNRemoteProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
+		programs[chainState.RMNRemote] = deployment.RMNRemoteProgramName
 	}
 	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		upgradeTx, err := closeIdlInstruction(e, tokenPool, deployment.BurnMintTokenPoolProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
+		programs[tokenPool] = deployment.BurnMintTokenPoolProgramName
 	}
 	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		upgradeTx, err := closeIdlInstruction(e, tokenPool, deployment.LockReleaseTokenPoolProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
+		programs[tokenPool] = deployment.LockReleaseTokenPoolProgramName
 	}
 	if c.CCTPTokenPool {
 		tokenPool := chainState.GetActiveTokenPool(shared.CCTPTokenPool, shared.CLLMetadata)
-		upgradeTx, err := closeIdlInstruction(e, tokenPool, deployment.CCTPTokenPoolProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
+		programs[tokenPool] = deployment.CCTPTokenPoolProgramName
 	}
-
 	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
+		return nil, fmt.Errorf("failed to get existing addresses: %w", err)
 	}
 	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
+		return nil, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
 	}
-
 	if c.AccessController {
-		upgradeTx, err := closeIdlInstruction(e, mcmState.AccessControllerProgram, deployment.AccessControllerProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
+		programs[mcmState.AccessControllerProgram] = deployment.AccessControllerProgramName
 	}
 	if c.Timelock {
-		upgradeTx, err := closeIdlInstruction(e, mcmState.TimelockProgram, deployment.TimelockProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
+		programs[mcmState.TimelockProgram] = deployment.TimelockProgramName
 	}
 	if c.MCM {
-		upgradeTx, err := closeIdlInstruction(e, mcmState.McmProgram, deployment.McmProgramName, c)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
-		}
-		if upgradeTx != nil {
-			mcmsTxs = append(mcmsTxs, *upgradeTx)
-		}
+		programs[mcmState.McmProgram] = deployment.McmProgramName
 	}
+	return programs, nil
+}
 
+func generateProposalIfMCMS(e cldf.Environment, c IDLConfig, mcmsTxs []mcmsTypes.Transaction) (cldf.ChangesetOutput, error) {
 	if len(mcmsTxs) > 0 {
 		proposal, err := BuildProposalsForTxns(
 			e, c.ChainSelector, "proposal to upgrade CCIP contracts", c.MCMS.MinDelay, mcmsTxs)
@@ -925,7 +688,7 @@ func calculateAuthority(e cldf.Environment, c IDLConfig) (solana.PublicKey, erro
 	return authority, err
 }
 
-func buildTxWithCorrectSigner(e cldf.Environment, programID string, programName string, c IDLConfig, instruction solana.GenericInstruction) (*mcmsTypes.Transaction, error) {
+func getTxIfMCMSExecuteIfNot(e cldf.Environment, programID string, programName string, c IDLConfig, instruction solana.GenericInstruction) (*mcmsTypes.Transaction, error) {
 	if c.MCMS != nil {
 		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
 		if err != nil {
@@ -941,9 +704,9 @@ func buildTxWithCorrectSigner(e cldf.Environment, programID string, programName 
 
 // generate set buffer ix using solana-go sdk
 func setBufferIdlInstruction(e cldf.Environment, programID, buffer, authority solana.PublicKey) (solana.GenericInstruction, error) {
-	accounts, instruction, err2 := getAccountsFoSetBufferIdlInstruction(e, programID, buffer, authority)
-	if err2 != nil {
-		return instruction, err2
+	accounts, instruction, err := getAccountsFoSetBufferIdlInstruction(e, programID, buffer, authority)
+	if err != nil {
+		return instruction, err
 	}
 	return buildIdlInstruction(programID, accounts, IdlInstructionSetBuffer, []byte{})
 }
@@ -1015,7 +778,7 @@ func closeIdlInstruction(e cldf.Environment, programID solana.PublicKey, program
 	if err != nil {
 		return nil, fmt.Errorf("error closing IDL account ix: %w", err)
 	}
-	return buildTxWithCorrectSigner(e, programID.String(), programName, c, instruction)
+	return getTxIfMCMSExecuteIfNot(e, programID.String(), programName, c, instruction)
 }
 
 func getAccountsForCloseIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey, spillAddress solana.PublicKey) (solana.AccountMetaSlice, error) {
@@ -1042,7 +805,7 @@ func setAuthorityIDLIx(e cldf.Environment, programID solana.PublicKey, programNa
 	if err != nil {
 		return nil, fmt.Errorf("error setting authority IDL ix: %w", err)
 	}
-	return buildTxWithCorrectSigner(e, programID.String(), programName, c, instruction)
+	return getTxIfMCMSExecuteIfNot(e, programID.String(), programName, c, instruction)
 }
 
 func getAccountsForSetAuthorityIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, error) {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -43,6 +43,7 @@ const IdlIxTag uint64 = 0x0a69e9a778bcf440
 type IDLConfig struct {
 	ChainSelector                uint64
 	GitCommitSha                 string                        // this will be used to download the correct artifacts (idls) -> best if same as what was used to deploy the programs
+	SpillAddress                 solana.PublicKey              // used when closing the IDL account
 	Router                       bool                          // whether to upload the IDL for the router
 	FeeQuoter                    bool                          // whether to upload the IDL for the fee quoter
 	OffRamp                      bool                          // whether to upload the IDL for the off ramp
@@ -203,98 +204,6 @@ func setIdlAuthority(e cldf.Environment, newAuthority, programsPath, programID, 
 	return nil
 }
 
-// changeset to close idl account for a program - this is needed when the idl increased so much in size that it no longer fits in the account
-// and the idl account can not be resized when it already contains data, so you need to close the account and reinitialize it
-func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
-	if err := c.Validate(e); err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
-	}
-	state, _ := stateview.LoadOnchainState(e)
-	chainState := state.SolChains[c.ChainSelector]
-	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
-
-	// close idl accounts
-
-	// CCIP Core Programs
-	if c.Router {
-		err := runCloseIDLAccount(e, chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.FeeQuoter {
-		err := runCloseIDLAccount(e, chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.OffRamp {
-		err := runCloseIDLAccount(e, chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.RMNRemote {
-		err := runCloseIDLAccount(e, chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-
-	// Token Pools
-	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
-		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		err := runCloseIDLAccount(e, chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
-		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		err := runCloseIDLAccount(e, chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.CCTPTokenPool {
-		err := runCloseIDLAccount(e, chain.ProgramsPath, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName)
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-
-	// MCMS Programs
-	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
-	}
-	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
-	}
-
-	if c.AccessController {
-		err = runCloseIDLAccount(e, chain.ProgramsPath, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String())
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.Timelock {
-		err = runCloseIDLAccount(e, chain.ProgramsPath, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String())
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-	if c.MCM {
-		err = runCloseIDLAccount(e, chain.ProgramsPath, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String())
-		if err != nil {
-			return cldf.ChangesetOutput{}, err
-		}
-	}
-
-	return cldf.ChangesetOutput{}, nil
-}
-
 // Close IDL account for a program
 func runCloseIDLAccount(e cldf.Environment, programsPath, programID, programName string) error {
 	e.Logger.Infow("Closing IDL Account", "programName", programName)
@@ -358,7 +267,7 @@ func setBufferIx(e cldf.Environment, programID, buffer, authority solana.PublicK
 		return solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
 	}
 	data := binary.LittleEndian.AppendUint64([]byte{}, IdlIxTag) // 4-byte Extend instruction identifier
-	data = append(data, byte(3))
+	data = append(data, byte(3))                                 // Id for CreateBuffer operation
 
 	instruction := solana.NewInstruction(
 		programID,
@@ -398,6 +307,54 @@ func upgradeIDLIx(e cldf.Environment, programsPath, programID, programName strin
 		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create upgrade transaction: %w", err)
+		}
+		return upgradeTx, nil
+	}
+	if err := e.BlockChains.SolanaChains()[c.ChainSelector].Confirm([]solana.Instruction{&instruction}); err != nil {
+		return nil, fmt.Errorf("failed to confirm instructions: %w", err)
+	}
+	return nil, nil
+}
+
+// generate set buffer ix using solana-go sdk
+func closeIDLAccountIx(e cldf.Environment, programID, authority, spillAddress solana.PublicKey) (solana.GenericInstruction, error) {
+	idlAddress, err := getIDLAddress(e, programID)
+	if err != nil {
+		return solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
+	}
+	data := binary.LittleEndian.AppendUint64([]byte{}, IdlIxTag) // 4-byte Extend instruction identifier
+	data = append(data, byte(2))                                 // ID for Close operation
+
+	instruction := solana.NewInstruction(
+		programID,
+		solana.AccountMetaSlice{
+			solana.NewAccountMeta(idlAddress, true, false), // IDL account
+			solana.NewAccountMeta(authority, false, true),
+			solana.NewAccountMeta(spillAddress, true, false), // sol destination for close funds
+		},
+		data,
+	)
+	return *instruction, nil
+}
+
+// generate upgrade IDL ix for a program via timelock
+func removeIDLIx(e cldf.Environment, programID, programName string, spillAddress solana.PublicKey, c IDLConfig) (*mcmsTypes.Transaction, error) {
+	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
+	}
+	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
+	if c.MCMS != nil {
+		authority = timelockSignerPDA
+	}
+	instruction, err := closeIDLAccountIx(e, solana.MustPublicKeyFromBase58(programID), authority, spillAddress)
+	if err != nil {
+		return nil, fmt.Errorf("error closing IDL account ix: %w", err)
+	}
+	if c.MCMS != nil {
+		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create close IDL transaction: %w", err)
 		}
 		return upgradeTx, nil
 	}
@@ -754,6 +711,140 @@ func UpgradeIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	}
 	if c.MCM {
 		upgradeTx, err := upgradeIDLIx(e, chain.ProgramsPath, mcmState.McmProgram.String(), deployment.McmProgramName, c)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+		}
+		if upgradeTx != nil {
+			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		}
+	}
+
+	if len(mcmsTxs) > 0 {
+		proposal, err := BuildProposalsForTxns(
+			e, c.ChainSelector, "proposal to upgrade CCIP contracts", c.MCMS.MinDelay, mcmsTxs)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to build proposal: %w", err)
+		}
+
+		return cldf.ChangesetOutput{
+			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
+		}, nil
+	}
+
+	return cldf.ChangesetOutput{}, nil
+}
+
+// changeset to close idl account for a program - this is needed when the idl increased so much in size that it no longer fits in the account
+// and the idl account can not be resized when it already contains data, so you need to close the account and reinitialize it
+func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
+	if err := c.Validate(e); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
+	}
+	if c.SpillAddress.IsZero() {
+		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config, spill address must be set")
+	}
+	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
+	state, _ := stateview.LoadOnchainState(e)
+	chainState := state.SolChains[c.ChainSelector]
+	spillAddress := c.SpillAddress
+
+	mcmsTxs := make([]mcmsTypes.Transaction, 0)
+	if c.Router {
+		upgradeTx, err := removeIDLIx(e, chainState.Router.String(), deployment.RouterProgramName, spillAddress, c)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+		}
+		if upgradeTx != nil {
+			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		}
+	}
+	if c.FeeQuoter {
+		upgradeTx, err := removeIDLIx(e, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, spillAddress, c)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+		}
+		if upgradeTx != nil {
+			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		}
+	}
+	if c.OffRamp {
+		upgradeTx, err := removeIDLIx(e, chainState.OffRamp.String(), deployment.OffRampProgramName, spillAddress, c)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+		}
+		if upgradeTx != nil {
+			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		}
+	}
+	if c.RMNRemote {
+		upgradeTx, err := removeIDLIx(e, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, spillAddress, c)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+		}
+		if upgradeTx != nil {
+			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		}
+	}
+	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
+		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
+		upgradeTx, err := removeIDLIx(e, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, spillAddress, c)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+		}
+		if upgradeTx != nil {
+			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		}
+	}
+	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
+		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
+		upgradeTx, err := removeIDLIx(e, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, spillAddress, c)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+		}
+		if upgradeTx != nil {
+			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		}
+	}
+	if c.CCTPTokenPool {
+		tokenPool := chainState.GetActiveTokenPool(shared.CCTPTokenPool, shared.CLLMetadata)
+		upgradeTx, err := removeIDLIx(e, tokenPool.String(), deployment.CCTPTokenPoolProgramName, spillAddress, c)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+		}
+		if upgradeTx != nil {
+			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		}
+	}
+
+	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
+	}
+	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
+	}
+
+	if c.AccessController {
+		upgradeTx, err := removeIDLIx(e, mcmState.AccessControllerProgram.String(), deployment.AccessControllerProgramName, spillAddress, c)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+		}
+		if upgradeTx != nil {
+			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		}
+	}
+	if c.Timelock {
+		upgradeTx, err := removeIDLIx(e, mcmState.TimelockProgram.String(), deployment.TimelockProgramName, spillAddress, c)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
+		}
+		if upgradeTx != nil {
+			mcmsTxs = append(mcmsTxs, *upgradeTx)
+		}
+	}
+	if c.MCM {
+		upgradeTx, err := removeIDLIx(e, mcmState.McmProgram.String(), deployment.McmProgramName, spillAddress, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("error generating upgrade tx: %w", err)
 		}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -32,7 +32,7 @@ import (
 var _ cldf.ChangeSet[IDLConfig] = UploadIDL
 
 // use this changeset to set the authority for the IDL of a program (timelock)
-var _ cldf.ChangeSet[IDLConfig] = SetAuthorityIDL
+var _ cldf.ChangeSet[IDLConfig] = SetAuthorityIDLByDeployerKey
 
 // use this changeset to upgrade the IDL of a program via timelock
 var _ cldf.ChangeSet[IDLConfig] = UpgradeIDL
@@ -200,20 +200,51 @@ func idlInit(e cldf.Environment, programsPath, programID, programName string) er
 	return nil
 }
 
-// set IDL authority for a program
-func setIdlAuthority(e cldf.Environment, newAuthority, programsPath, programID, programName, bufferAccount string) error {
-	e.Logger.Infow("Setting IDL authority", "programName", programName, "newAuthority", newAuthority)
-	args := []string{"idl", "set-authority", "-n", newAuthority, "-p", programID}
-	if bufferAccount != "" {
-		e.Logger.Infow("Setting IDL authority for buffer", "bufferAccount", bufferAccount)
-		args = append(args, bufferAccount)
+func setAuthorityIdlInstruction(e cldf.Environment, programID, authority solana.PublicKey) (solana.GenericInstruction, error) {
+	accounts, instruction, err2 := getAccountsForSetAuthorityIdlInstruction(e, programID, authority)
+	if err2 != nil {
+		return instruction, err2
 	}
-	e.Logger.Info(args)
-	_, err := runCommand("anchor", args, programsPath)
+	return buildIdlInstruction(programID, accounts, IdlInstructionSetAuthority)
+}
+
+func getAccountsForSetAuthorityIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
+	idlAddress, err := getIDLAddress(e, programID)
 	if err != nil {
-		return fmt.Errorf("error setting idl authority: %w", err)
+		return nil, solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
 	}
-	return nil
+	accounts := solana.AccountMetaSlice{
+		solana.NewAccountMeta(idlAddress, true, false), // IDL account
+		solana.NewAccountMeta(authority, false, true),
+	}
+	return accounts, solana.GenericInstruction{}, nil
+}
+
+// generate close IDL PDA ix for a program via timelock
+func setAuthorityIDLIx(e cldf.Environment, programID, programName string, c IDLConfig) (*mcmsTypes.Transaction, error) {
+	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
+	}
+	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
+	if c.MCMS != nil {
+		authority = timelockSignerPDA
+	}
+	instruction, err := setAuthorityIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), authority)
+	if err != nil {
+		return nil, fmt.Errorf("error setting authority IDL ix: %w", err)
+	}
+	if c.MCMS != nil {
+		upgradeTx, err := BuildMCMSTxn(&instruction, programID, cldf.ContractType(programName))
+		if err != nil {
+			return nil, fmt.Errorf("failed to set authority IDL transaction: %w", err)
+		}
+		return upgradeTx, nil
+	}
+	if err := e.BlockChains.SolanaChains()[c.ChainSelector].Confirm([]solana.Instruction{&instruction}); err != nil {
+		return nil, fmt.Errorf("failed to confirm instructions: %w", err)
+	}
+	return nil, nil
 }
 
 // get IDL address for a program
@@ -294,6 +325,21 @@ func buildIdlInstruction(programID solana.PublicKey, accountsForIx solana.Accoun
 	return *instruction, nil
 }
 
+func setAuthorityIDLByCLI(e cldf.Environment, newAuthority, programsPath, programID, programName, bufferAccount string) error {
+	e.Logger.Infow("Setting IDL authority", "programName", programName, "newAuthority", newAuthority)
+	args := []string{"idl", "set-authority", "-n", newAuthority, "-p", programID}
+	if bufferAccount != "" {
+		e.Logger.Infow("Setting IDL authority for buffer", "bufferAccount", bufferAccount)
+		args = append(args, bufferAccount)
+	}
+	e.Logger.Info(args)
+	_, err := runCommand("anchor", args, programsPath)
+	if err != nil {
+		return fmt.Errorf("error setting idl authority: %w", err)
+	}
+	return nil
+}
+
 // generate upgrade IDL ix for a program via timelock
 func upgradeIDLIx(e cldf.Environment, programsPath, programID, programName string, c IDLConfig) (*mcmsTypes.Transaction, error) {
 	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
@@ -307,7 +353,7 @@ func upgradeIDLIx(e cldf.Environment, programsPath, programID, programName strin
 	authority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
 	if c.MCMS != nil {
 		authority = timelockSignerPDA
-		err = setIdlAuthority(e, timelockSignerPDA.String(), programsPath, programID, programName, buffer.String())
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), programsPath, programID, programName, buffer.String())
 		if err != nil {
 			return nil, fmt.Errorf("error setting buffer authority: %w", err)
 		}
@@ -522,7 +568,7 @@ func UploadIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 }
 
 // changeset to set idl authority for a program to timelock
-func SetAuthorityIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
+func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
 	}
@@ -530,54 +576,71 @@ func SetAuthorityIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, err
 	chainState := state.SolChains[c.ChainSelector]
 	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
 
-	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("error loading timelockSignerPDA: %w", err)
-	}
-
 	// set idl authority
+	mcmsTxs := make([]mcmsTypes.Transaction, 0)
 	if c.Router {
-		err = setIdlAuthority(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName, "")
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.Router.String(), deployment.RouterProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
+		}
+		if setAuthorityTx != nil {
+			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
 		}
 	}
 	if c.FeeQuoter {
-		err = setIdlAuthority(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, "")
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
+		}
+		if setAuthorityTx != nil {
+			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
 		}
 	}
 	if c.OffRamp {
-		err = setIdlAuthority(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName, "")
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.OffRamp.String(), deployment.OffRampProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
+		if setAuthorityTx != nil {
+			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
+		}
 	}
 	if c.RMNRemote {
-		err = setIdlAuthority(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, "")
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
+		}
+		if setAuthorityTx != nil {
+			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
 		}
 	}
 	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		err = setIdlAuthority(e, timelockSignerPDA.String(), chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, "")
+		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
+		}
+		if setAuthorityTx != nil {
+			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
 		}
 	}
 	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		err = setIdlAuthority(e, timelockSignerPDA.String(), chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, "")
+		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
+		if setAuthorityTx != nil {
+			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
+		}
 	}
 	if c.CCTPTokenPool {
-		err = setIdlAuthority(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName, "")
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
+		}
+		if setAuthorityTx != nil {
+			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
 		}
 	}
 
@@ -591,21 +654,30 @@ func SetAuthorityIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, err
 	}
 
 	if c.AccessController {
-		err = setIdlAuthority(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String(), "")
+		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String(), c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
+		}
+		if setAuthorityTx != nil {
+			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
 		}
 	}
 	if c.Timelock {
-		err = setIdlAuthority(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String(), "")
+		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String(), c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
+		if setAuthorityTx != nil {
+			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
+		}
 	}
 	if c.MCM {
-		err = setIdlAuthority(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String(), "")
+		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String(), c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
+		}
+		if setAuthorityTx != nil {
+			mcmsTxs = append(mcmsTxs, *setAuthorityTx)
 		}
 	}
 

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -37,7 +37,26 @@ var _ cldf.ChangeSet[IDLConfig] = SetAuthorityIDL
 // use this changeset to upgrade the IDL of a program via timelock
 var _ cldf.ChangeSet[IDLConfig] = UpgradeIDL
 
+// Discriminator to invoke IDL operations
 const IdlIxTag uint64 = 0x0a69e9a778bcf440
+
+//Number ids of the operations:
+//pub enum IdlInstruction {
+//
+//	0 Create { data_len: u64 }, // One time initializer for creating the program's idl account.
+//
+//	1 CreateBuffer, // Creates a new IDL account buffer. Can be called several times.
+//
+//	2 Write { data: Vec<u8> }, // Appends the given data to the end of the idl account buffer.
+//
+//	3 SetBuffer, // Sets a new data buffer for the IdlAccount.
+//
+//	4 SetAuthority { new_authority: Pubkey }, // Sets a new authority on the IdlAccount.
+//
+//	5 Close, // Closes the IDL pda Account
+//
+//	6 Resize { data_len: u64 }, // Increases account size for accounts that need over 10kb.
+//}
 
 // IDL
 type IDLConfig struct {
@@ -323,7 +342,7 @@ func closeIDLAccountIx(e cldf.Environment, programID, authority, spillAddress so
 		return solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
 	}
 	data := binary.LittleEndian.AppendUint64([]byte{}, IdlIxTag) // 4-byte Extend instruction identifier
-	data = append(data, byte(2))                                 // ID for Close operation
+	data = append(data, byte(5))                                 // ID for Close operation
 
 	instruction := solana.NewInstruction(
 		programID,

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -32,7 +32,7 @@ import (
 var _ cldf.ChangeSet[IDLConfig] = UploadIDL
 
 // use this changeset to set the authority for the IDL of a program (timelock)
-var _ cldf.ChangeSet[IDLConfig] = SetAuthorityIDLByDeployerKey
+var _ cldf.ChangeSet[IDLConfig] = SetAuthorityIDL
 
 // use this changeset to upgrade the IDL of a program via timelock
 var _ cldf.ChangeSet[IDLConfig] = UpgradeIDL
@@ -55,7 +55,6 @@ const (
 type IDLConfig struct {
 	ChainSelector                uint64
 	GitCommitSha                 string                        // this will be used to download the correct artifacts (idls) -> best if same as what was used to deploy the programs
-	SpillAddress                 solana.PublicKey              // used when closing the IDL account
 	Router                       bool                          // whether to upload the IDL for the router
 	FeeQuoter                    bool                          // whether to upload the IDL for the fee quoter
 	OffRamp                      bool                          // whether to upload the IDL for the off ramp
@@ -569,7 +568,7 @@ func UploadIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 }
 
 // changeset to set idl authority for a program to timelock
-func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
+func SetAuthorityIDLByMCMs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
 	}
@@ -693,6 +692,97 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 		return cldf.ChangesetOutput{
 			MCMSTimelockProposals: []mcms.TimelockProposal{*proposal},
 		}, nil
+	}
+
+	return cldf.ChangesetOutput{}, nil
+}
+
+// changeset to set idl authority for a program to timelock
+func SetAuthorityIDL(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
+	if err := c.Validate(e); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
+	}
+	state, _ := stateview.LoadOnchainState(e)
+	chainState := state.SolChains[c.ChainSelector]
+	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
+
+	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("error loading timelockSignerPDA: %w", err)
+	}
+
+	// set idl authority
+	if c.Router {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.FeeQuoter {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.OffRamp {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.RMNRemote {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
+		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
+		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.CCTPTokenPool {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName, "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+
+	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
+	}
+	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
+	}
+
+	if c.AccessController {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String(), "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.Timelock {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String(), "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.MCM {
+		err = setAuthorityIDLByCLI(e, timelockSignerPDA.String(), chain.ProgramsPath, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String(), "")
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
 	}
 
 	return cldf.ChangesetOutput{}, nil
@@ -837,13 +927,10 @@ func CloseIDLs(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
 	if err := c.Validate(e); err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
 	}
-	if c.SpillAddress.IsZero() {
-		return cldf.ChangesetOutput{}, errors.New("error validating idl config, spill address must be set")
-	}
 	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
 	state, _ := stateview.LoadOnchainState(e)
 	chainState := state.SolChains[c.ChainSelector]
-	spillAddress := c.SpillAddress
+	spillAddress := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
 
 	mcmsTxs := make([]mcmsTypes.Transaction, 0)
 	if c.Router {

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -200,12 +200,12 @@ func idlInit(e cldf.Environment, programsPath, programID, programName string) er
 	return nil
 }
 
-func setAuthorityIdlInstruction(e cldf.Environment, programID, authority solana.PublicKey) (solana.GenericInstruction, error) {
+func setAuthorityIdlInstruction(e cldf.Environment, programID, authority, newAuthority solana.PublicKey) (solana.GenericInstruction, error) {
 	accounts, instruction, err2 := getAccountsForSetAuthorityIdlInstruction(e, programID, authority)
 	if err2 != nil {
 		return instruction, err2
 	}
-	return buildIdlInstruction(programID, accounts, IdlInstructionSetAuthority)
+	return buildIdlInstruction(programID, accounts, IdlInstructionSetAuthority, newAuthority.Bytes())
 }
 
 func getAccountsForSetAuthorityIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
@@ -221,7 +221,7 @@ func getAccountsForSetAuthorityIdlInstruction(e cldf.Environment, programID sola
 }
 
 // generate close IDL PDA ix for a program via timelock
-func setAuthorityIDLIx(e cldf.Environment, programID, programName string, c IDLConfig) (*mcmsTypes.Transaction, error) {
+func setAuthorityIDLIx(e cldf.Environment, programID, programName string, newAuthority solana.PublicKey, c IDLConfig) (*mcmsTypes.Transaction, error) {
 	timelockSignerPDA, err := FetchTimelockSigner(e, c.ChainSelector)
 	if err != nil {
 		return nil, fmt.Errorf("error loading timelockSignerPDA: %w", err)
@@ -230,7 +230,7 @@ func setAuthorityIDLIx(e cldf.Environment, programID, programName string, c IDLC
 	if c.MCMS != nil {
 		authority = timelockSignerPDA
 	}
-	instruction, err := setAuthorityIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), authority)
+	instruction, err := setAuthorityIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), authority, newAuthority)
 	if err != nil {
 		return nil, fmt.Errorf("error setting authority IDL ix: %w", err)
 	}
@@ -297,7 +297,7 @@ func setBufferIdlInstruction(e cldf.Environment, programID, buffer, authority so
 	if err2 != nil {
 		return instruction, err2
 	}
-	return buildIdlInstruction(programID, accounts, IdlInstructionSetBuffer)
+	return buildIdlInstruction(programID, accounts, IdlInstructionSetBuffer, []byte{})
 }
 
 func getAccountsForCreateBufferIdlInstruction(e cldf.Environment, programID solana.PublicKey, buffer solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
@@ -313,9 +313,10 @@ func getAccountsForCreateBufferIdlInstruction(e cldf.Environment, programID sola
 	return accounts, solana.GenericInstruction{}, nil
 }
 
-func buildIdlInstruction(programID solana.PublicKey, accountsForIx solana.AccountMetaSlice, idlInstruction int) (solana.GenericInstruction, error) {
+func buildIdlInstruction(programID solana.PublicKey, accountsForIx solana.AccountMetaSlice, idlInstruction int, params []byte) (solana.GenericInstruction, error) {
 	data := binary.LittleEndian.AppendUint64([]byte{}, IdlIxTag) // 4-byte Extend instruction identifier
 	data = append(data, byte(idlInstruction))                    // Append the numeric ID of the operation
+	data = append(data, params...)                               // Append any additional parameters
 
 	instruction := solana.NewInstruction(
 		programID,
@@ -381,7 +382,7 @@ func closeIdlInstruction(e cldf.Environment, programID, authority, spillAddress 
 	if err != nil {
 		return solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
 	}
-	return buildIdlInstruction(programID, accounts, IdlInstructionClose)
+	return buildIdlInstruction(programID, accounts, IdlInstructionClose, []byte{})
 }
 
 func getAccountsForCloseIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey, spillAddress solana.PublicKey) (solana.AccountMetaSlice, error) {
@@ -578,8 +579,9 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 
 	// set idl authority
 	mcmsTxs := make([]mcmsTypes.Transaction, 0)
+	newAuthority := e.BlockChains.SolanaChains()[c.ChainSelector].DeployerKey.PublicKey()
 	if c.Router {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.Router.String(), deployment.RouterProgramName, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.Router.String(), deployment.RouterProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -588,7 +590,7 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 		}
 	}
 	if c.FeeQuoter {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -597,7 +599,7 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 		}
 	}
 	if c.OffRamp {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.OffRamp.String(), deployment.OffRampProgramName, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.OffRamp.String(), deployment.OffRampProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -606,7 +608,7 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 		}
 	}
 	if c.RMNRemote {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -616,7 +618,7 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 	}
 	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
-		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool.String(), deployment.BurnMintTokenPoolProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -626,7 +628,7 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 	}
 	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
 		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
-		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -635,7 +637,7 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 		}
 	}
 	if c.CCTPTokenPool {
-		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName, c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName, newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -654,7 +656,7 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 	}
 
 	if c.AccessController {
-		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String(), c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String(), newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -663,7 +665,7 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 		}
 	}
 	if c.Timelock {
-		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String(), c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String(), newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}
@@ -672,7 +674,7 @@ func SetAuthorityIDLByDeployerKey(e cldf.Environment, c IDLConfig) (cldf.Changes
 		}
 	}
 	if c.MCM {
-		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String(), c)
+		setAuthorityTx, err := setAuthorityIDLIx(e, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String(), newAuthority, c)
 		if err != nil {
 			return cldf.ChangesetOutput{}, err
 		}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -41,22 +41,15 @@ var _ cldf.ChangeSet[IDLConfig] = UpgradeIDL
 const IdlIxTag uint64 = 0x0a69e9a778bcf440
 
 // Number ids of the operations:
-// pub enum IdlInstruction {
-//
-//	0 Create { data_len: u64 }, // One time initializer for creating the program's idl account.
-//
-//	1 CreateBuffer, // Creates a new IDL account buffer. Can be called several times.
-//
-//	2 Write { data: Vec<u8> }, // Appends the given data to the end of the idl account buffer.
-//
-//	3 SetBuffer, // Sets a new data buffer for the IdlAccount.
-//
-//	4 SetAuthority { new_authority: Pubkey }, // Sets a new authority on the IdlAccount.
-//
-//	5 Close, // Closes the IDL pda Account
-//
-//	6 Resize { data_len: u64 }, // Increases account size for accounts that need over 10kb.
-// }
+const (
+	IdlInstructionCreate       int = iota // One time initializer for creating the program's idl account.
+	IdlInstructionCreateBuffer            // Creates a new IDL account buffer. Can be called several times.
+	IdlInstructionWrite                   // Appends the given data to the end of the idl account buffer.
+	IdlInstructionSetBuffer               // Sets a new data buffer for the IdlAccount.
+	IdlInstructionSetAuthority            // Sets a new authority on the IdlAccount.
+	IdlInstructionClose                   // Closes the IDL pda Account
+	IdlInstructionResize                  // Increases account size for accounts that need over 10kb.
+)
 
 // IDL
 type IDLConfig struct {
@@ -268,21 +261,34 @@ func writeBuffer(e cldf.Environment, programsPath, programID, programName string
 }
 
 // generate set buffer ix using solana-go sdk
-func setBufferIx(e cldf.Environment, programID, buffer, authority solana.PublicKey) (solana.GenericInstruction, error) {
+func setBufferIdlInstruction(e cldf.Environment, programID, buffer, authority solana.PublicKey) (solana.GenericInstruction, error) {
+	accounts, instruction, err2 := getAccountsForCreateBufferIdlInstruction(e, programID, buffer, authority)
+	if err2 != nil {
+		return instruction, err2
+	}
+	return buildIdlInstruction(programID, accounts, IdlInstructionSetBuffer)
+}
+
+func getAccountsForCreateBufferIdlInstruction(e cldf.Environment, programID solana.PublicKey, buffer solana.PublicKey, authority solana.PublicKey) (solana.AccountMetaSlice, solana.GenericInstruction, error) {
 	idlAddress, err := getIDLAddress(e, programID)
 	if err != nil {
-		return solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
+		return nil, solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
 	}
+	accounts := solana.AccountMetaSlice{
+		solana.NewAccountMeta(buffer, true, false),
+		solana.NewAccountMeta(idlAddress, true, false),
+		solana.NewAccountMeta(authority, false, true),
+	}
+	return accounts, solana.GenericInstruction{}, nil
+}
+
+func buildIdlInstruction(programID solana.PublicKey, accountsForIx solana.AccountMetaSlice, idlInstruction int) (solana.GenericInstruction, error) {
 	data := binary.LittleEndian.AppendUint64([]byte{}, IdlIxTag) // 4-byte Extend instruction identifier
-	data = append(data, byte(3))                                 // Id for CreateBuffer operation
+	data = append(data, byte(idlInstruction))                    // Append the numeric ID of the operation
 
 	instruction := solana.NewInstruction(
 		programID,
-		solana.AccountMetaSlice{
-			solana.NewAccountMeta(buffer, true, false),
-			solana.NewAccountMeta(idlAddress, true, false),
-			solana.NewAccountMeta(authority, false, true),
-		},
+		accountsForIx,
 		data,
 	)
 	return *instruction, nil
@@ -306,7 +312,7 @@ func upgradeIDLIx(e cldf.Environment, programsPath, programID, programName strin
 			return nil, fmt.Errorf("error setting buffer authority: %w", err)
 		}
 	}
-	instruction, err := setBufferIx(e, solana.MustPublicKeyFromBase58(programID), buffer, authority)
+	instruction, err := setBufferIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), buffer, authority)
 	if err != nil {
 		return nil, fmt.Errorf("error generating set buffer ix: %w", err)
 	}
@@ -324,24 +330,22 @@ func upgradeIDLIx(e cldf.Environment, programsPath, programID, programName strin
 }
 
 // generate set buffer ix using solana-go sdk
-func closeIDLAccountIx(e cldf.Environment, programID, authority, spillAddress solana.PublicKey) (solana.GenericInstruction, error) {
-	idlAddress, err := getIDLAddress(e, programID)
+func closeIdlInstruction(e cldf.Environment, programID, authority, spillAddress solana.PublicKey) (solana.GenericInstruction, error) {
+	accounts, err := getAccountsForCloseIdlInstruction(e, programID, authority, spillAddress)
 	if err != nil {
 		return solana.GenericInstruction{}, fmt.Errorf("error getting idl address for %s: %w", programID.String(), err)
 	}
-	data := binary.LittleEndian.AppendUint64([]byte{}, IdlIxTag) // 4-byte Extend instruction identifier
-	data = append(data, byte(5))                                 // ID for Close operation
+	return buildIdlInstruction(programID, accounts, IdlInstructionClose)
+}
 
-	instruction := solana.NewInstruction(
-		programID,
-		solana.AccountMetaSlice{
-			solana.NewAccountMeta(idlAddress, true, false), // IDL account
-			solana.NewAccountMeta(authority, false, true),
-			solana.NewAccountMeta(spillAddress, true, false), // sol destination for close funds
-		},
-		data,
-	)
-	return *instruction, nil
+func getAccountsForCloseIdlInstruction(e cldf.Environment, programID solana.PublicKey, authority solana.PublicKey, spillAddress solana.PublicKey) (solana.AccountMetaSlice, error) {
+	idlAddress, err := getIDLAddress(e, programID)
+	accounts := solana.AccountMetaSlice{
+		solana.NewAccountMeta(idlAddress, true, false), // IDL account
+		solana.NewAccountMeta(authority, false, true),
+		solana.NewAccountMeta(spillAddress, true, false), // sol destination for close funds
+	}
+	return accounts, err
 }
 
 // generate close IDL PDA ix for a program via timelock
@@ -354,7 +358,7 @@ func removeIDLIx(e cldf.Environment, programID, programName string, spillAddress
 	if c.MCMS != nil {
 		authority = timelockSignerPDA
 	}
-	instruction, err := closeIDLAccountIx(e, solana.MustPublicKeyFromBase58(programID), authority, spillAddress)
+	instruction, err := closeIdlInstruction(e, solana.MustPublicKeyFromBase58(programID), authority, spillAddress)
 	if err != nil {
 		return nil, fmt.Errorf("error closing IDL account ix: %w", err)
 	}

--- a/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
+++ b/deployment/ccip/changeset/solana_v0_1_1/cs_idl.go
@@ -203,6 +203,110 @@ func setIdlAuthority(e cldf.Environment, newAuthority, programsPath, programID, 
 	return nil
 }
 
+// changeset to close idl account for a program - this is needed when the idl increased so much in size that it no longer fits in the account
+// and the idl account can not be resized when it already contains data, so you need to close the account and reinitialize it
+func CloseIDLAccount(e cldf.Environment, c IDLConfig) (cldf.ChangesetOutput, error) {
+	if err := c.Validate(e); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("error validating idl config: %w", err)
+	}
+	state, _ := stateview.LoadOnchainState(e)
+	chainState := state.SolChains[c.ChainSelector]
+	chain := e.BlockChains.SolanaChains()[c.ChainSelector]
+
+	// close idl accounts
+
+	// CCIP Core Programs
+	if c.Router {
+		err := closeIDLAccount(e, chain.ProgramsPath, chainState.Router.String(), deployment.RouterProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.FeeQuoter {
+		err := closeIDLAccount(e, chain.ProgramsPath, chainState.FeeQuoter.String(), deployment.FeeQuoterProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.OffRamp {
+		err := closeIDLAccount(e, chain.ProgramsPath, chainState.OffRamp.String(), deployment.OffRampProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.RMNRemote {
+		err := closeIDLAccount(e, chain.ProgramsPath, chainState.RMNRemote.String(), deployment.RMNRemoteProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+
+	// Token Pools
+	for _, bnmMetadata := range c.BurnMintTokenPoolMetadata {
+		tokenPool := chainState.GetActiveTokenPool(shared.BurnMintTokenPool, bnmMetadata)
+		err := closeIDLAccount(e, chain.ProgramsPath, tokenPool.String(), deployment.BurnMintTokenPoolProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	for _, lrMetadata := range c.LockReleaseTokenPoolMetadata {
+		tokenPool := chainState.GetActiveTokenPool(shared.LockReleaseTokenPool, lrMetadata)
+		err := closeIDLAccount(e, chain.ProgramsPath, tokenPool.String(), deployment.LockReleaseTokenPoolProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.CCTPTokenPool {
+		err := closeIDLAccount(e, chain.ProgramsPath, chainState.CCTPTokenPool.String(), deployment.CCTPTokenPoolProgramName)
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+
+	// MCMS Programs
+	addresses, err := e.ExistingAddresses.AddressesForChain(chain.Selector)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to get existing addresses: %w", err)
+	}
+	mcmState, err := commonstate.MaybeLoadMCMSWithTimelockChainStateSolana(chain, addresses)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load MCMS with timelock chain state: %w", err)
+	}
+
+	if c.AccessController {
+		err = closeIDLAccount(e, chain.ProgramsPath, mcmState.AccessControllerProgram.String(), types.AccessControllerProgram.String())
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.Timelock {
+		err = closeIDLAccount(e, chain.ProgramsPath, mcmState.TimelockProgram.String(), types.RBACTimelockProgram.String())
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+	if c.MCM {
+		err = closeIDLAccount(e, chain.ProgramsPath, mcmState.McmProgram.String(), types.ManyChainMultisigProgram.String())
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+	}
+
+	return cldf.ChangesetOutput{}, nil
+}
+
+// Close IDL account for a program
+func closeIDLAccount(e cldf.Environment, programsPath, programID, programName string) error {
+	e.Logger.Infow("Closing IDL Account", "programName", programName)
+	args := []string{"idl", "close", programID}
+	e.Logger.Info(args)
+	_, err := runCommand("anchor", args, programsPath)
+	if err != nil {
+		return fmt.Errorf("error closing idl account: %w", err)
+	}
+	return nil
+}
+
 // get IDL address for a program
 func getIDLAddress(e cldf.Environment, programID solana.PublicKey) (solana.PublicKey, error) {
 	base, _, _ := solana.FindProgramAddress([][]byte{}, programID)


### PR DESCRIPTION
Added changeset to close idl account for a Solana program - this is needed when the idl increased so much in size that it no longer fits in the account as the idl account can not be resized when it already contains data, so you need to close the account and reinitialize it