### PR TITLE
[Fix] remove not implemented error and add --with-contracts-version flag to workflow commands

### DIFF
--- a/core/scripts/cre/environment/environment/examples.go
+++ b/core/scripts/cre/environment/environment/examples.go
@@ -169,7 +169,7 @@ func deployAndVerifyExampleWorkflow(cmdContext context.Context, rpcURL, gatewayU
 		_ = os.Remove(configFilePath)
 	}()
 
-	deployErr := compileCopyAndRegisterWorkflow(cmdContext, workflowFilePath, workflowName, "", workflowRegistryAddress, "", creworkflow.DefaultWorkflowNodePattern, creworkflow.DefaultWorkflowTargetDir, configFilePath, "", rpcURL, workflowDonID)
+	deployErr := compileCopyAndRegisterWorkflow(cmdContext, workflowFilePath, workflowName, "", workflowRegistryAddress, "", creworkflow.DefaultWorkflowNodePattern, creworkflow.DefaultWorkflowTargetDir, configFilePath, "", rpcURL, "v1", workflowDonID)
 	if deployErr != nil {
 		return errors.Wrap(deployErr, "failed to deploy example workflow")
 	}
@@ -186,7 +186,7 @@ func deployAndVerifyExampleWorkflow(cmdContext context.Context, rpcURL, gatewayU
 		fmt.Print(libformat.PurpleText("\n[Stage 4/4] Example workflow executed in %.2f seconds\n", time.Since(totalStart).Seconds()))
 		start = time.Now()
 		fmt.Print(libformat.PurpleText("\n[CLEANUP] Deleting example workflow\n\n"))
-		deleteErr := deleteAllWorkflows(cmdContext, rpcURL, workflowRegistryAddress)
+		deleteErr := deleteAllWorkflows(cmdContext, rpcURL, workflowRegistryAddress, "v1")
 		if deleteErr != nil {
 			fmt.Printf("Failed to delete example workflow: %s\nPlease delete it manually\n", deleteErr)
 		}

--- a/core/scripts/cre/environment/environment/workflow.go
+++ b/core/scripts/cre/environment/environment/workflow.go
@@ -34,7 +34,7 @@ const (
 
 // getWorkflowRegistryTypeVersion returns the appropriate TypeAndVersion based on the contracts version flag
 func getWorkflowRegistryTypeVersion(contractsVersion string) deployment.TypeAndVersion {
-	switch contractsVersion {
+	switch strings.ToLower(contractsVersion) {
 	case "v1":
 		return deployment.TypeAndVersion{
 			Version: *semver.MustParse("1.0.0"),


### PR DESCRIPTION
### Description

- remove the `not implemented` error that was being returned for v2 contracts
- Replaced hardcoded `defaultWorkflowRegistryTypeVersion` with a configurable function `getWorkflowRegistryTypeVersion()` that accepts a string parameter and returns the appropriate deployment.TypeAndVersion based on the contracts version.

  Added `--with-contracts-version` flag to workflow commands:
  
  - deployWorkflowCmd
  - compileDeployWorkflowCmd
  - deleteWorkflowCmd
  - deleteAllWorkflowsCmd

