### PR TITLE
[CRE-879] Externalize cron workflow config struct to types

### DIFF
--- a/core/scripts/cre/environment/examples/workflows/v2/cron/main.go
+++ b/core/scripts/cre/environment/examples/workflows/v2/cron/main.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	"main/types"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron"
@@ -13,23 +15,19 @@ import (
 	"github.com/smartcontractkit/cre-sdk-go/cre/wasm"
 )
 
-type WorkflowConfig struct {
-	Schedule string `yaml:"schedule,omitempty"`
-}
-
 func main() {
-	wasm.NewRunner(func(configBytes []byte) (WorkflowConfig, error) {
-		cfg := WorkflowConfig{}
+	wasm.NewRunner(func(configBytes []byte) (types.WorkflowConfig, error) {
+		cfg := types.WorkflowConfig{}
 		if err := yaml.Unmarshal(configBytes, &cfg); err != nil {
-			return WorkflowConfig{}, fmt.Errorf("failed to unmarshal config: %w", err)
+			return types.WorkflowConfig{}, fmt.Errorf("failed to unmarshal config: %w", err)
 		}
 
 		return cfg, nil
 	}).Run(RunSimpleCronWorkflow)
 }
 
-func RunSimpleCronWorkflow(config WorkflowConfig, _ *slog.Logger, _ cre.SecretsProvider) (cre.Workflow[WorkflowConfig], error) {
-	workflows := cre.Workflow[WorkflowConfig]{
+func RunSimpleCronWorkflow(config types.WorkflowConfig, _ *slog.Logger, _ cre.SecretsProvider) (cre.Workflow[types.WorkflowConfig], error) {
+	workflows := cre.Workflow[types.WorkflowConfig]{
 		cre.Handler(
 			cron.Trigger(&cron.Config{Schedule: config.Schedule}),
 			onTrigger,
@@ -38,7 +36,7 @@ func RunSimpleCronWorkflow(config WorkflowConfig, _ *slog.Logger, _ cre.SecretsP
 	return workflows, nil
 }
 
-func onTrigger(_ WorkflowConfig, runtime cre.Runtime, _ *cron.Payload) (string, error) {
+func onTrigger(_ types.WorkflowConfig, runtime cre.Runtime, _ *cron.Payload) (string, error) {
 	runtime.Logger().Info("Amazing workflow user log")
 	return "such a lovely disaster", nil
 }

--- a/core/scripts/cre/environment/examples/workflows/v2/cron/types/types.go
+++ b/core/scripts/cre/environment/examples/workflows/v2/cron/types/types.go
@@ -1,0 +1,5 @@
+package types
+
+type WorkflowConfig struct {
+	Schedule string `yaml:"schedule,omitempty"`
+}


### PR DESCRIPTION
[CRE-879](https://smartcontract-it.atlassian.net/browse/CRE-879): moved a struct for cron workflow config to a separate pkg `types`.

### Supports
[CRE-889](https://smartcontract-it.atlassian.net/browse/CRE-889): Update tests to reuse the Cron workflow config from types.


[CRE-879]: https://smartcontract-it.atlassian.net/browse/CRE-879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRE-889]: https://smartcontract-it.atlassian.net/browse/CRE-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ