### PR TITLE
refactor(cre/contracts: support v2 cap reg cfg

### DIFF
--- a/deployment/cre/ocr3/v2/changeset/operations/contracts/types.go
+++ b/deployment/cre/ocr3/v2/changeset/operations/contracts/types.go
@@ -29,7 +29,7 @@ type DonNodeSet struct {
 	NodeIDs []string
 }
 
-// RegisteredDon is a representation of a don that exists in the in the capabilities registry all with the enriched node data
+// RegisteredDon is a representation of a don that exists in the capabilities registry all with the enriched node data
 type RegisteredDon struct {
 	Name  string
 	Info  capabilities_registry_v2.CapabilitiesRegistryDONInfo

--- a/system-tests/lib/cre/types.go
+++ b/system-tests/lib/cre/types.go
@@ -397,6 +397,8 @@ type ConfigureKeystoneInput struct {
 	ConsensusV2OCR3Address *common.Address
 
 	CapabilitiesRegistryAddress *common.Address
+
+	WithV2Registries bool
 }
 
 func (c *ConfigureKeystoneInput) Validate() error {


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

Refactor PR that enables configuring either a V1 or V2 capability registry when configuring the keystone contract set.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
