### PR TITLE
Fix cre yaml workflow benchmark

### DIFF
--- a/system-tests/tests/load/cre/workflow-don-benchmark-ci.toml
+++ b/system-tests/tests/load/cre/workflow-don-benchmark-ci.toml
@@ -84,7 +84,7 @@ CL_EVM_CMD=""
 # ----- CAPABILITIES NODES CONFIGURATION -----
 # Setup for a 3-node Capabilities cluster with individual configurations
 [[nodesets]]
-nodes = 3
+nodes = 4
 override_mode = "each"          # Apply different configuration to each node
 http_port_range_start = 10200   # Starting port for HTTP endpoints
 name = "capabilities"

--- a/system-tests/tests/load/cre/workflow-don-benchmark-ci.toml
+++ b/system-tests/tests/load/cre/workflow-don-benchmark-ci.toml
@@ -142,6 +142,22 @@ user_config_overrides = """
 [nodesets.node_specs.node.env_vars]
 CL_EVM_CMD=""
 
+# Capability node 4 configuration
+[[nodesets.node_specs]]
+[nodesets.node_specs.node]
+image = "injected-at-runtime"
+custom_ports = ["13404:7777"]   # External:internal port mapping
+user_config_overrides = """
+        [Feature]
+        LogPoller = true
+        FeedsManager = true
+        [OCR2]
+        Enabled = true
+        DatabaseTimeout = '1s'
+      """
+[nodesets.node_specs.node.env_vars]
+CL_EVM_CMD=""
+
 # ----- CHAOS TESTING CONFIGURATION -----
 #Settings for chaos engineering tests (optional), for simple load test you can ignore it
 [chaos]

--- a/system-tests/tests/load/cre/workflow-don-load-test-streams-kind.toml
+++ b/system-tests/tests/load/cre/workflow-don-load-test-streams-kind.toml
@@ -84,7 +84,7 @@ CL_EVM_CMD=""
 # ----- CAPABILITIES NODES CONFIGURATION -----
 # Setup for a 3-node Capabilities cluster with individual configurations
 [[nodesets]]
-nodes = 3
+nodes = 4
 override_mode = "each"          # Apply different configuration to each node
 http_port_range_start = 10200   # Starting port for HTTP endpoints
 name = "capabilities"
@@ -131,6 +131,22 @@ CL_EVM_CMD=""
 [nodesets.node_specs.node]
 image = "localhost:5001/chainlink-plugins"
 custom_ports = ["13403:7777"]   # External:internal port mapping
+user_config_overrides = """
+        [Feature]
+        LogPoller = true
+        FeedsManager = true
+        [OCR2]
+        Enabled = true
+        DatabaseTimeout = '1s'
+      """
+[nodesets.node_specs.node.env_vars]
+CL_EVM_CMD=""
+
+# Capability node 3 configuration
+[[nodesets.node_specs]]
+[nodesets.node_specs.node]
+image = "localhost:5001/chainlink-plugins"
+custom_ports = ["13404:7777"]   # External:internal port mapping
 user_config_overrides = """
         [Feature]
         LogPoller = true


### PR DESCRIPTION
Due to recent changes in the setup environment, the OCR contract is deployed but configuration cannot proceed because of an invalid f count. To resolve this, we need to increase the node count for the capability DON so that the f count requirement is satisfied.