### PR TITLE
[CRE-494] Use new chainlink-evm version where the logPoller is started by the plugin and not externally.

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-data-streams v0.1.2
 	github.com/smartcontractkit/chainlink-deployments-framework v0.42.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250829155125-f4655b0b4605
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-data-streams v0.1.2
 	github.com/smartcontractkit/chainlink-deployments-framework v0.42.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250829155125-f4655b0b4605
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1548,8 +1548,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6 h1:5BMWJBiVxafrXQ+cMj3GOnNQ6MTgsIC9T3q/04LZ3f0=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1548,8 +1548,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e h1:6cDtVC91Xdbu/+MK2qK27NkMV9L3c5KYLqsDbW6EilE=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e/go.mod h1:q0ZBvaoisNaqC8NcMYWNPTjee88nQktDEeJMQHq3hVI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -734,18 +734,6 @@ func NewApplication(ctx context.Context, opts ApplicationOpts) (Application, err
 	jobSpawner := job.NewSpawner(jobORM, cfg.Database(), healthChecker, delegates, globalLogger, lbs)
 	srvcs = append(srvcs, jobSpawner, pipelineRunner)
 
-	// We start the log poller after the job spawner
-	// so jobs have a chance to apply their initial log filters.
-	if cfg.Feature().LogPoller() {
-		for _, c := range legacyEVMChains.Slice() {
-			legacyChain, ok := c.(legacyevm.Chain)
-			if !ok {
-				continue
-			}
-			srvcs = append(srvcs, legacyChain.LogPoller())
-		}
-	}
-
 	var feedsService feeds.Service
 	if cfg.Feature().FeedsManager() {
 		feedsORM := feeds.NewORM(opts.DS, globalLogger)

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.42.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250729142306-508e798f6a5d
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250829155125-f4655b0b4605

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.42.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250729142306-508e798f6a5d
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250829155125-f4655b0b4605

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1282,8 +1282,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6 h1:5BMWJBiVxafrXQ+cMj3GOnNQ6MTgsIC9T3q/04LZ3f0=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/deployment/go.sum
+++ b/deployment/go.sum
@@ -1282,8 +1282,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e h1:6cDtVC91Xdbu/+MK2qK27NkMV9L3c5KYLqsDbW6EilE=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e/go.mod h1:q0ZBvaoisNaqC8NcMYWNPTjee88nQktDEeJMQHq3hVI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-data-streams v0.1.2
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250804184440-c0506474fc44
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-data-streams v0.1.2
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563

--- a/go.sum
+++ b/go.sum
@@ -1118,8 +1118,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20ob5SijxQen51DhnqTLr2f7BEc=
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6 h1:5BMWJBiVxafrXQ+cMj3GOnNQ6MTgsIC9T3q/04LZ3f0=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/go.sum
+++ b/go.sum
@@ -1118,8 +1118,8 @@ github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-2025041523564
 github.com/smartcontractkit/chainlink-common/pkg/monitoring v0.0.0-20250415235644-8703639403c7/go.mod h1:yaDOAZF6MNB+NGYpxGCUc+owIdKrjvFW0JODdTcQ3V0=
 github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20ob5SijxQen51DhnqTLr2f7BEc=
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e h1:6cDtVC91Xdbu/+MK2qK27NkMV9L3c5KYLqsDbW6EilE=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e/go.mod h1:q0ZBvaoisNaqC8NcMYWNPTjee88nQktDEeJMQHq3hVI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.42.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.42.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1534,8 +1534,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6 h1:5BMWJBiVxafrXQ+cMj3GOnNQ6MTgsIC9T3q/04LZ3f0=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1534,8 +1534,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e h1:6cDtVC91Xdbu/+MK2qK27NkMV9L3c5KYLqsDbW6EilE=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e/go.mod h1:q0ZBvaoisNaqC8NcMYWNPTjee88nQktDEeJMQHq3hVI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.42.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.15
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.42.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.15
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.5

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1510,8 +1510,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6 h1:5BMWJBiVxafrXQ+cMj3GOnNQ6MTgsIC9T3q/04LZ3f0=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1510,8 +1510,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e h1:6cDtVC91Xdbu/+MK2qK27NkMV9L3c5KYLqsDbW6EilE=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e/go.mod h1:q0ZBvaoisNaqC8NcMYWNPTjee88nQktDEeJMQHq3hVI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.67
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.42.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250829155125-f4655b0b4605
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1

--- a/system-tests/lib/go.mod
+++ b/system-tests/lib/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.67
 	github.com/smartcontractkit/chainlink-common v0.9.5-0.20250908133421-f9b356d61ca9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.42.0
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250829155125-f4655b0b4605
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1526,8 +1526,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e h1:6cDtVC91Xdbu/+MK2qK27NkMV9L3c5KYLqsDbW6EilE=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e/go.mod h1:q0ZBvaoisNaqC8NcMYWNPTjee88nQktDEeJMQHq3hVI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/lib/go.sum
+++ b/system-tests/lib/go.sum
@@ -1526,8 +1526,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6 h1:5BMWJBiVxafrXQ+cMj3GOnNQ6MTgsIC9T3q/04LZ3f0=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -519,7 +519,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1 // indirect
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e // indirect
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250717121125-2350c82883e2 // indirect

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -519,7 +519,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a // indirect
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1 // indirect
-	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 // indirect
+	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 // indirect
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 // indirect
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250717121125-2350c82883e2 // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1729,8 +1729,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e h1:6cDtVC91Xdbu/+MK2qK27NkMV9L3c5KYLqsDbW6EilE=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909081156-ef47a708447e/go.mod h1:q0ZBvaoisNaqC8NcMYWNPTjee88nQktDEeJMQHq3hVI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1729,8 +1729,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.2 h1:g/UmFJa/E1Zmc7NO20o
 github.com/smartcontractkit/chainlink-data-streams v0.1.2/go.mod h1:lxY97sDlDorQAmLGFo6x1tl8SQ2E7adsS0/wU8+mmTc=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0 h1:48m4KU+gj9BzehxqKw+GOAwNDh0JxdOx9x3Zmummppo=
 github.com/smartcontractkit/chainlink-deployments-framework v0.42.0/go.mod h1:pbj+mMphYAKdgQ+oSy0FZN3236wxJnAxCnbgUXJZR8s=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660 h1:l2y97izO077HpUENfgNX7uf+WLT85+Jm5X7+hnI8uJI=
-github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909175601-b4396bd65660/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6 h1:5BMWJBiVxafrXQ+cMj3GOnNQ6MTgsIC9T3q/04LZ3f0=
+github.com/smartcontractkit/chainlink-evm v0.3.4-0.20250909183314-c46f62fb74f6/go.mod h1:FvtivQibe2N7XYsZ/EqGcSLFy40yVMa/7zaHUA60VKk=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be h1:NRldnH+Q6v8TjO3sBGo1mL/VRGeaPVneY2L13tCx114=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250827130336-5922343458be/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-feeds v0.1.2-0.20250227211209-7cd000095135 h1:8u9xUrC+yHrTDexOKDd+jrA6LCzFFHeX1G82oj2fsSI=


### PR DESCRIPTION
Requires https://github.com/smartcontractkit/chainlink-evm/pull/219