### PR TITLE
Check abiConfigFieldName in NewEVMEncoder

### DIFF
--- a/core/services/relay/evm/cap_encoder.go
+++ b/core/services/relay/evm/cap_encoder.go
@@ -28,7 +28,14 @@ var _ consensustypes.Encoder = (*capEncoder)(nil)
 
 func NewEVMEncoder(config *values.Map) (consensustypes.Encoder, error) {
 	// parse the "inner" encoder config - user-defined fields
-	wrappedSelector, err := config.Underlying[abiConfigFieldName].Unwrap()
+	abiConfig, ok := config.Underlying[abiConfigFieldName]
+	if !ok {
+		return nil, fmt.Errorf("required field %s is missing", abiConfigFieldName)
+	}
+	wrappedSelector, err := abiConfig.Unwrap()
+	if err != nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/cap_encoder.go
+++ b/core/services/relay/evm/cap_encoder.go
@@ -36,9 +36,6 @@ func NewEVMEncoder(config *values.Map) (consensustypes.Encoder, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err != nil {
-		return nil, err
-	}
 	selectorStr, ok := wrappedSelector.(string)
 	if !ok {
 		return nil, fmt.Errorf("expected %s to be a string", abiConfigFieldName)


### PR DESCRIPTION
Fix panic in `NewEVMEncoder` if `abiConfigFieldName` is not passed