### PR TITLE
CCIP OCR2 beholder metrics

### DIFF
--- a/.changeset/wild-trees-doubt.md
+++ b/.changeset/wild-trees-doubt.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+CCIP OCR2 beholder metrics #nops

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -17,6 +17,7 @@ import (
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
@@ -139,7 +140,9 @@ func NewCommitServices(
 	onRampReader = observability.NewObservedOnRampReader(onRampReader, sourceChainID, ccip.CommitPluginLabel)
 	commitStoreReader = observability.NewObservedCommitStoreReader(commitStoreReader, destChainID, ccip.CommitPluginLabel)
 	offRampReader = observability.NewObservedOffRampReader(offRampReader, destChainID, ccip.CommitPluginLabel)
-	metricsCollector, err := ccip.NewPluginMetricsCollector(ccip.CommitPluginLabel, sourceChainID, destChainID, srcChain.Name, dstChain.Name)
+
+	bhClient := beholder.GetClient().ForPackage("ccip-ocr2-commit")
+	metricsCollector, err := ccip.NewPluginMetricsCollector(ccip.CommitPluginLabel, bhClient, sourceChainID, destChainID, srcChain.Name, dstChain.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plugin metrics collector: %w", err)
 	}

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -139,7 +139,10 @@ func NewCommitServices(
 	onRampReader = observability.NewObservedOnRampReader(onRampReader, sourceChainID, ccip.CommitPluginLabel)
 	commitStoreReader = observability.NewObservedCommitStoreReader(commitStoreReader, destChainID, ccip.CommitPluginLabel)
 	offRampReader = observability.NewObservedOffRampReader(offRampReader, destChainID, ccip.CommitPluginLabel)
-	metricsCollector := ccip.NewPluginMetricsCollector(ccip.CommitPluginLabel, sourceChainID, destChainID)
+	metricsCollector, err := ccip.NewPluginMetricsCollector(ccip.CommitPluginLabel, sourceChainID, destChainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create plugin metrics collector: %w", err)
+	}
 
 	chainHealthCheck := cache.NewObservedChainHealthCheck(
 		cache.NewChainHealthcheck(

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -122,7 +122,7 @@ func NewCommitServices(
 	}
 	srcChain, ok := chainselectors.ChainByEvmChainID(uint64(sourceChainID))
 	if !ok {
-		return nil, fmt.Errorf("failed to get source chain by evm ID %d", destChainID)
+		return nil, fmt.Errorf("failed to get source chain by evm ID %d", sourceChainID)
 	}
 	dstChain, ok2 := chainselectors.ChainByEvmChainID(uint64(destChainID))
 	if !ok2 {
@@ -139,7 +139,7 @@ func NewCommitServices(
 	onRampReader = observability.NewObservedOnRampReader(onRampReader, sourceChainID, ccip.CommitPluginLabel)
 	commitStoreReader = observability.NewObservedCommitStoreReader(commitStoreReader, destChainID, ccip.CommitPluginLabel)
 	offRampReader = observability.NewObservedOffRampReader(offRampReader, destChainID, ccip.CommitPluginLabel)
-	metricsCollector, err := ccip.NewPluginMetricsCollector(ccip.CommitPluginLabel, sourceChainID, destChainID)
+	metricsCollector, err := ccip.NewPluginMetricsCollector(ccip.CommitPluginLabel, sourceChainID, destChainID, srcChain.Name, dstChain.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plugin metrics collector: %w", err)
 	}

--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
@@ -106,6 +106,11 @@ func (r *CommitReportingPlugin) Observation(ctx context.Context, epochAndRound t
 		return nil, ccip.ErrChainIsNotHealthy
 	}
 
+	onRampAddress, err := r.onRampReader.Address(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Will return 0,0 if no messages are found. This is a valid case as the report could
 	// still contain fee updates.
 	minSeqNr, maxSeqNr, messageIDs, err := r.calculateMinMaxSequenceNumbers(ctx, lggr)
@@ -128,6 +133,8 @@ func (r *CommitReportingPlugin) Observation(ctx context.Context, epochAndRound t
 		"messageIDs", messageIDs,
 	)
 	r.metricsCollector.NumberOfMessagesBasedOnInterval(ccip.Observation, minSeqNr, maxSeqNr)
+	r.metricsCollector.CommitLatestRoundId(string(onRampAddress), uint64(epochAndRound.Round))
+	r.metricsCollector.SequenceNumber(ccip.Observation, maxSeqNr, string(onRampAddress))
 
 	// Even if all values are empty we still want to communicate our observation
 	// with the other nodes, therefore, we always return the observed values.
@@ -275,6 +282,11 @@ func (r *CommitReportingPlugin) Report(ctx context.Context, epochAndRound types.
 		return false, nil, ccip.ErrChainIsNotHealthy
 	}
 
+	onRampAddress, err := r.onRampReader.Address(ctx)
+	if err != nil {
+		return false, nil, err
+	}
+
 	parsableObservations := ccip.GetParsableObservations[ccip.CommitObservation](lggr, observations)
 
 	intervals, gasPriceObs, tokenPriceObs, err := extractObservationData(lggr, r.F, r.sourceChainSelector, parsableObservations)
@@ -305,7 +317,8 @@ func (r *CommitReportingPlugin) Report(ctx context.Context, epochAndRound types.
 	if err != nil {
 		return false, nil, err
 	}
-	r.metricsCollector.SequenceNumber(ccip.Report, report.Interval.Max)
+	r.metricsCollector.SequenceNumber(ccip.Report, report.Interval.Max, string(onRampAddress))
+	r.metricsCollector.CommitLatestRoundId(string(onRampAddress), uint64(epochAndRound.Round))
 	r.metricsCollector.NumberOfMessagesBasedOnInterval(ccip.Report, report.Interval.Min, report.Interval.Max)
 	lggr.Infow("Report",
 		"merkleRoot", hex.EncodeToString(report.MerkleRoot[:]),
@@ -634,7 +647,6 @@ func (r *CommitReportingPlugin) ShouldAcceptFinalizedReport(ctx context.Context,
 		return false, nil
 	}
 
-	r.metricsCollector.SequenceNumber(ccip.ShouldAccept, parsedReport.Interval.Max)
 	lggr.Infow("Accepting finalized report", "merkleRoot", hexutil.Encode(parsedReport.MerkleRoot[:]))
 	return true, nil
 }

--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
@@ -133,7 +133,7 @@ func (r *CommitReportingPlugin) Observation(ctx context.Context, epochAndRound t
 		"messageIDs", messageIDs,
 	)
 	r.metricsCollector.NumberOfMessagesBasedOnInterval(ccip.Observation, minSeqNr, maxSeqNr)
-	r.metricsCollector.CommitLatestRoundId(string(onRampAddress), uint64(epochAndRound.Round))
+	r.metricsCollector.CommitLatestRoundID(string(onRampAddress), uint64(epochAndRound.Round))
 	r.metricsCollector.SequenceNumber(ccip.Observation, maxSeqNr, string(onRampAddress))
 
 	// Even if all values are empty we still want to communicate our observation
@@ -318,7 +318,7 @@ func (r *CommitReportingPlugin) Report(ctx context.Context, epochAndRound types.
 		return false, nil, err
 	}
 	r.metricsCollector.SequenceNumber(ccip.Report, report.Interval.Max, string(onRampAddress))
-	r.metricsCollector.CommitLatestRoundId(string(onRampAddress), uint64(epochAndRound.Round))
+	r.metricsCollector.CommitLatestRoundID(string(onRampAddress), uint64(epochAndRound.Round))
 	r.metricsCollector.NumberOfMessagesBasedOnInterval(ccip.Report, report.Interval.Min, report.Interval.Max)
 	lggr.Infow("Report",
 		"merkleRoot", hex.EncodeToString(report.MerkleRoot[:]),

--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
@@ -172,6 +172,7 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 			onRampReader := ccipdatamocks.NewOnRampReader(t)
 			onRampReader.On("IsSourceChainHealthy", ctx).Return(true, nil)
 			onRampReader.On("IsSourceCursed", ctx).Return(tc.sourceChainCursed, nil)
+			onRampReader.On("Address", ctx).Return(cciptypes.Address(utils.RandomAddress().String()), nil).Maybe()
 			if len(tc.sendReqs) > 0 {
 				onRampReader.On("GetSendRequestsBetweenSeqNums", ctx, tc.commitStoreSeqNum, tc.commitStoreSeqNum+OnRampMessagesScanLimit, true).
 					Return(tc.sendReqs, nil)
@@ -234,7 +235,9 @@ func TestCommitReportingPlugin_Report(t *testing.T) {
 		p := &CommitReportingPlugin{}
 		p.lggr = logger.TestLogger(t)
 		p.F = 1
-
+		onRampReader := ccipdatamocks.NewOnRampReader(t)
+		onRampReader.On("Address", ctx).Return(cciptypes.Address(utils.RandomAddress().String()), nil).Maybe()
+		p.onRampReader = onRampReader
 		chainHealthcheck := ccipcachemocks.NewChainHealthcheck(t)
 		chainHealthcheck.On("IsHealthy", ctx).Return(true, nil).Maybe()
 		p.chainHealthcheck = chainHealthcheck
@@ -399,6 +402,7 @@ func TestCommitReportingPlugin_Report(t *testing.T) {
 			destPriceRegistryReader.On("GetTokenPriceUpdatesCreatedAfter", ctx, mock.Anything, 0).Return(tc.tokenPriceUpdates, nil)
 
 			onRampReader := ccipdatamocks.NewOnRampReader(t)
+			onRampReader.On("Address", ctx).Return(cciptypes.Address(utils.RandomAddress().String()), nil).Maybe()
 			if len(tc.sendRequests) > 0 {
 				onRampReader.On("GetSendRequestsBetweenSeqNums", ctx, tc.expSeqNumRange.Min, tc.expSeqNumRange.Max, true).Return(tc.sendRequests, nil)
 			}

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -18,6 +18,7 @@ import (
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
+
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -81,10 +82,12 @@ func NewExecServices(ctx context.Context, lggr logger.Logger, jb job.Job, srcPro
 	srcChainSelector := offRampConfig.SourceChainSelector
 	dstChainSelector := offRampConfig.ChainSelector
 
+	// nolint:gosec // srcChainID will never be negative
 	srcChain, ok := chainselectors.ChainByEvmChainID(uint64(srcChainID))
 	if !ok {
 		return nil, fmt.Errorf("failed to get source chain by evm ID %d", srcChainID)
 	}
+	// nolint:gosec // srcChainID will never be negative
 	dstChain, ok2 := chainselectors.ChainByEvmChainID(uint64(dstChainID))
 	if !ok2 {
 		return nil, fmt.Errorf("failed to get dest chain by evm ID %d", dstChainID)

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
 	"github.com/Masterminds/semver/v3"
@@ -151,7 +152,9 @@ func NewExecServices(ctx context.Context, lggr logger.Logger, jb job.Job, srcPro
 	onRampReader = observability.NewObservedOnRampReader(onRampReader, srcChainID, ccip.ExecPluginLabel)
 	commitStoreReader = observability.NewObservedCommitStoreReader(commitStoreReader, dstChainID, ccip.ExecPluginLabel)
 	offRampReader = observability.NewObservedOffRampReader(offRampReader, dstChainID, ccip.ExecPluginLabel)
-	metricsCollector, err := ccip.NewPluginMetricsCollector(ccip.ExecPluginLabel, srcChainID, dstChainID, srcChain.Name, dstChain.Name)
+
+	bhClient := beholder.GetClient().ForPackage("ccip-ocr2-exec")
+	metricsCollector, err := ccip.NewPluginMetricsCollector(ccip.ExecPluginLabel, bhClient, srcChainID, dstChainID, srcChain.Name, dstChain.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plugin metrics collector: %w", err)
 	}

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -16,10 +16,8 @@ import (
 
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
-
-	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/statuschecker"
-
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -33,6 +31,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/oraclelib"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/tokendata"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/promwrapper"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/statuschecker"
 )
 
 var (
@@ -80,6 +79,16 @@ func NewExecServices(ctx context.Context, lggr logger.Logger, jb job.Job, srcPro
 
 	srcChainSelector := offRampConfig.SourceChainSelector
 	dstChainSelector := offRampConfig.ChainSelector
+
+	srcChain, ok := chainselectors.ChainByEvmChainID(uint64(srcChainID))
+	if !ok {
+		return nil, fmt.Errorf("failed to get source chain by evm ID %d", srcChainID)
+	}
+	dstChain, ok2 := chainselectors.ChainByEvmChainID(uint64(dstChainID))
+	if !ok2 {
+		return nil, fmt.Errorf("failed to get dest chain by evm ID %d", dstChainID)
+	}
+
 	onRampReader, err := srcProvider.NewOnRampReader(ctx, offRampConfig.OnRamp, srcChainSelector, dstChainSelector)
 	if err != nil {
 		return nil, fmt.Errorf("create onRampReader: %w", err)
@@ -142,7 +151,7 @@ func NewExecServices(ctx context.Context, lggr logger.Logger, jb job.Job, srcPro
 	onRampReader = observability.NewObservedOnRampReader(onRampReader, srcChainID, ccip.ExecPluginLabel)
 	commitStoreReader = observability.NewObservedCommitStoreReader(commitStoreReader, dstChainID, ccip.ExecPluginLabel)
 	offRampReader = observability.NewObservedOffRampReader(offRampReader, dstChainID, ccip.ExecPluginLabel)
-	metricsCollector, err := ccip.NewPluginMetricsCollector(ccip.ExecPluginLabel, srcChainID, dstChainID)
+	metricsCollector, err := ccip.NewPluginMetricsCollector(ccip.ExecPluginLabel, srcChainID, dstChainID, srcChain.Name, dstChain.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plugin metrics collector: %w", err)
 	}

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -142,7 +142,10 @@ func NewExecServices(ctx context.Context, lggr logger.Logger, jb job.Job, srcPro
 	onRampReader = observability.NewObservedOnRampReader(onRampReader, srcChainID, ccip.ExecPluginLabel)
 	commitStoreReader = observability.NewObservedCommitStoreReader(commitStoreReader, dstChainID, ccip.ExecPluginLabel)
 	offRampReader = observability.NewObservedOffRampReader(offRampReader, dstChainID, ccip.ExecPluginLabel)
-	metricsCollector := ccip.NewPluginMetricsCollector(ccip.ExecPluginLabel, srcChainID, dstChainID)
+	metricsCollector, err := ccip.NewPluginMetricsCollector(ccip.ExecPluginLabel, srcChainID, dstChainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create plugin metrics collector: %w", err)
+	}
 
 	tokenPoolBatchedReader, err := dstProvider.NewTokenPoolBatchedReader(ctx, offRampAddress, srcChainSelector)
 	if err != nil {

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -82,12 +82,12 @@ func NewExecServices(ctx context.Context, lggr logger.Logger, jb job.Job, srcPro
 	srcChainSelector := offRampConfig.SourceChainSelector
 	dstChainSelector := offRampConfig.ChainSelector
 
-	// nolint:gosec // srcChainID will never be negative
+	//nolint:gosec // srcChainID will never be negative
 	srcChain, ok := chainselectors.ChainByEvmChainID(uint64(srcChainID))
 	if !ok {
 		return nil, fmt.Errorf("failed to get source chain by evm ID %d", srcChainID)
 	}
-	// nolint:gosec // srcChainID will never be negative
+	//nolint:gosec // srcChainID will never be negative
 	dstChain, ok2 := chainselectors.ChainByEvmChainID(uint64(dstChainID))
 	if !ok2 {
 		return nil, fmt.Errorf("failed to get dest chain by evm ID %d", dstChainID)

--- a/core/services/ocr2/plugins/ccip/ccipexec/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/ocr2.go
@@ -144,7 +144,9 @@ func (r *ExecutionReportingPlugin) Observation(ctx context.Context, timestamp ty
 	}
 	executableObservations = executableObservations[:capped]
 	r.metricsCollector.NumberOfMessagesProcessed(ccip.Observation, len(executableObservations))
-	r.metricsCollector.SequenceNumber(ccip.Observation, executableObservations[len(executableObservations)-1].SeqNr, string(offRampAddress))
+	if len(executableObservations) > 0 {
+		r.metricsCollector.SequenceNumber(ccip.Observation, executableObservations[len(executableObservations)-1].SeqNr, string(offRampAddress))
+	}
 	r.metricsCollector.ExecLatestRoundID(string(offRampAddress), uint64(timestamp.Round))
 	lggr.Infow("Observation", "executableMessages", executableObservations)
 	// Note can be empty

--- a/core/services/ocr2/plugins/ccip/ccipexec/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/ocr2.go
@@ -111,6 +111,11 @@ func (r *ExecutionReportingPlugin) Observation(ctx context.Context, timestamp ty
 		return nil, ccip.ErrChainIsNotHealthy
 	}
 
+	offRampAddress, err := r.offRampReader.Address(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Ensure that the source price registry is synchronized with the onRamp.
 	if err := r.ensurePriceRegistrySynchronization(ctx); err != nil {
 		return nil, fmt.Errorf("ensuring price registry synchronization: %w", err)
@@ -139,6 +144,8 @@ func (r *ExecutionReportingPlugin) Observation(ctx context.Context, timestamp ty
 	}
 	executableObservations = executableObservations[:capped]
 	r.metricsCollector.NumberOfMessagesProcessed(ccip.Observation, len(executableObservations))
+	r.metricsCollector.SequenceNumber(ccip.Observation, executableObservations[len(executableObservations)-1].SeqNr, string(offRampAddress))
+	r.metricsCollector.ExecLatestRoundId(string(offRampAddress), uint64(timestamp.Round))
 	lggr.Infow("Observation", "executableMessages", executableObservations)
 	// Note can be empty
 	return ccip.NewExecutionObservation(executableObservations).Marshal()
@@ -446,7 +453,7 @@ func (r *ExecutionReportingPlugin) getReportsWithSendRequests(
 
 // Assumes non-empty report. Messages to execute can span more than one report, but are assumed to be in order of increasing
 // sequence number.
-func (r *ExecutionReportingPlugin) buildReport(ctx context.Context, lggr logger.Logger, observedMessages []ccip.ObservedMessage) ([]byte, error) {
+func (r *ExecutionReportingPlugin) buildReport(ctx context.Context, lggr logger.Logger, observedMessages []ccip.ObservedMessage, timestamp types.ReportTimestamp) ([]byte, error) {
 	if err := validateSeqNumbers(ctx, r.commitStoreReader, observedMessages); err != nil {
 		return nil, err
 	}
@@ -457,6 +464,11 @@ func (r *ExecutionReportingPlugin) buildReport(ctx context.Context, lggr logger.
 	lggr.Infow("Building execution report", "observations", observedMessages, "merkleRoot", hexutil.Encode(commitReport.MerkleRoot[:]), "report", commitReport)
 
 	sendReqsInRoot, _, tree, err := getProofData(ctx, r.onRampReader, commitReport.Interval)
+	if err != nil {
+		return nil, err
+	}
+
+	offRampAddress, err := r.offRampReader.Address(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +515,8 @@ func (r *ExecutionReportingPlugin) buildReport(ctx context.Context, lggr logger.
 	}
 	if len(execReport.Messages) > 0 {
 		r.metricsCollector.NumberOfMessagesProcessed(ccip.Report, len(execReport.Messages))
-		r.metricsCollector.SequenceNumber(ccip.Report, execReport.Messages[len(execReport.Messages)-1].SequenceNumber)
+		r.metricsCollector.SequenceNumber(ccip.Report, execReport.Messages[len(execReport.Messages)-1].SequenceNumber, string(offRampAddress))
+		r.metricsCollector.ExecLatestRoundId(string(offRampAddress), uint64(timestamp.Round))
 	}
 	return encodedReport, nil
 }
@@ -545,7 +558,7 @@ func (r *ExecutionReportingPlugin) Report(ctx context.Context, timestamp types.R
 		return false, nil, nil
 	}
 
-	report, err := r.buildReport(ctx, lggr, observedMessages)
+	report, err := r.buildReport(ctx, lggr, observedMessages, timestamp)
 	if err != nil {
 		return false, nil, err
 	}
@@ -639,9 +652,6 @@ func (r *ExecutionReportingPlugin) ShouldAcceptFinalizedReport(ctx context.Conte
 	// Else just assume in flight
 	if err = r.inflightReports.add(lggr, execReport.Messages); err != nil {
 		return false, err
-	}
-	if len(execReport.Messages) > 0 {
-		r.metricsCollector.SequenceNumber(ccip.ShouldAccept, execReport.Messages[len(execReport.Messages)-1].SequenceNumber)
 	}
 	lggr.Info("Accepting finalized report")
 	return true, nil

--- a/core/services/ocr2/plugins/ccip/ccipexec/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/ocr2.go
@@ -145,7 +145,7 @@ func (r *ExecutionReportingPlugin) Observation(ctx context.Context, timestamp ty
 	executableObservations = executableObservations[:capped]
 	r.metricsCollector.NumberOfMessagesProcessed(ccip.Observation, len(executableObservations))
 	r.metricsCollector.SequenceNumber(ccip.Observation, executableObservations[len(executableObservations)-1].SeqNr, string(offRampAddress))
-	r.metricsCollector.ExecLatestRoundId(string(offRampAddress), uint64(timestamp.Round))
+	r.metricsCollector.ExecLatestRoundID(string(offRampAddress), uint64(timestamp.Round))
 	lggr.Infow("Observation", "executableMessages", executableObservations)
 	// Note can be empty
 	return ccip.NewExecutionObservation(executableObservations).Marshal()
@@ -516,7 +516,7 @@ func (r *ExecutionReportingPlugin) buildReport(ctx context.Context, lggr logger.
 	if len(execReport.Messages) > 0 {
 		r.metricsCollector.NumberOfMessagesProcessed(ccip.Report, len(execReport.Messages))
 		r.metricsCollector.SequenceNumber(ccip.Report, execReport.Messages[len(execReport.Messages)-1].SequenceNumber, string(offRampAddress))
-		r.metricsCollector.ExecLatestRoundId(string(offRampAddress), uint64(timestamp.Round))
+		r.metricsCollector.ExecLatestRoundID(string(offRampAddress), uint64(timestamp.Round))
 	}
 	return encodedReport, nil
 }

--- a/core/services/ocr2/plugins/ccip/ccipexec/ocr2_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/ocr2_test.go
@@ -220,7 +220,7 @@ func TestExecutionReportingPlugin_Observation(t *testing.T) {
 			bs := &BestEffortBatchingStrategy{}
 			p.batchingStrategy = bs
 
-			_, err = p.Observation(ctx, types.ReportTimestamp{}, types.Query{})
+			_, err = p.Observation(ctx, ocrtypes.ReportTimestamp{}, types.Query{})
 			if tc.expErr {
 				assert.Error(t, err)
 				return
@@ -331,6 +331,11 @@ func TestExecutionReportingPlugin_ShouldAcceptFinalizedReport(t *testing.T) {
 		Proofs:            [][32]byte{{}},
 		ProofFlagBits:     big.NewInt(1),
 	}
+	reportTimestamp := ocrtypes.ReportTimestamp{
+		ConfigDigest: [32]byte{1, 2, 3},
+		Epoch:        1,
+		Round:        1,
+	}
 
 	encodedReport := encodeExecutionReport(t, report)
 	mockOffRampReader := ccipdatamocks.NewOffRampReader(t)
@@ -349,13 +354,13 @@ func TestExecutionReportingPlugin_ShouldAcceptFinalizedReport(t *testing.T) {
 
 	mockedExecState := mockOffRampReader.On("GetExecutionState", mock.Anything, uint64(12)).Return(uint8(cciptypes.ExecutionStateUntouched), nil).Once()
 
-	should, err := plugin.ShouldAcceptFinalizedReport(testutils.Context(t), ocrtypes.ReportTimestamp{}, encodedReport)
+	should, err := plugin.ShouldAcceptFinalizedReport(testutils.Context(t), reportTimestamp, encodedReport)
 	require.NoError(t, err)
 	assert.True(t, should)
 
 	mockedExecState.Return(uint8(cciptypes.ExecutionStateSuccess), nil).Once()
 
-	should, err = plugin.ShouldAcceptFinalizedReport(testutils.Context(t), ocrtypes.ReportTimestamp{}, encodedReport)
+	should, err = plugin.ShouldAcceptFinalizedReport(testutils.Context(t), reportTimestamp, encodedReport)
 	require.NoError(t, err)
 	assert.False(t, should)
 }

--- a/core/services/ocr2/plugins/ccip/ccipexec/ocr2_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/ocr2_test.go
@@ -477,7 +477,7 @@ func TestExecutionReportingPlugin_buildReport(t *testing.T) {
 		ctx, observations[0].SeqNr, observations[len(observations)-1].SeqNr, false).Return(sendReqs, nil)
 	p.onRampReader = sourceReader
 
-	execReport, err := p.buildReport(ctx, p.lggr, observations)
+	execReport, err := p.buildReport(ctx, p.lggr, observations, ocrtypes.ReportTimestamp{})
 	assert.NoError(t, err)
 	assert.LessOrEqual(t, len(execReport), MaxExecutionReportLength, "built execution report length")
 }

--- a/core/services/ocr2/plugins/ccip/metrics.go
+++ b/core/services/ocr2/plugins/ccip/metrics.go
@@ -60,6 +60,7 @@ type PluginMetricsCollector interface {
 type pluginMetricsCollector struct {
 	pluginName                         string
 	source, dest, sourceName, destName string
+	bhClient                           beholder.Client
 	unexpiredCommitRoots               metric.Int64Gauge
 	messagesProcessed                  metric.Int64Gauge
 	maxSequenceNumber                  metric.Int64Gauge
@@ -68,28 +69,28 @@ type pluginMetricsCollector struct {
 	execLatestRoundId                  metric.Int64Gauge
 }
 
-func NewPluginMetricsCollector(pluginLabel string, sourceChainId, destChainId int64, srcChainName string, destChainName string) (*pluginMetricsCollector, error) {
-	unexpiredCommitRoots, err := beholder.GetMeter().Int64Gauge("ccip_unexpired_commit_roots")
+func NewPluginMetricsCollector(pluginLabel string, bhClient beholder.Client, sourceChainId, destChainId int64, srcChainName string, destChainName string) (*pluginMetricsCollector, error) {
+	unexpiredCommitRoots, err := bhClient.Meter.Int64Gauge("ccip_unexpired_commit_roots")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_unexpired_commit_roots gauge: %w", err)
 	}
-	messagesProcessed, err := beholder.GetMeter().Int64Gauge("ccip_messages_processed")
+	messagesProcessed, err := bhClient.Meter.Int64Gauge("ccip_number_of_messages_processed")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_messages_processed gauge: %w", err)
 	}
-	maxSequenceNumber, err := beholder.GetMeter().Int64Gauge("ccip_max_sequence_number")
+	maxSequenceNumber, err := bhClient.Meter.Int64Gauge("ccip_max_sequence_number")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_max_sequence_number gauge: %w", err)
 	}
-	newReportingPluginErrorCounter, err := beholder.GetMeter().Int64Counter("ccip_new_reporting_plugin_error_counter")
+	newReportingPluginErrorCounter, err := bhClient.Meter.Int64Counter("ccip_new_reporting_plugin_error_counter")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_new_reporting_plugin_error_counter counter: %w", err)
 	}
-	commitLatestRoundId, err := beholder.GetMeter().Int64Gauge("ccip_commit_round_id")
+	commitLatestRoundId, err := bhClient.Meter.Int64Gauge("ccip_commit_round_id")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_commit_round_id gauge: %w", err)
 	}
-	execLatestRoundId, err := beholder.GetMeter().Int64Gauge("ccip_exec_round_id")
+	execLatestRoundId, err := bhClient.Meter.Int64Gauge("ccip_exec_round_id")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_exec_round_id gauge: %w", err)
 	}
@@ -100,6 +101,7 @@ func NewPluginMetricsCollector(pluginLabel string, sourceChainId, destChainId in
 		dest:                           strconv.FormatInt(destChainId, 10),
 		sourceName:                     srcChainName,
 		destName:                       destChainName,
+		bhClient:                       bhClient,
 		unexpiredCommitRoots:           unexpiredCommitRoots,
 		messagesProcessed:              messagesProcessed,
 		maxSequenceNumber:              maxSequenceNumber,

--- a/core/services/ocr2/plugins/ccip/metrics.go
+++ b/core/services/ocr2/plugins/ccip/metrics.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 )
 
 var (
@@ -29,11 +30,11 @@ var (
 		Name: "ccip_new_reporting_plugin_error_counter",
 		Help: "The count of the number of errors when calling NewReportingPlugin",
 	}, []string{"plugin"})
-	commitLatestRoundId = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	commitLatestRoundID = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ccip_commit_round_id",
 		Help: "The latest round ID observed by the commit plugin",
 	}, []string{"source_network_name", "dest_network_name", "contract_address", "plugin"})
-	execLatestRoundId = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	execLatestRoundID = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ccip_exec_round_id",
 		Help: "The latest round ID observed by the exec plugin",
 	}, []string{"source_network_name", "dest_network_name", "contract_address", "plugin"})
@@ -53,8 +54,8 @@ type PluginMetricsCollector interface {
 	UnexpiredCommitRoots(count int)
 	SequenceNumber(phase ocrPhase, seqNr uint64, contractAddress string)
 	NewReportingPluginError()
-	CommitLatestRoundId(contractAddress string, roundId uint64)
-	ExecLatestRoundId(contractAddress string, roundId uint64)
+	CommitLatestRoundId(contractAddress string, roundID uint64)
+	ExecLatestRoundId(contractAddress string, roundID uint64)
 }
 
 type pluginMetricsCollector struct {
@@ -65,8 +66,8 @@ type pluginMetricsCollector struct {
 	messagesProcessed                  metric.Int64Gauge
 	maxSequenceNumber                  metric.Int64Gauge
 	newReportingPluginErrorCounter     metric.Int64Counter
-	commitLatestRoundId                metric.Int64Gauge
-	execLatestRoundId                  metric.Int64Gauge
+	commitLatestRoundID                metric.Int64Gauge
+	execLatestRoundID                  metric.Int64Gauge
 }
 
 func NewPluginMetricsCollector(pluginLabel string, bhClient beholder.Client, sourceChainId, destChainId int64, srcChainName string, destChainName string) (*pluginMetricsCollector, error) {
@@ -86,11 +87,11 @@ func NewPluginMetricsCollector(pluginLabel string, bhClient beholder.Client, sou
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_new_reporting_plugin_error_counter counter: %w", err)
 	}
-	commitLatestRoundId, err := bhClient.Meter.Int64Gauge("ccip_commit_round_id")
+	commitLatestRoundID, err := bhClient.Meter.Int64Gauge("ccip_commit_round_id")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_commit_round_id gauge: %w", err)
 	}
-	execLatestRoundId, err := bhClient.Meter.Int64Gauge("ccip_exec_round_id")
+	execLatestRoundID, err := bhClient.Meter.Int64Gauge("ccip_exec_round_id")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_exec_round_id gauge: %w", err)
 	}
@@ -106,14 +107,15 @@ func NewPluginMetricsCollector(pluginLabel string, bhClient beholder.Client, sou
 		messagesProcessed:              messagesProcessed,
 		maxSequenceNumber:              maxSequenceNumber,
 		newReportingPluginErrorCounter: newReportingPluginErrorCounter,
-		commitLatestRoundId:            commitLatestRoundId,
-		execLatestRoundId:              execLatestRoundId,
+		commitLatestRoundID:            commitLatestRoundID,
+		execLatestRoundID:              execLatestRoundID,
 	}, nil
 }
 
 func (p *pluginMetricsCollector) NumberOfMessagesProcessed(phase ocrPhase, count int) {
 	messagesProcessed.
 		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), p.sourceName, p.destName).
+		// nolint: gosec // count will never be negative or extremely large
 		Set(float64(count))
 	p.messagesProcessed.Record(context.Background(), int64(count), metric.WithAttributes(
 		attribute.String("plugin", p.pluginName),
@@ -128,6 +130,7 @@ func (p *pluginMetricsCollector) NumberOfMessagesProcessed(phase ocrPhase, count
 func (p *pluginMetricsCollector) NumberOfMessagesBasedOnInterval(phase ocrPhase, seqNrMin, seqNrMax uint64) {
 	messagesProcessed.
 		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), p.sourceName, p.destName).
+		// nolint: gosec // count will never be negative or extremely large
 		Set(float64(seqNrMax - seqNrMin + 1))
 	p.messagesProcessed.Record(context.Background(), int64(seqNrMax-seqNrMin+1), metric.WithAttributes(
 		attribute.String("plugin", p.pluginName),
@@ -181,11 +184,12 @@ func (p *pluginMetricsCollector) NewReportingPluginError() {
 	))
 }
 
-func (p *pluginMetricsCollector) CommitLatestRoundId(contractAddress string, roundId uint64) {
-	commitLatestRoundId.
+func (p *pluginMetricsCollector) CommitLatestRoundId(contractAddress string, roundID uint64) {
+	commitLatestRoundID.
 		WithLabelValues(p.source, p.dest, contractAddress, p.pluginName).
-		Set(float64(roundId))
-	p.commitLatestRoundId.Record(context.Background(), int64(roundId), metric.WithAttributes(
+		// nolint: gosec // count or roundID will never be negative or extremely large
+		Set(float64(roundID))
+	p.commitLatestRoundID.Record(context.Background(), int64(roundID), metric.WithAttributes(
 		attribute.String("source_network_name", p.sourceName),
 		attribute.String("dest_network_name", p.destName),
 		attribute.String("contract_address", contractAddress),
@@ -193,11 +197,12 @@ func (p *pluginMetricsCollector) CommitLatestRoundId(contractAddress string, rou
 	))
 }
 
-func (p *pluginMetricsCollector) ExecLatestRoundId(contractAddress string, roundId uint64) {
-	execLatestRoundId.
+func (p *pluginMetricsCollector) ExecLatestRoundId(contractAddress string, roundID uint64) {
+	execLatestRoundID.
 		WithLabelValues(p.source, p.dest, contractAddress, p.pluginName).
-		Set(float64(roundId))
-	p.execLatestRoundId.Record(context.Background(), int64(roundId), metric.WithAttributes(
+		// nolint: gosec // count or roundID will never be negative or extremely large
+		Set(float64(roundID))
+	p.execLatestRoundID.Record(context.Background(), int64(roundID), metric.WithAttributes(
 		attribute.String("source_network_name", p.source),
 		attribute.String("dest_network_name", p.dest),
 		attribute.String("contract_address", contractAddress),

--- a/core/services/ocr2/plugins/ccip/metrics.go
+++ b/core/services/ocr2/plugins/ccip/metrics.go
@@ -54,8 +54,8 @@ type PluginMetricsCollector interface {
 	UnexpiredCommitRoots(count int)
 	SequenceNumber(phase ocrPhase, seqNr uint64, contractAddress string)
 	NewReportingPluginError()
-	CommitLatestRoundId(contractAddress string, roundID uint64)
-	ExecLatestRoundId(contractAddress string, roundID uint64)
+	CommitLatestRoundID(contractAddress string, roundID uint64)
+	ExecLatestRoundID(contractAddress string, roundID uint64)
 }
 
 type pluginMetricsCollector struct {
@@ -70,7 +70,7 @@ type pluginMetricsCollector struct {
 	execLatestRoundID                  metric.Int64Gauge
 }
 
-func NewPluginMetricsCollector(pluginLabel string, bhClient beholder.Client, sourceChainId, destChainId int64, srcChainName string, destChainName string) (*pluginMetricsCollector, error) {
+func NewPluginMetricsCollector(pluginLabel string, bhClient beholder.Client, sourceChainID, destChainID int64, srcChainName string, destChainName string) (*pluginMetricsCollector, error) {
 	unexpiredCommitRoots, err := bhClient.Meter.Int64Gauge("ccip_unexpired_commit_roots")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_unexpired_commit_roots gauge: %w", err)
@@ -98,8 +98,8 @@ func NewPluginMetricsCollector(pluginLabel string, bhClient beholder.Client, sou
 
 	return &pluginMetricsCollector{
 		pluginName:                     pluginLabel,
-		source:                         strconv.FormatInt(sourceChainId, 10),
-		dest:                           strconv.FormatInt(destChainId, 10),
+		source:                         strconv.FormatInt(sourceChainID, 10),
+		dest:                           strconv.FormatInt(destChainID, 10),
 		sourceName:                     srcChainName,
 		destName:                       destChainName,
 		bhClient:                       bhClient,
@@ -115,8 +115,9 @@ func NewPluginMetricsCollector(pluginLabel string, bhClient beholder.Client, sou
 func (p *pluginMetricsCollector) NumberOfMessagesProcessed(phase ocrPhase, count int) {
 	messagesProcessed.
 		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), p.sourceName, p.destName).
-		// nolint: gosec // count will never be negative or extremely large
+		//nolint:gosec // count will never be negative or extremely large
 		Set(float64(count))
+		//nolint:gosec // count will never be negative or extremely large
 	p.messagesProcessed.Record(context.Background(), int64(count), metric.WithAttributes(
 		attribute.String("plugin", p.pluginName),
 		attribute.String("source", p.source),
@@ -130,8 +131,9 @@ func (p *pluginMetricsCollector) NumberOfMessagesProcessed(phase ocrPhase, count
 func (p *pluginMetricsCollector) NumberOfMessagesBasedOnInterval(phase ocrPhase, seqNrMin, seqNrMax uint64) {
 	messagesProcessed.
 		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), p.sourceName, p.destName).
-		// nolint: gosec // count will never be negative or extremely large
+		//nolint:gosec // count will never be negative or extremely large
 		Set(float64(seqNrMax - seqNrMin + 1))
+		//nolint:gosec // seqNr will never be negative or extremely large
 	p.messagesProcessed.Record(context.Background(), int64(seqNrMax-seqNrMin+1), metric.WithAttributes(
 		attribute.String("plugin", p.pluginName),
 		attribute.String("source", p.source),
@@ -145,6 +147,7 @@ func (p *pluginMetricsCollector) NumberOfMessagesBasedOnInterval(phase ocrPhase,
 func (p *pluginMetricsCollector) UnexpiredCommitRoots(count int) {
 	unexpiredCommitRoots.
 		WithLabelValues(p.pluginName, p.source, p.dest, p.sourceName, p.destName).
+		//nolint:gosec // count will never be negative or extremely large
 		Set(float64(count))
 	p.unexpiredCommitRoots.Record(context.Background(), int64(count), metric.WithAttributes(
 		attribute.String("plugin", p.pluginName),
@@ -163,7 +166,9 @@ func (p *pluginMetricsCollector) SequenceNumber(phase ocrPhase, seqNr uint64, co
 
 	maxSequenceNumber.
 		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), contractAddress, p.sourceName, p.destName).
+		//nolint:gosec // count will never be negative or extremely large
 		Set(float64(seqNr))
+		//nolint:gosec // seqNr will never be negative or extremely large
 	p.maxSequenceNumber.Record(context.Background(), int64(seqNr), metric.WithAttributes(
 		attribute.String("plugin", p.pluginName),
 		attribute.String("source", p.source),
@@ -184,11 +189,12 @@ func (p *pluginMetricsCollector) NewReportingPluginError() {
 	))
 }
 
-func (p *pluginMetricsCollector) CommitLatestRoundId(contractAddress string, roundID uint64) {
+func (p *pluginMetricsCollector) CommitLatestRoundID(contractAddress string, roundID uint64) {
 	commitLatestRoundID.
 		WithLabelValues(p.source, p.dest, contractAddress, p.pluginName).
-		// nolint: gosec // count or roundID will never be negative or extremely large
+		//nolint:gosec // count or roundID will never be negative or extremely large
 		Set(float64(roundID))
+		//nolint:gosec // count or roundID will never be negative or extremely large
 	p.commitLatestRoundID.Record(context.Background(), int64(roundID), metric.WithAttributes(
 		attribute.String("source_network_name", p.sourceName),
 		attribute.String("dest_network_name", p.destName),
@@ -197,11 +203,12 @@ func (p *pluginMetricsCollector) CommitLatestRoundId(contractAddress string, rou
 	))
 }
 
-func (p *pluginMetricsCollector) ExecLatestRoundId(contractAddress string, roundID uint64) {
+func (p *pluginMetricsCollector) ExecLatestRoundID(contractAddress string, roundID uint64) {
 	execLatestRoundID.
 		WithLabelValues(p.source, p.dest, contractAddress, p.pluginName).
-		// nolint: gosec // count or roundID will never be negative or extremely large
+		//nolint:gosec // count or roundID will never be negative or extremely large
 		Set(float64(roundID))
+		//nolint:gosec // count or roundID will never be negative or extremely large
 	p.execLatestRoundID.Record(context.Background(), int64(roundID), metric.WithAttributes(
 		attribute.String("source_network_name", p.source),
 		attribute.String("dest_network_name", p.dest),
@@ -232,8 +239,8 @@ func (d noop) SequenceNumber(ocrPhase, uint64, string) {
 func (d noop) NewReportingPluginError() {
 }
 
-func (d noop) CommitLatestRoundId(string, uint64) {
+func (d noop) CommitLatestRoundID(string, uint64) {
 }
 
-func (d noop) ExecLatestRoundId(string, uint64) {
+func (d noop) ExecLatestRoundID(string, uint64) {
 }

--- a/core/services/ocr2/plugins/ccip/metrics.go
+++ b/core/services/ocr2/plugins/ccip/metrics.go
@@ -1,10 +1,15 @@
 package ccip
 
 import (
+	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 var (
@@ -13,17 +18,25 @@ var (
 		Help: "Number of unexpired commit roots processed by the plugin",
 	}, []string{"plugin", "source", "dest"})
 	messagesProcessed = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "ccip_number_of_messages_processed",
+		Name: "ccip_messages_processed",
 		Help: "Number of messages processed by the plugin during different OCR phases",
 	}, []string{"plugin", "source", "dest", "ocrPhase"})
-	sequenceNumberCounter = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "ccip_sequence_number_counter",
+	maxSequenceNumber = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ccip_max_sequence_number",
 		Help: "Sequence number of the last message processed by the plugin",
-	}, []string{"plugin", "source", "dest", "ocrPhase"})
+	}, []string{"plugin", "source_network_name", "dest_network_name", "ocr_phase", "contract_address"})
 	newReportingPluginErrorCounter = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ccip_new_reporting_plugin_error_counter",
 		Help: "The count of the number of errors when calling NewReportingPlugin",
 	}, []string{"plugin"})
+	commitLatestRoundId = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ccip_commit_round_id",
+		Help: "The latest round ID observed by the commit plugin",
+	}, []string{"source_network_name", "dest_network_name", "contract_address", "plugin"})
+	execLatestRoundId = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ccip_exec_round_id",
+		Help: "The latest round ID observed by the exec plugin",
+	}, []string{"source_network_name", "dest_network_name", "contract_address", "plugin"})
 )
 
 type ocrPhase string
@@ -38,27 +51,60 @@ type PluginMetricsCollector interface {
 	NumberOfMessagesProcessed(phase ocrPhase, count int)
 	NumberOfMessagesBasedOnInterval(phase ocrPhase, seqNrMin, seqNrMax uint64)
 	UnexpiredCommitRoots(count int)
-	SequenceNumber(phase ocrPhase, seqNr uint64)
+	SequenceNumber(phase ocrPhase, seqNr uint64, contractAddress string)
 	NewReportingPluginError()
+	CommitLatestRoundId(contractAddress string, roundId uint64)
+	ExecLatestRoundId(contractAddress string, roundId uint64)
 }
 
 type pluginMetricsCollector struct {
-	pluginName   string
-	source, dest string
+	pluginName          string
+	source, dest        string
+	commitLatestRoundId metric.Int64Gauge
+	maxSequenceNumber   metric.Int64Gauge
+	execLatestRoundId   metric.Int64Gauge
+	messagesProcessed   metric.Int64Gauge
 }
 
-func NewPluginMetricsCollector(pluginLabel string, sourceChainId, destChainId int64) *pluginMetricsCollector {
-	return &pluginMetricsCollector{
-		pluginName: pluginLabel,
-		source:     strconv.FormatInt(sourceChainId, 10),
-		dest:       strconv.FormatInt(destChainId, 10),
+func NewPluginMetricsCollector(pluginLabel string, sourceChainId, destChainId int64) (*pluginMetricsCollector, error) {
+	commitLatestRoundId, err := beholder.GetMeter().Int64Gauge("ccip_commit_round_id")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_round_id gauge: %w", err)
 	}
+	execLatestRoundId, err := beholder.GetMeter().Int64Gauge("ccip_exec_round_id")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_exec_round_id gauge: %w", err)
+	}
+	maxSequenceNumber, err := beholder.GetMeter().Int64Gauge("ccip_max_sequence_number")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_max_sequence_number gauge: %w", err)
+	}
+	messagesProcessed, err := beholder.GetMeter().Int64Gauge("ccip_messages_processed")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_messages_processed gauge: %w", err)
+	}
+
+	return &pluginMetricsCollector{
+		pluginName:          pluginLabel,
+		source:              strconv.FormatInt(sourceChainId, 10),
+		dest:                strconv.FormatInt(destChainId, 10),
+		commitLatestRoundId: commitLatestRoundId,
+		maxSequenceNumber:   maxSequenceNumber,
+		execLatestRoundId:   execLatestRoundId,
+		messagesProcessed:   messagesProcessed,
+	}, nil
 }
 
 func (p *pluginMetricsCollector) NumberOfMessagesProcessed(phase ocrPhase, count int) {
 	messagesProcessed.
 		WithLabelValues(p.pluginName, p.source, p.dest, string(phase)).
 		Set(float64(count))
+	p.messagesProcessed.Record(context.Background(), int64(count), metric.WithAttributes(
+		attribute.String("plugin", p.pluginName),
+		attribute.String("source_network_name", p.source),
+		attribute.String("dest_network_name", p.dest),
+		attribute.String("ocr_phase", string(phase)),
+	))
 }
 
 func (p *pluginMetricsCollector) NumberOfMessagesBasedOnInterval(phase ocrPhase, seqNrMin, seqNrMax uint64) {
@@ -73,21 +119,52 @@ func (p *pluginMetricsCollector) UnexpiredCommitRoots(count int) {
 		Set(float64(count))
 }
 
-func (p *pluginMetricsCollector) SequenceNumber(phase ocrPhase, seqNr uint64) {
+func (p *pluginMetricsCollector) SequenceNumber(phase ocrPhase, seqNr uint64, contractAddress string) {
 	// Don't publish price reports
 	if seqNr == 0 {
 		return
 	}
 
-	sequenceNumberCounter.
-		WithLabelValues(p.pluginName, p.source, p.dest, string(phase)).
+	maxSequenceNumber.
+		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), contractAddress).
 		Set(float64(seqNr))
+	p.maxSequenceNumber.Record(context.Background(), int64(seqNr), metric.WithAttributes(
+		attribute.String("plugin", p.pluginName),
+		attribute.String("source_network_name", p.source),
+		attribute.String("dest_network_name", p.dest),
+		attribute.String("ocr_phase", string(phase)),
+		attribute.String("contract_address", contractAddress),
+	))
 }
 
 func (p *pluginMetricsCollector) NewReportingPluginError() {
 	newReportingPluginErrorCounter.
 		WithLabelValues(p.pluginName).
 		Inc()
+}
+
+func (p *pluginMetricsCollector) CommitLatestRoundId(contractAddress string, roundId uint64) {
+	commitLatestRoundId.
+		WithLabelValues(p.source, p.dest, contractAddress, p.pluginName).
+		Set(float64(roundId))
+	p.commitLatestRoundId.Record(context.Background(), int64(roundId), metric.WithAttributes(
+		attribute.String("source_network_name", p.source),
+		attribute.String("dest_network_name", p.dest),
+		attribute.String("contract_address", contractAddress),
+		attribute.String("plugin", p.pluginName),
+	))
+}
+
+func (p *pluginMetricsCollector) ExecLatestRoundId(contractAddress string, roundId uint64) {
+	execLatestRoundId.
+		WithLabelValues(p.source, p.dest, contractAddress, p.pluginName).
+		Set(float64(roundId))
+	p.execLatestRoundId.Record(context.Background(), int64(roundId), metric.WithAttributes(
+		attribute.String("source_network_name", p.source),
+		attribute.String("dest_network_name", p.dest),
+		attribute.String("contract_address", contractAddress),
+		attribute.String("plugin", p.pluginName),
+	))
 }
 
 var (
@@ -106,8 +183,14 @@ func (d noop) NumberOfMessagesBasedOnInterval(ocrPhase, uint64, uint64) {
 func (d noop) UnexpiredCommitRoots(int) {
 }
 
-func (d noop) SequenceNumber(ocrPhase, uint64) {
+func (d noop) SequenceNumber(ocrPhase, uint64, string) {
 }
 
 func (d noop) NewReportingPluginError() {
+}
+
+func (d noop) CommitLatestRoundId(string, uint64) {
+}
+
+func (d noop) ExecLatestRoundId(string, uint64) {
 }

--- a/core/services/ocr2/plugins/ccip/metrics.go
+++ b/core/services/ocr2/plugins/ccip/metrics.go
@@ -115,9 +115,7 @@ func NewPluginMetricsCollector(pluginLabel string, bhClient beholder.Client, sou
 func (p *pluginMetricsCollector) NumberOfMessagesProcessed(phase ocrPhase, count int) {
 	messagesProcessed.
 		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), p.sourceName, p.destName).
-		//nolint:gosec // count will never be negative or extremely large
 		Set(float64(count))
-		//nolint:gosec // count will never be negative or extremely large
 	p.messagesProcessed.Record(context.Background(), int64(count), metric.WithAttributes(
 		attribute.String("plugin", p.pluginName),
 		attribute.String("source", p.source),
@@ -131,10 +129,8 @@ func (p *pluginMetricsCollector) NumberOfMessagesProcessed(phase ocrPhase, count
 func (p *pluginMetricsCollector) NumberOfMessagesBasedOnInterval(phase ocrPhase, seqNrMin, seqNrMax uint64) {
 	messagesProcessed.
 		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), p.sourceName, p.destName).
-		//nolint:gosec // count will never be negative or extremely large
 		Set(float64(seqNrMax - seqNrMin + 1))
-		//nolint:gosec // seqNr will never be negative or extremely large
-	p.messagesProcessed.Record(context.Background(), int64(seqNrMax-seqNrMin+1), metric.WithAttributes(
+	p.messagesProcessed.Record(context.Background(), int64(seqNrMax-seqNrMin+1), metric.WithAttributes( //nolint:gosec // Number will not be negative
 		attribute.String("plugin", p.pluginName),
 		attribute.String("source", p.source),
 		attribute.String("dest", p.dest),
@@ -147,7 +143,6 @@ func (p *pluginMetricsCollector) NumberOfMessagesBasedOnInterval(phase ocrPhase,
 func (p *pluginMetricsCollector) UnexpiredCommitRoots(count int) {
 	unexpiredCommitRoots.
 		WithLabelValues(p.pluginName, p.source, p.dest, p.sourceName, p.destName).
-		//nolint:gosec // count will never be negative or extremely large
 		Set(float64(count))
 	p.unexpiredCommitRoots.Record(context.Background(), int64(count), metric.WithAttributes(
 		attribute.String("plugin", p.pluginName),
@@ -166,10 +161,8 @@ func (p *pluginMetricsCollector) SequenceNumber(phase ocrPhase, seqNr uint64, co
 
 	maxSequenceNumber.
 		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), contractAddress, p.sourceName, p.destName).
-		//nolint:gosec // count will never be negative or extremely large
 		Set(float64(seqNr))
-		//nolint:gosec // seqNr will never be negative or extremely large
-	p.maxSequenceNumber.Record(context.Background(), int64(seqNr), metric.WithAttributes(
+	p.maxSequenceNumber.Record(context.Background(), int64(seqNr), metric.WithAttributes( //nolint:gosec // Number will not be negative
 		attribute.String("plugin", p.pluginName),
 		attribute.String("source", p.source),
 		attribute.String("dest", p.dest),
@@ -192,10 +185,8 @@ func (p *pluginMetricsCollector) NewReportingPluginError() {
 func (p *pluginMetricsCollector) CommitLatestRoundID(contractAddress string, roundID uint64) {
 	commitLatestRoundID.
 		WithLabelValues(p.source, p.dest, contractAddress, p.pluginName).
-		//nolint:gosec // count or roundID will never be negative or extremely large
 		Set(float64(roundID))
-		//nolint:gosec // count or roundID will never be negative or extremely large
-	p.commitLatestRoundID.Record(context.Background(), int64(roundID), metric.WithAttributes(
+	p.commitLatestRoundID.Record(context.Background(), int64(roundID), metric.WithAttributes( //nolint:gosec // Number will not be negative
 		attribute.String("source_network_name", p.sourceName),
 		attribute.String("dest_network_name", p.destName),
 		attribute.String("contract_address", contractAddress),
@@ -206,10 +197,8 @@ func (p *pluginMetricsCollector) CommitLatestRoundID(contractAddress string, rou
 func (p *pluginMetricsCollector) ExecLatestRoundID(contractAddress string, roundID uint64) {
 	execLatestRoundID.
 		WithLabelValues(p.source, p.dest, contractAddress, p.pluginName).
-		//nolint:gosec // count or roundID will never be negative or extremely large
 		Set(float64(roundID))
-		//nolint:gosec // count or roundID will never be negative or extremely large
-	p.execLatestRoundID.Record(context.Background(), int64(roundID), metric.WithAttributes(
+	p.execLatestRoundID.Record(context.Background(), int64(roundID), metric.WithAttributes( //nolint:gosec // Number will not be negative
 		attribute.String("source_network_name", p.source),
 		attribute.String("dest_network_name", p.dest),
 		attribute.String("contract_address", contractAddress),

--- a/core/services/ocr2/plugins/ccip/metrics.go
+++ b/core/services/ocr2/plugins/ccip/metrics.go
@@ -16,16 +16,16 @@ var (
 	unexpiredCommitRoots = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ccip_unexpired_commit_roots",
 		Help: "Number of unexpired commit roots processed by the plugin",
-	}, []string{"plugin", "source", "dest"})
+	}, []string{"plugin", "source", "dest", "source_network_name", "dest_network_name"})
 	messagesProcessed = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "ccip_messages_processed",
+		Name: "ccip_number_of_messages_processed",
 		Help: "Number of messages processed by the plugin during different OCR phases",
-	}, []string{"plugin", "source", "dest", "ocrPhase"})
+	}, []string{"plugin", "source", "dest", "ocrPhase", "source_network_name", "dest_network_name"})
 	maxSequenceNumber = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ccip_max_sequence_number",
 		Help: "Sequence number of the last message processed by the plugin",
-	}, []string{"plugin", "source_network_name", "dest_network_name", "ocr_phase", "contract_address"})
-	newReportingPluginErrorCounter = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	}, []string{"plugin", "source", "dest", "ocr_phase", "contract_address", "source_network_name", "dest_network_name"})
+	newReportingPluginErrorCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "ccip_new_reporting_plugin_error_counter",
 		Help: "The count of the number of errors when calling NewReportingPlugin",
 	}, []string{"plugin"})
@@ -58,15 +58,33 @@ type PluginMetricsCollector interface {
 }
 
 type pluginMetricsCollector struct {
-	pluginName          string
-	source, dest        string
-	commitLatestRoundId metric.Int64Gauge
-	maxSequenceNumber   metric.Int64Gauge
-	execLatestRoundId   metric.Int64Gauge
-	messagesProcessed   metric.Int64Gauge
+	pluginName                         string
+	source, dest, sourceName, destName string
+	unexpiredCommitRoots               metric.Int64Gauge
+	messagesProcessed                  metric.Int64Gauge
+	maxSequenceNumber                  metric.Int64Gauge
+	newReportingPluginErrorCounter     metric.Int64Counter
+	commitLatestRoundId                metric.Int64Gauge
+	execLatestRoundId                  metric.Int64Gauge
 }
 
-func NewPluginMetricsCollector(pluginLabel string, sourceChainId, destChainId int64) (*pluginMetricsCollector, error) {
+func NewPluginMetricsCollector(pluginLabel string, sourceChainId, destChainId int64, srcChainName string, destChainName string) (*pluginMetricsCollector, error) {
+	unexpiredCommitRoots, err := beholder.GetMeter().Int64Gauge("ccip_unexpired_commit_roots")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_unexpired_commit_roots gauge: %w", err)
+	}
+	messagesProcessed, err := beholder.GetMeter().Int64Gauge("ccip_messages_processed")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_messages_processed gauge: %w", err)
+	}
+	maxSequenceNumber, err := beholder.GetMeter().Int64Gauge("ccip_max_sequence_number")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_max_sequence_number gauge: %w", err)
+	}
+	newReportingPluginErrorCounter, err := beholder.GetMeter().Int64Counter("ccip_new_reporting_plugin_error_counter")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_new_reporting_plugin_error_counter counter: %w", err)
+	}
 	commitLatestRoundId, err := beholder.GetMeter().Int64Gauge("ccip_commit_round_id")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_commit_round_id gauge: %w", err)
@@ -75,48 +93,61 @@ func NewPluginMetricsCollector(pluginLabel string, sourceChainId, destChainId in
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_exec_round_id gauge: %w", err)
 	}
-	maxSequenceNumber, err := beholder.GetMeter().Int64Gauge("ccip_max_sequence_number")
-	if err != nil {
-		return nil, fmt.Errorf("failed to register ccip_max_sequence_number gauge: %w", err)
-	}
-	messagesProcessed, err := beholder.GetMeter().Int64Gauge("ccip_messages_processed")
-	if err != nil {
-		return nil, fmt.Errorf("failed to register ccip_messages_processed gauge: %w", err)
-	}
 
 	return &pluginMetricsCollector{
-		pluginName:          pluginLabel,
-		source:              strconv.FormatInt(sourceChainId, 10),
-		dest:                strconv.FormatInt(destChainId, 10),
-		commitLatestRoundId: commitLatestRoundId,
-		maxSequenceNumber:   maxSequenceNumber,
-		execLatestRoundId:   execLatestRoundId,
-		messagesProcessed:   messagesProcessed,
+		pluginName:                     pluginLabel,
+		source:                         strconv.FormatInt(sourceChainId, 10),
+		dest:                           strconv.FormatInt(destChainId, 10),
+		sourceName:                     srcChainName,
+		destName:                       destChainName,
+		unexpiredCommitRoots:           unexpiredCommitRoots,
+		messagesProcessed:              messagesProcessed,
+		maxSequenceNumber:              maxSequenceNumber,
+		newReportingPluginErrorCounter: newReportingPluginErrorCounter,
+		commitLatestRoundId:            commitLatestRoundId,
+		execLatestRoundId:              execLatestRoundId,
 	}, nil
 }
 
 func (p *pluginMetricsCollector) NumberOfMessagesProcessed(phase ocrPhase, count int) {
 	messagesProcessed.
-		WithLabelValues(p.pluginName, p.source, p.dest, string(phase)).
+		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), p.sourceName, p.destName).
 		Set(float64(count))
 	p.messagesProcessed.Record(context.Background(), int64(count), metric.WithAttributes(
 		attribute.String("plugin", p.pluginName),
-		attribute.String("source_network_name", p.source),
-		attribute.String("dest_network_name", p.dest),
+		attribute.String("source", p.source),
+		attribute.String("dest", p.dest),
 		attribute.String("ocr_phase", string(phase)),
+		attribute.String("source_network_name", p.sourceName),
+		attribute.String("dest_network_name", p.destName),
 	))
 }
 
 func (p *pluginMetricsCollector) NumberOfMessagesBasedOnInterval(phase ocrPhase, seqNrMin, seqNrMax uint64) {
 	messagesProcessed.
-		WithLabelValues(p.pluginName, p.source, p.dest, string(phase)).
+		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), p.sourceName, p.destName).
 		Set(float64(seqNrMax - seqNrMin + 1))
+	p.messagesProcessed.Record(context.Background(), int64(seqNrMax-seqNrMin+1), metric.WithAttributes(
+		attribute.String("plugin", p.pluginName),
+		attribute.String("source", p.source),
+		attribute.String("dest", p.dest),
+		attribute.String("ocr_phase", string(phase)),
+		attribute.String("source_network_name", p.sourceName),
+		attribute.String("dest_network_name", p.destName),
+	))
 }
 
 func (p *pluginMetricsCollector) UnexpiredCommitRoots(count int) {
 	unexpiredCommitRoots.
-		WithLabelValues(p.pluginName, p.source, p.dest).
+		WithLabelValues(p.pluginName, p.source, p.dest, p.sourceName, p.destName).
 		Set(float64(count))
+	p.unexpiredCommitRoots.Record(context.Background(), int64(count), metric.WithAttributes(
+		attribute.String("plugin", p.pluginName),
+		attribute.String("source", p.source),
+		attribute.String("dest", p.dest),
+		attribute.String("source_network_name", p.sourceName),
+		attribute.String("dest_network_name", p.destName),
+	))
 }
 
 func (p *pluginMetricsCollector) SequenceNumber(phase ocrPhase, seqNr uint64, contractAddress string) {
@@ -126,14 +157,16 @@ func (p *pluginMetricsCollector) SequenceNumber(phase ocrPhase, seqNr uint64, co
 	}
 
 	maxSequenceNumber.
-		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), contractAddress).
+		WithLabelValues(p.pluginName, p.source, p.dest, string(phase), contractAddress, p.sourceName, p.destName).
 		Set(float64(seqNr))
 	p.maxSequenceNumber.Record(context.Background(), int64(seqNr), metric.WithAttributes(
 		attribute.String("plugin", p.pluginName),
-		attribute.String("source_network_name", p.source),
-		attribute.String("dest_network_name", p.dest),
+		attribute.String("source", p.source),
+		attribute.String("dest", p.dest),
 		attribute.String("ocr_phase", string(phase)),
 		attribute.String("contract_address", contractAddress),
+		attribute.String("source_network_name", p.sourceName),
+		attribute.String("dest_network_name", p.destName),
 	))
 }
 
@@ -141,6 +174,9 @@ func (p *pluginMetricsCollector) NewReportingPluginError() {
 	newReportingPluginErrorCounter.
 		WithLabelValues(p.pluginName).
 		Inc()
+	p.newReportingPluginErrorCounter.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("plugin", p.pluginName),
+	))
 }
 
 func (p *pluginMetricsCollector) CommitLatestRoundId(contractAddress string, roundId uint64) {
@@ -148,8 +184,8 @@ func (p *pluginMetricsCollector) CommitLatestRoundId(contractAddress string, rou
 		WithLabelValues(p.source, p.dest, contractAddress, p.pluginName).
 		Set(float64(roundId))
 	p.commitLatestRoundId.Record(context.Background(), int64(roundId), metric.WithAttributes(
-		attribute.String("source_network_name", p.source),
-		attribute.String("dest_network_name", p.dest),
+		attribute.String("source_network_name", p.sourceName),
+		attribute.String("dest_network_name", p.destName),
 		attribute.String("contract_address", contractAddress),
 		attribute.String("plugin", p.pluginName),
 	))

--- a/core/services/ocr2/plugins/ccip/metrics_test.go
+++ b/core/services/ocr2/plugins/ccip/metrics_test.go
@@ -14,19 +14,19 @@ const (
 
 func Test_SequenceNumbers(t *testing.T) {
 	t.Parallel()
-	collector := NewPluginMetricsCollector("test", sourceChainId, destChainId)
+	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId)
 
-	collector.SequenceNumber(Report, 10)
-	assert.Equal(t, float64(10), testutil.ToFloat64(sequenceNumberCounter.WithLabelValues("test", "1337", "2337", "report")))
+	collector.SequenceNumber(Report, 10, "0xabc")
+	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc")))
 
-	collector.SequenceNumber(Report, 0)
-	assert.Equal(t, float64(10), testutil.ToFloat64(sequenceNumberCounter.WithLabelValues("test", "1337", "2337", "report")))
+	collector.SequenceNumber(Report, 0, "0xabc")
+	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc")))
 }
 
 func Test_NumberOfMessages(t *testing.T) {
 	t.Parallel()
-	collector := NewPluginMetricsCollector("test", sourceChainId, destChainId)
-	collector2 := NewPluginMetricsCollector("test2", destChainId, sourceChainId)
+	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId)
+	collector2, _ := NewPluginMetricsCollector("test2", destChainId, sourceChainId)
 
 	collector.NumberOfMessagesBasedOnInterval(Observation, 1, 10)
 	assert.Equal(t, float64(10), testutil.ToFloat64(messagesProcessed.WithLabelValues("test", "1337", "2337", "observation")))
@@ -40,7 +40,7 @@ func Test_NumberOfMessages(t *testing.T) {
 
 func Test_UnexpiredCommitRoots(t *testing.T) {
 	t.Parallel()
-	collector := NewPluginMetricsCollector("test", sourceChainId, destChainId)
+	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId)
 
 	collector.UnexpiredCommitRoots(10)
 	assert.Equal(t, float64(10), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337")))

--- a/core/services/ocr2/plugins/ccip/metrics_test.go
+++ b/core/services/ocr2/plugins/ccip/metrics_test.go
@@ -28,11 +28,11 @@ func Test_SequenceNumbers(t *testing.T) {
 	collector, _ := NewPluginMetricsCollector("test", *bhClient, sourceChainId, destChainId, srcChainName, destChainName)
 
 	collector.SequenceNumber(Report, 10, "0xabc")
-	// nolint:testifylint // no need for indelta
+	//nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc", "sourceChain", "destChain")))
 
 	collector.SequenceNumber(Report, 0, "0xabc")
-	// nolint:testifylint // no need for indelta
+	//nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc", "sourceChain", "destChain")))
 
 	bhClient.Close()
@@ -50,15 +50,15 @@ func Test_NumberOfMessages(t *testing.T) {
 	collector2, _ := NewPluginMetricsCollector("test2", *bhClient, destChainId, sourceChainId, destChainName, srcChainName)
 
 	collector.NumberOfMessagesBasedOnInterval(Observation, 1, 10)
-	// nolint:testifylint // no need for indelta
+	//nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(10), testutil.ToFloat64(messagesProcessed.WithLabelValues("test", "1337", "2337", "observation", "sourceChain", "destChain")))
 
 	collector.NumberOfMessagesBasedOnInterval(Report, 5, 30)
-	// nolint:testifylint // no need for indelta
+	//nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(26), testutil.ToFloat64(messagesProcessed.WithLabelValues("test", "1337", "2337", "report", "sourceChain", "destChain")))
 
 	collector2.NumberOfMessagesProcessed(Report, 15)
-	// nolint:testifylint // no need for indelta
+	//nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(15), testutil.ToFloat64(messagesProcessed.WithLabelValues("test2", "2337", "1337", "report", "destChain", "sourceChain")))
 
 	bhClient.Close()
@@ -75,11 +75,11 @@ func Test_UnexpiredCommitRoots(t *testing.T) {
 	collector, _ := NewPluginMetricsCollector("test", *bhClient, sourceChainId, destChainId, srcChainName, destChainName)
 
 	collector.UnexpiredCommitRoots(10)
-	// nolint:testifylint // no need for indelta
+	//nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(10), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337", "sourceChain", "destChain")))
 
 	collector.UnexpiredCommitRoots(5)
-	// nolint:testifylint // no need for indelta
+	//nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(5), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337", "sourceChain", "destChain")))
 
 	bhClient.Close()

--- a/core/services/ocr2/plugins/ccip/metrics_test.go
+++ b/core/services/ocr2/plugins/ccip/metrics_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 )
 
 const (
@@ -25,10 +26,13 @@ func Test_SequenceNumbers(t *testing.T) {
 	bhClient, err := beholder.NewWriterClient(&b)
 	require.NoError(t, err)
 	collector, _ := NewPluginMetricsCollector("test", *bhClient, sourceChainId, destChainId, srcChainName, destChainName)
+
 	collector.SequenceNumber(Report, 10, "0xabc")
+	// nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc", "sourceChain", "destChain")))
 
 	collector.SequenceNumber(Report, 0, "0xabc")
+	// nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc", "sourceChain", "destChain")))
 
 	bhClient.Close()
@@ -46,12 +50,15 @@ func Test_NumberOfMessages(t *testing.T) {
 	collector2, _ := NewPluginMetricsCollector("test2", *bhClient, destChainId, sourceChainId, destChainName, srcChainName)
 
 	collector.NumberOfMessagesBasedOnInterval(Observation, 1, 10)
+	// nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(10), testutil.ToFloat64(messagesProcessed.WithLabelValues("test", "1337", "2337", "observation", "sourceChain", "destChain")))
 
 	collector.NumberOfMessagesBasedOnInterval(Report, 5, 30)
+	// nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(26), testutil.ToFloat64(messagesProcessed.WithLabelValues("test", "1337", "2337", "report", "sourceChain", "destChain")))
 
 	collector2.NumberOfMessagesProcessed(Report, 15)
+	// nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(15), testutil.ToFloat64(messagesProcessed.WithLabelValues("test2", "2337", "1337", "report", "destChain", "sourceChain")))
 
 	bhClient.Close()
@@ -68,9 +75,11 @@ func Test_UnexpiredCommitRoots(t *testing.T) {
 	collector, _ := NewPluginMetricsCollector("test", *bhClient, sourceChainId, destChainId, srcChainName, destChainName)
 
 	collector.UnexpiredCommitRoots(10)
+	// nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(10), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337", "sourceChain", "destChain")))
 
 	collector.UnexpiredCommitRoots(5)
+	// nolint:testifylint // no need for indelta
 	assert.Equal(t, float64(5), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337", "sourceChain", "destChain")))
 
 	bhClient.Close()

--- a/core/services/ocr2/plugins/ccip/metrics_test.go
+++ b/core/services/ocr2/plugins/ccip/metrics_test.go
@@ -1,10 +1,13 @@
 package ccip
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -15,20 +18,32 @@ const (
 )
 
 func Test_SequenceNumbers(t *testing.T) {
+	// setup
 	t.Parallel()
-	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId, srcChainName, destChainName)
+	var b strings.Builder
 
+	bhClient, err := beholder.NewWriterClient(&b)
+	require.NoError(t, err)
+	collector, _ := NewPluginMetricsCollector("test", *bhClient, sourceChainId, destChainId, srcChainName, destChainName)
 	collector.SequenceNumber(Report, 10, "0xabc")
 	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc", "sourceChain", "destChain")))
 
 	collector.SequenceNumber(Report, 0, "0xabc")
 	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc", "sourceChain", "destChain")))
+
+	bhClient.Close()
+	assert.Contains(t, b.String(), "ccip_max_sequence_number")
 }
 
 func Test_NumberOfMessages(t *testing.T) {
+	// setup
 	t.Parallel()
-	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId, srcChainName, destChainName)
-	collector2, _ := NewPluginMetricsCollector("test2", destChainId, sourceChainId, destChainName, srcChainName)
+	var b strings.Builder
+	bhClient, err := beholder.NewWriterClient(&b)
+	require.NoError(t, err)
+
+	collector, _ := NewPluginMetricsCollector("test", *bhClient, sourceChainId, destChainId, srcChainName, destChainName)
+	collector2, _ := NewPluginMetricsCollector("test2", *bhClient, destChainId, sourceChainId, destChainName, srcChainName)
 
 	collector.NumberOfMessagesBasedOnInterval(Observation, 1, 10)
 	assert.Equal(t, float64(10), testutil.ToFloat64(messagesProcessed.WithLabelValues("test", "1337", "2337", "observation", "sourceChain", "destChain")))
@@ -38,15 +53,26 @@ func Test_NumberOfMessages(t *testing.T) {
 
 	collector2.NumberOfMessagesProcessed(Report, 15)
 	assert.Equal(t, float64(15), testutil.ToFloat64(messagesProcessed.WithLabelValues("test2", "2337", "1337", "report", "destChain", "sourceChain")))
+
+	bhClient.Close()
+	assert.Contains(t, b.String(), "ccip_number_of_messages_processed")
 }
 
 func Test_UnexpiredCommitRoots(t *testing.T) {
+	// setup
 	t.Parallel()
-	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId, srcChainName, destChainName)
+	var b strings.Builder
+	bhClient, err := beholder.NewWriterClient(&b)
+	require.NoError(t, err)
+
+	collector, _ := NewPluginMetricsCollector("test", *bhClient, sourceChainId, destChainId, srcChainName, destChainName)
 
 	collector.UnexpiredCommitRoots(10)
 	assert.Equal(t, float64(10), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337", "sourceChain", "destChain")))
 
 	collector.UnexpiredCommitRoots(5)
 	assert.Equal(t, float64(5), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337", "sourceChain", "destChain")))
+
+	bhClient.Close()
+	assert.Contains(t, b.String(), "ccip_unexpired_commit_roots")
 }

--- a/core/services/ocr2/plugins/ccip/metrics_test.go
+++ b/core/services/ocr2/plugins/ccip/metrics_test.go
@@ -10,41 +10,43 @@ import (
 const (
 	sourceChainId = 1337
 	destChainId   = 2337
+	srcChainName  = "sourceChain"
+	destChainName = "destChain"
 )
 
 func Test_SequenceNumbers(t *testing.T) {
 	t.Parallel()
-	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId)
+	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId, srcChainName, destChainName)
 
 	collector.SequenceNumber(Report, 10, "0xabc")
-	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc")))
+	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc", "sourceChain", "destChain")))
 
 	collector.SequenceNumber(Report, 0, "0xabc")
-	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc")))
+	assert.Equal(t, float64(10), testutil.ToFloat64(maxSequenceNumber.WithLabelValues("test", "1337", "2337", "report", "0xabc", "sourceChain", "destChain")))
 }
 
 func Test_NumberOfMessages(t *testing.T) {
 	t.Parallel()
-	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId)
-	collector2, _ := NewPluginMetricsCollector("test2", destChainId, sourceChainId)
+	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId, srcChainName, destChainName)
+	collector2, _ := NewPluginMetricsCollector("test2", destChainId, sourceChainId, destChainName, srcChainName)
 
 	collector.NumberOfMessagesBasedOnInterval(Observation, 1, 10)
-	assert.Equal(t, float64(10), testutil.ToFloat64(messagesProcessed.WithLabelValues("test", "1337", "2337", "observation")))
+	assert.Equal(t, float64(10), testutil.ToFloat64(messagesProcessed.WithLabelValues("test", "1337", "2337", "observation", "sourceChain", "destChain")))
 
 	collector.NumberOfMessagesBasedOnInterval(Report, 5, 30)
-	assert.Equal(t, float64(26), testutil.ToFloat64(messagesProcessed.WithLabelValues("test", "1337", "2337", "report")))
+	assert.Equal(t, float64(26), testutil.ToFloat64(messagesProcessed.WithLabelValues("test", "1337", "2337", "report", "sourceChain", "destChain")))
 
 	collector2.NumberOfMessagesProcessed(Report, 15)
-	assert.Equal(t, float64(15), testutil.ToFloat64(messagesProcessed.WithLabelValues("test2", "2337", "1337", "report")))
+	assert.Equal(t, float64(15), testutil.ToFloat64(messagesProcessed.WithLabelValues("test2", "2337", "1337", "report", "destChain", "sourceChain")))
 }
 
 func Test_UnexpiredCommitRoots(t *testing.T) {
 	t.Parallel()
-	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId)
+	collector, _ := NewPluginMetricsCollector("test", sourceChainId, destChainId, srcChainName, destChainName)
 
 	collector.UnexpiredCommitRoots(10)
-	assert.Equal(t, float64(10), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337")))
+	assert.Equal(t, float64(10), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337", "sourceChain", "destChain")))
 
 	collector.UnexpiredCommitRoots(5)
-	assert.Equal(t, float64(5), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337")))
+	assert.Equal(t, float64(5), testutil.ToFloat64(unexpiredCommitRoots.WithLabelValues("test", "1337", "2337", "sourceChain", "destChain")))
 }


### PR DESCRIPTION
Implementing beholder metrics to CCIP 1.5 and adding key metric "latest round ID" to fully replace OTI requirements