### PR TITLE
Cherry-pick: remove OCR soak test reference from release build workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -188,13 +188,6 @@ jobs:
             }}
           docker-image-digest: ${{ steps.docker-outputs.outputs.digest }}
 
-  run-core-soak-on-release:
-    needs: docker-core
-    uses: smartcontractkit/chainlink/.github/workflows/on-demand-ocr-soak-test.yml@e8fa774450995fd45442a2e8e778f3a7eefc7af9 # 2025-08-08
-    with:
-      chainlink_version: ${{ github.ref_name }}
-      team: CRE
-
   deploy-core:
     needs: [checks, docker-core]
     permissions:


### PR DESCRIPTION
Cherry-picks de56253 from develop to release/2.28.0 so RC builds can proceed without the OCR soak test breaking permissions.