### PR TITLE
ensure don order is always the same - map iteration is not deterministic

### DIFF
--- a/system-tests/lib/cre/contracts/contract_test.go
+++ b/system-tests/lib/cre/contracts/contract_test.go
@@ -1,0 +1,24 @@
+package contracts
+
+import "testing"
+
+func TestDonsOrderedByID(t *testing.T) {
+	// Test donsOrderedByID sorts by id ascending
+	d := dons{
+		c: make(map[string]donConfig),
+	}
+
+	d.c["don3"] = donConfig{id: 3}
+	d.c["don1"] = donConfig{id: 1}
+	d.c["don2"] = donConfig{id: 2}
+
+	ordered := d.donsOrderedByID()
+	if len(ordered) != 3 {
+		t.Fatalf("expected 3 dons, got %d", len(ordered))
+	}
+
+	if ordered[0].id != 1 || ordered[1].id != 2 || ordered[2].id != 3 {
+		t.Fatalf("expected dons ordered by id 1,2,3 got %d,%d,%d", ordered[0].id, ordered[1].id, ordered[2].id)
+	}
+
+}

--- a/system-tests/lib/cre/contracts/contract_test.go
+++ b/system-tests/lib/cre/contracts/contract_test.go
@@ -20,5 +20,4 @@ func TestDonsOrderedByID(t *testing.T) {
 	if ordered[0].id != 1 || ordered[1].id != 2 || ordered[2].id != 3 {
 		t.Fatalf("expected dons ordered by id 1,2,3 got %d,%d,%d", ordered[0].id, ordered[1].id, ordered[2].id)
 	}
-
 }

--- a/system-tests/lib/cre/contracts/contracts.go
+++ b/system-tests/lib/cre/contracts/contracts.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
@@ -62,6 +63,20 @@ type dons struct {
 	c map[string]donConfig
 }
 
+func (d *dons) donsOrderedByID() []donConfig {
+	out := make([]donConfig, 0, len(d.c))
+	for _, don := range d.c {
+		out = append(out, don)
+	}
+
+	// Use sort library to sort by ID
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].id < out[j].id
+	})
+
+	return out
+}
+
 func (d *dons) GetByName(name string) (donConfig, error) {
 	c, ok := d.c[name]
 	if !ok {
@@ -72,7 +87,7 @@ func (d *dons) GetByName(name string) (donConfig, error) {
 
 func (d *dons) ListByFlag(flag cre.CapabilityFlag) ([]donConfig, error) {
 	out := make([]donConfig, 0)
-	for _, don := range d.c {
+	for _, don := range d.donsOrderedByID() {
 		if flags.HasFlag(don.flags, flag) {
 			out = append(out, don)
 		}
@@ -85,7 +100,7 @@ func (d *dons) ListByFlag(flag cre.CapabilityFlag) ([]donConfig, error) {
 
 func (d *dons) ListByCapability(capName, capVersion string) ([]donConfig, error) {
 	out := make([]donConfig, 0)
-	for _, don := range d.c {
+	for _, don := range d.donsOrderedByID() {
 		for _, cap := range don.Capabilities {
 			if strings.EqualFold(cap.Capability.LabelledName, capName) && strings.EqualFold(cap.Capability.Version, capVersion) {
 				out = append(out, don)
@@ -112,7 +127,7 @@ func (d *dons) shouldBeOneDon(flag cre.CapabilityFlag) (donConfig, error) {
 
 func (d *dons) donNodesets() []ks_contracts_op.ConfigureKeystoneDON {
 	out := make([]ks_contracts_op.ConfigureKeystoneDON, 0, len(d.c))
-	for _, don := range d.c {
+	for _, don := range d.donsOrderedByID() {
 		out = append(out, don.keystoneDonConfig())
 	}
 	return out
@@ -120,7 +135,7 @@ func (d *dons) donNodesets() []ks_contracts_op.ConfigureKeystoneDON {
 
 func (d *dons) allDonCapabilities() []keystone_changeset.DonCapabilities {
 	out := make([]keystone_changeset.DonCapabilities, 0, len(d.c))
-	for _, don := range d.c {
+	for _, don := range d.donsOrderedByID() {
 		out = append(out, don.DonCapabilities)
 	}
 	return out


### PR DESCRIPTION
Seeing a very occasional fail in CI system test, e.g: https://github.com/smartcontractkit/chainlink/actions/runs/17546490993/job/49829577867?pr=19274#step:10:1476.

The fail occurs because the don IDs of the workflow nodes do not match the don IDs set when registering workflows.  Attempt to diagnose this further with some debug logs has failed as the issue has not been reproducible whilst debug logging has been in place.   The symptoms of the issue suggest non deterministic behaviour, a common cause of this in go is iterating over a map (there is no guarantee that the elements of the iteration will be the same on each iteration) then typically relying on an index - such as we see e.g. here ->. https://github.com/smartcontractkit/chainlink/blob/develop/system-tests/lib/cre/contracts/workflowregistry.go#L187.  This change ensures that all the functions that convert the maps of dons to  a slice that occur in the dons type will be returned in the same order on each call.

Whilst it has not been conclusively determined that this change will fix the occasional flake we are seeing, it seems reasonably possible, and there are no harmful side effects to the change.  Time will tell if it fixed it.
