### PR TITLE
Custom cut for Staging Mainnet (includes #19222, #19215)

### DIFF
--- a/core/services/llo/mercurytransmitter/server.go
+++ b/core/services/llo/mercurytransmitter/server.go
@@ -188,6 +188,11 @@ func (s *server) spawnTransmitLoop(stopCh services.StopChan, wg *sync.WaitGroup,
 				// queue was closed
 				return false
 			}
+			if t.Report.Info.ReportFormat == llotypes.ReportFormatCapabilityTrigger {
+				// `capability_trigger` reports are Data Feeds product specific and aren't sent to the Mercury servers
+				s.pm.AsyncDelete(t.Hash())
+				return true
+			}
 
 			s.transmitThreadBusyCountInc()
 			defer s.transmitThreadBusyCountDec()

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.3
 	github.com/shopspring/decimal v1.4.0
 	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3
-	github.com/smartcontractkit/chain-selectors v1.0.66
+	github.com/smartcontractkit/chain-selectors v1.0.68
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a
 	github.com/smartcontractkit/chainlink-automation v0.8.1
 	github.com/smartcontractkit/chainlink-ccip v0.1.1-solana.0.20250731202037-a0d4a4f75964

--- a/go.sum
+++ b/go.sum
@@ -1074,8 +1074,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/smartcontractkit/chain-selectors v1.0.66 h1:Q8TAGYeR8Esr3nTIcUrkGVbgwRGSBHTC+724AjZUGKM=
-github.com/smartcontractkit/chain-selectors v1.0.66/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
+github.com/smartcontractkit/chain-selectors v1.0.68 h1:Xj1jfW4pSj6ru8dNxgpfGxmWHM3fMPOCRpqkRZaJhCk=
+github.com/smartcontractkit/chain-selectors v1.0.68/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a h1:45A1juQPvLV4xDt35wPiNpdzQwg2uGqbLQtHXLhZjWw=
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250626122206-319db248496a/go.mod h1:+LMKso9gI5B78xdk3uP69/WrsJTcalbKFO63amJexsE=
 github.com/smartcontractkit/chainlink-automation v0.8.1 h1:sTc9LKpBvcKPc1JDYAmgBc2xpDKBco/Q4h4ydl6+UUU=


### PR DESCRIPTION
Branch cut from v2.27.0 with #19222 already present in base and cherry-pick of #19215 applied. Includes bump of chain-selectors to v1.0.68 to satisfy CI.