### PR TITLE
[PRODCRE-530] Support global transmission config in Executable Client

### DIFF
--- a/core/capabilities/launcher.go
+++ b/core/capabilities/launcher.go
@@ -373,6 +373,7 @@ func (w *launcher) addRemoteCapabilities(ctx context.Context, myDON registrysync
 					myDON.DON,
 					w.dispatcher,
 					defaultTargetRequestTimeout,
+					nil, // V1 capabilities read transmission schedule from every request
 					w.lggr,
 				)
 				return client, nil
@@ -391,6 +392,7 @@ func (w *launcher) addRemoteCapabilities(ctx context.Context, myDON registrysync
 					myDON.DON,
 					w.dispatcher,
 					defaultTargetRequestTimeout,
+					nil, // V1 capabilities read transmission schedule from every request
 					w.lggr,
 				)
 				return client, nil

--- a/core/capabilities/remote/executable/client.go
+++ b/core/capabilities/remote/executable/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/executable/request"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/transmission"
 )
 
 // client is a shim for remote executable capabilities.
@@ -31,6 +32,8 @@ type client struct {
 	localDONInfo         commoncap.DON
 	dispatcher           types.Dispatcher
 	requestTimeout       time.Duration
+	// Has to be set only for V2 capabilities. V1 capabilities read transmission schedule from every request.
+	transmissionConfig *transmission.TransmissionConfig
 
 	requestIDToCallerRequest map[string]*request.ClientRequest
 	mutex                    sync.Mutex
@@ -49,14 +52,16 @@ var (
 	ErrContextDoneBeforeResponseQuorum = errors.New("context done before remote client received a quorum of responses")
 )
 
+// TransmissionConfig has to be set only for V2 capabilities. V1 capabilities read transmission schedule from every request.
 func NewClient(remoteCapabilityInfo commoncap.CapabilityInfo, localDonInfo commoncap.DON, dispatcher types.Dispatcher,
-	requestTimeout time.Duration, lggr logger.Logger) *client {
+	requestTimeout time.Duration, transmissionConfig *transmission.TransmissionConfig, lggr logger.Logger) *client {
 	return &client{
 		lggr:                     logger.Named(lggr, "ExecutableCapabilityClient"),
 		remoteCapabilityInfo:     remoteCapabilityInfo,
 		localDONInfo:             localDonInfo,
 		dispatcher:               dispatcher,
 		requestTimeout:           requestTimeout,
+		transmissionConfig:       transmissionConfig,
 		requestIDToCallerRequest: make(map[string]*request.ClientRequest),
 		stopCh:                   make(services.StopChan),
 	}
@@ -161,7 +166,7 @@ func (c *client) UnregisterFromWorkflow(ctx context.Context, unregisterRequest c
 
 func (c *client) Execute(ctx context.Context, capReq commoncap.CapabilityRequest) (commoncap.CapabilityResponse, error) {
 	req, err := request.NewClientExecuteRequest(ctx, c.lggr, capReq, c.remoteCapabilityInfo, c.localDONInfo, c.dispatcher,
-		c.requestTimeout)
+		c.requestTimeout, c.transmissionConfig)
 	if err != nil {
 		return commoncap.CapabilityResponse{}, fmt.Errorf("failed to create client request: %w", err)
 	}

--- a/core/capabilities/remote/executable/client_test.go
+++ b/core/capabilities/remote/executable/client_test.go
@@ -242,7 +242,7 @@ func testClient(t *testing.T, numWorkflowPeers int, workflowNodeResponseTimeout 
 
 	for i := 0; i < numWorkflowPeers; i++ {
 		workflowPeerDispatcher := broker.NewDispatcherForNode(workflowPeers[i])
-		caller := executable.NewClient(capInfo, workflowDonInfo, workflowPeerDispatcher, workflowNodeResponseTimeout, lggr)
+		caller := executable.NewClient(capInfo, workflowDonInfo, workflowPeerDispatcher, workflowNodeResponseTimeout, nil, lggr)
 		servicetest.Run(t, caller)
 		broker.RegisterReceiverNode(workflowPeers[i], caller)
 		callers[i] = caller

--- a/core/capabilities/remote/executable/endtoend_test.go
+++ b/core/capabilities/remote/executable/endtoend_test.go
@@ -303,7 +303,7 @@ func testRemoteExecutableCapability(ctx context.Context, t *testing.T, underlyin
 	workflowNodes := make([]commoncap.ExecutableCapability, numWorkflowPeers)
 	for i := 0; i < numWorkflowPeers; i++ {
 		workflowPeerDispatcher := broker.NewDispatcherForNode(workflowPeers[i])
-		workflowNode := executable.NewClient(capInfo, workflowDonInfo, workflowPeerDispatcher, workflowNodeTimeout, lggr)
+		workflowNode := executable.NewClient(capInfo, workflowDonInfo, workflowPeerDispatcher, workflowNodeTimeout, nil, lggr)
 		servicetest.Run(t, workflowNode)
 		broker.RegisterReceiverNode(workflowPeers[i], workflowNode)
 		workflowNodes[i] = workflowNode

--- a/core/capabilities/remote/executable/request/client_request_test.go
+++ b/core/capabilities/remote/executable/request/client_request_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"testing"
 	"time"
@@ -12,9 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder/beholdertest"
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
 	"github.com/smartcontractkit/chainlink-protos/workflows/go/events"
 
@@ -83,7 +84,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 
 		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
-			workflowDonInfo, dispatcher, 10*time.Minute)
+			workflowDonInfo, dispatcher, 10*time.Minute, nil)
 		defer req.Cancel(errors.New("test end"))
 
 		require.NoError(t, err)
@@ -134,7 +135,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 
 		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
-			workflowDonInfo, dispatcher, 10*time.Minute)
+			workflowDonInfo, dispatcher, 10*time.Minute, nil)
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
@@ -168,7 +169,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 
 		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
-			workflowDonInfo, dispatcher, 10*time.Minute)
+			workflowDonInfo, dispatcher, 10*time.Minute, nil)
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
@@ -199,7 +200,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 
 		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
-			workflowDonInfo, dispatcher, 10*time.Minute)
+			workflowDonInfo, dispatcher, 10*time.Minute, nil)
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
@@ -237,7 +238,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 
 		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
-			workflowDonInfo, dispatcher, 10*time.Minute)
+			workflowDonInfo, dispatcher, 10*time.Minute, nil)
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
@@ -298,7 +299,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 
 		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
-			workflowDonInfo, dispatcher, 10*time.Minute)
+			workflowDonInfo, dispatcher, 10*time.Minute, nil)
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
@@ -332,7 +333,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 	})
 
 	t.Run("Executes full schedule", func(t *testing.T) {
-		beholderTester := tests.Beholder(t)
+		beholderTester := beholdertest.NewObserver(t)
 		lggr, obs := logger.TestObserved(t, zapcore.DebugLevel)
 
 		capPeers, capDonInfo, capInfo := capabilityDon(t, 3, 1)
@@ -355,6 +356,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 			workflowDonInfo,
 			dispatcher,
 			10*time.Minute,
+			nil,
 		)
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
@@ -474,6 +476,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 			workflowDonInfo,
 			dispatcher,
 			10*time.Minute,
+			nil,
 		)
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
@@ -566,7 +569,7 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 
 		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody, 100)}
 		req, err := request.NewClientExecuteRequest(ctx, logger.Test(t), capabilityRequest, capInfo,
-			workflowDonInfo, dispatcher, 10*time.Minute)
+			workflowDonInfo, dispatcher, 10*time.Minute, nil)
 		require.NoError(t, err)
 		defer req.Cancel(errors.New("test end"))
 
@@ -602,6 +605,99 @@ func Test_ClientRequest_MessageValidation(t *testing.T) {
 		assert.Equal(t, "testunit_b", spendUnit)
 		assert.Equal(t, "17", spendValue)
 		assert.Equal(t, capabilityPeers[1].String(), p2pID)
+	})
+
+	capabilityRequestV2 := commoncap.CapabilityRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID:          workflowID1,
+			WorkflowExecutionID: workflowExecutionID1,
+			ReferenceID:         stepRef1,
+		},
+		// No Inputs or Config, including transmission schedule
+	}
+
+	t.Run("Executes full schedule for a V2 request", func(t *testing.T) {
+		beholderTester := beholdertest.NewObserver(t)
+		lggr, obs := logger.TestObserved(t, zapcore.DebugLevel)
+		capPeers, capDonInfo, capInfo := capabilityDon(t, 3, 1)
+		dispatcher := &clientRequestTestDispatcher{msgs: make(chan *types.MessageBody)}
+		req, err := request.NewClientExecuteRequest(
+			t.Context(),
+			lggr,
+			capabilityRequestV2,
+			capInfo,
+			workflowDonInfo,
+			dispatcher,
+			10*time.Minute,
+			&transmission.TransmissionConfig{
+				Schedule:   transmission.Schedule_OneAtATime,
+				DeltaStage: 1000 * time.Millisecond,
+			},
+		)
+		require.NoError(t, err)
+		defer req.Cancel(errors.New("test end"))
+
+		// Expect all 3 capability nodes to receive the request.
+		<-dispatcher.msgs
+		<-dispatcher.msgs
+		<-dispatcher.msgs
+		assert.Empty(t, dispatcher.msgs)
+
+		msg := &types.MessageBody{
+			CapabilityId:    capInfo.ID,
+			CapabilityDonId: capDonInfo.ID,
+			CallerDonId:     workflowDonInfo.ID,
+			Method:          types.MethodExecute,
+			Payload:         rawResponse,
+			MessageId:       []byte("messageID"),
+		}
+		msg.Sender = capPeers[0][:]
+		require.NoError(t, req.OnMessage(t.Context(), msg))
+		msg.Sender = capPeers[1][:]
+		require.NoError(t, req.OnMessage(t.Context(), msg))
+
+		response := <-req.ResponseChan()
+		capResponse, err := pb.UnmarshalCapabilityResponse(response.Result)
+		require.NoError(t, err)
+
+		resp := capResponse.Value.Underlying["response"]
+		assert.Equal(t, resp, values.NewString("response1"))
+		assert.Len(t, obs.FilterMessage("sending request to peers").All(), 1)
+
+		// Verify the TransmissionsScheduledEvent data
+		assert.Equal(t, 1, beholderTester.Len(t, "beholder_entity", fmt.Sprintf("%v.%v", request.TransmissionEventProtoPkg, request.TransmissionEventEntity)))
+
+		// Get the messages for the transmission event
+		messages := beholderTester.Messages(t, "beholder_entity", fmt.Sprintf("%v.%v", request.TransmissionEventProtoPkg, request.TransmissionEventEntity))
+		assert.Len(t, messages, 1)
+
+		// Unmarshal the message to verify its contents
+		var event events.TransmissionsScheduledEvent
+		err = proto.Unmarshal(messages[0].Body, &event)
+		require.NoError(t, err)
+
+		// Verify the event fields
+		assert.Equal(t, transmission.Schedule_OneAtATime, event.ScheduleType)
+		assert.Equal(t, workflowExecutionID1, event.WorkflowExecutionID)
+		assert.Equal(t, "cap_id@1.0.0", event.CapabilityID)
+		assert.Equal(t, stepRef1, event.StepRef)
+		assert.Equal(t, fmt.Sprintf("Execute:%v:%v", workflowExecutionID1, stepRef1), event.TransmissionID)
+		assert.NotEmpty(t, event.Timestamp)
+
+		// Verify the peer delays
+		assert.Len(t, event.PeerTransmissionDelays, 3)
+
+		// Convert map to slice of delays and sort them
+		var delays []int64
+		for _, delay := range event.PeerTransmissionDelays {
+			delays = append(delays, delay)
+		}
+		slices.Sort(delays)
+
+		// Verify delays are sorted and increment by 1000ms
+		for i := 1; i < len(delays); i++ {
+			assert.Equal(t, delays[i-1]+1000, delays[i], "delays should increment by 1000ms")
+		}
 	})
 }
 


### PR DESCRIPTION
Capabilities V2 won't use the setting from each request but have a per-chain-family one instead.

This will be followed with a PR that passes the config from Launcher.

