### PR TITLE
PLEX-1706 Adding EVM cap methods for remote don

### DIFF
--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
@@ -51,7 +51,6 @@
   [nodesets.chain_capabilities]
     # we want to write only to the home chain, so that we can test whether remote write-evm-2337 capability of the 'capabilities DON' is used
     write-evm = ["1337"]
-    evm = ["1337"] # TODO: move to capabilities DON when supported
     read-contract = ["1337"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
@@ -52,6 +52,7 @@
     # we want to write only to the home chain, so that we can test whether remote write-evm-2337 capability of the 'capabilities DON' is used
     write-evm = ["1337"]
     read-contract = ["1337"]
+    evm = ["1337"]
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 
@@ -104,7 +105,7 @@
   [nodesets.chain_capabilities]
   write-evm = ["2337"]
   read-contract = ["2337"]
-  evm = ["1337"]
+
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
@@ -52,7 +52,7 @@
     # we want to write only to the home chain, so that we can test whether remote write-evm-2337 capability of the 'capabilities DON' is used
     write-evm = ["1337"]
     read-contract = ["1337"]
-    evm = ["1337"]
+    evm = ["1337"] # TODO: move to capabilities DON when fix for WriteReport is done
 
   # See ./examples/workflow-don-overrides.toml to learn how to override capability configs
 
@@ -105,7 +105,6 @@
   [nodesets.chain_capabilities]
   write-evm = ["2337"]
   read-contract = ["2337"]
-
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
+++ b/core/scripts/cre/environment/configs/workflow-gateway-capabilities-don.toml
@@ -105,6 +105,7 @@
   [nodesets.chain_capabilities]
   write-evm = ["2337"]
   read-contract = ["2337"]
+  evm = ["1337"]
 
   [nodesets.db]
     image = "postgres:12.0"

--- a/system-tests/lib/cre/capabilities/evm/evm.go
+++ b/system-tests/lib/cre/capabilities/evm/evm.go
@@ -34,6 +34,8 @@ const (
 	configTemplate      = `'{"chainId":{{.ChainID}},"network":"{{.NetworkFamily}}","logTriggerPollInterval":{{.LogTriggerPollInterval}}, "creForwarderAddress":"{{.CreForwarderAddress}}","receiverGasMinimum":{{.ReceiverGasMinimum}},"nodeAddress":"{{.NodeAddress}}"}'`
 	registrationRefresh = 20 * time.Second
 	registrationExpiry  = 60 * time.Second
+	deltaStage          = 500*time.Millisecond + 1*time.Second // block time + 1 second delta
+	requestTimeout      = 30 * time.Second
 )
 
 func New(registryChainID uint64) (*capabilities.Capability, error) {
@@ -71,30 +73,101 @@ func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]k
 			return nil, errors.Wrapf(selectorErr, "failed to get selector from chainID: %d", chainID)
 		}
 
-		faultyNodes, faultyErr := nodeSetInput.MaxFaultyNodes()
-		if faultyErr != nil {
-			return nil, errors.Wrap(faultyErr, "failed to get faulty nodes")
+		evmMethodConfigs, err := getEvmMethodConfigs(nodeSetInput)
+		if err != nil {
+			return nil, errors.Wrap(err, "there was an error getting EVM method configs")
 		}
+
 		capabilities = append(capabilities, keystone_changeset.DONCapabilityWithConfig{
 			Capability: kcr.CapabilitiesRegistryCapability{
-				LabelledName:   "evm" + ":ChainSelector:" + strconv.FormatUint(selector, 10),
-				Version:        "1.0.0",
-				CapabilityType: 0, // TRIGGER
+				LabelledName: "evm" + ":ChainSelector:" + strconv.FormatUint(selector, 10),
+				Version:      "1.0.0",
 			},
 			Config: &capabilitiespb.CapabilityConfig{
-				RemoteConfig: &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
-					RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
-						// needed for message_cache.go#Ready(), without these events from the capability will never be accepted
-						RegistrationRefresh:     durationpb.New(registrationRefresh),
-						RegistrationExpiry:      durationpb.New(registrationExpiry),
-						MinResponsesToAggregate: faultyNodes + 1,
-					},
-				},
+				MethodConfigs: evmMethodConfigs,
 			},
 		})
 	}
 
 	return capabilities, nil
+}
+
+// getEvmMethodConfigs returns the method configs for all EVM methods we want to support, if any method is missing it
+// will not be reached by the node when running evm capability in remote don
+func getEvmMethodConfigs(nodeSetInput *cre.CapabilitiesAwareNodeSet) (map[string]*capabilitiespb.CapabilityMethodConfig, error) {
+
+	evmMethodConfigs := map[string]*capabilitiespb.CapabilityMethodConfig{}
+
+	// the read actions should be all defined in the proto that are neither a LogTrigger type, not a WriteReport type
+	// see the RPC methods to map here: https://github.com/smartcontractkit/chainlink-protos/blob/main/cre/capabilities/blockchain/evm/v1alpha/client.proto
+	readActions := []string{
+		"CallContract",
+		"FilterLogs",
+		"BalanceAt",
+		"EstimateGas",
+		"GetTransactionByHash",
+		"GetTransactionReceipt",
+		"HeaderByNumber",
+	}
+	for _, action := range readActions {
+		evmMethodConfigs[action] = readActionConfig()
+	}
+
+	triggerConfig, err := logTriggerConfig(nodeSetInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed get config for LogTrigger")
+	}
+
+	evmMethodConfigs["LogTrigger"] = triggerConfig
+	evmMethodConfigs["WriteReport"] = writeReportActionConfig()
+	return evmMethodConfigs, nil
+}
+
+func logTriggerConfig(nodeSetInput *cre.CapabilitiesAwareNodeSet) (*capabilitiespb.CapabilityMethodConfig, error) {
+	faultyNodes, faultyErr := nodeSetInput.MaxFaultyNodes()
+	if faultyErr != nil {
+		return nil, errors.Wrap(faultyErr, "failed to get faulty nodes")
+	}
+
+	return &capabilitiespb.CapabilityMethodConfig{
+		RemoteConfig: &capabilitiespb.CapabilityMethodConfig_RemoteTriggerConfig{
+			RemoteTriggerConfig: &capabilitiespb.RemoteTriggerConfig{
+				RegistrationRefresh:     durationpb.New(registrationRefresh),
+				RegistrationExpiry:      durationpb.New(registrationExpiry),
+				MinResponsesToAggregate: faultyNodes + 1,
+				MessageExpiry:           durationpb.New(2 * registrationExpiry),
+				MaxBatchSize:            25,
+				BatchCollectionPeriod:   durationpb.New(200 * time.Millisecond),
+			},
+		},
+	}, nil
+}
+
+func writeReportActionConfig() *capabilitiespb.CapabilityMethodConfig {
+	return &capabilitiespb.CapabilityMethodConfig{
+		RemoteConfig: &capabilitiespb.CapabilityMethodConfig_RemoteExecutableConfig{
+			RemoteExecutableConfig: &capabilitiespb.RemoteExecutableConfig{
+				TransmissionSchedule:      capabilitiespb.TransmissionSchedule_OneAtATime,
+				DeltaStage:                durationpb.New(deltaStage),
+				RequestTimeout:            durationpb.New(requestTimeout),
+				ServerMaxParallelRequests: 10,
+				RequestHasherType:         capabilitiespb.RequestHasherType_WriteReportExcludeSignatures,
+			},
+		},
+	}
+}
+
+func readActionConfig() *capabilitiespb.CapabilityMethodConfig {
+	return &capabilitiespb.CapabilityMethodConfig{
+		RemoteConfig: &capabilitiespb.CapabilityMethodConfig_RemoteExecutableConfig{
+			RemoteExecutableConfig: &capabilitiespb.RemoteExecutableConfig{
+				TransmissionSchedule:      capabilitiespb.TransmissionSchedule_AllAtOnce,
+				RequestTimeout:            durationpb.New(requestTimeout),
+				ServerMaxParallelRequests: 10,
+				RequestHasherType:         capabilitiespb.RequestHasherType_Simple,
+			},
+		},
+	}
 }
 
 // buildRuntimeValues creates runtime-generated  values for any keys not specified in TOML

--- a/system-tests/lib/cre/capabilities/evm/evm.go
+++ b/system-tests/lib/cre/capabilities/evm/evm.go
@@ -95,7 +95,6 @@ func registerWithV1(_ []string, nodeSetInput *cre.CapabilitiesAwareNodeSet) ([]k
 // getEvmMethodConfigs returns the method configs for all EVM methods we want to support, if any method is missing it
 // will not be reached by the node when running evm capability in remote don
 func getEvmMethodConfigs(nodeSetInput *cre.CapabilitiesAwareNodeSet) (map[string]*capabilitiespb.CapabilityMethodConfig, error) {
-
 	evmMethodConfigs := map[string]*capabilitiespb.CapabilityMethodConfig{}
 
 	// the read actions should be all defined in the proto that are neither a LogTrigger type, not a WriteReport type

--- a/system-tests/lib/cre/environment/env_artifact.go
+++ b/system-tests/lib/cre/environment/env_artifact.go
@@ -84,7 +84,7 @@ func (c *DONCapabilityConfig) UnmarshalJSON(data []byte) error {
 
 		// use a map to hold any nested shape: RemoteTriggerConfig/RemoteTargetConfig/RemoteExecutableConfig
 		RemoteConfig map[string]json.RawMessage `json:"RemoteConfig,omitempty"`
-		//use a map to hold any methods, if present, to iterate later
+		// use a map to hold any methods, if present, to iterate later
 		MethodConfigs map[string]json.RawMessage `json:"method_configs,omitempty"`
 	}
 
@@ -95,7 +95,7 @@ func (c *DONCapabilityConfig) UnmarshalJSON(data []byte) error {
 	}
 
 	if aux.RemoteConfig != nil {
-		//parse the remote config based on the key
+		// parse the remote config based on the key
 		switch {
 		case aux.RemoteConfig["RemoteTriggerConfig"] != nil:
 			var rt capabilitiespb.RemoteTriggerConfig

--- a/system-tests/lib/cre/environment/env_artifact.go
+++ b/system-tests/lib/cre/environment/env_artifact.go
@@ -84,6 +84,8 @@ func (c *DONCapabilityConfig) UnmarshalJSON(data []byte) error {
 
 		// use a map to hold any nested shape: RemoteTriggerConfig/RemoteTargetConfig/RemoteExecutableConfig
 		RemoteConfig map[string]json.RawMessage `json:"RemoteConfig,omitempty"`
+		//use a map to hold any methods, if present, to iterate later
+		MethodConfigs map[string]json.RawMessage `json:"method_configs,omitempty"`
 	}
 
 	aux.Alias = (*Alias)(c)
@@ -92,42 +94,85 @@ func (c *DONCapabilityConfig) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if aux.RemoteConfig == nil {
-		// nothing else to do, no remote config to parse
-		return nil
+	if aux.RemoteConfig != nil {
+		//parse the remote config based on the key
+		switch {
+		case aux.RemoteConfig["RemoteTriggerConfig"] != nil:
+			var rt capabilitiespb.RemoteTriggerConfig
+			if err := json.Unmarshal(aux.RemoteConfig["RemoteTriggerConfig"], &rt); err != nil {
+				return err
+			}
+			c.RemoteConfig = &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
+				RemoteTriggerConfig: &rt,
+			}
+		case aux.RemoteConfig["RemoteTargetConfig"] != nil:
+			var tgt capabilitiespb.RemoteTargetConfig
+			if err := json.Unmarshal(aux.RemoteConfig["RemoteTargetConfig"], &tgt); err != nil {
+				return err
+			}
+			c.RemoteConfig = &capabilitiespb.CapabilityConfig_RemoteTargetConfig{
+				RemoteTargetConfig: &tgt,
+			}
+		case aux.RemoteConfig["RemoteExecutableConfig"] != nil:
+			var ex capabilitiespb.RemoteExecutableConfig
+			if err := json.Unmarshal(aux.RemoteConfig["RemoteExecutableConfig"], &ex); err != nil {
+				return err
+			}
+			c.RemoteConfig = &capabilitiespb.CapabilityConfig_RemoteExecutableConfig{
+				RemoteExecutableConfig: &ex,
+			}
+		default:
+			keys := make([]string, 0, len(aux.RemoteConfig))
+			for k := range aux.RemoteConfig {
+				keys = append(keys, k)
+			}
+			return fmt.Errorf("unknown remote config type in capability config, keys: %v", keys)
+		}
 	}
 
-	switch {
-	case aux.RemoteConfig["RemoteTriggerConfig"] != nil:
-		var rt capabilitiespb.RemoteTriggerConfig
-		if err := json.Unmarshal(aux.RemoteConfig["RemoteTriggerConfig"], &rt); err != nil {
-			return err
+	if aux.MethodConfigs != nil {
+		methodConfigs := make(map[string]*capabilitiespb.CapabilityMethodConfig, len(aux.MethodConfigs))
+		for methodName, methodConfig := range aux.MethodConfigs {
+			var methodRemoteConfig map[string]json.RawMessage
+			if err := json.Unmarshal(methodConfig, &methodRemoteConfig); err != nil {
+				return err
+			}
+
+			var innerRemoteConfig map[string]json.RawMessage
+			if err := json.Unmarshal(methodRemoteConfig["RemoteConfig"], &innerRemoteConfig); err != nil {
+				return err
+			}
+			switch {
+			case innerRemoteConfig["RemoteTriggerConfig"] != nil:
+				var rt capabilitiespb.RemoteTriggerConfig
+				if err := json.Unmarshal(innerRemoteConfig["RemoteTriggerConfig"], &rt); err != nil {
+					return err
+				}
+				methodConfigs[methodName] = &capabilitiespb.CapabilityMethodConfig{
+					RemoteConfig: &capabilitiespb.CapabilityMethodConfig_RemoteTriggerConfig{
+						RemoteTriggerConfig: &rt,
+					},
+				}
+			case innerRemoteConfig["RemoteExecutableConfig"] != nil:
+				var ex capabilitiespb.RemoteExecutableConfig
+				if err := json.Unmarshal(innerRemoteConfig["RemoteExecutableConfig"], &ex); err != nil {
+					return err
+				}
+				methodConfigs[methodName] = &capabilitiespb.CapabilityMethodConfig{
+					RemoteConfig: &capabilitiespb.CapabilityMethodConfig_RemoteExecutableConfig{
+						RemoteExecutableConfig: &ex,
+					},
+				}
+			default:
+				keys := make([]string, 0, len(innerRemoteConfig))
+				for k := range innerRemoteConfig {
+					keys = append(keys, k)
+				}
+				return fmt.Errorf("unknown method config type for method %s, unknown config value keys: %s", methodName, strings.Join(keys, ","))
+			}
 		}
-		c.RemoteConfig = &capabilitiespb.CapabilityConfig_RemoteTriggerConfig{
-			RemoteTriggerConfig: &rt,
-		}
-	case aux.RemoteConfig["RemoteTargetConfig"] != nil:
-		var tgt capabilitiespb.RemoteTargetConfig
-		if err := json.Unmarshal(aux.RemoteConfig["RemoteTargetConfig"], &tgt); err != nil {
-			return err
-		}
-		c.RemoteConfig = &capabilitiespb.CapabilityConfig_RemoteTargetConfig{
-			RemoteTargetConfig: &tgt,
-		}
-	case aux.RemoteConfig["RemoteExecutableConfig"] != nil:
-		var ex capabilitiespb.RemoteExecutableConfig
-		if err := json.Unmarshal(aux.RemoteConfig["RemoteExecutableConfig"], &ex); err != nil {
-			return err
-		}
-		c.RemoteConfig = &capabilitiespb.CapabilityConfig_RemoteExecutableConfig{
-			RemoteExecutableConfig: &ex,
-		}
-	default:
-		keys := make([]string, 0, len(aux.RemoteConfig))
-		for k := range aux.RemoteConfig {
-			keys = append(keys, k)
-		}
-		return fmt.Errorf("unknown remote config type in capability config, keys: %v", keys)
+
+		c.MethodConfigs = methodConfigs
 	}
 
 	return nil

--- a/system-tests/lib/cre/environment/testdata/roundtrip/004-remote-executable/expected.json
+++ b/system-tests/lib/cre/environment/testdata/roundtrip/004-remote-executable/expected.json
@@ -2,15 +2,19 @@
   "config": {
     "RemoteConfig": {
       "RemoteExecutableConfig": {
-        "registrationExpiry": {
-          "seconds": 60
-        },
-        "registrationRefresh": {
-          "seconds": 20
+        "delta_stage": {
+          "nanos": 500000000,
+          "seconds": 1
         },
         "requestHashExcludedAttributes": [
           "data1"
-        ]
+        ],
+        "request_hasher_type": 1,
+        "request_timeout": {
+          "seconds": 30
+        },
+        "server_max_parallel_requests": 10,
+        "transmission_schedule": 1
       }
     }
   }

--- a/system-tests/lib/cre/environment/testdata/roundtrip/004-remote-executable/input.json
+++ b/system-tests/lib/cre/environment/testdata/roundtrip/004-remote-executable/input.json
@@ -3,8 +3,16 @@
     "RemoteConfig": {
       "RemoteExecutableConfig": {
         "requestHashExcludedAttributes": ["data1"],
-        "registrationRefresh": { "seconds": 20 },
-        "registrationExpiry": { "seconds": 60 }
+        "transmission_schedule": 1,
+        "delta_stage": {
+          "seconds": 1,
+          "nanos": 500000000
+        },
+        "request_timeout": {
+          "seconds": 30
+        },
+        "server_max_parallel_requests": 10,
+        "request_hasher_type": 1
       }
     }
   }

--- a/system-tests/lib/cre/environment/testdata/roundtrip/005-method-configs-trigger/expected.json
+++ b/system-tests/lib/cre/environment/testdata/roundtrip/005-method-configs-trigger/expected.json
@@ -1,0 +1,27 @@
+{
+  "config": {
+    "RemoteConfig": null,
+    "method_configs": {
+      "LogTrigger": {
+        "RemoteConfig": {
+          "RemoteTriggerConfig": {
+            "batchCollectionPeriod": {
+              "nanos": 200000000
+            },
+            "maxBatchSize": 25,
+            "messageExpiry": {
+              "seconds": 120
+            },
+            "minResponsesToAggregate": 2,
+            "registrationExpiry": {
+              "seconds": 60
+            },
+            "registrationRefresh": {
+              "seconds": 20
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/system-tests/lib/cre/environment/testdata/roundtrip/005-method-configs-trigger/input.json
+++ b/system-tests/lib/cre/environment/testdata/roundtrip/005-method-configs-trigger/input.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "method_configs": {
+      "LogTrigger": {
+        "RemoteConfig": {
+          "RemoteTriggerConfig": {
+            "registrationRefresh": {
+              "seconds": 20
+            },
+            "registrationExpiry": {
+              "seconds": 60
+            },
+            "minResponsesToAggregate": 2,
+            "messageExpiry": {
+              "seconds": 120
+            },
+            "maxBatchSize": 25,
+            "batchCollectionPeriod": {
+              "nanos": 200000000
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/system-tests/lib/cre/environment/testdata/roundtrip/006-method-configs-executable-all-at-once/expected.json
+++ b/system-tests/lib/cre/environment/testdata/roundtrip/006-method-configs-executable-all-at-once/expected.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "RemoteConfig": null,
+    "method_configs": {
+      "GetTransactionByHash": {
+        "RemoteConfig": {
+          "RemoteExecutableConfig": {
+            "request_timeout": {
+              "seconds": 30
+            },
+            "server_max_parallel_requests": 10
+          }
+        }
+      }
+    }
+  }
+}

--- a/system-tests/lib/cre/environment/testdata/roundtrip/006-method-configs-executable-all-at-once/input.json
+++ b/system-tests/lib/cre/environment/testdata/roundtrip/006-method-configs-executable-all-at-once/input.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "method_configs": {
+      "GetTransactionByHash": {
+        "RemoteConfig": {
+          "RemoteExecutableConfig": {
+            "request_timeout": {
+              "seconds": 30
+            },
+            "server_max_parallel_requests": 10
+          }
+        }
+      }
+    }
+  }
+}

--- a/system-tests/lib/cre/environment/testdata/roundtrip/007-method-configs-executable-one-at-a-time/expected.json
+++ b/system-tests/lib/cre/environment/testdata/roundtrip/007-method-configs-executable-one-at-a-time/expected.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "RemoteConfig": null,
+    "method_configs": {
+      "WriteReport": {
+        "RemoteConfig": {
+          "RemoteExecutableConfig": {
+            "delta_stage": {
+              "nanos": 500000000,
+              "seconds": 1
+            },
+            "request_hasher_type": 1,
+            "request_timeout": {
+              "seconds": 30
+            },
+            "server_max_parallel_requests": 10,
+            "transmission_schedule": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/system-tests/lib/cre/environment/testdata/roundtrip/007-method-configs-executable-one-at-a-time/input.json
+++ b/system-tests/lib/cre/environment/testdata/roundtrip/007-method-configs-executable-one-at-a-time/input.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "method_configs": {
+      "WriteReport": {
+        "RemoteConfig": {
+          "RemoteExecutableConfig": {
+            "transmission_schedule": 1,
+            "delta_stage": {
+              "seconds": 1,
+              "nanos": 500000000
+            },
+            "request_timeout": {
+              "seconds": 30
+            },
+            "server_max_parallel_requests": 10,
+            "request_hasher_type": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/system-tests/lib/cre/environment/testdata/roundtrip/008-method-configs-all-options/expected.json
+++ b/system-tests/lib/cre/environment/testdata/roundtrip/008-method-configs-all-options/expected.json
@@ -1,0 +1,53 @@
+{
+  "config": {
+    "RemoteConfig": null,
+    "method_configs": {
+      "GetTransactionByHash": {
+        "RemoteConfig": {
+          "RemoteExecutableConfig": {
+            "request_timeout": {
+              "seconds": 30
+            },
+            "server_max_parallel_requests": 10
+          }
+        }
+      },
+      "LogTrigger": {
+        "RemoteConfig": {
+          "RemoteTriggerConfig": {
+            "batchCollectionPeriod": {
+              "nanos": 200000000
+            },
+            "maxBatchSize": 25,
+            "messageExpiry": {
+              "seconds": 120
+            },
+            "minResponsesToAggregate": 2,
+            "registrationExpiry": {
+              "seconds": 60
+            },
+            "registrationRefresh": {
+              "seconds": 20
+            }
+          }
+        }
+      },
+      "WriteReport": {
+        "RemoteConfig": {
+          "RemoteExecutableConfig": {
+            "delta_stage": {
+              "nanos": 500000000,
+              "seconds": 1
+            },
+            "request_hasher_type": 1,
+            "request_timeout": {
+              "seconds": 30
+            },
+            "server_max_parallel_requests": 10,
+            "transmission_schedule": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/system-tests/lib/cre/environment/testdata/roundtrip/008-method-configs-all-options/input.json
+++ b/system-tests/lib/cre/environment/testdata/roundtrip/008-method-configs-all-options/input.json
@@ -1,0 +1,52 @@
+{
+  "config": {
+    "method_configs": {
+      "GetTransactionByHash": {
+        "RemoteConfig": {
+          "RemoteExecutableConfig": {
+            "request_timeout": {
+              "seconds": 30
+            },
+            "server_max_parallel_requests": 10
+          }
+        }
+      },
+      "LogTrigger": {
+        "RemoteConfig": {
+          "RemoteTriggerConfig": {
+            "registrationRefresh": {
+              "seconds": 20
+            },
+            "registrationExpiry": {
+              "seconds": 60
+            },
+            "minResponsesToAggregate": 2,
+            "messageExpiry": {
+              "seconds": 120
+            },
+            "maxBatchSize": 25,
+            "batchCollectionPeriod": {
+              "nanos": 200000000
+            }
+          }
+        }
+      },
+      "WriteReport": {
+        "RemoteConfig": {
+          "RemoteExecutableConfig": {
+            "transmission_schedule": 1,
+            "delta_stage": {
+              "seconds": 1,
+              "nanos": 500000000
+            },
+            "request_timeout": {
+              "seconds": 30
+            },
+            "server_max_parallel_requests": 10,
+            "request_hasher_type": 1
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Jira: https://smartcontract-it.atlassian.net/browse/PLEX-1706

After [PRODCRE-792](https://smartcontract-it.atlassian.net/browse/PRODCRE-792) was merge it is now possible to hook up a capability that had multiple capabilities types (read, trigger, etc.) while also adding the `one_at_a_time` strategy calling (needed for the WriteReport).

This PR enables the EVM Capability to be used in a remote/capabilities DON by registering all the methods configs (all reads, log trigger, and write report), while also using the cascade calling (`one_at_a_time` for the write report)


### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->


[PRODCRE-792]: https://smartcontract-it.atlassian.net/browse/PRODCRE-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ