### PR TITLE
fixing heartbeat labels

### DIFF
--- a/core/services/chainlink/heartbeat.go
+++ b/core/services/chainlink/heartbeat.go
@@ -75,7 +75,7 @@ func NewHeartbeat(cfg HeartbeatConfig, opts ...HeartbeatOpt) Heartbeat {
 	h := Heartbeat{
 		beat:    cfg.Beat,
 		opts:    cfg,
-		emitter: cme,
+		emitter: cme.WithMapLabels(labels),
 		meter:   beholder.GetMeter(),
 	}
 


### PR DESCRIPTION
The labels on the heartbeat were missing because they weren't fed into the emitter in the heartbeat constructor.