### PR TITLE
bump CTF's Beholder component to one that can handle v2 workflow protos

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250808121824-2c3544aab8f3
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250819150450-95ef563f6e6d
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.12
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.13
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.4
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based v0.0.0-20250826151008-ae5ec0ee6f2c

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1574,8 +1574,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250820135304-632bebc0e80
 github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250820135304-632bebc0e802/go.mod h1:5eoqu3QUfu8qHaCY6uX5Zq1nCt98t0GCtzctrvSOWT0=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12 h1:vITyX8uIoUjMGwJXbgE8Cl01oO+5QpbOAVut69Wi9Sc=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12/go.mod h1:gdW2dlrvHcTawMCtAIXQYZcZ9Ggx16L55kA7wONvzJ4=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.12 h1:FcM2biJWSWHEdGi0JbNx/ozqncZG1g3lnUVY3bp4cYs=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.12/go.mod h1:iTwZXTKcWwXemiJsklHbQC6SwAbTV7Zo9TkDzivEGW0=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.13 h1:HFEo1zC9LH6YQ37tuPR0AKCQQTOw13f3iILNdO5Sk7A=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.13/go.mod h1:iTwZXTKcWwXemiJsklHbQC6SwAbTV7Zo9TkDzivEGW0=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.4 h1:gbQqdsF8mVRgh4h4KRi+8b00OT3Wp/6zrN0uXr0i/J0=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250819150450-95ef563f6e6d
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.12
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.13
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.4
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1550,8 +1550,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250820135304-632bebc0e80
 github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250820135304-632bebc0e802/go.mod h1:5eoqu3QUfu8qHaCY6uX5Zq1nCt98t0GCtzctrvSOWT0=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12 h1:vITyX8uIoUjMGwJXbgE8Cl01oO+5QpbOAVut69Wi9Sc=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12/go.mod h1:gdW2dlrvHcTawMCtAIXQYZcZ9Ggx16L55kA7wONvzJ4=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.12 h1:FcM2biJWSWHEdGi0JbNx/ozqncZG1g3lnUVY3bp4cYs=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.12/go.mod h1:iTwZXTKcWwXemiJsklHbQC6SwAbTV7Zo9TkDzivEGW0=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.13 h1:HFEo1zC9LH6YQ37tuPR0AKCQQTOw13f3iILNdO5Sk7A=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.13/go.mod h1:iTwZXTKcWwXemiJsklHbQC6SwAbTV7Zo9TkDzivEGW0=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.4 h1:gbQqdsF8mVRgh4h4KRi+8b00OT3Wp/6zrN0uXr0i/J0=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -527,7 +527,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
 	github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250820135304-632bebc0e802 // indirect
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.12 // indirect
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.13 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1755,8 +1755,8 @@ github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250820135304-632bebc0e80
 github.com/smartcontractkit/chainlink-solana v1.1.2-0.20250820135304-632bebc0e802/go.mod h1:5eoqu3QUfu8qHaCY6uX5Zq1nCt98t0GCtzctrvSOWT0=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12 h1:vITyX8uIoUjMGwJXbgE8Cl01oO+5QpbOAVut69Wi9Sc=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12/go.mod h1:gdW2dlrvHcTawMCtAIXQYZcZ9Ggx16L55kA7wONvzJ4=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.12 h1:FcM2biJWSWHEdGi0JbNx/ozqncZG1g3lnUVY3bp4cYs=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.12/go.mod h1:iTwZXTKcWwXemiJsklHbQC6SwAbTV7Zo9TkDzivEGW0=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.13 h1:HFEo1zC9LH6YQ37tuPR0AKCQQTOw13f3iILNdO5Sk7A=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.13/go.mod h1:iTwZXTKcWwXemiJsklHbQC6SwAbTV7Zo9TkDzivEGW0=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7 h1:ANltXlvv6CbOXieasPD9erc4BewtCHm1tKDPAYvuWLw=


### PR DESCRIPTION
Now Beholder can successfully use `v2` protobufs:
<img width="1438" height="725" alt="image" src="https://github.com/user-attachments/assets/241a3d70-6feb-4e01-9ecc-74af79371c84" />

Source: https://github.com/smartcontractkit/chainlink/actions/runs/17375720544/job/49321926826?pr=19164
