### PR TITLE
feat: add UpdateAdminRole changeset

### DIFF
--- a/deployment/ccip/changeset/cs_orchestrate_changesets.go
+++ b/deployment/ccip/changeset/cs_orchestrate_changesets.go
@@ -127,7 +127,7 @@ func orchestrateChangesetsLogic(e cldf.Environment, c OrchestrateChangesetsConfi
 			finalOutput.Reports = append(finalOutput.Reports, output.Reports...)
 			return cldf.ChangesetOutput{Reports: finalOutput.Reports}, fmt.Errorf("failed to apply changeset at index %d: %w", i, err)
 		}
-		err = mergeChangesetOutput(e, &finalOutput, output)
+		err = MergeChangesetOutput(e, &finalOutput, output)
 		if err != nil {
 			finalOutput.Reports = append(finalOutput.Reports, output.Reports...)
 			return cldf.ChangesetOutput{Reports: finalOutput.Reports}, fmt.Errorf("failed to merge output of changeset at index %d: %w", i, err)
@@ -181,7 +181,7 @@ func orchestrateChangesetsPrecondition(e cldf.Environment, c OrchestrateChangese
 	return nil
 }
 
-func mergeChangesetOutput(e cldf.Environment, dest *cldf.ChangesetOutput, src cldf.ChangesetOutput) error {
+func MergeChangesetOutput(e cldf.Environment, dest *cldf.ChangesetOutput, src cldf.ChangesetOutput) error {
 	err := cldf.MergeChangesetOutput(e, dest, src)
 	if err != nil {
 		return fmt.Errorf("failed to merge changeset output: %w", err)

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
+
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	ccipcommoncs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
+
+	ccipcommoncs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
 
@@ -24,7 +26,7 @@ var UpdateAdminRoleChangesetV2 = cldf.CreateChangeSet(updateAdminRoleLogic, upda
 
 type UpdateAdminRoleConfig struct {
 	// Only applicable when **proposing** a new admin - this allows the existing pending administrator to be
-	// overriden if set to true. Use with caution as this will replace any existing pending admin proposals.
+	// overridden if set to true. Use with caution as this will replace any existing pending admin proposals
 	OverridePendingAdmin bool `json:"overridePendingAdmin"`
 
 	// A map of chain selector => slice of TokenAdminInfo which describes the updates to make on each chain

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
@@ -78,6 +79,13 @@ func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleC
 		proposeInfo := []TokenAdminInfo{}
 
 		for _, info := range updates {
+			// Ignore zero address (this will always have no token config)
+			if info.TokenAddress == utils.ZeroAddress {
+				e.Logger.Warnf("detected null token address for chain with selector '%s' - skipping", selector)
+				continue
+			}
+
+			// Get token info from in-mem cache or on-chain (duplicates + other checks will be validated at a later stage)
 			tokenConfig, hit := tokenConfigCache[info.TokenAddress]
 			if !hit {
 				e.Logger.Infof(
@@ -109,10 +117,23 @@ func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleC
 			}
 
 			// If no admin exists for the token, then propose one otherwise transfer ownership
-			if tokenConfig.Administrator == (common.Address{}) {
+			if tokenConfig.Administrator == utils.ZeroAddress {
 				proposeInfo = append(proposeInfo, info)
-			} else {
+				continue
+			}
+
+			// Instead of throwing an error, ignore transfers to the same admin (this will make it
+			// easier to re-run the changeset with the same inputs in case an error occurs midway)
+			if tokenConfig.Administrator != info.AdminAddress {
 				transferInfo = append(transferInfo, info)
+				continue
+			} else {
+				e.Logger.Warnf(
+					"detected a transfer to the same admin (%s) for token '%s' on chain with selector '%d' - skipping",
+					info.AdminAddress,
+					info.TokenAddress,
+					selector,
+				)
 			}
 		}
 
@@ -172,12 +193,17 @@ func updateAdminRolePrecondition(e cldf.Environment, cfg UpdateAdminRoleConfig) 
 		return fmt.Errorf("failed to populate internal configs: %w", err)
 	}
 
+	if configs.orchestrateChangesetsConfig == nil && configs.transferAdminRoleConfig == nil && configs.proposeAdminRoleConfig == nil {
+		e.Logger.Warn("no operations to perform - exiting precondition stage gracefully")
+		return nil
+	}
+
 	if configs.orchestrateChangesetsConfig != nil {
-		e.Logger.Info("MCMS config detected - using OrchestrateChangesets to verify preconditions")
+		e.Logger.Info("detected MCMS config - using OrchestrateChangesets to verify preconditions")
 		return ccipcommoncs.OrchestrateChangesets.VerifyPreconditions(e, *configs.orchestrateChangesetsConfig)
 	}
 
-	e.Logger.Info("no MCMS config detected - verifying preconditions for TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2 individually")
+	e.Logger.Info("no MCMS config detected - verifying preconditions individually")
 	if configs.transferAdminRoleConfig != nil {
 		e.Logger.Info("verifying preconditions TransferAdminRoleChangesetV2...")
 		err := TransferAdminRoleChangesetV2.VerifyPreconditions(e, *configs.transferAdminRoleConfig)
@@ -194,14 +220,12 @@ func updateAdminRolePrecondition(e cldf.Environment, cfg UpdateAdminRoleConfig) 
 		}
 		e.Logger.Info("successfully verified preconditions for ProposeAdminRoleChangesetV2")
 	}
-	e.Logger.Info("all preconditions have been satisfied for TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2")
 
 	return nil
 }
 
 func updateAdminRoleLogic(e cldf.Environment, cfg UpdateAdminRoleConfig) (cldf.ChangesetOutput, error) {
 	result := cldf.ChangesetOutput{}
-
 	if len(cfg.ChainUpdates) == 0 {
 		e.Logger.Warn("no chain updates were provided - exiting apply stage gracefully")
 		return cldf.ChangesetOutput{}, nil
@@ -213,12 +237,17 @@ func updateAdminRoleLogic(e cldf.Environment, cfg UpdateAdminRoleConfig) (cldf.C
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate internal configs: %w", err)
 	}
 
+	if configs.orchestrateChangesetsConfig == nil && configs.transferAdminRoleConfig == nil && configs.proposeAdminRoleConfig == nil {
+		e.Logger.Warn("no operations to perform - exiting apply stage gracefully")
+		return cldf.ChangesetOutput{}, nil
+	}
+
 	if configs.orchestrateChangesetsConfig != nil {
-		e.Logger.Info("MCMS config detected - using OrchestrateChangesets to batch all operations into one MCMS proposal")
+		e.Logger.Info("detected MCMS config - using OrchestrateChangesets to batch all operations into one MCMS proposal")
 		return ccipcommoncs.OrchestrateChangesets.Apply(e, *configs.orchestrateChangesetsConfig)
 	}
 
-	e.Logger.Info("no MCMS config detected - applying TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2 sequentially")
+	e.Logger.Info("no MCMS config detected - applying changesets individually")
 	if configs.transferAdminRoleConfig != nil {
 		e.Logger.Info("applying TransferAdminRoleChangesetV2...")
 		transferOutput, err := TransferAdminRoleChangesetV2.Apply(e, *configs.transferAdminRoleConfig)
@@ -226,9 +255,13 @@ func updateAdminRoleLogic(e cldf.Environment, cfg UpdateAdminRoleConfig) (cldf.C
 			result.Reports = append(result.Reports, transferOutput.Reports...)
 			return cldf.ChangesetOutput{Reports: result.Reports}, fmt.Errorf("failed to apply TransferAdminRoleChangesetV2: %w", err)
 		}
+		err = ccipcommoncs.MergeChangesetOutput(e, &result, transferOutput)
+		if err != nil {
+			result.Reports = append(result.Reports, transferOutput.Reports...)
+			return cldf.ChangesetOutput{Reports: result.Reports}, fmt.Errorf("failed to merge output of TransferAdminRoleChangesetV2: %w", err)
+		}
 		e.Logger.Info("successfully applied TransferAdminRoleChangesetV2")
 	}
-
 	if configs.proposeAdminRoleConfig != nil {
 		e.Logger.Info("applying ProposeAdminRoleChangesetV2...")
 		proposeOutput, err := ProposeAdminRoleChangesetV2.Apply(e, *configs.proposeAdminRoleConfig)
@@ -236,9 +269,13 @@ func updateAdminRoleLogic(e cldf.Environment, cfg UpdateAdminRoleConfig) (cldf.C
 			result.Reports = append(result.Reports, proposeOutput.Reports...)
 			return cldf.ChangesetOutput{Reports: result.Reports}, fmt.Errorf("failed to apply ProposeAdminRoleChangesetV2: %w", err)
 		}
+		err = ccipcommoncs.MergeChangesetOutput(e, &result, proposeOutput)
+		if err != nil {
+			result.Reports = append(result.Reports, proposeOutput.Reports...)
+			return cldf.ChangesetOutput{Reports: result.Reports}, fmt.Errorf("failed to merge output of ProposeAdminRoleChangesetV2: %w", err)
+		}
 		e.Logger.Info("successfully applied ProposeAdminRoleChangesetV2")
 	}
-	e.Logger.Info("finished applying TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2")
 
 	return result, nil
 }

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -1,0 +1,222 @@
+package v1_5_1
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	ccipcommoncs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+)
+
+// UpdateAdminRoleChangesetV2 is a changeset that can propose AND transfer administrator roles for tokens
+// on the token admin registry. It takes array of TokenAdminInfo by chain and infers whether an the admin
+// should be proposed or transferred. The TokenAdminInfo expects a TokenAddress and AdminAddress as input
+// and splits the data into one of two groups (either propose or transfer). Then it'll reuse the existing
+// validations + logic for TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2.
+var UpdateAdminRoleChangesetV2 = cldf.CreateChangeSet(updateAdminRoleLogic, updateAdminRolePrecondition)
+
+type UpdateAdminRoleConfig struct {
+	// Only applicable when **proposing** a new admin - this allows the existing pending administrator to be
+	// overriden if set to true. Use with caution as this will replace any existing pending admin proposals.
+	OverridePendingAdmin bool `json:"overridePendingAdmin"`
+
+	// A map of chain selector => slice of TokenAdminInfo which describes the updates to make on each chain
+	ChainUpdates map[uint64][]TokenAdminInfo `json:"ChainUpdates"`
+
+	// The timelock config - all updates can be folded into one MCMS proposal with this setting
+	MCMS *proposalutils.TimelockConfig `json:"mcms"`
+
+	// Internal property for caching purposes
+	configs *updateAdminRoleConfigs
+}
+
+type updateAdminRoleConfigs struct {
+	orchestrateChangesetsConfig *ccipcommoncs.OrchestrateChangesetsConfig
+	transferAdminRoleConfig     *TransferAdminRoleConfig
+	proposeAdminRoleConfig      *ProposeAdminRoleConfig
+}
+
+func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleConfigs, error) {
+	if cfg.configs != nil {
+		return *cfg.configs, nil
+	}
+
+	state, err := stateview.LoadOnchainState(e)
+	if err != nil {
+		return updateAdminRoleConfigs{}, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	transferAdminRoleConfig := TransferAdminRoleConfig{
+		TransferAdminByChain: map[uint64][]TokenAdminInfo{},
+		MCMS:                 cfg.MCMS,
+	}
+
+	proposeAdminRoleConfig := ProposeAdminRoleConfig{
+		ProposeAdminByChain:  map[uint64][]TokenAdminInfo{},
+		OverridePendingAdmin: cfg.OverridePendingAdmin,
+		MCMS:                 cfg.MCMS,
+	}
+
+	for selector, updates := range cfg.ChainUpdates {
+		chainState, ok := state.EVMChainState(selector)
+		if !ok {
+			return updateAdminRoleConfigs{}, fmt.Errorf("selector %d does not exist in state", selector)
+		}
+
+		tokenConfigCache := map[common.Address]token_admin_registry.TokenAdminRegistryTokenConfig{}
+		transferInfo := []TokenAdminInfo{}
+		proposeInfo := []TokenAdminInfo{}
+
+		for _, info := range updates {
+			tokenConfig, hit := tokenConfigCache[info.TokenAddress]
+			if !hit {
+				e.Logger.Infof(
+					"fetching token config for token '%s' from token admin registry at '%s' (chain selector = '%d')",
+					info.TokenAddress.Hex(),
+					chainState.TokenAdminRegistry.Address().Hex(),
+					selector,
+				)
+
+				tokenCfg, err := chainState.TokenAdminRegistry.GetTokenConfig(&bind.CallOpts{Context: e.GetContext()}, info.TokenAddress)
+				if err != nil {
+					return updateAdminRoleConfigs{}, fmt.Errorf(
+						"failed to get token config for token '%s' from chain with selector '%d'",
+						info.TokenAddress.Hex(),
+						selector,
+					)
+				}
+
+				e.Logger.Infof(
+					"found token config for token '%s' in token admin registry at '%s' (chain selector = '%d'): %+v",
+					info.TokenAddress.Hex(),
+					chainState.TokenAdminRegistry.Address().Hex(),
+					selector,
+					tokenCfg,
+				)
+
+				tokenConfigCache[info.TokenAddress] = tokenCfg
+				tokenConfig = tokenCfg
+			}
+
+			// If no admin exists for the token, then propose one otherwise transfer ownership
+			if tokenConfig.Administrator == (common.Address{}) {
+				proposeInfo = append(proposeInfo, info)
+			} else {
+				transferInfo = append(transferInfo, info)
+			}
+		}
+
+		if len(transferInfo) > 0 {
+			transferAdminRoleConfig.TransferAdminByChain[selector] = transferInfo
+		}
+
+		if len(proposeInfo) > 0 {
+			proposeAdminRoleConfig.ProposeAdminByChain[selector] = proposeInfo
+		}
+	}
+
+	changesets := []ccipcommoncs.WithConfig{}
+	configs := updateAdminRoleConfigs{
+		orchestrateChangesetsConfig: nil,
+		transferAdminRoleConfig:     nil,
+		proposeAdminRoleConfig:      nil,
+	}
+
+	if len(transferAdminRoleConfig.TransferAdminByChain) > 0 {
+		configs.transferAdminRoleConfig = &transferAdminRoleConfig
+		changesets = append(changesets, ccipcommoncs.CreateGenericChangeSetWithConfig(
+			TransferAdminRoleChangesetV2,
+			transferAdminRoleConfig,
+		))
+	}
+
+	if len(proposeAdminRoleConfig.ProposeAdminByChain) > 0 {
+		configs.proposeAdminRoleConfig = &proposeAdminRoleConfig
+		changesets = append(changesets, ccipcommoncs.CreateGenericChangeSetWithConfig(
+			ProposeAdminRoleChangesetV2,
+			proposeAdminRoleConfig,
+		))
+	}
+
+	if cfg.MCMS != nil {
+		configs.orchestrateChangesetsConfig = &ccipcommoncs.OrchestrateChangesetsConfig{
+			Description: "Propose or transfer admin roles",
+			MCMS:        cfg.MCMS,
+			ChangeSets:  changesets,
+		}
+	}
+
+	cfg.configs = &configs
+	return configs, nil
+}
+
+func updateAdminRolePrecondition(e cldf.Environment, cfg UpdateAdminRoleConfig) error {
+	if len(cfg.ChainUpdates) == 0 {
+		return nil
+	}
+
+	configs, err := cfg.populate(e)
+	if err != nil {
+		return fmt.Errorf("failed to populate internal configs: %w", err)
+	}
+
+	if configs.orchestrateChangesetsConfig != nil {
+		return ccipcommoncs.OrchestrateChangesets.VerifyPreconditions(e, *configs.orchestrateChangesetsConfig)
+	}
+
+	if configs.transferAdminRoleConfig != nil {
+		err := TransferAdminRoleChangesetV2.VerifyPreconditions(e, *configs.transferAdminRoleConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	if configs.proposeAdminRoleConfig != nil {
+		err := ProposeAdminRoleChangesetV2.VerifyPreconditions(e, *configs.proposeAdminRoleConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func updateAdminRoleLogic(e cldf.Environment, cfg UpdateAdminRoleConfig) (cldf.ChangesetOutput, error) {
+	if len(cfg.ChainUpdates) == 0 {
+		return cldf.ChangesetOutput{}, nil
+	}
+
+	configs, err := cfg.populate(e)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate internal configs: %w", err)
+	}
+
+	if configs.orchestrateChangesetsConfig != nil {
+		return ccipcommoncs.OrchestrateChangesets.Apply(e, *configs.orchestrateChangesetsConfig)
+	}
+
+	result := cldf.ChangesetOutput{}
+	if configs.transferAdminRoleConfig != nil {
+		transferOutput, err := TransferAdminRoleChangesetV2.Apply(e, *configs.transferAdminRoleConfig)
+		if err != nil {
+			result.Reports = append(result.Reports, transferOutput.Reports...)
+			return cldf.ChangesetOutput{Reports: result.Reports}, fmt.Errorf("failed to apply TransferAdminRoleChangesetV2: %w", err)
+		}
+		e.Logger.Info("successfully applied TransferAdminRoleChangesetV2")
+	}
+	if configs.proposeAdminRoleConfig != nil {
+		proposeOutput, err := ProposeAdminRoleChangesetV2.Apply(e, *configs.proposeAdminRoleConfig)
+		if err != nil {
+			result.Reports = append(result.Reports, proposeOutput.Reports...)
+			return cldf.ChangesetOutput{Reports: result.Reports}, fmt.Errorf("failed to apply ProposeAdminRoleChangesetV2: %w", err)
+		}
+		e.Logger.Info("successfully applied ProposeAdminRoleChangesetV2")
+	}
+
+	return result, nil
+}

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -16,8 +16,10 @@ import (
 // UpdateAdminRoleChangesetV2 is a changeset that can propose AND transfer administrator roles for tokens
 // on the token admin registry. It takes array of TokenAdminInfo by chain and infers whether an the admin
 // should be proposed or transferred. The TokenAdminInfo expects a TokenAddress and AdminAddress as input
-// and splits the data into one of two groups (either propose or transfer). Then it'll reuse the existing
-// validations + logic for TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2.
+// and divides the data into one of two groups (either propose or transfer) depending on whether an admin
+// already exists for the token. Then, it will reuse the existing logic for the following CLD migrations:
+// TransferAdminRoleChangesetV2, ProposeAdminRoleChangesetV2. The MCMS config is shared. If it is defined
+// then OrchestrateChangesets will be used. Otherwise, the operations are run individually.
 var UpdateAdminRoleChangesetV2 = cldf.CreateChangeSet(updateAdminRoleLogic, updateAdminRolePrecondition)
 
 type UpdateAdminRoleConfig struct {

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -16,13 +16,14 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
 
-// UpdateAdminRoleChangesetV2 is a changeset that can propose AND transfer administrator roles for tokens
-// on the token admin registry. It takes array of TokenAdminInfo by chain and infers whether an the admin
-// should be proposed or transferred. The TokenAdminInfo expects a TokenAddress and AdminAddress as input
-// and divides the data into one of two groups (either propose or transfer) depending on whether an admin
-// already exists for the token. Then, it will reuse the existing logic for the following CLD migrations:
-// TransferAdminRoleChangesetV2, ProposeAdminRoleChangesetV2. The MCMS config is shared. If it is defined
-// then OrchestrateChangesets will be used. Otherwise, the operations are run individually.
+// UpdateAdminRoleChangesetV2 is a changeset that combines TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2 into
+// one operation. It accepts the same inputs as TransferAdminRoleChangesetV2 + ProposeAdminRoleChangesetV2 then infers which
+// one should be run by analyzing each input token's config from the TokenAdminRegistry. If the administrator is NOT defined
+// then it'll try to propose one. Otherwise, it will assume that the existing admin should be transferred. Once the input is
+// divided into one of two groups (either propose or transfer depending on whether an admin already exists on the token), it
+// will reuse the pre-existing validation checks + logic for TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2 so
+// that code duplication is kept at a minimum. This changeset also accepts an optional MCMS property that is reused for both
+// underlying changesets. If it is defined, then OrchestrateChangesets will be used. Otherwise, things are run individually.
 var UpdateAdminRoleChangesetV2 = cldf.CreateChangeSet(updateAdminRoleLogic, updateAdminRolePrecondition)
 
 type UpdateAdminRoleConfig struct {

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -47,6 +47,7 @@ type updateAdminRoleConfigs struct {
 
 func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleConfigs, error) {
 	if cfg.configs != nil {
+		e.Logger.Info("using cached configs")
 		return *cfg.configs, nil
 	}
 
@@ -161,51 +162,65 @@ func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleC
 
 func updateAdminRolePrecondition(e cldf.Environment, cfg UpdateAdminRoleConfig) error {
 	if len(cfg.ChainUpdates) == 0 {
+		e.Logger.Warn("no chain updates were provided - exiting precondition stage gracefully")
 		return nil
 	}
 
+	e.Logger.Info("populating internal configs for TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2")
 	configs, err := cfg.populate(e)
 	if err != nil {
 		return fmt.Errorf("failed to populate internal configs: %w", err)
 	}
 
 	if configs.orchestrateChangesetsConfig != nil {
+		e.Logger.Info("MCMS config detected - using OrchestrateChangesets to verify preconditions")
 		return ccipcommoncs.OrchestrateChangesets.VerifyPreconditions(e, *configs.orchestrateChangesetsConfig)
 	}
 
+	e.Logger.Info("no MCMS config detected - verifying preconditions for TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2 individually")
 	if configs.transferAdminRoleConfig != nil {
+		e.Logger.Info("verifying preconditions TransferAdminRoleChangesetV2...")
 		err := TransferAdminRoleChangesetV2.VerifyPreconditions(e, *configs.transferAdminRoleConfig)
 		if err != nil {
 			return err
 		}
+		e.Logger.Info("successfully verified preconditions for TransferAdminRoleChangesetV2")
 	}
-
 	if configs.proposeAdminRoleConfig != nil {
+		e.Logger.Info("verifying preconditions ProposeAdminRoleChangesetV2...")
 		err := ProposeAdminRoleChangesetV2.VerifyPreconditions(e, *configs.proposeAdminRoleConfig)
 		if err != nil {
 			return err
 		}
+		e.Logger.Info("successfully verified preconditions for ProposeAdminRoleChangesetV2")
 	}
+	e.Logger.Info("all preconditions have been satisfied for TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2")
 
 	return nil
 }
 
 func updateAdminRoleLogic(e cldf.Environment, cfg UpdateAdminRoleConfig) (cldf.ChangesetOutput, error) {
+	result := cldf.ChangesetOutput{}
+
 	if len(cfg.ChainUpdates) == 0 {
+		e.Logger.Warn("no chain updates were provided - exiting apply stage gracefully")
 		return cldf.ChangesetOutput{}, nil
 	}
 
+	e.Logger.Info("populating internal configs for TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2")
 	configs, err := cfg.populate(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to populate internal configs: %w", err)
 	}
 
 	if configs.orchestrateChangesetsConfig != nil {
+		e.Logger.Info("MCMS config detected - using OrchestrateChangesets to batch all operations into one MCMS proposal")
 		return ccipcommoncs.OrchestrateChangesets.Apply(e, *configs.orchestrateChangesetsConfig)
 	}
 
-	result := cldf.ChangesetOutput{}
+	e.Logger.Info("no MCMS config detected - applying TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2 sequentially")
 	if configs.transferAdminRoleConfig != nil {
+		e.Logger.Info("applying TransferAdminRoleChangesetV2...")
 		transferOutput, err := TransferAdminRoleChangesetV2.Apply(e, *configs.transferAdminRoleConfig)
 		if err != nil {
 			result.Reports = append(result.Reports, transferOutput.Reports...)
@@ -213,7 +228,9 @@ func updateAdminRoleLogic(e cldf.Environment, cfg UpdateAdminRoleConfig) (cldf.C
 		}
 		e.Logger.Info("successfully applied TransferAdminRoleChangesetV2")
 	}
+
 	if configs.proposeAdminRoleConfig != nil {
+		e.Logger.Info("applying ProposeAdminRoleChangesetV2...")
 		proposeOutput, err := ProposeAdminRoleChangesetV2.Apply(e, *configs.proposeAdminRoleConfig)
 		if err != nil {
 			result.Reports = append(result.Reports, proposeOutput.Reports...)
@@ -221,6 +238,7 @@ func updateAdminRoleLogic(e cldf.Environment, cfg UpdateAdminRoleConfig) (cldf.C
 		}
 		e.Logger.Info("successfully applied ProposeAdminRoleChangesetV2")
 	}
+	e.Logger.Info("finished applying TransferAdminRoleChangesetV2 and ProposeAdminRoleChangesetV2")
 
 	return result, nil
 }

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -10,8 +10,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
-
 	ccipcommoncs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 )
@@ -75,10 +73,9 @@ func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleC
 			return updateAdminRoleConfigs{}, fmt.Errorf("selector %d does not exist in state", selector)
 		}
 
-		tokenConfigCache := map[common.Address]token_admin_registry.TokenAdminRegistryTokenConfig{}
+		tokenAddrSet := map[common.Address]bool{}
 		transferInfo := []TokenAdminInfo{}
 		proposeInfo := []TokenAdminInfo{}
-
 		for _, info := range updates {
 			// Ignore zero address (this will always have no token config)
 			if info.TokenAddress == utils.ZeroAddress {
@@ -86,36 +83,37 @@ func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleC
 				continue
 			}
 
-			// Get token info from in-mem cache or on-chain (duplicates + other checks will be validated at a later stage)
-			tokenConfig, hit := tokenConfigCache[info.TokenAddress]
-			if !hit {
-				e.Logger.Infof(
-					"fetching token config for token '%s' from token admin registry at '%s' (chain selector = '%d')",
-					info.TokenAddress.Hex(),
-					chainState.TokenAdminRegistry.Address().Hex(),
-					selector,
-				)
-
-				tokenCfg, err := chainState.TokenAdminRegistry.GetTokenConfig(&bind.CallOpts{Context: e.GetContext()}, info.TokenAddress)
-				if err != nil {
-					return updateAdminRoleConfigs{}, fmt.Errorf(
-						"failed to get token config for token '%s' from chain with selector '%d'",
-						info.TokenAddress.Hex(),
-						selector,
-					)
-				}
-
-				e.Logger.Infof(
-					"found token config for token '%s' in token admin registry at '%s' (chain selector = '%d'): %+v",
-					info.TokenAddress.Hex(),
-					chainState.TokenAdminRegistry.Address().Hex(),
-					selector,
-					tokenCfg,
-				)
-
-				tokenConfigCache[info.TokenAddress] = tokenCfg
-				tokenConfig = tokenCfg
+			// Ignore duplicate token addresses
+			exists := tokenAddrSet[info.TokenAddress]
+			if exists {
+				e.Logger.Warnf("detected duplicate token address (%s) for chain with selector '%d' - skipping", info.TokenAddress, selector)
+				continue
 			}
+
+			e.Logger.Infof(
+				"fetching token config for token '%s' from token admin registry at '%s' (chain selector = '%d')",
+				info.TokenAddress.Hex(),
+				chainState.TokenAdminRegistry.Address().Hex(),
+				selector,
+			)
+
+			tokenConfig, err := chainState.TokenAdminRegistry.GetTokenConfig(&bind.CallOpts{Context: e.GetContext()}, info.TokenAddress)
+			if err != nil {
+				return updateAdminRoleConfigs{}, fmt.Errorf(
+					"failed to get token config for token '%s' from chain with selector '%d'",
+					info.TokenAddress.Hex(),
+					selector,
+				)
+			}
+
+			tokenAddrSet[info.TokenAddress] = true
+			e.Logger.Infof(
+				"found token config for token '%s' in token admin registry at '%s' (chain selector = '%d'): %+v",
+				info.TokenAddress.Hex(),
+				chainState.TokenAdminRegistry.Address().Hex(),
+				selector,
+				tokenConfig,
+			)
 
 			// If no admin exists for the token, then propose one otherwise transfer ownership
 			if tokenConfig.Administrator == utils.ZeroAddress {

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role.go
@@ -81,7 +81,7 @@ func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleC
 		for _, info := range updates {
 			// Ignore zero address (this will always have no token config)
 			if info.TokenAddress == utils.ZeroAddress {
-				e.Logger.Warnf("detected null token address for chain with selector '%s' - skipping", selector)
+				e.Logger.Warnf("detected null token address for chain with selector '%d' - skipping", selector)
 				continue
 			}
 
@@ -127,13 +127,6 @@ func (cfg *UpdateAdminRoleConfig) populate(e cldf.Environment) (updateAdminRoleC
 			if tokenConfig.Administrator != info.AdminAddress {
 				transferInfo = append(transferInfo, info)
 				continue
-			} else {
-				e.Logger.Warnf(
-					"detected a transfer to the same admin (%s) for token '%s' on chain with selector '%d' - skipping",
-					info.AdminAddress,
-					info.TokenAddress,
-					selector,
-				)
 			}
 		}
 

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role_test.go
@@ -1,0 +1,363 @@
+package v1_5_1_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
+	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
+	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func TestUpdateAdminRoleChangesetV2_Validations(t *testing.T) {
+	t.Parallel()
+
+	mcmsConfig := &proposalutils.TimelockConfig{MinDelay: 0 * time.Second}
+	e, selectorA, selectorB, _ := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
+
+	tokenAddress := utils.RandomAddress()
+
+	// First, set up a token with a pending admin by proposing (timelock becomes pending admin)
+	e, err := commonchangeset.Apply(t, e,
+		commonchangeset.Configure(
+			v1_5_1.ProposeAdminRoleChangesetV2,
+			v1_5_1.ProposeAdminRoleConfig{
+				MCMS: mcmsConfig,
+				ProposeAdminByChain: map[uint64][]v1_5_1.TokenAdminInfo{
+					selectorA: {
+						{
+							TokenAddress: tokenAddress,
+							AdminAddress: utils.RandomAddress(),
+						},
+					},
+				},
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		Config v1_5_1.UpdateAdminRoleConfig
+		MsgStr string
+		ErrStr string
+	}{
+		{
+			ErrStr: "admin address cannot be the same as token address",
+			MsgStr: "Admin address same as token address",
+			Config: v1_5_1.UpdateAdminRoleConfig{
+				MCMS: mcmsConfig,
+				ChainUpdates: map[uint64][]v1_5_1.TokenAdminInfo{
+					selectorA: {
+						{
+							TokenAddress: tokenAddress,
+							AdminAddress: tokenAddress, // Same as token
+						},
+					},
+				},
+			},
+		},
+		{
+			ErrStr: "does not exist in state",
+			MsgStr: "Chain selector is invalid",
+			Config: v1_5_1.UpdateAdminRoleConfig{
+				ChainUpdates: map[uint64][]v1_5_1.TokenAdminInfo{
+					0: {
+						{
+							TokenAddress: tokenAddress,
+							AdminAddress: utils.RandomAddress(),
+						},
+					},
+				},
+			},
+		},
+		{
+			ErrStr: "does not exist in state",
+			MsgStr: "Chain selector doesn't exist in environment",
+			Config: v1_5_1.UpdateAdminRoleConfig{
+				ChainUpdates: map[uint64][]v1_5_1.TokenAdminInfo{
+					5009297550715157269: {
+						{
+							TokenAddress: tokenAddress,
+							AdminAddress: utils.RandomAddress(),
+						},
+					},
+				},
+			},
+		},
+		{
+			ErrStr: "token address cannot be zero",
+			MsgStr: "Zero token address",
+			Config: v1_5_1.UpdateAdminRoleConfig{
+				MCMS: mcmsConfig,
+				ChainUpdates: map[uint64][]v1_5_1.TokenAdminInfo{
+					selectorA: {
+						{
+							TokenAddress: utils.ZeroAddress,
+							AdminAddress: utils.RandomAddress(),
+						},
+					},
+				},
+			},
+		},
+		{
+			ErrStr: "admin address cannot be zero",
+			MsgStr: "Zero admin address",
+			Config: v1_5_1.UpdateAdminRoleConfig{
+				MCMS: mcmsConfig,
+				ChainUpdates: map[uint64][]v1_5_1.TokenAdminInfo{
+					selectorA: {
+						{
+							TokenAddress: tokenAddress,
+							AdminAddress: utils.ZeroAddress,
+						},
+					},
+				},
+			},
+		},
+		{
+			ErrStr: "token admin registry failed ownership validation",
+			MsgStr: "Ownership validation failure without MCMS",
+			Config: v1_5_1.UpdateAdminRoleConfig{
+				ChainUpdates: map[uint64][]v1_5_1.TokenAdminInfo{
+					selectorB: {
+						{
+							TokenAddress: tokenAddress,
+							AdminAddress: utils.RandomAddress(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.MsgStr, func(t *testing.T) {
+			_, err := commonchangeset.Apply(t, e,
+				commonchangeset.Configure(
+					v1_5_1.UpdateAdminRoleChangesetV2,
+					test.Config,
+				),
+			)
+			require.Error(t, err)
+			require.ErrorContains(t, err, test.ErrStr)
+		})
+	}
+}
+
+func TestUpdateAdminRoleChangesetV2_EmptyConfigIsGracefullyHandled(t *testing.T) {
+	t.Parallel()
+
+	e, _, _, _ := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
+
+	_, err := commonchangeset.Apply(t, e,
+		commonchangeset.Configure(
+			v1_5_1.UpdateAdminRoleChangesetV2,
+			v1_5_1.UpdateAdminRoleConfig{},
+		),
+	)
+	require.NoError(t, err)
+}
+
+func TestUpdateAdminRoleChangesetV2_ExecutionWithoutMCMS(t *testing.T) {
+	t.Parallel()
+
+	e, selectorA, selectorB, _ := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), false)
+
+	tokenAddressA := utils.RandomAddress()
+	tokenAddressB := utils.RandomAddress()
+	newAdminA := utils.RandomAddress()
+	newAdminB := utils.RandomAddress()
+
+	// First propose admin roles with deployer key (no MCMS) - deployer becomes pending admin
+	e, err := commonchangeset.Apply(t, e,
+		commonchangeset.Configure(
+			v1_5_1.ProposeAdminRoleChangesetV2,
+			v1_5_1.ProposeAdminRoleConfig{
+				ProposeAdminByChain: map[uint64][]v1_5_1.TokenAdminInfo{
+					selectorA: {
+						{
+							TokenAddress: tokenAddressA,
+							AdminAddress: e.BlockChains.EVMChains()[selectorA].DeployerKey.From,
+						},
+					},
+					selectorB: {
+						{
+							TokenAddress: tokenAddressB,
+							AdminAddress: e.BlockChains.EVMChains()[selectorB].DeployerKey.From,
+						},
+					},
+				},
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	// Manually accept the admin roles by calling acceptAdminRole directly on the registry
+	state, err := stateview.LoadOnchainState(e)
+	require.NoError(t, err)
+
+	// Get chain states
+	chainStateA := state.Chains[selectorA]
+	chainStateB := state.Chains[selectorB]
+
+	// Only accept admin role for tokenAddressA
+	tx, err := chainStateA.TokenAdminRegistry.AcceptAdminRole(
+		e.BlockChains.EVMChains()[selectorA].DeployerKey,
+		tokenAddressA,
+	)
+	require.NoError(t, err)
+	_, err = e.BlockChains.EVMChains()[selectorA].Confirm(tx)
+	require.NoError(t, err)
+
+	// Verify that the deployer is now the active administrator for tokenAddressA
+	configA, err := chainStateA.TokenAdminRegistry.GetTokenConfig(&bind.CallOpts{Context: e.GetContext()}, tokenAddressA)
+	require.NoError(t, err)
+	require.Equal(t, e.BlockChains.EVMChains()[selectorA].DeployerKey.From, configA.Administrator, "deployer should be the active administrator for tokenA")
+
+	// Verify that the deployer is NOT the active administrator for tokenAddressB (should still be pending)
+	configB, err := chainStateB.TokenAdminRegistry.GetTokenConfig(&bind.CallOpts{Context: e.GetContext()}, tokenAddressB)
+	require.NoError(t, err)
+	require.Equal(t, e.BlockChains.EVMChains()[selectorB].DeployerKey.From, configB.PendingAdministrator, "deployer should be the pending administrator for tokenB")
+
+	// This should run TransferAdminRoleChangesetV2 for tokenAddressA and override the pending admin for tokenAddressB
+	e, err = commonchangeset.Apply(t, e,
+		commonchangeset.Configure(
+			v1_5_1.UpdateAdminRoleChangesetV2,
+			v1_5_1.UpdateAdminRoleConfig{
+				// Need to override the pending admin (DeployerKey) for tokenAddressB
+				OverridePendingAdmin: true,
+				ChainUpdates: map[uint64][]v1_5_1.TokenAdminInfo{
+					selectorA: {
+						{
+							TokenAddress: tokenAddressA,
+							AdminAddress: newAdminA,
+						},
+					},
+					selectorB: {
+						{
+							TokenAddress: tokenAddressB,
+							AdminAddress: newAdminB,
+						},
+					},
+				},
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	// Verify the transfers - new admins should be in pending state
+	state, err = stateview.LoadOnchainState(e)
+	require.NoError(t, err)
+
+	registryOnA := state.Chains[selectorA].TokenAdminRegistry
+	configOnA, err := registryOnA.GetTokenConfig(nil, tokenAddressA)
+	require.NoError(t, err)
+	require.Equal(t, newAdminA, configOnA.PendingAdministrator)
+
+	registryOnB := state.Chains[selectorB].TokenAdminRegistry
+	configOnB, err := registryOnB.GetTokenConfig(nil, tokenAddressB)
+	require.NoError(t, err)
+	require.Equal(t, newAdminB, configOnB.PendingAdministrator)
+}
+
+func TestUpdateAdminRoleChangesetV2_ExecutionWithMCMS(t *testing.T) {
+	t.Parallel()
+
+	mcmsConfig := &proposalutils.TimelockConfig{MinDelay: 0 * time.Second}
+	e, selectorA, selectorB, _ := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
+
+	tokenAddressA := utils.RandomAddress()
+	tokenAddressB := utils.RandomAddress()
+	newAdminA := utils.RandomAddress()
+	newAdminB := utils.RandomAddress()
+
+	// First propose admin roles - the timelock becomes the pending admin
+	e, err := commonchangeset.Apply(t, e,
+		commonchangeset.Configure(
+			v1_5_1.UpdateAdminRoleChangesetV2,
+			v1_5_1.UpdateAdminRoleConfig{
+				MCMS: mcmsConfig,
+				ChainUpdates: map[uint64][]v1_5_1.TokenAdminInfo{
+					selectorA: {
+						{
+							TokenAddress: tokenAddressA,
+							AdminAddress: newAdminA,
+						},
+					},
+					selectorB: {
+						{
+							TokenAddress: tokenAddressB,
+							AdminAddress: newAdminB,
+						},
+					},
+				},
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	// Verify the proposed admin roles exist
+	state, err := stateview.LoadOnchainState(e)
+	require.NoError(t, err)
+
+	registryOnA := state.Chains[selectorA].TokenAdminRegistry
+	configOnA, err := registryOnA.GetTokenConfig(nil, tokenAddressA)
+	require.NoError(t, err)
+	require.Equal(t, newAdminA, configOnA.PendingAdministrator)
+
+	registryOnB := state.Chains[selectorB].TokenAdminRegistry
+	configOnB, err := registryOnB.GetTokenConfig(nil, tokenAddressB)
+	require.NoError(t, err)
+	require.Equal(t, newAdminB, configOnB.PendingAdministrator)
+}
+
+func TestUpdateAdminRoleChangesetV2_MultipleTokensPerChain(t *testing.T) {
+	t.Parallel()
+
+	mcmsConfig := &proposalutils.TimelockConfig{MinDelay: 0 * time.Second}
+	e, selectorA, _, _ := testhelpers.SetupTwoChainEnvironmentWithTokens(t, logger.TestLogger(t), true)
+
+	token1 := utils.RandomAddress()
+	token2 := utils.RandomAddress()
+	token3 := utils.RandomAddress()
+	newAdmin := utils.RandomAddress()
+
+	// First propose admin roles for multiple tokens - timelock becomes pending admin
+	e, err := commonchangeset.Apply(t, e,
+		commonchangeset.Configure(
+			v1_5_1.ProposeAdminRoleChangesetV2,
+			v1_5_1.ProposeAdminRoleConfig{
+				MCMS: mcmsConfig,
+				ProposeAdminByChain: map[uint64][]v1_5_1.TokenAdminInfo{
+					selectorA: {
+						{TokenAddress: token1, AdminAddress: newAdmin},
+						{TokenAddress: token2, AdminAddress: newAdmin},
+						{TokenAddress: token3, AdminAddress: newAdmin},
+					},
+				},
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	// Verify all transfers - all tokens should have the new admin as pending
+	state, err := stateview.LoadOnchainState(e)
+	require.NoError(t, err)
+
+	registry := state.Chains[selectorA].TokenAdminRegistry
+	for _, token := range []common.Address{token1, token2, token3} {
+		config, err := registry.GetTokenConfig(nil, token)
+		require.NoError(t, err)
+		require.Equal(t, newAdmin, config.PendingAdministrator)
+	}
+}

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role_test.go
@@ -4,16 +4,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	commonchangeset "github.com/smartcontractkit/chainlink/deployment/common/changeset"
 	"github.com/smartcontractkit/chainlink/deployment/common/proposalutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role_test.go
@@ -334,10 +334,10 @@ func TestUpdateAdminRoleChangesetV2_MultipleTokensPerChain(t *testing.T) {
 	// First propose admin roles for multiple tokens - timelock becomes pending admin
 	e, err := commonchangeset.Apply(t, e,
 		commonchangeset.Configure(
-			v1_5_1.ProposeAdminRoleChangesetV2,
-			v1_5_1.ProposeAdminRoleConfig{
+			v1_5_1.UpdateAdminRoleChangesetV2,
+			v1_5_1.UpdateAdminRoleConfig{
 				MCMS: mcmsConfig,
-				ProposeAdminByChain: map[uint64][]v1_5_1.TokenAdminInfo{
+				ChainUpdates: map[uint64][]v1_5_1.TokenAdminInfo{
 					selectorA: {
 						{TokenAddress: token1, AdminAddress: newAdmin},
 						{TokenAddress: token2, AdminAddress: newAdmin},

--- a/deployment/ccip/changeset/v1_5_1/cs_update_admin_role_test.go
+++ b/deployment/ccip/changeset/v1_5_1/cs_update_admin_role_test.go
@@ -94,21 +94,6 @@ func TestUpdateAdminRoleChangesetV2_Validations(t *testing.T) {
 			},
 		},
 		{
-			ErrStr: "token address cannot be zero",
-			MsgStr: "Zero token address",
-			Config: v1_5_1.UpdateAdminRoleConfig{
-				MCMS: mcmsConfig,
-				ChainUpdates: map[uint64][]v1_5_1.TokenAdminInfo{
-					selectorA: {
-						{
-							TokenAddress: utils.ZeroAddress,
-							AdminAddress: utils.RandomAddress(),
-						},
-					},
-				},
-			},
-		},
-		{
 			ErrStr: "admin address cannot be zero",
 			MsgStr: "Zero admin address",
 			Config: v1_5_1.UpdateAdminRoleConfig{


### PR DESCRIPTION
This PR adds a new changeset named `UpdateAdminRoleChangesetV2`, which combines `ProposeAdminRoleChangesetV2` and `TransferAdminRoleChangesetV2` into one operation

The input to this operation is the same as `ProposeAdminRoleChangesetV2` and `TransferAdminRoleChangesetV2`, but the main difference is that it can infer which op it needs to run by examining each input token's config from the TokenAdminRegistry onchain.

More specifically, this changeset will iterate over each token and for each one:
- It checks if the token has an administrator
- If it does, then it will run `TransferAdminRoleChangesetV2` for the token
- Otherwise, it will run `ProposeAdminRoleChangesetV2` for the token

The MCMS config is shared between both changesets - if it is specified, then `OrchestrateChangesets` will be used to batch them into one proposal. Otherwise, the operations are run separately.