### PR TITLE
make oracleFactoryDB type thread safe to fix CAPPL-1062 - core node panic

### DIFF
--- a/core/scripts/cre/environment/dashboards/dummy.json
+++ b/core/scripts/cre/environment/dashboards/dummy.json
@@ -1,0 +1,3 @@
+{
+  "example": "This file is needed for local testing so embedding can work."
+}

--- a/core/scripts/cre/environment/dashboards/dummy.json
+++ b/core/scripts/cre/environment/dashboards/dummy.json
@@ -1,3 +1,0 @@
-{
-  "example": "This file is needed for local testing so embedding can work."
-}


### PR DESCRIPTION
Fix for https://smartcontract-it.atlassian.net/browse/CAPPL-1062 causing core node panic when using oracle factory


Note: no long running operations or callbacks in the type, so simple mutex is sufficient