### PR TITLE
Reenable Test_CCIP_Messaging_Aptos2EVM e2e test

### DIFF
--- a/integration-tests/smoke/ccip/ccip_aptos_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_aptos_messaging_test.go
@@ -2,39 +2,32 @@ package ccip
 
 import (
 	"context"
+	"encoding/hex"
 	"math/big"
 	"strings"
 	"testing"
 
+	"github.com/aptos-labs/aptos-go-sdk"
+	aptosapi "github.com/aptos-labs/aptos-go-sdk/api"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
 	aptos_call_opts "github.com/smartcontractkit/chainlink-aptos/bindings/bind"
-
 	aptos_feequoter "github.com/smartcontractkit/chainlink-aptos/bindings/ccip/fee_quoter"
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
-
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/messagingtest"
-	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
-	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
-
-	"encoding/hex"
-
-	"github.com/aptos-labs/aptos-go-sdk"
-	aptosapi "github.com/aptos-labs/aptos-go-sdk/api"
-
-	"github.com/ethereum/go-ethereum/common/math"
-
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/utils/testcontext"
 	"github.com/smartcontractkit/chainlink/deployment"
-
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	mlt "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/messagelimitationstest"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers/messagingtest"
+	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
+	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 func Test_CCIP_Messaging_EVM2Aptos(t *testing.T) {
@@ -370,7 +363,6 @@ func getLatestDummyReceiverEvent(t *testing.T, rpcClient aptos.AptosRpcClient, d
 }
 
 func Test_CCIP_Messaging_Aptos2EVM(t *testing.T) {
-	t.Skipf("Skipping because flaky: https://chainlink-core.slack.com/archives/C05JDS9S64S/p1757374215352519")
 	ctx := testhelpers.Context(t)
 	lggr := logger.TestLogger(t)
 	e, _, _ := testsetups.NewIntegrationEnvironment(

--- a/integration-tests/smoke/ccip/ccip_aptos_msghasher_test.go
+++ b/integration-tests/smoke/ccip/ccip_aptos_msghasher_test.go
@@ -6,25 +6,22 @@ import (
 	"testing"
 
 	"github.com/aptos-labs/aptos-go-sdk"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
-
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
-
-	ccipocr3common "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
-
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipaptos"
-	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
 
 	aptos_call_opts "github.com/smartcontractkit/chainlink-aptos/bindings/bind"
 	aptos_ccip_offramp "github.com/smartcontractkit/chainlink-aptos/bindings/ccip_offramp/offramp"
+	ccipocr3common "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	aptosstate "github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview/aptos"
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipaptos"
+	"github.com/smartcontractkit/chainlink/v2/core/capabilities/ccip/ccipevm"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 // Test_CCIP_AptosMessageHasher_OnChainVerification compares off-chain aptos msghasher.go implementation

--- a/integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
+++ b/integration-tests/smoke/ccip/ccip_aptos_token_transfer_test.go
@@ -11,8 +11,6 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
-	ccipclient "github.com/smartcontractkit/chainlink/deployment/ccip/shared/client"
-
 	aptos_call_opts "github.com/smartcontractkit/chainlink-aptos/bindings/bind"
 	aptos_feequoter "github.com/smartcontractkit/chainlink-aptos/bindings/ccip/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
@@ -20,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared"
+	ccipclient "github.com/smartcontractkit/chainlink/deployment/ccip/shared/client"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/shared/stateview"
 	testsetups "github.com/smartcontractkit/chainlink/integration-tests/testsetups/ccip"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"


### PR DESCRIPTION
### Description
This re-enables the `Test_CCIP_Messaging_Aptos2EVM` e2e test.

It's been previously disabled due to being flaky in: https://github.com/smartcontractkit/chainlink/pull/19054

The flakiness has since been addressed by: https://github.com/smartcontractkit/chainlink/pull/19300