### PR TITLE
enable debugging of core nodes in localcre

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -15,6 +15,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 COPY . .
 
+# Install Delve for debugging with cache mounts
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go install github.com/go-delve/delve/cmd/dlv@v1.24.2
+
 # Flag to control installation of private plugins (default: true).
 ARG CL_INSTALL_PRIVATE_PLUGINS=true
 # Flag to control installation of testing plugins (default: false).
@@ -90,6 +95,9 @@ ENV CL_CHAIN_DEFAULTS=${CL_CHAIN_DEFAULTS}
 COPY --from=buildgo /gobins/ /usr/local/bin/
 # Copy shared libraries from the build stage.
 COPY --from=buildgo /tmp/lib /usr/lib/
+# Copy dlv (Delve debugger) from the build stage.
+COPY --from=buildgo /go/bin/dlv /usr/local/bin/
+
 
 WORKDIR /home/${CHAINLINK_USER}
 

--- a/core/scripts/cre/environment/README.md
+++ b/core/scripts/cre/environment/README.md
@@ -183,6 +183,13 @@ ctf bs r
 ```
 ---
 
+## Debugging core nodes 
+Before start the environment set the `CTF_CLNODE_DLV` environment variable to `true`
+```bash
+export CTF_CLNODE_DLV="true"
+```
+Nodes will open a Delve server on port `40000 + node index` (e.g. first node will be on `40000`, second on `40001` etc). You can connect to it using your IDE or `dlv` CLI.
+
 ## Workflow Commands
 
 The environment provides workflow management commands defined in `core/scripts/cre/environment/environment/workflow.go`:


### PR DESCRIPTION
updates the docker build to include the dlv debugger and localcre README with instructions on how to debug core nodes running in  localcre.   Support for debugging capabilities in localcre to follow.
