### PR TITLE
fix(registrysyncer/v2): removes unnecessary locks

### DIFF
--- a/core/services/registrysyncer/v2/syncer.go
+++ b/core/services/registrysyncer/v2/syncer.go
@@ -65,9 +65,7 @@ type registrySyncer struct {
 
 var _ services.Service = &registrySyncer{}
 
-var (
-	defaultTickInterval = 12 * time.Second
-)
+var defaultTickInterval = 12 * time.Second
 
 // New instantiates a new RegistrySyncer
 func New(
@@ -359,6 +357,7 @@ func (s *registrySyncer) Sync(ctx context.Context, isInitialSync bool) error {
 		select {
 		case <-s.stopCh:
 			s.lggr.Debug("sync cancelled, stopping")
+			return nil
 		case s.updateChan <- latestRegistry:
 			// Successfully sent state
 			s.lggr.Debug("remote registry update triggered successfully")
@@ -431,10 +430,8 @@ func (s *registrySyncer) AddListener(listeners ...registrysyncer.Listener) {
 func (s *registrySyncer) Close() error {
 	return s.StopOnce("RegistrySyncer", func() error {
 		close(s.stopCh)
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		close(s.updateChan)
 		s.wg.Wait()
+		close(s.updateChan)
 		return nil
 	})
 }


### PR DESCRIPTION
<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 
PR:
- exits `Sync` call on close of `stopCh`
- remove calls to lock during `Close`
### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
<!--- Does this work support other open PRs?  Please list them.
- https://github.com/smartcontractkit/ccip/pull/7777777
-->
