### PR TITLE
CRE-829: transform config capability inputs into v2

### DIFF
--- a/system-tests/lib/cre/contracts/contract_test.go
+++ b/system-tests/lib/cre/contracts/contract_test.go
@@ -1,6 +1,14 @@
 package contracts
 
-import "testing"
+import (
+	"math/big"
+	"testing"
+
+	capabilitiespb "github.com/smartcontractkit/chainlink-common/pkg/capabilities/pb"
+	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
+	keystone_changeset "github.com/smartcontractkit/chainlink/deployment/keystone/changeset"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
+)
 
 func TestDonsOrderedByID(t *testing.T) {
 	// Test donsOrderedByID sorts by id ascending
@@ -19,5 +27,94 @@ func TestDonsOrderedByID(t *testing.T) {
 
 	if ordered[0].id != 1 || ordered[1].id != 2 || ordered[2].id != 3 {
 		t.Fatalf("expected dons ordered by id 1,2,3 got %d,%d,%d", ordered[0].id, ordered[1].id, ordered[2].id)
+	}
+}
+
+func TestToV2ConfigureInput(t *testing.T) {
+	// Create test peer IDs
+	peerID1 := p2pkey.MustNewV2XXXTestingOnly(big.NewInt(1)).PeerID().String()
+	peerID2 := p2pkey.MustNewV2XXXTestingOnly(big.NewInt(2)).PeerID().String()
+
+	// Create test dons with sample data
+	d := &dons{
+		c: make(map[string]donConfig),
+	}
+
+	// Add a DON with capabilities and nodes
+	d.c["test-don"] = donConfig{
+		id: 1,
+		DonCapabilities: keystone_changeset.DonCapabilities{
+			Name: "test-don",
+			F:    1,
+			Nops: []keystone_changeset.NOP{
+				{
+					Name:  "test-nop",
+					Nodes: []string{peerID1, peerID2},
+				},
+			},
+			Capabilities: []keystone_changeset.DONCapabilityWithConfig{
+				{
+					Capability: kcr.CapabilitiesRegistryCapability{
+						LabelledName:   "test-capability",
+						Version:        "1.0.0",
+						CapabilityType: 1,
+					},
+					Config: &capabilitiespb.CapabilityConfig{},
+				},
+			},
+		},
+	}
+
+	// Call the method under test
+	result := d.toV2ConfigureInput(123, "0x1234567890abcdef")
+
+	// Verify the transformation
+	if result.RegistryChainSel != 123 {
+		t.Errorf("expected RegistryChainSel 123, got %d", result.RegistryChainSel)
+	}
+
+	if result.ContractAddress != "0x1234567890abcdef" {
+		t.Errorf("expected ContractAddress 0x1234567890abcdef, got %s", result.ContractAddress)
+	}
+
+	if len(result.Nops) != 1 {
+		t.Fatalf("expected 1 NOP, got %d", len(result.Nops))
+	}
+
+	if result.Nops[0].Name != "test-nop" {
+		t.Errorf("expected NOP name 'test-nop', got %s", result.Nops[0].Name)
+	}
+
+	if len(result.Nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(result.Nodes))
+	}
+
+	if len(result.Capabilities) != 1 {
+		t.Fatalf("expected 1 capability, got %d", len(result.Capabilities))
+	}
+
+	expectedCapID := "test-capability@1.0.0"
+	if result.Capabilities[0].CapabilityId != expectedCapID {
+		t.Errorf("expected capability ID '%s', got %s", expectedCapID, result.Capabilities[0].CapabilityId)
+	}
+
+	if len(result.DONs) != 1 {
+		t.Fatalf("expected 1 DON, got %d", len(result.DONs))
+	}
+
+	if result.DONs[0].Name != "test-don" {
+		t.Errorf("expected DON name 'test-don', got %s", result.DONs[0].Name)
+	}
+
+	if result.DONs[0].F != 1 {
+		t.Errorf("expected DON F value 1, got %d", result.DONs[0].F)
+	}
+
+	if len(result.DONs[0].Nodes) != 2 {
+		t.Errorf("expected DON to have 2 nodes, got %d", len(result.DONs[0].Nodes))
+	}
+
+	if len(result.DONs[0].CapabilityConfigurations) != 1 {
+		t.Errorf("expected DON to have 1 capability configuration, got %d", len(result.DONs[0].CapabilityConfigurations))
 	}
 }

--- a/system-tests/lib/cre/contracts/contracts.go
+++ b/system-tests/lib/cre/contracts/contracts.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
-	"github.com/smartcontractkit/chainlink/system-tests/lib/conversions"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
@@ -191,7 +190,7 @@ func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) 
 						continue // Skip invalid peer IDs
 					}
 					// Safe conversion: len(nops) is controlled and small
-					nodeOperatorID := conversions.MustSafeUint32(len(nops))
+					nodeOperatorID := libc.MustSafeUint32(len(nops))
 					nodes = append(nodes, capabilities_registry_v2.CapabilitiesRegistryNodeParams{
 						NodeOperatorId:      nodeOperatorID,
 						P2pId:               peerID,

--- a/system-tests/lib/cre/contracts/contracts.go
+++ b/system-tests/lib/cre/contracts/contracts.go
@@ -143,15 +143,15 @@ func (d *dons) allDonCapabilities() []keystone_changeset.DonCapabilities {
 }
 
 func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) cap_reg_v2_seq.ConfigureCapabilitiesRegistryInput {
-	var nops []capabilities_registry_v2.CapabilitiesRegistryNodeOperator
-	var nodes []capabilities_registry_v2.CapabilitiesRegistryNodeParams  
-	var capabilities []capabilities_registry_v2.CapabilitiesRegistryCapability
-	var donParams []capabilities_registry_v2.CapabilitiesRegistryNewDONParams
-	
+	nops := make([]capabilities_registry_v2.CapabilitiesRegistryNodeOperator, 0)
+	nodes := make([]capabilities_registry_v2.CapabilitiesRegistryNodeParams, 0)
+	capabilities := make([]capabilities_registry_v2.CapabilitiesRegistryCapability, 0)
+	donParams := make([]capabilities_registry_v2.CapabilitiesRegistryNewDONParams, 0)
+
 	// Collect unique capabilities and NOPs
 	capabilityMap := make(map[string]capabilities_registry_v2.CapabilitiesRegistryCapability)
 	nopMap := make(map[string]capabilities_registry_v2.CapabilitiesRegistryNodeOperator)
-	
+
 	for _, don := range d.donsOrderedByID() {
 		// Extract capabilities
 		for _, cap := range don.Capabilities {
@@ -164,7 +164,7 @@ func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) 
 				}
 			}
 		}
-		
+
 		// Extract NOPs and nodes
 		for _, nop := range don.Nops {
 			nopName := nop.Name
@@ -173,23 +173,25 @@ func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) 
 					Admin: common.Address{}, // Will be set by the deployment framework
 					Name:  nopName,
 				}
-				
+
 				// Add nodes for this NOP
 				for _, nodeID := range nop.Nodes {
 					peerID, err := p2pkey.MakePeerID(nodeID)
 					if err != nil {
 						continue // Skip invalid peer IDs
 					}
+					// Safe conversion: len(nops) is controlled and small
+					nodeOperatorID := uint32(len(nops)) //nolint:gosec // G115: len(nops) is small and controlled
 					nodes = append(nodes, capabilities_registry_v2.CapabilitiesRegistryNodeParams{
-						NodeOperatorId:      uint32(len(nops)), // Will be the index of the NOP
-						P2pId:              peerID,
-						Signer:             [32]byte{}, // Will be set by the deployment framework
+						NodeOperatorId:      nodeOperatorID,
+						P2pId:               peerID,
+						Signer:              [32]byte{}, // Will be set by the deployment framework
 						EncryptionPublicKey: [32]byte{}, // Will be set by the deployment framework
 					})
 				}
 			}
 		}
-		
+
 		// Create DON parameters
 		var capConfigs []capabilities_registry_v2.CapabilitiesRegistryCapabilityConfiguration
 		for _, cap := range don.Capabilities {
@@ -206,7 +208,7 @@ func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) 
 				Config:       configBytes,
 			})
 		}
-		
+
 		var donNodes [][32]byte
 		for _, nop := range don.Nops {
 			for _, nodeID := range nop.Nodes {
@@ -217,7 +219,7 @@ func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) 
 				donNodes = append(donNodes, peerID)
 			}
 		}
-		
+
 		donParams = append(donParams, capabilities_registry_v2.CapabilitiesRegistryNewDONParams{
 			Name:                     don.Name,
 			DonFamilies:              []string{}, // Default empty
@@ -229,7 +231,7 @@ func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) 
 			AcceptsWorkflows:         true,
 		})
 	}
-	
+
 	// Convert maps to slices
 	for _, cap := range capabilityMap {
 		capabilities = append(capabilities, cap)
@@ -237,7 +239,7 @@ func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) 
 	for _, nop := range nopMap {
 		nops = append(nops, nop)
 	}
-	
+
 	return cap_reg_v2_seq.ConfigureCapabilitiesRegistryInput{
 		RegistryChainSel: chainSelector,
 		ContractAddress:  contractAddress,

--- a/system-tests/lib/cre/contracts/contracts.go
+++ b/system-tests/lib/cre/contracts/contracts.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
@@ -141,6 +142,112 @@ func (d *dons) allDonCapabilities() []keystone_changeset.DonCapabilities {
 	return out
 }
 
+func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) cap_reg_v2_seq.ConfigureCapabilitiesRegistryInput {
+	var nops []capabilities_registry_v2.CapabilitiesRegistryNodeOperator
+	var nodes []capabilities_registry_v2.CapabilitiesRegistryNodeParams  
+	var capabilities []capabilities_registry_v2.CapabilitiesRegistryCapability
+	var donParams []capabilities_registry_v2.CapabilitiesRegistryNewDONParams
+	
+	// Collect unique capabilities and NOPs
+	capabilityMap := make(map[string]capabilities_registry_v2.CapabilitiesRegistryCapability)
+	nopMap := make(map[string]capabilities_registry_v2.CapabilitiesRegistryNodeOperator)
+	
+	for _, don := range d.donsOrderedByID() {
+		// Extract capabilities
+		for _, cap := range don.Capabilities {
+			capID := fmt.Sprintf("%s@%s", cap.Capability.LabelledName, cap.Capability.Version)
+			if _, exists := capabilityMap[capID]; !exists {
+				capabilityMap[capID] = capabilities_registry_v2.CapabilitiesRegistryCapability{
+					CapabilityId:          capID,
+					ConfigurationContract: common.Address{},
+					Metadata:              []byte("{}"),
+				}
+			}
+		}
+		
+		// Extract NOPs and nodes
+		for _, nop := range don.Nops {
+			nopName := nop.Name
+			if _, exists := nopMap[nopName]; !exists {
+				nopMap[nopName] = capabilities_registry_v2.CapabilitiesRegistryNodeOperator{
+					Admin: common.Address{}, // Will be set by the deployment framework
+					Name:  nopName,
+				}
+				
+				// Add nodes for this NOP
+				for _, nodeID := range nop.Nodes {
+					peerID, err := p2pkey.MakePeerID(nodeID)
+					if err != nil {
+						continue // Skip invalid peer IDs
+					}
+					nodes = append(nodes, capabilities_registry_v2.CapabilitiesRegistryNodeParams{
+						NodeOperatorId:      uint32(len(nops)), // Will be the index of the NOP
+						P2pId:              peerID,
+						Signer:             [32]byte{}, // Will be set by the deployment framework
+						EncryptionPublicKey: [32]byte{}, // Will be set by the deployment framework
+					})
+				}
+			}
+		}
+		
+		// Create DON parameters
+		var capConfigs []capabilities_registry_v2.CapabilitiesRegistryCapabilityConfiguration
+		for _, cap := range don.Capabilities {
+			capID := fmt.Sprintf("%s@%s", cap.Capability.LabelledName, cap.Capability.Version)
+			configBytes := []byte("{}")
+			if cap.Config != nil {
+				// Convert proto config to bytes if needed
+				if protoBytes, err := proto.Marshal(cap.Config); err == nil {
+					configBytes = protoBytes
+				}
+			}
+			capConfigs = append(capConfigs, capabilities_registry_v2.CapabilitiesRegistryCapabilityConfiguration{
+				CapabilityId: capID,
+				Config:       configBytes,
+			})
+		}
+		
+		var donNodes [][32]byte
+		for _, nop := range don.Nops {
+			for _, nodeID := range nop.Nodes {
+				peerID, err := p2pkey.MakePeerID(nodeID)
+				if err != nil {
+					continue
+				}
+				donNodes = append(donNodes, peerID)
+			}
+		}
+		
+		donParams = append(donParams, capabilities_registry_v2.CapabilitiesRegistryNewDONParams{
+			Name:                     don.Name,
+			DonFamilies:              []string{}, // Default empty
+			Config:                   []byte("{}"),
+			CapabilityConfigurations: capConfigs,
+			Nodes:                    donNodes,
+			F:                        don.F,
+			IsPublic:                 true,
+			AcceptsWorkflows:         true,
+		})
+	}
+	
+	// Convert maps to slices
+	for _, cap := range capabilityMap {
+		capabilities = append(capabilities, cap)
+	}
+	for _, nop := range nopMap {
+		nops = append(nops, nop)
+	}
+	
+	return cap_reg_v2_seq.ConfigureCapabilitiesRegistryInput{
+		RegistryChainSel: chainSelector,
+		ContractAddress:  contractAddress,
+		Nops:             nops,
+		Nodes:            nodes,
+		Capabilities:     capabilities,
+		DONs:             donParams,
+	}
+}
+
 func toDons(input cre.ConfigureKeystoneInput) (*dons, error) {
 	dons := &dons{
 		c: make(map[string]donConfig),
@@ -250,14 +357,15 @@ func ConfigureCapabilityRegistry(input cre.ConfigureKeystoneInput, dons *dons) (
 		return &registryWrapper{V1: capReg.Contract}, nil
 	}
 
-	// TODO: Turn don to inputs
+	// Transform dons data to V2 sequence input format
+	v2Input := dons.toV2ConfigureInput(input.ChainSelector, input.CapabilitiesRegistryAddress.Hex())
 	_, err := operations.ExecuteSequence(
 		input.CldEnv.OperationsBundle,
 		cap_reg_v2_seq.ConfigureCapabilitiesRegistry,
 		cap_reg_v2_seq.ConfigureCapabilitiesRegistryDeps{
 			Env: input.CldEnv,
 		},
-		cap_reg_v2_seq.ConfigureCapabilitiesRegistryInput{},
+		v2Input,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to configure capabilities registry")

--- a/system-tests/lib/cre/contracts/contracts.go
+++ b/system-tests/lib/cre/contracts/contracts.go
@@ -1,6 +1,7 @@
 package contracts
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -9,10 +10,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
+
 	"google.golang.org/protobuf/proto"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	"github.com/smartcontractkit/chainlink/system-tests/lib/conversions"
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/data-feeds/generated/data_feeds_cache"
 	kcr "github.com/smartcontractkit/chainlink-evm/gethwrappers/keystone/generated/capabilities_registry_1_1_0"
@@ -37,7 +40,10 @@ import (
 	capabilities_registry_v2 "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/capabilities_registry_wrapper_v2"
 	cap_reg_v2_seq "github.com/smartcontractkit/chainlink/deployment/cre/capabilities_registry/v2/changeset/sequences"
 	crenode "github.com/smartcontractkit/chainlink/system-tests/lib/cre/don/node"
+	syncer_v2 "github.com/smartcontractkit/chainlink/v2/core/services/registrysyncer/v2"
 )
+
+const DonFamily = "test-don-family"
 
 type donConfig struct {
 	id uint32 // the DON id as registered in the capabilities registry
@@ -154,13 +160,17 @@ func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) 
 
 	for _, don := range d.donsOrderedByID() {
 		// Extract capabilities
-		for _, cap := range don.Capabilities {
-			capID := fmt.Sprintf("%s@%s", cap.Capability.LabelledName, cap.Capability.Version)
+		for _, myCap := range don.Capabilities {
+			capID := fmt.Sprintf("%s@%s", myCap.Capability.LabelledName, myCap.Capability.Version)
 			if _, exists := capabilityMap[capID]; !exists {
+				metadataJSON, _ := json.Marshal(syncer_v2.CapabilityMetadata{
+					CapabilityType: myCap.Capability.CapabilityType,
+					ResponseType:   myCap.Capability.ResponseType,
+				})
 				capabilityMap[capID] = capabilities_registry_v2.CapabilitiesRegistryCapability{
 					CapabilityId:          capID,
 					ConfigurationContract: common.Address{},
-					Metadata:              []byte("{}"),
+					Metadata:              metadataJSON,
 				}
 			}
 		}
@@ -181,7 +191,7 @@ func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) 
 						continue // Skip invalid peer IDs
 					}
 					// Safe conversion: len(nops) is controlled and small
-					nodeOperatorID := uint32(len(nops)) //nolint:gosec // G115: len(nops) is small and controlled
+					nodeOperatorID := conversions.MustSafeUint32(len(nops))
 					nodes = append(nodes, capabilities_registry_v2.CapabilitiesRegistryNodeParams{
 						NodeOperatorId:      nodeOperatorID,
 						P2pId:               peerID,
@@ -222,7 +232,7 @@ func (d *dons) toV2ConfigureInput(chainSelector uint64, contractAddress string) 
 
 		donParams = append(donParams, capabilities_registry_v2.CapabilitiesRegistryNewDONParams{
 			Name:                     don.Name,
-			DonFamilies:              []string{}, // Default empty
+			DonFamilies:              []string{DonFamily}, // Default empty
 			Config:                   []byte("{}"),
 			CapabilityConfigurations: capConfigs,
 			Nodes:                    donNodes,


### PR DESCRIPTION
[CRE-829](https://smartcontract-it.atlassian.net/browse/CRE-829)

[CRE-829]: https://smartcontract-it.atlassian.net/browse/CRE-829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ