### PR TITLE
[CRE-889] Use cron workflow config from cron/types in the system-tests

### DIFF
--- a/core/scripts/cre/environment/examples/workflows/v2/cron/go.mod
+++ b/core/scripts/cre/environment/examples/workflows/v2/cron/go.mod
@@ -1,4 +1,4 @@
-module main
+module github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron
 
 go 1.24.5
 

--- a/core/scripts/cre/environment/examples/workflows/v2/cron/main.go
+++ b/core/scripts/cre/environment/examples/workflows/v2/cron/main.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"log/slog"
 
-	"main/types"
-
 	"gopkg.in/yaml.v3"
 
 	"github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron"
 	"github.com/smartcontractkit/cre-sdk-go/cre"
 	"github.com/smartcontractkit/cre-sdk-go/cre/wasm"
+
+	"github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron/types"
 )
 
 func main() {

--- a/go.md
+++ b/go.md
@@ -334,6 +334,8 @@ flowchart LR
 	click chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based href "https://github.com/smartcontractkit/chainlink"
 	chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based --> chainlink/v2
 	click chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based href "https://github.com/smartcontractkit/chainlink"
+	chainlink/core/scripts/cre/environment/examples/workflows/v2/cron --> cre-sdk-go/capabilities/scheduler/cron
+	click chainlink/core/scripts/cre/environment/examples/workflows/v2/cron href "https://github.com/smartcontractkit/chainlink"
 	chainlink/deployment --> ccip-contract-examples/chains/evm
 	chainlink/deployment --> chainlink-testing-framework/lib
 	chainlink/deployment --> chainlink-ton/deployment
@@ -354,6 +356,7 @@ flowchart LR
 	chainlink/system-tests/tests --> chainlink-testing-framework/havoc
 	chainlink/system-tests/tests --> chainlink-testing-framework/wasp
 	chainlink/system-tests/tests --> chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based
+	chainlink/system-tests/tests --> chainlink/core/scripts/cre/environment/examples/workflows/v2/cron
 	chainlink/system-tests/tests --> chainlink/system-tests/lib
 	chainlink/system-tests/tests --> chainlink/system-tests/tests/smoke/cre/evmread
 	click chainlink/system-tests/tests href "https://github.com/smartcontractkit/chainlink"
@@ -409,6 +412,7 @@ flowchart LR
 		 chainlink/core/scripts
 		 chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based
 		 chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/web-trigger-based
+		 chainlink/core/scripts/cre/environment/examples/workflows/v2/cron
 		 chainlink/deployment
 		 chainlink/integration-tests
 		 chainlink/load-tests

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -15,6 +15,8 @@ replace github.com/smartcontractkit/chainlink/system-tests/lib => ../lib
 
 replace github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based => ../../core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based
 
+replace github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron => ../../core/scripts/cre/environment/examples/workflows/v2/cron
+
 replace github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evmread => ./smoke/cre/evmread
 
 require (
@@ -42,6 +44,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.51.1
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based v0.0.0-20250826151008-ae5ec0ee6f2c
+	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron v0.0.0-20250916160605-4f051f3d3f51
 	github.com/smartcontractkit/chainlink/deployment v0.0.0-20250906212935-a1521d24f47f
 	github.com/smartcontractkit/chainlink/system-tests/lib v0.0.0-20250826151008-ae5ec0ee6f2c
 	github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evmread v0.0.0-20250903153815-8c93ebd9085c

--- a/system-tests/tests/smoke/cre/helpers_test.go
+++ b/system-tests/tests/smoke/cre/helpers_test.go
@@ -50,6 +50,7 @@ import (
 	creworkflow "github.com/smartcontractkit/chainlink/system-tests/lib/cre/workflow"
 
 	portypes "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based/types"
+	crontypes "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron/types"
 )
 
 /////////////////////////
@@ -222,16 +223,12 @@ func assertBeholderMessage(ctx context.Context, t *testing.T, expectedLog string
 // WORKFLOW-RELATED HELPERS //
 //////////////////////////////
 
-type CronWorkflowConfig struct {
-	Schedule string `yaml:"schedule,omitempty"`
-}
-
 // Generic WorkflowConfig interface for creation of different workflow configurations
 // Register your workflow configuration types here
 type WorkflowConfig interface {
 	None |
 		portypes.WorkflowConfig |
-		CronWorkflowConfig |
+		crontypes.WorkflowConfig |
 		HTTPWorkflowConfig |
 		evmread_config.Config
 }
@@ -305,7 +302,7 @@ func workflowConfigFactory[T WorkflowConfig](t *testing.T, testLogger zerolog.Lo
 			require.NoError(t, configErr, "failed to create PoR workflow config file")
 			testLogger.Info().Msg("PoR Workflow config file created.")
 
-		case *CronWorkflowConfig:
+		case *crontypes.WorkflowConfig:
 			workflowCfgFilePath, configErr := createWorkflowYamlConfigFile(workflowName, cfg)
 			workflowConfigFilePath = workflowCfgFilePath
 			require.NoError(t, configErr, "failed to create Cron workflow config file")

--- a/system-tests/tests/smoke/cre/v2_billing_test.go
+++ b/system-tests/tests/smoke/cre/v2_billing_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+
+	crontypes "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron/types"
 )
 
 func ExecuteBillingTest(t *testing.T, testEnv *TestEnvironment) {
@@ -56,7 +58,7 @@ func ExecuteBillingTest(t *testing.T, testEnv *TestEnvironment) {
 	initialCredits := credits[0]
 
 	testLogger.Info().Msg("Creating Cron workflow configuration file...")
-	workflowConfig := CronWorkflowConfig{
+	workflowConfig := crontypes.WorkflowConfig{
 		Schedule: "*/30 * * * * *", // every 30 seconds
 	}
 	compileAndDeployWorkflow(t, testEnv, testLogger, workflowName, &workflowConfig, workflowFileLocation)

--- a/system-tests/tests/smoke/cre/v2_cron_beholder_test.go
+++ b/system-tests/tests/smoke/cre/v2_cron_beholder_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+
+	crontypes "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron/types"
 )
 
 // smoke
@@ -18,7 +20,7 @@ func ExecuteCronBeholderTest(t *testing.T, testEnv *TestEnvironment) {
 	listenerCtx, messageChan, kafkaErrChan := startBeholder(t, testLogger, testEnv)
 
 	testLogger.Info().Msg("Creating Cron workflow configuration file...")
-	workflowConfig := CronWorkflowConfig{
+	workflowConfig := crontypes.WorkflowConfig{
 		Schedule: "*/30 * * * * *", // every 30 seconds
 	}
 	compileAndDeployWorkflow(t, testEnv, testLogger, workflowName, &workflowConfig, workflowFileLocation)
@@ -48,7 +50,7 @@ func CronBeholderFailWithInvalidScheduleTest(t *testing.T, testEnv *TestEnvironm
 	listenerCtx, messageChan, kafkaErrChan := startBeholder(t, testLogger, testEnv)
 
 	testLogger.Info().Msg("Creating Cron workflow configuration file...")
-	workflowConfig := CronWorkflowConfig{
+	workflowConfig := crontypes.WorkflowConfig{
 		Schedule: invalidSchedule,
 	}
 	compileAndDeployWorkflow(t, testEnv, testLogger, workflowName, &workflowConfig, workflowFileLocation)

--- a/system-tests/tests/smoke/cre/v2_dontime_test.go
+++ b/system-tests/tests/smoke/cre/v2_dontime_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+
+	crontypes "github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v2/cron/types"
 )
 
 func ExecuteDonTimeTest(t *testing.T, testEnv *TestEnvironment) {
@@ -18,7 +20,7 @@ func ExecuteDonTimeTest(t *testing.T, testEnv *TestEnvironment) {
 	listenerCtx, messageChan, kafkaErrChan := startBeholder(t, testLogger, testEnv)
 
 	testLogger.Info().Msg("Creating Cron workflow configuration file...")
-	workflowConfig := CronWorkflowConfig{
+	workflowConfig := crontypes.WorkflowConfig{
 		Schedule: "*/30 * * * * *", // every 30 seconds
 	}
 	compileAndDeployWorkflow(t, testEnv, testLogger, workflowName, &workflowConfig, workflowFileLocation)


### PR DESCRIPTION
[CRE-889](https://smartcontract-it.atlassian.net/browse/CRE-889): Update tests to reuse the Cron workflow config from types.

### Requires
[CRE-879](https://smartcontract-it.atlassian.net/browse/CRE-879): moved a struct for cron workflow config to a separate pkg `types`.




[CRE-889]: https://smartcontract-it.atlassian.net/browse/CRE-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRE-879]: https://smartcontract-it.atlassian.net/browse/CRE-879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ