### PR TITLE
[CRE-783] fix evm capability binary copying

### DIFF
--- a/core/scripts/cre/environment/configs/setup.toml
+++ b/core/scripts/cre/environment/configs/setup.toml
@@ -33,4 +33,4 @@ target_path = "./binaries"
 repository = "https://github.com/smartcontractkit/capabilities"
 branch = "main"
 build_command = "pnpm install && ./nx run-many -t build"
-artifacts_dir = "./bin/amd64"
+artifacts_dirs = ["./bin/amd64", "./chain_capabilities/bin/amd64"]

--- a/core/scripts/cre/environment/environment/setup.go
+++ b/core/scripts/cre/environment/environment/setup.go
@@ -95,10 +95,10 @@ type capabilitiesConfig struct {
 }
 
 type capabilityRepository struct {
-	RepoURL      string `toml:"repository"`
-	Branch       string `toml:"branch"`
-	BuildCommand string `toml:"build_command"`
-	ArtifactsDir string `toml:"artifacts_dir"`
+	RepoURL       string   `toml:"repository"`
+	Branch        string   `toml:"branch"`
+	BuildCommand  string   `toml:"build_command"`
+	ArtifactsDirs []string `toml:"artifacts_dirs"`
 }
 
 var (
@@ -559,11 +559,13 @@ func buildCapabilityBinaries(ctx context.Context, capabilitiesConfig capabilitie
 			return fmt.Errorf("failed to create target directory: %w", err)
 		}
 
-		logger.Info().Msgf("Copying build artifacts from %s to %s", repo.ArtifactsDir, targetPath)
-		artifactsDir := filepath.Join(workingDir, repo.ArtifactsDir)
-		copyCmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("cp -r %s/* %s/", artifactsDir, targetPath)) //nolint:gosec //G204: Subprocess launched with a potential tainted input or cmd arguments
-		if err := copyCmd.Run(); err != nil {
-			return fmt.Errorf("failed to copy directory: %w", err)
+		for _, artifactDir := range repo.ArtifactsDirs {
+			logger.Info().Msgf("Copying build artifacts from %s to %s", artifactDir, targetPath)
+			artifactsDir := filepath.Join(workingDir, artifactDir)
+			copyCmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("cp -r %s/* %s/", artifactsDir, targetPath)) //nolint:gosec //G204: Subprocess launched with a potential tainted input or cmd arguments
+			if err := copyCmd.Run(); err != nil {
+				return fmt.Errorf("failed to copy directory: %w", err)
+			}
 		}
 
 		logger.Info().Msgf("✓ Build artifacts copied to %s", targetPath)


### PR DESCRIPTION
This pull request updates the way build artifact directories are handled in the capability environment setup process. Instead of supporting only a single artifact directory, the configuration and build logic now support multiple artifact directories, allowing for more flexible builds.

**Configuration changes:**

* Updated the `setup.toml` configuration to use an `artifacts_dirs` array instead of a single `artifacts_dir` string, allowing multiple artifact directories to be specified.

**Code changes for handling multiple artifact directories:**

* Changed the `capabilityRepository` struct in `setup.go` to use a `[]string` for `ArtifactsDirs` instead of a single string, matching the new configuration.
* Updated the build logic in `buildCapabilityBinaries` to iterate over all specified artifact directories and copy their contents to the target directory, instead of handling just one.