### PR TITLE
fix: correct nurse memory profile rate assignment

### DIFF
--- a/core/services/nurse.go
+++ b/core/services/nurse.go
@@ -82,7 +82,7 @@ func NewNurse(cfg Config, log logger.Logger) *Nurse {
 func (n *Nurse) start(_ context.Context) error {
 	// This must be set *once*, and it must occur as early as possible
 	if n.cfg.MemProfileRate() != runtime.MemProfileRate {
-		runtime.MemProfileRate = n.cfg.BlockProfileRate()
+		runtime.MemProfileRate = n.cfg.MemProfileRate()
 	}
 
 	n.eng.Debugf("Starting nurse with config %+v", n.cfg)

--- a/core/services/nurse_test.go
+++ b/core/services/nurse_test.go
@@ -44,7 +44,8 @@ func newMockConfig(t *testing.T) *mockConfig {
 		gatherDuration:       commonconfig.MustNewDuration(testDuration),
 		traceDuration:        commonconfig.MustNewDuration(testDuration),
 		profileSize:          utils.FileSize(testSize),
-		memProfileRate:       runtime.MemProfileRate,
+		cpuProfileRate:       testRate,
+		memProfileRate:       testRate,
 		blockProfileRate:     testRate,
 		mutexProfileFraction: testRate,
 		memThreshold:         utils.FileSize(testSize),
@@ -98,12 +99,18 @@ func (c mockConfig) GoroutineThreshold() int {
 }
 
 func TestNurse(t *testing.T) {
+	origMemProfileRate := runtime.MemProfileRate
+	runtime.MemProfileRate = 0
+	t.Cleanup(func() { runtime.MemProfileRate = origMemProfileRate })
+
 	l := logger.TestLogger(t)
-	nrse := NewNurse(newMockConfig(t), l)
+	cfg := newMockConfig(t)
+	nrse := NewNurse(cfg, l)
 	nrse.AddCheck("test", func() (bool, Meta) { return true, Meta{} })
 
 	require.NoError(t, nrse.Start(t.Context()))
 	defer func() { require.NoError(t, nrse.Close()) }()
+	require.Equal(t, cfg.memProfileRate, runtime.MemProfileRate)
 
 	require.NoError(t, nrse.appendLog(time.Now(), "test", Meta{}))
 


### PR DESCRIPTION
 <!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
      - the PR title
      - branch name
      - commit message
  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
  -->
  External contribution; no internal ticket.

  ### Requires
  None.

  ### Supports
  None.

  ## Summary
  - set runtime.MemProfileRate from the configured mem profile rate instead of the block profile rate
  - update the nurse mock config to use distinct profiling rates so the test can catch regressions
  - assert that Nurse startup applies the configured memory profile rate
 
  ## Background
  - commit 7efb04d41b3c (BCF-2099) addressed a `go test -race` finding: the Nurse test started the service (which writes runtime.MemProfileRate) while other goroutines were
  also touching that runtime global, triggering “data race on runtime.MemProfileRate”
  - to reduce writes to the runtime variable they wrapped the assignment in a guard, but accidentally copied AutoPprofBlockProfileRate instead of AutoPprofMemProfileRate, leaving the mem profile rate stuck to the block profile value
  - later refactors (e.g. 69f7bd68199) kept the same line, so the regression persisted until now

  ## Rationale
  - restoring the mem profile rate ensures heap profiling obeys configuration while keeping the conditional guard that prevents the original race
  - the updated test resets runtime.MemProfileRate before startup, asserts the new value, and cleans up, so it exercises the fix without reintroducing the prior race condition

  ## Testing
  - GOTOOLCHAIN=go1.24.7 GOCACHE=$(pwd)/.gocache go test ./core/services -run TestNurse -count=1
