### PR TITLE
[PRODCRE-529] Remote Server Hasher for WriteReportRequest

### DIFF
--- a/core/capabilities/remote/executable/hasher.go
+++ b/core/capabilities/remote/executable/hasher.go
@@ -1,0 +1,89 @@
+package executable
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	evmcappb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/chain-capabilities/evm"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+)
+
+// V1 Capabilities only need a hasher for the ChainWrite Target.
+// This hasher excludes signatures from the Inputs map when hashing the request.
+type v1Hasher struct {
+	requestHashExcludedAttributes []string
+}
+
+func (r *v1Hasher) Hash(msg *types.MessageBody) ([32]byte, error) {
+	req, err := pb.UnmarshalCapabilityRequest(msg.Payload)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("failed to unmarshal capability request: %w", err)
+	}
+
+	// An attribute called StepDependency is used to define a data dependency between steps,
+	// and not to provide input values; we should therefore disregard it when hashing the request
+	if len(r.requestHashExcludedAttributes) == 0 {
+		r.requestHashExcludedAttributes = []string{"StepDependency"}
+	}
+
+	for _, path := range r.requestHashExcludedAttributes {
+		if req.Inputs != nil {
+			req.Inputs.DeleteAtPath(path)
+		}
+	}
+
+	reqBytes, err := pb.MarshalCapabilityRequest(req)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("failed to marshal capability request: %w", err)
+	}
+	hash := sha256.Sum256(reqBytes)
+	return hash, nil
+}
+
+func NewV1Hasher(requestHashExcludedAttributes []string) types.MessageHasher {
+	return &v1Hasher{
+		requestHashExcludedAttributes: requestHashExcludedAttributes,
+	}
+}
+
+// V2 Capabilities (Executables) default to a simple hasher that hashes the entire payload.
+// WriteReport methods use a hasher that excludes signatures from the WriteReportRequest.
+// Additional hashers can be added here as needed.
+type simpleHasher struct {
+}
+
+func (r *simpleHasher) Hash(msg *types.MessageBody) ([32]byte, error) {
+	return sha256.Sum256(msg.Payload), nil
+}
+
+func NewSimpleHasher() types.MessageHasher {
+	return &simpleHasher{}
+}
+
+type writeReportExcludeSignaturesHasher struct {
+}
+
+func (r *writeReportExcludeSignaturesHasher) Hash(msg *types.MessageBody) ([32]byte, error) {
+	req, err := pb.UnmarshalCapabilityRequest(msg.Payload)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("failed to unmarshal capability request: %w", err)
+	}
+
+	var wrReq evmcappb.WriteReportRequest
+	if err = req.Payload.UnmarshalTo(&wrReq); err != nil {
+		return [32]byte{}, fmt.Errorf("failed to unmarshal Payload to WriteReportRequest: %w", err)
+	}
+	wrReq.Report.Sigs = nil // exclude signatures from hash
+	filteredPayload, err := proto.Marshal(&wrReq)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("failed to marshal WriteReportRequest without signatures: %w", err)
+	}
+	return sha256.Sum256(filteredPayload), nil
+}
+
+func NewWriteReportExcludeSignaturesHasher() types.MessageHasher {
+	return &writeReportExcludeSignaturesHasher{}
+}

--- a/core/capabilities/remote/executable/hasher_test.go
+++ b/core/capabilities/remote/executable/hasher_test.go
@@ -1,0 +1,58 @@
+package executable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	evmcappb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/chain-capabilities/evm"
+	"github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+)
+
+func TestWriteReportExcludeSignaturesHasher_Hash(t *testing.T) {
+	req1a := getRequest(t, []byte("testdata"), [][]byte{[]byte("sig1"), []byte("sig2")})
+	req1b := getRequest(t, []byte("testdata"), [][]byte{[]byte("sig3"), []byte("sig4")})
+	req2 := getRequest(t, []byte("otherdata"), [][]byte{[]byte("sig1"), []byte("sig2")})
+
+	hasher := NewWriteReportExcludeSignaturesHasher()
+	hash1a, err := hasher.Hash(req1a)
+	require.NoError(t, err)
+	hash1b, err := hasher.Hash(req1b)
+	require.NoError(t, err)
+	hash2, err := hasher.Hash(req2)
+	require.NoError(t, err)
+
+	require.Equal(t, hash1a, hash1b)   // same data, different signatures
+	require.NotEqual(t, hash1a, hash2) // different data, same signatures
+}
+
+func getRequest(t *testing.T, data []byte, sigs [][]byte) *types.MessageBody {
+	attrSigs := []*sdk.AttributedSignature{}
+	for i, sig := range sigs {
+		attrSigs = append(attrSigs, &sdk.AttributedSignature{
+			Signature: sig,
+			SignerId:  uint32(i), //nolint:gosec // G115
+		})
+	}
+	report := &sdk.ReportResponse{
+		RawReport: data,
+		Sigs:      attrSigs,
+	}
+	wrReq := &evmcappb.WriteReportRequest{
+		Report: report,
+	}
+	wrAny, err := anypb.New(wrReq)
+	require.NoError(t, err)
+	capReq := capabilities.CapabilityRequest{
+		Payload: wrAny,
+	}
+	capReqBytes, err := pb.MarshalCapabilityRequest(capReq)
+	require.NoError(t, err)
+	return &types.MessageBody{
+		Payload: capReqBytes,
+	}
+}


### PR DESCRIPTION
This is needed to ignore signatures when comparing requests to Write() in the EVM capability.
