### PR TITLE
Custom cut for Staging Mainnet (includes #19222, #19215)

### DIFF
--- a/core/services/llo/mercurytransmitter/server.go
+++ b/core/services/llo/mercurytransmitter/server.go
@@ -188,6 +188,11 @@ func (s *server) spawnTransmitLoop(stopCh services.StopChan, wg *sync.WaitGroup,
 				// queue was closed
 				return false
 			}
+			if t.Report.Info.ReportFormat == llotypes.ReportFormatCapabilityTrigger {
+				// `capability_trigger` reports are Data Feeds product specific and aren't sent to the Mercury servers
+				s.pm.AsyncDelete(t.Hash())
+				return true
+			}
 
 			s.transmitThreadBusyCountInc()
 			defer s.transmitThreadBusyCountDec()


### PR DESCRIPTION
Branch cut from v2.27.0 with #19222 already present in base and cherry-pick of #19215 applied for the Staging Mainnet custom image.