### PR TITLE
[PRIV-176] Support Gateway job in ProposeJobSpec changeset

### DIFF
--- a/deployment/cre/jobs/evm.go
+++ b/deployment/cre/jobs/evm.go
@@ -7,28 +7,29 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
+	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
 	job_types "github.com/smartcontractkit/chainlink/deployment/cre/jobs/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 )
 
 func verifyEVMJobSpecInputs(inputs job_types.JobSpecInput) error {
-	if v, ok := inputs["command"]; !ok {
+	scj := &pkg.StandardCapabilityJob{}
+	if err := inputs.UnmarshalTo(scj); err != nil {
+		return errors.New("failed to unmarshal job spec input to StandardCapabilityJob: " + err.Error())
+	}
+
+	if strings.TrimSpace(scj.Command) == "" {
 		return errors.New("command is required and must be a string")
-	} else if s, ok := v.(string); !ok || strings.TrimSpace(s) == "" {
-		return errors.New("command is required and must be a string")
 	}
 
-	if v, ok := inputs["config"]; !ok {
-		return errors.New("config is required and must be a string")
-	} else if s, ok := v.(string); !ok || strings.TrimSpace(s) == "" {
+	if strings.TrimSpace(scj.Config) == "" {
 		return errors.New("config is required and must be a string")
 	}
 
-	of, err := job_types.DecodeOracleFactory(inputs)
-	if err != nil {
-		return err
+	of := scj.OracleFactory
+	if of == nil {
+		return errors.New("oracleFactory is required")
 	}
-
 	if !of.Enabled {
 		return errors.New("oracleFactory.enabled must be true for EVM jobs")
 	}
@@ -68,7 +69,7 @@ func verifyEVMJobSpecInputs(inputs job_types.JobSpecInput) error {
 		return errors.New("oracleFactory.onchainSigningStrategy.strategyName is required")
 	}
 
-	if of.OnchainSigningStrategy.Config == nil {
+	if len(of.OnchainSigningStrategy.Config) == 0 {
 		return errors.New("oracleFactory.onchainSigningStrategy.config is required")
 	}
 	if v, ok := of.OnchainSigningStrategy.Config["evm"]; !ok || strings.TrimSpace(v) == "" {

--- a/deployment/cre/jobs/operations/propose_gateway_job.go
+++ b/deployment/cre/jobs/operations/propose_gateway_job.go
@@ -1,0 +1,173 @@
+package operations
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
+	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
+
+	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
+	"github.com/smartcontractkit/chainlink/deployment/cre/pkg/offchain"
+)
+
+type ProposeGatewayJobInput struct {
+	Domain                  string
+	DONFilters              []offchain.TargetDONFilter
+	DONs                    []DON             `yaml:"dons"`
+	GatewayKeyChainSelector pkg.ChainSelector `yaml:"gateway_key_chain_selector"`
+	JobLabels               map[string]string
+}
+
+type DON struct {
+	Name     string
+	Handlers []string
+}
+
+type ProposeGatewayJobDeps struct {
+	Env cldf.Environment
+}
+
+type ProposeGatewayJobOutput struct {
+	Specs map[string][]string
+}
+
+var ProposeGatewayJob = operations.NewOperation[ProposeGatewayJobInput, ProposeGatewayJobOutput, ProposeGatewayJobDeps](
+	"propose-gateway-job-op",
+	semver.MustParse("1.0.0"),
+	"Propose Gateway Job",
+	func(b operations.Bundle, deps ProposeGatewayJobDeps, input ProposeGatewayJobInput) (ProposeGatewayJobOutput, error) {
+		targetDONs := make([]pkg.TargetDON, 0)
+		for _, ad := range input.DONs {
+			filter := offchain.TargetDONFilter{
+				Key:   offchain.FilterKeyDONName,
+				Value: ad.Name,
+			}
+			nodes, err := pkg.FetchNodeChainConfigsFromJD(deps.Env.GetContext(), deps.Env, filter)
+			if err != nil {
+				return ProposeGatewayJobOutput{}, err
+			}
+
+			fam, chainID, err := parseSelector(uint64(input.GatewayKeyChainSelector))
+			if err != nil {
+				return ProposeGatewayJobOutput{}, err
+			}
+
+			var members []pkg.TargetDONMember
+			for _, n := range nodes {
+				var found bool
+				for _, cc := range n.ChainConfigs {
+					if cc.Chain.Id == chainID && cc.Chain.Type == fam {
+						members = append(members, pkg.TargetDONMember{
+							Address: cc.AccountAddress,
+							Name:    fmt.Sprintf("DON %s - Node %s", ad.Name, n.NodeID),
+						})
+						found = true
+
+						break
+					}
+				}
+
+				if !found {
+					return ProposeGatewayJobOutput{}, fmt.Errorf("could not find key belonging to chain id %s", chainID)
+				}
+			}
+
+			td := pkg.TargetDON{
+				ID:       ad.Name,
+				Members:  members,
+				Handlers: ad.Handlers,
+			}
+
+			targetDONs = append(targetDONs, td)
+		}
+
+		gj := pkg.GatewayJob{
+			JobName:    "CRE Gateway",
+			TargetDONs: targetDONs,
+		}
+
+		err := gj.Validate()
+		if err != nil {
+			return ProposeGatewayJobOutput{}, err
+		}
+
+		spec, err := gj.Resolve()
+		if err != nil {
+			return ProposeGatewayJobOutput{}, err
+		}
+
+		nodes, err := pkg.FetchNodesFromJD(b.GetContext(), deps.Env, pkg.FetchNodesRequest{
+			Domain:  input.Domain,
+			Filters: input.DONFilters,
+		})
+		if err != nil {
+			return ProposeGatewayJobOutput{}, fmt.Errorf("failed to fetch nodes from JD: %w", err)
+		}
+
+		if len(nodes) == 0 {
+			return ProposeGatewayJobOutput{}, fmt.Errorf("no nodes found for domain %s with filters %+v", input.Domain, input.DONFilters)
+		}
+
+		labels := make([]*ptypes.Label, 0, len(input.JobLabels))
+		for k, v := range input.JobLabels {
+			newVal := v
+			labels = append(labels, &ptypes.Label{
+				Key:   k,
+				Value: &newVal,
+			})
+		}
+
+		output := ProposeGatewayJobOutput{
+			Specs: make(map[string][]string),
+		}
+		for _, n := range nodes {
+			_, err := deps.Env.Offchain.ProposeJob(b.GetContext(), &jobv1.ProposeJobRequest{
+				NodeId: n.GetId(),
+				Spec:   spec,
+				Labels: labels,
+			})
+			if err != nil {
+				return ProposeGatewayJobOutput{}, fmt.Errorf("error proposing job to node %s spec %s : %w", n.GetId(), spec, err)
+			}
+
+			output.Specs[n.GetId()] = append(output.Specs[n.GetId()], spec)
+		}
+
+		return output, nil
+	},
+)
+
+func parseSelector(sel uint64) (nodev1.ChainType, string, error) {
+	fam, err := chainsel.GetSelectorFamily(sel)
+	if err != nil {
+		return nodev1.ChainType_CHAIN_TYPE_UNSPECIFIED, "", err
+	}
+
+	var ct nodev1.ChainType
+	switch fam {
+	case chainsel.FamilyEVM:
+		ct = nodev1.ChainType_CHAIN_TYPE_EVM
+	case chainsel.FamilySolana:
+		ct = nodev1.ChainType_CHAIN_TYPE_SOLANA
+	case chainsel.FamilyStarknet:
+		ct = nodev1.ChainType_CHAIN_TYPE_STARKNET
+	case chainsel.FamilyAptos:
+		ct = nodev1.ChainType_CHAIN_TYPE_APTOS
+	default:
+		return nodev1.ChainType_CHAIN_TYPE_UNSPECIFIED, "", fmt.Errorf("unsupported chain type: %s", fam)
+	}
+
+	chainID, err := chainsel.GetChainIDFromSelector(sel)
+	if err != nil {
+		return nodev1.ChainType_CHAIN_TYPE_UNSPECIFIED, "", err
+	}
+
+	return ct, chainID, nil
+}

--- a/deployment/cre/jobs/operations/propose_job_spec.go
+++ b/deployment/cre/jobs/operations/propose_job_spec.go
@@ -48,7 +48,6 @@ var ProposeJobSpec = operations.NewOperation[ProposeJobSpecInput, ProposeJobSpec
 			DONName:   input.DONName,
 			Env:       deps.Env.Name,
 			JobLabels: input.JobLabels,
-			DONFilter: &node.ListNodesRequest_Filter{},
 		}
 
 		nodeType := PluginNodeType
@@ -65,7 +64,7 @@ var ProposeJobSpec = operations.NewOperation[ProposeJobSpecInput, ProposeJobSpec
 			},
 		}
 		for _, f := range input.DONFilters {
-			filter.Selectors = append(filter.Selectors, f.ToJDSelector())
+			filter = f.AddToFilter(filter)
 		}
 
 		req.DONFilter = filter

--- a/deployment/cre/jobs/operations/propose_ocr3_job.go
+++ b/deployment/cre/jobs/operations/propose_ocr3_job.go
@@ -58,9 +58,9 @@ var ProposeOCR3Job = operations.NewSequence[ProposeOCR3JobInput, ProposeOCR3JobO
 			return ProposeOCR3JobOutput{}, fmt.Errorf("failed to fetch nodes from JD: %w", err)
 		}
 
-		nodeIDToP2PID := make(map[string]string)
+		nodeToCSAKey := make(map[string]string)
 		for _, n := range nodes {
-			nodeIDToP2PID[n.Id] = offchain.GetP2pLabel(n.GetLabels())
+			nodeToCSAKey[n.Id] = n.GetPublicKey()
 		}
 
 		specs, err := pkg.BuildOCR3JobConfigSpecs(
@@ -78,8 +78,8 @@ var ProposeOCR3Job = operations.NewSequence[ProposeOCR3JobInput, ProposeOCR3JobO
 			// Let's limit the target to the specific node for this spec.
 			filters := []offchain.TargetDONFilter{
 				{
-					Key:   offchain.P2pIDLabel,
-					Value: nodeIDToP2PID[spec.NodeID],
+					Key:   offchain.FilterKeyCSAPublicKey,
+					Value: nodeToCSAKey[spec.NodeID],
 				},
 			}
 			filters = append(filters, input.DONFilters...)

--- a/deployment/cre/jobs/pkg/gateway_job.go
+++ b/deployment/cre/jobs/pkg/gateway_job.go
@@ -1,0 +1,238 @@
+package pkg
+
+import (
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/pelletier/go-toml/v2"
+)
+
+const (
+	GatewayHandlerTypeWebAPICapabilities = "web-api-capabilities"
+	GatewayHandlerTypeHTTPCapabilities   = "http-capabilities"
+	GatewayHandlerTypeVault              = "vault"
+)
+
+type TargetDONMember struct {
+	Address string
+	Name    string
+}
+
+type TargetDON struct {
+	ID       string
+	Members  []TargetDONMember
+	Handlers []string
+}
+
+type GatewayJob struct {
+	TargetDONs    []TargetDON
+	JobName       string
+	ExternalJobID string
+}
+
+func (g GatewayJob) Validate() error {
+	if g.JobName == "" {
+		return errors.New("must provide job name")
+	}
+
+	if len(g.TargetDONs) == 0 {
+		return errors.New("must provide at least one target DON")
+	}
+
+	return nil
+}
+
+func (g GatewayJob) Resolve() (string, error) {
+	externalJobID := g.ExternalJobID
+	if externalJobID == "" {
+		externalJobID = uuid.NewSHA1(uuid.Nil, []byte(g.JobName)).String()
+	}
+
+	dons := []don{}
+	for _, targetDON := range g.TargetDONs {
+		ms := []member{}
+		for _, mem := range targetDON.Members {
+			ms = append(ms, member(mem))
+		}
+
+		hs := []handler{}
+		for _, ht := range targetDON.Handlers {
+			switch ht {
+			case GatewayHandlerTypeWebAPICapabilities:
+				hs = append(hs, newDefaultWebAPICapabilitiesHandler())
+			case GatewayHandlerTypeVault:
+				hs = append(hs, newDefaultVaultHandler())
+			case GatewayHandlerTypeHTTPCapabilities:
+				// TODO: implement
+			default:
+				return "", errors.New("unknown handler type: " + ht)
+			}
+		}
+
+		d := don{
+			DonID:    targetDON.ID,
+			Members:  ms,
+			Handlers: hs,
+		}
+		dons = append(dons, d)
+	}
+
+	config := gatewayConfig{
+		ConnectionManagerConfig: connectionManagerConfig{
+			AuthChallengeLen:          10,
+			AuthGatewayID:             g.JobName,
+			AuthTimestampToleranceSec: 5,
+			HeartbeatIntervalSec:      20,
+		},
+		NodeServerConfig: nodeServerConfig{
+			HandshakeTimeoutMillis: 1_000,
+			MaxRequestBytes:        100_000,
+			Path:                   "/node",
+			Port:                   5_003,
+			ReadTimeoutMillis:      1_000,
+			RequestTimeoutMillis:   10_000,
+			WriteTimeoutMillis:     1_000,
+		},
+		UserServerConfig: userServerConfig{
+			ContentTypeHeader:    "application/jsonrpc",
+			MaxRequestBytes:      100_000,
+			Path:                 "/",
+			Port:                 5_002,
+			ReadTimeoutMillis:    80_000,
+			RequestTimeoutMillis: 80_000,
+			WriteTimeoutMillis:   80_000,
+		},
+		HTTPClientConfig: httpClientConfig{
+			MaxResponseBytes: 50_000_000,
+		},
+		Dons: dons,
+	}
+
+	spec := &gatewaySpec{
+		Type:              "gateway",
+		SchemaVersion:     1,
+		Name:              g.JobName,
+		ExternalJobID:     externalJobID,
+		ForwardingAllowed: false,
+		GatewayConfig:     config,
+	}
+	b, err := toml.Marshal(spec)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
+type webAPICapabilitiesHandlerConfig struct {
+	MaxAllowedMessageAgeSec int                   `toml:"maxAllowedMessageAgeSec"`
+	NodeRateLimiter         nodeRateLimiterConfig `toml:"NodeRateLimiter"`
+}
+
+func newDefaultWebAPICapabilitiesHandler() handler {
+	return handler{
+		Name: GatewayHandlerTypeWebAPICapabilities,
+		Config: webAPICapabilitiesHandlerConfig{
+			MaxAllowedMessageAgeSec: 1_000,
+			NodeRateLimiter: nodeRateLimiterConfig{
+				GlobalBurst:    10,
+				GlobalRPS:      50,
+				PerSenderBurst: 10,
+				PerSenderRPS:   10,
+			},
+		},
+	}
+}
+
+type vaultHandlerConfig struct {
+	RequestTimeoutSec int                   `toml:"requestTimeoutSec"`
+	NodeRateLimiter   nodeRateLimiterConfig `toml:"NodeRateLimiter"`
+}
+
+func newDefaultVaultHandler() handler {
+	return handler{
+		Name:        "vault",
+		ServiceName: "vault",
+		Config: vaultHandlerConfig{
+			RequestTimeoutSec: 70,
+			NodeRateLimiter: nodeRateLimiterConfig{
+				GlobalBurst:    10,
+				GlobalRPS:      50,
+				PerSenderBurst: 10,
+				PerSenderRPS:   10,
+			},
+		},
+	}
+}
+
+type gatewaySpec struct {
+	Type              string        `toml:"type"`
+	SchemaVersion     int           `toml:"schemaVersion"`
+	Name              string        `toml:"name"`
+	ExternalJobID     string        `toml:"externalJobID"`
+	ForwardingAllowed bool          `toml:"forwardingAllowed"`
+	GatewayConfig     gatewayConfig `toml:"gatewayConfig"`
+}
+
+type gatewayConfig struct {
+	ConnectionManagerConfig connectionManagerConfig `toml:"ConnectionManagerConfig"`
+	Dons                    []don                   `toml:"Dons"`
+	HTTPClientConfig        httpClientConfig        `toml:"HTTPClientConfig"`
+	NodeServerConfig        nodeServerConfig        `toml:"NodeServerConfig"`
+	UserServerConfig        userServerConfig        `toml:"UserServerConfig"`
+}
+
+type connectionManagerConfig struct {
+	AuthChallengeLen          int    `toml:"AuthChallengeLen"`
+	AuthGatewayID             string `toml:"AuthGatewayId"`
+	AuthTimestampToleranceSec int    `toml:"AuthTimestampToleranceSec"`
+	HeartbeatIntervalSec      int    `toml:"HeartbeatIntervalSec"`
+}
+
+type don struct {
+	DonID    string    `toml:"DonId"`
+	Handlers []handler `toml:"Handlers"`
+	Members  []member  `toml:"Members"`
+}
+
+type handler struct {
+	Name        string `toml:"Name"`
+	ServiceName string `toml:"ServiceName,omitempty"`
+	Config      any    `toml:"Config"`
+}
+
+type member struct {
+	Address string `toml:"Address"`
+	Name    string `toml:"Name"`
+}
+
+type httpClientConfig struct {
+	MaxResponseBytes int `toml:"MaxResponseBytes"`
+}
+
+type nodeServerConfig struct {
+	HandshakeTimeoutMillis int    `toml:"HandshakeTimeoutMillis"`
+	MaxRequestBytes        int    `toml:"MaxRequestBytes"`
+	Path                   string `toml:"Path"`
+	Port                   int    `toml:"Port"`
+	ReadTimeoutMillis      int    `toml:"ReadTimeoutMillis"`
+	RequestTimeoutMillis   int    `toml:"RequestTimeoutMillis"`
+	WriteTimeoutMillis     int    `toml:"WriteTimeoutMillis"`
+}
+
+type userServerConfig struct {
+	ContentTypeHeader    string `toml:"ContentTypeHeader"`
+	MaxRequestBytes      int    `toml:"MaxRequestBytes"`
+	Path                 string `toml:"Path"`
+	Port                 int    `toml:"Port"`
+	ReadTimeoutMillis    int    `toml:"ReadTimeoutMillis"`
+	RequestTimeoutMillis int    `toml:"RequestTimeoutMillis"`
+	WriteTimeoutMillis   int    `toml:"WriteTimeoutMillis"`
+}
+
+type nodeRateLimiterConfig struct {
+	GlobalBurst    int `toml:"globalBurst"`
+	GlobalRPS      int `toml:"globalRPS"`
+	PerSenderBurst int `toml:"perSenderBurst"`
+	PerSenderRPS   int `toml:"perSenderRPS"`
+}

--- a/deployment/cre/jobs/pkg/gateway_job_test.go
+++ b/deployment/cre/jobs/pkg/gateway_job_test.go
@@ -1,0 +1,345 @@
+package pkg
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGateway_Validate(t *testing.T) {
+	t.Parallel()
+
+	g := GatewayJob{}
+	require.ErrorContains(t, g.Validate(), "must provide job name")
+
+	g.JobName = "AGatewayJob"
+	require.ErrorContains(t, g.Validate(), "must provide at least one target DON")
+}
+
+const (
+	expected = `type = 'gateway'
+schemaVersion = 1
+name = 'Gateway1'
+externalJobID = '4657f08a-e8cd-526f-9c13-66bbef7e4e03'
+forwardingAllowed = false
+
+[gatewayConfig]
+[gatewayConfig.ConnectionManagerConfig]
+AuthChallengeLen = 10
+AuthGatewayId = 'Gateway1'
+AuthTimestampToleranceSec = 5
+HeartbeatIntervalSec = 20
+
+[[gatewayConfig.Dons]]
+DonId = 'workflow_1'
+
+[[gatewayConfig.Dons.Handlers]]
+Name = 'web-api-capabilities'
+
+[gatewayConfig.Dons.Handlers.Config]
+maxAllowedMessageAgeSec = 1000
+
+[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+globalBurst = 10
+globalRPS = 50
+perSenderBurst = 10
+perSenderRPS = 10
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xabc'
+Name = 'Node 1'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xdef'
+Name = 'Node 2'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xghi'
+Name = 'Node 3'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xjkl'
+Name = 'Node 4'
+
+[[gatewayConfig.Dons]]
+DonId = 'workflow_2'
+
+[[gatewayConfig.Dons.Handlers]]
+Name = 'web-api-capabilities'
+
+[gatewayConfig.Dons.Handlers.Config]
+maxAllowedMessageAgeSec = 1000
+
+[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+globalBurst = 10
+globalRPS = 50
+perSenderBurst = 10
+perSenderRPS = 10
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2abc'
+Name = 'Node 1'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2def'
+Name = 'Node 2'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2ghi'
+Name = 'Node 3'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2jkl'
+Name = 'Node 4'
+
+[gatewayConfig.HTTPClientConfig]
+MaxResponseBytes = 50000000
+
+[gatewayConfig.NodeServerConfig]
+HandshakeTimeoutMillis = 1000
+MaxRequestBytes = 100000
+Path = '/node'
+Port = 5003
+ReadTimeoutMillis = 1000
+RequestTimeoutMillis = 10000
+WriteTimeoutMillis = 1000
+
+[gatewayConfig.UserServerConfig]
+ContentTypeHeader = 'application/jsonrpc'
+MaxRequestBytes = 100000
+Path = '/'
+Port = 5002
+ReadTimeoutMillis = 80000
+RequestTimeoutMillis = 80000
+WriteTimeoutMillis = 80000
+`
+
+	expectedWithVault = `type = 'gateway'
+schemaVersion = 1
+name = 'Gateway1'
+externalJobID = '4657f08a-e8cd-526f-9c13-66bbef7e4e03'
+forwardingAllowed = false
+
+[gatewayConfig]
+[gatewayConfig.ConnectionManagerConfig]
+AuthChallengeLen = 10
+AuthGatewayId = 'Gateway1'
+AuthTimestampToleranceSec = 5
+HeartbeatIntervalSec = 20
+
+[[gatewayConfig.Dons]]
+DonId = 'workflow_1'
+
+[[gatewayConfig.Dons.Handlers]]
+Name = 'web-api-capabilities'
+
+[gatewayConfig.Dons.Handlers.Config]
+maxAllowedMessageAgeSec = 1000
+
+[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+globalBurst = 10
+globalRPS = 50
+perSenderBurst = 10
+perSenderRPS = 10
+
+[[gatewayConfig.Dons.Handlers]]
+Name = 'vault'
+ServiceName = 'vault'
+
+[gatewayConfig.Dons.Handlers.Config]
+requestTimeoutSec = 70
+
+[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+globalBurst = 10
+globalRPS = 50
+perSenderBurst = 10
+perSenderRPS = 10
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xabc'
+Name = 'Node 1'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xdef'
+Name = 'Node 2'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xghi'
+Name = 'Node 3'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0xjkl'
+Name = 'Node 4'
+
+[[gatewayConfig.Dons]]
+DonId = 'workflow_2'
+
+[[gatewayConfig.Dons.Handlers]]
+Name = 'web-api-capabilities'
+
+[gatewayConfig.Dons.Handlers.Config]
+maxAllowedMessageAgeSec = 1000
+
+[gatewayConfig.Dons.Handlers.Config.NodeRateLimiter]
+globalBurst = 10
+globalRPS = 50
+perSenderBurst = 10
+perSenderRPS = 10
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2abc'
+Name = 'Node 1'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2def'
+Name = 'Node 2'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2ghi'
+Name = 'Node 3'
+
+[[gatewayConfig.Dons.Members]]
+Address = '0x2jkl'
+Name = 'Node 4'
+
+[gatewayConfig.HTTPClientConfig]
+MaxResponseBytes = 50000000
+
+[gatewayConfig.NodeServerConfig]
+HandshakeTimeoutMillis = 1000
+MaxRequestBytes = 100000
+Path = '/node'
+Port = 5003
+ReadTimeoutMillis = 1000
+RequestTimeoutMillis = 10000
+WriteTimeoutMillis = 1000
+
+[gatewayConfig.UserServerConfig]
+ContentTypeHeader = 'application/jsonrpc'
+MaxRequestBytes = 100000
+Path = '/'
+Port = 5002
+ReadTimeoutMillis = 80000
+RequestTimeoutMillis = 80000
+WriteTimeoutMillis = 80000
+`
+)
+
+func TestGateway_Resolve(t *testing.T) {
+	t.Parallel()
+
+	g := GatewayJob{
+		JobName: "Gateway1",
+		TargetDONs: []TargetDON{
+			{
+				ID:       "workflow_1",
+				Handlers: []string{GatewayHandlerTypeWebAPICapabilities},
+				Members: []TargetDONMember{
+					{
+						Address: "0xabc",
+						Name:    "Node 1",
+					},
+					{
+						Address: "0xdef",
+						Name:    "Node 2",
+					},
+					{
+						Address: "0xghi",
+						Name:    "Node 3",
+					},
+					{
+						Address: "0xjkl",
+						Name:    "Node 4",
+					},
+				},
+			},
+			{
+				ID:       "workflow_2",
+				Handlers: []string{GatewayHandlerTypeWebAPICapabilities},
+				Members: []TargetDONMember{
+					{
+						Address: "0x2abc",
+						Name:    "Node 1",
+					},
+					{
+						Address: "0x2def",
+						Name:    "Node 2",
+					},
+					{
+						Address: "0x2ghi",
+						Name:    "Node 3",
+					},
+					{
+						Address: "0x2jkl",
+						Name:    "Node 4",
+					},
+				},
+			},
+		},
+	}
+
+	spec, err := g.Resolve()
+	require.NoError(t, err)
+	assert.Equal(t, expected, spec)
+}
+
+func TestGateway_Resolve_WithVaultHandler(t *testing.T) {
+	t.Parallel()
+
+	g := GatewayJob{
+		JobName: "Gateway1",
+		TargetDONs: []TargetDON{
+			{
+				ID:       "workflow_1",
+				Handlers: []string{GatewayHandlerTypeWebAPICapabilities, GatewayHandlerTypeVault},
+				Members: []TargetDONMember{
+					{
+						Address: "0xabc",
+						Name:    "Node 1",
+					},
+					{
+						Address: "0xdef",
+						Name:    "Node 2",
+					},
+					{
+						Address: "0xghi",
+						Name:    "Node 3",
+					},
+					{
+						Address: "0xjkl",
+						Name:    "Node 4",
+					},
+				},
+			},
+			{
+				ID:       "workflow_2",
+				Handlers: []string{GatewayHandlerTypeWebAPICapabilities},
+				Members: []TargetDONMember{
+					{
+						Address: "0x2abc",
+						Name:    "Node 1",
+					},
+					{
+						Address: "0x2def",
+						Name:    "Node 2",
+					},
+					{
+						Address: "0x2ghi",
+						Name:    "Node 3",
+					},
+					{
+						Address: "0x2jkl",
+						Name:    "Node 4",
+					},
+				},
+			},
+		},
+	}
+
+	spec, err := g.Resolve()
+	fmt.Println(spec)
+	require.NoError(t, err)
+	assert.Equal(t, expectedWithVault, spec)
+}

--- a/deployment/cre/jobs/pkg/jobs.go
+++ b/deployment/cre/jobs/pkg/jobs.go
@@ -27,14 +27,12 @@ func ProposeJob(ctx context.Context, e cldf.Environment, req ProposeJobRequest) 
 
 	jobSpecs := map[string][]string{}
 	for _, node := range nodes {
-		p2pID := offchain.GetP2pLabel(node.GetLabels())
-
 		e.Logger.Debugw("Proposing job", logLabels(req, node)...)
 		offchainReq := offchain.ProposeJobRequest{
 			Job:            req.Spec,
 			Domain:         offchain.ProductLabel,
 			Environment:    req.Env,
-			NodeLabels:     map[string]string{offchain.P2pIDLabel: p2pID},
+			PublicKeys:     []string{node.GetPublicKey()},
 			JobLabels:      req.JobLabels,
 			OffchainClient: e.Offchain,
 			Lggr:           e.Logger,
@@ -52,15 +50,13 @@ func ProposeJob(ctx context.Context, e cldf.Environment, req ProposeJobRequest) 
 }
 
 func logLabels(req ProposeJobRequest, node *nodeapiv1.Node) []any {
-	p2pID := offchain.GetP2pLabel(node.GetLabels())
-
 	labels := []any{
 		"nodeName",
 		node.Name,
 		"nodeID",
 		node.Id,
-		"p2pID",
-		p2pID,
+		"publicKey",
+		node.PublicKey,
 		"target DON",
 		req.DONName,
 	}

--- a/deployment/cre/jobs/pkg/nodes.go
+++ b/deployment/cre/jobs/pkg/nodes.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"context"
+	"fmt"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
@@ -32,8 +33,54 @@ func FetchNodesFromJD(ctx context.Context, e cldf.Environment, req FetchNodesReq
 	}
 
 	for _, f := range req.Filters {
-		filter.Selectors = append(filter.Selectors, f.ToJDSelector())
+		filter = f.AddToFilter(filter)
 	}
 
 	return offchain.FetchNodesFromJD(ctx, e.Offchain, filter)
+}
+
+type FetchNodeChainConfigsResponse struct {
+	NodeID       string
+	ChainConfigs []*nodev1.ChainConfig
+}
+
+func FetchNodeChainConfigsFromJD(ctx context.Context, e cldf.Environment, filter offchain.TargetDONFilter) ([]FetchNodeChainConfigsResponse, error) {
+	resp, err := e.Offchain.ListNodes(ctx, &nodev1.ListNodesRequest{Filter: filter.ToListFilter()})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	nodeIDs := []string{}
+	for _, n := range resp.Nodes {
+		nodeIDs = append(nodeIDs, n.Id)
+	}
+
+	chainConfigResp, err := e.Offchain.ListNodeChainConfigs(
+		ctx,
+		&nodev1.ListNodeChainConfigsRequest{
+			Filter: &nodev1.ListNodeChainConfigsRequest_Filter{NodeIds: nodeIDs},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chain config for nodes: %w", err)
+	}
+
+	m := map[string][]*nodev1.ChainConfig{}
+	for _, cc := range chainConfigResp.ChainConfigs {
+		if _, ok := m[cc.NodeId]; !ok {
+			m[cc.NodeId] = []*nodev1.ChainConfig{}
+		}
+
+		m[cc.NodeId] = append(m[cc.NodeId], cc)
+	}
+
+	fetchResp := []FetchNodeChainConfigsResponse{}
+	for nid, ccfgs := range m {
+		fetchResp = append(fetchResp, FetchNodeChainConfigsResponse{
+			NodeID:       nid,
+			ChainConfigs: ccfgs,
+		})
+	}
+
+	return fetchResp, err
 }

--- a/deployment/cre/jobs/pkg/ocr3_bootstrap_job.go
+++ b/deployment/cre/jobs/pkg/ocr3_bootstrap_job.go
@@ -12,8 +12,8 @@ import (
 const bootstrapPth = "ocr3_bootstrap.tmpl"
 
 type BootstrapJobInput struct {
-	ContractQualifier string `json:"contract_qualifier" yaml:"contract_qualifier"` // OCR contract address
-	ChainSelector     uint64 `json:"chain_selector" yaml:"chain_selector"`
+	ContractQualifier string        `json:"contract_qualifier" yaml:"contract_qualifier"` // OCR contract address
+	ChainSelector     ChainSelector `json:"chain_selector" yaml:"chain_selector"`
 }
 
 type BootstrapCfg struct {

--- a/deployment/cre/jobs/pkg/ocr3_job.go
+++ b/deployment/cre/jobs/pkg/ocr3_job.go
@@ -20,15 +20,15 @@ import (
 )
 
 type OCR3JobConfigInput struct {
-	TemplateName         string
-	ContractQualifier    string
-	ChainSelectorEVM     uint64
-	ChainSelectorAptos   uint64
-	BootstrapperOCR3Urls []string
+	TemplateName         string        `yaml:"template_name"`
+	ContractQualifier    string        `yaml:"contract_qualifier"`
+	ChainSelectorEVM     ChainSelector `yaml:"chain_selector_evm"`
+	ChainSelectorAptos   ChainSelector `yaml:"chain_selector_aptos"`
+	BootstrapperOCR3Urls []string      `yaml:"bootstrapper_ocr3_urls"`
 
 	// Optionals: specific to the worker vault OCR3 Job spec
-	MasterPublicKey          string
-	EncryptedPrivateKeyShare string
+	MasterPublicKey          string `yaml:"master_public_key"`
+	EncryptedPrivateKeyShare string `yaml:"encrypted_private_key_share"`
 }
 
 type OCR3JobConfig struct {

--- a/deployment/cre/jobs/pkg/std_cap.go
+++ b/deployment/cre/jobs/pkg/std_cap.go
@@ -16,13 +16,13 @@ const (
 
 type StandardCapabilityJob struct {
 	JobName string // Must be alphanumeric, with _, -, ., no spaces.
-	Command string
-	Config  string
+	Command string `yaml:"command"`
+	Config  string `yaml:"config"`
 
 	// If not provided, ExternalJobID is automatically filled in by calling `externalJobIDHashFunc`
-	ExternalJobID string
+	ExternalJobID string `yaml:"externalJobID"`
 	// OracleFactory is the configuration for the Oracle Factory job.
-	OracleFactory OracleFactory
+	OracleFactory *OracleFactory `yaml:"oracleFactory"`
 }
 
 func (s *StandardCapabilityJob) Validate() error {

--- a/deployment/cre/jobs/pkg/templates/stdcap.tmpl
+++ b/deployment/cre/jobs/pkg/templates/stdcap.tmpl
@@ -4,8 +4,7 @@ name = "{{ .JobName }}"
 externalJobID = "{{ .ExternalJobID }}"
 forwardingAllowed = false
 command = "{{ .Command }}"
-config = """{{ .Config }}"""
-{{ if .OracleFactory.Enabled }}
+config = """{{ .Config }}"""{{ if and .OracleFactory .OracleFactory.Enabled }}
 [oracle_factory]
 enabled = {{ .OracleFactory.Enabled }}
 bootstrap_peers = [{{ range $index, $peer := .OracleFactory.BootstrapPeers }}{{ if $index }}, {{ end }}"{{ $peer }}"{{ end }}]

--- a/deployment/cre/jobs/pkg/types.go
+++ b/deployment/cre/jobs/pkg/types.go
@@ -1,18 +1,24 @@
 package pkg
 
+import (
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
 type OracleFactory struct {
-	Enabled                bool
-	BootstrapPeers         []string
-	OCRContractAddress     string
-	OCRKeyBundleID         string
-	ChainID                string
-	TransmitterID          string
-	OnchainSigningStrategy OnchainSigningStrategy
+	Enabled                bool                   `yaml:"enabled"`
+	BootstrapPeers         []string               `yaml:"bootstrapPeers"`
+	OCRContractAddress     string                 `yaml:"ocrContractAddress"`
+	OCRKeyBundleID         string                 `yaml:"ocrKeyBundleID"`
+	ChainID                string                 `yaml:"chainID"`
+	TransmitterID          string                 `yaml:"transmitterID"`
+	OnchainSigningStrategy OnchainSigningStrategy `yaml:"onchainSigningStrategy"`
 }
 
 type OnchainSigningStrategy struct {
-	StrategyName string
-	Config       map[string]string
+	StrategyName string            `yaml:"strategyName"`
+	Config       map[string]string `yaml:"config"`
 }
 
 type OracleFactoryConfig struct {
@@ -21,4 +27,34 @@ type OracleFactoryConfig struct {
 	OCRContractAddress string   `toml:"ocr_contract_address"` // e.g., 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
 	ChainID            string   `toml:"chain_id"`             // e.g., "31337"
 	Network            string   `toml:"network"`              // e.g., "evm"
+}
+
+type ChainSelector uint64
+
+func (cs *ChainSelector) UnmarshalText(data []byte) error {
+	ui, err := strconv.ParseUint(string(data), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*cs = ChainSelector(ui)
+	return nil
+}
+
+func (cs ChainSelector) MarshalText() ([]byte, error) {
+	return []byte(strconv.FormatUint(uint64(cs), 10)), nil
+}
+
+func (cs *ChainSelector) UnmarshalYAML(node *yaml.Node) error {
+	ui, err := strconv.ParseUint(node.Value, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*cs = ChainSelector(ui)
+	return nil
+}
+
+func (cs ChainSelector) MarshalYAML() ([]byte, error) {
+	return []byte(strconv.FormatUint(uint64(cs), 10)), nil
 }

--- a/deployment/cre/jobs/propose_job_spec.go
+++ b/deployment/cre/jobs/propose_job_spec.go
@@ -60,7 +60,7 @@ func (u ProposeJobSpec) VerifyPreconditions(_ cldf.Environment, config ProposeJo
 		if err := verifyEVMJobSpecInputs(config.Inputs); err != nil {
 			return fmt.Errorf("invalid inputs for EVM job spec: %w", err)
 		}
-	case job_types.Cron, job_types.BootstrapOCR3, job_types.OCR3:
+	case job_types.Cron, job_types.BootstrapOCR3, job_types.OCR3, job_types.Gateway:
 	default:
 		return fmt.Errorf("unsupported template: %s", config.Template)
 	}
@@ -98,12 +98,13 @@ func (u ProposeJobSpec) Apply(e cldf.Environment, input ProposeJobSpecInput) (cl
 
 		report = r.ToGenericReport()
 	case job_types.BootstrapOCR3:
-		jobInput, err := input.Inputs.ToOCR3BootstrapJobInput()
+		jobInput := pkg.BootstrapJobInput{}
+		err := input.Inputs.UnmarshalTo(&jobInput)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to convert inputs to OCR3 bootstrap job input: %w", err)
 		}
 
-		addrRefKey := pkg.GetOCR3CapabilityAddressRefKey(jobInput.ChainSelector, jobInput.ContractQualifier)
+		addrRefKey := pkg.GetOCR3CapabilityAddressRefKey(uint64(jobInput.ChainSelector), jobInput.ContractQualifier)
 		contractAddrRef, err := e.DataStore.Addresses().Get(addrRefKey)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get OCR3 contract address for chain selector %d and qualifier %s: %w", jobInput.ChainSelector, jobInput.ContractQualifier, err)
@@ -118,7 +119,7 @@ func (u ProposeJobSpec) Apply(e cldf.Environment, input ProposeJobSpecInput) (cl
 				DONName:          input.DONName,
 				ContractID:       contractAddrRef.Address,
 				EnvironmentLabel: input.Environment,
-				ChainSelectorEVM: jobInput.ChainSelector,
+				ChainSelectorEVM: uint64(jobInput.ChainSelector),
 				JobName:          input.JobName,
 				DONFilters:       input.DONFilters,
 				ExtraLabels:      input.ExtraLabels,
@@ -135,7 +136,7 @@ func (u ProposeJobSpec) Apply(e cldf.Environment, input ProposeJobSpecInput) (cl
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to convert inputs to OCR3 job input: %w", err)
 		}
 
-		addrRefKey := pkg.GetOCR3CapabilityAddressRefKey(jobInput.ChainSelectorEVM, jobInput.ContractQualifier)
+		addrRefKey := pkg.GetOCR3CapabilityAddressRefKey(uint64(jobInput.ChainSelectorEVM), jobInput.ContractQualifier)
 		contractAddrRef, err := e.DataStore.Addresses().Get(addrRefKey)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to get OCR3 contract address for chain selector %d and qualifier %s: %w", jobInput.ChainSelectorEVM, jobInput.ContractQualifier, err)
@@ -152,8 +153,8 @@ func (u ProposeJobSpec) Apply(e cldf.Environment, input ProposeJobSpecInput) (cl
 				JobName:                  input.JobName,
 				TemplateName:             jobInput.TemplateName,
 				ContractAddress:          contractAddrRef.Address,
-				ChainSelectorEVM:         jobInput.ChainSelectorEVM,
-				ChainSelectorAptos:       jobInput.ChainSelectorAptos,
+				ChainSelectorEVM:         uint64(jobInput.ChainSelectorEVM),
+				ChainSelectorAptos:       uint64(jobInput.ChainSelectorAptos),
 				BootstrapperOCR3Urls:     jobInput.BootstrapperOCR3Urls,
 				MasterPublicKey:          jobInput.MasterPublicKey,
 				EncryptedPrivateKeyShare: jobInput.EncryptedPrivateKeyShare,
@@ -161,8 +162,31 @@ func (u ProposeJobSpec) Apply(e cldf.Environment, input ProposeJobSpecInput) (cl
 				ExtraLabels:              input.ExtraLabels,
 			},
 		)
+
 		if rErr != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to propose OCR3 job: %w", rErr)
+		}
+
+		report = r.ToGenericReport()
+	case job_types.Gateway:
+		typedInputs := operations2.ProposeGatewayJobInput{
+			Domain:     input.Domain,
+			DONFilters: input.DONFilters,
+			JobLabels:  input.ExtraLabels,
+		}
+		err := input.Inputs.UnmarshalTo(&typedInputs)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to unmarshal inputs to gateway job input: %w", err)
+		}
+
+		r, rErr := operations.ExecuteOperation(
+			e.OperationsBundle,
+			operations2.ProposeGatewayJob,
+			operations2.ProposeGatewayJobDeps{Env: e},
+			typedInputs,
+		)
+		if rErr != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to propose gateway job: %w", rErr)
 		}
 
 		report = r.ToGenericReport()

--- a/deployment/cre/jobs/propose_std_cap.go
+++ b/deployment/cre/jobs/propose_std_cap.go
@@ -57,7 +57,7 @@ func (u ProposeStandardCapabilityJob) Apply(e cldf.Environment, input ProposeSta
 				Command:       input.Command,
 				Config:        input.Config,
 				ExternalJobID: input.ExternalJobID,
-				OracleFactory: input.OracleFactory,
+				OracleFactory: &input.OracleFactory,
 			},
 			DONFilters:  input.DONFilters,
 			ExtraLabels: input.ExtraLabels,

--- a/deployment/cre/jobs/propose_std_cap_test.go
+++ b/deployment/cre/jobs/propose_std_cap_test.go
@@ -61,7 +61,7 @@ func TestProposeStandardCapabilityJob_Apply(t *testing.T) {
 		Command: "cron",
 		DONName: "test-don",
 		DONFilters: []offchain.TargetDONFilter{
-			{Key: offchain.FilterKeyDONName, Value: "don-" + test.DONName},
+			{Key: offchain.FilterKeyDONName, Value: test.DONName},
 			{Key: "environment", Value: "test"},
 			{Key: "product", Value: offchain.ProductLabel},
 		},

--- a/deployment/cre/jobs/types/job_spec.go
+++ b/deployment/cre/jobs/types/job_spec.go
@@ -1,207 +1,64 @@
 package job_types
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/smartcontractkit/chainlink/deployment/cre/jobs/pkg"
-	"github.com/smartcontractkit/chainlink/v2/core/config/parse"
 )
 
-type JobSpecInput map[string]interface{}
+type JobSpecInput map[string]any
+
+func (j JobSpecInput) UnmarshalTo(target any) error {
+	bytes, err := yaml.Marshal(j)
+	if err != nil {
+		return fmt.Errorf("failed to marshal job spec input to json: %w", err)
+	}
+
+	return yaml.Unmarshal(bytes, target)
+}
 
 func (j JobSpecInput) ToStandardCapabilityJob(jobName string) (pkg.StandardCapabilityJob, error) {
-	cmd, ok := j["command"].(string)
-	if !ok || cmd == "" {
+	out := pkg.StandardCapabilityJob{
+		JobName: jobName,
+	}
+	err := j.UnmarshalTo(&out)
+	if err != nil {
+		return pkg.StandardCapabilityJob{}, fmt.Errorf("failed to unmarshal job spec input to StandardCapabilityJob: %w", err)
+	}
+
+	if out.Command == "" {
 		return pkg.StandardCapabilityJob{}, errors.New("command is required and must be a string")
 	}
 
-	// config is optional; only validate type if provided.
-	var config string
-	if rawCfg, exists := j["config"]; exists {
-		castCfg, ok := rawCfg.(string)
-		if !ok {
-			return pkg.StandardCapabilityJob{}, errors.New("config must be a string")
-		}
-		if castCfg == "" {
-			return pkg.StandardCapabilityJob{}, errors.New("config cannot be an empty string")
-		}
-		config = castCfg
+	if out.ExternalJobID == "" {
+		return pkg.StandardCapabilityJob{}, errors.New("externalJobID cannot be an empty string")
 	}
 
-	// externalJobID is optional; only validate type if provided.
-	var externalJobID string
-	if rawEJID, exists := j["externalJobID"]; exists {
-		castEJID, ok := rawEJID.(string)
-		if !ok {
-			return pkg.StandardCapabilityJob{}, errors.New("externalJobID must be a string")
-		}
-		if castEJID == "" {
-			return pkg.StandardCapabilityJob{}, errors.New("externalJobID cannot be an empty string")
-		}
-		externalJobID = castEJID
-	}
-
-	// oracleFactory is optional; only validate type if provided.
-	var oracleFactory pkg.OracleFactory
-	if _, exists := j["oracleFactory"]; exists {
-		castOF, err := DecodeOracleFactory(j)
-		if err != nil {
-			return pkg.StandardCapabilityJob{}, err
-		}
-		oracleFactory = castOF
-	}
-
-	return pkg.StandardCapabilityJob{
-		JobName:       jobName,
-		Command:       cmd,
-		Config:        config,
-		ExternalJobID: externalJobID,
-		OracleFactory: oracleFactory,
-	}, nil
-}
-
-func (j JobSpecInput) ToOCR3BootstrapJobInput() (pkg.BootstrapJobInput, error) {
-	qualifier, ok := j["contract_qualifier"].(string)
-	if !ok || qualifier == "" {
-		return pkg.BootstrapJobInput{}, errors.New("contract_qualifier is required and must be a string")
-	}
-
-	chainSelector, ok := j["chain_selector"].(string)
-	if !ok {
-		return pkg.BootstrapJobInput{}, errors.New("chain_selector is required and must be a string")
-	}
-
-	chainSel, err := parse.Uint64(chainSelector)
-	if err != nil {
-		return pkg.BootstrapJobInput{}, fmt.Errorf("failed to parse chain_selector: %w", err)
-	}
-
-	return pkg.BootstrapJobInput{
-		ContractQualifier: qualifier,
-		ChainSelector:     chainSel,
-	}, nil
+	return out, nil
 }
 
 func (j JobSpecInput) ToOCR3JobConfigInput() (pkg.OCR3JobConfigInput, error) {
-	// Required: template_name
-	// TODO: validate all supported templates
-	rawTemplate, ok := j["template_name"].(string)
-	if !ok || strings.TrimSpace(rawTemplate) == "" {
+	out := pkg.OCR3JobConfigInput{}
+	err := j.UnmarshalTo(&out)
+	if err != nil {
+		return pkg.OCR3JobConfigInput{}, fmt.Errorf("failed to unmarshal job spec input to OCR3JobConfigInput: %w", err)
+	}
+
+	if out.TemplateName == "" || strings.TrimSpace(out.TemplateName) == "" {
 		return pkg.OCR3JobConfigInput{}, errors.New("template_name is required and must be a non-empty string")
 	}
 
-	// Required: contract_qualifier
-	rawQualifier, ok := j["contract_qualifier"].(string)
-	if !ok || strings.TrimSpace(rawQualifier) == "" {
+	if out.ContractQualifier == "" || strings.TrimSpace(out.ContractQualifier) == "" {
 		return pkg.OCR3JobConfigInput{}, errors.New("contract_qualifier is required and must be a non-empty string")
 	}
 
-	// Required: chain_selector_evm (as string)
-	rawEVM, ok := j["chain_selector_evm"].(string)
-	if !ok {
-		return pkg.OCR3JobConfigInput{}, errors.New("chain_selector_evm is required and must be a string")
-	}
-	evnSel, err := parse.Uint64(rawEVM)
-	if err != nil {
-		return pkg.OCR3JobConfigInput{}, fmt.Errorf("failed to parse chain_selector_evm: %w", err)
+	if len(out.BootstrapperOCR3Urls) == 0 {
+		return pkg.OCR3JobConfigInput{}, errors.New("bootstrapper_ocr3_urls is required and cannot be empty")
 	}
 
-	// Required: chain_selector_aptos (as string)
-	rawAptos, ok := j["chain_selector_aptos"].(string)
-	if !ok {
-		return pkg.OCR3JobConfigInput{}, errors.New("chain_selector_aptos is required and must be a string")
-	}
-	aptSel, err := parse.Uint64(rawAptos)
-	if err != nil {
-		return pkg.OCR3JobConfigInput{}, fmt.Errorf("failed to parse chain_selector_aptos: %w", err)
-	}
-
-	// Required: bootstrapper_ocr3_urls (slice of strings)
-	rawURLs, exists := j["bootstrapper_ocr3_urls"]
-	if !exists {
-		return pkg.OCR3JobConfigInput{}, errors.New("bootstrapper_ocr3_urls is required")
-	}
-	urls, err := toStringSlice(rawURLs)
-	if err != nil {
-		return pkg.OCR3JobConfigInput{}, fmt.Errorf("bootstrapper_ocr3_urls must be an array of strings: %w", err)
-	}
-	if len(urls) == 0 {
-		return pkg.OCR3JobConfigInput{}, errors.New("bootstrapper_ocr3_urls cannot be empty")
-	}
-
-	// Optional: master_public_key
-	var masterPub string
-	if v, ok := j["master_public_key"]; ok {
-		mpk, ok := v.(string)
-		if !ok {
-			return pkg.OCR3JobConfigInput{}, errors.New("master_public_key must be a string")
-		}
-		masterPub = mpk
-	}
-
-	// Optional: encrypted_private_key_share
-	var encShare string
-	if v, ok := j["encrypted_private_key_share"]; ok {
-		eps, ok := v.(string)
-		if !ok {
-			return pkg.OCR3JobConfigInput{}, errors.New("encrypted_private_key_share must be a string")
-		}
-		encShare = eps
-	}
-
-	return pkg.OCR3JobConfigInput{
-		TemplateName:             strings.TrimSpace(rawTemplate),
-		ContractQualifier:        strings.TrimSpace(rawQualifier),
-		ChainSelectorEVM:         evnSel,
-		ChainSelectorAptos:       aptSel,
-		BootstrapperOCR3Urls:     urls,
-		MasterPublicKey:          masterPub,
-		EncryptedPrivateKeyShare: encShare,
-	}, nil
-}
-
-// DecodeOracleFactory extracts an OracleFactory from the generic inputs map.
-// It supports both a concrete pkg.OracleFactory value and a raw map[string]any.
-func DecodeOracleFactory(inputs JobSpecInput) (pkg.OracleFactory, error) {
-	raw, ok := inputs["oracleFactory"]
-	if !ok {
-		return pkg.OracleFactory{}, errors.New("oracleFactory is required")
-	}
-
-	switch v := raw.(type) {
-	case pkg.OracleFactory:
-		return v, nil
-	case map[string]any:
-		var of pkg.OracleFactory
-		b, _ := json.Marshal(v)
-		if err := json.Unmarshal(b, &of); err != nil {
-			return pkg.OracleFactory{}, fmt.Errorf("invalid oracleFactory: %w", err)
-		}
-		return of, nil
-	default:
-		return pkg.OracleFactory{}, errors.New("oracleFactory must be of type OracleFactory or map[string]any")
-	}
-}
-
-// toStringSlice attempts to coerce v into []string, supporting []string and []any with string elements.
-func toStringSlice(v any) ([]string, error) {
-	switch s := v.(type) {
-	case []string:
-		return s, nil
-	case []any:
-		out := make([]string, 0, len(s))
-		for i, el := range s {
-			str, ok := el.(string)
-			if !ok {
-				return nil, fmt.Errorf("element %d is %T, expected string", i, el)
-			}
-			out = append(out, str)
-		}
-		return out, nil
-	default:
-		return nil, fmt.Errorf("unsupported type %T", v)
-	}
+	return out, nil
 }

--- a/deployment/cre/jobs/types/job_spec_template.go
+++ b/deployment/cre/jobs/types/job_spec_template.go
@@ -16,6 +16,7 @@ const (
 	BootstrapOCR3
 	OCR3
 	EVM
+	Gateway
 )
 
 func (jt JobSpecTemplate) String() string {
@@ -28,6 +29,8 @@ func (jt JobSpecTemplate) String() string {
 		return "ocr3"
 	case EVM:
 		return "evm"
+	case Gateway:
+		return "gateway"
 	default:
 		return "unknown"
 	}
@@ -44,6 +47,8 @@ func parseJobSpecTemplate(s string) (JobSpecTemplate, error) {
 		return OCR3, nil
 	case "evm":
 		return EVM, nil
+	case "gateway":
+		return Gateway, nil
 	case "", "unknown":
 		return 0, errors.New("job spec template cannot be empty")
 	default:

--- a/deployment/cre/jobs/types/job_spec_test.go
+++ b/deployment/cre/jobs/types/job_spec_test.go
@@ -63,7 +63,7 @@ func TestJobSpecInput_ToStandardCapabilityJob(t *testing.T) {
 
 	t.Run("invalid command type", func(t *testing.T) {
 		input := job_types.JobSpecInput{
-			"command":       123,
+			"command":       nil,
 			"config":        "param=value",
 			"externalJobID": "123",
 			"oracleFactory": pkg.OracleFactory{},
@@ -73,7 +73,7 @@ func TestJobSpecInput_ToStandardCapabilityJob(t *testing.T) {
 		assert.Contains(t, err.Error(), "command is required and must be a string")
 	})
 
-	t.Run("empty config", func(t *testing.T) {
+	t.Run("config is optional", func(t *testing.T) {
 		input := job_types.JobSpecInput{
 			"command":       "run",
 			"config":        "",
@@ -81,32 +81,31 @@ func TestJobSpecInput_ToStandardCapabilityJob(t *testing.T) {
 			"oracleFactory": pkg.OracleFactory{},
 		}
 		_, err := input.ToStandardCapabilityJob(jobName)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "config cannot be an empty string")
+		require.NoError(t, err)
 	})
 
 	t.Run("invalid config type", func(t *testing.T) {
 		input := job_types.JobSpecInput{
 			"command":       "run",
-			"config":        123,
+			"config":        struct{}{},
 			"externalJobID": "123",
 			"oracleFactory": pkg.OracleFactory{},
 		}
 		_, err := input.ToStandardCapabilityJob(jobName)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "config must be a string")
+		assert.Contains(t, err.Error(), "cannot unmarshal !!map into string")
 	})
 
 	t.Run("invalid externalJobID type", func(t *testing.T) {
 		input := job_types.JobSpecInput{
 			"command":       "run",
 			"config":        "param=value",
-			"externalJobID": 123,
+			"externalJobID": struct{}{},
 			"oracleFactory": pkg.OracleFactory{},
 		}
 		_, err := input.ToStandardCapabilityJob(jobName)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "externalJobID must be a string")
+		assert.Contains(t, err.Error(), "cannot unmarshal !!map into string")
 	})
 
 	t.Run("empty externalJobID", func(t *testing.T) {
@@ -118,7 +117,7 @@ func TestJobSpecInput_ToStandardCapabilityJob(t *testing.T) {
 		}
 		_, err := input.ToStandardCapabilityJob(jobName)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "externalJobID cannot be an empty string")
+		assert.Contains(t, err.Error(), "cannot be an empty string")
 	})
 
 	t.Run("invalid oracleFactory type", func(t *testing.T) {
@@ -130,6 +129,6 @@ func TestJobSpecInput_ToStandardCapabilityJob(t *testing.T) {
 		}
 		_, err := input.ToStandardCapabilityJob(jobName)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "oracleFactory must be of type OracleFactory")
+		assert.Contains(t, err.Error(), "cannot unmarshal !!str")
 	})
 }

--- a/deployment/cre/pkg/offchain/nodes.go
+++ b/deployment/cre/pkg/offchain/nodes.go
@@ -8,13 +8,11 @@ import (
 
 	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 	nodeapiv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
-	jdtypesv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
 )
 
 // labels used in JD to identify nodes and jobs
 const (
 	ProductLabel              = "cre"
-	P2pIDLabel                = "p2p_id"
 	WorkflowOwnerAddressLabel = "workflow_owner"
 	WorkflowNameLabel         = "workflow_name"
 	GatewayNameLabel          = "gateway_name"
@@ -30,21 +28,6 @@ func FetchNodesFromJD(ctx context.Context, jd cldf_offchain.Client, filter *node
 	slices.SortFunc(resp.Nodes, func(a, b *nodeapiv1.Node) int {
 		return strings.Compare(a.Name, b.Name)
 	})
-	for _, node := range resp.Nodes {
-		if GetP2pLabel(node.GetLabels()) == "" {
-			return nil, fmt.Errorf("node %s has no non-empty p2p_id label: %v", node.Name, node)
-		}
-	}
 
 	return resp.Nodes, nil
-}
-
-func GetP2pLabel(labels []*jdtypesv1.Label) string {
-	for _, label := range labels {
-		if label.GetKey() == P2pIDLabel {
-			return label.GetValue()
-		}
-	}
-
-	return ""
 }

--- a/deployment/cre/pkg/offchain/propose_job.go
+++ b/deployment/cre/pkg/offchain/propose_job.go
@@ -23,6 +23,7 @@ type ProposeJobRequest struct {
 	Environment string
 	// labels to filter nodes by
 	NodeLabels map[string]string
+	PublicKeys []string // optional
 	// labels to set on the new/updated job object
 	JobLabels      map[string]string
 	OffchainClient cldf_offchain.Client
@@ -81,8 +82,9 @@ func ProposeJob(ctx context.Context, req ProposeJobRequest) error {
 	selectors = append(selectors, req.ExtraSelectors...)
 
 	nodes, err := req.OffchainClient.ListNodes(ctx, &nodev1.ListNodesRequest{Filter: &nodev1.ListNodesRequest_Filter{
-		Enabled:   1,
-		Selectors: selectors,
+		Enabled:    1,
+		Selectors:  selectors,
+		PublicKeys: req.PublicKeys,
 	}})
 	if err != nil {
 		return err

--- a/deployment/environment/test/nodes.go
+++ b/deployment/environment/test/nodes.go
@@ -41,7 +41,7 @@ func NewNode(t *testing.T, c NodeConfig) *deployment.Node {
 	// make sure to add the p2p_id label b/c downstream systems expect it
 	c.Labels["p2p_id"] = p2p.PeerID().String()
 	return &deployment.Node{
-		NodeID:         c.Name,
+		NodeID:         "node_" + c.Name,
 		Name:           c.Name,
 		PeerID:         p2p.PeerID(),
 		CSAKey:         csakey.MustNewV2XXXTestingOnly(k).ID(),
@@ -108,6 +108,15 @@ func ApplyNodeFilter(filter *nodev1.ListNodesRequest_Filter, node *nodev1.Node) 
 			return false
 		}
 	}
+	if len(filter.PublicKeys) > 0 {
+		idx := slices.IndexFunc(filter.PublicKeys, func(id string) bool {
+			return node.PublicKey == id
+		})
+		if idx < 0 {
+			return false
+		}
+	}
+
 	for _, selector := range filter.Selectors {
 		idx := slices.IndexFunc(node.Labels, func(label *ptypes.Label) bool {
 			return label.Key == selector.Key


### PR DESCRIPTION
* Extend the ProposeJobSpec changeset so it supports Gateway Jobs.
* Add a GatewayJob type to encapsulate the creation of the Gateway Job.
* Small cleanups: use marshaling rather than manual type casts when going from generic -> job type specific inputs; use CSA public keys rather than p2p ids for filtering by nodes specifically.