### PR TITLE
[CRE-788] Support dynamic config updates in TriggerSubscriber

### DIFF
--- a/.changeset/dry-pets-knock.md
+++ b/.changeset/dry-pets-knock.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#changed Support dynamic config updates in TriggerSubscriber

--- a/core/capabilities/remote/combined_client_test.go
+++ b/core/capabilities/remote/combined_client_test.go
@@ -31,7 +31,7 @@ func TestCombinedClient_RegisterTrigger_Success(t *testing.T) {
 	mockTrigger := &mocks.TriggerCapability{}
 	method := "test-method"
 
-	client.AddTriggerSubscriber(method, mockTrigger)
+	client.SetTriggerSubscriber(method, mockTrigger)
 
 	request := commoncap.TriggerRegistrationRequest{
 		TriggerID: "test-trigger-id",
@@ -70,7 +70,7 @@ func TestCombinedClient_RegisterTrigger_ErrorFromSubscriber(t *testing.T) {
 	mockTrigger := &mocks.TriggerCapability{}
 	method := "test-method"
 
-	client.AddTriggerSubscriber(method, mockTrigger)
+	client.SetTriggerSubscriber(method, mockTrigger)
 
 	request := commoncap.TriggerRegistrationRequest{
 		TriggerID: "test-trigger-id",
@@ -94,7 +94,7 @@ func TestCombinedClient_UnregisterTrigger_Success(t *testing.T) {
 	mockTrigger := &mocks.TriggerCapability{}
 	method := "test-method"
 
-	client.AddTriggerSubscriber(method, mockTrigger)
+	client.SetTriggerSubscriber(method, mockTrigger)
 
 	request := commoncap.TriggerRegistrationRequest{
 		TriggerID: "test-trigger-id",
@@ -129,7 +129,7 @@ func TestCombinedClient_UnregisterTrigger_ErrorFromSubscriber(t *testing.T) {
 	mockTrigger := &mocks.TriggerCapability{}
 	method := "test-method"
 
-	client.AddTriggerSubscriber(method, mockTrigger)
+	client.SetTriggerSubscriber(method, mockTrigger)
 
 	request := commoncap.TriggerRegistrationRequest{
 		TriggerID: "test-trigger-id",
@@ -184,7 +184,7 @@ func TestCombinedClient_Execute_Success(t *testing.T) {
 	mockExecutable := &mocks.ExecutableCapability{}
 	method := "test-execute-method"
 
-	client.AddExecutableClient(method, mockExecutable)
+	client.SetExecutableClient(method, mockExecutable)
 
 	request := commoncap.CapabilityRequest{
 		Method: method,
@@ -237,7 +237,7 @@ func TestCombinedClient_Execute_ErrorFromExecutable(t *testing.T) {
 	mockExecutable := &mocks.ExecutableCapability{}
 	method := "test-execute-method"
 
-	client.AddExecutableClient(method, mockExecutable)
+	client.SetExecutableClient(method, mockExecutable)
 
 	request := commoncap.CapabilityRequest{
 		Method: method,
@@ -258,14 +258,14 @@ func TestCombinedClient_Execute_ErrorFromExecutable(t *testing.T) {
 	assert.Equal(t, expectedError, err)
 }
 
-func TestCombinedClient_AddTriggerSubscriber(t *testing.T) {
+func TestCombinedClient_SetTriggerSubscriber(t *testing.T) {
 	info := createTestCapabilityInfo("test-capability", commoncap.CapabilityTypeTrigger)
 
 	client := remote.NewCombinedClient(info)
 	mockTrigger := &mocks.TriggerCapability{}
 	method := "test-method"
 
-	client.AddTriggerSubscriber(method, mockTrigger)
+	client.SetTriggerSubscriber(method, mockTrigger)
 
 	ctx := testutils.Context(t)
 	request := commoncap.TriggerRegistrationRequest{
@@ -280,14 +280,14 @@ func TestCombinedClient_AddTriggerSubscriber(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestCombinedClient_AddExecutableClient(t *testing.T) {
+func TestCombinedClient_SetExecutableClient(t *testing.T) {
 	info := createTestCapabilityInfo("test-capability", commoncap.CapabilityTypeAction)
 
 	client := remote.NewCombinedClient(info)
 	mockExecutable := &mocks.ExecutableCapability{}
 	method := "test-method"
 
-	client.AddExecutableClient(method, mockExecutable)
+	client.SetExecutableClient(method, mockExecutable)
 
 	ctx := testutils.Context(t)
 	request := commoncap.CapabilityRequest{
@@ -321,8 +321,11 @@ func TestCombinedClient_MultipleMethodsAndCapabilities(t *testing.T) {
 	triggerMethod1 := "trigger-method-1"
 	triggerMethod2 := "trigger-method-2"
 
-	client.AddTriggerSubscriber(triggerMethod1, mockTrigger1)
-	client.AddTriggerSubscriber(triggerMethod2, mockTrigger2)
+	client.SetTriggerSubscriber(triggerMethod1, mockTrigger1)
+	client.SetTriggerSubscriber(triggerMethod2, mockTrigger2)
+
+	client.SetTriggerSubscriber(triggerMethod1, mockTrigger1)
+	client.SetTriggerSubscriber(triggerMethod2, mockTrigger2)
 
 	// Add multiple executable clients
 	mockExecutable1 := &mocks.ExecutableCapability{}
@@ -330,8 +333,8 @@ func TestCombinedClient_MultipleMethodsAndCapabilities(t *testing.T) {
 	execMethod1 := "exec-method-1"
 	execMethod2 := "exec-method-2"
 
-	client.AddExecutableClient(execMethod1, mockExecutable1)
-	client.AddExecutableClient(execMethod2, mockExecutable2)
+	client.SetExecutableClient(execMethod1, mockExecutable1)
+	client.SetExecutableClient(execMethod2, mockExecutable2)
 
 	// Test trigger method 1
 	triggerRequest1 := commoncap.TriggerRegistrationRequest{

--- a/core/capabilities/remote/dispatcher.go
+++ b/core/capabilities/remote/dispatcher.go
@@ -279,7 +279,7 @@ func (d *dispatcher) handleMessage(msg *p2ptypes.Message) {
 	receiver, ok := d.receivers[k]
 	d.mu.RUnlock()
 	if !ok {
-		d.lggr.Debugw("received message for unregistered capability", "capabilityId", SanitizeLogString(k.capID), "donId", k.donID)
+		d.lggr.Debugw("received message for unregistered capability or method", "capabilityId", SanitizeLogString(k.capID), "donId", k.donID, "method", k.methodName)
 		d.tryRespondWithError(msg.Sender, body, types.Error_CAPABILITY_NOT_FOUND)
 		return
 	}

--- a/core/capabilities/remote/executable/client.go
+++ b/core/capabilities/remote/executable/client.go
@@ -42,7 +42,12 @@ type client struct {
 	wg                       sync.WaitGroup
 }
 
-var _ commoncap.ExecutableCapability = &client{}
+type Client interface {
+	commoncap.ExecutableCapability
+	Receive(ctx context.Context, msg *types.MessageBody)
+}
+
+var _ Client = &client{}
 var _ types.Receiver = &client{}
 var _ services.Service = &client{}
 

--- a/core/capabilities/remote/executable/request/server_request.go
+++ b/core/capabilities/remote/executable/request/server_request.go
@@ -314,7 +314,7 @@ func (e *ServerRequest) sendResponse(ctx context.Context, requester p2ptypes.Pee
 		responseMsg.Payload = e.response.response
 	}
 
-	e.lggr.Debugw("Sending response", "receiver", requester)
+	e.lggr.Debugw("Sending response", "receiver", requester, "capabilityId", e.capabilityID, "donId", e.capabilityDonID, "method", e.capMethodName)
 	err := e.dispatcher.Send(requester, &responseMsg)
 	e.metrics.countExecutionResponse(ctx, e.response.error.String(), err != nil)
 	if err != nil {

--- a/core/capabilities/remote/trigger_subscriber.go
+++ b/core/capabilities/remote/trigger_subscriber.go
@@ -3,7 +3,9 @@ package remote
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	commoncap "github.com/smartcontractkit/chainlink-common/pkg/capabilities"
@@ -11,34 +13,39 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/messagecache"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
 )
 
 // TriggerSubscriber is a shim for remote trigger capabilities.
-// It translatesd between capability API calls and network messages.
+// It translates between capability API calls and network messages.
 // Its responsibilities are:
 //  1. Periodically refresh all registrations for remote triggers.
 //  2. Collect trigger events from remote nodes and aggregate responses via a customizable aggregator.
 //
 // TriggerSubscriber communicates with corresponding TriggerReceivers on remote nodes.
 type triggerSubscriber struct {
-	config              *commoncap.RemoteTriggerConfig
-	capInfo             commoncap.CapabilityInfo
-	capDonInfo          commoncap.DON
-	capDonMembers       map[p2ptypes.PeerID]struct{}
-	localDonInfo        commoncap.DON
-	dispatcher          types.Dispatcher
-	capMethodName       string
-	aggregator          types.Aggregator
+	capabilityID  string
+	capMethodName string
+	dispatcher    types.Dispatcher
+	cfg           atomic.Pointer[dynamicConfig]
+
 	messageCache        *messagecache.MessageCache[triggerEventKey, p2ptypes.PeerID]
 	registeredWorkflows map[string]*subRegState
 	mu                  sync.RWMutex // protects registeredWorkflows and messageCache
 	stopCh              services.StopChan
 	wg                  sync.WaitGroup
 	lggr                logger.Logger
+}
+
+type dynamicConfig struct {
+	remoteConfig  *commoncap.RemoteTriggerConfig
+	capInfo       commoncap.CapabilityInfo
+	capDonInfo    commoncap.DON
+	capDonMembers map[p2ptypes.PeerID]struct{}
+	localDonID    uint32
+	aggregator    types.Aggregator
 }
 
 type triggerEventKey struct {
@@ -54,41 +61,24 @@ type subRegState struct {
 type TriggerSubscriber interface {
 	commoncap.TriggerCapability
 	Receive(ctx context.Context, msg *types.MessageBody)
+	SetConfig(config *commoncap.RemoteTriggerConfig, capInfo commoncap.CapabilityInfo, localDONID uint32, remoteDON commoncap.DON, aggregator types.Aggregator) error
 }
 
 var _ commoncap.TriggerCapability = &triggerSubscriber{}
 var _ types.Receiver = &triggerSubscriber{}
 var _ services.Service = &triggerSubscriber{}
 
-// TODO makes this configurable with a default
 const (
-	defaultSendChannelBufferSize = 1000
-	maxBatchedWorkflowIDs        = 1000
+	// Engine reads trigger events without blocking and applies its own limits
+	sendChannelBufferSize = 1000
+	maxBatchedWorkflowIDs = 1000
 )
 
-func NewTriggerSubscriber(config *commoncap.RemoteTriggerConfig, capInfo commoncap.CapabilityInfo, capDonInfo commoncap.DON, localDonInfo commoncap.DON, dispatcher types.Dispatcher, aggregator types.Aggregator, capMethodName string, lggr logger.Logger) *triggerSubscriber {
-	if aggregator == nil {
-		lggr.Warnw("no aggregator provided, using default MODE aggregator", "capabilityId", capInfo.ID)
-		aggregator = aggregation.NewDefaultModeAggregator(uint32(capDonInfo.F + 1))
-	}
-	if config == nil {
-		lggr.Info("no config provided, using default values")
-		config = &commoncap.RemoteTriggerConfig{}
-	}
-	config.ApplyDefaults()
-	capDonMembers := make(map[p2ptypes.PeerID]struct{})
-	for _, member := range capDonInfo.Members {
-		capDonMembers[member] = struct{}{}
-	}
+func NewTriggerSubscriber(capabilityID string, capMethodName string, dispatcher types.Dispatcher, lggr logger.Logger) *triggerSubscriber {
 	return &triggerSubscriber{
-		config:              config,
-		capInfo:             capInfo,
-		capDonInfo:          capDonInfo,
-		capDonMembers:       capDonMembers,
-		localDonInfo:        localDonInfo,
-		dispatcher:          dispatcher,
+		capabilityID:        capabilityID,
 		capMethodName:       capMethodName,
-		aggregator:          aggregator,
+		dispatcher:          dispatcher,
 		messageCache:        messagecache.NewMessageCache[triggerEventKey, p2ptypes.PeerID](),
 		registeredWorkflows: make(map[string]*subRegState),
 		stopCh:              make(services.StopChan),
@@ -97,6 +87,33 @@ func NewTriggerSubscriber(config *commoncap.RemoteTriggerConfig, capInfo commonc
 }
 
 func (s *triggerSubscriber) Start(ctx context.Context) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cfg := s.cfg.Load()
+
+	// Validate that all required fields are set before starting
+	if cfg == nil {
+		return errors.New("config not set - call SetConfig() before Start()")
+	}
+	if cfg.remoteConfig == nil {
+		return errors.New("remoteConfig not set - call SetConfig() before Start()")
+	}
+	if cfg.capInfo.ID == "" {
+		return errors.New("capability info not set - call SetConfig() before Start()")
+	}
+	if cfg.localDonID == 0 {
+		return errors.New("local DON ID not set - call SetConfig() before Start()")
+	}
+	if len(cfg.capDonInfo.Members) == 0 {
+		return errors.New("capability DON info not set - call SetConfig() before Start()")
+	}
+	if cfg.aggregator == nil {
+		return errors.New("aggregator not set - call SetAggregator() before Start()")
+	}
+	if s.dispatcher == nil {
+		return errors.New("dispatcher set to nil, cannot start triggerSubscriber")
+	}
+
 	s.wg.Add(2)
 	go s.registrationLoop()
 	go s.eventCleanupLoop()
@@ -105,7 +122,11 @@ func (s *triggerSubscriber) Start(ctx context.Context) error {
 }
 
 func (s *triggerSubscriber) Info(ctx context.Context) (commoncap.CapabilityInfo, error) {
-	return s.capInfo, nil
+	cfg := s.cfg.Load()
+	if cfg == nil {
+		return commoncap.CapabilityInfo{}, errors.New("config not set - call SetConfig() before Info()")
+	}
+	return cfg.capInfo, nil
 }
 
 func (s *triggerSubscriber) RegisterTrigger(ctx context.Context, request commoncap.TriggerRegistrationRequest) (<-chan commoncap.TriggerResponse, error) {
@@ -116,20 +137,26 @@ func (s *triggerSubscriber) RegisterTrigger(ctx context.Context, request commonc
 	if request.Metadata.WorkflowID == "" {
 		return nil, errors.New("empty workflowID")
 	}
+
+	cfg := s.cfg.Load()
+	if cfg == nil {
+		return nil, errors.New("config not set - call SetConfig() first")
+	}
+	capID, capDonID := cfg.capInfo.ID, cfg.capDonInfo.ID
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	s.lggr.Infow("RegisterTrigger called", "capabilityId", s.capInfo.ID, "donId", s.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID)
+	s.lggr.Infow("RegisterTrigger called", "capabilityId", capID, "donId", capDonID, "workflowID", request.Metadata.WorkflowID)
 	regState, ok := s.registeredWorkflows[request.Metadata.WorkflowID]
 	if !ok {
 		regState = &subRegState{
-			callback:   make(chan commoncap.TriggerResponse, defaultSendChannelBufferSize),
+			callback:   make(chan commoncap.TriggerResponse, sendChannelBufferSize),
 			rawRequest: rawRequest,
 		}
 		s.registeredWorkflows[request.Metadata.WorkflowID] = regState
 	} else {
 		regState.rawRequest = rawRequest
-		s.lggr.Warnw("RegisterTrigger re-registering trigger", "capabilityId", s.capInfo.ID, "donId", s.capDonInfo.ID, "workflowID", request.Metadata.WorkflowID)
+		s.lggr.Warnw("RegisterTrigger re-registering trigger", "capabilityId", capID, "donId", capDonID, "workflowID", request.Metadata.WorkflowID)
 	}
 
 	return regState.callback, nil
@@ -137,32 +164,40 @@ func (s *triggerSubscriber) RegisterTrigger(ctx context.Context, request commonc
 
 func (s *triggerSubscriber) registrationLoop() {
 	defer s.wg.Done()
-	ticker := time.NewTicker(s.config.RegistrationRefresh)
+	cfg := s.cfg.Load()
+	tickerDuration := cfg.remoteConfig.RegistrationRefresh
+	ticker := time.NewTicker(tickerDuration)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-s.stopCh:
 			return
 		case <-ticker.C:
+			cfg := s.cfg.Load()
+			if cfg.remoteConfig.RegistrationRefresh != tickerDuration {
+				tickerDuration = cfg.remoteConfig.RegistrationRefresh
+				ticker.Reset(tickerDuration)
+			}
+
 			s.mu.RLock()
-			s.lggr.Infow("register trigger for remote capability", "capabilityId", s.capInfo.ID, "donId", s.capDonInfo.ID, "nMembers", len(s.capDonInfo.Members), "nWorkflows", len(s.registeredWorkflows))
+			s.lggr.Infow("register trigger for remote capability", "capabilityId", cfg.capInfo.ID, "donId", cfg.capDonInfo.ID, "nMembers", len(cfg.capDonInfo.Members), "nWorkflows", len(s.registeredWorkflows))
 			if len(s.registeredWorkflows) == 0 {
 				s.lggr.Infow("no workflows to register")
 			}
+
 			for _, registration := range s.registeredWorkflows {
-				// NOTE: send to all by default, introduce different strategies later (KS-76)
-				for _, peerID := range s.capDonInfo.Members {
+				for _, peerID := range cfg.capDonInfo.Members {
 					m := &types.MessageBody{
-						CapabilityId:     s.capInfo.ID,
-						CapabilityDonId:  s.capDonInfo.ID,
-						CallerDonId:      s.localDonInfo.ID,
+						CapabilityId:     cfg.capInfo.ID,
+						CapabilityDonId:  cfg.capDonInfo.ID,
+						CallerDonId:      cfg.localDonID,
 						Method:           types.MethodRegisterTrigger,
 						Payload:          registration.rawRequest,
 						CapabilityMethod: s.capMethodName,
 					}
 					err := s.dispatcher.Send(peerID, m)
 					if err != nil {
-						s.lggr.Errorw("failed to send message", "capabilityId", s.capInfo.ID, "donId", s.capDonInfo.ID, "peerId", peerID, "err", err)
+						s.lggr.Errorw("failed to send message", "capabilityId", cfg.capInfo.ID, "donId", cfg.capDonInfo.ID, "peerId", peerID, "err", err)
 					}
 				}
 			}
@@ -191,19 +226,24 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 		s.lggr.Errorw("failed to convert message sender to PeerID", "err", err)
 		return
 	}
-
-	if _, found := s.capDonMembers[sender]; !found {
-		s.lggr.Errorw("received message from unexpected node", "capabilityId", s.capInfo.ID, "sender", sender)
+	cfg := s.cfg.Load()
+	if cfg == nil {
+		s.lggr.Errorw("config not set - call SetConfig() first")
 		return
 	}
+	if _, found := cfg.capDonMembers[sender]; !found {
+		s.lggr.Errorw("received message from unexpected node", "capabilityId", cfg.capInfo.ID, "sender", sender)
+		return
+	}
+
 	if msg.Method == types.MethodTriggerEvent {
 		meta := msg.GetTriggerEventMetadata()
 		if meta == nil {
-			s.lggr.Errorw("received message with invalid trigger metadata", "capabilityId", s.capInfo.ID, "sender", sender)
+			s.lggr.Errorw("received message with invalid trigger metadata", "capabilityId", cfg.capInfo.ID, "sender", sender)
 			return
 		}
 		if len(meta.WorkflowIds) > maxBatchedWorkflowIDs {
-			s.lggr.Errorw("received message with too many workflow IDs - truncating", "capabilityId", s.capInfo.ID, "nWorkflows", len(meta.WorkflowIds), "sender", sender)
+			s.lggr.Errorw("received message with too many workflow IDs - truncating", "capabilityId", cfg.capInfo.ID, "nWorkflows", len(meta.WorkflowIds), "sender", sender)
 			meta.WorkflowIds = meta.WorkflowIds[:maxBatchedWorkflowIDs]
 		}
 		for _, workflowID := range meta.WorkflowIds {
@@ -211,7 +251,7 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 			registration, found := s.registeredWorkflows[workflowID]
 			s.mu.RUnlock()
 			if !found {
-				s.lggr.Errorw("received message for unregistered workflow", "capabilityId", s.capInfo.ID, "workflowID", SanitizeLogString(workflowID), "sender", sender)
+				s.lggr.Errorw("received message for unregistered workflow", "capabilityId", cfg.capInfo.ID, "workflowID", SanitizeLogString(workflowID), "sender", sender)
 				continue
 			}
 			key := triggerEventKey{
@@ -221,16 +261,16 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 			nowMs := time.Now().UnixMilli()
 			s.mu.Lock()
 			creationTs := s.messageCache.Insert(key, sender, nowMs, msg.Payload)
-			ready, payloads := s.messageCache.Ready(key, s.config.MinResponsesToAggregate, nowMs-s.config.MessageExpiry.Milliseconds(), true)
+			ready, payloads := s.messageCache.Ready(key, cfg.remoteConfig.MinResponsesToAggregate, nowMs-cfg.remoteConfig.MessageExpiry.Milliseconds(), true)
 			s.mu.Unlock()
-			s.lggr.Debugw("trigger event received", "triggerEventId", meta.TriggerEventId, "capabilityId", s.capInfo.ID, "workflowId", workflowID, "sender", sender, "ready", ready, "nowTs", nowMs, "creationTs", creationTs, "minResponsesToAggregate", s.config.MinResponsesToAggregate)
+			s.lggr.Debugw("trigger event received", "triggerEventId", meta.TriggerEventId, "capabilityId", cfg.capInfo.ID, "workflowId", workflowID, "sender", sender, "ready", ready, "nowTs", nowMs, "creationTs", creationTs, "minResponsesToAggregate", cfg.remoteConfig.MinResponsesToAggregate)
 			if ready {
-				aggregatedResponse, err := s.aggregator.Aggregate(meta.TriggerEventId, payloads)
+				aggregatedResponse, err := cfg.aggregator.Aggregate(meta.TriggerEventId, payloads)
 				if err != nil {
-					s.lggr.Errorw("failed to aggregate responses", "triggerEventID", meta.TriggerEventId, "capabilityId", s.capInfo.ID, "workflowId", workflowID, "err", err)
+					s.lggr.Errorw("failed to aggregate responses", "triggerEventID", meta.TriggerEventId, "capabilityId", cfg.capInfo.ID, "workflowId", workflowID, "err", err)
 					continue
 				}
-				s.lggr.Infow("remote trigger event aggregated", "triggerEventID", meta.TriggerEventId, "capabilityId", s.capInfo.ID, "workflowId", workflowID)
+				s.lggr.Infow("remote trigger event aggregated", "triggerEventID", meta.TriggerEventId, "capabilityId", cfg.capInfo.ID, "workflowId", workflowID)
 				registration.callback <- aggregatedResponse
 			}
 		}
@@ -241,15 +281,24 @@ func (s *triggerSubscriber) Receive(_ context.Context, msg *types.MessageBody) {
 
 func (s *triggerSubscriber) eventCleanupLoop() {
 	defer s.wg.Done()
-	ticker := time.NewTicker(s.config.MessageExpiry)
+	cfg := s.cfg.Load()
+	cleanupInterval := cfg.remoteConfig.MessageExpiry
+	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-s.stopCh:
 			return
 		case <-ticker.C:
+			freshCfg := s.cfg.Load()
+			remoteConfig := freshCfg.remoteConfig
+			// Update cleanup interval if config has changed
+			if remoteConfig.MessageExpiry != cleanupInterval {
+				cleanupInterval = remoteConfig.MessageExpiry
+				ticker.Reset(cleanupInterval)
+			}
 			s.mu.Lock()
-			s.messageCache.DeleteOlderThan(time.Now().UnixMilli() - s.config.MessageExpiry.Milliseconds())
+			s.messageCache.DeleteOlderThan(time.Now().UnixMilli() - remoteConfig.MessageExpiry.Milliseconds())
 			s.mu.Unlock()
 		}
 	}
@@ -272,4 +321,40 @@ func (s *triggerSubscriber) HealthReport() map[string]error {
 
 func (s *triggerSubscriber) Name() string {
 	return s.lggr.Name()
+}
+
+// SetConfig sets the remote trigger configuration, capability info, and DON information dynamically
+func (s *triggerSubscriber) SetConfig(config *commoncap.RemoteTriggerConfig, capInfo commoncap.CapabilityInfo, localDONID uint32, remoteDON commoncap.DON, aggregator types.Aggregator) error {
+	if config == nil {
+		return errors.New("no config provided")
+	}
+	if capInfo.ID == "" || capInfo.ID != s.capabilityID {
+		return fmt.Errorf("capability info provided does not match the subscriber's capabilityID: %s != %s", capInfo.ID, s.capabilityID)
+	}
+	if localDONID == 0 {
+		return errors.New("localDONID=0 provided")
+	}
+	if remoteDON.ID == 0 || len(remoteDON.Members) == 0 {
+		return errors.New("empty remoteDON provided")
+	}
+	if aggregator == nil {
+		return errors.New("aggregator not set - call SetAggregator() before SetConfig()")
+	}
+	config.ApplyDefaults()
+	// Rebuild the capDonMembers map
+	capDonMembers := make(map[p2ptypes.PeerID]struct{})
+	for _, member := range remoteDON.Members {
+		capDonMembers[member] = struct{}{}
+	}
+
+	// always replace the whole dynamicConfig object to avoid inconsistent state
+	s.cfg.Store(&dynamicConfig{
+		remoteConfig:  config,
+		capInfo:       capInfo,
+		capDonInfo:    remoteDON,
+		capDonMembers: capDonMembers,
+		localDonID:    localDONID,
+		aggregator:    aggregator,
+	})
+	return nil
 }

--- a/core/capabilities/remote/trigger_subscriber_test.go
+++ b/core/capabilities/remote/trigger_subscriber_test.go
@@ -1,6 +1,7 @@
 package remote_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/aggregation"
 	remotetypes "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types"
 	remoteMocks "github.com/smartcontractkit/chainlink/v2/core/capabilities/remote/types/mocks"
 	p2ptypes "github.com/smartcontractkit/chainlink/v2/core/services/p2p/types"
@@ -48,7 +50,9 @@ func TestTriggerSubscriber_RegisterAndReceive(t *testing.T) {
 		MinResponsesToAggregate: 1,
 		MessageExpiry:           100 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(config, capInfo, capDon, workflowDon, dispatcher, nil, "", lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
+	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 	require.NoError(t, subscriber.Start(t.Context()))
 
 	req := commoncap.TriggerRegistrationRequest{
@@ -95,7 +99,9 @@ func TestTriggerSubscriber_CorrectEventExpiryCheck(t *testing.T) {
 		MinResponsesToAggregate: 2,
 		MessageExpiry:           10 * time.Second,
 	}
-	subscriber := remote.NewTriggerSubscriber(config, capInfo, capDon, workflowDon, dispatcher, nil, "", lggr)
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
+	require.NoError(t, subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, agg))
 
 	require.NoError(t, subscriber.Start(t.Context()))
 	regReq := commoncap.TriggerRegistrationRequest{
@@ -136,6 +142,138 @@ func TestTriggerSubscriber_CorrectEventExpiryCheck(t *testing.T) {
 	triggerEventValue, err := values.NewMap(triggerEvent1)
 	require.NoError(t, err)
 	require.Equal(t, response.Event.Outputs, triggerEventValue)
+}
+
+func TestTriggerSubscriber_SetConfig_Basic(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	capInfo, capDon, workflowDon := buildTwoTestDONs(t, 3, 1)
+	agg := aggregation.NewDefaultModeAggregator(1)
+
+	t.Run("returns error when config is nil", func(t *testing.T) {
+		dispatcher := remoteMocks.NewDispatcher(t)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		err := subscriber.SetConfig(nil, capInfo, workflowDon.ID, capDon, agg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no config provided")
+	})
+
+	t.Run("returns error when capability info ID doesn't match subscriber's ID", func(t *testing.T) {
+		dispatcher := remoteMocks.NewDispatcher(t)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		config := &commoncap.RemoteTriggerConfig{}
+		mismatchedCapInfo := commoncap.CapabilityInfo{ID: "different_id", CapabilityType: commoncap.CapabilityTypeTrigger}
+		err := subscriber.SetConfig(config, mismatchedCapInfo, workflowDon.ID, capDon, agg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "capability info provided does not match")
+		require.Contains(t, err.Error(), "different_id")
+		require.Contains(t, err.Error(), capInfo.ID)
+	})
+
+	t.Run("returns error when aggregator is nil", func(t *testing.T) {
+		dispatcher := remoteMocks.NewDispatcher(t)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		config := &commoncap.RemoteTriggerConfig{}
+		err := subscriber.SetConfig(config, capInfo, workflowDon.ID, capDon, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "aggregator not set")
+	})
+
+	t.Run("updates existing config", func(t *testing.T) {
+		dispatcher := remoteMocks.NewDispatcher(t)
+		subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+		// Set initial config
+		initialConfig := &commoncap.RemoteTriggerConfig{
+			RegistrationRefresh:     100 * time.Millisecond,
+			MinResponsesToAggregate: 1,
+			MessageExpiry:           100 * time.Second,
+		}
+		err := subscriber.SetConfig(initialConfig, capInfo, workflowDon.ID, capDon, agg)
+		require.NoError(t, err)
+
+		// Update with new config
+		newConfig := &commoncap.RemoteTriggerConfig{
+			RegistrationRefresh:     500 * time.Millisecond,
+			MinResponsesToAggregate: 3,
+			MessageExpiry:           500 * time.Second,
+		}
+		err = subscriber.SetConfig(newConfig, capInfo, workflowDon.ID, capDon, agg)
+		require.NoError(t, err)
+
+		// Verify updated config works
+		require.NoError(t, subscriber.Start(t.Context()))
+		require.NoError(t, subscriber.Close())
+	})
+}
+
+func TestTriggerSubscriber_RegistrationLoopWithConfigUpdate(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+	capInfo, capDon, _ := buildTwoTestDONs(t, 1, 1)
+	dispatcher := remoteMocks.NewDispatcher(t)
+
+	var capturedMessages []*remotetypes.MessageBody
+	var messagesMu sync.Mutex
+	registrationMessageCh := make(chan struct{})
+
+	dispatcher.On("Send", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		messagesMu.Lock()
+		defer messagesMu.Unlock()
+		// append to capturedMessages and notify the channel without blockin
+		if msgBody, ok := args[1].(*remotetypes.MessageBody); ok {
+			capturedMessages = append(capturedMessages, msgBody)
+		}
+		select {
+		case registrationMessageCh <- struct{}{}:
+		default:
+		}
+	})
+
+	config := &commoncap.RemoteTriggerConfig{
+		RegistrationRefresh:     100 * time.Millisecond,
+		RegistrationExpiry:      100 * time.Second,
+		MinResponsesToAggregate: 1,
+		MessageExpiry:           100 * time.Second,
+	}
+	subscriber := remote.NewTriggerSubscriber(capInfo.ID, "method", dispatcher, lggr)
+	agg := aggregation.NewDefaultModeAggregator(config.MinResponsesToAggregate)
+
+	// Call SetConfig() with workflowDON ID = 1 and register trigger
+	require.NoError(t, subscriber.SetConfig(config, capInfo, 1, capDon, agg))
+	require.NoError(t, subscriber.Start(t.Context()))
+	req := commoncap.TriggerRegistrationRequest{
+		Metadata: commoncap.RequestMetadata{
+			WorkflowID: workflowID1,
+		},
+	}
+	_, err := subscriber.RegisterTrigger(t.Context(), req)
+	require.NoError(t, err)
+
+	// Wait for first registration message and validate CallerDonId = 1
+	<-registrationMessageCh
+	messagesMu.Lock()
+	require.NotEmpty(t, capturedMessages, "Expected at least one message to be sent")
+	lastMsg := capturedMessages[len(capturedMessages)-1]
+	require.Equal(t, uint32(1), lastMsg.CallerDonId, "First message should have CallerDonId = 1")
+	messagesMu.Unlock()
+
+	// Change config to workflow ID = 4
+	require.NoError(t, subscriber.SetConfig(config, capInfo, 4, capDon, agg))
+
+	// Wait until we receive a registration message with CallerDonId = 4
+	for {
+		<-registrationMessageCh
+		messagesMu.Lock()
+		if len(capturedMessages) > 0 && capturedMessages[len(capturedMessages)-1].CallerDonId == 4 {
+			messagesMu.Unlock()
+			break
+		}
+		messagesMu.Unlock()
+	}
+
+	// Gracefully shut down Trigger Subscriber
+	require.NoError(t, subscriber.UnregisterTrigger(t.Context(), req))
+	require.NoError(t, subscriber.Close())
 }
 
 func buildTwoTestDONs(t *testing.T, capDonSize int, workflowDonSize int) (commoncap.CapabilityInfo, commoncap.DON, commoncap.DON) {

--- a/core/capabilities/streams/trigger_test.go
+++ b/core/capabilities/streams/trigger_test.go
@@ -68,7 +68,7 @@ func TestStreamsTrigger(t *testing.T) {
 	feeds := newFeedsWithSignedReports(t, nodes, N, P, R)
 
 	allowedSigners := make([][]byte, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		allowedSigners[i] = nodes[i].bundle.PublicKey() // bad name - see comment on evmKeyring.PublicKey
 	}
 	lggr := logger.Test(t)
@@ -80,17 +80,19 @@ func TestStreamsTrigger(t *testing.T) {
 		ID: triggerID,
 	}
 	capMembers := make([]p2ptypes.PeerID, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		capMembers[i] = nodes[i].peerID
 	}
 	capDonInfo := capabilities.DON{
+		ID:      2,
 		Members: capMembers,
 		F:       uint8(F),
 	}
 	config := &capabilities.RemoteTriggerConfig{
 		MinResponsesToAggregate: uint32(F + 1),
 	}
-	subscriber := remote.NewTriggerSubscriber(config, capInfo, capDonInfo, capabilities.DON{}, nil, agg, "", lggr)
+	subscriber := remote.NewTriggerSubscriber(triggerID, "method", nil, lggr)
+	require.NoError(t, subscriber.SetConfig(config, capInfo, 1, capDonInfo, agg))
 
 	// register trigger
 	req := capabilities.TriggerRegistrationRequest{


### PR DESCRIPTION
Launcher is currently unable to update shims for remote capabilities. Once a shim is created and connected to underlying services (registry, dispatcher) it can't be replaced with a new one. This PR fixes that by introducing dynamic config updates for existing shims.

1. Modify Launcher to cache remote shims and update their config instead of creating new ones each time.
2. Move TriggerSubscriber config from constructor to SetConfig() and reload it dynamically, when necessary.
3. Make CombinedClient thread-safe.

To be followed up with another PR that migrates other shims to similar SetConfig() calls (i.e. TriggerPublisher, ExecutableClient and ExecutableServer)