### PR TITLE
chore: bump version for 2.27.3-datastreams release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.27.0",
+  "version": "2.27.3-datastreams",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Backports the version bump and go.mod updates from the 2.27.3-datastreams hotfix branch into develop for consistency and future cuts.