### PR TITLE
[COP-1572] use latest version of chip ingress from the CTF

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20250911124514-5874cc6d62b2
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.13.1
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.24
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14-0.20250912141514-907781001913
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14
 	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink/core/scripts/cre/environment/examples/workflows/v1/proof-of-reserve/cron-based v0.0.0-20250826151008-ae5ec0ee6f2c

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1640,8 +1640,8 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f/go.mod h1:CTR5agBB07sCpRltBkHmnkCZ+g8sXRafCJge/Hqr7aM=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.24 h1:i8+fR76yn0yxAFAkdhy7BgIB2VJgwec9BqnSPp6fZ7M=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.24/go.mod h1:gdW2dlrvHcTawMCtAIXQYZcZ9Ggx16L55kA7wONvzJ4=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14-0.20250912141514-907781001913 h1:vEAnog+i+oWnJMPgD/l4cBbcArc89ZZXZx0u5nA7Ipo=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14-0.20250912141514-907781001913/go.mod h1:j5dqJu5wLwbJ7GfEL7Ky5nX+hvL0R/3dcqbECmvuFUQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14 h1:BmYMQvgOUi1uWURfi4Jcj7t8EZ7brcIK9OFppTdtGBQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14/go.mod h1:/v0GS3ojcMOMgf7Jt+g5Oe8novCTqsX6x71IRwwXgw4=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.5 h1:jARz/SWbmWoGJJGVcAnWwGMb8JuHRTQQsM3m6ZwrAGk=

--- a/system-tests/tests/go.mod
+++ b/system-tests/tests/go.mod
@@ -546,7 +546,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/storage-service v0.3.0 // indirect
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0 // indirect
 	github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f // indirect
-	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14-0.20250912141514-907781001913 // indirect
+	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/parrot v0.6.2 // indirect
 	github.com/smartcontractkit/chainlink-ton v0.0.0-20250917170425-f6b7494e763a // indirect

--- a/system-tests/tests/go.sum
+++ b/system-tests/tests/go.sum
@@ -1821,8 +1821,8 @@ github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f h1:
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f/go.mod h1:CTR5agBB07sCpRltBkHmnkCZ+g8sXRafCJge/Hqr7aM=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.24 h1:i8+fR76yn0yxAFAkdhy7BgIB2VJgwec9BqnSPp6fZ7M=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.24/go.mod h1:gdW2dlrvHcTawMCtAIXQYZcZ9Ggx16L55kA7wONvzJ4=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14-0.20250912141514-907781001913 h1:vEAnog+i+oWnJMPgD/l4cBbcArc89ZZXZx0u5nA7Ipo=
-github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14-0.20250912141514-907781001913/go.mod h1:j5dqJu5wLwbJ7GfEL7Ky5nX+hvL0R/3dcqbECmvuFUQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14 h1:BmYMQvgOUi1uWURfi4Jcj7t8EZ7brcIK9OFppTdtGBQ=
+github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.1.14/go.mod h1:/v0GS3ojcMOMgf7Jt+g5Oe8novCTqsX6x71IRwwXgw4=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0 h1:PWAMYu0WaAMBfbpxCpFJGRIDHmcgmYin6a+UQC0OdtY=
 github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.0/go.mod h1:YEQbZRHFojvlQKeuckG/70t0WkAqOBmArSbkacgHSbc=
 github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.7 h1:ANltXlvv6CbOXieasPD9erc4BewtCHm1tKDPAYvuWLw=


### PR DESCRIPTION
More nuanced checks for Red Panda's readiness + retry on `EOF` during schema registration. This should help with late flakyness of Beholder startup of this kind:
```
  Error: failed to start Beholder: failed to register protos: proto registration failedfailed to fetch and register protos: failed to register protos from https://github.com/smartcontractkit/chainlink-protos: failed to register workflows/v1/transmissions_scheduled_event.proto as cre-workflows.v1.TransmissionsScheduledEvent: failed to register schema for subject cre-workflows.v1.TransmissionsScheduledEvent: All attempts fail:
  #1: failed to post to schema registry: Post "http://localhost:18081/subjects/cre-workflows.v1.TransmissionsScheduledEvent/versions": read tcp [::1]:55960->[::1]:18081: read: connection reset by peer
  #2: failed to post to schema registry: Post "http://localhost:18081/subjects/cre-workflows.v1.TransmissionsScheduledEvent/versions": read tcp [::1]:55976->[::1]:18081: read: connection reset by peer
  #3: failed to post to schema registry: Post "http://localhost:18081/subjects/cre-workflows.v1.TransmissionsScheduledEvent/versions": EOF
```