### PR TITLE
(fix) Bring WF Registry V2 fixes back to V1

### DIFF
--- a/.changeset/end-up-forward.md
+++ b/.changeset/end-up-forward.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#fix Workflow Registry Syncer V1 handles delete events first and handles orphaned pending events 

--- a/core/services/workflows/syncer/workflow_registry.go
+++ b/core/services/workflows/syncer/workflow_registry.go
@@ -594,14 +594,19 @@ func (w *workflowRegistry) generateReconciliationEvents(ctx context.Context, pen
 				DonID:         donID,
 				WorkflowName:  engine.WorkflowName,
 			}
-			events = append(events, &reconciliationEvent{
-				Event: Event{
-					Data:      toDeletedEvent,
-					EventType: WorkflowDeletedEvent,
+			events = append(
+				[]*reconciliationEvent{
+					{
+						Event: Event{
+							Data:      toDeletedEvent,
+							EventType: WorkflowDeletedEvent,
+						},
+						signature: signature,
+						id:        id,
+					},
 				},
-				signature: signature,
-				id:        id,
-			})
+				events...,
+			)
 		}
 	}
 

--- a/core/services/workflows/syncer/workflow_registry.go
+++ b/core/services/workflows/syncer/workflow_registry.go
@@ -605,6 +605,24 @@ func (w *workflowRegistry) generateReconciliationEvents(ctx context.Context, pen
 		}
 	}
 
+	// Clean up create events which no longer need to be attempted because
+	// the workflow no longer exists in the workflow registry contract
+
+	for id, event := range pendingEvents {
+		if event.EventType == WorkflowRegisteredEvent {
+			existsInMetadata := false
+			for _, wfMeta := range workflowMetadata {
+				if wfMeta.WorkflowID.Hex() == event.Data.(WorkflowRegisteredV1).WorkflowID.Hex() {
+					existsInMetadata = true
+					break
+				}
+			}
+			if !existsInMetadata {
+				delete(pendingEvents, id)
+			}
+		}
+	}
+
 	if len(pendingEvents) != 0 {
 		return nil, fmt.Errorf("invariant violation: some pending events were not handled in the reconcile loop: keys=%+v, len=%d", maps.Keys(pendingEvents), len(pendingEvents))
 	}

--- a/core/services/workflows/syncer/workflow_registry_test.go
+++ b/core/services/workflows/syncer/workflow_registry_test.go
@@ -510,6 +510,63 @@ func Test_generateReconciliationEvents(t *testing.T) {
 		require.Empty(t, pendingEvents)
 	})
 
+	t.Run("delete events are handled before any other events", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		ctx := testutils.Context(t)
+		donID := uint32(1)
+		workflowDonNotifier := capabilities.NewDonNotifier()
+		// Engine already in the workflow registry
+		er := NewEngineRegistry()
+		wfID := [32]byte{1}
+		owner := []byte{1}
+		wfName := "wf name 1"
+		err := er.Add(EngineRegistryKey{Owner: owner, Name: wfName}, &mockService{}, wfID)
+		require.NoError(t, err)
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
+				return nil, nil
+			},
+			"",
+			Config{
+				QueryCount:   20,
+				SyncStrategy: SyncStrategyReconciliation,
+			},
+			&eventHandler{},
+			workflowDonNotifier,
+			er,
+		)
+		fakeClock := clockwork.NewFakeClock()
+		wr.clock = fakeClock
+		require.NoError(t, err)
+
+		// The first workflow is delete and a second workflow is added
+		wfID2 := [32]byte{2}
+		wfName2 := "wf name 2"
+		binaryURL := "b1"
+		configURL := "c1"
+		metadata := []GetWorkflowMetadata{
+			{
+				WorkflowID:   wfID2,
+				Owner:        owner,
+				DonID:        donID,
+				Status:       WorkflowStatusActive,
+				WorkflowName: wfName2,
+				BinaryURL:    binaryURL,
+				ConfigURL:    configURL,
+				SecretsURL:   "",
+			},
+		}
+
+		pendingEvents := map[string]*reconciliationEvent{}
+		events, err := wr.generateReconciliationEvents(ctx, pendingEvents, metadata, donID)
+		require.NoError(t, err)
+
+		// Delete event happens before create event
+		require.Equal(t, WorkflowDeletedEvent, events[0].EventType)
+		require.Equal(t, WorkflowRegisteredEvent, events[1].EventType)
+	})
+
 	t.Run("reconciles with a pending event if it has the same signature", func(t *testing.T) {
 		lggr := logger.TestLogger(t)
 		ctx := testutils.Context(t)

--- a/core/services/workflows/syncer/workflow_registry_test.go
+++ b/core/services/workflows/syncer/workflow_registry_test.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"testing"
 	"time"
@@ -388,6 +389,125 @@ func Test_generateReconciliationEvents(t *testing.T) {
 			WorkflowName:  wfName,
 		}
 		require.Equal(t, expectedUpdatedEvent, events[0].Data)
+	})
+
+	t.Run("pending delete events are handled when workflow metadata no longer exists", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		ctx := testutils.Context(t)
+		donID := uint32(1)
+		workflowDonNotifier := capabilities.NewDonNotifier()
+		// Engine already in the workflow registry
+		er := NewEngineRegistry()
+		wfID := [32]byte{1}
+		owner := []byte{}
+		wfName := "wf name 1"
+		err := er.Add(EngineRegistryKey{Owner: owner, Name: wfName}, &mockService{}, wfID)
+		require.NoError(t, err)
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
+				return nil, nil
+			},
+			"",
+			Config{
+				QueryCount:   20,
+				SyncStrategy: SyncStrategyReconciliation,
+			},
+			&eventHandler{},
+			workflowDonNotifier,
+			er,
+		)
+		fakeClock := clockwork.NewFakeClock()
+		wr.clock = fakeClock
+		require.NoError(t, err)
+
+		// A workflow is to be removed, but hits a failure, causing it to stay pending
+		event := WorkflowDeletedV1{
+			WorkflowID: wfID,
+		}
+		pendingEvents := map[string]*reconciliationEvent{
+			idFor(owner, wfName): {
+				Event: Event{
+					Data:      event,
+					EventType: WorkflowDeletedEvent,
+				},
+				id:          idFor(owner, wfName),
+				signature:   fmt.Sprintf("%s-%s", WorkflowDeletedEvent, hex.EncodeToString(wfID[:])),
+				nextRetryAt: time.Now(),
+				retryCount:  5,
+			},
+		}
+
+		// No workflows in metadata
+		metadata := []GetWorkflowMetadata{}
+
+		events, err := wr.generateReconciliationEvents(ctx, pendingEvents, metadata, donID)
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+		require.Equal(t, WorkflowDeletedEvent, events[0].EventType)
+		require.Empty(t, pendingEvents)
+	})
+
+	t.Run("pending create events are handled when workflow metadata no longer exists", func(t *testing.T) {
+		lggr := logger.TestLogger(t)
+		ctx := testutils.Context(t)
+		donID := uint32(1)
+		workflowDonNotifier := capabilities.NewDonNotifier()
+		er := NewEngineRegistry()
+		wr, err := NewWorkflowRegistry(
+			lggr,
+			func(ctx context.Context, bytes []byte) (types.ContractReader, error) {
+				return nil, nil
+			},
+			"",
+			Config{
+				QueryCount:   20,
+				SyncStrategy: SyncStrategyReconciliation,
+			},
+			&eventHandler{},
+			workflowDonNotifier,
+			er,
+		)
+		fakeClock := clockwork.NewFakeClock()
+		wr.clock = fakeClock
+		require.NoError(t, err)
+
+		// A workflow is added, but hits a failure during creation, causing it to stay pending
+		binaryURL := "b1"
+		configURL := "c1"
+		wfID := [32]byte{1}
+		owner := []byte{}
+		wfName := "wf name 1"
+		event := WorkflowRegisteredV1{
+			WorkflowID:    wfID,
+			WorkflowOwner: owner,
+			DonID:         donID,
+			Status:        WorkflowStatusActive,
+			WorkflowName:  wfName,
+			BinaryURL:     binaryURL,
+			ConfigURL:     configURL,
+			SecretsURL:    "",
+		}
+		pendingEvents := map[string]*reconciliationEvent{
+			idFor(owner, wfName): {
+				Event: Event{
+					Data:      event,
+					EventType: WorkflowRegisteredEvent,
+				},
+				id:          idFor(owner, wfName),
+				signature:   fmt.Sprintf("%s-%s", WorkflowRegisteredEvent, hex.EncodeToString(wfID[:])),
+				nextRetryAt: time.Now(),
+				retryCount:  5,
+			},
+		}
+
+		// The workflow then gets removed
+		metadata := []GetWorkflowMetadata{}
+
+		events, err := wr.generateReconciliationEvents(ctx, pendingEvents, metadata, donID)
+		require.NoError(t, err)
+		require.Empty(t, events)
+		require.Empty(t, pendingEvents)
 	})
 
 	t.Run("reconciles with a pending event if it has the same signature", func(t *testing.T) {


### PR DESCRIPTION
### Description
Brings two fixes that went into WF Registry V2  back into V1
- https://github.com/smartcontractkit/chainlink/pull/19117
- https://github.com/smartcontractkit/chainlink/pull/18976

For more context on the reasoning behind individual fixes, see the previous PRs.