### PR TITLE
[COP-1694] verify that there are no command line arguments passed to any command

### DIFF
--- a/core/scripts/cre/environment/environment/beholder.go
+++ b/core/scripts/cre/environment/environment/beholder.go
@@ -44,9 +44,10 @@ func startBeholderCmd() *cobra.Command {
 		timeout      time.Duration
 	)
 	cmd := &cobra.Command{
-		Use:   "start",
-		Short: "Start the Beholder",
-		Long:  `Start the Beholder`,
+		Use:              "start",
+		Short:            "Start the Beholder",
+		Long:             `Start the Beholder`,
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			initDxTracker()
 			var startBeholderErr error
@@ -95,9 +96,10 @@ func startBeholderCmd() *cobra.Command {
 }
 
 var stopBeholderCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Stop the Beholder",
-	Long:  `Stop the Beholder`,
+	Use:              "stop",
+	Short:            "Stop the Beholder",
+	Long:             "Stop the Beholder",
+	PersistentPreRun: globalPreRunFunc,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return stopBeholder()
 	},
@@ -263,9 +265,10 @@ func createKafkaTopicsCmd() *cobra.Command {
 		purge  bool
 	)
 	cmd := &cobra.Command{
-		Use:   "create-topics",
-		Short: "Create Kafka topics",
-		Long:  `Create Kafka topics (with or without removing existing topics)`,
+		Use:              "create-topics",
+		Short:            "Create Kafka topics",
+		Long:             `Create Kafka topics (with or without removing existing topics)`,
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if url == "" {
 				return errors.New("red-panda-kafka-url cannot be empty")
@@ -305,9 +308,10 @@ func fetchAndRegisterProtosCmd() *cobra.Command {
 		protoConfigs []string
 	)
 	cmd := &cobra.Command{
-		Use:   "register-protos",
-		Short: "Fetch and register protos",
-		Long:  `Fetch and register protos`,
+		Use:              "register-protos",
+		Short:            "Fetch and register protos",
+		Long:             `Fetch and register protos`,
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Use default values if not provided
 			if schemaURL == "" {

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -969,16 +969,9 @@ func removeCtfConfigsCacheFiles(shouldRemove shouldRemove) error {
 	return nil
 }
 
-func globalPreRunFunc(_ *cobra.Command, args []string) {
-	if err := assertNoCommandLineArgs(args); err != nil {
-		fmt.Fprint(os.Stderr, libformat.RedText("\n%v\n\n", err))
+func globalPreRunFunc(cmd *cobra.Command, args []string) {
+	if err := cobra.NoArgs(cmd, args); err != nil {
+		fmt.Fprint(os.Stderr, libformat.RedText("\n%v. Please use flags to parameterise the command\n\n", err))
 		os.Exit(1)
 	}
-}
-
-func assertNoCommandLineArgs(args []string) error {
-	if len(args) > 0 {
-		return errors.New("command line arguments are not supported. Please use flags to parameterise the command")
-	}
-	return nil
 }

--- a/core/scripts/cre/environment/environment/environment.go
+++ b/core/scripts/cre/environment/environment/environment.go
@@ -978,7 +978,7 @@ func globalPreRunFunc(_ *cobra.Command, args []string) {
 
 func assertNoCommandLineArgs(args []string) error {
 	if len(args) > 0 {
-		return fmt.Errorf("command line arguments are not supported. Please use flags to parameterise the command")
+		return errors.New("command line arguments are not supported. Please use flags to parameterise the command")
 	}
 	return nil
 }

--- a/core/scripts/cre/environment/environment/examples.go
+++ b/core/scripts/cre/environment/environment/examples.go
@@ -36,9 +36,10 @@ func deployAndVerifyExampleWorkflowCmd() *cobra.Command {
 		workflowRegistryAddressFlag string
 	)
 	cmd := &cobra.Command{
-		Use:   "run-por-example",
-		Short: "Runs v1 Proof-of-Reserve example workflow",
-		Long:  `Deploys a simple Proof-of-Reserve workflow and, optionally, wait until it succeeds`,
+		Use:              "run-por-example",
+		Short:            "Runs v1 Proof-of-Reserve example workflow",
+		Long:             `Deploys a simple Proof-of-Reserve workflow and, optionally, wait until it succeeds`,
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			timeout, timeoutErr := time.ParseDuration(exampleWorkflowTimeoutFlag)
 			if timeoutErr != nil {

--- a/core/scripts/cre/environment/environment/swap.go
+++ b/core/scripts/cre/environment/environment/swap.go
@@ -51,10 +51,11 @@ func capabilitySwapCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:     "capability",
-		Short:   "Swaps the capability binary of the Chainlink nodes in the environment",
-		Long:    "Swaps the capability binary of the Chainlink nodes in the environment. Capability flag is used to find jobs with names containing the capability name, which are cancelled and approved, so that capability binary is reloaded. Only DONs that have the capability are impacted.",
-		Aliases: []string{"c", "cap"},
+		Use:              "capability",
+		Short:            "Swaps the capability binary of the Chainlink nodes in the environment",
+		Long:             "Swaps the capability binary of the Chainlink nodes in the environment. Capability flag is used to find jobs with names containing the capability name, which are cancelled and approved, so that capability binary is reloaded. Only DONs that have the capability are impacted.",
+		Aliases:          []string{"c", "cap"},
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			initDxTracker()
 			var swapErr error
@@ -313,10 +314,11 @@ func nodesSwapCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:     "nodes",
-		Short:   "Swaps the Docker images of the Chainlink nodes in the environment",
-		Long:    "Swaps the Docker images of the Chainlink nodes in the environment. If environment is configured to build the Docker image, it will be rebuilt if any change is detected in the source code.",
-		Aliases: []string{"n", "node"},
+		Use:              "nodes",
+		Short:            "Swaps the Docker images of the Chainlink nodes in the environment",
+		Long:             "Swaps the Docker images of the Chainlink nodes in the environment. If environment is configured to build the Docker image, it will be rebuilt if any change is detected in the source code.",
+		Aliases:          []string{"n", "node"},
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			initDxTracker()
 			var swapErr error

--- a/core/scripts/cre/environment/environment/workflow.go
+++ b/core/scripts/cre/environment/environment/workflow.go
@@ -80,9 +80,10 @@ func compileWorkflowCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "compile",
-		Short: "Compiles a workflow",
-		Long:  `Compiles, compresses with Brotli and encodes with base64 a workflow`,
+		Use:              "compile",
+		Short:            "Compiles a workflow",
+		Long:             `Compiles, compresses with Brotli and encodes with base64 a workflow`,
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, compileErr := compileWorkflow(workflowFilePathFlag, workflowNameFlag)
 			if compileErr != nil {
@@ -122,9 +123,10 @@ func deployWorkflowCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "deploy",
-		Short: "Deploys a workflow to the environment",
-		Long:  `Deploys a workflow to the environment by copying it to workflow nodes and registering with the workflow registry`,
+		Use:              "deploy",
+		Short:            "Deploys a workflow to the environment",
+		Long:             `Deploys a workflow to the environment by copying it to workflow nodes and registering with the workflow registry`,
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			initDxTracker()
 			var regErr error
@@ -208,10 +210,11 @@ func compileDeployWorkflowCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:    "compile-deploy",
-		Short:  "DEPRECATED: Use 'go run . env workflow deploy --compile' instead",
-		Long:   `DEPRECATED: Use 'go run . env workflow deploy --compile' instead`,
-		Hidden: true,
+		Use:              "compile-deploy",
+		Short:            "DEPRECATED: Use 'go run . env workflow deploy --compile' instead",
+		Long:             `DEPRECATED: Use 'go run . env workflow deploy --compile' instead`,
+		Hidden:           true,
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("\n⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️\n\n")
 			fmt.Printf("\033[31m'go run . env workflow compile-deploy' is DEPRECATED. Use 'go run . env workflow deploy --compile' instead\033[0m\n")
@@ -271,9 +274,10 @@ func deleteWorkflowCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Deletes a workflow from the workflow registry contract",
-		Long:  `Deletes a workflow from the workflow registry contract (but doesn't remove it from the Docker containers)`,
+		Use:              "delete",
+		Short:            "Deletes a workflow from the workflow registry contract",
+		Long:             `Deletes a workflow from the workflow registry contract (but doesn't remove it from the Docker containers)`,
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("\n⚙️ Deleting workflow '%s' from the workflow registry\n\n", workflowNameFlag)
 
@@ -337,9 +341,10 @@ func deleteAllWorkflowsCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "delete-all",
-		Short: "Deletes all workflows from the workflow registry contract",
-		Long:  `Deletes all workflows from the workflow registry contract (but doesn't remove them from the Docker containers)`,
+		Use:              "delete-all",
+		Short:            "Deletes all workflows from the workflow registry contract",
+		Long:             `Deletes all workflows from the workflow registry contract (but doesn't remove them from the Docker containers)`,
+		PersistentPreRun: globalPreRunFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("\n⚙️ Deleting all workflows from the workflow registry\n\n")
 

--- a/system-tests/lib/format/text.go
+++ b/system-tests/lib/format/text.go
@@ -6,6 +6,10 @@ func PurpleText(text string, args ...interface{}) string {
 	return fmt.Sprintf("\033[35m%s\033[0m", fmt.Sprintf(text, args...))
 }
 
+func RedText(text string, args ...any) string {
+	return fmt.Sprintf("\033[31m%s\033[0m", fmt.Sprintf(text, args...))
+}
+
 func DarkYellowText(text string, args ...interface{}) string {
 	return fmt.Sprintf("\033[33m\033[2m%s\033[0m", fmt.Sprintf(text, args...))
 }


### PR DESCRIPTION
Why?
Some users were intuitively passing arguments to commands. These were ignored, because commands can be parametrised only via flags. Arguments were silently ignored and it took some time to figure out why the command didn't behave as expected.

Now:
<img width="953" height="91" alt="image" src="https://github.com/user-attachments/assets/dd1b68bc-c43d-4305-a39b-1c50d2fce949" />
