### PR TITLE
disable consensus test until resoluation of  https://smartcontract-it.atlassian.net/browse/CRE-800 "

### DIFF
--- a/system-tests/tests/smoke/cre/v2_consensus_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_consensus_capability_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func executeConsensusTest(t *testing.T, testEnv *TestEnvironment) {
+	t.Skip("Pending resolution of this JIRA: https://smartcontract-it.atlassian.net/browse/CRE-800 ")
 	testLogger := framework.L
 	ctxWithTimeout, cancelCtx := context.WithTimeout(t.Context(), 4*time.Minute)
 	defer cancelCtx()


### PR DESCRIPTION
disable consensus test until resoluation of  https://smartcontract-it.atlassian.net/browse/CRE-800 " as its causing the test to flake.
