### PR TITLE
Add CSAKey handling in HeartbeatConfig and logging for key retrieval

### DIFF
--- a/.changeset/mighty-lemons-doubt.md
+++ b/.changeset/mighty-lemons-doubt.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Add CSAKey handling in HeartbeatConfig and logging for key retrieval

--- a/.changeset/mighty-lemons-doubt.md
+++ b/.changeset/mighty-lemons-doubt.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-Add CSAKey handling in HeartbeatConfig and logging for key retrieval
+Add CSAKey handling in HeartbeatConfig and logging for key retrieval #internal

--- a/core/services/chainlink/heartbeat.go
+++ b/core/services/chainlink/heartbeat.go
@@ -27,18 +27,32 @@ type Heartbeat struct {
 }
 
 type HeartbeatConfig struct {
-	Beat  time.Duration
-	Lggr  logger.Logger
-	P2P   string
-	AppID string
+	Beat   time.Duration
+	Lggr   logger.Logger
+	P2P    string
+	AppID  string
+	CSAKey string
 }
 
 func NewHeartbeatConfig(cfg ApplicationOpts) HeartbeatConfig {
+	csaKey := ""
+	csaKeys, err := cfg.KeyStore.CSA().GetAll()
+	if err != nil {
+		cfg.Logger.Errorw("failed to get CSA keys", "err", err)
+	}
+
+	if len(csaKeys) > 0 {
+		csaKey = csaKeys[0].PublicKeyString()
+	} else {
+		cfg.Logger.Warn("no CSA key found for heartbeat")
+	}
+
 	return HeartbeatConfig{
-		Beat:  cfg.Config.Telemetry().HeartbeatInterval(),
-		Lggr:  cfg.Logger,
-		P2P:   cfg.Config.P2P().PeerID().String(),
-		AppID: cfg.Config.AppID().String(),
+		Beat:   cfg.Config.Telemetry().HeartbeatInterval(),
+		Lggr:   cfg.Logger,
+		P2P:    cfg.Config.P2P().PeerID().String(),
+		AppID:  cfg.Config.AppID().String(),
+		CSAKey: csaKey,
 	}
 }
 
@@ -52,6 +66,9 @@ func NewHeartbeat(cfg HeartbeatConfig, opts ...HeartbeatOpt) Heartbeat {
 	}
 	if cfg.AppID != "" {
 		labels["appID"] = cfg.AppID
+	}
+	if cfg.CSAKey != "" {
+		labels["csa_key"] = cfg.CSAKey
 	}
 
 	cme.WithMapLabels(labels)

--- a/core/services/chainlink/heartbeat.go
+++ b/core/services/chainlink/heartbeat.go
@@ -27,11 +27,11 @@ type Heartbeat struct {
 }
 
 type HeartbeatConfig struct {
-	Beat   time.Duration
-	Lggr   logger.Logger
-	P2P    string
-	AppID  string
-	CSAKey string
+	Beat         time.Duration
+	Lggr         logger.Logger
+	P2P          string
+	AppID        string
+	CSAPublicKey string
 }
 
 func NewHeartbeatConfig(cfg ApplicationOpts) HeartbeatConfig {
@@ -48,11 +48,11 @@ func NewHeartbeatConfig(cfg ApplicationOpts) HeartbeatConfig {
 	}
 
 	return HeartbeatConfig{
-		Beat:   cfg.Config.Telemetry().HeartbeatInterval(),
-		Lggr:   cfg.Logger,
-		P2P:    cfg.Config.P2P().PeerID().String(),
-		AppID:  cfg.Config.AppID().String(),
-		CSAKey: csaKey,
+		Beat:         cfg.Config.Telemetry().HeartbeatInterval(),
+		Lggr:         cfg.Logger,
+		P2P:          cfg.Config.P2P().PeerID().String(),
+		AppID:        cfg.Config.AppID().String(),
+		CSAPublicKey: csaKey,
 	}
 }
 
@@ -67,8 +67,8 @@ func NewHeartbeat(cfg HeartbeatConfig, opts ...HeartbeatOpt) Heartbeat {
 	if cfg.AppID != "" {
 		labels["appID"] = cfg.AppID
 	}
-	if cfg.CSAKey != "" {
-		labels["csa_key"] = cfg.CSAKey
+	if cfg.CSAPublicKey != "" {
+		labels["csa_key"] = cfg.CSAPublicKey
 	}
 
 	cme.WithMapLabels(labels)


### PR DESCRIPTION
This PR adds CSA  key information to the heartbeat configuration.. The CSA key is now included as part of the heartbeat metadata for tracking and validation purposes.