### PR TITLE
[CRE-787] move node config modifications to write-evm and solana capabilities code

### DIFF
--- a/system-tests/lib/cre/capabilities/builder.go
+++ b/system-tests/lib/cre/capabilities/builder.go
@@ -9,7 +9,7 @@ import (
 type Capability struct {
 	flag                         cre.CapabilityFlag
 	jobSpecFn                    cre.JobSpecFn
-	nodeConfigFn                 cre.NodeConfigFn
+	nodeConfigFn                 cre.NodeConfigTransformerFn
 	gatewayJobHandlerConfigFn    cre.GatewayHandlerConfigFn
 	capabilityRegistryV1ConfigFn cre.CapabilityRegistryConfigFn
 	validateFn                   func(*Capability) error
@@ -23,7 +23,7 @@ func (c *Capability) JobSpecFn() cre.JobSpecFn {
 	return c.jobSpecFn
 }
 
-func (c *Capability) NodeConfigFn() cre.NodeConfigFn {
+func (c *Capability) NodeConfigTransformerFn() cre.NodeConfigTransformerFn {
 	return c.nodeConfigFn
 }
 
@@ -43,7 +43,7 @@ func WithJobSpecFn(jobSpecFn cre.JobSpecFn) Option {
 	}
 }
 
-func WithNodeConfigFn(nodeConfigFn cre.NodeConfigFn) Option {
+func WithNodeConfigTransformerFn(nodeConfigFn cre.NodeConfigTransformerFn) Option {
 	return func(c *Capability) {
 		c.nodeConfigFn = nodeConfigFn
 	}

--- a/system-tests/lib/cre/capabilities/gateway/gateway.go
+++ b/system-tests/lib/cre/capabilities/gateway/gateway.go
@@ -27,7 +27,7 @@ const flag = cre.GatewayDON
 func New(extraAllowedPorts []int, extraAllowedIPs []string, extraAllowedIPsCIDR []string) (*capabilities.Capability, error) {
 	return capabilities.New(
 		flag,
-		capabilities.WithNodeConfigFn(generateConfig),
+		capabilities.WithNodeConfigTransformerFn(generateConfig),
 		capabilities.WithJobSpecFn(jobSpec(extraAllowedPorts, extraAllowedIPs, extraAllowedIPsCIDR)),
 	)
 }
@@ -133,9 +133,7 @@ func jobSpec(extraAllowedPorts []int, extraAllowedIPs, extraAllowedIPsCIDR []str
 	}
 }
 
-func generateConfig(input cre.GenerateConfigsInput) (cre.NodeIndexToConfigOverride, error) {
-	configOverrides := make(cre.NodeIndexToConfigOverride)
-
+func generateConfig(input cre.GenerateConfigsInput, configOverrides cre.NodeIndexToConfigOverride) (cre.NodeIndexToConfigOverride, error) {
 	if input.GatewayConnectorOutput == nil || len(input.GatewayConnectorOutput.Configurations) == 0 {
 		return configOverrides, errors.New("gateway connector output or configurations are empty")
 	}

--- a/system-tests/lib/cre/capabilities/writeevm/write_evm.go
+++ b/system-tests/lib/cre/capabilities/writeevm/write_evm.go
@@ -1,16 +1,36 @@
 package writeevm
 
 import (
-	"errors"
+	"bytes"
+	"fmt"
+	"math/big"
+	"text/template"
+
+	"strconv"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/pelletier/go-toml/v2"
+	"github.com/pkg/errors"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
 	corevm "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
+
+	evmworkflow "github.com/smartcontractkit/chainlink-evm/pkg/config/toml"
+	chainlinkbig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
+	corechainlink "github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
+	libc "github.com/smartcontractkit/chainlink/system-tests/lib/conversions"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/capabilities"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/node"
+	envconfig "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/config"
 )
 
 const flag = cre.WriteEVMCapability
@@ -19,9 +39,7 @@ func New() (*capabilities.Capability, error) {
 	return capabilities.New(
 		flag,
 		capabilities.WithCapabilityRegistryV1ConfigFn(registerWithV1),
-		// Unfortunately, node config generation function is currently defined here system-tests/lib/cre/don/config/definitions.go
-		// Instead of being passed as functional option, because we need to add the [EVM.Workflow] section in a specific place
-		// of the config instead of concatenating it in any random place
+		capabilities.WithNodeConfigTransformerFn(transformNodeConfig),
 	)
 }
 
@@ -58,3 +76,184 @@ func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]k
 
 	return capabilities, nil
 }
+
+func transformNodeConfig(input cre.GenerateConfigsInput, existingConfigs cre.NodeIndexToConfigOverride) (cre.NodeIndexToConfigOverride, error) {
+	if input.NodeSet == nil {
+		return nil, errors.New("node set input is nil")
+	}
+
+	if input.NodeSet.ChainCapabilities == nil {
+		return existingConfigs, nil
+	}
+
+	workflowNodeSet, wErr := node.FindManyWithLabel(input.DonMetadata.NodesMetadata, &cre.Label{Key: node.NodeTypeKey, Value: cre.WorkerNode}, node.EqualLabels)
+	if wErr != nil {
+		return nil, errors.Wrap(wErr, "failed to find worker nodes")
+	}
+
+	for i := range workflowNodeSet {
+		var nodeIndex int
+		for _, label := range workflowNodeSet[i].Labels {
+			if label.Key == node.IndexKey {
+				var nErr error
+				nodeIndex, nErr = strconv.Atoi(label.Value)
+				if nErr != nil {
+					return nil, errors.Wrap(nErr, "failed to convert node index to int")
+				}
+			}
+		}
+
+		// // get all the forwarders and add workflow config (FromAddress + Forwarder) for chains that have write-evm enabled
+		data := []writeEVMData{}
+		for idx, chainID := range input.NodeSet.ChainCapabilities[flag].EnabledChains {
+			chain, exists := chain_selectors.ChainByEvmChainID(chainID)
+			if !exists {
+				return nil, errors.Errorf("failed to find selector for chain ID %d", chainID)
+			}
+
+			addrsForChains, addErr := input.AddressBook.AddressesForChain(chain.Selector)
+			if addErr != nil {
+				return nil, errors.Wrap(addErr, "failed to get addresses from address book")
+			}
+
+			for addr, addrValue := range addrsForChains {
+				if addrValue.Type == keystone_changeset.KeystoneForwarder {
+					input := writeEVMData{}
+					input.ForwarderAddress = addr
+					input.ChainID = chainID
+					input.ChainSelector = chain.Selector
+
+					expectedAddressKey := node.AddressKeyFromSelector(input.ChainSelector)
+					for _, label := range workflowNodeSet[i].Labels {
+						if label.Key == expectedAddressKey {
+							if label.Value == "" {
+								return nil, errors.Errorf("%s label value is empty", expectedAddressKey)
+							}
+							input.FromAddress = common.HexToAddress(label.Value)
+							break
+						}
+					}
+					if input.FromAddress == (common.Address{}) {
+						return nil, errors.Errorf("failed to get from address for chain %d", input.ChainSelector)
+					}
+
+					data = append(data, input)
+				}
+			}
+
+			if input.CapabilityConfigs == nil {
+				return nil, errors.New("additional capabilities configs are nil, but are required to configure the write-evm capability")
+			}
+
+			if writeEvmConfig, ok := input.CapabilityConfigs[cre.WriteEVMCapability]; ok {
+				enabled, mergedConfig, rErr := envconfig.ResolveCapabilityForChain(
+					cre.WriteEVMCapability,
+					input.NodeSet.ChainCapabilities,
+					writeEvmConfig.Config,
+					data[idx].ChainID,
+				)
+				if rErr != nil {
+					return nil, errors.Wrapf(rErr, "failed to resolve write-evm config for chain %d", data[idx].ChainID)
+				}
+
+				if !enabled {
+					// This should never happen, but guard anyway. We have already checked that the capability is enabled in the chain capabilities, when we generated the workerEVMInputs.
+					continue
+				}
+
+				runtimeValues := map[string]any{
+					"FromAddress":      data[idx].FromAddress.Hex(),
+					"ForwarderAddress": data[idx].ForwarderAddress,
+				}
+
+				var mErr error
+				data[idx].WorkflowConfig, mErr = don.ApplyRuntimeValues(mergedConfig, runtimeValues)
+				if mErr != nil {
+					return nil, errors.Wrap(mErr, "failed to apply runtime values")
+				}
+			}
+		}
+
+		if len(existingConfigs) < nodeIndex+1 {
+			return nil, errors.Errorf("missing config for node index %d", nodeIndex)
+		}
+
+		currentConfig := existingConfigs[nodeIndex]
+
+		var typedConfig corechainlink.Config
+		unmarshallErr := toml.Unmarshal([]byte(currentConfig), &typedConfig)
+		if unmarshallErr != nil {
+			return nil, errors.Wrapf(unmarshallErr, "failed to unmarshal config for node index %d", nodeIndex)
+		}
+
+		if len(typedConfig.EVM) < len(data) {
+			return nil, fmt.Errorf("not enough EVM chains configured in node index %d to add write-evm config. Expected at least %d chains, but found %d", nodeIndex, len(data), len(typedConfig.EVM))
+		}
+
+		for _, writeEVMInput := range data {
+			found := false
+		INNER:
+			for idx, evmChain := range typedConfig.EVM {
+				if evmChain.ChainID.Cmp(chainlinkbig.New(big.NewInt(libc.MustSafeInt64(writeEVMInput.ChainID)))) == 0 {
+					var evmWorkflow evmworkflow.Workflow
+
+					// Execute template with chain's workflow configuration
+					tmpl, tErr := template.New("evmWorkflowConfig").Parse(evmWorkflowConfigTemplate)
+					if tErr != nil {
+						return nil, errors.Wrap(tErr, "failed to parse evm workflow config template")
+					}
+					var configBuffer bytes.Buffer
+					if executeErr := tmpl.Execute(&configBuffer, writeEVMInput.WorkflowConfig); executeErr != nil {
+						return nil, errors.Wrap(executeErr, "failed to execute evm workflow config template")
+					}
+
+					configStr := configBuffer.String()
+					if err := don.ValidateTemplateSubstitution(configStr, flag); err != nil {
+						return nil, errors.Wrapf(err, "%s template validation failed", flag)
+					}
+
+					unmarshallErr := toml.Unmarshal([]byte(configStr), &evmWorkflow)
+					if unmarshallErr != nil {
+						return nil, errors.Wrapf(unmarshallErr, "failed to unmarshal EVM.Workflow config for chain %d", writeEVMInput.ChainID)
+					}
+
+					typedConfig.EVM[idx].Workflow = evmWorkflow
+					typedConfig.EVM[idx].Transactions.ForwardersEnabled = ptr.Ptr(true)
+
+					found = true
+					break INNER
+				}
+			}
+
+			if !found {
+				return nil, fmt.Errorf("failed to find EVM chain with ID %d in the config of node index %d to add write-evm config", writeEVMInput.ChainID, nodeIndex)
+			}
+		}
+
+		marshalledConfig, mErr := toml.Marshal(typedConfig)
+		if mErr != nil {
+			return nil, errors.Wrapf(mErr, "failed to marshal config for node index %d", nodeIndex)
+		}
+
+		existingConfigs[nodeIndex] = string(marshalledConfig)
+	}
+
+	return existingConfigs, nil
+}
+
+type writeEVMData struct {
+	ChainID          uint64
+	ChainSelector    uint64
+	FromAddress      common.Address
+	ForwarderAddress string
+	WorkflowConfig   map[string]any // Configuration for EVM.Workflow section
+}
+
+const evmWorkflowConfigTemplate = `
+	FromAddress = '{{.FromAddress}}'
+	ForwarderAddress = '{{.ForwarderAddress}}'
+	GasLimitDefault = {{.GasLimitDefault}}
+	TxAcceptanceState = {{.TxAcceptanceState}}
+	PollPeriod = '{{.PollPeriod}}'
+	AcceptanceTimeout = '{{.AcceptanceTimeout}}'
+`

--- a/system-tests/lib/cre/capabilities/writeevm/write_evm.go
+++ b/system-tests/lib/cre/capabilities/writeevm/write_evm.go
@@ -82,7 +82,7 @@ func transformNodeConfig(input cre.GenerateConfigsInput, existingConfigs cre.Nod
 		return nil, errors.New("node set input is nil")
 	}
 
-	if input.NodeSet.ChainCapabilities == nil {
+	if input.NodeSet.ChainCapabilities == nil || input.NodeSet.ChainCapabilities[flag] == nil {
 		return existingConfigs, nil
 	}
 

--- a/system-tests/lib/cre/capabilities/writesolana/write_solana.go
+++ b/system-tests/lib/cre/capabilities/writesolana/write_solana.go
@@ -1,15 +1,28 @@
 package writesolana
 
 import (
-	"errors"
+	"bytes"
 	"slices"
+	"strconv"
 	"strings"
+	"text/template"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gagliardetto/solana-go"
+	"github.com/pkg/errors"
 
 	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
+	ks_sol "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/solana"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/capabilities"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/node"
+	envconfig "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/config"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/flags"
+	corechainlink "github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 )
 
 const flag = cre.WriteSolanaCapability
@@ -18,6 +31,7 @@ func New() (*capabilities.Capability, error) {
 	return capabilities.New(
 		flag,
 		capabilities.WithCapabilityRegistryV1ConfigFn(registerWithV1),
+		capabilities.WithNodeConfigTransformerFn(transformNodeConfig),
 	)
 }
 
@@ -47,3 +61,186 @@ func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]k
 
 	return capabilities, nil
 }
+
+func transformNodeConfig(input cre.GenerateConfigsInput, existingConfigs cre.NodeIndexToConfigOverride) (cre.NodeIndexToConfigOverride, error) {
+	if !flags.HasFlagForAnyChain(input.NodeSet.ComputedCapabilities, flag) {
+		return existingConfigs, nil
+	}
+
+	data := solanaInput{}
+	for _, bcOut := range input.BlockchainOutput {
+		if bcOut.SolChain == nil {
+			continue
+		}
+		data.ChainSelector = bcOut.SolChain.ChainSelector
+		// find Solana forwarder address
+		forwarders := input.Datastore.Addresses().Filter(datastore.AddressRefByChainSelector(data.ChainSelector))
+		for _, addr := range forwarders {
+			if addr.Type == ks_sol.ForwarderState {
+				data.ForwarderState = addr.Address
+				continue
+			}
+			data.ForwarderAddress = addr.Address
+		}
+
+		break
+	}
+
+	workflowNodeSet, err := node.FindManyWithLabel(input.DonMetadata.NodesMetadata, &cre.Label{Key: node.NodeTypeKey, Value: cre.WorkerNode}, node.EqualLabels)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to find worker nodes")
+	}
+
+	for i := range workflowNodeSet {
+		var nodeIndex int
+		for _, label := range workflowNodeSet[i].Labels {
+			if label.Key == node.IndexKey {
+				nodeIndex, err = strconv.Atoi(label.Value)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to convert node index to int")
+				}
+			}
+		}
+
+		// find node's Solana address
+		expectedAddressKey := node.AddressKeyFromSelector(data.ChainSelector)
+		for _, label := range workflowNodeSet[i].Labels {
+			if label.Key == expectedAddressKey {
+				if label.Value == "" {
+					return nil, errors.Errorf("%s label value is empty", expectedAddressKey)
+				}
+				data.FromAddress = solana.MustPublicKeyFromBase58(label.Value)
+				break
+			}
+		}
+
+		if data.FromAddress.IsZero() {
+			return nil, errors.Errorf("failed to get from address for Solana chain %d", data.ChainSelector)
+		}
+
+		if input.CapabilityConfigs == nil {
+			return nil, errors.New("additional capabilities configs are nil, but are required to configure the write-solana capability")
+		}
+
+		if writeSolConfig, ok := input.CapabilityConfigs[cre.WriteSolanaCapability]; ok {
+			mergedConfig := envconfig.ResolveCapabilityConfigForDON(
+				cre.WriteSolanaCapability,
+				writeSolConfig.Config,
+				nil,
+			)
+
+			runtimeValues := map[string]any{
+				"FromAddress":      data.FromAddress.String(),
+				"ForwarderAddress": data.ForwarderAddress,
+				"ForwarderState":   data.ForwarderState,
+			}
+
+			var mErr error
+			data.WorkflowConfig, mErr = don.ApplyRuntimeValues(mergedConfig, runtimeValues)
+			if mErr != nil {
+				return nil, errors.Wrap(mErr, "failed to apply runtime values")
+			}
+		}
+
+		if len(existingConfigs) < nodeIndex+1 {
+			return nil, errors.Errorf("missing config for node index %d", nodeIndex)
+		}
+
+		currentConfig := existingConfigs[nodeIndex]
+
+		var typedConfig corechainlink.Config
+		unmarshallErr := toml.Unmarshal([]byte(currentConfig), &typedConfig)
+		if unmarshallErr != nil {
+			return nil, errors.Wrapf(unmarshallErr, "failed to unmarshal config for node index %d", nodeIndex)
+		}
+
+		if len(typedConfig.Solana) != 1 {
+			return nil, errors.Wrapf(err, "only 1 Solana chain is supported, but found %d for node at index %d", len(typedConfig.Solana), nodeIndex)
+		}
+
+		if typedConfig.Solana[0].ChainID == nil {
+			return nil, errors.Wrapf(err, "Solana chainID is nil for node at index %d", nodeIndex)
+		}
+
+		// TODO @Unheilbar: use typed config once https://github.com/smartcontractkit/chainlink/pull/19091 is merged
+		// use it the same way as write_evm.go does, i.e. unmarshall config to struct and use it to set [Solana.Workflow]
+		// and any other settings that might be required
+		// once we have final config, marshall it back to string and replace existing config: existingConfigs[nodeIndex] = string(marshalledConfig)
+		// ---------
+		// var solCfg solcfg.Config
+
+		// // Execute template with chain's workflow configuration
+		// tmpl, err := template.New("solanaWorkflowConfig").Parse(solWorkflowConfigTemplate)
+		// if err != nil {
+		// 	return nil, errors.Wrap(err, "failed to parse Solana workflow config template")
+		// }
+		// var configBuffer bytes.Buffer
+		// if executeErr := tmpl.Execute(&configBuffer, data.WorkflowConfig); executeErr != nil {
+		// 	return nil, errors.Wrap(executeErr, "failed to execute Solana workflow config template")
+		// }
+
+		// configStr := configBuffer.String()
+
+		// if err := don.ValidateTemplateSubstitution(configStr, flag); err != nil {
+		// 	return nil, errors.Wrapf(err, "%s template validation failed", flag)
+		// }
+
+		// unmarshallErr = toml.Unmarshal([]byte(configStr), &solCfg)
+		// if unmarshallErr != nil {
+		// 	return nil, errors.Wrap(unmarshallErr, "failed to unmarshal Solana.Workflow config")
+		// }
+
+		// typedConfig.Solana[0].Workflow = solCfg
+
+		marshalledConfig, mErr := toml.Marshal(typedConfig)
+		if mErr != nil {
+			return nil, errors.Wrapf(mErr, "failed to marshal config for node index %d", nodeIndex)
+		}
+
+		// TODO remove once typed config is used
+		tmpl, err := template.New("solanaWorkflowConfig").Parse(solWorkflowConfigTemplate)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse Solana workflow config template")
+		}
+		var configBuffer bytes.Buffer
+		if executeErr := tmpl.Execute(&configBuffer, data.WorkflowConfig); executeErr != nil {
+			return nil, errors.Wrap(executeErr, "failed to execute Solana workflow config template")
+		}
+
+		configStr := configBuffer.String()
+		if err := don.ValidateTemplateSubstitution(configStr, flag); err != nil {
+			return nil, errors.Wrapf(err, "%s template validation failed", flag)
+		}
+
+		marshalledConfig = append(marshalledConfig, []byte(configStr)...)
+
+		// leave this part after removing ^^
+		existingConfigs[nodeIndex] = string(marshalledConfig)
+	}
+
+	return existingConfigs, nil
+}
+
+type solanaInput struct {
+	ChainSelector    uint64
+	FromAddress      solana.PublicKey
+	ForwarderAddress string
+	ForwarderState   string
+	HasWrite         bool
+	WorkflowConfig   map[string]any // Configuration for Solana.Workflow section
+}
+
+const solWorkflowConfigTemplate = `
+		Enabled = true
+		TxRetentionTimeout = '{{.TxRetentionTimeout}}'
+
+		[Solana.Workflow]
+		Enabled = true
+		ForwarderAddress = '{{.ForwarderAddress}}'
+		FromAddress      = '{{.FromAddress}}'
+		ForwarderState   = '{{.ForwarderState}}'
+		PollPeriod = '{{.PollPeriod}}'
+		AcceptanceTimeout = '{{.AcceptanceTimeout}}'
+		TxAcceptanceState = {{.TxAcceptanceState}}
+		Local = {{.Local}}
+	`

--- a/system-tests/lib/cre/don/config/config.go
+++ b/system-tests/lib/cre/don/config/config.go
@@ -3,28 +3,23 @@ package config
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/gagliardetto/solana-go"
 	"github.com/pkg/errors"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	ns "github.com/smartcontractkit/chainlink-testing-framework/framework/components/simple_node_set"
 	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
-	ks_sol "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/solana"
 
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	crecontracts "github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
-	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/node"
-	envconfig "github.com/smartcontractkit/chainlink/system-tests/lib/cre/environment/config"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/flags"
 )
 
@@ -37,7 +32,7 @@ func Set(t *testing.T, nodeInput *cre.CapabilitiesAwareNodeSet, bc *blockchain.O
 	return &cre.WrappedNodeOutput{Output: nodeset, NodeSetName: nodeInput.Name, Capabilities: nodeInput.ComputedCapabilities}, nil
 }
 
-func Generate(input cre.GenerateConfigsInput, nodeConfigFns []cre.NodeConfigFn) (cre.NodeIndexToConfigOverride, error) {
+func Generate(input cre.GenerateConfigsInput, nodeConfigFns []cre.NodeConfigTransformerFn) (cre.NodeIndexToConfigOverride, error) {
 	if err := input.Validate(); err != nil {
 		return nil, errors.Wrap(err, "input validation failed")
 	}
@@ -53,56 +48,11 @@ func Generate(input cre.GenerateConfigsInput, nodeConfigFns []cre.NodeConfigFn) 
 		return nil, errors.Wrap(homeErr, "failed to get home chain ID")
 	}
 
-	// prepare chains, we need chainIDs, URLs and selectors to get contracts from AddressBook
-	workerEVMInputs := make([]*WorkerEVMInput, 0)
-	workerSolInputs := make([]*WorkerSolanaInput, 0)
-	for chainSelector, bcOut := range input.BlockchainOutput {
-		if bcOut.SolChain != nil {
-			chainID, err := bcOut.SolClient.GetGenesisHash(context.Background())
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to get chainID for Solana")
-			}
-
-			// Determine write-solana enablement per chain via node-set ChainCapabilities
-			hasWrite := false
-			hasWrite = slices.Contains(input.NodeSet.Capabilities, cre.WriteSolanaCapability)
-
-			workerSolInputs = append(workerSolInputs, &WorkerSolanaInput{
-				ChainSelector: bcOut.SolChain.ChainSelector,
-				Name:          fmt.Sprintf("node-%d", bcOut.SolChain.ChainSelector),
-				ChainID:       chainID.String(),
-				NodeURL:       bcOut.BlockchainOutput.Nodes[0].InternalHTTPUrl,
-				HasWrite:      hasWrite,
-			})
-
-			continue
-		}
-		// if the DON doesn't support the chain, we skip it; if slice is empty, it means that the DON supports all chains
-		if len(input.DonMetadata.SupportedChains) > 0 && !slices.Contains(input.DonMetadata.SupportedChains, bcOut.ChainID) {
-			continue
-		}
-
-		c, exists := chain_selectors.ChainByEvmChainID(bcOut.ChainID)
-		if !exists {
-			return configOverrides, errors.Errorf("failed to find selector for chain ID %d", bcOut.ChainID)
-		}
-		// Determine write-evm enablement per chain via node-set ChainCapabilities
-		hasWriteEVM := false
-		if input.NodeSet != nil && input.NodeSet.ChainCapabilities != nil {
-			if cc, ok := input.NodeSet.ChainCapabilities[cre.WriteEVMCapability]; ok && cc != nil {
-				if slices.Contains(cc.EnabledChains, bcOut.ChainID) {
-					hasWriteEVM = true
-				}
-			}
-		}
-		workerEVMInputs = append(workerEVMInputs, &WorkerEVMInput{
-			Name:          fmt.Sprintf("node-%d", chainSelector),
-			ChainID:       bcOut.ChainID,
-			ChainSelector: c.Selector,
-			HTTPRPC:       bcOut.BlockchainOutput.Nodes[0].InternalHTTPUrl,
-			WSRPC:         bcOut.BlockchainOutput.Nodes[0].InternalWSUrl,
-			WritesToEVM:   hasWriteEVM,
-		})
+	// prepare chains, we need chainIDs and URLs
+	evmChains := findEVMChains(input)
+	solanaChain, solErr := findOneSolanaChain(input)
+	if solErr != nil {
+		return nil, errors.Wrap(solErr, "failed to find Solana chain in the environment configuration")
 	}
 
 	// find contract addresses
@@ -156,12 +106,9 @@ func Generate(input cre.GenerateConfigsInput, nodeConfigFns []cre.NodeConfigFn) 
 		}
 
 		// generate configuration for the bootstrap node
-		configOverrides[nodeIndex] = BootstrapEVM(donBootstrapNodePeerID, homeChainID, capabilitiesRegistryAddress, workerEVMInputs)
+		configOverrides[nodeIndex] = BootstrapEVM(donBootstrapNodePeerID, homeChainID, capabilitiesRegistryAddress, evmChains)
 		if flags.HasFlag(input.Flags, cre.WorkflowDON) {
 			configOverrides[nodeIndex] += BoostrapDon2DonPeering(input.CapabilitiesPeeringData)
-		}
-		if len(workerSolInputs) > 0 {
-			configOverrides[nodeIndex] += BootstrapSolana(workerSolInputs)
 		}
 	default:
 		return nil, errors.New("multiple bootstrap nodes within a DON found, expected only one")
@@ -184,146 +131,83 @@ func Generate(input cre.GenerateConfigsInput, nodeConfigFns []cre.NodeConfigFn) 
 			}
 		}
 
-		// get all the forwarders and add workflow config (FromAddress + Forwarder) for chains that have write-evm enabled
-		for _, wi := range workerEVMInputs {
-			if !wi.WritesToEVM {
-				continue
-			}
-
-			addrsForChains, err := input.AddressBook.AddressesForChain(wi.ChainSelector)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to get addresses from address book")
-			}
-			for addr, addrValue := range addrsForChains {
-				if addrValue.Type == keystone_changeset.KeystoneForwarder {
-					wi.ForwarderAddress = addr
-					expectedAddressKey := node.AddressKeyFromSelector(wi.ChainSelector)
-					for _, label := range workflowNodeSet[i].Labels {
-						if label.Key == expectedAddressKey {
-							if label.Value == "" {
-								return nil, errors.Errorf("%s label value is empty", expectedAddressKey)
-							}
-							wi.FromAddress = common.HexToAddress(label.Value)
-							break
-						}
-					}
-					if wi.FromAddress == (common.Address{}) {
-						return nil, errors.Errorf("failed to get from address for chain %d", wi.ChainSelector)
-					}
-				}
-			}
-
-			if input.CapabilityConfigs == nil {
-				return nil, errors.New("additional capabilities configs are nil, but are required to configure the write-evm capability")
-			}
-
-			if writeEvmConfig, ok := input.CapabilityConfigs[cre.WriteEVMCapability]; ok {
-				enabled, mergedConfig, rErr := envconfig.ResolveCapabilityForChain(
-					cre.WriteEVMCapability,
-					input.NodeSet.ChainCapabilities,
-					writeEvmConfig.Config,
-					wi.ChainID,
-				)
-				if rErr != nil {
-					return nil, errors.Wrapf(rErr, "failed to resolve write-evm config for chain %d", wi.ChainID)
-				}
-
-				if !enabled {
-					// This should never happen, but guard anyway. We have already checked that the capability is enabled in the chain capabilities, when we generated the workerEVMInputs.
-					continue
-				}
-
-				runtimeValues := map[string]any{
-					"FromAddress":      wi.FromAddress.Hex(),
-					"ForwarderAddress": wi.ForwarderAddress,
-				}
-
-				var mErr error
-				wi.WorkflowConfig, mErr = don.ApplyRuntimeValues(mergedConfig, runtimeValues)
-				if mErr != nil {
-					return nil, errors.Wrap(mErr, "failed to apply runtime values")
-				}
-			}
-		}
-
-		// get all sol forwarders
-		for _, wi := range workerSolInputs {
-			if !wi.HasWrite {
-				continue
-			}
-			forwarders := input.Datastore.Addresses().Filter(datastore.AddressRefByChainSelector(wi.ChainSelector))
-			for _, addr := range forwarders {
-				if addr.Type == ks_sol.ForwarderState {
-					wi.ForwarderState = addr.Address
-					continue
-				}
-				expectedAddressKey := node.AddressKeyFromSelector(wi.ChainSelector)
-				wi.ForwarderAddress = addr.Address
-				for _, label := range workflowNodeSet[i].Labels {
-					if label.Key == expectedAddressKey {
-						if label.Value == "" {
-							return nil, errors.Errorf("%s label value is empty", expectedAddressKey)
-						}
-						wi.FromAddress = solana.MustPublicKeyFromBase58(label.Value)
-						break
-					}
-				}
-				if wi.FromAddress.IsZero() {
-					return nil, errors.Errorf("failed to get from address for Solana chain %d", wi.ChainSelector)
-				}
-			}
-			if input.CapabilityConfigs == nil {
-				return nil, errors.New("additional capabilities configs are nil, but are required to configure the write-evm capability")
-			}
-
-			if writeSolConfig, ok := input.CapabilityConfigs[cre.WriteSolanaCapability]; ok {
-				mergedConfig := envconfig.ResolveCapabilityConfigForDON(
-					cre.WriteSolanaCapability,
-					writeSolConfig.Config,
-					nil,
-				)
-
-				runtimeValues := map[string]any{
-					"FromAddress":      wi.FromAddress.String(),
-					"ForwarderAddress": wi.ForwarderAddress,
-					"ForwarderState":   wi.ForwarderState,
-				}
-
-				var mErr error
-				wi.WorkflowConfig, mErr = don.ApplyRuntimeValues(mergedConfig, runtimeValues)
-				if mErr != nil {
-					return nil, errors.Wrap(mErr, "failed to apply runtime values")
-				}
-			}
-		}
-
 		// connect worker nodes to all the chains, add chain ID for registry (home chain)
-		// we configure both EVM chains, nodes and EVM.Workflow with Forwarder
 		var workerErr error
-		configOverrides[nodeIndex], workerErr = WorkerEVM(donBootstrapNodePeerID, donBootstrapNodeHost, input.OCRPeeringData, input.CapabilitiesPeeringData, capabilitiesRegistryAddress, homeChainID, workerEVMInputs)
+		configOverrides[nodeIndex], workerErr = WorkerEVM(donBootstrapNodePeerID, donBootstrapNodeHost, input.OCRPeeringData, input.CapabilitiesPeeringData, capabilitiesRegistryAddress, homeChainID, evmChains)
 		if workerErr != nil {
 			return nil, errors.Wrap(workerErr, "failed to generate worker [EVM.Workflow] config")
 		}
-		solOverride, solWorkerErr := WorkerSolana(workerSolInputs)
-		if solWorkerErr != nil {
-			return nil, errors.Wrap(workerErr, "failed to generate worker [Solana.Workflow] config")
-		}
-
-		configOverrides[nodeIndex] += solOverride
+		configOverrides[nodeIndex] += WorkerSolana(solanaChain)
 	}
 
+	// execute capability-provided functions that transform the node config (currently: write-evm, write-solana)
 	for _, configFn := range nodeConfigFns {
 		if configFn == nil {
 			continue
 		}
-		newOverrides, err := configFn(input)
+
+		newOverrides, err := configFn(input, configOverrides)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to generate nodeset configs")
 		}
-		for nodeIndex, override := range newOverrides {
-			configOverrides[nodeIndex] += override
-		}
+
+		maps.Copy(configOverrides, newOverrides)
 	}
 
 	return configOverrides, nil
+}
+
+func findEVMChains(input cre.GenerateConfigsInput) []*EVMChain {
+	evmChains := make([]*EVMChain, 0)
+	for chainSelector, bcOut := range input.BlockchainOutput {
+		if bcOut.SolChain != nil {
+			continue
+		}
+
+		// if the DON doesn't support the chain, we skip it; if slice is empty, it means that the DON supports all chains
+		// TODO: review if we really need this SupportedChains functionality
+		if len(input.DonMetadata.SupportedChains) > 0 && !slices.Contains(input.DonMetadata.SupportedChains, bcOut.ChainID) {
+			continue
+		}
+
+		evmChains = append(evmChains, &EVMChain{
+			Name:    fmt.Sprintf("node-%d", chainSelector),
+			ChainID: bcOut.ChainID,
+			HTTPRPC: bcOut.BlockchainOutput.Nodes[0].InternalHTTPUrl,
+			WSRPC:   bcOut.BlockchainOutput.Nodes[0].InternalWSUrl,
+		})
+	}
+	return evmChains
+}
+
+func findOneSolanaChain(input cre.GenerateConfigsInput) (*SolanaChain, error) {
+	var solanaChain *SolanaChain
+	chainsFound := 0
+
+	for _, bcOut := range input.BlockchainOutput {
+		if bcOut.SolChain == nil {
+			continue
+		}
+
+		chainsFound++
+		if chainsFound > 1 {
+			return nil, errors.New("multiple Solana chains found, expected only one")
+		}
+
+		ctx, cancelFn := context.WithTimeout(context.Background(), 15*time.Second)
+		chainID, err := bcOut.SolClient.GetGenesisHash(ctx)
+		if err != nil {
+			cancelFn()
+			return nil, errors.Wrap(err, "failed to get chainID for Solana")
+		}
+		cancelFn()
+
+		solanaChain = &SolanaChain{
+			Name:    fmt.Sprintf("node-%d", bcOut.SolChain.ChainSelector),
+			ChainID: chainID.String(),
+			NodeURL: bcOut.BlockchainOutput.Nodes[0].InternalHTTPUrl,
+		}
+	}
+
+	return solanaChain, nil
 }

--- a/system-tests/lib/cre/don/config/config.go
+++ b/system-tests/lib/cre/don/config/config.go
@@ -141,6 +141,8 @@ func Generate(input cre.GenerateConfigsInput, nodeConfigFns []cre.NodeConfigTran
 	}
 
 	// execute capability-provided functions that transform the node config (currently: write-evm, write-solana)
+	// these functions must return whole node configs after transforming them, instead of just returning configuration parts
+	// that need to be merged into the existing config
 	for _, configFn := range nodeConfigFns {
 		if configFn == nil {
 			continue

--- a/system-tests/lib/cre/don/config/definitions.go
+++ b/system-tests/lib/cre/don/config/definitions.go
@@ -1,50 +1,14 @@
 package config
 
 import (
-	"bytes"
 	"fmt"
-	"text/template"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/gagliardetto/solana-go"
-	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
-	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don"
 )
 
-const (
-	// Template for EVM workflow configuration
-	evmWorkflowConfigTemplate = `
-		[EVM.Workflow]
-		FromAddress = '{{.FromAddress}}'
-		ForwarderAddress = '{{.ForwarderAddress}}'
-		GasLimitDefault = {{.GasLimitDefault}}
-		TxAcceptanceState = {{.TxAcceptanceState}}
-		PollPeriod = '{{.PollPeriod}}'
-		AcceptanceTimeout = '{{.AcceptanceTimeout}}'
-
-		[EVM.Transactions]
-		ForwardersEnabled = true
-`
-
-	solWorkflowConfigTemplate = `
-		Enabled = true
-		TxRetentionTimeout = '{{.TxRetentionTimeout}}'
-
-		[Solana.Workflow]
-		Enabled = true
-		ForwarderAddress = '{{.ForwarderAddress}}'
-		FromAddress      = '{{.FromAddress}}'
-		ForwarderState   = '{{.ForwarderState}}'
-		PollPeriod = '{{.PollPeriod}}'
-		AcceptanceTimeout = '{{.AcceptanceTimeout}}'
-		TxAcceptanceState = {{.TxAcceptanceState}}
-		Local = {{.Local}}
-	`
-)
-
-func BootstrapEVM(donBootstrapNodePeerID string, homeChainID uint64, capabilitiesRegistryAddress common.Address, chains []*WorkerEVMInput) string {
+func BootstrapEVM(donBootstrapNodePeerID string, homeChainID uint64, capabilitiesRegistryAddress common.Address, chains []*EVMChain) string {
 	evmChainsConfig := ""
 	for _, chain := range chains {
 		evmChainsConfig += fmt.Sprintf(`
@@ -107,19 +71,14 @@ func BoostrapDon2DonPeering(peeringData cre.CapabilitiesPeeringData) string {
 	)
 }
 
-type WorkerEVMInput struct {
-	Name             string
-	ChainID          uint64
-	ChainSelector    uint64
-	HTTPRPC          string
-	WSRPC            string
-	FromAddress      common.Address
-	ForwarderAddress string
-	WritesToEVM      bool
-	WorkflowConfig   map[string]any // Configuration for EVM.Workflow section
+type EVMChain struct {
+	Name    string
+	ChainID uint64
+	HTTPRPC string
+	WSRPC   string
 }
 
-func WorkerEVM(donBootstrapNodePeerID, donBootstrapNodeHost string, ocrPeeringData cre.OCRPeeringData, capabilitiesPeeringData cre.CapabilitiesPeeringData, capabilitiesRegistryAddress common.Address, homeChainID uint64, chains []*WorkerEVMInput) (string, error) {
+func WorkerEVM(donBootstrapNodePeerID, donBootstrapNodeHost string, ocrPeeringData cre.OCRPeeringData, capabilitiesPeeringData cre.CapabilitiesPeeringData, capabilitiesRegistryAddress common.Address, homeChainID uint64, chains []*EVMChain) (string, error) {
 	evmChainsConfig := ""
 	for _, chain := range chains {
 		evmChainsConfig += fmt.Sprintf(`
@@ -140,29 +99,6 @@ func WorkerEVM(donBootstrapNodePeerID, donBootstrapNodeHost string, ocrPeeringDa
 			chain.WSRPC,
 			chain.HTTPRPC,
 		)
-
-		// won't move this to a separate factory function, because this bit needs to be added in the very specific part of the node config
-		// it can't be just concatenated to the config in any random place
-		if chain.WritesToEVM {
-			// Execute template with chain's workflow configuration
-			tmpl, err := template.New("evmWorkflowConfig").Parse(evmWorkflowConfigTemplate)
-			if err != nil {
-				return "", errors.Wrap(err, "failed to parse evm workflow config template")
-			}
-			var configBuffer bytes.Buffer
-			if executeErr := tmpl.Execute(&configBuffer, chain.WorkflowConfig); executeErr != nil {
-				return "", errors.Wrap(executeErr, "failed to execute evm workflow config template")
-			}
-
-			flag := cre.WriteEVMCapability
-			configStr := configBuffer.String()
-
-			if err := don.ValidateTemplateSubstitution(configStr, flag); err != nil {
-				return "", errors.Wrapf(err, "%s template validation failed", flag)
-			}
-
-			evmChainsConfig += configStr
-		}
 	}
 
 	return fmt.Sprintf(`
@@ -206,22 +142,18 @@ func WorkerEVM(donBootstrapNodePeerID, donBootstrapNodeHost string, ocrPeeringDa
 	), nil
 }
 
-type WorkerSolanaInput struct {
-	Name             string
-	ChainID          string
-	ChainSelector    uint64
-	NodeURL          string
-	FromAddress      solana.PublicKey
-	ForwarderAddress string
-	ForwarderState   string
-	HasWrite         bool
-	WorkflowConfig   map[string]any // Configuration for Solana.Workflow section
+type SolanaChain struct {
+	Name    string
+	ChainID string
+	NodeURL string
 }
 
-func BootstrapSolana(chains []*WorkerSolanaInput) string {
-	var ret string
-	for _, chain := range chains {
-		ret += fmt.Sprintf(`
+func WorkerSolana(chain *SolanaChain) string {
+	if chain == nil {
+		return ""
+	}
+
+	return fmt.Sprintf(`
 		[[Solana]]
 		ChainID = '%s'
 		Enabled = true
@@ -230,50 +162,6 @@ func BootstrapSolana(chains []*WorkerSolanaInput) string {
 		Name = '%s'
 		URL = '%s'
 		`, chain.ChainID, chain.Name, chain.NodeURL)
-	}
-
-	return ret
-}
-
-func WorkerSolana(chains []*WorkerSolanaInput) (string, error) {
-	var ret string
-	for _, chain := range chains {
-		ret += fmt.Sprintf(`
-		[[Solana]]
-		ChainID = '%s'
-		`, chain.ChainID)
-
-		// won't move this to a separate factory function, because this bit needs to be added in the very specific part of the node config
-		// it can't be just concatenated to the config in any random place
-		if chain.HasWrite {
-			// Execute template with chain's workflow configuration
-			tmpl, err := template.New("solanaWorkflowConfig").Parse(solWorkflowConfigTemplate)
-			if err != nil {
-				return "", errors.Wrap(err, "failed to parse solana workflow config template")
-			}
-			var configBuffer bytes.Buffer
-			if executeErr := tmpl.Execute(&configBuffer, chain.WorkflowConfig); executeErr != nil {
-				return "", errors.Wrap(executeErr, "failed to execute solana workflow config template")
-			}
-
-			flag := cre.WriteSolanaCapability
-			configStr := configBuffer.String()
-
-			if err := don.ValidateTemplateSubstitution(configStr, flag); err != nil {
-				return "", errors.Wrapf(err, "%s template validation failed", flag)
-			}
-
-			ret += configStr
-		}
-
-		ret += fmt.Sprintf(`
-		[[Solana.Nodes]]
-		Name = '%s'
-		URL = '%s'
-		`, chain.Name, chain.NodeURL)
-	}
-
-	return ret, nil
 }
 
 func WorkerWorkflowRegistry(workflowRegistryAddr common.Address, homeChainID uint64) string {

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -92,7 +92,7 @@ type SetupInput struct {
 	Capabilities              []cre.InstallableCapability
 
 	// Deprecated: use Capabilities []cre.InstallableCapability instead
-	ConfigFactoryFunctions []cre.NodeConfigFn
+	ConfigFactoryFunctions []cre.NodeConfigTransformerFn
 	// Deprecated: use Capabilities []cre.InstallableCapability instead
 	JobSpecFactoryFunctions []cre.JobSpecFn
 	// Deprecated: use Capabilities []cre.InstallableCapability instead

--- a/system-tests/lib/cre/environment/topology.go
+++ b/system-tests/lib/cre/environment/topology.go
@@ -107,9 +107,9 @@ func BuildTopology(
 			return nil, nil, fmt.Errorf("nodese config overrides are provided for DON %d, but not secrets. You need to either provide both, only secrets or nothing at all", donMetadata.ID)
 		}
 
-		configFactoryFunctions := make([]cre.NodeConfigFn, 0)
+		configFactoryFunctions := make([]cre.NodeConfigTransformerFn, 0)
 		for _, capability := range capabilities {
-			configFactoryFunctions = append(configFactoryFunctions, capability.NodeConfigFn())
+			configFactoryFunctions = append(configFactoryFunctions, capability.NodeConfigTransformerFn())
 		}
 
 		// generate configs only if they are not provided

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -420,7 +420,7 @@ type Incoming struct {
 	ExternalPort int    `toml:"external_port" json:"external_port"`
 }
 
-type NodeConfigFn = func(input GenerateConfigsInput) (NodeIndexToConfigOverride, error)
+type NodeConfigTransformerFn = func(input GenerateConfigsInput, existingConfigs NodeIndexToConfigOverride) (NodeIndexToConfigOverride, error)
 
 type (
 	HandlerTypeToConfig    = map[string]string
@@ -1032,9 +1032,9 @@ type InstallableCapability interface {
 	// Exceptions include capabilities that are configured via the node config, like write-evm, aptos, tron or solana.
 	JobSpecFn() JobSpecFn
 
-	// NodeConfigFn returns a function to generate node-level configuration,
-	// or nil if no node-specific config is needed. Most capabilities don't need this.
-	NodeConfigFn() NodeConfigFn
+	// NodeConfigTransformerFn returns a function to modify node-level configuration,
+	// or nil if node config modification is not needed. Most capabilities don't need this.
+	NodeConfigTransformerFn() NodeConfigTransformerFn
 
 	// GatewayJobHandlerConfigFn returns a function to configure gateway handlers in the gateway jobspec,
 	// or nil if no gateway handler configuration is required for this capability. Only capabilities

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -16,6 +16,7 @@ replace github.com/smartcontractkit/chainlink/deployment => ../../deployment
 
 require (
 	dario.cat/mergo v1.0.2
+	github.com/BurntSushi/toml v1.4.0
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/andybalholm/brotli v1.1.1
 	github.com/cockroachdb/errors v1.11.3
@@ -69,7 +70,6 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
-	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e // indirect
 	github.com/DefangLabs/secret-detector v0.0.0-20250403165618-22662109213e // indirect
 	github.com/Khan/genqlient v0.7.0 // indirect


### PR DESCRIPTION
Preliminary work required for the bigger refactor of making the code more cohesive. It cleans up `don/config.go` by removing code related to `write-evm` and `write-solana` capabilities and moving it to capability files.

----
This pull request refactors the capability configuration system for node config generation, introducing a new, more flexible function signature for node config transformation and applying it to both EVM and Solana write capabilities. The changes enable capabilities to transform existing node configs rather than just generate them from scratch, and implement this logic for both WriteEVM and WriteSolana capabilities. The update also propagates this new approach throughout the codebase.

**Refactor of Node Config Generation and Capability Handling**

*General Refactoring:*
- Changed the type and usage of the node config function from `NodeConfigFn` to `NodeConfigTransformerFn` in the `Capability` struct and related functional options, allowing capabilities to transform existing node configurations instead of replacing them. Updates all related method names and usages accordingly. [[1]](diffhunk://#diff-fe20a76a43a0bd0f13de992ff04439b2ace511d7bdcd4b36ffecdbf95eb2e877L12-R12) [[2]](diffhunk://#diff-fe20a76a43a0bd0f13de992ff04439b2ace511d7bdcd4b36ffecdbf95eb2e877L26-R26) [[3]](diffhunk://#diff-fe20a76a43a0bd0f13de992ff04439b2ace511d7bdcd4b36ffecdbf95eb2e877L46-R46) [[4]](diffhunk://#diff-2d70359191da270ae39bb61c3200b66a9a49b30d3a1244d65ca23a909f2777b7L40-R35)

*Capability Implementations:*
- Updated the WriteEVM capability to use the new node config transformer, implementing `transformNodeConfig` to inject WriteEVM-specific configuration into the appropriate section of each worker node’s config. This includes dynamic template rendering and TOML marshaling/unmarshaling for the `[EVM.Workflow]` section. [[1]](diffhunk://#diff-30648a9d939049e25b2784391fa6456137006f970dfd984f5bf6756d4b23cef5L4-R33) [[2]](diffhunk://#diff-30648a9d939049e25b2784391fa6456137006f970dfd984f5bf6756d4b23cef5L22-R42) [[3]](diffhunk://#diff-30648a9d939049e25b2784391fa6456137006f970dfd984f5bf6756d4b23cef5R79-R259)
- Updated the WriteSolana capability to use the new node config transformer, implementing `transformNodeConfig` to inject WriteSolana-specific configuration, including template-based config generation for the `[Solana.Workflow]` section. [[1]](diffhunk://#diff-60ba3e5843970ffc3325583d7f56f19aaaccb73b18bfdffa87dd46fe7df82cf8L4-R25) [[2]](diffhunk://#diff-60ba3e5843970ffc3325583d7f56f19aaaccb73b18bfdffa87dd46fe7df82cf8R34) [[3]](diffhunk://#diff-60ba3e5843970ffc3325583d7f56f19aaaccb73b18bfdffa87dd46fe7df82cf8R64-R246)

*Gateway Capability Update:*
- Updated the Gateway capability to use the new `WithNodeConfigTransformerFn` option and adapted its config generation function signature to match the new transformer interface. [[1]](diffhunk://#diff-69cedf8cb08285d39763ec0341460e2a67f6608a2eba24e9008fa2354708f8e3L30-R30) [[2]](diffhunk://#diff-69cedf8cb08285d39763ec0341460e2a67f6608a2eba24e9008fa2354708f8e3L136-R136)

*Imports and Cleanup:*
- Updated imports across affected files to support the new logic, including TOML, template, and supporting libraries for address and config manipulation. [[1]](diffhunk://#diff-30648a9d939049e25b2784391fa6456137006f970dfd984f5bf6756d4b23cef5L4-R33) [[2]](diffhunk://#diff-60ba3e5843970ffc3325583d7f56f19aaaccb73b18bfdffa87dd46fe7df82cf8L4-R25) [[3]](diffhunk://#diff-2d70359191da270ae39bb61c3200b66a9a49b30d3a1244d65ca23a909f2777b7R6-L27)

These changes improve the flexibility and composability of capability-driven node configuration in the system tests framework, making it easier to add or modify capability-specific configuration logic in the future.