### PR TITLE
[CRE-904] Use helpers for evm system-tests

### DIFF
--- a/system-tests/tests/smoke/cre/beholder_provider.go
+++ b/system-tests/tests/smoke/cre/beholder_provider.go
@@ -75,7 +75,9 @@ func (b *Beholder) SubscribeToBeholderMessages(
 
 	// Start listening for messages in the background
 	go func() {
-		listenForKafkaMessages(ctx, b.lggr, b.cfg.ChipIngress.Output.RedPanda.KafkaExternalURL, b.cfg.Kafka.Topics[0], messageTypes, messageChan, kafkaErrChan)
+		kafkaURL := b.cfg.ChipIngress.Output.RedPanda.KafkaExternalURL
+		topic := b.cfg.Kafka.Topics[0]
+		listenForKafkaMessages(ctx, b.lggr, kafkaURL, topic, messageTypes, messageChan, kafkaErrChan)
 	}()
 
 	return messageChan, kafkaErrChan

--- a/system-tests/tests/smoke/cre/v2_evm_capability_test.go
+++ b/system-tests/tests/smoke/cre/v2_evm_capability_test.go
@@ -12,13 +12,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
-	commonevents "github.com/smartcontractkit/chainlink-protos/workflows/go/common"
-	workflowevents "github.com/smartcontractkit/chainlink-protos/workflows/go/events"
 	crecontracts "github.com/smartcontractkit/chainlink/system-tests/lib/cre/contracts"
 
 	"github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre/evmread/config"
@@ -34,34 +30,24 @@ import (
 )
 
 func executeEVMReadTest(t *testing.T, testEnv *TestEnvironment) {
-	enabledChains := map[string]struct{}{}
-	for _, nodeSet := range testEnv.Config.NodeSets {
-		require.NoError(t, nodeSet.ParseChainCapabilities())
-		if nodeSet.ChainCapabilities == nil || nodeSet.ChainCapabilities[cre.EVMCapability] == nil {
-			continue
-		}
-
-		for _, chainID := range nodeSet.ChainCapabilities[cre.EVMCapability].EnabledChains {
-			strChainID := strconv.FormatUint(chainID, 10)
-			enabledChains[strChainID] = struct{}{}
-		}
-	}
-	require.NotEmpty(t, enabledChains, "No chains have EVM capability enabled in any node set")
-	const workflowFileLocation = "./evmread/main.go"
 	lggr := framework.L
+	const workflowFileLocation = "./evmread/main.go"
+	enabledChains := getEVMEnabledChains(t, testEnv)
 	var workflowsWg sync.WaitGroup
 	var successfulWorkflowRuns atomic.Int32
+
 	for _, bcOutput := range testEnv.WrappedBlockchainOutputs {
-		if _, ok := enabledChains[bcOutput.BlockchainOutput.ChainID]; !ok {
-			lggr.Info().Msgf("Skipping chain %s as it is not enabled for EVM read workflow test", bcOutput.BlockchainOutput.ChainID)
+		chainID := bcOutput.BlockchainOutput.ChainID
+		if _, ok := enabledChains[chainID]; !ok {
+			lggr.Info().Msgf("Skipping chain %s as it is not enabled for EVM Read workflow test", chainID)
 			continue
 		}
-		workflowName := "evm-read-workflow-" + bcOutput.BlockchainOutput.ChainID
 
+		lggr.Info().Msg("Creating EVM Read workflow configuration...")
 		workflowConfig := configureEVMReadWorkflow(t, lggr, bcOutput)
 
-		lggr.Info().Msg("Proceeding to register workflow...")
-		compileAndDeployWorkflow(t, testEnv, lggr, fmt.Sprintf("evmreadtest-%d", bcOutput.ChainID), &workflowConfig, workflowFileLocation)
+		workflowName := "evm-read-workflow-" + chainID
+		compileAndDeployWorkflow(t, testEnv, lggr, workflowName, &workflowConfig, workflowFileLocation)
 
 		workflowsWg.Add(1)
 		forwarderAddress, _, err := crecontracts.FindAddressesForChain(testEnv.FullCldEnvOutput.Environment.ExistingAddresses, bcOutput.ChainSelector, keystonechangeset.KeystoneForwarder.String()) //nolint:staticcheck,nolintlint // SA1019: deprecated but we don't want to migrate now
@@ -81,52 +67,33 @@ func executeEVMReadTest(t *testing.T, testEnv *TestEnvironment) {
 		}(bcOutput)
 	}
 
+	_, messageChan, kafkaErrChan := startBeholder(t, lggr, testEnv)
 	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		workflowsWg.Wait()
 		cancel()
 	}()
-	logWorkflowLogs(ctx, t, testEnv)
+	logBeholderMessages(ctx, t, lggr, testEnv, messageChan, kafkaErrChan)
 	require.Equal(t, len(enabledChains), int(successfulWorkflowRuns.Load()), "Not all workflows executed successfully")
 }
 
-func logWorkflowLogs(ctx context.Context, t *testing.T, testEnv *TestEnvironment) {
-	beholder, err := NewBeholder(framework.L, testEnv.TestConfig.RelativePathToRepoRoot, testEnv.TestConfig.EnvironmentDirPath)
-	require.NoError(t, err, "failed to create beholder instance")
+func getEVMEnabledChains(t *testing.T, testEnv *TestEnvironment) map[string]struct{} {
+	t.Helper()
 
-	// We are interested in UserLogs (successful execution)
-	// or BaseMessage with specific error message (engine initialization failure)
-	beholderMessageTypes := map[string]func() proto.Message{
-		"workflows.v1.UserLogs": func() proto.Message {
-			return &workflowevents.UserLogs{}
-		},
-		"BaseMessage": func() proto.Message {
-			return &commonevents.BaseMessage{}
-		},
-	}
+	enabledChains := map[string]struct{}{}
+	for _, nodeSet := range testEnv.Config.NodeSets {
+		require.NoError(t, nodeSet.ParseChainCapabilities())
+		if nodeSet.ChainCapabilities == nil || nodeSet.ChainCapabilities[cre.EVMCapability] == nil {
+			continue
+		}
 
-	lggr := framework.L
-	beholderMsgChan, beholderErrChan := beholder.SubscribeToBeholderMessages(ctx, beholderMessageTypes)
-	// Check the beholder logs for the expected messages
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case err := <-beholderErrChan:
-			require.FailNowf(t, "Kafka error received from Kafka %s", err.Error())
-		case msg := <-beholderMsgChan:
-			switch typedMsg := msg.(type) {
-			case *commonevents.BaseMessage:
-				lggr.Info().Msgf("Received BaseMessage from Beholder: %s", typedMsg.Msg)
-			case *workflowevents.UserLogs:
-				for _, logLine := range typedMsg.LogLines {
-					lggr.Info().Msgf("Received workflow msg: %s", logLine.Message)
-				}
-			default:
-				lggr.Info().Msgf("Received unknown message of type '%T'", msg)
-			}
+		for _, chainID := range nodeSet.ChainCapabilities[cre.EVMCapability].EnabledChains {
+			strChainID := strconv.FormatUint(chainID, 10)
+			enabledChains[strChainID] = struct{}{}
 		}
 	}
+	require.NotEmpty(t, enabledChains, "No chains have EVM capability enabled in any node set")
+	return enabledChains
 }
 
 func validateWorkflowExecution(t *testing.T, lggr zerolog.Logger, bcOutput *cre.WrappedBlockchainOutput, workflowName string, forwarderAddr common.Address, cfg config.Config) error {
@@ -176,34 +143,44 @@ func validateWorkflowExecution(t *testing.T, lggr zerolog.Logger, bcOutput *cre.
 }
 
 func configureEVMReadWorkflow(t *testing.T, lggr zerolog.Logger, chain *cre.WrappedBlockchainOutput) config.Config {
-	lggr.Info().Msgf("Deploying message emitter for chain %s", chain.BlockchainOutput.ChainID)
+	t.Helper()
+	chainID := chain.BlockchainOutput.ChainID
+	chainSethClient := chain.SethClient
+
+	lggr.Info().Msgf("Deploying message emitter for chain %s", chainID)
 	msgEmitterContractAddr, tx, msgEmitter, err := evmreadcontracts.DeployMessageEmitter(chain.SethClient.NewTXOpts(), chain.SethClient.Client)
-	require.NoError(t, err)
-	lggr.Info().Msgf("Deployed message emitter for chain %s at %s", chain.BlockchainOutput.ChainID, msgEmitterContractAddr.String())
-	_, err = chain.SethClient.WaitMined(t.Context(), lggr, chain.SethClient.Client, tx)
-	require.NoError(t, err)
-	lggr.Printf("Emitting event to be picked up by workflow for chain %s", chain.BlockchainOutput.ChainID)
-	emittingTx, err := msgEmitter.EmitMessage(chain.SethClient.NewTXOpts(), "Initial message to be read by workflow")
-	require.NoError(t, err)
-	emittingReceipt, err := chain.SethClient.WaitMined(t.Context(), lggr, chain.SethClient.Client, emittingTx)
-	require.NoError(t, err)
-	lggr.Info().Msgf("Updating nonces for chain %s", chain.BlockchainOutput.ChainID)
+	require.NoError(t, err, "failed to deploy message emitter contract")
+
+	lggr.Info().Msgf("Deployed message emitter for chain '%s' at '%s'", chainID, msgEmitterContractAddr.String())
+	_, err = chainSethClient.WaitMined(t.Context(), lggr, chainSethClient.Client, tx)
+	require.NoError(t, err, "failed to get message emitter deployment tx")
+
+	lggr.Printf("Emitting event to be picked up by workflow for chain '%s'", chainID)
+	emittingTx, err := msgEmitter.EmitMessage(chainSethClient.NewTXOpts(), "Initial message to be read by workflow")
+	require.NoError(t, err, "failed to emit message from contract '%s'", msgEmitterContractAddr.String())
+
+	emittingReceipt, err := chainSethClient.WaitMined(t.Context(), lggr, chainSethClient.Client, emittingTx)
+	require.NoError(t, err, "failed to get message emitter event tx")
+
+	lggr.Info().Msgf("Updating nonces for chain %s", chainID)
 	// force update nonces to ensure the transfer works
-	require.NoError(t, chain.SethClient.NonceManager.UpdateNonces())
-	const expectedBalance = 10
-	pk, err := crypto.GenerateKey()
-	require.NoError(t, err)
-	accountAddr := crypto.PubkeyToAddress(pk.PublicKey)
-	lggr.Info().Msgf("Funding account %s for BalanceAt read test for chain %s", accountAddr.Hex(), chain.BlockchainOutput.ChainID)
-	err = chain.SethClient.TransferETHFromKey(t.Context(), 0, accountAddr.Hex(), big.NewInt(expectedBalance), nil)
-	require.NoError(t, err, "failed to transfer ETH to contract %s", msgEmitterContractAddr.String())
+	require.NoError(t, chainSethClient.NonceManager.UpdateNonces(), "failed to update nonces for chain %s", chainID)
+
+	amountToFund := big.NewInt(0).SetUint64(10) // 10 wei
+	numberOfAddressesToCreate := 1
+	addresses, addrErr := createAndFundAddresses(t, lggr, numberOfAddressesToCreate, amountToFund, chainSethClient)
+	require.NoError(t, addrErr, "failed to create and fund new addresses")
+	require.Len(t, addresses, numberOfAddressesToCreate, "failed to create the correct number of addresses")
+
 	marshalledTx, err := emittingTx.MarshalBinary()
 	require.NoError(t, err)
+
+	accountAddress := addresses[0].Bytes()
 	return config.Config{
 		ContractAddress:  msgEmitterContractAddr.Bytes(),
 		ChainSelector:    chain.ChainSelector,
-		AccountAddress:   accountAddr.Bytes(),
-		ExpectedBalance:  big.NewInt(expectedBalance),
+		AccountAddress:   accountAddress,
+		ExpectedBalance:  amountToFund,
 		ExpectedReceipt:  emittingReceipt,
 		TxHash:           emittingReceipt.TxHash.Bytes(),
 		ExpectedBinaryTx: marshalledTx,


### PR DESCRIPTION
[CRE-904](https://smartcontract-it.atlassian.net/browse/CRE-904): Update EVM test to re-use helpers

### Supports
[CRE-821](https://smartcontract-it.atlassian.net/browse/CRE-821): In the PoR test, validate that the last operation (write) fails the test when it throws an error.
[CRE-861](https://smartcontract-it.atlassian.net/browse/CRE-861): Provide negative tests for EVM capability API

[CRE-904]: https://smartcontract-it.atlassian.net/browse/CRE-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRE-821]: https://smartcontract-it.atlassian.net/browse/CRE-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRE-861]: https://smartcontract-it.atlassian.net/browse/CRE-861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ