### PR TITLE
[CRE-752] Add pre-creation and funding of test wallets to PoR system-test

### DIFF
--- a/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/types/types.go
+++ b/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/types/types.go
@@ -1,6 +1,9 @@
 package types
 
-import "github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-common/pkg/workflows/sdk"
+)
 
 type WorkflowConfig struct {
 	// name of the secret that stores authentication key
@@ -12,7 +15,8 @@ type WorkflowConfig struct {
 }
 
 type BalanceReaderConfig struct {
-	BalanceReaderAddress string `yaml:"balance_reader_address"`
+	BalanceReaderAddress string           `yaml:"balance_reader_address"`
+	AddressesToRead      []common.Address `yaml:"addresses_to_read,omitempty"`
 }
 
 type ComputeConfig struct {

--- a/system-tests/lib/crypto/evm.go
+++ b/system-tests/lib/crypto/evm.go
@@ -47,3 +47,12 @@ func GenerateNewKeyPair() (common.Address, *ecdsa.PrivateKey, error) {
 	publicKeyAddr := crypto.PubkeyToAddress(privateKey.PublicKey)
 	return publicKeyAddr, privateKey, nil
 }
+
+func PrivateKeyToAddress(privateKey *ecdsa.PrivateKey) (common.Address, error) {
+	publicKey := privateKey.Public()
+	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return common.Address{}, errors.New("error casting public key to ECDSA")
+	}
+	return crypto.PubkeyToAddress(*publicKeyECDSA), nil
+}

--- a/system-tests/lib/funding/funding.go
+++ b/system-tests/lib/funding/funding.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/programs/system"
 	"github.com/gagliardetto/solana-go/rpc"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/conversions"
 	"github.com/smartcontractkit/chainlink-testing-framework/seth"
+	crecrypto "github.com/smartcontractkit/chainlink/system-tests/lib/crypto"
 )
 
 type FundsToSend struct {
@@ -36,15 +36,6 @@ type FundsToSendSol struct {
 	Recipent   solana.PublicKey
 	PrivateKey solana.PrivateKey
 	Amount     uint64
-}
-
-func PrivateKeyToAddress(privateKey *ecdsa.PrivateKey) (common.Address, error) {
-	publicKey := privateKey.Public()
-	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
-	if !ok {
-		return common.Address{}, errors.New("error casting public key to ECDSA")
-	}
-	return crypto.PubkeyToAddress(*publicKeyECDSA), nil
 }
 
 func SendFundsSol(ctx context.Context, logger zerolog.Logger, client *rpc.Client, payload FundsToSendSol) error {
@@ -106,7 +97,7 @@ func SendFundsSol(ctx context.Context, logger zerolog.Logger, client *rpc.Client
 }
 
 func SendFunds(ctx context.Context, logger zerolog.Logger, client *seth.Client, payload FundsToSend) (*types.Receipt, error) {
-	fromAddress, err := PrivateKeyToAddress(payload.PrivateKey)
+	fromAddress, err := crecrypto.PrivateKeyToAddress(payload.PrivateKey)
 	if err != nil {
 		return nil, err
 	}

--- a/system-tests/tests/smoke/cre/cre_suite_test.go
+++ b/system-tests/tests/smoke/cre/cre_suite_test.go
@@ -17,13 +17,16 @@ Inside `core/scripts/cre/environment` directory
 */
 func Test_CRE_Suite(t *testing.T) {
 	testEnv := SetupTestEnvironment(t)
+	priceProvider, porWfCfg := beforePoRTest(t, testEnv)
 
 	// WARNING: currently we can't run these tests in parallel, because each test rebuilds environment structs and that includes
 	// logging into CL node with GraphQL API, which allows only 1 session per user at a time.
 	t.Run("[v1] CRE Suite", func(t *testing.T) {
 		// requires `readcontract`, `cron`
 		t.Run("[v1] CRE Proof of Reserve (PoR) Test", func(t *testing.T) {
-			ExecutePoRTest(t, testEnv)
+			porWfCfg.WorkflowFileLocation = "../../../../core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/main.go"
+			porWfCfg.WorkflowName = "por-workflow"
+			ExecutePoRTest(t, testEnv, priceProvider, porWfCfg)
 		})
 	})
 
@@ -58,7 +61,11 @@ func Test_withV2Registries(t *testing.T) {
 		const skipReason = "Integrate v2 registry contracts in local CRE/test setup - https://smartcontract-it.atlassian.net/browse/CRE-635"
 		t.Skipf("Skipping test for the following reason: %s", skipReason)
 		flags := []string{"--with-contracts-version", "v2"}
+
 		testEnv := SetupTestEnvironment(t, flags...)
-		ExecutePoRTest(t, testEnv)
+		priceProvider, wfConfig := beforePoRTest(t, testEnv)
+		wfConfig.WorkflowFileLocation = "../../../../core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/main.go"
+		wfConfig.WorkflowName = "por-workflow"
+		ExecutePoRTest(t, testEnv, priceProvider, wfConfig)
 	})
 }


### PR DESCRIPTION
[CRE-752](https://smartcontract-it.atlassian.net/browse/CRE-752): 

- Added pre-creation and funding of EOAs/wallets to PoR scenario
- Added validation of the funded amount on top of the price from a PriceProvider
- Renamed PoR test file, by removing `v1_` prefix, because the test is used by both CREv1 and v2

[CRE-752]: https://smartcontract-it.atlassian.net/browse/CRE-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ