### PR TITLE
chore: bump package.json version to 2.28.0-svr.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "2.28.0",
+  "version": "2.28.0-svr",
   "description": "node of the decentralized oracle network, bridging on and off-chain computation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix CI by bumping package.json version for release/2.28.0-svr