### PR TITLE
fix(ci): unique label for self-hosted runners

### DIFF
--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -100,8 +100,9 @@ jobs:
       matrix:
         tests: ${{fromJson(needs.define-test-matrix.outputs.matrix)}}
     needs: [define-test-matrix]
-    # we need a `test_id` here to ensure labels are unique which prevents job thefts
-    runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    # we need a `test_id` and `run_attempt` here to stop runner stealing
+    # see: https://runs-on.com/guides/troubleshoot/#runner-stealing-and-matrix-jobs
+    runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}-${{ github.run_attempt }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     environment: "integration"
     timeout-minutes: 40
     steps:

--- a/.github/workflows/cre-system-tests.yaml
+++ b/.github/workflows/cre-system-tests.yaml
@@ -65,10 +65,28 @@ jobs:
         shell: bash
         working-directory: system-tests/tests/smoke/cre
         run: |
-          # Get the list of tests, for each test add each of supported DON topologies and convert to JSON format
-          # This only needs to be updated if we want to run all tests on a new DON topology.
-          # Otherwise tests are auto-discovered and run on all topologies.
-          tests=$(go test github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre -list . | grep -v "ok" | grep -v "^$" | jq -R -s 'split("\n")[:-1] | map([{"test_name": ., "topology": "workflow", "configs":"configs/workflow-don.toml"}, {"test_name": ., "topology": "workflow-gateway", "configs":"configs/workflow-gateway-don.toml"}, {"test_name": ., "topology": "workflow-gateway-capabilities", "configs":"configs/workflow-gateway-capabilities-don.toml"}]) | flatten')
+          # Get the list of tests, for each test add each of supported DON topologies and create JSON array to form a job matrix.
+          # - This only needs to be updated if we want to run all tests on a new DON topology.
+          # - Otherwise tests are auto-discovered and run on all topologies.
+
+          TOPOLOGIES_JSON='[
+            {"topology":"workflow","configs":"configs/workflow-don.toml"},
+            {"topology":"workflow-gateway","configs":"configs/workflow-gateway-don.toml"},
+            {"topology":"workflow-gateway-capabilities","configs":"configs/workflow-gateway-capabilities-don.toml"}
+          ]'
+
+          test_names=$(go test github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre -list . | grep -v 'ok' | grep -v '^$')
+          tests=$(echo "$test_names" | jq -R -s --argjson tops "$TOPOLOGIES_JSON" '
+            # split into lines and remove last empty line
+            split("\n")[:-1]
+
+            # create entry for each test name combined with each topology
+            | [ .[] as $name | $tops[] | {test_name:$name} + . ]
+
+            # add unique test_id for each entry (needed for runners below)
+            | to_entries | map(.value + {test_id: .key})
+          ')
+
           tests=$(echo $tests | jq -c .)
 
           echo "matrix=$tests" | tee -a "${GITHUB_OUTPUT}"
@@ -82,7 +100,8 @@ jobs:
       matrix:
         tests: ${{fromJson(needs.define-test-matrix.outputs.matrix)}}
     needs: [define-test-matrix]
-    runs-on: runs-on=${{ github.run_id }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
+    # we need a `test_id` here to ensure labels are unique which prevents job thefts
+    runs-on: runs-on=${{ github.run_id }}-${{ matrix.tests.test_id }}/cpu=16/ram=64/family=m6i+m5.*/spot=false/image=ubuntu24-full-x64/extras=s3-cache+tmpfs
     environment: "integration"
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
### Changes

- Refactor CRE matrix JSON creation to increase readability
- Add `test_id` to array so self-hosted runners can receive a unique label

### Motivation

This is a recommended approach to deal with "runner/job stealing".  We saw this earlier today with: https://github.com/smartcontractkit/chainlink/actions/runs/17587642331/job/49964450601
  - https://runs-on.com/guides/troubleshoot/#runner-stealing.
  - https://runs-on.com/guides/troubleshoot/#runner-stealing-and-matrix-jobs

Log:
```
"message":"The instance launched by this job has processed a job and is now terminated. We unfortunately can't compare job ids or job names due to GitHub API limitations, so assuming that there was a runner theft, but will not retry to avoid unnecessary rescheduling. To avoid this situation, please verify that each job has unique labels - https://runs-on.com/guides/troubleshoot/#long-queuing-time-for-some-workflows. It might also be due to a delay in GitHub marking the job as in progress or completed."
```

I don't know why this is happening all of the sudden. This should fix all stealing events related to CRE.




