### PR TITLE
fix(workflow/syncer/v2): wait for DON before init reader

### DIFF
--- a/.changeset/rare-pianos-end.md
+++ b/.changeset/rare-pianos-end.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal #bugfix Wait for the DON on a workflow node before starting a contract reader

--- a/core/services/workflows/syncer/v2/workflow_registry.go
+++ b/core/services/workflows/syncer/v2/workflow_registry.go
@@ -16,7 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
-	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v2"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -171,7 +170,7 @@ func (w *workflowRegistry) Start(_ context.Context) error {
 
 		var (
 			initDoneCh = make(chan struct{})
-			reader     commontypes.ContractReader
+			reader     types.ContractReader
 			err        error
 		)
 
@@ -186,6 +185,10 @@ func (w *workflowRegistry) Start(_ context.Context) error {
 				return
 			}
 
+			// Async initialization of contract reader because there is an on-chain
+			// call dependency.  Blocking on initialization results in a
+			// deadlock.  Instead wait until the node has identified it's DON
+			// as a proxy for a DON and on-chain ready state .
 			reader, err = w.newWorkflowRegistryContractReader(ctx)
 			if err != nil {
 				w.lggr.Criticalf("contract reader unavailable : %s", err)


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

V2 WF Reg Syncer failed to start because the contract reader was not ready.  This change waits for the DON and the contract reader before starting sync loops.

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
