### PR TITLE
feat(ci): use branch-out-upload action

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -306,22 +306,21 @@ jobs:
           CL_DATABASE_URL: ${{ env.DB_URL }}
           OUTPUT_FILE: ./output.txt
           PRODUCE_JUNIT_XML: ${{ matrix.type.use-trunk }}
+          JUNIT_FILE: ${{ github.workspace }}/junit.xml
         run: |
           GODEBUG=goindex=0 ./tools/bin/${{ matrix.type.cmd }} ./...
           # See: https://github.com/golang/go/issues/69179
 
-      - name: Upload Test Results to Trunk.io
+      - name: Run branch-out-upload
         if: ${{ matrix.type.should-run == 'true' && matrix.type.use-trunk == 'true' && !cancelled() }}
-        uses: trunk-io/analytics-uploader@f2631c653f9675d391e6e68cc877370db927c64c # v2.0.0
-        continue-on-error: true # TODO: Remove this once ready
-        env:
-          TRUNK_TELEMETRY: "off"
-          JOB_URL: ${{ steps.run-url.outputs.run_url }}
+        uses: smartcontractkit/.github/actions/branch-out-upload@feat/junit-test-processing
         with:
-          junit-paths: "./junit.xml,*/junit.xml"
-          org-slug: chainlink
-          token: ${{ secrets.TRUNK_API_KEY }}
-          previous-step-outcome: ${{ steps.run-tests.outcome }}
+          junit-file-path: './junit.xml'
+          trunk-org-slug: chainlink
+          trunk-token: ${{ secrets.TRUNK_API_KEY }}
+          trunk-upload-only: "true"
+          trunk-previous-step-outcome: ${{ steps.run-tests.outcome }}
+          trunk-job-url: ${{ steps.run-url.outputs.run_url }}
 
       - name: Print Races
         id: print-races

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -313,7 +313,7 @@ jobs:
 
       - name: Run branch-out-upload
         if: ${{ matrix.type.should-run == 'true' && matrix.type.use-trunk == 'true' && !cancelled() }}
-        uses: smartcontractkit/.github/actions/branch-out-upload@feat/junit-test-processing
+        uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/0.1.0
         with:
           junit-file-path: './junit.xml'
           trunk-org-slug: chainlink


### PR DESCRIPTION
Switches to [`branch-out-upload`](https://github.com/smartcontractkit/.github/tree/main/actions/branch-out-upload) in place of the direct trunk action.

This new action can modify the JUnit report to:
1. Add files to the test case entries
2. Remove `TestMain` failures

### Testing

- https://github.com/smartcontractkit/chainlink/actions/runs/17438895157/job/49517381899?pr=19192
- https://github.com/smartcontractkit/chainlink/actions/runs/17438895157/job/49517381932?pr=19192

### Relates to

- https://github.com/smartcontractkit/.github/pull/1195
- https://github.com/smartcontractkit/quarantine/pull/4

---

DX-1671