### PR TITLE
dedup ocr configuration sequences

### DIFF
--- a/deployment/cre/ocr3/v2/changeset/deploy_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/deploy_ocr3.go
@@ -17,12 +17,12 @@ import (
 var _ cldf.ChangeSetV2[DeployOCR3Input] = DeployOCR3{}
 
 type DeployOCR3Input struct {
-	ChainSelector uint64                      `json:"chainSelector" yaml:"chainSelector"`
-	Qualifier     string                      `json:"qualifier" yaml:"qualifier"`
-	Dons          []contracts.ConfigureCREDON `json:"dons" yaml:"dons"`
-	OracleConfig  *ocr3.OracleConfig          `json:"oracleConfig" yaml:"oracleConfig"`
-	DryRun        bool                        `json:"dryRun" yaml:"dryRun"`
-	MCMSConfig    *ocr3.MCMSConfig            `json:"mcmsConfig" yaml:"mcmsConfig"`
+	ChainSelector uint64                    `json:"chainSelector" yaml:"chainSelector"`
+	Qualifier     string                    `json:"qualifier" yaml:"qualifier"`
+	Don           contracts.ConfigureCREDON `json:"dons" yaml:"dons"`
+	OracleConfig  *ocr3.OracleConfig        `json:"oracleConfig" yaml:"oracleConfig"`
+	DryRun        bool                      `json:"dryRun" yaml:"dryRun"`
+	MCMSConfig    *ocr3.MCMSConfig          `json:"mcmsConfig" yaml:"mcmsConfig"`
 }
 
 type DeployOCR3Deps struct {
@@ -43,10 +43,10 @@ func (l DeployOCR3) Apply(e cldf.Environment, config DeployOCR3Input) (cldf.Chan
 		sequences.DeployOCR3,
 		sequences.DeployOCR3Deps{Env: &e},
 		sequences.DeployOCR3Input{
-			RegistryChainSel: config.ChainSelector,
-			Qualifier:        config.Qualifier,
+			ChainSelector: config.ChainSelector,
+			Qualifier:     config.Qualifier,
 
-			DON:          config.Dons,
+			DON:          config.Don,
 			OracleConfig: config.OracleConfig,
 			DryRun:       config.DryRun,
 			MCMSConfig:   config.MCMSConfig,

--- a/deployment/cre/ocr3/v2/changeset/deploy_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/deploy_ocr3.go
@@ -17,12 +17,12 @@ import (
 var _ cldf.ChangeSetV2[DeployOCR3Input] = DeployOCR3{}
 
 type DeployOCR3Input struct {
-	ChainSelector uint64                    `json:"chainSelector" yaml:"chainSelector"`
-	Qualifier     string                    `json:"qualifier" yaml:"qualifier"`
-	Don           contracts.ConfigureCREDON `json:"dons" yaml:"dons"`
-	OracleConfig  *ocr3.OracleConfig        `json:"oracleConfig" yaml:"oracleConfig"`
-	DryRun        bool                      `json:"dryRun" yaml:"dryRun"`
-	MCMSConfig    *ocr3.MCMSConfig          `json:"mcmsConfig" yaml:"mcmsConfig"`
+	ChainSelector uint64               `json:"chainSelector" yaml:"chainSelector"`
+	Qualifier     string               `json:"qualifier" yaml:"qualifier"`
+	Don           contracts.DonNodeSet `json:"dons" yaml:"dons"`
+	OracleConfig  *ocr3.OracleConfig   `json:"oracleConfig" yaml:"oracleConfig"`
+	DryRun        bool                 `json:"dryRun" yaml:"dryRun"`
+	MCMSConfig    *ocr3.MCMSConfig     `json:"mcmsConfig" yaml:"mcmsConfig"`
 }
 
 type DeployOCR3Deps struct {

--- a/deployment/cre/ocr3/v2/changeset/deploy_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/deploy_ocr3.go
@@ -46,7 +46,7 @@ func (l DeployOCR3) Apply(e cldf.Environment, config DeployOCR3Input) (cldf.Chan
 			RegistryChainSel: config.ChainSelector,
 			Qualifier:        config.Qualifier,
 
-			DONs:         config.Dons,
+			DON:          config.Dons,
 			OracleConfig: config.OracleConfig,
 			DryRun:       config.DryRun,
 			MCMSConfig:   config.MCMSConfig,

--- a/deployment/cre/ocr3/v2/changeset/deploy_ocr3_test.go
+++ b/deployment/cre/ocr3/v2/changeset/deploy_ocr3_test.go
@@ -22,11 +22,9 @@ func TestDeployOCR3(t *testing.T) {
 	changesetOutput, err := DeployOCR3{}.Apply(*env.Env, DeployOCR3Input{
 		ChainSelector: env.RegistrySelector,
 		Qualifier:     "test-ocr3",
-		Dons: []contracts.ConfigureCREDON{
-			{
-				Name:    "test-don",      // This should match the DON created in SetupEnvV2
-				NodeIDs: env.Env.NodeIDs, // Use all available node IDs
-			},
+		Don: contracts.ConfigureCREDON{
+			Name:    "test-don",      // This should match the DON created in SetupEnvV2
+			NodeIDs: env.Env.NodeIDs, // Use all available node IDs
 		},
 		OracleConfig: &ocr3.OracleConfig{
 			MaxFaultyOracles:     1,

--- a/deployment/cre/ocr3/v2/changeset/deploy_ocr3_test.go
+++ b/deployment/cre/ocr3/v2/changeset/deploy_ocr3_test.go
@@ -22,7 +22,7 @@ func TestDeployOCR3(t *testing.T) {
 	changesetOutput, err := DeployOCR3{}.Apply(*env.Env, DeployOCR3Input{
 		ChainSelector: env.RegistrySelector,
 		Qualifier:     "test-ocr3",
-		Don: contracts.ConfigureCREDON{
+		Don: contracts.DonNodeSet{
 			Name:    "test-don",      // This should match the DON created in SetupEnvV2
 			NodeIDs: env.Env.NodeIDs, // Use all available node IDs
 		},

--- a/deployment/cre/ocr3/v2/changeset/operations/contracts/configure_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/operations/contracts/configure_ocr3.go
@@ -26,15 +26,14 @@ import (
 type ConfigureOCR3Deps struct {
 	Env                  *cldf.Environment
 	WriteGeneratedConfig io.Writer
-	//Registry             *capabilities_registry_v2.CapabilitiesRegistry
 }
 
 type ConfigureOCR3Input struct {
-	ContractAddress  *common.Address
-	RegistryChainSel uint64
-	DONs             ConfigureCREDON
-	Config           *ocr3.OracleConfig
-	DryRun           bool
+	ContractAddress *common.Address
+	ChainSelector   uint64
+	DON             ConfigureCREDON
+	Config          *ocr3.OracleConfig
+	DryRun          bool
 
 	MCMSConfig *ocr3.MCMSConfig
 }
@@ -56,9 +55,9 @@ var ConfigureOCR3 = operations.NewOperation[ConfigureOCR3Input, ConfigureOCR3OpO
 			return ConfigureOCR3OpOutput{}, errors.New("ContractAddress is required")
 		}
 
-		chain, ok := deps.Env.BlockChains.EVMChains()[input.RegistryChainSel]
+		chain, ok := deps.Env.BlockChains.EVMChains()[input.ChainSelector]
 		if !ok {
-			return ConfigureOCR3OpOutput{}, fmt.Errorf("chain %d not found in environment", input.RegistryChainSel)
+			return ConfigureOCR3OpOutput{}, fmt.Errorf("chain %d not found in environment", input.ChainSelector)
 		}
 
 		contract, err := contracts.GetOwnedContractV2[*ocr3_capability.OCR3Capability](deps.Env.DataStore.Addresses(), chain, input.ContractAddress.Hex())
@@ -67,8 +66,8 @@ var ConfigureOCR3 = operations.NewOperation[ConfigureOCR3Input, ConfigureOCR3OpO
 		}
 
 		resp, err := ocr3.ConfigureOCR3ContractFromJD(deps.Env, ocr3.ConfigureOCR3Config{
-			ChainSel:   input.RegistryChainSel,
-			NodeIDs:    input.DONs.NodeIDs,
+			ChainSel:   input.ChainSelector,
+			NodeIDs:    input.DON.NodeIDs,
 			OCR3Config: input.Config,
 			Contract:   contract.Contract,
 			DryRun:     input.DryRun,
@@ -104,18 +103,18 @@ var ConfigureOCR3 = operations.NewOperation[ConfigureOCR3Input, ConfigureOCR3OpO
 			}
 
 			timelocksPerChain := map[uint64]string{
-				input.RegistryChainSel: contract.McmsContracts.Timelock.Address().Hex(),
+				input.ChainSelector: contract.McmsContracts.Timelock.Address().Hex(),
 			}
 			proposerMCMSes := map[uint64]string{
-				input.RegistryChainSel: contract.McmsContracts.ProposerMcm.Address().Hex(),
+				input.ChainSelector: contract.McmsContracts.ProposerMcm.Address().Hex(),
 			}
 
-			inspector, err := proposalutils.McmsInspectorForChain(*deps.Env, input.RegistryChainSel)
+			inspector, err := proposalutils.McmsInspectorForChain(*deps.Env, input.ChainSelector)
 			if err != nil {
 				return ConfigureOCR3OpOutput{}, err
 			}
 			inspectorPerChain := map[uint64]sdk.Inspector{
-				input.RegistryChainSel: inspector,
+				input.ChainSelector: inspector,
 			}
 			proposal, err := proposalutils.BuildProposalFromBatchesV2(
 				*deps.Env,

--- a/deployment/cre/ocr3/v2/changeset/operations/contracts/configure_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/operations/contracts/configure_ocr3.go
@@ -17,7 +17,6 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	ocr3_capability "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/ocr3_capability_1_0_0"
-	capabilities_registry_v2 "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"
 
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/deployment/cre/contracts"
@@ -27,13 +26,13 @@ import (
 type ConfigureOCR3Deps struct {
 	Env                  *cldf.Environment
 	WriteGeneratedConfig io.Writer
-	Registry             *capabilities_registry_v2.CapabilitiesRegistry
+	//Registry             *capabilities_registry_v2.CapabilitiesRegistry
 }
 
 type ConfigureOCR3Input struct {
 	ContractAddress  *common.Address
 	RegistryChainSel uint64
-	DONs             []ConfigureCREDON
+	DONs             ConfigureCREDON
 	Config           *ocr3.OracleConfig
 	DryRun           bool
 
@@ -57,27 +56,6 @@ var ConfigureOCR3 = operations.NewOperation[ConfigureOCR3Input, ConfigureOCR3OpO
 			return ConfigureOCR3OpOutput{}, errors.New("ContractAddress is required")
 		}
 
-		var nodeIDs []string
-		for _, don := range input.DONs {
-			donConfig := RegisteredDonConfig{
-				NodeIDs:          don.NodeIDs,
-				Name:             don.Name,
-				RegistryChainSel: input.RegistryChainSel,
-				Registry:         deps.Registry,
-			}
-			d, err := newRegisteredDon(*deps.Env, donConfig)
-			if err != nil {
-				return ConfigureOCR3OpOutput{}, fmt.Errorf("configure-ocr3-op failed: failed to create registered DON %s: %w", don.Name, err)
-			}
-
-			// We double-check that the DON accepts workflows...
-			if d.Info.AcceptsWorkflows {
-				for _, node := range d.Nodes {
-					nodeIDs = append(nodeIDs, node.NodeID)
-				}
-			}
-		}
-
 		chain, ok := deps.Env.BlockChains.EVMChains()[input.RegistryChainSel]
 		if !ok {
 			return ConfigureOCR3OpOutput{}, fmt.Errorf("chain %d not found in environment", input.RegistryChainSel)
@@ -90,7 +68,7 @@ var ConfigureOCR3 = operations.NewOperation[ConfigureOCR3Input, ConfigureOCR3OpO
 
 		resp, err := ocr3.ConfigureOCR3ContractFromJD(deps.Env, ocr3.ConfigureOCR3Config{
 			ChainSel:   input.RegistryChainSel,
-			NodeIDs:    nodeIDs,
+			NodeIDs:    input.DONs.NodeIDs,
 			OCR3Config: input.Config,
 			Contract:   contract.Contract,
 			DryRun:     input.DryRun,

--- a/deployment/cre/ocr3/v2/changeset/operations/contracts/configure_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/operations/contracts/configure_ocr3.go
@@ -31,7 +31,7 @@ type ConfigureOCR3Deps struct {
 type ConfigureOCR3Input struct {
 	ContractAddress *common.Address
 	ChainSelector   uint64
-	DON             ConfigureCREDON
+	DON             DonNodeSet
 	Config          *ocr3.OracleConfig
 	DryRun          bool
 

--- a/deployment/cre/ocr3/v2/changeset/operations/contracts/deploy_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/operations/contracts/deploy_ocr3.go
@@ -30,6 +30,7 @@ type DeployOCR3Output struct {
 	Version       string
 	Labels        []string
 	Datastore     datastore.DataStore
+	AddressBook   cldf.AddressBook // backward compatibility, to be removed in CRE-742
 }
 
 // DeployOCR3 is an operation that deploys the OCR3 contract.
@@ -85,6 +86,7 @@ var DeployOCR3 = operations.NewOperation[DeployOCR3Input, DeployOCR3Output, Depl
 			Type:          datastore.ContractType(tv.Type),
 			Version:       &tv.Version,
 			Labels:        labels,
+			Qualifier:     input.Qualifier,
 		}
 
 		// Create a mutable datastore in order to be able to add the ocr3 address and access it from the configure step
@@ -95,11 +97,16 @@ var DeployOCR3 = operations.NewOperation[DeployOCR3Input, DeployOCR3Output, Depl
 		}
 
 		if err := ds.AddressRefStore.Add(addressRef); err != nil {
-			return DeployOCR3Output{}, err
+			return DeployOCR3Output{}, fmt.Errorf("failed to add OCR3 address %v to datastore: %w", addressRef, err)
 		}
 
 		lggr.Infof("Deployed %s on chain selector %d at address %s", tv.String(), chain.Selector, ocr3Addr.String())
 
+		ab := cldf.NewMemoryAddressBook()
+		err = ab.Save(chain.Selector, ocr3Addr.String(), tv)
+		if err != nil {
+			return DeployOCR3Output{}, fmt.Errorf("failed to save address to address book: %w", err)
+		}
 		return DeployOCR3Output{
 			Address:       ocr3Addr.String(),
 			ChainSelector: input.ChainSelector,
@@ -108,6 +115,7 @@ var DeployOCR3 = operations.NewOperation[DeployOCR3Input, DeployOCR3Output, Depl
 			Version:       tv.Version.String(),
 			Labels:        tv.Labels.List(),
 			Datastore:     ds.Seal(),
+			AddressBook:   ab, // TODO: CRE-742 remove AddressBook
 		}, nil
 	},
 )

--- a/deployment/cre/ocr3/v2/changeset/operations/contracts/types.go
+++ b/deployment/cre/ocr3/v2/changeset/operations/contracts/types.go
@@ -1,13 +1,6 @@
 package contracts
 
 import (
-	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
-	"errors"
-	"fmt"
-	"sort"
-
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	capabilities_registry_v2 "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"
 
@@ -31,7 +24,7 @@ type RegisteredDonConfig struct {
 	Registry         *capabilities_registry_v2.CapabilitiesRegistry
 }
 
-type ConfigureCREDON struct {
+type DonNodeSet struct {
 	Name    string
 	NodeIDs []string
 }
@@ -41,52 +34,4 @@ type RegisteredDon struct {
 	Name  string
 	Info  capabilities_registry_v2.CapabilitiesRegistryDONInfo
 	Nodes []deployment.Node
-}
-
-func newRegisteredDon(env cldf.Environment, cfg RegisteredDonConfig) (*RegisteredDon, error) {
-	if cfg.Registry == nil {
-		return nil, errors.New("capabilities registry not found in config")
-	}
-
-	var (
-		err    error
-		capReg = cfg.Registry
-	)
-
-	di, err := capReg.GetDONs(nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get dons: %w", err)
-	}
-	// load the nodes from the offchain client
-	nodes, err := deployment.NodeInfo(cfg.NodeIDs, env.Offchain)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node info: %w", err)
-	}
-	want := sortedHash(nodes.PeerIDs())
-	var don *capabilities_registry_v2.CapabilitiesRegistryDONInfo
-	for i, d := range di {
-		got := sortedHash(d.NodeP2PIds)
-		if got == want {
-			don = &di[i]
-		}
-	}
-	if don == nil {
-		return nil, errors.New("don not found in registry")
-	}
-	return &RegisteredDon{
-		Name:  cfg.Name,
-		Info:  *don,
-		Nodes: nodes,
-	}, nil
-}
-
-func sortedHash(p2pids [][32]byte) string {
-	sha256Hash := sha256.New()
-	sort.Slice(p2pids, func(i, j int) bool {
-		return bytes.Compare(p2pids[i][:], p2pids[j][:]) < 0
-	})
-	for _, id := range p2pids {
-		sha256Hash.Write(id[:])
-	}
-	return hex.EncodeToString(sha256Hash.Sum(nil))
 }

--- a/deployment/cre/ocr3/v2/changeset/sequences/deploy_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/sequences/deploy_ocr3.go
@@ -27,7 +27,7 @@ type DeployOCR3Input struct {
 	RegistryChainSel uint64
 	Qualifier        string
 
-	DONs         []contracts.ConfigureCREDON
+	DON          contracts.ConfigureCREDON
 	OracleConfig *ocr3.OracleConfig
 	DryRun       bool
 
@@ -65,25 +65,19 @@ var DeployOCR3 = operations.NewSequence(
 		// Update the environment datastore to include the newly deployed OCR3 contract
 		deps.Env.DataStore = ocr3DeploymentReport.Output.Datastore
 
-		// Step 2: Get the capabilities registry contract
-		capabilitiesRegistry, err := getCapabilitiesRegistryContract(deps, input)
-		if err != nil {
-			return DeployOCR3Output{}, fmt.Errorf("failed to get capabilities registry: %w", err)
-		}
-
 		// Step 3: Configure OCR3 Contract with DONs
-		deps.Env.Logger.Infow("Configuring OCR3 contract with DONs",
-			"numDONs", len(input.DONs),
+		deps.Env.Logger.Infow("Configuring OCR3 contract with DON",
+			"nodes", input.DON.NodeIDs,
 			"dryRun", input.DryRun)
 
 		_, err = operations.ExecuteOperation(b, contracts.ConfigureOCR3, contracts.ConfigureOCR3Deps{
 			Env:                  deps.Env,
 			WriteGeneratedConfig: deps.WriteGeneratedConfig,
-			Registry:             capabilitiesRegistry,
+			//	Registry:             capabilitiesRegistry,
 		}, contracts.ConfigureOCR3Input{
 			ContractAddress:  &ocr3ContractAddress,
 			RegistryChainSel: input.RegistryChainSel,
-			DONs:             input.DONs,
+			DONs:             input.DON,
 			Config:           input.OracleConfig,
 			DryRun:           input.DryRun,
 			MCMSConfig:       input.MCMSConfig,

--- a/deployment/cre/ocr3/v2/changeset/sequences/deploy_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/sequences/deploy_ocr3.go
@@ -1,19 +1,15 @@
 package sequences
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	capabilities_registry_v2 "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"
 
-	crecontracts "github.com/smartcontractkit/chainlink/deployment/cre/contracts"
 	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3"
 	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3/v2/changeset/operations/contracts"
 )
@@ -24,8 +20,8 @@ type DeployOCR3Deps struct {
 }
 
 type DeployOCR3Input struct {
-	RegistryChainSel uint64
-	Qualifier        string
+	ChainSelector uint64
+	Qualifier     string
 
 	DON          contracts.ConfigureCREDON
 	OracleConfig *ocr3.OracleConfig
@@ -53,7 +49,7 @@ var DeployOCR3 = operations.NewSequence(
 	func(b operations.Bundle, deps DeployOCR3Deps, input DeployOCR3Input) (DeployOCR3Output, error) {
 		// Step 1: Deploy OCR3 Contract for Consensus Capability
 		ocr3DeploymentReport, err := operations.ExecuteOperation(b, contracts.DeployOCR3, contracts.DeployOCR3Deps{Env: deps.Env}, contracts.DeployOCR3Input{
-			ChainSelector: input.RegistryChainSel,
+			ChainSelector: input.ChainSelector,
 			Qualifier:     input.Qualifier,
 		})
 		if err != nil {
@@ -73,14 +69,13 @@ var DeployOCR3 = operations.NewSequence(
 		_, err = operations.ExecuteOperation(b, contracts.ConfigureOCR3, contracts.ConfigureOCR3Deps{
 			Env:                  deps.Env,
 			WriteGeneratedConfig: deps.WriteGeneratedConfig,
-			//	Registry:             capabilitiesRegistry,
 		}, contracts.ConfigureOCR3Input{
-			ContractAddress:  &ocr3ContractAddress,
-			RegistryChainSel: input.RegistryChainSel,
-			DONs:             input.DON,
-			Config:           input.OracleConfig,
-			DryRun:           input.DryRun,
-			MCMSConfig:       input.MCMSConfig,
+			ContractAddress: &ocr3ContractAddress,
+			ChainSelector:   input.ChainSelector,
+			DON:             input.DON,
+			Config:          input.OracleConfig,
+			DryRun:          input.DryRun,
+			MCMSConfig:      input.MCMSConfig,
 		})
 		if err != nil {
 			return DeployOCR3Output{}, fmt.Errorf("failed to configure OCR3 contract: %w", err)
@@ -95,23 +90,3 @@ var DeployOCR3 = operations.NewSequence(
 		}, nil
 	},
 )
-
-func getCapabilitiesRegistryContract(deps DeployOCR3Deps, input DeployOCR3Input) (*capabilities_registry_v2.CapabilitiesRegistry, error) {
-	refs := deps.Env.DataStore.Addresses().Filter(
-		datastore.AddressRefByType("CapabilitiesRegistry"),
-		datastore.AddressRefByChainSelector(input.RegistryChainSel))
-	if len(refs) == 0 {
-		return nil, errors.New("failed to get capabilities registry ref")
-	}
-	capabilitiesRegistryRef := refs[0]
-
-	chain, ok := deps.Env.BlockChains.EVMChains()[input.RegistryChainSel]
-	if !ok {
-		return nil, fmt.Errorf("chain not found for selector %d", input.RegistryChainSel)
-	}
-	capabilitiesRegistry, err := crecontracts.GetOwnedContractV2[*capabilities_registry_v2.CapabilitiesRegistry](deps.Env.DataStore.Addresses(), chain, capabilitiesRegistryRef.Address)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get owned contract: %w", err)
-	}
-	return capabilitiesRegistry.Contract, nil
-}

--- a/deployment/cre/ocr3/v2/changeset/sequences/deploy_ocr3.go
+++ b/deployment/cre/ocr3/v2/changeset/sequences/deploy_ocr3.go
@@ -23,7 +23,7 @@ type DeployOCR3Input struct {
 	ChainSelector uint64
 	Qualifier     string
 
-	DON          contracts.ConfigureCREDON
+	DON          contracts.DonNodeSet
 	OracleConfig *ocr3.OracleConfig
 	DryRun       bool
 

--- a/deployment/keystone/changeset/operations/contracts/configure_ocr3_op.go
+++ b/deployment/keystone/changeset/operations/contracts/configure_ocr3_op.go
@@ -1,28 +1,16 @@
 package contracts
 
 import (
-	"errors"
-	"fmt"
-	"io"
-
-	"github.com/Masterminds/semver/v3"
-	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/smartcontractkit/mcms"
-
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
-	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3"
-	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/cre/capabilities_registry/v2/changeset/operations/contracts"
 )
 
+/*
 type ConfigureOCR3OpDeps struct {
 	Env                  *cldf.Environment
 	WriteGeneratedConfig io.Writer
-	//Registry             *capabilities_registry.CapabilitiesRegistry
 }
-
+*/
+/*
 type ConfigureOCR3OpInput struct {
 	ContractAddress  *common.Address
 	RegistryChainSel uint64
@@ -40,7 +28,14 @@ func (i ConfigureOCR3OpInput) UseMCMS() bool {
 type ConfigureOCR3OpOutput struct {
 	MCMSTimelockProposals []mcms.TimelockProposal
 }
+*/
+//type ConfigureOCR3OpInput contracts.ConfigureOCR3Input
 
+//type ConfigureOCR3OpOutput = contracts.ConfigureOCR3OpOutput
+
+var ConfigureOCR3Op = contracts.ConfigureOCR3
+
+/*
 var ConfigureOCR3Op = operations.NewOperation[ConfigureOCR3OpInput, ConfigureOCR3OpOutput, ConfigureOCR3OpDeps](
 	"configure-ocr3-op",
 	semver.MustParse("1.0.0"),
@@ -49,23 +44,7 @@ var ConfigureOCR3Op = operations.NewOperation[ConfigureOCR3OpInput, ConfigureOCR
 		if input.ContractAddress == nil {
 			return ConfigureOCR3OpOutput{}, errors.New("ContractAddress is required")
 		}
-		/*
-			donConfig := internal.RegisteredDonConfig{
-				NodeIDs:          input.DON.NodeIDs,
-				Name:             input.DON.Name,
-				RegistryChainSel: input.RegistryChainSel,
-				Registry:         deps.Registry,
-			}
-			d, err := internal.NewRegisteredDon(*deps.Env, donConfig)
-			if err != nil {
-				return ConfigureOCR3OpOutput{}, fmt.Errorf("configure-ocr3-op failed: failed to create registered DON %s: %w", input.DON.Name, err)
-			}
 
-			nodeIDs := make([]string, 0, len(d.Nodes))
-			for _, node := range d.Nodes {
-				nodeIDs = append(nodeIDs, node.NodeID)
-			}
-		*/
 		deps.Env.Logger.Infow("Configuring OCR3 contract with DON",
 			"nodes", input.DON.NodeIDs,
 			"dryRun", input.DryRun)
@@ -85,5 +64,5 @@ var ConfigureOCR3Op = operations.NewOperation[ConfigureOCR3OpInput, ConfigureOCR
 		return ConfigureOCR3OpOutput{MCMSTimelockProposals: resp.MCMSTimelockProposals}, nil
 	},
 )
-
+*/
 //

--- a/deployment/keystone/changeset/operations/contracts/configure_ocr3_op.go
+++ b/deployment/keystone/changeset/operations/contracts/configure_ocr3_op.go
@@ -12,17 +12,15 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
 	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3"
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
-	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset/internal"
 )
 
 type ConfigureOCR3OpDeps struct {
 	Env                  *cldf.Environment
 	WriteGeneratedConfig io.Writer
-	Registry             *capabilities_registry.CapabilitiesRegistry
+	//Registry             *capabilities_registry.CapabilitiesRegistry
 }
 
 type ConfigureOCR3OpInput struct {
@@ -51,26 +49,29 @@ var ConfigureOCR3Op = operations.NewOperation[ConfigureOCR3OpInput, ConfigureOCR
 		if input.ContractAddress == nil {
 			return ConfigureOCR3OpOutput{}, errors.New("ContractAddress is required")
 		}
+		/*
+			donConfig := internal.RegisteredDonConfig{
+				NodeIDs:          input.DON.NodeIDs,
+				Name:             input.DON.Name,
+				RegistryChainSel: input.RegistryChainSel,
+				Registry:         deps.Registry,
+			}
+			d, err := internal.NewRegisteredDon(*deps.Env, donConfig)
+			if err != nil {
+				return ConfigureOCR3OpOutput{}, fmt.Errorf("configure-ocr3-op failed: failed to create registered DON %s: %w", input.DON.Name, err)
+			}
 
-		donConfig := internal.RegisteredDonConfig{
-			NodeIDs:          input.DON.NodeIDs,
-			Name:             input.DON.Name,
-			RegistryChainSel: input.RegistryChainSel,
-			Registry:         deps.Registry,
-		}
-		d, err := internal.NewRegisteredDon(*deps.Env, donConfig)
-		if err != nil {
-			return ConfigureOCR3OpOutput{}, fmt.Errorf("configure-ocr3-op failed: failed to create registered DON %s: %w", input.DON.Name, err)
-		}
-
-		nodeIDs := make([]string, 0, len(d.Nodes))
-		for _, node := range d.Nodes {
-			nodeIDs = append(nodeIDs, node.NodeID)
-		}
-
+			nodeIDs := make([]string, 0, len(d.Nodes))
+			for _, node := range d.Nodes {
+				nodeIDs = append(nodeIDs, node.NodeID)
+			}
+		*/
+		deps.Env.Logger.Infow("Configuring OCR3 contract with DON",
+			"nodes", input.DON.NodeIDs,
+			"dryRun", input.DryRun)
 		resp, err := changeset.ConfigureOCR3Contract(*deps.Env, changeset.ConfigureOCR3Config{
 			ChainSel:             input.RegistryChainSel,
-			NodeIDs:              nodeIDs,
+			NodeIDs:              input.DON.NodeIDs,
 			Address:              input.ContractAddress,
 			OCR3Config:           input.Config,
 			DryRun:               input.DryRun,
@@ -84,3 +85,5 @@ var ConfigureOCR3Op = operations.NewOperation[ConfigureOCR3OpInput, ConfigureOCR
 		return ConfigureOCR3OpOutput{MCMSTimelockProposals: resp.MCMSTimelockProposals}, nil
 	},
 )
+
+//

--- a/deployment/keystone/changeset/operations/contracts/configure_ocr3_op.go
+++ b/deployment/keystone/changeset/operations/contracts/configure_ocr3_op.go
@@ -1,68 +1,12 @@
 package contracts
 
 import (
-	"github.com/smartcontractkit/chainlink/deployment/cre/capabilities_registry/v2/changeset/operations/contracts"
+	"github.com/smartcontractkit/chainlink/deployment/cre/ocr3/v2/changeset/operations/contracts"
 )
 
-/*
-type ConfigureOCR3OpDeps struct {
-	Env                  *cldf.Environment
-	WriteGeneratedConfig io.Writer
-}
-*/
-/*
-type ConfigureOCR3OpInput struct {
-	ContractAddress  *common.Address
-	RegistryChainSel uint64
-	DON              ConfigureKeystoneDON
-	Config           *ocr3.OracleConfig
-	DryRun           bool
+type ConfigureOCR3OpInput = contracts.ConfigureOCR3Input
 
-	MCMSConfig *changeset.MCMSConfig
-}
-
-func (i ConfigureOCR3OpInput) UseMCMS() bool {
-	return i.MCMSConfig != nil
-}
-
-type ConfigureOCR3OpOutput struct {
-	MCMSTimelockProposals []mcms.TimelockProposal
-}
-*/
-//type ConfigureOCR3OpInput contracts.ConfigureOCR3Input
-
-//type ConfigureOCR3OpOutput = contracts.ConfigureOCR3OpOutput
+type ConfigureOCR3OpOutput = contracts.ConfigureOCR3OpOutput
+type ConfigureOCR3OpDeps = contracts.ConfigureOCR3Deps
 
 var ConfigureOCR3Op = contracts.ConfigureOCR3
-
-/*
-var ConfigureOCR3Op = operations.NewOperation[ConfigureOCR3OpInput, ConfigureOCR3OpOutput, ConfigureOCR3OpDeps](
-	"configure-ocr3-op",
-	semver.MustParse("1.0.0"),
-	"Configure OCR3 Contract",
-	func(b operations.Bundle, deps ConfigureOCR3OpDeps, input ConfigureOCR3OpInput) (ConfigureOCR3OpOutput, error) {
-		if input.ContractAddress == nil {
-			return ConfigureOCR3OpOutput{}, errors.New("ContractAddress is required")
-		}
-
-		deps.Env.Logger.Infow("Configuring OCR3 contract with DON",
-			"nodes", input.DON.NodeIDs,
-			"dryRun", input.DryRun)
-		resp, err := changeset.ConfigureOCR3Contract(*deps.Env, changeset.ConfigureOCR3Config{
-			ChainSel:             input.RegistryChainSel,
-			NodeIDs:              input.DON.NodeIDs,
-			Address:              input.ContractAddress,
-			OCR3Config:           input.Config,
-			DryRun:               input.DryRun,
-			WriteGeneratedConfig: deps.WriteGeneratedConfig,
-			MCMSConfig:           input.MCMSConfig,
-		})
-		if err != nil {
-			return ConfigureOCR3OpOutput{}, fmt.Errorf("configure-ocr3-op failed: %w", err)
-		}
-
-		return ConfigureOCR3OpOutput{MCMSTimelockProposals: resp.MCMSTimelockProposals}, nil
-	},
-)
-*/
-//

--- a/deployment/keystone/changeset/operations/contracts/deploy_ocr3_op.go
+++ b/deployment/keystone/changeset/operations/contracts/deploy_ocr3_op.go
@@ -8,42 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
-	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
-)
-
-type DeployOCR3OpDeps struct {
-	Env *cldf.Environment
-}
-
-type DeployOCR3OpInput struct {
-	ChainSelector uint64
-	Qualifier     string
-}
-
-type DeployOCR3OpOutput struct {
-	Addresses   datastore.AddressRefStore
-	AddressBook cldf.AddressBook
-}
-
-// DeployOCR3Op is an operation that deploys the OCR3 contract.
-var DeployOCR3Op = operations.NewOperation[DeployOCR3OpInput, DeployOCR3OpOutput, DeployOCR3OpDeps](
-	"deploy-ocr3-op",
-	semver.MustParse("1.0.0"),
-	"Deploy OCR3 Contract",
-	func(b operations.Bundle, deps DeployOCR3OpDeps, input DeployOCR3OpInput) (DeployOCR3OpOutput, error) {
-		ocr3Output, err := changeset.DeployOCR3V2(*deps.Env, &changeset.DeployRequestV2{
-			ChainSel:  input.ChainSelector,
-			Qualifier: input.Qualifier,
-		})
-		if err != nil {
-			return DeployOCR3OpOutput{}, fmt.Errorf("DeployOCR3Op error: failed to deploy OCR3 contract: %w", err)
-		}
-
-		return DeployOCR3OpOutput{
-			Addresses: ocr3Output.DataStore.Addresses(), AddressBook: ocr3Output.AddressBook, //nolint:staticcheck // keeping the address book since not everything has been migrated to datastore
-		}, nil
-	},
+	contracts "github.com/smartcontractkit/chainlink/deployment/cre/ocr3/v2/changeset/operations/contracts"
 )
 
 type DeployOCR3ContractSequenceDeps struct {
@@ -51,8 +16,8 @@ type DeployOCR3ContractSequenceDeps struct {
 }
 
 type DeployOCR3ContractSequenceInput struct {
-	RegistryChainSelector uint64
-	Qualifier             string // qualifier for the OCR3 contract deployment
+	ChainSelector uint64
+	Qualifier     string // qualifier for the OCR3 contract deployment
 }
 
 type DeployOCR3ContractSequenceOutput struct {
@@ -61,23 +26,24 @@ type DeployOCR3ContractSequenceOutput struct {
 	Datastore   datastore.DataStore
 }
 
-// DeployKeystoneContractsSequence is a sequence that deploys the Keystone contracts (OCR3, Capabilities Registry, Workflow Registry, Keystone Forwarder).
+// DeployOCR3ContractsSequence is a sequence that deploys the OCR3 contract.
+// TODO dedup with sequence in ocr3/v2/changeset/sequences/deploy_ocr3.go
 var DeployOCR3ContractsSequence = operations.NewSequence[DeployOCR3ContractSequenceInput, DeployOCR3ContractSequenceOutput, DeployOCR3ContractSequenceDeps](
-	"deploy-registry-contracts-seq",
+	"deploy-ocr3-contracts-seq",
 	semver.MustParse("1.0.0"),
-	"Deploy registry Contracts (Capabilities Registry, Workflow Registry)",
+	"Deploy OCR3 Contracts",
 	func(b operations.Bundle, deps DeployOCR3ContractSequenceDeps, input DeployOCR3ContractSequenceInput) (output DeployOCR3ContractSequenceOutput, err error) {
 		ab := cldf.NewMemoryAddressBook()
 		as := datastore.NewMemoryDataStore()
 
 		// OCR3 Contract
-		ocr3DeployReport, err := operations.ExecuteOperation(b, DeployOCR3Op, DeployOCR3OpDeps(deps), DeployOCR3OpInput{ChainSelector: input.RegistryChainSelector, Qualifier: input.Qualifier})
+		ocr3DeployReport, err := operations.ExecuteOperation(b, contracts.DeployOCR3, contracts.DeployOCR3Deps(deps), contracts.DeployOCR3Input{ChainSelector: input.ChainSelector, Qualifier: input.Qualifier})
 		if err != nil {
-			return DeployOCR3ContractSequenceOutput{}, err
+			return DeployOCR3ContractSequenceOutput{}, fmt.Errorf("failed to execution operation DeployOCR3: %w", err)
 		}
-		err = updateAddresses(as.Addresses(), ocr3DeployReport.Output.Addresses, ab, ocr3DeployReport.Output.AddressBook)
+		err = updateAddresses(as.Addresses(), ocr3DeployReport.Output.Datastore.Addresses(), ab, ocr3DeployReport.Output.AddressBook)
 		if err != nil {
-			return DeployOCR3ContractSequenceOutput{}, err
+			return DeployOCR3ContractSequenceOutput{}, fmt.Errorf("failed to update addresses after OCR3 deployment: %w", err)
 		}
 		return DeployOCR3ContractSequenceOutput{
 			AddressBook: ab,

--- a/deployment/keystone/changeset/operations/contracts/deploy_ocr3_op.go
+++ b/deployment/keystone/changeset/operations/contracts/deploy_ocr3_op.go
@@ -27,7 +27,7 @@ type DeployOCR3ContractSequenceOutput struct {
 }
 
 // DeployOCR3ContractsSequence is a sequence that deploys the OCR3 contract.
-// TODO dedup with sequence in ocr3/v2/changeset/sequences/deploy_ocr3.go
+// TODO dedup with sequence in ocr3/v2/changeset/sequences/deploy_ocr3.go CRE-803
 var DeployOCR3ContractsSequence = operations.NewSequence[DeployOCR3ContractSequenceInput, DeployOCR3ContractSequenceOutput, DeployOCR3ContractSequenceDeps](
 	"deploy-ocr3-contracts-seq",
 	semver.MustParse("1.0.0"),

--- a/deployment/keystone/changeset/operations/contracts/types.go
+++ b/deployment/keystone/changeset/operations/contracts/types.go
@@ -1,6 +1,5 @@
 package contracts
 
-type ConfigureKeystoneDON struct {
-	Name    string
-	NodeIDs []string // jd node ids or peer IDs
-}
+import "github.com/smartcontractkit/chainlink/deployment/cre/ocr3/v2/changeset/operations/contracts"
+
+type ConfigureKeystoneDON = contracts.DonNodeSet

--- a/system-tests/lib/cre/contracts/contracts.go
+++ b/system-tests/lib/cre/contracts/contracts.go
@@ -296,8 +296,8 @@ func ConfigureKeystone(input cre.ConfigureKeystoneInput, capabilityRegistryConfi
 		input.CldEnv.OperationsBundle,
 		ks_contracts_op.ConfigureOCR3Op,
 		ks_contracts_op.ConfigureOCR3OpDeps{
-			Env:      input.CldEnv,
-			Registry: capReg.Contract,
+			Env: input.CldEnv,
+			//		Registry: capReg.Contract,
 		},
 		ks_contracts_op.ConfigureOCR3OpInput{
 			ContractAddress:  input.OCR3Address,
@@ -316,8 +316,8 @@ func ConfigureKeystone(input cre.ConfigureKeystoneInput, capabilityRegistryConfi
 		input.CldEnv.OperationsBundle,
 		ks_contracts_op.ConfigureOCR3Op,
 		ks_contracts_op.ConfigureOCR3OpDeps{
-			Env:      input.CldEnv,
-			Registry: capReg.Contract,
+			Env: input.CldEnv,
+			//	Registry: capReg.Contract,
 		},
 		ks_contracts_op.ConfigureOCR3OpInput{
 			ContractAddress:  input.DONTimeAddress,
@@ -341,8 +341,8 @@ func ConfigureKeystone(input cre.ConfigureKeystoneInput, capabilityRegistryConfi
 			input.CldEnv.OperationsBundle,
 			ks_contracts_op.ConfigureOCR3Op,
 			ks_contracts_op.ConfigureOCR3OpDeps{
-				Env:      input.CldEnv,
-				Registry: capReg.Contract,
+				Env: input.CldEnv,
+				//	Registry: capReg.Contract,
 			},
 			ks_contracts_op.ConfigureOCR3OpInput{
 				ContractAddress:  input.VaultOCR3Address,
@@ -369,8 +369,8 @@ func ConfigureKeystone(input cre.ConfigureKeystoneInput, capabilityRegistryConfi
 				input.CldEnv.OperationsBundle,
 				ks_contracts_op.ConfigureOCR3Op,
 				ks_contracts_op.ConfigureOCR3OpDeps{
-					Env:      input.CldEnv,
-					Registry: capReg.Contract,
+					Env: input.CldEnv,
+					//		Registry: capReg.Contract,
 				},
 				ks_contracts_op.ConfigureOCR3OpInput{
 					ContractAddress:  &evmOCR3Address,
@@ -395,8 +395,8 @@ func ConfigureKeystone(input cre.ConfigureKeystoneInput, capabilityRegistryConfi
 			input.CldEnv.OperationsBundle,
 			ks_contracts_op.ConfigureOCR3Op,
 			ks_contracts_op.ConfigureOCR3OpDeps{
-				Env:      input.CldEnv,
-				Registry: capReg.Contract,
+				Env: input.CldEnv,
+				//	Registry: capReg.Contract,
 			},
 			ks_contracts_op.ConfigureOCR3OpInput{
 				ContractAddress:  input.ConsensusV2OCR3Address,

--- a/system-tests/lib/cre/contracts/contracts.go
+++ b/system-tests/lib/cre/contracts/contracts.go
@@ -297,14 +297,13 @@ func ConfigureKeystone(input cre.ConfigureKeystoneInput, capabilityRegistryConfi
 		ks_contracts_op.ConfigureOCR3Op,
 		ks_contracts_op.ConfigureOCR3OpDeps{
 			Env: input.CldEnv,
-			//		Registry: capReg.Contract,
 		},
 		ks_contracts_op.ConfigureOCR3OpInput{
-			ContractAddress:  input.OCR3Address,
-			RegistryChainSel: input.ChainSelector,
-			DON:              consensusV1DON.keystoneDonConfig(),
-			Config:           consensusV1DON.resolveOcr3Config(input.OCR3Config),
-			DryRun:           false,
+			ContractAddress: input.OCR3Address,
+			ChainSelector:   input.ChainSelector,
+			DON:             consensusV1DON.keystoneDonConfig(),
+			Config:          consensusV1DON.resolveOcr3Config(input.OCR3Config),
+			DryRun:          false,
 		},
 	)
 	if err != nil {
@@ -317,14 +316,13 @@ func ConfigureKeystone(input cre.ConfigureKeystoneInput, capabilityRegistryConfi
 		ks_contracts_op.ConfigureOCR3Op,
 		ks_contracts_op.ConfigureOCR3OpDeps{
 			Env: input.CldEnv,
-			//	Registry: capReg.Contract,
 		},
 		ks_contracts_op.ConfigureOCR3OpInput{
-			ContractAddress:  input.DONTimeAddress,
-			RegistryChainSel: input.ChainSelector,
-			DON:              consensusV1DON.keystoneDonConfig(),
-			Config:           consensusV1DON.resolveOcr3Config(input.DONTimeConfig),
-			DryRun:           false,
+			ContractAddress: input.DONTimeAddress,
+			ChainSelector:   input.ChainSelector,
+			DON:             consensusV1DON.keystoneDonConfig(),
+			Config:          consensusV1DON.resolveOcr3Config(input.DONTimeConfig),
+			DryRun:          false,
 		},
 	)
 	if err != nil {
@@ -342,14 +340,13 @@ func ConfigureKeystone(input cre.ConfigureKeystoneInput, capabilityRegistryConfi
 			ks_contracts_op.ConfigureOCR3Op,
 			ks_contracts_op.ConfigureOCR3OpDeps{
 				Env: input.CldEnv,
-				//	Registry: capReg.Contract,
 			},
 			ks_contracts_op.ConfigureOCR3OpInput{
-				ContractAddress:  input.VaultOCR3Address,
-				RegistryChainSel: input.ChainSelector,
-				DON:              vaultDON.keystoneDonConfig(),
-				Config:           vaultDON.resolveOcr3Config(input.VaultOCR3Config),
-				DryRun:           false,
+				ContractAddress: input.VaultOCR3Address,
+				ChainSelector:   input.ChainSelector,
+				DON:             vaultDON.keystoneDonConfig(),
+				Config:          vaultDON.resolveOcr3Config(input.VaultOCR3Config),
+				DryRun:          false,
 			},
 		)
 		if err != nil {
@@ -370,14 +367,13 @@ func ConfigureKeystone(input cre.ConfigureKeystoneInput, capabilityRegistryConfi
 				ks_contracts_op.ConfigureOCR3Op,
 				ks_contracts_op.ConfigureOCR3OpDeps{
 					Env: input.CldEnv,
-					//		Registry: capReg.Contract,
 				},
 				ks_contracts_op.ConfigureOCR3OpInput{
-					ContractAddress:  &evmOCR3Address,
-					RegistryChainSel: chainSelector,
-					DON:              evmDON.keystoneDonConfig(),
-					Config:           evmDON.resolveOcr3Config(input.EVMOCR3Config),
-					DryRun:           false,
+					ContractAddress: &evmOCR3Address,
+					ChainSelector:   chainSelector,
+					DON:             evmDON.keystoneDonConfig(),
+					Config:          evmDON.resolveOcr3Config(input.EVMOCR3Config),
+					DryRun:          false,
 				},
 			)
 			if err != nil {
@@ -396,14 +392,13 @@ func ConfigureKeystone(input cre.ConfigureKeystoneInput, capabilityRegistryConfi
 			ks_contracts_op.ConfigureOCR3Op,
 			ks_contracts_op.ConfigureOCR3OpDeps{
 				Env: input.CldEnv,
-				//	Registry: capReg.Contract,
 			},
 			ks_contracts_op.ConfigureOCR3OpInput{
-				ContractAddress:  input.ConsensusV2OCR3Address,
-				RegistryChainSel: input.ChainSelector,
-				DON:              v2ConsensusDON.keystoneDonConfig(),
-				Config:           v2ConsensusDON.resolveOcr3Config(input.ConsensusV2OCR3Config),
-				DryRun:           false,
+				ContractAddress: input.ConsensusV2OCR3Address,
+				ChainSelector:   input.ChainSelector,
+				DON:             v2ConsensusDON.keystoneDonConfig(),
+				Config:          v2ConsensusDON.resolveOcr3Config(input.ConsensusV2OCR3Config),
+				DryRun:          false,
 			},
 		)
 		if err != nil {

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -997,8 +997,8 @@ func deployOCR3Contract(qualifier string, selector uint64, env *cldf.Environment
 			Env: env,
 		},
 		ks_contracts_op.DeployOCR3ContractSequenceInput{
-			RegistryChainSelector: selector,
-			Qualifier:             qualifier,
+			ChainSelector: selector,
+			Qualifier:     qualifier,
 		},
 	)
 	if err != nil {

--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -989,6 +989,7 @@ func getAllFilters(ctx context.Context, logger logger.Logger, chainID *big.Int, 
 	return orm.LoadFilters(ctx)
 }
 
+// TODO CRE-803 use a sequence that deploys and configures OCR3 contract
 func deployOCR3Contract(qualifier string, selector uint64, env *cldf.Environment, ds datastore.MutableDataStore) (*ks_contracts_op.DeployOCR3ContractSequenceOutput, error) {
 	ocr3DeployReport, err := operations.ExecuteSequence(
 		env.OperationsBundle,


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

this change dedups much of the overlap between the ocr3 deployment sequences.

the key point is that we don't need to pass in the registry contract, which had been the primary cause of duplication


note: in passing round the that cli wf deploy had been broken and fixing it here. env artifact locally:
```
    {
      "address": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
      "chainSelector": 3379446385462418246,
      "labels": [],
      "qualifier": "",
      "type": "CapabilitiesRegistry",
      "version": "1.1.0"
    },
    {
      "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
      "chainSelector": 3379446385462418246,
      "labels": [],
      "qualifier": "",
      "type": "WorkflowRegistry",
      "version": "1.0.0"
    },
    ```