### PR TITLE
PLEX-1734: making buffer and query limit parameterizazble for log tri…

### DIFF
--- a/core/scripts/cre/environment/configs/capability_defaults.toml
+++ b/core/scripts/cre/environment/configs/capability_defaults.toml
@@ -37,6 +37,8 @@
 [capability_configs.evm.config]
   LogTriggerPollInterval = 1500000000  # 1.5s in nanoseconds
   ReceiverGasMinimum = 500
+  # LogTriggerSendChannelBufferSize = 1000 # default 1000, ommited here to use default
+  # LogTriggerLimitQueryLogSize = 1000 # default 1000, ommited here to use default
   # Runtime values below are typically filled at runtime, but may be overridden
   # CreForwarderAddress = "0x0000000000000000000000000000000000000000"
   # NodeAddress = "0x0000000000000000000000000000000000000000"

--- a/plugins/plugins.private.yaml
+++ b/plugins/plugins.private.yaml
@@ -41,7 +41,7 @@ plugins:
       installPath: "github.com/smartcontractkit/capabilities/http_trigger"
   evm:
     - moduleURI: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
-      gitRef: "a460c47a24141f65a43fb3bd481f2e8f06b54bd4"
+      gitRef: "f972e04023347f532ed174979d97ae3687f4a58f"
       installPath: "github.com/smartcontractkit/capabilities/chain_capabilities/evm"
   mock:
     - moduleURI: "github.com/smartcontractkit/capabilities/mock"

--- a/system-tests/lib/cre/capabilities/evm/evm.go
+++ b/system-tests/lib/cre/capabilities/evm/evm.go
@@ -37,8 +37,7 @@ import (
 )
 
 const (
-	flag = cre.EVMCapability
-	//configTemplate      = `'{"chainId":{{.ChainID}},"network":"{{.NetworkFamily}}","logTriggerPollInterval":{{.LogTriggerPollInterval}}, "creForwarderAddress":"{{.CreForwarderAddress}}","receiverGasMinimum":{{.ReceiverGasMinimum}},"nodeAddress":"{{.NodeAddress}}"}'`
+	flag                = cre.EVMCapability
 	configTemplate      = `'{"chainId":{{.ChainID}}, "network":"{{.NetworkFamily}}", "logTriggerPollInterval":{{.LogTriggerPollInterval}}, "creForwarderAddress":"{{.CreForwarderAddress}}", "receiverGasMinimum":{{.ReceiverGasMinimum}}, "nodeAddress":"{{.NodeAddress}}"{{with .LogTriggerSendChannelBufferSize}},"logTriggerSendChannelBufferSize":{{.}}{{end}}{{with .LogTriggerLimitQueryLogSize}},"logTriggerLimitQueryLogSize":{{.}}{{end}}}'`
 	registrationRefresh = 20 * time.Second
 	registrationExpiry  = 60 * time.Second

--- a/system-tests/lib/cre/capabilities/evm/evm.go
+++ b/system-tests/lib/cre/capabilities/evm/evm.go
@@ -37,8 +37,9 @@ import (
 )
 
 const (
-	flag                = cre.EVMCapability
-	configTemplate      = `'{"chainId":{{.ChainID}},"network":"{{.NetworkFamily}}","logTriggerPollInterval":{{.LogTriggerPollInterval}}, "creForwarderAddress":"{{.CreForwarderAddress}}","receiverGasMinimum":{{.ReceiverGasMinimum}},"nodeAddress":"{{.NodeAddress}}"}'`
+	flag = cre.EVMCapability
+	//configTemplate      = `'{"chainId":{{.ChainID}},"network":"{{.NetworkFamily}}","logTriggerPollInterval":{{.LogTriggerPollInterval}}, "creForwarderAddress":"{{.CreForwarderAddress}}","receiverGasMinimum":{{.ReceiverGasMinimum}},"nodeAddress":"{{.NodeAddress}}"}'`
+	configTemplate      = `'{"chainId":{{.ChainID}}, "network":"{{.NetworkFamily}}", "logTriggerPollInterval":{{.LogTriggerPollInterval}}, "creForwarderAddress":"{{.CreForwarderAddress}}", "receiverGasMinimum":{{.ReceiverGasMinimum}}, "nodeAddress":"{{.NodeAddress}}"{{with .LogTriggerSendChannelBufferSize}},"logTriggerSendChannelBufferSize":{{.}}{{end}}{{with .LogTriggerLimitQueryLogSize}},"logTriggerLimitQueryLogSize":{{.}}{{end}}}'`
 	registrationRefresh = 20 * time.Second
 	registrationExpiry  = 60 * time.Second
 	deltaStage          = 500*time.Millisecond + 1*time.Second // block time + 1 second delta


### PR DESCRIPTION
…gger

jira: https://smartcontract-it.atlassian.net/browse/PLEX-1734

Enable LocalCRE parameterize buffer and limit size for evm log trigger (if none, it will use the defaults)

### Requires
- https://github.com/smartcontractkit/capabilities/pull/258

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
