### PR TITLE
[CRE-791] create background worker and clean up SetupTestEnvironment function

### DIFF
--- a/system-tests/lib/cre/contracts/contracts.go
+++ b/system-tests/lib/cre/contracts/contracts.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
@@ -430,48 +429,6 @@ func MergeAllDataStores(fullCldEnvOutput *cre.FullCLDEnvironmentOutput, changese
 	}
 
 	fullCldEnvOutput.Environment.DataStore = baseDataStore.Seal()
-}
-
-func ConfigureWorkflowRegistry(testLogger zerolog.Logger, input *cre.WorkflowRegistryInput) (*cre.WorkflowRegistryOutput, error) {
-	if input == nil {
-		return nil, errors.New("input is nil")
-	}
-	if input.Out != nil && input.Out.UseCache {
-		return input.Out, nil
-	}
-
-	if err := input.Validate(); err != nil {
-		return nil, errors.Wrap(err, "input validation failed")
-	}
-
-	allowedDonIDs := make([]uint32, len(input.AllowedDonIDs))
-	for i, donID := range input.AllowedDonIDs {
-		allowedDonIDs[i] = libc.MustSafeUint32FromUint64(donID)
-	}
-
-	report, err := operations.ExecuteSequence(
-		input.CldEnv.OperationsBundle,
-		ks_contracts_op.ConfigWorkflowRegistrySeq,
-		ks_contracts_op.ConfigWorkflowRegistrySeqDeps{
-			Env: input.CldEnv,
-		},
-		ks_contracts_op.ConfigWorkflowRegistrySeqInput{
-			ContractAddress:       input.ContractAddress,
-			RegistryChainSelector: input.ChainSelector,
-			AllowedDonIDs:         allowedDonIDs,
-			WorkflowOwners:        input.WorkflowOwners,
-		},
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to configure workflow registry")
-	}
-
-	input.Out = &cre.WorkflowRegistryOutput{
-		ChainSelector:  report.Output.RegistryChainSelector,
-		AllowedDonIDs:  report.Output.AllowedDonIDs,
-		WorkflowOwners: report.Output.WorkflowOwners,
-	}
-	return input.Out, nil
 }
 
 func ConfigureDataFeedsCache(testLogger zerolog.Logger, input *cre.ConfigureDataFeedsCacheInput) (*cre.ConfigureDataFeedsCacheOutput, error) {

--- a/system-tests/lib/cre/contracts/workflowregistry.go
+++ b/system-tests/lib/cre/contracts/workflowregistry.go
@@ -1,0 +1,263 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/scylladb/go-reflectx"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/postgres"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	ks_contracts_op "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/operations/contracts"
+
+	libc "github.com/smartcontractkit/chainlink/system-tests/lib/conversions"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/node"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/flags"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/infra"
+)
+
+// must match nubmer of events we track in core/services/workflows/syncer/handler.go
+const NumberOfTrackedWorkflowRegistryEvents = 6
+
+func WaitForWorkflowRegistryFiltersRegistration(
+	testLogger zerolog.Logger,
+	singleFileLogger logger.Logger,
+	infraType infra.Type,
+	registryChainID uint64,
+	topology *cre.DonTopology,
+	nodeSetInput []*cre.CapabilitiesAwareNodeSet,
+) error {
+	// we currently have no way of checking if filters were registered, when code runs in CRIB
+	// as we don't have a way to get its database connection string
+	if infraType == infra.CRIB {
+		return nil
+	}
+
+	hasGateway := false
+	for _, don := range topology.DonsWithMetadata {
+		if flags.HasFlag(don.Flags, cre.GatewayDON) {
+			hasGateway = true
+			break
+		}
+	}
+
+	if !hasGateway {
+		return nil
+	}
+
+	testLogger.Info().Msg("Waiting for all nodes to have expected LogPoller filters registered...")
+	return waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger, testLogger, registryChainID, topology, nodeSetInput)
+}
+
+func PrepareForWorkflowRegistryConfiguration(
+	ctx context.Context,
+	singleFileLogger logger.Logger,
+	environment *cldf.Environment,
+	donID uint64,
+	registryChainSelector uint64,
+	workflowRegistryAddress common.Address,
+	workflowOwnerAddress common.Address,
+) (*cre.WorkflowRegistryInput, error) {
+	// we need to filter out all chains from the environment struct
+	// that do not have at least one contract deployed to avoid validation errors
+	// when configuring workflow registry contract :shrug: :shrug: :shrug:
+	allAddresses, addrErr := environment.ExistingAddresses.Addresses() //nolint:staticcheck // ignore SA1019 as ExistingAddresses is deprecated but still used
+	if addrErr != nil {
+		return nil, errors.Wrap(addrErr, "failed to get addresses from address book")
+	}
+
+	chainsWithContracts := make(map[uint64]bool)
+	for chainSelector, addresses := range allAddresses {
+		chainsWithContracts[chainSelector] = len(addresses) > 0
+	}
+
+	addresses, addrErr1 := environment.DataStore.Addresses().Fetch()
+	if addrErr1 != nil {
+		return nil, errors.Wrap(addrErr1, "failed to get addresses from datastore")
+	}
+
+	for _, addr := range addresses {
+		chainsWithContracts[addr.ChainSelector] = true
+	}
+
+	nonEmptyBlockchains := make(map[uint64]cldf_chain.BlockChain, 0)
+	for chainSelector, chain := range environment.BlockChains.EVMChains() {
+		if chainsWithContracts[chain.Selector] {
+			nonEmptyBlockchains[chainSelector] = chain
+		}
+	}
+	for chainSelector, chain := range environment.BlockChains.SolanaChains() {
+		if chainsWithContracts[chain.Selector] {
+			nonEmptyBlockchains[chainSelector] = chain
+		}
+	}
+
+	nonEmptyChainsCLDEnvironment := &cldf.Environment{
+		Logger:            singleFileLogger,
+		ExistingAddresses: environment.ExistingAddresses, //nolint:staticcheck // ignore SA1019 as ExistingAddresses is deprecated but still used
+		GetContext: func() context.Context {
+			return ctx
+		},
+		DataStore:   environment.DataStore,
+		BlockChains: cldf_chain.NewBlockChains(nonEmptyBlockchains),
+	}
+	nonEmptyChainsCLDEnvironment.OperationsBundle = operations.NewBundle(nonEmptyChainsCLDEnvironment.GetContext, singleFileLogger, operations.NewMemoryReporter())
+
+	return &cre.WorkflowRegistryInput{
+		ContractAddress: workflowRegistryAddress,
+		ChainSelector:   registryChainSelector,
+		CldEnv:          nonEmptyChainsCLDEnvironment,
+		AllowedDonIDs:   []uint64{donID},
+		WorkflowOwners:  []common.Address{workflowOwnerAddress},
+	}, nil
+}
+
+func ConfigureWorkflowRegistry(testLogger zerolog.Logger, input *cre.WorkflowRegistryInput) (*cre.WorkflowRegistryOutput, error) {
+	if input == nil {
+		return nil, errors.New("input is nil")
+	}
+	if input.Out != nil && input.Out.UseCache {
+		return input.Out, nil
+	}
+
+	if err := input.Validate(); err != nil {
+		return nil, errors.Wrap(err, "input validation failed")
+	}
+
+	allowedDonIDs := make([]uint32, len(input.AllowedDonIDs))
+	for i, donID := range input.AllowedDonIDs {
+		allowedDonIDs[i] = libc.MustSafeUint32FromUint64(donID)
+	}
+
+	report, err := operations.ExecuteSequence(
+		input.CldEnv.OperationsBundle,
+		ks_contracts_op.ConfigWorkflowRegistrySeq,
+		ks_contracts_op.ConfigWorkflowRegistrySeqDeps{
+			Env: input.CldEnv,
+		},
+		ks_contracts_op.ConfigWorkflowRegistrySeqInput{
+			ContractAddress:       input.ContractAddress,
+			RegistryChainSelector: input.ChainSelector,
+			AllowedDonIDs:         allowedDonIDs,
+			WorkflowOwners:        input.WorkflowOwners,
+		},
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to configure workflow registry")
+	}
+
+	input.Out = &cre.WorkflowRegistryOutput{
+		ChainSelector:  report.Output.RegistryChainSelector,
+		AllowedDonIDs:  report.Output.AllowedDonIDs,
+		WorkflowOwners: report.Output.WorkflowOwners,
+	}
+	return input.Out, nil
+}
+
+// waitForAllNodesToHaveExpectedFiltersRegistered manually checks if all WorkflowRegistry filters used by the LogPoller are registered for all nodes. We want to see if this will help with the flakiness.
+func waitForAllNodesToHaveExpectedFiltersRegistered(singeFileLogger logger.Logger, testLogger zerolog.Logger, homeChainID uint64, donTopology *cre.DonTopology, nodeSetInput []*cre.CapabilitiesAwareNodeSet) error {
+	for donIdx, don := range donTopology.DonsWithMetadata {
+		if !flags.HasFlag(don.Flags, cre.WorkflowDON) {
+			continue
+		}
+
+		workderNodes, workersErr := node.FindManyWithLabel(don.NodesMetadata, &cre.Label{Key: node.NodeTypeKey, Value: cre.WorkerNode}, node.EqualLabels)
+		if workersErr != nil {
+			return errors.Wrap(workersErr, "failed to find worker nodes")
+		}
+
+		results := make(map[int]bool)
+		ticker := 5 * time.Second
+		timeout := 2 * time.Minute
+
+	INNER_LOOP:
+		for {
+			select {
+			case <-time.After(timeout):
+				return fmt.Errorf("timed out, when waiting for %.2f seconds, waiting for all nodes to have expected filters registered", timeout.Seconds())
+			case <-time.Tick(ticker):
+				if len(results) == len(workderNodes) {
+					testLogger.Info().Msgf("All %d nodes in DON %d have expected filters registered", len(workderNodes), don.ID)
+					break INNER_LOOP
+				}
+
+				for _, workerNode := range workderNodes {
+					nodeIndex, nodeIndexErr := node.FindLabelValue(workerNode, node.IndexKey)
+					if nodeIndexErr != nil {
+						return errors.Wrap(nodeIndexErr, "failed to find node index")
+					}
+
+					nodeIndexInt, nodeIdxErr := strconv.Atoi(nodeIndex)
+					if nodeIdxErr != nil {
+						return errors.Wrap(nodeIdxErr, "failed to convert node index to int")
+					}
+
+					if _, ok := results[nodeIndexInt]; ok {
+						continue
+					}
+
+					testLogger.Info().Msgf("Checking if all WorkflowRegistry filters are registered for worker node %d", nodeIndexInt)
+					allFilters, filtersErr := getAllFilters(context.Background(), singeFileLogger, big.NewInt(libc.MustSafeInt64(homeChainID)), nodeIndexInt, nodeSetInput[donIdx].DbInput.Port)
+					if filtersErr != nil {
+						return errors.Wrap(filtersErr, "failed to get filters")
+					}
+
+					for _, filter := range allFilters {
+						if strings.Contains(filter.Name, "WorkflowRegistry") {
+							if len(filter.EventSigs) == NumberOfTrackedWorkflowRegistryEvents {
+								testLogger.Debug().Msgf("Found all WorkflowRegistry filters for node %d", nodeIndexInt)
+								results[nodeIndexInt] = true
+								continue
+							}
+
+							testLogger.Debug().Msgf("Found only %d WorkflowRegistry filters for node %d", len(filter.EventSigs), nodeIndexInt)
+						}
+					}
+				}
+
+				// return if we have results for all nodes, don't wait for next tick
+				if len(results) == len(workderNodes) {
+					testLogger.Info().Msgf("All %d nodes in DON %d have expected filters registered", len(workderNodes), don.ID)
+					break INNER_LOOP
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func newORM(logger logger.Logger, chainID *big.Int, nodeIndex, externalPort int) (logpoller.ORM, *sqlx.DB, error) {
+	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", "127.0.0.1", externalPort, postgres.User, postgres.Password, fmt.Sprintf("db_%d", nodeIndex))
+	db, err := sqlx.Open("postgres", dsn)
+	if err != nil {
+		return nil, db, err
+	}
+
+	db.MapperFunc(reflectx.CamelToSnakeASCII)
+	return logpoller.NewORM(chainID, db, logger), db, nil
+}
+
+func getAllFilters(ctx context.Context, logger logger.Logger, chainID *big.Int, nodeIndex, externalPort int) (map[string]logpoller.Filter, error) {
+	orm, db, err := newORM(logger, chainID, nodeIndex, externalPort)
+	if err != nil {
+		return nil, err
+	}
+
+	defer db.Close()
+	return orm.LoadFilters(ctx)
+}

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -3,22 +3,15 @@ package environment
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"os"
-	"runtime/debug"
 	"slices"
-	"strconv"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 	solrpc "github.com/gagliardetto/solana-go/rpc"
-	"github.com/jmoiron/sqlx"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/scylladb/go-reflectx"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -31,12 +24,10 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/clclient"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/jd"
-	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/postgres"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/s3provider"
 	ctfconfig "github.com/smartcontractkit/chainlink-testing-framework/lib/config"
 	"github.com/smartcontractkit/chainlink-testing-framework/seth"
@@ -49,15 +40,15 @@ import (
 	ks_sol_op "github.com/smartcontractkit/chainlink/deployment/keystone/changeset/solana/sequence/operation"
 	libc "github.com/smartcontractkit/chainlink/system-tests/lib/conversions"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
-	libcontracts "github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
+	crecontracts "github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/crib"
 	libdevenv "github.com/smartcontractkit/chainlink/system-tests/lib/cre/devenv"
 	libdon "github.com/smartcontractkit/chainlink/system-tests/lib/cre/don"
-	crenode "github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/node"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/flags"
 	libformat "github.com/smartcontractkit/chainlink/system-tests/lib/format"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/infra"
 	libnix "github.com/smartcontractkit/chainlink/system-tests/lib/nix"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/worker"
 )
 
 const (
@@ -97,13 +88,6 @@ type SetupInput struct {
 	JobSpecFactoryFunctions []cre.JobSpecFn
 	// Deprecated: use Capabilities []cre.InstallableCapability instead
 	CapabilitiesContractFactoryFunctions []cre.CapabilityRegistryConfigFn
-}
-
-type backgroundStageResult struct {
-	err            error
-	successMessage string
-	panicValue     any
-	panicStack     []byte
 }
 
 func mustGetAddress(dataStore datastore.MutableDataStore, chainSel uint64, contractType string, version string, qualifier string) string {
@@ -416,90 +400,22 @@ func SetupTestEnvironment(
 
 	fmt.Print(libformat.PurpleText("%s", stageGen.WrapAndNext("DONs configuration prepared in %.2f seconds", stageGen.Elapsed().Seconds())))
 
-	// start 3 tasks in the background
-	backgroundStagesCount := 3
-	backgroundStagesWaitGroup := &sync.WaitGroup{}
-	backgroundStagesCh := make(chan backgroundStageResult, backgroundStagesCount)
-	backgroundStagesWaitGroup.Add(1)
-
-	// configure workflow registry contract in the background, so that we can continue with the next stage
-	var workflowRegistryInput *cre.WorkflowRegistryInput
-	var startTime time.Time
-	go func() {
-		defer backgroundStagesWaitGroup.Done()
-		defer func() {
-			if p := recover(); p != nil {
-				backgroundStagesCh <- backgroundStageResult{
-					panicValue: p,
-					panicStack: debug.Stack(),
-				}
-			}
-		}()
-		startTime = time.Now()
-		fmt.Print(libformat.PurpleText("---> [BACKGROUND 1/3] Configuring Workflow Registry contract\n"))
-
-		allAddresses, addrErr := allChainsCLDEnvironment.ExistingAddresses.Addresses() //nolint:staticcheck // ignore SA1019 as ExistingAddresses is deprecated but still used
-		if addrErr != nil {
-			backgroundStagesCh <- backgroundStageResult{err: pkgerrors.Wrap(addrErr, "failed to get addresses from address book")}
-			return
+	backgroundWorker := worker.NewTypedBackgroundRunner()
+	workflowRegistrationResult := worker.Add(backgroundWorker, "Workflow Registry Configuration", func() (*cre.WorkflowRegistryOutput, error) {
+		workflowRegistryInput, inputErr := crecontracts.PrepareForWorkflowRegistryConfiguration(
+			ctx,
+			singleFileLogger,
+			allChainsCLDEnvironment,
+			topology.WorkflowDONID,
+			homeChainOutput.ChainSelector,
+			common.HexToAddress(wfRegAddr),
+			homeChainOutput.SethClient.MustGetRootKeyAddress(),
+		)
+		if inputErr != nil {
+			return nil, pkgerrors.Wrap(inputErr, "failed to prepare workflow registry configuration")
 		}
-
-		chainsWithContracts := make(map[uint64]bool)
-		for chainSelector, addresses := range allAddresses {
-			chainsWithContracts[chainSelector] = len(addresses) > 0
-		}
-
-		addresses, addrErr1 := allChainsCLDEnvironment.DataStore.Addresses().Fetch()
-		if addrErr1 != nil {
-			backgroundStagesCh <- backgroundStageResult{err: pkgerrors.Wrap(addrErr1, "failed to get addresses from datastore")}
-			return
-		}
-
-		for _, addr := range addresses {
-			chainsWithContracts[addr.ChainSelector] = true
-		}
-
-		nonEmptyBlockchains := make(map[uint64]cldf_chain.BlockChain, 0)
-		for chainSelector, chain := range allChainsCLDEnvironment.BlockChains.EVMChains() {
-			if chainsWithContracts[chain.Selector] {
-				nonEmptyBlockchains[chainSelector] = chain
-			}
-		}
-		for chainSelector, chain := range allChainsCLDEnvironment.BlockChains.SolanaChains() {
-			if chainsWithContracts[chain.Selector] {
-				nonEmptyBlockchains[chainSelector] = chain
-			}
-		}
-
-		nonEmptyChainsCLDEnvironment := &cldf.Environment{
-			Logger:            singleFileLogger,
-			ExistingAddresses: allChainsCLDEnvironment.ExistingAddresses, //nolint:staticcheck // ignore SA1019 as ExistingAddresses is deprecated but still used
-			GetContext: func() context.Context {
-				return ctx
-			},
-			DataStore:   allChainsCLDEnvironment.DataStore,
-			BlockChains: cldf_chain.NewBlockChains(nonEmptyBlockchains),
-		}
-		nonEmptyChainsCLDEnvironment.OperationsBundle = operations.NewBundle(nonEmptyChainsCLDEnvironment.GetContext, singleFileLogger, operations.NewMemoryReporter())
-
-		// Configure Workflow Registry contract
-		workflowRegistryInput = &cre.WorkflowRegistryInput{
-			ContractAddress: common.HexToAddress(wfRegAddr),
-			ChainSelector:   homeChainOutput.ChainSelector,
-			// TODO, here we might need to pass new environment that doesn't have chains that do not have forwarders deployed
-			CldEnv:         nonEmptyChainsCLDEnvironment,
-			AllowedDonIDs:  []uint64{topology.WorkflowDONID},
-			WorkflowOwners: []common.Address{homeChainOutput.SethClient.MustGetRootKeyAddress()},
-		}
-
-		_, workflowErr := libcontracts.ConfigureWorkflowRegistry(testLogger, workflowRegistryInput)
-		if workflowErr != nil {
-			backgroundStagesCh <- backgroundStageResult{err: pkgerrors.Wrap(workflowErr, "failed to configure workflow registry"), successMessage: libformat.PurpleText("\n<--- [BACKGROUND 1/3] Workflow Registry configured in %.2f seconds\n", time.Since(startTime).Seconds())}
-			return
-		}
-
-		backgroundStagesCh <- backgroundStageResult{successMessage: libformat.PurpleText("\n<--- [BACKGROUND 1/3] Workflow Registry configured in %.2f seconds\n", time.Since(startTime).Seconds())}
-	}()
+		return crecontracts.ConfigureWorkflowRegistry(testLogger, workflowRegistryInput)
+	})
 
 	// JOB DISTRIBUTOR + JOBS (creation and distribution to nodes)
 	fmt.Print(libformat.PurpleText("%s", stageGen.Wrap("Starting Job Distributor, DONs and creating Jobs with Job Distributor")))
@@ -580,36 +496,16 @@ func SetupTestEnvironment(
 	// If the ConfigSet event is missed, OCR protocol will not start.
 	fmt.Print(libformat.PurpleText("%s", stageGen.WrapAndNext("Jobs created in %.2f seconds", stageGen.Elapsed().Seconds())))
 
-	// Fund nodes in the background, so that we can continue with the next stage
-	backgroundStagesWaitGroup.Add(1)
-	go func() {
-		defer backgroundStagesWaitGroup.Done()
-		defer func() {
-			if p := recover(); p != nil {
-				backgroundStagesCh <- backgroundStageResult{
-					panicValue: p,
-					panicStack: debug.Stack(),
-				}
-			}
-		}()
-
-		startTime = time.Now()
-		fmt.Print(libformat.PurpleText("---> [BACKGROUND 2/3] Funding Chainlink nodes\n\n"))
-
+	worker.AddVoid(backgroundWorker, "Funding Chainlink nodes", func() error {
 		_, fundErr := operations.ExecuteOperation(fullCldOutput.Environment.OperationsBundle, FundCLNodesOp, FundCLNodesOpDeps{
 			Env:               fullCldOutput.Environment,
 			BlockchainOutputs: blockchainOutputs,
 			DonTopology:       fullCldOutput.DonTopology,
 		}, FundCLNodesOpInput{FundAmount: 5000000000000000000})
-		if fundErr != nil {
-			backgroundStagesCh <- backgroundStageResult{err: pkgerrors.Wrap(fundErr, "failed to fund CL nodes")}
-			return
-		}
 
-		backgroundStagesCh <- backgroundStageResult{successMessage: libformat.PurpleText("\n<--- [BACKGROUND 2/3] Chainlink nodes funded in %.2f seconds\033[0m\n", time.Since(startTime).Seconds())}
-	}()
+		return fundErr
+	})
 
-	startTime = time.Now()
 	fmt.Print(libformat.PurpleText("%s", stageGen.Wrap("Waiting for Log Poller to start tracking OCR3 contract")))
 
 	for idx, nodeSetOut := range nodeSetOutput {
@@ -634,41 +530,9 @@ func SetupTestEnvironment(
 	fmt.Print(libformat.PurpleText("%s", stageGen.WrapAndNext("Log Poller started in %.2f seconds", stageGen.Elapsed().Seconds())))
 
 	// wait for log poller filters to be registered in the background, because we don't need it them at this stage yet
-	backgroundStagesWaitGroup.Add(1)
-	go func() {
-		defer backgroundStagesWaitGroup.Done()
-		defer func() {
-			if p := recover(); p != nil {
-				backgroundStagesCh <- backgroundStageResult{
-					panicValue: p,
-					panicStack: debug.Stack(),
-				}
-			}
-		}()
-
-		if input.InfraInput.Type != infra.CRIB {
-			hasGateway := false
-			for _, don := range fullCldOutput.DonTopology.DonsWithMetadata {
-				if flags.HasFlag(don.Flags, cre.GatewayDON) {
-					hasGateway = true
-					break
-				}
-			}
-
-			if hasGateway {
-				startTime = time.Now()
-				fmt.Print(libformat.PurpleText("---> [BACKGROUND 3/3] Waiting for all nodes to have expected LogPoller filters registered\n\n"))
-
-				testLogger.Info().Msg("Waiting for all nodes to have expected LogPoller filters registered...")
-				lpErr := waitForAllNodesToHaveExpectedFiltersRegistered(singleFileLogger, testLogger, homeChainOutput.ChainID, *fullCldOutput.DonTopology, updatedNodeSets)
-				if lpErr != nil {
-					backgroundStagesCh <- backgroundStageResult{err: pkgerrors.Wrap(lpErr, "failed to wait for all nodes to have expected LogPoller filters registered")}
-					return
-				}
-				backgroundStagesCh <- backgroundStageResult{successMessage: libformat.PurpleText("\n<--- [BACKGROUND 3/3] Waiting for all nodes to have expected LogPoller filters registered finished in %.2f seconds\n\n", time.Since(startTime).Seconds())}
-			}
-		}
-	}()
+	worker.AddVoid(backgroundWorker, "Waiting for all nodes to have expected LogPoller filters registered", func() error {
+		return crecontracts.WaitForWorkflowRegistryFiltersRegistration(testLogger, singleFileLogger, input.InfraInput.Type, homeChainOutput.ChainID, fullCldOutput.DonTopology, updatedNodeSets)
+	})
 
 	fmt.Print(libformat.PurpleText("%s", stageGen.Wrap("Configuring OCR3 and Keystone contracts")))
 
@@ -693,7 +557,7 @@ func SetupTestEnvironment(
 	if input.OCR3Config != nil {
 		configureKeystoneInput.OCR3Config = *input.OCR3Config
 	} else {
-		ocr3Config, ocr3ConfigErr := libcontracts.DefaultOCR3Config(topology)
+		ocr3Config, ocr3ConfigErr := crecontracts.DefaultOCR3Config(topology)
 		if ocr3ConfigErr != nil {
 			return nil, pkgerrors.Wrap(ocr3ConfigErr, "failed to generate default OCR3 config")
 		}
@@ -703,7 +567,7 @@ func SetupTestEnvironment(
 	if input.DONTimeConfig != nil {
 		configureKeystoneInput.DONTimeConfig = *input.DONTimeConfig
 	} else {
-		donTimeConfig, donTimeConfigErr := libcontracts.DefaultOCR3Config(topology)
+		donTimeConfig, donTimeConfigErr := crecontracts.DefaultOCR3Config(topology)
 		donTimeConfig.DeltaRoundMillis = 0 // Fastest rounds possible
 		if donTimeConfigErr != nil {
 			return nil, pkgerrors.Wrap(donTimeConfigErr, "failed to generate default DON Time config")
@@ -711,13 +575,13 @@ func SetupTestEnvironment(
 		configureKeystoneInput.DONTimeConfig = *donTimeConfig
 	}
 
-	ocr3Config, ocr3ConfigErr := libcontracts.DefaultOCR3Config(topology)
+	ocr3Config, ocr3ConfigErr := crecontracts.DefaultOCR3Config(topology)
 	if ocr3ConfigErr != nil {
 		return nil, pkgerrors.Wrap(ocr3ConfigErr, "failed to generate default OCR3 config")
 	}
 	configureKeystoneInput.VaultOCR3Config = *ocr3Config
 
-	defaultOcr3Config, defaultOcr3ConfigErr := libcontracts.DefaultOCR3Config(topology)
+	defaultOcr3Config, defaultOcr3ConfigErr := crecontracts.DefaultOCR3Config(topology)
 	if defaultOcr3ConfigErr != nil {
 		return nil, pkgerrors.Wrap(defaultOcr3ConfigErr, "failed to generate default OCR3 config for EVM")
 	}
@@ -732,7 +596,7 @@ func SetupTestEnvironment(
 	// Deprecated, use Capabilities instead
 	capabilitiesContractFactoryFunctions = append(capabilitiesContractFactoryFunctions, input.CapabilitiesContractFactoryFunctions...)
 
-	keystoneErr := libcontracts.ConfigureKeystone(configureKeystoneInput, capabilitiesContractFactoryFunctions)
+	keystoneErr := crecontracts.ConfigureKeystone(configureKeystoneInput, capabilitiesContractFactoryFunctions)
 	if keystoneErr != nil {
 		return nil, pkgerrors.Wrap(keystoneErr, "failed to configure keystone contracts")
 	}
@@ -758,26 +622,15 @@ func SetupTestEnvironment(
 		fmt.Print(libformat.PurpleText("%s", stageGen.WrapAndNext("Wrote bootstrapping data into disk in %.2f seconds", stageGen.Elapsed().Seconds())))
 	}
 
-	// block on background stages
-	backgroundStagesWaitGroup.Wait()
-	close(backgroundStagesCh)
-
-	for result := range backgroundStagesCh {
-		if result.err != nil {
-			return nil, pkgerrors.Wrap(result.err, "background stage failed")
-		}
-		if result.panicValue != nil {
-			// Print the original stack trace from the background goroutine
-			if result.panicStack != nil {
-				fmt.Fprintf(os.Stderr, "Original panic stack trace from background goroutine:\n%s\n", result.panicStack)
-			}
-			panic(result.panicValue)
-		}
-		fmt.Print(result.successMessage)
+	if err := backgroundWorker.Wait(); err != nil {
+		return nil, pkgerrors.Wrap(err, "background worker failed")
 	}
 
+	// we ignore the error, because if that task would have failed, backgroundWorker.Wait() would have returned that error already
+	workflowRegistryConfigurationOutput, _ := workflowRegistrationResult.Get()
+
 	return &SetupOutput{
-		WorkflowRegistryConfigurationOutput: workflowRegistryInput.Out, // pass to caller, so that it can be optionally attached to TestConfig and saved to disk
+		WorkflowRegistryConfigurationOutput: workflowRegistryConfigurationOutput, // pass to caller, so that it can be optionally attached to TestConfig and saved to disk
 		BlockchainOutput:                    blockchainOutputs,
 		DonTopology:                         fullCldOutput.DonTopology,
 		NodeOutput:                          nodeSetOutput,
@@ -843,101 +696,4 @@ func (c *ConcurrentNonceMap) Increment(chainID uint64) uint64 {
 	defer c.mu.Unlock()
 	c.nonceByChainID[chainID]++
 	return c.nonceByChainID[chainID]
-}
-
-// must match nubmer of events we track in core/services/workflows/syncer/handler.go
-const NumberOfTrackedWorkflowRegistryEvents = 6
-
-// waitForAllNodesToHaveExpectedFiltersRegistered manually checks if all WorkflowRegistry filters used by the LogPoller are registered for all nodes. We want to see if this will help with the flakiness.
-func waitForAllNodesToHaveExpectedFiltersRegistered(singeFileLogger logger.Logger, testLogger zerolog.Logger, homeChainID uint64, donTopology cre.DonTopology, nodeSetInput []*cre.CapabilitiesAwareNodeSet) error {
-	for donIdx, don := range donTopology.DonsWithMetadata {
-		if !flags.HasFlag(don.Flags, cre.WorkflowDON) {
-			continue
-		}
-
-		workderNodes, workersErr := crenode.FindManyWithLabel(don.NodesMetadata, &cre.Label{Key: crenode.NodeTypeKey, Value: cre.WorkerNode}, crenode.EqualLabels)
-		if workersErr != nil {
-			return pkgerrors.Wrap(workersErr, "failed to find worker nodes")
-		}
-
-		results := make(map[int]bool)
-		ticker := 5 * time.Second
-		timeout := 2 * time.Minute
-
-	INNER_LOOP:
-		for {
-			select {
-			case <-time.After(timeout):
-				return fmt.Errorf("timed out, when waiting for %.2f seconds, waiting for all nodes to have expected filters registered", timeout.Seconds())
-			case <-time.Tick(ticker):
-				if len(results) == len(workderNodes) {
-					testLogger.Info().Msgf("All %d nodes in DON %d have expected filters registered", len(workderNodes), don.ID)
-					break INNER_LOOP
-				}
-
-				for _, workerNode := range workderNodes {
-					nodeIndex, nodeIndexErr := crenode.FindLabelValue(workerNode, crenode.IndexKey)
-					if nodeIndexErr != nil {
-						return pkgerrors.Wrap(nodeIndexErr, "failed to find node index")
-					}
-
-					nodeIndexInt, nodeIdxErr := strconv.Atoi(nodeIndex)
-					if nodeIdxErr != nil {
-						return pkgerrors.Wrap(nodeIdxErr, "failed to convert node index to int")
-					}
-
-					if _, ok := results[nodeIndexInt]; ok {
-						continue
-					}
-
-					testLogger.Info().Msgf("Checking if all WorkflowRegistry filters are registered for worker node %d", nodeIndexInt)
-					allFilters, filtersErr := getAllFilters(context.Background(), singeFileLogger, big.NewInt(libc.MustSafeInt64(homeChainID)), nodeIndexInt, nodeSetInput[donIdx].DbInput.Port)
-					if filtersErr != nil {
-						return pkgerrors.Wrap(filtersErr, "failed to get filters")
-					}
-
-					for _, filter := range allFilters {
-						if strings.Contains(filter.Name, "WorkflowRegistry") {
-							if len(filter.EventSigs) == NumberOfTrackedWorkflowRegistryEvents {
-								testLogger.Debug().Msgf("Found all WorkflowRegistry filters for node %d", nodeIndexInt)
-								results[nodeIndexInt] = true
-								continue
-							}
-
-							testLogger.Debug().Msgf("Found only %d WorkflowRegistry filters for node %d", len(filter.EventSigs), nodeIndexInt)
-						}
-					}
-				}
-
-				// return if we have results for all nodes, don't wait for next tick
-				if len(results) == len(workderNodes) {
-					testLogger.Info().Msgf("All %d nodes in DON %d have expected filters registered", len(workderNodes), don.ID)
-					break INNER_LOOP
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func NewORM(logger logger.Logger, chainID *big.Int, nodeIndex, externalPort int) (logpoller.ORM, *sqlx.DB, error) {
-	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", "127.0.0.1", externalPort, postgres.User, postgres.Password, fmt.Sprintf("db_%d", nodeIndex))
-	db, err := sqlx.Open("postgres", dsn)
-	if err != nil {
-		return nil, db, err
-	}
-
-	db.MapperFunc(reflectx.CamelToSnakeASCII)
-	return logpoller.NewORM(chainID, db, logger), db, nil
-}
-
-func getAllFilters(ctx context.Context, logger logger.Logger, chainID *big.Int, nodeIndex, externalPort int) (map[string]logpoller.Filter, error) {
-	orm, db, err := NewORM(logger, chainID, nodeIndex, externalPort)
-	if err != nil {
-		return nil, err
-	}
-
-	defer db.Close()
-	return orm.LoadFilters(ctx)
 }

--- a/system-tests/lib/format/text.go
+++ b/system-tests/lib/format/text.go
@@ -2,10 +2,14 @@ package text
 
 import "fmt"
 
-func PurpleText(text string, args ...interface{}) string {
+func PurpleText(text string, args ...any) string {
 	return fmt.Sprintf("\033[35m%s\033[0m", fmt.Sprintf(text, args...))
 }
 
-func DarkYellowText(text string, args ...interface{}) string {
+func RedText(text string, args ...any) string {
+	return fmt.Sprintf("\033[31m%s\033[0m", fmt.Sprintf(text, args...))
+}
+
+func DarkYellowText(text string, args ...any) string {
 	return fmt.Sprintf("\033[33m\033[2m%s\033[0m", fmt.Sprintf(text, args...))
 }

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/gagliardetto/solana-go v1.13.0
 	github.com/goccy/go-yaml v1.18.0
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/pkg/errors v0.9.1
@@ -284,7 +285,6 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-metrics v0.5.4 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect

--- a/system-tests/lib/worker/background_worker.go
+++ b/system-tests/lib/worker/background_worker.go
@@ -1,0 +1,164 @@
+package worker
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+
+	libformat "github.com/smartcontractkit/chainlink/system-tests/lib/format"
+)
+
+// Future represents a typed result from a background task
+type Future[T any] struct {
+	value   T
+	err     error
+	done    chan struct{}
+	isReady bool
+	mutex   sync.RWMutex
+}
+
+// Get blocks until the task completes and returns the typed result
+func (f *Future[T]) Get() (T, error) {
+	<-f.done
+	f.mutex.RLock()
+	defer f.mutex.RUnlock()
+	return f.value, f.err
+}
+
+// IsReady returns true if the task has completed (non-blocking)
+func (f *Future[T]) IsReady() bool {
+	f.mutex.RLock()
+	defer f.mutex.RUnlock()
+	return f.isReady
+}
+
+// TypedBackgroundRunner manages execution of background tasks with full type safety
+type TypedBackgroundRunner struct {
+	wg             sync.WaitGroup
+	panicCh        chan panicInfo
+	errorCh        chan errorInfo
+	taskNames      []string
+	taskNamesMutex sync.Mutex
+}
+
+type panicInfo struct {
+	taskName   string
+	panicValue any
+	panicStack []byte
+}
+
+type errorInfo struct {
+	taskName   string
+	errorValue error
+}
+
+// NewTypedBackgroundRunner creates a new typed background runner
+func NewTypedBackgroundRunner() *TypedBackgroundRunner {
+	return &TypedBackgroundRunner{
+		panicCh: make(chan panicInfo, 10),
+		errorCh: make(chan errorInfo, 10),
+	}
+}
+
+// Add starts a background task and returns a typed Future.
+func Add[T any](runner *TypedBackgroundRunner, name string, fn func() (T, error)) *Future[T] {
+	future := &Future[T]{
+		done: make(chan struct{}),
+	}
+
+	runner.taskNamesMutex.Lock()
+	runner.taskNames = append(runner.taskNames, name)
+	runner.taskNamesMutex.Unlock()
+
+	runner.wg.Add(1)
+	go func() {
+		defer runner.wg.Done()
+		defer close(future.done)
+		defer func() {
+			if p := recover(); p != nil {
+				runner.panicCh <- panicInfo{
+					taskName:   name,
+					panicValue: p,
+					panicStack: debug.Stack(),
+				}
+			}
+		}()
+
+		fmt.Print(libformat.PurpleText("\n---> [BACKGROUND] Starting %s\n\n", name))
+		start := time.Now()
+
+		value, err := fn()
+
+		future.mutex.Lock()
+		future.value = value
+		future.err = err
+		future.isReady = true
+		future.mutex.Unlock()
+
+		if err == nil {
+			fmt.Print(libformat.PurpleText("\n<--- [BACKGROUND] %s completed in %.2f seconds\n\n", name, time.Since(start).Seconds()))
+		} else {
+			runner.errorCh <- errorInfo{
+				taskName:   name,
+				errorValue: err,
+			}
+			fmt.Print(libformat.RedText("\n<--- [BACKGROUND] %s failed in %.2f seconds: %v\n\n", name, time.Since(start).Seconds(), err))
+		}
+	}()
+
+	return future
+}
+
+// AddVoid starts a background task that doesn't return a value.
+// Returns a Future[struct{}] for consistency.
+func AddVoid(runner *TypedBackgroundRunner, name string, fn func() error) *Future[struct{}] {
+	return Add(runner, name, func() (struct{}, error) {
+		return struct{}{}, fn()
+	})
+}
+
+// Wait blocks until all background tasks complete.
+// Returns an error if any task panicked or errored. Individual task errors can also be checked via Future.Get()
+func (tbr *TypedBackgroundRunner) Wait() error {
+	// Close panic channel when all goroutines finish
+	go func() {
+		tbr.wg.Wait()
+		close(tbr.panicCh)
+		close(tbr.errorCh)
+	}()
+
+	// Check for panics
+	for panicInfo := range tbr.panicCh {
+		// Print the original stack trace from the background goroutine
+		if panicInfo.panicStack != nil {
+			fmt.Fprintf(os.Stderr, "Original panic stack trace from background task '%s':\n%s\n", panicInfo.taskName, panicInfo.panicStack)
+		}
+		// we want to surface panic as soon as possible to avoid executing operations, which are doomed to fail anyway
+		// since we assume all tasks must execute successfully
+		panic(fmt.Sprintf("Background task '%s' panicked: %v", panicInfo.taskName, panicInfo.panicValue))
+	}
+
+	// Check for errors
+	var err error
+	for errorInfo := range tbr.errorCh {
+		if errorInfo.errorValue != nil {
+			err = multierror.Append(err, errors.Wrapf(errorInfo.errorValue, "Background task '%s' failed", errorInfo.taskName))
+		}
+	}
+
+	return err
+}
+
+// GetTaskNames returns the names of all tasks that have been added
+func (tbr *TypedBackgroundRunner) GetTaskNames() []string {
+	tbr.taskNamesMutex.Lock()
+	defer tbr.taskNamesMutex.Unlock()
+	names := make([]string, len(tbr.taskNames))
+	copy(names, tbr.taskNames)
+	return names
+}

--- a/system-tests/lib/worker/background_worker_test.go
+++ b/system-tests/lib/worker/background_worker_test.go
@@ -1,0 +1,288 @@
+package worker
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// Example types to demonstrate type safety
+type WorkflowConfig struct {
+	ID       string
+	Settings map[string]string
+}
+
+type FundingInfo struct {
+	Amount   int64
+	TxHashes []string
+}
+
+func TestTypedBackgroundRunner_TypedResults(t *testing.T) {
+	runner := NewTypedBackgroundRunner()
+
+	// Add tasks with different return types - all fully typed
+	stringResult := Add(runner, "String Task", func() (string, error) {
+		time.Sleep(50 * time.Millisecond)
+		return "hello world", nil
+	})
+
+	intResult := Add(runner, "Int Task", func() (int, error) {
+		time.Sleep(30 * time.Millisecond)
+		return 42, nil
+	})
+
+	structResult := Add(runner, "Struct Task", func() (WorkflowConfig, error) {
+		return WorkflowConfig{
+			ID:       "workflow-123",
+			Settings: map[string]string{"key": "value"},
+		}, nil
+	})
+
+	sliceResult := Add(runner, "Slice Task", func() ([]string, error) {
+		return []string{"item1", "item2", "item3"}, nil
+	})
+
+	// Wait for all tasks to complete
+	err := runner.Wait()
+	if err != nil {
+		t.Fatalf("Expected no error from Wait(), got: %v", err)
+	}
+
+	// Get typed results - no type assertions needed!
+	str, err := stringResult.Get()
+	if err != nil {
+		t.Fatalf("String task failed: %v", err)
+	}
+	if str != "hello world" {
+		t.Errorf("Expected 'hello world', got: %s", str)
+	}
+
+	num, err := intResult.Get()
+	if err != nil {
+		t.Fatalf("Int task failed: %v", err)
+	}
+	if num != 42 {
+		t.Errorf("Expected 42, got: %d", num)
+	}
+
+	config, err := structResult.Get()
+	if err != nil {
+		t.Fatalf("Struct task failed: %v", err)
+	}
+	if config.ID != "workflow-123" || config.Settings["key"] != "value" {
+		t.Errorf("Unexpected struct result: %+v", config)
+	}
+
+	slice, err := sliceResult.Get()
+	if err != nil {
+		t.Fatalf("Slice task failed: %v", err)
+	}
+	if len(slice) != 3 || slice[0] != "item1" {
+		t.Errorf("Unexpected slice result: %v", slice)
+	}
+}
+
+func TestTypedBackgroundRunner_ErrorHandling(t *testing.T) {
+	runner := NewTypedBackgroundRunner()
+
+	successResult := Add(runner, "Success Task", func() (string, error) {
+		return "success", nil
+	})
+
+	errorResult := Add(runner, "Error Task", func() (int, error) {
+		return 0, errors.New("task failed")
+	})
+
+	err := runner.Wait()
+	if err == nil {
+		t.Fatal("Wait() should return error for task errors")
+	}
+
+	// Check individual results
+	successValue, err := successResult.Get()
+	if err != nil {
+		t.Errorf("Success task should not fail, got: %v", err)
+	}
+	if successValue != "success" {
+		t.Errorf("Expected 'success', got: %s", successValue)
+	}
+
+	errorValue, err := errorResult.Get()
+	if err == nil {
+		t.Error("Error task should have failed")
+	}
+	if errorValue != 0 {
+		t.Errorf("Error task should return zero value, got: %d", errorValue)
+	}
+	if err.Error() != "task failed" {
+		t.Errorf("Expected 'task failed', got: %v", err)
+	}
+}
+
+func TestTypedBackgroundRunner_VoidTasks(t *testing.T) {
+	runner := NewTypedBackgroundRunner()
+
+	var sideEffect1, sideEffect2 bool
+
+	voidResult1 := AddVoid(runner, "Void Task 1", func() error {
+		sideEffect1 = true
+		return nil
+	})
+
+	voidResult2 := AddVoid(runner, "Void Task 2", func() error {
+		sideEffect2 = true
+		return errors.New("void task error")
+	})
+
+	err := runner.Wait()
+	if err == nil {
+		t.Fatal("Wait() did not fail")
+	}
+
+	// Check void results
+	_, err = voidResult1.Get()
+	if err != nil {
+		t.Errorf("Void task 1 should succeed, got: %v", err)
+	}
+
+	_, err = voidResult2.Get()
+	if err == nil {
+		t.Error("Void task 2 should have failed")
+	}
+
+	if !sideEffect1 || !sideEffect2 {
+		t.Error("Side effects should have occurred")
+	}
+}
+
+func TestTypedBackgroundRunner_Panic(t *testing.T) {
+	runner := NewTypedBackgroundRunner()
+
+	_ = Add(runner, "Panicking Task", func() (string, error) {
+		panic("test panic")
+	})
+
+	// Should panic when Wait() is called
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected a panic, but didn't get one")
+		}
+	}()
+
+	_ = runner.Wait()
+}
+
+func TestTypedBackgroundRunner_IsReady(t *testing.T) {
+	runner := NewTypedBackgroundRunner()
+
+	slowResult := Add(runner, "Slow Task", func() (string, error) {
+		time.Sleep(100 * time.Millisecond)
+		return "done", nil
+	})
+
+	fastResult := Add(runner, "Fast Task", func() (string, error) {
+		return "quick", nil
+	})
+
+	// Check readiness before completion
+	time.Sleep(20 * time.Millisecond)
+
+	if slowResult.IsReady() {
+		t.Error("Slow task should not be ready yet")
+	}
+
+	// Fast task might be ready by now, but let's wait for both
+	err := runner.Wait()
+	if err != nil {
+		t.Fatalf("Wait() failed: %v", err)
+	}
+
+	// Now both should be ready
+	if !slowResult.IsReady() {
+		t.Error("Slow task should be ready after Wait()")
+	}
+	if !fastResult.IsReady() {
+		t.Error("Fast task should be ready after Wait()")
+	}
+
+	// Get results
+	slowValue, err := slowResult.Get()
+	if err != nil || slowValue != "done" {
+		t.Errorf("Unexpected slow result: %s, %v", slowValue, err)
+	}
+
+	fastValue, err := fastResult.Get()
+	if err != nil || fastValue != "quick" {
+		t.Errorf("Unexpected fast result: %s, %v", fastValue, err)
+	}
+}
+
+// Example of real-world usage pattern
+func TestTypedBackgroundRunner_RealWorldExample(t *testing.T) {
+	runner := NewTypedBackgroundRunner()
+
+	// Simulate complex setup tasks with different return types
+	workflowResult := Add(runner, "Configure Workflow Registry", func() (*WorkflowConfig, error) {
+		// Simulate complex contract configuration
+		time.Sleep(50 * time.Millisecond)
+		return &WorkflowConfig{
+			ID:       "registry-456",
+			Settings: map[string]string{"timeout": "30s"},
+		}, nil
+	})
+
+	fundingResult := Add(runner, "Fund Chainlink nodes", func() (FundingInfo, error) {
+		// Simulate funding operations
+		time.Sleep(30 * time.Millisecond)
+		return FundingInfo{
+			Amount:   1000000000000000000, // 1 ETH in wei
+			TxHashes: []string{"0xabc123", "0xdef456"},
+		}, nil
+	})
+
+	configResult := AddVoid(runner, "Load Node Configs", func() error {
+		// Simulate configuration loading
+		time.Sleep(20 * time.Millisecond)
+		return nil
+	})
+
+	// Wait for all background tasks
+	err := runner.Wait()
+	if err != nil {
+		t.Fatalf("Background setup failed: %v", err)
+	}
+
+	// Get typed results
+	workflow, err := workflowResult.Get()
+	if err != nil {
+		t.Fatalf("Workflow configuration failed: %v", err)
+	}
+
+	funding, err := fundingResult.Get()
+	if err != nil {
+		t.Fatalf("Node funding failed: %v", err)
+	}
+
+	_, err = configResult.Get()
+	if err != nil {
+		t.Fatalf("Config loading failed: %v", err)
+	}
+
+	// Use the typed results
+	if workflow.ID != "registry-456" {
+		t.Errorf("Unexpected workflow ID: %s", workflow.ID)
+	}
+	if funding.Amount != 1000000000000000000 {
+		t.Errorf("Unexpected funding amount: %d", funding.Amount)
+	}
+	if len(funding.TxHashes) != 2 {
+		t.Errorf("Expected 2 tx hashes, got: %d", len(funding.TxHashes))
+	}
+
+	// Verify all expected tasks were tracked
+	taskNames := runner.GetTaskNames()
+	expectedNames := []string{"Configure Workflow Registry", "Fund Chainlink nodes", "Load Node Configs"}
+	if len(taskNames) != len(expectedNames) {
+		t.Errorf("Expected %d tasks, got %d", len(expectedNames), len(taskNames))
+	}
+}


### PR DESCRIPTION
previously the code in `SetupTestEnvironment` was cluttered with handling background tasks. Now we have a dedicated background worker, to which we send tasks. Resulting code is cleaner and easier to reason about ;-)

Why I didn't use a library to handle background tasks?
- relatively simple logic 
- no extra dependencies

If we don't mind pulling extra deps, though, something like [https://github.com/alitto/pond](https://github.com/alitto/pond) should fulfill our needs.

----
This pull request refactors handling of background tasks in the system test environment setup. The main goal is to simplify background task management, and improve code clarity and maintainability. The changes also replace custom goroutine logic with a reusable background worker utility.

Key changes include:

**Background Task Management Improvements:**
- Replaced custom goroutine and channel-based background task execution with the `worker.NewTypedBackgroundRunner` utility, simplifying the orchestration of background tasks during environment setup. [[1]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L419-R418) [[2]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L583-L612) [[3]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L637-R535)
- Removed the `backgroundStageResult` struct and associated manual synchronization code, further simplifying background task handling.

**Workflow Registry Refactor and Modularization:**
- Moved the `ConfigureWorkflowRegistry` function and related logic from `contracts.go` to a new file, `workflowregistry.go`, and added helper functions for preparing configuration input and checking log poller filter registration. This makes Workflow Registry logic more modular and easier to maintain. [[1]](diffhunk://#diff-9aad37f05a55fe9cba2c55faa3a93b750b7a123cf384035d7a44fd5d4a038094R1-R263) [[2]](diffhunk://#diff-febbfdc86aa400a79f61d8c941b49fce89d69e3eb00577a3c385fd46d3678ea7L435-L476)

**Code Cleanup and Dependency Updates:**
- Updated imports to reflect the new modular structure and removed unused dependencies from `environment.go`. [[1]](diffhunk://#diff-febbfdc86aa400a79f61d8c941b49fce89d69e3eb00577a3c385fd46d3678ea7L12) [[2]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L6-L21) [[3]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L34-L39) [[4]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L52-R51)

These changes result in a cleaner, more maintainable codebase and pave the way for easier future enhancements to the Workflow Registry and environment setup process.

- Workflow Registry logic modularized into `workflowregistry.go` with additional helper functions for configuration and filter registration. [[1]](diffhunk://#diff-9aad37f05a55fe9cba2c55faa3a93b750b7a123cf384035d7a44fd5d4a038094R1-R263) [[2]](diffhunk://#diff-febbfdc86aa400a79f61d8c941b49fce89d69e3eb00577a3c385fd46d3678ea7L435-L476)
- Background task execution in environment setup refactored to use a typed background runner utility, replacing manual goroutine and channel management. [[1]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L419-R418) [[2]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L583-L612) [[3]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L637-R535)
- Removed the custom `backgroundStageResult` struct and related synchronization code.
- Cleaned up and updated imports to match the new structure and remove unused dependencies. [[1]](diffhunk://#diff-febbfdc86aa400a79f61d8c941b49fce89d69e3eb00577a3c385fd46d3678ea7L12) [[2]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L6-L21) [[3]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L34-L39) [[4]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L52-R51)