### PR TITLE
Add multi contract and event support to log event trigger 

### DIFF
--- a/core/capabilities/triggers/logevent/logeventcap/event_trigger-schema.json
+++ b/core/capabilities/triggers/logevent/logeventcap/event_trigger-schema.json
@@ -23,29 +23,43 @@
         "config": {
             "type": "object",
             "properties": {
-                "contractName": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "contractAddress": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "contractEventName": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "contractReaderConfig": {
-                    "type": "object",
-                    "properties": {
-                        "contracts": {
-                            "type": "object"
-                        }
+                "contracts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "contractName": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "contractAddress": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "contractEventNames": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "minItems": 1
+                            },
+                            "contractReaderConfig": {
+                                "type": "object",
+                                "properties": {
+                                    "contracts": {
+                                        "type": "object"
+                                    }
+                                },
+                                "required": ["contracts"]
+                            }
+                        },
+                        "required": ["contractName", "contractAddress", "contractEventNames", "contractReaderConfig"]
                     },
-                    "required": ["contracts"]
+                    "minItems": 1
                 }
             },
-            "required": ["contractName", "contractAddress", "contractEventName", "contractReaderConfig"]
+            "required": ["contracts"]
         },
         "output": {
             "type": "object",

--- a/core/capabilities/triggers/logevent/logeventcap/event_trigger_generated.go
+++ b/core/capabilities/triggers/logevent/logeventcap/event_trigger_generated.go
@@ -8,42 +8,83 @@ import (
 )
 
 type Config struct {
+	// Contracts corresponds to the JSON schema field "contracts".
+	Contracts []ConfigContractsElem `json:"contracts" yaml:"contracts" mapstructure:"contracts"`
+}
+
+type ConfigContractsElem struct {
 	// ContractAddress corresponds to the JSON schema field "contractAddress".
 	ContractAddress string `json:"contractAddress" yaml:"contractAddress" mapstructure:"contractAddress"`
 
-	// ContractEventName corresponds to the JSON schema field "contractEventName".
-	ContractEventName string `json:"contractEventName" yaml:"contractEventName" mapstructure:"contractEventName"`
+	// ContractEventNames corresponds to the JSON schema field "contractEventNames".
+	ContractEventNames []string `json:"contractEventNames" yaml:"contractEventNames" mapstructure:"contractEventNames"`
 
 	// ContractName corresponds to the JSON schema field "contractName".
 	ContractName string `json:"contractName" yaml:"contractName" mapstructure:"contractName"`
 
 	// ContractReaderConfig corresponds to the JSON schema field
 	// "contractReaderConfig".
-	ContractReaderConfig ConfigContractReaderConfig `json:"contractReaderConfig" yaml:"contractReaderConfig" mapstructure:"contractReaderConfig"`
+	ContractReaderConfig ConfigContractsElemContractReaderConfig `json:"contractReaderConfig" yaml:"contractReaderConfig" mapstructure:"contractReaderConfig"`
 }
 
-type ConfigContractReaderConfig struct {
+type ConfigContractsElemContractReaderConfig struct {
 	// Contracts corresponds to the JSON schema field "contracts".
-	Contracts ConfigContractReaderConfigContracts `json:"contracts" yaml:"contracts" mapstructure:"contracts"`
+	Contracts ConfigContractsElemContractReaderConfigContracts `json:"contracts" yaml:"contracts" mapstructure:"contracts"`
 }
 
-type ConfigContractReaderConfigContracts map[string]interface{}
+type ConfigContractsElemContractReaderConfigContracts map[string]interface{}
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *ConfigContractReaderConfig) UnmarshalJSON(b []byte) error {
+func (j *ConfigContractsElemContractReaderConfig) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["contracts"]; raw != nil && !ok {
-		return fmt.Errorf("field contracts in ConfigContractReaderConfig: required")
+		return fmt.Errorf("field contracts in ConfigContractsElemContractReaderConfig: required")
 	}
-	type Plain ConfigContractReaderConfig
+	type Plain ConfigContractsElemContractReaderConfig
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	*j = ConfigContractReaderConfig(plain)
+	*j = ConfigContractsElemContractReaderConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ConfigContractsElem) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["contractAddress"]; raw != nil && !ok {
+		return fmt.Errorf("field contractAddress in ConfigContractsElem: required")
+	}
+	if _, ok := raw["contractEventNames"]; raw != nil && !ok {
+		return fmt.Errorf("field contractEventNames in ConfigContractsElem: required")
+	}
+	if _, ok := raw["contractName"]; raw != nil && !ok {
+		return fmt.Errorf("field contractName in ConfigContractsElem: required")
+	}
+	if _, ok := raw["contractReaderConfig"]; raw != nil && !ok {
+		return fmt.Errorf("field contractReaderConfig in ConfigContractsElem: required")
+	}
+	type Plain ConfigContractsElem
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	if len(plain.ContractAddress) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "contractAddress", 1)
+	}
+	if plain.ContractEventNames != nil && len(plain.ContractEventNames) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "contractEventNames", 1)
+	}
+	if len(plain.ContractName) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "contractName", 1)
+	}
+	*j = ConfigContractsElem(plain)
 	return nil
 }
 
@@ -53,31 +94,16 @@ func (j *Config) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
-	if _, ok := raw["contractAddress"]; raw != nil && !ok {
-		return fmt.Errorf("field contractAddress in Config: required")
-	}
-	if _, ok := raw["contractEventName"]; raw != nil && !ok {
-		return fmt.Errorf("field contractEventName in Config: required")
-	}
-	if _, ok := raw["contractName"]; raw != nil && !ok {
-		return fmt.Errorf("field contractName in Config: required")
-	}
-	if _, ok := raw["contractReaderConfig"]; raw != nil && !ok {
-		return fmt.Errorf("field contractReaderConfig in Config: required")
+	if _, ok := raw["contracts"]; raw != nil && !ok {
+		return fmt.Errorf("field contracts in Config: required")
 	}
 	type Plain Config
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	if len(plain.ContractAddress) < 1 {
-		return fmt.Errorf("field %s length: must be >= %d", "contractAddress", 1)
-	}
-	if len(plain.ContractEventName) < 1 {
-		return fmt.Errorf("field %s length: must be >= %d", "contractEventName", 1)
-	}
-	if len(plain.ContractName) < 1 {
-		return fmt.Errorf("field %s length: must be >= %d", "contractName", 1)
+	if plain.Contracts != nil && len(plain.Contracts) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "contracts", 1)
 	}
 	*j = Config(plain)
 	return nil

--- a/core/capabilities/triggers/logevent/logeventcap/trigger_builders_generated.go
+++ b/core/capabilities/triggers/logevent/logeventcap/trigger_builders_generated.go
@@ -13,10 +13,7 @@ func (cfg Config) New(w *sdk.WorkflowSpecFactory, id string) OutputCap {
 		ID: id, Ref: ref,
 		Inputs: sdk.StepInputs{},
 		Config: map[string]any{
-			"contractAddress":      cfg.ContractAddress,
-			"contractEventName":    cfg.ContractEventName,
-			"contractName":         cfg.ContractName,
-			"contractReaderConfig": cfg.ContractReaderConfig,
+			"contracts": cfg.Contracts,
 		},
 		CapabilityType: capabilities.CapabilityTypeTrigger,
 	}

--- a/core/scripts/cre/environment/environment/workflow.go
+++ b/core/scripts/cre/environment/environment/workflow.go
@@ -151,14 +151,14 @@ func compileCopyAndRegisterWorkflow(ctx context.Context, workflowFilePathFlag, w
 		fmt.Printf("\n✅ Workflow config file copied to Docker container\n\n")
 	}
 
-	fmt.Printf("\n⚙️ Deleting all workflows from the workflow registry\n\n")
-
-	deleteErr := creworkflow.DeleteAllWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddressFlag))
-	if deleteErr != nil {
-		return errors.Wrapf(deleteErr, "❌ failed to delete all workflows from the registry %s", workflowRegistryAddressFlag)
-	}
-
-	fmt.Printf("\n✅ All workflows deleted from the workflow registry\n\n")
+	//fmt.Printf("\n⚙️ Deleting all workflows from the workflow registry\n\n")
+	//
+	//deleteErr := creworkflow.DeleteAllWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddressFlag))
+	//if deleteErr != nil {
+	//	return errors.Wrapf(deleteErr, "❌ failed to delete all workflows from the registry %s", workflowRegistryAddressFlag)
+	//}
+	//
+	//fmt.Printf("\n✅ All workflows deleted from the workflow registry\n\n")
 	fmt.Printf("\n⚙️ Registering workflow %s with the workflow registry\n\n", workflowNameFlag)
 
 	registerErr := creworkflow.RegisterWithContract(ctx, sethClient, common.HexToAddress(workflowRegistryAddressFlag), 1, workflowNameFlag, "file://"+compressedWorkflowWasmPath, configPath, nil, &containerTargetDirFlag)

--- a/core/services/workflows/syncer/workflow_registry.go
+++ b/core/services/workflows/syncer/workflow_registry.go
@@ -396,6 +396,7 @@ func (w *workflowRegistry) handleWithMetrics(ctx context.Context, event Event) e
 	start := time.Now()
 	err := w.handler.Handle(ctx, event)
 	totalDuration := time.Since(start)
+
 	w.metrics.recordHandleDuration(ctx, totalDuration, string(event.EventType), err == nil)
 	return err
 }

--- a/go.md
+++ b/go.md
@@ -247,6 +247,8 @@ flowchart LR
 	click chainlink-testing-framework/framework href "https://github.com/smartcontractkit/chainlink-testing-framework"
 	chainlink-testing-framework/framework/components/dockercompose --> chainlink-testing-framework/framework
 	click chainlink-testing-framework/framework/components/dockercompose href "https://github.com/smartcontractkit/chainlink-testing-framework"
+	chainlink-testing-framework/framework/components/fake --> chainlink-testing-framework/framework
+	click chainlink-testing-framework/framework/components/fake href "https://github.com/smartcontractkit/chainlink-testing-framework"
 	chainlink-testing-framework/havoc --> chainlink-testing-framework/lib/grafana
 	click chainlink-testing-framework/havoc href "https://github.com/smartcontractkit/chainlink-testing-framework"
 	chainlink-testing-framework/lib --> chainlink-testing-framework/parrot
@@ -266,8 +268,14 @@ flowchart LR
 	chainlink-tron/relayer --> chainlink-common
 	click chainlink-tron/relayer href "https://github.com/smartcontractkit/chainlink-tron"
 	chainlink/core/scripts --> chainlink-testing-framework/framework/components/dockercompose
+	chainlink/core/scripts --> chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based
+	chainlink/core/scripts --> chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based
 	chainlink/core/scripts --> chainlink/system-tests/lib
 	click chainlink/core/scripts href "https://github.com/smartcontractkit/chainlink"
+	chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based --> chainlink-common
+	click chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based href "https://github.com/smartcontractkit/chainlink"
+	chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based --> chainlink/v2
+	click chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based href "https://github.com/smartcontractkit/chainlink"
 	chainlink/deployment --> ccip-owner-contracts
 	chainlink/deployment --> chainlink-deployments-framework
 	chainlink/deployment --> chainlink-testing-framework/lib
@@ -282,6 +290,7 @@ flowchart LR
 	click chainlink/load-tests href "https://github.com/smartcontractkit/chainlink"
 	chainlink/system-tests/lib --> chainlink/deployment
 	click chainlink/system-tests/lib href "https://github.com/smartcontractkit/chainlink"
+	chainlink/system-tests/tests --> chainlink-testing-framework/framework/components/fake
 	chainlink/system-tests/tests --> chainlink-testing-framework/havoc
 	chainlink/system-tests/tests --> chainlink-testing-framework/wasp
 	chainlink/system-tests/tests --> chainlink/system-tests/lib
@@ -323,6 +332,8 @@ flowchart LR
 
 	subgraph chainlink-repo[chainlink]
 		 chainlink/core/scripts
+		 chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based
+		 chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based
 		 chainlink/deployment
 		 chainlink/integration-tests
 		 chainlink/load-tests
@@ -367,6 +378,7 @@ flowchart LR
 	subgraph chainlink-testing-framework-repo[chainlink-testing-framework]
 		 chainlink-testing-framework/framework
 		 chainlink-testing-framework/framework/components/dockercompose
+		 chainlink-testing-framework/framework/components/fake
 		 chainlink-testing-framework/havoc
 		 chainlink-testing-framework/lib
 		 chainlink-testing-framework/lib/grafana

--- a/system-tests/lib/cre/don/config/definitions.go
+++ b/system-tests/lib/cre/don/config/definitions.go
@@ -109,7 +109,7 @@ func WorkerEVM(donBootstrapNodePeerID, donBootstrapNodeHost string, peeringData 
 	[EVM.Workflow]
 	FromAddress = '%s'
 	ForwarderAddress = '%s'
-	GasLimitDefault = 400_000
+	GasLimitDefault = 800_000
 	TxAcceptanceState = 2
 	PollPeriod = '2s'
 	AcceptanceTimeout = '30s'

--- a/system-tests/lib/cre/environment/jobs.go
+++ b/system-tests/lib/cre/environment/jobs.go
@@ -21,7 +21,7 @@ import (
 
 func StartJD(lggr zerolog.Logger, nixShell *nix.Shell, jdInput jd.Input, infraType libtypes.InfraType) (*jd.Output, error) {
 	startTime := time.Now()
-	lggr.Info().Msg("Starting Jod Distributor")
+	lggr.Info().Msg("Starting Job Distributor")
 
 	var jdOutput *jd.Output
 	if infraType == libtypes.CRIB {
@@ -73,7 +73,6 @@ func SetupJobs(
 		if startJDErr != nil {
 			return pkgerrors.Wrap(startJDErr, "failed to start Job Distributor")
 		}
-
 		return nil
 	})
 
@@ -85,7 +84,6 @@ func SetupJobs(
 		if startDonsErr != nil {
 			return pkgerrors.Wrap(startDonsErr, "failed to start DONs")
 		}
-
 		return nil
 	})
 


### PR DESCRIPTION
This PR is amending the functionality of the log event trigger capability to:

- Support listening to multiple contracts
- Support listening for multiple events
- Send additional information in the log event payload:
  - Event name
  - Contract address 

This version of the capability is used in the cvn-courier-workflows (part of BCM) in this PR https://github.com/smartcontractkit/cvn-courier-service/pull/86

This change was made in as part of an investigation into reducing the number of workflow implementations and deployments as part of our DTA demo

As such, there's no design document or extensive planning for this change

BCM will need to build a new core image including this change and use that version in ST1 for the DTA demo
