### PR TITLE
Update chain_init Changeset to Deploy TokenPoolFactory

### DIFF
--- a/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
+++ b/deployment/ccip/changeset/v1_6/cs_add_new_chain_e2e.go
@@ -118,6 +118,9 @@ func (c AddCandidatesForNewChainConfig) prerequisiteConfigForNewChain() changese
 		Configs: []changeset.DeployPrerequisiteConfigPerChain{
 			changeset.DeployPrerequisiteConfigPerChain{
 				ChainSelector: c.NewChain.Selector,
+				Opts: []changeset.PrerequisiteOpt{
+					changeset.WithTokenPoolFactoryEnabled(),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### What 
- Updates chain_init Changeset to Deploy TokenPoolFactory

### Why
- This will ensure TokenPoolFactory is deployed for each new CCIP Integration
- Once this and associated contracts that are deployed are verified, subsequent user deployments would also be verified
- This corresponds to [CCIP-6717](https://smartcontract-it.atlassian.net/browse/CCIP-6717)

[CCIP-6717]: https://smartcontract-it.atlassian.net/browse/CCIP-6717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ