### PR TITLE
integration-tests/smoke/ccip: add multimsg root test for sol

### DIFF
--- a/deployment/ccip/changeset/testhelpers/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/helpers.go
@@ -6,8 +6,9 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/multicall3"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 )
 
 // CCIPSendCalldata packs the calldata for the Router's ccipSend method.

--- a/deployment/ccip/changeset/testhelpers/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/helpers.go
@@ -1,0 +1,73 @@
+package testhelpers
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/multicall3"
+)
+
+// CCIPSendCalldata packs the calldata for the Router's ccipSend method.
+// This is expected to be used in Multicall scenarios (i.e multiple ccipSend calls
+// in a single transaction).
+func CCIPSendCalldata(
+	destChainSelector uint64,
+	evm2AnyMessage router.ClientEVM2AnyMessage,
+) ([]byte, error) {
+	calldata, err := routerABI.Methods["ccipSend"].Inputs.Pack(
+		destChainSelector,
+		evm2AnyMessage,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("pack ccipSend calldata: %w", err)
+	}
+
+	calldata = append(routerABI.Methods["ccipSend"].ID, calldata...)
+	return calldata, nil
+}
+
+// GenMessagesForMulticall3 generates the calls and total value for the messages so that they can be used
+// with a multicall3 transaction.
+// Note that this is EVM-specific.
+func GenMessagesForMulticall3(
+	ctx context.Context,
+	sourceRouter *router.Router,
+	destChainSelector uint64,
+	count int,
+	baseMsg router.ClientEVM2AnyMessage,
+) (calls []multicall3.Multicall3Call3Value, totalValue *big.Int, err error) {
+	totalValue = big.NewInt(0)
+	for range count {
+		msg := router.ClientEVM2AnyMessage{
+			Receiver:     baseMsg.Receiver,
+			Data:         baseMsg.Data,
+			TokenAmounts: baseMsg.TokenAmounts,
+			FeeToken:     baseMsg.FeeToken,
+			ExtraArgs:    baseMsg.ExtraArgs,
+		}
+
+		fee, err := sourceRouter.GetFee(&bind.CallOpts{Context: ctx}, destChainSelector, msg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("router get fee: %w", err)
+		}
+
+		totalValue.Add(totalValue, fee)
+
+		calldata, err := CCIPSendCalldata(destChainSelector, msg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("generate calldata: %w", err)
+		}
+
+		calls = append(calls, multicall3.Multicall3Call3Value{
+			Target:       sourceRouter.Address(),
+			AllowFailure: false,
+			CallData:     calldata,
+			Value:        fee,
+		})
+	}
+
+	return calls, totalValue, nil
+}

--- a/deployment/ccip/changeset/testhelpers/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/helpers.go
@@ -6,9 +6,9 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/multicall3"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/multicall3"
 )
 
 // CCIPSendCalldata packs the calldata for the Router's ccipSend method.

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -235,6 +235,10 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		msgEVM2Any, ok := msg.(router.ClientEVM2AnyMessage)
 		require.True(tc.T, ok, "expected EVM message type")
 
+		onRamp := tc.OnchainState.MustGetEVMChainState(tc.SourceChain).OnRamp
+		nextSeqNum, err := onRamp.GetExpectedNextSequenceNumber(&bind.CallOpts{Context: tc.T.Context()}, tc.DestChain)
+		require.NoError(tc.T, err)
+
 		calls, totalValue, err := testhelpers.GenMessagesForMulticall3(
 			tc.T.Context(),
 			tc.OnchainState.MustGetEVMChainState(tc.SourceChain).Router,
@@ -263,8 +267,12 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		require.NoError(tc.T, err)
 
 		// check that the message was emitted
+		var expectedSeqNums []uint64
+		for i := range tc.NumberOfMessages {
+			expectedSeqNums = append(expectedSeqNums, nextSeqNum+uint64(i))
+		}
 		iter, err := tc.OnchainState.MustGetEVMChainState(tc.SourceChain).OnRamp.FilterCCIPMessageSent(
-			nil, []uint64{tc.DestChain}, nil,
+			nil, []uint64{tc.DestChain}, expectedSeqNums,
 		)
 		require.NoError(tc.T, err)
 

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -269,7 +269,8 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		// check that the message was emitted
 		var expectedSeqNums []uint64
 		for i := range tc.NumberOfMessages {
-			expectedSeqNums = append(expectedSeqNums, nextSeqNum+uint64(i)) //nolint:gosec no overflow risk here.
+			//nolint:gosec // disable G115
+			expectedSeqNums = append(expectedSeqNums, nextSeqNum+uint64(i))
 		}
 		iter, err := tc.OnchainState.MustGetEVMChainState(tc.SourceChain).OnRamp.FilterCCIPMessageSent(
 			nil, []uint64{tc.DestChain}, expectedSeqNums,

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -251,7 +251,8 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		sender := tc.Env.BlockChains.EVMChains()[tc.SourceChain].DeployerKey
 		currBalance, err := tc.Env.BlockChains.EVMChains()[tc.SourceChain].Client.BalanceAt(tc.T.Context(), sender.From, nil)
 		require.NoError(tc.T, err)
-		require.Greater(tc.T, currBalance, totalValue, "sender balance should be greater than total value")
+		//nolint:testifylint // incorrect lint, GreaterOrEqual can't be used with *big.Int.
+		require.True(tc.T, currBalance.Cmp(totalValue) >= 0, "sender balance should be greater than or equal to total value")
 
 		tx, err := tc.OnchainState.MustGetEVMChainState(tc.SourceChain).Multicall3.Aggregate3Value(
 			&bind.TransactOpts{

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -275,6 +275,17 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 				RawEvent:       iter.Event,
 			}
 		}
+		out.MsgSentEvent = msgSentEvents[len(msgSentEvents)-1]
+
+		// Expect a single root with this sequence number range.
+		expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{
+			ccipocr3.SeqNum(msgSentEvents[0].SequenceNumber),
+			ccipocr3.SeqNum(msgSentEvents[len(msgSentEvents)-1].SequenceNumber),
+		}
+		// Expect all messages to be executed.
+		for i := range msgSentEvents {
+			expectedSeqNumExec[sourceDest] = append(expectedSeqNumExec[sourceDest], msgSentEvents[i].SequenceNumber)
+		}
 	} else {
 		// Send sequentially
 		for i := 0; i < tc.NumberOfMessages; i++ {

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -96,6 +96,7 @@ type TestCase struct {
 	ExpRevertOnSource      bool
 	ExtraAssertions        []func(t *testing.T)
 	NumberOfMessages       int // number of messages to send, use same data and extraArgs
+	UseMulticall3          bool
 }
 
 type ValidationType int
@@ -228,28 +229,77 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 	}
 
 	// send all messages first, then validate them
-	for i := 0; i < tc.NumberOfMessages; i++ {
-		msgSentEventLocal := testhelpers.TestSendRequest(
-			tc.T,
-			tc.Env,
-			tc.OnchainState,
-			tc.SourceChain,
+	if tc.UseMulticall3 {
+		require.Equal(t, chain_selectors.FamilyEVM, family, "only EVM family supported for multicall3 usage")
+
+		msgEVM2Any, ok := msg.(router.ClientEVM2AnyMessage)
+		require.True(tc.T, ok, "expected EVM message type")
+
+		calls, totalValue, err := testhelpers.GenMessagesForMulticall3(
+			tc.T.Context(),
+			tc.OnchainState.MustGetEVMChainState(tc.SourceChain).Router,
 			tc.DestChain,
-			tc.TestRouter,
-			msg)
+			tc.NumberOfMessages,
+			msgEVM2Any,
+		)
+		require.NoError(tc.T, err)
 
-		_, ok := expectedSeqNumRange[sourceDest]
-		if !ok {
-			expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{ccipocr3.SeqNum(msgSentEventLocal.SequenceNumber)}
+		sender := tc.Env.BlockChains.EVMChains()[tc.SourceChain].DeployerKey
+		currBalance, err := tc.Env.BlockChains.EVMChains()[tc.SourceChain].Client.BalanceAt(tc.T.Context(), sender.From, nil)
+		require.NoError(tc.T, err)
+		require.True(tc.T, currBalance.Cmp(totalValue) >= 0, "sender balance should be greater than or equal to total value")
+
+		tx, err := tc.OnchainState.MustGetEVMChainState(tc.SourceChain).Multicall3.Aggregate3Value(
+			&bind.TransactOpts{
+				From:   sender.From,
+				Signer: sender.Signer,
+				Value:  totalValue,
+			},
+			calls,
+		)
+		require.NoError(tc.T, err)
+
+		_, err = cldf.ConfirmIfNoError(tc.Env.BlockChains.EVMChains()[tc.SourceChain], tx, err)
+		require.NoError(tc.T, err)
+
+		// check that the message was emitted
+		iter, err := tc.OnchainState.MustGetEVMChainState(tc.SourceChain).OnRamp.FilterCCIPMessageSent(
+			nil, []uint64{tc.DestChain}, nil,
+		)
+		require.NoError(tc.T, err)
+
+		for i := 0; i < tc.NumberOfMessages; i++ {
+			require.True(tc.T, iter.Next())
+			msgSentEvents[i] = &ccipclient.AnyMsgSentEvent{
+				SequenceNumber: iter.Event.SequenceNumber,
+				RawEvent:       iter.Event,
+			}
 		}
-		expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{expectedSeqNumRange[sourceDest].Start(),
-			ccipocr3.SeqNum(msgSentEventLocal.SequenceNumber)}
+	} else {
+		// Send sequentially
+		for i := 0; i < tc.NumberOfMessages; i++ {
+			msgSentEventLocal := testhelpers.TestSendRequest(
+				tc.T,
+				tc.Env,
+				tc.OnchainState,
+				tc.SourceChain,
+				tc.DestChain,
+				tc.TestRouter,
+				msg)
 
-		expectedSeqNumExec[sourceDest] = append(expectedSeqNumExec[sourceDest], msgSentEventLocal.SequenceNumber)
-		// TODO: If this feature is needed more we can refactor the function to return a slice of events
-		// return only last msg event
-		out.MsgSentEvent = msgSentEventLocal
-		msgSentEvents[i] = msgSentEventLocal
+			_, ok := expectedSeqNumRange[sourceDest]
+			if !ok {
+				expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{ccipocr3.SeqNum(msgSentEventLocal.SequenceNumber)}
+			}
+			expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{expectedSeqNumRange[sourceDest].Start(),
+				ccipocr3.SeqNum(msgSentEventLocal.SequenceNumber)}
+
+			expectedSeqNumExec[sourceDest] = append(expectedSeqNumExec[sourceDest], msgSentEventLocal.SequenceNumber)
+			// TODO: If this feature is needed more we can refactor the function to return a slice of events
+			// return only last msg event
+			out.MsgSentEvent = msgSentEventLocal
+			msgSentEvents[i] = msgSentEventLocal
+		}
 	}
 
 	// HACK: if the node booted or the logpoller filters got registered after ccipSend,

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -20,7 +20,7 @@ import (
 	solconfig "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_0/ccip_router"
 	solcommon "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	ccipocr3common "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	aptoscs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
@@ -220,7 +220,7 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		tc.NumberOfMessages = 1 // default to sending one message if not specified
 	}
 
-	expectedSeqNumRange := map[testhelpers.SourceDestPair]ccipocr3.SeqNumRange{}
+	expectedSeqNumRange := map[testhelpers.SourceDestPair]ccipocr3common.SeqNumRange{}
 	expectedSeqNumExec := map[testhelpers.SourceDestPair][]uint64{}
 	msgSentEvents := make([]*ccipclient.AnyMsgSentEvent, tc.NumberOfMessages)
 	sourceDest := testhelpers.SourceDestPair{
@@ -251,7 +251,7 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		sender := tc.Env.BlockChains.EVMChains()[tc.SourceChain].DeployerKey
 		currBalance, err := tc.Env.BlockChains.EVMChains()[tc.SourceChain].Client.BalanceAt(tc.T.Context(), sender.From, nil)
 		require.NoError(tc.T, err)
-		require.True(tc.T, currBalance.Cmp(totalValue) >= 0, "sender balance should be greater than or equal to total value")
+		require.Greater(tc.T, currBalance, totalValue, "sender balance should be greater than total value")
 
 		tx, err := tc.OnchainState.MustGetEVMChainState(tc.SourceChain).Multicall3.Aggregate3Value(
 			&bind.TransactOpts{
@@ -269,7 +269,7 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		// check that the message was emitted
 		var expectedSeqNums []uint64
 		for i := range tc.NumberOfMessages {
-			expectedSeqNums = append(expectedSeqNums, nextSeqNum+uint64(i))
+			expectedSeqNums = append(expectedSeqNums, nextSeqNum+uint64(i)) //nolint:gosec no overflow risk here.
 		}
 		iter, err := tc.OnchainState.MustGetEVMChainState(tc.SourceChain).OnRamp.FilterCCIPMessageSent(
 			nil, []uint64{tc.DestChain}, expectedSeqNums,
@@ -286,9 +286,9 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		out.MsgSentEvent = msgSentEvents[len(msgSentEvents)-1]
 
 		// Expect a single root with this sequence number range.
-		expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{
-			ccipocr3.SeqNum(msgSentEvents[0].SequenceNumber),
-			ccipocr3.SeqNum(msgSentEvents[len(msgSentEvents)-1].SequenceNumber),
+		expectedSeqNumRange[sourceDest] = ccipocr3common.SeqNumRange{
+			ccipocr3common.SeqNum(msgSentEvents[0].SequenceNumber),
+			ccipocr3common.SeqNum(msgSentEvents[len(msgSentEvents)-1].SequenceNumber),
 		}
 		// Expect all messages to be executed.
 		for i := range msgSentEvents {
@@ -308,10 +308,10 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 
 			_, ok := expectedSeqNumRange[sourceDest]
 			if !ok {
-				expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{ccipocr3.SeqNum(msgSentEventLocal.SequenceNumber)}
+				expectedSeqNumRange[sourceDest] = ccipocr3common.SeqNumRange{ccipocr3common.SeqNum(msgSentEventLocal.SequenceNumber)}
 			}
-			expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{expectedSeqNumRange[sourceDest].Start(),
-				ccipocr3.SeqNum(msgSentEventLocal.SequenceNumber)}
+			expectedSeqNumRange[sourceDest] = ccipocr3common.SeqNumRange{expectedSeqNumRange[sourceDest].Start(),
+				ccipocr3common.SeqNum(msgSentEventLocal.SequenceNumber)}
 
 			expectedSeqNumExec[sourceDest] = append(expectedSeqNumExec[sourceDest], msgSentEventLocal.SequenceNumber)
 			// TODO: If this feature is needed more we can refactor the function to return a slice of events

--- a/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
+++ b/deployment/ccip/changeset/testhelpers/messagingtest/helpers.go
@@ -20,7 +20,7 @@ import (
 	solconfig "github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_0/ccip_router"
 	solcommon "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
-	ccipocr3common "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	aptoscs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/testhelpers"
@@ -220,7 +220,7 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		tc.NumberOfMessages = 1 // default to sending one message if not specified
 	}
 
-	expectedSeqNumRange := map[testhelpers.SourceDestPair]ccipocr3common.SeqNumRange{}
+	expectedSeqNumRange := map[testhelpers.SourceDestPair]ccipocr3.SeqNumRange{}
 	expectedSeqNumExec := map[testhelpers.SourceDestPair][]uint64{}
 	msgSentEvents := make([]*ccipclient.AnyMsgSentEvent, tc.NumberOfMessages)
 	sourceDest := testhelpers.SourceDestPair{
@@ -288,9 +288,9 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 		out.MsgSentEvent = msgSentEvents[len(msgSentEvents)-1]
 
 		// Expect a single root with this sequence number range.
-		expectedSeqNumRange[sourceDest] = ccipocr3common.SeqNumRange{
-			ccipocr3common.SeqNum(msgSentEvents[0].SequenceNumber),
-			ccipocr3common.SeqNum(msgSentEvents[len(msgSentEvents)-1].SequenceNumber),
+		expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{
+			ccipocr3.SeqNum(msgSentEvents[0].SequenceNumber),
+			ccipocr3.SeqNum(msgSentEvents[len(msgSentEvents)-1].SequenceNumber),
 		}
 		// Expect all messages to be executed.
 		for i := range msgSentEvents {
@@ -310,10 +310,10 @@ func Run(t *testing.T, tc TestCase) (out TestCaseOutput) {
 
 			_, ok := expectedSeqNumRange[sourceDest]
 			if !ok {
-				expectedSeqNumRange[sourceDest] = ccipocr3common.SeqNumRange{ccipocr3common.SeqNum(msgSentEventLocal.SequenceNumber)}
+				expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{ccipocr3.SeqNum(msgSentEventLocal.SequenceNumber)}
 			}
-			expectedSeqNumRange[sourceDest] = ccipocr3common.SeqNumRange{expectedSeqNumRange[sourceDest].Start(),
-				ccipocr3common.SeqNum(msgSentEventLocal.SequenceNumber)}
+			expectedSeqNumRange[sourceDest] = ccipocr3.SeqNumRange{expectedSeqNumRange[sourceDest].Start(),
+				ccipocr3.SeqNum(msgSentEventLocal.SequenceNumber)}
 
 			expectedSeqNumExec[sourceDest] = append(expectedSeqNumExec[sourceDest], msgSentEventLocal.SequenceNumber)
 			// TODO: If this feature is needed more we can refactor the function to return a slice of events

--- a/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
@@ -69,6 +69,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/aggregator_v3_interface"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/mock_v3_aggregator_contract"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/multicall3"
 	"github.com/smartcontractkit/chainlink/deployment"
 	aptoscs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
@@ -460,6 +461,49 @@ func CCIPSendCalldata(
 
 	calldata = append(routerABI.Methods["ccipSend"].ID, calldata...)
 	return calldata, nil
+}
+
+// GenMessagesForMulticall3 generates the calls and total value for the messages so that they can be used
+// with a multicall3 transaction.
+// Note that this is EVM-specific.
+func GenMessagesForMulticall3(
+	ctx context.Context,
+	sourceRouter *router.Router,
+	destChainSelector uint64,
+	count int,
+	baseMsg router.ClientEVM2AnyMessage,
+) (calls []multicall3.Multicall3Call3Value, totalValue *big.Int, err error) {
+	totalValue = big.NewInt(0)
+	for range count {
+		msg := router.ClientEVM2AnyMessage{
+			Receiver:     baseMsg.Receiver,
+			Data:         baseMsg.Data,
+			TokenAmounts: baseMsg.TokenAmounts,
+			FeeToken:     baseMsg.FeeToken,
+			ExtraArgs:    baseMsg.ExtraArgs,
+		}
+
+		fee, err := sourceRouter.GetFee(&bind.CallOpts{Context: ctx}, destChainSelector, msg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("router get fee: %w", err)
+		}
+
+		totalValue.Add(totalValue, fee)
+
+		calldata, err := CCIPSendCalldata(destChainSelector, msg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("generate calldata: %w", err)
+		}
+
+		calls = append(calls, multicall3.Multicall3Call3Value{
+			Target:       sourceRouter.Address(),
+			AllowFailure: false,
+			CallData:     calldata,
+			Value:        fee,
+		})
+	}
+
+	return calls, totalValue, nil
 }
 
 // testhelpers.SendRequest(t, e, state, src, dest, msg, opts...)

--- a/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
+++ b/deployment/ccip/changeset/testhelpers/test_helpers_solana_v0_1_0.go
@@ -69,7 +69,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/aggregator_v3_interface"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/mock_v3_aggregator_contract"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/multicall3"
 	"github.com/smartcontractkit/chainlink/deployment"
 	aptoscs "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos"
 	"github.com/smartcontractkit/chainlink/deployment/ccip/changeset/aptos/config"
@@ -442,68 +441,6 @@ func retryCcipSendUntilNativeFeeIsSufficient(
 
 		return tx, blockNum, nil
 	}
-}
-
-// CCIPSendCalldata packs the calldata for the Router's ccipSend method.
-// This is expected to be used in Multicall scenarios (i.e multiple ccipSend calls
-// in a single transaction).
-func CCIPSendCalldata(
-	destChainSelector uint64,
-	evm2AnyMessage router.ClientEVM2AnyMessage,
-) ([]byte, error) {
-	calldata, err := routerABI.Methods["ccipSend"].Inputs.Pack(
-		destChainSelector,
-		evm2AnyMessage,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("pack ccipSend calldata: %w", err)
-	}
-
-	calldata = append(routerABI.Methods["ccipSend"].ID, calldata...)
-	return calldata, nil
-}
-
-// GenMessagesForMulticall3 generates the calls and total value for the messages so that they can be used
-// with a multicall3 transaction.
-// Note that this is EVM-specific.
-func GenMessagesForMulticall3(
-	ctx context.Context,
-	sourceRouter *router.Router,
-	destChainSelector uint64,
-	count int,
-	baseMsg router.ClientEVM2AnyMessage,
-) (calls []multicall3.Multicall3Call3Value, totalValue *big.Int, err error) {
-	totalValue = big.NewInt(0)
-	for range count {
-		msg := router.ClientEVM2AnyMessage{
-			Receiver:     baseMsg.Receiver,
-			Data:         baseMsg.Data,
-			TokenAmounts: baseMsg.TokenAmounts,
-			FeeToken:     baseMsg.FeeToken,
-			ExtraArgs:    baseMsg.ExtraArgs,
-		}
-
-		fee, err := sourceRouter.GetFee(&bind.CallOpts{Context: ctx}, destChainSelector, msg)
-		if err != nil {
-			return nil, nil, fmt.Errorf("router get fee: %w", err)
-		}
-
-		totalValue.Add(totalValue, fee)
-
-		calldata, err := CCIPSendCalldata(destChainSelector, msg)
-		if err != nil {
-			return nil, nil, fmt.Errorf("generate calldata: %w", err)
-		}
-
-		calls = append(calls, multicall3.Multicall3Call3Value{
-			Target:       sourceRouter.Address(),
-			AllowFailure: false,
-			CallData:     calldata,
-			Value:        fee,
-		})
-	}
-
-	return calls, totalValue, nil
 }
 
 // testhelpers.SendRequest(t, e, state, src, dest, msg, opts...)

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -2,7 +2,6 @@ package ccip
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -344,8 +343,9 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 
 func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 	// Setup 2 chains (EVM and Solana) and a single lane.
-	ctx := testhelpers.Context(t)
+	// ctx := testhelpers.Context(t)
 	e, _, _ := testsetups.NewIntegrationEnvironment(t,
+		testhelpers.WithMultiCall3(),
 		testhelpers.WithSolChains(1),
 		testhelpers.WithOCRConfigOverride(func(params v1_6.CCIPOCRParams) v1_6.CCIPOCRParams {
 			params.ExecuteOffChainConfig.InflightCacheExpiry = *config.MustNewDuration(1 * time.Hour)
@@ -400,132 +400,169 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 	receiverTargetAccountPDA, _, _ := solana.FindProgramAddress([][]byte{[]byte("counter")}, receiverProgram)
 	receiverExternalExecutionConfigPDA, _, _ := solana.FindProgramAddress([][]byte{[]byte("external_execution_config")}, receiverProgram)
 
-	solChains := e.Env.BlockChains.SolanaChains()
+	// solChains := e.Env.BlockChains.SolanaChains()
 
-	t.Run("message to contract implementing CCIPReceiver", func(t *testing.T) {
-		accounts := [][32]byte{
-			receiverExternalExecutionConfigPDA,
-			receiverTargetAccountPDA,
-			solana.SystemProgramID,
-		}
+	// t.Run("message to contract implementing CCIPReceiver", func(t *testing.T) {
+	// 	accounts := [][32]byte{
+	// 		receiverExternalExecutionConfigPDA,
+	// 		receiverTargetAccountPDA,
+	// 		solana.SystemProgramID,
+	// 	}
 
-		extraArgs, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
-			AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}),
-			Accounts:                 accounts,
-			ComputeUnits:             80_000,
-			AllowOutOfOrderExecution: true,
-		})
-		require.NoError(t, err)
+	// 	extraArgs, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
+	// 		AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}),
+	// 		Accounts:                 accounts,
+	// 		ComputeUnits:             80_000,
+	// 		AllowOutOfOrderExecution: true,
+	// 	})
+	// 	require.NoError(t, err)
 
-		// check that counter is 0
-		var receiverCounterAccount soltesthelpers.ReceiverCounter
-		err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
-		require.NoError(t, err, "failed to get account info")
-		require.Equal(t, uint8(0), receiverCounterAccount.Value)
+	// 	// check that counter is 0
+	// 	var receiverCounterAccount soltesthelpers.ReceiverCounter
+	// 	err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
+	// 	require.NoError(t, err, "failed to get account info")
+	// 	require.Equal(t, uint8(0), receiverCounterAccount.Value)
 
-		out = mt.Run(
-			t,
-			mt.TestCase{
-				ValidationType:         mt.ValidationTypeExec,
-				TestSetup:              setup,
-				Nonce:                  nil, // Solana nonce check is skipped
-				Receiver:               receiver,
-				MsgData:                []byte("hello CCIPReceiver"),
-				ExtraArgs:              extraArgs,
-				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
-				ExtraAssertions: []func(t *testing.T){
-					func(t *testing.T) {
-						var receiverCounterAccount soltesthelpers.ReceiverCounter
-						err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
-						require.NoError(t, err, "failed to get account info")
-						require.Equal(t, uint8(1), receiverCounterAccount.Value)
-					},
-				},
-			},
-		)
-	})
+	// 	out = mt.Run(
+	// 		t,
+	// 		mt.TestCase{
+	// 			ValidationType:         mt.ValidationTypeExec,
+	// 			TestSetup:              setup,
+	// 			Nonce:                  nil, // Solana nonce check is skipped
+	// 			Receiver:               receiver,
+	// 			MsgData:                []byte("hello CCIPReceiver"),
+	// 			ExtraArgs:              extraArgs,
+	// 			ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+	// 			ExtraAssertions: []func(t *testing.T){
+	// 				func(t *testing.T) {
+	// 					var receiverCounterAccount soltesthelpers.ReceiverCounter
+	// 					err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
+	// 					require.NoError(t, err, "failed to get account info")
+	// 					require.Equal(t, uint8(1), receiverCounterAccount.Value)
+	// 				},
+	// 			},
+	// 		},
+	// 	)
+	// })
 
-	t.Run("message sequence: failure (too many accounts) -> success", func(t *testing.T) {
-		// --- 1. First Message (Failure - Too Many Accounts) ---
-		t.Log("Sending first message (expecting failure due to too many accounts)...")
+	// t.Run("message sequence: failure (too many accounts) -> success", func(t *testing.T) {
+	// 	// --- 1. First Message (Failure - Too Many Accounts) ---
+	// 	t.Log("Sending first message (expecting failure due to too many accounts)...")
 
-		// Generate 60 dummy accounts
-		numAccounts := 60
-		accountsFailure := make([][32]byte, numAccounts)
-		writableIndexes := []int{0, 1, 2} // Mark first 3 as writable
-		for i := 0; i < numAccounts; i++ {
-			accountsFailure[i] = common.HexToHash(fmt.Sprintf("0x%064d", i+1))
-		}
-		// Set required accounts
-		accountsFailure[0] = receiverExternalExecutionConfigPDA
-		accountsFailure[1] = receiverTargetAccountPDA
-		accountsFailure[2] = solana.SystemProgramID
+	// 	// Generate 60 dummy accounts
+	// 	numAccounts := 60
+	// 	accountsFailure := make([][32]byte, numAccounts)
+	// 	writableIndexes := []int{0, 1, 2} // Mark first 3 as writable
+	// 	for i := 0; i < numAccounts; i++ {
+	// 		accountsFailure[i] = common.HexToHash(fmt.Sprintf("0x%064d", i+1))
+	// 	}
+	// 	// Set required accounts
+	// 	accountsFailure[0] = receiverExternalExecutionConfigPDA
+	// 	accountsFailure[1] = receiverTargetAccountPDA
+	// 	accountsFailure[2] = solana.SystemProgramID
 
-		extraArgsFailure, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
-			AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes(writableIndexes),
-			Accounts:                 accountsFailure,
-			ComputeUnits:             80_000,
-			AllowOutOfOrderExecution: true,
-		})
-		require.NoError(t, err, "failed to serialize extra args for failing message")
+	// 	extraArgsFailure, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
+	// 		AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes(writableIndexes),
+	// 		Accounts:                 accountsFailure,
+	// 		ComputeUnits:             80_000,
+	// 		AllowOutOfOrderExecution: true,
+	// 	})
+	// 	require.NoError(t, err, "failed to serialize extra args for failing message")
 
-		// Run the test case expecting failure
-		// Use initial replayed=false and nonce=0
-		out = mt.Run(
-			t,
-			mt.TestCase{
-				ValidationType: mt.ValidationTypeCommit,
-				TestSetup:      setup,
-				Nonce:          nil, // Nonce check skipped for Commit validation and Solana
-				Receiver:       receiver,
-				MsgData:        []byte("hello with too many accounts"),
-				ExtraArgs:      extraArgsFailure,
-			},
-		)
+	// 	// Run the test case expecting failure
+	// 	// Use initial replayed=false and nonce=0
+	// 	out = mt.Run(
+	// 		t,
+	// 		mt.TestCase{
+	// 			ValidationType: mt.ValidationTypeCommit,
+	// 			TestSetup:      setup,
+	// 			Nonce:          nil, // Nonce check skipped for Commit validation and Solana
+	// 			Receiver:       receiver,
+	// 			MsgData:        []byte("hello with too many accounts"),
+	// 			ExtraArgs:      extraArgsFailure,
+	// 		},
+	// 	)
 
-		// --- 2. Second Message (Success) ---
-		t.Log("Sending second message (expecting success)...")
-		accountsSuccess := [][32]byte{ // Use valid accounts
-			receiverExternalExecutionConfigPDA,
-			receiverTargetAccountPDA,
-			solana.SystemProgramID,
-		}
+	// 	// --- 2. Second Message (Success) ---
+	// 	t.Log("Sending second message (expecting success)...")
+	// 	accountsSuccess := [][32]byte{ // Use valid accounts
+	// 		receiverExternalExecutionConfigPDA,
+	// 		receiverTargetAccountPDA,
+	// 		solana.SystemProgramID,
+	// 	}
 
-		extraArgsSuccess, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
-			AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}), // Mark relevant accounts as writable
-			Accounts:                 accountsSuccess,
-			ComputeUnits:             80_000,
-			AllowOutOfOrderExecution: true,
-		})
-		require.NoError(t, err, "failed to serialize extra args for successful message")
+	// 	extraArgsSuccess, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
+	// 		AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}), // Mark relevant accounts as writable
+	// 		Accounts:                 accountsSuccess,
+	// 		ComputeUnits:             80_000,
+	// 		AllowOutOfOrderExecution: true,
+	// 	})
+	// 	require.NoError(t, err, "failed to serialize extra args for successful message")
 
-		// Run the test case expecting success
-		// Use Replayed and Nonce from the previous (failed) run's output stored in 'out'
-		out = mt.Run(
-			t,
-			mt.TestCase{
-				ValidationType:         mt.ValidationTypeExec,
-				TestSetup:              setup,
-				Nonce:                  nil, // Solana nonce check is skipped
-				Receiver:               receiver,
-				MsgData:                []byte("hello CCIPReceiver that should succeed"),
-				ExtraArgs:              extraArgsSuccess,
-				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
-				ExtraAssertions: []func(t *testing.T){
-					func(t *testing.T) {
-						// Check counter is now 2
-						var receiverCounterAccountAfterSuccess soltesthelpers.ReceiverCounter
-						err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccountAfterSuccess)
-						require.NoError(t, err, "failed to get account info after second message")
-						require.Equal(t, uint8(2), receiverCounterAccountAfterSuccess.Value, "Counter should have incremented to 2")
-						t.Logf("Confirmed counter incremented to 2 after second (successful) message")
-					},
-				},
-			},
-		)
-	})
+	// 	// Run the test case expecting success
+	// 	// Use Replayed and Nonce from the previous (failed) run's output stored in 'out'
+	// 	out = mt.Run(
+	// 		t,
+	// 		mt.TestCase{
+	// 			ValidationType:         mt.ValidationTypeExec,
+	// 			TestSetup:              setup,
+	// 			Nonce:                  nil, // Solana nonce check is skipped
+	// 			Receiver:               receiver,
+	// 			MsgData:                []byte("hello CCIPReceiver that should succeed"),
+	// 			ExtraArgs:              extraArgsSuccess,
+	// 			ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+	// 			ExtraAssertions: []func(t *testing.T){
+	// 				func(t *testing.T) {
+	// 					// Check counter is now 2
+	// 					var receiverCounterAccountAfterSuccess soltesthelpers.ReceiverCounter
+	// 					err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccountAfterSuccess)
+	// 					require.NoError(t, err, "failed to get account info after second message")
+	// 					require.Equal(t, uint8(2), receiverCounterAccountAfterSuccess.Value, "Counter should have incremented to 2")
+	// 					t.Logf("Confirmed counter incremented to 2 after second (successful) message")
+	// 				},
+	// 			},
+	// 		},
+	// 	)
+	// })
 
-	t.Run("message requiring buffering", func(t *testing.T) {
+	// t.Run("message requiring buffering", func(t *testing.T) {
+	// 	accounts := [][32]byte{
+	// 		receiverExternalExecutionConfigPDA,
+	// 		receiverTargetAccountPDA,
+	// 		solana.SystemProgramID,
+	// 	}
+
+	// 	extraArgs, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
+	// 		AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}),
+	// 		Accounts:                 accounts,
+	// 		ComputeUnits:             1_000_000,
+	// 		AllowOutOfOrderExecution: true,
+	// 	})
+	// 	require.NoError(t, err)
+
+	// 	out = mt.Run(
+	// 		t,
+	// 		mt.TestCase{
+	// 			ValidationType:         mt.ValidationTypeExec,
+	// 			TestSetup:              setup,
+	// 			Nonce:                  nil, // Solana nonce check is skipped
+	// 			Receiver:               receiver,
+	// 			MsgData:                make([]byte, 1233), // set large payload that cannot fit in single transaction but does not overflow memory allocation
+	// 			ExtraArgs:              extraArgs,
+	// 			ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+	// 			ExtraAssertions: []func(t *testing.T){
+	// 				func(t *testing.T) {
+	// 					var receiverCounterAccount soltesthelpers.ReceiverCounter
+	// 					err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
+	// 					require.NoError(t, err, "failed to get account info")
+	// 					require.Equal(t, uint8(3), receiverCounterAccount.Value)
+	// 				},
+	// 			},
+	// 		},
+	// 	)
+	// })
+
+	t.Run("message requiring merkle proof", func(t *testing.T) {
 		accounts := [][32]byte{
 			receiverExternalExecutionConfigPDA,
 			receiverTargetAccountPDA,
@@ -543,21 +580,14 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 		out = mt.Run(
 			t,
 			mt.TestCase{
-				ValidationType:         mt.ValidationTypeExec,
-				TestSetup:              setup,
-				Nonce:                  nil, // Solana nonce check is skipped
-				Receiver:               receiver,
-				MsgData:                make([]byte, 1233), // set large payload that cannot fit in single transaction but does not overflow memory allocation
-				ExtraArgs:              extraArgs,
-				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
-				ExtraAssertions: []func(t *testing.T){
-					func(t *testing.T) {
-						var receiverCounterAccount soltesthelpers.ReceiverCounter
-						err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
-						require.NoError(t, err, "failed to get account info")
-						require.Equal(t, uint8(3), receiverCounterAccount.Value)
-					},
-				},
+				ValidationType:   mt.ValidationTypeExec,
+				TestSetup:        setup,
+				Nonce:            nil, // Solana nonce check is skipped
+				Receiver:         receiver,
+				MsgData:          []byte("hello CCIPReceiver"),
+				ExtraArgs:        extraArgs,
+				NumberOfMessages: 3,
+				UseMulticall3:    true,
 			},
 		)
 	})

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -2,6 +2,7 @@ package ccip
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -343,7 +344,7 @@ func Test_CCIPMessaging_MultiExecReports_EVM2Solana(t *testing.T) {
 
 func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 	// Setup 2 chains (EVM and Solana) and a single lane.
-	// ctx := testhelpers.Context(t)
+	ctx := testhelpers.Context(t)
 	e, _, _ := testsetups.NewIntegrationEnvironment(t,
 		testhelpers.WithMultiCall3(),
 		testhelpers.WithSolChains(1),
@@ -400,167 +401,167 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 	receiverTargetAccountPDA, _, _ := solana.FindProgramAddress([][]byte{[]byte("counter")}, receiverProgram)
 	receiverExternalExecutionConfigPDA, _, _ := solana.FindProgramAddress([][]byte{[]byte("external_execution_config")}, receiverProgram)
 
-	// solChains := e.Env.BlockChains.SolanaChains()
+	solChains := e.Env.BlockChains.SolanaChains()
 
-	// t.Run("message to contract implementing CCIPReceiver", func(t *testing.T) {
-	// 	accounts := [][32]byte{
-	// 		receiverExternalExecutionConfigPDA,
-	// 		receiverTargetAccountPDA,
-	// 		solana.SystemProgramID,
-	// 	}
+	t.Run("message to contract implementing CCIPReceiver", func(t *testing.T) {
+		accounts := [][32]byte{
+			receiverExternalExecutionConfigPDA,
+			receiverTargetAccountPDA,
+			solana.SystemProgramID,
+		}
 
-	// 	extraArgs, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
-	// 		AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}),
-	// 		Accounts:                 accounts,
-	// 		ComputeUnits:             80_000,
-	// 		AllowOutOfOrderExecution: true,
-	// 	})
-	// 	require.NoError(t, err)
+		extraArgs, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
+			AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}),
+			Accounts:                 accounts,
+			ComputeUnits:             80_000,
+			AllowOutOfOrderExecution: true,
+		})
+		require.NoError(t, err)
 
-	// 	// check that counter is 0
-	// 	var receiverCounterAccount soltesthelpers.ReceiverCounter
-	// 	err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
-	// 	require.NoError(t, err, "failed to get account info")
-	// 	require.Equal(t, uint8(0), receiverCounterAccount.Value)
+		// check that counter is 0
+		var receiverCounterAccount soltesthelpers.ReceiverCounter
+		err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
+		require.NoError(t, err, "failed to get account info")
+		require.Equal(t, uint8(0), receiverCounterAccount.Value)
 
-	// 	out = mt.Run(
-	// 		t,
-	// 		mt.TestCase{
-	// 			ValidationType:         mt.ValidationTypeExec,
-	// 			TestSetup:              setup,
-	// 			Nonce:                  nil, // Solana nonce check is skipped
-	// 			Receiver:               receiver,
-	// 			MsgData:                []byte("hello CCIPReceiver"),
-	// 			ExtraArgs:              extraArgs,
-	// 			ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
-	// 			ExtraAssertions: []func(t *testing.T){
-	// 				func(t *testing.T) {
-	// 					var receiverCounterAccount soltesthelpers.ReceiverCounter
-	// 					err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
-	// 					require.NoError(t, err, "failed to get account info")
-	// 					require.Equal(t, uint8(1), receiverCounterAccount.Value)
-	// 				},
-	// 			},
-	// 		},
-	// 	)
-	// })
+		out = mt.Run(
+			t,
+			mt.TestCase{
+				ValidationType:         mt.ValidationTypeExec,
+				TestSetup:              setup,
+				Nonce:                  nil, // Solana nonce check is skipped
+				Receiver:               receiver,
+				MsgData:                []byte("hello CCIPReceiver"),
+				ExtraArgs:              extraArgs,
+				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+				ExtraAssertions: []func(t *testing.T){
+					func(t *testing.T) {
+						var receiverCounterAccount soltesthelpers.ReceiverCounter
+						err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
+						require.NoError(t, err, "failed to get account info")
+						require.Equal(t, uint8(1), receiverCounterAccount.Value)
+					},
+				},
+			},
+		)
+	})
 
-	// t.Run("message sequence: failure (too many accounts) -> success", func(t *testing.T) {
-	// 	// --- 1. First Message (Failure - Too Many Accounts) ---
-	// 	t.Log("Sending first message (expecting failure due to too many accounts)...")
+	t.Run("message sequence: failure (too many accounts) -> success", func(t *testing.T) {
+		// --- 1. First Message (Failure - Too Many Accounts) ---
+		t.Log("Sending first message (expecting failure due to too many accounts)...")
 
-	// 	// Generate 60 dummy accounts
-	// 	numAccounts := 60
-	// 	accountsFailure := make([][32]byte, numAccounts)
-	// 	writableIndexes := []int{0, 1, 2} // Mark first 3 as writable
-	// 	for i := 0; i < numAccounts; i++ {
-	// 		accountsFailure[i] = common.HexToHash(fmt.Sprintf("0x%064d", i+1))
-	// 	}
-	// 	// Set required accounts
-	// 	accountsFailure[0] = receiverExternalExecutionConfigPDA
-	// 	accountsFailure[1] = receiverTargetAccountPDA
-	// 	accountsFailure[2] = solana.SystemProgramID
+		// Generate 60 dummy accounts
+		numAccounts := 60
+		accountsFailure := make([][32]byte, numAccounts)
+		writableIndexes := []int{0, 1, 2} // Mark first 3 as writable
+		for i := 0; i < numAccounts; i++ {
+			accountsFailure[i] = common.HexToHash(fmt.Sprintf("0x%064d", i+1))
+		}
+		// Set required accounts
+		accountsFailure[0] = receiverExternalExecutionConfigPDA
+		accountsFailure[1] = receiverTargetAccountPDA
+		accountsFailure[2] = solana.SystemProgramID
 
-	// 	extraArgsFailure, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
-	// 		AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes(writableIndexes),
-	// 		Accounts:                 accountsFailure,
-	// 		ComputeUnits:             80_000,
-	// 		AllowOutOfOrderExecution: true,
-	// 	})
-	// 	require.NoError(t, err, "failed to serialize extra args for failing message")
+		extraArgsFailure, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
+			AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes(writableIndexes),
+			Accounts:                 accountsFailure,
+			ComputeUnits:             80_000,
+			AllowOutOfOrderExecution: true,
+		})
+		require.NoError(t, err, "failed to serialize extra args for failing message")
 
-	// 	// Run the test case expecting failure
-	// 	// Use initial replayed=false and nonce=0
-	// 	out = mt.Run(
-	// 		t,
-	// 		mt.TestCase{
-	// 			ValidationType: mt.ValidationTypeCommit,
-	// 			TestSetup:      setup,
-	// 			Nonce:          nil, // Nonce check skipped for Commit validation and Solana
-	// 			Receiver:       receiver,
-	// 			MsgData:        []byte("hello with too many accounts"),
-	// 			ExtraArgs:      extraArgsFailure,
-	// 		},
-	// 	)
+		// Run the test case expecting failure
+		// Use initial replayed=false and nonce=0
+		out = mt.Run(
+			t,
+			mt.TestCase{
+				ValidationType: mt.ValidationTypeCommit,
+				TestSetup:      setup,
+				Nonce:          nil, // Nonce check skipped for Commit validation and Solana
+				Receiver:       receiver,
+				MsgData:        []byte("hello with too many accounts"),
+				ExtraArgs:      extraArgsFailure,
+			},
+		)
 
-	// 	// --- 2. Second Message (Success) ---
-	// 	t.Log("Sending second message (expecting success)...")
-	// 	accountsSuccess := [][32]byte{ // Use valid accounts
-	// 		receiverExternalExecutionConfigPDA,
-	// 		receiverTargetAccountPDA,
-	// 		solana.SystemProgramID,
-	// 	}
+		// --- 2. Second Message (Success) ---
+		t.Log("Sending second message (expecting success)...")
+		accountsSuccess := [][32]byte{ // Use valid accounts
+			receiverExternalExecutionConfigPDA,
+			receiverTargetAccountPDA,
+			solana.SystemProgramID,
+		}
 
-	// 	extraArgsSuccess, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
-	// 		AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}), // Mark relevant accounts as writable
-	// 		Accounts:                 accountsSuccess,
-	// 		ComputeUnits:             80_000,
-	// 		AllowOutOfOrderExecution: true,
-	// 	})
-	// 	require.NoError(t, err, "failed to serialize extra args for successful message")
+		extraArgsSuccess, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
+			AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}), // Mark relevant accounts as writable
+			Accounts:                 accountsSuccess,
+			ComputeUnits:             80_000,
+			AllowOutOfOrderExecution: true,
+		})
+		require.NoError(t, err, "failed to serialize extra args for successful message")
 
-	// 	// Run the test case expecting success
-	// 	// Use Replayed and Nonce from the previous (failed) run's output stored in 'out'
-	// 	out = mt.Run(
-	// 		t,
-	// 		mt.TestCase{
-	// 			ValidationType:         mt.ValidationTypeExec,
-	// 			TestSetup:              setup,
-	// 			Nonce:                  nil, // Solana nonce check is skipped
-	// 			Receiver:               receiver,
-	// 			MsgData:                []byte("hello CCIPReceiver that should succeed"),
-	// 			ExtraArgs:              extraArgsSuccess,
-	// 			ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
-	// 			ExtraAssertions: []func(t *testing.T){
-	// 				func(t *testing.T) {
-	// 					// Check counter is now 2
-	// 					var receiverCounterAccountAfterSuccess soltesthelpers.ReceiverCounter
-	// 					err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccountAfterSuccess)
-	// 					require.NoError(t, err, "failed to get account info after second message")
-	// 					require.Equal(t, uint8(2), receiverCounterAccountAfterSuccess.Value, "Counter should have incremented to 2")
-	// 					t.Logf("Confirmed counter incremented to 2 after second (successful) message")
-	// 				},
-	// 			},
-	// 		},
-	// 	)
-	// })
+		// Run the test case expecting success
+		// Use Replayed and Nonce from the previous (failed) run's output stored in 'out'
+		out = mt.Run(
+			t,
+			mt.TestCase{
+				ValidationType:         mt.ValidationTypeExec,
+				TestSetup:              setup,
+				Nonce:                  nil, // Solana nonce check is skipped
+				Receiver:               receiver,
+				MsgData:                []byte("hello CCIPReceiver that should succeed"),
+				ExtraArgs:              extraArgsSuccess,
+				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+				ExtraAssertions: []func(t *testing.T){
+					func(t *testing.T) {
+						// Check counter is now 2
+						var receiverCounterAccountAfterSuccess soltesthelpers.ReceiverCounter
+						err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccountAfterSuccess)
+						require.NoError(t, err, "failed to get account info after second message")
+						require.Equal(t, uint8(2), receiverCounterAccountAfterSuccess.Value, "Counter should have incremented to 2")
+						t.Logf("Confirmed counter incremented to 2 after second (successful) message")
+					},
+				},
+			},
+		)
+	})
 
-	// t.Run("message requiring buffering", func(t *testing.T) {
-	// 	accounts := [][32]byte{
-	// 		receiverExternalExecutionConfigPDA,
-	// 		receiverTargetAccountPDA,
-	// 		solana.SystemProgramID,
-	// 	}
+	t.Run("message requiring buffering", func(t *testing.T) {
+		accounts := [][32]byte{
+			receiverExternalExecutionConfigPDA,
+			receiverTargetAccountPDA,
+			solana.SystemProgramID,
+		}
 
-	// 	extraArgs, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
-	// 		AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}),
-	// 		Accounts:                 accounts,
-	// 		ComputeUnits:             1_000_000,
-	// 		AllowOutOfOrderExecution: true,
-	// 	})
-	// 	require.NoError(t, err)
+		extraArgs, err := ccipevm.SerializeClientSVMExtraArgsV1(message_hasher.ClientSVMExtraArgsV1{
+			AccountIsWritableBitmap:  solccip.GenerateBitMapForIndexes([]int{0, 1}),
+			Accounts:                 accounts,
+			ComputeUnits:             1_000_000,
+			AllowOutOfOrderExecution: true,
+		})
+		require.NoError(t, err)
 
-	// 	out = mt.Run(
-	// 		t,
-	// 		mt.TestCase{
-	// 			ValidationType:         mt.ValidationTypeExec,
-	// 			TestSetup:              setup,
-	// 			Nonce:                  nil, // Solana nonce check is skipped
-	// 			Receiver:               receiver,
-	// 			MsgData:                make([]byte, 1233), // set large payload that cannot fit in single transaction but does not overflow memory allocation
-	// 			ExtraArgs:              extraArgs,
-	// 			ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
-	// 			ExtraAssertions: []func(t *testing.T){
-	// 				func(t *testing.T) {
-	// 					var receiverCounterAccount soltesthelpers.ReceiverCounter
-	// 					err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
-	// 					require.NoError(t, err, "failed to get account info")
-	// 					require.Equal(t, uint8(3), receiverCounterAccount.Value)
-	// 				},
-	// 			},
-	// 		},
-	// 	)
-	// })
+		out = mt.Run(
+			t,
+			mt.TestCase{
+				ValidationType:         mt.ValidationTypeExec,
+				TestSetup:              setup,
+				Nonce:                  nil, // Solana nonce check is skipped
+				Receiver:               receiver,
+				MsgData:                make([]byte, 1233), // set large payload that cannot fit in single transaction but does not overflow memory allocation
+				ExtraArgs:              extraArgs,
+				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
+				ExtraAssertions: []func(t *testing.T){
+					func(t *testing.T) {
+						var receiverCounterAccount soltesthelpers.ReceiverCounter
+						err = solcommon.GetAccountDataBorshInto(ctx, solChains[destChain].Client, receiverTargetAccountPDA, solconfig.DefaultCommitment, &receiverCounterAccount)
+						require.NoError(t, err, "failed to get account info")
+						require.Equal(t, uint8(3), receiverCounterAccount.Value)
+					},
+				},
+			},
+		)
+	})
 
 	t.Run("message requiring merkle proof", func(t *testing.T) {
 		accounts := [][32]byte{

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -1,6 +1,7 @@
 package ccip
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"
@@ -581,11 +582,12 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 		out = mt.Run(
 			t,
 			mt.TestCase{
-				ValidationType:         mt.ValidationTypeExec,
-				TestSetup:              setup,
-				Nonce:                  nil, // Solana nonce check is skipped
-				Receiver:               receiver,
-				MsgData:                []byte("hello CCIPReceiver"),
+				ValidationType: mt.ValidationTypeExec,
+				TestSetup:      setup,
+				Nonce:          nil, // Solana nonce check is skipped
+				Receiver:       receiver,
+				// set a large payload that requires a merkle proof so that we initiate tx buffering.
+				MsgData:                bytes.Repeat([]byte("a"), 1233),
 				ExtraArgs:              extraArgs,
 				NumberOfMessages:       3,
 				UseMulticall3:          true,

--- a/integration-tests/smoke/ccip/ccip_messaging_test.go
+++ b/integration-tests/smoke/ccip/ccip_messaging_test.go
@@ -580,14 +580,15 @@ func Test_CCIPMessaging_EVM2Solana(t *testing.T) {
 		out = mt.Run(
 			t,
 			mt.TestCase{
-				ValidationType:   mt.ValidationTypeExec,
-				TestSetup:        setup,
-				Nonce:            nil, // Solana nonce check is skipped
-				Receiver:         receiver,
-				MsgData:          []byte("hello CCIPReceiver"),
-				ExtraArgs:        extraArgs,
-				NumberOfMessages: 3,
-				UseMulticall3:    true,
+				ValidationType:         mt.ValidationTypeExec,
+				TestSetup:              setup,
+				Nonce:                  nil, // Solana nonce check is skipped
+				Receiver:               receiver,
+				MsgData:                []byte("hello CCIPReceiver"),
+				ExtraArgs:              extraArgs,
+				NumberOfMessages:       3,
+				UseMulticall3:          true,
+				ExpectedExecutionState: testhelpers.EXECUTION_STATE_SUCCESS,
 			},
 		)
 	})


### PR DESCRIPTION
This PR adds a test case to the `Test_CCIPMessaging_EVM2Solana` test which makes the commit plugin for Solana commit a merkle root with 3 messages (so merkle tree size == 3) and executes messages that therefore require a merkle proof and buffered transactions (ensured by making msg data big).