### PR TITLE
fix: add missing checkout step to deploy-core job in build-publish workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -195,6 +195,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
       - name: Deploy core
         # Only deploy if this is a final release (not a prerelease).
         if: ${{ needs.checks.outputs.is-release == 'true' }}


### PR DESCRIPTION
## Problem
GitHub Actions workflows fail with:
`Can't find 'action.yml' under '/home/runner/work/chainlink/chainlink/.github/actions/deploy-image'`

This happens because deploy jobs don't check out the repo before invoking the local action.

## Solution
Added `actions/checkout@v5` step before the `deploy-image` action in the `deploy-core` job of `.github/workflows/build-publish.yml`.

## Changes
- ✅ Added `actions/checkout@v5` step to `deploy-core` job in `build-publish.yml`
- ✅ Verified `docker-build.yml` already has correct checkout steps
- ✅ Preserved all existing job names, secrets, and inputs

## Testing
This fix ensures the repository is checked out before calling the local `deploy-image` action, resolving the missing `action.yml` error.