### PR TITLE
Fix release build workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -188,13 +188,6 @@ jobs:
             }}
           docker-image-digest: ${{ steps.docker-outputs.outputs.digest }}
 
-  run-core-soak-on-release:
-    needs: docker-core
-    uses: smartcontractkit/chainlink/.github/workflows/on-demand-ocr-soak-test.yml@e8fa774450995fd45442a2e8e778f3a7eefc7af9 # 2025-08-08
-    with:
-      chainlink_version: ${{ github.ref_name }}
-      team: CRE
-
   deploy-core:
     needs: [checks, docker-core]
     permissions:


### PR DESCRIPTION
Temporarily remove OCR soak test call from build-publish.yml to unblock release builds. Needs follow-up with Bartek to restore properly.