### PR TITLE
[PRIV-177] Wrap user callback in Gateway to prevent accidental misuse

### DIFF
--- a/core/services/gateway/gateway_test.go
+++ b/core/services/gateway/gateway_test.go
@@ -255,7 +255,7 @@ func TestGateway_LegacyRequest_HandlerResponse(t *testing.T) {
 		msg.Body.Payload = []byte(`{"result":"OK"}`)
 		msg.Signature = ""
 		codec := api.JsonRPCCodec{}
-		err := callback.SendResponse(t.Context(), handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
+		err := callback.SendResponse(handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
 		require.NoError(t, err)
 	})
 
@@ -284,7 +284,7 @@ func TestGateway_NewRequest_HandlerResponse(t *testing.T) {
 		}
 		rawMsg, err := json.Marshal(&response)
 		require.NoError(t, err)
-		err = callback.SendResponse(t.Context(), handlers.UserCallbackPayload{RawResponse: rawMsg, ErrorCode: api.NoError})
+		err = callback.SendResponse(handlers.UserCallbackPayload{RawResponse: rawMsg, ErrorCode: api.NoError})
 		require.NoError(t, err)
 	})
 
@@ -333,7 +333,7 @@ func newMockHandler(t *testing.T, method string) *handlermocks.Handler {
 		msg.Body.Payload = []byte(`{"result":"OK"}`)
 		msg.Signature = ""
 		codec := api.JsonRPCCodec{}
-		err := callback.SendResponse(t.Context(), handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
+		err := callback.SendResponse(handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
 		require.NoError(t, err)
 	})
 	handler.On("HandleJSONRPCUserMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -351,7 +351,7 @@ func newMockHandler(t *testing.T, method string) *handlermocks.Handler {
 			Result:  &rm,
 		})
 		require.NoError(t, err)
-		err = callback.SendResponse(t.Context(), handlers.UserCallbackPayload{RawResponse: resp, ErrorCode: api.NoError})
+		err = callback.SendResponse(handlers.UserCallbackPayload{RawResponse: resp, ErrorCode: api.NoError})
 		require.NoError(t, err)
 	})
 	return handler

--- a/core/services/gateway/gateway_test.go
+++ b/core/services/gateway/gateway_test.go
@@ -250,12 +250,13 @@ func TestGateway_LegacyRequest_HandlerResponse(t *testing.T) {
 	gw, handler := newGatewayWithMockHandler(t)
 	handler.On("HandleLegacyUserMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		msg := args.Get(1).(*api.Message)
-		callbackCh := args.Get(2).(chan<- handlers.UserCallbackPayload)
+		callback := args.Get(2).(handlers.Callback)
 		// echo back to sender with attached payload
 		msg.Body.Payload = []byte(`{"result":"OK"}`)
 		msg.Signature = ""
 		codec := api.JsonRPCCodec{}
-		callbackCh <- handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError}
+		err := callback.SendResponse(t.Context(), handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
+		require.NoError(t, err)
 	})
 
 	method := "request"
@@ -272,7 +273,7 @@ func TestGateway_NewRequest_HandlerResponse(t *testing.T) {
 	gw, handler := newGatewayWithMockHandler(t)
 	handler.On("HandleJSONRPCUserMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		request := args.Get(1).(jsonrpc.Request[json.RawMessage])
-		callbackCh := args.Get(2).(chan<- handlers.UserCallbackPayload)
+		callback := args.Get(2).(handlers.Callback)
 		// echo back to sender with attached payload
 		rawResult := json.RawMessage(`{"result":"OK"}`)
 		response := jsonrpc.Response[json.RawMessage]{
@@ -283,7 +284,8 @@ func TestGateway_NewRequest_HandlerResponse(t *testing.T) {
 		}
 		rawMsg, err := json.Marshal(&response)
 		require.NoError(t, err)
-		callbackCh <- handlers.UserCallbackPayload{RawResponse: rawMsg, ErrorCode: api.NoError}
+		err = callback.SendResponse(t.Context(), handlers.UserCallbackPayload{RawResponse: rawMsg, ErrorCode: api.NoError})
+		require.NoError(t, err)
 	})
 
 	req := newJSONRpcRequest(t, "abcd", "testDON", []byte(`{"type":"new"}`))
@@ -323,7 +325,7 @@ func newMockHandler(t *testing.T, method string) *handlermocks.Handler {
 	handler.On("Methods").Return([]string{method})
 	handler.On("HandleLegacyUserMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		msg := args.Get(1).(*api.Message)
-		callbackCh := args.Get(2).(chan<- handlers.UserCallbackPayload)
+		callback := args.Get(2).(handlers.Callback)
 		// echo back to sender with attached payload
 		if msg.Body.Method != method {
 			require.Fail(t, fmt.Sprintf("Expected method to be '%s'", method))
@@ -331,11 +333,12 @@ func newMockHandler(t *testing.T, method string) *handlermocks.Handler {
 		msg.Body.Payload = []byte(`{"result":"OK"}`)
 		msg.Signature = ""
 		codec := api.JsonRPCCodec{}
-		callbackCh <- handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError}
+		err := callback.SendResponse(t.Context(), handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
+		require.NoError(t, err)
 	})
 	handler.On("HandleJSONRPCUserMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		msg := args.Get(1).(jsonrpc.Request[json.RawMessage])
-		callbackCh := args.Get(2).(chan<- handlers.UserCallbackPayload)
+		callback := args.Get(2).(handlers.Callback)
 		// echo back to sender with attached payload
 		if msg.Method != method {
 			require.Fail(t, fmt.Sprintf("Expected method to be '%s'", method))
@@ -348,7 +351,8 @@ func newMockHandler(t *testing.T, method string) *handlermocks.Handler {
 			Result:  &rm,
 		})
 		require.NoError(t, err)
-		callbackCh <- handlers.UserCallbackPayload{RawResponse: resp, ErrorCode: api.NoError}
+		err = callback.SendResponse(t.Context(), handlers.UserCallbackPayload{RawResponse: resp, ErrorCode: api.NoError})
+		require.NoError(t, err)
 	})
 	return handler
 }

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -57,8 +57,8 @@ type HandlerConfig struct {
 }
 
 type savedCallback struct {
-	id         string
-	callbackCh chan<- handlers.UserCallbackPayload
+	id       string
+	callback handlers.SendResponse
 }
 
 var _ handlers.Handler = (*handler)(nil)
@@ -132,8 +132,7 @@ func (h *handler) handleWebAPITriggerMessage(ctx context.Context, msg *api.Messa
 		// TODO: in practice, we should wait for at least 2F+1 nodes to respond and then return an aggregated response
 		// back to the user.
 		codec := api.JsonRPCCodec{}
-		savedCb.callbackCh <- handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError}
-		close(savedCb.callbackCh)
+		return savedCb.callback(ctx, handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
 	}
 	return nil
 }
@@ -254,13 +253,13 @@ func (h *handler) Close() error {
 	return nil
 }
 
-func (h *handler) HandleJSONRPCUserMessage(_ context.Context, _ jsonrpc.Request[json.RawMessage], _ chan<- handlers.UserCallbackPayload) error {
+func (h *handler) HandleJSONRPCUserMessage(_ context.Context, _ jsonrpc.Request[json.RawMessage], _ handlers.SendResponse) error {
 	return errors.New("capabilities handler does not support JSON-RPC user messages")
 }
 
-func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callbackCh chan<- handlers.UserCallbackPayload) error {
+func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback handlers.SendResponse) error {
 	h.mu.Lock()
-	h.savedCallbacks[msg.Body.MessageId] = &savedCallback{msg.Body.MessageId, callbackCh}
+	h.savedCallbacks[msg.Body.MessageId] = &savedCallback{msg.Body.MessageId, callback}
 	don := h.don
 	h.mu.Unlock()
 	body := msg.Body
@@ -269,7 +268,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	err := json.Unmarshal(body.Payload, &payload)
 	if err != nil {
 		h.lggr.Errorw(ErrDecodingPayload, "err", err)
-		callbackCh <- handlers.UserCallbackPayload{
+		return callback(ctx, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UserMessageParseError),
@@ -277,14 +276,12 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 				nil,
 			),
 			ErrorCode: api.UserMessageParseError,
-		}
-		close(callbackCh)
-		return nil
+		})
 	}
 
 	if payload.Timestamp == 0 {
 		h.lggr.Errorw(ErrDecodingPayload)
-		callbackCh <- handlers.UserCallbackPayload{
+		return callback(ctx, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UserMessageParseError),
@@ -292,14 +289,12 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 				nil,
 			),
 			ErrorCode: api.UserMessageParseError,
-		}
-		close(callbackCh)
-		return nil
+		})
 	}
 
 	if uint(time.Now().Unix())-h.config.MaxAllowedMessageAgeSec > uint(payload.Timestamp) {
 		h.lggr.Errorw("stale message")
-		callbackCh <- handlers.UserCallbackPayload{
+		return callback(ctx, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.HandlerError),
@@ -307,14 +302,12 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 				nil,
 			),
 			ErrorCode: api.HandlerError,
-		}
-		close(callbackCh)
-		return nil
+		})
 	}
 	// TODO: apply allowlist and rate-limiting here
 	if msg.Body.Method != MethodWebAPITrigger {
 		h.lggr.Errorw("unsupported method", "method", body.Method)
-		callbackCh <- handlers.UserCallbackPayload{
+		return callback(ctx, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UnsupportedMethodError),
@@ -322,14 +315,12 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 				nil,
 			),
 			ErrorCode: api.UnsupportedMethodError,
-		}
-		close(callbackCh)
-		return nil
+		})
 	}
 	req, err := common.ValidatedRequestFromMessage(msg)
 	if err != nil {
 		h.lggr.Errorw(ErrTransformingMessageToRequest)
-		callbackCh <- handlers.UserCallbackPayload{
+		return callback(ctx, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UserMessageParseError),
@@ -337,9 +328,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 				nil,
 			),
 			ErrorCode: api.UserMessageParseError,
-		}
-		close(callbackCh)
-		return nil
+		})
 	}
 	// Send original request to all nodes
 	for _, member := range h.donConfig.Members {

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -132,7 +132,7 @@ func (h *handler) handleWebAPITriggerMessage(ctx context.Context, msg *api.Messa
 		// TODO: in practice, we should wait for at least 2F+1 nodes to respond and then return an aggregated response
 		// back to the user.
 		codec := api.JsonRPCCodec{}
-		return savedCb.SendResponse(ctx, handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
+		return savedCb.SendResponse(handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
 	}
 	return nil
 }
@@ -268,7 +268,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	err := json.Unmarshal(body.Payload, &payload)
 	if err != nil {
 		h.lggr.Errorw(ErrDecodingPayload, "err", err)
-		return callback.SendResponse(ctx, handlers.UserCallbackPayload{
+		return callback.SendResponse(handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UserMessageParseError),
@@ -281,7 +281,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 
 	if payload.Timestamp == 0 {
 		h.lggr.Errorw(ErrDecodingPayload)
-		return callback.SendResponse(ctx, handlers.UserCallbackPayload{
+		return callback.SendResponse(handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UserMessageParseError),
@@ -294,7 +294,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 
 	if uint(time.Now().Unix())-h.config.MaxAllowedMessageAgeSec > uint(payload.Timestamp) {
 		h.lggr.Errorw("stale message")
-		return callback.SendResponse(ctx, handlers.UserCallbackPayload{
+		return callback.SendResponse(handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.HandlerError),
@@ -307,7 +307,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	// TODO: apply allowlist and rate-limiting here
 	if msg.Body.Method != MethodWebAPITrigger {
 		h.lggr.Errorw("unsupported method", "method", body.Method)
-		return callback.SendResponse(ctx, handlers.UserCallbackPayload{
+		return callback.SendResponse(handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UnsupportedMethodError),
@@ -320,7 +320,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	req, err := common.ValidatedRequestFromMessage(msg)
 	if err != nil {
 		h.lggr.Errorw(ErrTransformingMessageToRequest)
-		return callback.SendResponse(ctx, handlers.UserCallbackPayload{
+		return callback.SendResponse(handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UserMessageParseError),

--- a/core/services/gateway/handlers/capabilities/handler.go
+++ b/core/services/gateway/handlers/capabilities/handler.go
@@ -57,8 +57,8 @@ type HandlerConfig struct {
 }
 
 type savedCallback struct {
-	id       string
-	callback handlers.SendResponse
+	id string
+	handlers.Callback
 }
 
 var _ handlers.Handler = (*handler)(nil)
@@ -132,7 +132,7 @@ func (h *handler) handleWebAPITriggerMessage(ctx context.Context, msg *api.Messa
 		// TODO: in practice, we should wait for at least 2F+1 nodes to respond and then return an aggregated response
 		// back to the user.
 		codec := api.JsonRPCCodec{}
-		return savedCb.callback(ctx, handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
+		return savedCb.SendResponse(ctx, handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError})
 	}
 	return nil
 }
@@ -253,11 +253,11 @@ func (h *handler) Close() error {
 	return nil
 }
 
-func (h *handler) HandleJSONRPCUserMessage(_ context.Context, _ jsonrpc.Request[json.RawMessage], _ handlers.SendResponse) error {
+func (h *handler) HandleJSONRPCUserMessage(_ context.Context, _ jsonrpc.Request[json.RawMessage], _ handlers.Callback) error {
 	return errors.New("capabilities handler does not support JSON-RPC user messages")
 }
 
-func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback handlers.SendResponse) error {
+func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback handlers.Callback) error {
 	h.mu.Lock()
 	h.savedCallbacks[msg.Body.MessageId] = &savedCallback{msg.Body.MessageId, callback}
 	don := h.don
@@ -268,7 +268,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	err := json.Unmarshal(body.Payload, &payload)
 	if err != nil {
 		h.lggr.Errorw(ErrDecodingPayload, "err", err)
-		return callback(ctx, handlers.UserCallbackPayload{
+		return callback.SendResponse(ctx, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UserMessageParseError),
@@ -281,7 +281,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 
 	if payload.Timestamp == 0 {
 		h.lggr.Errorw(ErrDecodingPayload)
-		return callback(ctx, handlers.UserCallbackPayload{
+		return callback.SendResponse(ctx, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UserMessageParseError),
@@ -294,7 +294,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 
 	if uint(time.Now().Unix())-h.config.MaxAllowedMessageAgeSec > uint(payload.Timestamp) {
 		h.lggr.Errorw("stale message")
-		return callback(ctx, handlers.UserCallbackPayload{
+		return callback.SendResponse(ctx, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.HandlerError),
@@ -307,7 +307,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	// TODO: apply allowlist and rate-limiting here
 	if msg.Body.Method != MethodWebAPITrigger {
 		h.lggr.Errorw("unsupported method", "method", body.Method)
-		return callback(ctx, handlers.UserCallbackPayload{
+		return callback.SendResponse(ctx, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UnsupportedMethodError),
@@ -320,7 +320,7 @@ func (h *handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message,
 	req, err := common.ValidatedRequestFromMessage(msg)
 	if err != nil {
 		h.lggr.Errorw(ErrTransformingMessageToRequest)
-		return callback(ctx, handlers.UserCallbackPayload{
+		return callback.SendResponse(ctx, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				msg.Body.MessageId,
 				api.ToJSONRPCErrorCode(api.UserMessageParseError),

--- a/core/services/gateway/handlers/capabilities/handler_test.go
+++ b/core/services/gateway/handlers/capabilities/handler_test.go
@@ -276,8 +276,6 @@ func TestHandlerReceiveHTTPMessageFromClient(t *testing.T) {
 	codec := api.JsonRPCCodec{}
 
 	t.Run("happy case", func(t *testing.T) {
-		ch := make(chan handlers.UserCallbackPayload, defaultSendChannelBufferSize)
-
 		// sends to 2 dons
 		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			nodeReq := nodeRequest(msg)
@@ -288,28 +286,28 @@ func TestHandlerReceiveHTTPMessageFromClient(t *testing.T) {
 			require.Equal(t, nodeReq, args.Get(2))
 		}).Return(nil).Once()
 
-		err := handler.HandleLegacyUserMessage(ctx, msg, ch)
+		cb := hc.NewCallback()
+		err := handler.HandleLegacyUserMessage(ctx, msg, cb)
 		require.NoError(t, err)
-		requireNoChanMsg(t, ch)
 
 		resp, err := hc.ValidatedResponseFromMessage(msg)
 		require.NoError(t, err)
 		err = handler.HandleNodeMessage(ctx, resp, nodes[0].Address)
 		require.NoError(t, err)
 
-		userPayload := <-ch
-		require.Equal(t, handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError}, userPayload)
-		_, open := <-ch
-		require.False(t, open)
+		r, err := cb.Wait(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(msg), ErrorCode: api.NoError}, r)
 	})
 
 	t.Run("sad case invalid method", func(t *testing.T) {
 		invalidMsg := triggerRequest(t, nodes[0].PrivateKey, []string{"daily_price_update"}, "foo", "", "")
-		ch := make(chan handlers.UserCallbackPayload, defaultSendChannelBufferSize)
-		err := handler.HandleLegacyUserMessage(ctx, invalidMsg, ch)
+		cb := hc.NewCallback()
+		err := handler.HandleLegacyUserMessage(ctx, invalidMsg, cb)
 		require.NoError(t, err)
-		resp := <-ch
 
+		r, err := cb.Wait(t.Context())
+		require.NoError(t, err)
 		require.Equal(t, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				invalidMsg.Body.MessageId,
@@ -318,17 +316,16 @@ func TestHandlerReceiveHTTPMessageFromClient(t *testing.T) {
 				nil,
 			),
 			ErrorCode: api.UnsupportedMethodError,
-		}, resp)
-		_, open := <-ch
-		require.False(t, open)
+		}, r)
 	})
 
 	t.Run("sad case stale message", func(t *testing.T) {
 		invalidMsg := triggerRequest(t, nodes[0].PrivateKey, []string{"daily_price_update"}, "", "123456", "")
-		ch := make(chan handlers.UserCallbackPayload, defaultSendChannelBufferSize)
-		err := handler.HandleLegacyUserMessage(ctx, invalidMsg, ch)
+		cb := hc.NewCallback()
+		err := handler.HandleLegacyUserMessage(ctx, invalidMsg, cb)
 		require.NoError(t, err)
-		resp := <-ch
+		r, err := cb.Wait(t.Context())
+		require.NoError(t, err)
 		require.Equal(t, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				invalidMsg.Body.MessageId,
@@ -337,17 +334,16 @@ func TestHandlerReceiveHTTPMessageFromClient(t *testing.T) {
 				nil,
 			),
 			ErrorCode: api.HandlerError,
-		}, resp)
-		_, open := <-ch
-		require.False(t, open)
+		}, r)
 	})
 
 	t.Run("sad case empty payload", func(t *testing.T) {
 		invalidMsg := triggerRequest(t, nodes[0].PrivateKey, []string{"daily_price_update"}, "", "123456", "{}")
-		ch := make(chan handlers.UserCallbackPayload, defaultSendChannelBufferSize)
-		err := handler.HandleLegacyUserMessage(ctx, invalidMsg, ch)
+		cb := hc.NewCallback()
+		err := handler.HandleLegacyUserMessage(ctx, invalidMsg, cb)
 		require.NoError(t, err)
-		resp := <-ch
+		r, err := cb.Wait(t.Context())
+		require.NoError(t, err)
 		require.Equal(t, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				invalidMsg.Body.MessageId,
@@ -356,17 +352,16 @@ func TestHandlerReceiveHTTPMessageFromClient(t *testing.T) {
 				nil,
 			),
 			ErrorCode: api.UserMessageParseError,
-		}, resp)
-		_, open := <-ch
-		require.False(t, open)
+		}, r)
 	})
 
 	t.Run("sad case invalid payload", func(t *testing.T) {
 		invalidMsg := triggerRequest(t, nodes[0].PrivateKey, []string{"daily_price_update"}, "", "123456", `{"foo":"bar"}`)
-		ch := make(chan handlers.UserCallbackPayload, defaultSendChannelBufferSize)
-		err := handler.HandleLegacyUserMessage(ctx, invalidMsg, ch)
+		cb := hc.NewCallback()
+		err := handler.HandleLegacyUserMessage(ctx, invalidMsg, cb)
 		require.NoError(t, err)
-		resp := <-ch
+		r, err := cb.Wait(t.Context())
+		require.NoError(t, err)
 		require.Equal(t, handlers.UserCallbackPayload{
 			RawResponse: codec.EncodeNewErrorResponse(
 				invalidMsg.Body.MessageId,
@@ -375,9 +370,7 @@ func TestHandlerReceiveHTTPMessageFromClient(t *testing.T) {
 				nil,
 			),
 			ErrorCode: api.UserMessageParseError,
-		}, resp)
-		_, open := <-ch
-		require.False(t, open)
+		}, r)
 	})
 	// TODO: Validate Senders and rate limit chck, pending question in trigger about where senders and rate limits are validated
 }

--- a/core/services/gateway/handlers/capabilities/v2/http_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler.go
@@ -238,11 +238,11 @@ func extractWorkflowIDFromRequestPath(path string) string {
 	return ""
 }
 
-func (h *gatewayHandler) HandleLegacyUserMessage(context.Context, *api.Message, handlers.SendResponse) error {
+func (h *gatewayHandler) HandleLegacyUserMessage(context.Context, *api.Message, handlers.Callback) error {
 	return errors.New("HTTP capability gateway handler does not support legacy messages")
 }
 
-func (h *gatewayHandler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Request[json.RawMessage], callback handlers.SendResponse) error {
+func (h *gatewayHandler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Request[json.RawMessage], callback handlers.Callback) error {
 	h.metrics.Trigger.IncrementRequestCount(ctx, h.lggr)
 	err := h.triggerHandler.HandleUserTriggerRequest(ctx, &req, callback, time.Now())
 	if err != nil {

--- a/core/services/gateway/handlers/capabilities/v2/http_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_handler.go
@@ -238,13 +238,13 @@ func extractWorkflowIDFromRequestPath(path string) string {
 	return ""
 }
 
-func (h *gatewayHandler) HandleLegacyUserMessage(context.Context, *api.Message, chan<- handlers.UserCallbackPayload) error {
+func (h *gatewayHandler) HandleLegacyUserMessage(context.Context, *api.Message, handlers.SendResponse) error {
 	return errors.New("HTTP capability gateway handler does not support legacy messages")
 }
 
-func (h *gatewayHandler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Request[json.RawMessage], responseCh chan<- handlers.UserCallbackPayload) error {
+func (h *gatewayHandler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Request[json.RawMessage], callback handlers.SendResponse) error {
 	h.metrics.Trigger.IncrementRequestCount(ctx, h.lggr)
-	err := h.triggerHandler.HandleUserTriggerRequest(ctx, &req, responseCh, time.Now())
+	err := h.triggerHandler.HandleUserTriggerRequest(ctx, &req, callback, time.Now())
 	if err != nil {
 		h.lggr.Errorw("failed to handle user trigger request", "requestID",
 			req.ID, "err", err)

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -29,7 +29,7 @@ import (
 var _ HTTPTriggerHandler = (*httpTriggerHandler)(nil)
 
 type savedCallback struct {
-	callback           handlers.SendResponse
+	handlers.Callback
 	requestStartTime   time.Time
 	createdAt          time.Time
 	responseAggregator *aggregation.IdenticalNodeResponseAggregator
@@ -51,7 +51,7 @@ type httpTriggerHandler struct {
 
 type HTTPTriggerHandler interface {
 	job.ServiceCtx
-	HandleUserTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.SendResponse, requestStartTime time.Time) error
+	HandleUserTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.Callback, requestStartTime time.Time) error
 	HandleNodeTriggerResponse(ctx context.Context, resp *jsonrpc.Response[json.RawMessage], nodeAddr string) error
 }
 
@@ -69,7 +69,7 @@ func NewHTTPTriggerHandler(lggr logger.Logger, cfg ServiceConfig, donConfig *con
 	}
 }
 
-func (h *httpTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.SendResponse, requestStartTime time.Time) error {
+func (h *httpTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.Callback, requestStartTime time.Time) error {
 	triggerReq, err := h.validatedTriggerRequest(ctx, req, callback)
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (h *httpTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *
 	return h.sendWithRetries(ctx, executionID, reqWithKey)
 }
 
-func (h *httpTriggerHandler) validatedTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.SendResponse) (*jsonrpc.Request[gateway_common.HTTPTriggerRequest], error) {
+func (h *httpTriggerHandler) validatedTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.Callback) (*jsonrpc.Request[gateway_common.HTTPTriggerRequest], error) {
 	if req.Params == nil {
 		h.handleUserError(ctx, "", jsonrpc.ErrInvalidRequest, "request params is nil", callback)
 		return nil, errors.New("request params is nil")
@@ -139,7 +139,7 @@ func (h *httpTriggerHandler) validatedTriggerRequest(ctx context.Context, req *j
 	}, nil
 }
 
-func (h *httpTriggerHandler) parseTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.SendResponse) (*gateway_common.HTTPTriggerRequest, error) {
+func (h *httpTriggerHandler) parseTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.Callback) (*gateway_common.HTTPTriggerRequest, error) {
 	var triggerReq gateway_common.HTTPTriggerRequest
 	err := json.Unmarshal(*req.Params, &triggerReq)
 	if err != nil {
@@ -149,7 +149,7 @@ func (h *httpTriggerHandler) parseTriggerRequest(ctx context.Context, req *jsonr
 	return &triggerReq, nil
 }
 
-func (h *httpTriggerHandler) validateRequestID(ctx context.Context, requestID string, callback handlers.SendResponse) error {
+func (h *httpTriggerHandler) validateRequestID(ctx context.Context, requestID string, callback handlers.Callback) error {
 	if requestID == "" {
 		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "empty request ID", callback)
 		return errors.New("empty request ID")
@@ -163,7 +163,7 @@ func (h *httpTriggerHandler) validateRequestID(ctx context.Context, requestID st
 	return nil
 }
 
-func (h *httpTriggerHandler) validateMethod(ctx context.Context, method, requestID string, callback handlers.SendResponse) error {
+func (h *httpTriggerHandler) validateMethod(ctx context.Context, method, requestID string, callback handlers.Callback) error {
 	if method != gateway_common.MethodWorkflowExecute {
 		h.handleUserError(ctx, requestID, jsonrpc.ErrMethodNotFound, "invalid method: "+method, callback)
 		return errors.New("invalid method: " + method)
@@ -171,7 +171,7 @@ func (h *httpTriggerHandler) validateMethod(ctx context.Context, method, request
 	return nil
 }
 
-func (h *httpTriggerHandler) validateTriggerParams(ctx context.Context, triggerReq *gateway_common.HTTPTriggerRequest, requestID string, callback handlers.SendResponse) error {
+func (h *httpTriggerHandler) validateTriggerParams(ctx context.Context, triggerReq *gateway_common.HTTPTriggerRequest, requestID string, callback handlers.Callback) error {
 	if !isValidJSON(triggerReq.Input) {
 		h.lggr.Errorw("invalid params JSON", "params", triggerReq.Input)
 		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "invalid params JSON", callback)
@@ -181,7 +181,7 @@ func (h *httpTriggerHandler) validateTriggerParams(ctx context.Context, triggerR
 	return h.validateWorkflowFields(ctx, triggerReq.Workflow, requestID, callback)
 }
 
-func (h *httpTriggerHandler) validateWorkflowFields(ctx context.Context, workflow gateway_common.WorkflowSelector, requestID string, callback handlers.SendResponse) error {
+func (h *httpTriggerHandler) validateWorkflowFields(ctx context.Context, workflow gateway_common.WorkflowSelector, requestID string, callback handlers.Callback) error {
 	if workflow.WorkflowID != "" {
 		if !strings.HasPrefix(workflow.WorkflowID, "0x") {
 			h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflowID must be prefixed with '0x'", callback)
@@ -205,7 +205,7 @@ func (h *httpTriggerHandler) validateWorkflowFields(ctx context.Context, workflo
 	return nil
 }
 
-func (h *httpTriggerHandler) resolveWorkflowID(ctx context.Context, triggerReq *jsonrpc.Request[gateway_common.HTTPTriggerRequest], requestID string, callback handlers.SendResponse) (string, error) {
+func (h *httpTriggerHandler) resolveWorkflowID(ctx context.Context, triggerReq *jsonrpc.Request[gateway_common.HTTPTriggerRequest], requestID string, callback handlers.Callback) (string, error) {
 	workflowID := triggerReq.Params.Workflow.WorkflowID
 	if workflowID != "" {
 		return workflowID, nil
@@ -224,7 +224,7 @@ func (h *httpTriggerHandler) resolveWorkflowID(ctx context.Context, triggerReq *
 	return workflowID, nil
 }
 
-func (h *httpTriggerHandler) authorizeRequest(ctx context.Context, workflowID string, req *jsonrpc.Request[json.RawMessage], callback handlers.SendResponse) (*gateway_common.AuthorizedKey, error) {
+func (h *httpTriggerHandler) authorizeRequest(ctx context.Context, workflowID string, req *jsonrpc.Request[json.RawMessage], callback handlers.Callback) (*gateway_common.AuthorizedKey, error) {
 	key, err := h.workflowMetadataHandler.Authorize(workflowID, req.Auth, req)
 	if err != nil {
 		h.handleUserError(ctx, req.ID, jsonrpc.ErrInvalidRequest, "Auth failure", callback)
@@ -233,7 +233,7 @@ func (h *httpTriggerHandler) authorizeRequest(ctx context.Context, workflowID st
 	return key, nil
 }
 
-func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, requestID string, callback handlers.SendResponse) error {
+func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, requestID string, callback handlers.Callback) error {
 	workflowRef, found := h.workflowMetadataHandler.GetWorkflowReference(workflowID)
 	if !found {
 		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflow reference not found", callback)
@@ -253,7 +253,7 @@ func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, req
 	return nil
 }
 
-func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string, callback handlers.SendResponse, requestStartTime time.Time) error {
+func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string, callback handlers.Callback, requestStartTime time.Time) error {
 	h.callbacksMu.Lock()
 	defer h.callbacksMu.Unlock()
 
@@ -269,7 +269,7 @@ func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string
 	}
 
 	h.callbacks[requestID] = savedCallback{
-		callback:           callback,
+		Callback:           callback,
 		requestStartTime:   requestStartTime,
 		createdAt:          time.Now(),
 		responseAggregator: agg,
@@ -298,7 +298,7 @@ func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp
 		return errors.New("failed to marshal response: " + err.Error())
 	}
 
-	err = saved.callback(ctx, handlers.UserCallbackPayload{
+	err = saved.SendResponse(ctx, handlers.UserCallbackPayload{
 		RawResponse: rawResp,
 		ErrorCode:   api.NoError,
 	})
@@ -372,7 +372,7 @@ func isValidJSON(data []byte) bool {
 	}
 }
 
-func (h *httpTriggerHandler) handleUserError(ctx context.Context, requestID string, code int64, message string, callback handlers.SendResponse) {
+func (h *httpTriggerHandler) handleUserError(ctx context.Context, requestID string, code int64, message string, callback handlers.Callback) {
 	resp := &jsonrpc.Response[json.RawMessage]{
 		Version: "2.0",
 		ID:      requestID,
@@ -388,7 +388,7 @@ func (h *httpTriggerHandler) handleUserError(ctx context.Context, requestID stri
 	}
 	errorCode := api.ErrorCode(code)
 	h.metrics.Trigger.IncrementRequestErrors(ctx, errorCode.String(), h.lggr)
-	err = callback(ctx, handlers.UserCallbackPayload{
+	err = callback.SendResponse(ctx, handlers.UserCallbackPayload{
 		RawResponse: rawResp,
 		ErrorCode:   errorCode,
 	})

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -29,7 +29,7 @@ import (
 var _ HTTPTriggerHandler = (*httpTriggerHandler)(nil)
 
 type savedCallback struct {
-	callbackCh         chan<- handlers.UserCallbackPayload
+	callback           handlers.SendResponse
 	requestStartTime   time.Time
 	createdAt          time.Time
 	responseAggregator *aggregation.IdenticalNodeResponseAggregator
@@ -51,7 +51,7 @@ type httpTriggerHandler struct {
 
 type HTTPTriggerHandler interface {
 	job.ServiceCtx
-	HandleUserTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callbackCh chan<- handlers.UserCallbackPayload, requestStartTime time.Time) error
+	HandleUserTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.SendResponse, requestStartTime time.Time) error
 	HandleNodeTriggerResponse(ctx context.Context, resp *jsonrpc.Response[json.RawMessage], nodeAddr string) error
 }
 
@@ -69,65 +69,65 @@ func NewHTTPTriggerHandler(lggr logger.Logger, cfg ServiceConfig, donConfig *con
 	}
 }
 
-func (h *httpTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callbackCh chan<- handlers.UserCallbackPayload, requestStartTime time.Time) error {
-	triggerReq, err := h.validatedTriggerRequest(ctx, req, callbackCh)
+func (h *httpTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.SendResponse, requestStartTime time.Time) error {
+	triggerReq, err := h.validatedTriggerRequest(ctx, req, callback)
 	if err != nil {
 		return err
 	}
 
-	workflowID, err := h.resolveWorkflowID(ctx, triggerReq, req.ID, callbackCh)
+	workflowID, err := h.resolveWorkflowID(ctx, triggerReq, req.ID, callback)
 	if err != nil {
 		return err
 	}
 
-	key, err := h.authorizeRequest(ctx, workflowID, req, callbackCh)
+	key, err := h.authorizeRequest(ctx, workflowID, req, callback)
 	if err != nil {
 		return err
 	}
 
-	if err = h.checkRateLimit(ctx, workflowID, req.ID, callbackCh); err != nil {
+	if err = h.checkRateLimit(ctx, workflowID, req.ID, callback); err != nil {
 		return err
 	}
 
 	executionID, err := workflows.EncodeExecutionID(workflowID, req.ID)
 	if err != nil {
-		h.handleUserError(ctx, req.ID, jsonrpc.ErrInternal, internalErrorMessage, callbackCh)
+		h.handleUserError(ctx, req.ID, jsonrpc.ErrInternal, internalErrorMessage, callback)
 		return errors.New("error generating execution ID: " + err.Error())
 	}
 
 	reqWithKey, err := reqWithAuthorizedKey(triggerReq, *key)
 	if err != nil {
-		h.handleUserError(ctx, req.ID, jsonrpc.ErrInvalidRequest, "Auth failure", callbackCh)
+		h.handleUserError(ctx, req.ID, jsonrpc.ErrInvalidRequest, "Auth failure", callback)
 		return errors.Join(errors.New("auth failure"), err)
 	}
 
-	if err := h.setupCallback(ctx, req.ID, callbackCh, requestStartTime); err != nil {
+	if err := h.setupCallback(ctx, req.ID, callback, requestStartTime); err != nil {
 		return err
 	}
 
 	return h.sendWithRetries(ctx, executionID, reqWithKey)
 }
 
-func (h *httpTriggerHandler) validatedTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callbackCh chan<- handlers.UserCallbackPayload) (*jsonrpc.Request[gateway_common.HTTPTriggerRequest], error) {
+func (h *httpTriggerHandler) validatedTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.SendResponse) (*jsonrpc.Request[gateway_common.HTTPTriggerRequest], error) {
 	if req.Params == nil {
-		h.handleUserError(ctx, "", jsonrpc.ErrInvalidRequest, "request params is nil", callbackCh)
+		h.handleUserError(ctx, "", jsonrpc.ErrInvalidRequest, "request params is nil", callback)
 		return nil, errors.New("request params is nil")
 	}
 
-	triggerReq, err := h.parseTriggerRequest(ctx, req, callbackCh)
+	triggerReq, err := h.parseTriggerRequest(ctx, req, callback)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := h.validateRequestID(ctx, req.ID, callbackCh); err != nil {
+	if err := h.validateRequestID(ctx, req.ID, callback); err != nil {
 		return nil, err
 	}
 
-	if err := h.validateMethod(ctx, req.Method, req.ID, callbackCh); err != nil {
+	if err := h.validateMethod(ctx, req.Method, req.ID, callback); err != nil {
 		return nil, err
 	}
 
-	if err := h.validateTriggerParams(ctx, triggerReq, req.ID, callbackCh); err != nil {
+	if err := h.validateTriggerParams(ctx, triggerReq, req.ID, callback); err != nil {
 		return nil, err
 	}
 
@@ -139,73 +139,73 @@ func (h *httpTriggerHandler) validatedTriggerRequest(ctx context.Context, req *j
 	}, nil
 }
 
-func (h *httpTriggerHandler) parseTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callbackCh chan<- handlers.UserCallbackPayload) (*gateway_common.HTTPTriggerRequest, error) {
+func (h *httpTriggerHandler) parseTriggerRequest(ctx context.Context, req *jsonrpc.Request[json.RawMessage], callback handlers.SendResponse) (*gateway_common.HTTPTriggerRequest, error) {
 	var triggerReq gateway_common.HTTPTriggerRequest
 	err := json.Unmarshal(*req.Params, &triggerReq)
 	if err != nil {
-		h.handleUserError(ctx, req.ID, jsonrpc.ErrParse, "error decoding payload: "+err.Error(), callbackCh)
+		h.handleUserError(ctx, req.ID, jsonrpc.ErrParse, "error decoding payload: "+err.Error(), callback)
 		return nil, err
 	}
 	return &triggerReq, nil
 }
 
-func (h *httpTriggerHandler) validateRequestID(ctx context.Context, requestID string, callbackCh chan<- handlers.UserCallbackPayload) error {
+func (h *httpTriggerHandler) validateRequestID(ctx context.Context, requestID string, callback handlers.SendResponse) error {
 	if requestID == "" {
-		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "empty request ID", callbackCh)
+		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "empty request ID", callback)
 		return errors.New("empty request ID")
 	}
 	// Request IDs from users must not contain "/", since this character is reserved
 	// for internal node-to-node message routing (e.g., "http_action/{workflowID}/{uuid}").
 	if strings.Contains(requestID, "/") {
-		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "request ID must not contain '/'", callbackCh)
+		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "request ID must not contain '/'", callback)
 		return errors.New("request ID must not contain '/'")
 	}
 	return nil
 }
 
-func (h *httpTriggerHandler) validateMethod(ctx context.Context, method, requestID string, callbackCh chan<- handlers.UserCallbackPayload) error {
+func (h *httpTriggerHandler) validateMethod(ctx context.Context, method, requestID string, callback handlers.SendResponse) error {
 	if method != gateway_common.MethodWorkflowExecute {
-		h.handleUserError(ctx, requestID, jsonrpc.ErrMethodNotFound, "invalid method: "+method, callbackCh)
+		h.handleUserError(ctx, requestID, jsonrpc.ErrMethodNotFound, "invalid method: "+method, callback)
 		return errors.New("invalid method: " + method)
 	}
 	return nil
 }
 
-func (h *httpTriggerHandler) validateTriggerParams(ctx context.Context, triggerReq *gateway_common.HTTPTriggerRequest, requestID string, callbackCh chan<- handlers.UserCallbackPayload) error {
+func (h *httpTriggerHandler) validateTriggerParams(ctx context.Context, triggerReq *gateway_common.HTTPTriggerRequest, requestID string, callback handlers.SendResponse) error {
 	if !isValidJSON(triggerReq.Input) {
 		h.lggr.Errorw("invalid params JSON", "params", triggerReq.Input)
-		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "invalid params JSON", callbackCh)
+		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "invalid params JSON", callback)
 		return errors.New("invalid params JSON")
 	}
 
-	return h.validateWorkflowFields(ctx, triggerReq.Workflow, requestID, callbackCh)
+	return h.validateWorkflowFields(ctx, triggerReq.Workflow, requestID, callback)
 }
 
-func (h *httpTriggerHandler) validateWorkflowFields(ctx context.Context, workflow gateway_common.WorkflowSelector, requestID string, callbackCh chan<- handlers.UserCallbackPayload) error {
+func (h *httpTriggerHandler) validateWorkflowFields(ctx context.Context, workflow gateway_common.WorkflowSelector, requestID string, callback handlers.SendResponse) error {
 	if workflow.WorkflowID != "" {
 		if !strings.HasPrefix(workflow.WorkflowID, "0x") {
-			h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflowID must be prefixed with '0x'", callbackCh)
+			h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflowID must be prefixed with '0x'", callback)
 			return errors.New("workflowID must be prefixed with '0x'")
 		}
 		if workflow.WorkflowID != strings.ToLower(workflow.WorkflowID) {
-			h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflowID must be lowercase", callbackCh)
+			h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflowID must be lowercase", callback)
 			return errors.New("workflowID must be lowercase")
 		}
 	}
 	if workflow.WorkflowOwner != "" {
 		if !strings.HasPrefix(workflow.WorkflowOwner, "0x") {
-			h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflowOwner must be prefixed with '0x'", callbackCh)
+			h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflowOwner must be prefixed with '0x'", callback)
 			return errors.New("workflowOwner must be prefixed with '0x'")
 		}
 		if workflow.WorkflowOwner != strings.ToLower(workflow.WorkflowOwner) {
-			h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflowOwner must be lowercase", callbackCh)
+			h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflowOwner must be lowercase", callback)
 			return errors.New("workflowOwner must be lowercase")
 		}
 	}
 	return nil
 }
 
-func (h *httpTriggerHandler) resolveWorkflowID(ctx context.Context, triggerReq *jsonrpc.Request[gateway_common.HTTPTriggerRequest], requestID string, callbackCh chan<- handlers.UserCallbackPayload) (string, error) {
+func (h *httpTriggerHandler) resolveWorkflowID(ctx context.Context, triggerReq *jsonrpc.Request[gateway_common.HTTPTriggerRequest], requestID string, callback handlers.SendResponse) (string, error) {
 	workflowID := triggerReq.Params.Workflow.WorkflowID
 	if workflowID != "" {
 		return workflowID, nil
@@ -218,47 +218,47 @@ func (h *httpTriggerHandler) resolveWorkflowID(ctx context.Context, triggerReq *
 		triggerReq.Params.Workflow.WorkflowTag,
 	)
 	if !found {
-		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflow not found", callbackCh)
+		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflow not found", callback)
 		return "", errors.New("workflow not found")
 	}
 	return workflowID, nil
 }
 
-func (h *httpTriggerHandler) authorizeRequest(ctx context.Context, workflowID string, req *jsonrpc.Request[json.RawMessage], callbackCh chan<- handlers.UserCallbackPayload) (*gateway_common.AuthorizedKey, error) {
+func (h *httpTriggerHandler) authorizeRequest(ctx context.Context, workflowID string, req *jsonrpc.Request[json.RawMessage], callback handlers.SendResponse) (*gateway_common.AuthorizedKey, error) {
 	key, err := h.workflowMetadataHandler.Authorize(workflowID, req.Auth, req)
 	if err != nil {
-		h.handleUserError(ctx, req.ID, jsonrpc.ErrInvalidRequest, "Auth failure", callbackCh)
+		h.handleUserError(ctx, req.ID, jsonrpc.ErrInvalidRequest, "Auth failure", callback)
 		return nil, errors.Join(errors.New("auth failure"), err)
 	}
 	return key, nil
 }
 
-func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, requestID string, callbackCh chan<- handlers.UserCallbackPayload) error {
+func (h *httpTriggerHandler) checkRateLimit(ctx context.Context, workflowID, requestID string, callback handlers.SendResponse) error {
 	workflowRef, found := h.workflowMetadataHandler.GetWorkflowReference(workflowID)
 	if !found {
-		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflow reference not found", callbackCh)
+		h.handleUserError(ctx, requestID, jsonrpc.ErrInvalidRequest, "workflow reference not found", callback)
 		return errors.New("workflow reference not found")
 	}
 	workflowOwnerAllow, globalAllow := h.userRateLimiter.AllowVerbose(workflowRef.workflowOwner)
 	if !workflowOwnerAllow {
 		h.metrics.Trigger.IncrementWorkflowOwnerThrottled(ctx, h.lggr)
-		h.handleUserError(ctx, requestID, jsonrpc.ErrLimitExceeded, "rate limit exceeded", callbackCh)
+		h.handleUserError(ctx, requestID, jsonrpc.ErrLimitExceeded, "rate limit exceeded", callback)
 		return errors.New("workflow owner rate limit exceeded")
 	}
 	if !globalAllow {
 		h.metrics.Trigger.IncrementGlobalThrottled(ctx, h.lggr)
-		h.handleUserError(ctx, requestID, jsonrpc.ErrLimitExceeded, "rate limit exceeded", callbackCh)
+		h.handleUserError(ctx, requestID, jsonrpc.ErrLimitExceeded, "rate limit exceeded", callback)
 		return errors.New("global rate limit exceeded")
 	}
 	return nil
 }
 
-func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string, callbackCh chan<- handlers.UserCallbackPayload, requestStartTime time.Time) error {
+func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string, callback handlers.SendResponse, requestStartTime time.Time) error {
 	h.callbacksMu.Lock()
 	defer h.callbacksMu.Unlock()
 
 	if _, found := h.callbacks[requestID]; found {
-		h.handleUserError(ctx, requestID, jsonrpc.ErrConflict, "in-flight request", callbackCh)
+		h.handleUserError(ctx, requestID, jsonrpc.ErrConflict, "in-flight request", callback)
 		return errors.New("in-flight request ID: " + requestID)
 	}
 
@@ -269,7 +269,7 @@ func (h *httpTriggerHandler) setupCallback(ctx context.Context, requestID string
 	}
 
 	h.callbacks[requestID] = savedCallback{
-		callbackCh:         callbackCh,
+		callback:           callback,
 		requestStartTime:   requestStartTime,
 		createdAt:          time.Now(),
 		responseAggregator: agg,
@@ -297,17 +297,18 @@ func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp
 	if err != nil {
 		return errors.New("failed to marshal response: " + err.Error())
 	}
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case saved.callbackCh <- handlers.UserCallbackPayload{
+
+	err = saved.callback(ctx, handlers.UserCallbackPayload{
 		RawResponse: rawResp,
 		ErrorCode:   api.NoError,
-	}:
-		delete(h.callbacks, resp.ID)
-		latencyMs := time.Since(saved.requestStartTime).Milliseconds()
-		h.metrics.Trigger.RecordRequestHandlerLatency(ctx, latencyMs, h.lggr)
+	})
+	if err != nil {
+		return err
 	}
+
+	delete(h.callbacks, resp.ID)
+	latencyMs := time.Since(saved.requestStartTime).Milliseconds()
+	h.metrics.Trigger.RecordRequestHandlerLatency(ctx, latencyMs, h.lggr)
 	return nil
 }
 
@@ -371,7 +372,7 @@ func isValidJSON(data []byte) bool {
 	}
 }
 
-func (h *httpTriggerHandler) handleUserError(ctx context.Context, requestID string, code int64, message string, callbackCh chan<- handlers.UserCallbackPayload) {
+func (h *httpTriggerHandler) handleUserError(ctx context.Context, requestID string, code int64, message string, callback handlers.SendResponse) {
 	resp := &jsonrpc.Response[json.RawMessage]{
 		Version: "2.0",
 		ID:      requestID,
@@ -387,9 +388,13 @@ func (h *httpTriggerHandler) handleUserError(ctx context.Context, requestID stri
 	}
 	errorCode := api.ErrorCode(code)
 	h.metrics.Trigger.IncrementRequestErrors(ctx, errorCode.String(), h.lggr)
-	callbackCh <- handlers.UserCallbackPayload{
+	err = callback(ctx, handlers.UserCallbackPayload{
 		RawResponse: rawResp,
 		ErrorCode:   errorCode,
+	})
+	if err != nil {
+		h.lggr.Errorw("failed to send user callback", "err", err, "requestID", requestID)
+		return
 	}
 }
 

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler.go
@@ -298,7 +298,7 @@ func (h *httpTriggerHandler) HandleNodeTriggerResponse(ctx context.Context, resp
 		return errors.New("failed to marshal response: " + err.Error())
 	}
 
-	err = saved.SendResponse(ctx, handlers.UserCallbackPayload{
+	err = saved.SendResponse(handlers.UserCallbackPayload{
 		RawResponse: rawResp,
 		ErrorCode:   api.NoError,
 	})
@@ -388,7 +388,7 @@ func (h *httpTriggerHandler) handleUserError(ctx context.Context, requestID stri
 	}
 	errorCode := api.ErrorCode(code)
 	h.metrics.Trigger.IncrementRequestErrors(ctx, errorCode.String(), h.lggr)
-	err = callback.SendResponse(ctx, handlers.UserCallbackPayload{
+	err = callback.SendResponse(handlers.UserCallbackPayload{
 		RawResponse: rawResp,
 		ErrorCode:   errorCode,
 	})

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
@@ -24,6 +23,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/capabilities/v2/metrics"
+	hc "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/common"
 	handlermocks "github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -40,15 +40,6 @@ func createTestMetrics(t *testing.T) *metrics.Metrics {
 func requireUserErrorSent(t *testing.T, payload handlers.UserCallbackPayload, errorCode int) {
 	require.NotEmpty(t, payload.RawResponse)
 	require.Equal(t, api.ErrorCode(errorCode), payload.ErrorCode)
-}
-
-type callback struct {
-	r handlers.UserCallbackPayload
-}
-
-func (c *callback) SendResponse(_ context.Context, cb handlers.UserCallbackPayload) error {
-	c.r = cb
-	return nil
 }
 
 func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
@@ -70,7 +61,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 	t.Run("successful trigger request", func(t *testing.T) {
 		handler, mockDon := createTestTriggerHandler(t)
 		registerWorkflow(t, handler, triggerReq.Workflow.WorkflowID, privateKey)
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		// Mock DON to expect sends to all nodes
 		mockDon.EXPECT().SendToNode(mock.Anything, "node1", mock.Anything).Return(nil)
@@ -91,7 +82,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 
 	t.Run("invalid JSON params", func(t *testing.T) {
 		handler, _ := createTestTriggerHandler(t)
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		rawParams := json.RawMessage(`{invalid json}`)
 		req := &jsonrpc.Request[json.RawMessage]{
@@ -104,12 +95,14 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 		err := handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.Error(t, err)
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrParse))
+		r, err := callback.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrParse))
 	})
 
 	t.Run("empty request ID", func(t *testing.T) {
 		handler, _ := createTestTriggerHandler(t)
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		triggerReq := createTestTriggerRequest()
 		reqBytes, err := json.Marshal(triggerReq)
@@ -127,12 +120,14 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty request ID")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
+		r, err := callback.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("request ID contains slash", func(t *testing.T) {
 		handler, _ := createTestTriggerHandler(t)
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -155,12 +150,14 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "must not contain '/'")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
+		r, err := callback.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("invalid method", func(t *testing.T) {
 		handler, _ := createTestTriggerHandler(t)
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -183,15 +180,17 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid method")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrMethodNotFound))
+		r, err := callback.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrMethodNotFound))
 	})
 
 	t.Run("duplicate request ID", func(t *testing.T) {
 		handler, mockDon := createTestTriggerHandler(t)
 		privateKey := createTestPrivateKey(t)
 		registerWorkflow(t, handler, workflowID, privateKey)
-		callback1 := &callback{}
-		callback2 := &callback{}
+		callback1 := hc.NewCallback()
+		callback2 := hc.NewCallback()
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -220,12 +219,14 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback2, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "in-flight request")
-		requireUserErrorSent(t, callback2.r, int(jsonrpc.ErrConflict))
+		r, err := callback2.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrConflict))
 	})
 
 	t.Run("invalid input JSON", func(t *testing.T) {
 		handler, _ := createTestTriggerHandler(t)
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		rawParams := json.RawMessage([]byte(`{"workflow":{"workflowID":"0x1234567890abcdef1234567890abcdef12345678901234567890abcdef123456"},"input":{"invalid json"}`))
 		req := &jsonrpc.Request[json.RawMessage]{
@@ -245,7 +246,7 @@ func TestHttpTriggerHandler_HandleNodeTriggerResponse(t *testing.T) {
 		handler, mockDon := createTestTriggerHandler(t)
 		privateKey := createTestPrivateKey(t)
 		registerWorkflow(t, handler, workflowID, privateKey)
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		// First, create a trigger request to set up the callback
 		triggerReq := gateway_common.HTTPTriggerRequest{
@@ -289,7 +290,8 @@ func TestHttpTriggerHandler_HandleNodeTriggerResponse(t *testing.T) {
 		require.NoError(t, err)
 
 		// Check that callback was called
-		payload := callback.r
+		payload, err := callback.Wait(t.Context())
+		require.NoError(t, err)
 		require.NotEmpty(t, payload.RawResponse)
 		require.Equal(t, api.NoError, payload.ErrorCode)
 
@@ -388,7 +390,7 @@ func TestHttpTriggerHandler_ReapExpiredCallbacks(t *testing.T) {
 	registerWorkflow(t, handler, workflowID, privateKey)
 
 	t.Run("reap expired callbacks", func(t *testing.T) {
-		callback := &callback{}
+		callback := hc.NewCallback()
 		mockDon.EXPECT().SendToNode(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3)
 		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.NoError(t, err)
@@ -412,7 +414,7 @@ func TestHttpTriggerHandler_ReapExpiredCallbacks(t *testing.T) {
 	})
 
 	t.Run("keep non-expired callbacks", func(t *testing.T) {
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		mockDon.EXPECT().SendToNode(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3)
 		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
@@ -519,7 +521,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Retries(t *testing.T) {
 		}
 		req.Auth = createTestJWTToken(t, req, privateKey)
 
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		// First attempt: node1 succeeds, node2 and node3 fail
 		mockDon.On("SendToNode", mock.Anything, "node1", mock.Anything).Return(nil).Once()
@@ -572,7 +574,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 	}
 
 	t.Run("successful JWT authorization", func(t *testing.T) {
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		triggerReq := createTestTriggerRequest()
 		reqBytes, err2 := json.Marshal(triggerReq)
@@ -606,7 +608,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 	})
 
 	t.Run("invalid JWT token", func(t *testing.T) {
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		triggerReq := createTestTriggerRequest()
 		reqBytes, err2 := json.Marshal(triggerReq)
@@ -625,11 +627,13 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "auth failure")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
+		r, ierr := callback.Wait(t.Context())
+		require.NoError(t, ierr)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("unauthorized signer", func(t *testing.T) {
-		callback := &callback{}
+		callback := hc.NewCallback()
 		unauthorizedKey := createTestPrivateKey(t)
 
 		triggerReq := createTestTriggerRequest()
@@ -651,11 +655,13 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "auth failure")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
+		r, ierr := callback.Wait(t.Context())
+		require.NoError(t, ierr)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("workflow not found", func(t *testing.T) {
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -681,7 +687,9 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "auth failure")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
+		r, err := callback.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrInvalidRequest))
 	})
 }
 
@@ -715,7 +723,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_WorkflowLookup(t *testing.T
 	handler.workflowMetadataHandler.workflowRefToID[workflowRef] = workflowID
 
 	t.Run("successful workflow lookup by name", func(t *testing.T) {
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -750,7 +758,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_WorkflowLookup(t *testing.T
 	})
 
 	t.Run("workflow not found by name", func(t *testing.T) {
-		callback := &callback{}
+		callback := hc.NewCallback()
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -778,14 +786,16 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_WorkflowLookup(t *testing.T
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflow not found")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
+		r, err := callback.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrInvalidRequest))
 	})
 }
 func TestHttpTriggerHandler_HandleUserTriggerRequest_Validation(t *testing.T) {
 	handler, _ := createTestTriggerHandler(t)
-	callback := &callback{}
 
 	t.Run("workflowID without 0x prefix", func(t *testing.T) {
+		callback := hc.NewCallback()
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
 				WorkflowID: "1234567890abcdef1234567890abcdef12345678901234567890abcdef123456", // Missing 0x
@@ -807,10 +817,13 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Validation(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflowID must be prefixed with '0x'")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
+		r, err := callback.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("workflowOwner without 0x prefix", func(t *testing.T) {
+		callback := hc.NewCallback()
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
 				WorkflowOwner: "1234567890abcdef1234567890abcdef12345678", // Missing 0x
@@ -834,10 +847,13 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Validation(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflowOwner must be prefixed with '0x'")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
+		r, err := callback.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("workflowID uppercase", func(t *testing.T) {
+		callback := hc.NewCallback()
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
 				WorkflowID: "0x1234567890ABCDEF1234567890abcdef12345678901234567890abcdef123456", // Contains uppercase
@@ -859,10 +875,13 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Validation(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflowID must be lowercase")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
+		r, err := callback.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("workflowOwner uppercase", func(t *testing.T) {
+		callback := hc.NewCallback()
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
 				WorkflowOwner: "0x1234567890ABCDEF1234567890abcdef12345678", // Contains uppercase
@@ -886,7 +905,9 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Validation(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflowOwner must be lowercase")
 
-		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
+		r, err := callback.Wait(t.Context())
+		require.NoError(t, err)
+		requireUserErrorSent(t, r, int(jsonrpc.ErrInvalidRequest))
 	})
 }
 

--- a/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
+++ b/core/services/gateway/handlers/capabilities/v2/http_trigger_handler_test.go
@@ -1,11 +1,11 @@
 package v2
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -37,15 +37,18 @@ func createTestMetrics(t *testing.T) *metrics.Metrics {
 	return m
 }
 
-func requireUserErrorSent(t *testing.T, callbackCh chan handlers.UserCallbackPayload, errorCode int) {
-	select {
-	case payload := <-callbackCh:
-		require.NotEmpty(t, payload.RawResponse)
-		fmt.Printf("Received error payload: %+v\n", payload.RawResponse)
-		require.Equal(t, api.ErrorCode(errorCode), payload.ErrorCode)
-	case <-t.Context().Done():
-		t.Fatal("Expected error callback")
-	}
+func requireUserErrorSent(t *testing.T, payload handlers.UserCallbackPayload, errorCode int) {
+	require.NotEmpty(t, payload.RawResponse)
+	require.Equal(t, api.ErrorCode(errorCode), payload.ErrorCode)
+}
+
+type callback struct {
+	r handlers.UserCallbackPayload
+}
+
+func (c *callback) SendResponse(_ context.Context, cb handlers.UserCallbackPayload) error {
+	c.r = cb
+	return nil
 }
 
 func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
@@ -67,14 +70,14 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 	t.Run("successful trigger request", func(t *testing.T) {
 		handler, mockDon := createTestTriggerHandler(t)
 		registerWorkflow(t, handler, triggerReq.Workflow.WorkflowID, privateKey)
-		callbackCh := make(chan<- handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		// Mock DON to expect sends to all nodes
 		mockDon.EXPECT().SendToNode(mock.Anything, "node1", mock.Anything).Return(nil)
 		mockDon.EXPECT().SendToNode(mock.Anything, "node2", mock.Anything).Return(nil)
 		mockDon.EXPECT().SendToNode(mock.Anything, "node3", mock.Anything).Return(nil)
 
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.NoError(t, err)
 
 		handler.callbacksMu.Lock()
@@ -82,13 +85,13 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 		handler.callbacksMu.Unlock()
 
 		require.True(t, exists)
-		require.Equal(t, callbackCh, saved.callbackCh)
+		require.Equal(t, callback, saved.Callback)
 		require.NotNil(t, saved.responseAggregator)
 	})
 
 	t.Run("invalid JSON params", func(t *testing.T) {
 		handler, _ := createTestTriggerHandler(t)
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		rawParams := json.RawMessage(`{invalid json}`)
 		req := &jsonrpc.Request[json.RawMessage]{
@@ -98,15 +101,15 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 			Params:  &rawParams,
 		}
 
-		err := handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err := handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.Error(t, err)
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrParse))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrParse))
 	})
 
 	t.Run("empty request ID", func(t *testing.T) {
 		handler, _ := createTestTriggerHandler(t)
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		triggerReq := createTestTriggerRequest()
 		reqBytes, err := json.Marshal(triggerReq)
@@ -120,16 +123,16 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 			Params:  &rawParams,
 		}
 
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty request ID")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrInvalidRequest))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("request ID contains slash", func(t *testing.T) {
 		handler, _ := createTestTriggerHandler(t)
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -148,16 +151,16 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 			Params:  &rawParams,
 		}
 
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "must not contain '/'")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrInvalidRequest))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("invalid method", func(t *testing.T) {
 		handler, _ := createTestTriggerHandler(t)
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -176,19 +179,19 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 			Params:  &rawParams,
 		}
 
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid method")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrMethodNotFound))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrMethodNotFound))
 	})
 
 	t.Run("duplicate request ID", func(t *testing.T) {
 		handler, mockDon := createTestTriggerHandler(t)
 		privateKey := createTestPrivateKey(t)
 		registerWorkflow(t, handler, workflowID, privateKey)
-		callbackCh1 := make(chan handlers.UserCallbackPayload, 1)
-		callbackCh2 := make(chan handlers.UserCallbackPayload, 1)
+		callback1 := &callback{}
+		callback2 := &callback{}
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -210,19 +213,19 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 
 		// First request should succeed
 		mockDon.EXPECT().SendToNode(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3)
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh1, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback1, time.Now())
 		require.NoError(t, err)
 
 		// Second request with same ID should fail
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh2, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback2, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "in-flight request")
-		requireUserErrorSent(t, callbackCh2, int(jsonrpc.ErrConflict))
+		requireUserErrorSent(t, callback2.r, int(jsonrpc.ErrConflict))
 	})
 
 	t.Run("invalid input JSON", func(t *testing.T) {
 		handler, _ := createTestTriggerHandler(t)
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		rawParams := json.RawMessage([]byte(`{"workflow":{"workflowID":"0x1234567890abcdef1234567890abcdef12345678901234567890abcdef123456"},"input":{"invalid json"}`))
 		req := &jsonrpc.Request[json.RawMessage]{
@@ -232,7 +235,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest(t *testing.T) {
 			Params:  &rawParams,
 		}
 
-		err := handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err := handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.Error(t, err)
 	})
 }
@@ -242,7 +245,7 @@ func TestHttpTriggerHandler_HandleNodeTriggerResponse(t *testing.T) {
 		handler, mockDon := createTestTriggerHandler(t)
 		privateKey := createTestPrivateKey(t)
 		registerWorkflow(t, handler, workflowID, privateKey)
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		// First, create a trigger request to set up the callback
 		triggerReq := gateway_common.HTTPTriggerRequest{
@@ -264,7 +267,7 @@ func TestHttpTriggerHandler_HandleNodeTriggerResponse(t *testing.T) {
 		req.Auth = createTestJWTToken(t, req, privateKey)
 
 		mockDon.EXPECT().SendToNode(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3)
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.NoError(t, err)
 		// Create node responses
 		rawRes := json.RawMessage(`{"result":"success"}`)
@@ -286,18 +289,14 @@ func TestHttpTriggerHandler_HandleNodeTriggerResponse(t *testing.T) {
 		require.NoError(t, err)
 
 		// Check that callback was called
-		select {
-		case payload := <-callbackCh:
-			require.NotEmpty(t, payload.RawResponse)
-			require.Equal(t, api.NoError, payload.ErrorCode)
+		payload := callback.r
+		require.NotEmpty(t, payload.RawResponse)
+		require.Equal(t, api.NoError, payload.ErrorCode)
 
-			var resp jsonrpc.Response[json.RawMessage]
-			err := json.Unmarshal(payload.RawResponse, &resp)
-			require.NoError(t, err)
-			require.Equal(t, nodeResp.Result, resp.Result)
-		case <-t.Context().Done():
-			t.Fatal("Expected callback")
-		}
+		var resp jsonrpc.Response[json.RawMessage]
+		err = json.Unmarshal(payload.RawResponse, &resp)
+		require.NoError(t, err)
+		require.Equal(t, nodeResp.Result, resp.Result)
 	})
 
 	t.Run("callback not found", func(t *testing.T) {
@@ -389,9 +388,9 @@ func TestHttpTriggerHandler_ReapExpiredCallbacks(t *testing.T) {
 	registerWorkflow(t, handler, workflowID, privateKey)
 
 	t.Run("reap expired callbacks", func(t *testing.T) {
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 		mockDon.EXPECT().SendToNode(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3)
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.NoError(t, err)
 
 		// Manually set the callback's createdAt to the past to simulate expiration
@@ -413,10 +412,10 @@ func TestHttpTriggerHandler_ReapExpiredCallbacks(t *testing.T) {
 	})
 
 	t.Run("keep non-expired callbacks", func(t *testing.T) {
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		mockDon.EXPECT().SendToNode(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3)
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.NoError(t, err)
 
 		// Optionally, set createdAt to now (should not be expired)
@@ -520,7 +519,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Retries(t *testing.T) {
 		}
 		req.Auth = createTestJWTToken(t, req, privateKey)
 
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		// First attempt: node1 succeeds, node2 and node3 fail
 		mockDon.On("SendToNode", mock.Anything, "node1", mock.Anything).Return(nil).Once()
@@ -537,7 +536,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Retries(t *testing.T) {
 		err := handler.Start(testutils.Context(t))
 		require.NoError(t, err)
 
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.NoError(t, err)
 
 		mockDon.AssertExpectations(t)
@@ -573,7 +572,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 	}
 
 	t.Run("successful JWT authorization", func(t *testing.T) {
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		triggerReq := createTestTriggerRequest()
 		reqBytes, err2 := json.Marshal(triggerReq)
@@ -598,7 +597,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 		mockDon.EXPECT().SendToNode(mock.Anything, "node2", mock.Anything).Return(nil)
 		mockDon.EXPECT().SendToNode(mock.Anything, "node3", mock.Anything).Return(nil)
 
-		err = handler.HandleUserTriggerRequest(ctx, req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(ctx, req, callback, time.Now())
 		require.NoError(t, err)
 		handler.callbacksMu.Lock()
 		_, exists := handler.callbacks[req.ID]
@@ -607,7 +606,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 	})
 
 	t.Run("invalid JWT token", func(t *testing.T) {
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		triggerReq := createTestTriggerRequest()
 		reqBytes, err2 := json.Marshal(triggerReq)
@@ -622,15 +621,15 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 			Auth:    "invalid.jwt.token",
 		}
 
-		err = handler.HandleUserTriggerRequest(ctx, req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(ctx, req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "auth failure")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrInvalidRequest))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("unauthorized signer", func(t *testing.T) {
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 		unauthorizedKey := createTestPrivateKey(t)
 
 		triggerReq := createTestTriggerRequest()
@@ -648,15 +647,15 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 		jwtToken := createTestJWTToken(t, req, unauthorizedKey)
 		req.Auth = jwtToken
 
-		err = handler.HandleUserTriggerRequest(ctx, req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(ctx, req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "auth failure")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrInvalidRequest))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("workflow not found", func(t *testing.T) {
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -678,11 +677,11 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_JWTAuthorization(t *testing
 		jwtToken := createTestJWTToken(t, req, privateKey)
 		req.Auth = jwtToken
 
-		err = handler.HandleUserTriggerRequest(ctx, req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(ctx, req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "auth failure")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrInvalidRequest))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
 	})
 }
 
@@ -716,7 +715,7 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_WorkflowLookup(t *testing.T
 	handler.workflowMetadataHandler.workflowRefToID[workflowRef] = workflowID
 
 	t.Run("successful workflow lookup by name", func(t *testing.T) {
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -746,12 +745,12 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_WorkflowLookup(t *testing.T
 		mockDon.EXPECT().SendToNode(mock.Anything, "node2", mock.Anything).Return(nil)
 		mockDon.EXPECT().SendToNode(mock.Anything, "node3", mock.Anything).Return(nil)
 
-		err = handler.HandleUserTriggerRequest(ctx, req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(ctx, req, callback, time.Now())
 		require.NoError(t, err)
 	})
 
 	t.Run("workflow not found by name", func(t *testing.T) {
-		callbackCh := make(chan handlers.UserCallbackPayload, 1)
+		callback := &callback{}
 
 		triggerReq := gateway_common.HTTPTriggerRequest{
 			Workflow: gateway_common.WorkflowSelector{
@@ -775,16 +774,16 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_WorkflowLookup(t *testing.T
 		jwtToken := createTestJWTToken(t, req, privateKey)
 		req.Auth = jwtToken
 
-		err = handler.HandleUserTriggerRequest(ctx, req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(ctx, req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflow not found")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrInvalidRequest))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
 	})
 }
 func TestHttpTriggerHandler_HandleUserTriggerRequest_Validation(t *testing.T) {
 	handler, _ := createTestTriggerHandler(t)
-	callbackCh := make(chan handlers.UserCallbackPayload, 1)
+	callback := &callback{}
 
 	t.Run("workflowID without 0x prefix", func(t *testing.T) {
 		triggerReq := gateway_common.HTTPTriggerRequest{
@@ -804,11 +803,11 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Validation(t *testing.T) {
 			Params:  &rawParams,
 		}
 
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflowID must be prefixed with '0x'")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrInvalidRequest))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("workflowOwner without 0x prefix", func(t *testing.T) {
@@ -831,11 +830,11 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Validation(t *testing.T) {
 			Params:  &rawParams,
 		}
 
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflowOwner must be prefixed with '0x'")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrInvalidRequest))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("workflowID uppercase", func(t *testing.T) {
@@ -856,11 +855,11 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Validation(t *testing.T) {
 			Params:  &rawParams,
 		}
 
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflowID must be lowercase")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrInvalidRequest))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
 	})
 
 	t.Run("workflowOwner uppercase", func(t *testing.T) {
@@ -883,11 +882,11 @@ func TestHttpTriggerHandler_HandleUserTriggerRequest_Validation(t *testing.T) {
 			Params:  &rawParams,
 		}
 
-		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callbackCh, time.Now())
+		err = handler.HandleUserTriggerRequest(testutils.Context(t), req, callback, time.Now())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflowOwner must be lowercase")
 
-		requireUserErrorSent(t, callbackCh, int(jsonrpc.ErrInvalidRequest))
+		requireUserErrorSent(t, callback.r, int(jsonrpc.ErrInvalidRequest))
 	})
 }
 

--- a/core/services/gateway/handlers/capabilities/v2/mocks/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/mocks/http_trigger_handler.go
@@ -121,17 +121,17 @@ func (_c *HTTPTriggerHandler_HandleNodeTriggerResponse_Call) RunAndReturn(run fu
 	return _c
 }
 
-// HandleUserTriggerRequest provides a mock function with given fields: ctx, req, callbackCh, requestStartTime
-func (_m *HTTPTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *jsonrpc2.Request[json.RawMessage], callbackCh chan<- handlers.UserCallbackPayload, requestStartTime time.Time) error {
-	ret := _m.Called(ctx, req, callbackCh, requestStartTime)
+// HandleUserTriggerRequest provides a mock function with given fields: ctx, req, callback, requestStartTime
+func (_m *HTTPTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *jsonrpc2.Request[json.RawMessage], callback handlers.SendResponse, requestStartTime time.Time) error {
+	ret := _m.Called(ctx, req, callback, requestStartTime)
 
 	if len(ret) == 0 {
 		panic("no return value specified for HandleUserTriggerRequest")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *jsonrpc2.Request[json.RawMessage], chan<- handlers.UserCallbackPayload, time.Time) error); ok {
-		r0 = rf(ctx, req, callbackCh, requestStartTime)
+	if rf, ok := ret.Get(0).(func(context.Context, *jsonrpc2.Request[json.RawMessage], handlers.SendResponse, time.Time) error); ok {
+		r0 = rf(ctx, req, callback, requestStartTime)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -147,15 +147,15 @@ type HTTPTriggerHandler_HandleUserTriggerRequest_Call struct {
 // HandleUserTriggerRequest is a helper method to define mock.On call
 //   - ctx context.Context
 //   - req *jsonrpc2.Request[json.RawMessage]
-//   - callbackCh chan<- handlers.UserCallbackPayload
+//   - callback handlers.SendResponse
 //   - requestStartTime time.Time
-func (_e *HTTPTriggerHandler_Expecter) HandleUserTriggerRequest(ctx interface{}, req interface{}, callbackCh interface{}, requestStartTime interface{}) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
-	return &HTTPTriggerHandler_HandleUserTriggerRequest_Call{Call: _e.mock.On("HandleUserTriggerRequest", ctx, req, callbackCh, requestStartTime)}
+func (_e *HTTPTriggerHandler_Expecter) HandleUserTriggerRequest(ctx interface{}, req interface{}, callback interface{}, requestStartTime interface{}) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
+	return &HTTPTriggerHandler_HandleUserTriggerRequest_Call{Call: _e.mock.On("HandleUserTriggerRequest", ctx, req, callback, requestStartTime)}
 }
 
-func (_c *HTTPTriggerHandler_HandleUserTriggerRequest_Call) Run(run func(ctx context.Context, req *jsonrpc2.Request[json.RawMessage], callbackCh chan<- handlers.UserCallbackPayload, requestStartTime time.Time)) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
+func (_c *HTTPTriggerHandler_HandleUserTriggerRequest_Call) Run(run func(ctx context.Context, req *jsonrpc2.Request[json.RawMessage], callback handlers.SendResponse, requestStartTime time.Time)) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*jsonrpc2.Request[json.RawMessage]), args[2].(chan<- handlers.UserCallbackPayload), args[3].(time.Time))
+		run(args[0].(context.Context), args[1].(*jsonrpc2.Request[json.RawMessage]), args[2].(handlers.SendResponse), args[3].(time.Time))
 	})
 	return _c
 }
@@ -165,7 +165,7 @@ func (_c *HTTPTriggerHandler_HandleUserTriggerRequest_Call) Return(_a0 error) *H
 	return _c
 }
 
-func (_c *HTTPTriggerHandler_HandleUserTriggerRequest_Call) RunAndReturn(run func(context.Context, *jsonrpc2.Request[json.RawMessage], chan<- handlers.UserCallbackPayload, time.Time) error) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
+func (_c *HTTPTriggerHandler_HandleUserTriggerRequest_Call) RunAndReturn(run func(context.Context, *jsonrpc2.Request[json.RawMessage], handlers.SendResponse, time.Time) error) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/gateway/handlers/capabilities/v2/mocks/http_trigger_handler.go
+++ b/core/services/gateway/handlers/capabilities/v2/mocks/http_trigger_handler.go
@@ -122,7 +122,7 @@ func (_c *HTTPTriggerHandler_HandleNodeTriggerResponse_Call) RunAndReturn(run fu
 }
 
 // HandleUserTriggerRequest provides a mock function with given fields: ctx, req, callback, requestStartTime
-func (_m *HTTPTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *jsonrpc2.Request[json.RawMessage], callback handlers.SendResponse, requestStartTime time.Time) error {
+func (_m *HTTPTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req *jsonrpc2.Request[json.RawMessage], callback handlers.Callback, requestStartTime time.Time) error {
 	ret := _m.Called(ctx, req, callback, requestStartTime)
 
 	if len(ret) == 0 {
@@ -130,7 +130,7 @@ func (_m *HTTPTriggerHandler) HandleUserTriggerRequest(ctx context.Context, req 
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *jsonrpc2.Request[json.RawMessage], handlers.SendResponse, time.Time) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *jsonrpc2.Request[json.RawMessage], handlers.Callback, time.Time) error); ok {
 		r0 = rf(ctx, req, callback, requestStartTime)
 	} else {
 		r0 = ret.Error(0)
@@ -147,15 +147,15 @@ type HTTPTriggerHandler_HandleUserTriggerRequest_Call struct {
 // HandleUserTriggerRequest is a helper method to define mock.On call
 //   - ctx context.Context
 //   - req *jsonrpc2.Request[json.RawMessage]
-//   - callback handlers.SendResponse
+//   - callback handlers.Callback
 //   - requestStartTime time.Time
 func (_e *HTTPTriggerHandler_Expecter) HandleUserTriggerRequest(ctx interface{}, req interface{}, callback interface{}, requestStartTime interface{}) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
 	return &HTTPTriggerHandler_HandleUserTriggerRequest_Call{Call: _e.mock.On("HandleUserTriggerRequest", ctx, req, callback, requestStartTime)}
 }
 
-func (_c *HTTPTriggerHandler_HandleUserTriggerRequest_Call) Run(run func(ctx context.Context, req *jsonrpc2.Request[json.RawMessage], callback handlers.SendResponse, requestStartTime time.Time)) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
+func (_c *HTTPTriggerHandler_HandleUserTriggerRequest_Call) Run(run func(ctx context.Context, req *jsonrpc2.Request[json.RawMessage], callback handlers.Callback, requestStartTime time.Time)) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*jsonrpc2.Request[json.RawMessage]), args[2].(handlers.SendResponse), args[3].(time.Time))
+		run(args[0].(context.Context), args[1].(*jsonrpc2.Request[json.RawMessage]), args[2].(handlers.Callback), args[3].(time.Time))
 	})
 	return _c
 }
@@ -165,7 +165,7 @@ func (_c *HTTPTriggerHandler_HandleUserTriggerRequest_Call) Return(_a0 error) *H
 	return _c
 }
 
-func (_c *HTTPTriggerHandler_HandleUserTriggerRequest_Call) RunAndReturn(run func(context.Context, *jsonrpc2.Request[json.RawMessage], handlers.SendResponse, time.Time) error) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
+func (_c *HTTPTriggerHandler_HandleUserTriggerRequest_Call) RunAndReturn(run func(context.Context, *jsonrpc2.Request[json.RawMessage], handlers.Callback, time.Time) error) *HTTPTriggerHandler_HandleUserTriggerRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/gateway/handlers/common/callback.go
+++ b/core/services/gateway/handlers/common/callback.go
@@ -3,44 +3,41 @@ package common
 import (
 	"context"
 	"errors"
-	"sync"
+	"sync/atomic"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 )
 
 type Callback struct {
-	c    chan handlers.UserCallbackPayload
-	mu   sync.Mutex
-	sent bool
+	ch chan handlers.UserCallbackPayload
+
+	sent       atomic.Bool
+	waitCalled atomic.Bool
 }
 
-func (c *Callback) SendResponse(ctx context.Context, payload handlers.UserCallbackPayload) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.sent {
+func (c *Callback) SendResponse(payload handlers.UserCallbackPayload) error {
+	if !c.sent.CompareAndSwap(false, true) {
 		return errors.New("response already sent: each callback can only be used once")
 	}
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case c.c <- payload:
-		c.sent = true
-		return nil
-	}
+	// The channel is initialized with a buffer size of 1,
+	// so this send will not block.
+	c.ch <- payload
+	return nil
 }
 
 func (c *Callback) Wait(ctx context.Context) (handlers.UserCallbackPayload, error) {
+	if !c.waitCalled.CompareAndSwap(false, true) {
+		return handlers.UserCallbackPayload{}, errors.New("Wait can only be called once per Callback instance")
+	}
 	select {
 	case <-ctx.Done():
 		return handlers.UserCallbackPayload{}, ctx.Err()
-	case r := <-c.c:
+	case r := <-c.ch:
 		return r, nil
 	}
 }
 
 func NewCallback() *Callback {
 	ch := make(chan handlers.UserCallbackPayload, 1)
-	return &Callback{c: ch}
+	return &Callback{ch: ch}
 }

--- a/core/services/gateway/handlers/common/callback.go
+++ b/core/services/gateway/handlers/common/callback.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
+)
+
+type Callback struct {
+	c    chan handlers.UserCallbackPayload
+	mu   sync.Mutex
+	sent bool
+}
+
+func (c *Callback) SendResponse(ctx context.Context, payload handlers.UserCallbackPayload) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.sent {
+		return errors.New("response already sent: each callback can only be used once")
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case c.c <- payload:
+		c.sent = true
+		return nil
+	}
+}
+
+func (c *Callback) Wait(ctx context.Context) (handlers.UserCallbackPayload, error) {
+	select {
+	case <-ctx.Done():
+		return handlers.UserCallbackPayload{}, ctx.Err()
+	case r := <-c.c:
+		return r, nil
+	}
+}
+
+func NewCallback() *Callback {
+	ch := make(chan handlers.UserCallbackPayload, 1)
+	return &Callback{c: ch}
+}

--- a/core/services/gateway/handlers/common/callback_test.go
+++ b/core/services/gateway/handlers/common/callback_test.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
+)
+
+func Test_Callback(t *testing.T) {
+	cb := NewCallback()
+	payload := handlers.UserCallbackPayload{RawResponse: []byte("test")}
+
+	err := cb.SendResponse(payload)
+	require.NoError(t, err)
+
+	err = cb.SendResponse(payload)
+	require.ErrorContains(t, err, "response already sent")
+
+	resp, err := cb.Wait(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, payload, resp)
+
+	_, err = cb.Wait(t.Context())
+	require.ErrorContains(t, err, "Wait can only be called once per Callback instance")
+}

--- a/core/services/gateway/handlers/common/requestcache.go
+++ b/core/services/gateway/handlers/common/requestcache.go
@@ -1,10 +1,12 @@
 package common
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 )
@@ -15,8 +17,8 @@ import (
 // Additionally, each request has a timeout, after which the netry will be removed from the cache and an error sent to the callback channel.
 // All methods are thread-safe.
 type RequestCache[T any] interface {
-	NewRequest(request *api.Message, callbackCh chan<- handlers.UserCallbackPayload, responseData *T) error
-	ProcessResponse(response *api.Message, process ResponseProcessor[T]) error
+	NewRequest(ctx context.Context, lggr logger.Logger, request *api.Message, callback handlers.Callback, responseData *T) error
+	ProcessResponse(ctx context.Context, response *api.Message, process ResponseProcessor[T]) error
 }
 
 // If aggregated != nil then the aggregated response is ready and the entry will be deleted from RequestCache.
@@ -36,7 +38,7 @@ type globalId struct {
 }
 
 type pendingRequest[T any] struct {
-	callbackCh   chan<- handlers.UserCallbackPayload
+	handlers.Callback
 	responseData *T
 	timeoutTimer *time.Timer
 	mu           sync.Mutex
@@ -46,7 +48,7 @@ func NewRequestCache[T any](timeout time.Duration, maxCacheSize uint32) RequestC
 	return &requestCache[T]{cache: make(map[globalId]*pendingRequest[T]), timeout: timeout, maxCacheSize: maxCacheSize}
 }
 
-func (c *requestCache[T]) NewRequest(request *api.Message, callbackCh chan<- handlers.UserCallbackPayload, responseData *T) error {
+func (c *requestCache[T]) NewRequest(ctx context.Context, lggr logger.Logger, request *api.Message, callback handlers.Callback, responseData *T) error {
 	if request == nil {
 		return errors.New("request is nil")
 	}
@@ -65,9 +67,12 @@ func (c *requestCache[T]) NewRequest(request *api.Message, callbackCh chan<- han
 	}
 	codec := api.JsonRPCCodec{}
 	timer := time.AfterFunc(c.timeout, func() {
-		c.deleteAndSendOnce(key, handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(request), ErrorCode: api.RequestTimeoutError})
+		err := c.deleteAndSendOnce(ctx, key, handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(request), ErrorCode: api.RequestTimeoutError})
+		if err != nil {
+			lggr.Errorw("failed to send timeout response", "error", err)
+		}
 	})
-	c.cache[key] = &pendingRequest[T]{callbackCh: callbackCh, responseData: responseData, timeoutTimer: timer}
+	c.cache[key] = &pendingRequest[T]{Callback: callback, responseData: responseData, timeoutTimer: timer}
 	return nil
 }
 
@@ -76,7 +81,7 @@ func (c *requestCache[T]) NewRequest(request *api.Message, callbackCh chan<- han
 //
 //	(a) remove request from cache and send aggregated response to the user
 //	(b) update request's responseData and keep it in cache, awaiting more responses from nodes
-func (c *requestCache[T]) ProcessResponse(response *api.Message, process ResponseProcessor[T]) error {
+func (c *requestCache[T]) ProcessResponse(ctx context.Context, response *api.Message, process ResponseProcessor[T]) error {
 	if response == nil {
 		return errors.New("response is nil")
 	}
@@ -99,19 +104,20 @@ func (c *requestCache[T]) ProcessResponse(response *api.Message, process Respons
 		return err
 	}
 	if aggregated != nil {
-		c.deleteAndSendOnce(key, *aggregated)
+		return c.deleteAndSendOnce(ctx, key, *aggregated)
 	}
 	return nil
 }
 
-func (c *requestCache[T]) deleteAndSendOnce(key globalId, callbackResponse handlers.UserCallbackPayload) {
+func (c *requestCache[T]) deleteAndSendOnce(ctx context.Context, key globalId, callbackResponse handlers.UserCallbackPayload) error {
 	c.mu.Lock()
 	entry, deleted := c.cache[key]
 	delete(c.cache, key)
 	c.mu.Unlock()
 	if deleted {
 		entry.timeoutTimer.Stop()
-		entry.callbackCh <- callbackResponse
-		close(entry.callbackCh)
+		return entry.SendResponse(ctx, callbackResponse)
 	}
+
+	return nil
 }

--- a/core/services/gateway/handlers/common/requestcache.go
+++ b/core/services/gateway/handlers/common/requestcache.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"context"
 	"errors"
 	"sync"
 	"time"
@@ -17,8 +16,8 @@ import (
 // Additionally, each request has a timeout, after which the netry will be removed from the cache and an error sent to the callback channel.
 // All methods are thread-safe.
 type RequestCache[T any] interface {
-	NewRequest(ctx context.Context, lggr logger.Logger, request *api.Message, callback handlers.Callback, responseData *T) error
-	ProcessResponse(ctx context.Context, response *api.Message, process ResponseProcessor[T]) error
+	NewRequest(lggr logger.Logger, request *api.Message, callback handlers.Callback, responseData *T) error
+	ProcessResponse(response *api.Message, process ResponseProcessor[T]) error
 }
 
 // If aggregated != nil then the aggregated response is ready and the entry will be deleted from RequestCache.
@@ -48,7 +47,7 @@ func NewRequestCache[T any](timeout time.Duration, maxCacheSize uint32) RequestC
 	return &requestCache[T]{cache: make(map[globalId]*pendingRequest[T]), timeout: timeout, maxCacheSize: maxCacheSize}
 }
 
-func (c *requestCache[T]) NewRequest(ctx context.Context, lggr logger.Logger, request *api.Message, callback handlers.Callback, responseData *T) error {
+func (c *requestCache[T]) NewRequest(lggr logger.Logger, request *api.Message, callback handlers.Callback, responseData *T) error {
 	if request == nil {
 		return errors.New("request is nil")
 	}
@@ -67,7 +66,7 @@ func (c *requestCache[T]) NewRequest(ctx context.Context, lggr logger.Logger, re
 	}
 	codec := api.JsonRPCCodec{}
 	timer := time.AfterFunc(c.timeout, func() {
-		err := c.deleteAndSendOnce(ctx, key, handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(request), ErrorCode: api.RequestTimeoutError})
+		err := c.deleteAndSendOnce(key, handlers.UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(request), ErrorCode: api.RequestTimeoutError})
 		if err != nil {
 			lggr.Errorw("failed to send timeout response", "error", err)
 		}
@@ -81,7 +80,7 @@ func (c *requestCache[T]) NewRequest(ctx context.Context, lggr logger.Logger, re
 //
 //	(a) remove request from cache and send aggregated response to the user
 //	(b) update request's responseData and keep it in cache, awaiting more responses from nodes
-func (c *requestCache[T]) ProcessResponse(ctx context.Context, response *api.Message, process ResponseProcessor[T]) error {
+func (c *requestCache[T]) ProcessResponse(response *api.Message, process ResponseProcessor[T]) error {
 	if response == nil {
 		return errors.New("response is nil")
 	}
@@ -104,19 +103,19 @@ func (c *requestCache[T]) ProcessResponse(ctx context.Context, response *api.Mes
 		return err
 	}
 	if aggregated != nil {
-		return c.deleteAndSendOnce(ctx, key, *aggregated)
+		return c.deleteAndSendOnce(key, *aggregated)
 	}
 	return nil
 }
 
-func (c *requestCache[T]) deleteAndSendOnce(ctx context.Context, key globalId, callbackResponse handlers.UserCallbackPayload) error {
+func (c *requestCache[T]) deleteAndSendOnce(key globalId, callbackResponse handlers.UserCallbackPayload) error {
 	c.mu.Lock()
 	entry, deleted := c.cache[key]
 	delete(c.cache, key)
 	c.mu.Unlock()
 	if deleted {
 		entry.timeoutTimer.Stop()
-		return entry.SendResponse(ctx, callbackResponse)
+		return entry.SendResponse(callbackResponse)
 	}
 
 	return nil

--- a/core/services/gateway/handlers/common/requestcache_test.go
+++ b/core/services/gateway/handlers/common/requestcache_test.go
@@ -29,11 +29,11 @@ func TestRequestCache_Simple(t *testing.T) {
 	req := &api.Message{Body: api.MessageBody{MessageId: "aa", Sender: "0x1234"}}
 	initialState := &requestState{}
 	lggr := logger.Test(t)
-	require.NoError(t, cache.NewRequest(t.Context(), lggr, req, callback, initialState))
+	require.NoError(t, cache.NewRequest(lggr, req, callback, initialState))
 
 	nodeResp := &api.Message{Body: api.MessageBody{MessageId: "aa", Receiver: "0x1234"}}
 	go func() {
-		assert.NoError(t, cache.ProcessResponse(t.Context(), nodeResp, func(response *api.Message, responseData *requestState) (aggregated *handlers.UserCallbackPayload, newResponseData *requestState, err error) {
+		assert.NoError(t, cache.ProcessResponse(nodeResp, func(response *api.Message, responseData *requestState) (aggregated *handlers.UserCallbackPayload, newResponseData *requestState, err error) {
 			// ready after first response
 			var rawResponse json.RawMessage
 			rawResponse, err = json.Marshal(response)
@@ -66,7 +66,7 @@ func TestRequestCache_MultiResponse(t *testing.T) {
 		cbs[i] = cb
 		reqs[i] = &api.Message{Body: api.MessageBody{MessageId: "abcd", Sender: fmt.Sprintf("sender_%d", i)}}
 		initialState := &requestState{counter: 0}
-		require.NoError(t, cache.NewRequest(t.Context(), lggr, reqs[i], cbs[i], initialState))
+		require.NoError(t, cache.NewRequest(lggr, reqs[i], cbs[i], initialState))
 	}
 
 	for i := 0; i < nRequests; i++ {
@@ -76,7 +76,7 @@ func TestRequestCache_MultiResponse(t *testing.T) {
 			go func() {
 				n := rand.Intn(maxDelayMillis) + 1
 				time.Sleep(time.Duration(n) * time.Millisecond)
-				assert.NoError(t, cache.ProcessResponse(t.Context(), resp, func(response *api.Message, responseData *requestState) (aggregated *handlers.UserCallbackPayload, newResponseData *requestState, err error) {
+				assert.NoError(t, cache.ProcessResponse(resp, func(response *api.Message, responseData *requestState) (aggregated *handlers.UserCallbackPayload, newResponseData *requestState, err error) {
 					responseData.counter++
 					if responseData.counter == nResponsesPerRequest {
 						var rawResponse json.RawMessage
@@ -111,7 +111,7 @@ func TestRequestCache_Timeout(t *testing.T) {
 
 	req := &api.Message{Body: api.MessageBody{MessageId: "aa", Sender: "0x1234"}}
 	initialState := &requestState{}
-	require.NoError(t, cache.NewRequest(t.Context(), lggr, req, callback, initialState))
+	require.NoError(t, cache.NewRequest(lggr, req, callback, initialState))
 
 	finalResp, err := callback.Wait(t.Context())
 	require.NoError(t, err)
@@ -131,11 +131,11 @@ func TestRequestCache_MaxSize(t *testing.T) {
 	initialState := &requestState{}
 
 	req := &api.Message{Body: api.MessageBody{MessageId: "aa", Sender: "0x1234"}}
-	require.NoError(t, cache.NewRequest(t.Context(), lggr, req, callback, initialState))
+	require.NoError(t, cache.NewRequest(lggr, req, callback, initialState))
 
 	req.Body.MessageId = "bb"
-	require.NoError(t, cache.NewRequest(t.Context(), lggr, req, callback, initialState))
+	require.NoError(t, cache.NewRequest(lggr, req, callback, initialState))
 
 	req.Body.MessageId = "cc"
-	require.Error(t, cache.NewRequest(t.Context(), lggr, req, callback, initialState))
+	require.Error(t, cache.NewRequest(lggr, req, callback, initialState))
 }

--- a/core/services/gateway/handlers/common/requestcache_test.go
+++ b/core/services/gateway/handlers/common/requestcache_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/common"
@@ -22,15 +24,16 @@ func TestRequestCache_Simple(t *testing.T) {
 	t.Parallel()
 
 	cache := common.NewRequestCache[requestState](time.Hour, 1000)
-	callbackCh := make(chan handlers.UserCallbackPayload)
+	callback := common.NewCallback()
 
 	req := &api.Message{Body: api.MessageBody{MessageId: "aa", Sender: "0x1234"}}
 	initialState := &requestState{}
-	require.NoError(t, cache.NewRequest(req, callbackCh, initialState))
+	lggr := logger.Test(t)
+	require.NoError(t, cache.NewRequest(t.Context(), lggr, req, callback, initialState))
 
 	nodeResp := &api.Message{Body: api.MessageBody{MessageId: "aa", Receiver: "0x1234"}}
 	go func() {
-		require.NoError(t, cache.ProcessResponse(nodeResp, func(response *api.Message, responseData *requestState) (aggregated *handlers.UserCallbackPayload, newResponseData *requestState, err error) {
+		assert.NoError(t, cache.ProcessResponse(t.Context(), nodeResp, func(response *api.Message, responseData *requestState) (aggregated *handlers.UserCallbackPayload, newResponseData *requestState, err error) {
 			// ready after first response
 			var rawResponse json.RawMessage
 			rawResponse, err = json.Marshal(response)
@@ -40,7 +43,8 @@ func TestRequestCache_Simple(t *testing.T) {
 			return &handlers.UserCallbackPayload{RawResponse: rawResponse}, nil, nil
 		}))
 	}()
-	finalResp := <-callbackCh
+	finalResp, err := callback.Wait(t.Context())
+	require.NoError(t, err)
 	var msg api.Message
 	require.NoError(t, json.Unmarshal(finalResp.RawResponse, &msg))
 	require.Equal(t, "aa", msg.Body.MessageId)
@@ -53,14 +57,16 @@ func TestRequestCache_MultiResponse(t *testing.T) {
 	nResponsesPerRequest := 100
 	maxDelayMillis := 100
 
+	lggr := logger.Test(t)
 	cache := common.NewRequestCache[requestState](time.Hour, 1000)
-	chans := make([]chan handlers.UserCallbackPayload, nRequests)
+	cbs := make([]*common.Callback, nRequests)
 	reqs := make([]*api.Message, nRequests)
 	for i := 0; i < nRequests; i++ {
-		chans[i] = make(chan handlers.UserCallbackPayload)
+		cb := common.NewCallback()
+		cbs[i] = cb
 		reqs[i] = &api.Message{Body: api.MessageBody{MessageId: "abcd", Sender: fmt.Sprintf("sender_%d", i)}}
 		initialState := &requestState{counter: 0}
-		require.NoError(t, cache.NewRequest(reqs[i], chans[i], initialState))
+		require.NoError(t, cache.NewRequest(t.Context(), lggr, reqs[i], cbs[i], initialState))
 	}
 
 	for i := 0; i < nRequests; i++ {
@@ -70,7 +76,7 @@ func TestRequestCache_MultiResponse(t *testing.T) {
 			go func() {
 				n := rand.Intn(maxDelayMillis) + 1
 				time.Sleep(time.Duration(n) * time.Millisecond)
-				require.NoError(t, cache.ProcessResponse(resp, func(response *api.Message, responseData *requestState) (aggregated *handlers.UserCallbackPayload, newResponseData *requestState, err error) {
+				assert.NoError(t, cache.ProcessResponse(t.Context(), resp, func(response *api.Message, responseData *requestState) (aggregated *handlers.UserCallbackPayload, newResponseData *requestState, err error) {
 					responseData.counter++
 					if responseData.counter == nResponsesPerRequest {
 						var rawResponse json.RawMessage
@@ -87,7 +93,8 @@ func TestRequestCache_MultiResponse(t *testing.T) {
 	}
 
 	for i := 0; i < nRequests; i++ {
-		resp := <-chans[i]
+		resp, err := cbs[i].Wait(t.Context())
+		require.NoError(t, err)
 		var msg api.Message
 		require.NoError(t, json.Unmarshal(resp.RawResponse, &msg))
 		require.Equal(t, "abcd", msg.Body.MessageId)
@@ -99,13 +106,15 @@ func TestRequestCache_Timeout(t *testing.T) {
 	t.Parallel()
 
 	cache := common.NewRequestCache[requestState](time.Millisecond*10, 1000)
-	callbackCh := make(chan handlers.UserCallbackPayload)
+	callback := common.NewCallback()
+	lggr := logger.Test(t)
 
 	req := &api.Message{Body: api.MessageBody{MessageId: "aa", Sender: "0x1234"}}
 	initialState := &requestState{}
-	require.NoError(t, cache.NewRequest(req, callbackCh, initialState))
+	require.NoError(t, cache.NewRequest(t.Context(), lggr, req, callback, initialState))
 
-	finalResp := <-callbackCh
+	finalResp, err := callback.Wait(t.Context())
+	require.NoError(t, err)
 	codec := api.JsonRPCCodec{}
 	rawResp, err := codec.DecodeLegacyResponse(finalResp.RawResponse)
 	require.NoError(t, err)
@@ -117,15 +126,16 @@ func TestRequestCache_MaxSize(t *testing.T) {
 	t.Parallel()
 
 	cache := common.NewRequestCache[requestState](time.Hour, 2)
-	callbackCh := make(chan handlers.UserCallbackPayload)
+	callback := common.NewCallback()
+	lggr := logger.Test(t)
 	initialState := &requestState{}
 
 	req := &api.Message{Body: api.MessageBody{MessageId: "aa", Sender: "0x1234"}}
-	require.NoError(t, cache.NewRequest(req, callbackCh, initialState))
+	require.NoError(t, cache.NewRequest(t.Context(), lggr, req, callback, initialState))
 
 	req.Body.MessageId = "bb"
-	require.NoError(t, cache.NewRequest(req, callbackCh, initialState))
+	require.NoError(t, cache.NewRequest(t.Context(), lggr, req, callback, initialState))
 
 	req.Body.MessageId = "cc"
-	require.Error(t, cache.NewRequest(req, callbackCh, initialState))
+	require.Error(t, cache.NewRequest(t.Context(), lggr, req, callback, initialState))
 }

--- a/core/services/gateway/handlers/functions/handler.functions.go
+++ b/core/services/gateway/handlers/functions/handler.functions.go
@@ -250,7 +250,7 @@ func (h *functionsHandler) HandleLegacyUserMessage(ctx context.Context, msg *api
 
 func (h *functionsHandler) handleRequest(ctx context.Context, msg *api.Message, callback handlers.Callback) error {
 	h.lggr.Debugw("handleRequest: processing message", "sender", msg.Body.Sender, "messageId", msg.Body.MessageId)
-	err := h.pendingRequests.NewRequest(ctx, h.lggr, msg, callback, &PendingRequest{request: msg, responses: make(map[string]*api.Message)})
+	err := h.pendingRequests.NewRequest(h.lggr, msg, callback, &PendingRequest{request: msg, responses: make(map[string]*api.Message)})
 	if err != nil {
 		h.lggr.Warnw("handleRequest: error adding new request", "sender", msg.Body.Sender, "err", err)
 		promHandlerError.WithLabelValues(h.donConfig.DonId, err.Error()).Inc()
@@ -288,9 +288,9 @@ func (h *functionsHandler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.
 	}
 	switch msg.Body.Method {
 	case MethodSecretsSet, MethodSecretsList:
-		return h.pendingRequests.ProcessResponse(ctx, msg, h.processSecretsResponse)
+		return h.pendingRequests.ProcessResponse(msg, h.processSecretsResponse)
 	case MethodHeartbeat:
-		return h.pendingRequests.ProcessResponse(ctx, msg, h.processHeartbeatResponse)
+		return h.pendingRequests.ProcessResponse(msg, h.processHeartbeatResponse)
 	default:
 		h.lggr.Debugw("unsupported method", "method", msg.Body.Method)
 		return ErrUnsupportedMethod

--- a/core/services/gateway/handlers/functions/handler.functions.go
+++ b/core/services/gateway/handlers/functions/handler.functions.go
@@ -202,11 +202,11 @@ func (h *functionsHandler) Methods() []string {
 	return []string{MethodSecretsSet, MethodSecretsList, MethodHeartbeat}
 }
 
-func (h *functionsHandler) HandleJSONRPCUserMessage(_ context.Context, _ jsonrpc.Request[json.RawMessage], _ chan<- handlers.UserCallbackPayload) error {
+func (h *functionsHandler) HandleJSONRPCUserMessage(_ context.Context, _ jsonrpc.Request[json.RawMessage], _ handlers.Callback) error {
 	return errors.New("functions handler does not support JSON-RPC user messages")
 }
 
-func (h *functionsHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callbackCh chan<- handlers.UserCallbackPayload) error {
+func (h *functionsHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback handlers.Callback) error {
 	sender := common.HexToAddress(msg.Body.Sender)
 	if h.allowlist != nil && !h.allowlist.Allow(sender) {
 		h.lggr.Debugw("received a message from a non-allowlisted address", "sender", msg.Body.Sender)
@@ -233,14 +233,14 @@ func (h *functionsHandler) HandleLegacyUserMessage(ctx context.Context, msg *api
 	}
 	switch msg.Body.Method {
 	case MethodSecretsSet, MethodSecretsList:
-		return h.handleRequest(ctx, msg, callbackCh)
+		return h.handleRequest(ctx, msg, callback)
 	case MethodHeartbeat:
 		if _, ok := h.allowedHeartbeatInitiators[msg.Body.Sender]; !ok {
 			h.lggr.Debugw("received heartbeat request from a non-allowed sender", "sender", msg.Body.Sender)
 			promHandlerError.WithLabelValues(h.donConfig.DonId, ErrNotAllowlisted.Error()).Inc()
 			return ErrUnsupportedMethod
 		}
-		return h.handleRequest(ctx, msg, callbackCh)
+		return h.handleRequest(ctx, msg, callback)
 	default:
 		h.lggr.Debugw("unsupported method", "method", msg.Body.Method)
 		promHandlerError.WithLabelValues(h.donConfig.DonId, ErrUnsupportedMethod.Error()).Inc()
@@ -248,9 +248,9 @@ func (h *functionsHandler) HandleLegacyUserMessage(ctx context.Context, msg *api
 	}
 }
 
-func (h *functionsHandler) handleRequest(ctx context.Context, msg *api.Message, callbackCh chan<- handlers.UserCallbackPayload) error {
+func (h *functionsHandler) handleRequest(ctx context.Context, msg *api.Message, callback handlers.Callback) error {
 	h.lggr.Debugw("handleRequest: processing message", "sender", msg.Body.Sender, "messageId", msg.Body.MessageId)
-	err := h.pendingRequests.NewRequest(msg, callbackCh, &PendingRequest{request: msg, responses: make(map[string]*api.Message)})
+	err := h.pendingRequests.NewRequest(ctx, h.lggr, msg, callback, &PendingRequest{request: msg, responses: make(map[string]*api.Message)})
 	if err != nil {
 		h.lggr.Warnw("handleRequest: error adding new request", "sender", msg.Body.Sender, "err", err)
 		promHandlerError.WithLabelValues(h.donConfig.DonId, err.Error()).Inc()
@@ -288,9 +288,9 @@ func (h *functionsHandler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.
 	}
 	switch msg.Body.Method {
 	case MethodSecretsSet, MethodSecretsList:
-		return h.pendingRequests.ProcessResponse(msg, h.processSecretsResponse)
+		return h.pendingRequests.ProcessResponse(ctx, msg, h.processSecretsResponse)
 	case MethodHeartbeat:
-		return h.pendingRequests.ProcessResponse(msg, h.processHeartbeatResponse)
+		return h.pendingRequests.ProcessResponse(ctx, msg, h.processHeartbeatResponse)
 	default:
 		h.lggr.Debugw("unsupported method", "method", msg.Body.Method)
 		return ErrUnsupportedMethod

--- a/core/services/gateway/handlers/handler.dummy.go
+++ b/core/services/gateway/handlers/handler.dummy.go
@@ -91,7 +91,7 @@ func (d *dummyHandler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Resp
 	if found {
 		// Send first response from a node back to the user, ignore any other ones.
 		codec := api.JsonRPCCodec{}
-		return savedCb.SendResponse(ctx, UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(&msg), ErrorCode: api.NoError})
+		return savedCb.SendResponse(UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(&msg), ErrorCode: api.NoError})
 	}
 	return nil
 }

--- a/core/services/gateway/handlers/handler.dummy.go
+++ b/core/services/gateway/handlers/handler.dummy.go
@@ -24,8 +24,8 @@ type dummyHandler struct {
 }
 
 type savedCallback struct {
-	id         string
-	callbackCh chan<- UserCallbackPayload
+	id       string
+	callback SendResponse
 }
 
 var _ Handler = (*dummyHandler)(nil)
@@ -43,13 +43,13 @@ func (d *dummyHandler) Methods() []string {
 	return []string{"dummy"}
 }
 
-func (d *dummyHandler) HandleJSONRPCUserMessage(_ context.Context, _ jsonrpc.Request[json.RawMessage], _ chan<- UserCallbackPayload) error {
+func (d *dummyHandler) HandleJSONRPCUserMessage(_ context.Context, _ jsonrpc.Request[json.RawMessage], _ SendResponse) error {
 	return errors.New("dummy handler does not support JSON-RPC user messages")
 }
 
-func (d *dummyHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callbackCh chan<- UserCallbackPayload) error {
+func (d *dummyHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback SendResponse) error {
 	d.mu.Lock()
-	d.savedCallbacks[msg.Body.MessageId] = &savedCallback{msg.Body.MessageId, callbackCh}
+	d.savedCallbacks[msg.Body.MessageId] = &savedCallback{msg.Body.MessageId, callback}
 	don := d.don
 	d.mu.Unlock()
 	params, err := json.Marshal(msg)
@@ -91,8 +91,7 @@ func (d *dummyHandler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Resp
 	if found {
 		// Send first response from a node back to the user, ignore any other ones.
 		codec := api.JsonRPCCodec{}
-		savedCb.callbackCh <- UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(&msg), ErrorCode: api.NoError}
-		close(savedCb.callbackCh)
+		savedCb.callback(ctx, UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(&msg), ErrorCode: api.NoError})
 	}
 	return nil
 }

--- a/core/services/gateway/handlers/handler.dummy.go
+++ b/core/services/gateway/handlers/handler.dummy.go
@@ -24,8 +24,8 @@ type dummyHandler struct {
 }
 
 type savedCallback struct {
-	id       string
-	callback SendResponse
+	id string
+	Callback
 }
 
 var _ Handler = (*dummyHandler)(nil)
@@ -43,11 +43,11 @@ func (d *dummyHandler) Methods() []string {
 	return []string{"dummy"}
 }
 
-func (d *dummyHandler) HandleJSONRPCUserMessage(_ context.Context, _ jsonrpc.Request[json.RawMessage], _ SendResponse) error {
+func (d *dummyHandler) HandleJSONRPCUserMessage(_ context.Context, _ jsonrpc.Request[json.RawMessage], _ Callback) error {
 	return errors.New("dummy handler does not support JSON-RPC user messages")
 }
 
-func (d *dummyHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback SendResponse) error {
+func (d *dummyHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback Callback) error {
 	d.mu.Lock()
 	d.savedCallbacks[msg.Body.MessageId] = &savedCallback{msg.Body.MessageId, callback}
 	don := d.don
@@ -91,7 +91,7 @@ func (d *dummyHandler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Resp
 	if found {
 		// Send first response from a node back to the user, ignore any other ones.
 		codec := api.JsonRPCCodec{}
-		savedCb.callback(ctx, UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(&msg), ErrorCode: api.NoError})
+		return savedCb.SendResponse(ctx, UserCallbackPayload{RawResponse: codec.EncodeLegacyResponse(&msg), ErrorCode: api.NoError})
 	}
 	return nil
 }

--- a/core/services/gateway/handlers/handler.dummy_test.go
+++ b/core/services/gateway/handlers/handler.dummy_test.go
@@ -67,8 +67,8 @@ func TestDummyHandler_BasicFlow(t *testing.T) {
 	require.NoError(t, err)
 	err = msg.Validate()
 	require.NoError(t, err)
-	callbackCh := make(chan handlers.UserCallbackPayload, 1)
-	require.NoError(t, handler.HandleLegacyUserMessage(ctx, &msg, callbackCh))
+	cb := hc.NewCallback()
+	require.NoError(t, handler.HandleLegacyUserMessage(ctx, &msg, cb))
 	require.Equal(t, 2, connMgr.sendCounter)
 
 	// Responses from both nodes
@@ -76,7 +76,8 @@ func TestDummyHandler_BasicFlow(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, handler.HandleNodeMessage(ctx, resp, msg.Body.Sender))
 	require.NoError(t, handler.HandleNodeMessage(ctx, resp, msg.Body.Sender))
-	response := <-callbackCh
+	response, err := cb.Wait(t.Context())
+	require.NoError(t, err)
 	codec := api.JsonRPCCodec{}
 	responseMsg, err := codec.DecodeLegacyResponse(response.RawResponse)
 	require.NoError(t, err)

--- a/core/services/gateway/handlers/handler.go
+++ b/core/services/gateway/handlers/handler.go
@@ -17,6 +17,8 @@ type UserCallbackPayload struct {
 	ErrorCode   api.ErrorCode
 }
 
+type SendResponse func(ctx context.Context, cb UserCallbackPayload) error
+
 // Handler implements service-specific logic for managing messages from users and nodes.
 // There is one Handler object created for each DON.
 //
@@ -31,12 +33,12 @@ type Handler interface {
 	// Each user request is processed by a separate goroutine, which:
 	//   1. calls HandleUserMessage
 	//   2. waits on callbackCh with a timeout
-	HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callbackCh chan<- UserCallbackPayload) error
+	HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback SendResponse) error
 
 	// Each user request is processed by a separate goroutine, which:
 	//   1. calls HandleUserMessage
 	//   2. waits on callbackCh with a timeout
-	HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc.Request[json.RawMessage], callbackCh chan<- UserCallbackPayload) error
+	HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc.Request[json.RawMessage], callback SendResponse) error
 
 	// Handlers should not make any assumptions about goroutines calling HandleNodeMessage.
 	// should be non-blocking

--- a/core/services/gateway/handlers/handler.go
+++ b/core/services/gateway/handlers/handler.go
@@ -17,7 +17,9 @@ type UserCallbackPayload struct {
 	ErrorCode   api.ErrorCode
 }
 
-type SendResponse func(ctx context.Context, cb UserCallbackPayload) error
+type Callback interface {
+	SendResponse(ctx context.Context, cb UserCallbackPayload) error
+}
 
 // Handler implements service-specific logic for managing messages from users and nodes.
 // There is one Handler object created for each DON.
@@ -33,12 +35,12 @@ type Handler interface {
 	// Each user request is processed by a separate goroutine, which:
 	//   1. calls HandleUserMessage
 	//   2. waits on callbackCh with a timeout
-	HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback SendResponse) error
+	HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback Callback) error
 
 	// Each user request is processed by a separate goroutine, which:
 	//   1. calls HandleUserMessage
 	//   2. waits on callbackCh with a timeout
-	HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc.Request[json.RawMessage], callback SendResponse) error
+	HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc.Request[json.RawMessage], callback Callback) error
 
 	// Handlers should not make any assumptions about goroutines calling HandleNodeMessage.
 	// should be non-blocking

--- a/core/services/gateway/handlers/handler.go
+++ b/core/services/gateway/handlers/handler.go
@@ -18,7 +18,7 @@ type UserCallbackPayload struct {
 }
 
 type Callback interface {
-	SendResponse(ctx context.Context, cb UserCallbackPayload) error
+	SendResponse(cb UserCallbackPayload) error
 }
 
 // Handler implements service-specific logic for managing messages from users and nodes.

--- a/core/services/gateway/handlers/mocks/handler.go
+++ b/core/services/gateway/handlers/mocks/handler.go
@@ -75,7 +75,7 @@ func (_c *Handler_Close_Call) RunAndReturn(run func() error) *Handler_Close_Call
 }
 
 // HandleJSONRPCUserMessage provides a mock function with given fields: ctx, jsonRequest, callback
-func (_m *Handler) HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc2.Request[json.RawMessage], callback handlers.SendResponse) error {
+func (_m *Handler) HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc2.Request[json.RawMessage], callback handlers.Callback) error {
 	ret := _m.Called(ctx, jsonRequest, callback)
 
 	if len(ret) == 0 {
@@ -83,7 +83,7 @@ func (_m *Handler) HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jso
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, jsonrpc2.Request[json.RawMessage], handlers.SendResponse) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, jsonrpc2.Request[json.RawMessage], handlers.Callback) error); ok {
 		r0 = rf(ctx, jsonRequest, callback)
 	} else {
 		r0 = ret.Error(0)
@@ -100,14 +100,14 @@ type Handler_HandleJSONRPCUserMessage_Call struct {
 // HandleJSONRPCUserMessage is a helper method to define mock.On call
 //   - ctx context.Context
 //   - jsonRequest jsonrpc2.Request[json.RawMessage]
-//   - callback handlers.SendResponse
+//   - callback handlers.Callback
 func (_e *Handler_Expecter) HandleJSONRPCUserMessage(ctx interface{}, jsonRequest interface{}, callback interface{}) *Handler_HandleJSONRPCUserMessage_Call {
 	return &Handler_HandleJSONRPCUserMessage_Call{Call: _e.mock.On("HandleJSONRPCUserMessage", ctx, jsonRequest, callback)}
 }
 
-func (_c *Handler_HandleJSONRPCUserMessage_Call) Run(run func(ctx context.Context, jsonRequest jsonrpc2.Request[json.RawMessage], callback handlers.SendResponse)) *Handler_HandleJSONRPCUserMessage_Call {
+func (_c *Handler_HandleJSONRPCUserMessage_Call) Run(run func(ctx context.Context, jsonRequest jsonrpc2.Request[json.RawMessage], callback handlers.Callback)) *Handler_HandleJSONRPCUserMessage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(jsonrpc2.Request[json.RawMessage]), args[2].(handlers.SendResponse))
+		run(args[0].(context.Context), args[1].(jsonrpc2.Request[json.RawMessage]), args[2].(handlers.Callback))
 	})
 	return _c
 }
@@ -117,13 +117,13 @@ func (_c *Handler_HandleJSONRPCUserMessage_Call) Return(_a0 error) *Handler_Hand
 	return _c
 }
 
-func (_c *Handler_HandleJSONRPCUserMessage_Call) RunAndReturn(run func(context.Context, jsonrpc2.Request[json.RawMessage], handlers.SendResponse) error) *Handler_HandleJSONRPCUserMessage_Call {
+func (_c *Handler_HandleJSONRPCUserMessage_Call) RunAndReturn(run func(context.Context, jsonrpc2.Request[json.RawMessage], handlers.Callback) error) *Handler_HandleJSONRPCUserMessage_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // HandleLegacyUserMessage provides a mock function with given fields: ctx, msg, callback
-func (_m *Handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback handlers.SendResponse) error {
+func (_m *Handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback handlers.Callback) error {
 	ret := _m.Called(ctx, msg, callback)
 
 	if len(ret) == 0 {
@@ -131,7 +131,7 @@ func (_m *Handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *api.Message, handlers.SendResponse) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *api.Message, handlers.Callback) error); ok {
 		r0 = rf(ctx, msg, callback)
 	} else {
 		r0 = ret.Error(0)
@@ -148,14 +148,14 @@ type Handler_HandleLegacyUserMessage_Call struct {
 // HandleLegacyUserMessage is a helper method to define mock.On call
 //   - ctx context.Context
 //   - msg *api.Message
-//   - callback handlers.SendResponse
+//   - callback handlers.Callback
 func (_e *Handler_Expecter) HandleLegacyUserMessage(ctx interface{}, msg interface{}, callback interface{}) *Handler_HandleLegacyUserMessage_Call {
 	return &Handler_HandleLegacyUserMessage_Call{Call: _e.mock.On("HandleLegacyUserMessage", ctx, msg, callback)}
 }
 
-func (_c *Handler_HandleLegacyUserMessage_Call) Run(run func(ctx context.Context, msg *api.Message, callback handlers.SendResponse)) *Handler_HandleLegacyUserMessage_Call {
+func (_c *Handler_HandleLegacyUserMessage_Call) Run(run func(ctx context.Context, msg *api.Message, callback handlers.Callback)) *Handler_HandleLegacyUserMessage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*api.Message), args[2].(handlers.SendResponse))
+		run(args[0].(context.Context), args[1].(*api.Message), args[2].(handlers.Callback))
 	})
 	return _c
 }
@@ -165,7 +165,7 @@ func (_c *Handler_HandleLegacyUserMessage_Call) Return(_a0 error) *Handler_Handl
 	return _c
 }
 
-func (_c *Handler_HandleLegacyUserMessage_Call) RunAndReturn(run func(context.Context, *api.Message, handlers.SendResponse) error) *Handler_HandleLegacyUserMessage_Call {
+func (_c *Handler_HandleLegacyUserMessage_Call) RunAndReturn(run func(context.Context, *api.Message, handlers.Callback) error) *Handler_HandleLegacyUserMessage_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/gateway/handlers/mocks/handler.go
+++ b/core/services/gateway/handlers/mocks/handler.go
@@ -74,17 +74,17 @@ func (_c *Handler_Close_Call) RunAndReturn(run func() error) *Handler_Close_Call
 	return _c
 }
 
-// HandleJSONRPCUserMessage provides a mock function with given fields: ctx, jsonRequest, callbackCh
-func (_m *Handler) HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc2.Request[json.RawMessage], callbackCh chan<- handlers.UserCallbackPayload) error {
-	ret := _m.Called(ctx, jsonRequest, callbackCh)
+// HandleJSONRPCUserMessage provides a mock function with given fields: ctx, jsonRequest, callback
+func (_m *Handler) HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc2.Request[json.RawMessage], callback handlers.SendResponse) error {
+	ret := _m.Called(ctx, jsonRequest, callback)
 
 	if len(ret) == 0 {
 		panic("no return value specified for HandleJSONRPCUserMessage")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, jsonrpc2.Request[json.RawMessage], chan<- handlers.UserCallbackPayload) error); ok {
-		r0 = rf(ctx, jsonRequest, callbackCh)
+	if rf, ok := ret.Get(0).(func(context.Context, jsonrpc2.Request[json.RawMessage], handlers.SendResponse) error); ok {
+		r0 = rf(ctx, jsonRequest, callback)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -100,14 +100,14 @@ type Handler_HandleJSONRPCUserMessage_Call struct {
 // HandleJSONRPCUserMessage is a helper method to define mock.On call
 //   - ctx context.Context
 //   - jsonRequest jsonrpc2.Request[json.RawMessage]
-//   - callbackCh chan<- handlers.UserCallbackPayload
-func (_e *Handler_Expecter) HandleJSONRPCUserMessage(ctx interface{}, jsonRequest interface{}, callbackCh interface{}) *Handler_HandleJSONRPCUserMessage_Call {
-	return &Handler_HandleJSONRPCUserMessage_Call{Call: _e.mock.On("HandleJSONRPCUserMessage", ctx, jsonRequest, callbackCh)}
+//   - callback handlers.SendResponse
+func (_e *Handler_Expecter) HandleJSONRPCUserMessage(ctx interface{}, jsonRequest interface{}, callback interface{}) *Handler_HandleJSONRPCUserMessage_Call {
+	return &Handler_HandleJSONRPCUserMessage_Call{Call: _e.mock.On("HandleJSONRPCUserMessage", ctx, jsonRequest, callback)}
 }
 
-func (_c *Handler_HandleJSONRPCUserMessage_Call) Run(run func(ctx context.Context, jsonRequest jsonrpc2.Request[json.RawMessage], callbackCh chan<- handlers.UserCallbackPayload)) *Handler_HandleJSONRPCUserMessage_Call {
+func (_c *Handler_HandleJSONRPCUserMessage_Call) Run(run func(ctx context.Context, jsonRequest jsonrpc2.Request[json.RawMessage], callback handlers.SendResponse)) *Handler_HandleJSONRPCUserMessage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(jsonrpc2.Request[json.RawMessage]), args[2].(chan<- handlers.UserCallbackPayload))
+		run(args[0].(context.Context), args[1].(jsonrpc2.Request[json.RawMessage]), args[2].(handlers.SendResponse))
 	})
 	return _c
 }
@@ -117,22 +117,22 @@ func (_c *Handler_HandleJSONRPCUserMessage_Call) Return(_a0 error) *Handler_Hand
 	return _c
 }
 
-func (_c *Handler_HandleJSONRPCUserMessage_Call) RunAndReturn(run func(context.Context, jsonrpc2.Request[json.RawMessage], chan<- handlers.UserCallbackPayload) error) *Handler_HandleJSONRPCUserMessage_Call {
+func (_c *Handler_HandleJSONRPCUserMessage_Call) RunAndReturn(run func(context.Context, jsonrpc2.Request[json.RawMessage], handlers.SendResponse) error) *Handler_HandleJSONRPCUserMessage_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// HandleLegacyUserMessage provides a mock function with given fields: ctx, msg, callbackCh
-func (_m *Handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callbackCh chan<- handlers.UserCallbackPayload) error {
-	ret := _m.Called(ctx, msg, callbackCh)
+// HandleLegacyUserMessage provides a mock function with given fields: ctx, msg, callback
+func (_m *Handler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback handlers.SendResponse) error {
+	ret := _m.Called(ctx, msg, callback)
 
 	if len(ret) == 0 {
 		panic("no return value specified for HandleLegacyUserMessage")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *api.Message, chan<- handlers.UserCallbackPayload) error); ok {
-		r0 = rf(ctx, msg, callbackCh)
+	if rf, ok := ret.Get(0).(func(context.Context, *api.Message, handlers.SendResponse) error); ok {
+		r0 = rf(ctx, msg, callback)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -148,14 +148,14 @@ type Handler_HandleLegacyUserMessage_Call struct {
 // HandleLegacyUserMessage is a helper method to define mock.On call
 //   - ctx context.Context
 //   - msg *api.Message
-//   - callbackCh chan<- handlers.UserCallbackPayload
-func (_e *Handler_Expecter) HandleLegacyUserMessage(ctx interface{}, msg interface{}, callbackCh interface{}) *Handler_HandleLegacyUserMessage_Call {
-	return &Handler_HandleLegacyUserMessage_Call{Call: _e.mock.On("HandleLegacyUserMessage", ctx, msg, callbackCh)}
+//   - callback handlers.SendResponse
+func (_e *Handler_Expecter) HandleLegacyUserMessage(ctx interface{}, msg interface{}, callback interface{}) *Handler_HandleLegacyUserMessage_Call {
+	return &Handler_HandleLegacyUserMessage_Call{Call: _e.mock.On("HandleLegacyUserMessage", ctx, msg, callback)}
 }
 
-func (_c *Handler_HandleLegacyUserMessage_Call) Run(run func(ctx context.Context, msg *api.Message, callbackCh chan<- handlers.UserCallbackPayload)) *Handler_HandleLegacyUserMessage_Call {
+func (_c *Handler_HandleLegacyUserMessage_Call) Run(run func(ctx context.Context, msg *api.Message, callback handlers.SendResponse)) *Handler_HandleLegacyUserMessage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*api.Message), args[2].(chan<- handlers.UserCallbackPayload))
+		run(args[0].(context.Context), args[1].(*api.Message), args[2].(handlers.SendResponse))
 	})
 	return _c
 }
@@ -165,7 +165,7 @@ func (_c *Handler_HandleLegacyUserMessage_Call) Return(_a0 error) *Handler_Handl
 	return _c
 }
 
-func (_c *Handler_HandleLegacyUserMessage_Call) RunAndReturn(run func(context.Context, *api.Message, chan<- handlers.UserCallbackPayload) error) *Handler_HandleLegacyUserMessage_Call {
+func (_c *Handler_HandleLegacyUserMessage_Call) RunAndReturn(run func(context.Context, *api.Message, handlers.SendResponse) error) *Handler_HandleLegacyUserMessage_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -71,13 +71,12 @@ func newMetrics() (*metrics, error) {
 }
 
 type activeRequest struct {
-	req          jsonrpc.Request[json.RawMessage]
-	responses    map[string]*jsonrpc.Response[json.RawMessage]
-	responseSent bool
-	mu           sync.Mutex
+	req       jsonrpc.Request[json.RawMessage]
+	responses map[string]*jsonrpc.Response[json.RawMessage]
+	mu        sync.Mutex
 
-	createdAt  time.Time
-	callbackCh chan<- gwhandlers.UserCallbackPayload
+	createdAt time.Time
+	callback  gwhandlers.SendResponse
 }
 
 func (ar *activeRequest) addResponseForNode(nodeAddr string, resp *jsonrpc.Response[json.RawMessage]) bool {
@@ -101,19 +100,7 @@ func (ar *activeRequest) copiedResponses() map[string]*jsonrpc.Response[json.Raw
 }
 
 func (ar *activeRequest) sendResponse(ctx context.Context, resp gwhandlers.UserCallbackPayload) error {
-	ar.mu.Lock()
-	defer ar.mu.Unlock()
-	if ar.responseSent {
-		return errors.New("response already sent for this request")
-	}
-
-	select {
-	case ar.callbackCh <- resp:
-		ar.responseSent = true
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return ar.callback(ctx, resp)
 }
 
 type capabilitiesRegistry interface {
@@ -268,11 +255,11 @@ func (h *handler) Methods() []string {
 	return vaulttypes.GetSupportedMethods(h.lggr)
 }
 
-func (h *handler) HandleLegacyUserMessage(_ context.Context, _ *api.Message, _ chan<- gwhandlers.UserCallbackPayload) error {
+func (h *handler) HandleLegacyUserMessage(_ context.Context, _ *api.Message, _ gwhandlers.SendResponse) error {
 	return errors.New("vault handler does not support legacy messages")
 }
 
-func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Request[json.RawMessage], callbackCh chan<- gwhandlers.UserCallbackPayload) error {
+func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Request[json.RawMessage], callback gwhandlers.SendResponse) error {
 	// Generate a unique ID for the request.
 	// We do this ourselves to ensure the ID is unique and can't be tampered with by the user.
 	if req.ID == "" {
@@ -284,7 +271,7 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 	// Note we cache this value quite aggressively so don't need to worry about DoS.
 	if req.Method == vaulttypes.MethodPublicKeyGet {
 		h.lggr.Debugw("handling vault request", "method", req.Method, "requestID", req.ID)
-		return h.handlePublicKeyGet(ctx, h.newActiveRequest(req, callbackCh))
+		return h.handlePublicKeyGet(ctx, h.newActiveRequest(req, callback))
 	}
 
 	isAuthorized, owner, err := h.requestAuthorizer.AuthorizeRequest(ctx, req)
@@ -297,7 +284,7 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 	req.ID = owner + "::" + req.ID
 
 	h.lggr.Debugw("handling authorized vault request", "method", req.Method, "requestID", req.ID, "owner", owner)
-	ar := h.newActiveRequest(req, callbackCh)
+	ar := h.newActiveRequest(req, callback)
 
 	switch req.Method {
 	case vaulttypes.MethodSecretsCreate:
@@ -315,12 +302,12 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 	}
 }
 
-func (h *handler) newActiveRequest(req jsonrpc.Request[json.RawMessage], callbackCh chan<- gwhandlers.UserCallbackPayload) *activeRequest {
+func (h *handler) newActiveRequest(req jsonrpc.Request[json.RawMessage], callback gwhandlers.SendResponse) *activeRequest {
 	ar := &activeRequest{
-		callbackCh: callbackCh,
-		req:        req,
-		createdAt:  h.clock.Now(),
-		responses:  map[string]*jsonrpc.Response[json.RawMessage]{},
+		callback:  callback,
+		req:       req,
+		createdAt: h.clock.Now(),
+		responses: map[string]*jsonrpc.Response[json.RawMessage]{},
 	}
 
 	h.mu.Lock()

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -691,7 +691,7 @@ func (h *handler) sendResponse(ctx context.Context, userRequest *activeRequest, 
 		))
 	}
 
-	err := userRequest.SendResponse(ctx, resp)
+	err := userRequest.SendResponse(resp)
 	if err != nil {
 		h.lggr.Errorw("error sending response to user", "requestID", userRequest.req.ID, "error", err)
 		return err

--- a/core/services/gateway/handlers/vault/handler.go
+++ b/core/services/gateway/handlers/vault/handler.go
@@ -76,7 +76,7 @@ type activeRequest struct {
 	mu        sync.Mutex
 
 	createdAt time.Time
-	callback  gwhandlers.SendResponse
+	gwhandlers.Callback
 }
 
 func (ar *activeRequest) addResponseForNode(nodeAddr string, resp *jsonrpc.Response[json.RawMessage]) bool {
@@ -97,10 +97,6 @@ func (ar *activeRequest) copiedResponses() map[string]*jsonrpc.Response[json.Raw
 	copied := make(map[string]*jsonrpc.Response[json.RawMessage], len(ar.responses))
 	maps.Copy(copied, ar.responses)
 	return copied
-}
-
-func (ar *activeRequest) sendResponse(ctx context.Context, resp gwhandlers.UserCallbackPayload) error {
-	return ar.callback(ctx, resp)
 }
 
 type capabilitiesRegistry interface {
@@ -255,11 +251,11 @@ func (h *handler) Methods() []string {
 	return vaulttypes.GetSupportedMethods(h.lggr)
 }
 
-func (h *handler) HandleLegacyUserMessage(_ context.Context, _ *api.Message, _ gwhandlers.SendResponse) error {
+func (h *handler) HandleLegacyUserMessage(_ context.Context, _ *api.Message, _ gwhandlers.Callback) error {
 	return errors.New("vault handler does not support legacy messages")
 }
 
-func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Request[json.RawMessage], callback gwhandlers.SendResponse) error {
+func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Request[json.RawMessage], callback gwhandlers.Callback) error {
 	// Generate a unique ID for the request.
 	// We do this ourselves to ensure the ID is unique and can't be tampered with by the user.
 	if req.ID == "" {
@@ -302,9 +298,9 @@ func (h *handler) HandleJSONRPCUserMessage(ctx context.Context, req jsonrpc.Requ
 	}
 }
 
-func (h *handler) newActiveRequest(req jsonrpc.Request[json.RawMessage], callback gwhandlers.SendResponse) *activeRequest {
+func (h *handler) newActiveRequest(req jsonrpc.Request[json.RawMessage], callback gwhandlers.Callback) *activeRequest {
 	ar := &activeRequest{
-		callback:  callback,
+		Callback:  callback,
 		req:       req,
 		createdAt: h.clock.Now(),
 		responses: map[string]*jsonrpc.Response[json.RawMessage]{},
@@ -695,7 +691,7 @@ func (h *handler) sendResponse(ctx context.Context, userRequest *activeRequest, 
 		))
 	}
 
-	err := userRequest.sendResponse(ctx, resp)
+	err := userRequest.SendResponse(ctx, resp)
 	if err != nil {
 		h.lggr.Errorw("error sending response to user", "requestID", userRequest.req.ID, "error", err)
 		return err

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/api"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers"
+	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/common"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/mocks"
 )
 
@@ -36,7 +37,7 @@ var NodeOne = config.NodeConfig{
 	Address: "0x1234",
 }
 
-func setupHandler(t *testing.T) (handlers.Handler, chan handlers.UserCallbackPayload, *mocks.DON, *clockwork.FakeClock) {
+func setupHandler(t *testing.T) (handlers.Handler, *common.Callback, *mocks.DON, *clockwork.FakeClock) {
 	lggr := logger.Test(t)
 	don := mocks.NewDON(t)
 	donConfig := &config.DONConfig{
@@ -61,7 +62,8 @@ func setupHandler(t *testing.T) (handlers.Handler, chan handlers.UserCallbackPay
 	handler, err := NewHandler(methodConfig, donConfig, don, nil, requestAuthorizer, lggr, clock)
 	require.NoError(t, err)
 	handler.aggregator = &mockAggregator{}
-	return handler, make(chan handlers.UserCallbackPayload, 1), don, clock
+	cb := common.NewCallback()
+	return handler, cb, don, clock
 }
 
 type mockAggregator struct {
@@ -100,26 +102,26 @@ func (m *mockCapabilitiesRegistry) DONsForCapability(_ context.Context, _ string
 
 func TestActiveRequest_SendResponse(t *testing.T) {
 	rm := json.RawMessage([]byte(`{}`))
-	callbackCh := make(chan handlers.UserCallbackPayload, 2)
+	cb := common.NewCallback()
 	activeRequest := &activeRequest{
 		req: jsonrpc.Request[json.RawMessage]{
 			ID:     "1",
 			Method: vaulttypes.MethodSecretsCreate,
 			Params: &rm,
 		},
-		callbackCh: callbackCh,
+		Callback: cb,
 	}
 
 	resp := handlers.UserCallbackPayload{
 		RawResponse: []byte(`{"jsonrpc":"2.0","id":"1","result":{}}`),
 	}
-	err := activeRequest.sendResponse(t.Context(), resp)
+	err := activeRequest.SendResponse(t.Context(), resp)
 	require.NoError(t, err)
 
 	// Prevents the handler from hanging because we're sending a response on a channel that isn't being read from.
 	// The upstream provider of the callbackCh only expects one response per request.
-	err = activeRequest.sendResponse(t.Context(), resp)
-	require.ErrorContains(t, err, "response already sent for this request")
+	err = activeRequest.SendResponse(t.Context(), resp)
+	require.ErrorContains(t, err, "response already sent: each callback can only be used once")
 }
 
 func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
@@ -140,7 +142,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 
 	t.Run("happy path", func(t *testing.T) {
 		var wg sync.WaitGroup
-		h, callbackCh, don, _ := setupHandler(t)
+		h, callback, don, _ := setupHandler(t)
 		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		requestID := "1"
@@ -168,9 +170,10 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			callback := <-callbackCh
+			resp, err2 := callback.Wait(t.Context())
+			assert.NoError(t, err2)
 			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err2 := json.Unmarshal(callback.RawResponse, &secretsResponse)
+			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
 			assert.Len(t, secretsResponse.Result.Responses, 1, "Should have one encrypted secret in response")
@@ -178,7 +181,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 			assert.True(t, secretsResponse.Result.Responses[0].Success, "Success should be true")
 		}()
 
-		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callbackCh)
+		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
 		require.NoError(t, err)
 
 		err = h.HandleNodeMessage(t.Context(), &response, NodeOne.Address)
@@ -188,7 +191,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 
 	t.Run("happy path - delete secrets", func(t *testing.T) {
 		var wg sync.WaitGroup
-		h, callbackCh, don, _ := setupHandler(t)
+		h, callback, don, _ := setupHandler(t)
 		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		id := &vaultcommon.SecretIdentifier{
@@ -233,15 +236,16 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			callback := <-callbackCh
+			resp, err2 := callback.Wait(t.Context())
+			assert.NoError(t, err2)
 			var secretsResponse jsonrpc.Response[vaultcommon.DeleteSecretsResponse]
-			err2 := json.Unmarshal(callback.RawResponse, &secretsResponse)
+			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
 			assert.True(t, proto.Equal(secretsResponse.Result, responseData), "Response data should match")
 		}()
 
-		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callbackCh)
+		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
 		require.NoError(t, err)
 
 		err = h.HandleNodeMessage(t.Context(), &response, NodeOne.Address)
@@ -251,7 +255,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 
 	t.Run("happy path - list secret identifiers", func(t *testing.T) {
 		var wg sync.WaitGroup
-		h, callbackCh, don, _ := setupHandler(t)
+		h, callback, don, _ := setupHandler(t)
 		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		requestID := "1"
@@ -291,15 +295,16 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			callback := <-callbackCh
+			resp, err2 := callback.Wait(t.Context())
+			assert.NoError(t, err2)
 			var secretsResponse jsonrpc.Response[vaultcommon.ListSecretIdentifiersResponse]
-			err2 := json.Unmarshal(callback.RawResponse, &secretsResponse)
+			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
 			assert.True(t, proto.Equal(secretsResponse.Result, responseData), "Response data should match")
 		}()
 
-		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callbackCh)
+		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
 		require.NoError(t, err)
 
 		err = h.HandleNodeMessage(t.Context(), &response, NodeOne.Address)
@@ -309,7 +314,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 
 	t.Run("unhappy path - quorum unobtainable", func(t *testing.T) {
 		var wg sync.WaitGroup
-		h, callbackCh, don, _ := setupHandler(t)
+		h, callback, don, _ := setupHandler(t)
 		h.(*handler).aggregator = &mockAggregator{err: errQuorumUnobtainable}
 
 		don.On("SendToNode", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -341,15 +346,16 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			callback := <-callbackCh
+			resp, err2 := callback.Wait(t.Context())
+			assert.NoError(t, err2)
 			var secretsResponse jsonrpc.Response[vaultcommon.ListSecretIdentifiersResponse]
-			err2 := json.Unmarshal(callback.RawResponse, &secretsResponse)
+			err2 = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err2)
 			assert.Equal(t, validJSONRequest.ID, secretsResponse.ID, "Request ID should match")
 			assert.Equal(t, response.Error, secretsResponse.Error, "Response error should match")
 		}()
 
-		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callbackCh)
+		err = h.HandleJSONRPCUserMessage(t.Context(), validJSONRequest, callback)
 		require.NoError(t, err)
 
 		err = h.HandleNodeMessage(t.Context(), &response, NodeOne.Address)
@@ -359,7 +365,7 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 
 	t.Run("unsupported method", func(t *testing.T) {
 		var wg sync.WaitGroup
-		h, callbackCh, don, _ := setupHandler(t)
+		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for unsupported methods
 		don.AssertNotCalled(t, "SendToNode")
 
@@ -372,23 +378,24 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			callback := <-callbackCh
+			resp, err := callback.Wait(t.Context())
+			assert.NoError(t, err)
 			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err := json.Unmarshal(callback.RawResponse, &secretsResponse)
+			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err)
 			assert.Equal(t, unsupportedMethodRequest.ID, secretsResponse.ID, "Request ID should match")
 			assert.Equal(t, "unsupported method: "+unsupportedMethodRequest.Method, secretsResponse.Error.Message, "Error message should match")
 			assert.Equal(t, api.ToJSONRPCErrorCode(api.UnsupportedMethodError), secretsResponse.Error.Code, "Error code should match")
 		}()
 
-		err := h.HandleJSONRPCUserMessage(t.Context(), unsupportedMethodRequest, callbackCh)
+		err := h.HandleJSONRPCUserMessage(t.Context(), unsupportedMethodRequest, callback)
 		require.NoError(t, err)
 		wg.Wait()
 	})
 
 	t.Run("empty params error", func(t *testing.T) {
 		var wg sync.WaitGroup
-		h, callbackCh, don, _ := setupHandler(t)
+		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for parse errors
 		don.AssertNotCalled(t, "SendToNode")
 
@@ -401,23 +408,24 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			callback := <-callbackCh
+			resp, err := callback.Wait(t.Context())
+			assert.NoError(t, err)
 			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err := json.Unmarshal(callback.RawResponse, &secretsResponse)
+			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err)
 			assert.Equal(t, emptyParamsRequest.ID, secretsResponse.ID, "Request ID should match")
 			assert.Equal(t, "user message parse error: unexpected end of JSON input", secretsResponse.Error.Message, "Error message should match")
 			assert.Equal(t, api.ToJSONRPCErrorCode(api.UserMessageParseError), secretsResponse.Error.Code, "Error code should match")
 		}()
 
-		err := h.HandleJSONRPCUserMessage(t.Context(), emptyParamsRequest, callbackCh)
+		err := h.HandleJSONRPCUserMessage(t.Context(), emptyParamsRequest, callback)
 		require.NoError(t, err)
 		wg.Wait()
 	})
 
 	t.Run("no request inside the batch request", func(t *testing.T) {
 		var wg sync.WaitGroup
-		h, callbackCh, don, _ := setupHandler(t)
+		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for invalid params
 		don.AssertNotCalled(t, "SendToNode")
 
@@ -431,23 +439,24 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			callback := <-callbackCh
+			resp, err := callback.Wait(t.Context())
+			assert.NoError(t, err)
 			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err := json.Unmarshal(callback.RawResponse, &secretsResponse)
+			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err)
 			assert.Equal(t, invalidParamsRequest.ID, secretsResponse.ID, "Request ID should match")
 			assert.Equal(t, "invalid params error: failed to validate create secrets request: request batch must contain at least 1 item", secretsResponse.Error.Message, "Error message should match")
 			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
 		}()
 
-		err := h.HandleJSONRPCUserMessage(t.Context(), invalidParamsRequest, callbackCh)
+		err := h.HandleJSONRPCUserMessage(t.Context(), invalidParamsRequest, callback)
 		require.NoError(t, err)
 		wg.Wait()
 	})
 
 	t.Run("invalid params error", func(t *testing.T) {
 		var wg sync.WaitGroup
-		h, callbackCh, don, _ := setupHandler(t)
+		h, callback, don, _ := setupHandler(t)
 		// Don't expect SendToNode to be called for invalid params
 		don.AssertNotCalled(t, "SendToNode")
 
@@ -474,22 +483,23 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			callback := <-callbackCh
+			resp, err := callback.Wait(t.Context())
+			assert.NoError(t, err)
 			var secretsResponse jsonrpc.Response[vaultcommon.CreateSecretsResponse]
-			err := json.Unmarshal(callback.RawResponse, &secretsResponse)
+			err = json.Unmarshal(resp.RawResponse, &secretsResponse)
 			assert.NoError(t, err)
 			assert.Equal(t, jsonRequest.ID, secretsResponse.ID, "Request ID should match")
 			assert.Contains(t, secretsResponse.Error.Message, "invalid params error: failed to validate create secrets request", "Error message should match")
 			assert.Equal(t, api.ToJSONRPCErrorCode(api.InvalidParamsError), secretsResponse.Error.Code, "Error code should match")
 		}()
 
-		err := h.HandleJSONRPCUserMessage(t.Context(), jsonRequest, callbackCh)
+		err := h.HandleJSONRPCUserMessage(t.Context(), jsonRequest, callback)
 		require.NoError(t, err)
 		wg.Wait()
 	})
 
 	t.Run("stale node response", func(t *testing.T) {
-		handler, callbackCh, _, _ := setupHandler(t)
+		handler, callback, _, _ := setupHandler(t)
 
 		// Create a response for a request that was never sent or has already been processed
 		responseData := &vaultcommon.CreateSecretsResponse{
@@ -513,17 +523,15 @@ func TestVaultHandler_HandleJSONRPCUserMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify that no callback was sent by checking that the channel is empty
-		select {
-		case <-callbackCh:
-			t.Error("Expected no callback for stale node response, but received one")
-		default:
-			// Expected: no callback should be sent for stale responses
-		}
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+		defer cancel()
+		_, err = callback.Wait(ctx)
+		require.Error(t, err)
 	})
 }
 
 func TestVaultHandler_PublicKeyGet(t *testing.T) {
-	h, callbackCh, don, clock := setupHandler(t)
+	h, callback, don, clock := setupHandler(t)
 	signers := []string{
 		"d6da96fe596705b32bc3a0e11cdefad77feaad79000000000000000000000000",
 		"327aa349c9718cd36c877d1e90458fe1929768ad000000000000000000000000",
@@ -543,7 +551,7 @@ func TestVaultHandler_PublicKeyGet(t *testing.T) {
 		Method: vaulttypes.MethodPublicKeyGet,
 		Params: nil,
 	}
-	err := h.HandleJSONRPCUserMessage(t.Context(), jsonRequest, callbackCh)
+	err := h.HandleJSONRPCUserMessage(t.Context(), jsonRequest, callback)
 	require.NoError(t, err)
 
 	_, pk, _, err := tdh2easy.GenerateKeys(1, 3)
@@ -566,50 +574,44 @@ func TestVaultHandler_PublicKeyGet(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	select {
-	case resp := <-callbackCh:
-		var publicKeyResponse jsonrpc.Response[vaultcommon.GetPublicKeyResponse]
-		ierr := json.Unmarshal(resp.RawResponse, &publicKeyResponse)
-		require.NoError(t, ierr)
+	resp, err := callback.Wait(t.Context())
+	require.NoError(t, err)
+	var publicKeyResponse jsonrpc.Response[vaultcommon.GetPublicKeyResponse]
+	err = json.Unmarshal(resp.RawResponse, &publicKeyResponse)
+	require.NoError(t, err)
 
-		assert.Equal(t, jsonRequest.ID, publicKeyResponse.ID, "request ID should match")
-		assert.Equal(t, publicKey, publicKeyResponse.Result.PublicKey, "public key should match")
-	default:
-		t.Error("Expected a callback for the public key response, but none was received")
-	}
+	assert.Equal(t, jsonRequest.ID, publicKeyResponse.ID, "request ID should match")
+	assert.Equal(t, publicKey, publicKeyResponse.Result.PublicKey, "public key should match")
 
 	// Now let's make another request, it'll have been cached due to the previous call.
-	callbackCh = make(chan handlers.UserCallbackPayload, 1)
+	callback = common.NewCallback()
 	jsonRequest = jsonrpc.Request[json.RawMessage]{
 		ID:     "another_request_id",
 		Method: vaulttypes.MethodPublicKeyGet,
 		Params: nil,
 	}
-	err = h.HandleJSONRPCUserMessage(t.Context(), jsonRequest, callbackCh)
+	err = h.HandleJSONRPCUserMessage(t.Context(), jsonRequest, callback)
 	require.NoError(t, err)
 
-	select {
-	case resp := <-callbackCh:
-		var publicKeyResponse jsonrpc.Response[vaultcommon.GetPublicKeyResponse]
-		ierr := json.Unmarshal(resp.RawResponse, &publicKeyResponse)
-		require.NoError(t, ierr)
+	resp, err = callback.Wait(t.Context())
+	require.NoError(t, err)
+	publicKeyResponse = jsonrpc.Response[vaultcommon.GetPublicKeyResponse]{}
+	err = json.Unmarshal(resp.RawResponse, &publicKeyResponse)
+	require.NoError(t, err)
 
-		assert.Equal(t, jsonRequest.ID, publicKeyResponse.ID, "request ID should match")
-		assert.Equal(t, publicKey, publicKeyResponse.Result.PublicKey, "public key should match")
-	default:
-		t.Error("Expected a callback for the public key response, but none was received")
-	}
+	assert.Equal(t, jsonRequest.ID, publicKeyResponse.ID, "request ID should match")
+	assert.Equal(t, publicKey, publicKeyResponse.Result.PublicKey, "public key should match")
 
 	// Now the value has expired, so we'll fetch it again.
 	clock.Advance(10 * time.Minute)
 
-	callbackCh = make(chan handlers.UserCallbackPayload, 1)
+	callback = common.NewCallback()
 	jsonRequest = jsonrpc.Request[json.RawMessage]{
 		ID:     "another_request_id_2",
 		Method: vaulttypes.MethodPublicKeyGet,
 		Params: nil,
 	}
-	err = h.HandleJSONRPCUserMessage(t.Context(), jsonRequest, callbackCh)
+	err = h.HandleJSONRPCUserMessage(t.Context(), jsonRequest, callback)
 	require.NoError(t, err)
 
 	newPublicKey := "new_test_public_key"
@@ -628,15 +630,12 @@ func TestVaultHandler_PublicKeyGet(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	select {
-	case resp := <-callbackCh:
-		var publicKeyResponse jsonrpc.Response[vaultcommon.GetPublicKeyResponse]
-		ierr := json.Unmarshal(resp.RawResponse, &publicKeyResponse)
-		require.NoError(t, ierr)
+	resp, err = callback.Wait(t.Context())
+	require.NoError(t, err)
+	publicKeyResponse = jsonrpc.Response[vaultcommon.GetPublicKeyResponse]{}
+	ierr := json.Unmarshal(resp.RawResponse, &publicKeyResponse)
+	require.NoError(t, ierr)
 
-		assert.Equal(t, jsonRequest.ID, publicKeyResponse.ID, "request ID should match")
-		assert.Equal(t, newPublicKey, publicKeyResponse.Result.PublicKey, "public key should match")
-	default:
-		t.Error("Expected a callback for the public key response, but none was received")
-	}
+	assert.Equal(t, jsonRequest.ID, publicKeyResponse.ID, "request ID should match")
+	assert.Equal(t, newPublicKey, publicKeyResponse.Result.PublicKey, "public key should match")
 }

--- a/core/services/gateway/handlers/vault/handler_test.go
+++ b/core/services/gateway/handlers/vault/handler_test.go
@@ -115,12 +115,12 @@ func TestActiveRequest_SendResponse(t *testing.T) {
 	resp := handlers.UserCallbackPayload{
 		RawResponse: []byte(`{"jsonrpc":"2.0","id":"1","result":{}}`),
 	}
-	err := activeRequest.SendResponse(t.Context(), resp)
+	err := activeRequest.SendResponse(resp)
 	require.NoError(t, err)
 
 	// Prevents the handler from hanging because we're sending a response on a channel that isn't being read from.
 	// The upstream provider of the callbackCh only expects one response per request.
-	err = activeRequest.SendResponse(t.Context(), resp)
+	err = activeRequest.SendResponse(resp)
 	require.ErrorContains(t, err, "response already sent: each callback can only be used once")
 }
 

--- a/core/services/gateway/multihandler.go
+++ b/core/services/gateway/multihandler.go
@@ -49,21 +49,22 @@ func (m *multiHandler) Methods() []string {
 	return slices.Collect(maps.Keys(m.methodToHandler))
 }
 
-func (m *multiHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callbackCh chan<- handlers.UserCallbackPayload) error {
+func (m *multiHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback handlers.SendResponse) error {
 	h, err := m.getHandler(msg.Body.Method)
 	if err != nil {
 		return fmt.Errorf("failed to get handler for method %s: %w", msg.Body.Method, err)
 	}
 
-	return h.HandleLegacyUserMessage(ctx, msg, callbackCh)
+	return h.HandleLegacyUserMessage(ctx, msg, callback)
 }
-func (m *multiHandler) HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc.Request[json.RawMessage], callbackCh chan<- handlers.UserCallbackPayload) error {
+
+func (m *multiHandler) HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc.Request[json.RawMessage], callback handlers.SendResponse) error {
 	h, err := m.getHandler(jsonRequest.Method)
 	if err != nil {
 		return fmt.Errorf("failed to get handler for method %s: %w", jsonRequest.Method, err)
 	}
 
-	return h.HandleJSONRPCUserMessage(ctx, jsonRequest, callbackCh)
+	return h.HandleJSONRPCUserMessage(ctx, jsonRequest, callback)
 }
 
 func (m *multiHandler) HandleNodeMessage(ctx context.Context, resp *jsonrpc.Response[json.RawMessage], nodeAddr string) error {

--- a/core/services/gateway/multihandler.go
+++ b/core/services/gateway/multihandler.go
@@ -49,7 +49,7 @@ func (m *multiHandler) Methods() []string {
 	return slices.Collect(maps.Keys(m.methodToHandler))
 }
 
-func (m *multiHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback handlers.SendResponse) error {
+func (m *multiHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Message, callback handlers.Callback) error {
 	h, err := m.getHandler(msg.Body.Method)
 	if err != nil {
 		return fmt.Errorf("failed to get handler for method %s: %w", msg.Body.Method, err)
@@ -58,7 +58,7 @@ func (m *multiHandler) HandleLegacyUserMessage(ctx context.Context, msg *api.Mes
 	return h.HandleLegacyUserMessage(ctx, msg, callback)
 }
 
-func (m *multiHandler) HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc.Request[json.RawMessage], callback handlers.SendResponse) error {
+func (m *multiHandler) HandleJSONRPCUserMessage(ctx context.Context, jsonRequest jsonrpc.Request[json.RawMessage], callback handlers.Callback) error {
 	h, err := m.getHandler(jsonRequest.Method)
 	if err != nil {
 		return fmt.Errorf("failed to get handler for method %s: %w", jsonRequest.Method, err)


### PR DESCRIPTION
* Introduce a callback abstraction rather than passing through a channel to handlers. This is used to enforce the policy that only a single response can be sent via the callback channel, as the gateway will only wait for one response.
* This addresses the bug we discovered a couple of weeks ago where accidentally sending two responses on this channel caused the gateway to stop processing responses for some nodes.