### PR TITLE
[PRODCRE-804] Update db contract id duplication test logic.

### DIFF
--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -889,20 +889,20 @@ func TestORM_CreateJob_OCR2_DuplicatedContractAddress(t *testing.T) {
 
 	jb2.Name = null.StringFrom("Job with same chain id & contract address")
 	jb2.OCR2OracleSpec.TransmitterID = null.StringFrom(address.String())
-	jb.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
+	jb2.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
 
 	err = jobORM.CreateJob(ctx, &jb2)
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	jb3, err := ocr2validate.ValidatedOracleSpecToml(testutils.Context(t), config.OCR2(), config.Insecure(), testspecs.GetOCR2EVMSpecMinimal(), nil)
 	require.NoError(t, err)
 	jb3.Name = null.StringFrom("Job with different chain id & same contract address")
 	jb3.OCR2OracleSpec.TransmitterID = null.StringFrom(address.String())
 	jb3.OCR2OracleSpec.RelayConfig["chainID"] = customChainID.Int64()
-	jb.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
+	jb3.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
 
 	err = jobORM.CreateJob(ctx, &jb3)
-	require.Error(t, err)
+	require.NoError(t, err)
 }
 
 func TestORM_CreateJob_OCR2_Sending_Keys_Transmitter_Keys_Validations(t *testing.T) {


### PR DESCRIPTION
The test `TestORM_CreateJob_OCR2_DuplicatedContractAddress` was supposed to check that jobs with duplicate contract addresses could not be created. However, both the test was wrong and the testing condition was incorrect:

- the testing condition is wrong: we can have multiple OCR2 jobs with the same contract address, created by the CreateJob method. There is no database limitation on that. Such a limitation existed on the table ocr2_oracle_specs but was dropped in https://github.com/smartcontractkit/chainlink/blob/e55a4ed0e70e9b9c86dd8356cd1992d60304b0b0/core/store/migrate/migrations/0163_mercury_jobs_multiple_per_contract.sql and replaced with a limitation on mercury only jobs ensuring uniqueness of (contract_id, feed_id) pair.

 - the testing code had two typos: it did not update `OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"]` of `jb2` and `jb3`. This lead to the validation error in their creation. So their creation failed but due to the validation error and not the duplicate address check.