### PR TITLE
CLD-605/swap-ocr-references

### DIFF
--- a/core/scripts/keystone/src/02_provision_ocr3_capability.go
+++ b/core/scripts/keystone/src/02_provision_ocr3_capability.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"text/template"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 
 	ksdeploy "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 
@@ -100,7 +100,7 @@ func deployOCR3Contract(
 func generateOCR3Config(nodeKeys []NodeKeys, configFile string) ksdeploy.OCR3OnchainConfig {
 	topLevelCfg := mustReadOCR3Config(configFile)
 	cfg := topLevelCfg.OracleConfig
-	secrets := deployment.XXXGenerateTestOCRSecrets()
+	secrets := focr.XXXGenerateTestOCRSecrets()
 	c, err := ksdeploy.GenerateOCR3Config(cfg, nodeKeysToKsDeployNodeKeys(nodeKeys[1:]), secrets) // skip the bootstrap node
 	helpers.PanicErr(err)
 	return c

--- a/core/scripts/keystone/src/02_provision_streams_trigger_capability.go
+++ b/core/scripts/keystone/src/02_provision_streams_trigger_capability.go
@@ -37,7 +37,7 @@ import (
 
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/mercury"
@@ -467,7 +467,7 @@ func generateMercuryOCR2Config(nca []NodeKeys) MercuryOCR2Config {
 		})
 	}
 
-	secrets := cldf.XXXGenerateTestOCRSecrets()
+	secrets := focr.XXXGenerateTestOCRSecrets()
 	// Values were taken from Data Streams 250ms feeds, given by @austinborn
 	signers, _, _, onchainConfig, offchainConfigVersion, offchainConfig, err := ocr3confighelper.ContractSetConfigArgsDeterministic(
 		secrets.EphemeralSk,

--- a/core/scripts/keystone/src/generate_local_ocr3_config.go
+++ b/core/scripts/keystone/src/generate_local_ocr3_config.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
+
 	"github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
 )
 
@@ -99,7 +100,7 @@ func (g *generateLocalOCR3Config) Run(args []string) {
 		panic(err)
 	}
 
-	ocrConfig, err := changeset.GenerateOCR3Config(cfg, pubKeys, deployment.XXXGenerateTestOCRSecrets())
+	ocrConfig, err := changeset.GenerateOCR3Config(cfg, pubKeys, focr.XXXGenerateTestOCRSecrets())
 	if err != nil {
 		panic(err)
 	}

--- a/deployment/ccip/changeset/internal/deploy_home_chain.go
+++ b/deployment/ccip/changeset/internal/deploy_home_chain.go
@@ -27,7 +27,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/offramp"
 	capabilities_registry "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/globals"
@@ -400,7 +400,7 @@ func BuildSetOCR3ConfigArgsAptos(
 
 func BuildOCR3ConfigForCCIPHome(
 	ccipHome *ccip_home.CCIPHome,
-	ocrSecrets cldf.OCRSecrets,
+	ocrSecrets focr.OCRSecrets,
 	offRampAddress []byte,
 	destSelector uint64,
 	nodes deployment.Nodes,

--- a/deployment/common/changeset/test_helpers_test.go
+++ b/deployment/common/changeset/test_helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
@@ -73,7 +74,7 @@ func NewNoopEnvironment(t *testing.T) cldf.Environment {
 		[]string{},
 		nil,
 		t.Context,
-		cldf.XXXGenerateTestOCRSecrets(),
+		focr.XXXGenerateTestOCRSecrets(),
 		chain.NewBlockChains(map[uint64]chain.BlockChain{}),
 	)
 }

--- a/deployment/cre/ocr3/config.go
+++ b/deployment/cre/ocr3/config.go
@@ -26,6 +26,7 @@ import (
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
@@ -201,7 +202,7 @@ func (c *OCR2OracleConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func GenerateOCR3Config(cfg OracleConfig, nca []NodeKeys, secrets cldf.OCRSecrets) (OCR2OracleConfig, error) {
+func GenerateOCR3Config(cfg OracleConfig, nca []NodeKeys, secrets focr.OCRSecrets) (OCR2OracleConfig, error) {
 	// the transmission schedule is very specific; arguably it should be not be a parameter
 	if len(cfg.TransmissionSchedule) != 1 || cfg.TransmissionSchedule[0] != len(nca) {
 		return OCR2OracleConfig{}, fmt.Errorf("transmission schedule must have exactly one entry, matching the len of the number of nodes want [%d], got %v. Total TransmissionSchedules = %d", len(nca), cfg.TransmissionSchedule, len(cfg.TransmissionSchedule))
@@ -363,7 +364,7 @@ type ConfigureOCR3Request struct {
 	Contract   *ocr3_capability.OCR3Capability
 	Nodes      []deployment.Node
 	DryRun     bool
-	OcrSecrets cldf.OCRSecrets
+	OcrSecrets focr.OCRSecrets
 
 	UseMCMS bool
 }

--- a/deployment/cre/ocr3/config_test.go
+++ b/deployment/cre/ocr3/config_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 	"github.com/smartcontractkit/chainlink/deployment/common/view"
@@ -95,7 +95,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 		Chain: cldf_evm.Chain{
 			Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 		},
-		OcrSecrets: cldf.XXXGenerateTestOCRSecrets(),
+		OcrSecrets: focr.XXXGenerateTestOCRSecrets(),
 	}
 	got, err := r.generateOCR3Config()
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 			Chain: cldf_evm.Chain{
 				Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 			},
-			OcrSecrets: cldf.XXXGenerateTestOCRSecrets(),
+			OcrSecrets: focr.XXXGenerateTestOCRSecrets(),
 		}
 		_, err := r.generateOCR3Config()
 		require.Error(t, err)
@@ -129,7 +129,7 @@ func Test_configureOCR3Request_generateOCR3Config(t *testing.T) {
 			Chain: cldf_evm.Chain{
 				Selector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
 			},
-			OcrSecrets: cldf.XXXGenerateTestOCRSecrets(),
+			OcrSecrets: focr.XXXGenerateTestOCRSecrets(),
 		}
 		_, err := r.generateOCR3Config()
 		require.Error(t, err)

--- a/deployment/cre/test/env_setup.go
+++ b/deployment/cre/test/env_setup.go
@@ -21,6 +21,7 @@ import (
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	capabilities_registry_v2 "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"
@@ -290,7 +291,7 @@ func setupViewOnlyNodeTest(t *testing.T, registryChainSel uint64, chains map[uin
 		nodes.IDs(),
 		jd,
 		t.Context,
-		cldf.XXXGenerateTestOCRSecrets(),
+		focr.XXXGenerateTestOCRSecrets(),
 		cldf_chain.NewBlockChains(blockChains),
 	)
 

--- a/deployment/environment/crib/types.go
+++ b/deployment/environment/crib/types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 
 	"github.com/smartcontractkit/chainlink/deployment/environment/devenv"
 )
@@ -40,7 +41,7 @@ func NewDeployEnvironmentFromCribOutput(lggr logger.Logger, output DeployOutput)
 		nil, // todo: populate the offchain client using output.DON
 		//nolint:gocritic // intentionally use a lambda to allow dynamic context replacement in Environment Commit 90ee880
 		func() context.Context { return context.Background() },
-		cldf.XXXGenerateTestOCRSecrets(),
+		focr.XXXGenerateTestOCRSecrets(),
 		blockChains,
 	), nil
 }

--- a/deployment/environment/devenv/environment.go
+++ b/deployment/environment/devenv/environment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 )
 
 const (
@@ -58,7 +59,7 @@ func NewEnvironment(ctx func() context.Context, lggr logger.Logger, config Envir
 		nodeIDs,
 		offChain,
 		ctx,
-		cldf.XXXGenerateTestOCRSecrets(),
+		focr.XXXGenerateTestOCRSecrets(),
 		blockChains,
 	), jd.don, nil
 }

--- a/deployment/environment/memory/environment.go
+++ b/deployment/environment/memory/environment.go
@@ -16,6 +16,7 @@ import (
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 	"github.com/smartcontractkit/chainlink/deployment"
 )
 
@@ -178,7 +179,7 @@ func NewMemoryEnvironmentFromChainsNodes(
 		nodeIDs, // Note these have the p2p_ prefix.
 		NewMemoryJobClient(nodes),
 		ctx,
-		cldf.XXXGenerateTestOCRSecrets(),
+		focr.XXXGenerateTestOCRSecrets(),
 		blockchains,
 	)
 }
@@ -235,7 +236,7 @@ func NewMemoryEnvironment(
 		nodeIDs,
 		NewMemoryJobClient(nodes),
 		t.Context,
-		cldf.XXXGenerateTestOCRSecrets(),
+		focr.XXXGenerateTestOCRSecrets(),
 		chains,
 	)
 }

--- a/deployment/keystone/changeset/test/env_setup.go
+++ b/deployment/keystone/changeset/test/env_setup.go
@@ -16,6 +16,7 @@ import (
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 
 	"github.com/smartcontractkit/chainlink/deployment"
 
@@ -458,7 +459,7 @@ func setupViewOnlyNodeTest(t *testing.T, registryChainSel uint64, chains map[uin
 		dons.NodeList().IDs(),
 		envtest.NewJDService(dons.NodeList()),
 		t.Context,
-		cldf.XXXGenerateTestOCRSecrets(),
+		focr.XXXGenerateTestOCRSecrets(),
 		cldf_chain.NewBlockChains(blockChains),
 	)
 

--- a/system-tests/lib/cre/environment/state.go
+++ b/system-tests/lib/cre/environment/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	deployment_devenv "github.com/smartcontractkit/chainlink/deployment/environment/devenv"
@@ -152,7 +153,7 @@ func BuildFromSavedState(ctx context.Context, cldLogger logger.Logger, cachedInp
 		func() context.Context {
 			return ctx
 		},
-		cldf.XXXGenerateTestOCRSecrets(),
+		focr.XXXGenerateTestOCRSecrets(),
 		blockChains,
 	)
 


### PR DESCRIPTION
This PR swaps references to `XXXGenerateTestOCRSecrets()` and `OCRSecrets`  from old location `github.com/smartcontractkit/chainlink-deployments-framework/deployment` to `github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr` 
