### PR TITLE
Add name to StandardCapabilities logger

### DIFF
--- a/core/services/standardcapabilities/delegate.go
+++ b/core/services/standardcapabilities/delegate.go
@@ -115,7 +115,7 @@ func (d *Delegate) BeforeJobCreated(job job.Job) {
 }
 
 func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.ServiceCtx, error) {
-	log := d.logger.Named("StandardCapabilities").Named(spec.StandardCapabilitiesSpec.GetID())
+	log := d.logger.Named("StandardCapabilities").Named(spec.StandardCapabilitiesSpec.GetID()).Named(spec.Name.ValueOrZero())
 
 	kvStore := job.NewKVStore(spec.ID, d.ds)
 


### PR DESCRIPTION
### Problem

The `/discovery` response does not expose an identifier for the capability. Multiple targets on the same host and port are indistinguishable, which makes dashboards and alerts hard to attribute.

### Change

Include capability name in `__metrics_path__` returned by `/discovery`, the metrics_path is populated from the logger name