### PR TITLE
[CRE-814] fix node funding in local CRE

### DIFF
--- a/system-tests/lib/cre/environment/environment.go
+++ b/system-tests/lib/cre/environment/environment.go
@@ -22,8 +22,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/credentials/insecure"
 
-	chainselectors "github.com/smartcontractkit/chain-selectors"
-
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -221,11 +219,6 @@ func SetupTestEnvironment(
 			if flags.RequiresForwarderContract(donMetadata.ComputedCapabilities, bcOut.ChainID) {
 				evmForwardersSelectors = append(evmForwardersSelectors, bcOut.ChainSelector)
 			}
-		}
-		if bcOut.SolChain != nil {
-			// we expect that if we have solana, solana write capability is enabled
-			solForwardersSelectors = append(solForwardersSelectors, bcOut.SolChain.ChainSelector)
-			continue
 		}
 	}
 
@@ -627,6 +620,19 @@ func SetupTestEnvironment(
 	// If the ConfigSet event is missed, OCR protocol will not start.
 	fmt.Print(libformat.PurpleText("%s", stageGen.WrapAndNext("Jobs created in %.2f seconds", stageGen.Elapsed().Seconds())))
 
+	preFundingOutput, prefundErr := operations.ExecuteOperation(fullCldOutput.Environment.OperationsBundle, PrepareCLNodesFundingOp, PrepareFundCLNodesOpDeps{
+		TestLogger:        testLogger,
+		Env:               fullCldOutput.Environment,
+		BlockchainOutputs: blockchainOutputs,
+		DonTopology:       fullCldOutput.DonTopology,
+	}, PrepareFundCLNodesOpInput{FundingPerChainFamilyForEachNode: map[string]uint64{
+		"evm":    10000000000000000, // 0.01 ETH
+		"solana": 50_000_000,        // 0.05 SOL
+	}})
+	if prefundErr != nil {
+		return nil, pkgerrors.Wrap(prefundErr, "failed to prepare funding of CL nodes")
+	}
+
 	// Fund nodes in the background, so that we can continue with the next stage
 	backgroundStagesWaitGroup.Add(1)
 	go func() {
@@ -644,10 +650,14 @@ func SetupTestEnvironment(
 		fmt.Print(libformat.PurpleText("---> [BACKGROUND 2/3] Funding Chainlink nodes\n\n"))
 
 		_, fundErr := operations.ExecuteOperation(fullCldOutput.Environment.OperationsBundle, FundCLNodesOp, FundCLNodesOpDeps{
+			TestLogger:        testLogger,
 			Env:               fullCldOutput.Environment,
 			BlockchainOutputs: blockchainOutputs,
 			DonTopology:       fullCldOutput.DonTopology,
-		}, FundCLNodesOpInput{FundAmount: 5000000000000000000})
+		}, FundCLNodesOpInput{
+			FundingAmountPerChainFamily: preFundingOutput.Output.FundingPerChainFamilyForEachNode,
+			PrivateKeyPerChainFamily:    preFundingOutput.Output.PrivateKeysPerChainFamily,
+		})
 		if fundErr != nil {
 			backgroundStagesCh <- backgroundStageResult{err: pkgerrors.Wrap(fundErr, "failed to fund CL nodes")}
 			return
@@ -855,41 +865,6 @@ func mergeJobSpecSlices(from, to cre.DonsToJobSpecs) {
 		}
 		to[fromDonID] = append(to[fromDonID], fromJobSpecs...)
 	}
-}
-
-type ConcurrentNonceMap struct {
-	mu             sync.Mutex
-	nonceByChainID map[uint64]uint64
-}
-
-func NewConcurrentNonceMap(ctx context.Context, blockchainOutputs []*cre.WrappedBlockchainOutput) (*ConcurrentNonceMap, error) {
-	nonceByChainID := make(map[uint64]uint64)
-	for _, bcOut := range blockchainOutputs {
-		if bcOut.BlockchainOutput.Family == chainselectors.FamilyEVM {
-			var err error
-			ctxWithTimeout, cancel := context.WithTimeout(ctx, bcOut.SethClient.Cfg.Network.TxnTimeout.Duration())
-			nonceByChainID[bcOut.ChainID], err = bcOut.SethClient.Client.PendingNonceAt(ctxWithTimeout, bcOut.SethClient.MustGetRootKeyAddress())
-			cancel()
-			if err != nil {
-				cancel()
-				return nil, pkgerrors.Wrapf(err, "failed to get nonce for chain %d", bcOut.ChainID)
-			}
-		}
-	}
-	return &ConcurrentNonceMap{nonceByChainID: nonceByChainID}, nil
-}
-
-func (c *ConcurrentNonceMap) Decrement(chainID uint64) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.nonceByChainID[chainID]--
-}
-
-func (c *ConcurrentNonceMap) Increment(chainID uint64) uint64 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.nonceByChainID[chainID]++
-	return c.nonceByChainID[chainID]
 }
 
 // must match nubmer of events we track in core/services/workflows/syncer/handler.go

--- a/system-tests/lib/cre/environment/fund_cl_nodes_op.go
+++ b/system-tests/lib/cre/environment/fund_cl_nodes_op.go
@@ -1,108 +1,243 @@
 package environment
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gagliardetto/solana-go"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"golang.org/x/sync/errgroup"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/ptr"
 
+	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
+	libc "github.com/smartcontractkit/chainlink/system-tests/lib/conversions"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre"
 	"github.com/smartcontractkit/chainlink/system-tests/lib/cre/flags"
 	libfunding "github.com/smartcontractkit/chainlink/system-tests/lib/funding"
 )
 
+type PrepareFundCLNodesOpDeps struct {
+	TestLogger        zerolog.Logger
+	Env               *cldf.Environment
+	BlockchainOutputs []*cre.WrappedBlockchainOutput
+	DonTopology       *cre.DonTopology
+}
+
+type PrepareFundCLNodesOpInput struct {
+	FundingPerChainFamilyForEachNode map[string]uint64
+}
+
+type PrepareFundCLNodesOpOutput struct {
+	PrivateKeysPerChainFamily        map[string]map[uint64][]byte
+	FundingPerChainFamilyForEachNode map[string]uint64
+}
+
+// PrepareCLNodesFundingOp prepares funding accounts for Chainlink nodes by generating new key pairs and funding them from the root account.
+// It cannot be run in parallel with other operations that modify blockchain state, as it relies on the root account's balance.
+var PrepareCLNodesFundingOp = operations.NewOperation[PrepareFundCLNodesOpInput, *PrepareFundCLNodesOpOutput, PrepareFundCLNodesOpDeps](
+	"prepare-cl-nodes-funding-op",
+	semver.MustParse("1.0.0"),
+	"Prepare inputs for funding of Chainlink Nodes",
+	func(b operations.Bundle, deps PrepareFundCLNodesOpDeps, input PrepareFundCLNodesOpInput) (*PrepareFundCLNodesOpOutput, error) {
+		ctx := b.GetContext()
+
+		output := &PrepareFundCLNodesOpOutput{
+			PrivateKeysPerChainFamily:        make(map[string]map[uint64][]byte),
+			FundingPerChainFamilyForEachNode: input.FundingPerChainFamilyForEachNode,
+		}
+		requiredFundingPerChain := make(map[uint64]uint64)
+		for _, metaDon := range deps.DonTopology.DonsWithMetadata {
+			for _, bcOut := range deps.BlockchainOutputs {
+				if !flags.RequiresForwarderContract(metaDon.Flags, bcOut.ChainID) {
+					continue
+				}
+
+				if bcOut.SolChain != nil {
+					requiredFundingPerChain[bcOut.ChainSelector] += input.FundingPerChainFamilyForEachNode["solana"] * uint64(len(metaDon.DON.Nodes))
+					continue
+				}
+
+				requiredFundingPerChain[bcOut.ChainSelector] += input.FundingPerChainFamilyForEachNode["evm"] * uint64(len(metaDon.DON.Nodes))
+			}
+		}
+
+		for _, bcOut := range deps.BlockchainOutputs {
+			if requiredFundingPerChain[bcOut.ChainSelector] == 0 {
+				continue
+			}
+
+			chainFamily := "evm"
+			if bcOut.SolChain != nil {
+				chainFamily = "solana"
+			}
+
+			switch chainFamily {
+			case "evm":
+				if _, exists := output.PrivateKeysPerChainFamily[chainFamily]; !exists {
+					output.PrivateKeysPerChainFamily[chainFamily] = make(map[uint64][]byte)
+				}
+
+				if _, exists := output.PrivateKeysPerChainFamily[chainFamily][bcOut.ChainSelector]; !exists {
+					publicAddress, privateKeyBytes, pkErr := generatePubPrivKeyPairForEth()
+					if pkErr != nil {
+						return nil, pkgerrors.Wrap(pkErr, "failed to generate pub/priv key pair for EVM funding account")
+					}
+
+					fundingAmount := libc.MustSafeInt64(requiredFundingPerChain[bcOut.ChainSelector])
+					fundingAmount = fundingAmount + (fundingAmount / 10) // add 10% to cover gas fees
+
+					_, fundingErr := libfunding.SendFunds(ctx, zerolog.Logger{}, bcOut.SethClient, libfunding.FundsToSend{
+						ToAddress:  *publicAddress,
+						Amount:     big.NewInt(fundingAmount),
+						PrivateKey: bcOut.SethClient.MustGetRootPrivateKey(),
+					})
+
+					if fundingErr != nil {
+						return nil, pkgerrors.Wrapf(fundingErr, "failed to fund funding account %s on chain %d", publicAddress.String(), bcOut.ChainID)
+					}
+
+					output.PrivateKeysPerChainFamily[chainFamily][bcOut.ChainSelector] = privateKeyBytes
+				}
+			case "solana":
+				// TODO implement creation of new key and funding it
+				panic("funding Solana nodes not implemented")
+			default:
+				return nil, fmt.Errorf("unsupported chain family %s", chainFamily)
+			}
+		}
+
+		return output, nil
+	},
+)
+
+func generatePubPrivKeyPairForEth() (*common.Address, []byte, error) {
+	privateKey, pkErr := crypto.GenerateKey()
+	if pkErr != nil {
+		return nil, nil, pkgerrors.Wrap(pkErr, "failed to generate private key for funding accounts")
+	}
+	privateKeyBytes := crypto.FromECDSA(privateKey)
+	publicKey := privateKey.Public()
+	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, nil, errors.New("error casting public key to ECDSA")
+	}
+	publicAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
+
+	return &publicAddress, privateKeyBytes, nil
+}
+
 type FundCLNodesOpDeps struct {
+	TestLogger        zerolog.Logger
 	Env               *cldf.Environment
 	BlockchainOutputs []*cre.WrappedBlockchainOutput
 	DonTopology       *cre.DonTopology
 }
 
 type FundCLNodesOpInput struct {
-	FundAmount int64
+	PrivateKeyPerChainFamily    map[string]map[uint64][]byte
+	FundingAmountPerChainFamily map[string]uint64
 }
 
 type FundCLNodesOpOutput struct {
 }
 
-var FundCLNodesOp = operations.NewOperation[FundCLNodesOpInput, FundCLNodesOpOutput, FundCLNodesOpDeps](
+var FundCLNodesOp = operations.NewOperation[FundCLNodesOpInput, *FundCLNodesOpOutput, FundCLNodesOpDeps](
 	"fund-cl-nodes-op",
 	semver.MustParse("1.0.0"),
 	"Fund Chainlink Nodes",
-	func(b operations.Bundle, deps FundCLNodesOpDeps, input FundCLNodesOpInput) (FundCLNodesOpOutput, error) {
+	func(b operations.Bundle, deps FundCLNodesOpDeps, input FundCLNodesOpInput) (*FundCLNodesOpOutput, error) {
 		ctx := b.GetContext()
-		// Fund the nodes
-		concurrentNonceMap, concurrentNonceMapErr := NewConcurrentNonceMap(ctx, deps.BlockchainOutputs)
-		if concurrentNonceMapErr != nil {
-			return FundCLNodesOpOutput{}, pkgerrors.Wrap(concurrentNonceMapErr, "failed to create concurrent nonce map")
-		}
-
-		// Decrement the nonce for each chain, because we will increment it in the next loop
-		for _, bcOut := range deps.BlockchainOutputs {
-			concurrentNonceMap.Decrement(bcOut.ChainID)
-		}
-
-		errGroup := &errgroup.Group{}
 		for _, metaDon := range deps.DonTopology.DonsWithMetadata {
 			for _, bcOut := range deps.BlockchainOutputs {
 				if !flags.RequiresForwarderContract(metaDon.Flags, bcOut.ChainID) {
 					continue
 				}
 				for _, node := range metaDon.DON.Nodes {
-					errGroup.Go(func() error {
-						if bcOut.SolChain != nil {
-							funder := bcOut.SolChain.PrivateKey
-							recipient := solana.MustPublicKeyFromBase58(node.AccountAddr[bcOut.SolChain.ChainID])
-							deps.Env.Logger.Infof("attempt to fund Solana account %s", recipient.String())
-							err := libfunding.SendFundsSol(ctx, zerolog.Logger{}, bcOut.SolClient, libfunding.FundsToSendSol{
-								Recipent:   recipient,
-								PrivateKey: funder,
-								Amount:     50_000_000,
-							})
-							if err != nil {
-								return fmt.Errorf("failed to fund Solana node: %w", err)
-							}
-							deps.Env.Logger.Infof("successfully funded Solana account %s", recipient.String())
-							return nil
-						}
+					chainFamily := "evm"
+					if bcOut.SolChain != nil {
+						chainFamily = "solana"
+					}
 
-						nodeAddress := node.AccountAddr[strconv.FormatUint(bcOut.ChainID, 10)]
-						if nodeAddress == "" {
-							return nil
-						}
+					fundingAmount, ok := input.FundingAmountPerChainFamily[chainFamily]
+					if !ok {
+						return nil, fmt.Errorf("missing funding amount for chain family %s", chainFamily)
+					}
 
-						deps.Env.Logger.Infof("attempt to fund evm account %s", nodeAddress)
-						nonce := concurrentNonceMap.Increment(bcOut.ChainID)
-
-						_, fundingErr := libfunding.SendFunds(ctx, zerolog.Logger{}, bcOut.SethClient, libfunding.FundsToSend{
-							ToAddress:  common.HexToAddress(nodeAddress),
-							Amount:     big.NewInt(input.FundAmount),
-							PrivateKey: bcOut.SethClient.MustGetRootPrivateKey(),
-							Nonce:      ptr.Ptr(nonce),
-						})
-						if fundingErr != nil {
-							return pkgerrors.Wrapf(fundingErr, "failed to fund node %s", nodeAddress)
+					switch chainFamily {
+					case "evm":
+						if err := fundEthAddress(ctx, deps.TestLogger, node, fundingAmount, bcOut, input.PrivateKeyPerChainFamily); err != nil {
+							return nil, err
 						}
-						deps.Env.Logger.Infof("successfully funded evm account %s", nodeAddress)
-						return nil
-					})
+					case "solana":
+						if err := fundSolanaAddress(ctx, deps.TestLogger, node, fundingAmount, bcOut, input.PrivateKeyPerChainFamily); err != nil {
+							return nil, err
+						}
+					default:
+						return nil, fmt.Errorf("unsupported chain family %s", chainFamily)
+					}
 				}
 			}
 		}
 
-		if err := errGroup.Wait(); err != nil {
-			return FundCLNodesOpOutput{}, pkgerrors.Wrap(err, "failed to fund nodes")
-		}
-
-		return FundCLNodesOpOutput{}, nil
+		return &FundCLNodesOpOutput{}, nil
 	},
 )
+
+func fundEthAddress(ctx context.Context, testLogger zerolog.Logger, node devenv.Node, fundingAmount uint64, bcOut *cre.WrappedBlockchainOutput, privateKeyPerChainFamily map[string]map[uint64][]byte) error {
+	nodeAddress := node.AccountAddr[strconv.FormatUint(bcOut.ChainID, 10)]
+	if nodeAddress == "" {
+		return nil // Skip nodes without addresses for this chain
+	}
+
+	testLogger.Info().Msgf("Attempting to fund EVM account %s", nodeAddress)
+
+	fundingPrivateKey, ok := privateKeyPerChainFamily["evm"][bcOut.ChainSelector]
+	if !ok {
+		return fmt.Errorf("missing funding private key for chain familyevm, chain %d", bcOut.ChainID)
+	}
+
+	fundingKey, fkErr := crypto.ToECDSA(fundingPrivateKey)
+	if fkErr != nil {
+		return pkgerrors.Wrap(fkErr, "failed to convert funding private key to ECDSA")
+	}
+
+	_, fundingErr := libfunding.SendFunds(ctx, zerolog.Logger{}, bcOut.SethClient, libfunding.FundsToSend{
+		ToAddress:  common.HexToAddress(nodeAddress),
+		Amount:     big.NewInt(libc.MustSafeInt64(fundingAmount)),
+		PrivateKey: fundingKey,
+	})
+
+	if fundingErr != nil {
+		return pkgerrors.Wrapf(fundingErr, "failed to fund node %s", nodeAddress)
+	}
+	testLogger.Info().Msgf("Successfully funded EVM account %s", nodeAddress)
+
+	return nil
+}
+
+func fundSolanaAddress(ctx context.Context, testLogger zerolog.Logger, node devenv.Node, fundingAmount uint64, bcOut *cre.WrappedBlockchainOutput, _ map[string]map[uint64][]byte) error {
+	funder := bcOut.SolChain.PrivateKey
+	recipient := solana.MustPublicKeyFromBase58(node.AccountAddr[bcOut.SolChain.ChainID])
+	testLogger.Info().Msgf("Attempting to fund Solana account %s", recipient.String())
+
+	err := libfunding.SendFundsSol(ctx, zerolog.Logger{}, bcOut.SolClient, libfunding.FundsToSendSol{
+		Recipent:   recipient,
+		PrivateKey: funder,
+		Amount:     fundingAmount,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to fund Solana node: %w", err)
+	}
+	testLogger.Info().Msgf("Successfully funded Solana account %s", recipient.String())
+
+	return nil
+}

--- a/system-tests/lib/cre/flags/flags.go
+++ b/system-tests/lib/cre/flags/flags.go
@@ -37,7 +37,7 @@ func HasFlagForAnyChain(values []string, capability string) bool {
 }
 
 func RequiresForwarderContract(values []string, chainID uint64) bool {
-	return HasFlagForChain(values, cre.EVMCapability, chainID) || HasFlagForChain(values, cre.WriteEVMCapability, chainID)
+	return HasFlagForChain(values, cre.EVMCapability, chainID) || HasFlagForChain(values, cre.WriteEVMCapability, chainID) || HasFlagForAnyChain(values, cre.WriteSolanaCapability)
 }
 
 func DonMetadataWithFlag(donTopologies []*cre.DonMetadata, flag string) []*cre.DonMetadata {


### PR DESCRIPTION
I have heard of random funding failures due to nonce mismatch and decide to solve the issue. Since we have 0 second blocks with Anvil there's no longer a need to fund nodes in parallel and we can do it sequentially. Environment startup time doesn't suffer from it also because funding is done in background.

Also, to make it more future-proof I added a prefunding step that:
- calculates funding amount required per each chain
- creates and funds a new private key

That way when funding operation runs in the background we will avoid nonce collisions in the future, since previously funding was using the master private key, just like all the other blockchain state-modifying functions. We didn't run into issues, because currently node funding wasn't overlapping with any other blockchain-related operation, but this doesn't have to be true in the future.

---
This pull request refactors and improves the Chainlink node funding process in system tests, making it safer and more flexible. The main changes include splitting the node funding operation into two distinct steps—preparation of funding accounts and actual funding—while introducing per-chain-family funding logic and removing concurrency issues related to nonce management.

### Node Funding Refactor and Improvements

* Split the node funding operation into two steps: `PrepareCLNodesFundingOp` (generates and funds new accounts per chain family) and `FundCLNodesOp` (uses those accounts to fund the Chainlink nodes), improving safety and flexibility. [[1]](diffhunk://#diff-b200ad2d52275a3b330d1ca8698ef95e42c8431d680a6d6208ddf850a4b3ccd5R4-R246) [[2]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1R552-R581)
* Funding logic now supports both EVM and Solana nodes, including dynamic calculation of required funding per chain and per node, with 10% extra for gas fees on EVM.
* Removed the `ConcurrentNonceMap` and related concurrency logic, as nonce management is now handled by separate funding accounts, eliminating race conditions. [[1]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L740-L774) [[2]](diffhunk://#diff-b200ad2d52275a3b330d1ca8698ef95e42c8431d680a6d6208ddf850a4b3ccd5R4-R246)

### Input Handling and Stage Management

* Introduced a `stageCount` variable for more consistent stage management and updated stage generation logic when S3 provider is used. [[1]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1R104-R105) [[2]](diffhunk://#diff-37bdd273fcd916f910f38306b569d83db26145f8ff44e45e7e81f8111d931ba1L146-R149)

### Funding Eligibility Logic

* Improved the `RequiresForwarderContract` function to also check for Solana write capability, ensuring Solana nodes are properly included in funding operations.
* Cleaned up logic for collecting selectors for Solana forwarders, removing redundant code.