### PR TITLE
[PRODCRE-804] Allow jobs with the same contract id and different relayers/chainIDs

### DIFF
--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -1320,27 +1320,40 @@ func (s *service) Unsafe_SetConnectionsManager(connMgr ConnectionsManager) {
 	s.connMgr = connMgr
 }
 
+func parseChainIDFromJSONConfig(config job.JSONConfig) int64 {
+	if chainID, ok := config["chainID"].(int64); ok {
+		return chainID
+	}
+	return 0
+}
+
 // findExistingJobForOCR2 looks for existing job for OCR2
 func findExistingJobForOCR2(ctx context.Context, j *job.Job, tx job.ORM) (int32, error) {
 	var contractID string
 	var feedID *common.Hash
+	var relay string
+	var chainID int64
 
 	switch j.Type {
 	case job.OffchainReporting2:
 		contractID = j.OCR2OracleSpec.ContractID
 		feedID = j.OCR2OracleSpec.FeedID
+		relay = j.OCR2OracleSpec.Relay
+		chainID = parseChainIDFromJSONConfig(j.OCR2OracleSpec.RelayConfig)
 	case job.Bootstrap:
 		contractID = j.BootstrapSpec.ContractID
 		if j.BootstrapSpec.FeedID != nil {
 			feedID = j.BootstrapSpec.FeedID
 		}
+		relay = j.BootstrapSpec.Relay
+		chainID = parseChainIDFromJSONConfig(j.BootstrapSpec.RelayConfig)
 	case job.FluxMonitor, job.OffchainReporting:
 		return 0, errors.Errorf("contractID and feedID not applicable for job type: %s", j.Type)
 	default:
 		return 0, errors.Errorf("unsupported job type: %s", j.Type)
 	}
 
-	return tx.FindOCR2JobIDByAddress(ctx, contractID, feedID)
+	return tx.FindOCR2JobIDByAddress(ctx, relay, chainID, contractID, feedID)
 }
 
 // findExistingJobForOCRFlux looks for existing job for OCR or flux

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -3277,6 +3277,8 @@ func Test_Service_ApproveSpec_OCR2(t *testing.T) {
 	feedIDHex := "0x0000000000000000000000000000000000000000000000000000000000000001"
 	feedID := common.HexToHash(feedIDHex)
 	externalJobID := uuid.New()
+	relay := "evm"
+	chainID := int64(0)
 
 	var (
 		ctx  = testutils.Context(t)
@@ -3398,7 +3400,7 @@ updateInterval = "20m"
 				svc.orm.On("GetJobProposal", mock.Anything, jp.ID).Return(jp, nil)
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
 
 				svc.spawner.
 					On("CreateJob",
@@ -3449,7 +3451,7 @@ updateInterval = "20m"
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
 
 				svc.spawner.
 					On("CreateJob",
@@ -3519,7 +3521,7 @@ updateInterval = "20m"
 				svc.orm.On("GetJobProposal", mock.Anything, jp.ID).Return(jp, nil)
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(j.ID, nil)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(j.ID, nil)
 				svc.orm.On("WithDataSource", mock.Anything).Return(feeds.ORM(svc.orm))
 				svc.jobORM.On("WithDataSource", mock.Anything).Return(job.ORM(svc.jobORM))
 			},
@@ -3537,7 +3539,7 @@ updateInterval = "20m"
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 				svc.orm.EXPECT().GetApprovedSpec(mock.Anything, jp.ID).Return(nil, sql.ErrNoRows)
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(j.ID, nil)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(j.ID, nil)
 				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, j.ID).Return(nil)
 
 				svc.spawner.
@@ -3585,7 +3587,7 @@ updateInterval = "20m"
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 				svc.orm.EXPECT().GetApprovedSpec(mock.Anything, jp.ID).Return(nil, sql.ErrNoRows)
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, &feedID).Return(j.ID, nil)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, &feedID).Return(j.ID, nil)
 				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, j.ID).Return(nil)
 
 				svc.spawner.
@@ -3628,7 +3630,7 @@ updateInterval = "20m"
 				svc.orm.EXPECT().GetApprovedSpec(mock.Anything, jp.ID).Return(&feeds.JobProposalSpec{ID: 100}, nil)
 				svc.orm.EXPECT().CancelSpec(mock.Anything, int64(100)).Return(nil)
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(j.ID, nil)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(j.ID, nil)
 				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, j.ID).Return(nil)
 
 				svc.spawner.
@@ -3741,7 +3743,7 @@ updateInterval = "20m"
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
 
 				svc.spawner.
 					On("CreateJob",
@@ -3769,7 +3771,7 @@ updateInterval = "20m"
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
 
 				svc.spawner.
 					On("CreateJob",
@@ -3803,7 +3805,7 @@ updateInterval = "20m"
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
 
 				svc.spawner.
 					On("CreateJob",
@@ -4386,6 +4388,8 @@ func Test_Service_ApproveSpec_Bootstrap(t *testing.T) {
 	feedIDHex := "0x0000000000000000000000000000000000000000000000000000000000000001"
 	feedID := common.HexToHash(feedIDHex)
 	externalJobID := uuid.New()
+	relay := "evm"
+	chainID := int64(0)
 
 	var (
 		ctx  = testutils.Context(t)
@@ -4461,7 +4465,7 @@ chainID = 0
 				svc.orm.On("GetJobProposal", mock.Anything, jp.ID).Return(jp, nil)
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
 
 				svc.spawner.
 					On("CreateJob",
@@ -4512,7 +4516,7 @@ chainID = 0
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
 
 				svc.spawner.
 					On("CreateJob",
@@ -4582,7 +4586,7 @@ chainID = 0
 				svc.orm.On("GetJobProposal", mock.Anything, jp.ID).Return(jp, nil)
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(j.ID, nil)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(j.ID, nil)
 				svc.orm.On("WithDataSource", mock.Anything).Return(feeds.ORM(svc.orm))
 				svc.jobORM.On("WithDataSource", mock.Anything).Return(job.ORM(svc.jobORM))
 			},
@@ -4600,7 +4604,7 @@ chainID = 0
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 				svc.orm.EXPECT().GetApprovedSpec(mock.Anything, jp.ID).Return(nil, sql.ErrNoRows)
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(j.ID, nil)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(j.ID, nil)
 				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, j.ID).Return(nil)
 
 				svc.spawner.
@@ -4648,7 +4652,7 @@ chainID = 0
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 				svc.orm.EXPECT().GetApprovedSpec(mock.Anything, jp.ID).Return(nil, sql.ErrNoRows)
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, &feedID).Return(j.ID, nil)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, &feedID).Return(j.ID, nil)
 				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, j.ID).Return(nil)
 
 				svc.spawner.
@@ -4691,7 +4695,7 @@ chainID = 0
 				svc.orm.EXPECT().GetApprovedSpec(mock.Anything, jp.ID).Return(&feeds.JobProposalSpec{ID: 100}, nil)
 				svc.orm.EXPECT().CancelSpec(mock.Anything, int64(100)).Return(nil)
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(j.ID, nil)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(j.ID, nil)
 				svc.spawner.On("DeleteJob", mock.Anything, mock.Anything, j.ID).Return(nil)
 
 				svc.spawner.
@@ -4804,7 +4808,7 @@ chainID = 0
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
 
 				svc.spawner.
 					On("CreateJob",
@@ -4832,7 +4836,7 @@ chainID = 0
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil), mock.Anything).Return(int32(0), sql.ErrNoRows)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil), mock.Anything).Return(int32(0), sql.ErrNoRows)
 
 				svc.spawner.
 					On("CreateJob",
@@ -4866,7 +4870,7 @@ chainID = 0
 				svc.jobORM.On("AssertBridgesExist", mock.Anything, mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobByExternalJobID", mock.Anything, externalJobID).Return(job.Job{}, sql.ErrNoRows)
-				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
+				svc.jobORM.On("FindOCR2JobIDByAddress", mock.Anything, relay, chainID, address, (*common.Hash)(nil)).Return(int32(0), sql.ErrNoRows)
 
 				svc.spawner.
 					On("CreateJob",

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -62,7 +62,7 @@ externalJobID = '00000000-0000-0000-0000-000000000001'
 contractID = '0x0000000000000000000000000000000000000006'
 transmitterID = '%s'
 feedID = '%s'
-relay = 'evm'
+relay = '%s'
 pluginType = 'mercury'
 observationSource = """
 	ds          [type=http method=GET url="https://chain.link/ETH-USD"];
@@ -72,7 +72,7 @@ observationSource = """
 """
 
 [relayConfig]
-chainID = 1
+chainID = %d
 fromBlock = 1000
 
 [onchainSigningStrategy]
@@ -1153,15 +1153,24 @@ func Test_FindJobs(t *testing.T) {
 func Test_FindJob(t *testing.T) {
 	t.Parallel()
 	ctx := testutils.Context(t)
+	evmRelay := "evm"
+	chainID1 := int64(1337)
+	chainID2 := int64(2337)
 
 	// Create a config with multiple EVM chains. The test fixtures already load 1337
 	// Additional chains will need additional fixture statements to add a chain to evm_chains.
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		chainID := big.NewI(1337)
+		chainID1Big := big.NewI(chainID1)
+		chainID2Big := big.NewI(chainID2)
 		enabled := true
 		c.EVM = append(c.EVM, &configtoml.EVMConfig{
-			ChainID: chainID,
-			Chain:   configtoml.Defaults(chainID),
+			ChainID: chainID1Big,
+			Chain:   configtoml.Defaults(chainID1Big),
+			Enabled: &enabled,
+			Nodes:   configtoml.EVMNodes{{}},
+		}, &configtoml.EVMConfig{
+			ChainID: chainID2Big,
+			Chain:   configtoml.Defaults(chainID2Big),
 			Enabled: &enabled,
 			Nodes:   configtoml.EVMNodes{{}},
 		})
@@ -1209,7 +1218,7 @@ func Test_FindJob(t *testing.T) {
 			JobID:              uuid.New().String(),
 			TransmitterAddress: address.Hex(),
 			Name:               "ocr spec dup addr",
-			EVMChainID:         "1337",
+			EVMChainID:         big.NewI(chainID1).String(),
 			DS1BridgeName:      bridge.Name.String(),
 			DS2BridgeName:      bridge2.Name.String(),
 		}).Toml(),
@@ -1227,6 +1236,19 @@ func Test_FindJob(t *testing.T) {
 	ds -> ds_parse -> ds_multiply;`
 
 	jobOCR2.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
+	jobOCR2.OCR2OracleSpec.RelayConfig["chainID"] = chainID1
+
+	jobOCR2SameContractIDChainID2_1, err := ocr2validate.ValidatedOracleSpecToml(testutils.Context(t), config.OCR2(), config.Insecure(), testspecs.GetOCR2EVMSpecMinimal(), nil)
+	require.NoError(t, err)
+	jobOCR2SameContractIDChainID2_1.OCR2OracleSpec.TransmitterID = null.StringFrom(address.String())
+	jobOCR2SameContractIDChainID2_1.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
+	jobOCR2SameContractIDChainID2_1.OCR2OracleSpec.RelayConfig["chainID"] = chainID2
+
+	jobOCR2SameContractIDChainID2_2, err := ocr2validate.ValidatedOracleSpecToml(testutils.Context(t), config.OCR2(), config.Insecure(), testspecs.GetOCR2EVMSpecMinimal(), nil)
+	require.NoError(t, err)
+	jobOCR2SameContractIDChainID2_2.OCR2OracleSpec.TransmitterID = null.StringFrom(address.String())
+	jobOCR2SameContractIDChainID2_2.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
+	jobOCR2SameContractIDChainID2_2.OCR2OracleSpec.RelayConfig["chainID"] = chainID2
 
 	ocr2WithFeedID1 := "0x0001000000000000000000000000000000000000000000000000000000000001"
 	ocr2WithFeedID2 := "0x0001000000000000000000000000000000000000000000000000000000000002"
@@ -1234,7 +1256,7 @@ func Test_FindJob(t *testing.T) {
 		testutils.Context(t),
 		config.OCR2(),
 		config.Insecure(),
-		fmt.Sprintf(mercuryOracleTOML, cltest.DefaultCSAKey.PublicKeyString(), ocr2WithFeedID1),
+		fmt.Sprintf(mercuryOracleTOML, cltest.DefaultCSAKey.PublicKeyString(), ocr2WithFeedID1, evmRelay, chainID1),
 		nil,
 	)
 	require.NoError(t, err)
@@ -1243,7 +1265,7 @@ func Test_FindJob(t *testing.T) {
 		testutils.Context(t),
 		config.OCR2(),
 		config.Insecure(),
-		fmt.Sprintf(mercuryOracleTOML, cltest.DefaultCSAKey.PublicKeyString(), ocr2WithFeedID2),
+		fmt.Sprintf(mercuryOracleTOML, cltest.DefaultCSAKey.PublicKeyString(), ocr2WithFeedID2, evmRelay, chainID1),
 		nil,
 	)
 	jobOCR2WithFeedID2.ExternalJobID = uuid.New()
@@ -1257,6 +1279,12 @@ func Test_FindJob(t *testing.T) {
 	require.NoError(t, err)
 
 	err = orm.CreateJob(ctx, &jobOCR2)
+	require.NoError(t, err)
+
+	err = orm.CreateJob(ctx, &jobOCR2SameContractIDChainID2_1)
+	require.NoError(t, err)
+
+	err = orm.CreateJob(ctx, &jobOCR2SameContractIDChainID2_2)
 	require.NoError(t, err)
 
 	err = orm.CreateJob(ctx, &jobOCR2WithFeedID1)
@@ -1324,12 +1352,12 @@ func Test_FindJob(t *testing.T) {
 		assert.Equal(t, job.ID, jbID)
 	})
 
-	t.Run("by contract id without feed id", func(t *testing.T) {
+	t.Run("by contract id without feed id (with duplicate contract ids on different chain ids)", func(t *testing.T) {
 		ctx := testutils.Context(t)
 		contractID := "0x613a38AC1659769640aaE063C651F48E0250454C"
 
 		// Find job ID for ocr2 job without feedID.
-		jbID, err2 := orm.FindOCR2JobIDByAddress(ctx, contractID, nil)
+		jbID, err2 := orm.FindOCR2JobIDByAddress(ctx, evmRelay, chainID1, contractID, nil)
 		require.NoError(t, err2)
 
 		assert.Equal(t, jobOCR2.ID, jbID)
@@ -1341,7 +1369,7 @@ func Test_FindJob(t *testing.T) {
 		feedID := common.HexToHash(ocr2WithFeedID1)
 
 		// Find job ID for ocr2 job with feed ID
-		jbID, err2 := orm.FindOCR2JobIDByAddress(ctx, contractID, &feedID)
+		jbID, err2 := orm.FindOCR2JobIDByAddress(ctx, evmRelay, chainID1, contractID, &feedID)
 		require.NoError(t, err2)
 
 		assert.Equal(t, jobOCR2WithFeedID1.ID, jbID)
@@ -1353,10 +1381,17 @@ func Test_FindJob(t *testing.T) {
 		feedID := common.HexToHash(ocr2WithFeedID2)
 
 		// Find job ID for ocr2 job with feed ID
-		jbID, err2 := orm.FindOCR2JobIDByAddress(ctx, contractID, &feedID)
+		jbID, err2 := orm.FindOCR2JobIDByAddress(ctx, evmRelay, chainID1, contractID, &feedID)
 		require.NoError(t, err2)
 
 		assert.Equal(t, jobOCR2WithFeedID2.ID, jbID)
+	})
+
+	t.Run("with duplicate contract id and the same chain id", func(t *testing.T) {
+		ctx := testutils.Context(t)
+		contractID := "0x613a38AC1659769640aaE063C651F48E0250454C"
+		_, err2 := orm.FindOCR2JobIDByAddress(ctx, evmRelay, chainID2, contractID, nil)
+		assert.EqualError(t, err2, "Find returned 2 > 1 job results")
 	})
 }
 

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -1391,7 +1391,7 @@ func Test_FindJob(t *testing.T) {
 		ctx := testutils.Context(t)
 		contractID := "0x613a38AC1659769640aaE063C651F48E0250454C"
 		_, err2 := orm.FindOCR2JobIDByAddress(ctx, evmRelay, chainID2, contractID, nil)
-		assert.EqualError(t, err2, "Find returned 2 > 1 job results")
+		assert.ErrorContains(t, err2, "find returned > 1 job results")
 	})
 }
 

--- a/core/services/job/mocks/orm.go
+++ b/core/services/job/mocks/orm.go
@@ -1014,9 +1014,9 @@ func (_c *ORM_FindJobsByPipelineSpecIDs_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-// FindOCR2JobIDByAddress provides a mock function with given fields: ctx, contractID, feedID
-func (_m *ORM) FindOCR2JobIDByAddress(ctx context.Context, contractID string, feedID *common.Hash) (int32, error) {
-	ret := _m.Called(ctx, contractID, feedID)
+// FindOCR2JobIDByAddress provides a mock function with given fields: ctx, relay, chainID, contractID, feedID
+func (_m *ORM) FindOCR2JobIDByAddress(ctx context.Context, relay string, chainID int64, contractID string, feedID *common.Hash) (int32, error) {
+	ret := _m.Called(ctx, relay, chainID, contractID, feedID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FindOCR2JobIDByAddress")
@@ -1024,17 +1024,17 @@ func (_m *ORM) FindOCR2JobIDByAddress(ctx context.Context, contractID string, fe
 
 	var r0 int32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *common.Hash) (int32, error)); ok {
-		return rf(ctx, contractID, feedID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, string, *common.Hash) (int32, error)); ok {
+		return rf(ctx, relay, chainID, contractID, feedID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *common.Hash) int32); ok {
-		r0 = rf(ctx, contractID, feedID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, string, *common.Hash) int32); ok {
+		r0 = rf(ctx, relay, chainID, contractID, feedID)
 	} else {
 		r0 = ret.Get(0).(int32)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, *common.Hash) error); ok {
-		r1 = rf(ctx, contractID, feedID)
+	if rf, ok := ret.Get(1).(func(context.Context, string, int64, string, *common.Hash) error); ok {
+		r1 = rf(ctx, relay, chainID, contractID, feedID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1049,15 +1049,17 @@ type ORM_FindOCR2JobIDByAddress_Call struct {
 
 // FindOCR2JobIDByAddress is a helper method to define mock.On call
 //   - ctx context.Context
+//   - relay string
+//   - chainID int64
 //   - contractID string
 //   - feedID *common.Hash
-func (_e *ORM_Expecter) FindOCR2JobIDByAddress(ctx interface{}, contractID interface{}, feedID interface{}) *ORM_FindOCR2JobIDByAddress_Call {
-	return &ORM_FindOCR2JobIDByAddress_Call{Call: _e.mock.On("FindOCR2JobIDByAddress", ctx, contractID, feedID)}
+func (_e *ORM_Expecter) FindOCR2JobIDByAddress(ctx interface{}, relay interface{}, chainID interface{}, contractID interface{}, feedID interface{}) *ORM_FindOCR2JobIDByAddress_Call {
+	return &ORM_FindOCR2JobIDByAddress_Call{Call: _e.mock.On("FindOCR2JobIDByAddress", ctx, relay, chainID, contractID, feedID)}
 }
 
-func (_c *ORM_FindOCR2JobIDByAddress_Call) Run(run func(ctx context.Context, contractID string, feedID *common.Hash)) *ORM_FindOCR2JobIDByAddress_Call {
+func (_c *ORM_FindOCR2JobIDByAddress_Call) Run(run func(ctx context.Context, relay string, chainID int64, contractID string, feedID *common.Hash)) *ORM_FindOCR2JobIDByAddress_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(*common.Hash))
+		run(args[0].(context.Context), args[1].(string), args[2].(int64), args[3].(string), args[4].(*common.Hash))
 	})
 	return _c
 }
@@ -1067,7 +1069,7 @@ func (_c *ORM_FindOCR2JobIDByAddress_Call) Return(_a0 int32, _a1 error) *ORM_Fin
 	return _c
 }
 
-func (_c *ORM_FindOCR2JobIDByAddress_Call) RunAndReturn(run func(context.Context, string, *common.Hash) (int32, error)) *ORM_FindOCR2JobIDByAddress_Call {
+func (_c *ORM_FindOCR2JobIDByAddress_Call) RunAndReturn(run func(context.Context, string, int64, string, *common.Hash) (int32, error)) *ORM_FindOCR2JobIDByAddress_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -1088,7 +1088,7 @@ WHERE ocr2spec.id IS NOT NULL OR bs.id IS NOT NULL
 		return 0, errors.Wrapf(err, "error searching for job by contract id=%s and feed id=%s", contractID, feedID)
 	}
 	if len(results) > 1 {
-		return 0, errors.Errorf("Find returned %d > 1 job results", len(results))
+		return 0, errors.Errorf("For contract id=%s, feed id=%s, find returned > 1 job results with ids = %v", contractID, feedID, results)
 	}
 	if len(results) == 0 {
 		return 0, nil

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -1093,8 +1093,8 @@ WHERE ocr2spec.id IS NOT NULL OR bs.id IS NOT NULL
 	if len(results) == 0 {
 		return 0, nil
 	}
-	// Sqlx scans into int64 types irrespectively of the underlying db type; id is serial4, which is 4 bytes.
-	return int32(results[0]), nil //nolint:gosec
+	//nolint:gosec // Sqlx scans into int64 types irrespectively of the underlying db type; id is serial4, which is 4 bytes.
+	return int32(results[0]), nil
 }
 
 func (o *orm) findJob(ctx context.Context, jb *Job, col string, arg interface{}) error {

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -49,7 +49,7 @@ type ORM interface {
 	FindJob(ctx context.Context, id int32) (Job, error)
 	FindJobByExternalJobID(ctx context.Context, uuid uuid.UUID) (Job, error)
 	FindJobIDByAddress(ctx context.Context, address evmtypes.EIP55Address, evmChainID *big.Big) (int32, error)
-	FindOCR2JobIDByAddress(ctx context.Context, contractID string, feedID *common.Hash) (int32, error)
+	FindOCR2JobIDByAddress(ctx context.Context, relay string, chainID int64, contractID string, feedID *common.Hash) (int32, error)
 	FindJobIDsWithBridge(ctx context.Context, name string) ([]int32, error)
 	DeleteJob(ctx context.Context, id int32, jobType Type) error
 	RecordError(ctx context.Context, jobID int32, description string) error
@@ -1062,26 +1062,39 @@ WHERE ocrspec.id IS NOT NULL OR fmspec.id IS NOT NULL
 	return
 }
 
-func (o *orm) FindOCR2JobIDByAddress(ctx context.Context, contractID string, feedID *common.Hash) (jobID int32, err error) {
+func (o *orm) FindOCR2JobIDByAddress(ctx context.Context, relay string, chainID int64, contractID string, feedID *common.Hash) (int32, error) {
 	// NOTE: We want to explicitly match on NULL feed_id hence usage of `IS
 	// NOT DISTINCT FROM` instead of `=`
 	stmt := `
 SELECT jobs.id
 FROM jobs
-LEFT JOIN ocr2_oracle_specs ocr2spec on ocr2spec.contract_id = $1 AND ocr2spec.feed_id IS NOT DISTINCT FROM $2 AND ocr2spec.id = jobs.ocr2_oracle_spec_id
-LEFT JOIN bootstrap_specs bs on bs.contract_id = $1 AND bs.feed_id IS NOT DISTINCT FROM $2 AND bs.id = jobs.bootstrap_spec_id
+LEFT JOIN ocr2_oracle_specs ocr2spec on 
+	ocr2spec.contract_id = $1 AND 
+	ocr2spec.feed_id IS NOT DISTINCT FROM $2 AND 
+	ocr2spec.id = jobs.ocr2_oracle_spec_id AND
+	ocr2spec.relay = $3 AND
+	ocr2spec.relay_config->'chainID' = $4
+LEFT JOIN bootstrap_specs bs on 
+	bs.contract_id = $1 AND 
+	bs.feed_id IS NOT DISTINCT FROM $2 AND 
+	bs.id = jobs.bootstrap_spec_id AND
+	bs.relay = $3 AND
+	bs.relay_config->'chainID' = $4
 WHERE ocr2spec.id IS NOT NULL OR bs.id IS NOT NULL
 `
-	err = o.ds.GetContext(ctx, &jobID, stmt, contractID, feedID)
+	var results []int64
+	err := o.ds.SelectContext(ctx, &results, stmt, contractID, feedID, relay, chainID)
 	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			err = errors.Wrapf(err, "error searching for job by contract id=%s and feed id=%s", contractID, feedID)
-		}
-		err = errors.Wrap(err, "FindOCR2JobIDByAddress failed")
-		return
+		return 0, errors.Wrapf(err, "error searching for job by contract id=%s and feed id=%s", contractID, feedID)
 	}
-
-	return
+	if len(results) > 1 {
+		return 0, errors.Errorf("Find returned %d > 1 job results", len(results))
+	}
+	if len(results) == 0 {
+		return 0, nil
+	}
+	// Sqlx scans into int64 types irrespectively of the underlying db type; id is serial4, which is 4 bytes.
+	return int32(results[0]), nil //nolint:gosec
 }
 
 func (o *orm) findJob(ctx context.Context, jb *Job, col string, arg interface{}) error {


### PR DESCRIPTION
Before this PR `FindOCR2JobIDByAddress` would not differentiate jobs with the same contract ID but different relayer/chainIDs. After this change `FindOCR2JobIDByAddress` explicitly requires relayer and chaindID to search for a corresponding job; this allows to approve OCR2 and bootstrap specs with the same contract ID but different relayer/chainIDs.

Furthermore, we refactored the SQL code inside FindOCR2JobIDByAddress. In this PR we use `SelectContext` to query job IDs instead of `GetContext` leading to the following changes:
 - We start to err if more than 1 job IDs is returned; previously, we would just return the first one.
 - We stop erroring if no job IDs is returned; previously, we would also return sql.ErrNoRows. This is a no-op because we have already treated returned 0 as job ID as "no jobs found" state.