### PR TITLE
Add checkout repository step before deploy-image action calls

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -195,7 +195,10 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Deploy core
         # Only deploy if this is a final release (not a prerelease).
         if: ${{ needs.checks.outputs.is-release == 'true' }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -249,7 +249,10 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Deploy
         uses: ./.github/actions/deploy-image
         with:
@@ -271,7 +274,10 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Deploy
         uses: ./.github/actions/deploy-image
         with:


### PR DESCRIPTION
## Summary

This PR updates checkout repository steps before each `deploy-image` action call in GitHub Actions workflows to ensure the action has proper repository context.

## Changes Made

### build-publish.yml
- **`deploy-core` job**: Updated existing checkout step to use proper format with name and fetch-depth

### docker-build.yml  
- **`deploy-nightly-core` job**: Updated existing checkout step to use proper format with name and fetch-depth
- **`deploy-nightly-ccip` job**: Updated existing checkout step to use proper format with name and fetch-depth

## Format Applied

Each checkout step now uses the specified format:
```yaml
- name: Checkout repository
  uses: actions/checkout@v4
  with:
    fetch-depth: 0
```

## Details
- All checkout steps are placed directly before each `deploy-image` call
- All checkout steps are within the same `steps:` list as the `deploy-image` call
- Uses `actions/checkout@v4` with `fetch-depth: 0` for full git history access
- No global or top-level changes were made
- All other workflow content remains unchanged

This ensures the `deploy-image` action has access to the full repository context it needs to function properly.