### PR TITLE
Move env-related constants shared between smoke tests to the TestConfig

### DIFF
--- a/core/scripts/cre/environment/environment/workflow.go
+++ b/core/scripts/cre/environment/environment/workflow.go
@@ -380,7 +380,7 @@ func compileWorkflow(workflowFilePathFlag, workflowNameFlag string) (string, err
 }
 
 func deployWorkflow(ctx context.Context, wasmWorkflowFilePathFlag, workflowNameFlag, workflowOwnerAddressFlag, workflowRegistryAddressFlag, capabilitiesRegistryAddressFlag, containerNamePatternFlag, containerTargetDirFlag, configFilePathFlag, secretsFilePathFlag, rpcURLFlag string, donIDFlag uint32, deleteWorkflowFile bool) error {
-	copyErr := creworkflow.CopyArtifactsToDockerContainers(wasmWorkflowFilePathFlag, containerNamePatternFlag, containerTargetDirFlag)
+	copyErr := creworkflow.CopyArtifactsToDockerContainers(containerTargetDirFlag, containerNamePatternFlag, wasmWorkflowFilePathFlag)
 	if copyErr != nil {
 		return errors.Wrap(copyErr, "❌ failed to copy workflow to Docker container")
 	}
@@ -409,7 +409,7 @@ func deployWorkflow(ctx context.Context, wasmWorkflowFilePathFlag, workflowNameF
 			return errors.Wrap(configPathAbsErr, "failed to get absolute path of the config file")
 		}
 
-		configCopyErr := creworkflow.CopyArtifactsToDockerContainers(configFilePathFlag, containerNamePatternFlag, containerTargetDirFlag)
+		configCopyErr := creworkflow.CopyArtifactsToDockerContainers(containerTargetDirFlag, containerNamePatternFlag, configFilePathFlag)
 		if configCopyErr != nil {
 			return errors.Wrap(configCopyErr, "❌ failed to copy config file to Docker container")
 		}
@@ -436,7 +436,7 @@ func deployWorkflow(ctx context.Context, wasmWorkflowFilePathFlag, workflowNameF
 		fmt.Printf("\n✅ Encrypted workflow secrets file prepared\n\n")
 
 		fmt.Printf("\n⚙️ Copying encrypted secrets file to Docker container\n")
-		secretsCopyErr := creworkflow.CopyArtifactsToDockerContainers(secretPathAbs, containerNamePatternFlag, containerTargetDirFlag)
+		secretsCopyErr := creworkflow.CopyArtifactsToDockerContainers(containerTargetDirFlag, containerNamePatternFlag, secretPathAbs)
 		if secretsCopyErr != nil {
 			return errors.Wrap(secretsCopyErr, "❌ failed to copy encrypted secrets file to Docker container")
 		}

--- a/system-tests/tests/smoke/cre/README.md
+++ b/system-tests/tests/smoke/cre/README.md
@@ -580,19 +580,11 @@ containerTargetDir := "/home/chainlink/workflows"
 
 // Copy compiled workflow binary
 workflowCopyErr := creworkflow.CopyArtifactsToDockerContainers(
-    compressedWorkflowWasmPath,
-    "workflow-node",
     containerTargetDir,
+    "workflow-node",
+    compressedWorkflowWasmPath, workflowConfigFilePath
 )
 require.NoError(t, workflowCopyErr, "failed to copy workflow to docker containers")
-
-// Copy configuration file
-configCopyErr := creworkflow.CopyArtifactsToDockerContainers(
-    workflowConfigFilePath,
-    "workflow-node",
-    containerTargetDir,
-)
-require.NoError(t, configCopyErr, "failed to copy workflow config to docker containers")
 ```
 
 #### Container Discovery

--- a/system-tests/tests/smoke/cre/before_suite.go
+++ b/system-tests/tests/smoke/cre/before_suite.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -21,14 +22,21 @@ import (
 	envconfig "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/config"
 )
 
-const (
-	DefaultConfigPath      = "../../../../core/scripts/cre/environment/configs/workflow-don.toml"
-	DefaultEnvironmentDir  = "../../../../core/scripts/cre/environment"
-	DefaultEnvArtifactFile = "../../../../core/scripts/cre/environment/env_artifact/env_artifact.json"
-)
+// TestConfig holds common test specific configurations related to the test execution
+// These configurations are not meant to impact the actual test logic
+type TestConfig struct {
+	VerificationTimeout     time.Duration
+	RetryInterval           time.Duration
+	EnvironmentConfigPath   string
+	EnvironmentDirPath      string
+	EnvironmentArtifactPath string
+	BeholderConfigPath      string
+}
 
+// TestEnvironment holds references to the main test components
 type TestEnvironment struct {
 	Config                   *envconfig.Config
+	TestConfig               *TestConfig
 	EnvArtifact              environment.EnvArtifact
 	Logger                   zerolog.Logger
 	FullCldEnvOutput         *cre.FullCLDEnvironmentOutput
@@ -39,7 +47,8 @@ type TestEnvironment struct {
 func SetupTestEnvironment(t *testing.T) *TestEnvironment {
 	t.Helper()
 
-	createEnvironment(t)
+	defaultTestConfig := getDefaultTestConfig(t)
+	createEnvironment(t, defaultTestConfig)
 	in := getEnvironmentConfig(t)
 	envArtifact := getEnvironmentArtifact(t)
 	fullCldEnvOutput, wrappedBlockchainOutputs, err := environment.BuildFromSavedState(t.Context(), cldlogger.NewSingleFileLogger(t), in, envArtifact)
@@ -47,6 +56,7 @@ func SetupTestEnvironment(t *testing.T) *TestEnvironment {
 
 	return &TestEnvironment{
 		Config:                   in,
+		TestConfig:               defaultTestConfig,
 		EnvArtifact:              envArtifact,
 		Logger:                   framework.L,
 		FullCldEnvOutput:         fullCldEnvOutput,
@@ -54,13 +64,30 @@ func SetupTestEnvironment(t *testing.T) *TestEnvironment {
 	}
 }
 
+func getDefaultTestConfig(t *testing.T) *TestConfig {
+	t.Helper()
+
+	return &TestConfig{
+		VerificationTimeout:     5 * time.Minute,
+		RetryInterval:           5 * time.Second,
+		EnvironmentDirPath:      "../../../../core/scripts/cre/environment",
+		EnvironmentConfigPath:   "../../../../core/scripts/cre/environment/configs/workflow-don.toml",
+		EnvironmentArtifactPath: "../../../../core/scripts/cre/environment/env_artifact/env_artifact.json",
+		BeholderConfigPath:      "../../../../core/scripts/cre/environment/configs/chip-ingress-cache.toml",
+	}
+}
+
 func getEnvironmentConfig(t *testing.T) *envconfig.Config {
+	t.Helper()
+
 	in, err := framework.Load[envconfig.Config](nil)
 	require.NoError(t, err, "couldn't load environment state")
 	return in
 }
 
 func getEnvironmentArtifact(t *testing.T) environment.EnvArtifact {
+	t.Helper()
+
 	var envArtifact environment.EnvArtifact
 	artFile, err := os.ReadFile(os.Getenv("ENV_ARTIFACT_PATH"))
 	require.NoError(t, err, "failed to read artifact file")
@@ -69,13 +96,13 @@ func getEnvironmentArtifact(t *testing.T) environment.EnvArtifact {
 	return envArtifact
 }
 
-func createEnvironment(t *testing.T) {
+func createEnvironment(t *testing.T, testConfig *TestConfig) {
 	t.Helper()
 
-	confErr := setConfigurationIfMissing(DefaultConfigPath, DefaultEnvArtifactFile)
+	confErr := setConfigurationIfMissing(testConfig.EnvironmentConfigPath, testConfig.EnvironmentArtifactPath)
 	require.NoError(t, confErr, "failed to set configuration")
 
-	createErr := createEnvironmentIfNotExists(DefaultEnvironmentDir)
+	createErr := createEnvironmentIfNotExists(testConfig.EnvironmentDirPath)
 	require.NoError(t, createErr, "failed to create environment")
 
 	// transform the config file to the cache file, so that we can use the cached environment

--- a/system-tests/tests/smoke/cre/before_suite.go
+++ b/system-tests/tests/smoke/cre/before_suite.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -25,8 +24,6 @@ import (
 // TestConfig holds common test specific configurations related to the test execution
 // These configurations are not meant to impact the actual test logic
 type TestConfig struct {
-	VerificationTimeout     time.Duration
-	RetryInterval           time.Duration
 	EnvironmentConfigPath   string
 	EnvironmentDirPath      string
 	EnvironmentArtifactPath string
@@ -68,8 +65,6 @@ func getDefaultTestConfig(t *testing.T) *TestConfig {
 	t.Helper()
 
 	return &TestConfig{
-		VerificationTimeout:     5 * time.Minute,
-		RetryInterval:           5 * time.Second,
 		EnvironmentDirPath:      "../../../../core/scripts/cre/environment",
 		EnvironmentConfigPath:   "../../../../core/scripts/cre/environment/configs/workflow-don.toml",
 		EnvironmentArtifactPath: "../../../../core/scripts/cre/environment/env_artifact/env_artifact.json",
@@ -91,6 +86,7 @@ func getEnvironmentArtifact(t *testing.T) environment.EnvArtifact {
 	var envArtifact environment.EnvArtifact
 	artFile, err := os.ReadFile(os.Getenv("ENV_ARTIFACT_PATH"))
 	require.NoError(t, err, "failed to read artifact file")
+
 	err = json.Unmarshal(artFile, &envArtifact)
 	require.NoError(t, err, "failed to unmarshal artifact file")
 	return envArtifact

--- a/system-tests/tests/smoke/cre/beholder_helpers.go
+++ b/system-tests/tests/smoke/cre/beholder_helpers.go
@@ -17,9 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/config"
 )
 
-const DefaultBeholderStackCacheFile = "../../../../core/scripts/cre/environment/configs/chip-ingress-cache.toml"
-
-func loadBeholderStackCache() (*config.ChipIngressConfig, error) {
+func loadBeholderStackCache(beholderConfigPath string) (*config.ChipIngressConfig, error) {
 	originalCtfConfigs := os.Getenv("CTF_CONFIGS")
 	defer func() {
 		setErr := os.Setenv("CTF_CONFIGS", originalCtfConfigs)
@@ -28,7 +26,7 @@ func loadBeholderStackCache() (*config.ChipIngressConfig, error) {
 		}
 	}()
 
-	setErr := os.Setenv("CTF_CONFIGS", DefaultBeholderStackCacheFile)
+	setErr := os.Setenv("CTF_CONFIGS", beholderConfigPath)
 	if setErr != nil {
 		return nil, errors.Wrap(setErr, "failed to set CTF_CONFIGS environment variable")
 	}

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -2,21 +2,6 @@ package cre
 
 import (
 	"testing"
-	"time"
-)
-
-// TODO: Where to move these constants? Is it appropriate place for keeping defaults here?
-const (
-	AuthorizationKeySecretName = "AUTH_KEY"
-	// TODO: use once we can run these tests in CI (https://smartcontract-it.atlassian.net/browse/DX-589)
-	// AuthorizationKey           = "12a-281j&@91.sj1:_}"
-	// It is needed for FakePriceProvider
-	AuthorizationKey = ""
-
-	// Test configuration constants
-	DefaultVerificationTimeout = 5 * time.Minute
-	DefaultRetryInterval       = 2 * time.Second
-	DefaultValidationInterval  = 10 * time.Second
 )
 
 /*

--- a/system-tests/tests/smoke/cre/helpers_test.go
+++ b/system-tests/tests/smoke/cre/helpers_test.go
@@ -36,28 +36,6 @@ import (
 	portypes "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/types"
 )
 
-// Generic WorkflowConfig interface for creation of different workflow configurations
-// Register your workflow configuration types here
-type WorkflowConfig interface {
-	None | portypes.WorkflowConfig | HTTPWorkflowConfig
-}
-
-// None represents an empty workflow configuration
-// It is used to satisfy the workflowConfigFactory, avoiding workflow config creation
-type None struct{}
-
-// WorkflowRegistrationConfig holds configuration for workflow registration
-type WorkflowRegistrationConfig struct {
-	WorkflowName         string
-	WorkflowLocation     string
-	ConfigFilePath       string
-	CompressedWasmPath   string
-	SecretsURL           string
-	WorkflowRegistryAddr common.Address
-	DonID                uint64
-	ContainerTargetDir   string
-}
-
 /////////////////////////
 // ENVIRONMENT HELPERS //
 /////////////////////////
@@ -91,6 +69,28 @@ func getWritableChainsFromSavedEnvironmentState(t *testing.T, testEnv *TestEnvir
 //////////////////////////////
 // WORKFLOW-RELATED HELPERS //
 //////////////////////////////
+
+// Generic WorkflowConfig interface for creation of different workflow configurations
+// Register your workflow configuration types here
+type WorkflowConfig interface {
+	None | portypes.WorkflowConfig | HTTPWorkflowConfig
+}
+
+// None represents an empty workflow configuration
+// It is used to satisfy the workflowConfigFactory, avoiding workflow config creation
+type None struct{}
+
+// WorkflowRegistrationConfig holds configuration for workflow registration
+type WorkflowRegistrationConfig struct {
+	WorkflowName         string
+	WorkflowLocation     string
+	ConfigFilePath       string
+	CompressedWasmPath   string
+	SecretsURL           string
+	WorkflowRegistryAddr common.Address
+	DonID                uint64
+	ContainerTargetDir   string
+}
 
 /*
 Creates the necessary workflow artifacts based on WorkflowConfig:
@@ -192,6 +192,9 @@ func registerWorkflow(ctx context.Context, t *testing.T, workflowConfig *Workflo
 Deletes workflows from:
  1. Local environment
  2. Workflow Registry
+
+Recommendation:
+Use it at the end of your test to `t.Cleanup()` the env after test run
 */
 func deleteWorkflows(t *testing.T, uniqueWorkflowName string, workflowConfigFilePath string, compressedWorkflowWasmPath string, blockchainOutputs []*cre.WrappedBlockchainOutput, workflowRegistryAddress common.Address) {
 	t.Helper()

--- a/system-tests/tests/smoke/cre/v1_por_test.go
+++ b/system-tests/tests/smoke/cre/v1_por_test.go
@@ -253,8 +253,8 @@ func validatePoRPrices(t *testing.T, testEnv *TestEnvironment, priceProvider Pri
 			}
 
 			startTime := time.Now()
-			waitFor := testEnv.TestConfig.VerificationTimeout
-			tick := testEnv.TestConfig.RetryInterval
+			waitFor := 5 * time.Minute
+			tick := 5 * time.Second
 			require.Eventually(t, func() bool {
 				elapsed := time.Since(startTime).Round(time.Second)
 				price, err := dataFeedsCacheInstance.GetLatestAnswer(bcOutput.SethClient.NewCallOpts(), [16]byte(common.Hex2Bytes(feedID)))

--- a/system-tests/tests/smoke/cre/v1_por_test.go
+++ b/system-tests/tests/smoke/cre/v1_por_test.go
@@ -37,11 +37,15 @@ type WorkflowTestConfig struct {
 	WorkflowName         string
 	WorkflowFileLocation string
 	FeedIDs              []string
-	Timeout              time.Duration
 }
 
 func ExecutePoRTest(t *testing.T, testEnv *TestEnvironment) {
 	testLogger := framework.L
+	// AuthorizationKeySecretName := "AUTH_KEY"
+	// TODO: use once we can run these tests in CI (https://smartcontract-it.atlassian.net/browse/DX-589)
+	// AuthorizationKey           = "12a-281j&@91.sj1:_}"
+	// It is needed for FakePriceProvider
+	AuthorizationKey := "" // required by FakePriceProvider
 	PoRWorkflowFileLocation := "../../../../core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/main.go"
 	blockchainOutputs := testEnv.WrappedBlockchainOutputs
 	homeChainSelector := blockchainOutputs[0].ChainSelector
@@ -51,7 +55,6 @@ func ExecutePoRTest(t *testing.T, testEnv *TestEnvironment) {
 		WorkflowName:         baseWorkflowName,
 		WorkflowFileLocation: PoRWorkflowFileLocation,
 		FeedIDs:              feedIDs,
-		Timeout:              DefaultVerificationTimeout,
 	}
 
 	writeableChains := getWritableChainsFromSavedEnvironmentState(t, testEnv)
@@ -250,6 +253,8 @@ func validatePoRPrices(t *testing.T, testEnv *TestEnvironment, priceProvider Pri
 			}
 
 			startTime := time.Now()
+			waitFor := testEnv.TestConfig.VerificationTimeout
+			tick := testEnv.TestConfig.RetryInterval
 			require.Eventually(t, func() bool {
 				elapsed := time.Since(startTime).Round(time.Second)
 				price, err := dataFeedsCacheInstance.GetLatestAnswer(bcOutput.SethClient.NewCallOpts(), [16]byte(common.Hex2Bytes(feedID)))
@@ -260,7 +265,7 @@ func validatePoRPrices(t *testing.T, testEnv *TestEnvironment, priceProvider Pri
 
 				// if there are no more prices to be found, we can stop waiting
 				return !priceProvider.NextPrice(feedID, price, elapsed)
-			}, config.Timeout, DefaultValidationInterval, "feed %s did not update, timeout after: %s", feedID, config.Timeout)
+			}, waitFor, tick, "feed %s did not update, timeout after: %s", feedID, waitFor.String())
 
 			expected := priceProvider.ExpectedPrices(feedID)
 			actual := priceProvider.ActualPrices(feedID)

--- a/system-tests/tests/smoke/cre/v1_por_test.go
+++ b/system-tests/tests/smoke/cre/v1_por_test.go
@@ -95,7 +95,7 @@ func ExecutePoRTest(t *testing.T, testEnv *TestEnvironment) {
 		crecontracts.MergeAllDataStores(fullCldEnvOutput, dfOutput, rbOutput)
 
 		testLogger.Info().Msgf("Configuring Data Feeds Cache contract...")
-		forwarderAddress, forwarderErr := crecontracts.FindAddressesForChain(fullCldEnvOutput.Environment.ExistingAddresses, chainSelector, keystone_changeset.KeystoneForwarder.String())
+		forwarderAddress, forwarderErr := crecontracts.FindAddressesForChain(fullCldEnvOutput.Environment.ExistingAddresses, chainSelector, keystone_changeset.KeystoneForwarder.String()) //nolint:staticcheck,nolintlint // SA1019: deprecated but we don't want to migrate now
 		require.NoError(t, forwarderErr, "failed to find Forwarder address for chain %d", chainSelector)
 
 		uniqueWorkflowName := baseWorkflowTestConfig.WorkflowName + "-" + bcOutput.BlockchainOutput.ChainID + "-" + uuid.New().String()[0:4] // e.g. 'por-workflow-1337-5f37_config'
@@ -133,7 +133,7 @@ func ExecutePoRTest(t *testing.T, testEnv *TestEnvironment) {
 
 		testLogger.Info().Msgf("Registering PoR workflow on chain %d (%d)", chainID, chainSelector)
 		workflowRegistryAddress, workflowRegistryErr := crecontracts.FindAddressesForChain(
-			fullCldEnvOutput.Environment.ExistingAddresses,
+			fullCldEnvOutput.Environment.ExistingAddresses, //nolint:staticcheck,nolintlint // SA1019: deprecated but we don't want to migrate now
 			homeChainSelector, // it should live only on one chain, it is not deployed to all chains
 			keystone_changeset.WorkflowRegistry.String(),
 		)
@@ -239,7 +239,7 @@ func validatePoRPrices(t *testing.T, testEnv *TestEnvironment, priceProvider Pri
 			testEnv.Logger.Info().Msgf("Waiting for feed %s to update...", feedID)
 
 			dataFeedsCacheAddresses, dataFeedsCacheErr := crecontracts.FindAddressesForChain(
-				testEnv.FullCldEnvOutput.Environment.ExistingAddresses,
+				testEnv.FullCldEnvOutput.Environment.ExistingAddresses, //nolint:staticcheck,nolintlint // SA1019: deprecated but we don't want to migrate now
 				bcOutput.ChainSelector,
 				df_changeset.DataFeedsCache.String(),
 			)

--- a/system-tests/tests/smoke/cre/v2_beholder_test.go
+++ b/system-tests/tests/smoke/cre/v2_beholder_test.go
@@ -21,8 +21,6 @@ import (
 	creworkflow "github.com/smartcontractkit/chainlink/system-tests/lib/cre/workflow"
 )
 
-type BeholderWorkflowConfig struct{}
-
 func ExecuteBeholderTest(t *testing.T, testEnv *TestEnvironment) {
 	testLogger := framework.L
 	timeout := 2 * time.Minute
@@ -31,10 +29,11 @@ func ExecuteBeholderTest(t *testing.T, testEnv *TestEnvironment) {
 	workflowName := "cronbeholder"
 
 	testLogger.Info().Msg("Starting Beholder...")
-	bErr := startBeholderStackIfIsNotRunning(DefaultBeholderStackCacheFile, DefaultEnvironmentDir)
+	beholderConfigPath := testEnv.TestConfig.BeholderConfigPath
+	bErr := startBeholderStackIfIsNotRunning(beholderConfigPath, testEnv.TestConfig.EnvironmentDirPath)
 	require.NoError(t, bErr, "failed to start Beholder")
 
-	chipConfig, chipErr := loadBeholderStackCache()
+	chipConfig, chipErr := loadBeholderStackCache(beholderConfigPath)
 	require.NoError(t, chipErr, "failed to load chip ingress cache")
 	require.NotNil(t, chipConfig.ChipIngress.Output.RedPanda.KafkaExternalURL, "kafka external url is not set in the cache")
 	require.NotEmpty(t, chipConfig.Kafka.Topics, "kafka topics are not set in the cache")

--- a/system-tests/tests/smoke/cre/v2_beholder_test.go
+++ b/system-tests/tests/smoke/cre/v2_beholder_test.go
@@ -40,7 +40,7 @@ func ExecuteBeholderTest(t *testing.T, testEnv *TestEnvironment) {
 
 	compressedWorkflowWasmPath, _ := createWorkflowArtifacts(t, testLogger, workflowName, &None{}, workflowFileLocation)
 
-	workflowRegistryAddress, workflowRegistryErr := crecontracts.FindAddressesForChain(testEnv.FullCldEnvOutput.Environment.ExistingAddresses, homeChainSelector, keystone_changeset.WorkflowRegistry.String())
+	workflowRegistryAddress, workflowRegistryErr := crecontracts.FindAddressesForChain(testEnv.FullCldEnvOutput.Environment.ExistingAddresses, homeChainSelector, keystone_changeset.WorkflowRegistry.String()) //nolint:staticcheck,nolintlint // SA1019: deprecated but we don't want to migrate now
 	require.NoError(t, workflowRegistryErr, "failed to find workflow registry address for chain %d", testEnv.WrappedBlockchainOutputs[0].ChainID)
 
 	t.Cleanup(func() {

--- a/system-tests/tests/smoke/cre/v2_http_trigger_action_test.go
+++ b/system-tests/tests/smoke/cre/v2_http_trigger_action_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -101,6 +102,7 @@ func executeHTTPTriggerRequest(t *testing.T, testEnv *TestEnvironment, gatewayUR
 	var finalResponse jsonrpc.Response[json.RawMessage]
 	var triggerRequest jsonrpc.Request[json.RawMessage]
 
+	tick := 5 * time.Second
 	require.Eventually(t, func() bool {
 		triggerRequest = createHTTPTriggerRequestWithKey(t, workflowName, workflowOwnerAddress, singingKey)
 		triggerRequestBody, err := json.Marshal(triggerRequest)
@@ -154,7 +156,7 @@ func executeHTTPTriggerRequest(t *testing.T, testEnv *TestEnvironment, gatewayUR
 
 		testEnv.Logger.Info().Msg("Successfully received 200 OK response from gateway")
 		return true
-	}, tests.WaitTimeout(t), testEnv.TestConfig.RetryInterval, "gateway should respond with 200 OK and valid response once workflow is loaded (ensure the workflow is loaded)")
+	}, tests.WaitTimeout(t), tick, "gateway should respond with 200 OK and valid response once workflow is loaded (ensure the workflow is loaded)")
 
 	require.Equal(t, jsonrpc.JsonRpcVersion, finalResponse.Version, "expected JSON-RPC version %s, got %s", jsonrpc.JsonRpcVersion, finalResponse.Version)
 	require.Equal(t, triggerRequest.ID, finalResponse.ID, "expected response ID %s, got %s", triggerRequest.ID, finalResponse.ID)
@@ -163,10 +165,11 @@ func executeHTTPTriggerRequest(t *testing.T, testEnv *TestEnvironment, gatewayUR
 
 // validateHTTPWorkflowRequest validates that the workflow made the expected HTTP request
 func validateHTTPWorkflowRequest(t *testing.T, testEnv *TestEnvironment) {
+	tick := 5 * time.Second
 	require.Eventually(t, func() bool {
 		records, err := fake.R.Get("POST", "/orders")
 		return err == nil && len(records) > 0
-	}, tests.WaitTimeout(t), testEnv.TestConfig.RetryInterval, "workflow should have made at least one HTTP request to mock server")
+	}, tests.WaitTimeout(t), tick, "workflow should have made at least one HTTP request to mock server")
 
 	records, err := fake.R.Get("POST", "/orders")
 	require.NoError(t, err, "failed to get recorded requests")

--- a/system-tests/tests/smoke/cre/v2_http_trigger_action_test.go
+++ b/system-tests/tests/smoke/cre/v2_http_trigger_action_test.go
@@ -58,7 +58,7 @@ func ExecuteHTTPTriggerActionTest(t *testing.T, testEnv *TestEnvironment) {
 	compressedWorkflowWasmPath, httpConfigFilePath := createWorkflowArtifacts(t, testLogger, uniqueWorkflowName, &httpWorkflowConfig, HTTPWorkflowFileLocation)
 
 	testLogger.Info().Msg("Registering HTTP workflow")
-	workflowRegistryAddress, err := crecontracts.FindAddressesForChain(testEnv.FullCldEnvOutput.Environment.ExistingAddresses, homeChainSelector, keystone_changeset.WorkflowRegistry.String())
+	workflowRegistryAddress, err := crecontracts.FindAddressesForChain(testEnv.FullCldEnvOutput.Environment.ExistingAddresses, homeChainSelector, keystone_changeset.WorkflowRegistry.String()) //nolint:staticcheck,nolintlint // SA1019: deprecated but we don't want to migrate now
 	require.NoError(t, err, "failed to find workflow registry address for chain %d", homeChainSelector)
 
 	regConfig := &WorkflowRegistrationConfig{

--- a/system-tests/tests/smoke/cre/v2_http_trigger_action_test.go
+++ b/system-tests/tests/smoke/cre/v2_http_trigger_action_test.go
@@ -154,7 +154,7 @@ func executeHTTPTriggerRequest(t *testing.T, testEnv *TestEnvironment, gatewayUR
 
 		testEnv.Logger.Info().Msg("Successfully received 200 OK response from gateway")
 		return true
-	}, tests.WaitTimeout(t), DefaultRetryInterval, "gateway should respond with 200 OK and valid response once workflow is loaded (ensure the workflow is loaded)")
+	}, tests.WaitTimeout(t), testEnv.TestConfig.RetryInterval, "gateway should respond with 200 OK and valid response once workflow is loaded (ensure the workflow is loaded)")
 
 	require.Equal(t, jsonrpc.JsonRpcVersion, finalResponse.Version, "expected JSON-RPC version %s, got %s", jsonrpc.JsonRpcVersion, finalResponse.Version)
 	require.Equal(t, triggerRequest.ID, finalResponse.ID, "expected response ID %s, got %s", triggerRequest.ID, finalResponse.ID)
@@ -166,7 +166,7 @@ func validateHTTPWorkflowRequest(t *testing.T, testEnv *TestEnvironment) {
 	require.Eventually(t, func() bool {
 		records, err := fake.R.Get("POST", "/orders")
 		return err == nil && len(records) > 0
-	}, tests.WaitTimeout(t), DefaultRetryInterval, "workflow should have made at least one HTTP request to mock server")
+	}, tests.WaitTimeout(t), testEnv.TestConfig.RetryInterval, "workflow should have made at least one HTTP request to mock server")
 
 	records, err := fake.R.Get("POST", "/orders")
 	require.NoError(t, err, "failed to get recorded requests")


### PR DESCRIPTION
Move env-related constants shared between smoke tests to the TestConfig (use idiomatic approach)